### PR TITLE
docs(api): Support method-level server overrides

### DIFF
--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -101,10 +101,12 @@ class CustomGenerator(SchemaGenerator):
 
 # Collected during preprocessing, used in postprocessing
 _ENDPOINT_SERVERS: dict[str, list[dict[str, Any]]] = {}
+_ENDPOINT_METHOD_SERVERS: dict[str, dict[str, list[dict[str, Any]]]] = {}
 
 
 def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, rename
     _ENDPOINT_SERVERS.clear()
+    _ENDPOINT_METHOD_SERVERS.clear()
 
     filtered = []
     ownership_data: dict[ApiOwner, dict] = {}
@@ -113,6 +115,12 @@ def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, 
         endpoint_servers = getattr(callback.view_class, "servers", None)
         if endpoint_servers is not None:
             _ENDPOINT_SERVERS[path] = endpoint_servers
+
+        endpoint_method_servers = getattr(callback.view_class, "method_servers", None)
+        if endpoint_method_servers is not None and method in endpoint_method_servers:
+            _ENDPOINT_METHOD_SERVERS.setdefault(path, {})[method.lower()] = endpoint_method_servers[
+                method
+            ]
 
         owner_team = callback.view_class.owner
         if owner_team not in ownership_data:
@@ -226,6 +234,12 @@ def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> An
         if path in result["paths"]:
             for method_info in result["paths"][path].values():
                 method_info["servers"] = servers
+
+    for path, method_servers in _ENDPOINT_METHOD_SERVERS.items():
+        if path in result["paths"]:
+            for method, servers in method_servers.items():
+                if method in result["paths"][path]:
+                    result["paths"][path][method]["servers"] = servers
 
     _fix_issue_paths(result)
 

--- a/tests/apidocs/test_hooks.py
+++ b/tests/apidocs/test_hooks.py
@@ -1,14 +1,20 @@
 from unittest import TestCase
 
-from sentry.apidocs.hooks import _ENDPOINT_SERVERS, custom_postprocessing_hook
+from sentry.apidocs.hooks import (
+    _ENDPOINT_METHOD_SERVERS,
+    _ENDPOINT_SERVERS,
+    custom_postprocessing_hook,
+)
 
 
 class EndpointServersTest(TestCase):
     def setUp(self) -> None:
         _ENDPOINT_SERVERS.clear()
+        _ENDPOINT_METHOD_SERVERS.clear()
 
     def tearDown(self) -> None:
         _ENDPOINT_SERVERS.clear()
+        _ENDPOINT_METHOD_SERVERS.clear()
 
     def test_servers_applied_to_endpoint(self) -> None:
         """Test that servers from _ENDPOINT_SERVERS are applied to matching paths."""
@@ -44,6 +50,38 @@ class EndpointServersTest(TestCase):
         ]
         # Servers should NOT be applied to non-matching endpoint
         assert "servers" not in processed["paths"]["/api/0/other/endpoint/"]["get"]
+
+    def test_method_servers_applied_to_single_method(self) -> None:
+        _ENDPOINT_METHOD_SERVERS["/api/0/releases/{version}/files/"] = {
+            "post": [{"url": "https://{region}.sentry.io"}]
+        }
+
+        result = {
+            "components": {"schemas": {}},
+            "paths": {
+                "/api/0/releases/{version}/files/": {
+                    "get": {
+                        "tags": ["Releases"],
+                        "description": "Get files",
+                        "operationId": "get files",
+                        "parameters": [],
+                    },
+                    "post": {
+                        "tags": ["Releases"],
+                        "description": "Upload file",
+                        "operationId": "upload file",
+                        "parameters": [],
+                    },
+                },
+            },
+        }
+
+        processed = custom_postprocessing_hook(result, None)
+
+        assert processed["paths"]["/api/0/releases/{version}/files/"]["post"]["servers"] == [
+            {"url": "https://{region}.sentry.io"}
+        ]
+        assert "servers" not in processed["paths"]["/api/0/releases/{version}/files/"]["get"]
 
 
 class FixIssueRoutesTest(TestCase):


### PR DESCRIPTION
Add apidocs support for method-level `servers` overrides. This lets endpoint classes keep a path-level default while attaching a region-specific server only to the HTTP method that needs it.

**Release File Uploads**

Release file upload docs need `https://{region}.sentry.io` on `POST`, but the same paths also expose metadata reads. The new `method_servers` hook keeps that upload guidance scoped to the upload method instead of applying it to every method on the path.

**Hook Coverage**

Add a focused postprocessing test that verifies the method-level server appears on `POST` and does not leak onto `GET`.
