### PR TITLE
feat(sentry-apps): Forward integrator error status and reason from external requests

### DIFF
--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -79,7 +79,7 @@ class SentryAppAlertRuleActionRequester:
                     message=self._get_response_message(e.response, DEFAULT_ERROR_MESSAGE),
                     error_type=SentryAppErrorType.INTEGRATOR,
                     webhook_context={"error_type": halt_reason, **extras},
-                    status_code=500,
+                    status_code=e.response.status_code if e.response is not None else 502,
                 )
             except SentryAppIntegratorError as e:
                 lifecycle.record_halt(halt_reason=e, extra={**extras})

--- a/src/sentry/sentry_apps/external_requests/issue_link_requester.py
+++ b/src/sentry/sentry_apps/external_requests/issue_link_requester.py
@@ -10,7 +10,11 @@ from requests import RequestException
 
 from sentry.http import safe_urlread
 from sentry.models.group import Group
-from sentry.sentry_apps.external_requests.utils import send_and_save_sentry_app_request, validate
+from sentry.sentry_apps.external_requests.utils import (
+    integrator_error_message,
+    send_and_save_sentry_app_request,
+    validate,
+)
 from sentry.sentry_apps.metrics import (
     SentryAppEventType,
     SentryAppExternalRequestFailureReason,
@@ -122,9 +126,12 @@ class IssueLinkRequester:
                 )
 
                 raise SentryAppIntegratorError(
-                    message=f"Issue occurred while trying to contact {self.sentry_app.slug} to link issue",
+                    message=integrator_error_message(
+                        e.response,
+                        f"Issue occurred while trying to contact {self.sentry_app.slug} to link issue",
+                    ),
                     webhook_context={"error_type": BAD_RESPONSE_HALT_REASON, **extras},
-                    status_code=500,
+                    status_code=e.response.status_code if e.response is not None else 502,
                 )
             except SentryAppIntegratorError as e:
                 lifecycle.record_halt(halt_reason=e, extra={**extras})

--- a/src/sentry/sentry_apps/external_requests/select_requester.py
+++ b/src/sentry/sentry_apps/external_requests/select_requester.py
@@ -8,7 +8,11 @@ from django.utils.functional import cached_property
 from requests import RequestException
 
 from sentry.http import safe_urlread
-from sentry.sentry_apps.external_requests.utils import send_and_save_sentry_app_request, validate
+from sentry.sentry_apps.external_requests.utils import (
+    integrator_error_message,
+    send_and_save_sentry_app_request,
+    validate,
+)
 from sentry.sentry_apps.metrics import (
     SentryAppEventType,
     SentryAppExternalRequestFailureReason,
@@ -85,9 +89,12 @@ class SelectRequester:
                 lifecycle.record_halt(halt_reason=e, extra={"reason": halt_reason, **extras})
 
                 raise SentryAppIntegratorError(
-                    message=f"Something went wrong while getting options for Select FormField from {self.sentry_app.slug}",
+                    message=integrator_error_message(
+                        e.response,
+                        f"Something went wrong while getting options for Select FormField from {self.sentry_app.slug}",
+                    ),
                     webhook_context={"error_type": halt_reason, **extras},
-                    status_code=500,
+                    status_code=e.response.status_code if e.response is not None else 502,
                 ) from e
 
             except SentryAppIntegratorError as e:

--- a/src/sentry/sentry_apps/external_requests/utils.py
+++ b/src/sentry/sentry_apps/external_requests/utils.py
@@ -19,6 +19,17 @@ from sentry.utils.sentry_apps.webhooks import TIMEOUT_STATUS_CODE
 
 logger = logging.getLogger(__name__)
 
+
+def integrator_error_message(response: Response | None, fallback: str) -> str:
+    # Shown to the submitting user only — never add this to logs; it may echo their input.
+    if response is None:
+        return fallback
+    try:
+        return response.json().get("message") or fallback
+    except Exception:
+        return fallback
+
+
 SELECT_OPTIONS_SCHEMA = {
     "type": "array",
     "definitions": {

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_requests.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_requests.py
@@ -92,7 +92,7 @@ class SentryAppInstallationExternalRequestsEndpointTest(APITestCase):
         )
         url = self.url + f"?uri={self.project.id}"
         response = self.client.get(url, format="json")
-        assert response.status_code == 500
+        assert response.status_code == 502
 
     def test_invalid_project_id_returns_400(self) -> None:
         self.login_as(user=self.user)

--- a/tests/sentry/sentry_apps/external_requests/test_issue_link_requester.py
+++ b/tests/sentry/sentry_apps/external_requests/test_issue_link_requester.py
@@ -219,6 +219,32 @@ class TestIssueLinkRequester(TestCase):
 
     @responses.activate
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_integrator_4xx_surfaces_message_and_status(self, mock_record: MagicMock) -> None:
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/link-issue",
+            json={"message": "Team is required"},
+            status=400,
+        )
+
+        with pytest.raises(SentryAppIntegratorError) as exception_info:
+            IssueLinkRequester(
+                install=self.install,
+                group=self.group,
+                uri="/link-issue",
+                fields={},
+                user=self.rpc_user,
+                action=IssueRequestActionType("create"),
+            ).run()
+
+        error = exception_info.value
+        assert error.status_code == 400
+        assert error.message == "Team is required"
+        # The integrator's message is shown to the user but never logged.
+        assert "Team is required" not in str(error.webhook_context)
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_invalid_json_response(self, mock_record: MagicMock) -> None:
         responses.add(
             method=responses.POST,


### PR DESCRIPTION
Sentry App external requests (issue link, select options, alert rule action) flattened every integrator failure into a generic 500 — hiding both the real status and the reason.

Now: forward the integrator's HTTP status verbatim (502 only when there's no response, e.g. a timeout) and surface the `message` from its error body to the submitting user — the same convention the alert-rule path already uses. The message is shown to the user but never logged (it can echo their input).

Refs DE-1275