### PR TITLE
fix(ourlogs): keep last column alignment stable on hover

### DIFF
--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -405,7 +405,6 @@ export function CellAction({
   if (triggerType === ActionTriggerType.BOLD_HOVER) {
     return (
       <Container
-        containsPin={!!pin}
         data-test-id={cellActions === null ? undefined : 'cell-action-container'}
       >
         {cellActions?.length ? (
@@ -473,10 +472,7 @@ export function CellAction({
   }
 
   return (
-    <Container
-      containsPin={!!pin}
-      data-test-id={cellActions === null ? undefined : 'cell-action-container'}
-    >
+    <Container data-test-id={cellActions === null ? undefined : 'cell-action-container'}>
       {children}
       {cellActions?.length && (
         <DropdownMenu
@@ -510,13 +506,9 @@ export function CellAction({
   );
 }
 
-const Container = styled('div')<{containsPin?: boolean}>`
-  --logsPinButtonArea: 2rem;
+const Container = styled('div')`
   position: relative;
-  width: ${p =>
-    p.containsPin
-      ? `calc(100% - var(--logsPinButtonArea) + ${p.theme.space.md})`
-      : `100%`};
+  width: 100%;
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -131,7 +131,7 @@ export const LogAttributeTreeWrapper = styled('div')`
   border-bottom: 0px;
 `;
 
-export const LogTableBodyCell = styled(TableBodyCell)`
+export const LogTableBodyCell = styled(TableBodyCell)<{reservePinGutter?: boolean}>`
   min-height: ${LOGS_GRID_BODY_ROW_HEIGHT}px;
 
   padding: 2px ${p => p.theme.space.xl};
@@ -145,7 +145,9 @@ export const LogTableBodyCell = styled(TableBodyCell)`
   }
 
   &:last-child {
-    padding: 0 ${p => p.theme.space.md};
+    padding: 0
+      ${p => (p.reservePinGutter ? 'var(--logsPinButtonArea, 2rem)' : p.theme.space.md)} 0
+      ${p => p.theme.space.md};
   }
 `;
 
@@ -154,6 +156,7 @@ function ContentsTable(props: React.ComponentProps<typeof Table>) {
 }
 
 export const LogTable = styled(ContentsTable)<{minWidth: string}>`
+  --logsPinButtonArea: 2rem;
   flex: 1;
   min-height: 0;
   display: flex;
@@ -302,7 +305,7 @@ export const LogsFilteredHelperText = styled('span')`
 
 export const LogPinButton = styled(Button)<{isPinned: boolean | undefined}>`
   position: absolute;
-  right: calc(-1 * var(--logsPinButtonArea));
+  right: calc(-1 * var(--logsPinButtonArea, 2rem));
   opacity: ${p => (p.isPinned ? 1 : 0)};
   transition: opacity 0.1s;
   z-index: 1;
@@ -340,6 +343,14 @@ export const AlignedCellContent = styled('div')<{
 export const FirstTableHeadCell = styled(TableHeadCell)`
   padding-right: ${p => p.theme.space.md};
   padding-left: ${p => p.theme.space.xl};
+`;
+
+export const LogTableHeadCell = styled(TableHeadCell)<{reservePinGutter?: boolean}>`
+  ${p =>
+    p.reservePinGutter &&
+    css`
+      padding-right: var(--logsPinButtonArea, 2rem);
+    `}
 `;
 
 export const LogsTableBodyFirstCell = styled(LogTableBodyCell)`

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -33,7 +33,6 @@ import {useDimensions} from 'sentry/utils/useDimensions';
 import {
   TableBodyCell,
   TableHead,
-  TableHeadCell,
   TableHeadCellContent,
   TableRow,
   TableStatus,
@@ -57,6 +56,7 @@ import {
   LOGS_GRID_BODY_ROW_HEIGHT,
   LogTable,
   LogTableBody,
+  LogTableHeadCell,
   LogTableRow,
 } from 'sentry/views/explore/logs/styles';
 import {calculateLogsTableMinWidth} from 'sentry/views/explore/logs/tables/calculateLogsTableMinWidth';
@@ -660,6 +660,7 @@ function LogsTableHeader({
   const setSortBys = useSetQueryParamsSortBys();
 
   const {data, meta, isError, isPending} = useLogsPageDataQueryResult();
+  const pinningEnabled = !!useLogsPinning();
   return (
     <TableHead>
       <LogTableRow>
@@ -679,13 +680,20 @@ function LogsTableHeader({
           );
 
           if (isPending) {
-            return <TableHeadCell key={index} isFirst={index === 0} />;
+            return (
+              <LogTableHeadCell
+                key={index}
+                isFirst={index === 0}
+                reservePinGutter={pinningEnabled && index === fields.length - 1}
+              />
+            );
           }
           return (
-            <TableHeadCell
+            <LogTableHeadCell
               align={index === 0 ? 'left' : align}
               key={index}
               isFirst={index === 0}
+              reservePinGutter={pinningEnabled && index === fields.length - 1}
             >
               <TableHeadCellContent
                 onClick={
@@ -728,7 +736,7 @@ function LogsTableHeader({
                   onMouseDown={e => onResizeMouseDown(e, index)}
                 />
               )}
-            </TableHeadCell>
+            </LogTableHeadCell>
           );
         })}
       </LogTableRow>

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -499,7 +499,7 @@ export const LogRowContent = memo(function LogRowContent({
 
           if (!defined(value)) {
             return (
-              <LogTableBodyCell key={field}>
+              <LogTableBodyCell key={field} reservePinGutter={!!pin}>
                 {shouldRenderActions ? (
                   <Flex position="relative" height="100%" width="100%" justify="end">
                     {pin}
@@ -533,7 +533,11 @@ export const LogRowContent = memo(function LogRowContent({
           };
 
           return (
-            <LogTableBodyCell key={field} data-test-id={'log-table-cell-' + field}>
+            <LogTableBodyCell
+              key={field}
+              data-test-id={'log-table-cell-' + field}
+              reservePinGutter={!!pin}
+            >
               {shouldRenderActions ? (
                 <CellAction
                   column={discoverColumn}


### PR DESCRIPTION
The last logs column reserved space for the hover-only pin button by shrinking the cell content box _only while hovered_. `onMouseLeave` never resets the hover state. So right-aligned values shifted left on hover and stayed misaligned after the cursor left (regression from my #115102).

This reserves the pin gutter consistently on the last column in both the header and body, so right-aligned values align to the same box whether or not the `CellAction` wrapper is mounted — no shift on hover, nothing to revert. The gutter (`--logsPinButtonArea`) is defined once on `LogTable`. 

To reproduce, go to Explore > Logs and alternate between hovering over a bunch of logs and scrolling the table down. The position of the pin icon should remain stable if you have pinned logs enabled. Otherwise it's the position of the '...' dropdown.

Closes LOGS-835