### PR TITLE
feat(vsts): Wire Marketplace installs through the API pipeline modal

### DIFF
--- a/static/app/components/pipeline/integrationVstsExtension/index.spec.tsx
+++ b/static/app/components/pipeline/integrationVstsExtension/index.spec.tsx
@@ -1,0 +1,75 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {
+  createMakeStepProps,
+  dispatchPipelineMessage,
+  setupMockPopup,
+} from 'sentry/components/pipeline/testUtils';
+
+import {vstsExtensionIntegrationPipeline} from '.';
+
+const VstsExtensionOAuthLoginStep = vstsExtensionIntegrationPipeline.steps[0].component;
+
+const makeStepProps = createMakeStepProps({totalSteps: 1});
+
+let mockPopup: Window;
+
+beforeEach(() => {
+  mockPopup = setupMockPopup();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('VstsExtensionOAuthLoginStep', () => {
+  it('is the only step (no account selection)', () => {
+    expect(vstsExtensionIntegrationPipeline.steps).toHaveLength(1);
+  });
+
+  it('renders the OAuth login step for Azure DevOps', () => {
+    render(
+      <VstsExtensionOAuthLoginStep
+        {...makeStepProps({
+          stepData: {
+            oauthUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+          },
+        })}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Authorize Azure DevOps'})
+    ).toBeInTheDocument();
+  });
+
+  it('calls advance with code and state on OAuth callback', async () => {
+    const advance = jest.fn();
+    render(
+      <VstsExtensionOAuthLoginStep
+        {...makeStepProps({
+          stepData: {
+            oauthUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+          },
+          advance,
+        })}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Authorize Azure DevOps'}));
+
+    dispatchPipelineMessage({
+      source: mockPopup,
+      data: {
+        _pipeline_source: 'sentry-pipeline',
+        code: 'auth-code-123',
+        state: 'state-xyz',
+      },
+    });
+
+    expect(advance).toHaveBeenCalledWith({
+      code: 'auth-code-123',
+      state: 'state-xyz',
+    });
+  });
+});

--- a/static/app/components/pipeline/integrationVstsExtension/index.tsx
+++ b/static/app/components/pipeline/integrationVstsExtension/index.tsx
@@ -1,0 +1,52 @@
+import {useCallback} from 'react';
+
+import type {OAuthCallbackData} from 'sentry/components/pipeline/shared/oauthLoginStep';
+import {OAuthLoginStep} from 'sentry/components/pipeline/shared/oauthLoginStep';
+import type {
+  PipelineDefinition,
+  PipelineStepProps,
+} from 'sentry/components/pipeline/types';
+import {pipelineComplete} from 'sentry/components/pipeline/types';
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+function VstsExtensionOAuthLoginStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<{oauthUrl?: string}, {code: string; state: string}>) {
+  const handleOAuthCallback = useCallback(
+    (data: OAuthCallbackData) => {
+      advance({code: data.code, state: data.state});
+    },
+    [advance]
+  );
+
+  return (
+    <OAuthLoginStep
+      oauthUrl={stepData?.oauthUrl}
+      isLoading={isAdvancing}
+      serviceName="Azure DevOps"
+      onOAuthCallback={handleOAuthCallback}
+    />
+  );
+}
+
+// The Azure DevOps Marketplace install reuses the main provider's OAuth step,
+// but unlike the in-app `vsts` pipeline there is no account-selection step: the
+// Marketplace already determined the account and bound it to pipeline state, so
+// OAuth alone completes the install.
+export const vstsExtensionIntegrationPipeline = {
+  type: 'integration',
+  provider: 'vsts-extension',
+  actionTitle: t('Installing Azure DevOps Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'oauth_login',
+      shortDescription: t('Authorizing via Azure DevOps OAuth'),
+      component: VstsExtensionOAuthLoginStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -19,6 +19,7 @@ import {
 } from './integrationSlack';
 import {vercelIntegrationPipeline} from './integrationVercel';
 import {vstsIntegrationPipeline} from './integrationVsts';
+import {vstsExtensionIntegrationPipeline} from './integrationVstsExtension';
 
 /**
  * All registered pipeline definitions.
@@ -42,6 +43,7 @@ export const PIPELINE_REGISTRY = [
   slackIntegrationPipeline,
   slackStagingIntegrationPipeline,
   vstsIntegrationPipeline,
+  vstsExtensionIntegrationPipeline,
   vercelIntegrationPipeline,
 ] as const;
 

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -62,6 +62,7 @@ const UNCONDITIONAL_API_PIPELINE_PROVIDERS = [
   'slack_staging',
   'vercel',
   'vsts',
+  'vsts-extension',
 ] as const satisfies ReadonlyArray<ProvidersByType['integration']>;
 
 type UnconditionalApiPipelineProvider =

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -101,6 +101,11 @@ function trackExternalAnalytics({
  *    `/extensions/vercel/configure/`). Drives the pipeline with
  *    `vercelParams`.
  *
+ *  - Azure DevOps (VSTS Marketplace)
+ *    `/extensions/vsts/link/?targetId=...&targetName=...` (redirected from
+ *    `/extensions/vsts/configure/`). Drives the `vsts-extension` pipeline with
+ *    `vstsExtensionParams`.
+ *
  *  - Anything else
  *    falls through to {@link finishLegacyInstallation}, which bounces to the
  *    legacy `/extensions/<slug>/configure/` backend endpoint.
@@ -276,6 +281,23 @@ export default function IntegrationOrganizationLink() {
     return {code};
   }, [integrationSlug, location.query]);
 
+  // Azure DevOps Marketplace installs arrive here with `targetId` / `targetName`
+  // in the URL query (forwarded from `/extensions/vsts/configure/`). These
+  // identify the Azure DevOps organization the install started from; the
+  // `vsts-extension` pipeline binds them as the account and finishes with just
+  // OAuth (no account-selection step).
+  const vstsExtensionParams = useMemo<Record<string, string> | null>(() => {
+    if (integrationSlug !== 'vsts') {
+      return null;
+    }
+    const targetId = location.query.targetId;
+    const targetName = location.query.targetName;
+    if (typeof targetId !== 'string' || typeof targetName !== 'string') {
+      return null;
+    }
+    return {targetId, targetName};
+  }, [integrationSlug, location.query]);
+
   // Legacy install path. Redirects to `/extensions/<slug>/configure/`, which
   // runs the Django-rendered `IntegrationExtensionConfigurationView` to drive
   // the install server-side via the legacy pipeline. Used by every provider
@@ -298,6 +320,21 @@ export default function IntegrationOrganizationLink() {
 
   const handleInstallClick = useCallback(() => {
     if (!provider || !organization) {
+      return;
+    }
+
+    // The Azure DevOps Marketplace install drives the OAuth-only
+    // `vsts-extension` pipeline rather than the in-app `vsts` pipeline (which
+    // has an account-selection step). The account is already known from the
+    // Marketplace params, so open the modal with the extension provider while
+    // keeping the resolved `vsts` provider for display and analytics.
+    if (vstsExtensionParams) {
+      startFlow({
+        provider: {...provider, key: 'vsts-extension'},
+        organization,
+        onInstall,
+        urlParams: vstsExtensionParams,
+      });
       return;
     }
 
@@ -324,6 +361,7 @@ export default function IntegrationOrganizationLink() {
     msTeamsParams,
     jiraParams,
     vercelParams,
+    vstsExtensionParams,
     startFlow,
     onInstall,
     finishLegacyInstallation,


### PR DESCRIPTION
When a user installs Sentry from the Azure DevOps Marketplace, the configure link forwards `targetId`/`targetName` to the org-link page, which now drives the API pipeline modal instead of the legacy server-rendered flow.

Azure DevOps has two providers: the in-app `vsts` provider (OAuth + account selection) and the marketplace-only `vsts-extension` provider. The Marketplace already knows the account, so the install must drive the OAuth-only `vsts-extension` pipeline. The org-link page resolves the `vsts` provider from the slug, so the install opens the modal with the `vsts-extension` provider key while keeping `vsts` for display and analytics.

- Add the `vstsExtensionIntegrationPipeline` (single OAuth step) and register it; add `vsts-extension` to the unconditional API pipeline providers.
- Add `vstsExtensionParams` in the org-link view, returning `{targetId, targetName}` when both are present, and route the install through the `vsts-extension` pipeline provider.

Depends on the backend pipeline support (#116903) and must not deploy before it: the modal calls the API pipeline initialize endpoint for `vsts-extension`. The `/extensions/vsts/configure/` URL still routes through the legacy server-rendered view until a follow-up swaps it to a redirect.

Refs [VDY-32](https://linear.app/getsentry/issue/VDY-32/migrate-integration-setup-pipelines-to-api-driven-flows)