### PR TITLE
ref(apidocs): add x-learn-more pagination link to cursor query param

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -3,7 +3,6 @@ from typing import Any
 from drf_spectacular.plumbing import build_array_type, build_basic_type
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
-from rest_framework import serializers
 
 from sentry import constants
 from sentry.snuba.dataset import Dataset
@@ -779,11 +778,15 @@ events that aren't in the top groups.""",
     )
 
 
-class CursorQueryParam(serializers.Serializer):
-    cursor = serializers.CharField(
-        help_text="A pointer to the last object fetched and its sort order; used to retrieve the next or previous results.",
-        required=False,
-    )
+CursorQueryParam = OpenApiParameter(
+    name="cursor",
+    location="query",
+    required=False,
+    type=str,
+    allow_blank=False,
+    description="A pointer to the last object fetched and its sort order; used to retrieve the next or previous results.",
+    extensions={"x-learn-more": "https://docs.sentry.io/api/pagination/"},
+)
 
 
 class MonitorParams:


### PR DESCRIPTION
## Summary

Adds the `x-learn-more` OpenAPI extension pointing to https://docs.sentry.io/api/pagination/ to the in-code `cursor` pagination query parameter (`CursorQueryParam` in `src/sentry/apidocs/parameters.py`).

This brings the drf-spectacular–generated docs in line with the legacy hand-written spec at `api-docs/components/parameters/pagination-cursor.json`, which already carries the same `x-learn-more` link:

```json
{
  "PaginationCursor": {
    "name": "cursor",
    "in": "query",
    "required": false,
    "description": "A pointer to the last object fetched and its sort order; used to retrieve the next or previous results.",
    "x-learn-more": "https://docs.sentry.io/api/pagination/",
    "schema": { "type": "string" }
  }
}
```

## Approach

`CursorQueryParam` was a DRF `Serializer`, which has no clean way to attach a parameter-level vendor extension. It's only ever used as a documentation parameter inside `@extend_schema(parameters=[...])` (all 46 call sites) — never instantiated or validated — so I converted it to an `OpenApiParameter`, which supports an `extensions=` kwarg (drf-spectacular ≥ 0.27). The name is unchanged, so no call sites needed to be touched, and the now-unused `serializers` import was removed.

I verified against drf-spectacular that `extensions` renders the key at the parameter-object level (sibling to `name`/`in`/`description`/`schema`), producing output identical to the previous serializer-generated parameter aside from the added `x-learn-more` key:

```json
{
  "in": "query",
  "name": "cursor",
  "schema": { "type": "string" },
  "description": "A pointer to the last object fetched and its sort order; used to retrieve the next or previous results.",
  "x-learn-more": "https://docs.sentry.io/api/pagination/"
}
```

## Test plan

- `make build-api-docs` (CI) regenerates the OpenAPI spec; the only diff is the added `x-learn-more` line on cursor-paginated endpoints.
- No call sites change and no tests reference `CursorQueryParam` directly.

https://claude.ai/code/session_01Qw47Ux46i6VL9VtbkWdyyS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qw47Ux46i6VL9VtbkWdyyS)_