### PR TITLE
[do not merge] ref: Migrate to span streaming (trace_lifecycle: stream)

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -370,7 +370,9 @@ class Endpoint(APIView):
         Identical to rest framework's dispatch except we add the ability
         to convert arguments (for common URL params).
         """
-        with sentry_sdk.start_span(op="base.dispatch.setup", name=type(self).__name__):
+        with sentry_sdk.traces.start_span(
+            name=type(self).__name__, attributes={"sentry.op": "base.dispatch.setup"}
+        ):
             self.args = args
             self.kwargs = kwargs
             request = self.initialize_request(request, *args, **kwargs)
@@ -393,7 +395,9 @@ class Endpoint(APIView):
             origin = None
 
         try:
-            with sentry_sdk.start_span(op="base.dispatch.request", name=type(self).__name__):
+            with sentry_sdk.traces.start_span(
+                name=type(self).__name__, attributes={"sentry.op": "base.dispatch.request"}
+            ):
                 if origin:
                     if request.auth:
                         allowed_origins = request.auth.get_allowed_origins()
@@ -426,11 +430,11 @@ class Endpoint(APIView):
                 else:
                     handler = self.http_method_not_allowed
 
-            with sentry_sdk.start_span(
-                op="base.dispatch.execute",
+            with sentry_sdk.traces.start_span(
                 name=".".join(
                     getattr(part, "__name__", None) or str(part) for part in (type(self), handler)
                 ),
+                attributes={"sentry.op": "base.dispatch.execute"},
             ) as span:
                 response = handler(request, *args, **kwargs)
 
@@ -446,11 +450,13 @@ class Endpoint(APIView):
             duration = time.time() - start_time
 
             if duration < (settings.SENTRY_API_RESPONSE_DELAY / 1000.0):
-                with sentry_sdk.start_span(
-                    op="base.dispatch.sleep",
+                with sentry_sdk.traces.start_span(
                     name=type(self).__name__,
+                    attributes={"sentry.op": "base.dispatch.sleep"},
                 ) as span:
-                    span.set_data("SENTRY_API_RESPONSE_DELAY", settings.SENTRY_API_RESPONSE_DELAY)
+                    span.set_attribute(
+                        "SENTRY_API_RESPONSE_DELAY", settings.SENTRY_API_RESPONSE_DELAY
+                    )
                     time.sleep(settings.SENTRY_API_RESPONSE_DELAY / 1000.0 - duration)
 
         # Only enforced in dev environment
@@ -534,9 +540,9 @@ class Endpoint(APIView):
         try:
             per_page = self.get_per_page(request, default_per_page, max_per_page)
             cursor = self.get_cursor_from_request(request, cursor_cls)
-            with sentry_sdk.start_span(
-                op="base.paginate.get_result",
+            with sentry_sdk.traces.start_span(
                 name=type(self).__name__,
+                attributes={"sentry.op": "base.paginate.get_result"},
             ) as span:
                 annotate_span_with_pagination_args(span, per_page)
                 paginator = get_paginator(paginator, paginator_cls, paginator_kwargs)
@@ -554,9 +560,9 @@ class Endpoint(APIView):
 
         # map results based on callback
         if on_results:
-            with sentry_sdk.start_span(
-                op="base.paginate.on_results",
+            with sentry_sdk.traces.start_span(
                 name=type(self).__name__,
+                attributes={"sentry.op": "base.paginate.on_results"},
             ):
                 results = on_results(cursor_result.results)
         else:

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -300,7 +300,10 @@ class ControlSiloOrganizationEndpoint(Endpoint):
         if organization_context is None:
             raise ResourceDoesNotExist
 
-        with sentry_sdk.start_span(op="check_object_permissions_on_organization"):
+        with sentry_sdk.traces.start_span(
+            name="check_object_permissions_on_organization",
+            attributes={"sentry.op": "check_object_permissions_on_organization"},
+        ):
             self.check_object_permissions(request, organization_context)
 
         bind_organization_context(organization_context.organization)
@@ -415,9 +418,12 @@ class OrganizationEndpoint(Endpoint):
                 qs = qs.filter(id__in=ids)
             # No project ids === `all projects I am a member of`
 
-        with sentry_sdk.start_span(op="fetch_organization_projects") as span:
+        with sentry_sdk.traces.start_span(
+            name="fetch_organization_projects",
+            attributes={"sentry.op": "fetch_organization_projects"},
+        ) as span:
             projects = list(qs)
-            span.set_data("Project Count", len(projects))
+            span.set_attribute("Project Count", len(projects))
 
         filter_by_membership = not bool(ids) and not bool(slugs)
         filtered_projects = self._filter_projects_by_permissions(
@@ -442,10 +448,12 @@ class OrganizationEndpoint(Endpoint):
         force_global_perms: bool = False,
         include_all_accessible: bool = False,
     ) -> list[Project]:
-        with sentry_sdk.start_span(op="apply_project_permissions") as span:
-            span.set_data("Project Count", len(projects))
+        with sentry_sdk.traces.start_span(
+            name="apply_project_permissions", attributes={"sentry.op": "apply_project_permissions"}
+        ) as span:
+            span.set_attribute("Project Count", len(projects))
             if force_global_perms:
-                span.set_tag("mode", "force_global_perms")
+                span.set_attribute("mode", "force_global_perms")
                 return projects
 
             # There is a special case for staff, where we want to fetch a single project (OrganizationStatsEndpointV2)
@@ -454,19 +462,19 @@ class OrganizationEndpoint(Endpoint):
             # mimics checking for active projects like has_project_access without further validation.
             # NOTE: We must check staff before superuser or else _admin will fail when both cookies are active
             if is_active_staff(request):
-                span.set_tag("mode", "staff_fetch_all")
+                span.set_attribute("mode", "staff_fetch_all")
                 proj_filter = lambda proj: proj.status == ObjectStatus.ACTIVE  # noqa: E731
             # Superuser should fetch all projects.
             # Also fetch all accessible projects if requesting $all
             elif is_active_superuser(request) or include_all_accessible:
-                span.set_tag("mode", "has_project_access")
+                span.set_attribute("mode", "has_project_access")
                 proj_filter = request.access.has_project_access
             # Check if explicitly requesting specific projects
             elif not filter_by_membership:
-                span.set_tag("mode", "has_project_access")
+                span.set_attribute("mode", "has_project_access")
                 proj_filter = request.access.has_project_access
             else:
-                span.set_tag("mode", "has_project_membership")
+                span.set_attribute("mode", "has_project_membership")
                 proj_filter = request.access.has_project_membership
 
             return [p for p in projects if proj_filter(p)]
@@ -632,7 +640,10 @@ class OrganizationEndpoint(Endpoint):
         except Organization.DoesNotExist:
             raise ResourceDoesNotExist
 
-        with sentry_sdk.start_span(op="check_object_permissions_on_organization"):
+        with sentry_sdk.traces.start_span(
+            name="check_object_permissions_on_organization",
+            attributes={"sentry.op": "check_object_permissions_on_organization"},
+        ):
             self.check_object_permissions(request, organization)
 
         bind_organization_context(organization)

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -172,7 +172,9 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         quantize_date_params: bool = True,
     ) -> SnubaParams:
         """Returns params to make snuba queries with"""
-        with sentry_sdk.start_span(op="discover.endpoint", name="filter_params(dataclass)"):
+        with sentry_sdk.traces.start_span(
+            name="filter_params(dataclass)", attributes={"sentry.op": "discover.endpoint"}
+        ):
             if (
                 len(self.get_field_list(organization, request))
                 + len(self.get_equation_list(organization, request))
@@ -406,7 +408,9 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         standard_meta: bool | None = False,
         dataset: Any | None = None,
     ) -> dict[str, Any]:
-        with sentry_sdk.start_span(op="discover.endpoint", name="base.handle_results"):
+        with sentry_sdk.traces.start_span(
+            name="base.handle_results", attributes={"sentry.op": "discover.endpoint"}
+        ):
             data = self.handle_data(request, organization, project_ids, results.get("data"))
             # these may get re-used by other timeseries
             meta = results.get("meta", {}).copy()
@@ -603,7 +607,9 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         use_rpc: bool = False,
     ) -> dict[str, Any]:
         with handle_query_errors():
-            with sentry_sdk.start_span(op="discover.endpoint", name="base.stats_query_creation"):
+            with sentry_sdk.traces.start_span(
+                name="base.stats_query_creation", attributes={"sentry.op": "discover.endpoint"}
+            ):
                 _columns = [query_column]
                 # temporary change to make topN query work for multi-axes requests
                 if additional_query_columns is not None:
@@ -629,7 +635,9 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 self.validate_comparison_delta(comparison_delta, snuba_params, organization)
 
                 query_columns = get_query_columns(columns, rollup)
-            with sentry_sdk.start_span(op="discover.endpoint", name="base.stats_query"):
+            with sentry_sdk.traces.start_span(
+                name="base.stats_query", attributes={"sentry.op": "discover.endpoint"}
+            ):
                 result = get_event_stats(
                     query_columns,
                     query,
@@ -641,7 +649,9 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
         serializer = SnubaTSResultSerializer(organization, None, request.user)
 
-        with sentry_sdk.start_span(op="discover.endpoint", name="base.stats_serialization"):
+        with sentry_sdk.traces.start_span(
+            name="base.stats_serialization", attributes={"sentry.op": "discover.endpoint"}
+        ):
             # When the request is for top_events, result can be a SnubaTSResult in the event that
             # there were no top events found. In this case, result contains a zerofilled series
             # that acts as a placeholder.

--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -143,7 +143,7 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
 
         return [replace(base_params, start=now - delta, end=now) for delta in steps]
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _fetch_spans(
         self,
         snuba_params: SnubaParams,

--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -223,7 +223,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 max_per_page=100,
             )
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _get_conversations(
         self,
         snuba_params,
@@ -251,7 +251,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
 
         return self._get_conversations_data(snuba_params, conversation_ids)
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _fetch_conversation_ids(
         self,
         snuba_params,
@@ -272,7 +272,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
             sampling_mode=sampling_mode,
         )
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _get_conversations_data(self, snuba_params, conversation_ids: list[str]) -> list[dict]:
         config = SearchResolverConfig(auto_fields=True)
         resolver = Spans.get_resolver(snuba_params, config)
@@ -285,13 +285,15 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
         ]
 
         # Execute all queries in a single bulk RPC call
-        with sentry_sdk.start_span(
-            op="ai_conversations.bulk_rpc", name="Execute bulk table queries"
+        with sentry_sdk.traces.start_span(
+            name="Execute bulk table queries", attributes={"sentry.op": "ai_conversations.bulk_rpc"}
         ):
             results = Spans.run_bulk_table_queries(queries)
 
         # Process results
-        with sentry_sdk.start_span(op="ai_conversations.process", name="Process query results"):
+        with sentry_sdk.traces.start_span(
+            name="Process query results", attributes={"sentry.op": "ai_conversations.process"}
+        ):
             conversations_map = self._build_conversations_from_aggregations(results["aggregations"])
             self._apply_enrichment(conversations_map, results["enrichment"])
             self._apply_first_last_io(conversations_map, results["first_last_io"])
@@ -378,9 +380,9 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     def _build_conversations_from_aggregations(
         self, aggregations: EAPResponse
     ) -> dict[str, dict[str, Any]]:
-        with sentry_sdk.start_span(
-            op="ai_conversations.build_from_aggregations",
+        with sentry_sdk.traces.start_span(
             name="Build conversations from aggregations",
+            attributes={"sentry.op": "ai_conversations.build_from_aggregations"},
         ):
             conversations_map: dict[str, dict[str, Any]] = {}
 
@@ -419,12 +421,12 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     def _apply_enrichment(
         self, conversations_map: dict[str, dict[str, Any]], enrichment_data: EAPResponse
     ) -> None:
-        with sentry_sdk.start_span(
-            op="ai_conversations.apply_enrichment",
+        with sentry_sdk.traces.start_span(
             name="Apply enrichment data",
+            attributes={"sentry.op": "ai_conversations.apply_enrichment"},
         ) as span:
             enrichment_rows = enrichment_data.get("data", [])
-            span.set_data("rows_count", len(enrichment_rows))
+            span.set_attribute("rows_count", len(enrichment_rows))
 
             flows_by_conversation: dict[str, list[str]] = defaultdict(list)
             traces_by_conversation: dict[str, set[str]] = defaultdict(set)
@@ -478,12 +480,12 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     def _apply_first_last_io(
         self, conversations_map: dict[str, dict[str, Any]], first_last_io_data: EAPResponse
     ) -> None:
-        with sentry_sdk.start_span(
-            op="ai_conversations.apply_first_last_io",
+        with sentry_sdk.traces.start_span(
             name="Apply first/last IO data",
+            attributes={"sentry.op": "ai_conversations.apply_first_last_io"},
         ) as span:
             io_rows = first_last_io_data.get("data", [])
-            span.set_data("rows_count", len(io_rows))
+            span.set_attribute("rows_count", len(io_rows))
 
             first_input_by_conv: dict[str, str] = {}
             last_output_by_conv: dict[str, tuple[float, str]] = {}

--- a/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
+++ b/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
@@ -33,7 +33,9 @@ class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoin
         """
         Assembles an artifact bundle and stores the debug ids in the database.
         """
-        with sentry_sdk.start_span(op="artifact_bundle.assemble"):
+        with sentry_sdk.traces.start_span(
+            name="artifact_bundle.assemble", attributes={"sentry.op": "artifact_bundle.assemble"}
+        ):
             schema = {
                 "type": "object",
                 "properties": {
@@ -86,7 +88,10 @@ class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoin
                 else:
                     input_project_slug.add(project)
 
-            with sentry_sdk.start_span(op="artifact_bundle.assemble.find_projects"):
+            with sentry_sdk.traces.start_span(
+                name="artifact_bundle.assemble.find_projects",
+                attributes={"sentry.op": "artifact_bundle.assemble.find_projects"},
+            ):
                 project_ids = Project.objects.filter(
                     (Q(id__in=input_project_id) | Q(slug__in=input_project_slug)),
                     organization=organization,
@@ -96,7 +101,10 @@ class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoin
             if len(project_ids) != len(input_projects):
                 return Response({"error": "One or more projects are invalid"}, status=400)
 
-            with sentry_sdk.start_span(op="artifact_bundle.assemble.check_release_permission"):
+            with sentry_sdk.traces.start_span(
+                name="artifact_bundle.assemble.check_release_permission",
+                attributes={"sentry.op": "artifact_bundle.assemble.check_release_permission"},
+            ):
                 if not self.has_release_permission(
                     request, organization, project_ids=set(project_ids)
                 ):
@@ -152,7 +160,10 @@ class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoin
                     {"error": "You need to specify a release together with a dist"}, status=400
                 )
 
-            with sentry_sdk.start_span(op="artifact_bundle.assemble.start_assemble_artifacts"):
+            with sentry_sdk.traces.start_span(
+                name="artifact_bundle.assemble.start_assemble_artifacts",
+                attributes={"sentry.op": "artifact_bundle.assemble.start_assemble_artifacts"},
+            ):
                 assemble_artifacts.apply_async(
                     kwargs={
                         "org_id": organization.id,

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -46,7 +46,9 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsEndpointBase):
         dataset = self.get_dataset(request, organization)
 
         def data_fn(offset, limit):
-            with sentry_sdk.start_span(op="discover.endpoint", name="discover_query"):
+            with sentry_sdk.traces.start_span(
+                name="discover_query", attributes={"sentry.op": "discover.endpoint"}
+            ):
                 with handle_query_errors():
                     facets = dataset.get_facets(
                         query=request.GET.get("query"),
@@ -56,8 +58,10 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsEndpointBase):
                         cursor=offset,
                     )
 
-            with sentry_sdk.start_span(op="discover.endpoint", name="populate_results") as span:
-                span.set_data("facet_count", len(facets or []))
+            with sentry_sdk.traces.start_span(
+                name="populate_results", attributes={"sentry.op": "discover.endpoint"}
+            ) as span:
+                span.set_attribute("facet_count", len(facets or []))
                 resp: dict[str, _KeyTopValues]
                 resp = defaultdict(lambda: {"key": "", "topValues": []})
                 for row in facets:

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -86,7 +86,9 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsFacetsPerfor
             tag_key = TAG_ALIASES.get(tag_key)
 
         def data_fn(offset, limit: int):
-            with sentry_sdk.start_span(op="discover.endpoint", name="discover_query"):
+            with sentry_sdk.traces.start_span(
+                name="discover_query", attributes={"sentry.op": "discover.endpoint"}
+            ):
                 referrer = "api.organization-events-facets-performance.top-tags"
                 tag_data = query_tag_data(
                     filter_query=filter_query,
@@ -171,7 +173,9 @@ class OrganizationEventsFacetsPerformanceHistogramEndpoint(
             tag_key = TAG_ALIASES[tag_key]
 
         def data_fn(offset, limit, raw_limit):
-            with sentry_sdk.start_span(op="discover.endpoint", name="discover_query"):
+            with sentry_sdk.traces.start_span(
+                name="discover_query", attributes={"sentry.op": "discover.endpoint"}
+            ):
                 referrer = "api.organization-events-facets-performance-histogram"
                 top_tags = query_top_tags(
                     tag_key=tag_key,
@@ -262,8 +266,10 @@ def query_tag_data(
     :return: Returns the row with aggregate and count if the query was successful
              Returns None if query was not successful which causes the endpoint to return early
     """
-    with sentry_sdk.start_span(op="discover.discover", name="facets.filter_transform") as span:
-        span.set_data("query", filter_query)
+    with sentry_sdk.traces.start_span(
+        name="facets.filter_transform", attributes={"sentry.op": "discover.discover"}
+    ) as span:
+        span.set_attribute("query", filter_query)
         tag_query = DiscoverQueryBuilder(
             dataset=Dataset.Discover,
             params={},
@@ -280,7 +286,9 @@ def query_tag_data(
             Condition(tag_query.resolve_column(aggregate_column), Op.IS_NOT_NULL)
         )
 
-    with sentry_sdk.start_span(op="discover.discover", name="facets.frequent_tags"):
+    with sentry_sdk.traces.start_span(
+        name="facets.frequent_tags", attributes={"sentry.op": "discover.discover"}
+    ):
         # Get the average and count to use to filter the next request to facets
         tag_data = tag_query.run_query(f"{referrer}.all_transactions")
 
@@ -316,7 +324,9 @@ def query_top_tags(
     """
     translated_aggregate_column = discover.resolve_discover_column(aggregate_column)
 
-    with sentry_sdk.start_span(op="discover.discover", name="facets.top_tags"):
+    with sentry_sdk.traces.start_span(
+        name="facets.top_tags", attributes={"sentry.op": "discover.discover"}
+    ):
         if not orderby:
             orderby = ["-count"]
 
@@ -391,8 +401,10 @@ def query_facet_performance(
 
     tag_key_limit = limit if tag_key else 1
 
-    with sentry_sdk.start_span(op="discover.discover", name="facets.filter_transform") as span:
-        span.set_data("query", filter_query)
+    with sentry_sdk.traces.start_span(
+        name="facets.filter_transform", attributes={"sentry.op": "discover.discover"}
+    ) as span:
+        span.set_attribute("query", filter_query)
         tag_query = DiscoverQueryBuilder(
             dataset=Dataset.Discover,
             params={},
@@ -417,9 +429,11 @@ def query_facet_performance(
         ["trace", "trace.ctx", "trace.span", "project", "browser", "celery_task_id", "url"],
     )
 
-    with sentry_sdk.start_span(op="discover.discover", name="facets.aggregate_tags"):
-        span.set_data("sample_rate", sample_rate)
-        span.set_data("target_sample", target_sample)
+    with sentry_sdk.traces.start_span(
+        name="facets.aggregate_tags", attributes={"sentry.op": "discover.discover"}
+    ) as span:
+        span.set_attribute("sample_rate", sample_rate)
+        span.set_attribute("target_sample", target_sample)
         aggregate_comparison = transaction_aggregate * 1.005 if transaction_aggregate else 0
         aggregate_column = Function("avg", [translated_aggregate_column], "aggregate")
         tag_query.where.append(excluded_tags)

--- a/src/sentry/api/endpoints/organization_events_has_measurements.py
+++ b/src/sentry/api/endpoints/organization_events_has_measurements.py
@@ -59,7 +59,9 @@ class OrganizationEventsHasMeasurementsEndpoint(OrganizationEventsEndpointBase):
         if not self.has_feature(organization, request):
             return Response(status=404)
 
-        with sentry_sdk.start_span(op="discover.endpoint", name="parse params"):
+        with sentry_sdk.traces.start_span(
+            name="parse params", attributes={"sentry.op": "discover.endpoint"}
+        ):
             try:
                 snuba_params = self.get_snuba_params(request, organization)
 

--- a/src/sentry/api/endpoints/organization_events_heatmap.py
+++ b/src/sentry/api/endpoints/organization_events_heatmap.py
@@ -103,8 +103,10 @@ class OrganizationEventsHeatmapEndpoint(OrganizationEventsEndpointBase):
             "organizations:data-browsing-heat-map-widget", organization, actor=request.user
         ):
             return Response(status=404)
-        with sentry_sdk.start_span(op="discover.endpoint", name="filter_params") as span:
-            span.set_data("organization", organization)
+        with sentry_sdk.traces.start_span(
+            name="filter_params", attributes={"sentry.op": "discover.endpoint"}
+        ) as span:
+            span.set_attribute("organization", organization)
 
             dataset = self.get_dataset(request, organization)
             if dataset not in HEATMAP_DATASETS:

--- a/src/sentry/api/endpoints/organization_events_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_histogram.py
@@ -62,7 +62,9 @@ class OrganizationEventsHistogramEndpoint(OrganizationEventsEndpointBase):
         except NoProjects:
             return Response({})
 
-        with sentry_sdk.start_span(op="discover.endpoint", name="histogram"):
+        with sentry_sdk.traces.start_span(
+            name="histogram", attributes={"sentry.op": "discover.endpoint"}
+        ):
             serializer = HistogramSerializer(data=request.GET)
             if serializer.is_valid():
                 data = serializer.validated_data

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -86,7 +86,9 @@ class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase):
         except NoProjects:
             return Response([])
 
-        with sentry_sdk.start_span(op="discover.endpoint", name="find_lookup_keys") as span:
+        with sentry_sdk.traces.start_span(
+            name="find_lookup_keys", attributes={"sentry.op": "discover.endpoint"}
+        ) as span:
             possible_keys = ["transaction"]
             lookup_keys = {key: request.query_params.get(key) for key in possible_keys}
 
@@ -99,7 +101,9 @@ class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase):
                 )
 
         with handle_query_errors():
-            with sentry_sdk.start_span(op="discover.endpoint", name="filter_creation"):
+            with sentry_sdk.traces.start_span(
+                name="filter_creation", attributes={"sentry.op": "discover.endpoint"}
+            ):
                 projects = self.get_projects(request, organization)
                 # Filter out None values from environments
                 environments = [e for e in snuba_params.environments if e is not None]
@@ -123,12 +127,16 @@ class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase):
 
                 query_kwargs["actor"] = request.user
 
-            with sentry_sdk.start_span(op="discover.endpoint", name="issue_search"):
+            with sentry_sdk.traces.start_span(
+                name="issue_search", attributes={"sentry.op": "discover.endpoint"}
+            ):
                 results_cursor = search.backend.query(**query_kwargs)
 
-        with sentry_sdk.start_span(op="discover.endpoint", name="serialize_results") as span:
+        with sentry_sdk.traces.start_span(
+            name="serialize_results", attributes={"sentry.op": "discover.endpoint"}
+        ) as span:
             results = list(results_cursor)
-            span.set_data("result_length", len(results))
+            span.set_attribute("result_length", len(results))
             context = serialize(
                 results,
                 request.user,

--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -346,7 +346,9 @@ class OrganizationEventsSpansStatsEndpoint(OrganizationEventsSpansEndpointBase):
             zerofill_results: bool,
             comparison_delta: timedelta | None = None,
         ) -> SnubaTSResult:
-            with sentry_sdk.start_span(op="discover.discover", name="timeseries.filter_transform"):
+            with sentry_sdk.traces.start_span(
+                name="timeseries.filter_transform", attributes={"sentry.op": "discover.discover"}
+            ):
                 builder = TimeseriesQueryBuilder(
                     Dataset.Discover,
                     {},
@@ -383,7 +385,9 @@ class OrganizationEventsSpansStatsEndpoint(OrganizationEventsSpansEndpointBase):
                     snql_query, "api.organization-events-spans-performance-stats"
                 )
 
-            with sentry_sdk.start_span(op="discover.discover", name="timeseries.transform_results"):
+            with sentry_sdk.traces.start_span(
+                name="timeseries.transform_results", attributes={"sentry.op": "discover.discover"}
+            ):
                 result = discover.zerofill(
                     results["data"],
                     snuba_params.start_date,

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -123,8 +123,10 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
             },
         )
 
-        with sentry_sdk.start_span(op="discover.endpoint", name="filter_params") as span:
-            span.set_data("organization", organization)
+        with sentry_sdk.traces.start_span(
+            name="filter_params", attributes={"sentry.op": "discover.endpoint"}
+        ) as span:
+            span.set_attribute("organization", organization)
 
             top_events = 0
 

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -165,8 +165,10 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
         This endpoint can return timeseries for either 1 or many axis, and results grouped to the top events depending
         on the parameters passed
         """
-        with sentry_sdk.start_span(op="discover.endpoint", name="filter_params") as span:
-            span.set_data("organization", organization)
+        with sentry_sdk.traces.start_span(
+            name="filter_params", attributes={"sentry.op": "discover.endpoint"}
+        ) as span:
+            span.set_attribute("organization", organization)
 
             top_events = self.get_top_events(request)
             comparison_delta = self.get_comparison_delta(request)

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -230,7 +230,9 @@ class TraceEvent:
     @property
     def nodestore_event(self) -> Event | GroupEvent | None:
         if self._nodestore_event is None and not self.fetched_nodestore:
-            with sentry_sdk.start_span(op="nodestore", name="get_event_by_id"):
+            with sentry_sdk.traces.start_span(
+                name="get_event_by_id", attributes={"sentry.op": "nodestore"}
+            ):
                 self.fetched_nodestore = True
                 self._nodestore_event = eventstore.backend.get_event_by_id(
                     self.event["project.id"], self.event["id"]
@@ -963,7 +965,9 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointBase):
     def record_analytics(
         transactions: Sequence[SnubaTransaction], trace_id: str, user_id: int, org_id: int
     ) -> None:
-        with sentry_sdk.start_span(op="recording.analytics"):
+        with sentry_sdk.traces.start_span(
+            name="recording.analytics", attributes={"sentry.op": "recording.analytics"}
+        ):
             len_transactions = len(transactions)
 
             sentry_sdk.set_tag("trace_view.trace", trace_id)
@@ -1148,7 +1152,9 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
             to_check.append(root)
 
         iteration = 0
-        with sentry_sdk.start_span(op="building.trace", name="full trace"):
+        with sentry_sdk.traces.start_span(
+            name="full trace", attributes={"sentry.op": "building.trace"}
+        ):
             has_orphans = False
 
             while parent_map or to_check:
@@ -1323,7 +1329,9 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
         if detailed:
             raise ParseError("Cannot return a detailed response using Spans")
 
-        with sentry_sdk.start_span(op="serialize", name="create parent map"):
+        with sentry_sdk.traces.start_span(
+            name="create parent map", attributes={"sentry.op": "serialize"}
+        ):
             parent_to_children_event_map = defaultdict(list)
             serialized_transactions: list[TraceEvent] = []
             for transaction in transactions:
@@ -1352,7 +1360,9 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
             else:
                 orphan_errors.append(error)
 
-        with sentry_sdk.start_span(op="serialize", name="associate children"):
+        with sentry_sdk.traces.start_span(
+            name="associate children", attributes={"sentry.op": "serialize"}
+        ):
             for trace_event in serialized_transactions:
                 event_id = trace_event.event["id"]
                 if event_id in parent_to_children_event_map:
@@ -1363,7 +1373,9 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
                         parent_error_map.pop(event_id), key=lambda k: k["timestamp"]
                     )
 
-        with sentry_sdk.start_span(op="serialize", name="more orphans"):
+        with sentry_sdk.traces.start_span(
+            name="more orphans", attributes={"sentry.op": "serialize"}
+        ):
             visited_transactions_ids: set[str] = {
                 root_trace.event["id"] for root_trace in root_traces
             }
@@ -1376,7 +1388,7 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
                     for child in serialized_transaction.children:
                         visited_transactions_ids.add(child.event["id"])
 
-        with sentry_sdk.start_span(op="serialize", name="sort"):
+        with sentry_sdk.traces.start_span(name="sort", attributes={"sentry.op": "serialize"}):
             # Sort the results so they're consistent
             orphan_errors.sort(key=lambda k: k["timestamp"])
             root_traces.sort(key=child_sort_key)
@@ -1398,7 +1410,7 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
             if serialized_orphan is not None:
                 result_transactions.append(serialized_orphan)
 
-        with sentry_sdk.start_span(op="serialize", name="to dict"):
+        with sentry_sdk.traces.start_span(name="to dict", attributes={"sentry.op": "serialize"}):
             return {
                 "transactions": result_transactions,
                 "orphan_errors": [self.serialize_error(error) for error in orphan_errors],

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -311,7 +311,9 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsEndpointBase):
         except NoProjects:
             return Response([])
 
-        with sentry_sdk.start_span(op="discover.endpoint", name="trend_dates"):
+        with sentry_sdk.traces.start_span(
+            name="trend_dates", attributes={"sentry.op": "discover.endpoint"}
+        ):
             middle_date = request.GET.get("middle")
             if middle_date:
                 try:

--- a/src/sentry/api/endpoints/organization_events_vitals.py
+++ b/src/sentry/api/endpoints/organization_events_vitals.py
@@ -29,7 +29,9 @@ class OrganizationEventsVitalsEndpoint(OrganizationEventsEndpointBase):
         if not self.has_feature(organization, request):
             return Response(status=404)
 
-        with sentry_sdk.start_span(op="discover.endpoint", name="parse params"):
+        with sentry_sdk.traces.start_span(
+            name="parse params", attributes={"sentry.op": "discover.endpoint"}
+        ):
             try:
                 snuba_params = self.get_snuba_params(request, organization)
             except NoProjects:

--- a/src/sentry/api/endpoints/organization_measurements_meta.py
+++ b/src/sentry/api/endpoints/organization_measurements_meta.py
@@ -1,6 +1,6 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry_sdk import start_span
+from sentry_sdk.traces import start_span
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -33,7 +33,7 @@ class OrganizationMeasurementsMeta(OrganizationEventsEndpointBase):
                 use_case_id=UseCaseID.TRANSACTIONS,
             )
 
-        with start_span(op="transform", name="metric meta"):
+        with start_span(name="metric meta", attributes={"sentry.op": "transform"}):
             result = {
                 item["name"]: {
                     "functions": METRIC_FUNCTION_LIST_BY_TYPE[item["type"]],

--- a/src/sentry/api/endpoints/organization_on_demand_metrics_estimation_stats.py
+++ b/src/sentry/api/endpoints/organization_on_demand_metrics_estimation_stats.py
@@ -66,8 +66,10 @@ class OrganizationOnDemandMetricsEstimationStatsEndpoint(OrganizationEventsEndpo
         if measurement is None:
             return Response({"detail": "missing required parameter yAxis"}, status=400)
 
-        with sentry_sdk.start_span(op="discover.metrics.endpoint", name="get_full_metrics") as span:
-            span.set_data("organization", organization)
+        with sentry_sdk.traces.start_span(
+            name="get_full_metrics", attributes={"sentry.op": "discover.metrics.endpoint"}
+        ) as span:
+            span.set_attribute("organization", organization)
 
             try:
                 # the discover stats

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -215,7 +215,7 @@ class ReleaseSerializerWithProjects(ReleaseWithVersionSerializer):
     refs = ListField(child=ReleaseHeadCommitSerializer(), required=False, allow_null=False)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def debounce_update_release_health_data(organization, project_ids: list[int]):
     """This causes a flush of snuba health data to the postgres tables once
     per minute for the given projects.

--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -81,7 +81,9 @@ class OrganizationSessionsEndpoint(OrganizationEndpoint):
 
         def data_fn(offset: int, limit: int) -> SessionsQueryResult:
             with self.handle_query_errors():
-                with sentry_sdk.start_span(op="sessions.endpoint", name="build_sessions_query"):
+                with sentry_sdk.traces.start_span(
+                    name="build_sessions_query", attributes={"sentry.op": "sessions.endpoint"}
+                ):
                     request_limit = None
                     if request.GET.get("per_page") is not None:
                         request_limit = limit

--- a/src/sentry/api/endpoints/organization_stats_summary.py
+++ b/src/sentry/api/endpoints/organization_stats_summary.py
@@ -148,14 +148,20 @@ class OrganizationStatsSummaryEndpoint(OrganizationEndpoint):
         """
         with self.handle_query_errors():
             tenant_ids = {"organization_id": organization.id}
-            with sentry_sdk.start_span(op="outcomes.endpoint", name="build_outcomes_query"):
+            with sentry_sdk.traces.start_span(
+                name="build_outcomes_query", attributes={"sentry.op": "outcomes.endpoint"}
+            ):
                 query = self.build_outcomes_query(
                     request,
                     organization,
                 )
-            with sentry_sdk.start_span(op="outcomes.endpoint", name="run_outcomes_query"):
+            with sentry_sdk.traces.start_span(
+                name="run_outcomes_query", attributes={"sentry.op": "outcomes.endpoint"}
+            ):
                 result_totals = run_outcomes_query_totals(query, tenant_ids=tenant_ids)
-            with sentry_sdk.start_span(op="outcomes.endpoint", name="massage_outcomes_result"):
+            with sentry_sdk.traces.start_span(
+                name="massage_outcomes_result", attributes={"sentry.op": "outcomes.endpoint"}
+            ):
                 projects, result = massage_sessions_result_summary(
                     query, result_totals, request.GET.getlist("outcome")
                 )

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -189,19 +189,25 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
         """
         with self.handle_query_errors():
             tenant_ids = {"organization_id": organization.id}
-            with sentry_sdk.start_span(op="outcomes.endpoint", name="build_outcomes_query"):
+            with sentry_sdk.traces.start_span(
+                name="build_outcomes_query", attributes={"sentry.op": "outcomes.endpoint"}
+            ):
                 query = self.build_outcomes_query(
                     request,
                     organization,
                 )
-            with sentry_sdk.start_span(op="outcomes.endpoint", name="run_outcomes_query"):
+            with sentry_sdk.traces.start_span(
+                name="run_outcomes_query", attributes={"sentry.op": "outcomes.endpoint"}
+            ):
                 result_totals = run_outcomes_query_totals(query, tenant_ids=tenant_ids)
                 result_timeseries = (
                     None
                     if "project_id" in query.query_groupby
                     else run_outcomes_query_timeseries(query, tenant_ids=tenant_ids)
                 )
-            with sentry_sdk.start_span(op="outcomes.endpoint", name="massage_outcomes_result"):
+            with sentry_sdk.traces.start_span(
+                name="massage_outcomes_result", attributes={"sentry.op": "outcomes.endpoint"}
+            ):
                 result = massage_outcomes_result(query, result_totals, result_timeseries)
             return Response(result, status=200)
 

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -98,7 +98,9 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
         else:
             dataset = Dataset.Discover
 
-        with sentry_sdk.start_span(op="tagstore", name="get_tag_keys_for_projects"):
+        with sentry_sdk.traces.start_span(
+            name="get_tag_keys_for_projects", attributes={"sentry.op": "tagstore"}
+        ):
             with handle_query_errors():
                 start = filter_params["start"]
                 end = filter_params["end"]

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -483,7 +483,9 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         attr_type = constants.ATTRIBUTES_QUERY_PARAM_TO_ATTRIBUTE_TYPE_MAP.get(
             attribute_type, AttributeKey.Type.TYPE_STRING
         )
-        with sentry_sdk.start_span(op="filter", name="hardcoded_aliases") as span:
+        with sentry_sdk.traces.start_span(
+            name="hardcoded_aliases", attributes={"sentry.op": "filter"}
+        ) as span:
             all_aliased_attributes = []
             # our aliases don't exist in the db, so filter over our aliases
             # virtually page through defined aliases before we hit the db
@@ -533,7 +535,9 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                                 )
                             )
             aliased_attributes = all_aliased_attributes[offset : offset + limit]
-        with sentry_sdk.start_span(op="query", name="attribute_names") as span:
+        with sentry_sdk.traces.start_span(
+            name="attribute_names", attributes={"sentry.op": "query"}
+        ) as span:
             if len(aliased_attributes) < limit:
                 offset -= len(all_aliased_attributes) - len(aliased_attributes)
                 limit -= len(aliased_attributes)
@@ -557,7 +561,9 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
             else:
                 rpc_response = TraceItemAttributeNamesResponse()
 
-        with sentry_sdk.start_span(op="query", name="serialize") as span:
+        with sentry_sdk.traces.start_span(
+            name="serialize", attributes={"sentry.op": "query"}
+        ) as span:
             attributes = self.serialize_trace_attributes(
                 rpc_response,
                 attribute_type,
@@ -569,8 +575,8 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
             )
 
             sentry_sdk.set_context("api_response", {"attributes": attributes})
-            span.set_data("attribute_count", len(attributes))
-            span.set_data("attribute_type", attribute_type)
+            span.set_attribute("attribute_count", len(attributes))
+            span.set_attribute("attribute_type", attribute_type)
         return attributes, debug_info
 
     def serialize_trace_attributes(

--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -126,10 +126,14 @@ def serialize(
                 pass
         else:
             return objects
-    with sentry_sdk.start_span(op="serialize", name=type(serializer).__name__) as span:
-        span.set_data("Object Count", len(objects))
+    with sentry_sdk.traces.start_span(
+        name=type(serializer).__name__, attributes={"sentry.op": "serialize"}
+    ) as span:
+        span.set_attribute("Object Count", len(objects))
 
-        with sentry_sdk.start_span(op="serialize.get_attrs", name=type(serializer).__name__):
+        with sentry_sdk.traces.start_span(
+            name=type(serializer).__name__, attributes={"sentry.op": "serialize.get_attrs"}
+        ):
             attrs = serializer.get_attrs(
                 # avoid passing NoneType's to the serializer as they're allowed and
                 # filtered out of serialize()
@@ -138,7 +142,9 @@ def serialize(
                 **kwargs,
             )
 
-        with sentry_sdk.start_span(op="serialize.iterate", name=type(serializer).__name__):
+        with sentry_sdk.traces.start_span(
+            name=type(serializer).__name__, attributes={"sentry.op": "serialize.iterate"}
+        ):
             return [serializer(o, attrs=attrs.get(o, {}), user=user, **kwargs) for o in objects]
 
 

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -516,7 +516,7 @@ class SqlFormatEventSerializer(EventSerializer):
         include_full_release_data = kwargs.pop("include_full_release_data", False)
         result = super().serialize(obj, attrs, user, **kwargs)
 
-        with sentry_sdk.start_span(op="serialize", name="Format SQL"):
+        with sentry_sdk.traces.start_span(name="Format SQL", attributes={"sentry.op": "serialize"}):
             result = self._format_breadcrumb_messages(result, obj, user)
             result = self._format_db_spans(result, obj, user)
             release_info = self._get_release_info(user, obj, include_full_release_data)

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -767,7 +767,10 @@ class GroupSerializerBase(Serializer, ABC):
 
     @staticmethod
     def _get_permalink(attrs, obj: Group) -> str:
-        with sentry_sdk.start_span(op="GroupSerializerBase.serialize.permalink.build"):
+        with sentry_sdk.traces.start_span(
+            name="GroupSerializerBase.serialize.permalink.build",
+            attributes={"sentry.op": "GroupSerializerBase.serialize.permalink.build"},
+        ):
             return obj.get_absolute_url()
 
     @staticmethod

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -473,7 +473,9 @@ class OrganizationSummarySerializer(Serializer[OrganizationSummarySerializerResp
         ]
         feature_set = set()
 
-        with sentry_sdk.start_span(op="features.check", name="check batch features"):
+        with sentry_sdk.traces.start_span(
+            name="check batch features", attributes={"sentry.op": "features.check"}
+        ):
             # Evaluate flags purely to populate the response — the user has not
             # actually encountered any experiments yet, so suppress the auto
             # exposure events the entity handler would otherwise log.
@@ -493,7 +495,9 @@ class OrganizationSummarySerializer(Serializer[OrganizationSummarySerializerResp
                     # This feature_name was found via `batch_has`, don't check again using `has`
                     org_features.remove(feature_name)
 
-        with sentry_sdk.start_span(op="features.check", name="check individual features"):
+        with sentry_sdk.traces.start_span(
+            name="check individual features", attributes={"sentry.op": "features.check"}
+        ):
             # Remaining features should not be checked via the entity handler
             for feature_name in org_features:
                 if features.has(feature_name, obj, actor=user, skip_entity=True):

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -136,7 +136,9 @@ def get_access_by_project(
 
     result: dict[Project, dict[str, Any]] = {}
     has_team_roles_cache: dict[int, bool] = {}
-    with sentry_sdk.start_span(op="project.check-access"):
+    with sentry_sdk.traces.start_span(
+        name="project.check-access", attributes={"sentry.op": "project.check-access"}
+    ):
         for project in projects:
             member_teams = [
                 memberships_by_team[tid]
@@ -367,8 +369,11 @@ class ProjectSerializer(Serializer):
         self, item_list: Sequence[Project], user: User | RpcUser | AnonymousUser, **kwargs: Any
     ) -> dict[Project, dict[str, Any]]:
         def measure_span(op_tag):
-            span = sentry_sdk.start_span(op=f"serialize.get_attrs.project.{op_tag}")
-            span.set_data("Object Count", len(item_list))
+            span = sentry_sdk.traces.start_span(
+                name=f"serialize.get_attrs.project.{op_tag}",
+                attributes={"sentry.op": f"serialize.get_attrs.project.{op_tag}"},
+            )
+            span.set_attribute("Object Count", len(item_list))
             return span
 
         with measure_span("preamble"):

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -929,7 +929,9 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         return instance
 
     def update_widgets(self, instance, widget_data):
-        with sentry_sdk.start_span(op="function", name="dashboard.update_widgets"):
+        with sentry_sdk.traces.start_span(
+            name="dashboard.update_widgets", attributes={"sentry.op": "function"}
+        ):
             widget_ids = [widget["id"] for widget in widget_data if "id" in widget]
 
             existing_widgets = DashboardWidget.objects.filter(dashboard=instance, id__in=widget_ids)
@@ -1072,8 +1074,8 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         organization = self.context["organization"]
         linked_dashboards = linked_dashboards or []
 
-        with sentry_sdk.start_span(
-            op="function", name="dashboard.update_or_create_field_links"
+        with sentry_sdk.traces.start_span(
+            name="dashboard.update_or_create_field_links", attributes={"sentry.op": "function"}
         ) as span:
             # Get the set of fields that should exist
             new_fields = set()
@@ -1081,16 +1083,16 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
 
             widget_display_type = widget.display_type
             legend_type = widget.detail.get("legend_type") if widget.detail else None
-            span.set_data(
+            span.set_attribute(
                 "linked_dashboards",
                 [
                     {"field": ld.get("field"), "dashboard_id": ld.get("dashboard_id")}
                     for ld in linked_dashboards
                 ],
             )
-            span.set_data("widget_display_type", widget_display_type)
-            span.set_data("query_id", query.id)
-            span.set_data("widget_id", widget.id)
+            span.set_attribute("widget_display_type", widget_display_type)
+            span.set_attribute("query_id", query.id)
+            span.set_attribute("widget_id", widget.id)
 
             is_breakdown_chart = (
                 widget_display_type
@@ -1163,21 +1165,22 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
                 field__in=new_fields
             ).delete()
 
-            with sentry_sdk.start_span(
-                op="db.bulk_create", name="dashboard.update_or_create_field_links.bulk_create"
+            with sentry_sdk.traces.start_span(
+                name="dashboard.update_or_create_field_links.bulk_create",
+                attributes={"sentry.op": "db.bulk_create"},
             ) as span:
-                span.set_data("new_fields", list(new_fields))
-                span.set_data("query_id", query.id)
-                span.set_data("widget_id", widget.id)
-                span.set_data("widget_display_type", widget.display_type)
-                span.set_data(
+                span.set_attribute("new_fields", list(new_fields))
+                span.set_attribute("query_id", query.id)
+                span.set_attribute("widget_id", widget.id)
+                span.set_attribute("widget_display_type", widget.display_type)
+                span.set_attribute(
                     "linked_dashboards",
                     [
                         {"field": ld.get("field"), "dashboard_id": ld.get("dashboard_id")}
                         for ld in linked_dashboards
                     ],
                 )
-                span.set_data("field_links_count", len(field_links_to_create))
+                span.set_attribute("field_links_count", len(field_links_to_create))
 
                 # Use bulk_create with update_conflicts to effectively upsert (i.e bulk update or create)
                 if field_links_to_create:

--- a/src/sentry/attachments/__init__.py
+++ b/src/sentry/attachments/__init__.py
@@ -29,7 +29,7 @@ attachment_cache: BaseAttachmentCache = import_string(settings.SENTRY_ATTACHMENT
 )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def store_attachments_for_event(
     project: Project, event: Any, attachments: list[CachedAttachment], timeout=None
 ):
@@ -61,7 +61,7 @@ def get_attachments_for_event(event: Any) -> Generator[CachedAttachment]:
     )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def delete_cached_and_ratelimited_attachments(
     project: Project, attachments: list[CachedAttachment]
 ):

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -282,14 +282,17 @@ class DbAccess(Access):
         if not teams:
             return frozenset()
 
-        with sentry_sdk.start_span(op="get_project_access_in_teams") as span:
+        with sentry_sdk.traces.start_span(
+            name="get_project_access_in_teams",
+            attributes={"sentry.op": "get_project_access_in_teams"},
+        ) as span:
             projects = frozenset(
                 Project.objects.filter(status=ObjectStatus.ACTIVE, teams__in=teams)
                 .distinct()
                 .values_list("id", flat=True)
             )
-            span.set_data("Project Count", len(projects))
-            span.set_data("Team Count", len(teams))
+            span.set_attribute("Project Count", len(projects))
+            span.set_attribute("Team Count", len(teams))
 
         return projects
 
@@ -360,15 +363,18 @@ class DbAccess(Access):
             return True
 
         if self._member and features.has("organizations:team-roles", self._member.organization):
-            with sentry_sdk.start_span(op="check_access_for_all_project_teams") as span:
+            with sentry_sdk.traces.start_span(
+                name="check_access_for_all_project_teams",
+                attributes={"sentry.op": "check_access_for_all_project_teams"},
+            ) as span:
                 memberships = [
                     self._team_memberships[team]
                     for team in project.teams.all()
                     if team in self._team_memberships
                 ]
-                span.set_tag("organization", self._member.organization.id)
-                span.set_tag("organization.slug", self._member.organization.slug)
-                span.set_data("membership_count", len(memberships))
+                span.set_attribute("organization", self._member.organization.id)
+                span.set_attribute("organization.slug", self._member.organization.slug)
+                span.set_attribute("membership_count", len(memberships))
 
             for membership in memberships:
                 team_scopes = membership.get_scopes()
@@ -573,14 +579,19 @@ class RpcBackedAccess(Access):
         if self.rpc_user_organization_context.member and features.has(
             "organizations:team-roles", self.rpc_user_organization_context.organization
         ):
-            with sentry_sdk.start_span(op="check_access_for_all_project_teams") as span:
+            with sentry_sdk.traces.start_span(
+                name="check_access_for_all_project_teams",
+                attributes={"sentry.op": "check_access_for_all_project_teams"},
+            ) as span:
                 project_teams_id = set(project.teams.values_list("id", flat=True))
                 orgmember_teams = self.rpc_user_organization_context.member.member_teams
-                span.set_tag("organization", self.rpc_user_organization_context.organization.id)
-                span.set_tag(
+                span.set_attribute(
+                    "organization", self.rpc_user_organization_context.organization.id
+                )
+                span.set_attribute(
                     "organization.slug", self.rpc_user_organization_context.organization.slug
                 )
-                span.set_data("membership_count", len(orgmember_teams))
+                span.set_attribute("membership_count", len(orgmember_teams))
 
             for member_team in orgmember_teams:
                 if not member_team.role:

--- a/src/sentry/charts/chartcuterie.py
+++ b/src/sentry/charts/chartcuterie.py
@@ -65,9 +65,9 @@ class Chartcuterie(ChartRenderer):
         if size:
             payload.update(size)
 
-        with sentry_sdk.start_span(
-            op="charts.chartcuterie.generate_chart",
+        with sentry_sdk.traces.start_span(
             name=type(self).__name__,
+            attributes={"sentry.op": "charts.chartcuterie.generate_chart"},
         ):
             # Using sentry json formatter to handle datetime objects
             assert self.service_url is not None
@@ -87,9 +87,9 @@ class Chartcuterie(ChartRenderer):
 
         file_name = f"{request_id}.png"
 
-        with sentry_sdk.start_span(
-            op="charts.chartcuterie.upload",
+        with sentry_sdk.traces.start_span(
             name=type(self).__name__,
+            attributes={"sentry.op": "charts.chartcuterie.upload"},
         ):
             storage = get_storage(self.storage_options)
             storage.save(file_name, BytesIO(resp.content))

--- a/src/sentry/conf/types/sdk_config.py
+++ b/src/sentry/conf/types/sdk_config.py
@@ -20,7 +20,7 @@ class SdkConfig(TypedDict):
     send_client_reports: NotRequired[bool]
     traces_sampler: NotRequired[Callable[[dict[str, Any]], float]]
     before_send: NotRequired[Callable[[Event, Hint], Event | None]]
-    before_send_transaction: NotRequired[Callable[[Event, Hint], Event | None]]
+    before_send_transaction: NotRequired[Callable[[dict[str, Any], Hint], dict[str, Any]]]
     enable_logs: NotRequired[bool]
     before_send_log: NotRequired[Callable[[Log, Hint], Log | None]]
     profiles_sample_rate: NotRequired[float]

--- a/src/sentry/consumers/profiler.py
+++ b/src/sentry/consumers/profiler.py
@@ -17,8 +17,8 @@ class JoinProfiler(ProcessingStrategy[TStrategyPayload]):
         self.__next_step = next_step
 
     def join(self, timeout: float | None = None):
-        with sentry_sdk.start_transaction(
-            op="consumer_join", name="consumer.join", custom_sampling_context={"sample_rate": 1.0}
+        with sentry_sdk.traces.start_span(
+            name="consumer.join", attributes={"sentry.op": "consumer_join"}, parent_span=None
         ):
             self.__next_step.join(timeout)
 

--- a/src/sentry/core/endpoints/organization_users.py
+++ b/src/sentry/core/endpoints/organization_users.py
@@ -34,7 +34,10 @@ class OrganizationUsersEndpoint(OrganizationEndpoint):
         """
         projects = self.get_projects(request, organization)
 
-        with sentry_sdk.start_span(op="OrganizationUsersEndpoint.get_members") as span:
+        with sentry_sdk.traces.start_span(
+            name="OrganizationUsersEndpoint.get_members",
+            attributes={"sentry.op": "OrganizationUsersEndpoint.get_members"},
+        ) as span:
             qs = OrganizationMember.objects.filter(
                 user_id__isnull=False,
                 user_is_active=True,
@@ -48,8 +51,8 @@ class OrganizationUsersEndpoint(OrganizationEndpoint):
 
             organization_members = list(qs)
 
-            span.set_data("Project Count", len(projects))
-            span.set_data("Member Count", len(organization_members))
+            span.set_attribute("Project Count", len(projects))
+            span.set_attribute("Member Count", len(organization_members))
 
         return Response(
             serialize(

--- a/src/sentry/core/endpoints/scim/utils.py
+++ b/src/sentry/core/endpoints/scim/utils.py
@@ -25,9 +25,9 @@ ACCEPTED_FILTERED_KEYS = ["userName", "value", "displayName"]
 
 class SCIMApiError(APIException):
     def __init__(self, detail, status_code=400):
-        transaction = sentry_sdk.get_current_scope().transaction
-        if transaction is not None:
-            transaction.set_tag("http.status_code", status_code)
+        span = sentry_sdk.traces.get_current_span()
+        if span is not None:
+            span.set_attribute("http.status_code", status_code)
         super().__init__({"schemas": [SCIM_API_ERROR], "detail": detail})
         self.status_code = status_code
 

--- a/src/sentry/data_export/processors/explore.py
+++ b/src/sentry/data_export/processors/explore.py
@@ -219,13 +219,15 @@ class TraceItemFullExportProcessor(ExploreProcessor):
             token = PageToken()
             token.ParseFromString(self.page_token)
             request.page_token.CopyFrom(token)
-        with sentry_sdk.start_span(op="snuba.rpc", name="ExportTraceItems") as span:
-            span.set_data("dataset", self.explore_query["dataset"])
-            span.set_data("limit", limit)
-            span.set_data("has_page_token", self.page_token is not None)
+        with sentry_sdk.traces.start_span(
+            name="ExportTraceItems", attributes={"sentry.op": "snuba.rpc"}
+        ) as span:
+            span.set_attribute("dataset", self.explore_query["dataset"])
+            span.set_attribute("limit", limit)
+            span.set_attribute("has_page_token", self.page_token is not None)
             http_resp = export_logs_rpc(request)
             self._sync_page_token_from_snuba_response(http_resp)
-            span.set_data("next_page_token", self.page_token is not None)
+            span.set_attribute("next_page_token", self.page_token is not None)
 
         rows = list(iter_export_trace_items_rows(http_resp, self._supported_trace_item_type))
         return rows or []

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -168,7 +168,9 @@ def export_chunk_to_stored_blobs(
     batch_size: int = SNUBA_MAX_RESULTS,
 ) -> AssembleChunkResult:
     """One activation: fill up to MAX_FRAGMENTS_PER_BATCH fragments and persist a blob chunk."""
-    with sentry_sdk.start_span(op="export.chunk", name=f"offset={offset}"):
+    with sentry_sdk.traces.start_span(
+        name=f"offset={offset}", attributes={"sentry.op": "export.chunk"}
+    ):
         output_mode = OutputMode.from_value(data_export.export_format)
         processor = get_processor(
             data_export,
@@ -336,7 +338,9 @@ def assemble_download(
         "requested_rows": export_limit,
         "offset_in": offset,
     }
-    with sentry_sdk.start_span(op="assemble", name="Async Export Data"):
+    with sentry_sdk.traces.start_span(
+        name="Async Export Data", attributes={"sentry.op": "assemble"}
+    ):
         first_page = offset == 0
         data_export = _fetch_exported_data_req_obj(data_export_id, first_page, extra)
         if data_export is None:
@@ -477,7 +481,9 @@ def export_data_to_stored_blobs_sync(
     sentry_sdk.set_tag("download_type", "sync")
     sentry_sdk.set_context("data_export", extra)
     _set_data_on_scope(data_export)
-    with sentry_sdk.start_span(op="assemble", name="Sync Export Data"):
+    with sentry_sdk.traces.start_span(
+        name="Sync Export Data", attributes={"sentry.op": "assemble"}
+    ):
         logger.info("dataexport.start", extra=extra)
         metrics.incr(
             "dataexport.start",
@@ -724,7 +730,7 @@ def merge_export_blobs(
         "requested_rows": export_limit,
         "actual_rows": actual_rows,
     }
-    with sentry_sdk.start_span(op="merge"):
+    with sentry_sdk.traces.start_span(name="merge", attributes={"sentry.op": "merge"}):
         try:
             data_export = ExportedData.objects.get(id=data_export_id)
         except ExportedData.DoesNotExist:

--- a/src/sentry/db/models/fields/encryption/_base.py
+++ b/src/sentry/db/models/fields/encryption/_base.py
@@ -91,7 +91,7 @@ class EncryptedField(Field):
         super().contribute_to_class(cls, name, private_only=private_only)
         self._model_name = cls.__name__
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _format_encrypted_value(
         self, encrypted_data: bytes, marker: str, key_id: str | None = None
     ) -> str:
@@ -111,7 +111,7 @@ class EncryptedField(Field):
         else:
             return f"{marker}:{encoded_data}"
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def get_prep_value(self, value: Any) -> Any:
         """Encrypt the value before saving to database."""
         value = super().get_prep_value(value)
@@ -147,11 +147,11 @@ class EncryptedField(Field):
             metrics.incr("database.encrypted_field.encrypt", tags={**tags, "status": "failure"})
             raise
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def from_db_value(self, value: Any, expression: Any, connection: Any) -> bytes | str | None:
         return self.to_python(value)
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def to_python(self, value: Any) -> Any:
         """Decrypt the value when loading from database."""
         if value is None:
@@ -182,7 +182,7 @@ class EncryptedField(Field):
                 return True
         return False
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _get_value_in_bytes(self, value: Any) -> bytes:
         if isinstance(value, str):
             return value.encode("utf-8")
@@ -191,13 +191,13 @@ class EncryptedField(Field):
         else:
             return str(value).encode("utf-8")
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _encrypt_plaintext(self, value: Any) -> str:
         """Store value as plain text (UTF-8 encoded)."""
         value_bytes = self._get_value_in_bytes(value)
         return self._format_encrypted_value(value_bytes, MARKER_PLAINTEXT)
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _decrypt_plaintext(self, value: str) -> bytes:
         """Decrypt plain text. Extracts data from the formatted value.
 
@@ -211,7 +211,7 @@ class EncryptedField(Field):
             logger.warning("Failed to decode base64 data: %s", e)
             raise ValueError("Invalid base64 encoding") from e
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _encrypt_fernet(self, value: Any) -> str:
         """Encrypt using Fernet symmetric encryption.
 
@@ -227,7 +227,7 @@ class EncryptedField(Field):
             sentry_sdk.capture_exception(e)
             raise
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _decrypt_fernet(self, value: str) -> bytes:
         """Decrypt using Fernet. Extracts key_id from the formatted value.
 
@@ -270,7 +270,7 @@ class EncryptedField(Field):
         """
         raise NotImplementedError("Keysets decryption not yet implemented")
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _decrypt_with_fallback(self, value: str) -> bytes | str:
         """
         Attempt to decrypt with the appropriate method based on the marker.

--- a/src/sentry/db/models/fields/encryption/encrypted_char_field.py
+++ b/src/sentry/db/models/fields/encryption/encrypted_char_field.py
@@ -7,7 +7,7 @@ from ._base import EncryptedField
 
 
 class EncryptedCharField(EncryptedField, CharField):
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def from_db_value(self, value: Any, expression: Any, connection: Any) -> Any:
         db_value = super().from_db_value(value, expression, connection)
         if db_value is None:

--- a/src/sentry/db/models/fields/encryption/encrypted_json_field.py
+++ b/src/sentry/db/models/fields/encryption/encrypted_json_field.py
@@ -33,7 +33,7 @@ class EncryptedJSONField(EncryptedField, JSONField):
 
     _encrypted_field_key = "sentry_encrypted_field_value"
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def get_prep_value(self, value: Any) -> dict | None:
         """
         Prepare value for database storage.
@@ -57,7 +57,7 @@ class EncryptedJSONField(EncryptedField, JSONField):
         # This will be stored as jsonb, not as a string
         return {self._encrypted_field_key: encrypted_value}
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def to_python(self, value: Any) -> Any:
         """
         Convert database value to Python object.

--- a/src/sentry/db/models/fields/encryption/encrypted_text_field.py
+++ b/src/sentry/db/models/fields/encryption/encrypted_text_field.py
@@ -7,7 +7,7 @@ from ._base import EncryptedField
 
 
 class EncryptedTextField(EncryptedField, TextField):
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def from_db_value(self, value: Any, expression: Any, connection: Any) -> Any:
         db_value = super().from_db_value(value, expression, connection)
         if db_value is None:

--- a/src/sentry/debug_files/upload.py
+++ b/src/sentry/debug_files/upload.py
@@ -9,14 +9,19 @@ from sentry.models.files import FileBlob
 
 def find_missing_chunks(organization_id: int, chunks: Set[str]) -> list[str]:
     """Returns a list of chunks which are missing for an org."""
-    with sentry_sdk.start_span(op="find_missing_chunks") as span:
-        span.set_tag("organization_id", organization_id)
-        span.set_data("chunks_size", len(chunks))
+    with sentry_sdk.traces.start_span(
+        name="find_missing_chunks", attributes={"sentry.op": "find_missing_chunks"}
+    ) as span:
+        span.set_attribute("organization_id", organization_id)
+        span.set_attribute("chunks_size", len(chunks))
 
         if not chunks:
             return []
 
-        with sentry_sdk.start_span(op="find_missing_chunks.fetch_owned_file_blobs"):
+        with sentry_sdk.traces.start_span(
+            name="find_missing_chunks.fetch_owned_file_blobs",
+            attributes={"sentry.op": "find_missing_chunks.fetch_owned_file_blobs"},
+        ):
             owned_file_blobs = FileBlob.objects.filter(
                 checksum__in=chunks, fileblobowner__organization_id=organization_id
             ).values_list(
@@ -30,7 +35,10 @@ def find_missing_chunks(organization_id: int, chunks: Set[str]) -> list[str]:
         owned_file_chunks = {checksum for _, checksum, _ in owned_file_blobs}
         unowned_file_chunks = chunks - owned_file_chunks
 
-        with sentry_sdk.start_span(op="find_missing_chunks.fetch_unowned_file_blobs"):
+        with sentry_sdk.traces.start_span(
+            name="find_missing_chunks.fetch_unowned_file_blobs",
+            attributes={"sentry.op": "find_missing_chunks.fetch_unowned_file_blobs"},
+        ):
             unowned_file_blobs = FileBlob.objects.filter(
                 checksum__in=unowned_file_chunks,
             ).values_list(
@@ -50,7 +58,10 @@ def find_missing_chunks(organization_id: int, chunks: Set[str]) -> list[str]:
                 file_blobs_to_renew.add(id)
 
         if file_blobs_to_renew:
-            with sentry_sdk.start_span(op="find_missing_chunks_new.update_timestamp"):
+            with sentry_sdk.traces.start_span(
+                name="find_missing_chunks_new.update_timestamp",
+                attributes={"sentry.op": "find_missing_chunks_new.update_timestamp"},
+            ):
                 # We update the timestamp of the file blobs that need renewal.
                 FileBlob.objects.filter(id__in=file_blobs_to_renew).update(timestamp=now)
 

--- a/src/sentry/demo_mode/tasks.py
+++ b/src/sentry/demo_mode/tasks.py
@@ -77,7 +77,7 @@ def _sync_project_debug_files(
     if not source_org or not target_org:
         return
 
-    with sentry_sdk.start_span(name="sync-project-debug-files-get-project-ids") as span:
+    with sentry_sdk.traces.start_span(name="sync-project-debug-files-get-project-ids") as span:
         source_project_ids = list(
             Project.objects.filter(
                 organization_id=source_org.id,
@@ -89,8 +89,8 @@ def _sync_project_debug_files(
                 organization_id=target_org.id,
             ).values_list("id", flat=True)
         )
-        span.set_data("source_project_ids", source_project_ids)
-        span.set_data("target_project_ids", target_project_ids)
+        span.set_attribute("source_project_ids", source_project_ids)
+        span.set_attribute("target_project_ids", target_project_ids)
 
     project_debug_files = ProjectDebugFile.objects.filter(
         Q(project_id__in=source_project_ids) | Q(project_id__in=target_project_ids),
@@ -110,8 +110,10 @@ def _sync_project_debug_files(
     )
 
     for source_project_debug_file in different_project_debug_files:
-        with sentry_sdk.start_span(name="sync-project-debug-files-sync-project-debug-file") as span:
-            span.set_data("source_project_debug_file_id", source_project_debug_file.id)
+        with sentry_sdk.traces.start_span(
+            name="sync-project-debug-files-sync-project-debug-file"
+        ) as span:
+            span.set_attribute("source_project_debug_file_id", source_project_debug_file.id)
             _sync_project_debug_file(source_project_debug_file, target_org)
 
 

--- a/src/sentry/discover/dashboard_widget_split.py
+++ b/src/sentry/discover/dashboard_widget_split.py
@@ -71,7 +71,7 @@ def _save_split_decision_for_widget(
     widget.save()
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def _get_and_save_split_decision_for_dashboard_widget(
     widget_query: DashboardWidgetQuery, dry_run: bool
 ) -> tuple[int, bool]:

--- a/src/sentry/discover/dataset_split.py
+++ b/src/sentry/discover/dataset_split.py
@@ -375,7 +375,7 @@ def _get_snuba_dataclass_for_saved_query(
     return _get_snuba_dataclass(saved_query.organization, projects, start, end, period, environment)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def _get_and_save_split_decision_for_query(
     saved_query: DiscoverSavedQuery, dry_run: bool
 ) -> tuple[int, bool]:

--- a/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
@@ -372,18 +372,21 @@ def record_latest_release(project: Project, release: Release, environment: str |
         return
 
     def on_release_boosted() -> None:
-        span.set_tag(
+        span.set_attribute(
             "dynamic_sampling.observe_release_status",
             "(release, environment) pair observed and boosted",
         )
-        span.set_data("release", release.id)
-        span.set_data("environment", environment)
+        span.set_attribute("release", release.id)
+        span.set_attribute("environment", environment)
 
         schedule_invalidate_project_config(
             project_id=project.id,
             trigger="dynamic_sampling:boost_release",
         )
 
-    with sentry_sdk.start_span(op="event_manager.dynamic_sampling_observe_latest_release") as span:
+    with sentry_sdk.traces.start_span(
+        name="event_manager.dynamic_sampling_observe_latest_release",
+        attributes={"sentry.op": "event_manager.dynamic_sampling_observe_latest_release"},
+    ) as span:
         params = LatestReleaseParams(release=release, project=project, environment=environment)
         LatestReleaseBias(params).observe_release(on_release_boosted)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -434,7 +434,7 @@ class EventManager:
     def get_data(self) -> MutableMapping[str, Any]:
         return self._data
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def save(
         self,
         project_id: int | None = None,
@@ -1488,13 +1488,16 @@ def create_group_with_grouphashes(job: Job, grouphashes: list[GroupHash]) -> Gro
     check_for_group_creation_load_shed(project, event)
 
     with (
-        sentry_sdk.start_span(op="event_manager.create_group_transaction") as span,
+        sentry_sdk.traces.start_span(
+            name="event_manager.create_group_transaction",
+            attributes={"sentry.op": "event_manager.create_group_transaction"},
+        ) as span,
         metrics.timer("event_manager.create_group_transaction") as metrics_timer_tags,
         transaction.atomic(router.db_for_write(GroupHash)),
     ):
         # These values will get overridden with whatever happens inside the lock if we do manage to
         # acquire it, so it should only end up with `wait-for-lock` if we don't
-        span.set_tag("outcome", "wait_for_lock")
+        span.set_attribute("outcome", "wait_for_lock")
         metrics_timer_tags["outcome"] = "wait_for_lock"
 
         # If we're in this branch, we checked our grouphashes and didn't find one with a group
@@ -1522,7 +1525,7 @@ def create_group_with_grouphashes(job: Job, grouphashes: list[GroupHash]) -> Gro
         # If we still haven't found a matching grouphash, we're now safe to go ahead and create
         # the group.
         if existing_grouphash is None:
-            span.set_tag("outcome", "new_group")
+            span.set_attribute("outcome", "new_group")
             metrics_timer_tags["outcome"] = "new_group"
             record_new_group_metrics(event)
 
@@ -2200,7 +2203,7 @@ def _get_severity_score(event: Event) -> tuple[float, str]:
 
     logger_data["payload"] = payload
 
-    with sentry_sdk.start_span(op=op):
+    with sentry_sdk.traces.start_span(name=op, attributes={"sentry.op": op}):
         try:
             with metrics.timer(op):
                 timeout = options.get(
@@ -2623,7 +2626,10 @@ def _record_transaction_info(
             event = job["event"]
 
             project = event.project
-            with sentry_sdk.start_span(op="event_manager.record_transaction_name_for_clustering"):
+            with sentry_sdk.traces.start_span(
+                name="event_manager.record_transaction_name_for_clustering",
+                attributes={"sentry.op": "event_manager.record_transaction_name_for_clustering"},
+            ):
                 record_transaction_name_for_clustering(project, event.data)
 
             record_event_processed(project, event)

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -110,14 +110,14 @@ class RegisteredFeatureManager:
                 if not remaining:
                     break
 
-                with sentry_sdk.start_span(
-                    op="feature.has_for_batch.handler",
+                with sentry_sdk.traces.start_span(
                     name=f"{type(handler).__name__} ({name})",
+                    attributes={"sentry.op": "feature.has_for_batch.handler"},
                 ) as span:
                     batch_size = len(remaining)
-                    span.set_data("Batch Size", batch_size)
-                    span.set_data("Feature Name", name)
-                    span.set_data("Handler Type", type(handler).__name__)
+                    span.set_attribute("Batch Size", batch_size)
+                    span.set_attribute("Feature Name", name)
+                    span.set_attribute("Handler Type", type(handler).__name__)
 
                     batch = FeatureCheckBatch(self, name, organization, remaining, actor)
                     handler_result = handler.has_for_batch(batch)
@@ -125,7 +125,7 @@ class RegisteredFeatureManager:
                         if flag is not None:
                             remaining.remove(obj)
                             result[obj] = flag
-                    span.set_data("Flags Found", batch_size - len(remaining))
+                    span.set_attribute("Flags Found", batch_size - len(remaining))
 
             default_flag = settings.SENTRY_FEATURES.get(name, False)
             for obj in remaining:

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -69,7 +69,10 @@ def _calculate_event_grouping(
             )
 
         with metrics.timer("event_manager.normalize_stacktraces_for_grouping", tags=metric_tags):
-            with sentry_sdk.start_span(op="event_manager.normalize_stacktraces_for_grouping"):
+            with sentry_sdk.traces.start_span(
+                name="event_manager.normalize_stacktraces_for_grouping",
+                attributes={"sentry.op": "event_manager.normalize_stacktraces_for_grouping"},
+            ):
                 event.normalize_stacktraces_for_grouping(loaded_grouping_config)
 
         with metrics.timer("event_manager.event.get_hashes", tags=metric_tags):
@@ -109,9 +112,9 @@ def _calculate_secondary_hashes(
     """
     secondary_hashes: list[str] = []
     try:
-        with sentry_sdk.start_span(
-            op="event_manager",
+        with sentry_sdk.traces.start_span(
             name="event_manager.save.secondary_calculate_event_grouping",
+            attributes={"sentry.op": "event_manager"},
         ):
             # create a copy since `_calculate_event_grouping` modifies the event to add all sorts
             # of grouping info and we don't want the secondary grouping data in there
@@ -136,9 +139,9 @@ def run_primary_grouping(
         job["data"]["grouping_config"] = grouping_config
 
     with (
-        sentry_sdk.start_span(
-            op="event_manager",
+        sentry_sdk.traces.start_span(
             name="event_manager.save.calculate_event_grouping",
+            attributes={"sentry.op": "event_manager"},
         ),
         metrics.timer("event_manager.calculate_event_grouping", tags=metric_tags),
     ):

--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -15,7 +15,7 @@ from django.db.models import Count, Max, Min
 from django.db.models.functions import Now
 from django.db.transaction import Atomic
 from django.utils import timezone
-from sentry_sdk.tracing import Span
+from sentry_sdk.traces import StreamedSpan
 
 from sentry import options
 from sentry.backup.scopes import RelocationScope
@@ -287,13 +287,13 @@ class OutboxBase(Model):
                 tags=tags,
             )
 
-    def _set_span_data_for_coalesced_message(self, span: Span, message: OutboxBase) -> None:
+    def _set_span_data_for_coalesced_message(self, span: StreamedSpan, message: OutboxBase) -> None:
         tag_for_outbox = OutboxScope.get_tag_name(message.shard_scope)
-        span.set_tag(tag_for_outbox, message.shard_identifier)
-        span.set_data("outbox_id", message.id)
-        span.set_data("outbox_shard_id", message.shard_identifier)
-        span.set_tag("outbox_category", OutboxCategory(message.category).name)
-        span.set_tag("outbox_scope", OutboxScope(message.shard_scope).name)
+        span.set_attribute(tag_for_outbox, message.shard_identifier)
+        span.set_attribute("outbox_id", message.id)
+        span.set_attribute("outbox_shard_id", message.shard_identifier)
+        span.set_attribute("outbox_category", OutboxCategory(message.category).name)
+        span.set_attribute("outbox_scope", OutboxScope(message.shard_scope).name)
 
     def process(self, is_synchronous_flush: bool) -> bool:
         with self.process_coalesced(is_synchronous_flush=is_synchronous_flush) as coalesced:
@@ -306,7 +306,9 @@ class OutboxBase(Model):
                             "synchronous": int(is_synchronous_flush),
                         },
                     ),
-                    sentry_sdk.start_span(op="outbox.process") as span,
+                    sentry_sdk.traces.start_span(
+                        name="outbox.process", attributes={"sentry.op": "outbox.process"}
+                    ) as span,
                 ):
                     self._set_span_data_for_coalesced_message(span=span, message=coalesced)
                     try:

--- a/src/sentry/hybridcloud/rpc/pagination.py
+++ b/src/sentry/hybridcloud/rpc/pagination.py
@@ -44,9 +44,9 @@ class RpcPaginationArgs(RpcModel):
         count_hits: bool | None = None,
     ) -> "RpcPaginationResult":
         cursor = get_cursor(self.encoded_cursor, cursor_cls)
-        with sentry_sdk.start_span(
-            op="hybrid_cloud.paginate.get_result",
+        with sentry_sdk.traces.start_span(
             name=description,
+            attributes={"sentry.op": "hybrid_cloud.paginate.get_result"},
         ) as span:
             annotate_span_with_pagination_args(span, self.per_page)
             paginator = get_paginator(

--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -655,9 +655,9 @@ class _RemoteSiloCall:
     @contextmanager
     def _open_request_context(self) -> Generator[None]:
         timer = metrics.timer("hybrid_cloud.dispatch_rpc.duration", tags=self._metrics_tags())
-        span = sentry_sdk.start_span(
-            op="hybrid_cloud.dispatch_rpc",
+        span = sentry_sdk.traces.start_span(
             name=f"rpc to {self.service_name}.{self.method_name}",
+            attributes={"sentry.op": "hybrid_cloud.dispatch_rpc"},
         )
         with span, timer:
             yield

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -370,10 +370,11 @@ def _discard_stale_mailbox_payloads(payload: WebhookPayload) -> None:
     Remove payloads in this mailbox that are older than MAX_DELIVERY_AGE.
     Once payloads are this old they are low value, and we're better off prioritizing new work.
     """
-    with sentry_sdk.start_span(
-        op="hybridcloud.deliver_webhooks.discard_stale_mailbox_payloads"
+    with sentry_sdk.traces.start_span(
+        name="hybridcloud.deliver_webhooks.discard_stale_mailbox_payloads",
+        attributes={"sentry.op": "hybridcloud.deliver_webhooks.discard_stale_mailbox_payloads"},
     ) as span:
-        span.set_tag("mailbox_name", payload.mailbox_name)
+        span.set_attribute("mailbox_name", payload.mailbox_name)
         max_age = timezone.now() - MAX_DELIVERY_AGE
         if payload.date_added >= max_age:
             return

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-import os
 from collections.abc import Mapping, MutableMapping
 from typing import Any
 
@@ -48,21 +47,8 @@ def trace_func(**span_kwargs):
     def wrapper(f):
         @functools.wraps(f)
         def inner(*args, **kwargs):
-            # First we check a local env var
-            # if that's not set we check our conf file
-            # if neither are set use 0
-            sample_rate = float(
-                os.getenv(
-                    "SENTRY_INGEST_CONSUMER_APM_SAMPLING",
-                    default=getattr(settings, "SENTRY_INGEST_CONSUMER_APM_SAMPLING", 0),
-                )
-            )
-            # New behavior is to add a custom `sample_rate` that is picked up by `traces_sampler`
-            span_kwargs.setdefault(
-                "custom_sampling_context",
-                {"sample_rate": sample_rate},
-            )
-            with sentry_sdk.start_transaction(**span_kwargs):
+            span_kwargs["parent_span"] = None
+            with sentry_sdk.traces.start_span(**span_kwargs):
                 return f(*args, **kwargs)
 
         return inner
@@ -105,7 +91,9 @@ def process_event(
     # This code has been ripped from the old python store endpoint. We're
     # keeping it around because it does provide some protection against
     # reprocessing good events if a single consumer is in a restart loop.
-    with sentry_sdk.start_span(op="deduplication_check"):
+    with sentry_sdk.traces.start_span(
+        name="deduplication_check", attributes={"sentry.op": "deduplication_check"}
+    ):
         deduplication_key = f"ev:{project_id}:{event_id}"
 
         try:
@@ -121,8 +109,9 @@ def process_event(
             )
             return  # message already processed do not reprocess
 
-    with sentry_sdk.start_span(
-        op="killswitch_matches_context", name="store.load-shed-pipeline-projects"
+    with sentry_sdk.traces.start_span(
+        name="store.load-shed-pipeline-projects",
+        attributes={"sentry.op": "killswitch_matches_context"},
     ):
         if killswitch_matches_context(
             "store.load-shed-pipeline-projects",
@@ -139,7 +128,9 @@ def process_event(
     # Parse the JSON payload. This is required to compute the cache key and
     # call process_event. The payload will be put into Kafka raw, to avoid
     # serializing it again.
-    with sentry_sdk.start_span(op="orjson.loads"):
+    with sentry_sdk.traces.start_span(
+        name="orjson.loads", attributes={"sentry.op": "orjson.loads"}
+    ):
         data = orjson.loads(payload)
 
     # We also need to check "type" as transactions are also sent to ingest-attachments
@@ -151,8 +142,9 @@ def process_event(
 
     sentry_sdk.set_extra("event_type", data.get("type"))
 
-    with sentry_sdk.start_span(
-        op="killswitch_matches_context", name="store.load-shed-parsed-pipeline-projects"
+    with sentry_sdk.traces.start_span(
+        name="store.load-shed-parsed-pipeline-projects",
+        attributes={"sentry.op": "killswitch_matches_context"},
     ):
         if killswitch_matches_context(
             "store.load-shed-parsed-pipeline-projects",
@@ -173,7 +165,10 @@ def process_event(
         # `processing_store`. We only continue here if the event *is* present, as that will eventually
         # process and consume the event from the `processing_store`, whereby getting it "unstuck".
         if reprocess_only_stuck_events:
-            with sentry_sdk.start_span(op="event_processing_store.exists"):
+            with sentry_sdk.traces.start_span(
+                name="event_processing_store.exists",
+                attributes={"sentry.op": "event_processing_store.exists"},
+            ):
                 if not processing_store.exists(data):
                     return
 
@@ -251,7 +246,10 @@ def process_event(
             # Preprocess this event, which spawns either process_event or
             # save_event. Pass data explicitly to avoid fetching it again from the
             # cache.
-            with sentry_sdk.start_span(op="ingest_consumer.process_event.preprocess_event"):
+            with sentry_sdk.traces.start_span(
+                name="ingest_consumer.process_event.preprocess_event",
+                attributes={"sentry.op": "ingest_consumer.process_event.preprocess_event"},
+            ):
                 preprocess_event(
                     cache_key=cache_key or "",
                     data=data,
@@ -262,11 +260,14 @@ def process_event(
                 )
 
         # remember for an 1 hour that we saved this event (deduplication protection)
-        with sentry_sdk.start_span(op="cache.set"):
+        with sentry_sdk.traces.start_span(name="cache.set", attributes={"sentry.op": "cache.set"}):
             cache.set(deduplication_key, "", CACHE_TIMEOUT)
 
         # emit event_accepted once everything is done
-        with sentry_sdk.start_span(op="event_accepted.send_robust"):
+        with sentry_sdk.traces.start_span(
+            name="event_accepted.send_robust",
+            attributes={"sentry.op": "event_accepted.send_robust"},
+        ):
             event_accepted.send_robust(
                 ip=remote_addr, data=data, project=project, sender=process_event
             )

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -86,7 +86,10 @@ def get_active_project_ids(namespace: ClustererNamespace) -> Iterator[int]:
 
 
 def _record_sample(namespace: ClustererNamespace, project: Project, sample: str) -> None:
-    with sentry_sdk.start_span(op=f"cluster.{namespace.value.name}.record_sample"):
+    with sentry_sdk.traces.start_span(
+        name=f"cluster.{namespace.value.name}.record_sample",
+        attributes={"sentry.op": f"cluster.{namespace.value.name}.record_sample"},
+    ):
         client = get_redis_client()
         redis_key = _get_redis_key(namespace, project)
         created = add_to_set([redis_key], [sample, MAX_SET_SIZE, SET_TTL], client)

--- a/src/sentry/ingest/transaction_clusterer/normalization.py
+++ b/src/sentry/ingest/transaction_clusterer/normalization.py
@@ -83,7 +83,7 @@ class Remark:
 
 # Ported from Relay:
 # https://github.com/getsentry/relay/blob/aad4b6099d12422e88dd5df49abae11247efdd99/relay-event-normalization/src/transactions/processor.rs#L350
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def _scrub_identifiers(segment_span: CompatibleSpan, segment_name: str):
     matches = TRANSACTION_NAME_NORMALIZER_REGEX.finditer(segment_name)
     remarks = []
@@ -127,7 +127,7 @@ def _scrub_identifiers(segment_span: CompatibleSpan, segment_name: str):
     segment_span["attributes"] = attributes
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def _apply_clustering_rules(
     project: Project, segment_span: CompatibleSpan, original_segment_name: str
 ):

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -47,7 +47,9 @@ CLUSTERING_TIMEOUT_PER_PROJECT = 0.3
 )
 def spawn_clusterers(**kwargs: Any) -> None:
     """Look for existing transaction name sets in redis and spawn clusterers for each"""
-    with sentry_sdk.start_span(op="txcluster_spawn"):
+    with sentry_sdk.traces.start_span(
+        name="txcluster_spawn", attributes={"sentry.op": "txcluster_spawn"}
+    ):
         project_count = 0
         project_iter = redis.get_active_project_ids(ClustererNamespace.TRANSACTIONS)
         while batch := list(islice(project_iter, PROJECTS_PER_TASK)):
@@ -69,8 +71,10 @@ def cluster_projects(project_ids: Sequence[int]) -> None:
     num_clustered = 0
     try:
         for project in projects:
-            with sentry_sdk.start_span(op="txcluster_project") as span:
-                span.set_data("project_id", project.id)
+            with sentry_sdk.traces.start_span(
+                name="txcluster_project", attributes={"sentry.op": "txcluster_project"}
+            ) as span:
+                span.set_attribute("project_id", project.id)
                 tx_names = list(redis.get_transaction_names(project))
                 new_rules = []
                 if len(tx_names) >= MERGE_THRESHOLD:

--- a/src/sentry/ingest/transaction_clusterer/tree.py
+++ b/src/sentry/ingest/transaction_clusterer/tree.py
@@ -100,7 +100,9 @@ class TreeClusterer(Clusterer):
 
     def _extract_rules(self) -> None:
         """Merge high-cardinality nodes in the graph and extract rules"""
-        with sentry_sdk.start_span(op="cluster_merge"):
+        with sentry_sdk.traces.start_span(
+            name="cluster_merge", attributes={"sentry.op": "cluster_merge"}
+        ):
             self._tree.merge(self._merge_threshold)
 
         # Generate exactly 1 rule for every merge

--- a/src/sentry/integrations/api/endpoints/integration_proxy.py
+++ b/src/sentry/integrations/api/endpoints/integration_proxy.py
@@ -258,7 +258,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
             return False
         return True
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _call_third_party_api(
         self, request: HttpRequest, full_url: str, headers: MutableMapping[str, str]
     ) -> StreamingHttpResponse:
@@ -293,7 +293,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
             reason=resp.reason,
         )
 
-    @sentry_sdk.trace(op="integration_proxy.http_method_not_allowed")
+    @sentry_sdk.traces.trace(attributes={"sentry.op": "integration_proxy.http_method_not_allowed"})
     def http_method_not_allowed(self, request):
         """
         Catch-all workaround instead of explicitly setting handlers for each method (GET, POST, etc.)

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -771,9 +771,9 @@ class GitHubBaseClient(
         if page_number_limit is None or page_number_limit > self.page_number_limit:
             page_number_limit = self.page_number_limit
 
-        with sentry_sdk.start_span(
-            op=f"{self.integration_type}.http.pagination",
+        with sentry_sdk.traces.start_span(
             name=f"{self.integration_type}.http_response.pagination.{self.name}",
+            attributes={"sentry.op": f"{self.integration_type}.http.pagination"},
         ):
             output: list[dict[str, Any]] = []
 

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -1246,12 +1246,12 @@ class GitHubIntegrationsWebhookEndpoint(Endpoint):
 
         # Create a new transaction for each webhook event to ensure separate traces
         transaction_name = f"github.webhook.{github_event.value}"
-        with sentry_sdk.start_transaction(
-            op="webhook",
+        with sentry_sdk.traces.start_span(
             name=transaction_name,
-            source="component",
-        ) as transaction:
-            transaction.set_tag("github_event", github_event.value)
+            attributes={"sentry.op": "webhook"},
+            parent_span=None,
+        ) as span:
+            span.set_attribute("github_event", github_event.value)
 
             github_delivery_id = request.META.get("HTTP_X_GITHUB_DELIVERY")
             if github_delivery_id is not None:

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -326,12 +326,12 @@ class GitHubEnterpriseWebhookBase(Endpoint):
 
         # Create a new transaction for each webhook event to ensure separate traces
         transaction_name = f"github_enterprise.webhook.{github_event}"
-        with sentry_sdk.start_transaction(
-            op="webhook",
+        with sentry_sdk.traces.start_span(
             name=transaction_name,
-            source="component",
-        ) as transaction:
-            transaction.set_tag("github_event", github_event)
+            attributes={"sentry.op": "webhook"},
+            parent_span=None,
+        ) as span:
+            span.set_attribute("github_event", github_event)
 
             with IntegrationWebhookEvent(
                 interaction_type=event_handler.event_type,

--- a/src/sentry/integrations/msteams/notifications.py
+++ b/src/sentry/integrations/msteams/notifications.py
@@ -103,7 +103,9 @@ def send_notification_as_msteams(
         )
         return
 
-    with sentry_sdk.start_span(op="notification.send_msteams", name="gen_channel_integration_map"):
+    with sentry_sdk.traces.start_span(
+        name="gen_channel_integration_map", attributes={"sentry.op": "notification.send_msteams"}
+    ):
         data = get_integrations_by_channel_by_recipient(
             organization=notification.organization,
             recipients=recipients,
@@ -111,11 +113,15 @@ def send_notification_as_msteams(
         )
 
         for recipient, integrations_by_channel in data.items():
-            with sentry_sdk.start_span(op="notification.send_msteams", name="send_one"):
+            with sentry_sdk.traces.start_span(
+                name="send_one", attributes={"sentry.op": "notification.send_msteams"}
+            ):
                 extra_context = (extra_context_by_actor or {}).get(recipient, {})
                 context = get_context(notification, recipient, shared_context, extra_context)
 
-                with sentry_sdk.start_span(op="notification.send_msteams", name="gen_attachments"):
+                with sentry_sdk.traces.start_span(
+                    name="gen_attachments", attributes={"sentry.op": "notification.send_msteams"}
+                ):
                     if isinstance(notification, GroupActivityNotification) or isinstance(
                         notification, AlertRuleNotification
                     ):
@@ -128,8 +134,9 @@ def send_notification_as_msteams(
 
                     client = MsTeamsClient(integration)
                     try:
-                        with sentry_sdk.start_span(
-                            op="notification.send_msteams", name="notify_recipient"
+                        with sentry_sdk.traces.start_span(
+                            name="notify_recipient",
+                            attributes={"sentry.op": "notification.send_msteams"},
                         ):
                             client.send_card(conversation_id, card)
 

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -29,14 +29,20 @@ def _send_slack_notification(
     Sending Slack notifications to a channel is in integrations/slack/actions/notification.py"""
 
     service = SlackService.default()
-    with sentry_sdk.start_span(op="notification.send_slack", name="gen_channel_integration_map"):
+    with sentry_sdk.traces.start_span(
+        name="gen_channel_integration_map", attributes={"sentry.op": "notification.send_slack"}
+    ):
         data = get_integrations_by_channel_by_recipient(
             notification.organization, recipients, provider
         )
 
     for recipient, integrations_by_channel in data.items():
-        with sentry_sdk.start_span(op="notification.send_slack", name="send_one"):
-            with sentry_sdk.start_span(op="notification.send_slack", name="gen_attachments"):
+        with sentry_sdk.traces.start_span(
+            name="send_one", attributes={"sentry.op": "notification.send_slack"}
+        ):
+            with sentry_sdk.traces.start_span(
+                name="gen_attachments", attributes={"sentry.op": "notification.send_slack"}
+            ):
                 attachments = service.get_attachments(
                     notification,
                     recipient,

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -412,7 +412,9 @@ class SlackService:
 
         """Send an "activity" or "alert rule" notification to a Slack user or team, but NOT to a channel directly.
         This is used in the send_notification_as_slack function."""
-        with sentry_sdk.start_span(op="notification.send_slack", name="notify_recipient"):
+        with sentry_sdk.traces.start_span(
+            name="notify_recipient", attributes={"sentry.op": "notification.send_slack"}
+        ):
             # Make a local copy to which we can append.
             local_attachments = copy(attachments)
 

--- a/src/sentry/issue_detection/detectors/io_main_thread_detector.py
+++ b/src/sentry/issue_detection/detectors/io_main_thread_detector.py
@@ -137,7 +137,10 @@ class FileIOMainThreadDetector(BaseIOMainThreadDetector):
 
             for image in images:
                 if image.get("type") == "proguard":
-                    with sentry_sdk.start_span(op="proguard.fetch_debug_files"):
+                    with sentry_sdk.traces.start_span(
+                        name="proguard.fetch_debug_files",
+                        attributes={"sentry.op": "proguard.fetch_debug_files"},
+                    ):
                         uuid = image.get("uuid")
                         dif_paths = ProjectDebugFile.difcache.fetch_difs(
                             project, [uuid], features=["mapping"]

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -196,7 +196,9 @@ def detect_performance_problems(
             sentry_sdk.set_tag("_did_analyze_performance_issue", "true")
             with (
                 metrics.timer("performance.detect_performance_issue", sample_rate=0.01),
-                sentry_sdk.start_span(op="py.detect_performance_issue", name="none") as sdk_span,
+                sentry_sdk.traces.start_span(
+                    name="none", attributes={"sentry.op": "py.detect_performance_issue"}
+                ) as sdk_span,
             ):
                 return _detect_performance_problems(data, sdk_span, project, standalone=standalone)
     except Exception:
@@ -743,7 +745,9 @@ def _detect_performance_problems(
     event_id = data.get("event_id", None)
     organization = project.organization
 
-    with sentry_sdk.start_span(op="function", name="get_detection_settings"):
+    with sentry_sdk.traces.start_span(
+        name="get_detection_settings", attributes={"sentry.op": "function"}
+    ):
         detection_settings = get_detection_settings(project)
 
     # The performance detectors expect the span list to be ordered/flattened in the way they
@@ -751,11 +755,15 @@ def _detect_performance_problems(
     # So we build a tree and flatten it depth first.
     # TODO: See if we can update the detectors to work without this assumption so we can
     # just pass it a list of spans.
-    with sentry_sdk.start_span(op="performance_detection", name="sort_spans"):
+    with sentry_sdk.traces.start_span(
+        name="sort_spans", attributes={"sentry.op": "performance_detection"}
+    ):
         tree, segment_id = build_tree(data.get("spans", []))
         data = {**data, "spans": flatten_tree(tree, segment_id)}
 
-    with sentry_sdk.start_span(op="initialize", name="PerformanceDetector"):
+    with sentry_sdk.traces.start_span(
+        name="PerformanceDetector", attributes={"sentry.op": "initialize"}
+    ):
         detectors: list[PerformanceDetector] = [
             detector_class(detection_settings[detector_class.settings_key], data)
             for detector_class in DETECTOR_CLASSES
@@ -763,12 +771,14 @@ def _detect_performance_problems(
         ]
 
     for detector in detectors:
-        with sentry_sdk.start_span(
-            op="function", name=f"run_detector_on_data.{detector.type.value}"
+        with sentry_sdk.traces.start_span(
+            name=f"run_detector_on_data.{detector.type.value}", attributes={"sentry.op": "function"}
         ):
             run_detector_on_data(detector, data)
 
-    with sentry_sdk.start_span(op="function", name="report_metrics_for_detectors"):
+    with sentry_sdk.traces.start_span(
+        name="report_metrics_for_detectors", attributes={"sentry.op": "function"}
+    ):
         # Metrics reporting only for detection, not created issues.
         report_metrics_for_detectors(
             data,
@@ -781,7 +791,9 @@ def _detect_performance_problems(
         )
 
     problems: list[PerformanceProblem] = []
-    with sentry_sdk.start_span(op="performance_detection", name="is_creation_allowed"):
+    with sentry_sdk.traces.start_span(
+        name="is_creation_allowed", attributes={"sentry.op": "performance_detection"}
+    ):
         for detector in detectors:
             if detector.is_creation_allowed():
                 problems.extend(detector.stored_problems.values())
@@ -883,11 +895,8 @@ def report_metrics_for_detectors(
     has_detected_problems = bool(all_detected_problems)
     sdk_name = get_sdk_name(event)
 
-    try:
-        # Setting a tag isn't critical, the transaction doesn't exist sometimes, if it's called outside prod code (eg. load-mocks / tests)
-        set_tag = sdk_span.containing_transaction.set_tag
-    except AttributeError:
-        set_tag = lambda *args: None
+    span = sentry_sdk.traces.get_current_span()
+    set_tag = span.set_attribute if span is not None else lambda *args: None
 
     if has_detected_problems:
         set_tag("_pi_all_issue_count", len(all_detected_problems))

--- a/src/sentry/issues/endpoints/group_current_release.py
+++ b/src/sentry/issues/endpoints/group_current_release.py
@@ -67,9 +67,12 @@ class GroupCurrentReleaseEndpoint(GroupEndpoint):
 
         environments = get_environments(request, group.project.organization)
 
-        with sentry_sdk.start_span(op="CurrentReleaseEndpoint.get.current_release") as span:
-            span.set_data("Environment Count", len(environments))
-            span.set_data(
+        with sentry_sdk.traces.start_span(
+            name="CurrentReleaseEndpoint.get.current_release",
+            attributes={"sentry.op": "CurrentReleaseEndpoint.get.current_release"},
+        ) as span:
+            span.set_attribute("Environment Count", len(environments))
+            span.set_attribute(
                 "Raw Parameters",
                 {
                     "group.id": group.id,

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -10,7 +10,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry_sdk import start_span
+from sentry_sdk.traces import start_span
 
 from sentry import analytics, search
 from sentry.analytics.events.issue_search_endpoint_queried import IssueSearchEndpointQueriedEvent
@@ -171,7 +171,7 @@ def search_issues(
     environments: Sequence[Environment],
     extra_query_kwargs: None | Mapping[str, Any] = None,
 ) -> tuple[CursorResult[Group], Mapping[str, Any]]:
-    with start_span(op="_search"):
+    with start_span(name="_search", attributes={"sentry.op": "_search"}):
         query_kwargs = build_query_params_from_request(
             request, organization, projects, environments
         )

--- a/src/sentry/issues/endpoints/organization_issues_count.py
+++ b/src/sentry/issues/endpoints/organization_issues_count.py
@@ -1,6 +1,6 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry_sdk import start_span
+from sentry_sdk.traces import start_span
 
 from sentry import search
 from sentry.api.api_owners import ApiOwner
@@ -67,8 +67,8 @@ class OrganizationIssuesCountEndpoint(OrganizationEndpoint):
             query_kwargs["max_hits"] = ISSUES_COUNT_MAX_HITS_LIMIT
 
             query_kwargs["actor"] = request.user
-        with start_span(op="start_search") as span:
-            span.set_data("query_kwargs", query_kwargs)
+        with start_span(name="start_search", attributes={"sentry.op": "start_search"}) as span:
+            span.set_attribute("query_kwargs", query_kwargs)
             result = search.backend.query(**query_kwargs)
             return result.hits
 

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -131,7 +131,10 @@ class GroupTypeRegistry:
     def get_visible(
         self, organization: Organization, actor: Any | None = None
     ) -> list[type[GroupType]]:
-        with sentry_sdk.start_span(op="GroupTypeRegistry.get_visible") as span:
+        with sentry_sdk.traces.start_span(
+            name="GroupTypeRegistry.get_visible",
+            attributes={"sentry.op": "GroupTypeRegistry.get_visible"},
+        ) as span:
             released = [gt for gt in self.all() if gt.released]
             feature_to_grouptype: dict[str, type[GroupType]] = {}
             for gt in self.all():
@@ -151,11 +154,11 @@ class GroupTypeRegistry:
                         if gt.type_id not in seen:
                             seen.add(gt.type_id)
                             enabled.append(gt)
-            span.set_tag("organization_id", organization.id)
-            span.set_tag("has_batch_features", batch_features is not None)
-            span.set_tag("released", released)
-            span.set_tag("enabled", enabled)
-            span.set_data("feature_to_grouptype", feature_to_grouptype)
+            span.set_attribute("organization_id", organization.id)
+            span.set_attribute("has_batch_features", batch_features is not None)
+            span.set_attribute("released", released)
+            span.set_attribute("enabled", enabled)
+            span.set_attribute("feature_to_grouptype", feature_to_grouptype)
             return released + enabled
 
     def get_all_group_type_ids(self) -> set[int]:

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -243,7 +243,10 @@ def save_issue_from_occurrence(
             return None
 
         with (
-            sentry_sdk.start_span(op="issues.save_issue_from_occurrence.transaction") as span,
+            sentry_sdk.traces.start_span(
+                name="issues.save_issue_from_occurrence.transaction",
+                attributes={"sentry.op": "issues.save_issue_from_occurrence.transaction"},
+            ) as span,
             metrics.timer(
                 "issues.save_issue_from_occurrence.transaction",
                 tags={"platform": event.platform or "unknown", "type": occurrence.type.type_id},
@@ -269,7 +272,7 @@ def save_issue_from_occurrence(
                     data={**open_period.data, "highest_seen_priority": highest_seen_priority}
                 )
             is_regression = False
-            span.set_tag("save_issue_from_occurrence.outcome", "new_group")
+            span.set_attribute("save_issue_from_occurrence.outcome", "new_group")
             metric_tags["save_issue_from_occurrence.outcome"] = "new_group"
             metrics.incr(
                 "group.created",

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -17,7 +17,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 from rest_framework import serializers
-from sentry_sdk.tracing import NoOpSpan, Span, Transaction
+from sentry_sdk.traces import StreamedSpan
 
 from sentry import nodestore, options
 from sentry.event_manager import GroupInfo
@@ -330,7 +330,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
 @sentry_sdk.tracing.trace
 @metrics.wraps("occurrence_consumer.process_occurrence_message")
 def process_occurrence_message(
-    message: Mapping[str, Any], txn: Transaction | NoOpSpan | Span
+    message: Mapping[str, Any], span: StreamedSpan
 ) -> tuple[IssueOccurrence, GroupInfo | None] | None:
     with metrics.timer("occurrence_consumer._process_message._get_kwargs"):
         kwargs = _get_kwargs(message)
@@ -343,15 +343,15 @@ def process_occurrence_message(
         sample_rate=1.0,
         tags=metric_tags,
     )
-    txn.set_tag("occurrence_type", occurrence_data["type"])
+    span.set_attribute("occurrence_type", occurrence_data["type"])
 
     project = Project.objects.get_from_cache(id=occurrence_data["project_id"])
     organization = Organization.objects.get_from_cache(id=project.organization_id)
 
-    txn.set_tag("organization_id", organization.id)
-    txn.set_tag("organization_slug", organization.slug)
-    txn.set_tag("project_id", project.id)
-    txn.set_tag("project_slug", project.slug)
+    span.set_attribute("organization_id", organization.id)
+    span.set_attribute("organization_slug", organization.slug)
+    span.set_attribute("project_id", project.id)
+    span.set_attribute("project_slug", project.slug)
 
     group_type = get_group_type_by_type_id(occurrence_data["type"])
     if not group_type.allow_ingest(organization):
@@ -360,7 +360,7 @@ def process_occurrence_message(
             sample_rate=1.0,
             tags=metric_tags,
         )
-        txn.set_tag("result", "dropped_feature_disabled")
+        span.set_attribute("result", "dropped_feature_disabled")
         return None
 
     if is_rate_limited(project.id, fingerprint=occurrence_data["fingerprint"][0]):
@@ -369,13 +369,13 @@ def process_occurrence_message(
             sample_rate=1.0,
             tags=metric_tags,
         )
-        txn.set_tag("result", "dropped_rate_limited")
+        span.set_attribute("result", "dropped_rate_limited")
         return None
 
     if "event_data" in kwargs and is_buffered_spans:
         return create_event_and_issue_occurrence(kwargs["occurrence_data"], kwargs["event_data"])
     elif "event_data" in kwargs:
-        txn.set_tag("result", "success")
+        span.set_attribute("result", "success")
         with metrics.timer(
             "occurrence_consumer._process_message.process_event_and_issue_occurrence",
             tags=metric_tags,
@@ -384,7 +384,7 @@ def process_occurrence_message(
                 kwargs["occurrence_data"], kwargs["event_data"]
             )
     else:
-        txn.set_tag("result", "success")
+        span.set_attribute("result", "success")
         with metrics.timer(
             "occurrence_consumer._process_message.lookup_event_and_process_issue_occurrence",
             tags=metric_tags,
@@ -401,21 +401,22 @@ def _process_message(
     :raises InvalidEventPayloadError: when the message is invalid
     :raises EventLookupError: when the provided event_id in the message couldn't be found.
     """
-    with sentry_sdk.start_transaction(
-        op="_process_message",
+    with sentry_sdk.traces.start_span(
         name="issues.occurrence_consumer",
-    ) as txn:
+        attributes={"sentry.op": "_process_message"},
+        parent_span=None,
+    ) as span:
         try:
             # Messages without payload_type default to an OCCURRENCE payload
             payload_type = message.get("payload_type", PayloadType.OCCURRENCE.value)
             if payload_type == PayloadType.STATUS_CHANGE.value:
-                group = process_status_change_message(message, txn)
+                group = process_status_change_message(message, span)
                 if not group:
                     return None
 
                 return None, GroupInfo(group=group, is_new=False, is_regression=False)
             elif payload_type == PayloadType.OCCURRENCE.value:
-                return process_occurrence_message(message, txn)
+                return process_occurrence_message(message, span)
             else:
                 metrics.incr(
                     "occurrence_consumer._process_message.dropped_invalid_payload_type",
@@ -427,7 +428,7 @@ def _process_message(
                 "occurrence_ingest.invalid_group_type", tags={"occurrence_type": e.group_type_id}
             )
         except (ValueError, KeyError) as e:
-            txn.set_tag("result", "error")
+            span.set_attribute("result", "error")
             raise InvalidEventPayloadError(e)
     return None
 
@@ -470,7 +471,11 @@ def process_occurrence_batch(
     # Number of groups we've collected to be processed in parallel
     metrics.gauge("occurrence_consumer.checkin.parallel_batch_groups", len(occcurrence_mapping))
     # Submit occurrences & status changes for processing
-    with sentry_sdk.start_transaction(op="process_batch", name="occurrence.occurrence_consumer"):
+    with sentry_sdk.traces.start_span(
+        name="occurrence.occurrence_consumer",
+        attributes={"sentry.op": "process_batch"},
+        parent_span=None,
+    ):
         futures = [
             worker.submit(process_occurrence_group, group) for group in occcurrence_mapping.values()
         ]

--- a/src/sentry/issues/ongoing.py
+++ b/src/sentry/issues/ongoing.py
@@ -20,15 +20,15 @@ def bulk_transition_group_to_ongoing(
     group_ids: list[int],
     activity_data: Mapping[str, Any] | None = None,
 ) -> None:
-    with sentry_sdk.start_span(name="groups_to_transition") as span:
+    with sentry_sdk.traces.start_span(name="groups_to_transition") as span:
         # make sure we don't update the Group when its already updated by conditionally updating the Group
         groups_to_transition = Group.objects.filter(
             id__in=group_ids, status=from_status, substatus=from_substatus
         ).select_related("project")
-        span.set_tag("group_ids", group_ids)
-        span.set_tag("groups_to_transition count", len(groups_to_transition))
+        span.set_attribute("group_ids", group_ids)
+        span.set_attribute("groups_to_transition count", len(groups_to_transition))
 
-    with sentry_sdk.start_span(name="update_group_status"):
+    with sentry_sdk.traces.start_span(name="update_group_status"):
         Group.objects.update_group_status(
             groups=groups_to_transition,
             status=GroupStatus.UNRESOLVED,
@@ -51,10 +51,10 @@ def bulk_transition_group_to_ongoing(
                 sender=bulk_transition_group_to_ongoing,
             )
 
-    with sentry_sdk.start_span(name="bulk_remove_groups_from_inbox"):
+    with sentry_sdk.traces.start_span(name="bulk_remove_groups_from_inbox"):
         bulk_remove_groups_from_inbox(groups_to_transition)
 
-    with sentry_sdk.start_span(name="post_save_send_robust"):
+    with sentry_sdk.traces.start_span(name="post_save_send_robust"):
         if not options.get("groups.enable-post-update-signal"):
             for group in groups_to_transition:
                 post_save.send_robust(

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any
 
 import sentry_sdk
-from sentry_sdk.tracing import NoOpSpan, Span, Transaction
+from sentry_sdk.traces import StreamedSpan
 
 from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
 from sentry.issues.escalating.escalating import manage_issue_states
@@ -253,9 +253,7 @@ def _get_status_change_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     return {"status_change": data}
 
 
-def process_status_change_message(
-    message: Mapping[str, Any], txn: Transaction | NoOpSpan | Span
-) -> Group | None:
+def process_status_change_message(message: Mapping[str, Any], span: StreamedSpan) -> Group | None:
     with metrics.timer("occurrence_consumer._process_message.status_change._get_kwargs"):
         kwargs = _get_status_change_kwargs(message)
     status_change_data = kwargs["status_change"]
@@ -265,15 +263,15 @@ def process_status_change_message(
         sample_rate=1.0,
         tags={"new_status": status_change_data["new_status"]},
     )
-    txn.set_tag("new_status", status_change_data["new_status"])
+    span.set_attribute("new_status", status_change_data["new_status"])
 
     project = Project.objects.get_from_cache(id=status_change_data["project_id"])
     organization = Organization.objects.get_from_cache(id=project.organization_id)
 
-    txn.set_tag("organization_id", organization.id)
-    txn.set_tag("organization_slug", organization.slug)
-    txn.set_tag("project_id", project.id)
-    txn.set_tag("project_slug", project.slug)
+    span.set_attribute("organization_id", organization.id)
+    span.set_attribute("organization_slug", organization.slug)
+    span.set_attribute("project_id", project.id)
+    span.set_attribute("project_slug", project.slug)
 
     with metrics.timer("occurrence_consumer._process_message.status_change.get_group"):
         fingerprint = status_change_data["fingerprint"]
@@ -292,7 +290,7 @@ def process_status_change_message(
                 sample_rate=1.0,
             )
             return None
-        txn.set_tag("group_id", group.id)
+        span.set_attribute("group_id", group.id)
 
     sentry_sdk.set_tag("group_type", group.issue_type.slug)
 

--- a/src/sentry/issues/suspect_flags.py
+++ b/src/sentry/issues/suspect_flags.py
@@ -29,7 +29,7 @@ class Score(TypedDict):
     is_filtered: bool
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_suspect_flag_scores(
     org_id: int,
     project_id: int,
@@ -81,7 +81,7 @@ def get_suspect_flag_scores(
     ]
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def query_baseline_set(
     organization_id: int,
     project_id: int,
@@ -167,7 +167,7 @@ def query_baseline_set(
     ]
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def query_selection_set(
     organization_id: int,
     project_id: int,
@@ -321,7 +321,7 @@ def _query_error_counts_eap(
     )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def query_error_counts(
     organization_id: int,
     project_id: int,

--- a/src/sentry/issues/suspect_tags.py
+++ b/src/sentry/issues/suspect_tags.py
@@ -20,7 +20,7 @@ class Score(NamedTuple):
     score: float
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_suspect_tag_scores(
     org_id: int,
     project_id: int,
@@ -52,7 +52,7 @@ def get_suspect_tag_scores(
     ]
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def query_baseline_set(
     organization_id: int,
     project_id: int,
@@ -138,7 +138,7 @@ def query_baseline_set(
     ]
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def query_selection_set(
     organization_id: int,
     project_id: int,
@@ -292,7 +292,7 @@ def _query_error_counts_eap(
     )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def query_error_counts(
     organization_id: int,
     project_id: int,

--- a/src/sentry/lang/dart/utils.py
+++ b/src/sentry/lang/dart/utils.py
@@ -36,7 +36,10 @@ def generate_dart_symbols_map(debug_ids: list[str], project: Project):
     Fetches and returns the dart symbols mapping for the first available debug_id.
     There should only be one mapping file per Flutter build, so we return the first mapping found.
     """
-    with sentry_sdk.start_span(op="dartsymbolmap.generate_dart_symbols_map") as span:
+    with sentry_sdk.traces.start_span(
+        name="dartsymbolmap.generate_dart_symbols_map",
+        attributes={"sentry.op": "dartsymbolmap.generate_dart_symbols_map"},
+    ) as span:
         dif_paths = ProjectDebugFile.difcache.fetch_difs(project, debug_ids, features=["mapping"])
         if not dif_paths:
             return None
@@ -45,7 +48,7 @@ def generate_dart_symbols_map(debug_ids: list[str], project: Project):
 
         try:
             dart_symbols_file_size_in_mb = os.path.getsize(debug_file_path) / (1024 * 1024.0)
-            span.set_tag("dartsymbolmap_file_size_in_mb", dart_symbols_file_size_in_mb)
+            span.set_attribute("dartsymbolmap_file_size_in_mb", dart_symbols_file_size_in_mb)
 
             with open(debug_file_path, "rb") as f:
                 data = orjson.loads(f.read())
@@ -83,7 +86,10 @@ def deobfuscate_exception_type(data: MutableMapping[str, Any]) -> None:
     if not exceptions:
         return None
 
-    with sentry_sdk.start_span(op="dartsymbolmap.deobfuscate_exception_type"):
+    with sentry_sdk.traces.start_span(
+        name="dartsymbolmap.deobfuscate_exception_type",
+        attributes={"sentry.op": "dartsymbolmap.deobfuscate_exception_type"},
+    ):
         symbol_map = generate_dart_symbols_map(list(debug_ids), project)
         if symbol_map is None:
             return None

--- a/src/sentry/lang/java/proguard.py
+++ b/src/sentry/lang/java/proguard.py
@@ -3,5 +3,7 @@ from symbolic.proguard import ProguardMapper
 
 
 def open_proguard_mapper(*args, **kwargs):
-    with sentry_sdk.start_span(op="proguard.open"):
+    with sentry_sdk.traces.start_span(
+        name="proguard.open", attributes={"sentry.op": "proguard.open"}
+    ):
         return ProguardMapper.open(*args, **kwargs)

--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -79,7 +79,7 @@ class AppleCrashReport:
             if new_image.get("image_vmaddr") is not None:
                 self.image_addrs_to_vmaddrs[new_image["image_addr"]] = new_image["image_vmaddr"]
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def __str__(self) -> str:
         rv = []
         rv.append(self._get_meta_header())
@@ -90,7 +90,7 @@ class AppleCrashReport:
 
         return "\n\n".join(rv) + "\n\nEOF"
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _get_meta_header(self):
         return "OS Version: {} {} ({})\nReport Version: {}".format(
             get_path(self.context, "os", "name"),
@@ -136,7 +136,7 @@ class AppleCrashReport:
         except Exception:
             return value
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _get_crashed_thread_registers(self):
         rv = []
         exception = get_path(self.exceptions, 0)
@@ -178,7 +178,7 @@ class AppleCrashReport:
 
         return "\n".join(rv)
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _get_exception_info(self):
         rv = []
 
@@ -216,7 +216,7 @@ class AppleCrashReport:
 
         return "\n".join(rv)
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def get_threads_apple_string(self):
         rv = []
         exceptions = self.exceptions or []
@@ -313,7 +313,7 @@ class AppleCrashReport:
     def _get_slide_value(self, image_addr):
         return self.image_addrs_to_vmaddrs.get(image_addr, 0)
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def get_binary_images_apple_string(self):
         # We don't need binary images on symbolicated crashreport
         if self.symbolicated or not self.debug_images:

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -116,20 +116,26 @@ def send_notification_as_email(
 ) -> None:
     for recipient in recipients:
         recipient_actor = Actor.from_object(recipient)
-        with sentry_sdk.start_span(op="notification.send_email", name="one_recipient"):
+        with sentry_sdk.traces.start_span(
+            name="one_recipient", attributes={"sentry.op": "notification.send_email"}
+        ):
             if recipient_actor.is_team:
                 # TODO(mgaeta): MessageBuilder only works with Users so filter out Teams for now.
                 continue
             _log_message(notification, recipient_actor)
 
-            with sentry_sdk.start_span(op="notification.send_email", name="build_message"):
+            with sentry_sdk.traces.start_span(
+                name="build_message", attributes={"sentry.op": "notification.send_email"}
+            ):
                 msg = MessageBuilder(
                     **get_builder_args(
                         notification, recipient_actor, shared_context, extra_context_by_actor
                     )
                 )
 
-            with sentry_sdk.start_span(op="notification.send_email", name="send_message"):
+            with sentry_sdk.traces.start_span(
+                name="send_message", attributes={"sentry.op": "notification.send_email"}
+            ):
                 # TODO: find better way of handling this
                 add_users_kwargs = {}
                 if isinstance(notification, ProjectNotification):

--- a/src/sentry/middleware/locale.py
+++ b/src/sentry/middleware/locale.py
@@ -8,7 +8,9 @@ from django.utils import translation
 
 class SentryLocaleMiddleware(LocaleMiddleware):
     def process_request(self, request: HttpRequest) -> None:
-        with sentry_sdk.start_span(op="middleware.locale", name="process_request"):
+        with sentry_sdk.traces.start_span(
+            name="process_request", attributes={"sentry.op": "middleware.locale"}
+        ):
             # No locale for static media, or RPC requests
             # This avoids touching user session, which means we avoid
             # setting `Vary: Cookie` as a response header which will

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -55,7 +55,9 @@ class RatelimitMiddleware:
 
     def __call__(self, request: HttpRequest) -> HttpResponseBase:
         # process_view is automatically called by Django
-        with sentry_sdk.start_span(op="ratelimit.__call__"):
+        with sentry_sdk.traces.start_span(
+            name="ratelimit.__call__", attributes={"sentry.op": "ratelimit.__call__"}
+        ):
             response = self.get_response(request)
             self.process_response(request, response)
             return response

--- a/src/sentry/models/groupinbox.py
+++ b/src/sentry/models/groupinbox.py
@@ -120,7 +120,7 @@ def bulk_remove_groups_from_inbox(
     action: GroupInboxRemoveAction | None = None,
     user: User | RpcUser | Team | None = None,
 ) -> None:
-    with sentry_sdk.start_span(name="bulk_remove_groups_from_inbox"):
+    with sentry_sdk.traces.start_span(name="bulk_remove_groups_from_inbox"):
         try:
             group_inbox = GroupInbox.objects.filter(group__in=groups)
             group_inbox.delete()

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -381,11 +381,13 @@ class Project(Model):
         from sentry.models.counter import Counter
 
         with (
-            sentry_sdk.start_span(op="project.next_short_id") as span,
+            sentry_sdk.traces.start_span(
+                name="project.next_short_id", attributes={"sentry.op": "project.next_short_id"}
+            ) as span,
             metrics.timer("project.next_short_id"),
         ):
-            span.set_data("project_id", self.id)
-            span.set_data("project_slug", self.slug)
+            span.set_attribute("project_id", self.id)
+            span.set_attribute("project_slug", self.slug)
             return Counter.increment(self, delta)
 
     def _save_project(self, *args, **kwargs):

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -184,7 +184,7 @@ class ProjectOwnership(Model):
 
     @classmethod
     @metrics.wraps("projectownership.get_issue_owners")
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def get_issue_owners(
         cls, project_id: int, data: Mapping[str, Any], limit: int = 2
     ) -> Sequence[tuple[Rule, Sequence[Team | RpcUser], str]]:

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -625,7 +625,7 @@ class Release(Model):
                 ref["previousCommit"], ref["commit"] = ref["commit"].split(COMMIT_RANGE_DELIMITER)
 
     def set_refs(self, refs, user_id, fetch=False):
-        with sentry_sdk.start_span(op="set_refs"):
+        with sentry_sdk.traces.start_span(name="set_refs", attributes={"sentry.op": "set_refs"}):
             from sentry.api.exceptions import InvalidRepository
             from sentry.models.releaseheadcommit import ReleaseHeadCommit
             from sentry.models.repository import Repository
@@ -666,7 +666,7 @@ class Release(Model):
                     }
                 )
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def set_commits(self, commit_list):
         """
         Bind a list of commits to this release.
@@ -747,7 +747,9 @@ class Release(Model):
         """
         Delete all release-specific commit data associated to this release. We will not delete the Commit model values because other releases may use these commits.
         """
-        with sentry_sdk.start_span(op="clear_commits"):
+        with sentry_sdk.traces.start_span(
+            name="clear_commits", attributes={"sentry.op": "clear_commits"}
+        ):
             from sentry.models.releasecommit import ReleaseCommit
             from sentry.models.releaseheadcommit import ReleaseHeadCommit
 

--- a/src/sentry/monitors/consumers/incident_occurrences_consumer.py
+++ b/src/sentry/monitors/consumers/incident_occurrences_consumer.py
@@ -15,7 +15,7 @@ from arroyo.types import BrokerValue, Commit, FilteredPayload, Message, Partitio
 from cachetools.func import ttl_cache
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.monitors_incident_occurrences_v1 import IncidentOccurrence
-from sentry_sdk.tracing import Span, Transaction
+from sentry_sdk.traces import StreamedSpan
 
 from sentry import options
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
@@ -42,7 +42,7 @@ def memoized_tick_decision(tick: datetime) -> TickAnomalyDecision | None:
 
 
 def _process_incident_occurrence(
-    message: Message[KafkaPayload | FilteredPayload], txn: Transaction | Span
+    message: Message[KafkaPayload | FilteredPayload], span: StreamedSpan
 ) -> None:
     """
     Process a incident occurrence message. This will immediately dispatch an
@@ -64,7 +64,7 @@ def _process_incident_occurrence(
         # the tick decision is resolved so we can know if it's OK to dispatch the
         # incident occurrence, or if we should drop the occurrence and mark the
         # associated check-ins as UNKNOWN due to a system incident.
-        txn.set_tag("result", "delayed")
+        span.set_attribute("result", "delayed")
 
         # XXX(epurkhiser): MessageRejected tells arroyo that we can't process
         # this message right now and it should try again
@@ -113,24 +113,25 @@ def _process_incident_occurrence(
         ).update(status=CheckInStatus.UNKNOWN)
 
         # Do NOT send the occurrence
-        txn.set_tag("result", "dropped")
+        span.set_attribute("result", "dropped")
         metrics.incr("monitors.incident_ocurrences.dropped_incident_occurrence")
         return None
 
     try:
         send_incident_occurrence(failed_checkin, previous_checkins, incident, received)
-        txn.set_tag("result", "sent")
+        span.set_attribute("result", "sent")
         metrics.incr("monitors.incident_ocurrences.sent_incident_occurrence")
     except Exception:
         logger.exception("failed_send_incident_occurrence")
 
 
 def process_incident_occurrence(message: Message[KafkaPayload | FilteredPayload]) -> None:
-    with sentry_sdk.start_transaction(
-        op="_process_incident_occurrence",
+    with sentry_sdk.traces.start_span(
         name="monitors.incident_occurrence_consumer",
-    ) as txn:
-        _process_incident_occurrence(message, txn)
+        attributes={"sentry.op": "_process_incident_occurrence"},
+        parent_span=None,
+    ) as span:
+        _process_incident_occurrence(message, span)
 
 
 class MonitorIncidentOccurenceStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -21,7 +21,7 @@ from django.db import router, transaction
 from rest_framework import serializers
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.ingest_monitors_v1 import IngestMonitorMessage
-from sentry_sdk.tracing import Span, Transaction
+from sentry_sdk.traces import StreamedSpan
 
 from sentry import options, quotas, ratelimits
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
@@ -248,7 +248,7 @@ class _CheckinUpdateKwargs(TypedDict):
 
 
 def transform_checkin_uuid(
-    txn: Transaction | Span,
+    span: StreamedSpan,
     metric_kwargs: dict[str, str],
     monitor_slug: str,
     check_in_id: str,
@@ -274,7 +274,7 @@ def transform_checkin_uuid(
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "failed_guid_validation"},
         )
-        txn.set_tag("result", "failed_guid_validation")
+        span.set_attribute("result", "failed_guid_validation")
         logger.info(
             "monitors.consumer.guid_validation_failed",
             extra={"guid": check_in_id, "slug": monitor_slug},
@@ -293,7 +293,7 @@ def transform_checkin_uuid(
 
 
 def update_existing_check_in(
-    txn: Transaction | Span,
+    span: StreamedSpan,
     metric_kwargs: dict[str, str],
     project_id: int,
     monitor_environment: MonitorEnvironment,
@@ -320,7 +320,7 @@ def update_existing_check_in(
             "monitors.checkin.result",
             tags={"source": "consumer", "status": "guid_mismatch"},
         )
-        txn.set_tag("result", "guid_mismatch")
+        span.set_attribute("result", "guid_mismatch")
         logger.info(
             "monitors.consumer.guid_exists",
             extra={
@@ -363,7 +363,7 @@ def update_existing_check_in(
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "checkin_finished"},
         )
-        txn.set_tag("result", "checkin_finished")
+        span.set_attribute("result", "checkin_finished")
         logger.info(
             "monitors.consumer.check_in_closed",
             extra={
@@ -395,7 +395,7 @@ def update_existing_check_in(
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "failed_duration_check"},
         )
-        txn.set_tag("result", "failed_duration_check")
+        span.set_attribute("result", "failed_duration_check")
         logger.info(
             "monitors.consumer.invalid_implicit_duration",
             extra={
@@ -454,7 +454,7 @@ def update_existing_check_in(
     existing_check_in.update(**updated_checkin)
 
 
-def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
+def _process_checkin(item: CheckinItem, span: StreamedSpan) -> None:
     params = item.payload
 
     # XXX: The start_time is when relay received the original envelope store
@@ -556,7 +556,7 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
         raise ProcessingErrorsException([overquota_error])
 
     guid, use_latest_checkin = transform_checkin_uuid(
-        txn,
+        span,
         metric_kwargs,
         monitor_slug,
         params["check_in_id"],
@@ -601,7 +601,7 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "failed_checkin_validation"},
         )
-        txn.set_tag("result", "failed_checkin_validation")
+        span.set_attribute("result", "failed_checkin_validation")
         logger.info(
             "monitors.consumer.checkin_validation_failed",
             extra={"guid": guid.hex, **params},
@@ -641,7 +641,7 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "failed_monitor_limits"},
         )
-        txn.set_tag("result", "failed_monitor_limits")
+        span.set_attribute("result", "failed_monitor_limits")
         logger.info(
             "monitors.consumer.monitor_limit_exceeded",
             extra={"guid": guid.hex, "project": project.id, "slug": monitor_slug},
@@ -673,7 +673,7 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "failed_validation"},
         )
-        txn.set_tag("result", "failed_validation")
+        span.set_attribute("result", "failed_validation")
         logger.info(
             "monitors.consumer.monitor_validation_failed",
             extra={"guid": guid.hex, "project": project.id, **params},
@@ -728,7 +728,7 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "monitor_disabled"},
         )
-        txn.set_tag("result", "monitor_disabled")
+        span.set_attribute("result", "monitor_disabled")
         track_outcome(
             org_id=project.organization_id,
             project_id=project.id,
@@ -754,7 +754,7 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "failed_monitor_environment_limits"},
         )
-        txn.set_tag("result", "failed_monitor_environment_limits")
+        span.set_attribute("result", "failed_monitor_environment_limits")
         logger.info(
             "monitors.consumer.monitor_environment_limit_exceeded",
             extra={
@@ -783,7 +783,7 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "failed_monitor_environment_name_length"},
         )
-        txn.set_tag("result", "failed_monitor_environment_name_length")
+        span.set_attribute("result", "failed_monitor_environment_name_length")
         logger.info(
             "monitors.consumer.monitor_environment_validation_failed",
             extra={
@@ -843,7 +843,7 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
                                 "status": "failed_monitor_environment_guid_match",
                             },
                         )
-                        txn.set_tag("result", "failed_monitor_environment_guid_match")
+                        span.set_attribute("result", "failed_monitor_environment_guid_match")
                         logger.info(
                             "monitors.consumer.monitor_environment_mismatch",
                             extra={
@@ -872,9 +872,9 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
                         }
                         raise ProcessingErrorsException([env_mismatch_error], monitor)
 
-                txn.set_tag("outcome", "process_existing_checkin")
+                span.set_attribute("outcome", "process_existing_checkin")
                 update_existing_check_in(
-                    txn,
+                    span,
                     metric_kwargs,
                     project_id,
                     monitor_environment,
@@ -934,9 +934,9 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
                 # XXX(epurkhiser): Is this needed since we're already
                 # locking this entire process?
                 if not created:
-                    txn.set_tag("outcome", "process_existing_checkin_race_condition")
+                    span.set_attribute("outcome", "process_existing_checkin_race_condition")
                     update_existing_check_in(
-                        txn,
+                        span,
                         metric_kwargs,
                         project_id,
                         monitor_environment,
@@ -946,7 +946,7 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
                         duration,
                     )
                 else:
-                    txn.set_tag("outcome", "create_new_checkin")
+                    span.set_attribute("outcome", "create_new_checkin")
                     with in_test_hide_transaction_boundary():
                         signal_first_checkin(project, monitor)
                     metrics.incr(
@@ -1012,7 +1012,7 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "error"},
         )
-        txn.set_tag("result", "error")
+        span.set_attribute("result", "error")
         logger.exception("Failed to process check-in")
 
     if non_fatal_processing_errors:
@@ -1024,13 +1024,14 @@ def process_checkin(item: CheckinItem) -> None:
     Process an individual check-in
     """
     try:
-        with sentry_sdk.start_transaction(
-            op="_process_checkin",
+        with sentry_sdk.traces.start_span(
             name="monitors.monitor_consumer",
-        ) as txn:
+            attributes={"sentry.op": "_process_checkin"},
+            parent_span=None,
+        ) as span:
             # Deepcopy the checkin here so that it's not modified. We need the original when we get a
             # `ProcessingErrorsException`
-            _process_checkin(deepcopy(item), txn)
+            _process_checkin(deepcopy(item), span)
     except ProcessingErrorsException as e:
         handle_processing_errors(item, e)
     except Exception:
@@ -1094,7 +1095,11 @@ def process_batch(
     metrics.gauge("monitors.checkin.parallel_batch_groups", len(checkin_mapping))
 
     # Submit check-in groups for processing
-    with sentry_sdk.start_transaction(op="process_batch", name="monitors.monitor_consumer"):
+    with sentry_sdk.traces.start_span(
+        name="monitors.monitor_consumer",
+        attributes={"sentry.op": "process_batch"},
+        parent_span=None,
+    ):
         futures = [
             executor.submit(process_checkin_group, group) for group in checkin_mapping.values()
         ]

--- a/src/sentry/net/socket.py
+++ b/src/sentry/net/socket.py
@@ -113,7 +113,7 @@ def is_safe_hostname(hostname: str | None) -> bool:
 
 
 # Modifed version of urllib3.util.connection.create_connection.
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def safe_create_connection(
     address: tuple[str, int],
     timeout: _TYPE_DEFAULT | float | None = _DEFAULT_TIMEOUT,
@@ -143,13 +143,17 @@ def safe_create_connection(
     except UnicodeError:
         raise LocationParseError("'{host}', label empty or too long") from None
 
-    with sentry_sdk.start_span(op="socket.getaddrinfo", name=f"DNS resolve: {host}") as gai_span:
+    with sentry_sdk.traces.start_span(
+        name=f"DNS resolve: {host}", attributes={"sentry.op": "socket.getaddrinfo"}
+    ) as gai_span:
         addresses = socket.getaddrinfo(host, port, family, socket.SOCK_STREAM)
-        gai_span.set_data("address_count", len(addresses))
-        gai_span.set_data("addresses", addresses)
+        gai_span.set_attribute("address_count", len(addresses))
+        gai_span.set_attribute("addresses", addresses)
 
     for res in addresses:
-        with sentry_sdk.start_span(op="socket.getaddrinfo.loop", name="socket.getaddrinfo.loop"):
+        with sentry_sdk.traces.start_span(
+            name="socket.getaddrinfo.loop", attributes={"sentry.op": "socket.getaddrinfo.loop"}
+        ):
             af, socktype, proto, canonname, sa = res
 
             # Begin custom code.
@@ -177,7 +181,9 @@ def safe_create_connection(
                     sock.settimeout(timeout)
                 if source_address:
                     sock.bind(source_address)
-                with sentry_sdk.start_span(op="socket.connect", name=f"sock.connect.{sa}"):
+                with sentry_sdk.traces.start_span(
+                    name=f"sock.connect.{sa}", attributes={"sentry.op": "socket.connect"}
+                ):
                     sock.connect(sa)
                 return sock
 

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -178,7 +178,9 @@ class BaseNotification(abc.ABC):
         from sentry.integrations.pagerduty.analytics import PagerdutyIntegrationNotificationSent
         from sentry.integrations.slack.analytics import SlackIntegrationNotificationSent
 
-        with sentry_sdk.start_span(op="notification.send", name="record_notification_sent"):
+        with sentry_sdk.traces.start_span(
+            name="record_notification_sent", attributes={"sentry.op": "notification.send"}
+        ):
             project: Project | None = getattr(self, "project", None)
             group: Group | None = getattr(self, "group", None)
 
@@ -313,14 +315,18 @@ class BaseNotification(abc.ABC):
         """The default way to send notifications that respects Notification Settings."""
         from sentry.notifications.notify import notify
 
-        with sentry_sdk.start_span(op="notification.send", name="get_participants"):
+        with sentry_sdk.traces.start_span(
+            name="get_participants", attributes={"sentry.op": "notification.send"}
+        ):
             participants_by_provider = self.get_participants()
             if not participants_by_provider:
                 return
 
         context = self.get_context()
         for provider, recipients in participants_by_provider.items():
-            with sentry_sdk.start_span(op="notification.send", name=f"send_for_{provider}"):
+            with sentry_sdk.traces.start_span(
+                name=f"send_for_{provider}", attributes={"sentry.op": "notification.send"}
+            ):
                 safe_execute(notify, provider, self, recipients, context)
 
 

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -144,7 +144,9 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
             )
         )
 
-        with sentry_sdk.start_span(op="preprod_artifact.assemble"):
+        with sentry_sdk.traces.start_span(
+            name="preprod_artifact.assemble", attributes={"sentry.op": "preprod_artifact.assemble"}
+        ):
             data, error_message = validate_preprod_artifact_schema(request.body)
             if error_message:
                 return Response({"error": error_message}, status=400)

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_assemble_generic.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_assemble_generic.py
@@ -109,7 +109,10 @@ class ProjectPreprodArtifactAssembleGenericEndpoint(ProjectEndpoint):
             )
         )
 
-        with sentry_sdk.start_span(op="preprod_artifact.assemble_generic"):
+        with sentry_sdk.traces.start_span(
+            name="preprod_artifact.assemble_generic",
+            attributes={"sentry.op": "preprod_artifact.assemble_generic"},
+        ):
             data, error_message = validate_preprod_artifact_generic_schema(request.body)
             if error_message:
                 return Response({"error": error_message}, status=400)

--- a/src/sentry/processing/backpressure/monitor.py
+++ b/src/sentry/processing/backpressure/monitor.py
@@ -110,7 +110,7 @@ def start_service_monitoring() -> None:
             time.sleep(options.get("backpressure.monitoring.interval"))
             continue
 
-        with sentry_sdk.start_transaction(name="backpressure.monitoring", sampled=True):
+        with sentry_sdk.traces.start_span(name="backpressure.monitoring", parent_span=None):
             # first, check each base service and record its health
             unhealthy_services = check_service_health(services)
 

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -403,7 +403,9 @@ def _symbolicate_profile(profile: Profile, project: Project) -> bool:
     if not _should_symbolicate(profile):
         return True
 
-    with sentry_sdk.start_span(op="task.profiling.symbolicate"):
+    with sentry_sdk.traces.start_span(
+        name="task.profiling.symbolicate", attributes={"sentry.op": "task.profiling.symbolicate"}
+    ):
         try:
             if "debug_meta" not in profile or not profile["debug_meta"]:
                 metrics.incr(
@@ -469,7 +471,9 @@ def _deobfuscate_profile(profile: Profile, project: Project) -> bool:
     if not _should_deobfuscate(profile):
         return True
 
-    with sentry_sdk.start_span(op="task.profiling.deobfuscate"):
+    with sentry_sdk.traces.start_span(
+        name="task.profiling.deobfuscate", attributes={"sentry.op": "task.profiling.deobfuscate"}
+    ):
         try:
             if "profile" not in profile or not profile["profile"]:
                 metrics.incr(
@@ -493,7 +497,9 @@ def _normalize_profile(profile: Profile, organization: Organization, project: Pr
     if profile.get("normalized", False):
         return True
 
-    with sentry_sdk.start_span(op="task.profiling.normalize"):
+    with sentry_sdk.traces.start_span(
+        name="task.profiling.normalize", attributes={"sentry.op": "task.profiling.normalize"}
+    ):
         try:
             _normalize(profile=profile, organization=organization)
             profile["normalized"] = True
@@ -532,7 +538,10 @@ def _normalize(profile: Profile, organization: Organization) -> None:
 def _prepare_frames_from_profile(
     profile: Profile, platform: str | None
 ) -> tuple[list[Any], list[Any], set[int]]:
-    with sentry_sdk.start_span(op="task.profiling.symbolicate.prepare_frames"):
+    with sentry_sdk.traces.start_span(
+        name="task.profiling.symbolicate.prepare_frames",
+        attributes={"sentry.op": "task.profiling.symbolicate.prepare_frames"},
+    ):
         modules = profile["debug_meta"]["images"]
         frames: list[Any] = []
         frames_sent: set[int] = set()
@@ -679,7 +688,10 @@ def run_symbolicate(
     )
 
     try:
-        with sentry_sdk.start_span(op="task.profiling.symbolicate.process_payload"):
+        with sentry_sdk.traces.start_span(
+            name="task.profiling.symbolicate.process_payload",
+            attributes={"sentry.op": "task.profiling.symbolicate.process_payload"},
+        ):
             response = symbolicate(
                 symbolicator=symbolicator,
                 profile=profile,
@@ -728,7 +740,10 @@ def _process_symbolicator_results(
     frames_sent: set[int],
     platform: str,
 ) -> None:
-    with sentry_sdk.start_span(op="task.profiling.symbolicate.process_results"):
+    with sentry_sdk.traces.start_span(
+        name="task.profiling.symbolicate.process_results",
+        attributes={"sentry.op": "task.profiling.symbolicate.process_results"},
+    ):
         # update images with status after symbolication
         profile["debug_meta"]["images"] = modules
 
@@ -947,7 +962,10 @@ def _deobfuscate_using_symbolicator(project: Project, profile: Profile, debug_fi
     )
 
     try:
-        with sentry_sdk.start_span(op="task.profiling.deobfuscate.process_payload"):
+        with sentry_sdk.traces.start_span(
+            name="task.profiling.deobfuscate.process_payload",
+            attributes={"sentry.op": "task.profiling.deobfuscate.process_payload"},
+        ):
             response = symbolicate(
                 symbolicator=symbolicator,
                 profile=profile,
@@ -1015,7 +1033,10 @@ def _deobfuscate(profile: Profile, project: Project) -> None:
         return
 
     try:
-        with sentry_sdk.start_span(op="deobfuscate_with_symbolicator"):
+        with sentry_sdk.traces.start_span(
+            name="deobfuscate_with_symbolicator",
+            attributes={"sentry.op": "deobfuscate_with_symbolicator"},
+        ):
             success = _deobfuscate_using_symbolicator(
                 project=project,
                 profile=profile,
@@ -1325,18 +1346,25 @@ def _process_vroomrs_profile(profile: Profile, project: Project) -> bool:
 
 
 def _process_vroomrs_transaction_profile(profile: Profile, project: Project) -> bool:
-    with sentry_sdk.start_span(op="task.profiling.process_vroomrs_transaction_profile"):
+    with sentry_sdk.traces.start_span(
+        name="task.profiling.process_vroomrs_transaction_profile",
+        attributes={"sentry.op": "task.profiling.process_vroomrs_transaction_profile"},
+    ):
         try:
             # todo (improvement): check the feasibility of passing the profile
             # dict directly to the PyO3 module to avoid json serialization/deserialization
-            with sentry_sdk.start_span(op="json.dumps"):
+            with sentry_sdk.traces.start_span(
+                name="json.dumps", attributes={"sentry.op": "json.dumps"}
+            ):
                 json_profile = json.dumps(profile)
                 metrics.distribution(
                     "profiling.profile.payload.size",
                     len(json_profile),
                     tags={"type": "profile", "platform": profile["platform"]},
                 )
-            with sentry_sdk.start_span(op="json.unmarshal"):
+            with sentry_sdk.traces.start_span(
+                name="json.unmarshal", attributes={"sentry.op": "json.unmarshal"}
+            ):
                 prof = vroomrs.profile_from_json_str(json_profile, profile["platform"])
             prof.normalize()
             if not prof.is_sampled():
@@ -1346,7 +1374,9 @@ def _process_vroomrs_transaction_profile(profile: Profile, project: Project) -> 
                 # either of snuba/sentry/front-end
                 prof.set_profile_id(UNSAMPLED_PROFILE_ID)
             if prof.is_sampled():
-                with sentry_sdk.start_span(op="gcs.write", name="compress and write"):
+                with sentry_sdk.traces.start_span(
+                    name="compress and write", attributes={"sentry.op": "gcs.write"}
+                ):
                     storage = get_profiles_storage()
                     with measure_storage_operation(
                         "put", "profiling", len(json_profile)
@@ -1356,7 +1386,9 @@ def _process_vroomrs_transaction_profile(profile: Profile, project: Project) -> 
                         storage.save(prof.storage_path(), io.BytesIO(compressed_profile))
                 # we only run find_occurrences for sampled profiles, unsampled profiles
                 # are skipped
-                with sentry_sdk.start_span(op="processing", name="find occurrences"):
+                with sentry_sdk.traces.start_span(
+                    name="find occurrences", attributes={"sentry.op": "processing"}
+                ):
                     occurrences = prof.find_occurrences()
                     occurrences.filter_none_type_issues()
                     for occurrence in occurrences.occurrences:
@@ -1366,7 +1398,9 @@ def _process_vroomrs_transaction_profile(profile: Profile, project: Project) -> 
                         )
                         profile_occurrences_producer.produce(topic, payload)
             # function metrics are extracted for both sampled and unsampled profiles
-            with sentry_sdk.start_span(op="processing", name="extract functions metrics"):
+            with sentry_sdk.traces.start_span(
+                name="extract functions metrics", attributes={"sentry.op": "processing"}
+            ):
                 functions = prof.extract_functions_metrics(
                     min_depth=1, filter_system_frames=True, max_unique_functions=100
                 )
@@ -1377,7 +1411,9 @@ def _process_vroomrs_transaction_profile(profile: Profile, project: Project) -> 
                     )
                     profile_functions_producer.produce(topic, payload)
             if features.has("projects:profile-functions-metrics-eap-ingestion", project):
-                with sentry_sdk.start_span(op="processing", name="extract functions metrics (eap)"):
+                with sentry_sdk.traces.start_span(
+                    name="extract functions metrics (eap)", attributes={"sentry.op": "processing"}
+                ):
                     eap_functions = prof.extract_functions_metrics(
                         min_depth=1,
                         filter_system_frames=True,
@@ -1400,7 +1436,9 @@ def _process_vroomrs_transaction_profile(profile: Profile, project: Project) -> 
                         )
             if prof.is_sampled():
                 # Send profile metadata to Kafka
-                with sentry_sdk.start_span(op="processing", name="send profile kafka message"):
+                with sentry_sdk.traces.start_span(
+                    name="send profile kafka message", attributes={"sentry.op": "processing"}
+                ):
                     payload = build_profile_kafka_message(prof)
                     topic = ArroyoTopic(
                         get_topic_definition(Topic.PROCESSED_PROFILES)["real_topic_name"]
@@ -1418,21 +1456,30 @@ def _process_vroomrs_transaction_profile(profile: Profile, project: Project) -> 
 
 
 def _process_vroomrs_chunk_profile(profile: Profile, project: Project) -> bool:
-    with sentry_sdk.start_span(op="task.profiling.process_vroomrs_chunk_profile"):
+    with sentry_sdk.traces.start_span(
+        name="task.profiling.process_vroomrs_chunk_profile",
+        attributes={"sentry.op": "task.profiling.process_vroomrs_chunk_profile"},
+    ):
         try:
             # todo (improvement): check the feasibility of passing the profile
             # dict directly to the PyO3 module to avoid json serialization/deserialization
-            with sentry_sdk.start_span(op="json.dumps"):
+            with sentry_sdk.traces.start_span(
+                name="json.dumps", attributes={"sentry.op": "json.dumps"}
+            ):
                 json_profile = json.dumps(profile)
                 metrics.distribution(
                     "profiling.profile.payload.size",
                     len(json_profile),
                     tags={"type": "chunk", "platform": profile["platform"]},
                 )
-            with sentry_sdk.start_span(op="json.unmarshal"):
+            with sentry_sdk.traces.start_span(
+                name="json.unmarshal", attributes={"sentry.op": "json.unmarshal"}
+            ):
                 chunk = vroomrs.profile_chunk_from_json_str(json_profile, profile["platform"])
             chunk.normalize()
-            with sentry_sdk.start_span(op="gcs.write", name="compress and write"):
+            with sentry_sdk.traces.start_span(
+                name="compress and write", attributes={"sentry.op": "gcs.write"}
+            ):
                 storage = get_profiles_storage()
                 with measure_storage_operation(
                     "put", "profiling", len(json_profile)
@@ -1440,11 +1487,15 @@ def _process_vroomrs_chunk_profile(profile: Profile, project: Project) -> bool:
                     compressed_chunk = chunk.compress()
                     metric_emitter.record_compressed_size(len(compressed_chunk), "lz4")
                     storage.save(chunk.storage_path(), io.BytesIO(compressed_chunk))
-            with sentry_sdk.start_span(op="processing", name="send chunk to kafka"):
+            with sentry_sdk.traces.start_span(
+                name="send chunk to kafka", attributes={"sentry.op": "processing"}
+            ):
                 payload = build_chunk_kafka_message(chunk)
                 topic = ArroyoTopic(get_topic_definition(Topic.PROFILE_CHUNKS)["real_topic_name"])
                 profile_chunks_producer.produce(topic, payload)
-            with sentry_sdk.start_span(op="processing", name="extract functions metrics"):
+            with sentry_sdk.traces.start_span(
+                name="extract functions metrics", attributes={"sentry.op": "processing"}
+            ):
                 functions = chunk.extract_functions_metrics(
                     min_depth=1, filter_system_frames=True, max_unique_functions=100
                 )
@@ -1455,7 +1506,9 @@ def _process_vroomrs_chunk_profile(profile: Profile, project: Project) -> bool:
                     )
                     profile_functions_producer.produce(topic, payload)
             if features.has("projects:profile-functions-metrics-eap-ingestion", project):
-                with sentry_sdk.start_span(op="processing", name="extract functions metrics (eap)"):
+                with sentry_sdk.traces.start_span(
+                    name="extract functions metrics (eap)", attributes={"sentry.op": "processing"}
+                ):
                     eap_functions = chunk.extract_functions_metrics(
                         min_depth=1,
                         filter_system_frames=True,

--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -111,7 +111,9 @@ def get_from_profiling_service(
                 "Content-Type": "application/json",
             }
         )
-        with sentry_sdk.start_span(op="json.dumps"):
+        with sentry_sdk.traces.start_span(
+            name="json.dumps", attributes={"sentry.op": "json.dumps"}
+        ):
             data = json.dumps(json_data).encode("utf-8")
         set_span_attribute("payload.size", len(data))
         if metric:

--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -73,8 +73,11 @@ class RedisQuota(Quota):
 
         results = [*self.get_abuse_quotas(project.organization)]
 
-        with sentry_sdk.start_span(op="redis.get_quotas.get_monitor_quota") as span:
-            span.set_tag("project.id", project.id)
+        with sentry_sdk.traces.start_span(
+            name="redis.get_quotas.get_monitor_quota",
+            attributes={"sentry.op": "redis.get_quotas.get_monitor_quota"},
+        ) as span:
+            span.set_attribute("project.id", project.id)
             mrlquota = self.get_monitor_quota(project)
             if mrlquota[0] is not None:
                 results.append(
@@ -95,8 +98,11 @@ class RedisQuota(Quota):
             keys = []
 
         for key in keys:
-            with sentry_sdk.start_span(op="redis.get_quotas.get_key_quota") as span:
-                span.set_tag("key.id", key.id)
+            with sentry_sdk.traces.start_span(
+                name="redis.get_quotas.get_key_quota",
+                attributes={"sentry.op": "redis.get_quotas.get_key_quota"},
+            ) as span:
+                span.set_attribute("key.id", key.id)
                 kquota = self.get_key_quota(key)
                 if kquota[0] is not None:
                     results.append(

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -227,7 +227,7 @@ def get_project_config(
     with sentry_sdk.isolation_scope() as scope:
         scope.set_tag("project", project.id)
         with (
-            sentry_sdk.start_transaction(name="get_project_config"),
+            sentry_sdk.traces.start_span(name="get_project_config", parent_span=None),
             metrics.timer("relay.config.get_project_config.duration"),
         ):
             return _get_project_config(project, project_keys=project_keys)
@@ -827,7 +827,9 @@ def _get_project_config(
 
     public_keys = get_public_key_configs(project_keys=project_keys)
 
-    with sentry_sdk.start_span(op="get_public_config"):
+    with sentry_sdk.traces.start_span(
+        name="get_public_config", attributes={"sentry.op": "get_public_config"}
+    ):
         now = datetime.now(timezone.utc)
         cfg = {
             "disabled": False,
@@ -860,7 +862,9 @@ def _get_project_config(
             )
         }
 
-    with sentry_sdk.start_span(op="get_exposed_features"):
+    with sentry_sdk.traces.start_span(
+        name="get_exposed_features", attributes={"sentry.op": "get_exposed_features"}
+    ):
         if exposed_features := get_exposed_features(project):
             config["features"] = exposed_features
 
@@ -910,24 +914,36 @@ def _get_project_config(
     if performance_score_profiles:
         config["performanceScore"] = {"profiles": performance_score_profiles}
 
-    with sentry_sdk.start_span(op="get_filter_settings"):
+    with sentry_sdk.traces.start_span(
+        name="get_filter_settings", attributes={"sentry.op": "get_filter_settings"}
+    ):
         if filter_settings := get_filter_settings(project):
             config["filterSettings"] = filter_settings
-    with sentry_sdk.start_span(op="get_grouping_config_dict_for_project"):
+    with sentry_sdk.traces.start_span(
+        name="get_grouping_config_dict_for_project",
+        attributes={"sentry.op": "get_grouping_config_dict_for_project"},
+    ):
         grouping_config = get_grouping_config_dict_for_project(project)
         if grouping_config is not None:
             config["groupingConfig"] = grouping_config
-    with sentry_sdk.start_span(op="get_event_retention"):
+    with sentry_sdk.traces.start_span(
+        name="get_event_retention", attributes={"sentry.op": "get_event_retention"}
+    ):
         event_retention = quotas.backend.get_event_retention(project.organization)
         if event_retention is not None:
             config["eventRetention"] = event_retention
-    with sentry_sdk.start_span(op="get_downsampled_event_retention"):
+    with sentry_sdk.traces.start_span(
+        name="get_downsampled_event_retention",
+        attributes={"sentry.op": "get_downsampled_event_retention"},
+    ):
         downsampled_event_retention = quotas.backend.get_downsampled_event_retention(
             project.organization
         )
         if downsampled_event_retention is not None:
             config["downsampledEventRetention"] = downsampled_event_retention
-    with sentry_sdk.start_span(op="get_retentions"):
+    with sentry_sdk.traces.start_span(
+        name="get_retentions", attributes={"sentry.op": "get_retentions"}
+    ):
         retentions = quotas.backend.get_retentions(project.organization)
         retentions_config = {
             RETENTIONS_CONFIG_MAPPING[c]: v.to_object()
@@ -937,12 +953,16 @@ def _get_project_config(
         if retentions_config:
             config["retentions"] = retentions_config
 
-    with sentry_sdk.start_span(op="get_trimming_configs"):
+    with sentry_sdk.traces.start_span(
+        name="get_trimming_configs", attributes={"sentry.op": "get_trimming_configs"}
+    ):
         trimming_configs = quotas.backend.get_trimming_configs(project.organization)
         if trimming_configs:
             config["trimming"] = trimming_configs
 
-    with sentry_sdk.start_span(op="get_all_quotas"):
+    with sentry_sdk.traces.start_span(
+        name="get_all_quotas", attributes={"sentry.op": "get_all_quotas"}
+    ):
         if quotas_config := get_quotas(project, keys=project_keys):
             config["quotas"] = quotas_config
 

--- a/src/sentry/relay/config/experimental.py
+++ b/src/sentry/relay/config/experimental.py
@@ -81,7 +81,10 @@ def build_safe_config(
     """
     timeout = TimeChecker(_FEATURE_BUILD_TIMEOUT)
 
-    with sentry_sdk.start_span(op=f"project_config.build_safe_config.{key}"):
+    with sentry_sdk.traces.start_span(
+        name=f"project_config.build_safe_config.{key}",
+        attributes={"sentry.op": f"project_config.build_safe_config.{key}"},
+    ):
         try:
             return function(timeout, *args, **kwargs)
         except TimeoutException as e:

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -113,11 +113,15 @@ def get_metric_extraction_config(project: Project) -> MetricExtractionConfig | N
     # For efficiency purposes, we fetch the flags in batch and propagate them downstream.
     sentry_sdk.set_tag("organization_id", project.organization_id)
 
-    with sentry_sdk.start_span(op="get_on_demand_metric_specs"):
+    with sentry_sdk.traces.start_span(
+        name="get_on_demand_metric_specs", attributes={"sentry.op": "get_on_demand_metric_specs"}
+    ):
         alert_specs, widget_specs = build_safe_config(
             "on_demand_metric_specs", get_on_demand_metric_specs, project
         ) or ([], [])
-    with sentry_sdk.start_span(op="merge_metric_specs"):
+    with sentry_sdk.traces.start_span(
+        name="merge_metric_specs", attributes={"sentry.op": "merge_metric_specs"}
+    ):
         metric_specs = _merge_metric_specs(alert_specs, widget_specs)
 
     if not metric_specs:
@@ -134,13 +138,18 @@ def get_metric_extraction_config(project: Project) -> MetricExtractionConfig | N
 def get_on_demand_metric_specs(
     timeout: TimeChecker, project: Project
 ) -> tuple[list[HashedMetricSpec], list[HashedMetricSpec]]:
-    with sentry_sdk.start_span(op="on_demand_metrics_feature_flags"):
+    with sentry_sdk.traces.start_span(
+        name="on_demand_metrics_feature_flags",
+        attributes={"sentry.op": "on_demand_metrics_feature_flags"},
+    ):
         enabled_features = on_demand_metrics_feature_flags(project.organization)
     timeout.check()
 
     prefilling = "organizations:on-demand-metrics-prefill" in enabled_features
 
-    with sentry_sdk.start_span(op="get_alert_metric_specs"):
+    with sentry_sdk.traces.start_span(
+        name="get_alert_metric_specs", attributes={"sentry.op": "get_alert_metric_specs"}
+    ):
         alert_specs = _get_alert_metric_specs(
             project,
             enabled_features,
@@ -148,7 +157,9 @@ def get_on_demand_metric_specs(
             prefilling_for_deprecation=False,
         )
     timeout.check()
-    with sentry_sdk.start_span(op="get_widget_metric_specs"):
+    with sentry_sdk.traces.start_span(
+        name="get_widget_metric_specs", attributes={"sentry.op": "get_widget_metric_specs"}
+    ):
         widget_specs = _get_widget_metric_specs(project, enabled_features, prefilling)
     timeout.check()
 
@@ -835,8 +846,11 @@ def _convert_aggregate_and_query_to_metrics(
         "groupbys": groupbys,
     }
 
-    with sentry_sdk.start_span(op="converting_aggregate_and_query") as span:
-        span.set_data("widget_query_args", {"query": query, "aggregate": aggregate})
+    with sentry_sdk.traces.start_span(
+        name="converting_aggregate_and_query",
+        attributes={"sentry.op": "converting_aggregate_and_query"},
+    ) as span:
+        span.set_attribute("widget_query_args", {"query": query, "aggregate": aggregate})
         # Create as many specs as we support
         for spec_version in OnDemandMetricSpecVersioning.get_spec_versions():
             try:

--- a/src/sentry/releases/use_cases/release.py
+++ b/src/sentry/releases/use_cases/release.py
@@ -33,7 +33,7 @@ from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def serialize(
     releases: list[Release],
     user: AnonymousUser | User | RpcUser,
@@ -125,7 +125,7 @@ def get_release_projects(
     return release_projects_map
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_projects(
     projects: Iterable[Project],
     fetch_platforms: Callable[[Iterable[int]], list[tuple[int, str]]],
@@ -147,7 +147,7 @@ def get_projects(
     }
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_release_adoption_stages(
     environment_ids: list[int],
     project_ids: list[int],
@@ -165,7 +165,7 @@ def get_release_adoption_stages(
     return result
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_release_project_first_last_seen(
     release_version_and_id_map: dict[str, int],
     organization_id: int,
@@ -209,7 +209,7 @@ def get_release_project_first_last_seen(
     return first_seen, last_seen
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_release_project_environment_first_last_seen(
     release_ids: list[int],
     environment_ids: list[int],
@@ -250,7 +250,7 @@ def get_release_project_environment_first_last_seen(
     return fs, ls
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_release_project_new_group_count(
     environment_ids: list[int],
     project_ids: list[int],
@@ -274,7 +274,7 @@ def get_release_project_new_group_count(
     return group_counts_by_release
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_authors(
     release_and_author_ids: list[tuple[int, list[str]]],
     fetch_authors: Callable[[Iterable[str]], Mapping[str, Author]],
@@ -294,7 +294,7 @@ def get_authors(
     return result
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_last_commits(
     release_and_commit_ids: Iterable[tuple[int, int | None]],
     fetch_last_commits: Callable[[Iterable[int]], dict[int, dict[str, Any]]],
@@ -305,7 +305,7 @@ def get_last_commits(
     return {r[0]: commit_map.get(r[1]) if r[1] else None for r in release_and_commit_ids}
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_last_deploys(
     release_and_deploy_ids: Iterable[tuple[int, int | None]],
     fetch_last_deploys: Callable[[Iterable[int]], dict[int, LastDeploy]],
@@ -316,7 +316,7 @@ def get_last_deploys(
     return {r[0]: deploy_map.get(r[1]) if r[1] else None for r in release_and_deploy_ids}
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_owners(
     release_and_owner_ids: Iterable[tuple[int, int | None]],
     fetch_owners: Callable[[Iterable[int]], dict[int, dict[str, Any]]],
@@ -327,7 +327,7 @@ def get_owners(
     return {r[0]: owner_map.get(r[1]) if r[1] else None for r in release_and_owner_ids}
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_releases_adoption_stages(
     environment_ids: list[int],
     project_ids: list[int],
@@ -341,7 +341,7 @@ def fetch_releases_adoption_stages(
     return list(queryset.values_list("release_id", "project_id", "adopted", "unadopted"))
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_authors(
     user: AnonymousUser | User | RpcUser, organization_id: int, author_ids: Iterable[str]
 ) -> Mapping[str, Any]:
@@ -349,7 +349,7 @@ def fetch_authors(
     return get_users_for_authors(organization_id=organization_id, authors=authors, user=user)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_commits(
     user: AnonymousUser | User | RpcUser, organization_id: int, commit_ids: Iterable[int]
 ) -> dict[int, dict[str, Any]]:
@@ -362,7 +362,7 @@ def fetch_commits(
     return {c.id: d for c, d in zip(commit_list, model_serializer(commit_list, user))}
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_deploys(
     user: AnonymousUser | User | RpcUser, organization_id: int, deploy_ids: Iterable[int]
 ) -> dict[int, LastDeploy]:
@@ -371,7 +371,7 @@ def fetch_deploys(
     return {d.id: c for d, c in zip(deploy_list, model_serializer(deploy_list, user))}
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_owners(
     user: AnonymousUser | User | RpcUser, owner_ids: Iterable[int]
 ) -> dict[int, dict[str, Any]]:
@@ -381,7 +381,7 @@ def fetch_owners(
     return {user["id"]: user for user in users}
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_issue_count(
     environment_ids: list[int],
     project_ids: list[int],
@@ -412,7 +412,7 @@ def fetch_issue_count(
         return list(qs2.values_list("project_id", "release_id", "new_groups"))
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_first_last_seen(
     environment_ids: list[int],
     project_ids: list[int],
@@ -427,7 +427,7 @@ def fetch_first_last_seen(
     return list(queryset.values_list("release_id", "first_seen", "last_seen"))
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_project_platforms(project_ids: Iterable[int]) -> list[tuple[int, str]]:
     """
     Returns a list of project-id platform pairs for a given set of project-ids.

--- a/src/sentry/remote_subscriptions/consumers/result_consumer.py
+++ b/src/sentry/remote_subscriptions/consumers/result_consumer.py
@@ -51,9 +51,10 @@ class ResultProcessor(abc.ABC, Generic[T, U]):
             try:
                 # TODO: Handle subscription not existing - we should remove the subscription from
                 # the remote system in that case.
-                with sentry_sdk.start_transaction(
+                with sentry_sdk.traces.start_span(
                     name=f"monitors.{identifier}.result_consumer.ResultProcessor",
-                    op="result_processor.handle_result",
+                    attributes={"sentry.op": "result_processor.handle_result"},
+                    parent_span=None,
                 ):
                     subscription = self.get_subscription(result)
                     if self.use_subscription_lock and subscription:
@@ -286,8 +287,10 @@ class ResultsStrategyFactory(ProcessingStrategyFactory[KafkaPayload], Generic[T,
         partitioned_values = self.partition_message_batch(message)
 
         # Submit groups for processing
-        with sentry_sdk.start_transaction(
-            op="process_batch", name=f"monitors.{self.identifier}.result_consumer"
+        with sentry_sdk.traces.start_span(
+            name=f"monitors.{self.identifier}.result_consumer",
+            attributes={"sentry.op": "process_batch"},
+            parent_span=None,
         ):
             futures = [
                 self.parallel_executor.submit(self.process_group, group)

--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -9,7 +9,6 @@ from arroyo.processing.strategies import RunTaskInThreads
 from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.types import Commit, Message, Partition
-from django.conf import settings
 from sentry_kafka_schemas.codecs import Codec, ValidationError
 from sentry_kafka_schemas.schema_types.ingest_replay_recordings_v1 import ReplayRecording
 from sentry_sdk import set_tag
@@ -90,14 +89,10 @@ class ProcessReplayRecordingStrategyFactory(ProcessingStrategyFactory[KafkaPaylo
 def process_and_commit_message(message: Message[KafkaPayload], context: ProcessorContext) -> None:
     isolation_scope = sentry_sdk.get_isolation_scope().fork()
     with sentry_sdk.scope.use_isolation_scope(isolation_scope):
-        with sentry_sdk.start_transaction(
+        with sentry_sdk.traces.start_span(
             name="replays.consumer.recording.process_and_commit_message",
-            op="replays.consumer.recording.process_and_commit_message",
-            custom_sampling_context={
-                "sample_rate": getattr(
-                    settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0
-                )
-            },
+            attributes={"sentry.op": "replays.consumer.recording.process_and_commit_message"},
+            parent_span=None,
         ):
             processed_message = process_message(message.payload.value)
             if processed_message:
@@ -107,7 +102,7 @@ def process_and_commit_message(message: Message[KafkaPayload], context: Processo
 # Processing Task
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def process_message(message: bytes) -> ProcessedEvent | None:
     try:
         recording_event = parse_recording_event(message)
@@ -124,7 +119,7 @@ def process_message(message: bytes) -> ProcessedEvent | None:
         return None
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def parse_recording_event(message: bytes) -> Event:
     recording = parse_request_message(message)
     segment_id, payload = parse_headers(cast(bytes, recording["payload"]), recording["replay_id"])
@@ -172,7 +167,7 @@ def parse_recording_event(message: bytes) -> Event:
     }
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def parse_request_message(message: bytes) -> ReplayRecording:
     try:
         return RECORDINGS_CODEC.decode(message)
@@ -181,7 +176,7 @@ def parse_request_message(message: bytes) -> ReplayRecording:
         raise DropSilently()
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def decompress_segment(segment: bytes) -> tuple[bytes, bytes]:
     try:
         return (segment, zlib.decompress(segment))
@@ -193,7 +188,7 @@ def decompress_segment(segment: bytes) -> tuple[bytes, bytes]:
             raise DropSilently()
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def parse_headers(recording: bytes, replay_id: str) -> tuple[int, bytes]:
     try:
         recording_headers_json, recording_segment = recording.split(b"\n", 1)
@@ -206,7 +201,7 @@ def parse_headers(recording: bytes, replay_id: str) -> tuple[int, bytes]:
 # I/O Task
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def commit_message(message: ProcessedEvent, context: ProcessorContext) -> None:
     try:
         commit_recording_message(message, context)

--- a/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
@@ -70,9 +70,9 @@ class ProjectReplayRecordingSegmentDetailsEndpoint(ProjectReplayEndpoint):
             )
 
     def download(self, segment: RecordingSegmentStorageMeta) -> StreamingHttpResponse:
-        with sentry_sdk.start_span(
-            op="download_segment",
+        with sentry_sdk.traces.start_span(
             name="ProjectReplayRecordingSegmentDetailsEndpoint.download_segment",
+            attributes={"sentry.op": "download_segment"},
         ) as child_span:
             segment_bytes = download_segment(segment, span=child_span)
             segment_reader = BytesIO(segment_bytes)

--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -7,7 +7,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features, options
+from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectPermission
@@ -56,13 +56,6 @@ class ProjectReplaySummaryEndpoint(ProjectReplayEndpoint):
 
     def __init__(self, **kw) -> None:
         storage.initialize_client()
-        # Trace sample rates for each method. Uses the default when not set (=0).
-        self.sample_rate_post = options.get(
-            "replay.endpoints.project_replay_summary.trace_sample_rate_post"
-        )
-        self.sample_rate_get = options.get(
-            "replay.endpoints.project_replay_summary.trace_sample_rate_get"
-        )
         super().__init__(**kw)
 
     def _make_seer_start_request(
@@ -158,12 +151,10 @@ class ProjectReplaySummaryEndpoint(ProjectReplayEndpoint):
     def get(self, request: Request, project: Project, replay_id: str) -> Response:
         """Poll for the status of a replay summary task in Seer."""
 
-        with sentry_sdk.start_transaction(
+        with sentry_sdk.traces.start_span(
             name="replays.endpoints.project_replay_summary.get",
-            op="replays.endpoints.project_replay_summary.get",
-            custom_sampling_context=(
-                {"sample_rate": self.sample_rate_get} if self.sample_rate_get else None
-            ),
+            attributes={"sentry.op": "replays.endpoints.project_replay_summary.get"},
+            parent_span=None,
         ):
             self.check_replay_access(request, project)
 
@@ -193,12 +184,10 @@ class ProjectReplaySummaryEndpoint(ProjectReplayEndpoint):
     def post(self, request: Request, project: Project, replay_id: str) -> Response:
         """Download replay segment data and parse it into logs. Then post to Seer to start a summary task."""
 
-        with sentry_sdk.start_transaction(
+        with sentry_sdk.traces.start_span(
             name="replays.endpoints.project_replay_summary.post",
-            op="replays.endpoints.project_replay_summary.post",
-            custom_sampling_context=(
-                {"sample_rate": self.sample_rate_post} if self.sample_rate_post else None
-            ),
+            attributes={"sentry.op": "replays.endpoints.project_replay_summary.post"},
+            parent_span=None,
         ):
             self.check_replay_access(request, project)
 

--- a/src/sentry/replays/post_process.py
+++ b/src/sentry/replays/post_process.py
@@ -90,7 +90,7 @@ class ReplayDetailsResponse(TypedDict, total=False):
     has_viewed: bool
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def process_raw_response(
     response: list[dict[str, Any]], fields: list[str]
 ) -> list[ReplayDetailsResponse]:

--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -147,7 +147,7 @@ class ProcessedEvent:
     video_size: int | None
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def process_recording_event(
     message: Event, use_new_recording_parser: bool = False
 ) -> ProcessedEvent:
@@ -281,12 +281,12 @@ def extract_user_info(replay_event: dict[str, Any] | None) -> dict[str, str | No
     return result
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def pack_replay_video(recording: bytes, video: bytes):
     return zlib.compress(pack(rrweb=recording, video=video))
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def commit_recording_message(recording: ProcessedEvent, context: ProcessorContext) -> None:
     # Write to GCS.
     storage_kv.set(recording.filename, recording.filedata)
@@ -340,7 +340,7 @@ def commit_recording_message(recording: ProcessedEvent, context: ProcessorContex
     emit_trace_items_to_eap(recording.trace_items)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def emit_replay_events(
     event_meta: ParsedEventMeta,
     org_id: int,
@@ -460,7 +460,7 @@ def _track_initial_segment_event_new(
     )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def track_recording_metadata(recording: ProcessedEvent) -> None:
     # Report size metrics to determine usage patterns.
     metrics.distribution(

--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -75,7 +75,7 @@ class ReplayActionsEvent(TypedDict):
     type: Literal["replay_event"]
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def emit_tap_events(
     tap_events: list[TapEvent],
     project_id: int,
@@ -119,7 +119,7 @@ def emit_tap_events(
     publish_replay_event(json.dumps(action))
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def emit_click_events(
     click_events: list[ClickEvent],
     project_id: int,
@@ -173,7 +173,7 @@ def emit_click_events(
     publish_replay_event(json.dumps(action))
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def emit_request_response_metrics(event_meta: ParsedEventMeta) -> None:
     for sizes in event_meta.request_response_sizes:
         req_size, res_size = sizes
@@ -187,7 +187,7 @@ def emit_request_response_metrics(event_meta: ParsedEventMeta) -> None:
             )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def log_canvas_size(
     event_meta: ParsedEventMeta, org_id: int, project_id: int, replay_id: str
 ) -> None:
@@ -204,7 +204,7 @@ def log_canvas_size(
         )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def log_mutation_events(event_meta: ParsedEventMeta, project_id: int, replay_id: str) -> None:
     # TODO: sampled differently from the rest (0 <= i <= 99)
     # probably fine to ignore.
@@ -215,7 +215,7 @@ def log_mutation_events(event_meta: ParsedEventMeta, project_id: int, replay_id:
         logger.info("Large DOM Mutations List:", extra=log)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def log_option_events(event_meta: ParsedEventMeta, project_id: int, replay_id: str) -> None:
     for option in event_meta.options_events:
         log = option["data"].get("payload", {}).copy()
@@ -224,7 +224,7 @@ def log_option_events(event_meta: ParsedEventMeta, project_id: int, replay_id: s
         logger.info("sentry.replays.slow_click", extra=log)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def log_multiclick_events(
     event_meta: ParsedEventMeta,
     project_id: int,
@@ -259,7 +259,7 @@ def log_multiclick_events(
         logger.info("sentry.replays.slow_click", extra=log)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def log_rage_click_events(
     event_meta: ParsedEventMeta,
     project_id: int,
@@ -293,7 +293,7 @@ def log_rage_click_events(
             logger.info("sentry.replays.slow_click", extra=log)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def report_hydration_error(
     event_meta: ParsedEventMeta,
     project_id: int,
@@ -368,7 +368,7 @@ def gen_rage_clicks(
         }
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def report_rage_click(
     event_meta: ParsedEventMeta,
     project_id: int,
@@ -410,7 +410,7 @@ def _attr_stats(ti: TraceItem) -> tuple[int, int]:
     return (count, total_size)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def emit_trace_items_to_eap(trace_items: list[TraceItem]) -> None:
     # Get largest attribute across trace items
     largest_attribute = max(
@@ -427,19 +427,21 @@ def emit_trace_items_to_eap(trace_items: list[TraceItem]) -> None:
         total_attr_count += c
         total_attr_size_bytes += s
 
-    with sentry_sdk.start_span(op="process", name="write_trace_items") as span:
-        span.set_data("attribute_count_total", total_attr_count)
-        span.set_data("attribute_size_total_bytes", total_attr_size_bytes)
+    with sentry_sdk.traces.start_span(
+        name="write_trace_items", attributes={"sentry.op": "process"}
+    ) as span:
+        span.set_attribute("attribute_count_total", total_attr_count)
+        span.set_attribute("attribute_size_total_bytes", total_attr_size_bytes)
 
         if largest_attribute:
             ti, name, size = largest_attribute
-            span.set_data("largest_attr_trace_id", ti.trace_id)
-            span.set_data("largest_attr_name", name)
-            span.set_data("largest_attr_size_bytes", size)
+            span.set_attribute("largest_attr_trace_id", ti.trace_id)
+            span.set_attribute("largest_attr_name", name)
+            span.set_attribute("largest_attr_size_bytes", size)
         write_trace_items(trace_items)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def _should_report_hydration_error_issue(project_id: int, context: ProcessorContext) -> bool:
     """
     Checks the project option, controlled by a project owner.
@@ -454,7 +456,7 @@ def _should_report_hydration_error_issue(project_id: int, context: ProcessorCont
         )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def _should_report_rage_click_issue(project_id: int, context: ProcessorContext) -> bool:
     """
     Checks the project option, controlled by a project owner.

--- a/src/sentry/replays/usecases/ingest/event_parser.py
+++ b/src/sentry/replays/usecases/ingest/event_parser.py
@@ -96,7 +96,7 @@ class EventContext(TypedDict):
     user_geo_subdivision: str | None
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def parse_events(
     context: EventContext, events: list[dict[str, Any]]
 ) -> tuple[ParsedEventMeta, list[TraceItem]]:

--- a/src/sentry/replays/usecases/reader.py
+++ b/src/sentry/replays/usecases/reader.py
@@ -34,7 +34,7 @@ from sentry.utils.snuba import raw_snql_query
 # METADATA QUERY BEHAVIOR.
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_segments_metadata(
     project_id: int,
     replay_id: str,
@@ -68,7 +68,7 @@ def fetch_segment_metadata(
     return fetch_direct_storage_segment_meta(project_id, replay_id, segment_id)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_filestore_segments_meta(
     project_id: int,
     replay_id: str,
@@ -131,7 +131,7 @@ def fetch_filestore_segment_meta(
     )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_direct_storage_segments_meta(
     project_id: int,
     replay_id: str,
@@ -166,7 +166,7 @@ def fetch_direct_storage_segment_meta(
         return results[0]
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def has_archived_segment(project_id: int, replay_id: str) -> bool:
     """Return true if an archive row exists for this replay."""
     snuba_request = Request(
@@ -249,7 +249,7 @@ def segment_row_to_storage_meta(
 # BLOB DOWNLOAD BEHAVIOR.
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def download_segments(segments: list[RecordingSegmentStorageMeta]) -> Iterator[bytes]:
     """Download segment data from remote storage."""
     yield b"["
@@ -301,7 +301,7 @@ def _download_segment(
     return unpack(decompressed)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def decompress(buffer: bytes) -> bytes:
     """Return decompressed output."""
     # If the file starts with a valid JSON character we assume its uncompressed.

--- a/src/sentry/replays/usecases/summarize.py
+++ b/src/sentry/replays/usecases/summarize.py
@@ -40,7 +40,7 @@ class EventDict(TypedDict):
     category: str
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_error_details(project_id: int, error_ids: list[str]) -> list[EventDict]:
     """Fetch error details given error IDs and return a list of EventDict objects."""
     try:
@@ -80,7 +80,7 @@ def _parse_iso_timestamp_to_ms(timestamp: str | None) -> float:
         return 0.0
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_trace_connected_errors(
     project: Project,
     trace_ids: list[str],
@@ -201,7 +201,7 @@ def fetch_trace_connected_errors(
     return events
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fetch_feedback_details(feedback_id: str | None, project_id) -> EventDict | None:
     """
     Fetch user feedback associated with a specific feedback event ID.
@@ -245,7 +245,7 @@ def generate_feedback_log_message(feedback: EventDict) -> str:
     return f"User submitted feedback: '{message}' at {timestamp}"
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_summary_logs(
     segment_data: Iterator[tuple[int, memoryview]],
     error_events: list[EventDict],
@@ -514,7 +514,7 @@ def _parse_url(s: str, trunc_length: int) -> str:
     return s
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def rpc_get_replay_summary_logs(
     project_id: int,
     replay_id: str,

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -182,13 +182,19 @@ class ReprocessableEvent:
 def pull_event_data(project_id: int, event_id: str) -> ReprocessableEvent:
     from sentry.lang.native.processing import get_required_attachment_types
 
-    with sentry_sdk.start_span(op="reprocess_events.eventstore.get"):
+    with sentry_sdk.traces.start_span(
+        name="reprocess_events.eventstore.get",
+        attributes={"sentry.op": "reprocess_events.eventstore.get"},
+    ):
         event = eventstore.backend.get_event_by_id(project_id, event_id)
 
     if event is None:
         raise CannotReprocess("event.not_found")
 
-    with sentry_sdk.start_span(op="reprocess_events.nodestore.get"):
+    with sentry_sdk.traces.start_span(
+        name="reprocess_events.nodestore.get",
+        attributes={"sentry.op": "reprocess_events.nodestore.get"},
+    ):
         node_id = Event.generate_node_id(project_id, event_id)
         data = nodestore.backend.get(node_id, subkey="unprocessed")
 
@@ -231,8 +237,11 @@ def reprocess_event(project_id: int, event_id: str, start_time: float) -> None:
     cache_key = cache_key_for_event(data)
     attachment_objects = []
     for attachment_id, attachment in enumerate(attachments):
-        with sentry_sdk.start_span(op="reprocess_event._maybe_copy_attachment_into_cache") as span:
-            span.set_data("attachment_id", attachment.id)
+        with sentry_sdk.traces.start_span(
+            name="reprocess_event._maybe_copy_attachment_into_cache",
+            attributes={"sentry.op": "reprocess_event._maybe_copy_attachment_into_cache"},
+        ) as span:
+            span.set_attribute("attachment_id", attachment.id)
             attachment_objects.append(
                 _maybe_copy_attachment_into_cache(
                     project=project,
@@ -397,8 +406,11 @@ def buffered_delete_old_primary_hash(
     scope.set_tag("old_group_id", group_id)
     scope.set_tag("old_primary_hash", old_primary_hash)
 
-    with sentry_sdk.start_span(
-        op="sentry.reprocessing2.buffered_delete_old_primary_hash.flush_events"
+    with sentry_sdk.traces.start_span(
+        name="sentry.reprocessing2.buffered_delete_old_primary_hash.flush_events",
+        attributes={
+            "sentry.op": "sentry.reprocessing2.buffered_delete_old_primary_hash.flush_events"
+        },
     ):
         _send_delete_old_primary_hash_messages(
             project_id, group_id, old_primary_hashes, force_flush_batch

--- a/src/sentry/rules/actions/integrations/base.py
+++ b/src/sentry/rules/actions/integrations/base.py
@@ -50,9 +50,9 @@ class IntegrationEventAction(EventAction, abc.ABC):
         **kwargs: Any,
     ) -> CallbackFuture:
         def wrapped_callback(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
-            with sentry_sdk.start_span(
-                op="IntegrationEventAction.future",
+            with sentry_sdk.traces.start_span(
                 name=type(self).__name__,
+                attributes={"sentry.op": "IntegrationEventAction.future"},
             ):
                 callback(event, futures)
 

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -126,8 +126,10 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
             return
 
         try:
-            with sentry_sdk.start_transaction(
-                op="cleanup", name=f"{TRANSACTION_PREFIX}.multiprocess_worker"
+            with sentry_sdk.traces.start_span(
+                name=f"{TRANSACTION_PREFIX}.multiprocess_worker",
+                attributes={"sentry.op": "cleanup"},
+                parent_span=None,
             ):
                 task_execution(model_name, chunk, project_id)
         except Exception:
@@ -346,9 +348,11 @@ def _cleanup(
     # Start transaction AFTER creating the multiprocessing pool to avoid
     # transaction context issues in child processes. This ensures only the
     # main process tracks the overall cleanup operation performance.
-    with sentry_sdk.start_transaction(
-        op="cleanup", name=f"{TRANSACTION_PREFIX}.main"
-    ) as transaction:
+    with sentry_sdk.traces.start_span(
+        name=f"{TRANSACTION_PREFIX}.main",
+        attributes={"sentry.op": "cleanup"},
+        parent_span=None,
+    ) as span:
         try:
             # Check if cleanup should be aborted before starting
             if options.get("cleanup.abort_execution"):
@@ -385,9 +389,9 @@ def _cleanup(
                 project, organization, days, deletes, bulk_query_deletes
             )
             if organization_id is not None:
-                transaction.set_tag("organization_id", organization_id)
+                span.set_attribute("organization_id", organization_id)
             if project_id is not None:
-                transaction.set_tag("project_id", project_id)
+                span.set_attribute("project_id", project_id)
 
             run_bulk_query_deletes(
                 bulk_query_deletes,

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -170,7 +170,9 @@ def devserver(
         dsn=os.environ.get("SENTRY_DEVSERVICES_DSN", ""),
         traces_sample_rate=1.0,
     )
-    with sentry_sdk.start_transaction(op="command", name="sentry.devserver"):
+    with sentry_sdk.traces.start_span(
+        name="sentry.devserver", attributes={"sentry.op": "command"}, parent_span=None
+    ):
         passed_options = {
             p.name: ctx.params[p.name]
             for p in ctx.command.params

--- a/src/sentry/scm/endpoints/scm_rpc.py
+++ b/src/sentry/scm/endpoints/scm_rpc.py
@@ -38,12 +38,12 @@ class ScmRpcServiceEndpoint(Endpoint):
     permission_classes = ()
     enforce_rate_limit = False
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def get(self, request: Request) -> HttpResponse:
         resp = make_server().get(headers={k: v for k, v in request.headers.items()})
         return HttpResponse(content=resp.content, status=resp.status_code, headers=resp.headers)
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def post(self, request: Request) -> StreamingHttpResponse:
         resp = make_server().post(request.body, headers={k: v for k, v in request.headers.items()})
         return StreamingHttpResponse(resp.content, status=resp.status_code, headers=resp.headers)

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -138,7 +138,7 @@ class SearchResolver:
         else:
             raise InvalidSearchQuery(f"Unknown function {function_name}")
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def resolve_meta(
         self,
         referrer: str,
@@ -147,9 +147,9 @@ class SearchResolver:
     ) -> RequestMeta:
         if self.params.organization_id is None:
             raise Exception("An organization is required to resolve queries")
-        span = sentry_sdk.get_current_span()
+        span = sentry_sdk.traces.get_current_span()
         if span:
-            span.set_tag("SearchResolver.params", self.params)
+            span.set_attribute("SearchResolver.params", self.params)
 
         projects = self.params.projects
 
@@ -173,7 +173,7 @@ class SearchResolver:
             downsampled_storage_config=validate_sampling(sampling_mode),
         )
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def resolve_query(
         self, querystring: str | None
     ) -> tuple[
@@ -187,11 +187,11 @@ class SearchResolver:
         also append the environment before returning the final TraceItemFilter"""
         environment_query = self.__resolve_environment_query()
         where, having, contexts = self.__resolve_query(querystring)
-        span = sentry_sdk.get_current_span()
+        span = sentry_sdk.traces.get_current_span()
         if span:
-            span.set_tag("SearchResolver.query_string", querystring)
-            span.set_tag("SearchResolver.resolved_query", where)
-            span.set_tag("SearchResolver.environment_query", environment_query)
+            span.set_attribute("SearchResolver.query_string", querystring)
+            span.set_attribute("SearchResolver.resolved_query", where)
+            span.set_attribute("SearchResolver.environment_query", environment_query)
 
         where = and_trace_item_filters(
             where,
@@ -202,7 +202,7 @@ class SearchResolver:
 
         return where, having, contexts
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def resolve_query_with_columns(
         self,
         querystring: str | None,
@@ -956,7 +956,7 @@ class SearchResolver:
                 final_contexts.append(context)
         return final_contexts
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def resolve_columns(
         self, selected_columns: list[str], has_aggregates: bool = False
     ) -> tuple[
@@ -967,12 +967,12 @@ class SearchResolver:
 
         This function will also dedupe the virtual column contexts if necessary
         """
-        span = sentry_sdk.get_current_span()
+        span = sentry_sdk.traces.get_current_span()
         resolved_columns = []
         resolved_contexts = []
         stripped_columns = [column.strip() for column in selected_columns]
         if span:
-            span.set_tag("SearchResolver.selected_columns", stripped_columns)
+            span.set_attribute("SearchResolver.selected_columns", stripped_columns)
         for column in stripped_columns:
             match = fields.is_function(column)
             has_aggregates = has_aggregates or match is not None
@@ -1031,7 +1031,7 @@ class SearchResolver:
         resolved_column, _ = self.resolve_column(column)
         return resolved_column.search_type
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def resolve_attributes(
         self, columns: list[str]
     ) -> tuple[list[ResolvedAttribute], list[VirtualColumnDefinition | None]]:
@@ -1169,7 +1169,7 @@ class SearchResolver:
         else:
             raise InvalidSearchQuery(f"Could not parse {column}")
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def resolve_functions(
         self, columns: list[str]
     ) -> tuple[

--- a/src/sentry/search/eap/sampling.py
+++ b/src/sentry/search/eap/sampling.py
@@ -29,10 +29,10 @@ def events_meta_from_rpc_request_meta(meta: ResponseMeta) -> EventsMeta:
         sum(info.stats.progress_bytes for info in meta.query_info) if meta.query_info else None
     )
 
-    span = sentry_sdk.get_current_span()
+    span = sentry_sdk.traces.get_current_span()
     if span:
-        span.set_data("data_scanned", "full" if full_scan else "partial")
-        span.set_data("bytes_scanned", bytes_scanned)
+        span.set_attribute("data_scanned", "full" if full_scan else "partial")
+        span.set_attribute("bytes_scanned", bytes_scanned)
 
     return EventsMeta(
         fields={},

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -6,6 +6,7 @@ from re import Match
 from typing import Any, Union, cast
 
 import sentry_sdk
+import sentry_sdk.traces
 from django.utils.functional import cached_property
 from parsimonious.exceptions import ParseError
 from snuba_sdk import (
@@ -332,20 +333,34 @@ class BaseQueryBuilder:
         equations: list[str] | None = None,
         orderby: list[str] | str | None = None,
     ) -> None:
-        with sentry_sdk.start_span(op="QueryBuilder", name="resolve_query"):
-            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_time_conditions"):
+        with sentry_sdk.traces.start_span(
+            name="resolve_query", attributes={"sentry.op": "QueryBuilder"}
+        ):
+            with sentry_sdk.traces.start_span(
+                name="resolve_time_conditions", attributes={"sentry.op": "QueryBuilder"}
+            ):
                 # Has to be done early, since other conditions depend on start and end
                 self.resolve_time_conditions()
-            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_conditions"):
+            with sentry_sdk.traces.start_span(
+                name="resolve_conditions", attributes={"sentry.op": "QueryBuilder"}
+            ):
                 self.where, self.having = self.resolve_conditions(query)
-            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_params"):
+            with sentry_sdk.traces.start_span(
+                name="resolve_params", attributes={"sentry.op": "QueryBuilder"}
+            ):
                 # params depends on parse_query, and conditions being resolved first since there may be projects in conditions
                 self.where += self.resolve_params()
-            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_columns"):
+            with sentry_sdk.traces.start_span(
+                name="resolve_columns", attributes={"sentry.op": "QueryBuilder"}
+            ):
                 self.columns = self.resolve_select(selected_columns, equations)
-            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_orderby"):
+            with sentry_sdk.traces.start_span(
+                name="resolve_orderby", attributes={"sentry.op": "QueryBuilder"}
+            ):
                 self.orderby = self.resolve_orderby(orderby)
-            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_groupby"):
+            with sentry_sdk.traces.start_span(
+                name="resolve_groupby", attributes={"sentry.op": "QueryBuilder"}
+            ):
                 self.groupby = self.resolve_groupby(groupby_columns)
 
     def parse_config(self) -> None:
@@ -1612,8 +1627,10 @@ class BaseQueryBuilder:
         return raw_snql_query(self.get_snql_query(), referrer, use_cache, query_source)
 
     def process_results(self, results: Any) -> EventsResponse:
-        with sentry_sdk.start_span(op="QueryBuilder", name="process_results") as span:
-            span.set_data("result_count", len(results.get("data", [])))
+        with sentry_sdk.traces.start_span(
+            name="process_results", attributes={"sentry.op": "QueryBuilder"}
+        ) as span:
+            span.set_attribute("result_count", len(results.get("data", [])))
             translated_columns = self.alias_to_typed_tag_map
             if self.builder_config.transform_alias_to_input_format:
                 translated_columns.update(

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any
 
 import sentry_sdk
+import sentry_sdk.traces
 from django.utils.functional import cached_property
 from snuba_sdk import (
     AliasedExpression,
@@ -408,10 +409,14 @@ class MetricsQueryBuilder(BaseQueryBuilder):
         orderby: list[str] | None = None,
     ) -> None:
         # Resolutions that we always must perform, irrespectively of on demand.
-        with sentry_sdk.start_span(op="QueryBuilder", name="resolve_time_conditions"):
+        with sentry_sdk.traces.start_span(
+            name="resolve_time_conditions", attributes={"sentry.op": "QueryBuilder"}
+        ):
             # Has to be done early, since other conditions depend on start and end
             self.resolve_time_conditions()
-        with sentry_sdk.start_span(op="QueryBuilder", name="resolve_granularity"):
+        with sentry_sdk.traces.start_span(
+            name="resolve_granularity", attributes={"sentry.op": "QueryBuilder"}
+        ):
             # Needs to happen before params and after time conditions since granularity can change start&end
             self.granularity = self.resolve_granularity()
             if self.start is not None:
@@ -423,17 +428,27 @@ class MetricsQueryBuilder(BaseQueryBuilder):
         # for building an on demand query we only require a time interval and granularity. All the other fields are
         # automatically computed given the OnDemandMetricSpec.
         if not self.use_on_demand:
-            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_conditions"):
+            with sentry_sdk.traces.start_span(
+                name="resolve_conditions", attributes={"sentry.op": "QueryBuilder"}
+            ):
                 self.where, self.having = self.resolve_conditions(query)
-            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_params"):
+            with sentry_sdk.traces.start_span(
+                name="resolve_params", attributes={"sentry.op": "QueryBuilder"}
+            ):
                 # params depends on parse_query, and conditions being resolved first since there may be projects
                 # in conditions
                 self.where += self.resolve_params()
-            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_columns"):
+            with sentry_sdk.traces.start_span(
+                name="resolve_columns", attributes={"sentry.op": "QueryBuilder"}
+            ):
                 self.columns = self.resolve_select(selected_columns, equations)
-            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_orderby"):
+            with sentry_sdk.traces.start_span(
+                name="resolve_orderby", attributes={"sentry.op": "QueryBuilder"}
+            ):
                 self.orderby = self.resolve_orderby(orderby)
-            with sentry_sdk.start_span(op="QueryBuilder", name="resolve_groupby"):
+            with sentry_sdk.traces.start_span(
+                name="resolve_groupby", attributes={"sentry.op": "QueryBuilder"}
+            ):
                 self.groupby = self.resolve_groupby(groupby_columns)
         else:
             # On demand still needs to call resolve since resolving columns has a side_effect
@@ -999,7 +1014,9 @@ class MetricsQueryBuilder(BaseQueryBuilder):
         one"""
         seen_metrics_metas = {}
         seen_total_keys = set()
-        with sentry_sdk.start_span(op="metric_layer", name="transform_results"):
+        with sentry_sdk.traces.start_span(
+            name="transform_results", attributes={"sentry.op": "metric_layer"}
+        ):
             metric_layer_result: Any = {
                 "data": [],
                 "meta": [],
@@ -1149,7 +1166,9 @@ class MetricsQueryBuilder(BaseQueryBuilder):
             for query_details in [query_framework.pop(primary), *query_framework.values()]:
                 try:
                     metrics_queries = []
-                    with sentry_sdk.start_span(op="metric_layer", name="transform_query"):
+                    with sentry_sdk.traces.start_span(
+                        name="transform_query", attributes={"sentry.op": "metric_layer"}
+                    ):
                         aggregates = self._get_aggregates()
                         group_bys = self._get_group_bys()
                         for agg in aggregates:
@@ -1164,7 +1183,9 @@ class MetricsQueryBuilder(BaseQueryBuilder):
                             )
                     metrics_data = []
                     for metrics_query in metrics_queries:
-                        with sentry_sdk.start_span(op="metric_layer", name="run_query"):
+                        with sentry_sdk.traces.start_span(
+                            name="run_query", attributes={"sentry.op": "metric_layer"}
+                        ):
                             metrics_data.append(
                                 get_series(
                                     projects=self.params.projects,
@@ -1176,7 +1197,9 @@ class MetricsQueryBuilder(BaseQueryBuilder):
                             )
                 except Exception as err:
                     raise IncompatibleMetricsQuery(err)
-                with sentry_sdk.start_span(op="metric_layer", name="transform_results"):
+                with sentry_sdk.traces.start_span(
+                    name="transform_results", attributes={"sentry.op": "metric_layer"}
+                ):
                     metric_layer_result = self.convert_metric_layer_result(metrics_data)
                     for row in metric_layer_result["data"]:
                         # Arrays in clickhouse cannot contain multiple types, and since groupby values
@@ -1609,7 +1632,9 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
 
             try:
                 metrics_queries = []
-                with sentry_sdk.start_span(op="metric_layer", name="transform_query"):
+                with sentry_sdk.traces.start_span(
+                    name="transform_query", attributes={"sentry.op": "metric_layer"}
+                ):
                     for agg in self.selected_columns:
                         spec = self._on_demand_metric_spec_map[agg]
                         metrics_query = self._get_metrics_query_from_on_demand_spec(
@@ -1618,7 +1643,9 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
                         )
                         metrics_queries.append(metrics_query)
                 metrics_data = []
-                with sentry_sdk.start_span(op="metric_layer", name="run_query"):
+                with sentry_sdk.traces.start_span(
+                    name="run_query", attributes={"sentry.op": "metric_layer"}
+                ):
                     for metrics_query in metrics_queries:
                         metrics_data.append(
                             get_series(
@@ -1632,7 +1659,9 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
             except Exception as err:
                 raise IncompatibleMetricsQuery(err)
 
-            with sentry_sdk.start_span(op="metric_layer", name="transform_results"):
+            with sentry_sdk.traces.start_span(
+                name="transform_results", attributes={"sentry.op": "metric_layer"}
+            ):
                 return self._metric_layer_result(metrics_data, use_first_group_only=False)
 
         queries = self.get_snql_query()
@@ -1850,7 +1879,9 @@ class TopMetricsQueryBuilder(TimeseriesMetricQueryBuilder):
 
             try:
                 metrics_queries = []
-                with sentry_sdk.start_span(op="metric_layer", name="transform_query"):
+                with sentry_sdk.traces.start_span(
+                    name="transform_query", attributes={"sentry.op": "metric_layer"}
+                ):
                     group_bys = self._get_group_bys()
 
                     for agg in self.timeseries_columns:
@@ -1870,7 +1901,9 @@ class TopMetricsQueryBuilder(TimeseriesMetricQueryBuilder):
                         metrics_queries.append(metrics_query)
                 metrics_data = []
                 for metrics_query in metrics_queries:
-                    with sentry_sdk.start_span(op="metric_layer", name="run_query"):
+                    with sentry_sdk.traces.start_span(
+                        name="run_query", attributes={"sentry.op": "metric_layer"}
+                    ):
                         metrics_data.append(
                             get_series(
                                 projects=self.params.projects,
@@ -1886,7 +1919,9 @@ class TopMetricsQueryBuilder(TimeseriesMetricQueryBuilder):
                         )
             except Exception as err:
                 raise IncompatibleMetricsQuery(err)
-            with sentry_sdk.start_span(op="metric_layer", name="transform_results"):
+            with sentry_sdk.traces.start_span(
+                name="transform_results", attributes={"sentry.op": "metric_layer"}
+            ):
                 result = self._metric_layer_result(metrics_data, use_first_group_only=False)
                 return result
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -13,6 +13,7 @@ from math import floor
 from typing import Any, TypedDict, cast
 
 import sentry_sdk
+import sentry_sdk.traces
 from django.utils import timezone
 from snuba_sdk.query import Query
 
@@ -1015,12 +1016,14 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         # clause.
         max_candidates = options.get("snuba.search.max-pre-snuba-candidates")
 
-        with sentry_sdk.start_span(op="snuba_group_query") as span:
+        with sentry_sdk.traces.start_span(
+            name="snuba_group_query", attributes={"sentry.op": "snuba_group_query"}
+        ) as span:
             group_ids = list(
                 group_queryset.using_replica().values_list("id", flat=True)[: max_candidates + 1]
             )
-            span.set_data("Max Candidates", max_candidates)
-            span.set_data("Result Size", len(group_ids))
+            span.set_attribute("Max Candidates", max_candidates)
+            span.set_attribute("Result Size", len(group_ids))
         metrics.distribution("snuba.search.num_candidates", len(group_ids))
         too_many_candidates = False
         original_group_ids: list[int] | None = None

--- a/src/sentry/seer/agent/service_map_utils.py
+++ b/src/sentry/seer/agent/service_map_utils.py
@@ -16,6 +16,7 @@ from typing import Any, cast
 
 import orjson
 import sentry_sdk
+import sentry_sdk.traces
 
 from sentry import options
 from sentry.search.eap.types import SearchResolverConfig
@@ -79,8 +80,11 @@ def _query_service_dependencies(snuba_params: SnubaParams) -> list[dict]:
 
     # Broad scan: Org-wide — only segments WITH a parent (cross-project candidates).
     page_limit = min(_SNUBA_MAX_ROWS, max_segments)
-    with sentry_sdk.start_span(op="explorer.service_map.broad_scan") as span:
-        span.set_data("limit", page_limit)
+    with sentry_sdk.traces.start_span(
+        name="explorer.service_map.broad_scan",
+        attributes={"sentry.op": "explorer.service_map.broad_scan"},
+    ) as span:
+        span.set_attribute("limit", page_limit)
         result = Spans.run_table_query(
             params=snuba_params,
             query_string="is_transaction:true has:parent_span",
@@ -93,8 +97,8 @@ def _query_service_dependencies(snuba_params: SnubaParams) -> list[dict]:
         )
         rows = result.get("data", [])
         _process_rows(rows)
-        span.set_data("rows_returned", len(rows))
-        span.set_data("covered_projects", len(covered_project_ids))
+        span.set_attribute("rows_returned", len(rows))
+        span.set_attribute("covered_projects", len(covered_project_ids))
 
     # Fallback scan: One scoped query for projects with no representation in the broad scan.
     # No has:parent_span filter — broad scan to give low-traffic projects a second chance.
@@ -106,9 +110,12 @@ def _query_service_dependencies(snuba_params: SnubaParams) -> list[dict]:
         )
         uncovered_params = dataclasses.replace(snuba_params, projects=uncovered)
         page_limit = min(_SNUBA_MAX_ROWS, max_segments)
-        with sentry_sdk.start_span(op="explorer.service_map.fallback_scan") as span:
-            span.set_data("uncovered_projects", len(uncovered))
-            span.set_data("limit", page_limit)
+        with sentry_sdk.traces.start_span(
+            name="explorer.service_map.fallback_scan",
+            attributes={"sentry.op": "explorer.service_map.fallback_scan"},
+        ) as span:
+            span.set_attribute("uncovered_projects", len(uncovered))
+            span.set_attribute("limit", page_limit)
             result = Spans.run_table_query(
                 params=uncovered_params,
                 query_string="is_transaction:true",
@@ -127,7 +134,7 @@ def _query_service_dependencies(snuba_params: SnubaParams) -> list[dict]:
             )
             rows = result.get("data", [])
             _process_rows(rows)
-            span.set_data("rows_returned", len(rows))
+            span.set_attribute("rows_returned", len(rows))
 
     unique_parent_span_ids = list(segments_by_parent.keys())
     if not unique_parent_span_ids:
@@ -139,9 +146,12 @@ def _query_service_dependencies(snuba_params: SnubaParams) -> list[dict]:
     edges_by_pair: dict[tuple[int, str, int, str], int] = defaultdict(int)
     batch_size = options.get("explorer.service_map.parent_span_batch_size")
 
-    with sentry_sdk.start_span(op="explorer.service_map.resolve_parents") as span:
-        span.set_data("unique_parent_spans", len(unique_parent_span_ids))
-        span.set_data("batch_count", math.ceil(len(unique_parent_span_ids) / batch_size))
+    with sentry_sdk.traces.start_span(
+        name="explorer.service_map.resolve_parents",
+        attributes={"sentry.op": "explorer.service_map.resolve_parents"},
+    ) as span:
+        span.set_attribute("unique_parent_spans", len(unique_parent_span_ids))
+        span.set_attribute("batch_count", math.ceil(len(unique_parent_span_ids) / batch_size))
         for i in range(0, len(unique_parent_span_ids), batch_size):
             batch = unique_parent_span_ids[i : i + batch_size]
             span_ids = ",".join(batch)
@@ -173,7 +183,7 @@ def _query_service_dependencies(snuba_params: SnubaParams) -> list[dict]:
                             segment["child_project_slug"],
                         )
                         edges_by_pair[edge_key] += 1
-        span.set_data("edges_found", len(edges_by_pair))
+        span.set_attribute("edges_found", len(edges_by_pair))
 
     edges = [
         {

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import sentry_sdk
+import sentry_sdk.traces
 
 from sentry import tagstore
 from sentry.api.endpoints.organization_trace import OrganizationTraceEndpoint
@@ -89,7 +90,10 @@ def get_trace_tree_for_event(
         }
 
     try:
-        with sentry_sdk.start_span(op="seer.autofix.get_trace_tree_for_event"):
+        with sentry_sdk.traces.start_span(
+            name="seer.autofix.get_trace_tree_for_event",
+            attributes={"sentry.op": "seer.autofix.get_trace_tree_for_event"},
+        ):
             with ContextPropagatingThreadPoolExecutor() as executor:
                 future = executor.submit(_fetch_trace)
                 return future.result(timeout=timeout)

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -6,6 +6,7 @@ from typing import Any, NotRequired, TypedDict
 
 import orjson
 import sentry_sdk
+import sentry_sdk.traces
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from taskbroker_client.retry import Retry
@@ -160,7 +161,9 @@ def _trigger_autofix_task(
             sentry_sdk.capture_exception(e)
             return
 
-    with sentry_sdk.start_span(op="ai_summary.trigger_autofix"):
+    with sentry_sdk.traces.start_span(
+        name="ai_summary.trigger_autofix", attributes={"sentry.op": "ai_summary.trigger_autofix"}
+    ):
         try:
             group = Group.objects.get(id=group_id)
         except Group.DoesNotExist:
@@ -331,7 +334,10 @@ def get_and_update_group_fixability_score(
             extra={"group_id": group.id},
         )
 
-    with sentry_sdk.start_span(op="ai_summary.generate_fixability_score"):
+    with sentry_sdk.traces.start_span(
+        name="ai_summary.generate_fixability_score",
+        attributes={"sentry.op": "ai_summary.generate_fixability_score"},
+    ):
         issue_summary = _generate_fixability_score(group, summary=summary)
 
     if not issue_summary.scores:

--- a/src/sentry/seer/endpoints/organization_seer_rpc.py
+++ b/src/sentry/seer/endpoints/organization_seer_rpc.py
@@ -207,7 +207,7 @@ class OrganizationSeerRpcEndpoint(OrganizationEndpoint):
 
         return project
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _dispatch_to_local_method(
         self,
         request: Request,
@@ -240,7 +240,7 @@ class OrganizationSeerRpcEndpoint(OrganizationEndpoint):
 
         raise RpcResolutionException(f"Unknown method {method_name}")
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def post(self, request: Request, organization: Organization, method_name: str) -> Response:
         sentry_sdk.set_tag("rpc.method", method_name)
         seer_referrer = request.headers.get("X-Seer-Referrer")

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from typing import Any, TypedDict
 
 import sentry_sdk
+import sentry_sdk.traces
 from cryptography.fernet import Fernet
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -230,7 +231,7 @@ class SeerRpcServiceEndpoint(Endpoint):
     permission_classes = ()
     enforce_rate_limit = False
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _is_authorized(self, request: Request) -> bool:
         if request.auth and isinstance(
             request.successful_authenticator, SeerRpcSignatureAuthentication
@@ -238,7 +239,7 @@ class SeerRpcServiceEndpoint(Endpoint):
             return True
         return False
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _dispatch_to_local_method(self, method_name: str, arguments: dict[str, Any]) -> Any:
         if method_name not in seer_method_registry:
             raise RpcResolutionException(f"Unknown method {method_name}")
@@ -246,7 +247,7 @@ class SeerRpcServiceEndpoint(Endpoint):
         method = seer_method_registry[method_name]
         return method(**arguments)
 
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def post(self, request: Request, method_name: str) -> Response:
         sentry_sdk.set_tag("rpc.method", method_name)
         seer_referrer = request.headers.get("X-Seer-Referrer")
@@ -340,7 +341,9 @@ def get_organization_features(*, org_id: int, user_id: int | None = None) -> dic
 
     feature_set: set[str] = set()
 
-    with sentry_sdk.start_span(op="features.check", name="check batch features"):
+    with sentry_sdk.traces.start_span(
+        name="check batch features", attributes={"sentry.op": "features.check"}
+    ):
         batch = features.batch_has(
             list(features_to_check),
             actor=actor,
@@ -354,7 +357,9 @@ def get_organization_features(*, org_id: int, user_id: int | None = None) -> dic
                     feature_set.add(name[len(_ORGANIZATION_SCOPE_PREFIX) :])
                 features_to_check.discard(name)
 
-    with sentry_sdk.start_span(op="features.check", name="check individual features"):
+    with sentry_sdk.traces.start_span(
+        name="check individual features", attributes={"sentry.op": "features.check"}
+    ):
         for name in features_to_check:
             if features.has(name, organization, actor=actor, skip_entity=True):
                 feature_set.add(name[len(_ORGANIZATION_SCOPE_PREFIX) :])

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_components.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_components.py
@@ -1,6 +1,7 @@
 import logging
 
 import sentry_sdk
+import sentry_sdk.traces
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -61,14 +62,22 @@ class OrganizationSentryAppComponentsEndpoint(ControlSiloOrganizationEndpoint):
         components = []
         errors = {}
 
-        with sentry_sdk.start_transaction(name="sentry.api.sentry_app_components.get"):
-            with sentry_sdk.start_span(op="sentry-app-components.get_installs"):
+        with sentry_sdk.traces.start_span(
+            name="sentry.api.sentry_app_components.get", parent_span=None
+        ):
+            with sentry_sdk.traces.start_span(
+                name="sentry-app-components.get_installs",
+                attributes={"sentry.op": "sentry-app-components.get_installs"},
+            ):
                 installs = SentryAppInstallation.objects.get_installed_for_organization(
                     organization.id
                 ).order_by("pk")
 
             for install in installs:
-                with sentry_sdk.start_span(op="sentry-app-components.filter_components"):
+                with sentry_sdk.traces.start_span(
+                    name="sentry-app-components.filter_components",
+                    attributes={"sentry.op": "sentry-app-components.filter_components"},
+                ):
                     _components = SentryAppComponent.objects.filter(
                         sentry_app_id=install.sentry_app_id
                     ).order_by("pk")
@@ -77,7 +86,10 @@ class OrganizationSentryAppComponentsEndpoint(ControlSiloOrganizationEndpoint):
                         _components = _components.filter(type=request.GET["filter"])
 
                 for component in _components:
-                    with sentry_sdk.start_span(op="sentry-app-components.prepare_components"):
+                    with sentry_sdk.traces.start_span(
+                        name="sentry-app-components.prepare_components",
+                        attributes={"sentry.op": "sentry-app-components.prepare_components"},
+                    ):
                         try:
                             SentryAppComponentPreparer(component=component, install=install).run()
 

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -445,7 +445,7 @@ def _does_project_filter_allow_project(service_hook_id: int, project_id: int) ->
     silo_mode=SiloMode.CELL,
     silenced_exceptions=_SENTRY_APP_WEBHOOK_SILENCED,
 )
-@sentry_sdk.trace(name="process_resource_change_bound")
+@sentry_sdk.traces.trace(name="process_resource_change_bound")
 def process_resource_change_bound(
     action: str, sender: str, instance_id: str, **kwargs: Any
 ) -> None:

--- a/src/sentry/sentry_metrics/consumers/indexer/processing.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/processing.py
@@ -2,8 +2,8 @@ import logging
 from collections.abc import Callable, Mapping
 
 import sentry_sdk
+import sentry_sdk.traces
 from arroyo.types import Message
-from django.conf import settings
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 
@@ -74,13 +74,9 @@ class MessageProcessor:
         ).validate
 
     def process_messages(self, outer_message: Message[MessageBatch]) -> IndexerOutputMessageBatch:
-        sample_rate = (
-            settings.SENTRY_METRICS_INDEXER_TRANSACTIONS_SAMPLE_RATE
-            * settings.SENTRY_BACKEND_APM_SAMPLING
-        )
-        with sentry_sdk.start_transaction(
+        with sentry_sdk.traces.start_span(
             name="sentry.sentry_metrics.consumers.indexer.processing.process_messages",
-            custom_sampling_context={"sample_rate": sample_rate},
+            parent_span=None,
         ):
             return self._process_messages_impl(outer_message)
 
@@ -130,7 +126,12 @@ class MessageProcessor:
 
         set_span_attribute("org_strings.len", len(extracted_strings))
 
-        with metrics.timer("metrics_consumer.bulk_record"), sentry_sdk.start_span(op="bulk_record"):
+        with (
+            metrics.timer("metrics_consumer.bulk_record"),
+            sentry_sdk.traces.start_span(
+                name="bulk_record", attributes={"sentry.op": "bulk_record"}
+            ),
+        ):
             record_result = self._indexer.bulk_record(extracted_strings)
 
         mapping = record_result.get_mapped_results()

--- a/src/sentry/services/eventstore/base.py
+++ b/src/sentry/services/eventstore/base.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Any, Literal, Self, overload
 
 import sentry_sdk
+import sentry_sdk.traces
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
 from snuba_sdk import Condition
 
@@ -341,7 +342,10 @@ class EventStorage(Service):
         """
         sentry_sdk.set_tag("eventstore.backend", "nodestore")
 
-        with sentry_sdk.start_span(op="eventstore.base.bind_nodes"):
+        with sentry_sdk.traces.start_span(
+            name="eventstore.base.bind_nodes",
+            attributes={"sentry.op": "eventstore.base.bind_nodes"},
+        ):
             object_node_list = [(i, i.data) for i in object_list if i.data.id]
 
             # Remove duplicates from the list of nodes to be fetched

--- a/src/sentry/services/eventstore/models.py
+++ b/src/sentry/services/eventstore/models.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, cast, overload
 
 import orjson
 import sentry_sdk
+import sentry_sdk.traces
 from dateutil.parser import parse as parse_date
 from django.conf import settings
 from django.utils.encoding import force_str
@@ -439,14 +440,20 @@ class BaseEvent(metaclass=abc.ABCMeta):
             loaded_grouping_config = load_grouping_config(grouping_config)
 
         if normalize_stacktraces:
-            with sentry_sdk.start_span(op="grouping.normalize_stacktraces_for_grouping") as span:
-                span.set_tag("project", self.project_id)
-                span.set_tag("event_id", self.event_id)
+            with sentry_sdk.traces.start_span(
+                name="grouping.normalize_stacktraces_for_grouping",
+                attributes={"sentry.op": "grouping.normalize_stacktraces_for_grouping"},
+            ) as span:
+                span.set_attribute("project", self.project_id)
+                span.set_attribute("event_id", self.event_id)
                 self.normalize_stacktraces_for_grouping(loaded_grouping_config)
 
-        with sentry_sdk.start_span(op="grouping.get_grouping_variants") as span:
-            span.set_tag("project", self.project_id)
-            span.set_tag("event_id", self.event_id)
+        with sentry_sdk.traces.start_span(
+            name="grouping.get_grouping_variants",
+            attributes={"sentry.op": "grouping.get_grouping_variants"},
+        ) as span:
+            span.set_attribute("project", self.project_id)
+            span.set_attribute("event_id", self.event_id)
 
             return get_grouping_variants_for_event(self, loaded_grouping_config)
 

--- a/src/sentry/services/eventstore/query_preprocessing.py
+++ b/src/sentry/services/eventstore/query_preprocessing.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import sentry_sdk
+import sentry_sdk.traces
 from django.core.cache import cache
 from django.db.models import Q, QuerySet
 
@@ -63,7 +64,9 @@ def _try_get_from_cache(
 def get_all_merged_group_ids(
     group_ids: Iterable[str | int], threshold=SIZE_THRESHOLD_FOR_CLICKHOUSE
 ) -> set[str | int]:
-    with sentry_sdk.start_span(op="get_all_merged_group_ids") as span:
+    with sentry_sdk.traces.start_span(
+        name="get_all_merged_group_ids", attributes={"sentry.op": "get_all_merged_group_ids"}
+    ) as span:
         # Initialize all IDs with a future time to ensure they aren't filtered out.
         running_data = {
             (group_id, datetime.now(UTC) + timedelta(minutes=1)) for group_id in group_ids
@@ -99,7 +102,7 @@ def get_all_merged_group_ids(
         #         date_added and only return newest threshold # of results.
         output_set = {datum[0] for datum in running_data}
         original_count = len(output_set)
-        span.set_data("true_group_id_len", original_count)
+        span.set_attribute("true_group_id_len", original_count)
 
         if original_count > threshold:
             # Sort by datetime, decreasing, and then take first threshold results
@@ -118,7 +121,7 @@ def get_all_merged_group_ids(
                 threshold,
                 truncated_count,
             )
-        span.set_data("returned_group_id_len", len(output_set))
+        span.set_attribute("returned_group_id_len", len(output_set))
 
     return output_set
 

--- a/src/sentry/services/eventstore/snuba/backend.py
+++ b/src/sentry/services/eventstore/snuba/backend.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Literal, overload
 
 import sentry_sdk
+import sentry_sdk.traces
 from django.utils import timezone
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
 from snuba_sdk import (
@@ -239,7 +240,10 @@ class SnubaEventStorage(EventStorage):
         """
         Get events from Snuba, with node data loaded.
         """
-        with sentry_sdk.start_span(op="eventstore.snuba.get_events"):
+        with sentry_sdk.traces.start_span(
+            name="eventstore.snuba.get_events",
+            attributes={"sentry.op": "eventstore.snuba.get_events"},
+        ):
             return self.__get_events(
                 filter,
                 eap_conditions=eap_conditions,

--- a/src/sentry/services/nodestore/base.py
+++ b/src/sentry/services/nodestore/base.py
@@ -6,6 +6,7 @@ from threading import local
 from typing import Any
 
 import sentry_sdk
+import sentry_sdk.traces
 from django.core.cache import BaseCache, InvalidCacheBackendError, caches
 from django.utils.functional import cached_property
 
@@ -136,27 +137,29 @@ class NodeStorage(local, Service):
         >>> nodestore.get('key1')
         {"message": "hello world"}
         """
-        with sentry_sdk.start_span(op="nodestore.get") as span:
-            span.set_tag("node_id", id)
+        with sentry_sdk.traces.start_span(
+            name="nodestore.get", attributes={"sentry.op": "nodestore.get"}
+        ) as span:
+            span.set_attribute("node_id", id)
             if subkey is None:
                 item_from_cache = self._get_cache_item(id)
                 if item_from_cache:
                     metrics.incr("nodestore.get", tags={"cache": "hit"})
-                    span.set_tag("origin", "from_cache")
-                    span.set_tag("found", bool(item_from_cache))
+                    span.set_attribute("origin", "from_cache")
+                    span.set_attribute("found", bool(item_from_cache))
                     return item_from_cache
 
-            span.set_tag("subkey", str(subkey))
+            span.set_attribute("subkey", str(subkey))
             bytes_data = self._get_bytes(id)
             rv = self._decode(bytes_data, subkey=subkey)
             if subkey is None:
                 # set cache item only after we know decoding did not fail
                 self._set_cache_item(id, rv)
 
-            span.set_tag("result", "from_service")
+            span.set_attribute("result", "from_service")
             if bytes_data:
-                span.set_tag("bytes.size", len(bytes_data))
-            span.set_tag("found", bool(rv))
+                span.set_attribute("bytes.size", len(bytes_data))
+            span.set_attribute("found", bool(rv))
             metrics.incr("nodestore.get", tags={"cache": "miss", "found": bool(rv)})
 
             return rv
@@ -179,17 +182,19 @@ class NodeStorage(local, Service):
             "key2": {"message": "hello world"}
         }
         """
-        with sentry_sdk.start_span(op="nodestore.get_multi") as span:
+        with sentry_sdk.traces.start_span(
+            name="nodestore.get_multi", attributes={"sentry.op": "nodestore.get_multi"}
+        ) as span:
             # Deduplicate ids, preserving order
             id_list = list(dict.fromkeys(id_list))
-            span.set_tag("subkey", str(subkey))
-            span.set_tag("num_ids", len(id_list))
+            span.set_attribute("subkey", str(subkey))
+            span.set_attribute("num_ids", len(id_list))
 
             if subkey is None:
                 cache_items = self._get_cache_items(id_list)
                 if len(cache_items) == len(id_list):
                     metrics.incr("nodestore.get_multi", amount=len(id_list), tags={"cache": "hit"})
-                    span.set_tag("result", "from_cache")
+                    span.set_attribute("result", "from_cache")
                     return cache_items
 
                 uncached_ids = [id for id in id_list if id not in cache_items]
@@ -200,7 +205,10 @@ class NodeStorage(local, Service):
             else:
                 uncached_ids = id_list
 
-            with sentry_sdk.start_span(op="nodestore._get_bytes_multi_and_decode") as span:
+            with sentry_sdk.traces.start_span(
+                name="nodestore._get_bytes_multi_and_decode",
+                attributes={"sentry.op": "nodestore._get_bytes_multi_and_decode"},
+            ) as span:
                 items = {
                     id: self._decode(value, subkey=subkey)
                     for id, value in self._get_bytes_multi(uncached_ids).items()
@@ -209,8 +217,8 @@ class NodeStorage(local, Service):
                 self._set_cache_items(items)
                 items.update(cache_items)
 
-            span.set_tag("result", "from_service")
-            span.set_tag("found", len(items))
+            span.set_attribute("result", "from_service")
+            span.set_attribute("found", len(items))
 
             return items
 

--- a/src/sentry/services/nodestore/bigtable/backend.py
+++ b/src/sentry/services/nodestore/bigtable/backend.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from typing import Any
 
 import sentry_sdk
+import sentry_sdk.traces
 
 from sentry.objectstore.metrics import measure_storage_operation
 from sentry.services.nodestore.base import NodeStorage
@@ -93,7 +94,9 @@ class BigtableNodeStorage(NodeStorage):
         if self.skip_deletes:
             return
 
-        with sentry_sdk.start_span(op="nodestore.bigtable.delete"):
+        with sentry_sdk.traces.start_span(
+            name="nodestore.bigtable.delete", attributes={"sentry.op": "nodestore.bigtable.delete"}
+        ):
             try:
                 with measure_storage_operation("delete", "nodestore"):
                     self.store.delete(id)
@@ -104,8 +107,11 @@ class BigtableNodeStorage(NodeStorage):
         if self.skip_deletes:
             return
 
-        with sentry_sdk.start_span(op="nodestore.bigtable.delete_multi") as span:
-            span.set_tag("num_ids", len(id_list))
+        with sentry_sdk.traces.start_span(
+            name="nodestore.bigtable.delete_multi",
+            attributes={"sentry.op": "nodestore.bigtable.delete_multi"},
+        ) as span:
+            span.set_attribute("num_ids", len(id_list))
 
             if len(id_list) == 1:
                 self.delete(id_list[0])

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from typing import Any, Literal, cast
 
 import sentry_sdk
+import sentry_sdk.traces
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 from snuba_sdk import Column, Condition
 
@@ -315,7 +316,9 @@ def timeseries_query(
         Dataset.Transactions,
     ], "A dataset is required to query discover"
 
-    with sentry_sdk.start_span(op="discover.discover", name="timeseries.filter_transform"):
+    with sentry_sdk.traces.start_span(
+        name="timeseries.filter_transform", attributes={"sentry.op": "discover.discover"}
+    ):
         equations, columns = categorize_columns(selected_columns)
         base_builder = TimeseriesQueryBuilder(
             dataset,
@@ -355,7 +358,9 @@ def timeseries_query(
             [query.get_snql_query() for query in query_list], referrer, query_source=query_source
         )
 
-    with sentry_sdk.start_span(op="discover.discover", name="timeseries.transform_results"):
+    with sentry_sdk.traces.start_span(
+        name="timeseries.transform_results", attributes={"sentry.op": "discover.discover"}
+    ):
         results = []
         for snql_query, snuba_result in zip(query_list, query_results):
             results.append(
@@ -497,7 +502,9 @@ def top_events_timeseries(
     ], "A dataset is required to query discover"
 
     if top_events is None:
-        with sentry_sdk.start_span(op="discover.discover", name="top_events.fetch_events"):
+        with sentry_sdk.traces.start_span(
+            name="top_events.fetch_events", attributes={"sentry.op": "discover.discover"}
+        ):
             top_events = query(
                 selected_columns,
                 query=user_query,
@@ -569,8 +576,10 @@ def top_events_timeseries(
             snuba_params.end_date,
             rollup,
         )
-    with sentry_sdk.start_span(op="discover.discover", name="top_events.transform_results") as span:
-        span.set_data("result_count", len(result.get("data", [])))
+    with sentry_sdk.traces.start_span(
+        name="top_events.transform_results", attributes={"sentry.op": "discover.discover"}
+    ) as span:
+        span.set_attribute("result_count", len(result.get("data", [])))
         result = top_events_builder.process_results(result)
 
         issues: Mapping[int, str | None] = {}
@@ -663,7 +672,9 @@ def get_facets(
     sample = len(snuba_params.project_ids) > 2
     fetch_projects = len(snuba_params.project_ids) > 1
 
-    with sentry_sdk.start_span(op="discover.discover", name="facets.frequent_tags"):
+    with sentry_sdk.traces.start_span(
+        name="facets.frequent_tags", attributes={"sentry.op": "discover.discover"}
+    ):
         key_name_builder = DiscoverQueryBuilder(
             dataset,
             params={},
@@ -709,7 +720,9 @@ def get_facets(
     project_results = []
     # Inject project data on the first page if multiple projects are selected
     if fetch_projects and cursor == 0:
-        with sentry_sdk.start_span(op="discover.discover", name="facets.projects"):
+        with sentry_sdk.traces.start_span(
+            name="facets.projects", attributes={"sentry.op": "discover.discover"}
+        ):
             project_value_builder = DiscoverQueryBuilder(
                 dataset,
                 params={},
@@ -743,8 +756,10 @@ def get_facets(
         else:
             individual_tags.append(tag)
 
-    with sentry_sdk.start_span(op="discover.discover", name="facets.individual_tags") as span:
-        span.set_data("tag_count", len(individual_tags))
+    with sentry_sdk.traces.start_span(
+        name="facets.individual_tags", attributes={"sentry.op": "discover.discover"}
+    ) as span:
+        span.set_attribute("tag_count", len(individual_tags))
         for tag_name in individual_tags:
             tag = f"tags[{tag_name}]"
             tag_value_builder = DiscoverQueryBuilder(
@@ -768,7 +783,9 @@ def get_facets(
             )
 
     if aggregate_tags:
-        with sentry_sdk.start_span(op="discover.discover", name="facets.aggregate_tags"):
+        with sentry_sdk.traces.start_span(
+            name="facets.aggregate_tags", attributes={"sentry.op": "discover.discover"}
+        ):
             aggregate_value_builder = DiscoverQueryBuilder(
                 dataset,
                 params={},

--- a/src/sentry/snuba/errors.py
+++ b/src/sentry/snuba/errors.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from typing import cast
 
 import sentry_sdk
+import sentry_sdk.traces
 from snuba_sdk import Column, Condition
 
 from sentry.discover.arithmetic import categorize_columns
@@ -120,7 +121,9 @@ def timeseries_query(
     *,
     referrer: str,
 ) -> SnubaTSResult:
-    with sentry_sdk.start_span(op="errors", name="timeseries.filter_transform"):
+    with sentry_sdk.traces.start_span(
+        name="timeseries.filter_transform", attributes={"sentry.op": "errors"}
+    ):
         equations, columns = categorize_columns(selected_columns)
 
         column_resolver = functools.partial(get_snuba_column_name, dataset=Dataset.Events)
@@ -169,7 +172,9 @@ def timeseries_query(
             [query.get_snql_query() for query in query_list], referrer, query_source=query_source
         )
 
-    with sentry_sdk.start_span(op="errors", name="timeseries.transform_results"):
+    with sentry_sdk.traces.start_span(
+        name="timeseries.transform_results", attributes={"sentry.op": "errors"}
+    ):
         results = []
         for snql_query, result in zip(query_list, query_results):
             assert snql_query.params.start is not None
@@ -263,7 +268,9 @@ def top_events_timeseries(
 
     """
     if top_events is None:
-        with sentry_sdk.start_span(op="discover.errors", name="top_events.fetch_events"):
+        with sentry_sdk.traces.start_span(
+            name="top_events.fetch_events", attributes={"sentry.op": "discover.errors"}
+        ):
             top_events = query(
                 selected_columns,
                 query=user_query,
@@ -334,8 +341,10 @@ def top_events_timeseries(
             snuba_params.end_date,
             rollup,
         )
-    with sentry_sdk.start_span(op="discover.errors", name="top_events.transform_results") as span:
-        span.set_data("result_count", len(result.get("data", [])))
+    with sentry_sdk.traces.start_span(
+        name="top_events.transform_results", attributes={"sentry.op": "discover.errors"}
+    ) as span:
+        span.set_attribute("result_count", len(result.get("data", [])))
         result = top_events_builder.process_results(result)
 
         issues: Mapping[int, str | None] = {}

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from typing import Any
 
 import sentry_sdk
+import sentry_sdk.traces
 
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events.builder.profile_functions import (
@@ -158,7 +159,9 @@ def top_events_timeseries(
     assert not include_other, "Other is not supported"  # TODO: support other
 
     if top_events is None:
-        with sentry_sdk.start_span(op="discover.discover", name="top_events.fetch_events"):
+        with sentry_sdk.traces.start_span(
+            name="top_events.fetch_events", attributes={"sentry.op": "discover.discover"}
+        ):
             top_events = query(
                 selected_columns,
                 query=user_query,
@@ -234,10 +237,12 @@ def format_top_events_timeseries_results(
             rollup,
         )
 
-    with sentry_sdk.start_span(op="discover.discover", name="top_events.transform_results") as span:
+    with sentry_sdk.traces.start_span(
+        name="top_events.transform_results", attributes={"sentry.op": "discover.discover"}
+    ) as span:
         result = query_builder.strip_alias_prefix(result)
 
-        span.set_data("result_count", len(result.get("data", [])))
+        span.set_attribute("result_count", len(result.get("data", [])))
         processed_result = query_builder.process_results(result)
 
         if result_key_order is None:

--- a/src/sentry/snuba/issue_platform.py
+++ b/src/sentry/snuba/issue_platform.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from datetime import timedelta
 
 import sentry_sdk
+import sentry_sdk.traces
 
 from sentry.discover.arithmetic import categorize_columns
 from sentry.exceptions import InvalidSearchQuery
@@ -149,7 +150,9 @@ def timeseries_query(
     allow_metric_aggregates (bool) Ignored here, only used in metric enhanced performance
     """
 
-    with sentry_sdk.start_span(op="issueplatform", name="timeseries.filter_transform"):
+    with sentry_sdk.traces.start_span(
+        name="timeseries.filter_transform", attributes={"sentry.op": "issueplatform"}
+    ):
         equations, columns = categorize_columns(selected_columns)
 
         column_resolver = functools.partial(get_snuba_column_name, dataset=Dataset.IssuePlatform)
@@ -194,7 +197,9 @@ def timeseries_query(
             [query.get_snql_query() for query in query_list], referrer, query_source=query_source
         )
 
-    with sentry_sdk.start_span(op="issueplatform", name="timeseries.transform_results"):
+    with sentry_sdk.traces.start_span(
+        name="timeseries.transform_results", attributes={"sentry.op": "issueplatform"}
+    ):
         results = []
         for snql_query, result in zip(query_list, query_results):
             assert snql_query.params.start is not None

--- a/src/sentry/snuba/metrics/fields/histogram.py
+++ b/src/sentry/snuba/metrics/fields/histogram.py
@@ -1,6 +1,7 @@
 import math
 
 import sentry_sdk
+import sentry_sdk.traces
 from snuba_sdk import Column, Function
 
 from sentry.exceptions import InvalidParams
@@ -49,11 +50,12 @@ def rebucket_histogram(
 
     rv = {bucket: 0.0 for bucket in buckets}
 
-    with sentry_sdk.start_span(
-        op="sentry.snuba.metrics.fields.histogram.rebucket_histogram"
+    with sentry_sdk.traces.start_span(
+        name="sentry.snuba.metrics.fields.histogram.rebucket_histogram",
+        attributes={"sentry.op": "sentry.snuba.metrics.fields.histogram.rebucket_histogram"},
     ) as span:
-        span.set_data("len_data", len(data))
-        span.set_data("len_rv", len(rv))
+        span.set_attribute("len_data", len(data))
+        span.set_attribute("len_rv", len(rv))
 
         # XXX: quadratic function
         assert len(data) < 300

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from typing import Any, Literal, overload
 
 import sentry_sdk
+import sentry_sdk.traces
 from snuba_sdk import Column, Condition
 
 from sentry.discover.arithmetic import categorize_columns
@@ -56,7 +57,7 @@ def query(
     *,
     referrer: str,
 ) -> EventsResponse:
-    with sentry_sdk.start_span(op="mep", name="MetricQueryBuilder"):
+    with sentry_sdk.traces.start_span(name="MetricQueryBuilder", attributes={"sentry.op": "mep"}):
         metrics_query = MetricsQueryBuilder(
             dataset=Dataset.PerformanceMetrics,
             params={},
@@ -85,7 +86,9 @@ def query(
         results = metrics_query.run_query(
             referrer=metrics_referrer, query_source=query_source, use_cache=True
         )
-    with sentry_sdk.start_span(op="mep", name="query.transform_results"):
+    with sentry_sdk.traces.start_span(
+        name="query.transform_results", attributes={"sentry.op": "mep"}
+    ):
         results = metrics_query.process_results(results)
         results["meta"]["isMetricsData"] = True
         results["meta"]["isMetricsExtractedData"] = metrics_query.use_on_demand
@@ -165,7 +168,9 @@ def bulk_timeseries_query(
         metrics_compatible = True
 
     if metrics_compatible:
-        with sentry_sdk.start_span(op="mep", name="TimeseriesMetricQueryBuilder"):
+        with sentry_sdk.traces.start_span(
+            name="TimeseriesMetricQueryBuilder", attributes={"sentry.op": "mep"}
+        ):
             metrics_queries = []
             for query in queries:
                 metrics_query = TimeseriesMetricQueryBuilder(
@@ -193,7 +198,9 @@ def bulk_timeseries_query(
             for br in bulk_result:
                 _result["data"] = [*_result["data"], *br["data"]]
                 _result["meta"] = br["meta"]
-        with sentry_sdk.start_span(op="mep", name="query.transform_results"):
+        with sentry_sdk.traces.start_span(
+            name="query.transform_results", attributes={"sentry.op": "mep"}
+        ):
             result = metrics_query.process_results(_result)
             sentry_sdk.set_tag("performance.dataset", "metrics")
             result["meta"]["isMetricsData"] = True
@@ -273,7 +280,9 @@ def timeseries_query(
     metrics_compatible = not equations
 
     def run_metrics_query(inner_params: SnubaParams):
-        with sentry_sdk.start_span(op="mep", name="TimeseriesMetricQueryBuilder"):
+        with sentry_sdk.traces.start_span(
+            name="TimeseriesMetricQueryBuilder", attributes={"sentry.op": "mep"}
+        ):
             metrics_query = TimeseriesMetricQueryBuilder(
                 params={},
                 interval=rollup,
@@ -293,7 +302,9 @@ def timeseries_query(
             )
             metrics_referrer = referrer + ".metrics-enhanced"
             result = metrics_query.run_query(referrer=metrics_referrer, query_source=query_source)
-        with sentry_sdk.start_span(op="mep", name="query.transform_results"):
+        with sentry_sdk.traces.start_span(
+            name="query.transform_results", attributes={"sentry.op": "mep"}
+        ):
             result = metrics_query.process_results(result)
             result["data"] = (
                 discover.zerofill(

--- a/src/sentry/snuba/occurrences_rpc.py
+++ b/src/sentry/snuba/occurrences_rpc.py
@@ -55,7 +55,7 @@ class Occurrences(rpc_dataset_common.RPCBase):
     DEFINITIONS = OCCURRENCE_DEFINITIONS
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_table_query(
         cls,
         *,
@@ -99,7 +99,7 @@ class Occurrences(rpc_dataset_common.RPCBase):
         )
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_table_query_with_tags(
         cls,
         tag_names: set[str],
@@ -161,7 +161,7 @@ class Occurrences(rpc_dataset_common.RPCBase):
         )
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_grouped_timeseries_query(
         cls,
         *,
@@ -269,7 +269,7 @@ class Occurrences(rpc_dataset_common.RPCBase):
         return results
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_stats_query(
         cls,
         *,

--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -23,7 +23,7 @@ class OurLogs(rpc_dataset_common.RPCBase):
         return get_has_logs(project)
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_table_query(
         cls,
         *,

--- a/src/sentry/snuba/preprod_size.py
+++ b/src/sentry/snuba/preprod_size.py
@@ -24,7 +24,7 @@ class PreprodSize(rpc_dataset_common.RPCBase):
     DEFINITIONS = PREPROD_SIZE_DEFINITIONS
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_table_query(
         cls,
         *,

--- a/src/sentry/snuba/processing_errors_rpc.py
+++ b/src/sentry/snuba/processing_errors_rpc.py
@@ -16,7 +16,7 @@ class ProcessingErrors(rpc_dataset_common.RPCBase):
     DEFINITIONS = PROCESSING_ERROR_DEFINITIONS
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_table_query(
         cls,
         *,

--- a/src/sentry/snuba/profile_functions.py
+++ b/src/sentry/snuba/profile_functions.py
@@ -16,7 +16,7 @@ class ProfileFunctions(rpc_dataset_common.RPCBase):
     DEFINITIONS = PROFILE_FUNCTIONS_DEFINITIONS
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_table_query(
         cls,
         *,

--- a/src/sentry/snuba/query_subscriptions/consumer.py
+++ b/src/sentry/snuba/query_subscriptions/consumer.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from datetime import timezone
 
 import sentry_sdk
+import sentry_sdk.traces
 from dateutil.parser import parse as parse_date
 from sentry_kafka_schemas.codecs import Codec, ValidationError
 from sentry_kafka_schemas.schema_types.events_subscription_results_v1 import SubscriptionResult
@@ -156,22 +157,24 @@ def handle_message(
 
         callback = subscriber_registry[subscription.type]
         with (
-            sentry_sdk.start_span(op="process_message") as span,
+            sentry_sdk.traces.start_span(
+                name="process_message", attributes={"sentry.op": "process_message"}
+            ) as span,
             metrics.timer(
                 "snuba_query_subscriber.callback.duration",
                 instance=subscription.type,
                 tags={"dataset": dataset},
             ),
         ):
-            span.set_data("payload", contents)
-            span.set_data("subscription_dataset", subscription.snuba_query.dataset)
-            span.set_data("subscription_query", subscription.snuba_query.query)
-            span.set_data("subscription_aggregation", subscription.snuba_query.aggregate)
-            span.set_data("subscription_time_window", subscription.snuba_query.time_window)
-            span.set_data("subscription_resolution", subscription.snuba_query.resolution)
-            span.set_data("message_offset", message_offset)
-            span.set_data("message_partition", message_partition)
-            span.set_data("message_value", message_value)
+            span.set_attribute("payload", contents)
+            span.set_attribute("subscription_dataset", subscription.snuba_query.dataset)
+            span.set_attribute("subscription_query", subscription.snuba_query.query)
+            span.set_attribute("subscription_aggregation", subscription.snuba_query.aggregate)
+            span.set_attribute("subscription_time_window", subscription.snuba_query.time_window)
+            span.set_attribute("subscription_resolution", subscription.snuba_query.resolution)
+            span.set_attribute("message_offset", message_offset)
+            span.set_attribute("message_partition", message_partition)
+            span.set_attribute("message_value", message_value)
 
             callback(contents, subscription)
 

--- a/src/sentry/snuba/query_subscriptions/run.py
+++ b/src/sentry/snuba/query_subscriptions/run.py
@@ -14,7 +14,6 @@ from arroyo.types import BrokerValue, Commit, Message, Partition
 from sentry_kafka_schemas import get_codec
 from taskbroker_client.registry import TaskNamespace
 
-from sentry import options
 from sentry.conf.types.kafka_definition import Topic
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
@@ -88,10 +87,10 @@ def process_message(
     from sentry.utils import metrics
 
     with (
-        sentry_sdk.start_transaction(
-            op="handle_message",
+        sentry_sdk.traces.start_span(
             name="query_subscription_consumer_process_message",
-            custom_sampling_context={"sample_rate": options.get("subscriptions-query.sample-rate")},
+            attributes={"sentry.op": "handle_message"},
+            parent_span=None,
         ),
         metrics.timer("snuba_query_subscriber.handle_message", tags={"dataset": dataset.value}),
     ):
@@ -132,10 +131,10 @@ def _process_subscription_message(message_bytes: bytes, dataset: Dataset) -> Non
     topic = get_topic_definition(Topic(logical_topic))["real_topic_name"]
 
     with (
-        sentry_sdk.start_transaction(
-            op="handle_message",
+        sentry_sdk.traces.start_span(
             name="query_subscription_consumer_process_message",
-            custom_sampling_context={"sample_rate": options.get("subscriptions-query.sample-rate")},
+            attributes={"sentry.op": "handle_message"},
+            parent_span=None,
         ),
         metrics.timer("snuba_query_subscriber.handle_message", tags={"dataset": dataset.value}),
     ):

--- a/src/sentry/snuba/replays.py
+++ b/src/sentry/snuba/replays.py
@@ -16,7 +16,7 @@ class Replays(rpc_dataset_common.RPCBase):
     DEFINITIONS = REPLAYS_DEFINITIONS
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_table_query(
         cls,
         *,

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -394,7 +394,7 @@ class RPCBase:
         )
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def _run_table_query(
         cls,
         query: TableQuery,
@@ -440,7 +440,7 @@ class RPCBase:
         raise NotImplementedError()
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_bulk_table_queries(
         cls, queries: list[TableQuery], debug: str | bool = False
     ) -> dict[str, EAPResponse]:
@@ -806,7 +806,7 @@ class RPCBase:
         )
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_timeseries_query(
         cls,
         *,
@@ -902,7 +902,7 @@ class RPCBase:
         )
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def build_top_event_conditions(
         cls, resolver: SearchResolver, top_events: EAPResponse, groupby_columns: list[str]
     ) -> Any:
@@ -949,7 +949,7 @@ class RPCBase:
         )
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_top_events_timeseries_query(
         cls,
         *,

--- a/src/sentry/snuba/spans_indexed.py
+++ b/src/sentry/snuba/spans_indexed.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from datetime import timedelta
 
 import sentry_sdk
+import sentry_sdk.traces
 
 from sentry.discover.arithmetic import categorize_columns
 from sentry.search.events.builder.spans_indexed import (
@@ -102,7 +103,9 @@ def timeseries_query(
     """
     equations, columns = categorize_columns(selected_columns)
 
-    with sentry_sdk.start_span(op="spans_indexed", name="TimeseriesSpanIndexedQueryBuilder"):
+    with sentry_sdk.traces.start_span(
+        name="TimeseriesSpanIndexedQueryBuilder", attributes={"sentry.op": "spans_indexed"}
+    ):
         query_obj = TimeseriesSpanIndexedQueryBuilder(
             Dataset.SpansIndexed,
             {},
@@ -116,7 +119,9 @@ def timeseries_query(
             ),
         )
         result = query_obj.run_query(referrer, query_source=query_source)
-    with sentry_sdk.start_span(op="spans_indexed", name="query.transform_results"):
+    with sentry_sdk.traces.start_span(
+        name="query.transform_results", attributes={"sentry.op": "spans_indexed"}
+    ):
         result = query_obj.process_results(result)
         result["data"] = (
             discover.zerofill(
@@ -171,7 +176,9 @@ def top_events_timeseries(
     """
 
     if top_events is None:
-        with sentry_sdk.start_span(op="spans_indexed", name="top_events.fetch_events"):
+        with sentry_sdk.traces.start_span(
+            name="top_events.fetch_events", attributes={"sentry.op": "spans_indexed"}
+        ):
             top_events = query(
                 selected_columns,
                 query=user_query,
@@ -244,8 +251,10 @@ def top_events_timeseries(
             snuba_params.end_date,
             rollup,
         )
-    with sentry_sdk.start_span(op="spans_indexed", name="top_events.transform_results") as span:
-        span.set_data("result_count", len(result.get("data", [])))
+    with sentry_sdk.traces.start_span(
+        name="top_events.transform_results", attributes={"sentry.op": "spans_indexed"}
+    ) as span:
+        span.set_attribute("result_count", len(result.get("data", [])))
         result = top_events_builder.process_results(result)
 
         issues: dict[int, str | None] = {}

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -42,7 +42,7 @@ class Spans(rpc_dataset_common.RPCBase):
         return project.flags.has_transactions
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_table_query(
         cls,
         *,
@@ -80,7 +80,7 @@ class Spans(rpc_dataset_common.RPCBase):
         )
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_trace_query(
         cls,
         *,
@@ -212,7 +212,7 @@ class Spans(rpc_dataset_common.RPCBase):
         return spans
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_stats_query(
         cls,
         *,

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import orjson
 import sentry_sdk
+import sentry_sdk.traces
 from django.utils import timezone
 from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import CreateSubscriptionRequest
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
@@ -224,8 +225,10 @@ def delete_subscription_from_snuba(query_subscription_id: int, **kwargs: Any) ->
 
 
 def _create_in_snuba(subscription: QuerySubscription) -> str:
-    with sentry_sdk.start_span(op="snuba.tasks", name="create_in_snuba") as span:
-        span.set_tag("dataset", subscription.snuba_query.dataset)
+    with sentry_sdk.traces.start_span(
+        name="create_in_snuba", attributes={"sentry.op": "snuba.tasks"}
+    ) as span:
+        span.set_attribute("dataset", subscription.snuba_query.dataset)
 
         snuba_query = subscription.snuba_query
         entity_subscription = get_entity_subscription_from_snuba_query(
@@ -349,9 +352,11 @@ def subscription_checker(**kwargs: Any) -> None:
         ),
         date_updated__lt=timezone.now() - SUBSCRIPTION_STATUS_MAX_AGE,
     ):
-        with sentry_sdk.start_span(op="repair_subscription") as span:
-            span.set_data("subscription_id", subscription.id)
-            span.set_data("status", subscription.status)
+        with sentry_sdk.traces.start_span(
+            name="repair_subscription", attributes={"sentry.op": "repair_subscription"}
+        ) as span:
+            span.set_attribute("subscription_id", subscription.id)
+            span.set_attribute("status", subscription.status)
             count += 1
             if subscription.status == QuerySubscription.Status.CREATING.value:
                 create_subscription_in_snuba.delay(query_subscription_id=subscription.id)

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -12,6 +12,7 @@ from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 logger = logging.getLogger(__name__)
 
 import sentry_sdk
+import sentry_sdk.traces
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
@@ -762,14 +763,18 @@ def query_trace_data(
     for event in errors_data:
         id_to_error.setdefault(event["trace.span"], []).append(event)
     id_to_occurrence = defaultdict(list)
-    with sentry_sdk.start_span(op="process.occurrence_data") as sdk_span:
+    with sentry_sdk.traces.start_span(
+        name="process.occurrence_data", attributes={"sentry.op": "process.occurrence_data"}
+    ) as sdk_span:
         for event in occurrence_data:
             offender_span_ids = event["occurrence"].evidence_data.get("offender_span_ids", [])
             if len(offender_span_ids) == 0:
-                sdk_span.set_data("evidence_data.empty", event["occurrence"].evidence_data)
+                sdk_span.set_attribute("evidence_data.empty", event["occurrence"].evidence_data)
             for span_id in offender_span_ids:
                 id_to_occurrence[span_id].append(event)
-    with sentry_sdk.start_span(op="process.trace_data"):
+    with sentry_sdk.traces.start_span(
+        name="process.trace_data", attributes={"sentry.op": "process.trace_data"}
+    ):
         # calculate min & max start as a metric then log as a metric to see if we need to adjust
         # performance.traces.transaction_query_timebuffer_days
         span_min_ts = None
@@ -838,11 +843,15 @@ def query_trace_data(
             for attr in metric_only_attributes:
                 span.pop(attr, None)
 
-    with sentry_sdk.start_span(op="process.errors_data"):
+    with sentry_sdk.traces.start_span(
+        name="process.errors_data", attributes={"sentry.op": "process.errors_data"}
+    ):
         for errors in id_to_error.values():
             result.extend(errors)
     group_cache: dict[int, Group] = {}
-    with sentry_sdk.start_span(op="serializing_data"):
+    with sentry_sdk.traces.start_span(
+        name="serializing_data", attributes={"sentry.op": "serializing_data"}
+    ):
         return [
             event
             for event in [

--- a/src/sentry/snuba/trace_metrics.py
+++ b/src/sentry/snuba/trace_metrics.py
@@ -23,7 +23,7 @@ class TraceMetrics(rpc_dataset_common.RPCBase):
         return get_has_trace_metrics(project)
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_table_query(
         cls,
         *,

--- a/src/sentry/snuba/uptime_results.py
+++ b/src/sentry/snuba/uptime_results.py
@@ -19,7 +19,7 @@ class UptimeResults(rpc_dataset_common.RPCBase):
     DEFINITIONS = UPTIME_RESULT_DEFINITIONS
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_table_query(
         cls,
         *,
@@ -73,7 +73,7 @@ class UptimeResults(rpc_dataset_common.RPCBase):
         raise NotImplementedError()
 
     @classmethod
-    @sentry_sdk.trace
+    @sentry_sdk.traces.trace
     def run_top_events_timeseries_query(
         cls,
         *,

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from typing import Any
 
 import sentry_sdk
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from sentry_conventions.attributes import ATTRIBUTE_NAMES
 from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
@@ -51,15 +50,9 @@ outcome_aggregator = OutcomeAggregator()
 def process_segment(
     unprocessed_spans: list[SpanEvent], skip_produce: bool = False, skip_enrichment: bool = False
 ) -> list[CompatibleSpan]:
-    sample_rate = (
-        settings.SENTRY_PROCESS_SEGMENTS_TRANSACTIONS_SAMPLE_RATE
-        * settings.SENTRY_PROCESS_EVENT_APM_SAMPLING
-    )
-    with sentry_sdk.start_transaction(
+    with sentry_sdk.traces.start_span(
         name="spans.consumers.process_segments.process_segment",
-        custom_sampling_context={
-            "sample_rate": sample_rate,
-        },
+        parent_span=None,
     ):
         return _process_segment(unprocessed_spans, skip_produce, skip_enrichment)
 

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -354,7 +354,7 @@ def normalize_stacktraces_for_grouping(
     # the trimming produces a different function than the function we have
     # otherwise stored in `function` to not make the payload larger
     # unnecessarily.
-    with sentry_sdk.start_span(op=op, name="iterate_frames"):
+    with sentry_sdk.traces.start_span(name="iterate_frames", attributes={"sentry.op": op}):
         stripped_querystring = False
         for frames in stacktrace_frames:
             for frame in frames:
@@ -439,7 +439,9 @@ def normalize_stacktraces_for_grouping(
 
     # If a grouping config is available, run grouping enhancers
     if grouping_config is not None:
-        with sentry_sdk.start_span(op=op, name="apply_modifications_to_frame"):
+        with sentry_sdk.traces.start_span(
+            name="apply_modifications_to_frame", attributes={"sentry.op": op}
+        ):
             for frames, stacktrace_container in zip(stacktrace_frames, stacktrace_containers):
                 # This call has a caching mechanism when the same stacktrace and rules are used
                 grouping_config.enhancements.apply_category_and_updated_in_app_to_frames(
@@ -697,32 +699,41 @@ def process_stacktraces(
     try:
         # Preprocess step
         for processor in processing_task.iter_processors():
-            with sentry_sdk.start_span(
-                op="stacktraces.processing.process_stacktraces.preprocess_step"
+            with sentry_sdk.traces.start_span(
+                name="stacktraces.processing.process_stacktraces.preprocess_step",
+                attributes={
+                    "sentry.op": "stacktraces.processing.process_stacktraces.preprocess_step"
+                },
             ) as span:
-                span.set_data("processor", processor.__class__.__name__)
+                span.set_attribute("processor", processor.__class__.__name__)
                 if processor.preprocess_step(processing_task):
                     changed = True
-                    span.set_data("data_changed", True)
+                    span.set_attribute("data_changed", True)
 
         # Process all stacktraces
         for stacktrace_info, processable_frames in processing_task.iter_processable_stacktraces():
             # Let the stacktrace processors touch the exception
             if stacktrace_info.is_exception and stacktrace_info.container:
                 for processor in processing_task.iter_processors():
-                    with sentry_sdk.start_span(
-                        op="stacktraces.processing.process_stacktraces.process_exception"
+                    with sentry_sdk.traces.start_span(
+                        name="stacktraces.processing.process_stacktraces.process_exception",
+                        attributes={
+                            "sentry.op": "stacktraces.processing.process_stacktraces.process_exception"
+                        },
                     ) as span:
-                        span.set_data("processor", processor.__class__.__name__)
+                        span.set_attribute("processor", processor.__class__.__name__)
                         if processor.process_exception(stacktrace_info.container):
                             changed = True
-                            span.set_data("data_changed", True)
+                            span.set_attribute("data_changed", True)
 
             # If the stacktrace is empty we skip it for processing
             if not stacktrace_info.stacktrace:
                 continue
-            with sentry_sdk.start_span(
-                op="stacktraces.processing.process_stacktraces.process_single_stacktrace"
+            with sentry_sdk.traces.start_span(
+                name="stacktraces.processing.process_stacktraces.process_single_stacktrace",
+                attributes={
+                    "sentry.op": "stacktraces.processing.process_stacktraces.process_single_stacktrace"
+                },
             ) as span:
                 new_frames, new_raw_frames, errors = process_single_stacktrace(
                     processing_task, stacktrace_info, processable_frames
@@ -730,7 +741,7 @@ def process_stacktraces(
                 if new_frames is not None:
                     stacktrace_info.stacktrace["frames"] = new_frames
                     changed = True
-                    span.set_data("data_changed", True)
+                    span.set_attribute("data_changed", True)
             if (
                 set_raw_stacktrace
                 and new_raw_frames is not None

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -625,19 +625,20 @@ class SnubaTagStorage(TagStorage):
             end = snuba.quantize_time(end, key_hash)
             cache_key += f":{duration}@{end.isoformat()}"
 
-            with sentry_sdk.start_span(
-                op="cache.get", name="sentry.tagstore.cache.__get_tag_keys_for_projects"
+            with sentry_sdk.traces.start_span(
+                name="sentry.tagstore.cache.__get_tag_keys_for_projects",
+                attributes={"sentry.op": "cache.get"},
             ) as span:
                 result = cache.get(cache_key, None)
 
-                span.set_data("cache.key", [cache_key])
+                span.set_attribute("cache.key", [cache_key])
 
                 if result is not None:
-                    span.set_data("cache.hit", True)
-                    span.set_data("cache.item_size", len(str(result)))
+                    span.set_attribute("cache.hit", True)
+                    span.set_attribute("cache.item_size", len(str(result)))
                     metrics.incr("testing.tagstore.cache_tag_key.hit")
                 else:
-                    span.set_data("cache.hit", False)
+                    span.set_attribute("cache.hit", False)
                     metrics.incr("testing.tagstore.cache_tag_key.miss")
 
         if result is None:
@@ -655,12 +656,13 @@ class SnubaTagStorage(TagStorage):
                 **kwargs,
             )
             if should_cache:
-                with sentry_sdk.start_span(
-                    op="cache.put", name="sentry.tagstore.cache.__get_tag_keys_for_projects"
+                with sentry_sdk.traces.start_span(
+                    name="sentry.tagstore.cache.__get_tag_keys_for_projects",
+                    attributes={"sentry.op": "cache.put"},
                 ) as span:
                     cache.set(cache_key, result, 300)
-                    span.set_data("cache.key", [cache_key])
-                    span.set_data("cache.item_size", len(str(result)))
+                    span.set_attribute("cache.key", [cache_key])
+                    span.set_attribute("cache.item_size", len(str(result)))
                     metrics.incr("testing.tagstore.cache_tag_key.len", amount=len(result))
 
         ctor: _KeyCallable[TagKey, Never] | _KeyCallable[GroupTagKey, Never]

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -91,7 +91,7 @@ def schedule_auto_transition_issues_new_to_ongoing(
         extra=logger_extra,
     )
 
-    with sentry_sdk.start_span(name="iterate_chunked_group_ids"):
+    with sentry_sdk.traces.start_span(name="iterate_chunked_group_ids"):
         for groups in chunked(
             RangeQuerySetWrapper(
                 base_queryset,
@@ -129,8 +129,8 @@ def run_auto_transition_issues_new_to_ongoing(
     Child task of `auto_transition_issues_new_to_ongoing`
     to conduct the update of specified Groups to Ongoing.
     """
-    with sentry_sdk.start_span(name="bulk_transition_group_to_ongoing") as span:
-        span.set_tag("group_ids", group_ids)
+    with sentry_sdk.traces.start_span(name="bulk_transition_group_to_ongoing") as span:
+        span.set_attribute("group_ids", group_ids)
         bulk_transition_group_to_ongoing(
             GroupStatus.UNRESOLVED,
             GroupSubStatus.NEW,
@@ -187,7 +187,7 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
         )
     )
 
-    with sentry_sdk.start_span(name="iterate_chunked_group_ids"):
+    with sentry_sdk.traces.start_span(name="iterate_chunked_group_ids"):
         for group_ids_with_regressed_history in chunked(
             RangeQuerySetWrapper(
                 base_queryset.values_list("id", flat=True),
@@ -224,8 +224,8 @@ def run_auto_transition_issues_regressed_to_ongoing(
     Child task of `auto_transition_issues_regressed_to_ongoing`
     to conduct the update of specified Groups to Ongoing.
     """
-    with sentry_sdk.start_span(name="bulk_transition_group_to_ongoing") as span:
-        span.set_tag("group_ids", group_ids)
+    with sentry_sdk.traces.start_span(name="bulk_transition_group_to_ongoing") as span:
+        span.set_attribute("group_ids", group_ids)
         bulk_transition_group_to_ongoing(
             GroupStatus.UNRESOLVED,
             GroupSubStatus.REGRESSED,
@@ -284,7 +284,7 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
         )
     )
 
-    with sentry_sdk.start_span(name="iterate_chunked_group_ids"):
+    with sentry_sdk.traces.start_span(name="iterate_chunked_group_ids"):
         for new_group_ids in chunked(
             RangeQuerySetWrapper(
                 base_queryset.values_list("id", flat=True),
@@ -321,8 +321,8 @@ def run_auto_transition_issues_escalating_to_ongoing(
     Child task of `auto_transition_issues_escalating_to_ongoing`
     to conduct the update of specified Groups to Ongoing.
     """
-    with sentry_sdk.start_span(name="bulk_transition_group_to_ongoing") as span:
-        span.set_tag("group_ids", group_ids)
+    with sentry_sdk.traces.start_span(name="bulk_transition_group_to_ongoing") as span:
+        span.set_attribute("group_ids", group_ids)
         bulk_transition_group_to_ongoing(
             GroupStatus.UNRESOLVED,
             GroupSubStatus.ESCALATING,

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -300,7 +300,7 @@ def fetch_commits_for_ref_with_lifecycle(
             except IntegrationResourceNotFoundError:
                 repo_commits = None
             except Exception as e:
-                span = sentry_sdk.get_current_span()
+                span = sentry_sdk.traces.get_current_span()
                 if span:
                     span.set_status("unknown_error")
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -152,7 +152,7 @@ def _capture_group_stats(job: PostProcessJob) -> None:
     metrics.incr("events.unique", tags={"platform": platform}, skip_internal=False)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def should_issue_owners_ratelimit(
     project_id: int, group_id: int, organization_id: int | None
 ) -> bool:
@@ -184,7 +184,7 @@ def should_issue_owners_ratelimit(
 
 
 @metrics.wraps("post_process.handle_owner_assignment")
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def handle_owner_assignment(job: PostProcessJob) -> None:
     """
     The handle_owner_assignment task attempts to find issue owners for a group.
@@ -297,7 +297,7 @@ def handle_owner_assignment(job: PostProcessJob) -> None:
         handle_invalid_group_owners(group)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def handle_invalid_group_owners(group: Group) -> None:
     from sentry.models.groupowner import GroupOwner, GroupOwnerType
 
@@ -313,7 +313,7 @@ def handle_invalid_group_owners(group: Group) -> None:
         )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def handle_group_owners(
     project: Project,
     group: Group,
@@ -339,7 +339,10 @@ def handle_group_owners(
     try:
         logger.info("handle_group_owners.start", extra=logging_params)
         with (
-            sentry_sdk.start_span(op="post_process.handle_group_owners"),
+            sentry_sdk.traces.start_span(
+                name="post_process.handle_group_owners",
+                attributes={"sentry.op": "post_process.handle_group_owners"},
+            ),
             lock.acquire(),
         ):
             current_group_owners = GroupOwner.objects.filter(
@@ -588,7 +591,10 @@ def post_process_group(
 
         # Re-bind Project and Org since we're reading the Event object
         # from cache which may contain stale parent models.
-        with sentry_sdk.start_span(op="tasks.post_process_group.project_get_from_cache"):
+        with sentry_sdk.traces.start_span(
+            name="tasks.post_process_group.project_get_from_cache",
+            attributes={"sentry.op": "tasks.post_process_group.project_get_from_cache"},
+        ):
             try:
                 event.project = Project.objects.get_from_cache(id=event.project_id)
             except Project.DoesNotExist:
@@ -665,7 +671,10 @@ def run_post_process_job(job: PostProcessJob) -> None:
                         "is_reprocessed": job["is_reprocessed"],
                     },
                 ),
-                sentry_sdk.start_span(op=f"tasks.post_process_group.{pipeline_step.__name__}"),
+                sentry_sdk.traces.start_span(
+                    name=f"tasks.post_process_group.{pipeline_step.__name__}",
+                    attributes={"sentry.op": f"tasks.post_process_group.{pipeline_step.__name__}"},
+                ),
             ):
                 pipeline_step(job)
         except Exception:
@@ -720,7 +729,10 @@ def update_event_group(event: Event, group_state: GroupState) -> GroupEvent:
     # We fetch buffered updates to group aggregates here and populate them on the Group. This
     # helps us avoid problems with processing group ignores and alert rules that rely on these
     # stats.
-    with sentry_sdk.start_span(op="tasks.post_process_group.fetch_buffered_group_stats"):
+    with sentry_sdk.traces.start_span(
+        name="tasks.post_process_group.fetch_buffered_group_stats",
+        attributes={"sentry.op": "tasks.post_process_group.fetch_buffered_group_stats"},
+    ):
         fetch_buffered_group_stats(rebound_group)
 
     rebound_group.project = event.project
@@ -738,7 +750,10 @@ def process_inbox_adds(job: PostProcessJob) -> None:
     from sentry.models.group import GroupStatus
     from sentry.types.group import GroupSubStatus
 
-    with sentry_sdk.start_span(op="tasks.post_process_group.add_group_to_inbox"):
+    with sentry_sdk.traces.start_span(
+        name="tasks.post_process_group.add_group_to_inbox",
+        attributes={"sentry.op": "tasks.post_process_group.add_group_to_inbox"},
+    ):
         event = job["event"]
         is_reprocessed = job["is_reprocessed"]
         is_new = job["group_state"]["is_new"]
@@ -1221,7 +1236,10 @@ def process_similarity(job: PostProcessJob) -> None:
 
     event = job["event"]
 
-    with sentry_sdk.start_span(op="tasks.post_process_group.similarity"):
+    with sentry_sdk.traces.start_span(
+        name="tasks.post_process_group.similarity",
+        attributes={"sentry.op": "tasks.post_process_group.similarity"},
+    ):
         safe_execute(similarity.record, event.project, [event])
 
 
@@ -1274,12 +1292,18 @@ def sdk_crash_monitoring(job: PostProcessJob) -> None:
     if not features.has("organizations:sdk-crash-detection", event.project.organization):
         return
 
-    with sentry_sdk.start_span(op="post_process.build_sdk_crash_config"):
+    with sentry_sdk.traces.start_span(
+        name="post_process.build_sdk_crash_config",
+        attributes={"sentry.op": "post_process.build_sdk_crash_config"},
+    ):
         configs = build_sdk_crash_detection_configs()
         if not configs or len(configs) == 0:
             return None
 
-    with sentry_sdk.start_span(op="post_process.detect_sdk_crash"):
+    with sentry_sdk.traces.start_span(
+        name="post_process.detect_sdk_crash",
+        attributes={"sentry.op": "post_process.detect_sdk_crash"},
+    ):
         sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)
 
 

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -338,10 +338,13 @@ def schedule_invalidate_project_config(
             countdown=countdown,
         )
 
-    with sentry_sdk.start_span(
-        op="relay.projectconfig_cache.invalidation.schedule_after_db_transaction",
+    with sentry_sdk.traces.start_span(
+        name="relay.projectconfig_cache.invalidation.schedule_after_db_transaction",
+        attributes={
+            "sentry.op": "relay.projectconfig_cache.invalidation.schedule_after_db_transaction"
+        },
     ) as span:
-        span.set_tag("transaction_db", transaction_db)
+        span.set_attribute("transaction_db", transaction_db)
         if (
             options.get("relay.invalidation-direct-outside-atomic")
             and not connections[transaction_db].in_atomic_block

--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -94,7 +94,9 @@ def reprocess_group(
 
     for event in events:
         if max_events is None or max_events > 0:
-            with sentry_sdk.start_span(op="reprocess_event"):
+            with sentry_sdk.traces.start_span(
+                name="reprocess_event", attributes={"sentry.op": "reprocess_event"}
+            ):
                 try:
                     reprocess_event(
                         project_id=project_id,

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -92,13 +92,22 @@ def index_org_project_knowledge(org_id: int) -> None:
         )
         return
 
-    with sentry_sdk.start_span(op="explorer.context_engine.get_top_transactions_for_org_projects"):
+    with sentry_sdk.traces.start_span(
+        name="explorer.context_engine.get_top_transactions_for_org_projects",
+        attributes={"sentry.op": "explorer.context_engine.get_top_transactions_for_org_projects"},
+    ):
         transactions_by_project = get_top_transactions_for_org_projects(
             high_volume_projects, start, end
         )
-    with sentry_sdk.start_span(op="explorer.context_engine.get_top_span_ops_for_org_projects"):
+    with sentry_sdk.traces.start_span(
+        name="explorer.context_engine.get_top_span_ops_for_org_projects",
+        attributes={"sentry.op": "explorer.context_engine.get_top_span_ops_for_org_projects"},
+    ):
         span_ops_by_project = get_top_span_ops_for_org_projects(high_volume_projects, start, end)
-    with sentry_sdk.start_span(op="explorer.context_engine.get_sdk_names_for_org_projects"):
+    with sentry_sdk.traces.start_span(
+        name="explorer.context_engine.get_sdk_names_for_org_projects",
+        attributes={"sentry.op": "explorer.context_engine.get_sdk_names_for_org_projects"},
+    ):
         sdk_names_by_project = get_sdk_names_for_org_projects(high_volume_projects, start, end)
 
     project_data: list[OrgProjectKnowledgeProjectData] = []
@@ -309,8 +318,11 @@ def get_allowed_org_ids_context_engine_indexing() -> list[int]:
     Only the bucket matching the current hour is checked for the seer-explorer-index
     feature flag, keeping feature check volume at ~1/24th of total orgs.
     """
-    with sentry_sdk.start_span(
-        op="explorer.context_engine.get_allowed_org_ids_context_engine_indexing"
+    with sentry_sdk.traces.start_span(
+        name="explorer.context_engine.get_allowed_org_ids_context_engine_indexing",
+        attributes={
+            "sentry.op": "explorer.context_engine.get_allowed_org_ids_context_engine_indexing"
+        },
     ):
         now = datetime.now(UTC)
         TOTAL_HOURLY_SLOTS = 24

--- a/src/sentry/tasks/seer/explorer_index.py
+++ b/src/sentry/tasks/seer/explorer_index.py
@@ -68,7 +68,10 @@ def get_seer_explorer_enabled_projects() -> Generator[tuple[int, int]]:
             continue
 
         is_eligible = False
-        with sentry_sdk.start_span(op="seer_explorer_index.has_feature"):
+        with sentry_sdk.traces.start_span(
+            name="seer_explorer_index.has_feature",
+            attributes={"sentry.op": "seer_explorer_index.has_feature"},
+        ):
             batch_result = features.batch_has(FEATURE_NAMES, organization=project.organization)
 
             if batch_result:

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -351,7 +351,10 @@ def do_process_event(
         return _continue_to_save_event()
 
     # NOTE: This span ranges in the 1-2ms range.
-    with sentry_sdk.start_span(op="tasks.store.process_event.get_project_from_cache"):
+    with sentry_sdk.traces.start_span(
+        name="tasks.store.process_event.get_project_from_cache",
+        attributes={"sentry.op": "tasks.store.process_event.get_project_from_cache"},
+    ):
         project = Project.objects.get_from_cache(id=project_id)
 
     project.set_cached_field_value(
@@ -398,9 +401,12 @@ def do_process_event(
     # TODO(dcramer): ideally we would know if data changed by default
     # Default event processors.
     for plugin in plugins.all(version=2):
-        with sentry_sdk.start_span(op="task.store.process_event.preprocessors") as span:
-            span.set_data("plugin", plugin.slug)
-            span.set_data("from_symbolicate", from_symbolicate)
+        with sentry_sdk.traces.start_span(
+            name="task.store.process_event.preprocessors",
+            attributes={"sentry.op": "task.store.process_event.preprocessors"},
+        ) as span:
+            span.set_attribute("plugin", plugin.slug)
+            span.set_attribute("from_symbolicate", from_symbolicate)
             processors = safe_execute(plugin.get_event_preprocessors, data=data)
             for processor in processors or ():
                 try:

--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -37,7 +37,10 @@ class OrganizationReportContextFactory:
         """Find the projects associated with each user.
         Populates context.project_ownership which is { user_id: set<project_id> }
         """
-        with sentry_sdk.start_span(op="weekly_reports.user_project_ownership"):
+        with sentry_sdk.traces.start_span(
+            name="weekly_reports.user_project_ownership",
+            attributes={"sentry.op": "weekly_reports.user_project_ownership"},
+        ):
             for project_id, user_id in OrganizationMember.objects.filter(
                 organization_id=ctx.organization.id,
                 teams__projectteam__project__isnull=False,
@@ -48,7 +51,10 @@ class OrganizationReportContextFactory:
 
     @metrics.wraps("weekly_report.create_context.project_event_counts")
     def _append_project_event_counts(self, ctx: OrganizationReportContext) -> None:
-        with sentry_sdk.start_span(op="weekly_reports.project_event_counts_for_organization"):
+        with sentry_sdk.traces.start_span(
+            name="weekly_reports.project_event_counts_for_organization",
+            attributes={"sentry.op": "weekly_reports.project_event_counts_for_organization"},
+        ):
             event_counts = project_event_counts_for_organization(
                 start=ctx.start, end=ctx.end, ctx=ctx, referrer=Referrer.REPORTS_OUTCOMES.value
             )
@@ -101,14 +107,20 @@ class OrganizationReportContextFactory:
     def _append_organization_project_issue_substatus_summaries(
         self, ctx: OrganizationReportContext
     ) -> None:
-        with sentry_sdk.start_span(
-            op="weekly_reports.organization_project_issue_substatus_summaries"
+        with sentry_sdk.traces.start_span(
+            name="weekly_reports.organization_project_issue_substatus_summaries",
+            attributes={
+                "sentry.op": "weekly_reports.organization_project_issue_substatus_summaries"
+            },
         ):
             organization_project_issue_substatus_summaries(ctx)
 
     @metrics.wraps("weekly_report.create_context.project_key_errors")
     def _append_project_key_errors(self, ctx: OrganizationReportContext) -> None:
-        with sentry_sdk.start_span(op="weekly_reports.project_passes"):
+        with sentry_sdk.traces.start_span(
+            name="weekly_reports.project_passes",
+            attributes={"sentry.op": "weekly_reports.project_passes"},
+        ):
             organization = ctx.organization
             # Run project passes
             for project in organization.project_set.all():
@@ -158,12 +170,18 @@ class OrganizationReportContextFactory:
 
     @metrics.wraps("weekly_report.create_context.hydrate_key_error_groups")
     def _hydrate_key_error_groups(self, ctx: OrganizationReportContext) -> None:
-        with sentry_sdk.start_span(op="weekly_reports.fetch_key_error_groups"):
+        with sentry_sdk.traces.start_span(
+            name="weekly_reports.fetch_key_error_groups",
+            attributes={"sentry.op": "weekly_reports.fetch_key_error_groups"},
+        ):
             fetch_key_error_groups(ctx)
 
     @metrics.wraps("weekly_report.create_context.hydrate_key_performance_issues")
     def _hydrate_key_performance_issue_groups(self, ctx: OrganizationReportContext) -> None:
-        with sentry_sdk.start_span(op="weekly_reports.fetch_key_performance_issue_groups"):
+        with sentry_sdk.traces.start_span(
+            name="weekly_reports.fetch_key_performance_issue_groups",
+            attributes={"sentry.op": "weekly_reports.fetch_key_performance_issue_groups"},
+        ):
             fetch_key_performance_issue_groups(ctx)
 
     def create_context(self) -> OrganizationReportContext:

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -142,7 +142,7 @@ def project_key_errors(
     # Take the 3 most frequently occuring events
     op = "weekly_reports.project_key_errors"
 
-    with sentry_sdk.start_span(op=op):
+    with sentry_sdk.traces.start_span(name=op, attributes={"sentry.op": op}):
         snuba_rows = _project_key_errors_snuba(ctx=ctx, project=project, referrer=referrer)
         query_result = snuba_rows
 
@@ -312,7 +312,7 @@ def project_key_performance_issues(ctx: OrganizationReportContext, project: Proj
 
     op = "weekly_reports.project_key_performance_issues"
 
-    with sentry_sdk.start_span(op=op):
+    with sentry_sdk.traces.start_span(name=op, attributes={"sentry.op": op}):
         # Pick the 50 top frequent performance issues last seen within a month with the highest event count from all time.
         # Then, we use this to join with snuba, hoping that the top 3 issue by volume counted in snuba would be within this list.
         # We do this to limit the number of group_ids snuba has to join with.
@@ -465,7 +465,10 @@ def _project_key_performance_issues_eap(
 def project_key_transactions_this_week(ctx, project):
     if not project.flags.has_transactions:
         return
-    with sentry_sdk.start_span(op="weekly_reports.project_key_transactions"):
+    with sentry_sdk.traces.start_span(
+        name="weekly_reports.project_key_transactions",
+        attributes={"sentry.op": "weekly_reports.project_key_transactions"},
+    ):
         # Take the 3 most frequently occuring transactions this week
         query = Query(
             match=Entity("transactions"),

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -210,7 +210,10 @@ def prepare_organization_report(
             timestamp=timestamp, duration=duration, organization=organization
         ).create_context()
 
-        with sentry_sdk.start_span(op="weekly_reports.check_if_ctx_is_empty"):
+        with sentry_sdk.traces.start_span(
+            name="weekly_reports.check_if_ctx_is_empty",
+            attributes={"sentry.op": "weekly_reports.check_if_ctx_is_empty"},
+        ):
             report_is_available = not ctx.is_empty()
         set_tag("report.available", report_is_available)
 
@@ -220,7 +223,10 @@ def prepare_organization_report(
 
     # Finally, deliver the reports
     batch = OrganizationReportBatch(ctx, batch_id, dry_run, target_user, email_override)
-    with sentry_sdk.start_span(op="weekly_reports.deliver_reports"):
+    with sentry_sdk.traces.start_span(
+        name="weekly_reports.deliver_reports",
+        attributes={"sentry.op": "weekly_reports.deliver_reports"},
+    ):
         logger.info(
             "weekly_reports.deliver_reports",
             extra={"batch_id": str(batch_id), "organization": organization_id},

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -151,7 +151,10 @@ def _do_symbolicate_event(
     project = Project.objects.get_from_cache(id=project_id)
     # needed for efficient featureflag checks in getsentry
     # NOTE: The `organization` is used for constructing the symbol sources.
-    with sentry_sdk.start_span(op="lang.native.symbolicator.organization.get_from_cache"):
+    with sentry_sdk.traces.start_span(
+        name="lang.native.symbolicator.organization.get_from_cache",
+        attributes={"sentry.op": "lang.native.symbolicator.organization.get_from_cache"},
+    ):
         project.set_cached_field_value(
             "organization", Organization.objects.get_from_cache(id=project.organization_id)
         )
@@ -178,13 +181,16 @@ def _do_symbolicate_event(
             "tasks.store.symbolicate_event.symbolication",
             tags={"symbolication_function": symbolication_function_name},
         ),
-        sentry_sdk.start_span(
-            op=f"tasks.store.symbolicate_event.{symbolication_function_name}"
+        sentry_sdk.traces.start_span(
+            name=f"tasks.store.symbolicate_event.{symbolication_function_name}",
+            attributes={
+                "sentry.op": f"tasks.store.symbolicate_event.{symbolication_function_name}"
+            },
         ) as span,
     ):
         try:
             symbolicated_data = symbolication_function(symbolicator, data)
-            span.set_data("symbolicated_data", bool(symbolicated_data))
+            span.set_attribute("symbolicated_data", bool(symbolicated_data))
 
             if symbolicated_data:
                 data = symbolicated_data

--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -437,10 +437,12 @@ def fetch_latest_id_from_tempest(
 
     timeout = options.get("tempest.latest-id-timeout")
 
-    with sentry_sdk.start_span(op="http.client", name="POST /latest-id") as span:
-        span.set_data("tempest.org_id", org_id)
-        span.set_data("tempest.project_id", project_id)
-        span.set_data("tempest.timeout", timeout)
+    with sentry_sdk.traces.start_span(
+        name="POST /latest-id", attributes={"sentry.op": "http.client"}
+    ) as span:
+        span.set_attribute("tempest.org_id", org_id)
+        span.set_attribute("tempest.project_id", project_id)
+        span.set_attribute("tempest.timeout", timeout)
 
         response = requests.post(
             url=settings.SENTRY_TEMPEST_URL + "/latest-id",
@@ -449,9 +451,9 @@ def fetch_latest_id_from_tempest(
             timeout=timeout,
         )
 
-        span.set_data("http.status_code", response.status_code)
-        span.set_data("http.response_content_length", len(response.content))
-        span.set_data("tempest.response_text", response.text[:1000])  # Truncate for safety
+        span.set_attribute("http.status_code", response.status_code)
+        span.set_attribute("http.response_content_length", len(response.content))
+        span.set_attribute("tempest.response_text", response.text[:1000])  # Truncate for safety
 
     return response
 
@@ -481,13 +483,15 @@ def fetch_items_from_tempest(
 
     timeout = options.get("tempest.crashes-timeout")
 
-    with sentry_sdk.start_span(op="http.client", name="POST /crashes") as span:
-        span.set_data("tempest.org_id", org_id)
-        span.set_data("tempest.project_id", project_id)
-        span.set_data("tempest.offset", offset)
-        span.set_data("tempest.limit", limit)
-        span.set_data("tempest.attach_screenshot", attach_screenshot)
-        span.set_data("tempest.timeout", timeout)
+    with sentry_sdk.traces.start_span(
+        name="POST /crashes", attributes={"sentry.op": "http.client"}
+    ) as span:
+        span.set_attribute("tempest.org_id", org_id)
+        span.set_attribute("tempest.project_id", project_id)
+        span.set_attribute("tempest.offset", offset)
+        span.set_attribute("tempest.limit", limit)
+        span.set_attribute("tempest.attach_screenshot", attach_screenshot)
+        span.set_attribute("tempest.timeout", timeout)
 
         response = requests.post(
             url=settings.SENTRY_TEMPEST_URL + "/crashes",
@@ -496,9 +500,9 @@ def fetch_items_from_tempest(
             timeout=timeout,
         )
 
-        span.set_data("http.status_code", response.status_code)
-        span.set_data("http.response_content_length", len(response.content))
+        span.set_attribute("http.status_code", response.status_code)
+        span.set_attribute("http.response_content_length", len(response.content))
         # Don't log full response for crashes - it can be huge
-        span.set_data("tempest.response_preview", response.text[:500])
+        span.set_attribute("tempest.response_preview", response.text[:500])
 
     return response

--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -58,8 +58,10 @@ class DjangoAtomicIntegration(Integration):
         original_exit = Atomic.__exit__
 
         def _enter(self):
-            self._sentry_sdk_span = sentry_sdk.start_span(op="transaction.atomic")
-            self._sentry_sdk_span.set_data("using", self.using)
+            self._sentry_sdk_span = sentry_sdk.traces.start_span(
+                name="transaction.atomic", attributes={"sentry.op": "transaction.atomic"}
+            )
+            self._sentry_sdk_span.set_attribute("using", self.using)
             self._sentry_sdk_span.__enter__()
             return original_enter(self)
 

--- a/src/sentry/utils/kvstore/bigtable.py
+++ b/src/sentry/utils/kvstore/bigtable.py
@@ -117,7 +117,9 @@ class BigtableKVStorage(KVStorage[str, bytes]):
             return table
 
     def get(self, key: str) -> bytes | None:
-        with sentry_sdk.start_span(op="bigtable.get"):
+        with sentry_sdk.traces.start_span(
+            name="bigtable.get", attributes={"sentry.op": "bigtable.get"}
+        ):
             # Default timeout is 60 seconds, much too long for our ingestion pipeline
             # Modify retry based on https://cloud.google.com/python/docs/reference/storage/latest/retry_timeout#configuring-retries
             modified_retry = DEFAULT_RETRY_READ_ROWS.with_timeout(5.0)

--- a/src/sentry/utils/pagination_factory.py
+++ b/src/sentry/utils/pagination_factory.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from typing import Any, Protocol
 
 import sentry_sdk
-from sentry_sdk.tracing import Span
+from sentry_sdk.traces import StreamedSpan
 
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.numbers import format_grouped_length
@@ -66,7 +66,7 @@ def get_paginator(
     return paginator or paginator_cls(**(paginator_kwargs or {}))
 
 
-def annotate_span_with_pagination_args(span: Span, per_page: int) -> None:
-    span.set_data("Limit", per_page)
+def annotate_span_with_pagination_args(span: StreamedSpan, per_page: int) -> None:
+    span.set_attribute("Limit", per_page)
     sentry_sdk.set_tag("query.per_page", per_page)
     sentry_sdk.set_tag("query.per_page.grouped", format_grouped_length(per_page, [1, 10, 50, 100]))

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -4,8 +4,7 @@ import asyncio
 import copy
 import logging
 import sys
-import typing
-from collections.abc import Generator, Mapping, Sequence, Sized
+from collections.abc import Generator, Mapping, Sequence
 from types import FrameType
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -17,7 +16,6 @@ from rest_framework.request import Request
 # Reexport sentry_sdk just in case we ever have to write another shim like we
 # did for raven
 from sentry_sdk import Scope, capture_exception, capture_message, isolation_scope
-from sentry_sdk._types import AnnotatedValue
 from sentry_sdk.client import get_options
 from sentry_sdk.integrations.django.transactions import LEGACY_RESOLVER
 from sentry_sdk.transport import make_transport
@@ -218,37 +216,8 @@ def profiles_sampler(sampling_context):
     return float(settings.SENTRY_PROFILES_SAMPLE_RATE or 0)
 
 
-def before_send_transaction(event: Event, _: Hint) -> Event | None:
-    # Discard generic redirects.
-    # This condition can be removed once https://github.com/getsentry/team-sdks/issues/48 is fixed.
-    if (
-        event.get("tags", {}).get("http.status_code") == "301"
-        and event.get("transaction_info", {}).get("source") == "url"
-    ):
-        return None
-
-    # Occasionally the span limit is hit and we drop spans from transactions, this helps find transactions where this occurs.
-    if isinstance(event["spans"], AnnotatedValue):
-        # AnnotatedValue isn't generic so we check its inner value's type otherwise mypy will
-        # complain. The TypeError should be unreachable.
-        if isinstance(event["spans"].value, Sized):
-            num_of_spans = len(event["spans"].value)
-        else:
-            raise TypeError("Expected a list of spans.")
-    else:
-        num_of_spans = len(event["spans"])
-
-    event["tags"]["spans_over_limit"] = str(num_of_spans >= 1000)
-
-    # Type safety: `event["contexts"]["trace"]["data"]` is a dictionary if it is set.
-    # See https://develop.sentry.dev/sdk/data-model/event-payloads/contexts/#trace-context.
-    data = typing.cast(
-        dict[str, object],
-        event.setdefault("contexts", {}).setdefault("trace", {}).setdefault("data", {}),
-    )
-    data["num_of_spans"] = num_of_spans
-
-    return event
+def before_send_span(span: dict[str, Any], _: Hint) -> dict[str, Any]:
+    return span
 
 
 def before_send(event: Event, hint: Hint) -> Event | None:
@@ -313,7 +282,9 @@ def _get_sdk_options() -> tuple[SdkConfig, Dsns]:
     sdk_options["add_full_stack"] = True
     sdk_options["traces_sampler"] = traces_sampler
     sdk_options["before_send"] = before_send
-    sdk_options["before_send_transaction"] = before_send_transaction
+    sdk_options["before_send_transaction"] = (
+        before_send_span  # TODO: remove once streaming is fully rolled out
+    )
     sdk_options["enable_logs"] = True
     sdk_options["before_send_log"] = before_send_log
     sdk_options["release"] = (
@@ -321,6 +292,8 @@ def _get_sdk_options() -> tuple[SdkConfig, Dsns]:
     )
     sdk_options.setdefault("_experiments", {}).update(
         transport_http2=options.get("sdk_http2_experiment.enabled"),
+        trace_lifecycle="stream",
+        before_send_span=before_send_span,
     )
 
     # Modify SENTRY_SDK_CONFIG in your deployment scripts to specify your desired DSN
@@ -694,7 +667,9 @@ def bind_organization_context(organization: Organization | RpcOrganization) -> N
     set_viewer_context_organization(organization.id)
 
     # XXX(dcramer): this is duplicated in organizationContext.jsx on the frontend
-    with sentry_sdk.start_span(op="other", name="bind_organization_context"):
+    with sentry_sdk.traces.start_span(
+        name="bind_organization_context", attributes={"sentry.op": "other"}
+    ):
         # This can be used to find errors that may have been mistagged
         check_tag_for_scope_bleed("organization.slug", organization.slug)
 
@@ -762,16 +737,16 @@ def bind_ambiguous_org_context(
 
 
 def get_trace_id():
-    span = sentry_sdk.get_current_span()
+    span = sentry_sdk.traces.get_current_span()
     if span is not None:
         return span.get_trace_context().get("trace_id")
     return None
 
 
 def set_span_attribute(data_name, value):
-    span = sentry_sdk.get_current_span()
+    span = sentry_sdk.traces.get_current_span()
     if span is not None:
-        span.set_data(data_name, value)
+        span.set_attribute(data_name, value)
 
 
 def merge_context_into_scope(
@@ -791,7 +766,7 @@ __all__ = (
     "Scope",
     "UNSAFE_FILES",
     "UNSAFE_TAG",
-    "before_send_transaction",
+    "before_send_span",
     "bind_ambiguous_org_context",
     "bind_organization_context",
     "capture_exception",

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -208,7 +208,7 @@ def _send_webhook_request(
         )
 
 
-@sentry_sdk.trace(name="send_and_save_webhook_request")
+@sentry_sdk.traces.trace(name="send_and_save_webhook_request")
 @ignore_unpublished_app_errors
 def send_and_save_webhook_request(
     sentry_app: SentryApp | RpcSentryApp,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -527,7 +527,10 @@ class RetrySkipTimeout(urllib3.Retry):
         Just rely on the parent class unless we have a read timeout. In that case
         immediately give up
         """
-        with sentry_sdk.start_span(op="snuba_pool.retry.increment") as span:
+        with sentry_sdk.traces.start_span(
+            name="snuba_pool.retry.increment",
+            attributes={"sentry.op": "snuba_pool.retry.increment"},
+        ) as span:
             # This next block is all debugging to try to track down a bug where we're seeing duplicate snuba requests
             # Wrapping the entire thing in a try/except to be safe cause none of it actually needs to run
             try:
@@ -535,14 +538,14 @@ class RetrySkipTimeout(urllib3.Retry):
                     error_class = error.__class__
                     module = error_class.__module__
                     name = error_class.__name__
-                    span.set_tag("snuba_pool.retry.error", f"{module}.{name}")
+                    span.set_attribute("snuba_pool.retry.error", f"{module}.{name}")
                 else:
-                    span.set_tag("snuba_pool.retry.error", "None")
-                span.set_tag("snuba_pool.retry.total", self.total)
-                span.set_tag("snuba_pool.response.status", "unknown")
+                    span.set_attribute("snuba_pool.retry.error", "None")
+                span.set_attribute("snuba_pool.retry.total", self.total)
+                span.set_attribute("snuba_pool.response.status", "unknown")
                 if response:
                     if response.status:
-                        span.set_tag("snuba_pool.response.status", response.status)
+                        span.set_attribute("snuba_pool.response.status", response.status)
             except Exception:
                 pass
 
@@ -1240,8 +1243,10 @@ def _is_rejected_query(body: Any) -> bool:
 def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
     snuba_requests_list = list(snuba_requests)
 
-    with sentry_sdk.start_span(op="snuba_query") as span:
-        span.set_tag("snuba.num_queries", len(snuba_requests_list))
+    with sentry_sdk.traces.start_span(
+        name="snuba_query", attributes={"sentry.op": "snuba_query"}
+    ) as span:
+        span.set_attribute("snuba.num_queries", len(snuba_requests_list))
 
         if len(snuba_requests_list) > 1:
             with ContextPropagatingThreadPoolExecutor(
@@ -1300,18 +1305,20 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
             allocation_policy_prefix = "allocation_policy."
             bytes_scanned = body.get("profile", {}).get("progress_bytes", None)
             if bytes_scanned is not None:
-                span.set_data(f"{allocation_policy_prefix}.bytes_scanned", bytes_scanned)
+                span.set_attribute(f"{allocation_policy_prefix}.bytes_scanned", bytes_scanned)
             if _is_rejected_query(body):
                 quota_allowance_summary = body["quota_allowance"]["summary"]
                 for k, v in quota_allowance_summary.items():
                     if isinstance(v, dict):
                         for nested_k, nested_v in v.items():
-                            span.set_tag(allocation_policy_prefix + k + "." + nested_k, nested_v)
+                            span.set_attribute(
+                                allocation_policy_prefix + k + "." + nested_k, nested_v
+                            )
                             sentry_sdk.set_tag(
                                 allocation_policy_prefix + k + "." + nested_k, nested_v
                             )
                     else:
-                        span.set_tag(allocation_policy_prefix + k, v)
+                        span.set_attribute(allocation_policy_prefix + k, v)
                         sentry_sdk.set_tag(allocation_policy_prefix + k, v)
 
             if response.status != 200:
@@ -1461,12 +1468,16 @@ def _raw_delete_query(
     # Enter hub such that http spans are properly nested
     with metrics.timer("snuba.client.delete_query"):
         referrer = headers.get("referer", "unknown")
-        with sentry_sdk.start_span(op="snuba_delete.validation", name=referrer) as span:
-            span.set_tag("snuba.referrer", referrer)
+        with sentry_sdk.traces.start_span(
+            name=referrer, attributes={"sentry.op": "snuba_delete.validation"}
+        ) as span:
+            span.set_attribute("snuba.referrer", referrer)
             body = request.serialize()
 
-        with sentry_sdk.start_span(op="snuba_delete.run", name=body) as span:
-            span.set_tag("snuba.referrer", referrer)
+        with sentry_sdk.traces.start_span(
+            name=body, attributes={"sentry.op": "snuba_delete.run"}
+        ) as span:
+            span.set_attribute("snuba.referrer", referrer)
             return _snuba_pool.urlopen(
                 "DELETE", f"/{query.storage_name}", body=body, headers=headers
             )
@@ -1479,12 +1490,16 @@ def _raw_mql_query(request: Request, headers: Mapping[str, str]) -> urllib3.resp
 
         # TODO: This can be changed back to just `serialize` after we remove SnQL support for MetricsQuery
         serialized_req = request.serialize()
-        with sentry_sdk.start_span(op="snuba_mql.validation", name=referrer) as span:
-            span.set_tag("snuba.referrer", referrer)
+        with sentry_sdk.traces.start_span(
+            name=referrer, attributes={"sentry.op": "snuba_mql.validation"}
+        ) as span:
+            span.set_attribute("snuba.referrer", referrer)
             body = serialized_req
 
-        with sentry_sdk.start_span(op="snuba_mql.run", name=serialized_req) as span:
-            span.set_tag("snuba.referrer", referrer)
+        with sentry_sdk.traces.start_span(
+            name=serialized_req, attributes={"sentry.op": "snuba_mql.run"}
+        ) as span:
+            span.set_attribute("snuba.referrer", referrer)
             return _snuba_pool.urlopen(
                 "POST", f"/{request.dataset}/mql", body=body, headers=headers
             )
@@ -1496,12 +1511,16 @@ def _raw_snql_query(request: Request, headers: Mapping[str, str]) -> urllib3.res
         referrer = headers.get("referer", "<unknown>")
 
         serialized_req = request.serialize()
-        with sentry_sdk.start_span(op="snuba_snql.validation", name=referrer) as span:
-            span.set_tag("snuba.referrer", referrer)
+        with sentry_sdk.traces.start_span(
+            name=referrer, attributes={"sentry.op": "snuba_snql.validation"}
+        ) as span:
+            span.set_attribute("snuba.referrer", referrer)
             body = serialized_req
 
-        with sentry_sdk.start_span(op="snuba_snql.run", name=serialized_req) as span:
-            span.set_tag("snuba.referrer", referrer)
+        with sentry_sdk.traces.start_span(
+            name=serialized_req, attributes={"sentry.op": "snuba_snql.run"}
+        ) as span:
+            span.set_attribute("snuba.referrer", referrer)
             return _snuba_pool.urlopen(
                 "POST", f"/{request.dataset}/snql", body=body, headers=headers
             )
@@ -1742,7 +1761,9 @@ def aliased_query(**kwargs):
     This method should be used sparingly. Instead prefer to use sentry.eventstore
     sentry.tagstore, or sentry.snuba.discover instead when reading data.
     """
-    with sentry_sdk.start_span(op="sentry.snuba.aliased_query"):
+    with sentry_sdk.traces.start_span(
+        name="sentry.snuba.aliased_query", attributes={"sentry.op": "sentry.snuba.aliased_query"}
+    ):
         return _aliased_query_impl(**kwargs)
 
 

--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -125,7 +125,7 @@ def get_trace_rpc(request: GetTraceRequest) -> GetTraceResponse:
     return response
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def _make_rpc_requests(
     table_requests: list[TraceItemTableRequest] | None = None,
     timeseries_requests: list[TimeSeriesRequest] | None = None,
@@ -354,7 +354,7 @@ def export_logs_rpc(req: ExportTraceItemsRequest) -> ExportTraceItemsResponse:
     return response
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def _make_rpc_request(
     endpoint_name: str,
     class_version: str,
@@ -394,10 +394,12 @@ def _make_rpc_request(
         log_snuba_info(f"{referrer}.body:\n{MessageToJson(req)}")  # type: ignore[arg-type]
     with sentry_sdk.scope.use_isolation_scope(thread_isolation_scope):
         with sentry_sdk.scope.use_scope(thread_current_scope):
-            with sentry_sdk.start_span(op="snuba_rpc.run", name=req.__class__.__name__) as span:
+            with sentry_sdk.traces.start_span(
+                name=req.__class__.__name__, attributes={"sentry.op": "snuba_rpc.run"}
+            ) as span:
                 if referrer:
-                    span.set_tag("snuba.referrer", referrer)
-                    span.set_data("snuba.query", req)
+                    span.set_attribute("snuba.referrer", referrer)
+                    span.set_attribute("snuba.query", req)
                 try:
                     http_resp = _snuba_pool.urlopen(
                         "POST",
@@ -416,7 +418,7 @@ def _make_rpc_request(
                         metrics.incr("snuba_rpc.read_timeout_error", tags={"referrer": referrer})
                         raise SnubaRPCTimeout(err)
                     raise SnubaRPCError(err)
-                span.set_tag("timeout", "False")
+                span.set_attribute("timeout", "False")
                 if http_resp.status != 200 and http_resp.status != 202:
                     error = _parse_error(http_resp)
                     if SNUBA_INFO:

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -219,7 +219,7 @@ def _get_data_conditions_for_group_shim(data_condition_group_id: int) -> list[Da
     return get_data_conditions_for_group(data_condition_group_id)
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_slow_conditions_for_groups(
     data_condition_group_ids: list[int],
 ) -> dict[int, list[DataCondition]]:

--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -27,7 +27,10 @@ def process_data_source[T](
 ) -> tuple[DataPacket[T], list[Detector]]:
     metrics.incr("workflow_engine.process_data_sources", tags={"query_type": query_type})
 
-    with sentry_sdk.start_span(op="workflow_engine.process_data_sources.get_enabled_detectors"):
+    with sentry_sdk.traces.start_span(
+        name="workflow_engine.process_data_sources.get_enabled_detectors",
+        attributes={"sentry.op": "workflow_engine.process_data_sources.get_enabled_detectors"},
+    ):
         detectors = bulk_fetch_enabled_detectors(data_packet.source_id, query_type)
 
     if detectors:

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -393,7 +393,7 @@ def generate_unique_queries(
     return unique_queries
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_condition_query_groups(
     data_condition_groups: list[DataConditionGroup],
     event_data: EventRedisData,
@@ -434,7 +434,7 @@ def get_condition_query_groups(
     # We want this to be accurate enough for alerting, so sample 100%
     sample_rate=1.0,
 )
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_condition_group_results(
     queries_to_groups: dict[UniqueConditionQuery, GroupQueryParams],
 ) -> dict[UniqueConditionQuery, QueryResult]:
@@ -606,7 +606,7 @@ class DelayedWorkflowEvaluationResult:
         }
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_groups_to_fire(
     data_condition_groups: list[DataConditionGroup],
     workflows_to_envs: Mapping[WorkflowId, int | None],
@@ -714,7 +714,7 @@ def get_groups_to_fire(
     )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def bulk_fetch_events(event_ids: list[str], project: Project) -> dict[str, Event]:
     node_id_to_event_id = {
         Event.generate_node_id(project.id, event_id=event_id): event_id for event_id in event_ids
@@ -743,7 +743,7 @@ def bulk_fetch_events(event_ids: list[str], project: Project) -> dict[str, Event
     "workflow_engine.delayed_workflow.get_group_to_groupevent",
     sample_rate=1.0,
 )
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def get_group_to_groupevent(
     event_data: EventRedisData,
     groups_to_dcgs: dict[GroupId, set[DataConditionGroup]],
@@ -786,7 +786,7 @@ def get_group_to_groupevent(
     return group_to_groupevent
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def fire_actions_for_groups(
     organization: Organization,
     groups_to_fire: dict[GroupId, set[DataConditionGroup]],
@@ -876,7 +876,7 @@ def fire_actions_for_groups(
     )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def cleanup_redis_buffer(
     client: ProjectDelayedWorkflowClient, event_keys: Iterable[EventKey], batch_key: str | None
 ) -> None:
@@ -897,7 +897,10 @@ def _summarize_by_first[T1, T2: int | str](it: Iterable[tuple[T1, T2]]) -> dict[
 
 def _process_workflows_for_project(project: Project, event_data: EventRedisData) -> None:
     """Process workflows for a project - evaluate conditions and fire actions."""
-    with sentry_sdk.start_span(op="delayed_workflow.prepare_data"):
+    with sentry_sdk.traces.start_span(
+        name="delayed_workflow.prepare_data",
+        attributes={"sentry.op": "delayed_workflow.prepare_data"},
+    ):
         if features.has(
             "organizations:workflow-engine-process-workflows-logs", project.organization
         ):
@@ -1017,7 +1020,7 @@ def _process_workflows_for_project(project: Project, event_data: EventRedisData)
         )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def process_delayed_workflows(
     batch_client: DelayedWorkflowClient, project_id: int, batch_key: str | None = None
 ) -> None:

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -224,7 +224,7 @@ def create_issue_platform_payload(result: DetectorEvaluationResult, detector_typ
     )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 def process_detectors[T](
     data_packet: DataPacket[T], detectors: list[Detector]
 ) -> list[tuple[Detector, dict[DetectorGroupKey, DetectorEvaluationResult]]]:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -130,7 +130,7 @@ def _get_data_conditions_for_group_by_dcg(dcg_ids: Sequence[int]) -> dict[int, l
     )
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 @scopedstats.timer()
 def evaluate_workflow_triggers(
     workflows: set[Workflow],
@@ -234,7 +234,7 @@ def evaluate_workflow_triggers(
     return triggered_workflows, queue_items_by_workflow, stats
 
 
-@sentry_sdk.trace
+@sentry_sdk.traces.trace
 @scopedstats.timer()
 def evaluate_workflows_action_filters(
     triggered_workflows: dict[Workflow, TriggerResult],


### PR DESCRIPTION
Do not merge: Testing a span streaming migration skill

Migrate from transaction-based to streamed span delivery using the new sentry_sdk.traces API. This enables spans to be sent individually as they complete instead of being batched into transactions.

- Enable trace_lifecycle: stream in _experiments
- Replace before_send_transaction with before_send_span
- Migrate sentry_sdk.start_span → sentry_sdk.traces.start_span
- Migrate sentry_sdk.start_transaction → sentry_sdk.traces.start_span(parent_span=None)
- Migrate @sentry_sdk.trace → @sentry_sdk.traces.trace
- Migrate span.set_data/set_tag → span.set_attribute
- Migrate get_current_span → traces.get_current_span
- Update Span/Transaction imports to StreamedSpan

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
