### PR TITLE
ref(api): tighten 2 endpoint annotations via local TypedDict

### DIFF
--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -71,7 +71,7 @@ class ProjectTagsEndpoint(ProjectEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project) -> Response[list[ProjectTagKeyResponse]]:
         """
         Return a list of the tag keys that have been seen within a project.
         """
@@ -118,15 +118,15 @@ class ProjectTagsEndpoint(ProjectEndpoint):
                 key=lambda x: x.key,
             )
 
-        data = []
+        data: list[ProjectTagKeyResponse] = []
         for tag_key in tag_keys:
-            data.append(
-                {
-                    "key": tagstore.backend.get_standardized_key(tag_key.key),
-                    "name": tagstore.backend.get_tag_key_label(tag_key.key),
-                    **({"uniqueValues": tag_key.values_seen} if include_values_seen else {}),
-                    "canDelete": tag_key.key not in PROTECTED_TAG_KEYS and not use_flag_backend,
-                }
-            )
+            entry: ProjectTagKeyResponse = {
+                "key": tagstore.backend.get_standardized_key(tag_key.key),
+                "name": tagstore.backend.get_tag_key_label(tag_key.key),
+                "canDelete": tag_key.key not in PROTECTED_TAG_KEYS and not use_flag_backend,
+            }
+            if include_values_seen:
+                entry["uniqueValues"] = tag_key.values_seen
+            data.append(entry)
 
         return Response(data)

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_stats_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_stats_details.py
@@ -65,7 +65,7 @@ class SentryAppStatsEndpoint(SentryAppBaseEndpoint, StatsMixin):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, sentry_app) -> Response:
+    def get(self, request: Request, sentry_app) -> Response[SentryAppStatsResponse]:
         """
         Return the number of installations and uninstallations of a custom integration
         (Sentry App) over a time series range.
@@ -99,7 +99,7 @@ class SentryAppStatsEndpoint(SentryAppBaseEndpoint, StatsMixin):
                 if uninstall_norm_epoch in uninstall_stats:
                     uninstall_stats[uninstall_norm_epoch] += 1
 
-        result = {
+        result: SentryAppStatsResponse = {
             "totalInstalls": install_count,
             "totalUninstalls": uninstall_count,
             "installStats": sorted(install_stats.items(), key=lambda x: x[0]),


### PR DESCRIPTION
Tightens `project_tags.get` to `Response[list[ProjectTagKeyResponse]]` and `sentry_app_stats_details.get` to `Response[SentryAppStatsResponse]`. Both fixes type the response-building local variable (`data` / `result`) so the body matches the existing decorator-declared `T`. Pattern is the same as the cohort-2 PRs but reaches sites whose bodies are built inline rather than via a typed `Serializer`.

Part of the march toward 100% \`@extend_schema\` typed coverage tracked in the umbrella \`type-http-response-coverage\` change. Drives Goal #1 from 67.1% → 68.5%. Other remaining sites need denylist removal (cohort 2e) or pydantic source rework (cohort 2d) — handled in follow-up PRs.