### PR TITLE
docs(agents): Trim re-derivable inventory from static/AGENTS.md

### DIFF
--- a/static/AGENTS.md
+++ b/static/AGENTS.md
@@ -2,23 +2,8 @@
 
 > For critical commands and testing rules, see the "Command Execution Guide" section in `/AGENTS.md` in the repository root.
 
-## Frontend Tech Stack
+## File Location Map
 
-- **Language**: TypeScript
-- **Framework**: React 19
-- **Build Tool**: Rspack (Webpack alternative)
-- **Package management**: pnpm
-- **State Management**: Reflux, React Query (TanStack Query)
-- **Styling**: Emotion (CSS-in-JS), Less
-- **Testing**: Jest, React Testing Library
-
-## Important Files and Directories
-
-- `package.json`: Node.js dependencies and scripts
-- `rspack.config.ts`: Frontend build configuration
-- `tsconfig.json`: TypeScript configuration
-- `eslint.config.ts`: ESLint configuration
-- `stylelint.config.js`: CSS/styling linting
 - **Components**: `static/app/components/{component}/`
 - **Views**: `static/app/views/{area}/{page}.tsx`
 - **Stores**: `static/app/stores/{store}Store.tsx`


### PR DESCRIPTION
Remove the `Frontend Tech Stack` list and the build/config-file inventory (`package.json`, `rspack.config.ts`, `tsconfig.json`, `eslint.config.ts`, `stylelint.config.js`) from `static/AGENTS.md`. Both are cheaply re-derivable from the repo and drift out of date when duplicated in always-in-context guidance. The kept directory map is renamed to `File Location Map` to match `src/AGENTS.md` and `tests/AGENTS.md`. No actionable rule removed (16 deletions).

Continues the AGENTS.md context-bloat cleanup (#116868, #116874, #116875, #116881). This is the category-2 (cheaply re-derivable) cut for the frontend guide, reviving the change from #116876 which was closed unmerged.

The design-system → skill extraction already landed in #116881; the React Testing and TanStack sections are intentionally left inline — a loading experiment confirmed they apply repo-wide within `static/` with no narrower subtree to scope them to, so relocating would reduce coverage.


Agent transcript: https://claudescope.sentry.dev/share/6jt1q0dNuOlu6QAPglxoILYOZbbPGyFwcApmh7s033w