### PR TITLE
feat(preprod): Set Content-Disposition filename on snapshot images

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import os
+from urllib.parse import quote
 
 from django.http import HttpResponse
 from objectstore_client.client import RequestError
@@ -17,6 +19,22 @@ from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger(__name__)
+
+
+def _content_disposition(raw_filename: str | None) -> str | None:
+    if not raw_filename:
+        return None
+
+    filename = os.path.basename(raw_filename.replace("\\", "/"))
+    filename = "".join(c for c in filename if c >= " " and c != "\x7f").replace('"', "").strip()
+    if not filename or filename in (".", ".."):
+        return None
+
+    try:
+        filename.encode("ascii")
+        return f'inline; filename="{filename}"'
+    except UnicodeEncodeError:
+        return f"inline; filename*=utf-8''{quote(filename)}"
 
 
 @cell_silo_endpoint
@@ -41,7 +59,7 @@ class ProjectPreprodArtifactImageEndpoint(ProjectEndpoint):
 
     def get(
         self,
-        _: Request,
+        request: Request,
         project: Project,
         image_id: str,
     ) -> HttpResponse:
@@ -57,7 +75,12 @@ class ProjectPreprodArtifactImageEndpoint(ProjectEndpoint):
             image_data = result.payload.read()
 
             # Detect content type from the image data
-            return HttpResponse(image_data, content_type=result.metadata.content_type)
+            response = HttpResponse(image_data, content_type=result.metadata.content_type)
+            # Let "Save Image As" prefill the original filename the frontend supplies.
+            content_disposition = _content_disposition(request.GET.get("filename"))
+            if content_disposition:
+                response["Content-Disposition"] = content_disposition
+            return response
         except RequestError as e:
             if e.status == 404:
                 return Response({"detail": "Image not found"}, status=404)

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_image.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_image.py
@@ -104,6 +104,136 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         mock_get_session.assert_called_once_with(self.org.id, self.project.id)
         mock_session.get.assert_called_once_with(f"{self.org.id}/{self.project.id}/{self.image_id}")
 
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    def test_content_disposition_with_filename(self, mock_get_session):
+        mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
+        mock_get_session.return_value = mock_session
+
+        url = self._get_url()
+        response = self.client.get(
+            url,
+            data={"filename": "alert-dark-danger-no-icon.png"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+
+        assert response.status_code == 200
+        assert response["Content-Disposition"] == 'inline; filename="alert-dark-danger-no-icon.png"'
+
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    def test_no_content_disposition_without_filename_param(self, mock_get_session):
+        mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
+        mock_get_session.return_value = mock_session
+
+        url = self._get_url()
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 200
+        assert not response.has_header("Content-Disposition")
+
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    def test_content_disposition_strips_path_traversal(self, mock_get_session):
+        mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
+        mock_get_session.return_value = mock_session
+
+        url = self._get_url()
+        response = self.client.get(
+            url,
+            data={"filename": "static/app/components/core/alert/alert-dark-danger-no-icon.png"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+
+        assert response.status_code == 200
+        assert response["Content-Disposition"] == 'inline; filename="alert-dark-danger-no-icon.png"'
+
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    def test_content_disposition_strips_parent_dir_traversal(self, mock_get_session):
+        mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
+        mock_get_session.return_value = mock_session
+
+        url = self._get_url()
+        response = self.client.get(
+            url,
+            data={"filename": "../../etc/passwd"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+
+        assert response.status_code == 200
+        assert response["Content-Disposition"] == 'inline; filename="passwd"'
+
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    def test_content_disposition_strips_header_injection(self, mock_get_session):
+        mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
+        mock_get_session.return_value = mock_session
+
+        url = self._get_url()
+        response = self.client.get(
+            url,
+            data={"filename": "foo.png\r\nSet-Cookie: evil=1"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+
+        assert response.status_code == 200
+        cd = response["Content-Disposition"]
+        assert "\r" not in cd
+        assert "\n" not in cd
+        assert not response.has_header("Set-Cookie")
+
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    def test_content_disposition_strips_quotes(self, mock_get_session):
+        mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
+        mock_get_session.return_value = mock_session
+
+        url = self._get_url()
+        response = self.client.get(
+            url,
+            data={"filename": 'foo".png'},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+
+        assert response.status_code == 200
+        assert response["Content-Disposition"] == 'inline; filename="foo.png"'
+
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    def test_no_content_disposition_when_filename_empties_out(self, mock_get_session):
+        mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
+        mock_get_session.return_value = mock_session
+
+        url = self._get_url()
+        response = self.client.get(
+            url,
+            data={"filename": "../"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+
+        assert response.status_code == 200
+        assert not response.has_header("Content-Disposition")
+
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    def test_content_disposition_non_ascii_filename(self, mock_get_session):
+        mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
+        mock_get_session.return_value = mock_session
+
+        url = self._get_url()
+        response = self.client.get(
+            url,
+            data={"filename": "café.png"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
+        )
+
+        assert response.status_code == 200
+        cd = response["Content-Disposition"]
+        assert cd.startswith("inline; ")
+        assert "filename*=utf-8''caf%C3%A9.png" in cd
+
     def test_endpoint_requires_project_access(self) -> None:
         other_user = self.create_user()
         self.login_as(user=other_user)


### PR DESCRIPTION
Right-clicking a snapshot image and choosing "Save Image As" prefilled the generic name `download` with no extension, because the image endpoint never sent a `Content-Disposition` header and the image URL ends in a trailing slash.

The endpoint now accepts an optional `filename` query param and reflects it into an **`inline`** `Content-Disposition` header so the browser suggests a real filename. `inline` (not `attachment`) keeps images rendering in-page while still naming the saved file.

**Filename sanitization**

The param is untrusted, so it is reduced to a bare basename before use: directory components and path traversal are stripped, then control characters (preventing header injection) and quotes. Non-ASCII names fall back to the RFC 5987 `filename*=utf-8''…` form. If nothing usable remains, no header is sent and behavior is unchanged.

Backend half of a two-PR change; the frontend that supplies the `filename` param is stacked on top.