### PR TITLE
ref(integrations): Remove GA coding agent feature flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -124,9 +124,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:increased-issue-owners-rate-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Starfish: extract metrics from the spans
     manager.add("organizations:indexed-spans-extraction", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # These flags follow the pattern expected by IntegrationProvider.requires_feature_flag's usage on the config endpoint
-    manager.add("organizations:integrations-claude-code", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    manager.add("organizations:integrations-github-copilot-agent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-github-platform-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:github-repo-auto-sync-webhook", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:integrations-slack-staging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -8,7 +8,6 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -94,9 +93,7 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
         ]
 
         github_copilot_installed = any(i.provider == "github_copilot" for i in integrations)
-        if github_copilot_installed and features.has(
-            "organizations:integrations-github-copilot-agent", organization
-        ):
+        if github_copilot_installed:
             has_identity = False
             if request.user and request.user.id:
                 try:

--- a/src/sentry/integrations/claude_code/integration.py
+++ b/src/sentry/integrations/claude_code/integration.py
@@ -183,6 +183,7 @@ class ClaudeCodeAgentIntegrationProvider(CodingAgentIntegrationProvider):
     key = PROVIDER_KEY
     name = PROVIDER_NAME
     metadata = metadata
+    requires_feature_flag = False
 
     def get_pipeline_views(self):
         return []

--- a/src/sentry/integrations/github_copilot/integration.py
+++ b/src/sentry/integrations/github_copilot/integration.py
@@ -53,7 +53,7 @@ class GithubCopilotIntegrationProvider(CodingAgentIntegrationProvider):
     name = "GitHub Copilot"
     metadata = metadata
     integration_cls = GithubCopilotIntegration
-    feature_flag_name = "organizations:integrations-github-copilot-agent"
+    requires_feature_flag = False
 
     def get_agent_name(self) -> str:
         return "GitHub Copilot"

--- a/src/sentry/seer/agent/coding_agent_handoff.py
+++ b/src/sentry/seer/agent/coding_agent_handoff.py
@@ -13,7 +13,6 @@ import sentry_sdk
 from requests import HTTPError
 from rest_framework.exceptions import PermissionDenied, ValidationError
 
-from sentry import features
 from sentry.integrations.coding_agent.client import CodingAgentClient
 from sentry.integrations.coding_agent.integration import CodingAgentIntegration
 from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
@@ -50,8 +49,6 @@ def _resolve_client(
         Tuple of (client, installation). Exactly one will be non-None.
     """
     if provider == "github_copilot":
-        if not features.has("organizations:integrations-github-copilot-agent", organization):
-            raise PermissionDenied("GitHub Copilot is not enabled for this organization")
         user_access_token: str | None = None
         if user_id is not None:
             user_access_token = github_copilot_identity_service.get_access_token_for_user(

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -11,7 +11,7 @@ from django.conf import settings as django_settings
 from requests import HTTPError
 from rest_framework.exceptions import APIException, NotFound, PermissionDenied, ValidationError
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.models.project import Project
 
 
@@ -476,8 +476,6 @@ def launch_coding_agents_for_run(
     is_github_copilot = provider == "github_copilot"
 
     if is_github_copilot:
-        if not features.has("organizations:integrations-github-copilot-agent", organization):
-            raise PermissionDenied("GitHub Copilot is not enabled for this organization")
         user_access_token: str | None = None
         if user_id is not None:
             user_access_token = github_copilot_identity_service.get_access_token_for_user(

--- a/tests/sentry/api/endpoints/test_organization_config_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_config_integrations.py
@@ -33,10 +33,9 @@ class OrganizationConfigIntegrationsTest(APITestCase):
 
     def test_allow_multiple_false_can_add_true_when_no_installation(self) -> None:
         """Coding agent providers with allow_multiple=False show canAdd=True when not yet installed."""
-        with self.feature("organizations:integrations-claude-code"):
-            response = self.get_success_response(
-                self.organization.slug, qs_params={"provider_key": "claude_code"}
-            )
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"provider_key": "claude_code"}
+        )
         assert len(response.data["providers"]) == 1
         assert response.data["providers"][0]["canAdd"] is True
 
@@ -47,10 +46,9 @@ class OrganizationConfigIntegrationsTest(APITestCase):
             provider="claude_code",
             external_id="claude-ext-1",
         )
-        with self.feature("organizations:integrations-claude-code"):
-            response = self.get_success_response(
-                self.organization.slug, qs_params={"provider_key": "claude_code"}
-            )
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"provider_key": "claude_code"}
+        )
         assert len(response.data["providers"]) == 1
         assert response.data["providers"][0]["canAdd"] is False
 
@@ -62,10 +60,9 @@ class OrganizationConfigIntegrationsTest(APITestCase):
             external_id="claude-ext-1",
             status=ObjectStatus.DISABLED,
         )
-        with self.feature("organizations:integrations-claude-code"):
-            response = self.get_success_response(
-                self.organization.slug, qs_params={"provider_key": "claude_code"}
-            )
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"provider_key": "claude_code"}
+        )
         assert len(response.data["providers"]) == 1
         assert response.data["providers"][0]["canAdd"] is True
 
@@ -77,10 +74,9 @@ class OrganizationConfigIntegrationsTest(APITestCase):
             external_id="claude-ext-1",
             status=ObjectStatus.PENDING_DELETION,
         )
-        with self.feature("organizations:integrations-claude-code"):
-            response = self.get_success_response(
-                self.organization.slug, qs_params={"provider_key": "claude_code"}
-            )
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"provider_key": "claude_code"}
+        )
         assert len(response.data["providers"]) == 1
         assert response.data["providers"][0]["canAdd"] is True
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -339,13 +339,10 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
         mock.provider = "github_copilot"
         return mock
 
-    def test_github_copilot_shown_when_installed_and_feature_flag_enabled(self):
-        """Test GET endpoint shows GitHub Copilot when installed and feature flag is enabled."""
+    def test_github_copilot_shown_when_installed(self):
+        """Test GET endpoint shows GitHub Copilot when installed."""
         copilot = self._mock_github_copilot_integration()
-        with (
-            self.feature("organizations:integrations-github-copilot-agent"),
-            self.mock_integration_service_calls(integrations=[copilot]),
-        ):
+        with self.mock_integration_service_calls(integrations=[copilot]):
             response = self.get_success_response(self.organization.slug)
 
             integrations = response.data["integrations"]
@@ -357,11 +354,8 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
             assert integrations[0]["has_identity"] is False
 
     def test_github_copilot_not_shown_when_not_installed(self):
-        """Test GET endpoint does not show GitHub Copilot when feature flag is on but integration is not installed."""
-        with (
-            self.feature("organizations:integrations-github-copilot-agent"),
-            self.mock_integration_service_calls(integrations=[]),
-        ):
+        """Test GET endpoint does not show GitHub Copilot when integration is not installed."""
+        with self.mock_integration_service_calls(integrations=[]):
             response = self.get_success_response(self.organization.slug)
             assert response.data["integrations"] == []
 
@@ -373,10 +367,7 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
         mock_identity_service.get_access_token_for_user.return_value = "mock-access-token"
         copilot = self._mock_github_copilot_integration()
 
-        with (
-            self.feature("organizations:integrations-github-copilot-agent"),
-            self.mock_integration_service_calls(integrations=[copilot]),
-        ):
+        with self.mock_integration_service_calls(integrations=[copilot]):
             response = self.get_success_response(self.organization.slug)
 
             integrations = response.data["integrations"]
@@ -395,10 +386,7 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
         mock_identity_service.get_access_token_for_user.return_value = None
         copilot = self._mock_github_copilot_integration()
 
-        with (
-            self.feature("organizations:integrations-github-copilot-agent"),
-            self.mock_integration_service_calls(integrations=[copilot]),
-        ):
+        with self.mock_integration_service_calls(integrations=[copilot]):
             response = self.get_success_response(self.organization.slug)
 
             integrations = response.data["integrations"]
@@ -421,10 +409,7 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
         )
         copilot = self._mock_github_copilot_integration()
 
-        with (
-            self.feature("organizations:integrations-github-copilot-agent"),
-            self.mock_integration_service_calls(integrations=[copilot]),
-        ):
+        with self.mock_integration_service_calls(integrations=[copilot]):
             response = self.get_success_response(self.organization.slug)
 
             integrations = response.data["integrations"]
@@ -434,17 +419,6 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
             mock_identity_service.get_access_token_for_user.assert_called_once_with(
                 user_id=self.user.id
             )
-
-    def test_github_copilot_not_shown_without_feature_flag(self) -> None:
-        """Test GET endpoint does not show GitHub Copilot without feature flag."""
-        with (
-            self.feature({"organizations:integrations-github-copilot-agent": False}),
-            self.mock_integration_service_calls(integrations=[]),
-        ):
-            response = self.get_success_response(self.organization.slug)
-
-            integrations = response.data["integrations"]
-            assert len(integrations) == 0
 
 
 class OrganizationCodingAgentsPostCodingDisabledTest(BaseOrganizationCodingAgentsTest):
@@ -497,14 +471,14 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
         )
         assert "integration_id" in response.data
 
-    def test_invalid_provider(self) -> None:
-        """Test POST endpoint with invalid provider (not enabled)."""
+    def test_github_copilot_requires_user_authorization(self) -> None:
+        """Test POST endpoint with GitHub Copilot and no user authorization."""
         data = {"provider": "github_copilot", "run_id": 123}
 
         response = self.get_error_response(
             self.organization.slug, method="post", status_code=403, **data
         )
-        assert "GitHub Copilot is not enabled" in response.data["detail"]
+        assert "GitHub Copilot requires user authorization" in response.data["detail"]
 
     def test_non_coding_agent_integration(self) -> None:
         """Test POST endpoint with non-coding agent integration."""
@@ -1118,10 +1092,7 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
 
         data = {"provider": "github_copilot", "run_id": 123}
 
-        with (
-            self.feature("organizations:integrations-github-copilot-agent"),
-            patch("sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer"),
-        ):
+        with patch("sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer"):
             response = self.get_success_response(self.organization.slug, method="post", **data)
             assert response.data["success"] is False
             assert response.data["failed_count"] >= 1
@@ -1161,10 +1132,7 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
 
         data = {"provider": "github_copilot", "run_id": 123}
 
-        with (
-            self.feature("organizations:integrations-github-copilot-agent"),
-            patch("sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer"),
-        ):
+        with patch("sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer"):
             response = self.get_success_response(self.organization.slug, method="post", **data)
             assert response.data["success"] is False
             assert response.data["failed_count"] >= 1

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_direct_enable.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_direct_enable.py
@@ -14,8 +14,7 @@ class OrganizationIntegrationDirectEnableTest(APITestCase):
         self.login_as(self.user)
 
     def test_enables_github_copilot(self):
-        with self.feature("organizations:integrations-github-copilot-agent"):
-            response = self.get_success_response(self.organization.slug, "github_copilot")
+        response = self.get_success_response(self.organization.slug, "github_copilot")
 
         integration = Integration.objects.get(provider="github_copilot")
         assert OrganizationIntegration.objects.filter(
@@ -34,14 +33,10 @@ class OrganizationIntegrationDirectEnableTest(APITestCase):
         self.get_error_response(self.organization.slug, "cursor", status_code=400)
 
     def test_prevents_duplicate_installation(self):
-        with self.feature("organizations:integrations-github-copilot-agent"):
-            self.get_success_response(self.organization.slug, "github_copilot")
-            self.get_error_response(self.organization.slug, "github_copilot", status_code=400)
+        self.get_success_response(self.organization.slug, "github_copilot")
+        self.get_error_response(self.organization.slug, "github_copilot", status_code=400)
 
         assert Integration.objects.filter(provider="github_copilot").count() == 1
-
-    def test_returns_404_when_feature_flag_disabled(self):
-        self.get_error_response(self.organization.slug, "github_copilot", status_code=404)
 
     def test_requires_org_write_permission(self):
         member = self.create_user()

--- a/tests/sentry/integrations/claude_code/test_integration.py
+++ b/tests/sentry/integrations/claude_code/test_integration.py
@@ -24,7 +24,6 @@ from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, IntegrationTestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 MOCK_GET_CLIENT_CLASS = "sentry.integrations.claude_code.integration._get_client_class"
@@ -594,7 +593,6 @@ class ClaudeCodeApiPipelineTest(APITestCase):
     def _advance_step(self, data: dict[str, Any]) -> Any:
         return self.client.post(self._get_pipeline_url(), data=data, format="json")
 
-    @with_feature("organizations:integrations-claude-code")
     def test_initialize_pipeline(self) -> None:
         resp = self._initialize_pipeline()
         assert resp.status_code == 200
@@ -603,13 +601,11 @@ class ClaudeCodeApiPipelineTest(APITestCase):
         assert resp.data["totalSteps"] == 1
         assert resp.data["provider"] == "claude_code"
 
-    @with_feature("organizations:integrations-claude-code")
     def test_missing_api_key(self) -> None:
         self._initialize_pipeline()
         resp = self._advance_step({})
         assert resp.status_code == 400
 
-    @with_feature("organizations:integrations-claude-code")
     def test_full_pipeline_flow(self) -> None:
         mock_cls, _ = _mock_client_class()
 

--- a/tests/sentry/integrations/github_copilot/test_integration.py
+++ b/tests/sentry/integrations/github_copilot/test_integration.py
@@ -10,11 +10,8 @@ class GithubCopilotIntegrationProviderTest(TestCase):
     def test_key(self):
         assert self.provider.key == "github_copilot"
 
-    def test_requires_feature_flag_true(self):
-        assert self.provider.requires_feature_flag is True
-
-    def test_feature_flag_name(self):
-        assert self.provider.feature_flag_name == "organizations:integrations-github-copilot-agent"
+    def test_requires_feature_flag_false(self):
+        assert self.provider.requires_feature_flag is False
 
     def test_no_pipeline_views(self):
         assert self.provider.get_pipeline_views() == []

--- a/tests/sentry/seer/agent/test_coding_agent_handoff.py
+++ b/tests/sentry/seer/agent/test_coding_agent_handoff.py
@@ -140,10 +140,8 @@ class TestLaunchCodingAgents(TestCase):
     @patch("sentry.seer.agent.coding_agent_handoff.store_coding_agent_states_to_seer")
     @patch("sentry.seer.agent.coding_agent_handoff.GithubCopilotAgentClient")
     @patch("sentry.seer.agent.coding_agent_handoff.github_copilot_identity_service")
-    @patch("sentry.seer.agent.coding_agent_handoff.features.has")
     def test_copilot_not_licensed_403_returns_github_copilot_not_licensed_failure_type(
         self,
-        mock_features,
         mock_identity_service,
         mock_copilot_client_class,
         mock_store,
@@ -154,7 +152,6 @@ class TestLaunchCodingAgents(TestCase):
         account lacks an active Copilot subscription. This is distinct from a GitHub App
         permissions issue, so we should NOT show the permissions modal.
         """
-        mock_features.return_value = True
         mock_identity_service.get_access_token_for_user.return_value = "test-token"
 
         mock_client_instance = MagicMock()
@@ -251,9 +248,8 @@ class TestResolveClient(TestCase):
         assert client is None
         assert installation is mock_installation
 
-    @patch(f"{MOCK_HANDOFF_PATH}.features.has", return_value=True)
     @patch(f"{MOCK_HANDOFF_PATH}.github_copilot_identity_service")
-    def test_returns_client_for_github_copilot(self, mock_identity_service, mock_features):
+    def test_returns_client_for_github_copilot(self, mock_identity_service):
         mock_identity_service.get_access_token_for_user.return_value = "test-token"
 
         client, installation = _resolve_client(
@@ -264,18 +260,8 @@ class TestResolveClient(TestCase):
         assert installation is None
         mock_identity_service.get_access_token_for_user.assert_called_once_with(user_id=1)
 
-    @patch(f"{MOCK_HANDOFF_PATH}.features.has", return_value=False)
-    def test_raises_permission_denied_when_copilot_not_enabled(self, mock_features):
-        with pytest.raises(PermissionDenied):
-            _resolve_client(
-                self.organization, integration_id=None, provider="github_copilot", user_id=1
-            )
-
-    @patch(f"{MOCK_HANDOFF_PATH}.features.has", return_value=True)
     @patch(f"{MOCK_HANDOFF_PATH}.github_copilot_identity_service")
-    def test_raises_permission_denied_when_no_copilot_token(
-        self, mock_identity_service, mock_features
-    ):
+    def test_raises_permission_denied_when_no_copilot_token(self, mock_identity_service):
         mock_identity_service.get_access_token_for_user.return_value = None
 
         with pytest.raises(PermissionDenied):
@@ -283,8 +269,7 @@ class TestResolveClient(TestCase):
                 self.organization, integration_id=None, provider="github_copilot", user_id=1
             )
 
-    @patch(f"{MOCK_HANDOFF_PATH}.features.has", return_value=True)
-    def test_raises_permission_denied_when_copilot_no_user_id(self, mock_features):
+    def test_raises_permission_denied_when_copilot_no_user_id(self):
         with pytest.raises(PermissionDenied):
             _resolve_client(
                 self.organization, integration_id=None, provider="github_copilot", user_id=None


### PR DESCRIPTION
Remove the backend gates for the GA Claude Code and GitHub Copilot coding agent integrations.

**GA Provider Access**

Claude Code and GitHub Copilot providers now opt out of `IntegrationProvider` feature gating. GitHub Copilot is returned by the coding agents endpoint and launch paths no longer require the temporary organization flag.

**Temporary Flags**

Remove the temporary `organizations:integrations-claude-code` and `organizations:integrations-github-copilot-agent` registrations and update backend tests to assert the permanent behavior.

This backend-only PR should land after the frontend flag-check removal PR because frontend and backend deploy separately.