### PR TITLE
feat(mypy): auto-derive Serializer[T] from typed serialize() returns

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_combined.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_combined.py
@@ -62,17 +62,21 @@ class WorkflowEngineCombinedRuleSerializer(Serializer[MutableMapping[Any, Any]])
         serialized_cron_monitors = serialize(cron_monitors, user=user)
 
         # Map by position since serializers return fake IDs that can't be used for lookup
-        for detector, serialized in zip(metric_detectors, serialized_metric_detectors):
-            results[detector] = serialized
+        for metric_detector, serialized_metric in zip(
+            metric_detectors, serialized_metric_detectors
+        ):
+            results[metric_detector] = serialized_metric
 
-        for workflow, serialized in zip(workflows, serialized_workflows):
-            results[workflow] = serialized
+        for workflow, serialized_workflow in zip(workflows, serialized_workflows):
+            results[workflow] = serialized_workflow
 
-        for detector, serialized in zip(uptime_detectors, serialized_uptime_detectors):
-            results[detector] = serialized
+        for uptime_detector, serialized_uptime in zip(
+            uptime_detectors, serialized_uptime_detectors
+        ):
+            results[uptime_detector] = serialized_uptime
 
-        for monitor, serialized in zip(cron_monitors, serialized_cron_monitors):
-            results[monitor] = serialized
+        for monitor, serialized_monitor in zip(cron_monitors, serialized_cron_monitors):
+            results[monitor] = serialized_monitor
 
         return results
 

--- a/tests/tools/mypy_helpers/test_plugin.py
+++ b/tests/tools/mypy_helpers/test_plugin.py
@@ -57,6 +57,34 @@ def call_mypy(src: str, *, plugins: list[str] | None = None) -> tuple[int, str]:
                 "    def __init__(self, data: T, status: int | None = ...) -> None: ...\n"
             )
 
+        # stub for sentry.api.serializers.base.Serializer + free `serialize()` —
+        # mirrors the runtime shape used by the autoderive hook. The free
+        # function has overloads so we can verify end-to-end that an autoderived
+        # `Serializer[T]` flows through to a typed return.
+        api_dir = _fill_init_pyi(tmpdir, "sentry/api/serializers")
+        with open(os.path.join(api_dir, "base.pyi"), "w") as f:
+            f.write(
+                "from collections.abc import Mapping, Sequence\n"
+                "from typing import Any, Generic, TypeVar, overload\n"
+                "T = TypeVar('T', default=Any)\n"
+                "class Serializer(Generic[T]):\n"
+                "    def serialize(self, obj: Any, attrs: Mapping[Any, Any], user: Any, **kwargs: Any) -> T: ...\n"
+                "@overload\n"
+                "def serialize(objects: Any, user: Any = ..., serializer: None = ..., **kwargs: Any) -> Any: ...\n"
+                "@overload\n"
+                "def serialize(objects: Sequence[Any], user: Any = ..., *, serializer: Serializer[T], **kwargs: Any) -> list[T]: ...\n"
+                "@overload\n"
+                "def serialize(objects: Sequence[Any], user: Any, serializer: Serializer[T], **kwargs: Any) -> list[T]: ...\n"
+                "@overload\n"
+                "def serialize(objects: object, user: Any = ..., *, serializer: Serializer[T], **kwargs: Any) -> T: ...\n"
+                "@overload\n"
+                "def serialize(objects: object, user: Any, serializer: Serializer[T], **kwargs: Any) -> T: ...\n"
+            )
+        with open(os.path.join(api_dir, "__init__.pyi"), "w") as f:
+            f.write(
+                "from sentry.api.serializers.base import Serializer as Serializer, serialize as serialize\n"
+            )
+
         ret = subprocess.run(
             (
                 *(sys.executable, "-m", "mypy"),
@@ -716,3 +744,201 @@ def view() -> Response[FooResponse] | Response[StatsPeriodErrorResponse]:
 """
     ret, out = call_mypy(src)
     assert ret == 0, out
+
+
+# -- Serializer auto-derive ----------------------------------------------------
+
+
+def test_serializer_autoderive_typed_return() -> None:
+    """`class Foo(Serializer):` with `serialize(...) -> Concrete` is promoted
+    to `Serializer[Concrete]`, and the free `serialize(obj, user, FooSerializer())`
+    overload resolves to `Concrete` instead of `Any`.
+    """
+    src = """\
+from typing import Any, TypedDict
+from collections.abc import Mapping
+from sentry.api.serializers import Serializer, serialize
+
+class FooResponse(TypedDict):
+    name: str
+
+class FooSerializer(Serializer):
+    def serialize(self, obj: Any, attrs: Mapping[Any, Any], user: Any, **kwargs: Any) -> FooResponse:
+        return {"name": "x"}
+
+reveal_type(serialize(object(), None, FooSerializer()))
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+    assert "FooResponse" in out
+
+
+def test_serializer_autoderive_skipped_when_already_parameterized() -> None:
+    """If the subclass already writes `Serializer[X]`, the hook is a no-op —
+    no double-substitution, no clobbering of an explicit parameterization.
+    """
+    src = """\
+from typing import Any, TypedDict
+from collections.abc import Mapping
+from sentry.api.serializers import Serializer, serialize
+
+class FooResponse(TypedDict):
+    name: str
+
+class FooSerializer(Serializer[FooResponse]):
+    def serialize(self, obj: Any, attrs: Mapping[Any, Any], user: Any, **kwargs: Any) -> FooResponse:
+        return {"name": "x"}
+
+reveal_type(serialize(object(), None, FooSerializer()))
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+    assert "FooResponse" in out
+
+
+def test_serializer_autoderive_skipped_when_serialize_unannotated() -> None:
+    """An unannotated `serialize` keeps `T = Any` — we don't fabricate a type
+    from a missing annotation.
+    """
+    src = """\
+from sentry.api.serializers import Serializer, serialize
+
+class FooSerializer(Serializer):
+    def serialize(self, obj, attrs, user, **kwargs):
+        return {"name": "x"}
+
+reveal_type(serialize(object(), None, FooSerializer()))
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+    assert 'Revealed type is "Any"' in out
+
+
+def test_serializer_autoderive_denylist_entries_are_fully_qualified() -> None:
+    """Sanity check on `_AUTODERIVE_DENYLIST`: every entry is a dotted module
+    path (no bare class names, no typos like leading/trailing dots). End-to-end
+    denylist behavior is exercised by the full mypy run on `src/` — each
+    denylisted class corresponds to a known caller-drift case the plugin would
+    otherwise surface as a CI failure.
+    """
+    from tools.mypy_helpers.serializer_autoderive import _AUTODERIVE_DENYLIST
+
+    assert _AUTODERIVE_DENYLIST, "denylist should not be empty"
+    for fullname in _AUTODERIVE_DENYLIST:
+        assert "." in fullname, fullname
+        assert not fullname.startswith("."), fullname
+        assert not fullname.endswith("."), fullname
+        # All Sentry serializers live under the `sentry.` namespace; this
+        # catches typos that drop the package prefix.
+        assert fullname.startswith("sentry."), fullname
+
+
+def test_serializer_autoderive_skipped_when_serialize_returns_any() -> None:
+    """Explicit `-> Any` is a deliberate opt-out — the hook respects it."""
+    src = """\
+from typing import Any
+from collections.abc import Mapping
+from sentry.api.serializers import Serializer, serialize
+
+class FooSerializer(Serializer):
+    def serialize(self, obj: Any, attrs: Mapping[Any, Any], user: Any, **kwargs: Any) -> Any:
+        return {"name": "x"}
+
+reveal_type(serialize(object(), None, FooSerializer()))
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+    assert 'Revealed type is "Any' in out
+
+
+def test_serializer_autoderive_typed_dict_remains_indexable() -> None:
+    """An autoderived `Serializer[FooResponse]` (where FooResponse is a
+    TypedDict) must produce a result that supports string-literal indexing —
+    `o["key"]` — and iteration over a list of them must yield TypedDict items.
+    Regression guard: an early implementation produced a TypedDict-via-typevar
+    type that mypy refused to index.
+    """
+    src = """\
+from typing import Any, TypedDict
+from collections.abc import Mapping
+from sentry.api.serializers import Serializer, serialize
+
+class FooResponse(TypedDict):
+    name: str
+    id: str
+
+class FooSerializer(Serializer):
+    def serialize(self, obj: Any, attrs: Mapping[Any, Any], user: Any, **kwargs: Any) -> FooResponse:
+        return {"name": "x", "id": "1"}
+
+single = serialize(object(), None, FooSerializer())
+n = single["name"]
+reveal_type(n)
+
+many = serialize([object()], None, FooSerializer())
+keyed = {(o["id"], o["name"]): o for o in many}
+reveal_type(keyed)
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+
+
+def test_serializer_autoderive_resolves_forward_reference_in_serialize_return() -> None:
+    """The `serialize()` return annotation can name a type defined *later* in
+    the file (or in a `TYPE_CHECKING` block). At base-class-hook time, that
+    name is an `UnboundType`; the hook routes it through `ctx.api.anal_type`
+    so the resolved `Serializer[T]` ends up as a proper TypedDict, not a
+    `Serializer[UnboundType("FooResponse")]` that mypy renders with `?` and
+    refuses to index. Regression guard for the resolution path.
+    """
+    src = """\
+from __future__ import annotations
+from typing import Any, TypedDict
+from collections.abc import Mapping
+from sentry.api.serializers import Serializer, serialize
+
+class FooSerializer(Serializer):
+    def serialize(self, obj: Any, attrs: Mapping[Any, Any], user: Any, **kwargs: Any) -> FooResponse:
+        return {"name": "x", "id": "1"}
+
+class FooResponse(TypedDict):
+    name: str
+    id: str
+
+result = serialize(object(), None, FooSerializer())
+# If the forward reference was not resolved, `result` would be the unbound
+# `FooResponse?` which mypy refuses to index — this line would error.
+n = result["name"]
+reveal_type(n)
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+    # `n` is `str` (the TypedDict's declared value type) — proves the
+    # forward reference resolved to a real `FooResponse` TypedDict.
+    assert 'Revealed type is "str"' in out
+
+
+def test_serializer_autoderive_propagates_through_subclass() -> None:
+    """A subclass of an autoderived `Serializer[T]` inherits the derived `T`
+    without needing its own `serialize` override.
+    """
+    src = """\
+from typing import Any, TypedDict
+from collections.abc import Mapping
+from sentry.api.serializers import Serializer, serialize
+
+class FooResponse(TypedDict):
+    name: str
+
+class FooSerializer(Serializer):
+    def serialize(self, obj: Any, attrs: Mapping[Any, Any], user: Any, **kwargs: Any) -> FooResponse:
+        return {"name": "x"}
+
+class FancyFooSerializer(FooSerializer):
+    pass
+
+reveal_type(serialize(object(), None, FancyFooSerializer()))
+"""
+    ret, out = call_mypy(src)
+    assert ret == 0, out
+    assert "FooResponse" in out

--- a/tools/mypy_helpers/plugin.py
+++ b/tools/mypy_helpers/plugin.py
@@ -416,6 +416,14 @@ def _dispatch_response_hook(ctx: FunctionContext) -> Type:
     return _check_response_body_not_any(ctx)
 
 
+from tools.mypy_helpers.serializer_autoderive import (
+    SERIALIZER_FULLNAME as _SERIALIZER_FULLNAME,
+)
+from tools.mypy_helpers.serializer_autoderive import (
+    autoderive_serializer_generic as _autoderive_serializer_generic,
+)
+
+
 class SentryMypyPlugin(Plugin):
     def get_function_hook(self, fullname: str) -> Callable[[FunctionContext], Type] | None:
         if fullname == _RESPONSE_FULLNAME:
@@ -457,6 +465,11 @@ class SentryMypyPlugin(Plugin):
             return _adjust_http_response_members
         else:
             return None
+
+    def get_base_class_hook(self, fullname: str) -> Callable[[ClassDefContext], None] | None:
+        if fullname == _SERIALIZER_FULLNAME:
+            return _autoderive_serializer_generic
+        return None
 
     def get_attribute_hook(self, fullname: str) -> Callable[[AttributeContext], Type] | None:
         if fullname.startswith("sentry.utils.lazy_service_wrapper.LazyServiceWrapper."):

--- a/tools/mypy_helpers/serializer_autoderive.py
+++ b/tools/mypy_helpers/serializer_autoderive.py
@@ -1,0 +1,109 @@
+"""Auto-derive `Serializer[T]` from a typed `serialize()` return.
+
+A mypy plugin hook that, for any bare `class Foo(Serializer):` whose
+`serialize(...) -> Concrete` has a non-`Any` return annotation, rewrites the
+`Serializer` base Instance to `Serializer[Concrete]` so mypy sees the typed
+shape without authors writing `[Concrete]` by hand. Wired into
+`SentryMypyPlugin.get_base_class_hook` in `plugin.py`.
+"""
+
+from __future__ import annotations
+
+from mypy.nodes import FuncDef
+from mypy.plugin import ClassDefContext
+from mypy.types import AnyType, CallableType, Instance, Type, UnboundType, get_proper_type
+
+SERIALIZER_FULLNAME = "sentry.api.serializers.base.Serializer"
+
+
+# Serializers exempt from autoderive: each has caller-side drift the typed
+# return shape would surface. Remove an entry only as part of the PR that
+# fixes its callers — landing the fix is more valuable than the exemption.
+_AUTODERIVE_DENYLIST: frozenset[str] = frozenset(
+    {
+        "sentry.api.serializers.models.actor.ActorSerializer",
+        "sentry.api.serializers.models.commit.CommitSerializer",
+        "sentry.api.serializers.models.dashboard.DashboardListSerializer",
+        "sentry.api.serializers.models.event.EventSerializer",
+        "sentry.api.serializers.models.group.GroupSerializerBase",
+        "sentry.api.serializers.models.organization_member.base.OrganizationMemberSerializer",
+        "sentry.api.serializers.models.project.ProjectSerializer",
+        "sentry.api.serializers.models.release.GroupEventReleaseSerializer",
+        "sentry.api.serializers.models.release.ReleaseSerializer",
+        "sentry.api.serializers.models.rule.WorkflowEngineRuleSerializer",
+        "sentry.api.serializers.models.team.BaseTeamSerializer",
+        "sentry.api.serializers.models.userreport.UserReportSerializer",
+        "sentry.incidents.endpoints.serializers.workflow_engine_detector.WorkflowEngineDetectorSerializer",
+        "sentry.incidents.endpoints.serializers.workflow_engine_incident.WorkflowEngineIncidentSerializer",
+        "sentry.integrations.api.serializers.models.integration.IntegrationSerializer",
+        "sentry.sentry_apps.api.serializers.sentry_app_avatar.SentryAppAvatarSerializer",
+        "sentry.users.api.serializers.authenticator.AuthenticatorInterfaceSerializer",
+        "sentry.users.api.serializers.user.UserSerializer",
+    }
+)
+
+
+def autoderive_serializer_generic(ctx: ClassDefContext) -> None:
+    """For `class Foo(Serializer):` where Foo defines `serialize(...) -> Concrete`,
+    rewrite the `Serializer` base Instance to `Serializer[Concrete]` so mypy
+    sees the typed shape — equivalent to authors writing `Serializer[Concrete]`
+    by hand.
+
+    Only fires when:
+      - The class directly inherits `Serializer` (i.e. has it in its direct
+        `info.bases`).
+      - The class is not in `_AUTODERIVE_DENYLIST`.
+      - The class directly defines `serialize(...)` with a concrete (not `Any`)
+        return annotation.
+
+    Skips classes that already parameterize the base (`Serializer[X]`),
+    classes that inherit from already-typed Serializer subclasses (no direct
+    `Serializer` base in `info.bases`), and classes whose `serialize` is
+    unannotated or returns `Any`.
+    """
+    info = ctx.cls.info
+    if info.fullname in _AUTODERIVE_DENYLIST:
+        return
+
+    target_idx: int | None = None
+    for i, base in enumerate(info.bases):
+        if (
+            base.type is not None
+            and base.type.fullname == SERIALIZER_FULLNAME
+            and len(base.args) == 1
+            and isinstance(get_proper_type(base.args[0]), AnyType)
+        ):
+            target_idx = i
+            break
+    if target_idx is None:
+        return
+
+    serialize_ret: Type | None = None
+    for stmt in ctx.cls.defs.body:
+        if isinstance(stmt, FuncDef) and stmt.name == "serialize":
+            if not isinstance(stmt.type, CallableType):
+                return
+            raw_ret = stmt.type.ret_type
+            # `get_base_class_hook` fires while semantic analysis of the class
+            # body is in progress; method-level type annotations may still be
+            # `UnboundType` (just the parsed name). Run them through
+            # `anal_type` so names get bound to their TypeInfo — otherwise we
+            # install a broken `Serializer[UnboundType("FooResponse")]` base
+            # that mypy renders with a trailing `?` and refuses to index.
+            # `anal_type` returns `None` and auto-defers when something isn't
+            # ready; bail in that case and let the next pass try again.
+            if isinstance(get_proper_type(raw_ret), UnboundType):
+                resolved = ctx.api.anal_type(raw_ret)
+                if resolved is None:
+                    return
+                raw_ret = resolved
+            ret = get_proper_type(raw_ret)
+            if isinstance(ret, AnyType):
+                return
+            serialize_ret = raw_ret
+            break
+    if serialize_ret is None:
+        return
+
+    base = info.bases[target_idx]
+    info.bases[target_idx] = Instance(base.type, [serialize_ret])


### PR DESCRIPTION
Without this plugin, when a Serializer declares `serialize(...) -> FooResponse`, callers of the free `serialize(obj, user, FooSerializer())` get back `Any` — the typed return is documentation only, not enforced. Authors who want the return shape to flow into mypy have to also write `class FooSerializer(Serializer[FooResponse])` by hand, and the previous backfill (#116816) added that boilerplate to 61 serializers.

This plugin adds a `get_base_class_hook` that auto-derives `Serializer[T]` from a typed `serialize()` return, removing the boilerplate. With autoderive in place, `serialize(obj, user, FooSerializer())` returns `FooResponse` instead of `Any`, which feeds into the existing `Response[T]` body-Any check and lets API endpoint return types be statically verified end-to-end.

~17 serializers are listed in an `_AUTODERIVE_DENYLIST` for now — promoting them surfaces real caller-side drift (TypedDicts missing keys, helpers typed too narrowly). Each follow-up PR removes a denylist entry and fixes its callers. Names get resolved through `anal_type()` so forward references work with auto-defer.