### PR TITLE
ref(types): replace TypedDict total=False with per-field NotRequired

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_meta_types.py
+++ b/src/sentry/api/endpoints/organization_trace_meta_types.py
@@ -1,10 +1,10 @@
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from sentry.search.events.types import SnubaData
 
 
-class OrganizationTraceMetaResponseOptional(TypedDict, total=False):
-    uptimeCount: int
+class OrganizationTraceMetaResponseOptional(TypedDict):
+    uptimeCount: NotRequired[int]
 
 
 class OrganizationTraceMetaResponse(OrganizationTraceMetaResponseOptional):

--- a/src/sentry/api/endpoints/organization_trace_meta_types.py
+++ b/src/sentry/api/endpoints/organization_trace_meta_types.py
@@ -3,11 +3,8 @@ from typing import NotRequired, TypedDict
 from sentry.search.events.types import SnubaData
 
 
-class OrganizationTraceMetaResponseOptional(TypedDict):
+class OrganizationTraceMetaResponse(TypedDict):
     uptimeCount: NotRequired[int]
-
-
-class OrganizationTraceMetaResponse(OrganizationTraceMetaResponseOptional):
     errorsCount: int
     logsCount: float
     metricsCount: float

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from django.http import HttpResponse
 from rest_framework import serializers
@@ -21,12 +21,12 @@ from sentry.models.release_threshold.constants import TriggerType as ReleaseThre
 from sentry.models.release_threshold.release_threshold import ReleaseThreshold
 
 
-class ReleaseThresholdPOSTData(TypedDict, total=False):
-    threshold_type: int
-    trigger_type: int
-    value: int
-    window_in_seconds: int
-    environment: object
+class ReleaseThresholdPOSTData(TypedDict):
+    threshold_type: NotRequired[int]
+    trigger_type: NotRequired[int]
+    value: NotRequired[int]
+    window_in_seconds: NotRequired[int]
+    environment: NotRequired[object]
 
 
 class ReleaseThresholdPOSTSerializer(serializers.Serializer[ReleaseThresholdPOSTData]):

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from django.db.models import Q
 from django.http import HttpResponse
@@ -16,9 +16,9 @@ from sentry.models.organization import Organization
 from sentry.models.release_threshold.release_threshold import ReleaseThreshold
 
 
-class ReleaseThresholdIndexGETData(TypedDict, total=False):
-    environment: list[str]
-    project: list[int]
+class ReleaseThresholdIndexGETData(TypedDict):
+    environment: NotRequired[list[str]]
+    project: NotRequired[list[int]]
 
 
 class ReleaseThresholdIndexGETValidator(serializers.Serializer[ReleaseThresholdIndexGETData]):

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 from django.db.models import F, Q
 from django.http import HttpResponse
@@ -50,12 +50,12 @@ if TYPE_CHECKING:
     from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 
 
-class ReleaseThresholdStatusIndexData(TypedDict, total=False):
-    start: datetime
-    end: datetime
-    environment: list[str]
-    projectSlug: list[str]
-    release: list[str]
+class ReleaseThresholdStatusIndexData(TypedDict):
+    start: NotRequired[datetime]
+    end: NotRequired[datetime]
+    environment: NotRequired[list[str]]
+    projectSlug: NotRequired[list[str]]
+    release: NotRequired[list[str]]
 
 
 class ReleaseThresholdStatusIndexSerializer(

--- a/src/sentry/api/endpoints/release_thresholds/types.py
+++ b/src/sentry/api/endpoints/release_thresholds/types.py
@@ -1,17 +1,17 @@
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 
-class SerializedThreshold(TypedDict, total=False):
-    id: str
-    date: datetime
-    environment: dict[str, Any] | None
-    project: dict[str, Any]
-    release: str
-    threshold_type: int
-    trigger_type: str
-    value: int
-    window_in_seconds: int
+class SerializedThreshold(TypedDict):
+    id: NotRequired[str]
+    date: NotRequired[datetime]
+    environment: NotRequired[dict[str, Any] | None]
+    project: NotRequired[dict[str, Any]]
+    release: NotRequired[str]
+    threshold_type: NotRequired[int]
+    trigger_type: NotRequired[str]
+    value: NotRequired[int]
+    window_in_seconds: NotRequired[int]
 
 
 class EnrichedThreshold(SerializedThreshold):

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -59,8 +59,8 @@ class DashboardWidgetQueryResponse(TypedDict):
     linkedDashboards: list[LinkedDashboardResponse]
 
 
-class ThresholdTypeOptional(TypedDict, total=False):
-    preferredPolarity: str
+class ThresholdTypeOptional(TypedDict):
+    preferredPolarity: NotRequired[str]
 
 
 class ThresholdType(ThresholdTypeOptional):
@@ -458,12 +458,12 @@ class _Widget(TypedDict):
     last_visited: str | None
 
 
-class PageFiltersOptional(TypedDict, total=False):
-    period: str
-    utc: str
-    expired: bool
-    start: datetime
-    end: datetime
+class PageFiltersOptional(TypedDict):
+    period: NotRequired[str]
+    utc: NotRequired[str]
+    expired: NotRequired[bool]
+    start: NotRequired[datetime]
+    end: NotRequired[datetime]
 
 
 class PageFilters(PageFiltersOptional):
@@ -601,19 +601,19 @@ class DashboardListSerializer(Serializer, DashboardFiltersMixin):
         }
 
 
-class DashboardFilters(TypedDict, total=False):
-    release: list[str]
-    releaseId: list[str]
-    globalFilter: list[dict[str, Any]]
+class DashboardFilters(TypedDict):
+    release: NotRequired[list[str]]
+    releaseId: NotRequired[list[str]]
+    globalFilter: NotRequired[list[dict[str, Any]]]
 
 
-class DashboardDetailsResponseOptional(TypedDict, total=False):
-    environment: list[str]
-    period: str
-    utc: str
-    expired: bool
-    start: datetime
-    end: datetime
+class DashboardDetailsResponseOptional(TypedDict):
+    environment: NotRequired[list[str]]
+    period: NotRequired[str]
+    utc: NotRequired[str]
+    expired: NotRequired[bool]
+    start: NotRequired[datetime]
+    end: NotRequired[datetime]
 
 
 class DashboardDetailsResponse(DashboardDetailsResponseOptional):

--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.constants import ALL_ACCESS_PROJECTS
@@ -12,23 +12,23 @@ from sentry.utils.dates import outside_retention_with_modified_start, parse_time
 DATASET_SOURCES = dict(DatasetSourcesTypes.as_choices())
 
 
-class DiscoverSavedQueryResponseOptional(TypedDict, total=False):
-    environment: list[str]
-    query: str
-    fields: list[str]
-    widths: list[str]
-    conditions: list[str]
-    aggregations: list[str]
-    range: str
-    start: str
-    end: str
-    orderby: str
-    limit: str
-    yAxis: list[str]
-    display: str
-    topEvents: int
-    interval: str
-    exploreQuery: dict
+class DiscoverSavedQueryResponseOptional(TypedDict):
+    environment: NotRequired[list[str]]
+    query: NotRequired[str]
+    fields: NotRequired[list[str]]
+    widths: NotRequired[list[str]]
+    conditions: NotRequired[list[str]]
+    aggregations: NotRequired[list[str]]
+    range: NotRequired[str]
+    start: NotRequired[str]
+    end: NotRequired[str]
+    orderby: NotRequired[str]
+    limit: NotRequired[str]
+    yAxis: NotRequired[list[str]]
+    display: NotRequired[str]
+    topEvents: NotRequired[int]
+    interval: NotRequired[str]
+    exploreQuery: NotRequired[dict]
 
 
 class DiscoverSavedQueryResponse(DiscoverSavedQueryResponseOptional):

--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -12,7 +12,7 @@ from sentry.utils.dates import outside_retention_with_modified_start, parse_time
 DATASET_SOURCES = dict(DatasetSourcesTypes.as_choices())
 
 
-class DiscoverSavedQueryResponseOptional(TypedDict):
+class DiscoverSavedQueryResponse(TypedDict):
     environment: NotRequired[list[str]]
     query: NotRequired[str]
     fields: NotRequired[list[str]]
@@ -29,9 +29,6 @@ class DiscoverSavedQueryResponseOptional(TypedDict):
     topEvents: NotRequired[int]
     interval: NotRequired[str]
     exploreQuery: NotRequired[dict]
-
-
-class DiscoverSavedQueryResponse(DiscoverSavedQueryResponseOptional):
     id: str
     name: str
     projects: list[int]

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -41,11 +41,8 @@ MAX_SQL_FORMAT_OPS = 20
 MAX_SQL_FORMAT_LENGTH = 1500
 
 
-class EventTagOptional(TypedDict):
+class EventTag(TypedDict):
     query: NotRequired[str]
-
-
-class EventTag(EventTagOptional):
     key: str
     value: str
 

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -4,7 +4,7 @@ import re
 from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime, timezone
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import sentry_sdk
 import sqlparse
@@ -41,8 +41,8 @@ MAX_SQL_FORMAT_OPS = 20
 MAX_SQL_FORMAT_LENGTH = 1500
 
 
-class EventTagOptional(TypedDict, total=False):
-    query: str
+class EventTagOptional(TypedDict):
+    query: NotRequired[str]
 
 
 class EventTag(EventTagOptional):
@@ -167,19 +167,19 @@ class BaseEventSerializerResponse(TypedDict):
     _meta: dict[str, Any]
 
 
-class ErrorEventFields(TypedDict, total=False):
-    crashFile: str | None
-    culprit: str | None
-    dateCreated: datetime
-    fingerprints: list[str]
-    groupingConfig: Any
+class ErrorEventFields(TypedDict):
+    crashFile: NotRequired[str | None]
+    culprit: NotRequired[str | None]
+    dateCreated: NotRequired[datetime]
+    fingerprints: NotRequired[list[str]]
+    groupingConfig: NotRequired[Any]
 
 
-class TransactionEventFields(TypedDict, total=False):
-    startTimestamp: datetime
-    endTimestamp: datetime
-    measurements: Any
-    breakdowns: Any
+class TransactionEventFields(TypedDict):
+    startTimestamp: NotRequired[datetime]
+    endTimestamp: NotRequired[datetime]
+    measurements: NotRequired[Any]
+    breakdowns: NotRequired[Any]
 
 
 class EventSerializerResponse(

--- a/src/sentry/api/serializers/models/exploresavedquery.py
+++ b/src/sentry/api/serializers/models/exploresavedquery.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.constants import ALL_ACCESS_PROJECTS
@@ -14,8 +14,8 @@ from sentry.users.services.user.service import user_service
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
 
 
-class MetricResponseTypeOptional(TypedDict, total=False):
-    unit: str | None
+class MetricResponseTypeOptional(TypedDict):
+    unit: NotRequired[str | None]
 
 
 class MetricResponseType(MetricResponseTypeOptional):
@@ -23,8 +23,8 @@ class MetricResponseType(MetricResponseTypeOptional):
     type: str
 
 
-class CrossEventResponseTypeOptional(TypedDict, total=False):
-    metric: MetricResponseType
+class CrossEventResponseTypeOptional(TypedDict):
+    metric: NotRequired[MetricResponseType]
 
 
 class CrossEventResponseType(CrossEventResponseTypeOptional):
@@ -32,15 +32,15 @@ class CrossEventResponseType(CrossEventResponseTypeOptional):
     type: str
 
 
-class ExploreSavedQueryResponseOptional(TypedDict, total=False):
-    environment: list[str]
-    query: str
-    range: str
-    start: str
-    end: str
-    interval: str
-    mode: str
-    crossEvents: list[CrossEventResponseType]
+class ExploreSavedQueryResponseOptional(TypedDict):
+    environment: NotRequired[list[str]]
+    query: NotRequired[str]
+    range: NotRequired[str]
+    start: NotRequired[str]
+    end: NotRequired[str]
+    interval: NotRequired[str]
+    mode: NotRequired[str]
+    crossEvents: NotRequired[list[CrossEventResponseType]]
 
 
 class ExploreSavedQueryChangedReasonType(TypedDict):

--- a/src/sentry/api/serializers/models/exploresavedquery.py
+++ b/src/sentry/api/serializers/models/exploresavedquery.py
@@ -14,33 +14,16 @@ from sentry.users.services.user.service import user_service
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
 
 
-class MetricResponseTypeOptional(TypedDict):
+class MetricResponseType(TypedDict):
     unit: NotRequired[str | None]
-
-
-class MetricResponseType(MetricResponseTypeOptional):
     name: str
     type: str
 
 
-class CrossEventResponseTypeOptional(TypedDict):
+class CrossEventResponseType(TypedDict):
     metric: NotRequired[MetricResponseType]
-
-
-class CrossEventResponseType(CrossEventResponseTypeOptional):
     query: str
     type: str
-
-
-class ExploreSavedQueryResponseOptional(TypedDict):
-    environment: NotRequired[list[str]]
-    query: NotRequired[str]
-    range: NotRequired[str]
-    start: NotRequired[str]
-    end: NotRequired[str]
-    interval: NotRequired[str]
-    mode: NotRequired[str]
-    crossEvents: NotRequired[list[CrossEventResponseType]]
 
 
 class ExploreSavedQueryChangedReasonType(TypedDict):
@@ -49,7 +32,15 @@ class ExploreSavedQueryChangedReasonType(TypedDict):
     columns: list[str]
 
 
-class ExploreSavedQueryResponse(ExploreSavedQueryResponseOptional):
+class ExploreSavedQueryResponse(TypedDict):
+    environment: NotRequired[list[str]]
+    query: NotRequired[str]
+    range: NotRequired[str]
+    start: NotRequired[str]
+    end: NotRequired[str]
+    interval: NotRequired[str]
+    mode: NotRequired[str]
+    crossEvents: NotRequired[list[CrossEventResponseType]]
     id: str
     name: str
     projects: list[int]

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Any, Protocol, TypedDict, TypeGuard
+from typing import Any, NotRequired, Protocol, TypedDict, TypeGuard
 
 import sentry_sdk
 from django.conf import settings
@@ -79,19 +79,19 @@ class GroupAnnotation(TypedDict):
     url: str
 
 
-class GroupStatusDetailsResponseOptional(TypedDict, total=False):
-    autoResolved: bool
-    ignoreCount: int
-    ignoreUntil: datetime
-    ignoreUserCount: int
-    ignoreUserWindow: int
-    ignoreWindow: int
-    actor: UserSerializerResponse
-    inNextRelease: bool
-    inRelease: str
-    inCommit: str
-    pendingEvents: int
-    info: Any
+class GroupStatusDetailsResponseOptional(TypedDict):
+    autoResolved: NotRequired[bool]
+    ignoreCount: NotRequired[int]
+    ignoreUntil: NotRequired[datetime]
+    ignoreUserCount: NotRequired[int]
+    ignoreUserWindow: NotRequired[int]
+    ignoreWindow: NotRequired[int]
+    actor: NotRequired[UserSerializerResponse]
+    inNextRelease: NotRequired[bool]
+    inRelease: NotRequired[str]
+    inCommit: NotRequired[str]
+    pendingEvents: NotRequired[int]
+    info: NotRequired[Any]
 
 
 class GroupProjectResponse(TypedDict):
@@ -101,12 +101,12 @@ class GroupProjectResponse(TypedDict):
     platform: str | None
 
 
-class BaseGroupResponseOptional(TypedDict, total=False):
-    isUnhandled: bool
-    count: str
-    userCount: int
-    firstSeen: datetime | None
-    lastSeen: datetime | None
+class BaseGroupResponseOptional(TypedDict):
+    isUnhandled: NotRequired[bool]
+    count: NotRequired[str]
+    userCount: NotRequired[int]
+    firstSeen: NotRequired[datetime | None]
+    lastSeen: NotRequired[datetime | None]
 
 
 class BaseGroupSerializerResponse(BaseGroupResponseOptional):
@@ -142,19 +142,19 @@ class BaseGroupSerializerResponse(BaseGroupResponseOptional):
     annotations: list[GroupAnnotation]
 
 
-class GroupDetailsResponseOptional(TypedDict, total=False):
+class GroupDetailsResponseOptional(TypedDict):
     # Included by default; removable via `?collapse=release|tags|stats`
-    firstRelease: dict[str, Any] | None
-    lastRelease: dict[str, Any] | None
-    tags: list[dict[str, Any]]
-    stats: dict[str, list[list[float]]]
+    firstRelease: NotRequired[dict[str, Any] | None]
+    lastRelease: NotRequired[dict[str, Any] | None]
+    tags: NotRequired[list[dict[str, Any]]]
+    stats: NotRequired[dict[str, list[list[float]]]]
     # Opt-in via `?expand=...`
-    inbox: dict[str, Any] | None
-    owners: list[dict[str, Any]] | None
-    forecast: dict[str, Any]
-    integrationIssues: list[dict[str, Any]]
-    sentryAppIssues: list[dict[str, Any]]
-    latestEventHasAttachments: bool
+    inbox: NotRequired[dict[str, Any] | None]
+    owners: NotRequired[list[dict[str, Any]] | None]
+    forecast: NotRequired[dict[str, Any]]
+    integrationIssues: NotRequired[list[dict[str, Any]]]
+    sentryAppIssues: NotRequired[list[dict[str, Any]]]
+    latestEventHasAttachments: NotRequired[bool]
 
 
 class GroupDetailsResponse(BaseGroupSerializerResponse, GroupDetailsResponseOptional):

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -101,15 +101,12 @@ class GroupProjectResponse(TypedDict):
     platform: str | None
 
 
-class BaseGroupResponseOptional(TypedDict):
+class BaseGroupSerializerResponse(TypedDict):
     isUnhandled: NotRequired[bool]
     count: NotRequired[str]
     userCount: NotRequired[int]
     firstSeen: NotRequired[datetime | None]
     lastSeen: NotRequired[datetime | None]
-
-
-class BaseGroupSerializerResponse(BaseGroupResponseOptional):
     id: str
     shareId: str | None
     shortId: str

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -178,8 +178,8 @@ class GroupStatsMixin:
             )
 
 
-class _MaybeStats(TypedDict, total=False):
-    stats: dict[str, dict[int, list[tuple[int, int]]]]
+class _MaybeStats(TypedDict):
+    stats: NotRequired[dict[str, dict[int, list[tuple[int, int]]]]]
 
 
 class StreamGroupSerializerResponse(BaseGroupSerializerResponse, _MaybeStats):

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, NotRequired, TypedDict, cast
 
 import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
@@ -133,11 +133,13 @@ class OnboardingTasksSerializerResponse(TypedDict):
     data: Any  # JSON objec
 
 
-class OrganizationSummarySerializerResponseOptional(TypedDict, total=False):
-    features: list[str]  # Only included if include_feature_flags is True
-    extraOptions: dict[str, dict[str, Any]]
-    access: frozenset[str]  # Only if access=... is passed
-    onboardingTasks: list[OnboardingTasksSerializerResponse]  # Only if access=... is passed
+class OrganizationSummarySerializerResponseOptional(TypedDict):
+    features: NotRequired[list[str]]  # Only included if include_feature_flags is True
+    extraOptions: NotRequired[dict[str, dict[str, Any]]]
+    access: NotRequired[frozenset[str]]  # Only if access=... is passed
+    onboardingTasks: NotRequired[
+        list[OnboardingTasksSerializerResponse]
+    ]  # Only if access=... is passed
 
 
 class OrganizationSummarySerializerResponse(OrganizationSummarySerializerResponseOptional):
@@ -233,12 +235,12 @@ class BaseOrganizationSerializer(serializers.Serializer):
         return value
 
 
-class TrustedRelaySerializerResponse(TypedDict, total=False):
-    name: str
-    description: str
-    publicKey: str
-    created: datetime
-    lastModified: datetime
+class TrustedRelaySerializerResponse(TypedDict):
+    name: NotRequired[str]
+    description: NotRequired[str]
+    publicKey: NotRequired[str]
+    created: NotRequired[datetime]
+    lastModified: NotRequired[datetime]
 
 
 def _relay_internal_to_external(d: dict[str, Any]) -> TrustedRelaySerializerResponse:
@@ -633,17 +635,17 @@ class OnboardingTasksSerializer(Serializer[OnboardingTasksSerializerResponse]):
         }
 
 
-class _OrganizationSerializerResponseOptional(OrganizationSummarySerializerResponse, total=False):
-    role: Any  # TODO: replace with enum/literal
-    orgRole: str
-    targetSampleRate: float
-    samplingMode: str
-    planSampleRate: float
-    desiredSampleRate: float
-    ingestThroughTrustedRelaysOnly: bool
-    enabledConsolePlatforms: list[str]
-    consoleSdkInviteQuota: int
-    dashboardsAsyncQueueParallelLimit: int
+class _OrganizationSerializerResponseOptional(OrganizationSummarySerializerResponse):
+    role: NotRequired[Any]  # TODO: replace with enum/literal
+    orgRole: NotRequired[str]
+    targetSampleRate: NotRequired[float]
+    samplingMode: NotRequired[str]
+    planSampleRate: NotRequired[float]
+    desiredSampleRate: NotRequired[float]
+    ingestThroughTrustedRelaysOnly: NotRequired[bool]
+    enabledConsolePlatforms: NotRequired[list[str]]
+    consoleSdkInviteQuota: NotRequired[int]
+    dashboardsAsyncQueueParallelLimit: NotRequired[int]
 
 
 @extend_schema_serializer(exclude_fields=["availableRoles"])

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -133,16 +133,13 @@ class OnboardingTasksSerializerResponse(TypedDict):
     data: Any  # JSON objec
 
 
-class OrganizationSummarySerializerResponseOptional(TypedDict):
+class OrganizationSummarySerializerResponse(TypedDict):
     features: NotRequired[list[str]]  # Only included if include_feature_flags is True
     extraOptions: NotRequired[dict[str, dict[str, Any]]]
     access: NotRequired[frozenset[str]]  # Only if access=... is passed
     onboardingTasks: NotRequired[
         list[OnboardingTasksSerializerResponse]
     ]  # Only if access=... is passed
-
-
-class OrganizationSummarySerializerResponse(OrganizationSummarySerializerResponseOptional):
     id: str
     slug: str
     status: _Status

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -26,10 +26,10 @@ class SCIMMeta(TypedDict):
     resourceType: str
 
 
-class OrganizationMemberSCIMSerializerOptional(TypedDict, total=False):
+class OrganizationMemberSCIMSerializerOptional(TypedDict):
     """Sentry doesn't use this field but is expected by SCIM"""
 
-    active: bool
+    active: NotRequired[bool]
 
 
 class OrganizationMemberSCIMSerializerResponse(OrganizationMemberSCIMSerializerOptional):

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -26,17 +26,13 @@ class SCIMMeta(TypedDict):
     resourceType: str
 
 
-class OrganizationMemberSCIMSerializerOptional(TypedDict):
-    """Sentry doesn't use this field but is expected by SCIM"""
-
-    active: NotRequired[bool]
-
-
-class OrganizationMemberSCIMSerializerResponse(OrganizationMemberSCIMSerializerOptional):
+class OrganizationMemberSCIMSerializerResponse(TypedDict):
     """
     Conforming to the SCIM RFC, this represents a Sentry Org Member
     as a SCIM user object.
     """
+
+    active: NotRequired[bool]
 
     schemas: list[str]
     id: str

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -273,13 +273,10 @@ def get_has_trace_metrics(project: Project) -> bool:
     return True
 
 
-class _ProjectSerializerOptionalBaseResponse(TypedDict):
+class ProjectSerializerBaseResponse(TypedDict):
     stats: NotRequired[Any]
     transactionStats: NotRequired[Any]
     sessionStats: NotRequired[Any]
-
-
-class ProjectSerializerBaseResponse(_ProjectSerializerOptionalBaseResponse):
     id: str
     slug: str
     name: str  # TODO: add deprecation about this field (not used in app)

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -273,10 +273,10 @@ def get_has_trace_metrics(project: Project) -> bool:
     return True
 
 
-class _ProjectSerializerOptionalBaseResponse(TypedDict, total=False):
-    stats: Any
-    transactionStats: Any
-    sessionStats: Any
+class _ProjectSerializerOptionalBaseResponse(TypedDict):
+    stats: NotRequired[Any]
+    transactionStats: NotRequired[Any]
+    sessionStats: NotRequired[Any]
 
 
 class ProjectSerializerBaseResponse(_ProjectSerializerOptionalBaseResponse):
@@ -621,8 +621,8 @@ class TeamResponseDict(TypedDict):
     slug: str
 
 
-class _MaybeTeam(TypedDict, total=False):
-    team: TeamResponseDict
+class _MaybeTeam(TypedDict):
+    team: NotRequired[TeamResponseDict]
 
 
 class ProjectWithTeamResponseDict(ProjectSerializerResponse, _MaybeTeam):
@@ -676,9 +676,9 @@ class LatestReleaseDict(TypedDict):
     version: str
 
 
-class _OrganizationProjectOptionalResponse(TypedDict, total=False):
-    latestDeploys: dict[str, dict[str, str]] | None
-    options: dict[str, Any]
+class _OrganizationProjectOptionalResponse(TypedDict):
+    latestDeploys: NotRequired[dict[str, dict[str, str]] | None]
+    options: NotRequired[dict[str, Any]]
 
 
 class OrganizationProjectResponse(

--- a/src/sentry/api/serializers/models/projectownership.py
+++ b/src/sentry/api/serializers/models/projectownership.py
@@ -24,13 +24,9 @@ OwnershipSchemaResponse = TypedDict(
 )
 
 
-# JSON object representing optional part of API response
-class ProjectOwnershipResponseOptional(TypedDict):
-    schema: NotRequired[OwnershipSchemaResponse | None]
-
-
 # JSON object representing this serializer in API response
-class ProjectOwnershipResponse(ProjectOwnershipResponseOptional):
+class ProjectOwnershipResponse(TypedDict):
+    schema: NotRequired[OwnershipSchemaResponse | None]
     raw: str
     fallthrough: bool
     dateCreated: datetime

--- a/src/sentry/api/serializers/models/projectownership.py
+++ b/src/sentry/api/serializers/models/projectownership.py
@@ -25,8 +25,8 @@ OwnershipSchemaResponse = TypedDict(
 
 
 # JSON object representing optional part of API response
-class ProjectOwnershipResponseOptional(TypedDict, total=False):
-    schema: OwnershipSchemaResponse | None
+class ProjectOwnershipResponseOptional(TypedDict):
+    schema: NotRequired[OwnershipSchemaResponse | None]
 
 
 # JSON object representing this serializer in API response

--- a/src/sentry/api/serializers/models/repository.py
+++ b/src/sentry/api/serializers/models/repository.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.models.repository import Repository
@@ -12,17 +12,17 @@ class RepositorySettingsSerializerResponse(TypedDict):
     codeReviewTriggers: list[str]
 
 
-class RepositorySerializerResponse(TypedDict, total=False):
-    id: str
-    name: str
-    url: str | None
-    provider: dict[str, str]
-    status: str
-    dateCreated: datetime
-    integrationId: str | None
-    externalSlug: str | None
-    externalId: str | None
-    settings: RepositorySettingsSerializerResponse | None
+class RepositorySerializerResponse(TypedDict):
+    id: NotRequired[str]
+    name: NotRequired[str]
+    url: NotRequired[str | None]
+    provider: NotRequired[dict[str, str]]
+    status: NotRequired[str]
+    dateCreated: NotRequired[datetime]
+    integrationId: NotRequired[str | None]
+    externalSlug: NotRequired[str | None]
+    externalId: NotRequired[str | None]
+    settings: NotRequired[RepositorySettingsSerializerResponse | None]
 
 
 @register(RepositorySettings)

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -86,7 +86,11 @@ class _ErrorDict(TypedDict):
     detail: str
 
 
-class RuleSerializerResponseOptional(TypedDict):
+class RuleSerializerResponse(TypedDict):
+    """
+    This represents a Sentry Rule.
+    """
+
     owner: NotRequired[str | None]
     createdBy: NotRequired[RuleCreatedBy | None]
     environment: NotRequired[str | None]
@@ -96,12 +100,6 @@ class RuleSerializerResponseOptional(TypedDict):
     disableReason: NotRequired[str]
     disableDate: NotRequired[str]
     errors: NotRequired[list[_ErrorDict]]
-
-
-class RuleSerializerResponse(RuleSerializerResponseOptional):
-    """
-    This represents a Sentry Rule.
-    """
 
     id: str | None
     conditions: list[dict]

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from django.db.models import Prefetch, Q, prefetch_related_objects
 from rest_framework import serializers
@@ -86,16 +86,16 @@ class _ErrorDict(TypedDict):
     detail: str
 
 
-class RuleSerializerResponseOptional(TypedDict, total=False):
-    owner: str | None
-    createdBy: RuleCreatedBy | None
-    environment: str | None
-    lastTriggered: str | None
-    snoozeCreatedBy: str | None
-    snoozeForEveryone: bool | None
-    disableReason: str
-    disableDate: str
-    errors: list[_ErrorDict]
+class RuleSerializerResponseOptional(TypedDict):
+    owner: NotRequired[str | None]
+    createdBy: NotRequired[RuleCreatedBy | None]
+    environment: NotRequired[str | None]
+    lastTriggered: NotRequired[str | None]
+    snoozeCreatedBy: NotRequired[str | None]
+    snoozeForEveryone: NotRequired[bool | None]
+    disableReason: NotRequired[str]
+    disableDate: NotRequired[str]
+    errors: NotRequired[list[_ErrorDict]]
 
 
 class RuleSerializerResponse(RuleSerializerResponseOptional):

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -345,14 +345,11 @@ class SCIMTeamMemberListItem(TypedDict):
     display: str
 
 
-class OrganizationTeamSCIMSerializerRequired(TypedDict):
+class OrganizationTeamSCIMSerializerResponse(TypedDict):
     schemas: list[str]
     id: str
     displayName: str
     meta: SCIMMeta
-
-
-class OrganizationTeamSCIMSerializerResponse(OrganizationTeamSCIMSerializerRequired):
     members: NotRequired[list[SCIMTeamMemberListItem]]
 
 

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -4,7 +4,7 @@ import dataclasses
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Count
@@ -122,10 +122,10 @@ def get_access_requests(
     return frozenset()
 
 
-class _TeamSerializerResponseOptional(TypedDict, total=False):
-    externalTeams: list[ExternalActorResponse]
-    organization: OrganizationSummarySerializerResponse
-    projects: list[ProjectSerializerResponse]
+class _TeamSerializerResponseOptional(TypedDict):
+    externalTeams: NotRequired[list[ExternalActorResponse]]
+    organization: NotRequired[OrganizationSummarySerializerResponse]
+    projects: NotRequired[list[ProjectSerializerResponse]]
 
 
 class BaseTeamSerializerResponse(TypedDict):
@@ -352,8 +352,8 @@ class OrganizationTeamSCIMSerializerRequired(TypedDict):
     meta: SCIMMeta
 
 
-class OrganizationTeamSCIMSerializerResponse(OrganizationTeamSCIMSerializerRequired, total=False):
-    members: list[SCIMTeamMemberListItem]
+class OrganizationTeamSCIMSerializerResponse(OrganizationTeamSCIMSerializerRequired):
+    members: NotRequired[list[SCIMTeamMemberListItem]]
 
 
 @dataclasses.dataclass

--- a/src/sentry/api/serializers/release_details_types.py
+++ b/src/sentry/api/serializers/release_details_types.py
@@ -1,11 +1,11 @@
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from sentry.users.api.serializers.user import UserSerializerResponse
 
 
-class VersionInfoOptional(TypedDict, total=False):
-    description: str
+class VersionInfoOptional(TypedDict):
+    description: NotRequired[str]
 
 
 class VersionInfo(VersionInfoOptional):
@@ -14,9 +14,9 @@ class VersionInfo(VersionInfoOptional):
     buildHash: str | None
 
 
-class LastDeployOptional(TypedDict, total=False):
-    dateStarted: str | None
-    url: str | None
+class LastDeployOptional(TypedDict):
+    dateStarted: NotRequired[str | None]
+    url: NotRequired[str | None]
 
 
 class LastDeploy(LastDeployOptional):
@@ -34,19 +34,19 @@ class NonMappableUser(TypedDict):
 Author = UserSerializerResponse | NonMappableUser
 
 
-class HealthDataOptional(TypedDict, total=False):
-    durationP50: float | None
-    durationP90: float | None
-    crashFreeUsers: float | None
-    crashFreeSessions: float | None
-    totalUsers: int | None
-    totalUsers24h: int | None
-    totalProjectUsers24h: int | None
-    totalSessions: int | None
-    totalSessions24h: int | None
-    totalProjectSessions24h: int | None
-    adoption: float | None
-    sessionsAdoption: float | None
+class HealthDataOptional(TypedDict):
+    durationP50: NotRequired[float | None]
+    durationP90: NotRequired[float | None]
+    crashFreeUsers: NotRequired[float | None]
+    crashFreeSessions: NotRequired[float | None]
+    totalUsers: NotRequired[int | None]
+    totalUsers24h: NotRequired[int | None]
+    totalProjectUsers24h: NotRequired[int | None]
+    totalSessions: NotRequired[int | None]
+    totalSessions24h: NotRequired[int | None]
+    totalProjectSessions24h: NotRequired[int | None]
+    adoption: NotRequired[float | None]
+    sessionsAdoption: NotRequired[float | None]
 
 
 class HealthData(HealthDataOptional):
@@ -56,11 +56,11 @@ class HealthData(HealthDataOptional):
     stats: dict[str, Any]
 
 
-class ProjectOptional(TypedDict, total=False):
-    healthData: HealthData | None
-    dateReleased: datetime | None
-    dateCreated: datetime | None
-    dateStarted: datetime | None
+class ProjectOptional(TypedDict):
+    healthData: NotRequired[HealthData | None]
+    dateReleased: NotRequired[datetime | None]
+    dateCreated: NotRequired[datetime | None]
+    dateStarted: NotRequired[datetime | None]
 
 
 class BaseProject(ProjectOptional):

--- a/src/sentry/api/serializers/release_details_types.py
+++ b/src/sentry/api/serializers/release_details_types.py
@@ -4,22 +4,16 @@ from typing import Any, NotRequired, TypedDict
 from sentry.users.api.serializers.user import UserSerializerResponse
 
 
-class VersionInfoOptional(TypedDict):
+class VersionInfo(TypedDict):
     description: NotRequired[str]
-
-
-class VersionInfo(VersionInfoOptional):
     package: str | None
     version: dict[str, Any]
     buildHash: str | None
 
 
-class LastDeployOptional(TypedDict):
+class LastDeploy(TypedDict):
     dateStarted: NotRequired[str | None]
     url: NotRequired[str | None]
-
-
-class LastDeploy(LastDeployOptional):
     id: str
     environment: str
     dateFinished: str
@@ -34,7 +28,7 @@ class NonMappableUser(TypedDict):
 Author = UserSerializerResponse | NonMappableUser
 
 
-class HealthDataOptional(TypedDict):
+class HealthData(TypedDict):
     durationP50: NotRequired[float | None]
     durationP90: NotRequired[float | None]
     crashFreeUsers: NotRequired[float | None]
@@ -47,23 +41,17 @@ class HealthDataOptional(TypedDict):
     totalProjectSessions24h: NotRequired[int | None]
     adoption: NotRequired[float | None]
     sessionsAdoption: NotRequired[float | None]
-
-
-class HealthData(HealthDataOptional):
     sessionsCrashed: int
     sessionsErrored: int
     hasHealthData: bool
     stats: dict[str, Any]
 
 
-class ProjectOptional(TypedDict):
+class BaseProject(TypedDict):
     healthData: NotRequired[HealthData | None]
     dateReleased: NotRequired[datetime | None]
     dateCreated: NotRequired[datetime | None]
     dateStarted: NotRequired[datetime | None]
-
-
-class BaseProject(ProjectOptional):
     id: int
     slug: str
     name: str

--- a/src/sentry/api/serializers/types.py
+++ b/src/sentry/api/serializers/types.py
@@ -4,8 +4,7 @@ from typing import Any, NotRequired, TypedDict
 from sentry.api.serializers.release_details_types import Author, LastDeploy, Project, VersionInfo
 
 
-# Reponse type for OrganizationReleaseDetailsEndpoint
-class ReleaseSerializerResponseOptional(TypedDict):
+class ReleaseSerializerResponse(TypedDict):
     ref: NotRequired[str | None]
     url: NotRequired[str | None]
     dateReleased: NotRequired[datetime | None]
@@ -21,9 +20,6 @@ class ReleaseSerializerResponseOptional(TypedDict):
     adoptionStages: NotRequired[
         dict[str, Any] | None
     ]  # Only included if with_adoption_stages is True
-
-
-class ReleaseSerializerResponse(ReleaseSerializerResponseOptional):
     # NOTE: The API design guidelines (https://develop.sentry.dev/backend/api/design/)
     # call for resource identifiers to be returned as strings. This release `id` is a
     # long-standing integer in the public response and is relied on by existing clients,

--- a/src/sentry/api/serializers/types.py
+++ b/src/sentry/api/serializers/types.py
@@ -1,24 +1,26 @@
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from sentry.api.serializers.release_details_types import Author, LastDeploy, Project, VersionInfo
 
 
 # Reponse type for OrganizationReleaseDetailsEndpoint
-class ReleaseSerializerResponseOptional(TypedDict, total=False):
-    ref: str | None
-    url: str | None
-    dateReleased: datetime | None
-    dateCreated: datetime | None
-    dateStarted: datetime | None
-    owner: dict[str, Any] | None
-    lastCommit: dict[str, Any] | None
-    lastDeploy: LastDeploy | None
-    firstEvent: datetime | None
-    lastEvent: datetime | None
-    currentProjectMeta: dict[str, Any] | None
-    userAgent: str | None
-    adoptionStages: dict[str, Any] | None  # Only included if with_adoption_stages is True
+class ReleaseSerializerResponseOptional(TypedDict):
+    ref: NotRequired[str | None]
+    url: NotRequired[str | None]
+    dateReleased: NotRequired[datetime | None]
+    dateCreated: NotRequired[datetime | None]
+    dateStarted: NotRequired[datetime | None]
+    owner: NotRequired[dict[str, Any] | None]
+    lastCommit: NotRequired[dict[str, Any] | None]
+    lastDeploy: NotRequired[LastDeploy | None]
+    firstEvent: NotRequired[datetime | None]
+    lastEvent: NotRequired[datetime | None]
+    currentProjectMeta: NotRequired[dict[str, Any] | None]
+    userAgent: NotRequired[str | None]
+    adoptionStages: NotRequired[
+        dict[str, Any] | None
+    ]  # Only included if with_adoption_stages is True
 
 
 class ReleaseSerializerResponse(ReleaseSerializerResponseOptional):
@@ -40,18 +42,18 @@ class ReleaseSerializerResponse(ReleaseSerializerResponseOptional):
     projects: list[Project]
 
 
-class GroupEventReleaseSerializerResponse(TypedDict, total=False):
-    id: int
-    commitCount: int
-    data: dict[str, Any]
-    dateCreated: datetime
-    dateReleased: datetime | None
-    deployCount: int
-    ref: str | None
-    lastCommit: dict[str, Any] | None
-    lastDeploy: LastDeploy | None
-    status: str
-    url: str | None
-    userAgent: str | None
-    version: str | None
-    versionInfo: VersionInfo | None
+class GroupEventReleaseSerializerResponse(TypedDict):
+    id: NotRequired[int]
+    commitCount: NotRequired[int]
+    data: NotRequired[dict[str, Any]]
+    dateCreated: NotRequired[datetime]
+    dateReleased: NotRequired[datetime | None]
+    deployCount: NotRequired[int]
+    ref: NotRequired[str | None]
+    lastCommit: NotRequired[dict[str, Any] | None]
+    lastDeploy: NotRequired[LastDeploy | None]
+    status: NotRequired[str]
+    url: NotRequired[str | None]
+    userAgent: NotRequired[str | None]
+    version: NotRequired[str | None]
+    versionInfo: NotRequired[VersionInfo | None]

--- a/src/sentry/auth_v2/utils/session.py
+++ b/src/sentry/auth_v2/utils/session.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
@@ -10,19 +10,19 @@ from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 
 
-class SessionSerializerResponse(TypedDict, total=False):
+class SessionSerializerResponse(TypedDict):
     # Flags to control the authentication flow on frontend.
     # Keep the keys sorted in order of importance!!
     # Maintaining the hierarchy is good context for future engineers.
-    todoEmailVerification: bool | None
-    todo2faVerification: bool | None
-    todoPasswordReset: bool | None
-    todo2faSetup: bool | None
+    todoEmailVerification: NotRequired[bool | None]
+    todo2faVerification: NotRequired[bool | None]
+    todoPasswordReset: NotRequired[bool | None]
+    todo2faSetup: NotRequired[bool | None]
 
-    userId: str | None
-    sessionCsrfToken: str | None
-    sessionExpiryDate: datetime | None
-    sessionOrgs: list[str] | None
+    userId: NotRequired[str | None]
+    sessionCsrfToken: NotRequired[str | None]
+    sessionExpiryDate: NotRequired[datetime | None]
+    sessionOrgs: NotRequired[list[str] | None]
 
 
 class SessionSerializer(Serializer[SessionSerializerResponse]):

--- a/src/sentry/conf/types/bgtask.py
+++ b/src/sentry/conf/types/bgtask.py
@@ -1,6 +1,6 @@
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 
-class BgTaskConfig(TypedDict, total=False):
-    roles: list[str]
-    interval: int
+class BgTaskConfig(TypedDict):
+    roles: NotRequired[list[str]]
+    interval: NotRequired[int]

--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from enum import Enum
-from typing import Any, Required, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import click
 from sentry_kafka_schemas import get_codec
@@ -113,35 +113,35 @@ class Topic(Enum):
     TASKWORKER_WORKFLOWS_ENGINE_DLQ = "taskworker-workflows-engine-dlq"
 
 
-class ConsumerDefinition(TypedDict, total=False):
+class ConsumerDefinition(TypedDict):
     # Default topic
-    topic: Required[Topic]
+    topic: Topic
 
     # Schema validation will be run if true
-    validate_schema: bool | None
+    validate_schema: NotRequired[bool | None]
 
-    strategy_factory: Required[str]
+    strategy_factory: str
 
     # Additional CLI options the consumer should accept. These arguments are
     # passed as kwargs to the strategy_factory.
-    click_options: Sequence[click.Option]
+    click_options: NotRequired[Sequence[click.Option]]
 
     # Hardcoded additional kwargs for strategy_factory
-    static_args: Mapping[str, Any]
+    static_args: NotRequired[Mapping[str, Any]]
 
     # Pass optional kwargs to the strategy factory
-    pass_consumer_group: bool
-    pass_kafka_slice_id: bool
+    pass_consumer_group: NotRequired[bool]
+    pass_kafka_slice_id: NotRequired[bool]
 
-    require_synchronization: bool
-    synchronize_commit_group_default: str
-    synchronize_commit_log_topic_default: str
+    require_synchronization: NotRequired[bool]
+    synchronize_commit_group_default: NotRequired[str]
+    synchronize_commit_log_topic_default: NotRequired[str]
 
-    dlq_topic: Topic
-    dlq_max_invalid_ratio: float | None
-    dlq_max_consecutive_count: int | None
+    dlq_topic: NotRequired[Topic]
+    dlq_max_invalid_ratio: NotRequired[float | None]
+    dlq_max_consecutive_count: NotRequired[int | None]
 
-    stale_topic: Topic
+    stale_topic: NotRequired[Topic]
 
 
 def validate_consumer_definition(consumer_definition: ConsumerDefinition) -> None:

--- a/src/sentry/conf/types/service_options.py
+++ b/src/sentry/conf/types/service_options.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 
-class ServiceOptions(TypedDict, total=False):
-    path: str
-    options: dict[str, object]
-    executor: ServiceOptions
+class ServiceOptions(TypedDict):
+    path: NotRequired[str]
+    options: NotRequired[dict[str, object]]
+    executor: NotRequired[ServiceOptions]

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import Any, Required, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import sentry_sdk
 from django.db import IntegrityError, router, transaction
@@ -90,10 +90,10 @@ class PrebuiltDashboardId(IntEnum):
     NODE_RUNTIME_METRICS = 29
 
 
-class PrebuiltDashboard(TypedDict, total=False):
-    prebuilt_id: Required[PrebuiltDashboardId]
-    title: Required[str]
-    hidden: bool
+class PrebuiltDashboard(TypedDict):
+    prebuilt_id: PrebuiltDashboardId
+    title: str
+    hidden: NotRequired[bool]
 
 
 # Prebuilt dashboards store minimal fields in the database. The actual dashboard and widget settings are

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2653,17 +2653,17 @@ def _record_transaction_info(
             sentry_sdk.capture_exception()
 
 
-class PerformanceJob(TypedDict, total=False):
-    performance_problems: Sequence[PerformanceProblem]
-    event: Event
-    groups: list[GroupInfo]
-    culprit: str
-    received_timestamp: float
-    event_metadata: Mapping[str, Any]
-    platform: str
-    level: str
-    logger_name: str
-    release: Release
+class PerformanceJob(TypedDict):
+    performance_problems: NotRequired[Sequence[PerformanceProblem]]
+    event: NotRequired[Event]
+    groups: NotRequired[list[GroupInfo]]
+    culprit: NotRequired[str]
+    received_timestamp: NotRequired[float]
+    event_metadata: NotRequired[Mapping[str, Any]]
+    platform: NotRequired[str]
+    level: NotRequired[str]
+    logger_name: NotRequired[str]
+    release: NotRequired[Release]
 
 
 def save_grouphash_and_group(

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -277,12 +277,12 @@ class SaltedComponentVariant(ComponentVariant):
         }
 
 
-class VariantsByDescriptor(TypedDict, total=False):
-    system: ComponentVariant
-    app: ComponentVariant
-    custom_fingerprint: CustomFingerprintVariant
-    built_in_fingerprint: CustomFingerprintVariant
-    checksum: ChecksumVariant
-    hashed_checksum: HashedChecksumVariant
-    default: ComponentVariant
-    fallback: FallbackVariant
+class VariantsByDescriptor(TypedDict):
+    system: NotRequired[ComponentVariant]
+    app: NotRequired[ComponentVariant]
+    custom_fingerprint: NotRequired[CustomFingerprintVariant]
+    built_in_fingerprint: NotRequired[CustomFingerprintVariant]
+    checksum: NotRequired[ChecksumVariant]
+    hashed_checksum: NotRequired[HashedChecksumVariant]
+    default: NotRequired[ComponentVariant]
+    fallback: NotRequired[FallbackVariant]

--- a/src/sentry/identity/services/identity/model.py
+++ b/src/sentry/identity/services/identity/model.py
@@ -2,7 +2,7 @@
 #     from __future__ import annotations
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 from pydantic import Field
 
@@ -36,11 +36,11 @@ class RpcIdentity(RpcModel):
         return get(identity_provider.type)
 
 
-class IdentityFilterArgs(TypedDict, total=False):
-    id: int
-    user_id: int
-    identity_ext_id: str
-    identity_ext_ids: list[str]
-    provider_id: int
-    provider_ext_id: str
-    provider_type: str
+class IdentityFilterArgs(TypedDict):
+    id: NotRequired[int]
+    user_id: NotRequired[int]
+    identity_ext_id: NotRequired[str]
+    identity_ext_ids: NotRequired[list[str]]
+    provider_id: NotRequired[int]
+    provider_ext_id: NotRequired[str]
+    provider_type: NotRequired[str]

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -1,30 +1,30 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from drf_spectacular.utils import extend_schema_serializer
 
 
-class AlertRuleSerializerResponseOptional(TypedDict, total=False):
-    environment: str | None
-    projects: list[str] | None
-    queryType: int | None
-    resolveThreshold: float | None
-    dataset: str | None
-    thresholdType: int | None
-    eventTypes: list[str] | None
-    owner: str | None
-    originalAlertRuleId: str | None
-    comparisonDelta: float | None
-    weeklyAvg: float | None
-    totalThisWeek: int | None
-    snooze: bool | None
-    latestIncident: datetime | None
-    errors: list[str] | None
-    sensitivity: str | None
-    seasonality: str | None
-    extrapolationMode: str | None
+class AlertRuleSerializerResponseOptional(TypedDict):
+    environment: NotRequired[str | None]
+    projects: NotRequired[list[str] | None]
+    queryType: NotRequired[int | None]
+    resolveThreshold: NotRequired[float | None]
+    dataset: NotRequired[str | None]
+    thresholdType: NotRequired[int | None]
+    eventTypes: NotRequired[list[str] | None]
+    owner: NotRequired[str | None]
+    originalAlertRuleId: NotRequired[str | None]
+    comparisonDelta: NotRequired[float | None]
+    weeklyAvg: NotRequired[float | None]
+    totalThisWeek: NotRequired[int | None]
+    snooze: NotRequired[bool | None]
+    latestIncident: NotRequired[datetime | None]
+    errors: NotRequired[list[str] | None]
+    sensitivity: NotRequired[str | None]
+    seasonality: NotRequired[str | None]
+    extrapolationMode: NotRequired[str | None]
 
 
 @extend_schema_serializer(
@@ -63,11 +63,11 @@ class AlertRuleSerializerResponse(AlertRuleSerializerResponseOptional):
     detectionType: str
 
 
-class DetailedAlertRuleSerializerResponse(AlertRuleSerializerResponse, total=False):
+class DetailedAlertRuleSerializerResponse(AlertRuleSerializerResponse):
     """
     Response type that includes additional snooze-related fields beyond the base
     AlertRuleSerializerResponse.
     """
 
-    snoozeForEveryone: bool | None
-    snoozeCreatedBy: str | None
+    snoozeForEveryone: NotRequired[bool | None]
+    snoozeCreatedBy: NotRequired[str | None]

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -6,7 +6,25 @@ from typing import Any, NotRequired, TypedDict
 from drf_spectacular.utils import extend_schema_serializer
 
 
-class AlertRuleSerializerResponseOptional(TypedDict):
+@extend_schema_serializer(
+    exclude_fields=[
+        "status",
+        "resolution",
+        "thresholdPeriod",
+        "weeklyAvg",
+        "totalThisWeek",
+        "latestIncident",
+        "description",  # TODO: remove this once the feature has been released to add to the public docs, being sure to denote it will only display in Slack notifications
+        "sensitivity",  # For anomaly detection, which is behind a feature flag
+        "seasonality",  # For anomaly detection, which is behind a feature flag
+        "detectionType",  # For anomaly detection, which is behind a feature flag
+    ]
+)
+class AlertRuleSerializerResponse(TypedDict):
+    """
+    This represents a Sentry Metric Alert Rule.
+    """
+
     environment: NotRequired[str | None]
     projects: NotRequired[list[str] | None]
     queryType: NotRequired[int | None]
@@ -25,26 +43,6 @@ class AlertRuleSerializerResponseOptional(TypedDict):
     sensitivity: NotRequired[str | None]
     seasonality: NotRequired[str | None]
     extrapolationMode: NotRequired[str | None]
-
-
-@extend_schema_serializer(
-    exclude_fields=[
-        "status",
-        "resolution",
-        "thresholdPeriod",
-        "weeklyAvg",
-        "totalThisWeek",
-        "latestIncident",
-        "description",  # TODO: remove this once the feature has been released to add to the public docs, being sure to denote it will only display in Slack notifications
-        "sensitivity",  # For anomaly detection, which is behind a feature flag
-        "seasonality",  # For anomaly detection, which is behind a feature flag
-        "detectionType",  # For anomaly detection, which is behind a feature flag
-    ]
-)
-class AlertRuleSerializerResponse(AlertRuleSerializerResponseOptional):
-    """
-    This represents a Sentry Metric Alert Rule.
-    """
 
     id: str
     name: str

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -31,11 +31,11 @@ class LaunchFailure(TypedDict):
     github_installation_id: NotRequired[str]
 
 
-class LaunchResponse(TypedDict, total=False):
-    success: bool
-    launched_count: int
-    failed_count: int
-    failures: list[LaunchFailure]
+class LaunchResponse(TypedDict):
+    success: NotRequired[bool]
+    launched_count: NotRequired[int]
+    failed_count: NotRequired[int]
+    failures: NotRequired[list[LaunchFailure]]
 
 
 class OrganizationCodingAgentLaunchSerializer(serializers.Serializer[dict[str, object]]):

--- a/src/sentry/integrations/api/serializers/models/external_actor.py
+++ b/src/sentry/integrations/api/serializers/models/external_actor.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, MutableMapping, Sequence
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from django.contrib.auth.models import AnonymousUser
 
@@ -10,10 +10,10 @@ from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 
 
-class ExternalActorResponseOptional(TypedDict, total=False):
-    externalId: str
-    userId: str
-    teamId: str
+class ExternalActorResponseOptional(TypedDict):
+    externalId: NotRequired[str]
+    userId: NotRequired[str]
+    teamId: NotRequired[str]
 
 
 class ExternalActorResponse(ExternalActorResponseOptional):

--- a/src/sentry/integrations/api/serializers/rest_framework/data_forwarder.py
+++ b/src/sentry/integrations/api/serializers/rest_framework/data_forwarder.py
@@ -1,6 +1,6 @@
 import re
 from collections.abc import Mapping, MutableMapping
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from django.db import router, transaction
 from rest_framework import serializers
@@ -14,24 +14,24 @@ from sentry.models.project import Project
 from sentry_plugins.amazon_sqs.plugin import get_regions
 
 
-class SQSConfig(TypedDict, total=False):
-    queue_url: str
-    region: str
-    access_key: str
-    secret_key: str
-    message_group_id: str | None
-    s3_bucket: str | None
+class SQSConfig(TypedDict):
+    queue_url: NotRequired[str]
+    region: NotRequired[str]
+    access_key: NotRequired[str]
+    secret_key: NotRequired[str]
+    message_group_id: NotRequired[str | None]
+    s3_bucket: NotRequired[str | None]
 
 
-class SegmentConfig(TypedDict, total=False):
-    write_key: str
+class SegmentConfig(TypedDict):
+    write_key: NotRequired[str]
 
 
-class SplunkConfig(TypedDict, total=False):
-    instance_url: str
-    index: str
-    source: str
-    token: str
+class SplunkConfig(TypedDict):
+    instance_url: NotRequired[str]
+    index: NotRequired[str]
+    source: NotRequired[str]
+    token: NotRequired[str]
 
 
 SQS_REQUIRED_KEYS = ["queue_url", "region", "access_key", "secret_key"]

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from enum import StrEnum
 from functools import cached_property
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import orjson
 import sentry_sdk
@@ -1124,8 +1124,8 @@ class GitHubBaseClient(
         return self.get(endpoint, api_request_type=GitHubApiRequestType.GET_CHECK_RUNS)
 
 
-class _IntegrationIdParams(TypedDict, total=False):
-    integration_id: int
+class _IntegrationIdParams(TypedDict):
+    integration_id: NotRequired[int]
 
 
 # TODO: Emerge Team - Update to be -> {"emerge": 0.05}.

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -78,12 +78,12 @@ class DetectedPlatform(TypedDict):
     priority: int  # Higher = more relevant for onboarding
 
 
-class DetectorRule(TypedDict, total=False):
-    path: str  # File must exist in root directory
-    match_content: str  # Regex pattern to match in file content (requires path)
-    match_package: str  # Package name in package.json/composer.json deps
-    match_dir: str  # Directory must exist in root
-    match_ext: str  # File extension must exist in root (e.g., ".csproj")
+class DetectorRule(TypedDict):
+    path: NotRequired[str]  # File must exist in root directory
+    match_content: NotRequired[str]  # Regex pattern to match in file content (requires path)
+    match_package: NotRequired[str]  # Package name in package.json/composer.json deps
+    match_dir: NotRequired[str]  # Directory must exist in root
+    match_ext: NotRequired[str]  # File extension must exist in root (e.g., ".csproj")
 
 
 class FrameworkDef(TypedDict):

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -57,12 +57,12 @@ class AttachmentInfo(TypedDict):
     date_started: NotRequired[datetime | None]
 
 
-class TitleLinkParams(TypedDict, total=False):
-    alert: str
-    referrer: str
-    detection_type: str
-    notification_uuid: str
-    project_id: int | None
+class TitleLinkParams(TypedDict):
+    alert: NotRequired[str]
+    referrer: NotRequired[str]
+    detection_type: NotRequired[str]
+    notification_uuid: NotRequired[str]
+    project_id: NotRequired[int | None]
 
 
 def logo_url() -> str:

--- a/src/sentry/integrations/msteams/card_builder/block.py
+++ b/src/sentry/integrations/msteams/card_builder/block.py
@@ -79,15 +79,15 @@ class ActionSet(TypedDict):
     actions: list[Action]
 
 
-class _TextBlockNotRequired(TypedDict, total=False):
-    size: TextSize
-    weight: TextWeight
-    horizontalAlignment: ContentAlignment
-    spacing: Literal["None"]
-    isSubtle: bool
-    height: Literal["stretch"]
-    wrap: bool
-    fontType: Literal["Default"]
+class _TextBlockNotRequired(TypedDict):
+    size: NotRequired[TextSize]
+    weight: NotRequired[TextWeight]
+    horizontalAlignment: NotRequired[ContentAlignment]
+    spacing: NotRequired[Literal["None"]]
+    isSubtle: NotRequired[bool]
+    height: NotRequired[Literal["stretch"]]
+    wrap: NotRequired[bool]
+    fontType: NotRequired[Literal["Default"]]
 
 
 class TextBlock(_TextBlockNotRequired):
@@ -95,11 +95,11 @@ class TextBlock(_TextBlockNotRequired):
     text: str
 
 
-class _ImageBlockNotRequired(TypedDict, total=False):
-    size: ImageSize
-    height: str
-    width: str
-    altText: str
+class _ImageBlockNotRequired(TypedDict):
+    size: NotRequired[ImageSize]
+    height: NotRequired[str]
+    width: NotRequired[str]
+    altText: NotRequired[str]
 
 
 class ImageBlock(_ImageBlockNotRequired):
@@ -107,11 +107,11 @@ class ImageBlock(_ImageBlockNotRequired):
     url: str
 
 
-class _ColumnBlockNotRequired(TypedDict, total=False):
-    style: Literal["good", "warning", "attention"]
-    isSubtle: bool
-    spacing: str
-    verticalContentAlignment: ContentAlignment
+class _ColumnBlockNotRequired(TypedDict):
+    style: NotRequired[Literal["good", "warning", "attention"]]
+    isSubtle: NotRequired[bool]
+    spacing: NotRequired[str]
+    verticalContentAlignment: NotRequired[ContentAlignment]
 
 
 class ColumnBlock(_ColumnBlockNotRequired):
@@ -140,8 +140,8 @@ class InputChoice(TypedDict):
     value: object
 
 
-class _InputChoiceSetBlockNotRequired(TypedDict, total=False):
-    value: object
+class _InputChoiceSetBlockNotRequired(TypedDict):
+    value: NotRequired[object]
 
 
 class InputChoiceSetBlock(_InputChoiceSetBlockNotRequired):

--- a/src/sentry/integrations/perforce/client.py
+++ b/src/sentry/integrations/perforce/client.py
@@ -6,7 +6,7 @@ import tempfile
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 # Tell P4 to look for a ".p4config" file when resolving per-connection
 # settings like P4TRUST and P4TICKETS. Each _connect() call creates a temp
@@ -55,12 +55,12 @@ class P4DepotInfo(TypedDict):
     description: str
 
 
-class P4UserInfo(TypedDict, total=False):
+class P4UserInfo(TypedDict):
     """Type definition for Perforce user information."""
 
-    email: str
-    full_name: str
-    username: str
+    email: NotRequired[str]
+    full_name: NotRequired[str]
+    username: NotRequired[str]
 
 
 class P4CommitInfo(TypedDict):

--- a/src/sentry/integrations/perforce/integration.py
+++ b/src/sentry/integrations/perforce/integration.py
@@ -4,7 +4,7 @@ import hashlib
 import logging
 from collections.abc import Mapping
 from types import SimpleNamespace
-from typing import Any, TypedDict, cast
+from typing import Any, NotRequired, TypedDict, cast
 
 from django.db import models
 from django.http import HttpRequest
@@ -39,17 +39,17 @@ from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, Int
 logger = logging.getLogger(__name__)
 
 
-class PerforceMetadata(TypedDict, total=False):
+class PerforceMetadata(TypedDict):
     """Type definition for Perforce integration metadata stored in Integration.metadata."""
 
-    p4port: str
-    user: str
-    password: str
-    auth_type: str
-    client: str
-    ssl_fingerprint: str
-    web_url: str
-    charset: str
+    p4port: NotRequired[str]
+    user: NotRequired[str]
+    password: NotRequired[str]
+    auth_type: NotRequired[str]
+    client: NotRequired[str]
+    ssl_fingerprint: NotRequired[str]
+    web_url: NotRequired[str]
+    charset: NotRequired[str]
 
 
 DESCRIPTION = """

--- a/src/sentry/integrations/services/github_copilot_identity/model.py
+++ b/src/sentry/integrations/services/github_copilot_identity/model.py
@@ -3,7 +3,7 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from sentry.hybridcloud.rpc import RpcModel
 
@@ -16,7 +16,7 @@ class RpcGitHubCopilotIdentity(RpcModel):
     date_added: str | None = None
 
 
-class GitHubCopilotIdentityFilterArgs(TypedDict, total=False):
-    id: int
-    user_id: int
-    github_id: str
+class GitHubCopilotIdentityFilterArgs(TypedDict):
+    id: NotRequired[int]
+    user_id: NotRequired[int]
+    github_id: NotRequired[str]

--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -1,3 +1,5 @@
+from typing import NotRequired
+
 __all__ = ("User",)
 
 
@@ -9,14 +11,14 @@ from sentry.utils.json import prune_empty_keys
 from sentry.web.helpers import render_to_string
 
 
-class EventUserApiContext(TypedDict, total=False):
-    id: str | None
-    email: str | None
-    username: str | None
-    ip_address: str | None
-    name: str | None
-    geo: dict[str, str] | None
-    data: dict[str, Any] | None
+class EventUserApiContext(TypedDict):
+    id: NotRequired[str | None]
+    email: NotRequired[str | None]
+    username: NotRequired[str | None]
+    ip_address: NotRequired[str | None]
+    name: NotRequired[str | None]
+    geo: NotRequired[dict[str, str] | None]
+    data: NotRequired[dict[str, Any] | None]
 
 
 class User(Interface):

--- a/src/sentry/issue_detection/types.py
+++ b/src/sentry/issue_detection/types.py
@@ -1,23 +1,23 @@
 from __future__ import annotations
 
-from typing import Any, Required, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 # Ideally this would be fully aligned with sentry_kafka_schemas, but many mutations
 # happen in the ingestion pipeline (adding new attributes and removing required
 # ones) and it's not clear we want to fully couple those types yet.
 
 
-class Span(TypedDict, total=False):
-    span_id: Required[str]
-    start_timestamp: Required[float]
-    timestamp: Required[float]
+class Span(TypedDict):
+    span_id: str
+    start_timestamp: float
+    timestamp: float
 
-    op: str
-    description: str
-    hash: str
-    parent_span_id: str
-    data: dict[str, Any] | None
-    sentry_tags: SentryTags
+    op: NotRequired[str]
+    description: NotRequired[str]
+    hash: NotRequired[str]
+    parent_span_id: NotRequired[str]
+    data: NotRequired[dict[str, Any] | None]
+    sentry_tags: NotRequired[SentryTags]
 
 
 #: Sentry tags used in performance issue detection.
@@ -30,12 +30,11 @@ class Span(TypedDict, total=False):
 SentryTags = TypedDict(
     "SentryTags",
     {
-        "description": str,
-        "environment": str,
-        "platform": str,
-        "release": str,
-        "sdk.name": str,
-        "system": str,
+        "description": NotRequired[str],
+        "environment": NotRequired[str],
+        "platform": NotRequired[str],
+        "release": NotRequired[str],
+        "sdk.name": NotRequired[str],
+        "system": NotRequired[str],
     },
-    total=False,
 )

--- a/src/sentry/issues/ignored.py
+++ b/src/sentry/issues/ignored.py
@@ -4,7 +4,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime, timedelta
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from django.utils import timezone
 
@@ -35,13 +35,13 @@ IGNORED_CONDITION_FIELDS = {
 }
 
 
-class IgnoredStatusDetails(TypedDict, total=False):
-    ignoreCount: int | None
-    ignoreUntil: datetime | None
-    ignoreUserCount: int | None
-    ignoreUserWindow: int | None
-    ignoreWindow: int | None
-    actor: User | None
+class IgnoredStatusDetails(TypedDict):
+    ignoreCount: NotRequired[int | None]
+    ignoreUntil: NotRequired[datetime | None]
+    ignoreUserCount: NotRequired[int | None]
+    ignoreUserWindow: NotRequired[int | None]
+    ignoreWindow: NotRequired[int | None]
+    actor: NotRequired[User | None]
 
 
 def handle_archived_until_escalating(

--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -4,7 +4,7 @@ import functools
 import logging
 from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
-from typing import Any, Optional, Protocol, TypedDict, TypeGuard
+from typing import Any, NotRequired, Optional, Protocol, TypedDict, TypeGuard
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.issues import grouptype
@@ -66,8 +66,8 @@ GroupSearchStrategy = Callable[
 ]
 
 
-class MergeableRow(TypedDict, total=False):
-    group_id: int
+class MergeableRow(TypedDict):
+    group_id: NotRequired[int]
 
 
 class _IssueSearchFilterValue(Protocol):

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import Any, ClassVar, Literal, TypedDict, cast
+from typing import Any, ClassVar, Literal, NotRequired, TypedDict, cast
 
 import orjson
 import sentry_sdk
@@ -52,10 +52,10 @@ from sentry.utils.sdk import set_span_attribute
 logger = logging.getLogger(__name__)
 
 
-class _CommitDataKwargs(TypedDict, total=False):
-    author: CommitAuthor
-    message: str
-    date_added: str
+class _CommitDataKwargs(TypedDict):
+    author: NotRequired[CommitAuthor]
+    message: NotRequired[str]
+    date_added: NotRequired[str]
 
 
 class ReleaseStatus:

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 import logging
 import re
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from django.db import IntegrityError, router
 
@@ -38,10 +38,10 @@ from sentry.models.repository import Repository
 from sentry.plugins.providers.repository import RepositoryProvider
 
 
-class _CommitDataKwargs(TypedDict, total=False):
-    author: CommitAuthor
-    message: str
-    date_added: str
+class _CommitDataKwargs(TypedDict):
+    author: NotRequired[CommitAuthor]
+    message: NotRequired[str]
+    date_added: NotRequired[str]
 
 
 def set_commits(release, commit_list):

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -3,7 +3,7 @@ from collections.abc import MutableMapping, Sequence
 from datetime import datetime
 from itertools import groupby
 from operator import attrgetter
-from typing import Any, Literal, TypedDict, cast
+from typing import Any, Literal, NotRequired, TypedDict, cast
 
 from django.db.models import prefetch_related_objects
 
@@ -171,8 +171,8 @@ class MonitorAlertRuleSerializerResponse(TypedDict):
     environment: str
 
 
-class MonitorSerializerResponseOptional(TypedDict, total=False):
-    alertRule: MonitorAlertRuleSerializerResponse
+class MonitorSerializerResponseOptional(TypedDict):
+    alertRule: NotRequired[MonitorAlertRuleSerializerResponse]
 
 
 class MonitorSerializerResponse(MonitorSerializerResponseOptional):
@@ -322,8 +322,8 @@ class MonitorSerializer(Serializer[MonitorSerializerResponse]):
         return key in self.expand
 
 
-class MonitorCheckInSerializerResponseOptional(TypedDict, total=False):
-    groups: list[str]
+class MonitorCheckInSerializerResponseOptional(TypedDict):
+    groups: NotRequired[list[str]]
 
 
 class MonitorCheckInSerializerResponse(MonitorCheckInSerializerResponseOptional):

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -171,11 +171,8 @@ class MonitorAlertRuleSerializerResponse(TypedDict):
     environment: str
 
 
-class MonitorSerializerResponseOptional(TypedDict):
+class MonitorSerializerResponse(TypedDict):
     alertRule: NotRequired[MonitorAlertRuleSerializerResponse]
-
-
-class MonitorSerializerResponse(MonitorSerializerResponseOptional):
     id: str
     name: str
     slug: str
@@ -322,11 +319,8 @@ class MonitorSerializer(Serializer[MonitorSerializerResponse]):
         return key in self.expand
 
 
-class MonitorCheckInSerializerResponseOptional(TypedDict):
+class MonitorCheckInSerializerResponse(TypedDict):
     groups: NotRequired[list[str]]
-
-
-class MonitorCheckInSerializerResponse(MonitorCheckInSerializerResponseOptional):
     id: str
     environment: str
     status: str

--- a/src/sentry/notifications/api/serializers/notification_action_request.py
+++ b/src/sentry/notifications/api/serializers/notification_action_request.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from django.db import router, transaction
 from drf_spectacular.utils import extend_schema_serializer
@@ -35,15 +35,15 @@ INTEGRATION_SERVICES = {
 
 
 # Note the ordering of fields affects the Spike Protection API Documentation
-class NotificationActionInputData(TypedDict, total=False):
-    trigger_type: int
-    service_type: int
-    integration_id: int
-    target_identifier: str
-    target_display: str
-    projects: list[Project]
-    sentry_app_id: int
-    target_type: int
+class NotificationActionInputData(TypedDict):
+    trigger_type: NotRequired[int]
+    service_type: NotRequired[int]
+    integration_id: NotRequired[int]
+    target_identifier: NotRequired[str]
+    target_display: NotRequired[str]
+    projects: NotRequired[list[Project]]
+    sentry_app_id: NotRequired[int]
+    target_type: NotRequired[int]
 
 
 @extend_schema_serializer(exclude_fields=["sentry_app_id", "target_type"])

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, MutableMapping
-from typing import TYPE_CHECKING, Any, TypedDict, TypeGuard
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict, TypeGuard
 
 from django.db.models import Subquery
 
@@ -74,9 +74,9 @@ def validate(type: NotificationSettingEnum, value: NotificationSettingsOptionEnu
     return value in VALID_VALUES_FOR_KEY.get(type, {})
 
 
-class SubscriptionDetails(TypedDict, total=False):
-    disabled: bool
-    reason: str
+class SubscriptionDetails(TypedDict):
+    disabled: NotRequired[bool]
+    reason: NotRequired[str]
 
 
 def get_subscription_from_attributes(

--- a/src/sentry/organizations/services/organization/model.py
+++ b/src/sentry/organizations/services/organization/model.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import datetime
 from enum import IntEnum
 from functools import cached_property
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from django.dispatch import Signal
 from django.utils import timezone
@@ -419,7 +419,7 @@ class RpcAuditLogEntryActor(RpcModel):
     ip_address: str | None
 
 
-class OrganizationMemberUpdateArgs(TypedDict, total=False):
-    flags: RpcOrganizationMemberFlags | None
-    role: str
-    invite_status: int
+class OrganizationMemberUpdateArgs(TypedDict):
+    flags: NotRequired[RpcOrganizationMemberFlags | None]
+    role: NotRequired[str]
+    invite_status: NotRequired[int]

--- a/src/sentry/organizations/services/organization_actions/impl.py
+++ b/src/sentry/organizations/services/organization_actions/impl.py
@@ -1,5 +1,5 @@
 import hashlib
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 from uuid import uuid4
 
 from django.db import router, transaction
@@ -10,12 +10,12 @@ from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.models.organization import Organization, OrganizationStatus
 
 
-class OrganizationCreateAndUpdateOptions(TypedDict, total=False):
-    name: str
-    slug: str
-    status: OrganizationStatus
-    flags: CombinedExpression
-    default_role: int
+class OrganizationCreateAndUpdateOptions(TypedDict):
+    name: NotRequired[str]
+    slug: NotRequired[str]
+    status: NotRequired[OrganizationStatus]
+    flags: NotRequired[CombinedExpression]
+    default_role: NotRequired[int]
 
 
 def update_organization_with_outbox_message(

--- a/src/sentry/preprod/api/models/public/snapshots.py
+++ b/src/sentry/preprod/api/models/public/snapshots.py
@@ -1,75 +1,75 @@
 from __future__ import annotations
 
-from typing import Literal, TypedDict
+from typing import Literal, NotRequired, TypedDict
 
 
-class VcsInfoResponseDict(TypedDict, total=False):
-    head_sha: str | None
-    base_sha: str | None
-    provider: str | None
-    head_repo_name: str | None
-    base_repo_name: str | None
-    head_ref: str | None
-    base_ref: str | None
-    pr_number: int | None
+class VcsInfoResponseDict(TypedDict):
+    head_sha: NotRequired[str | None]
+    base_sha: NotRequired[str | None]
+    provider: NotRequired[str | None]
+    head_repo_name: NotRequired[str | None]
+    base_repo_name: NotRequired[str | None]
+    head_ref: NotRequired[str | None]
+    base_ref: NotRequired[str | None]
+    pr_number: NotRequired[int | None]
 
 
-class SnapshotImageResponseDict(TypedDict, total=False):
-    key: str
-    display_name: str | None
-    group: str | None
-    image_file_name: str
-    width: int
-    height: int
+class SnapshotImageResponseDict(TypedDict):
+    key: NotRequired[str]
+    display_name: NotRequired[str | None]
+    group: NotRequired[str | None]
+    image_file_name: NotRequired[str]
+    width: NotRequired[int]
+    height: NotRequired[int]
 
 
-class SnapshotDiffPairResponseDict(TypedDict, total=False):
-    base_image: SnapshotImageResponseDict
-    head_image: SnapshotImageResponseDict
-    diff_image_key: str | None
-    diff: float | None
+class SnapshotDiffPairResponseDict(TypedDict):
+    base_image: NotRequired[SnapshotImageResponseDict]
+    head_image: NotRequired[SnapshotImageResponseDict]
+    diff_image_key: NotRequired[str | None]
+    diff: NotRequired[float | None]
 
 
-class SnapshotApproverResponseDict(TypedDict, total=False):
-    id: str | None
-    name: str | None
-    email: str | None
-    username: str | None
-    avatar_url: str | None
-    approved_at: str | None
-    source: Literal["sentry", "github"]
+class SnapshotApproverResponseDict(TypedDict):
+    id: NotRequired[str | None]
+    name: NotRequired[str | None]
+    email: NotRequired[str | None]
+    username: NotRequired[str | None]
+    avatar_url: NotRequired[str | None]
+    approved_at: NotRequired[str | None]
+    source: NotRequired[Literal["sentry", "github"]]
 
 
-class SnapshotDetailsResponseDict(TypedDict, total=False):
-    head_artifact_id: str
-    base_artifact_id: str | None
-    project_id: str
-    comparison_type: str
-    state: str
-    vcs_info: VcsInfoResponseDict
-    app_id: str | None
-    is_selective: bool
-    images: list[SnapshotImageResponseDict]
-    image_count: int
-    added: list[SnapshotImageResponseDict]
-    added_count: int
-    removed: list[SnapshotImageResponseDict]
-    removed_count: int
-    renamed: list[SnapshotDiffPairResponseDict]
-    renamed_count: int
-    changed: list[SnapshotDiffPairResponseDict]
-    changed_count: int
-    unchanged: list[SnapshotImageResponseDict]
-    unchanged_count: int
-    errored: list[SnapshotDiffPairResponseDict]
-    errored_count: int
-    skipped: list[SnapshotImageResponseDict]
-    skipped_count: int
-    diff_threshold: float | None
-    comparison_state: str | None
-    approval_status: str | None
-    comparison_error_message: str | None
-    approvers: list[SnapshotApproverResponseDict]
+class SnapshotDetailsResponseDict(TypedDict):
+    head_artifact_id: NotRequired[str]
+    base_artifact_id: NotRequired[str | None]
+    project_id: NotRequired[str]
+    comparison_type: NotRequired[str]
+    state: NotRequired[str]
+    vcs_info: NotRequired[VcsInfoResponseDict]
+    app_id: NotRequired[str | None]
+    is_selective: NotRequired[bool]
+    images: NotRequired[list[SnapshotImageResponseDict]]
+    image_count: NotRequired[int]
+    added: NotRequired[list[SnapshotImageResponseDict]]
+    added_count: NotRequired[int]
+    removed: NotRequired[list[SnapshotImageResponseDict]]
+    removed_count: NotRequired[int]
+    renamed: NotRequired[list[SnapshotDiffPairResponseDict]]
+    renamed_count: NotRequired[int]
+    changed: NotRequired[list[SnapshotDiffPairResponseDict]]
+    changed_count: NotRequired[int]
+    unchanged: NotRequired[list[SnapshotImageResponseDict]]
+    unchanged_count: NotRequired[int]
+    errored: NotRequired[list[SnapshotDiffPairResponseDict]]
+    errored_count: NotRequired[int]
+    skipped: NotRequired[list[SnapshotImageResponseDict]]
+    skipped_count: NotRequired[int]
+    diff_threshold: NotRequired[float | None]
+    comparison_state: NotRequired[str | None]
+    approval_status: NotRequired[str | None]
+    comparison_error_message: NotRequired[str | None]
+    approvers: NotRequired[list[SnapshotApproverResponseDict]]
 
 
 class SnapshotCreateResponseDict(TypedDict):
@@ -79,55 +79,55 @@ class SnapshotCreateResponseDict(TypedDict):
     snapshotUrl: str
 
 
-class SnapshotImageDetailImageInfoResponseDict(TypedDict, total=False):
-    content_hash: str
-    display_name: str | None
-    group: str | None
-    image_file_name: str
-    width: int
-    height: int
-    diff_threshold: float | None
-    description: str | None
-    tags: dict[str, str] | None
-    image_url: str
+class SnapshotImageDetailImageInfoResponseDict(TypedDict):
+    content_hash: NotRequired[str]
+    display_name: NotRequired[str | None]
+    group: NotRequired[str | None]
+    image_file_name: NotRequired[str]
+    width: NotRequired[int]
+    height: NotRequired[int]
+    diff_threshold: NotRequired[float | None]
+    description: NotRequired[str | None]
+    tags: NotRequired[dict[str, str] | None]
+    image_url: NotRequired[str]
 
 
-class SnapshotImageDetailResponseDict(TypedDict, total=False):
-    image_file_name: str
-    comparison_status: str | None
-    head_image: SnapshotImageDetailImageInfoResponseDict | None
-    base_image: SnapshotImageDetailImageInfoResponseDict | None
-    diff_image_url: str | None
-    diff_percentage: float | None
-    previous_image_file_name: str | None
+class SnapshotImageDetailResponseDict(TypedDict):
+    image_file_name: NotRequired[str]
+    comparison_status: NotRequired[str | None]
+    head_image: NotRequired[SnapshotImageDetailImageInfoResponseDict | None]
+    base_image: NotRequired[SnapshotImageDetailImageInfoResponseDict | None]
+    diff_image_url: NotRequired[str | None]
+    diff_percentage: NotRequired[float | None]
+    previous_image_file_name: NotRequired[str | None]
 
 
-class LatestBaseSnapshotImageResponseDict(TypedDict, total=False):
-    key: str
-    display_name: str | None
-    group: str | None
-    image_file_name: str
-    width: int
-    height: int
-    image_url: str
+class LatestBaseSnapshotImageResponseDict(TypedDict):
+    key: NotRequired[str]
+    display_name: NotRequired[str | None]
+    group: NotRequired[str | None]
+    image_file_name: NotRequired[str]
+    width: NotRequired[int]
+    height: NotRequired[int]
+    image_url: NotRequired[str]
 
 
-class LatestBaseSnapshotVcsInfoResponseDict(TypedDict, total=False):
-    head_sha: str | None
-    base_sha: str | None
-    head_ref: str | None
-    base_ref: str | None
-    head_repo_name: str | None
-    pr_number: int | None
+class LatestBaseSnapshotVcsInfoResponseDict(TypedDict):
+    head_sha: NotRequired[str | None]
+    base_sha: NotRequired[str | None]
+    head_ref: NotRequired[str | None]
+    base_ref: NotRequired[str | None]
+    head_repo_name: NotRequired[str | None]
+    pr_number: NotRequired[int | None]
 
 
-class LatestBaseSnapshotResponseDict(TypedDict, total=False):
-    head_artifact_id: str
-    project_id: str
-    project_slug: str
-    app_id: str | None
-    image_count: int
-    images: list[LatestBaseSnapshotImageResponseDict]
-    diff_threshold: float | None
-    date_added: str
-    vcs_info: LatestBaseSnapshotVcsInfoResponseDict
+class LatestBaseSnapshotResponseDict(TypedDict):
+    head_artifact_id: NotRequired[str]
+    project_id: NotRequired[str]
+    project_slug: NotRequired[str]
+    app_id: NotRequired[str | None]
+    image_count: NotRequired[int]
+    images: NotRequired[list[LatestBaseSnapshotImageResponseDict]]
+    diff_threshold: NotRequired[float | None]
+    date_added: NotRequired[str]
+    vcs_info: NotRequired[LatestBaseSnapshotVcsInfoResponseDict]

--- a/src/sentry/preprod/snapshots/zip_builder.py
+++ b/src/sentry/preprod/snapshots/zip_builder.py
@@ -5,7 +5,7 @@ import zipfile
 from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import as_completed
-from typing import IO, TypedDict, Unpack, cast
+from typing import IO, NotRequired, TypedDict, Unpack, cast
 
 from objectstore_client import Session
 
@@ -21,13 +21,13 @@ FETCH_MAX_WORKERS = 16
 ZIP_EXTRAS_KEY = "images_zip"
 
 
-class ZipState(TypedDict, total=False):
-    status: str
-    enqueued_at: str
-    file_id: int | None
-    size: int
-    built_at: str
-    progress: int
+class ZipState(TypedDict):
+    status: NotRequired[str]
+    enqueued_at: NotRequired[str]
+    file_id: NotRequired[int | None]
+    size: NotRequired[int]
+    built_at: NotRequired[str]
+    progress: NotRequired[int]
 
 
 class SnapshotZipBuildError(Exception):

--- a/src/sentry/projects/services/project/model.py
+++ b/src/sentry/projects/services/project/model.py
@@ -5,7 +5,7 @@
 
 from collections.abc import Callable
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from pydantic.fields import Field
 
@@ -17,15 +17,15 @@ def _project_status_visible() -> int:
     return int(ObjectStatus.ACTIVE)
 
 
-class ProjectFilterArgs(TypedDict, total=False):
-    project_ids: list[int]
+class ProjectFilterArgs(TypedDict):
+    project_ids: NotRequired[list[int]]
 
 
-class ProjectUpdateArgs(TypedDict, total=False):
-    name: str
-    slug: str
-    platform: str | None
-    external_id: str | None
+class ProjectUpdateArgs(TypedDict):
+    name: NotRequired[str]
+    slug: NotRequired[str]
+    platform: NotRequired[str | None]
+    external_id: NotRequired[str | None]
 
 
 class RpcProjectFlags(RpcModel):

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import IntEnum, unique
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 
 from django.core.cache import cache
 
@@ -84,8 +84,8 @@ class TrimmingConfig(TypedDict):
 
 # This mirrors the TrimmingConfigs struct in Relay
 # https://github.com/getsentry/relay/blob/73e5f9816b10c518b4451d46ebffa709f9f7e897/relay-dynamic-config/src/project.rs#L297-L301
-class TrimmingConfigs(TypedDict, total=False):
-    span: TrimmingConfig
+class TrimmingConfigs(TypedDict):
+    span: NotRequired[TrimmingConfig]
 
 
 def build_metric_abuse_quotas() -> list[AbuseQuota]:

--- a/src/sentry/relay/config/ai_model_costs.py
+++ b/src/sentry/relay/config/ai_model_costs.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Required, TypedDict
+from typing import NotRequired, Required, TypedDict
 
 from django.conf import settings
 
@@ -25,9 +25,9 @@ class AIModelCost(TypedDict):
     inputCacheWritePerToken: float
 
 
-class AIModelMetadata(TypedDict, total=False):
-    costs: Required[AIModelCost]
-    contextSize: int
+class AIModelMetadata(TypedDict):
+    costs: AIModelCost
+    contextSize: NotRequired[int]
 
 
 class AIModelMetadataConfig(TypedDict):

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -1,4 +1,4 @@
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import sentry.options
 from sentry.relay.config.ai_model_costs import AIModelMetadataConfig, ai_model_metadata_config
@@ -37,13 +37,13 @@ class SpanOpDefaults(TypedDict):
     rules: list[SpanOpDefaultRule]
 
 
-class GlobalConfig(TypedDict, total=False):
-    measurements: MeasurementsConfig
-    aiModelMetadata: AIModelMetadataConfig | None
-    metricExtraction: MetricExtractionGroups
-    filters: GenericFiltersConfig | None
-    spanOpDefaults: SpanOpDefaults
-    options: dict[str, Any]
+class GlobalConfig(TypedDict):
+    measurements: NotRequired[MeasurementsConfig]
+    aiModelMetadata: NotRequired[AIModelMetadataConfig | None]
+    metricExtraction: NotRequired[MetricExtractionGroups]
+    filters: NotRequired[GenericFiltersConfig | None]
+    spanOpDefaults: NotRequired[SpanOpDefaults]
+    options: NotRequired[dict[str, Any]]
 
 
 def get_global_generic_filters() -> GenericFiltersConfig:

--- a/src/sentry/release_health/base.py
+++ b/src/sentry/release_health/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, TypedDict, TypeIs, TypeVar, Union
+from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict, TypeIs, TypeVar, Union
 
 from sentry.utils.services import Service
 
@@ -64,8 +64,12 @@ ProjectWithCount = tuple[ProjectId, int]
 #: Group key as featured in output format
 GroupKeyDict = TypedDict(
     "GroupKeyDict",
-    {"project": int, "release": str, "environment": str, "session.status": str},
-    total=False,
+    {
+        "project": NotRequired[int],
+        "release": NotRequired[str],
+        "environment": NotRequired[str],
+        "session.status": NotRequired[str],
+    },
 )
 
 
@@ -150,26 +154,26 @@ class ReleaseAdoption(TypedDict):
 ReleasesAdoption = Mapping[tuple[ProjectId, ReleaseName], ReleaseAdoption]
 
 
-class ReleaseHealthOverview(TypedDict, total=False):
-    adoption: float | None
-    sessions_adoption: float | None
-    total_users_24h: int | None
-    total_project_users_24h: int | None
-    total_sessions_24h: int | None
-    total_project_sessions_24h: int | None
-    total_sessions: int | None
-    total_users: int | None
-    has_health_data: bool
-    sessions_crashed: int
-    crash_free_users: float | None
-    crash_free_sessions: float | None
-    sessions_errored: int
-    duration_p50: float | None
-    duration_p90: float | None
-    stats: Mapping[StatsPeriod, ReleaseHealthStats]
-    sessions_unhandled: int
-    unhandled_session_rate: float | None
-    unhandled_user_rate: float | None
+class ReleaseHealthOverview(TypedDict):
+    adoption: NotRequired[float | None]
+    sessions_adoption: NotRequired[float | None]
+    total_users_24h: NotRequired[int | None]
+    total_project_users_24h: NotRequired[int | None]
+    total_sessions_24h: NotRequired[int | None]
+    total_project_sessions_24h: NotRequired[int | None]
+    total_sessions: NotRequired[int | None]
+    total_users: NotRequired[int | None]
+    has_health_data: NotRequired[bool]
+    sessions_crashed: NotRequired[int]
+    crash_free_users: NotRequired[float | None]
+    crash_free_sessions: NotRequired[float | None]
+    sessions_errored: NotRequired[int]
+    duration_p50: NotRequired[float | None]
+    duration_p90: NotRequired[float | None]
+    stats: NotRequired[Mapping[StatsPeriod, ReleaseHealthStats]]
+    sessions_unhandled: NotRequired[int]
+    unhandled_session_rate: NotRequired[float | None]
+    unhandled_user_rate: NotRequired[float | None]
 
 
 class CrashFreeBreakdown(TypedDict):

--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -10,7 +10,7 @@ from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequenc
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from enum import Enum
-from typing import Any, Optional, TypedDict, Union, cast
+from typing import Any, NotRequired, Optional, TypedDict, Union, cast
 
 from snuba_sdk import (
     BooleanCondition,
@@ -62,10 +62,10 @@ Scalar = Union[int, float, None]
 
 
 #: Group key as featured in metrics format
-class MetricsGroupKeyDict(TypedDict, total=False):
-    project_id: int
-    release: str
-    environment: str
+class MetricsGroupKeyDict(TypedDict):
+    project_id: NotRequired[int]
+    release: NotRequired[str]
+    environment: NotRequired[str]
 
 
 class SessionStatus(Enum):

--- a/src/sentry/replays/endpoints/organization_replay_selector_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_selector_index.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import ParseError
@@ -66,12 +66,12 @@ ElementResponseType = TypedDict(
 )
 
 
-class ReplaySelectorResponseData(TypedDict, total=False):
-    count_dead_clicks: int
-    count_rage_clicks: int
-    dom_element: str
-    element: ElementResponseType
-    project_id: str
+class ReplaySelectorResponseData(TypedDict):
+    count_dead_clicks: NotRequired[int]
+    count_rage_clicks: NotRequired[int]
+    dom_element: NotRequired[str]
+    element: NotRequired[ElementResponseType]
+    project_id: NotRequired[str]
 
 
 class ReplaySelectorResponse(TypedDict):

--- a/src/sentry/replays/lib/eap/snuba_transpiler.py
+++ b/src/sentry/replays/lib/eap/snuba_transpiler.py
@@ -18,7 +18,7 @@ normalize it first.
 
 from collections.abc import MutableMapping, Sequence
 from datetime import date, datetime
-from typing import Any, NotRequired, Required, TypedDict, cast
+from typing import Any, NotRequired, TypedDict, cast
 from typing import Literal as TLiteral
 
 import urllib3
@@ -280,7 +280,7 @@ class RequestMeta(TypedDict):
     trace_item_type: TRACE_ITEM_TYPES
 
 
-class Settings(TypedDict, total=False):
+class Settings(TypedDict):
     """
     Query settings are extra metadata items which are not representable within a Snuba query. They
     are not sent to EAP in the form they are supplied. Instead they are used as helper metadata in
@@ -335,10 +335,10 @@ class Settings(TypedDict, total=False):
         ... }
     """
 
-    attribute_types: Required[dict[str, type[bool | float | int | str]]]
-    default_limit: int
-    default_offset: int
-    extrapolation_modes: MutableMapping[str, TLiteral["weighted", "none"]]  # noqa
+    attribute_types: dict[str, type[bool | float | int | str]]
+    default_limit: NotRequired[int]
+    default_offset: NotRequired[int]
+    extrapolation_modes: NotRequired[MutableMapping[str, TLiteral["weighted", "none"]]]  # noqa
 
 
 VirtualColumn = TypedDict(

--- a/src/sentry/replays/post_process.py
+++ b/src/sentry/replays/post_process.py
@@ -3,91 +3,91 @@ from __future__ import annotations
 import collections
 from collections.abc import Generator, Iterable, Iterator, MutableMapping
 from itertools import zip_longest
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import sentry_sdk
 from drf_spectacular.utils import extend_schema_serializer
 
 
-class DeviceResponseType(TypedDict, total=False):
-    name: str | None
-    brand: str | None
-    model: str | None
-    family: str | None
+class DeviceResponseType(TypedDict):
+    name: NotRequired[str | None]
+    brand: NotRequired[str | None]
+    model: NotRequired[str | None]
+    family: NotRequired[str | None]
 
 
-class SDKResponseType(TypedDict, total=False):
-    name: str | None
-    version: str | None
+class SDKResponseType(TypedDict):
+    name: NotRequired[str | None]
+    version: NotRequired[str | None]
 
 
-class OSResponseType(TypedDict, total=False):
-    name: str | None
-    version: str | None
+class OSResponseType(TypedDict):
+    name: NotRequired[str | None]
+    version: NotRequired[str | None]
 
 
-class BrowserResponseType(TypedDict, total=False):
-    name: str | None
-    version: str | None
+class BrowserResponseType(TypedDict):
+    name: NotRequired[str | None]
+    version: NotRequired[str | None]
 
 
-class UserGeoResponseType(TypedDict, total=False):
-    city: str | None
-    country_code: str | None
-    region: str | None
-    subdivision: str | None
+class UserGeoResponseType(TypedDict):
+    city: NotRequired[str | None]
+    country_code: NotRequired[str | None]
+    region: NotRequired[str | None]
+    subdivision: NotRequired[str | None]
 
 
-class UserResponseType(TypedDict, total=False):
-    id: str | None
-    username: str | None
-    email: str | None
-    ip: str | None
-    display_name: str | None
-    geo: UserGeoResponseType
+class UserResponseType(TypedDict):
+    id: NotRequired[str | None]
+    username: NotRequired[str | None]
+    email: NotRequired[str | None]
+    ip: NotRequired[str | None]
+    display_name: NotRequired[str | None]
+    geo: NotRequired[UserGeoResponseType]
 
 
-class OTAUpdatesResponseType(TypedDict, total=False):
-    channel: str | None
-    runtime_version: str | None
-    update_id: str | None
+class OTAUpdatesResponseType(TypedDict):
+    channel: NotRequired[str | None]
+    runtime_version: NotRequired[str | None]
+    update_id: NotRequired[str | None]
 
 
 @extend_schema_serializer(exclude_fields=["info_ids", "warning_ids"])
-class ReplayDetailsResponse(TypedDict, total=False):
-    id: str
-    project_id: str
-    trace_ids: list[str]
-    error_ids: list[str]
-    environment: str | None
-    tags: dict[str, list[str]] | list
-    user: UserResponseType
-    sdk: SDKResponseType
-    os: OSResponseType
-    browser: BrowserResponseType
-    device: DeviceResponseType
-    ota_updates: OTAUpdatesResponseType
-    is_archived: bool | None
-    urls: list[str] | None
-    clicks: list[dict[str, Any]]
-    count_dead_clicks: int | None
-    count_rage_clicks: int | None
-    count_errors: int | None
-    duration: int | None
-    finished_at: str | None
-    started_at: str | None
-    activity: int | None
-    count_urls: int | None
-    replay_type: str
-    count_segments: int | None
-    platform: str | None
-    releases: list[str]
-    dist: str | None
-    warning_ids: list[str] | None
-    info_ids: list[str] | None
-    count_warnings: int | None
-    count_infos: int | None
-    has_viewed: bool
+class ReplayDetailsResponse(TypedDict):
+    id: NotRequired[str]
+    project_id: NotRequired[str]
+    trace_ids: NotRequired[list[str]]
+    error_ids: NotRequired[list[str]]
+    environment: NotRequired[str | None]
+    tags: NotRequired[dict[str, list[str]] | list]
+    user: NotRequired[UserResponseType]
+    sdk: NotRequired[SDKResponseType]
+    os: NotRequired[OSResponseType]
+    browser: NotRequired[BrowserResponseType]
+    device: NotRequired[DeviceResponseType]
+    ota_updates: NotRequired[OTAUpdatesResponseType]
+    is_archived: NotRequired[bool | None]
+    urls: NotRequired[list[str] | None]
+    clicks: NotRequired[list[dict[str, Any]]]
+    count_dead_clicks: NotRequired[int | None]
+    count_rage_clicks: NotRequired[int | None]
+    count_errors: NotRequired[int | None]
+    duration: NotRequired[int | None]
+    finished_at: NotRequired[str | None]
+    started_at: NotRequired[str | None]
+    activity: NotRequired[int | None]
+    count_urls: NotRequired[int | None]
+    replay_type: NotRequired[str]
+    count_segments: NotRequired[int | None]
+    platform: NotRequired[str | None]
+    releases: NotRequired[list[str]]
+    dist: NotRequired[str | None]
+    warning_ids: NotRequired[list[str] | None]
+    info_ids: NotRequired[list[str] | None]
+    count_warnings: NotRequired[int | None]
+    count_infos: NotRequired[int | None]
+    has_viewed: NotRequired[bool]
 
 
 @sentry_sdk.trace

--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterator, MutableMapping
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Literal, TypedDict, TypeVar
+from typing import Any, Literal, NotRequired, TypedDict, TypeVar
 
 import sentry_sdk
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
@@ -692,15 +692,15 @@ def set_if(keys: list[str], data: dict[str, Any], value_fn: Callable[[Any], T]) 
 #
 
 
-class HighlightedEvents(TypedDict, total=False):
-    canvas_sizes: list[int]
-    hydration_errors: list[HydrationError]
-    mutations: list[MutationEvent]
-    clicks: list[ClickEvent]
-    multiclicks: list[MultiClickEvent]
-    request_response_sizes: list[tuple[int | None, int | None]]
-    options: list[dict[str, Any]]
-    taps: list[TapEvent]
+class HighlightedEvents(TypedDict):
+    canvas_sizes: NotRequired[list[int]]
+    hydration_errors: NotRequired[list[HydrationError]]
+    mutations: NotRequired[list[MutationEvent]]
+    clicks: NotRequired[list[ClickEvent]]
+    multiclicks: NotRequired[list[MultiClickEvent]]
+    request_response_sizes: NotRequired[list[tuple[int | None, int | None]]]
+    options: NotRequired[list[dict[str, Any]]]
+    taps: NotRequired[list[TapEvent]]
 
 
 class HighlightedEventsBuilder:

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from datetime import datetime
-from typing import Any, TypedDict, Union
+from typing import Any, NotRequired, TypedDict, Union
 
 import orjson
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
@@ -52,11 +52,11 @@ from sentry.utils.strings import oxfordize_list
 from sentry.utils.validators import INVALID_ID_DETAILS, INVALID_SPAN_ID, WILDCARD_NOT_ALLOWED
 
 
-class FilterConvertParams(TypedDict, total=False):
-    organization_id: int
-    project_id: Sequence[int]
-    environment: Sequence[str] | None
-    environment_id: list[int] | None
+class FilterConvertParams(TypedDict):
+    organization_id: NotRequired[int]
+    project_id: NotRequired[Sequence[int]]
+    environment: NotRequired[Sequence[str] | None]
+    environment_id: NotRequired[list[int] | None]
 
 
 def translate_transaction_status(val: str) -> int:

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -28,12 +28,12 @@ WhereType = Union[Condition, BooleanCondition]
 
 
 # Replaced by SnubaParams
-class ParamsType(TypedDict, total=False):
-    project_id: Sequence[int]
-    projects: list[Project]
-    project_objects: list[Project]
-    start: datetime
-    end: datetime
+class ParamsType(TypedDict):
+    project_id: NotRequired[Sequence[int]]
+    projects: NotRequired[list[Project]]
+    project_objects: NotRequired[list[Project]]
+    start: NotRequired[datetime]
+    end: NotRequired[datetime]
     environment: NotRequired[str | list[str]]
     organization_id: NotRequired[int | None]
     use_case_id: NotRequired[str]

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -707,13 +707,13 @@ def bulk_read_preferences_from_sentry_db(
     return result
 
 
-class SeerProjectSettingsUpdate(TypedDict, total=False):
-    agent: AutomationCodingAgent
-    integration_id: int
-    stopping_point: str
-    automation_tuning: str
-    scanner_automation: bool
-    auto_create_pr: bool
+class SeerProjectSettingsUpdate(TypedDict):
+    agent: NotRequired[AutomationCodingAgent]
+    integration_id: NotRequired[int]
+    stopping_point: NotRequired[str]
+    automation_tuning: NotRequired[str]
+    scanner_automation: NotRequired[bool]
+    auto_create_pr: NotRequired[bool]
 
 
 def update_seer_project_settings(project_ids: list[int], data: SeerProjectSettingsUpdate) -> None:

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -19,14 +19,14 @@ from sentry.viewer_context import (
 )
 
 
-class SeerViewerContext(TypedDict, total=False):
-    organization_id: int
+class SeerViewerContext(TypedDict):
+    organization_id: NotRequired[int]
     # TODO(jeremy.stanley): user_id is int | None as a temporary state while
     # consolidating viewer context across call sites. Some pass request.user.id
     # (which can be None for anonymous users), others omit the key entirely.
     # Once all call sites are wired up, tighten this to int and ensure callers
     # only set user_id when an authenticated user is present.
-    user_id: int | None
+    user_id: NotRequired[int | None]
 
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
@@ -30,13 +30,13 @@ FAILURE_REASON_BASE = f"{SentryAppEventType.ALERT_RULE_ACTION_REQUESTED}.{{}}"
 logger = logging.getLogger("sentry.sentry_apps.external_requests")
 
 
-class SentryAppAlertRuleActionResult(TypedDict, total=False):
-    success: bool
-    message: str
-    error_type: SentryAppErrorType | None
-    webhook_context: dict[str, Any] | None
-    public_context: dict[str, Any] | None
-    status_code: int | None
+class SentryAppAlertRuleActionResult(TypedDict):
+    success: NotRequired[bool]
+    message: NotRequired[str]
+    error_type: NotRequired[SentryAppErrorType | None]
+    webhook_context: NotRequired[dict[str, Any] | None]
+    public_context: NotRequired[dict[str, Any] | None]
+    status_code: NotRequired[int | None]
 
 
 @dataclass

--- a/src/sentry/sentry_apps/external_requests/select_requester.py
+++ b/src/sentry/sentry_apps/external_requests/select_requester.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Annotated, Any, TypedDict
+from typing import Annotated, Any, NotRequired, TypedDict
 from urllib.parse import urlencode, urlparse, urlunparse
 from uuid import uuid4
 
@@ -24,10 +24,10 @@ from sentry.utils import json
 FAILURE_REASON_BASE = f"{SentryAppEventType.SELECT_OPTIONS_REQUESTED}.{{}}"
 
 
-class SelectRequesterResult(TypedDict, total=False):
+class SelectRequesterResult(TypedDict):
     # Each contained Sequence of strings is of length 2 i.e ["label", "value"]
-    choices: Sequence[Annotated[Sequence[str], 2]]
-    defaultValue: str
+    choices: NotRequired[Sequence[Annotated[Sequence[str], 2]]]
+    defaultValue: NotRequired[str]
 
 
 @dataclass

--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -7,7 +7,7 @@ import datetime
 import hmac
 from collections.abc import MutableMapping
 from hashlib import sha256
-from typing import Any, Protocol, TypedDict
+from typing import Any, NotRequired, Protocol, TypedDict
 from urllib.parse import urljoin
 
 from pydantic.fields import Field
@@ -190,17 +190,17 @@ class RpcSentryAppEventData(RpcModel):
         )
 
 
-class SentryAppInstallationFilterArgs(TypedDict, total=False):
-    installation_ids: list[int]
-    app_ids: list[int]
-    organization_id: int
-    uuids: list[str]
-    status: int
-    api_token_id: int
-    api_installation_token_id: int
+class SentryAppInstallationFilterArgs(TypedDict):
+    installation_ids: NotRequired[list[int]]
+    app_ids: NotRequired[list[int]]
+    organization_id: NotRequired[int]
+    uuids: NotRequired[list[str]]
+    status: NotRequired[int]
+    api_token_id: NotRequired[int]
+    api_installation_token_id: NotRequired[int]
 
 
-class SentryAppUpdateArgs(TypedDict, total=False):
-    events: list[str]
-    name: str
+class SentryAppUpdateArgs(TypedDict):
+    events: NotRequired[list[str]]
+    name: NotRequired[str]
     # TODO add whatever else as needed

--- a/src/sentry/sentry_apps/services/app_request/model.py
+++ b/src/sentry/sentry_apps/services/app_request/model.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from pydantic import Field
 
@@ -24,6 +24,6 @@ class RpcSentryAppRequest(RpcModel):
     response_body: str | None = None
 
 
-class SentryAppRequestFilterArgs(TypedDict, total=False):
-    event: str | list[str]
-    errors_only: bool
+class SentryAppRequestFilterArgs(TypedDict):
+    event: NotRequired[str | list[str]]
+    errors_only: NotRequired[bool]

--- a/src/sentry/sentry_apps/utils/errors.py
+++ b/src/sentry/sentry_apps/utils/errors.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import sentry_sdk
 from rest_framework.response import Response
@@ -11,9 +11,9 @@ class SentryAppErrorType(Enum):
     SENTRY = "sentry"
 
 
-class SentryAppPublicErrorBody(TypedDict, total=False):
-    detail: str
-    context: dict[str, Any]
+class SentryAppPublicErrorBody(TypedDict):
+    detail: NotRequired[str]
+    context: NotRequired[dict[str, Any]]
 
 
 class SentryAppBaseError(Exception):

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, TypedDict, Union
+from typing import Any, NotRequired, TypedDict, Union
 
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
@@ -117,10 +117,10 @@ def apply_dataset_query_conditions(
     return event_type_conditions
 
 
-class _EntitySpecificParams(TypedDict, total=False):
-    org_id: int
-    extrapolation_mode: ExtrapolationMode | None
-    event_types: list[SnubaQueryEventType.EventType] | None
+class _EntitySpecificParams(TypedDict):
+    org_id: NotRequired[int]
+    extrapolation_mode: NotRequired[ExtrapolationMode | None]
+    event_types: NotRequired[list[SnubaQueryEventType.EventType] | None]
 
 
 @dataclass

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, TypedDict, overload
+from typing import Any, NotRequired, TypedDict, overload
 
 import sentry_sdk
 from snuba_sdk import (
@@ -1239,9 +1239,9 @@ class SnubaQueryBuilder:
         return queries_dict, fields_in_entities
 
 
-class _SeriesTotals(TypedDict, total=False):
-    series: dict[str, list[Any]]
-    totals: dict[str, Any]
+class _SeriesTotals(TypedDict):
+    series: NotRequired[dict[str, list[Any]]]
+    totals: NotRequired[dict[str, Any]]
 
 
 class _BySeriesTotals(_SeriesTotals):

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -7,7 +7,7 @@ import re
 from collections import defaultdict
 from collections.abc import Iterable, MutableMapping, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Any, Never, Protocol, TypedDict
+from typing import Any, Never, NotRequired, Protocol, TypedDict
 
 import sentry_sdk
 from dateutil.parser import parse as parse_datetime
@@ -227,9 +227,9 @@ def _reasonable_group_tag_value_iter_match(
     return True
 
 
-class _OptimizeKwargs(TypedDict, total=False):
-    turbo: bool
-    sample: int
+class _OptimizeKwargs(TypedDict):
+    turbo: NotRequired[bool]
+    sample: NotRequired[int]
 
 
 class _KeyCallable[T, U](Protocol):

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 from datetime import datetime
-from typing import Any, ClassVar, TypedDict
+from typing import Any, ClassVar, NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.search.utils import convert_user_tag_to_query
@@ -129,10 +129,10 @@ class GroupTagValue(TagType):
         self.last_seen = last_seen
 
 
-class TagKeySerializerResponseOptional(TypedDict, total=False):
-    uniqueValues: int | None
-    totalValues: int | None
-    topValues: list[TagValueSerializerResponse] | None
+class TagKeySerializerResponseOptional(TypedDict):
+    uniqueValues: NotRequired[int | None]
+    totalValues: NotRequired[int | None]
+    topValues: NotRequired[list[TagValueSerializerResponse] | None]
 
 
 class TagKeySerializerResponse(TagKeySerializerResponseOptional):
@@ -159,8 +159,8 @@ class TagKeySerializer(Serializer[TagKeySerializerResponse]):
         return output
 
 
-class TagValueSerializerResponseOptional(TypedDict, total=False):
-    query: str | None
+class TagValueSerializerResponseOptional(TypedDict):
+    query: NotRequired[str | None]
 
 
 class TagValueSerializerResponse(TagValueSerializerResponseOptional):

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -129,13 +129,10 @@ class GroupTagValue(TagType):
         self.last_seen = last_seen
 
 
-class TagKeySerializerResponseOptional(TypedDict):
+class TagKeySerializerResponse(TypedDict):
     uniqueValues: NotRequired[int | None]
     totalValues: NotRequired[int | None]
     topValues: NotRequired[list[TagValueSerializerResponse] | None]
-
-
-class TagKeySerializerResponse(TagKeySerializerResponseOptional):
     key: str
     name: str
 
@@ -159,11 +156,8 @@ class TagKeySerializer(Serializer[TagKeySerializerResponse]):
         return output
 
 
-class TagValueSerializerResponseOptional(TypedDict):
+class TagValueSerializerResponse(TypedDict):
     query: NotRequired[str | None]
-
-
-class TagValueSerializerResponse(TagValueSerializerResponseOptional):
     key: str
     name: str
     value: str | None

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -6,7 +6,7 @@ import uuid
 from collections.abc import MutableMapping, Sequence
 from datetime import datetime
 from time import time
-from typing import TYPE_CHECKING, Any, Callable, TypedDict
+from typing import TYPE_CHECKING, Any, Callable, NotRequired, TypedDict
 
 import sentry_sdk
 from django.conf import settings
@@ -63,13 +63,13 @@ ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT = 50
 HIGHER_ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT = 200
 
 
-class PostProcessJob(TypedDict, total=False):
-    event: GroupEvent
-    group_state: GroupState
-    is_reprocessed: bool
-    has_reappeared: bool
+class PostProcessJob(TypedDict):
+    event: NotRequired[GroupEvent]
+    group_state: NotRequired[GroupState]
+    is_reprocessed: NotRequired[bool]
+    has_reappeared: NotRequired[bool]
     # True when an issue transitions to the ESCALATING substatus for any reason.
-    has_escalated: bool
+    has_escalated: NotRequired[bool]
 
 
 def _should_send_error_created_hooks(project: Project) -> bool:

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -5,7 +5,7 @@ import logging
 import time
 from collections.abc import Mapping, Sequence
 from datetime import timedelta
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 import sentry_sdk
 from django.utils import timezone
@@ -84,16 +84,16 @@ class SeerNightShiftRunOptions(TypedDict):
     extra_triage_instructions: str
 
 
-class SeerNightShiftRunOptionsPartial(TypedDict, total=False):
+class SeerNightShiftRunOptionsPartial(TypedDict):
     """Caller-facing options dict — every field is optional. Missing fields
     are filled in by build_run_options with shared defaults."""
 
-    source: NightShiftRunSource
-    max_candidates: int
-    dry_run: bool
-    intelligence_level: IntelligenceLevel
-    reasoning_effort: ReasoningEffort
-    extra_triage_instructions: str
+    source: NotRequired[NightShiftRunSource]
+    max_candidates: NotRequired[int]
+    dry_run: NotRequired[bool]
+    intelligence_level: NotRequired[IntelligenceLevel]
+    reasoning_effort: NotRequired[ReasoningEffort]
+    extra_triage_instructions: NotRequired[str]
 
 
 @instrumented_task(

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from enum import Enum
 from io import BytesIO
-from typing import Any, Literal, TypedDict, Union
+from typing import Any, Literal, NotRequired, TypedDict, Union
 from unittest import mock
 from urllib.parse import urlencode
 from uuid import UUID, uuid4
@@ -3262,8 +3262,8 @@ class UptimeTestCaseMixin:
         }
 
 
-class _OptionalCheckResult(TypedDict, total=False):
-    region: str
+class _OptionalCheckResult(TypedDict):
+    region: NotRequired[str]
 
 
 class UptimeTestCase(UptimeTestCaseMixin, TestCase):
@@ -3374,14 +3374,14 @@ class SpanTestCase(BaseTestCase):
         return span
 
 
-class _OptionalOurLogData(TypedDict, total=False):
-    body: str
-    trace_id: str
-    replay_id: str
-    severity_text: str
-    severity_number: int
-    trace_flags: int
-    item_id: int
+class _OptionalOurLogData(TypedDict):
+    body: NotRequired[str]
+    trace_id: NotRequired[str]
+    replay_id: NotRequired[str]
+    severity_text: NotRequired[str]
+    severity_number: NotRequired[int]
+    trace_flags: NotRequired[int]
+    item_id: NotRequired[int]
 
 
 def scalar_to_any_value(value: Any) -> AnyValue:

--- a/src/sentry/uptime/types.py
+++ b/src/sentry/uptime/types.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import IntEnum
-from typing import Any, Literal, Required, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
     Assertion,
@@ -66,68 +66,68 @@ The HTTP method to use for the request.
 """
 
 
-class CheckConfig(TypedDict, total=False):
+class CheckConfig(TypedDict):
     """
     A message containing the configuration for a check to scheduled and
     executed by the uptime-checker.
     """
 
-    subscription_id: Required[str]
+    subscription_id: str
     """
     UUID of the subscription that this check config represents.
     """
 
-    interval_seconds: Required[CheckInterval]
+    interval_seconds: CheckInterval
     """
     The interval between each check run in seconds.
     """
 
-    timeout_ms: Required[int | float]
+    timeout_ms: int | float
     """
     The total time we will allow to make the request in milliseconds.
     """
 
-    url: Required[str]
+    url: str
     """
     The actual HTTP URL to check.
     """
 
-    request_method: RequestMethod
+    request_method: NotRequired[RequestMethod]
     """
     The HTTP method to use for the request.
     """
 
-    request_headers: Sequence[RequestHeader]
+    request_headers: NotRequired[Sequence[RequestHeader]]
     """
     Additional HTTP headers to send with the request.
     """
 
-    request_body: str
+    request_body: NotRequired[str]
     """
     Additional HTTP headers to send with the request.
     """
 
-    trace_sampling: bool
+    trace_sampling: NotRequired[bool]
     """
     Whether to allow for sampled trace spans for the request.
     """
 
-    active_regions: Sequence[str]
+    active_regions: NotRequired[Sequence[str]]
     """
     A list of region slugs the uptime check is configured to run in.
     """
 
-    region_schedule_mode: "RegionScheduleMode"
+    region_schedule_mode: NotRequired["RegionScheduleMode"]
     """
     Defines how we'll schedule checks based on other active regions.
     """
 
-    assertion: Any | None
+    assertion: NotRequired[Any | None]
     """
     The runtime assertion to execute, or null.
     """
 
-    capture_response_on_failure: bool
+    capture_response_on_failure: NotRequired[bool]
     """
     Whether to capture response body and headers on check failures.
     """

--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import Any, TypedDict, cast
+from typing import Any, NotRequired, TypedDict, cast
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -33,10 +33,10 @@ from sentry.utils.avatar import get_gravatar_url
 from sentry.utils.serializers import manytoone_to_dict
 
 
-class SerializedAvatarFields(TypedDict, total=False):
-    avatarType: str
-    avatarUuid: str | None
-    avatarUrl: str | None
+class SerializedAvatarFields(TypedDict):
+    avatarType: NotRequired[str]
+    avatarUuid: NotRequired[str | None]
+    avatarUrl: NotRequired[str | None]
 
 
 class _UserEmails(TypedDict):
@@ -80,15 +80,15 @@ class _UserOptions(TypedDict):
     prefersIssueDetailsStreamlinedUI: bool | None
 
 
-class UserSerializerResponseOptional(TypedDict, total=False):
+class UserSerializerResponseOptional(TypedDict):
     # NOTE: There is a bug here where trying to move these fields to
     # UserSerializerResponse and using NotRequired. "identities" is marked as
     # required for places where UserSerializerResponse is used as a field (e.g
     # OrganizationMemberResponse).
-    identities: list[_Identity]
-    avatar: SerializedAvatarFields
-    authenticators: list[Any]  # TODO: find out what type this is
-    canReset2fa: bool
+    identities: NotRequired[list[_Identity]]
+    avatar: NotRequired[SerializedAvatarFields]
+    authenticators: NotRequired[list[Any]]  # TODO: find out what type this is
+    canReset2fa: NotRequired[bool]
 
 
 class UserSerializerResponse(UserSerializerResponseOptional):

--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -80,7 +80,7 @@ class _UserOptions(TypedDict):
     prefersIssueDetailsStreamlinedUI: bool | None
 
 
-class UserSerializerResponseOptional(TypedDict):
+class UserSerializerResponse(TypedDict):
     # NOTE: There is a bug here where trying to move these fields to
     # UserSerializerResponse and using NotRequired. "identities" is marked as
     # required for places where UserSerializerResponse is used as a field (e.g
@@ -89,9 +89,6 @@ class UserSerializerResponseOptional(TypedDict):
     avatar: NotRequired[SerializedAvatarFields]
     authenticators: NotRequired[list[Any]]  # TODO: find out what type this is
     canReset2fa: NotRequired[bool]
-
-
-class UserSerializerResponse(UserSerializerResponseOptional):
     id: str
     name: str
     username: str

--- a/src/sentry/users/services/user/model.py
+++ b/src/sentry/users/services/user/model.py
@@ -5,7 +5,7 @@
 
 import datetime
 from enum import IntEnum
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from pydantic.fields import Field
 
@@ -139,36 +139,38 @@ class UserSerializeType(IntEnum):  # annoying
     SELF_DETAILED = 2
 
 
-class UserFilterArgs(TypedDict, total=False):
-    user_ids: list[int]
+class UserFilterArgs(TypedDict):
+    user_ids: NotRequired[list[int]]
     """List of user ids to search with"""
 
-    is_active: bool
+    is_active: NotRequired[bool]
     """Whether the user needs to be active"""
 
-    organization_id: int
+    organization_id: NotRequired[int]
     """Organization to check membership in"""
 
-    emails: list[str]
+    emails: NotRequired[list[str]]
     """list of emails to match with"""
 
-    email_verified: bool
+    email_verified: NotRequired[bool]
     """Whether emails have to be verified or not"""
 
-    query: str
+    query: NotRequired[str]
     """Filter by email or name"""
 
-    authenticator_types: list[int] | None
+    authenticator_types: NotRequired[list[int] | None]
     """The type of MFA authenticator you want to query by"""
 
 
-class UserUpdateArgs(TypedDict, total=False):
-    avatar_url: str
-    avatar_type: int
-    actor_id: int  # TODO(hybrid-cloud): Remove this after the actor migration is complete
-    is_active: bool
-    is_superuser: bool
-    is_staff: bool
+class UserUpdateArgs(TypedDict):
+    avatar_url: NotRequired[str]
+    avatar_type: NotRequired[int]
+    actor_id: NotRequired[
+        int
+    ]  # TODO(hybrid-cloud): Remove this after the actor migration is complete
+    is_active: NotRequired[bool]
+    is_superuser: NotRequired[bool]
+    is_staff: NotRequired[bool]
 
 
 class UserIdEmailArgs(TypedDict):

--- a/src/sentry/users/services/user_option/model.py
+++ b/src/sentry/users/services/user_option/model.py
@@ -3,7 +3,7 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from sentry.hybridcloud.rpc import RpcModel
 
@@ -17,10 +17,10 @@ class RpcUserOption(RpcModel):
     organization_id: int | None = None
 
 
-class UserOptionFilterArgs(TypedDict, total=False):
-    user_ids: list[int]
-    keys: list[str]
-    key: str
-    project_id: int | None
-    project_ids: list[int] | None
-    organization_id: int | None
+class UserOptionFilterArgs(TypedDict):
+    user_ids: NotRequired[list[int]]
+    keys: NotRequired[list[str]]
+    key: NotRequired[str]
+    project_id: NotRequired[int | None]
+    project_ids: NotRequired[list[int] | None]
+    organization_id: NotRequired[int | None]

--- a/src/sentry/users/services/usersocialauth/model.py
+++ b/src/sentry/users/services/usersocialauth/model.py
@@ -3,7 +3,7 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from pydantic import Field
 
@@ -27,8 +27,8 @@ class RpcUserSocialAuth(RpcModel):
         return tokens(instance=self)
 
 
-class UserSocialAuthFilterArgs(TypedDict, total=False):
-    id: int
-    user_id: int
-    provider: str
-    uid: str
+class UserSocialAuthFilterArgs(TypedDict):
+    id: NotRequired[int]
+    user_id: NotRequired[int]
+    provider: NotRequired[str]
+    uid: NotRequired[str]

--- a/src/sentry/utils/ai_message_normalizer.py
+++ b/src/sentry/utils/ai_message_normalizer.py
@@ -1,6 +1,6 @@
 import ast
 import json  # noqa: S003
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 FILTERED = "[Filtered]"
 FILE_CONTENT_PARTS = ("blob", "uri", "file")
@@ -18,11 +18,11 @@ class AIOutputResult(TypedDict):
     tool_calls: str | None
 
 
-class RawMessage(TypedDict, total=False):
-    role: str
-    content: Any
-    parts: list[Any]
-    role_explicit: bool
+class RawMessage(TypedDict):
+    role: NotRequired[str]
+    content: NotRequired[Any]
+    parts: NotRequired[list[Any]]
+    role_explicit: NotRequired[bool]
 
 
 class PartBuckets(TypedDict):

--- a/src/sentry/utils/circuit_breaker.py
+++ b/src/sentry/utils/circuit_breaker.py
@@ -3,7 +3,7 @@ NOTE: This circuit breaker implementation is deprecated and is slated to eventua
 the `CircuitBreaker` class found in `circuit_breaker2.py` instead.
 """
 
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from django.core.cache import cache
 
@@ -20,20 +20,20 @@ class CircuitBreakerPassthrough(TypedDict, total=True):
     window: int
 
 
-class CircuitBreakerConfig(TypedDict, total=False):
+class CircuitBreakerConfig(TypedDict):
     # The number of consecutive failures within a given window required to trigger the circuit breaker
-    error_limit: int
+    error_limit: NotRequired[int]
     # The window of time in which those errors must happen
-    error_limit_window: int
+    error_limit_window: NotRequired[int]
     # Allow a configurable subset of function calls to bypass the circuit breaker, for the purposes
     # of determining when the service is healthy again and requests to it can resume.
-    allow_passthrough: bool
+    allow_passthrough: NotRequired[bool]
     # The number of function calls allowed to bypass the circuit breaker every
     # `passthrough_interval` seconds
-    passthrough_attempts_per_interval: int
+    passthrough_attempts_per_interval: NotRequired[int]
     # The window of time, in seconds, during which to allow `passthrough_attempts_per_interval`
     # calls to bypass the circuit breaker
-    passthrough_interval: int
+    passthrough_interval: NotRequired[int]
 
 
 CIRCUIT_BREAKER_DEFAULTS = CircuitBreakerConfig(

--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from django.db.models import OuterRef, Subquery
 from drf_spectacular.utils import extend_schema_serializer
@@ -24,13 +24,13 @@ from sentry.workflow_engine.models import (
 )
 
 
-class DetectorSerializerResponseOptional(TypedDict, total=False):
-    owner: ActorSerializerResponse | None
-    createdBy: str | None
-    alertRuleId: int | None
-    ruleId: int | None
-    latestGroup: dict[str, Any] | None
-    description: str | None
+class DetectorSerializerResponseOptional(TypedDict):
+    owner: NotRequired[ActorSerializerResponse | None]
+    createdBy: NotRequired[str | None]
+    alertRuleId: NotRequired[int | None]
+    ruleId: NotRequired[int | None]
+    latestGroup: NotRequired[dict[str, Any] | None]
+    description: NotRequired[str | None]
 
 
 @extend_schema_serializer(exclude_fields=["alertRuleId", "ruleId"])

--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -24,17 +24,14 @@ from sentry.workflow_engine.models import (
 )
 
 
-class DetectorSerializerResponseOptional(TypedDict):
+@extend_schema_serializer(exclude_fields=["alertRuleId", "ruleId"])
+class DetectorSerializerResponse(TypedDict):
     owner: NotRequired[ActorSerializerResponse | None]
     createdBy: NotRequired[str | None]
     alertRuleId: NotRequired[int | None]
     ruleId: NotRequired[int | None]
     latestGroup: NotRequired[dict[str, Any] | None]
     description: NotRequired[str | None]
-
-
-@extend_schema_serializer(exclude_fields=["alertRuleId", "ruleId"])
-class DetectorSerializerResponse(DetectorSerializerResponseOptional):
     id: str
     projectId: str
     name: str

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
@@ -15,13 +15,13 @@ from sentry.workflow_engine.models import (
 from sentry.workflow_engine.processors.workflow_fire_history import get_last_fired_dates
 
 
-class ActionSerializerResponse(TypedDict, total=False):
-    id: str
-    type: str
-    integrationId: str | None
-    data: dict[str, str]
-    config: dict[str, Any]
-    status: str
+class ActionSerializerResponse(TypedDict):
+    id: NotRequired[str]
+    type: NotRequired[str]
+    integrationId: NotRequired[str | None]
+    data: NotRequired[dict[str, str]]
+    config: NotRequired[dict[str, Any]]
+    status: NotRequired[str]
 
 
 class ConditionSerializerResponse(TypedDict):
@@ -31,12 +31,12 @@ class ConditionSerializerResponse(TypedDict):
     conditionResult: bool
 
 
-class TriggerSerializerResponse(TypedDict, total=False):
-    id: str
-    organizationId: str
-    logicType: str
-    conditions: list[ConditionSerializerResponse] | list[Any]
-    actions: list[ActionSerializerResponse] | list[Any]
+class TriggerSerializerResponse(TypedDict):
+    id: NotRequired[str]
+    organizationId: NotRequired[str]
+    logicType: NotRequired[str]
+    conditions: NotRequired[list[ConditionSerializerResponse] | list[Any]]
+    actions: NotRequired[list[ActionSerializerResponse] | list[Any]]
 
 
 class WorkflowSerializerResponse(TypedDict):

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -6,7 +6,17 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import IntEnum, StrEnum
 from logging import Logger
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, Sequence, TypeAlias, TypedDict, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Generic,
+    NotRequired,
+    Sequence,
+    TypeAlias,
+    TypedDict,
+    TypeVar,
+)
 
 from django.db.models import Q
 from sentry_sdk import logger as sentry_logger
@@ -96,8 +106,8 @@ class DetectorEvaluationResult:
     event_data: dict[str, Any] | None = None
 
 
-class _WorkflowEventLocalCache(TypedDict, total=False):
-    group_assignees: Sequence[GroupAssignee]
+class _WorkflowEventLocalCache(TypedDict):
+    group_assignees: NotRequired[Sequence[GroupAssignee]]
 
 
 @dataclass(frozen=True)
@@ -419,16 +429,16 @@ class DataConditionType(TypedDict):
 
 
 # TODO - Move this to snuba module
-class SnubaQueryDataSourceType(TypedDict, total=False):
-    query_type: SnubaQuery.Type
-    dataset: Dataset
-    query: str
-    aggregate: str
-    time_window: float
-    resolution: float
-    extrapolation_mode: ExtrapolationMode | None
-    environment: Environment | None
-    event_types: list[SnubaQueryEventType.EventType]
+class SnubaQueryDataSourceType(TypedDict):
+    query_type: NotRequired[SnubaQuery.Type]
+    dataset: NotRequired[Dataset]
+    query: NotRequired[str]
+    aggregate: NotRequired[str]
+    time_window: NotRequired[float]
+    resolution: NotRequired[float]
+    extrapolation_mode: NotRequired[ExtrapolationMode | None]
+    environment: NotRequired[Environment | None]
+    event_types: NotRequired[list[SnubaQueryEventType.EventType]]
 
 
 @dataclass(frozen=True)

--- a/tests/sentry/apidocs/test_extensions.py
+++ b/tests/sentry/apidocs/test_extensions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 import pytest
 from drf_spectacular.openapi import AutoSchema
@@ -21,8 +21,8 @@ class NestedDict(TypedDict):
     zz: str
 
 
-class BasicSerializerOptional(TypedDict, total=False):
-    a: int
+class BasicSerializerOptional(TypedDict):
+    a: NotRequired[int]
 
 
 @extend_schema_serializer(exclude_fields=["excluded"])

--- a/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
+++ b/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 from unittest.mock import MagicMock, Mock, patch
 
 from django.http.request import HttpHeaders
@@ -42,11 +42,11 @@ from sentry.testutils.silo import control_silo_test
 from sentry.utils import metrics
 
 
-class SiloHttpHeaders(TypedDict, total=False):
-    HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION: str
-    HTTP_X_SENTRY_SUBNET_SIGNATURE: str
-    HTTP_X_SENTRY_SUBNET_BASE_URL: str
-    HTTP_X_SENTRY_SUBNET_PATH: str
+class SiloHttpHeaders(TypedDict):
+    HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION: NotRequired[str]
+    HTTP_X_SENTRY_SUBNET_SIGNATURE: NotRequired[str]
+    HTTP_X_SENTRY_SUBNET_BASE_URL: NotRequired[str]
+    HTTP_X_SENTRY_SUBNET_PATH: NotRequired[str]
 
 
 def test_ensure_http_headers_match() -> None:

--- a/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
+++ b/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, MutableMapping
-from typing import Any, TypedDict, TypeVar
+from typing import Any, NotRequired, TypedDict, TypeVar
 from unittest.mock import MagicMock, patch
 
 import responses
@@ -25,9 +25,9 @@ from tests.sentry.integrations.slack.utils.test_mock_slack_response import mock_
 ActionRegistrationT = TypeVar("ActionRegistrationT", bound=ActionRegistration)
 
 
-class _Query(TypedDict, total=False):
-    triggerType: str
-    project: int
+class _Query(TypedDict):
+    triggerType: NotRequired[str]
+    project: NotRequired[int]
 
 
 class _QueryResult(TypedDict):

--- a/tests/sentry/workflow_engine/endpoints/test_organization_deduplicate_workflows.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_deduplicate_workflows.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from random import randint
-from typing import Any, TypedDict, Unpack
+from typing import Any, NotRequired, TypedDict, Unpack
 
 import pytest
 
@@ -21,15 +21,15 @@ from sentry.workflow_engine.models import (
 from sentry.workflow_engine.models.data_condition import Condition
 
 
-class MockWorkflowConfig(TypedDict, total=False):
-    actions: list[Action] | None
-    action_filters: list[DataCondition] | None
-    enabled: bool | None
-    triggers: list[DataCondition] | None
-    config: dict[str, Any] | None
-    mock_actions: bool
-    mock_action_filters: bool
-    mock_triggers: bool
+class MockWorkflowConfig(TypedDict):
+    actions: NotRequired[list[Action] | None]
+    action_filters: NotRequired[list[DataCondition] | None]
+    enabled: NotRequired[bool | None]
+    triggers: NotRequired[list[DataCondition] | None]
+    config: NotRequired[dict[str, Any] | None]
+    mock_actions: NotRequired[bool]
+    mock_action_filters: NotRequired[bool]
+    mock_triggers: NotRequired[bool]
 
 
 # This is a list of workflows to create for every test case.


### PR DESCRIPTION
A two-part, type-annotation-only cleanup to get off `total=False`. No runtime behavior change.

## What

1. **Replace `total=False` with per-field `NotRequired[...]`** (commit 1) — 143 TypedDicts across 92 files. A `total=False` TypedDict makes *every* key optional; this just makes that explicit per field (PEP 655). Redundant `Required[...]` markers are unwrapped since fields default to required once `total=False` is gone. Covers both class syntax and the functional `TypedDict("X", {...})` form.
2. **Collapse the split `X` + `XOptional`/`XRequired` idiom** (commit 2) — 25 classes removed. Once every field carries its own marker, splitting a type into a "required half" + a "`total=False` optional half" joined by inheritance is pointless. Each such base (used nowhere else) is inlined into its single subclass and deleted.

## Why

`total=False` is all-or-nothing, which forces the awkward two-class split whenever a type mixes required and optional keys. Per-field `NotRequired`/`Required` reads better and lets one TypedDict express both.

## How

Applied via libcst codemods, not by hand:
- Migration wraps each non-`Required` field in `NotRequired`, unwraps redundant `Required`, drops `total=False`, and adds the `from typing import NotRequired` import.
- Collapse only removes a base when it's a `TypedDict` referenced *exactly once* (as that subclass's base), has no non-field body, and an unambiguous `Optional`/`Required` "half" name. Base fields are kept first, preserving MRO/annotation order.

## Behavior preservation

Purely type-checker-facing:
- `total=False` + all-`NotRequired` yield identical `__required_keys__` / `__optional_keys__`, so runtime introspection — including drf-spectacular schema generation and the lone `__required_keys__` reader in `spectacular_ports.py` — is unchanged. (`__total__` is read nowhere.)
- Collapsing keeps base fields first → identical annotation order → **identical generated OpenAPI schemas**.

## Intentionally left alone

- The 18 functional `TypedDict("X", {...})` defs whose keys aren't valid identifiers (`"session.status"`, `"$version"`, `"project:read"`, `"class"`, …) — they must stay functional; only a stray `total=False` was stripped where present.
- `EnrichedThreshold <- SerializedThreshold` — `SerializedThreshold` is a meaningfully-named standalone type, not a throwaway half.
- A drf-spectacular inheritance test fixture in `tests/sentry/apidocs/test_extensions.py` that deliberately exercises inherited TypedDicts.

## Verification

- ✅ `ruff check` + `ruff format --check` clean across all changed files. (The 6 `UP042` warnings ruff emits are pre-existing in `card_builder/block.py`, unrelated to this change.)
- ✅ No dangling references to any removed base class (repo-wide, all file types).
- ⚠️ `mypy` and the test suite were **not** run locally — relying on CI as the gate. The change is type-only and, as noted above, runtime-identical.

https://claude.ai/code/session_01NBWP7ZEBn4xR8dECDro3SH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBWP7ZEBn4xR8dECDro3SH)_