### PR TITLE
fix(webhooks): Return disabled projects in org legacy webhooks endpoint

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/organization_legacy_webhooks.py
+++ b/src/sentry/sentry_apps/api/endpoints/organization_legacy_webhooks.py
@@ -26,8 +26,6 @@ class OrganizationLegacyWebhooksEndpoint(OrganizationEndpoint):
 
         result = []
         for option in project_options:
-            if not option.value:
-                continue
             project = option.project
             result.append(
                 {
@@ -35,7 +33,7 @@ class OrganizationLegacyWebhooksEndpoint(OrganizationEndpoint):
                     "projectSlug": project.slug,
                     "projectName": project.name,
                     "projectPlatform": project.platform,
-                    "enabled": True,
+                    "enabled": bool(option.value),
                 }
             )
 

--- a/tests/sentry/sentry_apps/api/endpoints/test_organization_legacy_webhooks.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_organization_legacy_webhooks.py
@@ -10,7 +10,7 @@ class OrganizationLegacyWebhooksTest(APITestCase):
         super().setUp()
         self.login_as(self.user)
 
-    def test_empty_when_no_webhooks_enabled(self) -> None:
+    def test_empty_when_no_webhooks_configured(self) -> None:
         response = self.get_success_response(self.organization.slug, status_code=200)
         assert response.data == {"projects": []}
 
@@ -23,24 +23,27 @@ class OrganizationLegacyWebhooksTest(APITestCase):
         assert project_data["projectSlug"] == self.project.slug
         assert project_data["enabled"] is True
 
-    def test_excludes_disabled_projects(self) -> None:
+    def test_returns_disabled_project(self) -> None:
         ProjectOption.objects.set_value(self.project, "webhooks:enabled", False)
 
         response = self.get_success_response(self.organization.slug, status_code=200)
-        assert response.data == {"projects": []}
+        assert len(response.data["projects"]) == 1
+        project_data = response.data["projects"][0]
+        assert project_data["projectSlug"] == self.project.slug
+        assert project_data["enabled"] is False
 
-    def test_multiple_projects(self) -> None:
+    def test_multiple_projects_mixed_states(self) -> None:
         project_b = self.create_project(
             slug="proj-b", organization=self.organization, platform="react"
         )
         ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
-        ProjectOption.objects.set_value(project_b, "webhooks:enabled", True)
+        ProjectOption.objects.set_value(project_b, "webhooks:enabled", False)
 
         response = self.get_success_response(self.organization.slug, status_code=200)
         assert len(response.data["projects"]) == 2
-        slugs = [p["projectSlug"] for p in response.data["projects"]]
-        assert self.project.slug in slugs
-        assert "proj-b" in slugs
+        by_slug = {p["projectSlug"]: p for p in response.data["projects"]}
+        assert by_slug[self.project.slug]["enabled"] is True
+        assert by_slug["proj-b"]["enabled"] is False
 
     def test_excludes_deleted_projects(self) -> None:
         deleted_project = self.create_project(slug="deleted", organization=self.organization)


### PR DESCRIPTION
- when disabling a configuration, we don't want the row to disspear in the frontend so change the endpoint to return both enabled and disabled configs