### PR TITLE
fix(cells) Add separate api gateway address to cell config

### DIFF
--- a/src/sentry/conf/types/cell_config.py
+++ b/src/sentry/conf/types/cell_config.py
@@ -8,7 +8,7 @@ class CellConfig(TypedDict):
     snowflake_id: int
     address: str
     category: str  # TODO(cells): drop once category is fully moved to LocalityConfig
-    api_gateway_address: NotRequired[bool]
+    api_gateway_address: NotRequired[str]
     visible: NotRequired[bool]
 
 

--- a/src/sentry/conf/types/cell_config.py
+++ b/src/sentry/conf/types/cell_config.py
@@ -8,6 +8,7 @@ class CellConfig(TypedDict):
     snowflake_id: int
     address: str
     category: str  # TODO(cells): drop once category is fully moved to LocalityConfig
+    api_gateway_address: NotRequired[bool]
     visible: NotRequired[bool]
 
 

--- a/src/sentry/hybridcloud/apigateway/apigateway.py
+++ b/src/sentry/hybridcloud/apigateway/apigateway.py
@@ -68,14 +68,6 @@ def proxy_request_if_needed(
         org_id_or_slug = str(
             view_kwargs.get("organization_slug") or view_kwargs.get("organization_id_or_slug", "")
         )
-
-        metrics.incr(
-            "apigateway.proxy_request",
-            tags={
-                "url_name": url_name,
-                "kind": "orgslug",
-            },
-        )
         return proxy_request(request, org_id_or_slug, url_name)
 
     resolver = _get_view_cell_resolver(view_func)

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -160,7 +160,11 @@ def proxy_error_embed_request(
 def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpResponseBase:
     """Take a django request object and proxy it to a cell silo"""
 
-    metric_tags = {"destination_cell": cell.name, "url_name": url_name}
+    host = cell.address
+    if cell.api_gateway_address and in_random_rollout("apigateway.proxy.use_gateway_address"):
+        host = cell.api_gateway_address
+
+    metric_tags = {"destination_cell": cell.name, "url_name": url_name, "destination_host": host}
     circuit_breaker: CircuitBreaker | None = None
     use_pooling = in_random_rollout("hybridcloud.apigateway.use_pooling.rate")
 
@@ -187,9 +191,6 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
                 }
                 return JsonResponse(body, status=503)
 
-    host = cell.address
-    if cell.api_gateway_address and in_random_rollout("apigateway.proxy.use_gateway_address"):
-        host = cell.api_gateway_address
     target_url = urljoin(host, request.path)
 
     if settings.APIGW_WARN_REQS:

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -115,6 +115,14 @@ def proxy_request(request: HttpRequest, org_id_or_slug: str, url_name: str) -> H
         logger.info("region_resolution_error", extra={"org_slug": org_id_or_slug, "error": str(e)})
         return HttpResponse(status=404)
 
+    metrics.incr(
+        "apigateway.proxy_request",
+        tags={
+            "url_name": url_name,
+            "kind": "orgslug",
+            "target": cell.name,
+        },
+    )
     return proxy_cell_request(request, cell, url_name)
 
 
@@ -179,7 +187,10 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
                 }
                 return JsonResponse(body, status=503)
 
-    target_url = urljoin(cell.address, request.path)
+    host = cell.address
+    if cell.api_gateway_address and in_random_rollout("apigateway.proxy.use_gateway_address"):
+        host = cell.api_gateway_address
+    target_url = urljoin(host, request.path)
 
     if settings.APIGW_WARN_REQS:
         logger.warning("apigateway.legacy-sync-request", extra={"endpoint": target_url})

--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -18,6 +18,7 @@ from django.http.response import HttpResponseBase
 from sentry import options
 from sentry.api.exceptions import RequestTimeout
 from sentry.objectstore.endpoints.organization import get_raw_body_async
+from sentry.options.rollout import in_random_rollout
 from sentry.silo.util import (
     PROXY_APIGATEWAY_HEADER,
     PROXY_DIRECT_LOCATION_HEADER,
@@ -152,7 +153,11 @@ async def proxy_cell_request(
 ) -> HttpResponseBase:
     """Take a django request object and proxy it to a cell silo"""
     metric_tags = {"destination_cell": cell.name, "url_name": url_name}
-    target_url = urljoin(cell.address, request.path)
+    host = cell.address
+    if cell.api_gateway_address and in_random_rollout("apigateway.proxy.use_gateway_address"):
+        host = cell.api_gateway_address
+
+    target_url = urljoin(host, request.path)
 
     content_encoding = request.headers.get("Content-Encoding")
     content_length = request.headers.get("Content-Length")

--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -152,11 +152,15 @@ async def proxy_cell_request(
     url_name: str,
 ) -> HttpResponseBase:
     """Take a django request object and proxy it to a cell silo"""
-    metric_tags = {"destination_cell": cell.name, "url_name": url_name}
     host = cell.address
     if cell.api_gateway_address and in_random_rollout("apigateway.proxy.use_gateway_address"):
         host = cell.api_gateway_address
 
+    metric_tags = {
+        "destination_cell": cell.name,
+        "url_name": url_name,
+        "destination_host": host,
+    }
     target_url = urljoin(host, request.path)
 
     content_encoding = request.headers.get("Content-Encoding")

--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -1,5 +1,5 @@
 from sentry.options import FLAG_AUTOMATOR_MODIFIABLE, register
-from sentry.utils.types import Bool, Dict, Int, Sequence
+from sentry.utils.types import Bool, Dict, Float, Int, Sequence
 
 register(
     "outbox_replication.sentry_organizationmember.replication_version",
@@ -199,5 +199,11 @@ register(
     "apigateway.proxy.circuit-breaker.enforce",
     type=Bool,
     default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "apigateway.proxy.use_gateway_address",
+    type=Float,
+    default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -19,6 +19,7 @@ from requests.adapters import Retry
 from sentry import options
 from sentry.http import build_session
 from sentry.net.http import SafeSession
+from sentry.options.rollout import in_random_rollout
 from sentry.shared_integrations.client.base import BaseApiClient
 from sentry.silo.base import SiloMode
 from sentry.silo.util import (
@@ -116,6 +117,10 @@ class CellSiloClient(BaseApiClient):
         # Ensure the cell is registered
         self.cell = get_cell_by_name(cell.name)
         self.base_url = self.cell.address
+        if self.cell.api_gateway_address and in_random_rollout(
+            "apigateway.proxy.use_gateway_address"
+        ):
+            self.base_url = self.cell.api_gateway_address
         self.retry = retry
 
     def proxy_request(self, incoming_request: HttpRequest) -> HttpResponse:

--- a/src/sentry/types/cell.py
+++ b/src/sentry/types/cell.py
@@ -99,6 +99,9 @@ class Cell:
     # TODO(cells): drop once category is fully moved to Locality
     category: RegionCategory
 
+    api_gateway_address: str | None = None
+    """optional address for API gateway traffic."""
+
     visible: bool = True
     """Whether the cell is visible in API responses"""
 

--- a/src/sentry/types/cell.py
+++ b/src/sentry/types/cell.py
@@ -230,6 +230,7 @@ def _parse_raw_config(cell_config: list[CellConfig]) -> Iterable[Cell]:
             snowflake_id=config_value["snowflake_id"],
             category=RegionCategory(config_value["category"]),
             address=config_value["address"],
+            api_gateway_address=config_value.get("api_gateway_address", None),
             visible=config_value.get("visible", True),
         )
 

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -26,6 +26,7 @@ from sentry.testutils.helpers.apigateway import (
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.response import close_streaming_response
 from sentry.testutils.silo import control_silo_test
+from sentry.types.cell import Cell, RegionCategory
 from sentry.utils import json
 
 proxy_request = async_to_sync(_proxy_request)
@@ -335,3 +336,33 @@ class ProxyTestCase(ApiGatewayTestCase):
 
         resp = proxy_request(request, self.organization.slug, url_name)
         assert not any([header in resp for header in INVALID_OUTBOUND_HEADERS])
+
+
+api_gateway_address_cell = Cell(
+    name="us",
+    snowflake_id=1,
+    address="http://sentry-rpc:8999",
+    api_gateway_address="http://sentry-api-gateway-rpc:8999",
+    category=RegionCategory.MULTI_TENANT,
+)
+
+
+@control_silo_test(cells=[api_gateway_address_cell], include_monolith_run=True)
+class ApiGatewayAddressProxyTestCase(ApiGatewayTestCase):
+    @responses.activate
+    @override_options({"apigateway.proxy.use_gateway_address": 1.0})
+    def test_sync_post(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://sentry-api-gateway-rpc:8999/post",
+            body=json.dumps({"test": "header"}),
+        )
+        request = RequestFactory().post(
+            "http://sentry.io/post", data={"test": "header"}, content_type="application/json"
+        )
+        resp = sync_proxy.proxy_request(request, self.organization.slug, url_name)
+        resp_json = json.loads(close_streaming_response(resp))
+
+        assert resp.status_code == 200
+        assert resp_json["test"]
+        assert resp.has_header(PROXY_DIRECT_LOCATION_HEADER)

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -27,6 +27,15 @@ from sentry.testutils.silo import control_silo_test
 from sentry.types.cell import Cell, CellResolutionError, RegionCategory
 
 cell_config = [Cell("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT)]
+cell_config_with_gateway = [
+    Cell(
+        name="us",
+        snowflake_id=1,
+        address="http://us.testserver",
+        api_gateway_address="http://sentry-rpc-gateway",
+        category=RegionCategory.MULTI_TENANT,
+    )
+]
 
 
 @control_silo_test
@@ -565,6 +574,22 @@ class DrainMailboxTest(TestCase):
         assert hook.attempts == 1
 
         assert len(responses.calls) == 1
+
+    @responses.activate
+    @override_cells(cell_config_with_gateway)
+    @override_options({"apigateway.proxy.use_gateway_address": 1.0})
+    def test_drain_success_api_gateway_address(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://sentry-rpc-gateway/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        records = create_payloads(3, "github:123")
+        drain_mailbox(records[0].id)
+
+        # Mailbox should be empty
+        assert not WebhookPayload.objects.filter().exists()
 
 
 @control_silo_test

--- a/tests/sentry/types/test_cell.py
+++ b/tests/sentry/types/test_cell.py
@@ -54,6 +54,7 @@ class CellDirectoryTest(TestCase):
             "name": "eu",
             "snowflake_id": 2,
             "address": "http://eu.testserver",
+            "api_gateway_address": "http://eu-gateway.testserver",
             "category": RegionCategory.MULTI_TENANT.name,
         },
         {
@@ -66,7 +67,13 @@ class CellDirectoryTest(TestCase):
 
     _EXPECTED_OUTPUTS = (
         Cell("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT),
-        Cell("eu", 2, "http://eu.testserver", RegionCategory.MULTI_TENANT),
+        Cell(
+            "eu",
+            2,
+            "http://eu.testserver",
+            RegionCategory.MULTI_TENANT,
+            "http://eu-gateway.testserver",
+        ),
         Cell("acme", 3, "http://acme.testserver", RegionCategory.SINGLE_TENANT),
     )
 


### PR DESCRIPTION
We want to try splitting up the RPC traffic from api gateway + webhooks. Expand `Cell` to have a second address for these requests.

An option will be used to incrementally enable this once deployments and config are updated.

Refs INC-2198