### PR TITLE
feat(preprod): Prefill original filename when saving snapshot images

### DIFF
--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -10,6 +10,7 @@ import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
 import {t} from 'sentry/locale';
 import {computeMaskSize} from 'sentry/views/preprod/snapshots/main/computeMaskSize';
 import {DiffOverlay} from 'sentry/views/preprod/snapshots/main/diffOverlay';
+import {getSnapshotImageUrl} from 'sentry/views/preprod/types/snapshotTypes';
 import type {SnapshotDiffPair} from 'sentry/views/preprod/types/snapshotTypes';
 
 import {useBufferedImageGroup} from './useBufferedImageUrl';
@@ -45,8 +46,8 @@ export function DiffImageDisplay({
 }: DiffImageDisplayProps) {
   const [onionOpacity, setOnionOpacity] = useState(50);
 
-  const baseImageUrl = `${imageBaseUrl}${pair.base_image.key}/`;
-  const headImageUrl = `${imageBaseUrl}${pair.head_image.key}/`;
+  const baseImageUrl = getSnapshotImageUrl(imageBaseUrl, pair.base_image);
+  const headImageUrl = getSnapshotImageUrl(imageBaseUrl, pair.head_image);
   const diffMaskUrl = pair.diff_image_key
     ? `${diffImageBaseUrl}${pair.diff_image_key}/`
     : null;

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -20,7 +20,11 @@ import type {
   SnapshotDiffPair,
   SnapshotImage,
 } from 'sentry/views/preprod/types/snapshotTypes';
-import {DiffStatus, getImageName} from 'sentry/views/preprod/types/snapshotTypes';
+import {
+  DiffStatus,
+  getImageName,
+  getSnapshotImageUrl,
+} from 'sentry/views/preprod/types/snapshotTypes';
 
 import type {DiffMode} from './imageDisplay/diffImageDisplay';
 import {CollapsibleBadgeRow} from './collapsibleBadgeRow';
@@ -79,8 +83,8 @@ export const PairCard = memo(function PairCard({
 }) {
   const [isDark, setIsDark] = useState(false);
   const image = pair.head_image;
-  const baseUrl = `${imageBaseUrl}${pair.base_image.key}/`;
-  const headUrl = `${imageBaseUrl}${image.key}/`;
+  const baseUrl = getSnapshotImageUrl(imageBaseUrl, pair.base_image);
+  const headUrl = getSnapshotImageUrl(imageBaseUrl, image);
 
   const handleSelect = onSelectSnapshot
     ? (e: React.MouseEvent) => {
@@ -181,7 +185,7 @@ export const ImageCard = memo(function ImageCard({
   onSelectSnapshot?: (key: string | null) => void;
 }) {
   const [isDark, setIsDark] = useState(false);
-  const imageUrl = `${imageBaseUrl}${image.key}/`;
+  const imageUrl = getSnapshotImageUrl(imageBaseUrl, image);
   let status: DiffStatus | null;
   switch (cardType) {
     case 'solo':

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -12,7 +12,11 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useBreakpoints} from 'sentry/utils/useBreakpoints';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {DiffStatus, getImageName} from 'sentry/views/preprod/types/snapshotTypes';
+import {
+  DiffStatus,
+  getImageName,
+  getSnapshotImageUrl,
+} from 'sentry/views/preprod/types/snapshotTypes';
 import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
 import {DiffImageDisplay, type DiffMode} from './imageDisplay/diffImageDisplay';
@@ -322,7 +326,7 @@ export function SnapshotMainContent({
       return null;
     }
     const image = currentPair.head_image;
-    const imageUrl = `${imageBaseUrl}${image.key}/`;
+    const imageUrl = getSnapshotImageUrl(imageBaseUrl, image);
     return (
       <SingleViewLayout
         isDark={isDark}
@@ -364,7 +368,7 @@ export function SnapshotMainContent({
   if (!currentImage) {
     return null;
   }
-  const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
+  const imageUrl = getSnapshotImageUrl(imageBaseUrl, currentImage);
   let status: DiffStatus | null;
   switch (selectedItem.type) {
     case 'solo':

--- a/static/app/views/preprod/types/snapshotTypes.spec.tsx
+++ b/static/app/views/preprod/types/snapshotTypes.spec.tsx
@@ -1,0 +1,48 @@
+import {getSnapshotImageUrl} from 'sentry/views/preprod/types/snapshotTypes';
+import type {SnapshotImage} from 'sentry/views/preprod/types/snapshotTypes';
+
+function makeImage(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
+  return {
+    display_name: 'danger-no-icon',
+    image_file_name: 'static/app/components/core/alert/alert-dark-danger-no-icon.png',
+    height: 130,
+    key: 'abc123',
+    tags: null,
+    width: 800,
+    ...overrides,
+  };
+}
+
+describe('getSnapshotImageUrl', () => {
+  const baseUrl = '/api/0/projects/org/1/files/images/';
+
+  it('appends the basename of image_file_name as a filename query param', () => {
+    expect(getSnapshotImageUrl(baseUrl, makeImage())).toBe(
+      `${baseUrl}abc123/?filename=alert-dark-danger-no-icon.png`
+    );
+  });
+
+  it('encodes special characters in the filename', () => {
+    const url = getSnapshotImageUrl(
+      baseUrl,
+      makeImage({image_file_name: 'a b/café & co.png'})
+    );
+    expect(url).toBe(`${baseUrl}abc123/?filename=${encodeURIComponent('café & co.png')}`);
+  });
+
+  it('never falls back to display_name when image_file_name is empty', () => {
+    const url = getSnapshotImageUrl(
+      baseUrl,
+      makeImage({image_file_name: '', display_name: 'fallback.png'})
+    );
+    expect(url).toBe(`${baseUrl}abc123/`);
+  });
+
+  it('omits the query param when image_file_name is empty', () => {
+    const url = getSnapshotImageUrl(
+      baseUrl,
+      makeImage({image_file_name: '', display_name: null})
+    );
+    expect(url).toBe(`${baseUrl}abc123/`);
+  });
+});

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -79,6 +79,12 @@ export function getImageName(image: SnapshotImage): string {
   return image.display_name ?? image.image_file_name;
 }
 
+export function getSnapshotImageUrl(imageBaseUrl: string, image: SnapshotImage): string {
+  const url = `${imageBaseUrl}${image.key}/`;
+  const fileName = image.image_file_name?.split('/').pop();
+  return fileName ? `${url}?filename=${encodeURIComponent(fileName)}` : url;
+}
+
 interface SidebarItemBase {
   displayName: string;
   key: string;


### PR DESCRIPTION
Snapshot image URLs now carry the image's original filename as a `filename` query param, so right-clicking an image and choosing "Save Image As" prefills the real name (e.g. `alert-dark-danger-no-icon.png`) instead of the generic `download` with no extension. The backend reads that param and sets the `Content-Disposition` header.

**Shared URL helper**

A new `getSnapshotImageUrl` helper centralizes image URL construction and appends the basename of `image_file_name` (falling back to `display_name`). Card thumbnails, the single-image view, and the split/wipe/onion diff views all route through it, so every saveable image gets a name. Diff-mask overlays are CSS masks rather than saveable images and are left unchanged.

Requires the backend `Content-Disposition` support in #116953 to land first.