### PR TITLE
ref(seer): Default SeerRun double-write and drop flag gates

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -280,12 +280,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Gate display of Seer action events in the issue activity timeline
     # https://linear.app/getsentry/project/add-seer-actions-to-issue-activityaction-log-0e641e1f5dac/overview
     manager.add("organizations:display-seer-actions-as-issue-activities", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Gate outbox-based mirroring of SeerRun records to Seer
-    manager.add("organizations:seer-run-mirror", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Gate outbox-based mirroring for autofix writes
-    manager.add("organizations:seer-run-mirror-autofix", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Gate outbox-based mirroring for explorer writes
-    manager.add("organizations:seer-run-mirror-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable search query attribute validation
     manager.add("organizations:search-query-attribute-validation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Disables the enableSeerCoding setting, preventing orgs from changing code generation behavior

--- a/src/sentry/receivers/outbox/cell.py
+++ b/src/sentry/receivers/outbox/cell.py
@@ -33,12 +33,10 @@ from sentry.models.project import Project
 from sentry.receivers.outbox import maybe_process_tombstone
 from sentry.seer.agent.client import _trigger_explorer_indexes_if_needed
 from sentry.seer.agent.client_utils import AgentChatRequest, make_agent_chat_request
-from sentry.seer.autofix.utils import make_autofix_start_request
 from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus, SeerRunType
 from sentry.seer.signed_seer_api import SearchAgentStartRequest, make_search_agent_start_request
 from sentry.sentry_apps.services.app.service import app_service
 from sentry.types.cell import get_local_cell
-from sentry.utils import json as sentry_json
 from sentry.workflow_engine.models import Action
 
 logger = logging.getLogger(__name__)
@@ -235,10 +233,6 @@ def handle_seer_run_create(object_identifier: int, payload: Any, **kwds: Any) ->
         return
 
     match run_type:
-        case SeerRunType.AUTOFIX:
-            response = make_autofix_start_request(
-                sentry_json.dumps(body).encode(), viewer_context=viewer_context
-            )
         case SeerRunType.EXPLORER:
             response = make_agent_chat_request(
                 cast(AgentChatRequest, body), viewer_context=viewer_context

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -6,7 +6,6 @@ import time
 from datetime import datetime
 from typing import Any, Literal, overload
 
-import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
 from django.db import router, transaction
 from django.utils import timezone as django_timezone
@@ -425,86 +424,63 @@ class SeerAgentClient:
         ):
             agent_run_options["use_agent_sandbox"] = True
 
-        if features.has("organizations:seer-run-mirror-explorer", self.organization):
-            user_id = (
-                self.user.id
-                if self.user and hasattr(self.user, "id") and self.user.id is not None
-                else None
-            )
-            try:
-                with outbox_context(
-                    transaction.atomic(using=router.db_for_write(SeerRun)), flush=True
-                ):
-                    run = SeerRun.objects.create(
-                        organization=self.organization,
-                        user_id=user_id,
-                        type=SeerRunType.EXPLORER,
-                        last_triggered_at=now(),
-                    )
-                    source = self.category_key or ""
-                    if not source:
-                        logger.warning(
-                            "seer_agent_run.missing_source",
-                            extra={
-                                "organization_id": self.organization.id,
-                                "seer_run_id": run.id,
-                                "user_id": user_id,
-                            },
-                        )
-                    SeerAgentRun.objects.create(
-                        run=run,
-                        title=prompt[:255] + "…" if len(prompt) > 256 else prompt,
-                        source=source,
-                        project=self.project,
-                        extras=(
-                            {"category_value": self.category_value} if self.category_value else {}
-                        ),
-                    )
-                    CellOutbox(
-                        shard_scope=OutboxScope.SEER_SCOPE,
-                        shard_identifier=run.id,
-                        category=OutboxCategory.SEER_RUN_CREATE,
-                        object_identifier=run.id,
-                        payload={
-                            "body": dict(chat_body),
-                            "viewer_context": dict(self.viewer_context),
-                        },
-                    ).save()
-            except (OutboxFlushError, OutboxDatabaseError):
-                metrics.incr("seer.outbox_flush_error", tags={"type": "explorer"})
-                logger.exception(
-                    "explorer.outbox_flush_error",
-                    extra={
-                        "organization_id": self.organization.id,
-                        "seer_run_id": run.id,
-                        "seer_run_uuid": str(run.uuid),
-                    },
-                )
-                run.mirror_status = SeerRunMirrorStatus.FAILED
-                run.save(update_fields=["mirror_status"])
-                raise SeerApiError("Outbox flush failed for explorer SeerRun", 500)
-            run.refresh_from_db()
-            if run.mirror_status == SeerRunMirrorStatus.FAILED:
-                raise SeerApiError("Seer run failed during outbox drain", 500)
-            return run.seer_run_state_id
-
-        response = make_agent_chat_request(chat_body, viewer_context=self.viewer_context)
-
-        if response.status >= 400:
-            raise SeerApiError("Seer request failed", response.status)
-        result = response.json()
-
+        user_id = (
+            self.user.id
+            if self.user and hasattr(self.user, "id") and self.user.id is not None
+            else None
+        )
         try:
-            _trigger_explorer_indexes_if_needed(
-                self.organization.id,
-                has_explorer_index=result.get("has_explorer_index"),
-                has_org_project_context=result.get("has_org_project_context"),
+            with outbox_context(transaction.atomic(using=router.db_for_write(SeerRun)), flush=True):
+                run = SeerRun.objects.create(
+                    organization=self.organization,
+                    user_id=user_id,
+                    type=SeerRunType.EXPLORER,
+                    last_triggered_at=now(),
+                )
+                source = self.category_key or ""
+                if not source:
+                    logger.warning(
+                        "seer_agent_run.missing_source",
+                        extra={
+                            "organization_id": self.organization.id,
+                            "seer_run_id": run.id,
+                            "user_id": user_id,
+                        },
+                    )
+                SeerAgentRun.objects.create(
+                    run=run,
+                    title=prompt[:255] + "…" if len(prompt) > 256 else prompt,
+                    source=source,
+                    project=self.project,
+                    extras=({"category_value": self.category_value} if self.category_value else {}),
+                )
+                CellOutbox(
+                    shard_scope=OutboxScope.SEER_SCOPE,
+                    shard_identifier=run.id,
+                    category=OutboxCategory.SEER_RUN_CREATE,
+                    object_identifier=run.id,
+                    payload={
+                        "body": dict(chat_body),
+                        "viewer_context": dict(self.viewer_context),
+                    },
+                ).save()
+        except (OutboxFlushError, OutboxDatabaseError):
+            metrics.incr("seer.outbox_flush_error", tags={"type": "explorer"})
+            logger.exception(
+                "explorer.outbox_flush_error",
+                extra={
+                    "organization_id": self.organization.id,
+                    "seer_run_id": run.id,
+                    "seer_run_uuid": str(run.uuid),
+                },
             )
-
-        except Exception as e:
-            sentry_sdk.capture_exception(e)
-
-        return result["run_id"]
+            run.mirror_status = SeerRunMirrorStatus.FAILED
+            run.save(update_fields=["mirror_status"])
+            raise SeerApiError("Outbox flush failed for explorer SeerRun", 500)
+        run.refresh_from_db()
+        if run.mirror_status == SeerRunMirrorStatus.FAILED:
+            raise SeerApiError("Seer run failed during outbox drain", 500)
+        return run.seer_run_state_id
 
     def continue_run(
         self,
@@ -593,6 +569,9 @@ class SeerAgentClient:
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
         result = response.json()
+
+        SeerRun.objects.filter(seer_run_state_id=run_id).update(last_triggered_at=now())
+
         return result["run_id"]
 
     def get_run(

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -296,19 +296,6 @@ def make_update_coding_agent_state_request(
     )
 
 
-def make_autofix_start_request(
-    body: bytes,
-    connection_pool: HTTPConnectionPool | None = None,
-    viewer_context: SeerViewerContext | None = None,
-) -> BaseHTTPResponse:
-    return make_signed_seer_api_request(
-        connection_pool or autofix_connection_pool,
-        "/v1/automation/autofix/start",
-        body=body,
-        viewer_context=viewer_context,
-    )
-
-
 def make_store_coding_agent_states_request(
     body: StoreCodingAgentStatesRequest,
     connection_pool: HTTPConnectionPool | None = None,

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -28,11 +28,7 @@ from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplo
 from sentry.seer.models import SeerApiError
 from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus, SeerRunType
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import (
-    SearchAgentStartRequest,
-    SeerViewerContext,
-    make_search_agent_start_request,
-)
+from sentry.seer.signed_seer_api import SearchAgentStartRequest, SeerViewerContext
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -80,8 +76,8 @@ def send_search_agent_start_request(
     model_name: str | None = None,
     metric_context: dict[str, Any] | None = None,
     viewer_context: SeerViewerContext | None = None,
-) -> SeerRun | int:
-    """Start an async search agent and return a run_id for polling."""
+) -> SeerRun:
+    """Create the SeerRun mirror and enqueue the outbox that starts the agent in Seer."""
     body = SearchAgentStartRequest(
         org_id=organization.id,
         org_slug=organization.slug,
@@ -102,59 +98,41 @@ def send_search_agent_start_request(
     if options:
         body["options"] = options
 
-    if features.has("organizations:seer-run-mirror", organization):
-        try:
-            with outbox_context(transaction.atomic(using=router.db_for_write(SeerRun)), flush=True):
-                run = SeerRun.objects.create(
-                    organization=organization,
-                    user_id=user_id,
-                    type=SeerRunType.ASSISTED_QUERY,
-                    last_triggered_at=now(),
-                )
-                CellOutbox(
-                    shard_scope=OutboxScope.SEER_SCOPE,
-                    shard_identifier=run.id,
-                    category=OutboxCategory.SEER_RUN_CREATE,
-                    object_identifier=run.id,
-                    payload={
-                        "body": dict(body),
-                        "viewer_context": dict(viewer_context) if viewer_context else None,
-                    },
-                ).save()
-        except (OutboxFlushError, OutboxDatabaseError):
-            metrics.incr("seer.outbox_flush_error", tags={"type": "assisted_query"})
-            logger.exception(
-                "search_agent.outbox_flush_error",
-                extra={
-                    "organization_id": organization.id,
-                    "seer_run_id": run.id,
-                    "seer_run_uuid": str(run.uuid),
-                },
+    try:
+        with outbox_context(transaction.atomic(using=router.db_for_write(SeerRun)), flush=True):
+            run = SeerRun.objects.create(
+                organization=organization,
+                user_id=user_id,
+                type=SeerRunType.ASSISTED_QUERY,
+                last_triggered_at=now(),
             )
-            run.mirror_status = SeerRunMirrorStatus.FAILED
-            run.save(update_fields=["mirror_status"])
-            raise SeerApiError("Outbox flush failed", 500)
-        run.refresh_from_db()
-        if run.mirror_status == SeerRunMirrorStatus.FAILED:
-            raise SeerApiError("Seer run failed during outbox drain", 500)
-        return run
-
-    response = make_search_agent_start_request(body, timeout=30, viewer_context=viewer_context)
-    if response.status >= 400:
-        raise SeerApiError("Seer request failed", response.status)
-    data = response.json()
-    run_id = data.get("run_id")
-    if run_id is None:
-        logger.error(
-            "search_agent.missing_run_id",
+            CellOutbox(
+                shard_scope=OutboxScope.SEER_SCOPE,
+                shard_identifier=run.id,
+                category=OutboxCategory.SEER_RUN_CREATE,
+                object_identifier=run.id,
+                payload={
+                    "body": dict(body),
+                    "viewer_context": dict(viewer_context) if viewer_context else None,
+                },
+            ).save()
+    except (OutboxFlushError, OutboxDatabaseError):
+        metrics.incr("seer.outbox_flush_error", tags={"type": "assisted_query"})
+        logger.exception(
+            "search_agent.outbox_flush_error",
             extra={
                 "organization_id": organization.id,
-                "project_ids": project_ids,
-                "response_data": data,
+                "seer_run_id": run.id,
+                "seer_run_uuid": str(run.uuid),
             },
         )
-        raise SeerApiError("Seer response missing run_id", 500)
-    return run_id
+        run.mirror_status = SeerRunMirrorStatus.FAILED
+        run.save(update_fields=["mirror_status"])
+        raise SeerApiError("Outbox flush failed", 500)
+    run.refresh_from_db()
+    if run.mirror_status == SeerRunMirrorStatus.FAILED:
+        raise SeerApiError("Seer run failed during outbox drain", 500)
+    return run
 
 
 @cell_silo_endpoint
@@ -179,7 +157,7 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
         Start an async search agent and return a run_id for polling.
 
         Returns:
-            {"run_id": int}
+            {"run_id": int, "sentry_run_id": str}
         """
         serializer = SearchAgentStartSerializer(data=request.data)
         if not serializer.is_valid():
@@ -246,14 +224,12 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
                 metric_context=metric_context,
                 viewer_context=viewer_context,
             )
-            if isinstance(result, SeerRun):
-                return Response(
-                    {
-                        "run_id": result.seer_run_state_id,
-                        "sentry_run_id": str(result.uuid),
-                    }
-                )
-            return Response({"run_id": result})
+            return Response(
+                {
+                    "run_id": result.seer_run_state_id,
+                    "sentry_run_id": str(result.uuid),
+                }
+            )
 
         except SeerApiError as e:
             logger.exception(

--- a/src/sentry/seer/models/run.py
+++ b/src/sentry/seer/models/run.py
@@ -12,7 +12,6 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 
 class SeerRunType(models.TextChoices):
     EXPLORER = "explorer"
-    AUTOFIX = "autofix"
     PR_REVIEW = "pr_review"
     ASSISTED_QUERY = "assisted_query"
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2882,6 +2882,6 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CELL)
-    def create_seer_run(organization, type: str = SeerRunType.AUTOFIX, **kwargs) -> SeerRun:
+    def create_seer_run(organization, type: str = SeerRunType.EXPLORER, **kwargs) -> SeerRun:
         kwargs.setdefault("last_triggered_at", timezone.now())
         return SeerRun.objects.create(organization=organization, type=type, **kwargs)

--- a/tests/sentry/receivers/outbox/test_cell.py
+++ b/tests/sentry/receivers/outbox/test_cell.py
@@ -130,21 +130,6 @@ class HandleSeerRunCreateTest(TestCase):
             "viewer_context": {"organization_id": self.organization.id},
         }
 
-    @patch("sentry.receivers.outbox.cell.make_autofix_start_request")
-    def test_happy_path_autofix(self, mock_request: Mock) -> None:
-        mock_request.return_value = Mock(status=200, json=Mock(return_value={"run_id": 42}))
-        run = self.create_seer_run(type=SeerRunType.AUTOFIX)
-
-        handle_seer_run_create(
-            object_identifier=run.id,
-            payload=self._make_payload(),
-            shard_identifier=run.id,
-        )
-
-        run.refresh_from_db()
-        assert run.seer_run_state_id == 42
-        assert run.mirror_status == SeerRunMirrorStatus.LIVE
-
     @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_happy_path_explorer(self, mock_request: Mock) -> None:
         mock_request.return_value = Mock(status=200, json=Mock(return_value={"run_id": 99}))
@@ -175,7 +160,7 @@ class HandleSeerRunCreateTest(TestCase):
         assert run.seer_run_state_id == 7
         assert run.mirror_status == SeerRunMirrorStatus.LIVE
 
-    @patch("sentry.receivers.outbox.cell.make_autofix_start_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_idempotent_retry_already_set(self, mock_request: Mock) -> None:
         run = self.create_seer_run(seer_run_state_id=123)
 
@@ -196,7 +181,7 @@ class HandleSeerRunCreateTest(TestCase):
             shard_identifier=999999,
         )
 
-    @patch("sentry.receivers.outbox.cell.make_autofix_start_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_4xx_marks_failed(self, mock_request: Mock) -> None:
         mock_request.return_value = Mock(status=400)
         run = self.create_seer_run()
@@ -211,7 +196,7 @@ class HandleSeerRunCreateTest(TestCase):
         assert run.mirror_status == SeerRunMirrorStatus.FAILED
         assert run.seer_run_state_id is None
 
-    @patch("sentry.receivers.outbox.cell.make_autofix_start_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_5xx_raises_for_retry(self, mock_request: Mock) -> None:
         mock_request.return_value = Mock(status=502)
         run = self.create_seer_run()
@@ -226,7 +211,7 @@ class HandleSeerRunCreateTest(TestCase):
         run.refresh_from_db()
         assert run.mirror_status == SeerRunMirrorStatus.PENDING
 
-    @patch("sentry.receivers.outbox.cell.make_autofix_start_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_2xx_with_malformed_json_marks_failed(self, mock_request: Mock) -> None:
         response = Mock(status=200)
         response.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
@@ -243,7 +228,7 @@ class HandleSeerRunCreateTest(TestCase):
         assert run.mirror_status == SeerRunMirrorStatus.FAILED
         assert run.seer_run_state_id is None
 
-    @patch("sentry.receivers.outbox.cell.make_autofix_start_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_invalid_payload_marks_failed_without_dispatch(self, mock_request: Mock) -> None:
         run = self.create_seer_run()
 
@@ -272,7 +257,7 @@ class HandleSeerRunCreateTest(TestCase):
         assert run.mirror_status == SeerRunMirrorStatus.FAILED
         assert run.seer_run_state_id is None
 
-    @patch("sentry.receivers.outbox.cell.make_autofix_start_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_2xx_without_run_id_marks_failed(self, mock_request: Mock) -> None:
         mock_request.return_value = Mock(status=200, json=Mock(return_value={}))
         run = self.create_seer_run()

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -1,6 +1,8 @@
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.utils import timezone
 from pydantic import BaseModel
 
 from sentry.seer.agent.client import SeerAgentClient
@@ -58,7 +60,7 @@ class TestSeerAgentClient(TestCase):
         assert client.enable_coding is True
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_start_run_basic(self, mock_collect_context, mock_post, mock_access):
         """Test starting a new run collects user context"""
@@ -79,7 +81,7 @@ class TestSeerAgentClient(TestCase):
         assert "enable_frontend_code_search" not in body["agent_run_options"]
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_start_run_with_request(self, mock_collect_context, mock_post, mock_access):
         """Test starting a new run passes request object to collect_user_org_context"""
@@ -99,7 +101,7 @@ class TestSeerAgentClient(TestCase):
         assert mock_post.called
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_start_run_with_optional_params(self, mock_post, mock_access):
         """Test starting a run with optional parameters"""
         mock_access.return_value = (True, None)
@@ -116,7 +118,7 @@ class TestSeerAgentClient(TestCase):
         assert call_args is not None
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_start_run_http_error(self, mock_post, mock_access):
         """Test that HTTP errors are propagated"""
         mock_access.return_value = (True, None)
@@ -127,7 +129,7 @@ class TestSeerAgentClient(TestCase):
             client.start_run("Test query")
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_start_run_with_categories(self, mock_collect_context, mock_post, mock_access):
         """Test starting a run with category fields"""
@@ -151,7 +153,7 @@ class TestSeerAgentClient(TestCase):
         assert body["agent_run_options"]["enable_frontend_code_search"] is True
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_start_run_defaults_code_review_disabled(
         self, mock_collect_context, mock_post, mock_access
@@ -170,7 +172,7 @@ class TestSeerAgentClient(TestCase):
         assert body["agent_run_options"]["code_review_enabled"] is False
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_start_run_passes_code_review_enabled(
         self, mock_collect_context, mock_post, mock_access
@@ -225,7 +227,7 @@ class TestSeerAgentClient(TestCase):
         assert client.intelligence_level == "medium"
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_start_run_includes_intelligence_level(
         self, mock_collect_context, mock_post, mock_access
@@ -262,7 +264,7 @@ class TestSeerAgentClient(TestCase):
         assert client.max_iterations is None
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_start_run_includes_max_iterations(self, mock_collect_context, mock_post, mock_access):
         """Test that max_iterations is included in the payload when set"""
@@ -281,7 +283,7 @@ class TestSeerAgentClient(TestCase):
         assert body["max_iterations"] == 3
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_start_run_excludes_max_iterations_when_none(
         self, mock_collect_context, mock_post, mock_access
@@ -349,6 +351,24 @@ class TestSeerAgentClient(TestCase):
         client = SeerAgentClient(self.organization, self.user)
         with pytest.raises(SeerApiError):
             client.continue_run(123, "Test query")
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    def test_continue_run_bumps_last_triggered_at(self, mock_post, mock_access):
+        mock_access.return_value = (True, None)
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"run_id": 456}
+        mock_response.status = 200
+        mock_post.return_value = mock_response
+
+        stale = timezone.now() - timedelta(days=10)
+        run = self.create_seer_run(seer_run_state_id=456, last_triggered_at=stale)
+
+        client = SeerAgentClient(self.organization, self.user)
+        client.continue_run(456, "Follow up query")
+
+        run.refresh_from_db()
+        assert run.last_triggered_at > stale
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.fetch_run_status")
@@ -445,7 +465,7 @@ class TestSeerAgentClientArtifacts(TestCase):
         self.organization = self.create_organization(owner=self.user)
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_start_run_with_artifact_schema(self, mock_collect_context, mock_post, mock_access):
         """Test that artifact key and schema are serialized and sent to API"""
@@ -476,7 +496,7 @@ class TestSeerAgentClientArtifacts(TestCase):
         assert "severity" in body["artifact_schema"]["properties"]
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_start_run_artifact_schema_requires_key(self, mock_post, mock_access):
         """Test that artifact_schema without artifact_key raises ValueError"""
         mock_access.return_value = (True, None)
@@ -1027,7 +1047,7 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         return mock_response
 
     @patch("sentry.seer.agent.client.dispatch_explorer_index_projects")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_triggers_indexing_when_explorer_index_missing(self, mock_chat, mock_dispatch):
         mock_chat.return_value = self._mock_chat_response(has_explorer_index=False)
         mock_dispatch.return_value = iter([])
@@ -1047,7 +1067,7 @@ class TestStartRunExplorerIndexTrigger(TestCase):
     @patch("sentry.seer.agent.client.index_org_project_knowledge")
     @patch("sentry.seer.agent.client.build_service_map")
     @patch("sentry.seer.agent.client.dispatch_explorer_index_projects")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_triggers_indexing_when_org_project_context_missing(
         self, mock_chat, mock_dispatch, mock_build_service_map, mock_index_knowledge
     ):
@@ -1072,7 +1092,7 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         mock_build_service_map.apply_async.assert_called_once_with(args=[self.organization.id])
 
     @patch("sentry.seer.agent.client.dispatch_explorer_index_projects")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_excludes_projects_without_transactions_from_batch(self, mock_chat, mock_dispatch):
         mock_chat.return_value = self._mock_chat_response(has_explorer_index=False)
         mock_dispatch.return_value = iter([])
@@ -1090,7 +1110,7 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         assert (project_without_txns.id, self.organization.id) not in projects_batch
 
     @patch("sentry.seer.agent.client.dispatch_explorer_index_projects")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_skips_indexing_when_index_present(self, mock_chat, mock_dispatch):
         mock_chat.return_value = self._mock_chat_response(
             has_explorer_index=True, has_org_project_context=True
@@ -1103,7 +1123,7 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         mock_dispatch.assert_not_called()
 
     @patch("sentry.seer.agent.client.dispatch_explorer_index_projects")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_skips_indexing_when_flags_absent_from_response(self, mock_chat, mock_dispatch):
         mock_chat.return_value = self._mock_chat_response()
 
@@ -1116,7 +1136,7 @@ class TestStartRunExplorerIndexTrigger(TestCase):
     @patch("sentry.seer.agent.client.index_org_project_knowledge")
     @patch("sentry.seer.agent.client.build_service_map")
     @patch("sentry.seer.agent.client.dispatch_explorer_index_projects")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_skips_indexing_when_killswitch_on(
         self, mock_chat, mock_dispatch, mock_build_service_map, mock_index_knowledge
     ):
@@ -1141,7 +1161,7 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         mock_build_service_map.apply_async.assert_not_called()
 
     @patch("sentry.seer.agent.client.dispatch_explorer_index_projects")
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     def test_skips_indexing_when_no_projects_with_transactions(self, mock_chat, mock_dispatch):
         mock_chat.return_value = self._mock_chat_response(has_explorer_index=False)
         self.create_project(organization=self.organization)

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -347,10 +347,9 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             self.organization, self.user, is_interactive=True, reasoning_effort="medium"
         )
 
-        with self.feature("organizations:seer-run-mirror-explorer"):
-            run_id = client.start_run(
-                prompt="What happened?",
-            )
+        run_id = client.start_run(
+            prompt="What happened?",
+        )
 
         assert run_id == 99
 
@@ -390,10 +389,9 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         )
 
         with pytest.raises(SeerApiError, match="Outbox flush failed"):
-            with self.feature("organizations:seer-run-mirror-explorer"):
-                client.start_run(
-                    prompt="What happened?",
-                )
+            client.start_run(
+                prompt="What happened?",
+            )
 
         run = SeerRun.objects.get(organization_id=self.organization.id)
         assert run.mirror_status == SeerRunMirrorStatus.FAILED
@@ -413,7 +411,7 @@ class OrganizationSeerAgentChatContextEngineTest(APITestCase):
         self.login_as(user=self.user)
         self.url = f"/api/0/organizations/{self.organization.slug}/seer/explorer-chat/"
 
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_override_ce_enable_false_sets_context_engine_disabled(
@@ -434,7 +432,7 @@ class OrganizationSeerAgentChatContextEngineTest(APITestCase):
         body = mock_chat_request.call_args[0][0]
         assert body["agent_run_options"]["is_context_engine_enabled"] is False
 
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_override_ce_enable_true_sets_context_engine_enabled(
@@ -455,7 +453,7 @@ class OrganizationSeerAgentChatContextEngineTest(APITestCase):
         body = mock_chat_request.call_args[0][0]
         assert body["agent_run_options"]["is_context_engine_enabled"] is True
 
-    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_override_ce_enable_ignored_without_feature_flag(

--- a/tests/sentry/seer/endpoints/test_search_agent_start.py
+++ b/tests/sentry/seer/endpoints/test_search_agent_start.py
@@ -17,15 +17,14 @@ class SendSearchAgentStartRequestTest(TestCase):
             organization_id=self.organization.id, user_id=self.user.id
         )
 
-        with self.feature("organizations:seer-run-mirror"):
-            result = send_search_agent_start_request(
-                organization=self.organization,
-                user_id=self.user.id,
-                project_ids=[self.project.id],
-                natural_language_query="errors today",
-                strategy="Issues",
-                viewer_context=viewer_context,
-            )
+        result = send_search_agent_start_request(
+            organization=self.organization,
+            user_id=self.user.id,
+            project_ids=[self.project.id],
+            natural_language_query="errors today",
+            strategy="Issues",
+            viewer_context=viewer_context,
+        )
 
         assert isinstance(result, SeerRun)
         assert result.type == SeerRunType.ASSISTED_QUERY
@@ -41,15 +40,14 @@ class SendSearchAgentStartRequestTest(TestCase):
             organization_id=self.organization.id, user_id=self.user.id
         )
 
-        with self.feature("organizations:seer-run-mirror"):
-            with pytest.raises(SeerApiError):
-                send_search_agent_start_request(
-                    organization=self.organization,
-                    user_id=self.user.id,
-                    project_ids=[self.project.id],
-                    natural_language_query="errors today",
-                    viewer_context=viewer_context,
-                )
+        with pytest.raises(SeerApiError):
+            send_search_agent_start_request(
+                organization=self.organization,
+                user_id=self.user.id,
+                project_ids=[self.project.id],
+                natural_language_query="errors today",
+                viewer_context=viewer_context,
+            )
 
     @patch("sentry.receivers.outbox.cell.make_search_agent_start_request")
     def test_terminal_seer_failure_raises(self, mock_request: Mock) -> None:
@@ -58,12 +56,11 @@ class SendSearchAgentStartRequestTest(TestCase):
             organization_id=self.organization.id, user_id=self.user.id
         )
 
-        with self.feature("organizations:seer-run-mirror"):
-            with pytest.raises(SeerApiError):
-                send_search_agent_start_request(
-                    organization=self.organization,
-                    user_id=self.user.id,
-                    project_ids=[self.project.id],
-                    natural_language_query="errors today",
-                    viewer_context=viewer_context,
-                )
+        with pytest.raises(SeerApiError):
+            send_search_agent_start_request(
+                organization=self.organization,
+                user_id=self.user.id,
+                project_ids=[self.project.id],
+                natural_language_query="errors today",
+                viewer_context=viewer_context,
+            )


### PR DESCRIPTION
Graduates the SeerRun mirror rollout so the outbox-based double-write is the default for every org, and removes the now-dead direct-HTTP paths it gated.

**Flag graduation**

Removes the `organizations:seer-run-mirror`, `seer-run-mirror-explorer`, and `seer-run-mirror-autofix` feature flags. Explorer and assisted-query starts now always create a `SeerRun` (+`SeerAgentRun`) and enqueue the `SEER_RUN_CREATE` outbox instead of calling Seer directly. The direct-HTTP fallbacks and the `SeerRun | int` return union are deleted.

The FlagPole YAML for these three flags lives in `sentry-options-automator` and should be cleaned up there; since that repo deploys independently, remove/zero its rollout before or alongside this merge.

**Legacy autofix scaffolding removed**

Deletes `SeerRunType.AUTOFIX`, the receiver's AUTOFIX dispatch arm, and `make_autofix_start_request` (`/v1/automation/autofix/start`). Agent-based autofix runs through `SeerAgentClient.start_run` (recorded as `type=EXPLORER`, `source="autofix"`), so nothing created AUTOFIX rows — the path went away with legacy autofix. No migration is needed; Sentry strips `choices` from migration state.

**`last_triggered_at` on continuation**

`continue_run` now bumps `last_triggered_at`, mirroring Seer's `mark_triggered()`. Without it, an actively-continued run kept only its first-trigger time and could be reaped early by the TTL sweep / mis-sorted in the recency indexes.