### PR TITLE
fix(explore): heatmap z-axis value in tooltip showing logarithmic value

### DIFF
--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -171,7 +171,13 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
               }
 
               if (defined(zValue) && typeof zValue === 'number') {
-                formattedZValue = formatAbbreviatedNumber(zValue, 4, false);
+                // when the z-axis is in log scale, the values are log values and don't reflect the actual value
+                // so we need to convert them back to the actual value
+                formattedZValue = formatAbbreviatedNumber(
+                  scale === 'log' ? Math.expm1(zValue) : zValue,
+                  4,
+                  false
+                );
               }
             }
 


### PR DESCRIPTION
To use logarithmic z-axis colour scale, the z-axis values were being converted to log values. We were just displaying that value in the tooltip instead of converting it back to it's regular value (aka an integer) so now it looks normal.

| Before | After |
|--------|--------|
| <img width="627" height="348" alt="image" src="https://github.com/user-attachments/assets/304a971a-2b2b-4d63-b492-d1c9e933cefd" /> | <img width="604" height="375" alt="image" src="https://github.com/user-attachments/assets/461aae86-4db6-495a-9f14-16a5e6e9396d" /> | 