### PR TITLE
fix(grouping): Fix performance issues in grouping parameterization regexes

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -111,7 +111,7 @@ def is_valid_hostname(maybe_hostname_str: str) -> bool:
 DEFAULT_PARAMETERIZATION_REGEXES = [
     ParameterizationRegex(
         name="email",
-        raw_pattern=r"""[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*""",
+        raw_pattern=r"""[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]{1,254}@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*""",
     ),
     ParameterizationRegex(
         name="url",
@@ -271,7 +271,9 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             (datetime.datetime\(.*?\))
         """,
     ),
-    ParameterizationRegex(name="duration", raw_pattern=r"""\b(\d+ms) | (\d+(\.\d+)?s)\b"""),
+    ParameterizationRegex(
+        name="duration", raw_pattern=r"""\b(\d{1,20}ms)\b | \b(\d{1,20}(\.\d{1,20})?s)\b"""
+    ),
     ParameterizationRegex(
         name="mac_addr",
         raw_pattern=r"""
@@ -528,6 +530,9 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
 
 
 class Parameterizer:
+    # Inputs longer than this are not parameterized, as a defense against ReDoS
+    MAX_INPUT_LENGTH = 8192
+
     def __init__(
         self,
         # List of `ParameterizationRegex` objects defining the regexes to use. If nothing is passed,
@@ -592,6 +597,10 @@ class Parameterizer:
 
         For example, turn "Error with order #1231" into "Error with order #<int>".
         """
+
+        if len(input_str) > self.MAX_INPUT_LENGTH:
+            metrics.incr("grouping.parameterization_skipped_long_input")
+            return input_str
 
         replacement_counts: defaultdict[str, int] = defaultdict(int)
         # Track whether any regex matches don't lead to a replacement

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -28,6 +28,8 @@ standard_cases = [
     ("email", "maisey@dogsaregreat.com", "<email>"),
     ("email - with period", "maisey.thedog@dogsaregreat.com", "<email>"),
     ("email - with plus sign", "maisey+thedog@dogsaregreat.com", "<email>"),
+    ("email - 254-char local part", "a" * 254 + "@example.com", "<email>"),
+    ("email - 255-char local part partially matched", "a" * 255 + "@example.com", "a<email>"),
     ("url - no subdomain", "http://dogsaregreat.com", "<url>"),
     ("url - with subdomain", "http://dogs.squirrelchasers.net", "<url>"),
     ("url - with path", "http://dogsaregreat.com/adopt/dont/shop", "<url>"),
@@ -180,6 +182,11 @@ standard_cases = [
     ("duration - 1.234s", "1.234s", "<duration>"),
     ("duration - 10s", "10s", "<duration>"),
     ("duration - 100.0000s", "100.0000s", "<duration>"),
+    ("duration - 20-digit ms", "9" * 20 + "ms", "<duration>"),
+    ("duration - 20-digit s", "9" * 20 + "s", "<duration>"),
+    ("duration - 20-digit decimal s", "9" * 20 + "." + "9" * 20 + "s", "<duration>"),
+    ("duration - 21-digit ms not matched", "9" * 21 + "ms", "9" * 21 + "ms"),
+    ("duration - 21-digit s not matched", "9" * 21 + "s", "9" * 21 + "s"),
     # OpenStack Swift transaction IDs
     ("swift_txn_id - base", "tx274a77a8975c4a66aeb24-0052d95365", "<swift_txn_id>"),
     (
@@ -831,3 +838,20 @@ def test_example_data_logging(mock_logger: MagicMock) -> None:
         )
         == 100
     )
+
+
+def test_parameterization_skips_long_input() -> None:
+    long_input = "error code 12345 " * 1000  # 18000 chars, well over the limit
+    assert len(long_input) > Parameterizer.MAX_INPUT_LENGTH
+    result = parameterizer.parameterize(long_input)
+    assert result == long_input
+
+
+def test_parameterization_at_max_length_still_works() -> None:
+    base = "error code 12345 "
+    repeats = Parameterizer.MAX_INPUT_LENGTH // len(base)
+    at_limit_input = base * repeats
+    assert len(at_limit_input) <= Parameterizer.MAX_INPUT_LENGTH
+    result = parameterizer.parameterize(at_limit_input)
+    assert result != at_limit_input
+    assert "<int>" in result


### PR DESCRIPTION
Fixes some performance issues related to grouping parameterization regex rules.

- Duration regex: add bounding
- Email regex: bound the local-part character class length
- Add a global `MAX_INPUT_LENGTH` as a general guard against regex performance issues