### PR TITLE
ref(types): move SelectValue out of types/core into scraps/select

### DIFF
--- a/static/app/components/actions/archive.tsx
+++ b/static/app/components/actions/archive.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {Button, ButtonBar} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {openConfirmModal} from 'sentry/components/confirm';
@@ -12,7 +13,6 @@ import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {IconChevron} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {GroupStatusResolution, IgnoredStatusDetails} from 'sentry/types/group';
 import {GroupStatus, GroupSubstatus} from 'sentry/types/group';
 import {getDuration} from 'sentry/utils/duration/getDuration';

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -5,12 +5,12 @@ import {z} from 'zod';
 import type {ButtonProps} from '@sentry/scraps/button';
 import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
 import {Stack} from '@sentry/scraps/layout';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {unreachable} from 'sentry/utils/unreachable';
 

--- a/static/app/components/core/compactSelect/types.tsx
+++ b/static/app/components/core/compactSelect/types.tsx
@@ -1,4 +1,4 @@
-import type {SelectValue} from 'sentry/types/core';
+import type {SelectValue} from '@sentry/scraps/select/types';
 
 // explicitly using object here because Record<PropertyKey, unknown> requires an index signature
 // eslint-disable-next-line @typescript-eslint/no-restricted-types

--- a/static/app/components/core/compactSelect/types.tsx
+++ b/static/app/components/core/compactSelect/types.tsx
@@ -1,4 +1,4 @@
-import type {SelectValue} from '@sentry/scraps/select/types';
+import type {SelectValue} from '@sentry/scraps/select';
 
 // explicitly using object here because Record<PropertyKey, unknown> requires an index signature
 // eslint-disable-next-line @typescript-eslint/no-restricted-types

--- a/static/app/components/core/form/field/selectAsyncField.tsx
+++ b/static/app/components/core/form/field/selectAsyncField.tsx
@@ -2,7 +2,8 @@ import {useState} from 'react';
 import {useQuery, type UseQueryOptions} from '@tanstack/react-query';
 import type {DistributedOmit} from 'type-fest';
 
-import type {SelectValue} from 'sentry/types/core';
+import type {SelectValue} from '@sentry/scraps/select/types';
+
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 
 import {type BaseFieldProps} from './baseField';

--- a/static/app/components/core/form/field/selectAsyncField.tsx
+++ b/static/app/components/core/form/field/selectAsyncField.tsx
@@ -2,7 +2,7 @@ import {useState} from 'react';
 import {useQuery, type UseQueryOptions} from '@tanstack/react-query';
 import type {DistributedOmit} from 'type-fest';
 
-import type {SelectValue} from '@sentry/scraps/select/types';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 

--- a/static/app/components/core/form/field/selectField.spec.tsx
+++ b/static/app/components/core/form/field/selectField.spec.tsx
@@ -4,8 +4,7 @@ import {z} from 'zod';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {AutoSaveForm, defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
-
-import type {SelectValue} from 'sentry/types/core';
+import type {SelectValue} from '@sentry/scraps/select';
 
 const OPTIONS = [
   {value: 'apple', label: 'Apple'},

--- a/static/app/components/core/form/field/selectField.tsx
+++ b/static/app/components/core/form/field/selectField.tsx
@@ -3,7 +3,7 @@ import {useRef, type Ref} from 'react';
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
-import type {SelectValue} from '@sentry/scraps/select/types';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import type {Props as ReactSelectProps} from 'sentry/components/forms/controls/reactSelectWrapper';
 import {components} from 'sentry/components/forms/controls/reactSelectWrapper';

--- a/static/app/components/core/form/field/selectField.tsx
+++ b/static/app/components/core/form/field/selectField.tsx
@@ -3,10 +3,10 @@ import {useRef, type Ref} from 'react';
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select/types';
 
 import type {Props as ReactSelectProps} from 'sentry/components/forms/controls/reactSelectWrapper';
 import {components} from 'sentry/components/forms/controls/reactSelectWrapper';
-import type {SelectValue} from 'sentry/types/core';
 
 import {BaseField, useAutoSaveIndicator, type BaseFieldProps} from './baseField';
 

--- a/static/app/components/core/select/index.tsx
+++ b/static/app/components/core/select/index.tsx
@@ -9,3 +9,5 @@ export {
 export {SelectAsync, type SelectAsyncControlProps, type Result} from './async';
 
 export {SelectOption} from './option';
+
+export type {SelectValue} from './types';

--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -9,7 +9,7 @@ import type {CSSObject} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import type {SelectValue} from '@sentry/scraps/select/types';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import type {
   GroupedOptionsType,

--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -9,6 +9,7 @@ import type {CSSObject} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import type {SelectValue} from '@sentry/scraps/select/types';
 
 import type {
   GroupedOptionsType,
@@ -26,7 +27,7 @@ import {
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconChevron, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {Choices, SelectValue} from 'sentry/types/core';
+import type {Choices} from 'sentry/types/core';
 import {convertFromSelect2Choices} from 'sentry/utils/convertFromSelect2Choices';
 import {defined} from 'sentry/utils/defined';
 import {PanelProvider} from 'sentry/utils/panelProvider';

--- a/static/app/components/core/select/types.tsx
+++ b/static/app/components/core/select/types.tsx
@@ -1,0 +1,14 @@
+import type {MenuListItemProps} from '@sentry/scraps/menuListItem';
+
+/**
+ * The option format used by react-select based components
+ */
+export interface SelectValue<T> extends MenuListItemProps {
+  value: T;
+  /**
+   * In scenarios where you're using a react element as the label react-select
+   * will be unable to filter to that label. Use this to specify the plain text of
+   * the label.
+   */
+  textValue?: string;
+}

--- a/static/app/components/customIgnoreCountModal.tsx
+++ b/static/app/components/customIgnoreCountModal.tsx
@@ -2,12 +2,12 @@ import {Fragment, useState} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {Grid} from '@sentry/scraps/layout';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {NumberField} from 'sentry/components/forms/fields/numberField';
 import {SelectField} from 'sentry/components/forms/fields/selectField';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {IgnoredStatusDetails} from 'sentry/types/group';
 
 type CountNames = 'ignoreCount' | 'ignoreUserCount';

--- a/static/app/components/deprecatedforms/selectCreatableField.tsx
+++ b/static/app/components/deprecatedforms/selectCreatableField.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
 
 import {Select} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {StyledForm} from 'sentry/components/deprecatedforms/form';
 import {SelectField} from 'sentry/components/deprecatedforms/selectField';
 import {withFormContext} from 'sentry/components/deprecatedforms/withFormContext';
-import type {SelectValue} from 'sentry/types/core';
 import {convertFromSelect2Choices} from 'sentry/utils/convertFromSelect2Choices';
 import {defined} from 'sentry/utils/defined';
 

--- a/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingSidebar.tsx
+++ b/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingSidebar.tsx
@@ -11,6 +11,7 @@ import {useDrawer} from '@sentry/scraps/drawer';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {FeatureFlagOnboardingLayout} from 'sentry/components/events/featureFlags/onboarding/featureFlagOnboardingLayout';
 import {FeatureFlagOtherPlatformOnboarding} from 'sentry/components/events/featureFlags/onboarding/featureFlagOtherPlatformOnboarding';
@@ -29,7 +30,6 @@ import {
   OnboardingDrawerStore,
 } from 'sentry/stores/onboardingDrawerStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {SelectValue} from 'sentry/types/core';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';

--- a/static/app/components/externalIssues/externalIssueForm.tsx
+++ b/static/app/components/externalIssues/externalIssueForm.tsx
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/react';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {Container} from '@sentry/scraps/layout';
+import type {SelectValue} from '@sentry/scraps/select';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 import {Heading} from '@sentry/scraps/text';
 
@@ -18,7 +19,7 @@ import {getConfigName} from 'sentry/components/externalIssues/utils';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t, tct} from 'sentry/locale';
-import type {Choice, Choices, SelectValue} from 'sentry/types/core';
+import type {Choice, Choices} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
 import type {
   GroupIntegration,

--- a/static/app/components/externalIssues/ticketRuleModal.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.tsx
@@ -5,6 +5,7 @@ import {useQueryClient} from '@tanstack/react-query';
 
 import {Container} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Heading} from '@sentry/scraps/text';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -19,7 +20,7 @@ import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t, tct} from 'sentry/locale';
 import type {TicketActionData} from 'sentry/types/alerts';
-import type {Choices, SelectValue} from 'sentry/types/core';
+import type {Choices} from 'sentry/types/core';
 import type {IntegrationIssueConfig, IssueConfigField} from 'sentry/types/integrations';
 import {parseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';

--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -11,6 +11,7 @@ import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {useDrawer} from '@sentry/scraps/drawer';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {FeedbackOnboardingLayout} from 'sentry/components/feedback/feedbackOnboarding/feedbackOnboardingLayout';
 import {CRASH_REPORT_HASH} from 'sentry/components/feedback/useFeedbackOnboarding';
@@ -40,7 +41,6 @@ import {
   OnboardingDrawerStore,
 } from 'sentry/stores/onboardingDrawerStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {SelectValue} from 'sentry/types/core';
 import type {PlatformKey} from 'sentry/types/platform';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';

--- a/static/app/components/forms/fields/selectField.tsx
+++ b/static/app/components/forms/fields/selectField.tsx
@@ -2,6 +2,7 @@ import {Component} from 'react';
 
 import type {ControlProps} from '@sentry/scraps/select';
 import {Select, SelectOption} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {openConfirmModal} from 'sentry/components/confirm';
@@ -14,7 +15,7 @@ import {components as SelectComponents} from 'sentry/components/forms/controls/r
 import {FormField} from 'sentry/components/forms/formField';
 import {FormFieldControlState} from 'sentry/components/forms/formField/controlState';
 import {t} from 'sentry/locale';
-import type {Choices, SelectValue} from 'sentry/types/core';
+import type {Choices} from 'sentry/types/core';
 
 // XXX(epurkhiser): This is wrong, it should not be inheriting these props
 import type {InputFieldProps} from './inputField';

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -1,11 +1,11 @@
 import type {AlertProps} from '@sentry/scraps/alert';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import type {createFilter} from 'sentry/components/forms/controls/reactSelectWrapper';
 import type {ChoiceMapperProps} from 'sentry/components/forms/fields/choiceMapperField';
 import type {SelectAsyncFieldProps} from 'sentry/components/forms/fields/selectAsyncField';
 import type {FormModel} from 'sentry/components/forms/model';
 import type {SliderProps} from 'sentry/components/slider';
-import type {SelectValue} from 'sentry/types/core';
 import type {AvatarProject, Project} from 'sentry/types/project';
 
 type FieldType =

--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -14,6 +14,7 @@ import {Button, LinkButton} from '@sentry/scraps/button';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Pagination} from '@sentry/scraps/pagination';
 import {Select, SelectOption} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {fetchTotalCount} from 'sentry/actionCreators/events';
@@ -23,7 +24,7 @@ import {components} from 'sentry/components/forms/controls/reactSelectWrapper';
 import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {t, tct} from 'sentry/locale';
-import type {PageFilters, SelectValue} from 'sentry/types/core';
+import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {User} from 'sentry/types/user';

--- a/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -6,13 +6,13 @@ import styled from '@emotion/styled';
 import {Stack} from '@sentry/scraps/layout';
 import type {StylesConfig} from '@sentry/scraps/select';
 import {Select} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import type {MultiValueProps} from 'sentry/components/forms/controls/reactSelectWrapper';
 import {useInviteMembersContext} from 'sentry/components/modals/inviteMembersModal/inviteMembersContext';
 import {RoleSelectControl} from 'sentry/components/roleSelectControl';
 import {TeamSelector} from 'sentry/components/teamSelector';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Organization, OrgRole} from 'sentry/types/organization';
 import {useOrganization} from 'sentry/utils/useOrganization';
 

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -8,6 +8,7 @@ import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
 import {Grid, type GridProps, Container} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {
   fetchDashboard,
@@ -22,7 +23,7 @@ import {
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {pageFiltersToQueryParams} from 'sentry/components/pageFilters/parse';
 import {t, tct, tn} from 'sentry/locale';
-import type {PageFilters, SelectValue} from 'sentry/types/core';
+import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -6,6 +6,7 @@ import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {useDrawer} from '@sentry/scraps/drawer';
 import {Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {IdBadge} from 'sentry/components/idBadge';
 import {LoadingError} from 'sentry/components/loadingError';
@@ -34,7 +35,6 @@ import {
   OnboardingDrawerStore,
 } from 'sentry/stores/onboardingDrawerStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {SelectValue} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformIntegration, Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -11,6 +11,7 @@ import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {useDrawer} from '@sentry/scraps/drawer';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {RadioGroup} from 'sentry/components/forms/controls/radioGroup';
 import {IdBadge} from 'sentry/components/idBadge';
@@ -37,7 +38,6 @@ import {
   OnboardingDrawerStore,
 } from 'sentry/stores/onboardingDrawerStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {SelectValue} from 'sentry/types/core';
 import type {PlatformKey} from 'sentry/types/platform';
 import type {Project} from 'sentry/types/project';
 import {useOrganization} from 'sentry/utils/useOrganization';

--- a/static/app/components/selectMembers/index.tsx
+++ b/static/app/components/selectMembers/index.tsx
@@ -3,11 +3,11 @@ import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
 import {Select, type GeneralSelectValue, type StylesConfig} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IdBadge} from 'sentry/components/idBadge';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import {useProjectMembersQueryOptions} from 'sentry/utils/members/projectMembers';

--- a/static/app/data/timezones.tsx
+++ b/static/app/data/timezones.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import groupBy from 'lodash/groupBy';
 import moment from 'moment-timezone';
 
-import type {SelectValue} from 'sentry/types/core';
+import type {SelectValue} from '@sentry/scraps/select';
 
 type TimezoneGroup =
   | null

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -4,8 +4,6 @@
  * Before a type is put here it should be required in multiple other types.
  * or used in multiple views.
  */
-import type {MenuListItemProps} from '@sentry/scraps/menuListItem';
-
 import type {getInterval} from 'sentry/components/charts/utils';
 
 export type {Scope} from 'sentry/constants/scopes';
@@ -44,19 +42,6 @@ export type TimeseriesValue = [timestamp: number, value: number];
 
 // taken from https://stackoverflow.com/questions/46634876/how-can-i-change-a-readonly-property-in-typescript
 export type Writable<T> = {-readonly [K in keyof T]: T[K]};
-
-/**
- * The option format used by react-select based components
- */
-export interface SelectValue<T> extends MenuListItemProps {
-  value: T;
-  /**
-   * In scenarios where you're using a react element as the label react-select
-   * will be unable to filter to that label. Use this to specify the plain text of
-   * the label.
-   */
-  textValue?: string;
-}
 
 /**
  * The 'other' option format used by checkboxes, radios and more.

--- a/static/app/utils/convertFromSelect2Choices.tsx
+++ b/static/app/utils/convertFromSelect2Choices.tsx
@@ -1,4 +1,6 @@
-import type {Choices, SelectValue} from 'sentry/types/core';
+import type {SelectValue} from '@sentry/scraps/select';
+
+import type {Choices} from 'sentry/types/core';
 
 function isStringList(maybe: string[] | Choices): maybe is string[] {
   return typeof maybe[0] === 'string';

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -6,13 +6,15 @@ import pick from 'lodash/pick';
 import uniqBy from 'lodash/uniqBy';
 import moment from 'moment-timezone';
 
+import type {SelectValue} from '@sentry/scraps/select';
+
 import type {EventQuery} from 'sentry/actionCreators/events';
 import {ALL_ACCESS_PROJECTS, URL_PARAM} from 'sentry/components/pageFilters/constants';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEditable';
 import {DEFAULT_PER_PAGE} from 'sentry/constants';
 import {t} from 'sentry/locale';
-import type {PageFilters, SelectValue} from 'sentry/types/core';
+import type {PageFilters} from 'sentry/types/core';
 import type {NewQuery, Organization, SavedQuery} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {User} from 'sentry/types/user';

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -1,8 +1,9 @@
 import isEqual from 'lodash/isEqual';
 
+import type {SelectValue} from '@sentry/scraps/select';
+
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import {RELEASE_ADOPTION_STAGES} from 'sentry/constants';
-import type {SelectValue} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {assert} from 'sentry/types/utils';
 import {

--- a/static/app/utils/discover/types.tsx
+++ b/static/app/utils/discover/types.tsx
@@ -1,5 +1,6 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 
 export const TOP_N = 5;

--- a/static/app/utils/regions/index.tsx
+++ b/static/app/utils/regions/index.tsx
@@ -1,6 +1,7 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
-import type {SelectValue} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Region} from 'sentry/types/system';
 

--- a/static/app/utils/useOwnerOptions.tsx
+++ b/static/app/utils/useOwnerOptions.tsx
@@ -2,9 +2,9 @@ import groupBy from 'lodash/groupBy';
 
 import type {AvatarProps} from '@sentry/scraps/avatar';
 import {TeamAvatar, UserAvatar} from '@sentry/scraps/avatar';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {DetailedTeam, Team} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 

--- a/static/app/views/alerts/rules/metric/details/constants.tsx
+++ b/static/app/views/alerts/rules/metric/details/constants.tsx
@@ -1,5 +1,6 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {TimePeriod, TimeWindow} from 'sentry/views/alerts/rules/metric/types';
 
 export const SELECTOR_RELATIVE_PERIODS = {

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -7,6 +7,7 @@ import {Alert} from '@sentry/scraps/alert';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Select} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -38,7 +39,6 @@ import {
 } from 'sentry/components/searchQueryBuilder';
 import {defaultConfig, InvalidReason} from 'sentry/components/searchSyntax/parser';
 import {t, tct, tctCode} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Tag, TagCollection} from 'sentry/types/group';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/actionTargetSelector.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/actionTargetSelector.tsx
@@ -1,9 +1,9 @@
 import {Input} from '@sentry/scraps/input';
 import {Select} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import SelectMembers from 'sentry/components/selectMembers';
 import {TeamSelector} from 'sentry/components/teamSelector';
-import type {SelectValue} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {Action, MetricActionTemplate} from 'sentry/views/alerts/rules/metric/types';

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -6,6 +6,7 @@ import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Select} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
@@ -14,7 +15,6 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {PanelItem} from 'sentry/components/panels/panelItem';
 import {IconAdd, IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {removeAtArrayIndex} from 'sentry/utils/array/removeAtArrayIndex';

--- a/static/app/views/automations/components/actionFilterBlock.tsx
+++ b/static/app/views/automations/components/actionFilterBlock.tsx
@@ -2,12 +2,12 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Container, Flex} from '@sentry/scraps/layout';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
 import {IconDelete, IconMail} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Action} from 'sentry/types/workflowEngine/actions';
 import {
   DataConditionGroupLogicType,

--- a/static/app/views/automations/components/actionFilters/ageComparison.tsx
+++ b/static/app/views/automations/components/actionFilters/ageComparison.tsx
@@ -1,7 +1,8 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {AutomationBuilderNumberInput} from 'sentry/components/workflowEngine/form/automationBuilderNumberInput';
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import type {AgeComparison} from 'sentry/views/automations/components/actionFilters/constants';
 import {

--- a/static/app/views/automations/components/actionFilters/assignedTo.tsx
+++ b/static/app/views/automations/components/actionFilters/assignedTo.tsx
@@ -1,4 +1,5 @@
 import {Container} from '@sentry/scraps/layout';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import SelectMembers from 'sentry/components/selectMembers';
 import {TeamSelector} from 'sentry/components/teamSelector';
@@ -8,7 +9,6 @@ import {
 } from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTeamsById} from 'sentry/utils/useTeamsById';

--- a/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
+++ b/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
 
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {AutomationBuilderNumberInput} from 'sentry/components/workflowEngine/form/automationBuilderNumberInput';
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {
   COMPARISON_INTERVAL_CHOICES,
   INTERVAL_CHOICES,

--- a/static/app/views/automations/components/actionFilters/eventAttribute.tsx
+++ b/static/app/views/automations/components/actionFilters/eventAttribute.tsx
@@ -1,7 +1,8 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {AutomationBuilderInput} from 'sentry/components/workflowEngine/form/automationBuilderInput';
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {
   Attribute,

--- a/static/app/views/automations/components/actionFilters/eventFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventFrequency.tsx
@@ -1,8 +1,9 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {RowLine} from 'sentry/components/workflowEngine/form/automationBuilderRowLine';
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import {

--- a/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
@@ -1,8 +1,9 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {RowLine} from 'sentry/components/workflowEngine/form/automationBuilderRowLine';
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import {

--- a/static/app/views/automations/components/actionFilters/issueCategory.tsx
+++ b/static/app/views/automations/components/actionFilters/issueCategory.tsx
@@ -1,6 +1,7 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import type {ValidateDataConditionProps} from 'sentry/views/automations/components/automationFormData';

--- a/static/app/views/automations/components/actionFilters/issuePriority.tsx
+++ b/static/app/views/automations/components/actionFilters/issuePriority.tsx
@@ -1,6 +1,7 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {
   PRIORITY_CHOICES,

--- a/static/app/views/automations/components/actionFilters/issueType.tsx
+++ b/static/app/views/automations/components/actionFilters/issueType.tsx
@@ -1,6 +1,7 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {getIssueTitleFromType, VISIBLE_ISSUE_TYPES} from 'sentry/types/group';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';

--- a/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
+++ b/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
@@ -1,6 +1,7 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Environment} from 'sentry/types/project';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';

--- a/static/app/views/automations/components/actionFilters/level.tsx
+++ b/static/app/views/automations/components/actionFilters/level.tsx
@@ -1,6 +1,7 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {
   LEVEL_CHOICES,

--- a/static/app/views/automations/components/actionFilters/percentSessions.tsx
+++ b/static/app/views/automations/components/actionFilters/percentSessions.tsx
@@ -1,8 +1,9 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {RowLine} from 'sentry/components/workflowEngine/form/automationBuilderRowLine';
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import {

--- a/static/app/views/automations/components/actionFilters/seerActivityTrigger.tsx
+++ b/static/app/views/automations/components/actionFilters/seerActivityTrigger.tsx
@@ -1,9 +1,9 @@
 import {Flex} from '@sentry/scraps/layout';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Text} from '@sentry/scraps/text';
 
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import type {ValidateDataConditionProps} from 'sentry/views/automations/components/automationFormData';

--- a/static/app/views/automations/components/actionFilters/subfiltersList.tsx
+++ b/static/app/views/automations/components/actionFilters/subfiltersList.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {uuid4} from '@sentry/core';
 
 import {Button} from '@sentry/scraps/button';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {AutomationBuilderInput} from 'sentry/components/workflowEngine/form/automationBuilderInput';
 import {RowLine} from 'sentry/components/workflowEngine/form/automationBuilderRowLine';
@@ -10,7 +11,6 @@ import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/aut
 import {PurpleTextButton} from 'sentry/components/workflowEngine/ui/purpleTextButton';
 import {IconAdd, IconDelete} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {
   DataConditionType,
   type AttributeSubfilter,

--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -1,10 +1,11 @@
 import {useMemo} from 'react';
 
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {useFetchOrganizationTags} from 'sentry/actionCreators/tags';
 import {AutomationBuilderInput} from 'sentry/components/workflowEngine/form/automationBuilderInput';
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Tag} from 'sentry/types/group';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {useOrganization} from 'sentry/utils/useOrganization';

--- a/static/app/views/automations/components/actions/email.tsx
+++ b/static/app/views/automations/components/actions/email.tsx
@@ -1,4 +1,5 @@
 import {Container} from '@sentry/scraps/layout';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import SelectMembers from 'sentry/components/selectMembers';
 import {TeamSelector} from 'sentry/components/teamSelector';
@@ -8,7 +9,6 @@ import {
 } from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Action} from 'sentry/types/workflowEngine/actions';
 import {ActionTarget} from 'sentry/types/workflowEngine/actions';
 import {useOrganization} from 'sentry/utils/useOrganization';

--- a/static/app/views/automations/components/actions/integrationField.tsx
+++ b/static/app/views/automations/components/actions/integrationField.tsx
@@ -1,6 +1,7 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {useActionNodeContext} from 'sentry/views/automations/components/actionNodes';
 
 export function IntegrationField() {

--- a/static/app/views/automations/components/actions/opsgenie.tsx
+++ b/static/app/views/automations/components/actions/opsgenie.tsx
@@ -1,7 +1,8 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {ActionMetadata} from 'sentry/components/workflowEngine/ui/actionMetadata';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Action, ActionHandler} from 'sentry/types/workflowEngine/actions';
 import {ActionType} from 'sentry/types/workflowEngine/actions';
 import {useActionNodeContext} from 'sentry/views/automations/components/actionNodes';

--- a/static/app/views/automations/components/actions/pagerduty.tsx
+++ b/static/app/views/automations/components/actions/pagerduty.tsx
@@ -1,7 +1,8 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {ActionMetadata} from 'sentry/components/workflowEngine/ui/actionMetadata';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Action, ActionHandler} from 'sentry/types/workflowEngine/actions';
 import {ActionType} from 'sentry/types/workflowEngine/actions';
 import {useActionNodeContext} from 'sentry/views/automations/components/actionNodes';

--- a/static/app/views/automations/components/actions/serviceField.tsx
+++ b/static/app/views/automations/components/actions/serviceField.tsx
@@ -1,6 +1,7 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {useActionNodeContext} from 'sentry/views/automations/components/actionNodes';
 
 export function ServiceField() {

--- a/static/app/views/automations/components/actions/webhook.tsx
+++ b/static/app/views/automations/components/actions/webhook.tsx
@@ -1,6 +1,7 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Action, ActionHandler} from 'sentry/types/workflowEngine/actions';
 import {useActionNodeContext} from 'sentry/views/automations/components/actionNodes';
 

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -3,12 +3,12 @@ import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Container, Flex} from '@sentry/scraps/layout';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
 import {PurpleTextButton} from 'sentry/components/workflowEngine/ui/purpleTextButton';
 import {IconAdd} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {
   DataConditionGroupLogicType,
   DataConditionHandlerGroupType,

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -1,9 +1,11 @@
 import trimStart from 'lodash/trimStart';
 
+import type {SelectValue} from '@sentry/scraps/select';
+
 import type {Client} from 'sentry/api';
 import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
-import type {PageFilters, SelectValue} from 'sentry/types/core';
+import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
 import type {TagCollection} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -2,13 +2,13 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import {Link} from '@sentry/scraps/link';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {doEventsRequest} from 'sentry/actionCreators/events';
 import type {ResponseMeta} from 'sentry/api';
 import {isMultiSeriesStats} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import type {
   EventsStats,

--- a/static/app/views/dashboards/datasetConfig/releases.tsx
+++ b/static/app/views/dashboards/datasetConfig/releases.tsx
@@ -1,7 +1,8 @@
 import omit from 'lodash/omit';
 
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Organization, SessionApiResponse} from 'sentry/types/organization';
 import {SessionField} from 'sentry/types/sessions';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
@@ -2,11 +2,11 @@ import {Fragment, useEffect} from 'react';
 
 import {Flex} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {FieldGroup} from 'sentry/components/forms/fieldGroup';
 import {t, tn} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import {useOrganization} from 'sentry/utils/useOrganization';

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelectors.tsx
@@ -4,10 +4,10 @@ import trimStart from 'lodash/trimStart';
 import uniqBy from 'lodash/uniqBy';
 
 import {Select} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import {
   EQUATION_PREFIX,

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -11,12 +11,12 @@ import {Input} from '@sentry/scraps/input';
 import {Container, Flex, Stack, type FlexProps} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {RadioLineItem} from 'sentry/components/forms/controls/radioGroup';
 import {FieldGroup} from 'sentry/components/forms/fieldGroup';
 import {IconDelete} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import {defined} from 'sentry/utils/defined';

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
@@ -4,9 +4,9 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/visualizeGhostField.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/visualizeGhostField.tsx
@@ -2,11 +2,11 @@ import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {DragReorderButton} from 'sentry/components/dnd/dragReorderButton';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {
   generateFieldAsString,
   parseFunction,

--- a/static/app/views/dashboards/widgetBuilder/issueWidget/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/issueWidget/utils.tsx
@@ -1,4 +1,5 @@
-import type {SelectValue} from 'sentry/types/core';
+import type {SelectValue} from '@sentry/scraps/select';
+
 import type {Organization} from 'sentry/types/organization';
 import {DisplayType} from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';

--- a/static/app/views/dashboards/widgetBuilder/releaseWidget/fields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/releaseWidget/fields.tsx
@@ -1,6 +1,7 @@
 import invert from 'lodash/invert';
 
-import type {SelectValue} from 'sentry/types/core';
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {SessionStatus} from 'sentry/types/organization';
 import type {
   SessionAggregationColumn,

--- a/static/app/views/detectors/components/forms/cron/detect.tsx
+++ b/static/app/views/detectors/components/forms/cron/detect.tsx
@@ -3,6 +3,7 @@ import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {ExternalLink} from '@sentry/scraps/link';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Text} from '@sentry/scraps/text';
 
 import {FieldWrapper} from 'sentry/components/forms/fieldGroup/fieldWrapper';
@@ -16,7 +17,6 @@ import {
 } from 'sentry/components/workflowEngine/ui/formSection';
 import {timezoneOptions} from 'sentry/data/timezones';
 import {t, tct, tn} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {
   CRON_DEFAULT_CHECKIN_MARGIN,
   CRON_DEFAULT_FAILURE_ISSUE_THRESHOLD,

--- a/static/app/views/detectors/components/forms/metric/useDatasetChoices.tsx
+++ b/static/app/views/detectors/components/forms/metric/useDatasetChoices.tsx
@@ -1,9 +1,9 @@
 import {useMemo} from 'react';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';

--- a/static/app/views/detectors/components/forms/metric/visualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/visualize.tsx
@@ -6,11 +6,11 @@ import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Input} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {FormContext} from 'sentry/components/forms/formContext';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {AggregateParameter} from 'sentry/utils/discover/fields';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {

--- a/static/app/views/detectors/datasetConfig/base.tsx
+++ b/static/app/views/detectors/datasetConfig/base.tsx
@@ -1,6 +1,7 @@
 import type {UseQueryOptions} from '@tanstack/react-query';
 
-import type {SelectValue} from 'sentry/types/core';
+import type {SelectValue} from '@sentry/scraps/select';
+
 import type {Series} from 'sentry/types/echarts';
 import type {TagCollection} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';

--- a/static/app/views/detectors/datasetConfig/eapBase.tsx
+++ b/static/app/views/detectors/datasetConfig/eapBase.tsx
@@ -1,4 +1,5 @@
-import type {SelectValue} from 'sentry/types/core';
+import type {SelectValue} from '@sentry/scraps/select';
+
 import type {Series} from 'sentry/types/echarts';
 import type {TagCollection} from 'sentry/types/group';
 import type {EventsStats, Organization} from 'sentry/types/organization';

--- a/static/app/views/detectors/datasetConfig/errors.tsx
+++ b/static/app/views/detectors/datasetConfig/errors.tsx
@@ -1,5 +1,6 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {EventsStats} from 'sentry/types/organization';
 import type {QueryFieldValue} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';

--- a/static/app/views/detectors/datasetConfig/releases.tsx
+++ b/static/app/views/detectors/datasetConfig/releases.tsx
@@ -1,5 +1,6 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {SessionField} from 'sentry/types/sessions';
 import type {

--- a/static/app/views/detectors/datasetConfig/spans.tsx
+++ b/static/app/views/detectors/datasetConfig/spans.tsx
@@ -1,5 +1,6 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import type {EventsStats, Organization} from 'sentry/types/organization';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';

--- a/static/app/views/detectors/datasetConfig/transactions.tsx
+++ b/static/app/views/detectors/datasetConfig/transactions.tsx
@@ -1,5 +1,6 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import type {EventsStats, Organization} from 'sentry/types/organization';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';

--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -7,6 +7,7 @@ import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Switch} from '@sentry/scraps/switch';
 
 import Feature from 'sentry/components/acl/feature';
@@ -17,7 +18,6 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SearchBar} from 'sentry/components/searchBar';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {SavedQuery} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';

--- a/static/app/views/discover/results/chartFooter.tsx
+++ b/static/app/views/discover/results/chartFooter.tsx
@@ -1,3 +1,5 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {IntervalSelector} from 'sentry/components/charts/intervalSelector';
 import {OptionSelector} from 'sentry/components/charts/optionSelector';
 import {
@@ -7,7 +9,6 @@ import {
   SectionValue,
 } from 'sentry/components/charts/styles';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {EventView} from 'sentry/utils/discover/eventView';
 import {TOP_EVENT_MODES} from 'sentry/utils/discover/types';
 

--- a/static/app/views/discover/results/resultsChart.tsx
+++ b/static/app/views/discover/results/resultsChart.tsx
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 import type {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 
+import type {SelectValue} from '@sentry/scraps/select';
+
 import type {Client} from 'sentry/api';
 import {AreaChart} from 'sentry/components/charts/areaChart';
 import {BarChart} from 'sentry/components/charts/barChart';
@@ -12,7 +14,6 @@ import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {Panel} from 'sentry/components/panels/panel';
 import {Placeholder} from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import {CustomMeasurementsContext} from 'sentry/utils/customMeasurements/customMeasurementsContext';

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -8,6 +8,7 @@ import type {InputProps} from '@sentry/scraps/input';
 import {Input} from '@sentry/scraps/input';
 import type {ControlProps} from '@sentry/scraps/select';
 import {Select} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import type {SingleValueProps} from 'sentry/components/forms/controls/reactSelectWrapper';
@@ -15,7 +16,6 @@ import {components} from 'sentry/components/forms/controls/reactSelectWrapper';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {pulse} from 'sentry/styles/animations';
-import type {SelectValue} from 'sentry/types/core';
 import type {
   AggregateParameter,
   AggregationKeyWithAlias,

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -1,11 +1,13 @@
 import type {Location} from 'history';
 import * as Papa from 'papaparse';
 
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
 import {URL_PARAM} from 'sentry/components/pageFilters/constants';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEditable';
 import {t} from 'sentry/locale';
-import type {PageFilters, SelectValue} from 'sentry/types/core';
+import type {PageFilters} from 'sentry/types/core';
 import type {Event} from 'sentry/types/event';
 import type {NewQuery, Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';

--- a/static/app/views/explore/logs/exports/generateLogExportRowCountOptions.ts
+++ b/static/app/views/explore/logs/exports/generateLogExportRowCountOptions.ts
@@ -1,5 +1,6 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {formatNumber} from 'sentry/utils/number/formatNumber';
 import {QUERY_PAGE_LIMIT} from 'sentry/views/explore/logs/constants';

--- a/static/app/views/insights/crons/components/monitorForm.tsx
+++ b/static/app/views/insights/crons/components/monitorForm.tsx
@@ -5,6 +5,7 @@ import {Observer} from 'mobx-react-lite';
 
 import {Alert, AlertLink} from '@sentry/scraps/alert';
 import {ExternalLink} from '@sentry/scraps/link';
+import type {SelectValue} from '@sentry/scraps/select';
 import {Text} from '@sentry/scraps/text';
 
 import {FieldWrapper} from 'sentry/components/forms/fieldGroup/fieldWrapper';
@@ -24,7 +25,6 @@ import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {timezoneOptions} from 'sentry/data/timezones';
 import {t, tct, tn} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {slugify} from 'sentry/utils/slugify';
 import {useOrganization} from 'sentry/utils/useOrganization';

--- a/static/app/views/insights/crons/utils.tsx
+++ b/static/app/views/insights/crons/utils.tsx
@@ -1,6 +1,7 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import type {TickStyle} from 'sentry/components/checkInTimeline/types';
 import {t, tn} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -2,6 +2,8 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {BarSeriesOption, LegendComponentOption, SeriesOption} from 'echarts';
 
+import type {SelectValue} from '@sentry/scraps/select';
+
 import type {BaseChartProps} from 'sentry/components/charts/baseChart';
 import {BaseChart} from 'sentry/components/charts/baseChart';
 import {Legend} from 'sentry/components/charts/components/legend';
@@ -14,7 +16,7 @@ import {Placeholder} from 'sentry/components/placeholder';
 import {DATA_CATEGORY_INFO} from 'sentry/constants';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {DataCategory, IntervalPeriod, SelectValue} from 'sentry/types/core';
+import type {DataCategory, IntervalPeriod} from 'sentry/types/core';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import type {Theme} from 'sentry/utils/theme';

--- a/static/app/views/performance/transactionSummary/transactionTags/constants.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/constants.tsx
@@ -1,5 +1,6 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 
 import {XAxisOption} from './types';
 

--- a/static/app/views/projectDetail/projectCharts.tsx
+++ b/static/app/views/projectDetail/projectCharts.tsx
@@ -3,6 +3,8 @@ import type {Theme} from '@emotion/react';
 import {withTheme} from '@emotion/react';
 import type {Location} from 'history';
 
+import type {SelectValue} from '@sentry/scraps/select';
+
 import type {Client} from 'sentry/api';
 import {BarChart} from 'sentry/components/charts/barChart';
 import {LoadingPanel} from 'sentry/components/charts/loadingPanel';
@@ -24,7 +26,6 @@ import {
 import {Panel} from 'sentry/components/panels/panel';
 import {Placeholder} from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';

--- a/static/app/views/settings/account/notifications/fields.tsx
+++ b/static/app/views/settings/account/notifications/fields.tsx
@@ -2,12 +2,12 @@ import {Fragment} from 'react';
 import upperFirst from 'lodash/upperFirst';
 
 import {ExternalLink} from '@sentry/scraps/link';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import type {Field} from 'sentry/components/forms/types';
 import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {DATA_CATEGORY_INFO} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import {DataCategoryExact} from 'sentry/types/core';
 import {getPricingDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
 

--- a/static/app/views/settings/organizationDataForwarding/util/forms.tsx
+++ b/static/app/views/settings/organizationDataForwarding/util/forms.tsx
@@ -1,10 +1,10 @@
 import {z} from 'zod';
 
 import {withFieldGroup} from '@sentry/scraps/form';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {IdBadge} from 'sentry/components/idBadge';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Project} from 'sentry/types/project';
 import type {DataForwarder} from 'sentry/views/settings/organizationDataForwarding/util/types';
 

--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.new.tsx
@@ -11,12 +11,13 @@ import {queryOptions, useMutation, useQueryClient} from '@tanstack/react-query';
 import omitBy from 'lodash/omitBy';
 
 import {Flex} from '@sentry/scraps/layout';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {BackendJsonSubmitForm} from 'sentry/components/backendJsonFormAdapter/backendJsonSubmitForm';
 import type {JsonFormAdapterFieldConfig} from 'sentry/components/backendJsonFormAdapter/types';
 import {t} from 'sentry/locale';
-import type {Choices, Choice, SelectValue} from 'sentry/types/core';
+import type {Choices, Choice} from 'sentry/types/core';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {unreachable} from 'sentry/utils/unreachable';

--- a/static/gsApp/views/spendAllocations/components/projectSelectControl.tsx
+++ b/static/gsApp/views/spendAllocations/components/projectSelectControl.tsx
@@ -5,10 +5,10 @@
 import {useMemo} from 'react';
 
 import {Select} from '@sentry/scraps/select';
+import type {SelectValue} from '@sentry/scraps/select';
 
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {t} from 'sentry/locale';
-import type {SelectValue} from 'sentry/types/core';
 import type {Project} from 'sentry/types/project';
 import {useProjects} from 'sentry/utils/useProjects';
 


### PR DESCRIPTION
## Why

Part of the series shrinking the frontend's largest type-import strongly-connected component (SCC).

`types/core` is a foundational types module (imported by ~155 other modules), but it imported `MenuListItemProps` from `@sentry/scraps/menuListItem` for a single reason: to declare `export interface SelectValue<T> extends MenuListItemProps`. `SelectValue` is the option format for react-select-based components — a UI-component concept with no business in a foundational types module. That one edge gave every `types/core` dependent a transitive type-import edge into the heavy `menuListItem` component.

## What

Move `SelectValue` to a leaf `components/core/select/types` and expose it through the `@sentry/scraps/select` public entry, alongside the existing `GeneralSelectValue` (`SelectValue<any>`) and `ControlProps` types that already live there.

- `types/core` no longer imports `@sentry/scraps/menuListItem` — the edge is cut at the foundational module.
- The ~90 files that actually use `SelectValue` now import it from `@sentry/scraps/select`; the other ~65 `types/core` dependents shed the transitive dependency entirely.
- Files inside `components/core` import from the `components/core/select/types` leaf directly (allowed within the `core` boundary), avoiding the public-entry self-cycle.

No behavior change — type-only move.
