### PR TITLE
docs(agents): Trim re-derivable inventory from static/AGENTS.md

### DIFF
--- a/static/AGENTS.md
+++ b/static/AGENTS.md
@@ -2,23 +2,8 @@
 
 > For critical commands and testing rules, see the "Command Execution Guide" section in `/AGENTS.md` in the repository root.
 
-## Frontend Tech Stack
+## File Location Map
 
-- **Language**: TypeScript
-- **Framework**: React 19
-- **Build Tool**: Rspack (Webpack alternative)
-- **Package management**: pnpm
-- **State Management**: Reflux, React Query (TanStack Query)
-- **Styling**: Emotion (CSS-in-JS), Less
-- **Testing**: Jest, React Testing Library
-
-## Important Files and Directories
-
-- `package.json`: Node.js dependencies and scripts
-- `rspack.config.ts`: Frontend build configuration
-- `tsconfig.json`: TypeScript configuration
-- `eslint.config.ts`: ESLint configuration
-- `stylelint.config.js`: CSS/styling linting
 - **Components**: `static/app/components/{component}/`
 - **Views**: `static/app/views/{area}/{page}.tsx`
 - **Stores**: `static/app/stores/{store}Store.tsx`


### PR DESCRIPTION
## Summary

Continues the AGENTS.md cleanup (#116868, #116874, #116875). Applies the category-2 (cheaply re-derivable / drifts when duplicated) cut to the frontend guide. **17 deletions, no actionable rule removed.**

## Changes
- **`static/AGENTS.md`** — removed the `Frontend Tech Stack` inventory and the build/config-file list (`package.json`, `rspack.config.ts`, `tsconfig.json`, `eslint.config.ts`, `stylelint.config.js`), both re-derivable from the repo and prone to drift. Kept the directory location map and renamed its section to `File Location Map` to match `src/` and `tests/`.

## Why this PR is small (on purpose)
`static/AGENTS.md` is 844 lines, but the bulk is the **design-system guidance** (Grid/Flex/Container/Heading/Text/Image/Avatar/Disclosure), which duplicates the `design-system` skill and is already enforced by `eslintPluginScraps` lint rules. Extracting that to a skill pointer is **category-3** work — and it carries real risk (skills load on-trigger, whereas AGENTS.md is always in context for the subtree), so per earlier discussion it's deferred to its own PR with explicit sign-off rather than bundled here.

## Draft
Opened as draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/5mJVRiByPlK7e9g0putOCxCaaWdvy_qPDUDovkbSdp0