### PR TITLE
fix(report): enforce enhanced privacy settings for weekly report

### DIFF
--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -178,8 +178,11 @@ class OrganizationReportContextFactory:
             self._append_user_project_ownership(ctx)
             self._append_project_event_counts(ctx)
             self._append_organization_project_issue_substatus_summaries(ctx)
-            self._append_project_key_errors(ctx)
-            self._hydrate_key_error_groups(ctx)
-            self._hydrate_key_performance_issue_groups(ctx)
+
+            # Enhanced privacy flag hides issue titles, transaction names, and source details
+            if not self.organization.flags.enhanced_privacy:
+                self._append_project_key_errors(ctx)
+                self._hydrate_key_error_groups(ctx)
+                self._hydrate_key_performance_issue_groups(ctx)
 
         return ctx

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -767,6 +767,7 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
         "issue_summary": issue_summary(),
         "user_project_count": len(user_projects),
         "notification_uuid": notification_uuid,
+        "enhanced_privacy": ctx.organization.flags.enhanced_privacy,
     }
 
 

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -480,7 +480,9 @@
   <div style="padding: 16px; margin: 16px 0; background-color: #f5f3f7; border-radius: 4px; font-size: 14px;">
     Details about specific issues and transactions are not shown in this report since enhanced privacy
     controls are enabled. For more details,
-    <a href="{% absolute_uri '/organizations/' %}{{ organization.slug }}/issues/?referrer=weekly_report&notification_uuid={{ notification_uuid }}">view your issues on Sentry</a>.
+    {% url 'sentry-organization-issue-list' organization.slug as issue_list %}
+    {% querystring referrer="weekly_report" notification_uuid=notification_uuid as query %}
+    <a href="{% org_url organization issue_list query=query %}">view your issues on Sentry</a>.
   </div>
   {% endif %}
 

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -476,7 +476,15 @@
 
   </div>
 
-  {% if key_errors|length > 0 %}
+  {% if enhanced_privacy %}
+  <div style="padding: 16px; margin: 16px 0; background-color: #f5f3f7; border-radius: 4px; font-size: 14px;">
+    Details about specific issues and transactions are not shown in this report since enhanced privacy
+    controls are enabled. For more details,
+    <a href="{% absolute_uri '/organizations/' %}{{ organization.slug }}/issues/?referrer=weekly_report&notification_uuid={{ notification_uuid }}">view your issues on Sentry</a>.
+  </div>
+  {% endif %}
+
+  {% if key_errors|length > 0 and not enhanced_privacy %}
   <div id="key-errors">
     <h4>Issues with the most errors</h4>
     {% for a in key_errors %}
@@ -498,7 +506,7 @@
     {% endfor %}
   </div>
   {% endif %}
-  {% if key_performance_issues|length > 0 %}
+  {% if key_performance_issues|length > 0 and not enhanced_privacy %}
   <div id="key-performance-issues">
     <h4>Most frequent performance issues</h4>
     {% for a in key_performance_issues %}
@@ -516,7 +524,7 @@
     {% endfor %}
   </div>
   {% endif %}
-  {% if key_transactions|length > 0 %}
+  {% if key_transactions|length > 0 and not enhanced_privacy %}
   <div id="key-transactions">
     <h4>Most frequent transactions</h4>
     {% for a in key_transactions %}

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -29,6 +29,9 @@ class DebugWeeklyReportView(MailPreviewView):
     def get_context(self, request):
         organization = Organization(id=1, slug="myorg", name="MyOrg")
 
+        if request.GET.get("enhanced_privacy"):
+            organization.flags.enhanced_privacy = True
+
         random = get_random(request)
 
         duration = 60 * 60 * 24 * 7

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -15,6 +15,7 @@ from sentry.constants import DataCategory
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.models.group import GroupStatus
 from sentry.models.grouphistory import GroupHistoryStatus
+from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
 from sentry.models.team import TeamStatus
@@ -23,6 +24,9 @@ from sentry.notifications.models.notificationsettingoption import NotificationSe
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
 from sentry.snuba.referrer import Referrer
+from sentry.tasks.summaries.organization_report_context_factory import (
+    OrganizationReportContextFactory,
+)
 from sentry.tasks.summaries.utils import (
     ONE_DAY,
     OrganizationReportContext,
@@ -1431,3 +1435,104 @@ class WeeklyReportsTest(
             message_params = call_args.kwargs
             context = message_params["context"]
             assert len(context["trends"]["legend"]) == 0
+
+    @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
+    def test_enhanced_privacy_hides_key_errors_and_transactions(
+        self, message_builder: mock.MagicMock
+    ) -> None:
+        self.organization.update(flags=F("flags").bitor(Organization.flags.enhanced_privacy))
+
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "sensitive error message",
+                "timestamp": self.three_days_ago.isoformat(),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+            default_event_type=EventType.DEFAULT,
+        )
+        self.store_event_outcomes(
+            self.organization.id, self.project.id, self.three_days_ago, num_times=2
+        )
+
+        prepare_organization_report(
+            self.timestamp, ONE_DAY * 7, self.organization.id, self._dummy_batch_id
+        )
+
+        message_params = message_builder.call_args.kwargs
+        ctx = message_params["context"]
+
+        assert ctx["enhanced_privacy"]
+        assert len(ctx["key_errors"]) == 0
+        assert len(ctx["key_transactions"]) == 0
+        assert len(ctx["key_performance_issues"]) == 0
+        assert ctx["trends"]["total_error_count"] == 2
+        assert ctx["issue_summary"] is not None
+
+    def test_enhanced_privacy_context_factory_skips_key_data(self) -> None:
+        self.organization.update(flags=F("flags").bitor(Organization.flags.enhanced_privacy))
+        self.organization.refresh_from_db()
+
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "message",
+                "timestamp": self.three_days_ago.isoformat(),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+            default_event_type=EventType.DEFAULT,
+        )
+        self.store_event_outcomes(
+            self.organization.id, self.project.id, self.three_days_ago, num_times=2
+        )
+
+        factory = OrganizationReportContextFactory(
+            timestamp=self.timestamp,
+            duration=ONE_DAY * 7,
+            organization=self.organization,
+        )
+        ctx = factory.create_context()
+
+        for project_ctx in ctx.projects_context_map.values():
+            assert project_ctx.key_errors_by_group == []
+            assert project_ctx.key_transactions == []
+            assert project_ctx.key_performance_issues == []
+
+    @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
+    def test_enhanced_privacy_email_does_not_contain_sensitive_data(self) -> None:
+        self.organization.update(flags=F("flags").bitor(Organization.flags.enhanced_privacy))
+
+        with unguarded_write(using=router.db_for_write(Project)):
+            Project.objects.all().delete()
+        project = self.create_project(
+            organization=self.organization,
+            teams=[self.team],
+            date_added=self.now - timedelta(days=90),
+        )
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "sensitive error title xyz123",
+                "timestamp": before_now(days=1).isoformat(),
+                "fingerprint": ["group-1"],
+            },
+            project_id=project.id,
+            default_event_type=EventType.DEFAULT,
+        )
+        self.store_event_outcomes(
+            self.organization.id, project.id, self.three_days_ago, num_times=1
+        )
+
+        with self.tasks():
+            schedule_organizations(timestamp=self.now.timestamp())
+            assert len(mail.outbox) >= 1
+            message = mail.outbox[0]
+            assert isinstance(message, EmailMultiAlternatives)
+            html = message.alternatives[0][0]
+            assert isinstance(html, str)
+
+            assert "sensitive error title xyz123" not in html
+            assert "enhanced privacy" in html.lower()
+            assert "Total Project Errors" in html


### PR DESCRIPTION
Resolves [ID-1610](https://linear.app/getsentry/issue/ID-1610/enhanced-privacy-inconsistently-scrubbing-emails)

Problem statement: weekly digest emails don't enforce org-level enhanced privacy settings

When `organization.flags.enhanced_privacy` is `true`:
- What's still visible: count of errors, transactions, and issues breakdown
- What's not visible: Top Issue details section

To test:
- Run dev environment (`devservices serve`)
- Go to `/debug/mail/weekly-reports/?enhanced_privacy=1`
- Details about specific issues / transactions should not be visible. Instead, there should be a block of text that reads 

"Details about specific issues and transactions are not shown in this report since enhanced privacy controls are enabled. For more details, [view your issues on Sentry]()." 

The link leads back to the Issue Details page.