### PR TITLE
ref(pr-metrics): Collapse SEER_APP into SENTRY_APP attribution signal

### DIFF
--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -35,7 +35,6 @@ class PullRequestLifecycleState(models.TextChoices):
 
 
 class PullRequestAttributionSignalType(models.TextChoices):
-    SEER_APP = "seer_app"
     SENTRY_APP = "sentry_app"
     SEER_DELEGATED_CURSOR = "seer_delegated:cursor"
     SEER_DELEGATED_GITHUB_COPILOT = "seer_delegated:github_copilot"

--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -45,11 +45,9 @@ _KNOWN_SCM_PROVIDERS = frozenset(
 
 # Precedence for picking a PR's primary attribution when more than one valid
 # signal is present (highest first): direct agent-authored signals rank above
-# weaker heuristics like a bare issue reference. The exact seer_app vs sentry_app
-# ordering is a product call and may yet change.
+# weaker heuristics like a bare issue reference.
 SIGNAL_TYPE_CONFIDENCE: dict[str, int] = {
-    PullRequestAttributionSignalType.SEER_APP: 100,
-    PullRequestAttributionSignalType.SENTRY_APP: 95,
+    PullRequestAttributionSignalType.SENTRY_APP: 100,
     PullRequestAttributionSignalType.SEER_DELEGATED_CURSOR: 80,
     PullRequestAttributionSignalType.SEER_DELEGATED_GITHUB_COPILOT: 80,
     PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE: 80,
@@ -120,7 +118,7 @@ def attribute_seer_created_pull_requests(
 
     For each reported PR: resolve the org-scoped ``Repository`` by name and
     provider, find-or-create the canonical ``PullRequest`` row (keyed on the PR
-    number), and idempotently record a ``seer_app`` attribution signal.
+    number), and idempotently record a ``sentry_app`` attribution signal.
 
     A find-or-create here may run before the SCM ``opened`` webhook arrives, so
     the ``PullRequest`` row can be a shell (no title/body); the GitHub webhook
@@ -173,12 +171,10 @@ def attribute_seer_created_pull_requests(
                 repository_id=repository.id,
                 key=str(pr_number),
             )
-            # Always SENTRY_APP for now: Seer chooses between the Sentry and Seer
-            # GitHub apps at push time (its write client falls back to the Seer
-            # app only when the Sentry app lacks write access), but the
-            # seer.pr_created payload doesn't carry which one it used. We default
-            # to SENTRY_APP until Seer threads that app kind through the payload;
-            # a faithful SEER_APP vs SENTRY_APP split is tracked as follow-up.
+            # SENTRY_APP covers both of our GitHub apps: Seer chooses between the
+            # Sentry and Seer apps at push time (its write client falls back to
+            # the Seer app only when the Sentry app lacks write access), but we
+            # don't distinguish them — both are internal-agent authorship.
             record_attribution_signal(
                 pull_request=pull_request,
                 signal_type=PullRequestAttributionSignalType.SENTRY_APP,

--- a/tests/sentry/deletions/test_pullrequest.py
+++ b/tests/sentry/deletions/test_pullrequest.py
@@ -179,7 +179,7 @@ class PullRequestDeletionTaskTest(TestCase):
         )
         attribution = PullRequestAttribution.objects.create(
             pull_request=pr,
-            signal_type=PullRequestAttributionSignalType.SEER_APP,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
             source="webhook_data",
         )
         metrics = PullRequestMetrics.objects.create(pull_request=pr)

--- a/tests/sentry/pr_metrics/test_attribution.py
+++ b/tests/sentry/pr_metrics/test_attribution.py
@@ -197,7 +197,7 @@ class RecordAttributionSignalTest(TestCase):
     def _record_seer_signal(self, **kwargs: Any) -> PullRequestAttribution:
         return record_attribution_signal(
             pull_request=self.pull_request,
-            signal_type=PullRequestAttributionSignalType.SEER_APP,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
             source=PullRequestAttributionSource.SEER_DATA,
             **kwargs,
         )
@@ -247,16 +247,16 @@ class RecomputePullRequestAttributionTest(TestCase):
 
     def test_picks_highest_confidence_signal(self) -> None:
         self._add(PullRequestAttributionSignalType.REFERENCED_ISSUE)
-        self._add(PullRequestAttributionSignalType.SEER_APP)
+        self._add(PullRequestAttributionSignalType.SENTRY_APP)
         self._add(PullRequestAttributionSignalType.MCP)
 
         assert (
             recompute_pull_request_attribution(self.pull_request)
-            == PullRequestAttributionSignalType.SEER_APP
+            == PullRequestAttributionSignalType.SENTRY_APP
         )
 
     def test_ignores_invalid_signals(self) -> None:
-        self._add(PullRequestAttributionSignalType.SEER_APP, is_valid=False)
+        self._add(PullRequestAttributionSignalType.SENTRY_APP, is_valid=False)
         self._add(PullRequestAttributionSignalType.REFERENCED_ISSUE)
 
         assert (


### PR DESCRIPTION
Collapses the unused `SEER_APP` member of `PullRequestAttributionSignalType` into `SENTRY_APP`.

### Why

We decided that it suffices to say `SENTRY_APP` as attribution. It logically maps into "internal agent".

### No migration needed

`signal_type` is a plain `CharField(max_length=64)` with no choices in the DB schema, and `"seer_app"` was never persisted — so there is no schema or data migration.

Resolves CORE-222.