### PR TITLE
Fix profiling copy markdown transaction evidence

### DIFF
--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
@@ -396,6 +396,7 @@ describe('useCopyIssueDetails', () => {
       // 2001 is the occurrence type for File I/O on Main Thread
       const profileEvent = EventFixture({
         ...event,
+        title: 'TypeError: Cannot read properties of undefined',
         occurrence: {
           type: 2001,
           evidenceData: {},
@@ -409,7 +410,34 @@ describe('useCopyIssueDetails', () => {
       const result = issueAndEventToMarkdown(group, profileEvent, null, null, undefined);
 
       expect(result).toContain('## Span Evidence');
+      expect(result).not.toContain(
+        '**Transaction:** TypeError: Cannot read properties of undefined'
+      );
       expect(result).toContain('**Transaction Name:** app.start');
+      expect(result).toContain('**File Path:** /data/cache.db');
+    });
+
+    it('uses evidence data for profiling issue transaction names', () => {
+      // 2001 is the occurrence type for File I/O on Main Thread
+      const profileEvent = EventFixture({
+        ...event,
+        title: 'TypeError: Cannot read properties of undefined',
+        occurrence: {
+          type: 2001,
+          evidenceData: {
+            transactionName: 'app.start',
+          },
+          evidenceDisplay: [{name: 'File Path', value: '/data/cache.db', important: false}],
+        },
+      });
+
+      const result = issueAndEventToMarkdown(group, profileEvent, null, null, undefined);
+
+      expect(result).toContain('## Span Evidence');
+      expect(result).toContain('**Transaction Name:** app.start');
+      expect(result).not.toContain(
+        '**Transaction:** TypeError: Cannot read properties of undefined'
+      );
       expect(result).toContain('**File Path:** /data/cache.db');
     });
 

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
@@ -427,7 +427,9 @@ describe('useCopyIssueDetails', () => {
           evidenceData: {
             transactionName: 'app.start',
           },
-          evidenceDisplay: [{name: 'File Path', value: '/data/cache.db', important: false}],
+          evidenceDisplay: [
+            {name: 'File Path', value: '/data/cache.db', important: false},
+          ],
         },
       });
 

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
@@ -19,7 +19,11 @@ import {
 import {NODE_ENV} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {EntryType, type Event, type EventTransaction} from 'sentry/types/event';
-import {getIssueTypeFromOccurrenceType, type Group} from 'sentry/types/group';
+import {
+  getIssueTypeFromOccurrenceType,
+  isTransactionBased,
+  type Group,
+} from 'sentry/types/group';
 import type {StacktraceType} from 'sentry/types/stacktrace';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
@@ -165,9 +169,10 @@ function getSpanMarkdownValue(
  */
 function formatSpanEvidenceToMarkdown(event: Event): string {
   const eventTransaction = event as EventTransaction;
+  const occurrenceType = event.occurrence?.type;
   const issueType =
     eventTransaction.perfProblem?.issueType ??
-    getIssueTypeFromOccurrenceType(event.occurrence?.type);
+    getIssueTypeFromOccurrenceType(occurrenceType);
 
   if (!issueType) {
     return '';
@@ -185,8 +190,17 @@ function formatSpanEvidenceToMarkdown(event: Event): string {
   type EvidenceSpan = {description?: string; op?: string} | null | undefined;
   const lines: string[] = [];
 
-  if (event.title) {
+  const hasTransactionNameEvidenceDisplay = evidenceDisplay.some(
+    item => item?.name === 'Transaction Name'
+  );
+
+  if ((eventTransaction.perfProblem || isTransactionBased(occurrenceType)) && event.title) {
     lines.push(`**Transaction:** ${event.title}`);
+  } else if (
+    typeof evidenceData.transactionName === 'string' &&
+    !hasTransactionNameEvidenceDisplay
+  ) {
+    lines.push(`**Transaction Name:** ${evidenceData.transactionName}`);
   }
 
   if (spanInfo?.parentSpan) {

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
@@ -194,7 +194,10 @@ function formatSpanEvidenceToMarkdown(event: Event): string {
     item => item?.name === 'Transaction Name'
   );
 
-  if ((eventTransaction.perfProblem || isTransactionBased(occurrenceType)) && event.title) {
+  if (
+    (eventTransaction.perfProblem || isTransactionBased(occurrenceType)) &&
+    event.title
+  ) {
     lines.push(`**Transaction:** ${event.title}`);
   } else if (
     typeof evidenceData.transactionName === 'string' &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- Describe your PR here. -->

Fixes copied issue markdown for profiling-style occurrences so it no longer emits a misleading `Transaction` row from `event.title`. Profiling markdown now uses occurrence transaction evidence when present and avoids duplicating `evidenceDisplay` rows.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f001bdbf-e4b7-4fd7-bbb5-ff7e5c9d5b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f001bdbf-e4b7-4fd7-bbb5-ff7e5c9d5b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

