### PR TITLE
ref(seer): Remove coding agent frontend flag checks

### DIFF
--- a/static/app/components/events/autofix/claudeCodeIntegrationCta.spec.tsx
+++ b/static/app/components/events/autofix/claudeCodeIntegrationCta.spec.tsx
@@ -14,9 +14,7 @@ describe('ClaudeCodeIntegrationCta', () => {
     seerScannerAutomation: true,
     autofixAutomationTuning: 'medium',
   });
-  const organization = OrganizationFixture({
-    features: ['integrations-claude-code'],
-  });
+  const organization = OrganizationFixture();
 
   function mockDetailedProject(projectBody = enabledProject) {
     return MockApiClient.addMockResponse({
@@ -47,20 +45,8 @@ describe('ClaudeCodeIntegrationCta', () => {
     });
   });
 
-  describe('Feature Flag', () => {
-    it('does not render without integrations-claude-code feature flag', () => {
-      const orgWithoutFlag = OrganizationFixture({
-        features: [],
-      });
-
-      const {container} = render(<ClaudeCodeIntegrationCta project={project} />, {
-        organization: orgWithoutFlag,
-      });
-
-      expect(container).toBeEmptyDOMElement();
-    });
-
-    it('renders with integrations-claude-code feature flag', async () => {
+  describe('Availability', () => {
+    it('renders without a feature flag', async () => {
       render(<ClaudeCodeIntegrationCta project={project} />, {
         organization,
       });

--- a/static/app/components/events/autofix/claudeCodeIntegrationCta.tsx
+++ b/static/app/components/events/autofix/claudeCodeIntegrationCta.tsx
@@ -3,7 +3,6 @@ import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
 
 export const ClaudeCodeIntegrationCta = makeCodingAgentIntegrationCta({
   provider: 'claude_code',
-  featureFlag: 'integrations-claude-code',
   target: CodingAgentProvider.CLAUDE_CODE_AGENT,
   pluginId: 'claude_code',
   displayName: 'Claude',

--- a/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
+++ b/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
@@ -34,14 +34,7 @@ export function GithubCopilotIntegrationCta() {
     integration => integration.provider === 'github_copilot'
   );
 
-  const hasGithubCopilotFeatureFlag = organization.features.includes(
-    'integrations-github-copilot-agent'
-  );
   const hasGithubCopilotIntegration = Boolean(githubCopilotIntegration);
-
-  if (!hasGithubCopilotFeatureFlag) {
-    return null;
-  }
 
   if (isLoadingIntegrations) {
     return (

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -572,10 +572,6 @@ describe('ProjectSeer', () => {
   });
 
   it('can enable automation handoff to Claude when Claude integration is available', async () => {
-    const orgWithClaudeFeature = OrganizationFixture({
-      features: ['integrations-claude-code'],
-    });
-
     const initialProject: DetailedProject = {
       ...project,
       autofixAutomationTuning: 'medium',
@@ -583,7 +579,7 @@ describe('ProjectSeer', () => {
     };
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${orgWithClaudeFeature.slug}/seer/setup-check/`,
+      url: `/organizations/${organization.slug}/seer/setup-check/`,
       method: 'GET',
       body: {
         billing: {
@@ -594,20 +590,20 @@ describe('ProjectSeer', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${orgWithClaudeFeature.slug}/repos/`,
+      url: `/organizations/${organization.slug}/repos/`,
       query: {status: 'active'},
       method: 'GET',
       body: [],
     });
 
     MockApiClient.addMockResponse({
-      url: `/projects/${orgWithClaudeFeature.slug}/${project.slug}/`,
+      url: `/projects/${organization.slug}/${project.slug}/`,
       method: 'GET',
       body: initialProject,
     });
 
     MockApiClient.addMockResponse({
-      url: `/projects/${orgWithClaudeFeature.slug}/${project.slug}/seer/preferences/`,
+      url: `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
       method: 'GET',
       body: {
         code_mapping_repos: [],
@@ -617,7 +613,7 @@ describe('ProjectSeer', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${orgWithClaudeFeature.slug}/integrations/coding-agents/`,
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
       method: 'GET',
       body: {
         integrations: [
@@ -631,18 +627,18 @@ describe('ProjectSeer', () => {
     });
 
     const projectPutRequest = MockApiClient.addMockResponse({
-      url: `/projects/${orgWithClaudeFeature.slug}/${project.slug}/`,
+      url: `/projects/${organization.slug}/${project.slug}/`,
       method: 'PUT',
       body: {},
     });
 
     const seerPreferencesPostRequest = MockApiClient.addMockResponse({
-      url: `/projects/${orgWithClaudeFeature.slug}/${project.slug}/seer/preferences/`,
+      url: `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
       method: 'POST',
     });
 
     render(<ProjectSeer />, {
-      organization: orgWithClaudeFeature,
+      organization,
       outletContext: {project: initialProject},
     });
 
@@ -1127,10 +1123,6 @@ describe('ProjectSeer', () => {
     it('only shows same-provider integrations in selector when both cursor and claude exist', async () => {
       MockApiClient.clearMockResponses();
 
-      const orgWithBothFeatures = OrganizationFixture({
-        features: ['integrations-claude-code'],
-      });
-
       const initialProject: DetailedProject = {
         ...project,
         autofixAutomationTuning: 'medium',
@@ -1142,7 +1134,7 @@ describe('ProjectSeer', () => {
       });
 
       MockApiClient.addMockResponse({
-        url: `/organizations/${orgWithBothFeatures.slug}/seer/setup-check/`,
+        url: `/organizations/${organization.slug}/seer/setup-check/`,
         method: 'GET',
         body: {
           billing: {hasAutofixQuota: true, hasScannerQuota: true},
@@ -1150,14 +1142,14 @@ describe('ProjectSeer', () => {
       });
 
       MockApiClient.addMockResponse({
-        url: `/organizations/${orgWithBothFeatures.slug}/repos/`,
+        url: `/organizations/${organization.slug}/repos/`,
         query: {status: 'active'},
         method: 'GET',
         body: [],
       });
 
       MockApiClient.addMockResponse({
-        url: `/organizations/${orgWithBothFeatures.slug}/integrations/coding-agents/`,
+        url: `/organizations/${organization.slug}/integrations/coding-agents/`,
         method: 'GET',
         body: {
           integrations: [
@@ -1176,7 +1168,7 @@ describe('ProjectSeer', () => {
       });
 
       MockApiClient.addMockResponse({
-        url: `/projects/${orgWithBothFeatures.slug}/${project.slug}/seer/preferences/`,
+        url: `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
         method: 'GET',
         body: {
           preference: {
@@ -1194,7 +1186,7 @@ describe('ProjectSeer', () => {
       });
 
       render(<ProjectSeer />, {
-        organization: orgWithBothFeatures,
+        organization,
         outletContext: {project: initialProject},
       });
 

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -228,9 +228,7 @@ function ProjectSeerGeneralForm({project}: {project: DetailedProject}) {
 
   const hasCursorIntegration = Boolean(cursorIntegration);
 
-  const hasClaudeIntegration = Boolean(
-    organization.features.includes('integrations-claude-code') && claudeIntegration
-  );
+  const hasClaudeIntegration = Boolean(claudeIntegration);
 
   const handleStoppingPointChange = useCallback(
     (


### PR DESCRIPTION
Remove the frontend checks for the GA Claude Code and GitHub Copilot coding agent feature flags.

**Coding Agent UI**

The Seer settings dropdown and coding agent CTAs now render from integration availability instead of `organization.features`. This lets the UI keep showing GA integrations after the backend stops exposing the temporary flags.

This frontend-only PR should land before the backend flag registration cleanup because frontend and backend deploy separately.