### PR TITLE
feat(issues): Instrument TRIGGER_AUTOFIX on autofix kickoff

### DIFF
--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -24,6 +24,13 @@ from sentry.apidocs.examples.autofix_examples import AutofixExamples
 from sentry.apidocs.parameters import GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
+from sentry.issues.action_log import (
+    SYSTEM_ACTOR,
+    GroupActionActor,
+    publish_action,
+    resolve_action_source,
+)
+from sentry.issues.action_log.types import TriggerAutofixAction
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.group import Group
 from sentry.ratelimits.config import RateLimitConfig
@@ -240,7 +247,9 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 return Response(status=status.HTTP_404_NOT_FOUND)
             return Response({"run_id": run_id}, status=status.HTTP_202_ACCEPTED)
 
-        # Handle all built-in Seer steps
+        # Handle all built-in Seer steps. A missing run_id means this call starts a new
+        # autofix run (the kickoff); a provided run_id is advancing an existing run.
+        is_autofix_kickoff = run_id is None
         try:
             run_id = trigger_autofix_agent(
                 group=group,
@@ -251,6 +260,21 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 user_context=data.get("user_context"),
                 insert_index=data.get("insert_index"),
             )
+            # Only record the action when autofix is actually kicked off, not on each
+            # subsequent step advancement within the same run.
+            if is_autofix_kickoff:
+                publish_action(
+                    TriggerAutofixAction(),
+                    source=resolve_action_source(request),
+                    group_id=group.id,
+                    organization_id=group.project.organization_id,
+                    project_id=group.project_id,
+                    actor=(
+                        GroupActionActor.user(request.user.id)
+                        if request.user and request.user.is_authenticated
+                        else SYSTEM_ACTOR
+                    ),
+                )
             return Response({"run_id": run_id}, status=status.HTTP_202_ACCEPTED)
         except NoSeerQuotaException:
             return Response("No budget for Seer Autofix.", status=status.HTTP_402_PAYMENT_REQUIRED)

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+from sentry.issues.action_log.types import TriggerAutofixAction
 from sentry.seer.agent.client_models import SeerRunState
 from sentry.seer.autofix.autofix_agent import AutofixStep, NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -102,6 +103,60 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             user_context=None,
             insert_index=3,
         )
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.publish_action", autospec=True)
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    def test_kickoff_emits_trigger_autofix_action(self, mock_trigger, mock_publish):
+        # A kickoff (no run_id) records the action.
+        group = self.create_group()
+        mock_trigger.return_value = 123
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "root_cause"},
+            format="json",
+        )
+
+        assert response.status_code == 202, response.data
+        mock_publish.assert_called_once()
+        assert isinstance(mock_publish.call_args.args[0], TriggerAutofixAction)
+        assert mock_publish.call_args.kwargs["group_id"] == group.id
+        assert mock_publish.call_args.kwargs["actor"].actor_id == self.user.id
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.publish_action", autospec=True)
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    def test_advancing_existing_run_skips_action(self, mock_trigger, mock_publish):
+        # Advancing an existing run (run_id provided) is steering, not a new trigger.
+        group = self.create_group()
+        mock_trigger.return_value = 42
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "solution", "run_id": 42},
+            format="json",
+        )
+
+        assert response.status_code == 202, response.data
+        mock_publish.assert_not_called()
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.publish_action", autospec=True)
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_coding_agent_handoff")
+    def test_coding_agent_handoff_skips_action(self, mock_handoff, mock_publish):
+        # The handoff path returns before the built-in-step branch, so it must not log.
+        mock_handoff.return_value = {"successes": [], "failures": []}
+        group = self.create_group()
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "coding_agent_handoff", "run_id": 123, "integration_id": 456},
+            format="json",
+        )
+
+        assert response.status_code == 202, response.data
+        mock_publish.assert_not_called()
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_post_continue_unknown_run_returns_404(self, mock_trigger_explorer):


### PR DESCRIPTION
Records a `TriggerAutofixAction` in the action log when a Seer autofix run is kicked off via `GroupAutofixEndpoint`, capturing **who triggered it** — the actor (authenticated user, or `SYSTEM` for automated kickoffs) and source (`mcp:cursor`, web, slack, cli, …).

### Why this is attribution, not duplication

The run's lifecycle (`SEER_RCA_*`, `SEER_SOLUTION_*`, `SEER_CODING_*`, `SEER_PR_CREATED`) is already recorded as issue Activities (#115486), so a trigger entry can look redundant with `SEER_RCA_STARTED`. It isn't — the kickoff request is the **only** point where the actor is knowable. `request.user` is never threaded into `trigger_autofix_agent`, and the lifecycle activities are built from async Seer webhooks with no user (system-attributed by construction). Mirroring them could never recover the triggering user; this entry captures the attribution the activity model structurally drops.

### Scope

Only the **kickoff** is logged (a new run — no `run_id` on input). `coding_agent_handoff`/`open_pr` return earlier, and advancing an existing run isn't re-logged, so one engagement = one entry.

Logs/metrics only; the DB write stays gated behind the action-log option.

Refs ID-1591
