### PR TITLE
ref(seer-issue-activity) Refactor the Seer Issue Activity hook to be generic

### DIFF
--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -29,7 +29,7 @@ from sentry.issues.grouptype import get_group_type_by_type_id
 from sentry.tasks import activity
 from sentry.types.activity import CHOICES, STATUS_CHANGE_ACTIVITY_TYPES, ActivityType
 from sentry.types.group import PriorityLevel
-from sentry.workflow_engine.registry import invoke_workflow_activity_handlers
+from sentry.workflow_engine.handlers.registry import invoke_workflow_activity_handlers
 from sentry.workflow_engine.types import DetectorId
 
 if TYPE_CHECKING:

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -29,6 +29,8 @@ from sentry.issues.grouptype import get_group_type_by_type_id
 from sentry.tasks import activity
 from sentry.types.activity import CHOICES, STATUS_CHANGE_ACTIVITY_TYPES, ActivityType
 from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.registry import invoke_workflow_activity_handlers
+from sentry.workflow_engine.types import DetectorId
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
@@ -85,6 +87,7 @@ class ActivityManager(BaseManager["Activity"]):
         data: Mapping[str, Any] | None = None,
         send_notification: bool = True,
         datetime: datetime | None = None,
+        detector_id: DetectorId | None = None,
     ) -> Activity:
         if user:
             user_id = user.id
@@ -102,6 +105,8 @@ class ActivityManager(BaseManager["Activity"]):
 
         if send_notification:
             activity.send_notification()
+
+        invoke_workflow_activity_handlers(group, activity, detector_id)
 
         return activity
 

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -36,7 +36,6 @@ from sentry.taskworker.namespaces import seer_tasks
 from sentry.types.activity import ActivityType
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
-from sentry.workflow_engine.registry import invoke_workflow_activity_handlers
 
 SEER_EVENT_TO_ACTIVITY_TYPE: dict[SentryAppEventType, ActivityType] = {
     SentryAppEventType.SEER_ROOT_CAUSE_STARTED: ActivityType.SEER_RCA_STARTED,
@@ -587,13 +586,12 @@ def _create_seer_activity(
         if pull_requests:
             activity_data["pull_requests"] = pull_requests
 
-    activity = Activity.objects.create_group_activity(
+    Activity.objects.create_group_activity(
         group,
         activity_type,
         data=activity_data if activity_data else None,
         send_notification=False,
     )
-    invoke_workflow_activity_handlers(group=group, activity=activity)
 
 
 @instrumented_task(

--- a/src/sentry/workflow_engine/handlers/registry/__init__.py
+++ b/src/sentry/workflow_engine/handlers/registry/__init__.py
@@ -1,0 +1,5 @@
+from .invoke_activities import invoke_workflow_activity_handlers
+
+__all__ = [
+    "invoke_workflow_activity_handlers",
+]

--- a/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
+++ b/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from sentry.utils import metrics
+from sentry.workflow_engine.registry import workflow_activity_registry
+from sentry.workflow_engine.types import DetectorId
+from sentry.workflow_engine.utils import scopedstats
+
+if TYPE_CHECKING:
+    from sentry.models.activity import Activity
+    from sentry.models.group import Group
+
+logger = logging.getLogger(__name__)
+
+DURATION_METRIC = "workflow_engine.invoke_workflow_activity_handlers.duration"
+
+
+def invoke_workflow_activity_handlers(
+    group: Group,
+    activity: Activity,
+    detector_id: DetectorId | None = None,
+) -> None:
+    # TODO - move the workflow_activity_registry to the activity model.
+    for handler_key, handler in workflow_activity_registry.registrations.items():
+        # Each handler gets its own recorder so we can attribute timing per handler. The
+        # recorder always captures the overall wall-clock as `total_recording_duration`;
+        # any `@scopedstats.timer()` inside the handler adds a `calls.<fn>.total_dur`
+        # breakdown into the same collector automatically.
+        recorder = scopedstats.Recorder()
+        try:
+            with recorder.record():
+                handler(group, activity, detector_id)
+        except Exception:
+            logger.exception(
+                "workflow_engine.invoke_workflow_activity_handlers.error",
+                extra={
+                    "group_id": group.id,
+                    "activity_id": activity.id,
+                    "handler_name": handler_key,
+                    "activity_type": activity.type,
+                },
+            )
+            continue
+        finally:
+            # Emit the recorded durations as metrics (the backend handles sampling).
+            # `.count` keys are always 1 for a single invocation, so they're skipped.
+            for stat_key, value in recorder.get_result().items():
+                if stat_key.endswith(".count"):
+                    continue
+                metrics.timing(
+                    DURATION_METRIC,
+                    value,
+                    tags={"handler": handler_key, "stat": stat_key},
+                )

--- a/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
+++ b/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 from sentry.utils import metrics
 from sentry.workflow_engine.registry import workflow_activity_registry
 from sentry.workflow_engine.types import DetectorId
-from sentry.workflow_engine.utils import scopedstats
 
 if TYPE_CHECKING:
     from sentry.models.activity import Activity
@@ -22,15 +21,19 @@ def invoke_workflow_activity_handlers(
     activity: Activity,
     detector_id: DetectorId | None = None,
 ) -> None:
-    # TODO - move the workflow_activity_registry to the activity model.
+    """
+    Call each workflow activity handler in a consistent way. This allows us to have
+    shared metrics for each activity, and each handler. Showing us the timing metrics
+    for how long each handler took, for a given activity.
+
+    This also means that if there's a new handler registered, it will automatically
+    have metrics and timing support out of the box.
+    """
     for handler_key, handler in workflow_activity_registry.registrations.items():
-        # Each handler gets its own recorder so we can attribute timing per handler. The
-        # recorder always captures the overall wall-clock as `total_recording_duration`;
-        # any `@scopedstats.timer()` inside the handler adds a `calls.<fn>.total_dur`
-        # breakdown into the same collector automatically.
-        recorder = scopedstats.Recorder()
         try:
-            with recorder.record():
+            # metrics.timer emits the duration even when the handler raises,
+            # tagged with result=success|failure.
+            with metrics.timer(DURATION_METRIC, tags={"handler": handler_key}):
                 handler(group, activity, detector_id)
         except Exception:
             logger.exception(
@@ -42,15 +45,3 @@ def invoke_workflow_activity_handlers(
                     "activity_type": activity.type,
                 },
             )
-            continue
-        finally:
-            # Emit the recorded durations as metrics (the backend handles sampling).
-            # `.count` keys are always 1 for a single invocation, so they're skipped.
-            for stat_key, value in recorder.get_result().items():
-                if stat_key.endswith(".count"):
-                    continue
-                metrics.timing(
-                    DURATION_METRIC,
-                    value,
-                    tags={"handler": handler_key, "stat": stat_key},
-                )

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -28,7 +28,7 @@ SEER_WORKFLOW_ACTIVITIES = [
 def seer_activity_handler(
     group: Group,
     activity: Activity,
-    detector_id: DetectorId,
+    detector_id: DetectorId | None = None,
 ) -> None:
     logging_ctx = {
         "activity_type": activity.type,

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -9,7 +9,7 @@ from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.processors.detector import get_preferred_detector
 from sentry.workflow_engine.registry import workflow_activity_registry
 from sentry.workflow_engine.tasks.workflows import process_workflow_activity
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import DetectorId, WorkflowEventData
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,11 @@ SEER_WORKFLOW_ACTIVITIES = [
 
 
 @workflow_activity_registry.register("seer_activity")
-def seer_activity_handler(group: Group, activity: Activity) -> None:
+def seer_activity_handler(
+    group: Group,
+    activity: Activity,
+    detector_id: DetectorId,
+) -> None:
     logging_ctx = {
         "activity_type": activity.type,
         "group_id": group.id,
@@ -50,13 +54,18 @@ def seer_activity_handler(group: Group, activity: Activity) -> None:
         return
 
     event_data = WorkflowEventData(event=activity, group=group)
+
     try:
-        detector = get_preferred_detector(event_data=event_data)
+        if detector_id is not None:
+            detector = Detector.objects.get(pk=detector_id)
+        else:
+            detector = get_preferred_detector(event_data=event_data)
     except Detector.DoesNotExist:
         logger.exception(
             "workflow_engine.seer_activity_handler.missing_detector", extra=logging_ctx
         )
         return
+
     logging_ctx["detector_id"] = detector.id
     logging_ctx["detector_type"] = detector.type
 

--- a/src/sentry/workflow_engine/registry.py
+++ b/src/sentry/workflow_engine/registry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING, Any
 

--- a/src/sentry/workflow_engine/registry.py
+++ b/src/sentry/workflow_engine/registry.py
@@ -1,8 +1,6 @@
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from sentry.models.activity import Activity
-from sentry.models.group import Group
 from sentry.utils.registry import Registry
 from sentry.workflow_engine.types import (
     ActionHandler,
@@ -11,6 +9,11 @@ from sentry.workflow_engine.types import (
     DetectorId,
     WorkflowActivityHandler,
 )
+
+if TYPE_CHECKING:
+    from sentry.models.activity import Activity
+    from sentry.models.group import Group
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/workflow_engine/registry.py
+++ b/src/sentry/workflow_engine/registry.py
@@ -8,6 +8,7 @@ from sentry.workflow_engine.types import (
     ActionHandler,
     DataConditionHandler,
     DataSourceTypeHandler,
+    DetectorId,
     WorkflowActivityHandler,
 )
 
@@ -19,10 +20,14 @@ action_handler_registry = Registry[type[ActionHandler]](enable_reverse_lookup=Fa
 workflow_activity_registry = Registry[WorkflowActivityHandler](enable_reverse_lookup=False)
 
 
-def invoke_workflow_activity_handlers(group: Group, activity: Activity) -> None:
+def invoke_workflow_activity_handlers(
+    group: Group,
+    activity: Activity,
+    detector_id: DetectorId | None = None,
+) -> None:
     for handler_key, handler in workflow_activity_registry.registrations.items():
         try:
-            handler(group, activity)
+            handler(group, activity, detector_id)
         except Exception:
             logger.exception(
                 "workflow_engine.invoke_workflow_activity_handlers.error",

--- a/src/sentry/workflow_engine/registry.py
+++ b/src/sentry/workflow_engine/registry.py
@@ -1,46 +1,14 @@
-from __future__ import annotations
-
-import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from sentry.utils.registry import Registry
 from sentry.workflow_engine.types import (
     ActionHandler,
     DataConditionHandler,
     DataSourceTypeHandler,
-    DetectorId,
     WorkflowActivityHandler,
 )
-
-if TYPE_CHECKING:
-    from sentry.models.activity import Activity
-    from sentry.models.group import Group
-
-
-logger = logging.getLogger(__name__)
 
 data_source_type_registry = Registry[type[DataSourceTypeHandler[Any]]]()
 condition_handler_registry = Registry[type[DataConditionHandler[Any]]](enable_reverse_lookup=False)
 action_handler_registry = Registry[type[ActionHandler]](enable_reverse_lookup=False)
 workflow_activity_registry = Registry[WorkflowActivityHandler](enable_reverse_lookup=False)
-
-
-def invoke_workflow_activity_handlers(
-    group: Group,
-    activity: Activity,
-    detector_id: DetectorId | None = None,
-) -> None:
-    for handler_key, handler in workflow_activity_registry.registrations.items():
-        try:
-            handler(group, activity, detector_id)
-        except Exception:
-            logger.exception(
-                "workflow_engine.invoke_workflow_activity_handlers.error",
-                extra={
-                    "group_id": group.id,
-                    "activity_id": activity.id,
-                    "handler_name": handler_key,
-                    "activity_type": activity.type,
-                },
-            )
-            continue

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -451,4 +451,4 @@ class DetectorSettings:
     filter: Q | None = None
 
 
-WorkflowActivityHandler: TypeAlias = Callable[["Group", "Activity"], None]
+WorkflowActivityHandler: TypeAlias = Callable[["Group", "Activity", DetectorId | None], None]

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -644,7 +644,7 @@ class SeerOperatorTest(TestCase):
             == "https://github.com/owner/repo/pull/42"
         )
 
-    @patch("sentry.seer.entrypoints.operator.invoke_workflow_activity_handlers")
+    @patch("sentry.models.activity.invoke_workflow_activity_handlers")
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)
     def test_create_seer_activity_invokes_workflow_activity_handlers(
         self, _mock_has_access, mock_invoke
@@ -658,9 +658,9 @@ class SeerOperatorTest(TestCase):
         )
 
         mock_invoke.assert_called_once()
-        call_kwargs = mock_invoke.call_args[1]
-        assert call_kwargs["group"] == self.group
-        assert call_kwargs["activity"].type == ActivityType.SEER_RCA_STARTED.value
+        group, activity = mock_invoke.call_args[0][:2]
+        assert group == self.group
+        assert activity.type == ActivityType.SEER_RCA_STARTED.value
 
 
 class TestGetAutofixExplorerStatus(TestCase):

--- a/tests/sentry/workflow_engine/handlers/registry/test_invoke_activities.py
+++ b/tests/sentry/workflow_engine/handlers/registry/test_invoke_activities.py
@@ -1,0 +1,92 @@
+from unittest import mock
+from unittest.mock import MagicMock
+
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+from sentry.workflow_engine.handlers.registry import invoke_workflow_activity_handlers
+from sentry.workflow_engine.handlers.registry.invoke_activities import DURATION_METRIC
+from sentry.workflow_engine.registry import workflow_activity_registry
+
+
+class InvokeWorkflowActivityHandlersTest(TestCase):
+    def setUp(self) -> None:
+        self.group = self.create_group()
+        self.activity = self.create_group_activity(
+            group=self.group, type=ActivityType.SEER_PR_CREATED.value
+        )
+
+    def test_invoke_handlers_safely(self) -> None:
+        handler_a = mock.Mock()
+        handler_b = mock.Mock(side_effect=Exception("Test error"))
+        handler_c = mock.Mock()
+
+        with mock.patch.dict(
+            workflow_activity_registry.registrations,
+            {"handler_a": handler_a, "handler_b": handler_b, "handler_c": handler_c},
+            clear=True,
+        ):
+            invoke_workflow_activity_handlers(self.group, self.activity)
+
+        # A raising handler does not prevent the others from running.
+        handler_a.assert_called_once_with(self.group, self.activity, None)
+        handler_b.assert_called_once_with(self.group, self.activity, None)
+        handler_c.assert_called_once_with(self.group, self.activity, None)
+
+    def test_invoke_handlers_no_registrants(self) -> None:
+        with mock.patch.dict(workflow_activity_registry.registrations, {}, clear=True):
+            invoke_workflow_activity_handlers(self.group, self.activity)
+
+    def test_passes_detector_id_to_handlers(self) -> None:
+        handler = mock.Mock()
+        with mock.patch.dict(
+            workflow_activity_registry.registrations, {"handler": handler}, clear=True
+        ):
+            invoke_workflow_activity_handlers(self.group, self.activity, detector_id=123)
+
+        handler.assert_called_once_with(self.group, self.activity, 123)
+
+    @mock.patch("sentry.workflow_engine.handlers.registry.invoke_activities.metrics")
+    def test_emits_duration_metric_per_handler(self, mock_metrics: MagicMock) -> None:
+        handler_a = mock.Mock()
+        handler_b = mock.Mock()
+
+        with mock.patch.dict(
+            workflow_activity_registry.registrations,
+            {"handler_a": handler_a, "handler_b": handler_b},
+            clear=True,
+        ):
+            invoke_workflow_activity_handlers(self.group, self.activity)
+
+        # One timing per handler, tagged by the registry key, for the overall duration.
+        assert mock_metrics.timing.call_count == 2
+        mock_metrics.timing.assert_any_call(
+            DURATION_METRIC,
+            mock.ANY,
+            tags={"handler": "handler_a", "stat": "total_recording_duration"},
+        )
+        mock_metrics.timing.assert_any_call(
+            DURATION_METRIC,
+            mock.ANY,
+            tags={"handler": "handler_b", "stat": "total_recording_duration"},
+        )
+
+    @mock.patch("sentry.workflow_engine.handlers.registry.invoke_activities.metrics")
+    def test_emits_timing_when_handler_raises(self, mock_metrics: MagicMock) -> None:
+        handler_a = mock.Mock(side_effect=Exception("Test error"))
+        handler_b = mock.Mock()
+
+        with mock.patch.dict(
+            workflow_activity_registry.registrations,
+            {"handler_a": handler_a, "handler_b": handler_b},
+            clear=True,
+        ):
+            invoke_workflow_activity_handlers(self.group, self.activity)
+
+        # Failed handlers are still timed, and the loop continues to the next handler.
+        assert mock_metrics.timing.call_count == 2
+        mock_metrics.timing.assert_any_call(
+            DURATION_METRIC,
+            mock.ANY,
+            tags={"handler": "handler_a", "stat": "total_recording_duration"},
+        )
+        handler_b.assert_called_once_with(self.group, self.activity, None)

--- a/tests/sentry/workflow_engine/handlers/registry/test_invoke_activities.py
+++ b/tests/sentry/workflow_engine/handlers/registry/test_invoke_activities.py
@@ -45,8 +45,8 @@ class InvokeWorkflowActivityHandlersTest(TestCase):
 
         handler.assert_called_once_with(self.group, self.activity, 123)
 
-    @mock.patch("sentry.workflow_engine.handlers.registry.invoke_activities.metrics")
-    def test_emits_duration_metric_per_handler(self, mock_metrics: MagicMock) -> None:
+    @mock.patch("sentry.utils.metrics.timing")
+    def test_emits_duration_metric_per_handler(self, mock_timing: MagicMock) -> None:
         handler_a = mock.Mock()
         handler_b = mock.Mock()
 
@@ -57,21 +57,15 @@ class InvokeWorkflowActivityHandlersTest(TestCase):
         ):
             invoke_workflow_activity_handlers(self.group, self.activity)
 
-        # One timing per handler, tagged by the registry key, for the overall duration.
-        assert mock_metrics.timing.call_count == 2
-        mock_metrics.timing.assert_any_call(
-            DURATION_METRIC,
-            mock.ANY,
-            tags={"handler": "handler_a", "stat": "total_recording_duration"},
-        )
-        mock_metrics.timing.assert_any_call(
-            DURATION_METRIC,
-            mock.ANY,
-            tags={"handler": "handler_b", "stat": "total_recording_duration"},
-        )
+        # One timing per handler, tagged by the registry key.
+        emitted = [(call.args[0], call.args[3]) for call in mock_timing.call_args_list]
+        assert emitted == [
+            (DURATION_METRIC, {"handler": "handler_a", "result": "success"}),
+            (DURATION_METRIC, {"handler": "handler_b", "result": "success"}),
+        ]
 
-    @mock.patch("sentry.workflow_engine.handlers.registry.invoke_activities.metrics")
-    def test_emits_timing_when_handler_raises(self, mock_metrics: MagicMock) -> None:
+    @mock.patch("sentry.utils.metrics.timing")
+    def test_emits_timing_when_handler_raises(self, mock_timing: MagicMock) -> None:
         handler_a = mock.Mock(side_effect=Exception("Test error"))
         handler_b = mock.Mock()
 
@@ -83,10 +77,9 @@ class InvokeWorkflowActivityHandlersTest(TestCase):
             invoke_workflow_activity_handlers(self.group, self.activity)
 
         # Failed handlers are still timed, and the loop continues to the next handler.
-        assert mock_metrics.timing.call_count == 2
-        mock_metrics.timing.assert_any_call(
-            DURATION_METRIC,
-            mock.ANY,
-            tags={"handler": "handler_a", "stat": "total_recording_duration"},
-        )
+        emitted = [(call.args[0], call.args[3]) for call in mock_timing.call_args_list]
+        assert emitted == [
+            (DURATION_METRIC, {"handler": "handler_a", "result": "failure"}),
+            (DURATION_METRIC, {"handler": "handler_b", "result": "success"}),
+        ]
         handler_b.assert_called_once_with(self.group, self.activity, None)

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -41,9 +41,9 @@ class WorkflowActivityRegistryTest(TestCase):
         ):
             invoke_workflow_activity_handlers(self.group, self.activity)
 
-        handler_a.assert_called_once_with(self.group, self.activity)
-        handler_b.assert_called_once_with(self.group, self.activity)
-        handler_c.assert_called_once_with(self.group, self.activity)
+        handler_a.assert_called_once_with(self.group, self.activity, None)
+        handler_b.assert_called_once_with(self.group, self.activity, None)
+        handler_c.assert_called_once_with(self.group, self.activity, None)
 
     def test_invoke_handlers_no_registrants(self) -> None:
         with mock.patch.dict(workflow_activity_registry.registrations, {}, clear=True):

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -11,43 +11,14 @@ from sentry.workflow_engine.handlers.workflow.workflow_activity_handlers import 
     seer_activity_handler,
 )
 from sentry.workflow_engine.models import Detector
-from sentry.workflow_engine.registry import (
-    invoke_workflow_activity_handlers,
-    workflow_activity_registry,
-)
+from sentry.workflow_engine.registry import workflow_activity_registry
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 
 class WorkflowActivityRegistryTest(TestCase):
-    def setUp(self) -> None:
-        self.group = self.create_group()
-        self.activity = self.create_group_activity(
-            group=self.group, type=ActivityType.SEER_PR_CREATED.value
-        )
-
     def test_registrants(self) -> None:
         assert "seer_activity" in workflow_activity_registry.registrations
         assert len(workflow_activity_registry.registrations) == 1
-
-    def test_invoke_handlers_safely(self) -> None:
-        handler_a = mock.Mock()
-        handler_b = mock.Mock(side_effect=Exception("Test error"))
-        handler_c = mock.Mock()
-
-        with mock.patch.dict(
-            workflow_activity_registry.registrations,
-            {"handler_a": handler_a, "handler_b": handler_b, "handler_c": handler_c},
-            clear=True,
-        ):
-            invoke_workflow_activity_handlers(self.group, self.activity)
-
-        handler_a.assert_called_once_with(self.group, self.activity, None)
-        handler_b.assert_called_once_with(self.group, self.activity, None)
-        handler_c.assert_called_once_with(self.group, self.activity, None)
-
-    def test_invoke_handlers_no_registrants(self) -> None:
-        with mock.patch.dict(workflow_activity_registry.registrations, {}, clear=True):
-            invoke_workflow_activity_handlers(self.group, self.activity)
 
 
 class SeerActivityHandlerTest(TestCase):

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -62,7 +62,7 @@ class SeerActivityHandlerTest(TestCase):
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
     )
     def test_feature_flag_disabled(self, mock_process_workflow_activity: MagicMock) -> None:
-        seer_activity_handler(self.group, self.activity)
+        seer_activity_handler(self.group, self.activity, None)
         mock_process_workflow_activity.delay.assert_not_called()
 
     @with_feature("organizations:workflow-engine-evaluate-seer-activities")
@@ -75,7 +75,7 @@ class SeerActivityHandlerTest(TestCase):
         for activity_type in SEER_WORKFLOW_ACTIVITIES:
             mock_process_workflow_activity.reset_mock()
             activity = self.create_group_activity(group=self.group, type=activity_type.value)
-            seer_activity_handler(self.group, activity)
+            seer_activity_handler(self.group, activity, None)
             assert mock_process_workflow_activity.delay.called, (
                 f"Task not dispatched for {activity_type.value}"
             )
@@ -93,7 +93,7 @@ class SeerActivityHandlerTest(TestCase):
         self, mock_process_workflow_activity: MagicMock
     ) -> None:
         activity = self.create_group_activity(group=self.group, type=ActivityType.NOTE.value)
-        seer_activity_handler(self.group, activity)
+        seer_activity_handler(self.group, activity, None)
 
         mock_process_workflow_activity.delay.assert_not_called()
 
@@ -108,7 +108,7 @@ class SeerActivityHandlerTest(TestCase):
     def test_skips_when_no_detector(
         self, mock_get_detector: MagicMock, mock_process_workflow_activity: MagicMock
     ) -> None:
-        seer_activity_handler(self.group, self.activity)
+        seer_activity_handler(self.group, self.activity, None)
 
         mock_process_workflow_activity.delay.assert_not_called()
 
@@ -122,7 +122,7 @@ class SeerActivityHandlerTest(TestCase):
         )
         self.create_detector_group(detector=detector, group=self.group)
 
-        seer_activity_handler(self.group, self.activity)
+        seer_activity_handler(self.group, self.activity, None)
 
         mock_process_workflow_activity.delay.assert_called_once_with(
             activity_id=self.activity.id,
@@ -142,7 +142,7 @@ class SeerActivityHandlerTest(TestCase):
             project=self.project, type=IssueStreamGroupType.slug
         )
 
-        seer_activity_handler(self.group, self.activity)
+        seer_activity_handler(self.group, self.activity, None)
 
         mock_process_workflow_activity.delay.assert_called_once_with(
             activity_id=self.activity.id,


### PR DESCRIPTION
# Description
Moves the callsite for the activity handler out of the seer operators and into a generic `create_group_activity` method. This method is invoked for all of the activities that we are concerned with.

Move the registry util into handlers/registry, this is to move all the circular dependency issues out of the registry.py file. This also adds the metrics to the util method, so we can get timing metrics on every handler.

An upcoming PR will migrate the status change handlers to use this generic registry.