### PR TITLE
ref(buffers): Disable deprecated transactions in buffer usage

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -368,7 +368,7 @@ class RedisBuffer(Buffer):
         key = make_key(model, filters)
         # We can't use conn.map() due to wanting to support multiple pending
         # keys (one per Redis partition)
-        pipe = self.get_redis_connection(key)
+        pipe = self.get_redis_connection(key, transaction=(not self.is_redis_cluster))
         pipe.hsetnx(key, "m", f"{model.__module__}.{model.__name__}")
         _validate_json_roundtrip(filters, model)
 


### PR DESCRIPTION
Throwing exception on cluster mode. 
Setting transaction to false

```
Traceback (most recent call last):
  File "/.venv/lib/python3.13/site-packages/taskbroker_client/worker/workerchild.py", line 371, in run_worker
    _execute_activation(task_func, inflight.activation, app.context_hooks)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.13/site-packages/taskbroker_client/worker/workerchild.py", line 551, in _execute_activation
    task_func(*args, **kwargs)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/src/sentry/src/sentry/silo/base.py", line 157, in override
    return original_method(*args, **kwargs)
  File "/.venv/lib/python3.13/site-packages/taskbroker_client/task.py", line 157, in __call__
    return self._func(*args, **kwargs)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/src/sentry/src/sentry/tasks/store.py", line 651, in save_event
    _do_save_event(
    ~~~~~~~~~~~~~~^
        cache_key,
        ^^^^^^^^^^
    ...<5 lines>...
        **kwargs,
        ^^^^^^^^^
    )
    ^
  File "/usr/src/sentry/src/sentry/tasks/store.py", line 585, in _do_save_event
    manager.save(
    ~~~~~~~~~~~~^
        project=project,
        ^^^^^^^^^^^^^^^^
    ...<3 lines>...
        attachments=attachments,
        ^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/.venv/lib/python3.13/site-packages/sentry_sdk/tracing_utils.py", line 1109, in sync_wrapper
    result = f(*args, **kwargs)
  File "/usr/src/sentry/src/sentry/event_manager.py", line 513, in save
    return self.save_error_events(
           ~~~~~~~~~~~~~~~~~~~~~~^
        project, job, projects, metric_tags, attachments or [], raw, cache_key
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/.venv/lib/python3.13/site-packages/sentry_sdk/tracing_utils.py", line 1109, in sync_wrapper
    result = f(*args, **kwargs)
  File "/usr/src/sentry/src/sentry/event_manager.py", line 547, in save_error_events
    group_info = assign_event_to_group(event=job["event"], job=job, metric_tags=metric_tags)
  File "/.venv/lib/python3.13/site-packages/sentry_sdk/tracing_utils.py", line 1109, in sync_wrapper
    result = f(*args, **kwargs)
  File "/usr/src/sentry/src/sentry/event_manager.py", line 1328, in assign_event_to_group
    group_info = handle_existing_grouphash(job, primary.existing_grouphash, primary.grouphashes)
  File "/.venv/lib/python3.13/site-packages/sentry_sdk/tracing_utils.py", line 1109, in sync_wrapper
    result = f(*args, **kwargs)
  File "/usr/src/sentry/src/sentry/event_manager.py", line 1462, in handle_existing_grouphash
    is_regression = _process_existing_aggregate(
        group=group,
    ...<2 lines>...
        release=job["release"],
    )
  File "/usr/src/sentry/src/sentry/event_manager.py", line 1951, in _process_existing_aggregate
    buffer_incr(Group, {"times_seen": times_seen}, {"id": group.id}, updated_group_values)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/sentry/src/sentry/tasks/process_buffer.py", line 82, in buffer_incr
    buffer.backend.incr(model, *args, **kwargs)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/sentry/src/sentry/buffer/redis.py", line 371, in incr
    pipe = self.get_redis_connection(key)
  File "/usr/src/sentry/src/sentry/buffer/redis.py", line 348, in get_redis_connection
    pipe = conn.pipeline(transaction=transaction)
  File "/.venv/lib/python3.13/site-packages/rediscluster/client.py", line 456, in pipeline
    raise RedisClusterException("transaction is deprecated in cluster mode")
rediscluster.exceptions.RedisClusterException: transaction is deprecated in cluster mode
```

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
