### PR TITLE
fix(issue details): Show PR author name instead of "Sentry" in activity feed

### DIFF
--- a/static/app/components/commitRow.spec.tsx
+++ b/static/app/components/commitRow.spec.tsx
@@ -98,6 +98,8 @@ describe('commitRow', () => {
       pullRequest: {
         id: '9',
         title: 'cool pr',
+        message: null,
+        dateCreated: '2022-10-07T19:35:27.370422Z',
         externalUrl: 'https://github.com/getsentry/sentry/pull/1',
         repository: {
           id: '14',

--- a/static/app/components/discover/quickContextCommitRow.spec.tsx
+++ b/static/app/components/discover/quickContextCommitRow.spec.tsx
@@ -53,6 +53,8 @@ describe('Quick Context Commit Row', () => {
       pullRequest: {
         id: '9',
         title: 'cool pr',
+        message: null,
+        dateCreated: '2022-10-07T19:35:27.370422Z',
         externalUrl: 'https://github.com/getsentry/sentry/pull/1',
         repository: {
           id: '14',

--- a/static/app/components/pullRequestLink.tsx
+++ b/static/app/components/pullRequestLink.tsx
@@ -32,7 +32,7 @@ type Props = {
 };
 
 export function PullRequestLink({pullRequest, repository}: Props) {
-  const displayId = `${repository.name} #${pullRequest.id}: ${pullRequest.title}`;
+  const displayId = `${repository.name} #${pullRequest.id}: ${pullRequest.title ?? ''}`;
 
   if (!pullRequest.externalUrl) {
     return (

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -144,10 +144,13 @@ export type CommitFile = {
 };
 
 export type PullRequest = {
+  dateCreated: string;
   externalUrl: string;
   id: string;
+  message: string | null;
   repository: Repository;
-  title: string;
+  title: string | null;
+  author?: CommitAuthor;
 };
 
 /**

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -2,6 +2,7 @@ import {CommitFixture} from 'sentry-fixture/commit';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {PullRequestFixture} from 'sentry-fixture/pullRequest';
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 import {UserFixture} from 'sentry-fixture/user';
 
@@ -658,5 +659,77 @@ describe('ActivitySection', () => {
 
     render(<ActivitySection group={seerPrGroup} />, {organization: org});
     expect(screen.queryByText('Pull Request Created')).not.toBeInTheDocument();
+  });
+
+  it('renders PR author name when activity user is null', async () => {
+    const prGroup = GroupFixture({
+      id: '1345',
+      activity: [
+        {
+          type: GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST,
+          id: 'pr-author-1',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            pullRequest: PullRequestFixture({
+              author: {name: 'Shashank N Jarmale', email: 'shash@sentry.io'},
+            }),
+          },
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(<ActivitySection group={prGroup} />);
+    expect(await screen.findByText('Pull Request Created')).toBeInTheDocument();
+    expect(screen.getByText('Shashank N Jarmale')).toBeInTheDocument();
+    expect(screen.queryByText('Sentry')).not.toBeInTheDocument();
+  });
+
+  it('falls back to Sentry when PR has no author', async () => {
+    const prGroup = GroupFixture({
+      id: '1346',
+      activity: [
+        {
+          type: GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST,
+          id: 'pr-author-2',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            pullRequest: PullRequestFixture(),
+          },
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(<ActivitySection group={prGroup} />);
+    expect(await screen.findByText('Pull Request Created')).toBeInTheDocument();
+    expect(screen.getByText('Sentry')).toBeInTheDocument();
+  });
+
+  it('falls back to Sentry for bot authors with @localhost email', async () => {
+    const prGroup = GroupFixture({
+      id: '1347',
+      activity: [
+        {
+          type: GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST,
+          id: 'pr-author-3',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            pullRequest: PullRequestFixture({
+              author: {name: 'sentry[bot]', email: 'sentry[bot]@localhost'},
+            }),
+          },
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(<ActivitySection group={prGroup} />);
+    expect(await screen.findByText('Pull Request Created')).toBeInTheDocument();
+    expect(screen.getByText('Sentry')).toBeInTheDocument();
+    expect(screen.queryByText('sentry[bot]')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -44,6 +44,13 @@ function getAuthorName(item: GroupActivity) {
   if (item.user) {
     return item.user.name;
   }
+  if (
+    item.type === GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST &&
+    item.data.pullRequest?.author?.name &&
+    !item.data.pullRequest.author.email?.endsWith('@localhost')
+  ) {
+    return item.data.pullRequest.author.name;
+  }
   return 'Sentry';
 }
 

--- a/tests/js/fixtures/pullRequest.ts
+++ b/tests/js/fixtures/pullRequest.ts
@@ -7,6 +7,8 @@ export function PullRequestFixture(params: Partial<PullRequest> = {}): PullReque
     id: '3',
     repository: RepositoryFixture(),
     title: 'Fix first issue',
+    message: null,
+    dateCreated: '2024-01-01T00:00:00.000000Z',
     externalUrl: 'https://example.github.com/example/repo-name/pulls/3',
     ...params,
   };


### PR DESCRIPTION
The issue activity feed showed "Pull Request Created by Sentry" for all PRs where the author's GitHub email was private, since we were unable to match GitHub user with Sentry user based on email at the time of `Activity` creation. The PR serializer already resolves the correct author at read time via `ExternalActor` mappings, so this PR updates the frontend to actually use that data if needed (aka as a fallback).

This PR updates the `PullRequest` TypeScript type to match the backend's `PullRequestSerializerResponse` (added missing `dateCreated`, `message`, nullable `title`, and `author` fields). `getAuthorName()` now falls back to `pullRequest.author.name` when `Activity.user` is null, skipping bot/unresolved authors with `@localhost` placeholder emails.

[Example issue where this fix applies](https://sentry.sentry.io/issues/7462207863/?project=6178942)

**Before**

<img width="334" height="204" alt="image" src="https://github.com/user-attachments/assets/2edf0dd1-2a42-480a-ba8d-ec5c157b169f" />

**After**

<img width="335" height="199" alt="image" src="https://github.com/user-attachments/assets/7810e66c-d22c-4a8a-898b-aa36032c2b0a" />


[Slack thread for context](https://sentry.slack.com/archives/C04KZQBNQ2U/p1780481679570519)