### PR TITLE
docs(agents): Trim noise from root and tests AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,32 +2,6 @@
 
 > **IMPORTANT**: AGENTS.md files are the source of truth for AI agent instructions. Always update the relevant AGENTS.md file when adding or modifying agent guidance. Do not add to CLAUDE.md or Cursor rules.
 
-## Overview
-
-Sentry is a developer-first error tracking and performance monitoring platform. This repository contains the main Sentry application, which is a large-scale Django application with a React frontend.
-
-## Project Structure
-
-```
-sentry/
-├── src/
-│   ├── sentry/           # Main Django application
-│   │   ├── api/          # REST API endpoints
-│   │   ├── models/       # Django models
-│   │   ├── tasks/        # Celery tasks
-│   │   ├── integrations/ # Third-party integrations
-│   │   ├── issues/       # Issue tracking logic
-│   │   └── web/          # Web views and middleware
-│   ├── sentry_plugins/   # Plugin system
-│   └── social_auth/      # Social authentication
-├── static/               # Frontend application
-├── tests/                # Backend test suite
-├── fixtures/             # Test fixtures
-├── devenv/               # Development environment config
-├── migrations/           # Database migrations
-└── config/               # Configuration files
-```
-
 ## Command Execution Guide
 
 This section contains critical command execution instructions that apply across all Sentry development.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -17,10 +17,6 @@ Notice that we prefix `tests/` to the path and prefix `test_` to the module name
 
 ### Python Tests
 
-- Use pytest fixtures
-- Mock external services
-- Test database isolation with transactions
-- Use factories for test data
 - For Kafka/Arroyo components: Use `LocalProducer` with `MemoryMessageStorage` instead of mocks
 
 ### Test Pattern
@@ -94,13 +90,3 @@ For example, a diff that uses `pytest` instead of `unittest` would look like:
 - **Python**: `tests/` mirrors `src/` structure
 - **Fixtures**: `fixtures/{type}/`
 - **Factories**: `tests/sentry/testutils/factories.py`
-
-## Rule Enforcement
-
-These rules are MANDATORY for all Python development in the Sentry codebase. Violations will:
-
-- Cause CI failures
-- Require code review rejection
-- Must be fixed before merging the pull request
-
-Agents MUST follow these rules without exception to maintain code quality and consistency across the project.


### PR DESCRIPTION
## Summary

Continues the AGENTS.md cleanup (#116868, #116874), applying the same category-1 (slogans that don't change agent behavior) and category-2 (cheaply re-derivable / drifts when duplicated) cuts to the root and tests guides. **40 deletions, no additions, no actionable rule removed.**

## Changes
- **`AGENTS.md`** — dropped the generic `Overview` blurb (no instruction) and the `Project Structure` ASCII tree (re-derivable by listing the repo, and it goes stale as directories move).
- **`tests/AGENTS.md`** — dropped the generic best-practice bullets (`use pytest fixtures`, `mock external services`, `test database isolation`, `use factories for test data` — the last already covered in depth by the dedicated factories section), **keeping** the non-obvious `LocalProducer` / `MemoryMessageStorage` note. Also removed the `Rule Enforcement` closing block ("these rules are MANDATORY… cause CI failures…"), which is pure exhortation.

## Draft
Opened as draft for review of the judgment calls before merge — in particular the trimmed `Python Tests` bullets. Skill-extraction and `static/AGENTS.md` (844 lines) remain for follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/o8s3zz5HXT94ZXAy62YxyKNJgZDOzymMZL2gencSX98