### PR TITLE
chore(cells) Add localities and cells to client_config

### DIFF
--- a/src/sentry/auth/staff.py
+++ b/src/sentry/auth/staff.py
@@ -5,7 +5,7 @@ import ipaddress
 import logging
 from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
-from typing import Any, Final
+from typing import Any, Final, TypeIs, overload
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -13,10 +13,12 @@ from django.core.signing import BadSignature
 from django.http import HttpRequest, HttpResponse
 from django.utils import timezone as django_timezone
 from django.utils.crypto import constant_time_compare, get_random_string
+from rest_framework.request import Request
 
 from sentry import options
 from sentry.auth.elevated_mode import ElevatedMode, InactiveReason
 from sentry.auth.system import is_system_auth
+from sentry.types.request import _HttpRequestWithUser, _RequestWithUser
 from sentry.users.models.user import User
 from sentry.utils.auth import has_completed_sso
 
@@ -47,7 +49,15 @@ _UnsetType = enum.Enum("_UnsetType", "UNSET")
 _Unset: Final = _UnsetType.UNSET
 
 
-def is_active_staff(request: HttpRequest) -> bool:
+@overload
+def is_active_staff(request: Request) -> TypeIs[_RequestWithUser]: ...
+
+
+@overload
+def is_active_staff(request: HttpRequest) -> TypeIs[_HttpRequestWithUser]: ...
+
+
+def is_active_staff(request: HttpRequest | Request) -> bool:
     if is_system_auth(getattr(request, "auth", None)):
         return True
     staff = getattr(request, "staff", None) or Staff(request)

--- a/src/sentry/auth/staff.py
+++ b/src/sentry/auth/staff.py
@@ -5,7 +5,7 @@ import ipaddress
 import logging
 from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
-from typing import Any, Final, TypeIs, overload
+from typing import Any, Final
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -18,7 +18,6 @@ from rest_framework.request import Request
 from sentry import options
 from sentry.auth.elevated_mode import ElevatedMode, InactiveReason
 from sentry.auth.system import is_system_auth
-from sentry.types.request import _HttpRequestWithUser, _RequestWithUser
 from sentry.users.models.user import User
 from sentry.utils.auth import has_completed_sso
 
@@ -47,14 +46,6 @@ STAFF_ORG_ID = getattr(settings, "STAFF_ORG_ID", None)
 
 _UnsetType = enum.Enum("_UnsetType", "UNSET")
 _Unset: Final = _UnsetType.UNSET
-
-
-@overload
-def is_active_staff(request: Request) -> TypeIs[_RequestWithUser]: ...
-
-
-@overload
-def is_active_staff(request: HttpRequest) -> TypeIs[_HttpRequestWithUser]: ...
 
 
 def is_active_staff(request: HttpRequest | Request) -> bool:

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -150,7 +150,7 @@ def is_active_superuser(request: Request) -> TypeIs[_RequestWithUser]: ...
 def is_active_superuser(request: HttpRequest) -> TypeIs[_HttpRequestWithUser]: ...
 
 
-def is_active_superuser(request: HttpRequest) -> bool:
+def is_active_superuser(request: HttpRequest | Request) -> bool:
     if is_system_auth(getattr(request, "auth", None)):
         return True
     su = getattr(request, "superuser", None) or Superuser(request)

--- a/src/sentry/types/cell.py
+++ b/src/sentry/types/cell.py
@@ -125,6 +125,13 @@ class Cell:
 
         return self.name == settings.SENTRY_MONOLITH_REGION
 
+    def api_serialize(self) -> dict[str, Any]:
+        """Serialize a Cell into a JSON compatible dict"""
+        locality_name = get_locality_name_for_cell(self.name)
+        locality = get_locality_by_name(locality_name)
+
+        return {"name": self.name, "locality_url": locality.to_url(""), "visible": self.visible}
+
 
 class CellResolutionError(Exception):
     """Indicate that a cell's identity could not be resolved."""

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -432,17 +432,14 @@ class _ClientConfig:
         ):
             return []
 
-        cell_names = find_all_cell_names()
-        if not cell_names:
-            cell_names = [settings.SENTRY_MONOLITH_REGION]
-
         def cell_display_order(cell: Cell) -> tuple[bool, bool, str]:
             return (
                 cell.category != RegionCategory.MULTI_TENANT,  # multi-tenant before single
-                cell.visible,  # visible cells first
+                not cell.visible,  # visible cells first
                 cell.name,  # then sort alphabetically
             )
 
+        cell_names = find_all_cell_names()
         cells = [get_cell_by_name(name) for name in cell_names]
         cells.sort(key=cell_display_order)
 

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -19,6 +19,7 @@ from sentry import features, options
 from sentry.api.utils import generate_locality_url
 from sentry.auth import superuser
 from sentry.auth.services.auth import AuthenticationContext
+from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
 from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_user
 from sentry.models.organizationmapping import OrganizationMapping
@@ -31,9 +32,12 @@ from sentry.organizations.services.organization import (
 from sentry.projects.services.project_key import ProjectKeyRole, project_key_service
 from sentry.silo.base import SiloMode
 from sentry.types.cell import (
+    Cell,
     Locality,
     RegionCategory,
+    find_all_cell_names,
     find_all_multitenant_locality_names,
+    get_cell_by_name,
     get_global_directory,
     get_locality_by_name,
     get_locality_name_for_cell,
@@ -359,8 +363,9 @@ class _ClientConfig:
 
         This will include *all* multi-tenant regions, and if the user
         has membership on any single-tenant regions those will also be included.
-        """
 
+        :deprecated: Once the UI has been transitioned to `localities` and `cells` this can be removed.
+        """
         # Only expose visible regions.
         # When new regions are added they can take some work to get working correctly.
         # Before they are working we need ways to bring parts of the region online without
@@ -389,8 +394,59 @@ class _ClientConfig:
     def member_regions(self) -> list[Mapping[str, Any]]:
         """
         The regions the user has membership in. Includes single-tenant regions.
+
+        :deprecated: Once the UI has been transitioned to use control silo org-list this can be removed.
         """
         return self._serialize_localities(self._member_locality_names, lambda loc: loc.name)
+
+    @property
+    def localities(self) -> list[Mapping[str, Any]]:
+        """
+        The localities (formerly regions) that are visible to customers
+        """
+        locality_names = find_all_multitenant_locality_names()
+
+        if not locality_names:
+            return [{"name": "default", "url": options.get("system.url-prefix")}]
+
+        monolith_locality = get_locality_name_for_cell(settings.SENTRY_MONOLITH_REGION)
+
+        def region_display_order(region: Locality) -> tuple[bool, bool, str]:
+            return (
+                region.name != monolith_locality,  # default locality comes first
+                region.category != RegionCategory.MULTI_TENANT,  # multi-tenant before single
+                region.name,  # then sort alphabetically
+            )
+
+        return self._serialize_localities(locality_names, region_display_order)
+
+    @property
+    def cells(self) -> list[Mapping[str, Any]]:
+        """
+        The list of cells available.
+
+        The cell list is only available with a staff/superuser session.
+        """
+        if not self.request or not (
+            is_active_staff(self.request) or is_active_superuser(self.request)
+        ):
+            return []
+
+        cell_names = find_all_cell_names()
+        if not cell_names:
+            cell_names = [settings.SENTRY_MONOLITH_REGION]
+
+        def cell_display_order(cell: Cell) -> tuple[bool, bool, str]:
+            return (
+                cell.category != RegionCategory.MULTI_TENANT,  # multi-tenant before single
+                cell.visible,  # visible cells first
+                cell.name,  # then sort alphabetically
+            )
+
+        cells = [get_cell_by_name(name) for name in cell_names]
+        cells.sort(key=cell_display_order)
+
+        return [cell.api_serialize() for cell in cells]
 
     @property
     def should_preload_data(self) -> bool:
@@ -449,6 +505,8 @@ class _ClientConfig:
             # organization is not in context
             "lastOrganization": self.last_org_slug,
             "languageCode": self.language_code,
+            "cells": self.cells,
+            "localities": self.localities,
             "userIdentity": dict(self.user_identity),
             "csrfCookieName": settings.CSRF_COOKIE_NAME,
             "superUserCookieName": superuser.COOKIE_NAME,

--- a/static/app/utils/regions/index.tsx
+++ b/static/app/utils/regions/index.tsx
@@ -63,7 +63,7 @@ export function getRegions(): Region[] {
 }
 
 /**
- * Get a list of choice tuples with (url, display name)
+ * Get a list of option objects {label: displayName, value: url}
  */
 export function getRegionUrlOptions(
   exclude: RegionData[] = [],
@@ -96,7 +96,7 @@ export function getRegionUrlOptions(
 const CUSTOMER_HIDDEN_REGIONS = new Set(['us2']);
 
 /**
- * Create a list of Choice tuples with (name, display name)
+ * Create a list of option objects with {label: displayName, value: name}
  */
 export function getRegionNameOptions(): Array<SelectValue<string>> {
   const regions = getRegions();

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -414,6 +414,7 @@ export function OrganizationSettingsForm({initialData, onSave}: Props) {
   const access = useMemo(() => new Set(organization.access), [organization]);
   const hasWriteAccess = access.has('org:write');
   const hasGenAiFeatureFlag = organization.features.includes('gen-ai-features');
+  // TODO(cells) This should be localities
   const regionData =
     getRegions().length > 1 ? getRegionDataFromOrganization(organization) : null;
 
@@ -554,7 +555,7 @@ export function OrganizationSettingsForm({initialData, onSave}: Props) {
                 </Text>
               </Stack>
               <Container flexGrow={1}>
-                <Text>{`${regionData?.flag ?? ''} ${regionData.displayName}`}</Text>
+                <Text>{regionData.label}</Text>
               </Container>
             </Flex>
           )}

--- a/static/gsAdmin/components/customers/customerInvoices.tsx
+++ b/static/gsAdmin/components/customers/customerInvoices.tsx
@@ -7,6 +7,7 @@ import {ResultGrid} from 'admin/components/resultGrid';
 
 type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
   orgId: string;
+  // TODO(cells) region here is actually a cell
   region: string;
 };
 

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -475,6 +475,7 @@ export function CustomerOverview({customer, onAction, organization}: Props) {
     orgUrl = `${organization.links.organizationUrl}/issues/`;
   }
 
+  // TODO(cells) this needs the full list of cells
   const regionMap = getRegions().reduce<Record<string, string>>((acc, region) => {
     acc[region.url] = region.name;
     return acc;

--- a/static/gsAdmin/components/forkCustomer.tsx
+++ b/static/gsAdmin/components/forkCustomer.tsx
@@ -41,6 +41,7 @@ class ForkCustomerActionImpl extends Component<Props> {
     const api = new Client({headers: {Accept: 'application/json; charset=utf-8'}});
     const {organization} = this.props;
     const {regionUrl} = this.state;
+    // TODO(cells) this needs to be a list of localities.
     const regions = getRegions();
     const region = regions.find(r => r.url === regionUrl);
 

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -253,6 +253,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     const {cursor, query, sortBy, regionUrl} = queryParams;
 
     const needsRegion = this.props.isRegional || this.props.isCellScoped;
+    // TODO(cells) We need cells here
     const regions = getRegions();
 
     this.state = {
@@ -484,6 +485,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       resultTable
     );
 
+    // TODO(cells) We need cells here.
     const regions = getRegions();
     const needsRegion = this.props.isRegional || this.props.isCellScoped;
 

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -323,6 +323,7 @@ export function CustomerDetails() {
     }
   };
 
+  // TODO(cells) need to have all cells here.
   const regionMap = getRegions().reduce<Record<string, string>>(
     (acc: any, region: any) => {
       acc[region.url] = region.name;

--- a/static/gsAdmin/views/generateSpikeProjectionsForBatch.tsx
+++ b/static/gsAdmin/views/generateSpikeProjectionsForBatch.tsx
@@ -17,6 +17,7 @@ import {PageHeader} from 'admin/components/pageHeader';
 
 export function GenerateSpikeProjectionsForBatch() {
   const [batchId, setBatchId] = useState<number | null>(null);
+  // TODO(cells) Needs to be a list of cells
   const regions = getRegions();
   const [region, setRegion] = useState(regions[0] ?? null);
 

--- a/static/gsAdmin/views/home.tsx
+++ b/static/gsAdmin/views/home.tsx
@@ -16,6 +16,7 @@ import {Overview} from 'admin/views/overview';
 
 export function HomePage() {
   const navigate = useNavigate();
+  // TODO(cells) This needs to be a list of cells
   const regions = getRegions();
   const [oldSplash, setOldSplash] = useState(false);
   const [regionUrl, setRegionUrl] = useState(regions[0]!.url);

--- a/static/gsAdmin/views/invoiceComparison.tsx
+++ b/static/gsAdmin/views/invoiceComparison.tsx
@@ -157,6 +157,7 @@ function utcIsoToDatetimeLocalValue(iso: string): string {
 }
 
 export function InvoiceComparison() {
+  // TODO(cells) This needs to be a list of cells
   const regions = getRegions();
   const location = useLocation();
   const navigate = useNavigate();

--- a/static/gsAdmin/views/invoiceDetails.tsx
+++ b/static/gsAdmin/views/invoiceDetails.tsx
@@ -32,6 +32,7 @@ export function InvoiceDetails() {
     orgId: string;
     region: string;
   }>();
+  // TODO(cells) this needs a list of cells (and their localities)
   const regionInfo = getRegions().find(
     (r: any) => r.name.toLowerCase() === region.toLowerCase()
   );

--- a/static/gsAdmin/views/launchpadAdminPage.tsx
+++ b/static/gsAdmin/views/launchpadAdminPage.tsx
@@ -28,6 +28,7 @@ export function LaunchpadAdminPage() {
   const [batchDeleteArtifactIds, setBatchDeleteArtifactIds] = useState('');
   const [downloadArtifactId, setDownloadArtifactId] = useState('');
   const [fetchedArtifactInfo, setFetchedArtifactInfo] = useState<any>(null);
+  // TODO(cells) We need localities here for host
   const regions = getRegions();
   const [region, setRegion] = useState(regions[0] ?? null);
 

--- a/static/gsAdmin/views/relocationArtifactDetails.tsx
+++ b/static/gsAdmin/views/relocationArtifactDetails.tsx
@@ -21,6 +21,7 @@ export function RelocationArtifactDetails() {
     regionName: string;
     relocationUuid: string;
   }>();
+  // TODO(cells) Need locality here for host.
   const region = getRegions().find((r: any) => r.name === regionName);
 
   const {data, isPending, isError} = useApiQuery<RelocationData>(

--- a/static/gsAdmin/views/relocationCreate.tsx
+++ b/static/gsAdmin/views/relocationCreate.tsx
@@ -29,6 +29,7 @@ function RelocationForm() {
   const promoCodeApi = useApi({
     api: new Client({baseUrl: ''}),
   });
+  // TODO(cells) Will cells with their locality
   const regions = getRegions();
   const inputFileRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File>();

--- a/static/gsAdmin/views/relocationDetails.tsx
+++ b/static/gsAdmin/views/relocationDetails.tsx
@@ -181,6 +181,7 @@ export function RelocationDetails() {
   const [artifactsState, setArtifactsState] = useState(ArtifactsState.DISABLED);
   const navigate = useNavigate();
 
+  // TODO(cells) This needs to be a list of cells.
   const regions = getRegions();
   const region = regions.find((r: any) => r.name === regionName);
   const regionClient = new Client({baseUrl: `${region?.url || ''}/api/0`});

--- a/static/gsAdmin/views/seerAdminPage.tsx
+++ b/static/gsAdmin/views/seerAdminPage.tsx
@@ -20,6 +20,7 @@ export function SeerAdminPage() {
   const [organizationId, setOrganizationId] = useState('');
   const [dryRun, setDryRun] = useState(false);
   const [maxCandidates, setMaxCandidates] = useState('');
+  // TODO(cells) Need cell + locality here
   const regions = getRegions();
   const [region, setRegion] = useState(regions[0] ?? null);
 

--- a/tests/sentry/auth/test_staff.py
+++ b/tests/sentry/auth/test_staff.py
@@ -227,6 +227,7 @@ class StaffTestCase(TestCase):
 
         middleware = StaffMiddleware(placeholder_get_response)
         middleware.process_request(request)
+        assert request.staff
         assert request.staff.is_active
         assert is_active_staff(request)
 

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -261,6 +261,25 @@ def test_client_config_with_hidden_region_data() -> None:
     assert {r["name"] for r in localities} == {"us"}
 
 
+@control_silo_test(cells=hidden_regions)
+@django_db_all
+def test_client_config_with_hidden_cell_membership() -> None:
+    request, user = make_user_request_from_org()
+
+    Factories.create_organization(slug="acme-co", owner=user, cell="eu")
+    request.user = user
+
+    result = get_client_config(request)
+
+    # Localities (customer facing) don't include hidden cells/localities
+    assert len(result["localities"]) == 1
+    localities = result["localities"]
+    assert [r["name"] for r in localities] == ["us"]
+
+    # Cell list is hidden for regular users.
+    assert len(result["cells"]) == 0
+
+
 @multiregion_client_config_test
 @django_db_all
 def test_client_config_with_multiple_membership() -> None:

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -10,6 +10,7 @@ from django.test import override_settings
 from django.urls import get_resolver
 
 from sentry import options
+from sentry.auth.staff import Staff
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organization import Organization
@@ -100,6 +101,8 @@ def test_client_config_in_silo_modes(request_factory: RequestFactory) -> None:
     def normalize(value: dict[str, Any]):
         # Removing the region lists as it varies based on silo mode.
         # See Region.to_url()
+        value.pop("localities")
+        value.pop("cells")
         value.pop("regions")
         value.pop("memberRegions")
         value["links"].pop("regionUrl")
@@ -162,6 +165,13 @@ def test_client_config_default_region_data() -> None:
     request.user = user
     result = get_client_config(request)
 
+    assert len(result["localities"]) == 1
+    localities = result["localities"]
+    assert localities[0]["name"] == settings.SENTRY_MONOLITH_REGION
+    assert localities[0]["url"] == options.get("system.url-prefix")
+
+    assert len(result["cells"]) == 0, "No staff session"
+
     assert len(result["regions"]) == 1
     regions = result["regions"]
     assert regions[0]["name"] == settings.SENTRY_MONOLITH_REGION
@@ -191,6 +201,12 @@ def test_client_config_empty_region_data() -> None:
     assert regions[0]["name"] == settings.SENTRY_MONOLITH_REGION
     assert regions[0]["url"] == options.get("system.url-prefix")
 
+    assert len(result["cells"]) == 0, "no staff session"
+    assert len(result["localities"]) == 1
+    localities = result["localities"]
+    assert localities[0]["name"] == settings.SENTRY_MONOLITH_REGION
+    assert localities[0]["url"] == options.get("system.url-prefix")
+
 
 @multiregion_client_config_test
 @django_db_all
@@ -198,6 +214,11 @@ def test_client_config_with_region_data() -> None:
     request, user = make_user_request_from_org()
     request.user = user
     result = get_client_config(request)
+
+    assert len(result["cells"]) == 0, "no staff session"
+    assert len(result["localities"]) == 2
+    localities = result["localities"]
+    assert {r["name"] for r in localities} == {"eu", "us"}
 
     assert len(result["regions"]) == 2
     regions = result["regions"]
@@ -234,6 +255,10 @@ def test_client_config_with_hidden_region_data() -> None:
     regions = result["regions"]
     assert {r["name"] for r in regions} == {"us"}
     assert len(result["memberRegions"]) == 1
+
+    assert len(result["localities"]) == 1
+    localities = result["localities"]
+    assert {r["name"] for r in localities} == {"us"}
 
 
 @multiregion_client_config_test
@@ -279,6 +304,30 @@ def test_client_config_with_single_tenant_membership() -> None:
     assert len(result["memberRegions"]) == 2
     regions = result["memberRegions"]
     assert {r["name"] for r in regions} == {"us", "acme"}
+
+
+@control_silo_test(cells=create_test_cells("us", "eu"))
+@django_db_all
+def test_client_config_with_staff_session_fills_cells() -> None:
+    request, user = make_user_request_from_org()
+    user.is_staff = True
+    request.user = user
+
+    # Simulate an active staff session
+    staff = Staff(request)
+    staff.set_logged_in(user)
+    request.staff = staff  # type: ignore[attr-defined]
+
+    result = get_client_config(request)
+
+    assert len(result["localities"]) == 2
+    localities = result["localities"]
+    assert {r["name"] for r in localities} == {"us", "eu"}
+
+    assert len(result["cells"]) == 2
+    cells = result["cells"]
+    assert {r["name"] for r in cells} == {"us", "eu"}
+    assert {r["locality_url"] for r in cells} == {"http://us.testserver", "http://eu.testserver"}
 
 
 @multiregion_client_config_test

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -316,7 +316,7 @@ def test_client_config_with_staff_session_fills_cells() -> None:
     # Simulate an active staff session
     staff = Staff(request)
     staff.set_logged_in(user)
-    request.staff = staff  # type: ignore[attr-defined]
+    request.staff = staff
 
     result = get_client_config(request)
 
@@ -342,7 +342,7 @@ def test_client_config_with_staff_session_includes_hidden_cells() -> None:
     # Simulate an active staff session
     staff = Staff(request)
     staff.set_logged_in(user)
-    request.staff = staff  # type: ignore[attr-defined]
+    request.staff = staff
 
     result = get_client_config(request)
 

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -322,10 +322,12 @@ def test_client_config_with_staff_session_fills_cells() -> None:
 
     assert len(result["localities"]) == 2
     localities = result["localities"]
+    # default historical cell (us) is first
     assert [r["name"] for r in localities] == ["us", "eu"]
 
     assert len(result["cells"]) == 2
     cells = result["cells"]
+    # visible cells sorted by name.
     assert [r["name"] for r in cells] == ["eu", "us"]
     assert [r["locality_url"] for r in cells] == ["http://eu.testserver", "http://us.testserver"]
 
@@ -349,10 +351,10 @@ def test_client_config_with_staff_session_includes_hidden_cells() -> None:
     localities = result["localities"]
     assert [r["name"] for r in localities] == ["us"]
 
-    # Cells list includes hidden items
+    # Cells list includes hidden items last
     assert len(result["cells"]) == 2
     cells = result["cells"]
-    assert [r["name"] for r in cells] == ["eu", "us"]
+    assert [r["name"] for r in cells] == ["us", "eu"]
 
 
 @multiregion_client_config_test

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -322,12 +322,37 @@ def test_client_config_with_staff_session_fills_cells() -> None:
 
     assert len(result["localities"]) == 2
     localities = result["localities"]
-    assert {r["name"] for r in localities} == {"us", "eu"}
+    assert [r["name"] for r in localities] == ["us", "eu"]
 
     assert len(result["cells"]) == 2
     cells = result["cells"]
-    assert {r["name"] for r in cells} == {"us", "eu"}
-    assert {r["locality_url"] for r in cells} == {"http://us.testserver", "http://eu.testserver"}
+    assert [r["name"] for r in cells] == ["eu", "us"]
+    assert [r["locality_url"] for r in cells] == ["http://eu.testserver", "http://us.testserver"]
+
+
+@control_silo_test(cells=hidden_regions)
+@django_db_all
+def test_client_config_with_staff_session_includes_hidden_cells() -> None:
+    request, user = make_user_request_from_org()
+    user.is_staff = True
+    request.user = user
+
+    # Simulate an active staff session
+    staff = Staff(request)
+    staff.set_logged_in(user)
+    request.staff = staff  # type: ignore[attr-defined]
+
+    result = get_client_config(request)
+
+    # Localities (customer facing) don't include hidden cells/localities
+    assert len(result["localities"]) == 1
+    localities = result["localities"]
+    assert [r["name"] for r in localities] == ["us"]
+
+    # Cells list includes hidden items
+    assert len(result["cells"]) == 2
+    cells = result["cells"]
+    assert [r["name"] for r in cells] == ["eu", "us"]
 
 
 @multiregion_client_config_test


### PR DESCRIPTION
Currently the UI logic uses `region` in a few different places. With regions being split into localities and cells, I want to update the UI code to be consistent with server-side concepts.

The customer facing surfaces of our UI only need to deal with localities, while the admin features work with both localities and cells. I've annotated all of the region function usage with the intended future state.

The `cells` context data will only be emit if the the request comes from an active staff/superuser session. Once these changes have landed we can update the region functions to read the new data and better represent the locality/cell split.

Refs INFRENG-332