### PR TITLE
fix(preprod): Run expired-artifacts reaper every 30 minutes

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1201,7 +1201,7 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
     },
     "preprod-detect-expired-artifacts": {
         "task": "preprod:sentry.preprod.tasks.detect_expired_preprod_artifacts",
-        "schedule": crontab("0", "*", "*", "*", "*"),
+        "schedule": crontab("*/30", "*", "*", "*", "*"),
     },
     "web-vitals-issue-detection": {
         "task": "issues:sentry.tasks.web_vitals_issue_detection.run_web_vitals_issue_detection",


### PR DESCRIPTION
Run the `detect_expired_preprod_artifacts` reaper every 30 minutes instead of hourly to tighten how quickly stuck rows are detected and marked failed.

The reaper marks `PreprodSnapshotComparison` rows (and sibling artifact, size-metrics, and size-comparison rows) that are stuck in `PROCESSING` past a 30-minute staleness threshold as `FAILED` with a `TIMEOUT` reason.

**Why halve the cadence**

At an hourly cadence, worst-case detection latency for a stuck row was ~90 minutes: up to ~60 minutes until the next run, on top of the 30-minute staleness threshold. Running every 30 minutes tightens worst-case latency to ~60 minutes.

**Negligible cost**

The sweep is an idempotent, indexed bulk `UPDATE` filtered by `state` and `date_updated`, so doubling the cadence is negligible load and changes no behavior beyond timing.

This is a small standalone config change split out from the preprod snapshot-comparison fan-out work, which is moving to rely on this reaper as its timeout backstop.