### PR TITLE
fix(cells): Org member serialization returns empty email if user and email fields not available"

### DIFF
--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -102,8 +102,8 @@ class OrganizationMemberSerializer(Serializer):
             # `email` on the OrganizationMember will be null, so we need to pull
             # the email address from the user's actual account. When the
             # control-silo User cannot be resolved (deleted, replication lag),
-            # fall back to the outbox-denormalized `user_email` and finally to
-            # an empty string so the response still serializes.
+            # fall back to the org member's email, or empty string if none
+            # exists to ensure serialization still succeeds.
             email = serialized_user["email"] if serialized_user else obj.email or ""
         else:
             # when there is no user_id, the OrganizationMember is an invited user

--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -100,8 +100,11 @@ class OrganizationMemberSerializer(Serializer):
         if obj.user_id:
             # if the OrganizationMember has a user_id, the user has an account
             # `email` on the OrganizationMember will be null, so we need to pull
-            # the email address from the user's actual account
-            email = serialized_user["email"] if serialized_user else obj.email
+            # the email address from the user's actual account. When the
+            # control-silo User cannot be resolved (deleted, replication lag),
+            # fall back to the outbox-denormalized `user_email` and finally to
+            # an empty string so the response still serializes.
+            email = serialized_user["email"] if serialized_user else obj.email or ""
         else:
             # when there is no user_id, the OrganizationMember is an invited user
             # and the email field on OrganizationMember will be populated, so we
@@ -116,7 +119,6 @@ class OrganizationMemberSerializer(Serializer):
         # invited users do not yet have a full account and the email field
         # on OrganizationMember will be populated in such cases
         assert email is not None
-
         inviter_name = None
         if obj.inviter_id:
             inviter = attrs["inviter"]

--- a/tests/sentry/api/serializers/test_organization_member.py
+++ b/tests/sentry/api/serializers/test_organization_member.py
@@ -54,7 +54,7 @@ class OrganizationMemberSerializerTest(TestCase):
         assert result["user"]["id"] == str(user.id)
         assert result["user"]["name"] == "bob"
 
-    def test_member_with_missing_control_user_and_no_denormalized_email(self) -> None:
+    def test_member_with_missing_user_and_no_denormalized_email(self) -> None:
         # Tests the case where we have no user to resolve, and need to have
         # _something_ to populate the user email field with.
         user = self.create_user(name="deleted_user", email="deleted@example.com")

--- a/tests/sentry/api/serializers/test_organization_member.py
+++ b/tests/sentry/api/serializers/test_organization_member.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from sentry.api.serializers import (
     OrganizationMemberSerializer,
     OrganizationMemberWithProjectsSerializer,
@@ -11,6 +9,7 @@ from sentry.api.serializers.models.organization_member import (
 )
 from sentry.models.organizationmember import InviteStatus
 from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.users.models.user import User
 
 
@@ -55,45 +54,21 @@ class OrganizationMemberSerializerTest(TestCase):
         assert result["user"]["id"] == str(user.id)
         assert result["user"]["name"] == "bob"
 
-    def test_member_with_deleted_user(self) -> None:
-        """
-        Test that documents current serializer behavior when a member's user has been deleted.
-
-        During hybrid cloud user deletion, there's an eventual consistency window where
-        the user may be deleted from the control silo but the OrganizationMember still
-        exists in the region silo with a user_id reference.
-
-        CURRENT BEHAVIOR (as of 2026-02-17):
-        When user_service.serialize_many() returns empty (user deleted), the serializer
-        fails with AssertionError because:
-        1. serialized_user is None (user was deleted)
-        2. OrganizationMember.email is also None (cleared when user_id was set)
-        3. The code hits: assert email is not None
-
-        The base serializer catches the exception and returns None for the member.
-
-        This test documents the current behavior, not necessarily the desired behavior.
-        Future improvements might include:
-        - Using user_email field as fallback
-        - Returning a partial serialization with user=None but other fields populated
-        """
+    def test_member_with_missing_control_user_and_no_denormalized_email(self) -> None:
+        # Tests the case where we have no user to resolve, and need to have
+        # _something_ to populate the user email field with.
         user = self.create_user(name="deleted_user", email="deleted@example.com")
-        member = self.create_member(
-            organization=self.org,
-            user_id=user.id,
-        )
+        member = self.create_member(organization=self.org, user_id=user.id)
+        member.update(user_email=None)
 
-        # Simulate the user being deleted but OrganizationMember still existing
-        # by mocking the user service to return empty for this user
-        with patch(
-            "sentry.api.serializers.models.organization_member.base.user_service.serialize_many"
-        ) as mock_serialize:
-            mock_serialize.return_value = []  # No users returned (deleted)
-            result = serialize(member, self.user_2, OrganizationMemberSerializer())
+        with assume_test_silo_mode_of(User):
+            user.delete()
 
-        # Current behavior: serializer returns None when email cannot be determined
-        # This happens because both user.email (from deleted user) and member.email are None
-        assert result is None
+        result = serialize(member, self.user_2, OrganizationMemberSerializer())
+
+        assert result is not None
+        assert result["email"] == ""
+        assert result["user"] is None
 
 
 class OrganizationMemberWithProjectsSerializerTest(OrganizationMemberSerializerTest):

--- a/tests/sentry/core/endpoints/test_organization_member_index.py
+++ b/tests/sentry/core/endpoints/test_organization_member_index.py
@@ -267,7 +267,7 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase, HybridCloudTest
         assert response.data[0]["email"] == "billy@localhost"
 
     def test_list_with_missing_user(self) -> None:
-        # .We can't guarantee that a user will always exist, due to tombstone
+        # We can't guarantee that a user will always exist, due to tombstone
         # deletions, so we need to ensure we can still serialize the org member.
         secondary_user = self.create_user("secondary@localhost", username="dos")
         OrganizationMember.objects.create(

--- a/tests/sentry/core/endpoints/test_organization_member_index.py
+++ b/tests/sentry/core/endpoints/test_organization_member_index.py
@@ -265,6 +265,29 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase, HybridCloudTest
         assert len(response.data) == 1
         assert response.data[0]["email"] == "billy@localhost"
 
+    def test_list_with_missing_control_user(self) -> None:
+        # Control-silo User can be missing for a member whose user_id is set
+        # (deletion in Control, replication lag, RPC tombstone). The list
+        # endpoint must still return the member, using the outbox-denormalized
+        # user_email as the email fallback rather than crashing on the
+        # serializer's `assert email is not None`.
+        member = OrganizationMember.objects.get(
+            organization=self.organization, user_id=self.user2.id
+        )
+        member.update(user_email="bar@localhost")
+
+        with patch(
+            "sentry.api.serializers.models.organization_member.base.user_service.serialize_many",
+            return_value=[],
+        ):
+            response = self.get_success_response(self.organization.slug)
+
+        assert len(response.data) == 2
+        emails = {row["email"] for row in response.data}
+        assert "bar@localhost" in emails
+        missing_user_row = next(row for row in response.data if row["email"] == "bar@localhost")
+        assert missing_user_row["user"] is None
+
     def test_email_query(self) -> None:
         response = self.get_success_response(
             self.organization.slug, qs_params={"query": self.user.email}

--- a/tests/sentry/core/endpoints/test_organization_member_index.py
+++ b/tests/sentry/core/endpoints/test_organization_member_index.py
@@ -15,8 +15,9 @@ from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers import Feature, with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import assume_test_silo_mode
+from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of
 from sentry.users.models.authenticator import Authenticator
+from sentry.users.models.user import User
 from sentry.users.models.useremail import UserEmail
 
 
@@ -265,28 +266,22 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase, HybridCloudTest
         assert len(response.data) == 1
         assert response.data[0]["email"] == "billy@localhost"
 
-    def test_list_with_missing_control_user(self) -> None:
-        # Control-silo User can be missing for a member whose user_id is set
-        # (deletion in Control, replication lag, RPC tombstone). The list
-        # endpoint must still return the member, using the outbox-denormalized
-        # user_email as the email fallback rather than crashing on the
-        # serializer's `assert email is not None`.
-        member = OrganizationMember.objects.get(
-            organization=self.organization, user_id=self.user2.id
+    def test_list_with_missing_user(self) -> None:
+        # .We can't guarantee that a user will always exist, due to tombstone
+        # deletions, so we need to ensure we can still serialize the org member.
+        secondary_user = self.create_user("secondary@localhost", username="dos")
+        OrganizationMember.objects.create(
+            user_id=secondary_user.id, email=None, organization=self.organization
         )
-        member.update(user_email="bar@localhost")
+        user_id = secondary_user.id
+        with assume_test_silo_mode_of(User):
+            secondary_user.delete()
 
-        with patch(
-            "sentry.api.serializers.models.organization_member.base.user_service.serialize_many",
-            return_value=[],
-        ):
-            response = self.get_success_response(self.organization.slug)
-
-        assert len(response.data) == 2
-        emails = {row["email"] for row in response.data}
-        assert "bar@localhost" in emails
-        missing_user_row = next(row for row in response.data if row["email"] == "bar@localhost")
-        assert missing_user_row["user"] is None
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": f"user.id:{user_id}"}
+        )
+        assert len(response.data) == 1
+        assert response.data[0]["email"] == ""
 
     def test_email_query(self) -> None:
         response = self.get_success_response(


### PR DESCRIPTION
Adds handling to org member serialization when the backing control user is missing, causing the serialization to fail. We can't always guarantee we have a user object due to eventually consistent deletions, and potential drift.

Relates to INFRENG-263
