### PR TITLE
ref(mypy): remove 5 serializers from autoderive denylist

### DIFF
--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -1,15 +1,28 @@
+from typing import TypedDict
+
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.commit import CommitWithReleaseSerializer
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.group import Group
 from sentry.models.pullrequest import PullRequest
-from sentry.sentry_apps.api.serializers.sentry_app_avatar import SentryAppAvatarSerializer
+from sentry.sentry_apps.api.serializers.sentry_app_avatar import (
+    SentryAppAvatarSerializer,
+    SentryAppAvatarSerializerResponse,
+)
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.services.app.model import RpcSentryApp
 from sentry.types.activity import ActivityType
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
+
+
+class _MinimalSentryAppPayload(TypedDict):
+    id: str
+    name: str
+    slug: str
+    avatars: list[SentryAppAvatarSerializerResponse]
+
 
 COMMIT_ACTIVITY_TYPES = {
     ActivityType.SET_RESOLVED_IN_COMMIT.value,
@@ -39,7 +52,7 @@ class ActivitySerializer(Serializer):
         if user_ids:
             sentry_apps_list = app_service.get_sentry_apps_by_proxy_users(proxy_user_ids=user_ids)
         # Minimal Sentry App serialization to keep the payload minimal
-        sentry_apps = {
+        sentry_apps: dict[str, _MinimalSentryAppPayload] = {
             str(app.proxy_user_id): {
                 "id": str(app.id),
                 "name": app.name,

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -17,7 +17,7 @@ from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
 
 
-class _MinimalSentryAppPayload(TypedDict):
+class _ActivitySentryAppEmbed(TypedDict):
     id: str
     name: str
     slug: str
@@ -52,7 +52,7 @@ class ActivitySerializer(Serializer):
         if user_ids:
             sentry_apps_list = app_service.get_sentry_apps_by_proxy_users(proxy_user_ids=user_ids)
         # Minimal Sentry App serialization to keep the payload minimal
-        sentry_apps: dict[str, _MinimalSentryAppPayload] = {
+        sentry_apps: dict[str, _ActivitySentryAppEmbed] = {
             str(app.proxy_user_id): {
                 "id": str(app.id),
                 "name": app.name,

--- a/src/sentry/api/serializers/models/incidentactivity.py
+++ b/src/sentry/api/serializers/models/incidentactivity.py
@@ -17,7 +17,7 @@ class IncidentActivitySerializerResponse(TypedDict):
     user: EventUserApiContext
     type: int
     value: str
-    previousValue: str
+    previousValue: str | None
     comment: str
     dateCreated: datetime
 

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -107,8 +107,8 @@ class RuleSerializerResponse(RuleSerializerResponseOptional):
     conditions: list[dict]
     filters: list[dict]
     actions: list[dict]
-    actionMatch: str
-    filterMatch: str
+    actionMatch: str | None
+    filterMatch: str | None
     frequency: int
     name: str
     dateCreated: datetime

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from drf_spectacular.utils import extend_schema_serializer
+
+if TYPE_CHECKING:
+    from sentry.incidents.endpoints.serializers.incident import IncidentSerializerResponse
 
 
 class AlertRuleSerializerResponseOptional(TypedDict, total=False):
@@ -20,7 +23,7 @@ class AlertRuleSerializerResponseOptional(TypedDict, total=False):
     weeklyAvg: float | None
     totalThisWeek: int | None
     snooze: bool | None
-    latestIncident: datetime | None
+    latestIncident: IncidentSerializerResponse | None
     errors: list[str] | None
     sensitivity: str | None
     seasonality: str | None

--- a/src/sentry/sentry_apps/api/serializers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/serializers/sentry_app.py
@@ -101,7 +101,7 @@ class SentryAppSerializer(Serializer):
         return {
             item: {
                 "features": app_feature_attrs.get(item.id, set()),
-                "avatars": app_avatar_attrs.get(item.id, set()),
+                "avatars": app_avatar_attrs.get(item.id, []),
                 "owner": organizations.get(item.owner_id, None),
                 "application": applications.get(item.application_id, None),
                 "user_org_ids": user_org_ids,
@@ -125,7 +125,7 @@ class SentryAppSerializer(Serializer):
             allowedOrigins=application.get_allowed_origins(),
             author=obj.author,
             avatars=serialize(
-                objects=attrs.get("avatars"),
+                objects=attrs["avatars"],
                 user=user,
                 serializer=ResponseSentryAppAvatarSerializer(),
             ),

--- a/src/sentry/sentry_apps/models/sentry_app_avatar.py
+++ b/src/sentry/sentry_apps/models/sentry_app_avatar.py
@@ -32,14 +32,14 @@ class SentryAppAvatarTypes(Enum):
 class SentryAppAvatarManager(BaseManager["SentryAppAvatar"]):
     def get_by_apps_as_dict(
         self, sentry_apps: Iterable[SentryApp]
-    ) -> dict[int, set[SentryAppAvatar]]:
+    ) -> dict[int, list[SentryAppAvatar]]:
         """
         Returns a dict mapping sentry_app_id (key) to List[SentryAppAvatar] (value)
         """
         avatars = SentryAppAvatar.objects.filter(sentry_app__in=sentry_apps)
-        avatar_to_app_map = defaultdict(set)
+        avatar_to_app_map: dict[int, list[SentryAppAvatar]] = defaultdict(list)
         for avatar in avatars:
-            avatar_to_app_map[avatar.sentry_app_id].add(avatar)
+            avatar_to_app_map[avatar.sentry_app_id].append(avatar)
         return avatar_to_app_map
 
 

--- a/src/sentry/tasks/user_report.py
+++ b/src/sentry/tasks/user_report.py
@@ -31,7 +31,7 @@ def user_report(
     project = Project.objects.get_from_cache(id=project_id)
     if report_id:
         user_report = UserReport.objects.get(id=report_id)
-        user_report = serialize(user_report, AnonymousUser(), UserReportWithGroupSerializer())
-        safe_execute(mail_adapter.handle_user_report, report=user_report, project=project)
+        serialized_report = serialize(user_report, AnonymousUser(), UserReportWithGroupSerializer())
+        safe_execute(mail_adapter.handle_user_report, report=serialized_report, project=project)
     else:
         safe_execute(mail_adapter.handle_user_report, report=report, project=project)

--- a/src/sentry/users/api/serializers/authenticator.py
+++ b/src/sentry/users/api/serializers/authenticator.py
@@ -37,6 +37,15 @@ class AuthenticatorInterfaceSerializerResponse(TypedDict):
     authId: NotRequired[str]
     createdAt: NotRequired[datetime]
     lastUsedAt: NotRequired[datetime | None]
+    # Interface-specific extensions populated by enroll/details endpoints
+    # after calling serialize(); kept as NotRequired so the base serializer
+    # output remains a structurally valid AuthenticatorInterfaceSerializerResponse.
+    form: NotRequired[list[dict[str, Any]]]
+    secret: NotRequired[str]
+    qrcode: NotRequired[str]
+    challenge: NotRequired[dict[str, Any]]
+    codes: NotRequired[list[str]]
+    devices: NotRequired[list[dict[str, Any]]]
 
 
 @register(AuthenticatorInterface)

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -124,11 +124,11 @@ class WorkflowRuleSerializerTest(TestCase):
             workflow, self.user, WorkflowEngineRuleSerializer(prepare_component_fields=True)
         )
 
-        # Pop and compare lists of dicts
-        rule_conditions = serialized_rule.pop("conditions")
-        workflow_conditions = serialized_workflow_rule.pop("conditions")
-        rule_filters = serialized_rule.pop("filters")
-        workflow_filters = serialized_workflow_rule.pop("filters")
+        # Compare lists of dicts independent of order, then compare the rest.
+        rule_conditions = serialized_rule["conditions"]
+        workflow_conditions = serialized_workflow_rule["conditions"]
+        rule_filters = serialized_rule["filters"]
+        workflow_filters = serialized_workflow_rule["filters"]
 
         assert len(rule_conditions) == len(workflow_conditions)
         for condition in rule_conditions:
@@ -138,14 +138,17 @@ class WorkflowRuleSerializerTest(TestCase):
         for filter in rule_filters:
             assert filter in workflow_filters
 
-        rule_actions = serialized_rule.pop("actions")
-        workflow_actions = serialized_workflow_rule.pop("actions")
+        rule_actions = serialized_rule["actions"]
+        workflow_actions = serialized_workflow_rule["actions"]
 
         assert len(rule_actions) == len(workflow_actions)
         for action in rule_actions:
             assert action in workflow_actions
 
-        assert serialized_rule == serialized_workflow_rule
+        list_keys = {"conditions", "filters", "actions"}
+        rule_rest = {k: v for k, v in serialized_rule.items() if k not in list_keys}
+        workflow_rest = {k: v for k, v in serialized_workflow_rule.items() if k not in list_keys}
+        assert rule_rest == workflow_rest
 
     def test_fetch_workflow_users(self) -> None:
         workflow = self.create_workflow(created_by_id=self.user.id)

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Any
 
 from sentry.api.serializers import serialize
@@ -54,14 +55,14 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
         }
 
     @staticmethod
-    def _sort_triggers(incident: dict[str, Any]) -> dict[str, Any]:
+    def _sort_triggers(incident: Mapping[str, Any]) -> dict[str, Any]:
         """Sort triggers by label for order-independent comparison."""
-        incident = dict(incident)
-        incident["alertRule"] = dict(incident["alertRule"])
-        incident["alertRule"]["triggers"] = sorted(
-            incident["alertRule"]["triggers"], key=lambda t: t["label"]
+        out = dict(incident)
+        out["alertRule"] = dict(out["alertRule"])
+        out["alertRule"]["triggers"] = sorted(
+            out["alertRule"]["triggers"], key=lambda t: t["label"]
         )
-        return incident
+        return out
 
     def test_simple(self) -> None:
         serialized_incident = serialize(
@@ -144,8 +145,10 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
             self.user,
             WorkflowEngineIncidentSerializer(expand=["activities"]),
         )
-        assert len(serialized_incident["activities"]) == 1
-        assert serialized_incident["activities"][0] == {
+        activities = serialized_incident["activities"]
+        assert activities is not None
+        assert len(activities) == 1
+        assert activities[0] == {
             "id": str(gopa.id),
             "type": IncidentActivityType.STATUS_CHANGE.value,
             "value": str(IncidentStatus.CRITICAL.value),
@@ -172,6 +175,7 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
             WorkflowEngineIncidentSerializer(expand=["activities"]),
         )
         activities = serialized_incident["activities"]
+        assert activities is not None
         assert len(activities) == 2
         assert activities[0]["value"] == str(IncidentStatus.CRITICAL.value)
         assert activities[0]["previousValue"] is None
@@ -198,6 +202,7 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
             WorkflowEngineIncidentSerializer(expand=["activities"]),
         )
         activities = serialized_incident["activities"]
+        assert activities is not None
         assert len(activities) == 2
         assert activities[1]["id"] == str(gopa_closed.id)
         assert activities[1]["value"] == str(IncidentStatus.CLOSED.value)
@@ -215,5 +220,7 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
             self.user,
             WorkflowEngineIncidentSerializer(expand=["activities"]),
         )
-        activity_ids = [a["id"] for a in serialized_incident["activities"]]
+        activities = serialized_incident["activities"]
+        assert activities is not None
+        activity_ids = [a["id"] for a in activities]
         assert str(gopa_malformed.id) not in activity_ids

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
@@ -161,7 +161,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
                 },
             ],
             "popularity": self.popularity,
-            "avatars": set(),
+            "avatars": [],
             "metadata": {},
         }
 

--- a/tools/mypy_helpers/serializer_autoderive.py
+++ b/tools/mypy_helpers/serializer_autoderive.py
@@ -29,13 +29,7 @@ _AUTODERIVE_DENYLIST: frozenset[str] = frozenset(
         "sentry.api.serializers.models.project.ProjectSerializer",
         "sentry.api.serializers.models.release.GroupEventReleaseSerializer",
         "sentry.api.serializers.models.release.ReleaseSerializer",
-        "sentry.api.serializers.models.rule.WorkflowEngineRuleSerializer",
         "sentry.api.serializers.models.team.BaseTeamSerializer",
-        "sentry.api.serializers.models.userreport.UserReportSerializer",
-        "sentry.incidents.endpoints.serializers.workflow_engine_detector.WorkflowEngineDetectorSerializer",
-        "sentry.incidents.endpoints.serializers.workflow_engine_incident.WorkflowEngineIncidentSerializer",
-        "sentry.sentry_apps.api.serializers.sentry_app_avatar.SentryAppAvatarSerializer",
-        "sentry.users.api.serializers.authenticator.AuthenticatorInterfaceSerializer",
         "sentry.users.api.serializers.user.UserSerializer",
     }
 )


### PR DESCRIPTION
Removes `AuthenticatorInterfaceSerializer`, `UserReportSerializer`, `SentryAppAvatarSerializer`, `WorkflowEngineRuleSerializer`, and the `WorkflowEngineDetector` / `WorkflowEngineIncidentSerializer` pair from `_AUTODERIVE_DENYLIST` (16 → 10). With these out, the autoderive plugin rewrites their bare `Serializer` base to `Serializer[ConcreteResponse]`, so the free `serialize(...)` call sites get the typed return instead of `Any`.

The bundled drift fixes are at the source, not at the call sites:

- `AuthenticatorInterfaceSerializerResponse` gains six `NotRequired` keys (`form`, `secret`, `qrcode`, `challenge`, `codes`, `devices`) covering the interface-specific extensions the enroll/details endpoints append after `serialize()`.
- `SentryAppAvatarManager.get_by_apps_as_dict` returns `list[...]` instead of `set[...]` (matches its own docstring).
- `latestIncident` on `AlertRuleSerializerResponseOptional` is `IncidentSerializerResponse | None`, not `datetime | None` — the workflow_engine detector serializer has always attached the full incident dict.
- `RuleSerializerResponse.actionMatch`/`filterMatch` and `IncidentActivitySerializerResponse.previousValue` widen to `str | None` to match what the workflow_engine serializers actually return.