### PR TITLE
ref(releases): Remove defer commit resolution flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -83,8 +83,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-revisions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Data Secrecy
     manager.add("organizations:data-secrecy", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Defer issue resolution from commit push to release creation
-    manager.add("organizations:defer-commit-resolution", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Data Secrecy v2 (with Break the Glass feature)
     manager.add("organizations:data-secrecy-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Intercom support widget (replaces Zendesk when enabled)

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -7,7 +7,6 @@ from typing import TypedDict
 
 from django.db import IntegrityError, router
 
-from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.locks import locks
@@ -230,10 +229,6 @@ def update_group_resolutions(release, commit_author_by_commit):
     user_by_author: dict[CommitAuthor | None, RpcUser | None] = {None: None}
 
     commits_and_prs = list(itertools.chain(commit_group_authors, pull_request_group_authors))
-    create_resolution_activities = features.has(
-        "organizations:defer-commit-resolution", release.organization
-    )
-
     group_project_lookup = dict(
         Group.objects.filter(id__in=[group_id for group_id, _ in commits_and_prs]).values_list(
             "id", "project_id"
@@ -267,9 +262,7 @@ def update_group_resolutions(release, commit_author_by_commit):
                 },
             )
             group = Group.objects.get(id=group_id)
-            should_create_resolution_activity = (
-                create_resolution_activities and group.status != GroupStatus.RESOLVED
-            )
+            should_create_resolution_activity = group.status != GroupStatus.RESOLVED
             group.update(status=GroupStatus.RESOLVED, substatus=None)
             remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED, user=actor)
             if should_create_resolution_activity:

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -2,9 +2,8 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError, router, transaction
 from django.db.models import F
 from django.db.models.signals import post_save, pre_save
-from django.utils import timezone
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.integrations.analytics import IntegrationResolveCommitEvent, IntegrationResolvePREvent
 from sentry.models.activity import Activity
@@ -16,17 +15,15 @@ from sentry.models.grouphistory import (
     record_group_history,
     record_group_history_from_activity_type,
 )
-from sentry.models.groupinbox import GroupInboxRemoveAction, remove_group_from_inbox
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupsubscription import GroupSubscription
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.pullrequest import PullRequest
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.repository import Repository
 from sentry.notifications.types import GroupSubscriptionReason
-from sentry.signals import buffer_incr_complete, issue_resolved
+from sentry.signals import buffer_incr_complete
 from sentry.tasks.clear_expired_resolutions import clear_expired_resolutions
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
@@ -75,15 +72,12 @@ def remove_resolved_link(link):
 
 def resolved_in_commit(instance: Commit, created, **kwargs):
     """
-    Creates GroupLinks and Activity entries for commits that reference issues.
+    Creates GroupLinks and referenced activity for commits that reference issues.
 
-    With the "organizations:defer-commit-resolution" feature flag:
-    - Flag ON (new behavior): Creates GroupLinks and REFERENCED_IN_COMMIT Activity but
-      does NOT immediately resolve issues. Resolution happens when a release is created
-      that includes these commits, via update_group_resolutions() in
-      src/sentry/models/releases/set_commits.py. This prevents issues from being resolved
-      prematurely when commits are pushed to feature branches.
-    - Flag OFF (legacy behavior): Immediately resolves issues when commits are pushed.
+    Resolution happens when a release is created that includes these commits, via
+    update_group_resolutions() in src/sentry/models/releases/set_commits.py. This
+    prevents issues from being resolved prematurely when commits are pushed to
+    feature branches.
     """
     groups = instance.find_referenced_groups()
 
@@ -105,15 +99,6 @@ def resolved_in_commit(instance: Commit, created, **kwargs):
         repo = Repository.objects.get(id=instance.repository_id)
     except Repository.DoesNotExist:
         repo = None
-
-    # Check feature flag - determines whether to defer resolution to release creation
-    defer_resolution = False
-    if repo:
-        try:
-            org = Organization.objects.get_from_cache(id=repo.organization_id)
-            defer_resolution = features.has("organizations:defer-commit-resolution", org)
-        except Organization.DoesNotExist:
-            pass
 
     if instance.author:
         with in_test_hide_transaction_boundary():
@@ -163,26 +148,10 @@ def resolved_in_commit(instance: Commit, created, **kwargs):
                             reason=GroupSubscriptionReason.status_change,
                         )
 
-                if not defer_resolution:
-                    # Legacy behavior: Immediately resolve the issue
-                    Group.objects.filter(id=group.id).update(
-                        status=GroupStatus.RESOLVED,
-                        resolved_at=timezone.now(),
-                        substatus=None,
-                    )
-                    group.status = GroupStatus.RESOLVED
-                    group.substatus = None
-                    remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED)
-
-                activity_type = (
-                    ActivityType.REFERENCED_IN_COMMIT
-                    if defer_resolution
-                    else ActivityType.SET_RESOLVED_IN_COMMIT
-                )
                 activity_kwargs = {
                     "project_id": group.project_id,
                     "group": group,
-                    "type": activity_type.value,
+                    "type": ActivityType.REFERENCED_IN_COMMIT.value,
                     "ident": instance.id,
                     "data": {"commit": instance.id},
                 }
@@ -190,13 +159,6 @@ def resolved_in_commit(instance: Commit, created, **kwargs):
                     activity_kwargs["user_id"] = acting_user.id
 
                 Activity.objects.create(**activity_kwargs)
-
-                if not defer_resolution:
-                    record_group_history_from_activity_type(
-                        group,
-                        ActivityType.SET_RESOLVED_IN_COMMIT.value,
-                        actor=acting_user if acting_user else None,
-                    )
 
         except IntegrityError:
             pass
@@ -208,17 +170,6 @@ def resolved_in_commit(instance: Commit, created, **kwargs):
                         id=repo.integration_id,
                         organization_id=repo.organization_id,
                     )
-                )
-
-            if not defer_resolution:
-                # Legacy behavior: Send resolution signal
-                issue_resolved.send_robust(
-                    organization_id=repo.organization_id if repo else group.organization.id,
-                    user=user_list[0] if user_list else None,
-                    group=group,
-                    project=group.project,
-                    resolution_type="with_commit",
-                    sender="resolved_with_commit",
                 )
 
 

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -15,57 +15,15 @@ from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseheadcommit import ReleaseHeadCommit
 from sentry.models.repository import Repository
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 
 
 class FindReferencedGroupsTest(TestCase):
     def test_resolve_in_commit(self) -> None:
         """
-        Legacy behavior (defer-commit-resolution flag OFF): commits with
-        "Fixes ISSUE-123" immediately resolve the referenced issue. Kept until
-        the new behavior is fully shipped.
-        """
-        group = self.create_group()
-
-        repo = Repository.objects.create(name="example", organization_id=group.organization.id)
-
-        commit = Commit.objects.create(
-            key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
-            repository_id=repo.id,
-            organization_id=group.organization.id,
-            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
-        )
-
-        groups = commit.find_referenced_groups()
-        assert len(groups) == 1
-        assert group in groups
-        assert GroupLink.objects.filter(
-            group=group,
-            linked_type=GroupLink.LinkedType.commit,
-            linked_id=commit.id,
-        ).exists()
-        assert Activity.objects.filter(
-            group=group,
-            type=ActivityType.SET_RESOLVED_IN_COMMIT.value,
-        ).exists()
-        assert not Activity.objects.filter(
-            group=group,
-            type=ActivityType.REFERENCED_IN_COMMIT.value,
-        ).exists()
-        assert GroupHistory.objects.filter(
-            group=group,
-            status=GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
-        ).exists()
-        group.refresh_from_db()
-        assert group.status == GroupStatus.RESOLVED
-
-    @with_feature("organizations:defer-commit-resolution")
-    def test_resolve_in_commit_deferred(self) -> None:
-        """
-        With defer-commit-resolution ON: commits create GroupLinks and referenced
-        activity but do NOT immediately resolve issues. Resolution happens when a
-        release is created that includes these commits, via update_group_resolutions().
+        Commits create GroupLinks and referenced activity, but do NOT immediately
+        resolve issues. Resolution happens when a release is created that includes
+        these commits, via update_group_resolutions().
         """
         group = self.create_group()
 
@@ -102,13 +60,12 @@ class FindReferencedGroupsTest(TestCase):
         group.refresh_from_db()
         assert group.status == GroupStatus.UNRESOLVED
 
-    @with_feature("organizations:defer-commit-resolution")
     def test_resolve_in_commit_resolved_via_release(self) -> None:
         """
-        With defer-commit-resolution ON: a commit referencing a group on a
-        feature branch leaves the group unresolved. Once that commit lands in a
-        release (i.e. is merged to the default branch and shipped), the release
-        creation flow resolves the group via update_group_resolutions().
+        A commit referencing a group on a feature branch leaves the group unresolved.
+        Once that commit lands in a release (i.e. is merged to the default branch
+        and shipped), the release creation flow resolves the group via
+        update_group_resolutions().
         """
         group = self.create_group()
 
@@ -177,7 +134,6 @@ class FindReferencedGroupsTest(TestCase):
         group.refresh_from_db()
         assert group.status == GroupStatus.UNRESOLVED
 
-    @with_feature("organizations:defer-commit-resolution")
     def test_resolve_in_pull_request_resolved_via_release(self) -> None:
         group = self.create_group()
         repo = Repository.objects.create(name="example", organization_id=group.organization.id)
@@ -215,36 +171,6 @@ class FindReferencedGroupsTest(TestCase):
         )
         assert activity.data == {"version": release.version}
         assert activity.ident == str(resolution.id)
-
-    def test_resolve_in_pull_request_resolved_via_release_with_defer_flag_off(self) -> None:
-        group = self.create_group()
-        repo = Repository.objects.create(name="example", organization_id=group.organization.id)
-        merge_commit_sha = sha1(uuid4().hex.encode("utf-8")).hexdigest()
-
-        PullRequest.objects.create(
-            key="1",
-            repository_id=repo.id,
-            organization_id=group.organization.id,
-            title="very cool PR to fix the thing",
-            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
-            merge_commit_sha=merge_commit_sha,
-        )
-
-        release = self.create_release(project=group.project, version="1.0.0")
-        release.set_commits([{"id": merge_commit_sha, "repository": repo.name}])
-
-        group.refresh_from_db()
-        assert group.status == GroupStatus.RESOLVED
-        assert GroupResolution.objects.filter(
-            group=group,
-            release=release,
-            type=GroupResolution.Type.in_release,
-            status=GroupResolution.Status.resolved,
-        ).exists()
-        assert not Activity.objects.filter(
-            group=group,
-            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
-        ).exists()
 
 
 class PullRequestRetentionTest(TestCase):

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -19,7 +19,6 @@ from sentry.models.repository import Repository
 from sentry.signals import buffer_incr_complete, receivers_raise_on_send
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
 from sentry.users.models.user_option import UserOption
@@ -42,13 +41,9 @@ class ResolvedInCommitTest(TestCase):
     """
     Tests for resolved_in_commit signal handler.
 
-    With "organizations:defer-commit-resolution" flag ON (new behavior):
     Commits with "Fixes ISSUE-123" create GroupLinks and REFERENCED_IN_COMMIT
     Activity entries, but do NOT immediately resolve issues. Resolution happens
     when a release is created that includes these commits, via update_group_resolutions().
-
-    With flag OFF (legacy behavior): Issues are immediately resolved when commits
-    are pushed.
     """
 
     def assertLinkedFromCommitDeferred(self, group, commit):
@@ -72,25 +67,6 @@ class ResolvedInCommitTest(TestCase):
         # Inbox should NOT be modified
         assert GroupInbox.objects.filter(group=group).exists()
 
-    def assertLinkedFromCommitImmediate(self, group, commit):
-        """Assert that a GroupLink, Activity, GroupHistory were created, and issue IS resolved (legacy behavior)."""
-        assert GroupLink.objects.filter(
-            group_id=group.id, linked_type=GroupLink.LinkedType.commit, linked_id=commit.id
-        ).exists()
-        assert Activity.objects.filter(
-            group=group, type=ActivityType.SET_RESOLVED_IN_COMMIT.value
-        ).exists()
-        assert not Activity.objects.filter(
-            group=group, type=ActivityType.REFERENCED_IN_COMMIT.value
-        ).exists()
-        assert GroupHistory.objects.filter(
-            group=group, status=GroupHistoryStatus.SET_RESOLVED_IN_COMMIT
-        ).exists()
-        # Issue should be resolved immediately (legacy behavior)
-        assert Group.objects.filter(id=group.id, status=GroupStatus.RESOLVED).exists()
-        # Inbox should be removed
-        assert not GroupInbox.objects.filter(group=group).exists()
-
     def assertNotLinkedFromCommit(self, group, commit):
         """Assert that no GroupLink exists for this commit."""
         assert not GroupLink.objects.filter(
@@ -99,12 +75,9 @@ class ResolvedInCommitTest(TestCase):
         assert not Group.objects.filter(id=group.id, status=GroupStatus.RESOLVED).exists()
         assert GroupInbox.objects.filter(group=group).exists()
 
-    # Tests with defer-commit-resolution flag ON (new behavior) #
-
-    @with_feature("organizations:defer-commit-resolution")
     @receivers_raise_on_send()
     def test_simple_no_author(self) -> None:
-        """With defer-commit-resolution ON, commits create links but don't resolve issues."""
+        """Commits create links but don't resolve issues."""
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.MANUAL)
 
@@ -119,10 +92,9 @@ class ResolvedInCommitTest(TestCase):
 
         self.assertLinkedFromCommitDeferred(group, commit)
 
-    @with_feature("organizations:defer-commit-resolution")
     @receivers_raise_on_send()
     def test_updating_commit(self) -> None:
-        """With defer-commit-resolution ON, updating a commit message creates links but doesn't resolve."""
+        """Updating a commit message creates links but doesn't resolve."""
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.MANUAL)
 
@@ -141,10 +113,9 @@ class ResolvedInCommitTest(TestCase):
 
         self.assertLinkedFromCommitDeferred(group, commit)
 
-    @with_feature("organizations:defer-commit-resolution")
     @receivers_raise_on_send()
     def test_updating_commit_with_existing_grouplink(self) -> None:
-        """With defer-commit-resolution ON, updating commit with existing link keeps deferred state."""
+        """Updating commit with existing link keeps deferred state."""
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.MANUAL)
 
@@ -164,7 +135,6 @@ class ResolvedInCommitTest(TestCase):
 
         self.assertLinkedFromCommitDeferred(group, commit)
 
-    @with_feature("organizations:defer-commit-resolution")
     @receivers_raise_on_send()
     def test_removes_group_link_when_message_changes(self) -> None:
         group = self.create_group()
@@ -186,7 +156,6 @@ class ResolvedInCommitTest(TestCase):
 
         self.assertNotLinkedFromCommit(group, commit)
 
-    @with_feature("organizations:defer-commit-resolution")
     @receivers_raise_on_send()
     def test_no_matching_group(self) -> None:
         repo = Repository.objects.create(name="example", organization_id=self.organization.id)
@@ -202,10 +171,9 @@ class ResolvedInCommitTest(TestCase):
             linked_type=GroupLink.LinkedType.commit, linked_id=commit.id
         ).exists()
 
-    @with_feature("organizations:defer-commit-resolution")
     @receivers_raise_on_send()
     def test_matching_author_with_assignment(self) -> None:
-        """With defer-commit-resolution ON, commits assign users but don't resolve issues."""
+        """Commits assign users but don't resolve issues."""
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.MANUAL)
         user = self.create_user(name="Foo Bar", email="foo@example.com", is_active=True)
@@ -247,10 +215,9 @@ class ResolvedInCommitTest(TestCase):
 
         assert GroupSubscription.objects.filter(group=group, user_id=user.id).exists()
 
-    @with_feature("organizations:defer-commit-resolution")
     @receivers_raise_on_send()
     def test_matching_author_without_assignment(self) -> None:
-        """With defer-commit-resolution ON, commits subscribe users but don't resolve issues."""
+        """Commits subscribe users but don't resolve issues."""
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.MANUAL)
         user = self.create_user(name="Foo Bar", email="foo@example.com", is_active=True)
@@ -279,62 +246,6 @@ class ResolvedInCommitTest(TestCase):
             project=group.project, group=group, type=ActivityType.ASSIGNED.value, user_id=user.id
         ).exists()
 
-        assert GroupSubscription.objects.filter(group=group, user_id=user.id).exists()
-
-    # Tests with defer-commit-resolution flag OFF (legacy behavior) #
-
-    @with_feature({"organizations:defer-commit-resolution": False})
-    @receivers_raise_on_send()
-    def test_immediate_resolution_without_flag(self) -> None:
-        """Without defer-commit-resolution flag, commits immediately resolve issues (legacy behavior)."""
-        group = self.create_group()
-        add_group_to_inbox(group, GroupInboxReason.MANUAL)
-
-        repo = Repository.objects.create(name="example", organization_id=self.group.organization.id)
-
-        commit = Commit.objects.create(
-            key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
-            repository_id=repo.id,
-            organization_id=group.organization.id,
-            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
-        )
-
-        self.assertLinkedFromCommitImmediate(group, commit)
-
-    @with_feature({"organizations:defer-commit-resolution": False})
-    @receivers_raise_on_send()
-    def test_immediate_resolution_with_author(self) -> None:
-        """Without flag, commits with authors immediately resolve and assign issues."""
-        group = self.create_group()
-        add_group_to_inbox(group, GroupInboxReason.MANUAL)
-        user = self.create_user(name="Foo Bar", email="foo@example.com", is_active=True)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            email = UserEmail.objects.get_primary_email(user=user)
-            email.is_verified = True
-            email.save()
-            UserOption.objects.set_value(user=user, key="self_assign_issue", value="1")
-
-        repo = Repository.objects.create(name="example", organization_id=self.group.organization.id)
-        OrganizationMember.objects.create(organization=group.project.organization, user_id=user.id)
-
-        author = CommitAuthor.objects.create(
-            organization_id=group.organization.id, name=user.name, email=user.email
-        )
-        author.preload_users()
-
-        commit = Commit.objects.create(
-            key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
-            organization_id=group.organization.id,
-            repository_id=repo.id,
-            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
-            author=author,
-        )
-
-        # Issue should be immediately resolved (legacy behavior)
-        self.assertLinkedFromCommitImmediate(group, commit)
-
-        # Author should still be assigned
-        assert GroupAssignee.objects.filter(group=group, user_id=user.id).exists()
         assert GroupSubscription.objects.filter(group=group, user_id=user.id).exists()
 
 


### PR DESCRIPTION
Remove the fully rolled-out `organizations:defer-commit-resolution` temporary flag and make the shipped commit-resolution behavior unconditional.

**Commit References**

Commits that reference issues now always create `GroupLink` records and `REFERENCED_IN_COMMIT` activity without resolving the issue immediately. Release commit processing remains responsible for resolving linked issues and creating release-resolution activity.

**Tests**

The affected receiver and model tests now assert the permanent behavior without feature decorators or legacy-off cases.