### PR TITLE
chore: Add provider for issue.resolved event

### DIFF
--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -184,7 +184,7 @@ def update_group_resolutions(release, commit_author_by_commit):
     release_commits = list(
         ReleaseCommit.objects.filter(release=release)
         .select_related("commit")
-        .values("commit_id", "commit__key")
+        .values("commit_id", "commit__key", "commit__repository_id")
     )
 
     commit_resolutions = list(
@@ -199,12 +199,15 @@ def update_group_resolutions(release, commit_author_by_commit):
         for cr in commit_resolutions  # group_id
     ]
 
-    pr_ids_by_merge_commit = list(
+    # repository_id is fetched here so we don't need a second PullRequest query
+    # below to resolve providers (pull_request_resolutions is always a subset).
+    pr_repo_ids = dict(
         PullRequest.objects.filter(
             merge_commit_sha__in=[rc["commit__key"] for rc in release_commits],
             organization_id=release.organization_id,
-        ).values_list("id", flat=True)
+        ).values_list("id", "repository_id")
     )
+    pr_ids_by_merge_commit = list(pr_repo_ids.keys())
 
     pull_request_resolutions = list(
         GroupLink.objects.filter(
@@ -225,6 +228,27 @@ def update_group_resolutions(release, commit_author_by_commit):
     pull_request_group_authors = [
         (prr[0], pr_authors_dict.get(prr[1])) for prr in pull_request_resolutions
     ]
+
+    # Map each resolved group to the (normalized) provider of the commit/PR that
+    # resolved it, so the issue_resolved analytics event records e.g. "github".
+    # commit -> repository_id comes for free from the select_related above;
+    # pr -> repository_id was already collected in pr_repo_ids above.
+    commit_repo_ids = {rc["commit_id"]: rc["commit__repository_id"] for rc in release_commits}
+    repo_providers = dict(
+        Repository.objects.filter(
+            id__in=set(commit_repo_ids.values()) | set(pr_repo_ids.values())
+        ).values_list("id", "provider")
+    )
+    # Iterate PRs first, commits second, so a commit-derived provider wins when a
+    # group is resolved by both. The repo_id guards prevent a repo-less link from
+    # overwriting a valid provider with None.
+    provider_by_group: dict[int, str | None] = {}
+    for group_id, pr_id in pull_request_resolutions:
+        if (repo_id := pr_repo_ids.get(pr_id)) is not None:
+            provider_by_group[group_id] = normalize_provider_key(repo_providers.get(repo_id))
+    for group_id, commit_id in commit_resolutions:
+        if (repo_id := commit_repo_ids.get(commit_id)) is not None:
+            provider_by_group[group_id] = normalize_provider_key(repo_providers.get(repo_id))
 
     user_by_author: dict[CommitAuthor | None, RpcUser | None] = {None: None}
 
@@ -284,12 +308,19 @@ def update_group_resolutions(release, commit_author_by_commit):
             group=group,
             project=group.project,
             resolution_type="with_commit",
+            provider=provider_by_group.get(group_id),
             sender=type(release),
         )
 
         kick_off_status_syncs.apply_async(
             kwargs={"project_id": group_project_lookup[group_id], "group_id": group_id}
         )
+
+
+def normalize_provider_key(provider: str | None) -> str | None:
+    """Strip the ``integrations:`` prefix so a repository provider like
+    ``integrations:github`` becomes the short key ``github``."""
+    return provider.removeprefix("integrations:") if provider else None
 
 
 def create_commit_authors(commit_list, release):

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -245,7 +245,9 @@ def record_issue_assigned(project, group, user, **kwargs):
 
 
 @issue_resolved.connect(weak=False)
-def record_issue_resolved(organization_id, project, group, user, resolution_type, **kwargs):
+def record_issue_resolved(
+    organization_id, project, group, user, resolution_type, provider=None, **kwargs
+):
     """There are three main types of ways to resolve issues
     1) via a release (current release, next release, or other)
     2) via commit (in the UI with the commit hash (marked as "in_commit")
@@ -276,6 +278,7 @@ def record_issue_resolved(organization_id, project, group, user, resolution_type
                 organization_id=organization_id,
                 group_id=group.id,
                 resolution_type=resolution_type,
+                provider=provider,
                 issue_type=group.issue_type.slug,
                 issue_category=group.issue_category.name.lower(),
             )

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -5,6 +5,7 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
+from sentry.analytics.events.issue_resolved import IssueResolvedEvent
 from sentry.api.exceptions import InvalidRepository
 from sentry.api.release_search import INVALID_SEMVER_MESSAGE
 from sentry.exceptions import InvalidSearchQuery
@@ -39,6 +40,7 @@ from sentry.search.events.filter import parse_semver
 from sentry.signals import receivers_raise_on_send
 from sentry.testutils.cases import SetRefsTestCase, TestCase
 from sentry.testutils.factories import Factories
+from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils.strings import truncatechars
 
@@ -520,6 +522,74 @@ class SetCommitsTestCase(TestCase):
 
         assert Group.objects.get(id=group.id).status == GroupStatus.RESOLVED
         assert not GroupInbox.objects.filter(group=group).exists()
+
+    @patch("sentry.analytics.record")
+    @receivers_raise_on_send()
+    def test_resolution_records_commit_provider(self, mock_record: MagicMock) -> None:
+        org = self.create_organization(owner=Factories.create_user())
+        project = self.create_project(organization=org, name="foo")
+        group = self.create_group(project=project)
+        add_group_to_inbox(group, GroupInboxReason.MANUAL)
+        repo = Repository.objects.create(
+            organization_id=org.id, name="test/repo", provider="integrations:github"
+        )
+        commit = Commit.objects.create(
+            organization_id=org.id,
+            repository_id=repo.id,
+            message="fixes %s" % (group.qualified_short_id),
+            key="alksdflskdfjsldkfajsflkslk",
+        )
+
+        release = self.create_release(project=project, version="abcdabc")
+        release.set_commits([{"id": commit.key, "repository": repo.name}])
+
+        assert Group.objects.get(id=group.id).status == GroupStatus.RESOLVED
+        assert_any_analytics_event(
+            mock_record,
+            IssueResolvedEvent(
+                user_id=None,
+                project_id=project.id,
+                default_user_id=org.default_owner_id,
+                organization_id=org.id,
+                group_id=group.id,
+                resolution_type="with_commit",
+                provider="github",
+                issue_type=group.issue_type.slug,
+                issue_category=group.issue_category.name.lower(),
+            ),
+        )
+
+    @patch("sentry.analytics.record")
+    @receivers_raise_on_send()
+    def test_resolution_without_repository_records_no_provider(
+        self, mock_record: MagicMock
+    ) -> None:
+        """A commit with no repository configured (as uploaded manually via the API)
+        still resolves the referenced issue; the auto-created repo has no provider,
+        so the IssueResolvedEvent records provider=None."""
+        org = self.create_organization(owner=Factories.create_user())
+        project = self.create_project(organization=org, name="foo")
+        group = self.create_group(project=project)
+        add_group_to_inbox(group, GroupInboxReason.MANUAL)
+
+        release = self.create_release(project=project, version="abcdabc")
+        release.set_commits([{"id": "a" * 40, "message": "fixes %s" % (group.qualified_short_id)}])
+
+        assert Group.objects.get(id=group.id).status == GroupStatus.RESOLVED
+        assert_any_analytics_event(
+            mock_record,
+            IssueResolvedEvent(
+                user_id=None,
+                project_id=project.id,
+                default_user_id=org.default_owner_id,
+                organization_id=org.id,
+                group_id=group.id,
+                resolution_type="with_commit",
+                provider=None,
+                issue_type=group.issue_type.slug,
+                issue_category=group.issue_category.name.lower(),
+            ),
+        )
 
     @patch("sentry.integrations.example.integration.ExampleIntegration.sync_status_outbound")
     @receivers_raise_on_send()


### PR DESCRIPTION
This already has providers like jira. Extend it so it adds the repo provider for issues resolved from commits.