### PR TITLE
ref(api): remove legacy `blue-thunder-edition` URL

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2771,12 +2771,6 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-event-source-map-debug",
     ),
     re_path(
-        # Legacy alias the frontend still hardcodes; remove once it migrates to source-map-debug/.
-        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/events/(?P<event_id>[^/]+)/source-map-debug-blue-thunder-edition/$",
-        SourceMapDebugEndpoint.as_view(),
-        name="sentry-api-0-event-source-map-debug-blue-thunder-edition",
-    ),
-    re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/events/(?P<event_id>[^/]+)/actionable-items/$",
         ActionableItemsEndpoint.as_view(),
         name="sentry-api-0-event-actionable-items",

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -35,8 +35,6 @@ EXCLUSION_PATH_PREFIXES = [
     "/api/0/monitors/",
     # Issue URLS have an expression of group|issue that resolves to `var`
     "/api/0/{var}/{issue_id}/",
-    # Legacy alias of source-map-debug/; documented only at the canonical path.
-    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/events/{event_id}/source-map-debug-blue-thunder-edition/",
 ]
 
 

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -625,7 +625,6 @@ export type KnownSentryApiUrls =
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/events/$eventId/json/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/events/$eventId/owners/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/events/$eventId/reprocessable/'
-  | '/projects/$organizationIdOrSlug/$projectIdOrSlug/events/$eventId/source-map-debug-blue-thunder-edition/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/events/$eventId/source-map-debug/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/files/artifact-bundles/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/files/difs/assemble/'

--- a/tests/sentry/api/endpoints/test_source_map_debug.py
+++ b/tests/sentry/api/endpoints/test_source_map_debug.py
@@ -72,7 +72,7 @@ def create_event(
 
 
 class SourceMapDebugEndpointTestCase(APITestCase):
-    endpoint = "sentry-api-0-event-source-map-debug-blue-thunder-edition"
+    endpoint = "sentry-api-0-event-source-map-debug"
 
     def setUp(self) -> None:
         self.login_as(self.user)


### PR DESCRIPTION
The frontend migrated to the canonical `source-map-debug` URL. Logs show no real programmatic usage. Remove the URL entirely.

Follow up of https://github.com/getsentry/sentry/pull/116691