### PR TITLE
ref(api): tighten 4 workflow-engine endpoint annotations

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -32,6 +32,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.workflow_engine_examples import WorkflowEngineExamples
 from sentry.apidocs.parameters import DetectorParams, GlobalParams, OrganizationParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
@@ -270,7 +271,9 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         },
         examples=WorkflowEngineExamples.LIST_ORG_DETECTORS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[DetectorSerializerResponse]] | Response[DetailResponse]:
         """
         List an Organization's Monitors
         """
@@ -342,7 +345,9 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         },
         examples=WorkflowEngineExamples.LIST_ORG_DETECTORS,
     )
-    def put(self, request: Request, organization: Organization) -> Response:
+    def put(
+        self, request: Request, organization: Organization
+    ) -> Response[list[DetectorSerializerResponse]] | Response[DetailResponse]:
         """
         Bulk enable or disable an Organization's Monitors
         """

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -44,6 +44,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.workflow_engine_examples import WorkflowEngineExamples
 from sentry.apidocs.parameters import GlobalParams, OrganizationParams, WorkflowParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
@@ -236,7 +237,9 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         },
         examples=WorkflowEngineExamples.LIST_WORKFLOWS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[WorkflowSerializerResponse]] | Response[DetailResponse]:
         """
         Returns a list of alerts for a given organization
         """
@@ -356,7 +359,9 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         ),
         examples=WorkflowEngineExamples.LIST_WORKFLOWS,
     )
-    def put(self, request: Request, organization: Organization) -> Response:
+    def put(
+        self, request: Request, organization: Organization
+    ) -> Response[list[WorkflowSerializerResponse]] | Response[DetailResponse]:
         """
         Bulk enable or disable alerts for a given Organization
         """


### PR DESCRIPTION
Adds `-> Response[T] | Response[DetailResponse]` to four bare `-> Response` methods on `organization_detector_index` and `organization_workflow_index`. The success arm matches the `inline_sentry_response_serializer` T already declared in the `@extend_schema` decorator; the `Response[DetailResponse]` arm covers the `{"detail": "..."}` error paths.

No source changes — the autoderive plugin from #116879 plus mypy's literal-narrowing already match each error-path body to `DetailResponse`.

Part of the march toward 100% `@extend_schema` typed coverage tracked in the umbrella `type-http-response-coverage` change. Drives the Goal #1 metric from 64.4% → 67.1%. Other remaining sites need denylist removal or per-endpoint source typing — handled in follow-up PRs.