### PR TITLE
chore(support): Remove remaining Zendesk references

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -118,7 +118,7 @@ const ORG_SETTINGS_ICONS: Record<string, React.ReactElement> = {
   '/settings/account/notifications/': <IconSubscribed />,
 };
 
-const helpSearch = new SentryGlobalSearch(['docs', 'help-center', 'develop']);
+const helpSearch = new SentryGlobalSearch(['docs', 'develop']);
 const EVENT_ID_PATTERN =
   /^(?:[A-Fa-f0-9]{32}|[A-Fa-f0-9]{8}(?:-[A-Fa-f0-9]{4}){3}-[A-Fa-f0-9]{12})$/;
 const SHORT_ID_PATTERN = /^[A-Za-z][\w-]*-\w{3,}$/;

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -118,7 +118,7 @@ const ORG_SETTINGS_ICONS: Record<string, React.ReactElement> = {
   '/settings/account/notifications/': <IconSubscribed />,
 };
 
-const helpSearch = new SentryGlobalSearch(['docs', 'zendesk_sentry_articles', 'develop']);
+const helpSearch = new SentryGlobalSearch(['docs', 'help-center', 'develop']);
 const EVENT_ID_PATTERN =
   /^(?:[A-Fa-f0-9]{32}|[A-Fa-f0-9]{8}(?:-[A-Fa-f0-9]{4}){3}-[A-Fa-f0-9]{12})$/;
 const SHORT_ID_PATTERN = /^[A-Za-z][\w-]*-\w{3,}$/;

--- a/static/gsApp/overrides/superuserAccessCategory.tsx
+++ b/static/gsApp/overrides/superuserAccessCategory.tsx
@@ -20,7 +20,7 @@ const EngineeringCategories: SuperuserAccessCategories[] = [
 const ReactiveSupportCategories: SuperuserAccessCategories[] = [
   ['_admin_actions', '_admin actions'],
   ['organization_setting_change', 'Change organization settings'],
-  ['zendesk', 'Zendesk'],
+  ['intercom', 'Intercom'],
 ];
 
 const ProactiveSupportCategories: SuperuserAccessCategories[] = [


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/116822 to remove a couple remaining references. I talked to Nick about the command palette change and adding the new https://www.sentry.help/ articles will take a larger change so we'll just omit the old Zendesk articles for now. 