### PR TITLE
fix(tracemetrics): Auto select equation when switching to equation mode

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.spec.tsx
@@ -348,7 +348,7 @@ describe('useTraceMetricsVisualizeModeState', () => {
     });
   });
 
-  it('falls back to first query when selectedLabel does not match', async () => {
+  it('falls back to equation row when selectedLabel does not match', async () => {
     const {result} = renderHookWithProviders(useTraceMetricsVisualizeModeState, {
       organization: OrganizationFixture({features: EQUATION_FEATURES}),
       additionalWrapper: WidgetBuilderProvider,
@@ -379,12 +379,9 @@ describe('useTraceMetricsVisualizeModeState', () => {
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({
-            yAxis: serializeFields([
-              {
-                kind: FieldValueKind.FUNCTION,
-                function: ['sum', 'value', 'alpha_metric', 'counter', 'none'],
-              },
-            ]),
+            yAxis: [
+              'equation|sum(value,alpha_metric,counter,none) + avg(value,beta_metric,counter,none)',
+            ],
           }),
         }),
         expect.anything()
@@ -534,7 +531,7 @@ describe('useTraceMetricsVisualizeModeState', () => {
     });
   });
 
-  it('does not dispatch when equation snapshot is empty', () => {
+  it('seeds snapshot and dispatches equation yAxis when toggling to equation mode without a cached snapshot', async () => {
     const {result} = renderHookWithProviders(useTraceMetricsVisualizeModeState, {
       organization: OrganizationFixture({features: EQUATION_FEATURES}),
       additionalWrapper: WidgetBuilderProvider,
@@ -556,13 +553,18 @@ describe('useTraceMetricsVisualizeModeState', () => {
     });
 
     expect(result.current.isEquationMode).toBe(true);
-    expect(mockNavigate).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({
-          yAxis: expect.anything(),
+    expect(result.current.equationSnapshot.current).not.toBeNull();
+    expect(result.current.equationSnapshot.current?.selectedLabel).toBe('ƒ1');
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            yAxis: ['equation|'],
+          }),
         }),
-      }),
-      expect.anything()
-    );
+        expect.anything()
+      );
+    });
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.spec.tsx
@@ -348,7 +348,7 @@ describe('useTraceMetricsVisualizeModeState', () => {
     });
   });
 
-  it('falls back to equation row when selectedLabel does not match', async () => {
+  it('falls back to first aggregate when selectedLabel does not match', async () => {
     const {result} = renderHookWithProviders(useTraceMetricsVisualizeModeState, {
       organization: OrganizationFixture({features: EQUATION_FEATURES}),
       additionalWrapper: WidgetBuilderProvider,
@@ -358,7 +358,10 @@ describe('useTraceMetricsVisualizeModeState', () => {
           query: {
             dataset: WidgetType.TRACEMETRICS,
             displayType: DisplayType.LINE,
-            yAxis: ['count(value,gamma_metric,counter,none)'],
+            yAxis: [
+              'equation|sum(value,alpha_metric,counter,none) + avg(value,gamma_metric,counter,none)',
+            ],
+            label: 'test',
           },
         },
       },
@@ -379,9 +382,7 @@ describe('useTraceMetricsVisualizeModeState', () => {
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.objectContaining({
           query: expect.objectContaining({
-            yAxis: [
-              'equation|sum(value,alpha_metric,counter,none) + avg(value,beta_metric,counter,none)',
-            ],
+            yAxis: ['sum(value,alpha_metric,counter,none)'],
           }),
         }),
         expect.anything()

--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
@@ -161,10 +161,6 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
 
     const selected =
       snapshot.queries.find(q => q.label === snapshot.selectedLabel) ??
-      snapshot.queries.find(q => {
-        const vis = q.queryParams.visualizes[0];
-        return vis && isVisualizeEquation(vis);
-      }) ??
       snapshot.queries[0];
     if (!selected) {
       return;

--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
@@ -1,6 +1,5 @@
 import {type RefObject, useCallback, useEffect, useRef, useState} from 'react';
 
-import {defined} from 'sentry/utils';
 import {
   explodeFieldString,
   generateFieldAsString,
@@ -135,9 +134,9 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
         .filter(f => f.kind === FieldValueKind.FUNCTION)
         .map(f => {
           const parsed = parseAggregateExpression(generateFieldAsString(f));
-          return parsed.metricQueries[0];
+          return parsed.metricQueries[0] ?? defaultMetricQuery();
         })
-        .filter(defined);
+        .filter(Boolean);
       if (queries.length === 0) {
         queries.push(defaultMetricQuery());
       }

--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
@@ -1,6 +1,11 @@
 import {type RefObject, useCallback, useEffect, useRef, useState} from 'react';
 
-import {explodeFieldString, type QueryFieldValue} from 'sentry/utils/discover/fields';
+import {defined} from 'sentry/utils';
+import {
+  explodeFieldString,
+  generateFieldAsString,
+  type QueryFieldValue,
+} from 'sentry/utils/discover/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {WidgetType} from 'sentry/views/dashboards/types';
@@ -12,9 +17,15 @@ import {
   getTraceMetricAggregateSource,
 } from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
+import {assignSequentialLabels} from 'sentry/views/explore/metrics/hooks/useStableLabels';
 import type {BaseMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
+import {defaultMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
 import {canUseMetricsEquationsInDashboards} from 'sentry/views/explore/metrics/metricsFlags';
-import {isVisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {parseAggregateExpression} from 'sentry/views/explore/metrics/parseAggregateExpression';
+import {
+  isVisualizeEquation,
+  isVisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
 
 interface SeriesModeSnapshot {
   fields: QueryFieldValue[];
@@ -109,12 +120,46 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
   }, [state.displayType, dispatch]);
 
   const restoreEquationState = useCallback(() => {
-    const snapshot = equationSnapshot.current;
+    let snapshot = equationSnapshot.current;
+
     if (!snapshot) {
-      return;
+      // If no equation snapshot state, then we need to derive the first state to
+      // update the widget builder
+      const aggregateSource = getTraceMetricAggregateSource(
+        state.displayType,
+        state.yAxis,
+        state.fields
+      );
+
+      const queries = (aggregateSource ?? [])
+        .filter(f => f.kind === FieldValueKind.FUNCTION)
+        .map(f => {
+          const parsed = parseAggregateExpression(generateFieldAsString(f));
+          return parsed.metricQueries[0];
+        })
+        .filter(defined);
+      if (queries.length === 0) {
+        queries.push(defaultMetricQuery());
+      }
+      queries.push(defaultMetricQuery({type: 'equation'}));
+
+      const labels = assignSequentialLabels(queries);
+      const equationIdx = queries.findIndex(q => {
+        const vis = q.queryParams.visualizes[0];
+        return vis && isVisualizeEquation(vis);
+      });
+      const selectedLabel = equationIdx >= 0 ? labels[equationIdx] : labels[0];
+
+      snapshot = {queries, selectedLabel};
+      equationSnapshot.current = snapshot;
     }
+
     const selected =
       snapshot.queries.find(q => q.label === snapshot.selectedLabel) ??
+      snapshot.queries.find(q => {
+        const vis = q.queryParams.visualizes[0];
+        return vis && isVisualizeEquation(vis);
+      }) ??
       snapshot.queries[0];
     if (!selected) {
       return;
@@ -133,7 +178,7 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
       type: BuilderStateAction.SET_QUERY,
       payload: [selected.queryParams.query],
     });
-  }, [state.displayType, state.fields, dispatch]);
+  }, [state.displayType, state.yAxis, state.fields, dispatch]);
 
   // Auto-restore the previous visualize mode when the dataset returns
   // to TRACEMETRICS. Detects equation yAxis on return and restores the

--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
@@ -148,6 +148,12 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
         const vis = q.queryParams.visualizes[0];
         return vis && isVisualizeEquation(vis);
       });
+
+      // Assign the labels to the queries so the state is in sync
+      queries.forEach((q, index) => {
+        q.label = labels[index];
+      });
+
       const selectedLabel = equationIdx >= 0 ? labels[equationIdx] : labels[0];
 
       snapshot = {queries, selectedLabel};


### PR DESCRIPTION
Currently, the widget builder state doesn't update its yaxis and query filters. This updates it so if we switch into equation mode and there isn't a cached state, we generate it and automatically select the equation and dispatch the updates so the widget builder preview can reflect the latest state (otherwise it didn't show any updates)

In this PR, an empty equation will continuously spin a loader in the preview, but there is another PR to fix that default state: https://github.com/getsentry/sentry/pull/116869