### PR TITLE
ref(mypy): remove IntegrationSerializer + DashboardListSerializer from autoderive denylist

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import Any, Required, TypedDict
+from typing import Required, TypedDict
 
 import sentry_sdk
 from django.db import IntegrityError, router, transaction
@@ -524,7 +524,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
 
         list_serializer = DashboardListSerializer()
 
-        def handle_results(results: list[Dashboard]) -> list[dict[str, Any]]:
+        def handle_results(results: list[Dashboard]) -> list[DashboardListResponse]:
             return serialize(
                 results,
                 request.user,

--- a/src/sentry/issues/endpoints/project_stacktrace_link.py
+++ b/src/sentry/issues/endpoints/project_stacktrace_link.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TypedDict
+from collections.abc import Collection
+from typing import Any, TypedDict
 
 from django.http import QueryDict
 from rest_framework.request import Request
@@ -79,7 +80,7 @@ def set_top_tags(
         logger.exception("We failed to set a tag.")
 
 
-def set_tags(scope: Scope, result: StacktraceLinkOutcome, integrations: list[None]) -> None:
+def set_tags(scope: Scope, result: StacktraceLinkOutcome, integrations: Collection[Any]) -> None:
     scope.set_tag("stacktrace_link.found", result["source_url"] is not None)
     scope.set_tag("stacktrace_link.source_url", result["source_url"])
     scope.set_tag("stacktrace_link.error", result["error"])

--- a/tools/mypy_helpers/serializer_autoderive.py
+++ b/tools/mypy_helpers/serializer_autoderive.py
@@ -23,7 +23,6 @@ _AUTODERIVE_DENYLIST: frozenset[str] = frozenset(
     {
         "sentry.api.serializers.models.actor.ActorSerializer",
         "sentry.api.serializers.models.commit.CommitSerializer",
-        "sentry.api.serializers.models.dashboard.DashboardListSerializer",
         "sentry.api.serializers.models.event.EventSerializer",
         "sentry.api.serializers.models.group.GroupSerializerBase",
         "sentry.api.serializers.models.organization_member.base.OrganizationMemberSerializer",
@@ -35,7 +34,6 @@ _AUTODERIVE_DENYLIST: frozenset[str] = frozenset(
         "sentry.api.serializers.models.userreport.UserReportSerializer",
         "sentry.incidents.endpoints.serializers.workflow_engine_detector.WorkflowEngineDetectorSerializer",
         "sentry.incidents.endpoints.serializers.workflow_engine_incident.WorkflowEngineIncidentSerializer",
-        "sentry.integrations.api.serializers.models.integration.IntegrationSerializer",
         "sentry.sentry_apps.api.serializers.sentry_app_avatar.SentryAppAvatarSerializer",
         "sentry.users.api.serializers.authenticator.AuthenticatorInterfaceSerializer",
         "sentry.users.api.serializers.user.UserSerializer",


### PR DESCRIPTION
Removes two entries from \`_AUTODERIVE_DENYLIST\` in \`tools/mypy_helpers/serializer_autoderive.py\` and fixes the two caller-side drift sites that were blocking removal:

- \`project_stacktrace_link.set_tags\` had \`integrations: list[None]\` — a buggy pre-existing annotation that only worked while autoderive was off for \`IntegrationSerializer\`. Replaced with \`Collection[Any]\` (matches actual usage, which is just \`len(integrations)\`).
- \`organization_dashboards.handle_results\` was annotated as returning \`list[dict[str, Any]]\`, which conflicted with \`DashboardListSerializer\`'s typed \`T\`. Tightened to \`list[DashboardListResponse]\` — matches the decorator already declared on the calling endpoint.

Cohort 2e per \`tighten-response-annotations\`, tracked under the umbrella \`type-http-response-coverage\`. Each denylist removal brings the autoderive plugin from #116879 closer to doing its job for the whole Serializer surface.