### PR TITLE
feat(cmdk): surface Client Keys (DSN) when searching "SENTRY_DSN"

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
@@ -331,8 +331,10 @@ describe('GlobalCommandPaletteActions - search recall', () => {
     ['codeowners', /Project Settings.*Ownership Rules/],
     ['inbound', /Project Settings.*Inbound Filters/],
     ['size', /Project Settings.*Mobile Builds/],
-    // The SDK env var name should surface Client Keys (DSN), just like "dsn".
+    // The SDK env var name (and its spaced form) should surface Client Keys
+    // (DSN), just like "dsn".
     ['SENTRY_DSN', /Project Settings.*Client Keys \(DSN\)/],
+    ['sentry dsn', /Project Settings.*Client Keys \(DSN\)/],
   ])('finds expected actions for %s', async (query, ...expectedOptions) => {
     renderPalette();
 

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
@@ -331,6 +331,8 @@ describe('GlobalCommandPaletteActions - search recall', () => {
     ['codeowners', /Project Settings.*Ownership Rules/],
     ['inbound', /Project Settings.*Inbound Filters/],
     ['size', /Project Settings.*Mobile Builds/],
+    // The SDK env var name should surface Client Keys (DSN), just like "dsn".
+    ['SENTRY_DSN', /Project Settings.*Client Keys \(DSN\)/],
   ])('finds expected actions for %s', async (query, ...expectedOptions) => {
     renderPalette();
 

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -644,6 +644,7 @@ export function GlobalCommandPaletteActions() {
                 t('client keys'),
                 t('dsn key'),
                 'SENTRY_DSN',
+                'Sentry DSN',
                 project.slug,
               ]}
               to={`/settings/${organization.slug}/projects/${project.slug}/keys/`}

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -639,7 +639,13 @@ export function GlobalCommandPaletteActions() {
                 icon: <ProjectAvatar project={project} size={16} />,
                 trailingItem: <Tag variant="muted">{t('Current')}</Tag>,
               }}
-              keywords={[t('dsn'), t('client keys'), t('dsn key'), project.slug]}
+              keywords={[
+                t('dsn'),
+                t('client keys'),
+                t('dsn key'),
+                'SENTRY_DSN',
+                project.slug,
+              ]}
               to={`/settings/${organization.slug}/projects/${project.slug}/keys/`}
             />
           ))}

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -182,9 +182,11 @@ export function getNavigationConfiguration({
           description: t("View and manage the project's client keys (DSN)"),
           keywords: [
             t('dsn'),
-            // The SDK environment variable name developers search for.
-            // Not wrapped in t() — it's a fixed config token, not translatable.
+            // The SDK environment variable name (and its spaced form) that
+            // developers search for. Not wrapped in t() — these are fixed
+            // config/product tokens, not translatable prose.
             'SENTRY_DSN',
+            'Sentry DSN',
             t('auth'),
             t('token'),
             t('client key'),

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -182,6 +182,9 @@ export function getNavigationConfiguration({
           description: t("View and manage the project's client keys (DSN)"),
           keywords: [
             t('dsn'),
+            // The SDK environment variable name developers search for.
+            // Not wrapped in t() — it's a fixed config token, not translatable.
+            'SENTRY_DSN',
             t('auth'),
             t('token'),
             t('client key'),


### PR DESCRIPTION
## Summary

Typing `SENTRY_DSN` (or `Sentry DSN`) into the CMD-K command palette now surfaces **Client Keys (DSN)**, just like typing `dsn` already does.

`SENTRY_DSN` is the SDK environment variable developers set to configure their DSN, so it's a natural thing to search for when looking for that page — but it returned nothing before.

## Why it didn't work

The palette scores each action by fuzzy-matching the query against its `label`, `details`, and `keywords` via `fzf` (`commandPalette.tsx`). `fzf` is a strict **subsequence** matcher: every character of the query must appear, in order, in a candidate string. Plain `dsn` worked because `dsn` is a keyword on the Client Keys actions. `SENTRY_DSN` failed because none of those keywords contained an underscore, so the `_` alone broke the match.

## Change

Add `SENTRY_DSN` and the spaced `Sentry DSN` form as keywords in the two places that surface Client Keys (DSN):

- **`navigationConfiguration.tsx`** — the canonical "Client Keys (DSN)" project-settings nav item. This feeds both the CMD-K project-settings group and the regular settings search, so both now respond.
- **`commandPaletteGlobalActions.tsx`** — the current-project quick shortcut ("Client Keys (DSN) - <project>"), so on a project page you get the same parity with `dsn`.

The two keyword forms together cover the env-var (`sentry_dsn`), spaced (`sentry dsn`), and no-separator (`sentrydsn`) inputs. The tokens are left unwrapped (not `t()`) since they're fixed config/product strings, not translatable prose — matching how `project.slug` is already used in those arrays.

## Test plan

- Added `SENTRY_DSN` and `sentry dsn` cases to the existing search-recall `it.each` in `commandPaletteGlobalActions.spec.tsx`.
- `commandPaletteGlobalActions.spec.tsx` → 17/17 pass.
- `lint:js` on all changed files → clean.

https://claude.ai/code/session_01PMrmgRxmMfZF3J7XyhF5yG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMrmgRxmMfZF3J7XyhF5yG)_