### PR TITLE
ref(ACI): Add / adopt `DetectorId` instead of `int`

### DIFF
--- a/src/sentry/workflow_engine/caches/workflow.py
+++ b/src/sentry/workflow_engine/caches/workflow.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 from sentry.models.environment import Environment
 from sentry.workflow_engine.caches import CacheMapping
 from sentry.workflow_engine.models import Detector, DetectorWorkflow, Workflow
+from sentry.workflow_engine.types import DetectorId
 from sentry.workflow_engine.utils import scopedstats
 from sentry.workflow_engine.utils.metrics import metrics_incr
 
@@ -19,7 +20,7 @@ WORKFLOW_CACHE_PREFIX = "workflows_by_detector_env"
 
 
 class _WorkflowCacheKey(NamedTuple):
-    detector_id: int
+    detector_id: DetectorId
     env_id: int | None
 
 
@@ -36,7 +37,7 @@ class _CacheLookupResult(NamedTuple):
     """
 
     cached_workflows: set[Workflow]
-    missed_detector_ids: list[int]
+    missed_detector_ids: list[DetectorId]
 
     @property
     def all_hits(self) -> bool:
@@ -48,7 +49,7 @@ class _WorkflowsByDetector(NamedTuple):
     Workflows grouped by detector ID with helper methods.
     """
 
-    mapping: dict[int, set[Workflow]]
+    mapping: dict[DetectorId, set[Workflow]]
 
     @property
     def all_workflows(self) -> set[Workflow]:
@@ -71,7 +72,7 @@ class _SplitWorkflowsByDetector(NamedTuple):
     env_workflows: _WorkflowsByDetector  # env_id=X workflows (may be empty)
 
 
-def _invalidate_all_environments(detector_id: int) -> bool:
+def _invalidate_all_environments(detector_id: DetectorId) -> bool:
     """
     Invalidate all cache entries for a detector across all environments.
 
@@ -95,7 +96,8 @@ def _invalidate_all_environments(detector_id: int) -> bool:
 
 @scopedstats.timer()
 def invalidate_processing_workflows(
-    detector_id: int, env_id: int | None | Literal["default"] = DEFAULT_VALUE
+    detector_id: DetectorId,
+    env_id: int | None | Literal["default"] = DEFAULT_VALUE,
 ) -> bool:
     """
     Invalidate workflow processing cache entries for a specific detector.
@@ -133,7 +135,7 @@ def _check_caches_for_detectors(
         _CacheLookupResult with cached_workflows and missed_detector_ids
     """
     workflows: set[Workflow] = set()
-    missed_detector_ids: list[int] = []
+    missed_detector_ids: list[DetectorId] = []
 
     keys = [_WorkflowCacheKey(d.id, env_id) for d in detectors]
     for key, cached in _workflow_cache.get_many(keys).items():
@@ -148,7 +150,8 @@ def _check_caches_for_detectors(
 
 
 def _query_workflows_by_detector_ids(
-    detector_ids: Collection[int], env_id: int | None
+    detector_ids: Collection[DetectorId],
+    env_id: int | None,
 ) -> _SplitWorkflowsByDetector:
     """
     Query DB for workflows and split by actual environment_id.

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -65,6 +65,7 @@ from sentry.workflow_engine.endpoints.validators.detector_workflow_mutation impo
 )
 from sentry.workflow_engine.models import DetectorWorkflow, Workflow
 from sentry.workflow_engine.models.workflow_fire_history import WorkflowFireHistory
+from sentry.workflow_engine.types import DetectorId
 
 # Maps API field name to database field name, with synthetic aggregate fields keeping
 # to our field naming scheme for consistency.
@@ -245,7 +246,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         queryset = self.filter_workflows(request, organization)
 
         # When the `priorityDetector` query param is provided, workflows connected to this detector are sorted first
-        priority_detector_id: int | None = None
+        priority_detector_id: DetectorId | None = None
         if raw_priority := request.GET.get("priorityDetector"):
             priority_detector_id = to_valid_int_id("priorityDetector", raw_priority)
 

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -20,9 +20,8 @@ from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.utils import metrics
 from sentry.utils.audit import create_audit_entry
-from sentry.workflow_engine.models.detector import Detector
-from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
-from sentry.workflow_engine.models.workflow import Workflow
+from sentry.workflow_engine.models import Detector, DetectorWorkflow, Workflow
+from sentry.workflow_engine.types import DetectorId, WorkflowId
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +122,7 @@ def can_edit_detector_workflow_connections(detector: Detector, request: Request)
 
 
 def validate_detectors_exist_and_have_permissions(
-    detector_ids: list[int], organization: Organization, request: Request
+    detector_ids: list[DetectorId], organization: Organization, request: Request
 ) -> QuerySet[Detector]:
     detectors = Detector.objects.filter(
         project__organization=organization,
@@ -158,14 +157,14 @@ def connect_workflows_to_detectors(
     request: Request,
     organization: Organization,
     workflow_id: int,
-    detector_ids: list[int] | None,
+    detector_ids: list[DetectorId] | None,
     update: bool = False,
 ) -> None:
     if detector_ids is not None:
         validate_detectors_exist_and_have_permissions(detector_ids, organization, request)
 
         def get_detector_workflows_to_add(
-            workflow_id: int, detector_ids: set[int]
+            workflow_id: WorkflowId, detector_ids: set[DetectorId]
         ) -> list[dict[Literal["detector_id", "workflow_id"], int]]:
             detector_workflows_to_add: list[dict[Literal["detector_id", "workflow_id"], int]] = [
                 {"detector_id": detector_id, "workflow_id": workflow_id}
@@ -205,7 +204,7 @@ def connect_workflows_to_detectors(
 def connect_detectors_to_workflows(
     request: Request,
     organization: Organization,
-    detector_id: int,
+    detector_id: DetectorId,
     workflow_ids: list[int] | None,
     update: bool = False,
 ) -> None:
@@ -213,7 +212,7 @@ def connect_detectors_to_workflows(
         validate_workflows_exist(workflow_ids, organization)
 
         def get_detector_workflows_to_add(
-            detector_id: int, workflow_ids: set[int]
+            detector_id: DetectorId, workflow_ids: set[WorkflowId]
         ) -> list[dict[Literal["detector_id", "workflow_id"], int]]:
             detector_workflows_to_add: list[dict[Literal["detector_id", "workflow_id"], int]] = [
                 {"detector_id": detector_id, "workflow_id": workflow_id}

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -17,6 +17,7 @@ from sentry.workflow_engine.processors.data_condition_group import ProcessedData
 from sentry.workflow_engine.types import (
     DetectorEvaluationResult,
     DetectorGroupKey,
+    DetectorId,
     DetectorPriorityLevel,
 )
 
@@ -31,7 +32,7 @@ EventData = dict[str, Any]
 @dataclass
 class EvidenceData(Generic[DataPacketEvaluationType]):
     value: DataPacketEvaluationType
-    detector_id: int
+    detector_id: DetectorId
     data_packet_source_id: int
     conditions: list[dict[str, Any]]
     config: dict[str, Any] = dataclasses.field(default_factory=dict, kw_only=True)

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -24,6 +24,7 @@ from sentry.workflow_engine.models.detector_group import DetectorGroup
 from sentry.workflow_engine.types import (
     DetectorEvaluationResult,
     DetectorGroupKey,
+    DetectorId,
     WorkflowEventData,
 )
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
@@ -281,7 +282,7 @@ def process_detectors[T](
 
 
 # TODO - move to another file / location
-def associate_new_group_with_detector(group: Group, detector_id: int | None = None) -> bool:
+def associate_new_group_with_detector(group: Group, detector_id: DetectorId | None = None) -> bool:
     """
     Associate a new Group with it's Detector in the database.
     If the Group is an error, it can be associated without a detector ID.
@@ -359,7 +360,7 @@ def associate_new_group_with_detector(group: Group, detector_id: int | None = No
 
 
 # TODO - move to another file / location
-def ensure_association_with_detector(group: Group, detector_id: int | None = None) -> bool:
+def ensure_association_with_detector(group: Group, detector_id: DetectorId | None = None) -> bool:
     """
     Ensure a Group has a DetectorGroup association, creating it if missing.
     Backdates date_added to group.first_seen for gradual backfill of existing groups.

--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -100,7 +100,6 @@ def trigger_action(
     occurrence_id: str | None,
     group_state: GroupState,
     has_escalated: bool,
-    detector_id: int | None = None,  # TODO: remove
     notification_uuid: str | None = None,
     **kwargs: dict[str, object],
 ) -> None:

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -27,7 +27,7 @@ from sentry.workflow_engine.tasks.utils import (
     ProjectNotActiveError,
     build_workflow_event_data_from_event,
 )
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import DetectorId, WorkflowEventData
 from sentry.workflow_engine.utils import log_context, scopedstats
 
 logger = log_context.get_logger(__name__)
@@ -40,7 +40,7 @@ logger = log_context.get_logger(__name__)
     retry=Retry(times=3, delay=5, on=(Exception,)),
     silo_mode=SiloMode.CELL,
 )
-def process_workflow_activity(activity_id: int, group_id: int, detector_id: int) -> None:
+def process_workflow_activity(activity_id: int, group_id: int, detector_id: DetectorId) -> None:
     """
     Process a workflow task identified by the given activity, group, and detector.
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -43,9 +43,10 @@ T = TypeVar("T")
 ERROR_DETECTOR_NAME = "Error Monitor"
 ISSUE_STREAM_DETECTOR_NAME = "Issue Stream"
 
-GroupId: TypeAlias = int
-DataConditionGroupId: TypeAlias = int
 ActionId: TypeAlias = int
+DataConditionGroupId: TypeAlias = int
+DetectorId: TypeAlias = int
+GroupId: TypeAlias = int
 WorkflowId: TypeAlias = int
 
 


### PR DESCRIPTION
# Description
Use a type alias for `DetectorId` and consistently use it. Hoping the clarity of a named variable helps provide more context than `int`.