### PR TITLE
docs(agents): Remove cross-doc duplication in AGENTS.md files

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -162,12 +162,7 @@ return Response({"message": "Invalid input"}, status=400)
 
 ### Feature Flags
 
-```python
-from sentry import features
-
-if features.has('organizations:new-feature', organization):
-    # New feature code
-```
+See **Feature Flags (FlagPole)** in `/AGENTS.md` for registration, the `features.has(...)` check, and test usage.
 
 ### Permissions
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,16 +1,6 @@
 # Python Testing Guide
 
-> For critical test commands, see the "Command Execution Guide" section in `/AGENTS.md` in the repository root.
-
-## Running Tests Locally
-
-For backend-scoped changes, prefer `make test-selective` over running the full suite — it detects tests affected by your local diff and runs only those:
-
-```bash
-make test-selective
-```
-
-Fall back to `pytest -svv --reuse-db <path>` when you need to target a specific file or `test-selective` doesn't cover your case.
+> For test commands (`make test-selective`, `pytest`), see the "Command Execution Guide" section in `/AGENTS.md` in the repository root.
 
 ## How to Determine Where to Add New Test Cases
 


### PR DESCRIPTION
## Summary

Follow-up to #116868. That PR removed codebase-derivable duplication within `src/AGENTS.md`; this one removes **doc-to-doc** duplication across the AGENTS.md files.

Principle: each rule lives in exactly one place; the others point to it. The root `AGENTS.md` is the canonical home for both **feature flags** (`Feature Flags (FlagPole)`) and **commands** (`Command Execution Guide`), and the area files already reference it.

## Changes
- **`src/AGENTS.md`** — replaced the duplicated `features.has(...)` snippet with a pointer to the root Feature Flags section (which already documents registration, checks, and tests). The two copies had already drifted — differing example args (`actor=user` vs not), exactly the staleness this avoids.
- **`tests/AGENTS.md`** — dropped the `Running Tests Locally` section, which restated the root `make test-selective` / `pytest` guidance the file already links to in its header pointer.

## Not in scope
The `detail`-key convention appears in several files, but those are incidental uses of the word in prose/examples, not a duplicated rule — left alone. Slogan-trimming (e.g. the `Rule Enforcement` block in `tests/AGENTS.md`) and skill-extraction remain for separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/2IAjZ5VR-kOjCHjqL1f3DrApmGi_E_fkxssXs7KBRwo