### PR TITLE
feat(preprod): Smart-download or email-deliver snapshot images

### DIFF
--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.spec.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.spec.tsx
@@ -1,0 +1,139 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+
+import {downloadFromHref} from 'sentry/utils/downloadFromHref';
+import type {SnapshotDetailsApiResponse} from 'sentry/views/preprod/types/snapshotTypes';
+
+import {SnapshotHeaderActions} from './snapshotHeaderActions';
+
+jest.mock('sentry/utils/downloadFromHref');
+
+const ORG_SLUG = 'org-slug';
+const ARTIFACT_ID = '123';
+const API_URL = `/organizations/${ORG_SLUG}/preprodartifacts/snapshots/${ARTIFACT_ID}/`;
+const ARCHIVE_URL = `/organizations/${ORG_SLUG}/preprodartifacts/snapshots/${ARTIFACT_ID}/archive/`;
+
+const data = {
+  head_artifact_id: ARTIFACT_ID,
+  project_id: '456',
+  comparison_type: 'solo',
+  comparison_state: 'success',
+  approval_status: 'approved',
+  approvers: [],
+  base_artifact_id: null,
+  image_count: 0,
+  images: [],
+  state: 'processed',
+  vcs_info: {},
+  added: [],
+  added_count: 0,
+  changed: [],
+  changed_count: 0,
+  removed: [],
+  removed_count: 0,
+  unchanged: [],
+  unchanged_count: 0,
+} as unknown as SnapshotDetailsApiResponse;
+
+function renderActions() {
+  const organization = OrganizationFixture({slug: ORG_SLUG});
+  return render(
+    <SnapshotHeaderActions data={data} organizationSlug={ORG_SLUG} apiUrl={API_URL} />,
+    {organization}
+  );
+}
+
+async function clickDownloadImages() {
+  await userEvent.click(screen.getByRole('button', {name: 'More actions'}));
+  await userEvent.click(await screen.findByText('Download Images'));
+}
+
+describe('SnapshotHeaderActions download images', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+  });
+
+  it('downloads directly when the archive is already built', async () => {
+    const probeMock = MockApiClient.addMockResponse({
+      url: ARCHIVE_URL,
+      method: 'GET',
+      body: {ready: true},
+    });
+    const buildMock = MockApiClient.addMockResponse({
+      url: ARCHIVE_URL,
+      method: 'POST',
+      statusCode: 202,
+      body: {detail: 'building'},
+    });
+
+    renderActions();
+    renderGlobalModal();
+    await clickDownloadImages();
+
+    await waitFor(() => expect(probeMock).toHaveBeenCalled());
+    await waitFor(() => expect(downloadFromHref).toHaveBeenCalledTimes(1));
+    expect(buildMock).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText(/Export all snapshots to a zip file/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('confirms then triggers a build when the archive is not ready', async () => {
+    MockApiClient.addMockResponse({
+      url: ARCHIVE_URL,
+      method: 'GET',
+      body: {ready: false},
+    });
+    const buildMock = MockApiClient.addMockResponse({
+      url: ARCHIVE_URL,
+      method: 'POST',
+      statusCode: 202,
+      body: {detail: 'building'},
+    });
+
+    renderActions();
+    renderGlobalModal();
+    await clickDownloadImages();
+
+    expect(
+      await screen.findByText(/Export all snapshots to a zip file/)
+    ).toBeInTheDocument();
+    expect(buildMock).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
+
+    await waitFor(() => expect(buildMock).toHaveBeenCalledTimes(1));
+    expect(downloadFromHref).not.toHaveBeenCalled();
+  });
+
+  it('does not build when the confirm modal is cancelled', async () => {
+    MockApiClient.addMockResponse({
+      url: ARCHIVE_URL,
+      method: 'GET',
+      body: {ready: false},
+    });
+    const buildMock = MockApiClient.addMockResponse({
+      url: ARCHIVE_URL,
+      method: 'POST',
+      statusCode: 202,
+      body: {detail: 'building'},
+    });
+
+    renderActions();
+    renderGlobalModal();
+    await clickDownloadImages();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Cancel'}));
+
+    expect(buildMock).not.toHaveBeenCalled();
+    expect(downloadFromHref).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -10,6 +10,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
+import {openConfirmModal} from 'sentry/components/confirm';
 import {ConfirmDelete} from 'sentry/components/confirmDelete';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
@@ -62,6 +63,8 @@ export function SnapshotHeaderActions({
   const project = ProjectsStore.getById(data.project_id);
   const [isApproving, setIsApproving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const exportConfirmedRef = useRef(false);
 
   const comparisonState = data.comparison_state;
   const approvalStatus = data.approval_status;
@@ -168,9 +171,71 @@ export function SnapshotHeaderActions({
   }, [apiUrl, navigate]);
 
   const handleDownloadImages = useCallback(() => {
-    const downloadUrl = `/api/0/organizations/${organizationSlug}/preprodartifacts/snapshots/${data.head_artifact_id}/download/`;
+    const archiveUrl = `/organizations/${organizationSlug}/preprodartifacts/snapshots/${data.head_artifact_id}/archive/`;
 
-    downloadFromHref(`snapshot_images_${data.head_artifact_id}.zip`, downloadUrl);
+    const triggerBuild = () => {
+      setIsExporting(true);
+      clientRef.current.request(archiveUrl, {
+        method: 'POST',
+        success: () => {
+          setIsExporting(false);
+          addSuccessMessage(
+            t(
+              "We're building your snapshot images — we'll email you a download link when it's ready."
+            )
+          );
+        },
+        error: (resp: any) => {
+          setIsExporting(false);
+          if (resp?.status === 403) {
+            handleStaffPermissionError(resp?.responseJSON?.detail);
+          } else {
+            addErrorMessage(t('Failed to start snapshot image export.'));
+          }
+        },
+      });
+    };
+
+    // Probe readiness first: a built archive downloads immediately, otherwise we
+    // confirm and kick off an async build that emails a link when it's ready.
+    setIsExporting(true);
+    clientRef.current.request(archiveUrl, {
+      method: 'GET',
+      success: (resp: {ready?: boolean}) => {
+        if (resp?.ready) {
+          setIsExporting(false);
+          downloadFromHref(
+            `snapshot_images_${data.head_artifact_id}.zip`,
+            `/api/0${archiveUrl}?download=true`
+          );
+          return;
+        }
+        exportConfirmedRef.current = false;
+        openConfirmModal({
+          header: t('Export all snapshots to a zip file'),
+          message: t(
+            "Exporting can take a bit, so we'll email you when the .zip is ready and available for download here."
+          ),
+          onConfirm: () => {
+            exportConfirmedRef.current = true;
+            triggerBuild();
+          },
+          onClose: () => {
+            if (!exportConfirmedRef.current) {
+              setIsExporting(false);
+            }
+          },
+        });
+      },
+      error: (resp: any) => {
+        setIsExporting(false);
+        if (resp?.status === 403) {
+          handleStaffPermissionError(resp?.responseJSON?.detail);
+        } else {
+          addErrorMessage(t('Failed to check snapshot image download.'));
+        }
+      },
+    });
   }, [organizationSlug, data.head_artifact_id]);
 
   return (
@@ -277,6 +342,7 @@ export function SnapshotHeaderActions({
               ),
               onAction: handleDownloadImages,
               textValue: t('Download Images'),
+              disabled: isExporting,
             },
             {
               key: 'rerun-status-checks',


### PR DESCRIPTION
The snapshot "Download Images" action now resolves through the async archive endpoint instead of a synchronous on-the-fly download. It probes readiness first: if the archive is already built it downloads immediately; otherwise it confirms with the user and kicks off a background build that emails a download link when ready.

**Probe-then-build flow**

Clicking "Download Images" issues a readiness `GET` to the `/archive/` endpoint. When `{ready: true}`, it downloads the prebuilt zip directly (`?download=true`). When not ready, it opens a confirm modal and `POST`s to enqueue a build, telling the user they'll be emailed a link once it's done.

**Depends on the objectstore `/archive/` backend**

This targets the objectstore-backed archive contract (`GET` → `{ready}`, `POST` to enqueue, `?download=true` to stream), which ships in #116928. That backend must land and deploy first — frontend and backend deploy separately, so this is a separate PR per the repo's split rule.