### PR TITLE
ref(types): collapse split Optional/Required TypedDicts into one

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_meta_types.py
+++ b/src/sentry/api/endpoints/organization_trace_meta_types.py
@@ -3,11 +3,8 @@ from typing import NotRequired, TypedDict
 from sentry.search.events.types import SnubaData
 
 
-class OrganizationTraceMetaResponseOptional(TypedDict):
+class OrganizationTraceMetaResponse(TypedDict):
     uptimeCount: NotRequired[int]
-
-
-class OrganizationTraceMetaResponse(OrganizationTraceMetaResponseOptional):
     errorsCount: int
     logsCount: float
     metricsCount: float

--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -12,7 +12,7 @@ from sentry.utils.dates import outside_retention_with_modified_start, parse_time
 DATASET_SOURCES = dict(DatasetSourcesTypes.as_choices())
 
 
-class DiscoverSavedQueryResponseOptional(TypedDict):
+class DiscoverSavedQueryResponse(TypedDict):
     environment: NotRequired[list[str]]
     query: NotRequired[str]
     fields: NotRequired[list[str]]
@@ -29,9 +29,6 @@ class DiscoverSavedQueryResponseOptional(TypedDict):
     topEvents: NotRequired[int]
     interval: NotRequired[str]
     exploreQuery: NotRequired[dict]
-
-
-class DiscoverSavedQueryResponse(DiscoverSavedQueryResponseOptional):
     id: str
     name: str
     projects: list[int]

--- a/src/sentry/api/serializers/models/exploresavedquery.py
+++ b/src/sentry/api/serializers/models/exploresavedquery.py
@@ -14,33 +14,16 @@ from sentry.users.services.user.service import user_service
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
 
 
-class MetricResponseTypeOptional(TypedDict):
+class MetricResponseType(TypedDict):
     unit: NotRequired[str | None]
-
-
-class MetricResponseType(MetricResponseTypeOptional):
     name: str
     type: str
 
 
-class CrossEventResponseTypeOptional(TypedDict):
+class CrossEventResponseType(TypedDict):
     metric: NotRequired[MetricResponseType]
-
-
-class CrossEventResponseType(CrossEventResponseTypeOptional):
     query: str
     type: str
-
-
-class ExploreSavedQueryResponseOptional(TypedDict):
-    environment: NotRequired[list[str]]
-    query: NotRequired[str]
-    range: NotRequired[str]
-    start: NotRequired[str]
-    end: NotRequired[str]
-    interval: NotRequired[str]
-    mode: NotRequired[str]
-    crossEvents: NotRequired[list[CrossEventResponseType]]
 
 
 class ExploreSavedQueryChangedReasonType(TypedDict):
@@ -49,7 +32,15 @@ class ExploreSavedQueryChangedReasonType(TypedDict):
     columns: list[str]
 
 
-class ExploreSavedQueryResponse(ExploreSavedQueryResponseOptional):
+class ExploreSavedQueryResponse(TypedDict):
+    environment: NotRequired[list[str]]
+    query: NotRequired[str]
+    range: NotRequired[str]
+    start: NotRequired[str]
+    end: NotRequired[str]
+    interval: NotRequired[str]
+    mode: NotRequired[str]
+    crossEvents: NotRequired[list[CrossEventResponseType]]
     id: str
     name: str
     projects: list[int]

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -26,17 +26,13 @@ class SCIMMeta(TypedDict):
     resourceType: str
 
 
-class OrganizationMemberSCIMSerializerOptional(TypedDict):
-    """Sentry doesn't use this field but is expected by SCIM"""
-
-    active: NotRequired[bool]
-
-
-class OrganizationMemberSCIMSerializerResponse(OrganizationMemberSCIMSerializerOptional):
+class OrganizationMemberSCIMSerializerResponse(TypedDict):
     """
     Conforming to the SCIM RFC, this represents a Sentry Org Member
     as a SCIM user object.
     """
+
+    active: NotRequired[bool]
 
     schemas: list[str]
     id: str

--- a/src/sentry/api/serializers/models/projectownership.py
+++ b/src/sentry/api/serializers/models/projectownership.py
@@ -24,13 +24,9 @@ OwnershipSchemaResponse = TypedDict(
 )
 
 
-# JSON object representing optional part of API response
-class ProjectOwnershipResponseOptional(TypedDict):
-    schema: NotRequired[OwnershipSchemaResponse | None]
-
-
 # JSON object representing this serializer in API response
-class ProjectOwnershipResponse(ProjectOwnershipResponseOptional):
+class ProjectOwnershipResponse(TypedDict):
+    schema: NotRequired[OwnershipSchemaResponse | None]
     raw: str
     fallthrough: bool
     dateCreated: datetime

--- a/src/sentry/api/serializers/models/repository.py
+++ b/src/sentry/api/serializers/models/repository.py
@@ -12,7 +12,7 @@ class RepositorySettingsSerializerResponse(TypedDict):
     codeReviewTriggers: list[str]
 
 
-class RepositorySerializerResponseOptional(TypedDict):
+class RepositorySerializerResponse(TypedDict):
     url: NotRequired[str | None]
     provider: NotRequired[dict[str, str]]
     status: NotRequired[str]
@@ -20,9 +20,6 @@ class RepositorySerializerResponseOptional(TypedDict):
     externalSlug: NotRequired[str | None]
     externalId: NotRequired[str | None]
     settings: NotRequired[RepositorySettingsSerializerResponse | None]
-
-
-class RepositorySerializerResponse(RepositorySerializerResponseOptional):
     id: str
     name: str
     dateCreated: datetime

--- a/src/sentry/api/serializers/release_details_types.py
+++ b/src/sentry/api/serializers/release_details_types.py
@@ -4,22 +4,16 @@ from typing import Any, NotRequired, TypedDict
 from sentry.users.api.serializers.user import UserSerializerResponse
 
 
-class VersionInfoOptional(TypedDict):
+class VersionInfo(TypedDict):
     description: NotRequired[str]
-
-
-class VersionInfo(VersionInfoOptional):
     package: str | None
     version: dict[str, Any]
     buildHash: str | None
 
 
-class LastDeployOptional(TypedDict):
+class LastDeploy(TypedDict):
     dateStarted: NotRequired[str | None]
     url: NotRequired[str | None]
-
-
-class LastDeploy(LastDeployOptional):
     id: str
     environment: str
     dateFinished: str
@@ -34,7 +28,7 @@ class NonMappableUser(TypedDict):
 Author = UserSerializerResponse | NonMappableUser
 
 
-class HealthDataOptional(TypedDict):
+class HealthData(TypedDict):
     durationP50: NotRequired[float | None]
     durationP90: NotRequired[float | None]
     crashFreeUsers: NotRequired[float | None]
@@ -47,23 +41,17 @@ class HealthDataOptional(TypedDict):
     totalProjectSessions24h: NotRequired[int | None]
     adoption: NotRequired[float | None]
     sessionsAdoption: NotRequired[float | None]
-
-
-class HealthData(HealthDataOptional):
     sessionsCrashed: int
     sessionsErrored: int
     hasHealthData: bool
     stats: dict[str, Any]
 
 
-class ProjectOptional(TypedDict):
+class BaseProject(TypedDict):
     healthData: NotRequired[HealthData | None]
     dateReleased: NotRequired[datetime | None]
     dateCreated: NotRequired[datetime | None]
     dateStarted: NotRequired[datetime | None]
-
-
-class BaseProject(ProjectOptional):
     id: int
     slug: str
     name: str

--- a/src/sentry/api/serializers/types.py
+++ b/src/sentry/api/serializers/types.py
@@ -4,8 +4,7 @@ from typing import Any, NotRequired, TypedDict
 from sentry.api.serializers.release_details_types import Author, LastDeploy, Project, VersionInfo
 
 
-# Reponse type for OrganizationReleaseDetailsEndpoint
-class ReleaseSerializerResponseOptional(TypedDict):
+class ReleaseSerializerResponse(TypedDict):
     ref: NotRequired[str | None]
     url: NotRequired[str | None]
     dateReleased: NotRequired[datetime | None]
@@ -21,9 +20,6 @@ class ReleaseSerializerResponseOptional(TypedDict):
     adoptionStages: NotRequired[
         dict[str, Any] | None
     ]  # Only included if with_adoption_stages is True
-
-
-class ReleaseSerializerResponse(ReleaseSerializerResponseOptional):
     # NOTE: The API design guidelines (https://develop.sentry.dev/backend/api/design/)
     # call for resource identifiers to be returned as strings. This release `id` is a
     # long-standing integer in the public response and is relied on by existing clients,

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -171,11 +171,8 @@ class MonitorAlertRuleSerializerResponse(TypedDict):
     environment: str
 
 
-class MonitorSerializerResponseOptional(TypedDict):
+class MonitorSerializerResponse(TypedDict):
     alertRule: NotRequired[MonitorAlertRuleSerializerResponse]
-
-
-class MonitorSerializerResponse(MonitorSerializerResponseOptional):
     id: str
     name: str
     slug: str
@@ -322,11 +319,8 @@ class MonitorSerializer(Serializer[MonitorSerializerResponse]):
         return key in self.expand
 
 
-class MonitorCheckInSerializerResponseOptional(TypedDict):
+class MonitorCheckInSerializerResponse(TypedDict):
     groups: NotRequired[list[str]]
-
-
-class MonitorCheckInSerializerResponse(MonitorCheckInSerializerResponseOptional):
     id: str
     environment: str
     status: str

--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -24,17 +24,14 @@ from sentry.workflow_engine.models import (
 )
 
 
-class DetectorSerializerResponseOptional(TypedDict):
+@extend_schema_serializer(exclude_fields=["alertRuleId", "ruleId"])
+class DetectorSerializerResponse(TypedDict):
     owner: NotRequired[ActorSerializerResponse | None]
     createdBy: NotRequired[str | None]
     alertRuleId: NotRequired[int | None]
     ruleId: NotRequired[int | None]
     latestGroup: NotRequired[dict[str, Any] | None]
     description: NotRequired[str | None]
-
-
-@extend_schema_serializer(exclude_fields=["alertRuleId", "ruleId"])
-class DetectorSerializerResponse(DetectorSerializerResponseOptional):
     id: str
     projectId: str
     name: str


### PR DESCRIPTION
**Part 2 of 2** — stacked on #116931 (review/merge that first). Base is the Part-1 branch, so this diff shows only the collapse.

## What

Now that the optional/required halves carry explicit per-field markers (#116931), the two-class `X` + `XOptional`/`XRequired` idiom (a base holding one half of the fields, inherited to add the other) is redundant. Inline each such base into its single subclass and delete it. **16 classes removed** across 10 files.

## How

libcst codemod. A base is removed only when it is a `TypedDict` referenced **exactly once** (as that subclass's base), has no non-field body, no name collision, and an unambiguous `Optional`/`Required` "half" name. Base fields are inlined **first**, preserving MRO/annotation order.

## Scope

Limited to the non-`from __future__ import annotations` modules migrated in #116931. Modules that retain `total=False` (future-annotations — see the constraint explained in #116931) are left untouched, since their halves still rely on `total=False`.

## Behavior preservation

Field markers unchanged and base fields kept first → identical `__required_keys__`/`__optional_keys__` and annotation order → generated OpenAPI schemas unchanged. Verified no dangling references to any removed base class.

## Verification

- ✅ `ruff check` + `ruff format --check` clean.
- ✅ No collapsed module uses `from __future__ import annotations`.
- ⚠️ mypy/tests rely on CI (no dev env in sandbox).

https://claude.ai/code/session_01NBWP7ZEBn4xR8dECDro3SH