### PR TITLE
feat(vsts): Support installing the extension via the API pipeline modal

### DIFF
--- a/src/sentry/integrations/vsts_extension/integration.py
+++ b/src/sentry/integrations/vsts_extension/integration.py
@@ -5,18 +5,52 @@ from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
+from rest_framework import serializers
 
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.integrations.base import IntegrationData
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.vsts.integration import AccountConfigView, VstsIntegrationProvider
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.utils.http import absolute_uri
+
+# Azure DevOps organization name rules: letters, numbers, or hyphens, starting
+# and ending with an alphanumeric, up to 50 characters.
+# https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/rename-organization?view=azure-devops#rename-your-organization
+VSTS_ACCOUNT_NAME_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9-]{0,48}[A-Za-z0-9]$"
+
+
+class VstsExtensionInitialDataSerializer(CamelSnakeSerializer[dict[str, Any]]):
+    """Initial pipeline data for Azure DevOps Marketplace installs.
+
+    The Marketplace redirects to the configure link with `targetId` /
+    `targetName` identifying the Azure DevOps organization the install was
+    started from. The account is therefore already known: we validate the name
+    and bind it to top-level pipeline state as `account` so the OAuth step can
+    finish the install without an account-selection screen.
+    """
+
+    target_id = serializers.CharField()
+    target_name = serializers.RegexField(
+        VSTS_ACCOUNT_NAME_PATTERN,
+        error_messages={"invalid": "Invalid targetName parameter"},
+    )
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "account": {
+                "accountId": attrs["target_id"],
+                "accountName": attrs["target_name"],
+            }
+        }
 
 
 class VstsExtensionIntegrationProvider(VstsIntegrationProvider):
     key = "vsts-extension"
     integration_key = IntegrationProviderSlug.AZURE_DEVOPS.value
+
+    can_add_externally = True
 
     # This is only to enable the VSTS -> Sentry installation flow, so we don't
     # want it to actually appear of the Integrations page.
@@ -28,16 +62,23 @@ class VstsExtensionIntegrationProvider(VstsIntegrationProvider):
         views.append(VstsExtensionFinishedView())
         return views
 
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        # Unlike the main Azure DevOps provider, the account is already known
+        # from the Marketplace params (bound to state as `account` by the
+        # initial-data serializer), so there is no account-selection step.
+        return [self._make_oauth_api_step()]
+
+    def get_initial_data_serializer_cls(self) -> type[VstsExtensionInitialDataSerializer]:
+        return VstsExtensionInitialDataSerializer
+
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
-        return super().build_integration(
-            {
-                **state,
-                "account": {
-                    "accountId": state[IntegrationProviderSlug.AZURE_DEVOPS.value]["accountId"],
-                    "accountName": state[IntegrationProviderSlug.AZURE_DEVOPS.value]["accountName"],
-                },
-            }
-        )
+        # The API pipeline binds the account top-level via the initial-data
+        # serializer; the legacy configure view binds it under the provider key.
+        account = state.get("account") or {
+            "accountId": state[IntegrationProviderSlug.AZURE_DEVOPS.value]["accountId"],
+            "accountName": state[IntegrationProviderSlug.AZURE_DEVOPS.value]["accountName"],
+        }
+        return super().build_integration({**state, "account": account})
 
 
 class VstsExtensionFinishedView:

--- a/tests/sentry/integrations/vsts_extension/test_provider.py
+++ b/tests/sentry/integrations/vsts_extension/test_provider.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, Mock, patch
 from urllib.parse import parse_qs, urlparse
 
+import orjson
 from django.urls import reverse
 
 from fixtures.vsts import VstsIntegrationTestCase
@@ -10,7 +11,8 @@ from sentry.integrations.vsts_extension import (
     VstsExtensionFinishedView,
     VstsExtensionIntegrationProvider,
 )
-from sentry.testutils.silo import control_silo_test
+from sentry.silo.base import SiloMode
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from tests.sentry.integrations.vsts.test_integration import FULL_SCOPES
 
 
@@ -79,3 +81,81 @@ class VstsExtensionIntegrationProviderTest(VstsIntegrationTestCase):
 
         # Should have create the Integration using the ``vsts`` key
         assert Integration.objects.filter(provider="vsts").exists()
+
+
+@control_silo_test
+class VstsExtensionApiPipelineTest(VstsIntegrationTestCase):
+    provider = VstsExtensionIntegrationProvider()
+
+    @assume_test_silo_mode(SiloMode.CONTROL)
+    def test_install_skips_account_selection(self) -> None:
+        pipeline_url = reverse(
+            "sentry-api-0-organization-pipeline",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "pipeline_name": "integration_pipeline",
+            },
+        )
+
+        # The Marketplace already knows the account, so it is supplied as
+        # initialData rather than chosen via an account-selection step.
+        resp = self.client.post(
+            pipeline_url,
+            data=orjson.dumps(
+                {
+                    "action": "initialize",
+                    "provider": "vsts-extension",
+                    "initialData": {
+                        "targetId": self.vsts_account_id,
+                        "targetName": self.vsts_account_name,
+                    },
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200, resp.content
+        resp_data = resp.json()
+        assert resp_data["step"] == "oauth_login"
+
+        oauth_url = resp_data["data"]["oauthUrl"]
+        pipeline_signature = parse_qs(urlparse(oauth_url).query)["state"][0]
+
+        # Advancing through OAuth completes the install directly, with no
+        # account-selection step in between.
+        resp = self.client.post(
+            pipeline_url,
+            data=orjson.dumps({"code": "oauth-code", "state": pipeline_signature}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200, resp.content
+        assert resp.json()["status"] == "complete"
+
+        integration = Integration.objects.get(provider="vsts")
+        assert integration.external_id == self.vsts_account_id
+        assert integration.name == self.vsts_account_name
+
+    @assume_test_silo_mode(SiloMode.CONTROL)
+    def test_rejects_invalid_account_name(self) -> None:
+        pipeline_url = reverse(
+            "sentry-api-0-organization-pipeline",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "pipeline_name": "integration_pipeline",
+            },
+        )
+
+        resp = self.client.post(
+            pipeline_url,
+            data=orjson.dumps(
+                {
+                    "action": "initialize",
+                    "provider": "vsts-extension",
+                    "initialData": {
+                        "targetId": self.vsts_account_id,
+                        "targetName": "invalid name with spaces",
+                    },
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400, resp.content


### PR DESCRIPTION
Adds the API-mode pipeline machinery for the Azure DevOps Marketplace extension install alongside the existing server-rendered configure flow, **without changing the entry point**. The legacy configure view and pipeline views are untouched, so nothing changes for users until the frontend can drive the modal and the legacy views are removed in a follow-up.

Azure DevOps has two providers: the in-app `vsts` provider (OAuth + account selection) and the marketplace-only `vsts-extension` provider (`visible = False`). The Marketplace already knows the account, so the extension does OAuth but skips account selection.

- `VstsExtensionInitialDataSerializer` validates the Marketplace `targetId`/`targetName` and binds the chosen account to top-level pipeline state, so the account is known before OAuth.
- `get_pipeline_api_steps` reuses the parent OAuth step but omits the account-selection step.
- `build_integration` reads the top-level `account`, falling back to the nested provider-key state the legacy configure view binds.
- Sets `can_add_externally` so the externally-initiated Marketplace install is allowed through the pipeline endpoint while the in-app directory still hides this provider.

Follows the same structure as Jira (#116500) and MS Teams (#116490): backend (this PR) -> frontend (#116904) -> backend cleanup (legacy-view removal + configure redirect).

Refs [VDY-32](https://linear.app/getsentry/issue/VDY-32/migrate-integration-setup-pipelines-to-api-driven-flows)