### PR TITLE
feat(autofix): Explain when code changes step makes no edits

### DIFF
--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -26,9 +26,18 @@ jest.mock('sentry/views/seerExplorer/components/fileDiffViewer', () => ({
 function makeSection(
   step: string,
   status: AutofixSection['status'],
-  artifacts: AutofixArtifact[]
+  artifacts: AutofixArtifact[],
+  blocks: AutofixSection['blocks'] = []
 ): AutofixSection {
-  return {step, artifacts, blocks: [], status};
+  return {step, artifacts, blocks, status};
+}
+
+function makeAssistantBlock(content: string | null): AutofixSection['blocks'][number] {
+  return {
+    id: 'block-1',
+    timestamp: '2026-01-01T00:00:00Z',
+    message: {role: 'assistant', content},
+  };
 }
 
 function makePatch(repoName: string, path: string): ExplorerFilePatch {
@@ -534,6 +543,86 @@ describe('ArtifactCard', () => {
       );
 
       expect(screen.queryByTestId('file-diff-viewer')).not.toBeInTheDocument();
+    });
+
+    it('surfaces the agent explanation when no patches but a final message exists', () => {
+      render(
+        <CodeChangesCard
+          autofix={mockAutofixWithRunState}
+          section={makeSection(
+            'code_changes',
+            'completed',
+            [],
+            [
+              makeAssistantBlock(
+                'This fix requires a database migration, not a code change.'
+              ),
+            ]
+          )}
+        />
+      );
+
+      expect(
+        screen.getByText("Seer proposed a fix but couldn't apply it automatically")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('This fix requires a database migration, not a code change.')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Add context & retry'})
+      ).toBeInTheDocument();
+      // The generic "this one is on us" copy should not appear here.
+      expect(
+        screen.queryByText(
+          'Seer failed to generate a code change. This one is on us. Try running it again.'
+        )
+      ).not.toBeInTheDocument();
+    });
+
+    it('opens the context prompt from the explanation state', async () => {
+      render(
+        <CodeChangesCard
+          autofix={mockAutofixWithRunState}
+          section={makeSection(
+            'code_changes',
+            'completed',
+            [],
+            [makeAssistantBlock('The relevant files are not in the connected repo.')]
+          )}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Add context & retry'}));
+
+      expect(
+        screen.getByText('What additional context should Seer use?')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Add context & retry'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('falls back to the generic failure copy when there is no explanation', () => {
+      render(
+        <CodeChangesCard
+          autofix={mockAutofix}
+          section={makeSection(
+            'code_changes',
+            'completed',
+            [],
+            [makeAssistantBlock('   ')]
+          )}
+        />
+      );
+
+      expect(
+        screen.getByText(
+          'Seer failed to generate a code change. This one is on us. Try running it again.'
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Seer proposed a fix but couldn't apply it automatically")
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -2,6 +2,7 @@ import {Fragment, useMemo} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 
 import {
@@ -28,6 +29,23 @@ interface CodeChangesCardProps {
   section: AutofixSection;
 }
 
+/**
+ * When the coding step finishes without producing any patches, the agent often
+ * still leaves a final assistant message explaining why — e.g. the real fix is a
+ * database migration / infra change, or the relevant files aren't in the
+ * connected repo. Surface that explanation instead of a generic "this one is on
+ * us" message so the user knows a plain re-run won't help.
+ */
+function getFinalExplanation(section: AutofixSection): string | null {
+  for (let i = section.blocks.length - 1; i >= 0; i--) {
+    const message = section.blocks[i]!.message;
+    if (message.role === 'assistant' && message.content?.trim()) {
+      return message.content.trim();
+    }
+  }
+  return null;
+}
+
 export function CodeChangesCard({autofix, section}: CodeChangesCardProps) {
   const artifact = useMemo(() => {
     const sectionArtifact = getAutofixArtifactFromSection(section);
@@ -48,6 +66,8 @@ export function CodeChangesCard({autofix, section}: CodeChangesCardProps) {
     });
 
   const patchesByRepo = useMemo(() => collectPatches(artifact ?? []), [artifact]);
+
+  const explanation = useMemo(() => getFinalExplanation(section), [section]);
 
   const summary = useMemo(() => {
     const reposChanged = patchesByRepo.size;
@@ -119,6 +139,33 @@ export function CodeChangesCard({autofix, section}: CodeChangesCardProps) {
             </ArtifactDetails>
           ))}
         </Fragment>
+      ) : explanation ? (
+        <ArtifactDetails>
+          {shouldShowReset ? (
+            <AutofixResetPrompt
+              onClosePrompt={() => setShouldShowReset(false)}
+              onReset={handleReset}
+              placeholder={t(
+                'Add context that could unblock the change, e.g. the repo or files to edit.'
+              )}
+              prompt={t('What additional context should Seer use?')}
+            />
+          ) : null}
+          <Text bold>{t("Seer proposed a fix but couldn't apply it automatically")}</Text>
+          <Markdown raw={explanation} />
+          {shouldShowReset ? null : (
+            <div>
+              <Button
+                variant="primary"
+                icon={<IconRefresh />}
+                disabled={!canReset}
+                onClick={() => setShouldShowReset(true)}
+              >
+                {t('Add context & retry')}
+              </Button>
+            </div>
+          )}
+        </ArtifactDetails>
       ) : (
         <ArtifactDetails>
           <Text>


### PR DESCRIPTION
## Summary

When Seer's coding step completes without producing any file patches, the Code Changes card showed a single generic message — *"Seer failed to generate a code change. This one is on us. Try running it again."* — plus a Re-run button.

That copy is misleading in a common case: the agent successfully diagnosed the issue and even described the fix, but couldn't apply it as a code edit — e.g. the real fix is a database migration, or the relevant files aren't in the connected repo. A plain re-run just reproduces the same dead end.

This PR differentiates the two outcomes in `CodeChangesCard`:

- **Completed, no patches, but a final assistant message exists** → surface that explanation under *"Seer proposed a fix but couldn't apply it automatically"*, rendered as Markdown, with an **"Add context & retry"** action that opens the existing reset prompt. This steers the user to supply the missing context (e.g. the right repo/files) instead of blindly retrying.
- **No explanation (genuine empty/crash run)** → unchanged: original *"this one is on us"* copy and plain Re-run.

Detection is heuristic and frontend-only: it reads the last assistant block's content from the completed `code_changes` section.

## Follow-up

A more authoritative signal would be a Seer-side `termination_reason` (e.g. `no_actionable_edit` vs `error`) on the coding step, so the UI doesn't have to infer intent from message presence. Tracked separately.


Agent transcript: https://claudescope.sentry.dev/share/taJ0EFVrqCNWH5CTRKFDZghW8YJwl6RaR325v8eoyuY