### PR TITLE
ref(types): replace TypedDict total=False with per-field NotRequired

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_meta_types.py
+++ b/src/sentry/api/endpoints/organization_trace_meta_types.py
@@ -1,10 +1,10 @@
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from sentry.search.events.types import SnubaData
 
 
-class OrganizationTraceMetaResponseOptional(TypedDict, total=False):
-    uptimeCount: int
+class OrganizationTraceMetaResponseOptional(TypedDict):
+    uptimeCount: NotRequired[int]
 
 
 class OrganizationTraceMetaResponse(OrganizationTraceMetaResponseOptional):

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from django.http import HttpResponse
 from rest_framework import serializers
@@ -21,12 +21,12 @@ from sentry.models.release_threshold.constants import TriggerType as ReleaseThre
 from sentry.models.release_threshold.release_threshold import ReleaseThreshold
 
 
-class ReleaseThresholdPOSTData(TypedDict, total=False):
-    threshold_type: int
-    trigger_type: int
-    value: int
-    window_in_seconds: int
-    environment: object
+class ReleaseThresholdPOSTData(TypedDict):
+    threshold_type: NotRequired[int]
+    trigger_type: NotRequired[int]
+    value: NotRequired[int]
+    window_in_seconds: NotRequired[int]
+    environment: NotRequired[object]
 
 
 class ReleaseThresholdPOSTSerializer(serializers.Serializer[ReleaseThresholdPOSTData]):

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from django.db.models import Q
 from django.http import HttpResponse
@@ -16,9 +16,9 @@ from sentry.models.organization import Organization
 from sentry.models.release_threshold.release_threshold import ReleaseThreshold
 
 
-class ReleaseThresholdIndexGETData(TypedDict, total=False):
-    environment: list[str]
-    project: list[int]
+class ReleaseThresholdIndexGETData(TypedDict):
+    environment: NotRequired[list[str]]
+    project: NotRequired[list[int]]
 
 
 class ReleaseThresholdIndexGETValidator(serializers.Serializer[ReleaseThresholdIndexGETData]):

--- a/src/sentry/api/endpoints/release_thresholds/types.py
+++ b/src/sentry/api/endpoints/release_thresholds/types.py
@@ -1,17 +1,17 @@
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 
-class SerializedThreshold(TypedDict, total=False):
-    id: str
-    date: datetime
-    environment: dict[str, Any] | None
-    project: dict[str, Any]
-    release: str
-    threshold_type: int
-    trigger_type: str
-    value: int
-    window_in_seconds: int
+class SerializedThreshold(TypedDict):
+    id: NotRequired[str]
+    date: NotRequired[datetime]
+    environment: NotRequired[dict[str, Any] | None]
+    project: NotRequired[dict[str, Any]]
+    release: NotRequired[str]
+    threshold_type: NotRequired[int]
+    trigger_type: NotRequired[str]
+    value: NotRequired[int]
+    window_in_seconds: NotRequired[int]
 
 
 class EnrichedThreshold(SerializedThreshold):

--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.constants import ALL_ACCESS_PROJECTS
@@ -12,23 +12,23 @@ from sentry.utils.dates import outside_retention_with_modified_start, parse_time
 DATASET_SOURCES = dict(DatasetSourcesTypes.as_choices())
 
 
-class DiscoverSavedQueryResponseOptional(TypedDict, total=False):
-    environment: list[str]
-    query: str
-    fields: list[str]
-    widths: list[str]
-    conditions: list[str]
-    aggregations: list[str]
-    range: str
-    start: str
-    end: str
-    orderby: str
-    limit: str
-    yAxis: list[str]
-    display: str
-    topEvents: int
-    interval: str
-    exploreQuery: dict
+class DiscoverSavedQueryResponseOptional(TypedDict):
+    environment: NotRequired[list[str]]
+    query: NotRequired[str]
+    fields: NotRequired[list[str]]
+    widths: NotRequired[list[str]]
+    conditions: NotRequired[list[str]]
+    aggregations: NotRequired[list[str]]
+    range: NotRequired[str]
+    start: NotRequired[str]
+    end: NotRequired[str]
+    orderby: NotRequired[str]
+    limit: NotRequired[str]
+    yAxis: NotRequired[list[str]]
+    display: NotRequired[str]
+    topEvents: NotRequired[int]
+    interval: NotRequired[str]
+    exploreQuery: NotRequired[dict]
 
 
 class DiscoverSavedQueryResponse(DiscoverSavedQueryResponseOptional):

--- a/src/sentry/api/serializers/models/exploresavedquery.py
+++ b/src/sentry/api/serializers/models/exploresavedquery.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.constants import ALL_ACCESS_PROJECTS
@@ -14,8 +14,8 @@ from sentry.users.services.user.service import user_service
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
 
 
-class MetricResponseTypeOptional(TypedDict, total=False):
-    unit: str | None
+class MetricResponseTypeOptional(TypedDict):
+    unit: NotRequired[str | None]
 
 
 class MetricResponseType(MetricResponseTypeOptional):
@@ -23,8 +23,8 @@ class MetricResponseType(MetricResponseTypeOptional):
     type: str
 
 
-class CrossEventResponseTypeOptional(TypedDict, total=False):
-    metric: MetricResponseType
+class CrossEventResponseTypeOptional(TypedDict):
+    metric: NotRequired[MetricResponseType]
 
 
 class CrossEventResponseType(CrossEventResponseTypeOptional):
@@ -32,15 +32,15 @@ class CrossEventResponseType(CrossEventResponseTypeOptional):
     type: str
 
 
-class ExploreSavedQueryResponseOptional(TypedDict, total=False):
-    environment: list[str]
-    query: str
-    range: str
-    start: str
-    end: str
-    interval: str
-    mode: str
-    crossEvents: list[CrossEventResponseType]
+class ExploreSavedQueryResponseOptional(TypedDict):
+    environment: NotRequired[list[str]]
+    query: NotRequired[str]
+    range: NotRequired[str]
+    start: NotRequired[str]
+    end: NotRequired[str]
+    interval: NotRequired[str]
+    mode: NotRequired[str]
+    crossEvents: NotRequired[list[CrossEventResponseType]]
 
 
 class ExploreSavedQueryChangedReasonType(TypedDict):

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -26,10 +26,10 @@ class SCIMMeta(TypedDict):
     resourceType: str
 
 
-class OrganizationMemberSCIMSerializerOptional(TypedDict, total=False):
+class OrganizationMemberSCIMSerializerOptional(TypedDict):
     """Sentry doesn't use this field but is expected by SCIM"""
 
-    active: bool
+    active: NotRequired[bool]
 
 
 class OrganizationMemberSCIMSerializerResponse(OrganizationMemberSCIMSerializerOptional):

--- a/src/sentry/api/serializers/models/projectownership.py
+++ b/src/sentry/api/serializers/models/projectownership.py
@@ -25,8 +25,8 @@ OwnershipSchemaResponse = TypedDict(
 
 
 # JSON object representing optional part of API response
-class ProjectOwnershipResponseOptional(TypedDict, total=False):
-    schema: OwnershipSchemaResponse | None
+class ProjectOwnershipResponseOptional(TypedDict):
+    schema: NotRequired[OwnershipSchemaResponse | None]
 
 
 # JSON object representing this serializer in API response

--- a/src/sentry/api/serializers/models/repository.py
+++ b/src/sentry/api/serializers/models/repository.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.models.repository import Repository
@@ -12,14 +12,14 @@ class RepositorySettingsSerializerResponse(TypedDict):
     codeReviewTriggers: list[str]
 
 
-class RepositorySerializerResponseOptional(TypedDict, total=False):
-    url: str | None
-    provider: dict[str, str]
-    status: str
-    integrationId: str | None
-    externalSlug: str | None
-    externalId: str | None
-    settings: RepositorySettingsSerializerResponse | None
+class RepositorySerializerResponseOptional(TypedDict):
+    url: NotRequired[str | None]
+    provider: NotRequired[dict[str, str]]
+    status: NotRequired[str]
+    integrationId: NotRequired[str | None]
+    externalSlug: NotRequired[str | None]
+    externalId: NotRequired[str | None]
+    settings: NotRequired[RepositorySettingsSerializerResponse | None]
 
 
 class RepositorySerializerResponse(RepositorySerializerResponseOptional):

--- a/src/sentry/api/serializers/release_details_types.py
+++ b/src/sentry/api/serializers/release_details_types.py
@@ -1,11 +1,11 @@
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from sentry.users.api.serializers.user import UserSerializerResponse
 
 
-class VersionInfoOptional(TypedDict, total=False):
-    description: str
+class VersionInfoOptional(TypedDict):
+    description: NotRequired[str]
 
 
 class VersionInfo(VersionInfoOptional):
@@ -14,9 +14,9 @@ class VersionInfo(VersionInfoOptional):
     buildHash: str | None
 
 
-class LastDeployOptional(TypedDict, total=False):
-    dateStarted: str | None
-    url: str | None
+class LastDeployOptional(TypedDict):
+    dateStarted: NotRequired[str | None]
+    url: NotRequired[str | None]
 
 
 class LastDeploy(LastDeployOptional):
@@ -34,19 +34,19 @@ class NonMappableUser(TypedDict):
 Author = UserSerializerResponse | NonMappableUser
 
 
-class HealthDataOptional(TypedDict, total=False):
-    durationP50: float | None
-    durationP90: float | None
-    crashFreeUsers: float | None
-    crashFreeSessions: float | None
-    totalUsers: int | None
-    totalUsers24h: int | None
-    totalProjectUsers24h: int | None
-    totalSessions: int | None
-    totalSessions24h: int | None
-    totalProjectSessions24h: int | None
-    adoption: float | None
-    sessionsAdoption: float | None
+class HealthDataOptional(TypedDict):
+    durationP50: NotRequired[float | None]
+    durationP90: NotRequired[float | None]
+    crashFreeUsers: NotRequired[float | None]
+    crashFreeSessions: NotRequired[float | None]
+    totalUsers: NotRequired[int | None]
+    totalUsers24h: NotRequired[int | None]
+    totalProjectUsers24h: NotRequired[int | None]
+    totalSessions: NotRequired[int | None]
+    totalSessions24h: NotRequired[int | None]
+    totalProjectSessions24h: NotRequired[int | None]
+    adoption: NotRequired[float | None]
+    sessionsAdoption: NotRequired[float | None]
 
 
 class HealthData(HealthDataOptional):
@@ -56,11 +56,11 @@ class HealthData(HealthDataOptional):
     stats: dict[str, Any]
 
 
-class ProjectOptional(TypedDict, total=False):
-    healthData: HealthData | None
-    dateReleased: datetime | None
-    dateCreated: datetime | None
-    dateStarted: datetime | None
+class ProjectOptional(TypedDict):
+    healthData: NotRequired[HealthData | None]
+    dateReleased: NotRequired[datetime | None]
+    dateCreated: NotRequired[datetime | None]
+    dateStarted: NotRequired[datetime | None]
 
 
 class BaseProject(ProjectOptional):

--- a/src/sentry/api/serializers/types.py
+++ b/src/sentry/api/serializers/types.py
@@ -1,24 +1,26 @@
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from sentry.api.serializers.release_details_types import Author, LastDeploy, Project, VersionInfo
 
 
 # Reponse type for OrganizationReleaseDetailsEndpoint
-class ReleaseSerializerResponseOptional(TypedDict, total=False):
-    ref: str | None
-    url: str | None
-    dateReleased: datetime | None
-    dateCreated: datetime | None
-    dateStarted: datetime | None
-    owner: dict[str, Any] | None
-    lastCommit: dict[str, Any] | None
-    lastDeploy: LastDeploy | None
-    firstEvent: datetime | None
-    lastEvent: datetime | None
-    currentProjectMeta: dict[str, Any] | None
-    userAgent: str | None
-    adoptionStages: dict[str, Any] | None  # Only included if with_adoption_stages is True
+class ReleaseSerializerResponseOptional(TypedDict):
+    ref: NotRequired[str | None]
+    url: NotRequired[str | None]
+    dateReleased: NotRequired[datetime | None]
+    dateCreated: NotRequired[datetime | None]
+    dateStarted: NotRequired[datetime | None]
+    owner: NotRequired[dict[str, Any] | None]
+    lastCommit: NotRequired[dict[str, Any] | None]
+    lastDeploy: NotRequired[LastDeploy | None]
+    firstEvent: NotRequired[datetime | None]
+    lastEvent: NotRequired[datetime | None]
+    currentProjectMeta: NotRequired[dict[str, Any] | None]
+    userAgent: NotRequired[str | None]
+    adoptionStages: NotRequired[
+        dict[str, Any] | None
+    ]  # Only included if with_adoption_stages is True
 
 
 class ReleaseSerializerResponse(ReleaseSerializerResponseOptional):
@@ -40,18 +42,18 @@ class ReleaseSerializerResponse(ReleaseSerializerResponseOptional):
     projects: list[Project]
 
 
-class GroupEventReleaseSerializerResponse(TypedDict, total=False):
-    id: int
-    commitCount: int
-    data: dict[str, Any]
-    dateCreated: datetime
-    dateReleased: datetime | None
-    deployCount: int
-    ref: str | None
-    lastCommit: dict[str, Any] | None
-    lastDeploy: LastDeploy | None
-    status: str
-    url: str | None
-    userAgent: str | None
-    version: str | None
-    versionInfo: VersionInfo | None
+class GroupEventReleaseSerializerResponse(TypedDict):
+    id: NotRequired[int]
+    commitCount: NotRequired[int]
+    data: NotRequired[dict[str, Any]]
+    dateCreated: NotRequired[datetime]
+    dateReleased: NotRequired[datetime | None]
+    deployCount: NotRequired[int]
+    ref: NotRequired[str | None]
+    lastCommit: NotRequired[dict[str, Any] | None]
+    lastDeploy: NotRequired[LastDeploy | None]
+    status: NotRequired[str]
+    url: NotRequired[str | None]
+    userAgent: NotRequired[str | None]
+    version: NotRequired[str | None]
+    versionInfo: NotRequired[VersionInfo | None]

--- a/src/sentry/auth_v2/utils/session.py
+++ b/src/sentry/auth_v2/utils/session.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
@@ -10,19 +10,19 @@ from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 
 
-class SessionSerializerResponse(TypedDict, total=False):
+class SessionSerializerResponse(TypedDict):
     # Flags to control the authentication flow on frontend.
     # Keep the keys sorted in order of importance!!
     # Maintaining the hierarchy is good context for future engineers.
-    todoEmailVerification: bool | None
-    todo2faVerification: bool | None
-    todoPasswordReset: bool | None
-    todo2faSetup: bool | None
+    todoEmailVerification: NotRequired[bool | None]
+    todo2faVerification: NotRequired[bool | None]
+    todoPasswordReset: NotRequired[bool | None]
+    todo2faSetup: NotRequired[bool | None]
 
-    userId: str | None
-    sessionCsrfToken: str | None
-    sessionExpiryDate: datetime | None
-    sessionOrgs: list[str] | None
+    userId: NotRequired[str | None]
+    sessionCsrfToken: NotRequired[str | None]
+    sessionExpiryDate: NotRequired[datetime | None]
+    sessionOrgs: NotRequired[list[str] | None]
 
 
 class SessionSerializer(Serializer[SessionSerializerResponse]):

--- a/src/sentry/conf/types/bgtask.py
+++ b/src/sentry/conf/types/bgtask.py
@@ -1,6 +1,6 @@
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 
-class BgTaskConfig(TypedDict, total=False):
-    roles: list[str]
-    interval: int
+class BgTaskConfig(TypedDict):
+    roles: NotRequired[list[str]]
+    interval: NotRequired[int]

--- a/src/sentry/identity/services/identity/model.py
+++ b/src/sentry/identity/services/identity/model.py
@@ -2,7 +2,7 @@
 #     from __future__ import annotations
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 from pydantic import Field
 
@@ -36,11 +36,11 @@ class RpcIdentity(RpcModel):
         return get(identity_provider.type)
 
 
-class IdentityFilterArgs(TypedDict, total=False):
-    id: int
-    user_id: int
-    identity_ext_id: str
-    identity_ext_ids: list[str]
-    provider_id: int
-    provider_ext_id: str
-    provider_type: str
+class IdentityFilterArgs(TypedDict):
+    id: NotRequired[int]
+    user_id: NotRequired[int]
+    identity_ext_id: NotRequired[str]
+    identity_ext_ids: NotRequired[list[str]]
+    provider_id: NotRequired[int]
+    provider_ext_id: NotRequired[str]
+    provider_type: NotRequired[str]

--- a/src/sentry/integrations/api/serializers/models/external_actor.py
+++ b/src/sentry/integrations/api/serializers/models/external_actor.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, MutableMapping, Sequence
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from django.contrib.auth.models import AnonymousUser
 
@@ -10,10 +10,10 @@ from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 
 
-class ExternalActorResponseOptional(TypedDict, total=False):
-    externalId: str
-    userId: str
-    teamId: str
+class ExternalActorResponseOptional(TypedDict):
+    externalId: NotRequired[str]
+    userId: NotRequired[str]
+    teamId: NotRequired[str]
 
 
 class ExternalActorResponse(ExternalActorResponseOptional):

--- a/src/sentry/integrations/api/serializers/rest_framework/data_forwarder.py
+++ b/src/sentry/integrations/api/serializers/rest_framework/data_forwarder.py
@@ -1,6 +1,6 @@
 import re
 from collections.abc import Mapping, MutableMapping
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from django.db import router, transaction
 from rest_framework import serializers
@@ -14,24 +14,24 @@ from sentry.models.project import Project
 from sentry_plugins.amazon_sqs.plugin import get_regions
 
 
-class SQSConfig(TypedDict, total=False):
-    queue_url: str
-    region: str
-    access_key: str
-    secret_key: str
-    message_group_id: str | None
-    s3_bucket: str | None
+class SQSConfig(TypedDict):
+    queue_url: NotRequired[str]
+    region: NotRequired[str]
+    access_key: NotRequired[str]
+    secret_key: NotRequired[str]
+    message_group_id: NotRequired[str | None]
+    s3_bucket: NotRequired[str | None]
 
 
-class SegmentConfig(TypedDict, total=False):
-    write_key: str
+class SegmentConfig(TypedDict):
+    write_key: NotRequired[str]
 
 
-class SplunkConfig(TypedDict, total=False):
-    instance_url: str
-    index: str
-    source: str
-    token: str
+class SplunkConfig(TypedDict):
+    instance_url: NotRequired[str]
+    index: NotRequired[str]
+    source: NotRequired[str]
+    token: NotRequired[str]
 
 
 SQS_REQUIRED_KEYS = ["queue_url", "region", "access_key", "secret_key"]

--- a/src/sentry/integrations/services/github_copilot_identity/model.py
+++ b/src/sentry/integrations/services/github_copilot_identity/model.py
@@ -3,7 +3,7 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from sentry.hybridcloud.rpc import RpcModel
 
@@ -16,7 +16,7 @@ class RpcGitHubCopilotIdentity(RpcModel):
     date_added: str | None = None
 
 
-class GitHubCopilotIdentityFilterArgs(TypedDict, total=False):
-    id: int
-    user_id: int
-    github_id: str
+class GitHubCopilotIdentityFilterArgs(TypedDict):
+    id: NotRequired[int]
+    user_id: NotRequired[int]
+    github_id: NotRequired[str]

--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -1,3 +1,5 @@
+from typing import NotRequired
+
 __all__ = ("User",)
 
 
@@ -9,14 +11,14 @@ from sentry.utils.json import prune_empty_keys
 from sentry.web.helpers import render_to_string
 
 
-class EventUserApiContext(TypedDict, total=False):
-    id: str | None
-    email: str | None
-    username: str | None
-    ip_address: str | None
-    name: str | None
-    geo: dict[str, str] | None
-    data: dict[str, Any] | None
+class EventUserApiContext(TypedDict):
+    id: NotRequired[str | None]
+    email: NotRequired[str | None]
+    username: NotRequired[str | None]
+    ip_address: NotRequired[str | None]
+    name: NotRequired[str | None]
+    geo: NotRequired[dict[str, str] | None]
+    data: NotRequired[dict[str, Any] | None]
 
 
 class User(Interface):

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -3,7 +3,7 @@ from collections.abc import MutableMapping, Sequence
 from datetime import datetime
 from itertools import groupby
 from operator import attrgetter
-from typing import Any, Literal, TypedDict, cast
+from typing import Any, Literal, NotRequired, TypedDict, cast
 
 from django.db.models import prefetch_related_objects
 
@@ -171,8 +171,8 @@ class MonitorAlertRuleSerializerResponse(TypedDict):
     environment: str
 
 
-class MonitorSerializerResponseOptional(TypedDict, total=False):
-    alertRule: MonitorAlertRuleSerializerResponse
+class MonitorSerializerResponseOptional(TypedDict):
+    alertRule: NotRequired[MonitorAlertRuleSerializerResponse]
 
 
 class MonitorSerializerResponse(MonitorSerializerResponseOptional):
@@ -322,8 +322,8 @@ class MonitorSerializer(Serializer[MonitorSerializerResponse]):
         return key in self.expand
 
 
-class MonitorCheckInSerializerResponseOptional(TypedDict, total=False):
-    groups: list[str]
+class MonitorCheckInSerializerResponseOptional(TypedDict):
+    groups: NotRequired[list[str]]
 
 
 class MonitorCheckInSerializerResponse(MonitorCheckInSerializerResponseOptional):

--- a/src/sentry/notifications/api/serializers/notification_action_request.py
+++ b/src/sentry/notifications/api/serializers/notification_action_request.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from django.db import router, transaction
 from drf_spectacular.utils import extend_schema_serializer
@@ -35,15 +35,15 @@ INTEGRATION_SERVICES = {
 
 
 # Note the ordering of fields affects the Spike Protection API Documentation
-class NotificationActionInputData(TypedDict, total=False):
-    trigger_type: int
-    service_type: int
-    integration_id: int
-    target_identifier: str
-    target_display: str
-    projects: list[Project]
-    sentry_app_id: int
-    target_type: int
+class NotificationActionInputData(TypedDict):
+    trigger_type: NotRequired[int]
+    service_type: NotRequired[int]
+    integration_id: NotRequired[int]
+    target_identifier: NotRequired[str]
+    target_display: NotRequired[str]
+    projects: NotRequired[list[Project]]
+    sentry_app_id: NotRequired[int]
+    target_type: NotRequired[int]
 
 
 @extend_schema_serializer(exclude_fields=["sentry_app_id", "target_type"])

--- a/src/sentry/organizations/services/organization/model.py
+++ b/src/sentry/organizations/services/organization/model.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import datetime
 from enum import IntEnum
 from functools import cached_property
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from django.dispatch import Signal
 from django.utils import timezone
@@ -419,7 +419,7 @@ class RpcAuditLogEntryActor(RpcModel):
     ip_address: str | None
 
 
-class OrganizationMemberUpdateArgs(TypedDict, total=False):
-    flags: RpcOrganizationMemberFlags | None
-    role: str
-    invite_status: int
+class OrganizationMemberUpdateArgs(TypedDict):
+    flags: NotRequired[RpcOrganizationMemberFlags | None]
+    role: NotRequired[str]
+    invite_status: NotRequired[int]

--- a/src/sentry/organizations/services/organization_actions/impl.py
+++ b/src/sentry/organizations/services/organization_actions/impl.py
@@ -1,5 +1,5 @@
 import hashlib
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 from uuid import uuid4
 
 from django.db import router, transaction
@@ -10,12 +10,12 @@ from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.models.organization import Organization, OrganizationStatus
 
 
-class OrganizationCreateAndUpdateOptions(TypedDict, total=False):
-    name: str
-    slug: str
-    status: OrganizationStatus
-    flags: CombinedExpression
-    default_role: int
+class OrganizationCreateAndUpdateOptions(TypedDict):
+    name: NotRequired[str]
+    slug: NotRequired[str]
+    status: NotRequired[OrganizationStatus]
+    flags: NotRequired[CombinedExpression]
+    default_role: NotRequired[int]
 
 
 def update_organization_with_outbox_message(

--- a/src/sentry/projects/services/project/model.py
+++ b/src/sentry/projects/services/project/model.py
@@ -5,7 +5,7 @@
 
 from collections.abc import Callable
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from pydantic.fields import Field
 
@@ -17,15 +17,15 @@ def _project_status_visible() -> int:
     return int(ObjectStatus.ACTIVE)
 
 
-class ProjectFilterArgs(TypedDict, total=False):
-    project_ids: list[int]
+class ProjectFilterArgs(TypedDict):
+    project_ids: NotRequired[list[int]]
 
 
-class ProjectUpdateArgs(TypedDict, total=False):
-    name: str
-    slug: str
-    platform: str | None
-    external_id: str | None
+class ProjectUpdateArgs(TypedDict):
+    name: NotRequired[str]
+    slug: NotRequired[str]
+    platform: NotRequired[str | None]
+    external_id: NotRequired[str | None]
 
 
 class RpcProjectFlags(RpcModel):

--- a/src/sentry/relay/config/ai_model_costs.py
+++ b/src/sentry/relay/config/ai_model_costs.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Required, TypedDict
+from typing import NotRequired, Required, TypedDict
 
 from django.conf import settings
 
@@ -25,9 +25,9 @@ class AIModelCost(TypedDict):
     inputCacheWritePerToken: float
 
 
-class AIModelMetadata(TypedDict, total=False):
-    costs: Required[AIModelCost]
-    contextSize: int
+class AIModelMetadata(TypedDict):
+    costs: AIModelCost
+    contextSize: NotRequired[int]
 
 
 class AIModelMetadataConfig(TypedDict):

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -1,4 +1,4 @@
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import sentry.options
 from sentry.relay.config.ai_model_costs import AIModelMetadataConfig, ai_model_metadata_config
@@ -37,13 +37,13 @@ class SpanOpDefaults(TypedDict):
     rules: list[SpanOpDefaultRule]
 
 
-class GlobalConfig(TypedDict, total=False):
-    measurements: MeasurementsConfig
-    aiModelMetadata: AIModelMetadataConfig | None
-    metricExtraction: MetricExtractionGroups
-    filters: GenericFiltersConfig | None
-    spanOpDefaults: SpanOpDefaults
-    options: dict[str, Any]
+class GlobalConfig(TypedDict):
+    measurements: NotRequired[MeasurementsConfig]
+    aiModelMetadata: NotRequired[AIModelMetadataConfig | None]
+    metricExtraction: NotRequired[MetricExtractionGroups]
+    filters: NotRequired[GenericFiltersConfig | None]
+    spanOpDefaults: NotRequired[SpanOpDefaults]
+    options: NotRequired[dict[str, Any]]
 
 
 def get_global_generic_filters() -> GenericFiltersConfig:

--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -10,7 +10,7 @@ from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequenc
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from enum import Enum
-from typing import Any, Optional, TypedDict, Union, cast
+from typing import Any, NotRequired, Optional, TypedDict, Union, cast
 
 from snuba_sdk import (
     BooleanCondition,
@@ -62,10 +62,10 @@ Scalar = Union[int, float, None]
 
 
 #: Group key as featured in metrics format
-class MetricsGroupKeyDict(TypedDict, total=False):
-    project_id: int
-    release: str
-    environment: str
+class MetricsGroupKeyDict(TypedDict):
+    project_id: NotRequired[int]
+    release: NotRequired[str]
+    environment: NotRequired[str]
 
 
 class SessionStatus(Enum):

--- a/src/sentry/replays/lib/eap/snuba_transpiler.py
+++ b/src/sentry/replays/lib/eap/snuba_transpiler.py
@@ -18,7 +18,7 @@ normalize it first.
 
 from collections.abc import MutableMapping, Sequence
 from datetime import date, datetime
-from typing import Any, NotRequired, Required, TypedDict, cast
+from typing import Any, NotRequired, TypedDict, cast
 from typing import Literal as TLiteral
 
 import urllib3
@@ -280,7 +280,7 @@ class RequestMeta(TypedDict):
     trace_item_type: TRACE_ITEM_TYPES
 
 
-class Settings(TypedDict, total=False):
+class Settings(TypedDict):
     """
     Query settings are extra metadata items which are not representable within a Snuba query. They
     are not sent to EAP in the form they are supplied. Instead they are used as helper metadata in
@@ -335,10 +335,10 @@ class Settings(TypedDict, total=False):
         ... }
     """
 
-    attribute_types: Required[dict[str, type[bool | float | int | str]]]
-    default_limit: int
-    default_offset: int
-    extrapolation_modes: MutableMapping[str, TLiteral["weighted", "none"]]  # noqa
+    attribute_types: dict[str, type[bool | float | int | str]]
+    default_limit: NotRequired[int]
+    default_offset: NotRequired[int]
+    extrapolation_modes: NotRequired[MutableMapping[str, TLiteral["weighted", "none"]]]  # noqa
 
 
 VirtualColumn = TypedDict(

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -707,13 +707,13 @@ def bulk_read_preferences_from_sentry_db(
     return result
 
 
-class SeerProjectSettingsUpdate(TypedDict, total=False):
-    agent: AutomationCodingAgent
-    integration_id: int
-    stopping_point: str
-    automation_tuning: str
-    scanner_automation: bool
-    auto_create_pr: bool
+class SeerProjectSettingsUpdate(TypedDict):
+    agent: NotRequired[AutomationCodingAgent]
+    integration_id: NotRequired[int]
+    stopping_point: NotRequired[str]
+    automation_tuning: NotRequired[str]
+    scanner_automation: NotRequired[bool]
+    auto_create_pr: NotRequired[bool]
 
 
 def update_seer_project_settings(project_ids: list[int], data: SeerProjectSettingsUpdate) -> None:

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -19,14 +19,14 @@ from sentry.viewer_context import (
 )
 
 
-class SeerViewerContext(TypedDict, total=False):
-    organization_id: int
+class SeerViewerContext(TypedDict):
+    organization_id: NotRequired[int]
     # TODO(jeremy.stanley): user_id is int | None as a temporary state while
     # consolidating viewer context across call sites. Some pass request.user.id
     # (which can be None for anonymous users), others omit the key entirely.
     # Once all call sites are wired up, tighten this to int and ensure callers
     # only set user_id when an authenticated user is present.
-    user_id: int | None
+    user_id: NotRequired[int | None]
 
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
@@ -30,13 +30,13 @@ FAILURE_REASON_BASE = f"{SentryAppEventType.ALERT_RULE_ACTION_REQUESTED}.{{}}"
 logger = logging.getLogger("sentry.sentry_apps.external_requests")
 
 
-class SentryAppAlertRuleActionResult(TypedDict, total=False):
-    success: bool
-    message: str
-    error_type: SentryAppErrorType | None
-    webhook_context: dict[str, Any] | None
-    public_context: dict[str, Any] | None
-    status_code: int | None
+class SentryAppAlertRuleActionResult(TypedDict):
+    success: NotRequired[bool]
+    message: NotRequired[str]
+    error_type: NotRequired[SentryAppErrorType | None]
+    webhook_context: NotRequired[dict[str, Any] | None]
+    public_context: NotRequired[dict[str, Any] | None]
+    status_code: NotRequired[int | None]
 
 
 @dataclass

--- a/src/sentry/sentry_apps/external_requests/select_requester.py
+++ b/src/sentry/sentry_apps/external_requests/select_requester.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Annotated, Any, TypedDict
+from typing import Annotated, Any, NotRequired, TypedDict
 from urllib.parse import urlencode, urlparse, urlunparse
 from uuid import uuid4
 
@@ -24,10 +24,10 @@ from sentry.utils import json
 FAILURE_REASON_BASE = f"{SentryAppEventType.SELECT_OPTIONS_REQUESTED}.{{}}"
 
 
-class SelectRequesterResult(TypedDict, total=False):
+class SelectRequesterResult(TypedDict):
     # Each contained Sequence of strings is of length 2 i.e ["label", "value"]
-    choices: Sequence[Annotated[Sequence[str], 2]]
-    defaultValue: str
+    choices: NotRequired[Sequence[Annotated[Sequence[str], 2]]]
+    defaultValue: NotRequired[str]
 
 
 @dataclass

--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -7,7 +7,7 @@ import datetime
 import hmac
 from collections.abc import MutableMapping
 from hashlib import sha256
-from typing import Any, Protocol, TypedDict
+from typing import Any, NotRequired, Protocol, TypedDict
 from urllib.parse import urljoin
 
 from pydantic.fields import Field
@@ -190,17 +190,17 @@ class RpcSentryAppEventData(RpcModel):
         )
 
 
-class SentryAppInstallationFilterArgs(TypedDict, total=False):
-    installation_ids: list[int]
-    app_ids: list[int]
-    organization_id: int
-    uuids: list[str]
-    status: int
-    api_token_id: int
-    api_installation_token_id: int
+class SentryAppInstallationFilterArgs(TypedDict):
+    installation_ids: NotRequired[list[int]]
+    app_ids: NotRequired[list[int]]
+    organization_id: NotRequired[int]
+    uuids: NotRequired[list[str]]
+    status: NotRequired[int]
+    api_token_id: NotRequired[int]
+    api_installation_token_id: NotRequired[int]
 
 
-class SentryAppUpdateArgs(TypedDict, total=False):
-    events: list[str]
-    name: str
+class SentryAppUpdateArgs(TypedDict):
+    events: NotRequired[list[str]]
+    name: NotRequired[str]
     # TODO add whatever else as needed

--- a/src/sentry/sentry_apps/services/app_request/model.py
+++ b/src/sentry/sentry_apps/services/app_request/model.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from pydantic import Field
 
@@ -24,6 +24,6 @@ class RpcSentryAppRequest(RpcModel):
     response_body: str | None = None
 
 
-class SentryAppRequestFilterArgs(TypedDict, total=False):
-    event: str | list[str]
-    errors_only: bool
+class SentryAppRequestFilterArgs(TypedDict):
+    event: NotRequired[str | list[str]]
+    errors_only: NotRequired[bool]

--- a/src/sentry/sentry_apps/utils/errors.py
+++ b/src/sentry/sentry_apps/utils/errors.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import sentry_sdk
 from rest_framework.response import Response
@@ -11,9 +11,9 @@ class SentryAppErrorType(Enum):
     SENTRY = "sentry"
 
 
-class SentryAppPublicErrorBody(TypedDict, total=False):
-    detail: str
-    context: dict[str, Any]
+class SentryAppPublicErrorBody(TypedDict):
+    detail: NotRequired[str]
+    context: NotRequired[dict[str, Any]]
 
 
 class SentryAppBaseError(Exception):

--- a/src/sentry/uptime/types.py
+++ b/src/sentry/uptime/types.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import IntEnum
-from typing import Any, Literal, Required, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
     Assertion,
@@ -66,68 +66,68 @@ The HTTP method to use for the request.
 """
 
 
-class CheckConfig(TypedDict, total=False):
+class CheckConfig(TypedDict):
     """
     A message containing the configuration for a check to scheduled and
     executed by the uptime-checker.
     """
 
-    subscription_id: Required[str]
+    subscription_id: str
     """
     UUID of the subscription that this check config represents.
     """
 
-    interval_seconds: Required[CheckInterval]
+    interval_seconds: CheckInterval
     """
     The interval between each check run in seconds.
     """
 
-    timeout_ms: Required[int | float]
+    timeout_ms: int | float
     """
     The total time we will allow to make the request in milliseconds.
     """
 
-    url: Required[str]
+    url: str
     """
     The actual HTTP URL to check.
     """
 
-    request_method: RequestMethod
+    request_method: NotRequired[RequestMethod]
     """
     The HTTP method to use for the request.
     """
 
-    request_headers: Sequence[RequestHeader]
+    request_headers: NotRequired[Sequence[RequestHeader]]
     """
     Additional HTTP headers to send with the request.
     """
 
-    request_body: str
+    request_body: NotRequired[str]
     """
     Additional HTTP headers to send with the request.
     """
 
-    trace_sampling: bool
+    trace_sampling: NotRequired[bool]
     """
     Whether to allow for sampled trace spans for the request.
     """
 
-    active_regions: Sequence[str]
+    active_regions: NotRequired[Sequence[str]]
     """
     A list of region slugs the uptime check is configured to run in.
     """
 
-    region_schedule_mode: "RegionScheduleMode"
+    region_schedule_mode: NotRequired["RegionScheduleMode"]
     """
     Defines how we'll schedule checks based on other active regions.
     """
 
-    assertion: Any | None
+    assertion: NotRequired[Any | None]
     """
     The runtime assertion to execute, or null.
     """
 
-    capture_response_on_failure: bool
+    capture_response_on_failure: NotRequired[bool]
     """
     Whether to capture response body and headers on check failures.
     """

--- a/src/sentry/users/services/user/model.py
+++ b/src/sentry/users/services/user/model.py
@@ -5,7 +5,7 @@
 
 import datetime
 from enum import IntEnum
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from pydantic.fields import Field
 
@@ -139,36 +139,38 @@ class UserSerializeType(IntEnum):  # annoying
     SELF_DETAILED = 2
 
 
-class UserFilterArgs(TypedDict, total=False):
-    user_ids: list[int]
+class UserFilterArgs(TypedDict):
+    user_ids: NotRequired[list[int]]
     """List of user ids to search with"""
 
-    is_active: bool
+    is_active: NotRequired[bool]
     """Whether the user needs to be active"""
 
-    organization_id: int
+    organization_id: NotRequired[int]
     """Organization to check membership in"""
 
-    emails: list[str]
+    emails: NotRequired[list[str]]
     """list of emails to match with"""
 
-    email_verified: bool
+    email_verified: NotRequired[bool]
     """Whether emails have to be verified or not"""
 
-    query: str
+    query: NotRequired[str]
     """Filter by email or name"""
 
-    authenticator_types: list[int] | None
+    authenticator_types: NotRequired[list[int] | None]
     """The type of MFA authenticator you want to query by"""
 
 
-class UserUpdateArgs(TypedDict, total=False):
-    avatar_url: str
-    avatar_type: int
-    actor_id: int  # TODO(hybrid-cloud): Remove this after the actor migration is complete
-    is_active: bool
-    is_superuser: bool
-    is_staff: bool
+class UserUpdateArgs(TypedDict):
+    avatar_url: NotRequired[str]
+    avatar_type: NotRequired[int]
+    actor_id: NotRequired[
+        int
+    ]  # TODO(hybrid-cloud): Remove this after the actor migration is complete
+    is_active: NotRequired[bool]
+    is_superuser: NotRequired[bool]
+    is_staff: NotRequired[bool]
 
 
 class UserIdEmailArgs(TypedDict):

--- a/src/sentry/users/services/user_option/model.py
+++ b/src/sentry/users/services/user_option/model.py
@@ -3,7 +3,7 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from sentry.hybridcloud.rpc import RpcModel
 
@@ -17,10 +17,10 @@ class RpcUserOption(RpcModel):
     organization_id: int | None = None
 
 
-class UserOptionFilterArgs(TypedDict, total=False):
-    user_ids: list[int]
-    keys: list[str]
-    key: str
-    project_id: int | None
-    project_ids: list[int] | None
-    organization_id: int | None
+class UserOptionFilterArgs(TypedDict):
+    user_ids: NotRequired[list[int]]
+    keys: NotRequired[list[str]]
+    key: NotRequired[str]
+    project_id: NotRequired[int | None]
+    project_ids: NotRequired[list[int] | None]
+    organization_id: NotRequired[int | None]

--- a/src/sentry/users/services/usersocialauth/model.py
+++ b/src/sentry/users/services/usersocialauth/model.py
@@ -3,7 +3,7 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from pydantic import Field
 
@@ -27,8 +27,8 @@ class RpcUserSocialAuth(RpcModel):
         return tokens(instance=self)
 
 
-class UserSocialAuthFilterArgs(TypedDict, total=False):
-    id: int
-    user_id: int
-    provider: str
-    uid: str
+class UserSocialAuthFilterArgs(TypedDict):
+    id: NotRequired[int]
+    user_id: NotRequired[int]
+    provider: NotRequired[str]
+    uid: NotRequired[str]

--- a/src/sentry/utils/ai_message_normalizer.py
+++ b/src/sentry/utils/ai_message_normalizer.py
@@ -1,6 +1,6 @@
 import ast
 import json  # noqa: S003
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 FILTERED = "[Filtered]"
 FILE_CONTENT_PARTS = ("blob", "uri", "file")
@@ -18,11 +18,11 @@ class AIOutputResult(TypedDict):
     tool_calls: str | None
 
 
-class RawMessage(TypedDict, total=False):
-    role: str
-    content: Any
-    parts: list[Any]
-    role_explicit: bool
+class RawMessage(TypedDict):
+    role: NotRequired[str]
+    content: NotRequired[Any]
+    parts: NotRequired[list[Any]]
+    role_explicit: NotRequired[bool]
 
 
 class PartBuckets(TypedDict):

--- a/src/sentry/utils/circuit_breaker.py
+++ b/src/sentry/utils/circuit_breaker.py
@@ -3,7 +3,7 @@ NOTE: This circuit breaker implementation is deprecated and is slated to eventua
 the `CircuitBreaker` class found in `circuit_breaker2.py` instead.
 """
 
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from django.core.cache import cache
 
@@ -20,20 +20,20 @@ class CircuitBreakerPassthrough(TypedDict, total=True):
     window: int
 
 
-class CircuitBreakerConfig(TypedDict, total=False):
+class CircuitBreakerConfig(TypedDict):
     # The number of consecutive failures within a given window required to trigger the circuit breaker
-    error_limit: int
+    error_limit: NotRequired[int]
     # The window of time in which those errors must happen
-    error_limit_window: int
+    error_limit_window: NotRequired[int]
     # Allow a configurable subset of function calls to bypass the circuit breaker, for the purposes
     # of determining when the service is healthy again and requests to it can resume.
-    allow_passthrough: bool
+    allow_passthrough: NotRequired[bool]
     # The number of function calls allowed to bypass the circuit breaker every
     # `passthrough_interval` seconds
-    passthrough_attempts_per_interval: int
+    passthrough_attempts_per_interval: NotRequired[int]
     # The window of time, in seconds, during which to allow `passthrough_attempts_per_interval`
     # calls to bypass the circuit breaker
-    passthrough_interval: int
+    passthrough_interval: NotRequired[int]
 
 
 CIRCUIT_BREAKER_DEFAULTS = CircuitBreakerConfig(

--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from django.db.models import OuterRef, Subquery
 from drf_spectacular.utils import extend_schema_serializer
@@ -24,13 +24,13 @@ from sentry.workflow_engine.models import (
 )
 
 
-class DetectorSerializerResponseOptional(TypedDict, total=False):
-    owner: ActorSerializerResponse | None
-    createdBy: str | None
-    alertRuleId: int | None
-    ruleId: int | None
-    latestGroup: dict[str, Any] | None
-    description: str | None
+class DetectorSerializerResponseOptional(TypedDict):
+    owner: NotRequired[ActorSerializerResponse | None]
+    createdBy: NotRequired[str | None]
+    alertRuleId: NotRequired[int | None]
+    ruleId: NotRequired[int | None]
+    latestGroup: NotRequired[dict[str, Any] | None]
+    description: NotRequired[str | None]
 
 
 @extend_schema_serializer(exclude_fields=["alertRuleId", "ruleId"])

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
@@ -15,13 +15,13 @@ from sentry.workflow_engine.models import (
 from sentry.workflow_engine.processors.workflow_fire_history import get_last_fired_dates
 
 
-class ActionSerializerResponse(TypedDict, total=False):
-    id: str
-    type: str
-    integrationId: str | None
-    data: dict[str, str]
-    config: dict[str, Any]
-    status: str
+class ActionSerializerResponse(TypedDict):
+    id: NotRequired[str]
+    type: NotRequired[str]
+    integrationId: NotRequired[str | None]
+    data: NotRequired[dict[str, str]]
+    config: NotRequired[dict[str, Any]]
+    status: NotRequired[str]
 
 
 class ConditionSerializerResponse(TypedDict):
@@ -31,12 +31,12 @@ class ConditionSerializerResponse(TypedDict):
     conditionResult: bool
 
 
-class TriggerSerializerResponse(TypedDict, total=False):
-    id: str
-    organizationId: str
-    logicType: str
-    conditions: list[ConditionSerializerResponse] | list[Any]
-    actions: list[ActionSerializerResponse] | list[Any]
+class TriggerSerializerResponse(TypedDict):
+    id: NotRequired[str]
+    organizationId: NotRequired[str]
+    logicType: NotRequired[str]
+    conditions: NotRequired[list[ConditionSerializerResponse] | list[Any]]
+    actions: NotRequired[list[ActionSerializerResponse] | list[Any]]
 
 
 class WorkflowSerializerResponse(TypedDict):

--- a/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
+++ b/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, MutableMapping
-from typing import Any, TypedDict, TypeVar
+from typing import Any, NotRequired, TypedDict, TypeVar
 from unittest.mock import MagicMock, patch
 
 import responses
@@ -25,9 +25,9 @@ from tests.sentry.integrations.slack.utils.test_mock_slack_response import mock_
 ActionRegistrationT = TypeVar("ActionRegistrationT", bound=ActionRegistration)
 
 
-class _Query(TypedDict, total=False):
-    triggerType: str
-    project: int
+class _Query(TypedDict):
+    triggerType: NotRequired[str]
+    project: NotRequired[int]
 
 
 class _QueryResult(TypedDict):

--- a/tests/sentry/workflow_engine/endpoints/test_organization_deduplicate_workflows.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_deduplicate_workflows.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from random import randint
-from typing import Any, TypedDict, Unpack
+from typing import Any, NotRequired, TypedDict, Unpack
 
 import pytest
 
@@ -21,15 +21,15 @@ from sentry.workflow_engine.models import (
 from sentry.workflow_engine.models.data_condition import Condition
 
 
-class MockWorkflowConfig(TypedDict, total=False):
-    actions: list[Action] | None
-    action_filters: list[DataCondition] | None
-    enabled: bool | None
-    triggers: list[DataCondition] | None
-    config: dict[str, Any] | None
-    mock_actions: bool
-    mock_action_filters: bool
-    mock_triggers: bool
+class MockWorkflowConfig(TypedDict):
+    actions: NotRequired[list[Action] | None]
+    action_filters: NotRequired[list[DataCondition] | None]
+    enabled: NotRequired[bool | None]
+    triggers: NotRequired[list[DataCondition] | None]
+    config: NotRequired[dict[str, Any] | None]
+    mock_actions: NotRequired[bool]
+    mock_action_filters: NotRequired[bool]
+    mock_triggers: NotRequired[bool]
 
 
 # This is a list of workflows to create for every test case.


### PR DESCRIPTION
Type-annotation cleanup to reduce `total=False`. **Part 1 of 2** — follow-up #116932 collapses the now-redundant split TypedDicts.

## What

Replace `total=False` with explicit per-field `NotRequired[...]` (PEP 655) — in the **44 modules that do _not_ use `from __future__ import annotations`**.

## ⚠️ Why not everywhere — the future-annotations constraint

`total=False` and per-field `NotRequired` are **not** runtime-equivalent in modules with `from __future__ import annotations`. Under stringized annotations, CPython (3.11–3.13) does not detect `NotRequired[...]` at class creation, so with the default `total=True` **every field is computed as required**, flipping `__required_keys__`/`__optional_keys__`. That changes runtime introspection — notably drf-spectacular's generated OpenAPI schema.

```python
# with `from __future__ import annotations`
class A(TypedDict, total=False): x: int    # __required_keys__ == frozenset()      ✅
class B(TypedDict): x: NotRequired[int]     # __required_keys__ == {'x'}  ← WRONG   ❌
```

So this PR migrates only the modules where the two forms are provably identical (verified on 3.11/3.12/3.13). The modules that use `from __future__ import annotations` **keep `total=False`** — there it's load-bearing, not stylistic. (Static type-checking is correct either way; only runtime introspection breaks, which is why an early all-modules version failed the api-docs / schema checks.)

## How

libcst codemod: wrap each field in `NotRequired`, unwrap now-redundant `Required`, drop `total=False`. Covers class syntax and the functional `TypedDict("X", {...})` form.

## Behavior preservation

For the migrated (non-future) modules, `total=False` ≡ all-`NotRequired` at runtime — identical `__required_keys__`/`__optional_keys__`, so generated OpenAPI schemas are unchanged.

## Verification

- ✅ `ruff check` + `ruff format --check` clean across all changed files.
- ✅ Confirmed **no** migrated module uses `from __future__ import annotations`.
- ⚠️ mypy/tests not run locally (no dev env in sandbox); relying on CI.

https://claude.ai/code/session_01NBWP7ZEBn4xR8dECDro3SH