### PR TITLE
feat(seer): add autofix high-intelligence and code-review org experiments

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -271,6 +271,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:context-engine-structured-page-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable autofix introspection for early stopping of autofix runs
     manager.add("organizations:seer-autofix-introspection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Run new autofix sessions with high intelligence and reasoning levels
+    manager.add("organizations:seer-autofix-high-intelligence-high-reasoning", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Show Seer run ID in Slack notification footers
     manager.add("organizations:seer-run-id-in-slack", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Gate display of Seer action events in the issue activity timeline

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -273,6 +273,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-autofix-introspection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Run new autofix sessions with high intelligence and reasoning levels
     manager.add("organizations:seer-autofix-high-intelligence-high-reasoning", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Expose the code review tool to autofix coding runs
+    manager.add("organizations:seer-autofix-code-review", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Show Seer run ID in Slack notification footers
     manager.add("organizations:seer-run-id-in-slack", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Gate display of Seer action events in the issue activity timeline

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -248,6 +248,7 @@ class SeerAgentClient:
             intelligence_level: Optionally set the intelligence level of the agent. Higher intelligence gives better result quality at the cost of significantly higher latency and cost.
             is_interactive: Enable full interactive, human-like features of the agent. Only enable if you support *all* available interactions in Seer. An example use of this is the explorer chat in Sentry UI.
             enable_coding: Include code editing tools. When False, the agent cannot make code changes. Default is False. If enable_coding is True and the organization does not have the enable_seer_coding option, a SeerPermissionError will be raised.
+            code_review_enabled: Expose the review_code_changes tool, which spawns a reviewer agent to check accumulated code edits before finalizing. Only useful alongside enable_coding. Default is False.
             max_iterations: Optional maximum number of agent iterations. Useful for lightweight/fast runs that don't need full exploration depth.
     """
 
@@ -265,6 +266,7 @@ class SeerAgentClient:
         is_interactive: bool = False,
         enable_coding: bool = False,
         enable_code_mode_tools: str = "off",
+        code_review_enabled: bool = False,
         max_iterations: int | None = None,
     ):
         self.organization = organization
@@ -278,6 +280,7 @@ class SeerAgentClient:
         self.category_value = category_value
         self.is_interactive = is_interactive
         self.enable_code_mode_tools = enable_code_mode_tools
+        self.code_review_enabled = code_review_enabled
         self.max_iterations = max_iterations
 
         if enable_coding and not organization.get_option("sentry:enable_seer_coding", True):
@@ -343,6 +346,7 @@ class SeerAgentClient:
         agent_run_options: dict[str, Any] = {
             "enable_coding": self.enable_coding,
             "enable_code_mode_tools": self.enable_code_mode_tools,
+            "code_review_enabled": self.code_review_enabled,
         }
 
         chat_body: AgentChatRequest = AgentChatRequest(
@@ -541,6 +545,7 @@ class SeerAgentClient:
         agent_run_options: dict[str, Any] = {
             "enable_coding": self.enable_coding,
             "enable_code_mode_tools": self.enable_code_mode_tools,
+            "code_review_enabled": self.code_review_enabled,
         }
 
         chat_body: AgentChatRequest = AgentChatRequest(

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import BaseModel
 from rest_framework.exceptions import PermissionDenied
 
-from sentry import analytics, quotas
+from sentry import analytics, features, quotas
 from sentry.analytics.events.autofix_events import (
     AiAutofixAgentHandoffEvent,
     AiAutofixCodeChangesCompletedEvent,
@@ -223,13 +223,28 @@ def _get_group_run_state(client: SeerAgentClient, group: Group, run_id: int) -> 
     return state
 
 
+def _default_intelligence_level(organization: Organization) -> Literal["low", "medium", "high"]:
+    if features.has("organizations:seer-autofix-high-intelligence-high-reasoning", organization):
+        return "high"
+    return "medium"
+
+
+def _default_reasoning_effort(
+    organization: Organization,
+    step_default: Literal["low", "medium", "high"] | None,
+) -> Literal["low", "medium", "high"] | None:
+    if features.has("organizations:seer-autofix-high-intelligence-high-reasoning", organization):
+        return "high"
+    return step_default
+
+
 def trigger_autofix_agent(
     group: Group,
     step: AutofixStep,
     referrer: AutofixReferrer,
     run_id: int | None = None,
     stopping_point: AutofixStoppingPoint | None = None,
-    intelligence_level: Literal["low", "medium", "high"] = "medium",
+    intelligence_level: Literal["low", "medium", "high"] = _UNSET,
     reasoning_effort: Literal["low", "medium", "high"] | None = _UNSET,
     user_context: str | None = None,
     insert_index: int | None = None,
@@ -257,12 +272,21 @@ def trigger_autofix_agent(
 
     config = STEP_CONFIGS[step]
 
+    resolved_intelligence_level = (
+        _default_intelligence_level(group.organization)
+        if intelligence_level is _UNSET
+        else intelligence_level
+    )
+    resolved_reasoning_effort = (
+        _default_reasoning_effort(group.organization, config.reasoning_effort)
+        if reasoning_effort is _UNSET
+        else reasoning_effort
+    )
+
     client = get_autofix_agent_client(
         group,
-        intelligence_level=intelligence_level,
-        reasoning_effort=(
-            config.reasoning_effort if reasoning_effort is _UNSET else reasoning_effort
-        ),
+        intelligence_level=resolved_intelligence_level,
+        reasoning_effort=resolved_reasoning_effort,
         enable_coding=config.enable_coding,
     )
     if run_id is not None:

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -189,6 +189,7 @@ def get_autofix_agent_client(
     intelligence_level: Literal["low", "medium", "high"] = "medium",
     reasoning_effort: Literal["low", "medium", "high"] | None = None,
     enable_coding: bool = False,
+    code_review_enabled: bool = False,
 ) -> SeerAgentClient:
     from sentry.seer.autofix.on_completion_hook import (
         AutofixOnCompletionHook,  # nested to avoid circular import
@@ -204,6 +205,7 @@ def get_autofix_agent_client(
         reasoning_effort=reasoning_effort,
         on_completion_hook=AutofixOnCompletionHook,
         enable_coding=enable_coding,
+        code_review_enabled=code_review_enabled,
     )
 
 
@@ -236,6 +238,12 @@ def _default_reasoning_effort(
     if features.has("organizations:seer-autofix-high-intelligence-high-reasoning", organization):
         return "high"
     return step_default
+
+
+def _code_review_enabled(organization: Organization, enable_coding: bool) -> bool:
+    # The review_code_changes tool only operates on accumulated patches, so it is
+    # only useful on coding-enabled steps.
+    return enable_coding and features.has("organizations:seer-autofix-code-review", organization)
 
 
 def trigger_autofix_agent(
@@ -288,6 +296,7 @@ def trigger_autofix_agent(
         intelligence_level=resolved_intelligence_level,
         reasoning_effort=resolved_reasoning_effort,
         enable_coding=config.enable_coding,
+        code_review_enabled=_code_review_enabled(group.organization, config.enable_coding),
     )
     if run_id is not None:
         _get_group_run_state(client, group, run_id)

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -248,7 +248,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 referrer=_parse_autofix_referrer(data.get("referrer")),
                 stopping_point=AutofixStoppingPoint(stopping_point) if stopping_point else None,
                 run_id=run_id,
-                intelligence_level="medium",
                 user_context=data.get("user_context"),
                 insert_index=data.get("insert_index"),
             )

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -151,6 +151,44 @@ class TestSeerAgentClient(TestCase):
         assert body["agent_run_options"]["enable_frontend_code_search"] is True
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.seer.agent.client.collect_user_org_context")
+    def test_start_run_defaults_code_review_disabled(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"run_id": 123}
+        mock_response.status = 200
+        mock_post.return_value = mock_response
+
+        client = SeerAgentClient(self.organization, self.user)
+        client.start_run("Test query")
+
+        body = mock_post.call_args[0][0]
+        assert body["agent_run_options"]["code_review_enabled"] is False
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.seer.agent.client.collect_user_org_context")
+    def test_start_run_passes_code_review_enabled(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"run_id": 123}
+        mock_response.status = 200
+        mock_post.return_value = mock_response
+
+        client = SeerAgentClient(self.organization, self.user, code_review_enabled=True)
+        client.start_run("Test query")
+
+        body = mock_post.call_args[0][0]
+        assert body["agent_run_options"]["code_review_enabled"] is True
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     def test_init_category_key_only_raises_error(self, mock_access):
         """Test that ValueError is raised when only category_key is provided"""
         mock_access.return_value = (True, None)

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -512,6 +512,77 @@ class TestTriggerAutofixAgent(TestCase):
 
         assert mock_client_class.call_args.kwargs["reasoning_effort"] is None
 
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_code_review_disabled_without_flag(
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        # Guard against this test passing because the step stopped enabling coding.
+        assert STEP_CONFIGS[AutofixStep.CODE_CHANGES].enable_coding is True
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.start_run.return_value = 123
+
+        trigger_autofix_agent(
+            group=self.group,
+            step=AutofixStep.CODE_CHANGES,
+            referrer=AutofixReferrer.UNKNOWN,
+            run_id=None,
+        )
+
+        assert mock_client_class.call_args.kwargs["code_review_enabled"] is False
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_code_review_enabled_on_coding_step_with_flag(
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        assert STEP_CONFIGS[AutofixStep.CODE_CHANGES].enable_coding is True
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.start_run.return_value = 123
+
+        with self.feature("organizations:seer-autofix-code-review"):
+            trigger_autofix_agent(
+                group=self.group,
+                step=AutofixStep.CODE_CHANGES,
+                referrer=AutofixReferrer.UNKNOWN,
+                run_id=None,
+            )
+
+        assert mock_client_class.call_args.kwargs["code_review_enabled"] is True
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_code_review_stays_disabled_on_non_coding_step_with_flag(
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        # The review tool only operates on accumulated patches, so it should stay
+        # off for steps that don't enable coding, even when the flag is on.
+        assert STEP_CONFIGS[AutofixStep.ROOT_CAUSE].enable_coding is False
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.start_run.return_value = 123
+
+        with self.feature("organizations:seer-autofix-code-review"):
+            trigger_autofix_agent(
+                group=self.group,
+                step=AutofixStep.ROOT_CAUSE,
+                referrer=AutofixReferrer.UNKNOWN,
+                run_id=None,
+            )
+
+        assert mock_client_class.call_args.kwargs["code_review_enabled"] is False
+
 
 class TestTriggerCodingAgentHandoff(TestCase):
     """Tests for trigger_coding_agent_handoff function."""

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -75,7 +75,6 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
             stopping_point=AutofixStoppingPoint.CODE_CHANGES,
             run_id=None,
-            intelligence_level="medium",
             user_context=None,
             insert_index=None,
         )
@@ -100,7 +99,6 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
             stopping_point=None,
             run_id=42,
-            intelligence_level="medium",
             user_context=None,
             insert_index=3,
         )


### PR DESCRIPTION
Adds two opt-in org feature flags that change how new autofix sessions run for enrolled organizations. Both resolve inside `trigger_autofix_agent`, so they apply to every caller (API, night shift, operator, on-completion hook, issue summary) and never override an explicit value supplied by a caller.

**High intelligence / reasoning** — `organizations:seer-autofix-high-intelligence-high-reasoning`

When enabled, new sessions run at `intelligence_level="high"` and `reasoning_effort="high"`. `intelligence_level` now defaults to an `_UNSET` sentinel (matching `reasoning_effort`); the flag-based default applies only when the caller doesn't pass an explicit value. With the flag off, behavior is unchanged: `medium` intelligence and the per-step reasoning default. The hardcoded `intelligence_level="medium"` was removed from the autofix API endpoint so it picks up the resolved default.

**Code review tool** — `organizations:seer-autofix-code-review`

When enabled, the autofix agent gets the `review_code_changes` tool, which spawns a reviewer agent to check accumulated patches before finalizing. This is wired through a new `code_review_enabled` option on `SeerAgentClient` that sets `code_review_enabled` in the `agent_run_options` payload sent to Seer. The flag is gated on the step enabling coding, since the review tool only operates on accumulated patches — non-coding steps (root cause, solution) never receive it even when the flag is on.

Both flags are `api_expose=False` (FlagPole) and the night shift triage agent is intentionally out of scope.