### PR TITLE
feat(night_shift): Gate Seer feature delivery behind an option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1187,6 +1187,12 @@ register(
     default=10,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "seer.night_shift.use_feature_delivery",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "seer.supergroups_backfill_lightweight.killswitch",

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -102,6 +102,12 @@ class AgentPrStateRequest(TypedDict):
     pr_id: int
 
 
+class SeerFeatureRunRequest(TypedDict):
+    feature_id: str
+    ref: str
+    payload: dict[str, Any]
+
+
 def make_agent_state_request(
     body: AgentStateRequest,
     connection_pool: HTTPConnectionPool | None = None,
@@ -165,6 +171,28 @@ def make_agent_state_pr_request(
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
         viewer_context=viewer_context,
     )
+
+
+def trigger_seer_feature(
+    body: SeerFeatureRunRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
+) -> int | None:
+    """Trigger a Seer feature run and return the resulting agent run id.
+
+    Seer runs the feature asynchronously and pushes results back via
+    deliver_feature_result. Raises SeerApiError on a non-2xx response.
+    """
+    response = make_signed_seer_api_request(
+        connection_pool or agent_connection_pool,
+        "/v1/automation/agent/feature/run",
+        body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+        viewer_context=viewer_context,
+    )
+    if response.status >= 400:
+        raise SeerApiError("Seer feature run request failed", response.status)
+
+    return response.json().get("run_id")
 
 
 def get_agent_state_from_pr_id(

--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -70,6 +70,14 @@ def deliver_night_shift_result(
     options = (run.extras or {}).get("options") or {}
     dry_run = bool(options.get("dry_run", False))
 
+    # A failed dispatch may have left a stale error_message even though Seer went
+    # on to process the run and is now delivering verdicts. Clear it so the run's
+    # state reflects the successful delivery.
+    if (run.extras or {}).get("error_message"):
+        extras = {**run.extras}
+        del extras["error_message"]
+        run.update(extras=extras)
+
     _process_verdicts(
         run=run,
         organization=run.organization,

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -8,7 +8,9 @@ from datetime import timedelta
 from typing import Any, Literal, TypedDict
 
 import sentry_sdk
+from django.utils import timezone
 
+import sentry
 from sentry import features, options, quotas
 from sentry.constants import (
     SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
@@ -17,6 +19,7 @@ from sentry.constants import (
 )
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
+from sentry.seer.agent.client_utils import SeerFeatureRunRequest, trigger_seer_feature
 from sentry.seer.autofix.autofix_agent import AutofixStep, trigger_autofix_agent
 from sentry.seer.autofix.constants import (
     AutofixAutomationTuningSettings,
@@ -29,11 +32,13 @@ from sentry.seer.models.night_shift import (
     SeerNightShiftRunResult,
 )
 from sentry.seer.models.project_repository import SeerProjectRepository
-from sentry.seer.models.run import SeerRun
+from sentry.seer.models.run import SeerRun, SeerRunType
 from sentry.seer.models.workflow import SeerWorkflowConfig, SeerWorkflowStrategy
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.seer.night_shift.agentic_triage import agentic_triage_strategy
 from sentry.tasks.seer.night_shift.models import TriageAction, TriageResult
+from sentry.tasks.seer.night_shift.simple_triage import fixability_score_strategy
 from sentry.tasks.seer.night_shift.tweaks import (
     DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS,
     DEFAULT_INTELLIGENCE_LEVEL,
@@ -299,73 +304,13 @@ def run_night_shift_execution(
         logger.info("night_shift.no_eligible_projects", extra=log_extra)
         return None
 
-    eligible_projects = [ep.project for ep in eligible]
-    agent_run_id: int | None = None
-    try:
-        candidates, agent_run_id = agentic_triage_strategy(
-            eligible_projects,
-            organization,
-            resolved_options["max_candidates"],
-            intelligence_level=resolved_options["intelligence_level"],
-            reasoning_effort=resolved_options["reasoning_effort"],
-            extra_triage_instructions=resolved_options["extra_triage_instructions"],
-            run=run,
+    # sentry.options.get (not options.get) because the `options` param shadows the module here.
+    if sentry.options.get("seer.night_shift.use_feature_delivery"):
+        _dispatch_to_seer_feature(
+            run, organization, eligible, resolved_options, log_extra, start_time
         )
-        if agent_run_id is not None:
-            log_extra["agent_run_id"] = agent_run_id
-    except Exception:
-        sentry_sdk.metrics.count("night_shift.run_error", 1)
-        _fail_run(
-            run,
-            message="Night shift run failed",
-            event="night_shift.run_failed",
-            extra={**log_extra, "agent_run_id": agent_run_id},
-        )
-        return None
-
-    sentry_sdk.metrics.distribution("night_shift.candidates_selected", len(candidates))
-    sentry_sdk.metrics.distribution("night_shift.org_run_duration", time.monotonic() - start_time)
-
-    seer_run_id_by_group: dict[int, str | None] = {}
-    if not resolved_options["dry_run"]:
-        # Populate each candidate group's FK cache so trigger_autofix_agent doesn't
-        # re-fetch group.project on every call. Group.organization is a property that
-        # delegates to self.project.organization, so caching the org on the project is
-        # enough to avoid both lookups.
-        projects_by_id = {}
-        for p in eligible_projects:
-            p.organization = organization
-            projects_by_id[p.id] = p
-        for c in candidates:
-            c.group.project = projects_by_id[c.group.project_id]
-
-        stopping_point_by_project_id = {ep.project.id: ep.stopping_point for ep in eligible}
-        results = _run_autofix_for_candidates(
-            run=run,
-            candidates=candidates,
-            stopping_point_by_project_id=stopping_point_by_project_id,
-            log_extra=log_extra,
-        )
-        seer_run_id_by_group = {r.group_id: r.seer_run_id for r in results}
-
-    logger.info(
-        "night_shift.candidates_selected",
-        extra={
-            **log_extra,
-            "num_eligible_projects": len(eligible_projects),
-            "num_candidates": len(candidates),
-            "dry_run": resolved_options["dry_run"],
-            "candidates": [
-                {
-                    "group_id": c.group.id,
-                    "action": c.action,
-                    "seer_run_id": seer_run_id_by_group.get(c.group.id),
-                    "num_occurrences": c.group.times_seen,
-                }
-                for c in candidates
-            ],
-        },
-    )
+    else:
+        _run_triage_in_process(run, organization, eligible, resolved_options, log_extra, start_time)
 
 
 def _run_option_defaults(data: Mapping[str, Any]) -> SeerNightShiftRunOptions:
@@ -487,6 +432,164 @@ def _get_eligible_projects(
     if source == "cron":
         eligible = [ep for ep in eligible if ep.tweaks.enabled]
     return eligible
+
+
+def _dispatch_to_seer_feature(
+    run: SeerNightShiftRun,
+    organization: Organization,
+    eligible: Sequence[EligibleProject],
+    resolved_options: SeerNightShiftRunOptions,
+    log_extra: dict[str, object],
+    start_time: float,
+) -> None:
+    """Hand triage off to Seer's feature-run endpoint. Seer runs the triage agent
+    and pushes verdicts back via deliver_feature_result, which marks skips and
+    triggers autofix (using dry_run from run.extras["options"])."""
+    eligible_projects = [ep.project for ep in eligible]
+    scored = fixability_score_strategy(eligible_projects, resolved_options["max_candidates"])
+    if not scored:
+        logger.info("night_shift.no_candidates", extra=log_extra)
+        return
+
+    # SeerRun gives the run a uuid that the pushed-back result correlates on.
+    seer_run = SeerRun.objects.create(
+        organization=organization,
+        type=SeerRunType.EXPLORER,
+        last_triggered_at=timezone.now(),
+    )
+    run.update(seer_run=seer_run)
+
+    request = SeerFeatureRunRequest(
+        feature_id="night_shift",
+        ref=str(seer_run.uuid),
+        payload={
+            "candidates": [
+                {
+                    "group_id": c.group.id,
+                    "title": c.group.title,
+                    "culprit": c.group.culprit,
+                    "fixability": c.fixability,
+                    "times_seen": c.group.times_seen,
+                    "first_seen": c.group.first_seen,
+                    "priority": str(c.group.priority) if c.group.priority is not None else None,
+                }
+                for c in scored
+            ],
+            "tweaks": {
+                "intelligence_level": resolved_options["intelligence_level"],
+                "reasoning_effort": resolved_options["reasoning_effort"],
+                "extra_triage_instructions": resolved_options["extra_triage_instructions"],
+            },
+        },
+    )
+    try:
+        agent_run_id = trigger_seer_feature(
+            request,
+            viewer_context=SeerViewerContext(organization_id=organization.id),
+        )
+    except Exception:
+        sentry_sdk.metrics.count("night_shift.run_error", 1)
+        _fail_run(
+            run,
+            message="Night shift run failed",
+            event="night_shift.run_failed",
+            extra=log_extra,
+        )
+        return
+
+    if agent_run_id is not None:
+        run.update(extras={**run.extras, "agent_run_id": agent_run_id})
+
+    sentry_sdk.metrics.distribution("night_shift.org_run_duration", time.monotonic() - start_time)
+    logger.info(
+        "night_shift.feature_dispatched",
+        extra={
+            **log_extra,
+            "agent_run_id": agent_run_id,
+            "num_eligible_projects": len(eligible_projects),
+            "num_candidates": len(scored),
+        },
+    )
+
+
+def _run_triage_in_process(
+    run: SeerNightShiftRun,
+    organization: Organization,
+    eligible: Sequence[EligibleProject],
+    resolved_options: SeerNightShiftRunOptions,
+    log_extra: dict[str, object],
+    start_time: float,
+) -> None:
+    """DEPRECATED: run the triage agent in-process and trigger autofix directly.
+    Superseded by _dispatch_to_seer_feature; kept behind the
+    seer.night_shift.use_feature_delivery option until the cutover is complete."""
+    eligible_projects = [ep.project for ep in eligible]
+    agent_run_id: int | None = None
+    try:
+        candidates, agent_run_id = agentic_triage_strategy(
+            eligible_projects,
+            organization,
+            resolved_options["max_candidates"],
+            intelligence_level=resolved_options["intelligence_level"],
+            reasoning_effort=resolved_options["reasoning_effort"],
+            extra_triage_instructions=resolved_options["extra_triage_instructions"],
+            run=run,
+        )
+        if agent_run_id is not None:
+            log_extra["agent_run_id"] = agent_run_id
+    except Exception:
+        sentry_sdk.metrics.count("night_shift.run_error", 1)
+        _fail_run(
+            run,
+            message="Night shift run failed",
+            event="night_shift.run_failed",
+            extra={**log_extra, "agent_run_id": agent_run_id},
+        )
+        return
+
+    sentry_sdk.metrics.distribution("night_shift.candidates_selected", len(candidates))
+    sentry_sdk.metrics.distribution("night_shift.org_run_duration", time.monotonic() - start_time)
+
+    seer_run_id_by_group: dict[int, str | None] = {}
+    if not resolved_options["dry_run"]:
+        # Populate each candidate group's FK cache so trigger_autofix_agent doesn't
+        # re-fetch group.project on every call. Group.organization is a property that
+        # delegates to self.project.organization, so caching the org on the project is
+        # enough to avoid both lookups.
+        projects_by_id = {}
+        for p in eligible_projects:
+            p.organization = organization
+            projects_by_id[p.id] = p
+        for c in candidates:
+            c.group.project = projects_by_id[c.group.project_id]
+
+        stopping_point_by_project_id = {ep.project.id: ep.stopping_point for ep in eligible}
+        results = _run_autofix_for_candidates(
+            run=run,
+            candidates=candidates,
+            stopping_point_by_project_id=stopping_point_by_project_id,
+            log_extra=log_extra,
+        )
+        seer_run_id_by_group = {r.group_id: r.seer_run_id for r in results}
+
+    logger.info(
+        "night_shift.candidates_selected",
+        extra={
+            **log_extra,
+            "num_eligible_projects": len(eligible_projects),
+            "num_candidates": len(candidates),
+            "dry_run": resolved_options["dry_run"],
+            "candidates": [
+                {
+                    "group_id": c.group.id,
+                    "action": c.action,
+                    "seer_run_id": seer_run_id_by_group.get(c.group.id),
+                    "num_occurrences": c.group.times_seen,
+                }
+                for c in candidates
+            ],
+        },
+    )
 
 
 def _run_autofix_for_candidates(

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -38,7 +38,7 @@ from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.seer.night_shift.agentic_triage import agentic_triage_strategy
 from sentry.tasks.seer.night_shift.models import TriageAction, TriageResult
-from sentry.tasks.seer.night_shift.simple_triage import fixability_score_strategy
+from sentry.tasks.seer.night_shift.simple_triage import fixability_score_strategy, priority_label
 from sentry.tasks.seer.night_shift.tweaks import (
     DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS,
     DEFAULT_INTELLIGENCE_LEVEL,
@@ -471,7 +471,7 @@ def _dispatch_to_seer_feature(
                     "fixability": c.fixability,
                     "times_seen": c.group.times_seen,
                     "first_seen": c.group.first_seen,
-                    "priority": str(c.group.priority) if c.group.priority is not None else None,
+                    "priority": priority_label(c.group.priority),
                 }
                 for c in scored
             ],

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -339,6 +339,31 @@ class TestDeliverNightShiftResult(TestCase):
             user_context = mock_trigger.call_args.kwargs["user_context"]
             assert "This issue is caused by a null pointer" in user_context
 
+    def test_successful_delivery_clears_stale_error_message(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        group = self.create_group(project=project)
+        run = self._create_night_shift_run(organization=org, error_message="Night shift run failed")
+
+        result = {
+            "verdicts": [
+                {"group_id": group.id, "action": TriageAction.AUTOFIX.value, "reason": "fixable"}
+            ]
+        }
+
+        assert run.seer_run is not None
+        with patch("sentry.tasks.seer.night_shift.cron.trigger_autofix_agent", return_value=1):
+            deliver_night_shift_result(
+                organization_id=org.id,
+                run_uuid=str(run.seer_run.uuid),
+                status="completed",
+                result=result,
+                error=None,
+            )
+
+        run.refresh_from_db()
+        assert "error_message" not in run.extras
+
     def test_empty_reason_no_user_context(self) -> None:
         """Empty reason should result in no user_context."""
         org = self.create_organization()

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -671,7 +671,7 @@ class TestRunNightShiftFeatureDelivery(TestCase, SnubaTestCase):
         self._make_eligible(project)
 
         group = self._store_event_and_update_group(
-            project, "fixable", seer_fixability_score=0.9, times_seen=5
+            project, "fixable", seer_fixability_score=0.9, times_seen=5, priority=75
         )
 
         with (
@@ -693,6 +693,8 @@ class TestRunNightShiftFeatureDelivery(TestCase, SnubaTestCase):
         request = mock_trigger.call_args.args[0]
         assert request["feature_id"] == "night_shift"
         assert [c["group_id"] for c in request["payload"]["candidates"]] == [group.id]
+        # Priority is sent as a label ("high"), matching the in-process path.
+        assert request["payload"]["candidates"][0]["priority"] == "high"
         assert mock_trigger.call_args.kwargs["viewer_context"] == {"organization_id": org.id}
 
         run = SeerNightShiftRun.objects.get(organization=org)

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -639,6 +639,109 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
 
 
 @django_db_all
+class TestRunNightShiftFeatureDelivery(TestCase, SnubaTestCase):
+    """Coverage for the seer.night_shift.use_feature_delivery path, which hands
+    triage off to Seer's feature-run endpoint instead of running it in-process."""
+
+    reset_snuba_data = False
+
+    def _make_eligible(self, project, **tweak_overrides):
+        project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
+        )
+        repo = self.create_repo(project=project, provider="github", name=f"owner/{project.slug}")
+        self.create_seer_project_repository(project=project, repository=repo)
+        project.update_option("sentry:seer_nightshift_tweaks", {"enabled": True, **tweak_overrides})
+
+    def _store_event_and_update_group(self, project, fingerprint, **group_attrs):
+        event = self.store_event(
+            data={
+                "fingerprint": [fingerprint],
+                "timestamp": before_now(hours=1).isoformat(),
+                "environment": "production",
+            },
+            project_id=project.id,
+        )
+        Group.objects.filter(id=event.group_id).update(**group_attrs)
+        return Group.objects.get(id=event.group_id)
+
+    def test_dispatches_candidates_to_seer_feature(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project)
+
+        group = self._store_event_and_update_group(
+            project, "fixable", seer_fixability_score=0.9, times_seen=5
+        )
+
+        with (
+            self.options({"seer.night_shift.use_feature_delivery": True}),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.trigger_seer_feature",
+                return_value=4242,
+            ) as mock_trigger,
+            patch("sentry.tasks.seer.night_shift.cron.agentic_triage_strategy") as mock_in_process,
+            patch("sentry.tasks.seer.night_shift.cron.trigger_autofix_agent") as mock_autofix,
+        ):
+            run_night_shift_for_org(org.id)
+
+        # The deprecated in-process path is bypassed entirely.
+        mock_in_process.assert_not_called()
+        mock_autofix.assert_not_called()
+
+        mock_trigger.assert_called_once()
+        request = mock_trigger.call_args.args[0]
+        assert request["feature_id"] == "night_shift"
+        assert [c["group_id"] for c in request["payload"]["candidates"]] == [group.id]
+        assert mock_trigger.call_args.kwargs["viewer_context"] == {"organization_id": org.id}
+
+        run = SeerNightShiftRun.objects.get(organization=org)
+        assert run.seer_run is not None
+        assert request["ref"] == str(run.seer_run.uuid)
+        assert run.extras["agent_run_id"] == 4242
+        assert run.extras.get("error_message") is None
+        # Verdicts and autofix are Seer's responsibility now; no result rows here.
+        assert not SeerNightShiftRunResult.objects.filter(run=run).exists()
+
+    def test_no_candidates_skips_dispatch(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project)
+
+        with (
+            self.options({"seer.night_shift.use_feature_delivery": True}),
+            patch("sentry.tasks.seer.night_shift.cron.trigger_seer_feature") as mock_trigger,
+        ):
+            run_night_shift_for_org(org.id)
+
+        mock_trigger.assert_not_called()
+        run = SeerNightShiftRun.objects.get(organization=org)
+        assert run.seer_run is None
+
+    def test_seer_feature_error_records_error_message(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project)
+
+        self._store_event_and_update_group(
+            project, "fixable", seer_fixability_score=0.9, times_seen=5
+        )
+
+        with (
+            self.options({"seer.night_shift.use_feature_delivery": True}),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.trigger_seer_feature",
+                side_effect=RuntimeError("seer down"),
+            ),
+        ):
+            run_night_shift_for_org(org.id)
+
+        run = SeerNightShiftRun.objects.get(organization=org)
+        assert run.extras["error_message"] == "Night shift run failed"
+        assert "agent_run_id" not in run.extras
+
+
+@django_db_all
 class TestRunNightShiftForOrgManualPath(TestCase):
     """Manual-path coverage for run_night_shift_for_org — invoked from the
     project-settings "Run Now" endpoint with source="manual" and project_ids."""


### PR DESCRIPTION
Adds the `seer.night_shift.use_feature_delivery` option to control how night
shift triage runs.

When the option is enabled, night shift hands scored candidates to Seer's
feature-run endpoint via a new `trigger_seer_feature` helper, attaches a
`SeerRun` so the pushed-back result can be correlated, and stores the returned
agent run id on the run. Seer runs the triage agent and pushes verdicts back
through `deliver_feature_result` (marking skips / triggering autofix on its
side). When the option is disabled (the default), the existing in-process path
is used unchanged.

The in-process path is now isolated in `_run_triage_in_process` and marked
**deprecated** — keeping it behind the flag lets us validate the
feature-delivery path in production and cut over gradually before removing the
old code.

Also tidies the Seer call out of the cron module: the raw
`make_signed_seer_api_request` plumbing now lives in a dedicated
`trigger_seer_feature` function in `client_utils.py`, alongside the other
`make_agent_*` helpers.

Rollout of the option lives in `sentry-options-automator` (not in this repo).