### PR TITLE
feat(project transfer): Attempt to reconnect integration when Action is transferred

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -519,6 +519,7 @@ class Project(Model):
         )
         from sentry.workflow_engine.processors.project_transfer import (
             clone_workflow_to_organization,
+            reconnect_moved_workflow_actions,
         )
 
         old_org_id = self.organization_id
@@ -751,6 +752,12 @@ class Project(Model):
                 )
                 DataConditionGroup.objects.filter(id__in=when_condition_group_ids).update(
                     organization_id=organization.id
+                )
+
+                # update the integration id or disable the action
+                reconnect_moved_workflow_actions(
+                    exclusive_condition_group_ids + list(when_condition_group_ids),
+                    destination_integration_ids_by_provider,
                 )
 
                 # Clone the shared workflows into the new org and re-point only this project's links.

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -665,12 +665,11 @@ class Project(Model):
         )
         if detector_ids:
             # grab the destination org's integrations outside of the transaction since it's an RPC call
-            destination_integration_ids_by_provider = {
-                integration.provider: integration.id
-                for integration in integration_service.get_integrations(
-                    organization_id=organization.id, status=ObjectStatus.ACTIVE
-                )
-            }
+            destination_integration_ids_by_provider: dict[str, list[int]] = defaultdict(list)
+            for integration in integration_service.get_integrations(
+                organization_id=organization.id, status=ObjectStatus.ACTIVE
+            ):
+                destination_integration_ids_by_provider[integration.provider].append(integration.id)
             with transaction.atomic(router.db_for_write(Workflow)):
                 # DataSources are 1:1 with their source (e.g. QuerySubscription, Monitor) and are
                 # detector-scoped, so they always transfer.

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -499,6 +499,7 @@ class Project(Model):
         from sentry.integrations.models.repository_project_path_config import (
             RepositoryProjectPathConfig,
         )
+        from sentry.integrations.services.integration import integration_service
         from sentry.models.environment import Environment, EnvironmentProject
         from sentry.models.projectcodeowners import ProjectCodeOwners
         from sentry.models.projectrepository import ProjectRepository
@@ -663,6 +664,13 @@ class Project(Model):
             Detector.objects.filter(project_id=self.id).values_list("id", flat=True)
         )
         if detector_ids:
+            # grab the destination org's integrations outside of the transaction since it's an RPC call
+            destination_integration_ids_by_provider = {
+                integration.provider: integration.id
+                for integration in integration_service.get_integrations(
+                    organization_id=organization.id, status=ObjectStatus.ACTIVE
+                )
+            }
             with transaction.atomic(router.db_for_write(Workflow)):
                 # DataSources are 1:1 with their source (e.g. QuerySubscription, Monitor) and are
                 # detector-scoped, so they always transfer.
@@ -762,6 +770,7 @@ class Project(Model):
                             workflow,
                             organization,
                             resolve_environment_id(workflow.environment_id),
+                            destination_integration_ids_by_provider,
                         )
                         # Detectors are project-scoped and move with this project, so re-point all
                         # of their workflow links (cron, issue_stream, error, ...) onto the clone.

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -754,9 +754,10 @@ class Project(Model):
                     organization_id=organization.id
                 )
 
-                # update the integration id or disable the action
+                # update the integration id or disable the action. Actions only ever attach to
+                # the if_condition_groups, not the when_condition_groups
                 reconnect_moved_workflow_actions(
-                    exclusive_condition_group_ids + list(when_condition_group_ids),
+                    exclusive_condition_group_ids,
                     destination_integration_ids_by_provider,
                 )
 

--- a/src/sentry/workflow_engine/processors/project_transfer.py
+++ b/src/sentry/workflow_engine/processors/project_transfer.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import copy
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
+from sentry.constants import ObjectStatus
 from sentry.db.models import DefaultFieldsModel
 from sentry.workflow_engine.models import (
+    Action,
     DataCondition,
     DataConditionGroup,
     DataConditionGroupAction,
@@ -30,6 +33,7 @@ def clone_workflow_to_organization(
     workflow: Workflow,
     destination_organization: Organization,
     environment_id: int | None,
+    destination_integration_ids_by_provider: Mapping[str, int],
 ) -> Workflow:
     """Deep-copy a workflow and its condition graph into the destination organization.
 
@@ -37,10 +41,15 @@ def clone_workflow_to_organization(
     projects: the transferring project gets its own copy in the new org while the original
     is left intact for the projects that remain. The owner team/user is dropped because it
     won't belong to the new org, and fire history / detector state are not copied.
+
+    destination_integration_ids_by_provider maps an integration provider to an active
+    integration id in the destination org so we can re-connect the Action if possible,
+    and disable the Action if it's not
     """
 
     def clone_condition_group(
         condition_group: DataConditionGroup,
+        destination_organization: Organization,
     ) -> DataConditionGroup:
         new_group = DataConditionGroup.objects.create(
             organization_id=destination_organization.id,
@@ -61,11 +70,25 @@ def clone_workflow_to_organization(
             condition_group=condition_group
         ).select_related("action"):
             action = group_action.action
+
+            new_integration_id = action.integration_id
+            new_status = action.status
+            if Action.Type(action.type).is_integration():
+                destination_integration_id = destination_integration_ids_by_provider.get(
+                    action.type
+                )
+                if destination_integration_id is not None:
+                    new_integration_id = destination_integration_id
+                else:
+                    # No matching integration in the destination org; keep the dangling reference
+                    # but disable the action so it can't fire against the old org's integration
+                    new_status = ObjectStatus.DISABLED
+
             action_overrides = {
                 "type": action.type,
                 "data": action.data,
-                "integration_id": action.integration_id,
-                "status": action.status,
+                "integration_id": new_integration_id,
+                "status": new_status,
                 "config": action.config,
             }
             new_action = _simple_shallow_clone(action, **action_overrides)
@@ -84,7 +107,9 @@ def clone_workflow_to_organization(
         # destination org; drop it rather than carry a dangling reference.
         "owner_user_id": None,
         "owner_team_id": None,
-        "when_condition_group": clone_condition_group(when_condition_group)
+        "when_condition_group": clone_condition_group(
+            when_condition_group, destination_organization
+        )
         if when_condition_group is not None
         else None,
         "environment_id": environment_id,
@@ -96,7 +121,9 @@ def clone_workflow_to_organization(
             workflow_dcg,
             **{
                 "workflow": new_workflow,
-                "condition_group": clone_condition_group(workflow_dcg.condition_group),
+                "condition_group": clone_condition_group(
+                    workflow_dcg.condition_group, destination_organization
+                ),
             },
         )
 

--- a/src/sentry/workflow_engine/processors/project_transfer.py
+++ b/src/sentry/workflow_engine/processors/project_transfer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from sentry.constants import ObjectStatus
@@ -33,7 +33,7 @@ def clone_workflow_to_organization(
     workflow: Workflow,
     destination_organization: Organization,
     environment_id: int | None,
-    destination_integration_ids_by_provider: Mapping[str, int],
+    destination_integration_ids_by_provider: Mapping[str, Sequence[int]],
 ) -> Workflow:
     """Deep-copy a workflow and its condition graph into the destination organization.
 
@@ -42,9 +42,11 @@ def clone_workflow_to_organization(
     is left intact for the projects that remain. The owner team/user is dropped because it
     won't belong to the new org, and fire history / detector state are not copied.
 
-    destination_integration_ids_by_provider maps an integration provider to an active
-    integration id in the destination org so we can re-connect the Action if possible,
-    and disable the Action if it's not
+    destination_integration_ids_by_provider maps an integration provider to the active
+    integration ids in the destination org so we can re-connect the Action if there's
+    exactly one match, and disable the Action otherwise. If the destination org has
+    multiple active integrations of the same provider (e.g. several Slack workspaces) we
+    can't know which one the Action meant, so we disable it rather than guess.
     """
 
     def clone_condition_group(
@@ -74,14 +76,12 @@ def clone_workflow_to_organization(
             new_integration_id = action.integration_id
             new_status = action.status
             if Action.Type(action.type).is_integration():
-                destination_integration_id = destination_integration_ids_by_provider.get(
-                    action.type
+                destination_integration_ids = destination_integration_ids_by_provider.get(
+                    action.type, []
                 )
-                if destination_integration_id is not None:
-                    new_integration_id = destination_integration_id
+                if len(destination_integration_ids) == 1:
+                    new_integration_id = destination_integration_ids[0]
                 else:
-                    # No matching integration in the destination org; keep the dangling reference
-                    # but disable the action so it can't fire against the old org's integration
                     new_status = ObjectStatus.DISABLED
 
             action_overrides = {

--- a/src/sentry/workflow_engine/processors/project_transfer.py
+++ b/src/sentry/workflow_engine/processors/project_transfer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from sentry.constants import ObjectStatus
@@ -27,6 +27,45 @@ def _simple_shallow_clone[T: DefaultFieldsModel](original: T, **overrides: Any) 
         setattr(new, attr, value)
     new.save()
     return new
+
+
+def resolve_destination_integration(
+    action: Action,
+    destination_integration_ids_by_provider: Mapping[str, Sequence[int]],
+) -> tuple[int | None, int]:
+    """
+    Resolve the (integration_id, status) an Action should use in the destination org.
+       Updates the integration ID on an Action if the same type of integration exists in the
+       destination org - disables it if not or if there are more than 1 of that type of integration
+    """
+    if not Action.Type(action.type).is_integration():
+        return action.integration_id, action.status
+
+    destination_integration_ids = destination_integration_ids_by_provider.get(action.type, [])
+    if len(destination_integration_ids) == 1:
+        return destination_integration_ids[0], action.status
+    return action.integration_id, ObjectStatus.DISABLED
+
+
+def reconnect_moved_workflow_actions(
+    condition_group_ids: Collection[int],
+    destination_integration_ids_by_provider: Mapping[str, Sequence[int]],
+) -> None:
+    """
+    Re-point integration Actions of workflows that were moved into the new org
+    """
+    if not condition_group_ids:
+        return
+
+    actions = Action.objects.filter(
+        dataconditiongroupaction__condition_group_id__in=condition_group_ids
+    ).distinct()
+    for action in actions:
+        new_integration_id, new_status = resolve_destination_integration(
+            action, destination_integration_ids_by_provider
+        )
+        if new_integration_id != action.integration_id or new_status != action.status:
+            action.update(integration_id=new_integration_id, status=new_status)
 
 
 def clone_workflow_to_organization(
@@ -73,16 +112,9 @@ def clone_workflow_to_organization(
         ).select_related("action"):
             action = group_action.action
 
-            new_integration_id = action.integration_id
-            new_status = action.status
-            if Action.Type(action.type).is_integration():
-                destination_integration_ids = destination_integration_ids_by_provider.get(
-                    action.type, []
-                )
-                if len(destination_integration_ids) == 1:
-                    new_integration_id = destination_integration_ids[0]
-                else:
-                    new_status = ObjectStatus.DISABLED
+            new_integration_id, new_status = resolve_destination_integration(
+                action, destination_integration_ids_by_provider
+            )
 
             action_overrides = {
                 "type": action.type,

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -511,10 +511,23 @@ class TestProjectTransfer(TestCase):
         ).exists()
 
     def test_transfer_to_organization_with_workflow_data_condition_groups(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            from_integration = self.create_integration(
+                organization=self.from_org, external_id="from-slack", provider="slack"
+            )
+            to_integration = self.create_integration(
+                organization=self.to_org, external_id="to-slack", provider="slack"
+            )
+
         condition_group = self.create_data_condition_group(organization=self.from_org)
         self.create_workflow_data_condition_group(
             workflow=self.workflow, condition_group=condition_group
         )
+        action = self.create_action(
+            integration_id=from_integration.id,
+            status=ObjectStatus.ACTIVE,
+        )
+        self.create_data_condition_group_action(action=action, condition_group=condition_group)
 
         self.project.transfer_to(organization=self.to_org)
 
@@ -530,6 +543,12 @@ class TestProjectTransfer(TestCase):
         wdcg = condition_group.workflowdataconditiongroup_set.first()
         assert wdcg is not None
         assert wdcg.workflow_id == self.workflow.id
+
+        # The workflow moved in place; the destination org has a matching active Slack integration,
+        # so the same action is remapped to it and stays active.
+        action.refresh_from_db()
+        assert action.integration_id == to_integration.id
+        assert action.status == ObjectStatus.ACTIVE
 
     def test_transfer_to_organization_clones_shared_workflows(self) -> None:
         project_a = self.create_project(teams=[self.team], name="Project A")

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -763,6 +763,61 @@ class TestProjectTransfer(TestCase):
         action.refresh_from_db()
         assert action.status == ObjectStatus.ACTIVE
 
+    def test_transfer_to_organization_disables_integration_action_with_multiple_destination_integrations(
+        self,
+    ) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            from_integration = self.create_integration(
+                organization=self.from_org, external_id="from-slack", provider="slack"
+            )
+            self.create_integration(
+                organization=self.to_org, external_id="to-slack-1", provider="slack"
+            )
+            self.create_integration(
+                organization=self.to_org, external_id="to-slack-2", provider="slack"
+            )
+
+        project_a = self.create_project(teams=[self.team], name="Project A")
+        project_b = self.create_project(
+            teams=[self.team], organization=self.from_org, name="Project B"
+        )
+
+        detector_a = self.create_detector(project=project_a)
+        detector_b = self.create_detector(project=project_b)
+
+        shared_workflow = self.create_workflow(organization=self.from_org, name="Shared Workflow")
+        self.create_detector_workflow(detector=detector_a, workflow=shared_workflow)
+        self.create_detector_workflow(detector=detector_b, workflow=shared_workflow)
+
+        shared_dcg = self.create_data_condition_group(organization=self.from_org)
+        self.create_workflow_data_condition_group(
+            workflow=shared_workflow, condition_group=shared_dcg
+        )
+        action = self.create_action(
+            integration_id=from_integration.id,
+            status=ObjectStatus.ACTIVE,
+        )
+        self.create_data_condition_group_action(action=action, condition_group=shared_dcg)
+
+        project_a.transfer_to(organization=self.to_org)
+
+        # The destination org has multiple active Slack integrations, so we can't tell which one
+        # the action meant; the cloned action keeps the original integration_id but is disabled.
+        clone = Workflow.objects.get(organization=self.to_org, name="Shared Workflow")
+        clone_condition_group_ids = WorkflowDataConditionGroup.objects.filter(
+            workflow=clone
+        ).values_list("condition_group_id", flat=True)
+        clone_action = Action.objects.get(
+            dataconditiongroupaction__condition_group_id__in=clone_condition_group_ids
+        )
+        assert clone_action.id != action.id
+        assert clone_action.integration_id == from_integration.id
+        assert clone_action.status == ObjectStatus.DISABLED
+
+        # The original action stays behind untouched.
+        action.refresh_from_db()
+        assert action.status == ObjectStatus.ACTIVE
+
     def test_transfer_to_organization_clones_shared_workflows_is_idempotent(self) -> None:
         project_a = self.create_project(teams=[self.team], name="Project A")
         project_b = self.create_project(

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 from unittest.mock import MagicMock, patch
 
+from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.deletions.tasks.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs_control
 from sentry.grouping.grouptype import ErrorGroupType
@@ -659,6 +660,108 @@ class TestProjectTransfer(TestCase):
         assert DataConditionGroupAction.objects.filter(
             condition_group=shared_dcg, action=action
         ).exists()
+
+    def test_transfer_to_organization_remaps_integration_action_to_destination_integration(
+        self,
+    ) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            from_integration = self.create_integration(
+                organization=self.from_org, external_id="from-slack", provider="slack"
+            )
+            to_integration = self.create_integration(
+                organization=self.to_org, external_id="to-slack", provider="slack"
+            )
+
+        project_a = self.create_project(teams=[self.team], name="Project A")
+        project_b = self.create_project(
+            teams=[self.team], organization=self.from_org, name="Project B"
+        )
+
+        detector_a = self.create_detector(project=project_a)
+        detector_b = self.create_detector(project=project_b)
+
+        shared_workflow = self.create_workflow(organization=self.from_org, name="Shared Workflow")
+        self.create_detector_workflow(detector=detector_a, workflow=shared_workflow)
+        self.create_detector_workflow(detector=detector_b, workflow=shared_workflow)
+
+        shared_dcg = self.create_data_condition_group(organization=self.from_org)
+        self.create_workflow_data_condition_group(
+            workflow=shared_workflow, condition_group=shared_dcg
+        )
+        action = self.create_action(
+            integration_id=from_integration.id,
+            status=ObjectStatus.ACTIVE,
+        )
+        self.create_data_condition_group_action(action=action, condition_group=shared_dcg)
+
+        project_a.transfer_to(organization=self.to_org)
+
+        # The destination org has a matching active Slack integration, so the cloned action is
+        # remapped to it and stays active.
+        clone = Workflow.objects.get(organization=self.to_org, name="Shared Workflow")
+        clone_condition_group_ids = WorkflowDataConditionGroup.objects.filter(
+            workflow=clone
+        ).values_list("condition_group_id", flat=True)
+        clone_action = Action.objects.get(
+            dataconditiongroupaction__condition_group_id__in=clone_condition_group_ids
+        )
+        assert clone_action.id != action.id
+        assert clone_action.integration_id == to_integration.id
+        assert clone_action.status == ObjectStatus.ACTIVE
+
+        # The original action stays behind untouched.
+        action.refresh_from_db()
+        assert action.integration_id == from_integration.id
+        assert action.status == ObjectStatus.ACTIVE
+
+    def test_transfer_to_organization_disables_integration_action_without_destination_integration(
+        self,
+    ) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            from_integration = self.create_integration(
+                organization=self.from_org, external_id="from-slack", provider="slack"
+            )
+
+        project_a = self.create_project(teams=[self.team], name="Project A")
+        project_b = self.create_project(
+            teams=[self.team], organization=self.from_org, name="Project B"
+        )
+
+        detector_a = self.create_detector(project=project_a)
+        detector_b = self.create_detector(project=project_b)
+
+        shared_workflow = self.create_workflow(organization=self.from_org, name="Shared Workflow")
+        self.create_detector_workflow(detector=detector_a, workflow=shared_workflow)
+        self.create_detector_workflow(detector=detector_b, workflow=shared_workflow)
+
+        shared_dcg = self.create_data_condition_group(organization=self.from_org)
+        self.create_workflow_data_condition_group(
+            workflow=shared_workflow, condition_group=shared_dcg
+        )
+        action = self.create_action(
+            integration_id=from_integration.id,
+            status=ObjectStatus.ACTIVE,
+        )
+        self.create_data_condition_group_action(action=action, condition_group=shared_dcg)
+
+        project_a.transfer_to(organization=self.to_org)
+
+        # The destination org has no matching integration, so the cloned action keeps the original
+        # integration_id but is disabled.
+        clone = Workflow.objects.get(organization=self.to_org, name="Shared Workflow")
+        clone_condition_group_ids = WorkflowDataConditionGroup.objects.filter(
+            workflow=clone
+        ).values_list("condition_group_id", flat=True)
+        clone_action = Action.objects.get(
+            dataconditiongroupaction__condition_group_id__in=clone_condition_group_ids
+        )
+        assert clone_action.id != action.id
+        assert clone_action.integration_id == from_integration.id
+        assert clone_action.status == ObjectStatus.DISABLED
+
+        # The original action stays behind untouched.
+        action.refresh_from_db()
+        assert action.status == ObjectStatus.ACTIVE
 
     def test_transfer_to_organization_clones_shared_workflows_is_idempotent(self) -> None:
         project_a = self.create_project(teams=[self.team], name="Project A")


### PR DESCRIPTION
During project transfer we now deep copy (since https://github.com/getsentry/sentry/pull/116522) a `Workflow` and all of it's related models including `Action`. If the action is for an integration, we'll now attempt to look up an integration of the same type in the new organization the project is being transferred to and update the action's integration ID to point to that. If we can't, we'll disable the action so it can't fire. We already have a warning in place on the workflow details page when an action is disabled letting the user know they need to take action for it to fire.