### PR TITLE
ref(api): tighten 15 endpoint return annotations to Response[T]

### DIFF
--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -144,7 +144,7 @@ class ProjectRepoPathParsingEndpoint(ProjectEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def post(self, request: Request, project: Project) -> Response:
+    def post(self, request: Request, project: Project) -> Response[RepoPathParsingResponse]:
         """
         Derive the code-mapping parameters (stack root, source root, default branch) that
         Sentry would create for a given stack trace frame and source code URL.

--- a/src/sentry/api/endpoints/project_servicehook_stats.py
+++ b/src/sentry/api/endpoints/project_servicehook_stats.py
@@ -73,7 +73,9 @@ class ProjectServiceHookStatsEndpoint(ServiceHookEndpoint, StatsMixin):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project: Project, hook: ServiceHook, **kwargs) -> Response:
+    def get(
+        self, request: Request, project: Project, hook: ServiceHook, **kwargs
+    ) -> Response[list[ServiceHookStatsResponse]]:
         """
         Return the number of times a service hook has fired over a time series range.
         """

--- a/src/sentry/api/endpoints/project_servicehooks.py
+++ b/src/sentry/api/endpoints/project_servicehooks.py
@@ -57,7 +57,7 @@ class ProjectServiceHooksEndpoint(ProjectEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project) -> Response[list[ServiceHookSerializerResponse]]:
         """
         Return a list of service hooks bound to a project.
 
@@ -100,7 +100,7 @@ class ProjectServiceHooksEndpoint(ProjectEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def post(self, request: Request, project) -> Response:
+    def post(self, request: Request, project) -> Response[ServiceHookSerializerResponse]:
         """
         Register a new service hook on a project.
 

--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -69,7 +69,7 @@ class ProjectTagKeyValuesEndpoint(ProjectEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project, key) -> Response:
+    def get(self, request: Request, project, key) -> Response[list[TagValueSerializerResponse]]:
         """
         Return a list of values associated with this tag key. The `query` parameter
         can be used to perform a "contains" match on values. Paginated, returning at

--- a/src/sentry/api/endpoints/user_organizations.py
+++ b/src/sentry/api/endpoints/user_organizations.py
@@ -55,7 +55,9 @@ class UserOrganizationsEndpoint(RegionSiloUserEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, user: RpcUser) -> Response:
+    def get(
+        self, request: Request, user: RpcUser
+    ) -> Response[list[OrganizationSummarySerializerResponse]]:
         """
         Return a list of organizations that the given user is a member of.
         """

--- a/src/sentry/core/endpoints/project_users.py
+++ b/src/sentry/core/endpoints/project_users.py
@@ -62,7 +62,7 @@ class ProjectUsersEndpoint(ProjectEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project) -> Response[list[EventUserSerializerResponse]]:
         """
         Return a list of users seen within this project.
         """

--- a/src/sentry/integrations/api/endpoints/organization_integration_serverless_functions.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_serverless_functions.py
@@ -79,7 +79,7 @@ class OrganizationIntegrationServerlessFunctionsEndpoint(CellOrganizationIntegra
         organization: Organization,
         integration_id: int,
         **kwds: Any,
-    ) -> Response:
+    ) -> Response[list[ServerlessFunctionResponse]]:
         """
         Return the serverless functions discovered for an organization's integration.
         """
@@ -117,7 +117,7 @@ class OrganizationIntegrationServerlessFunctionsEndpoint(CellOrganizationIntegra
         organization: Organization,
         integration_id: int,
         **kwds: Any,
-    ) -> Response:
+    ) -> Response[ServerlessFunctionResponse]:
         """
         Enable, disable, or update the Sentry layer version of a serverless function in
         an organization's integration.

--- a/src/sentry/releases/endpoints/organization_release_files.py
+++ b/src/sentry/releases/endpoints/organization_release_files.py
@@ -87,7 +87,9 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, Release
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, organization, version) -> Response:
+    def get(
+        self, request: Request, organization, version
+    ) -> Response[list[ReleaseFileSerializerResponse]]:
         """
         Retrieve a list of files for a given release.
         """
@@ -116,7 +118,9 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, Release
             409: RESPONSE_CONFLICT,
         },
     )
-    def post(self, request: Request, organization, version) -> Response:
+    def post(
+        self, request: Request, organization, version
+    ) -> Response[ReleaseFileSerializerResponse]:
         """
         Upload a new file for the given release.
 

--- a/src/sentry/releases/endpoints/project_release_files.py
+++ b/src/sentry/releases/endpoints/project_release_files.py
@@ -319,7 +319,9 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project, version) -> Response:
+    def get(
+        self, request: Request, project, version
+    ) -> Response[list[ReleaseFileSerializerResponse]]:
         """
         Retrieve a list of files for a given release.
         """
@@ -351,7 +353,7 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
             409: RESPONSE_CONFLICT,
         },
     )
-    def post(self, request: Request, project, version) -> Response:
+    def post(self, request: Request, project, version) -> Response[ReleaseFileSerializerResponse]:
         """
         Upload a new file for the given release.
 

--- a/src/sentry/releases/endpoints/project_release_setup.py
+++ b/src/sentry/releases/endpoints/project_release_setup.py
@@ -47,7 +47,7 @@ class ProjectReleaseSetupCompletionEndpoint(ProjectEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project) -> Response[list[ReleaseSetupStepResponse]]:
         """
         Return the release-setup onboarding progress for a project: whether the project
         has tagged an error, linked a repo, associated commits, and reported a deploy.

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_features.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_features.py
@@ -38,7 +38,7 @@ class SentryAppFeaturesEndpoint(SentryAppBaseEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, sentry_app) -> Response:
+    def get(self, request: Request, sentry_app) -> Response[list[IntegrationFeatureResponse]]:
         """
         Return the list of features that a custom integration (Sentry App) declares.
         """


### PR DESCRIPTION
Each tightening replaces `-> Response` with `-> Response[T]` where `T` is the same shape already declared in the method's `@extend_schema` decorator's `inline_sentry_response_serializer("...", T)` call. No source changes were needed — the autoderive plugin from #116879 already exposes `Serializer[T]` for the 15 sites' bodies, so mypy verifies them end-to-end without any helper or serializer touchups.

Part of the march toward 100% `@extend_schema` typed coverage. Drives the Goal #1 metric from 54.1% → 64.4% (79 → 94 typed of 146 with-inline-serializer methods). Remaining ~50 sites need denylist removal + caller fixes, pydantic source rework, or helper annotations — handled per-cohort in follow-up PRs.