### PR TITLE
fix(attachments): Disable preview for large text/JSON attachments

### DIFF
--- a/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
+++ b/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
@@ -76,3 +76,12 @@ export const getInlineAttachmentRenderer = (
 export const hasInlineAttachmentRenderer = (attachment: IssueAttachment): boolean => {
   return !!getInlineAttachmentRenderer(attachment);
 };
+
+const MAX_TEXT_PREVIEW_SIZE = 20 * 1024 * 1024; // 20 MiB
+
+export const isAttachmentTooLargeForPreview = (attachment: IssueAttachment): boolean => {
+  if (getImageAttachmentRenderer(attachment)) {
+    return false;
+  }
+  return attachment.size > MAX_TEXT_PREVIEW_SIZE;
+};

--- a/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
+++ b/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
@@ -77,7 +77,7 @@ export const hasInlineAttachmentRenderer = (attachment: IssueAttachment): boolea
   return !!getInlineAttachmentRenderer(attachment);
 };
 
-const MAX_TEXT_PREVIEW_SIZE = 20 * 1024 * 1024; // 20 MiB
+const MAX_TEXT_PREVIEW_SIZE = 1 * 1024 * 1024; // 1 MiB
 
 export const isAttachmentTooLargeForPreview = (attachment: IssueAttachment): boolean => {
   if (getImageAttachmentRenderer(attachment)) {

--- a/static/app/components/events/eventAttachmentActions.tsx
+++ b/static/app/components/events/eventAttachmentActions.tsx
@@ -3,7 +3,10 @@ import {Grid} from '@sentry/scraps/layout';
 
 import {useRole} from 'sentry/components/acl/useRole';
 import {Confirm} from 'sentry/components/confirm';
-import {hasInlineAttachmentRenderer} from 'sentry/components/events/attachmentViewers/previewAttachmentTypes';
+import {
+  hasInlineAttachmentRenderer,
+  isAttachmentTooLargeForPreview,
+} from 'sentry/components/events/attachmentViewers/previewAttachmentTypes';
 import {IconDelete, IconDownload, IconShow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {IssueAttachment} from 'sentry/types/group';
@@ -30,21 +33,25 @@ export function EventAttachmentActions({
   const {hasRole: hasAttachmentRole} = useRole({role: 'attachmentsRole'});
   const url = `/api/0/projects/${organization.slug}/${projectSlug}/events/${attachment.event_id}/attachments/${attachment.id}/`;
   const hasPreview = hasInlineAttachmentRenderer(attachment);
+  const isTooLarge = isAttachmentTooLargeForPreview(attachment);
+  const canPreview = hasPreview && !isTooLarge;
 
   return (
     <Grid flow="column" align="center" gap="md">
       {withPreviewButton && (
         <Button
           size="xs"
-          disabled={!hasAttachmentRole || !hasPreview}
+          disabled={!hasAttachmentRole || !canPreview}
           variant={previewIsOpen ? 'primary' : 'secondary'}
           icon={<IconShow />}
           onClick={onPreviewClick}
           tooltipProps={{
             title: hasAttachmentRole
-              ? hasPreview
+              ? canPreview
                 ? undefined
-                : t('This attachment cannot be previewed')
+                : isTooLarge
+                  ? t('This file is too large to preview')
+                  : t('This attachment cannot be previewed')
               : t('Insufficient permissions to preview attachments'),
           }}
         >

--- a/static/app/components/events/eventAttachmentActions.tsx
+++ b/static/app/components/events/eventAttachmentActions.tsx
@@ -49,7 +49,7 @@ export function EventAttachmentActions({
             title: hasAttachmentRole
               ? canPreview
                 ? undefined
-                : isTooLarge
+                : hasPreview
                   ? t('This file is too large to preview')
                   : t('This attachment cannot be previewed')
               : t('Insufficient permissions to preview attachments'),

--- a/static/app/components/events/eventAttachmentActions.tsx
+++ b/static/app/components/events/eventAttachmentActions.tsx
@@ -50,7 +50,9 @@ export function EventAttachmentActions({
               ? canPreview
                 ? undefined
                 : hasPreview
-                  ? t('This file is too large to preview')
+                  ? isTooLarge
+                    ? t('This file is too large to preview')
+                    : t('This attachment cannot be previewed')
                   : t('This attachment cannot be previewed')
               : t('Insufficient permissions to preview attachments'),
           }}


### PR DESCRIPTION
We offer previews of attachments, but for large files these can slow down or even freeze a page (see below). Since we are introducing large file attachments (e.g., this [sentry-native PR](https://github.com/getsentry/sentry-native/pull/1795)), trying to preview files up to 1GiB seems too ambitious for a browser window.

We could do the same thing we do for certain attachment types (like minidumps, binary files, ...) and disable the preview button as such:
<img width="1073" height="188" alt="Screenshot 2026-06-05 at 11 57 48" src="https://github.com/user-attachments/assets/9bdec060-0388-4a68-a5e1-50de363b4c18" />

TBD: currently set the `MAX_TEXT_PREVIEW_SIZE` to 20MiB, not sure if this is an appropriate value? Currently it is based on the recommended `max_attachment_size` set in some SDKs (defaults to 20MiB), and text fields of this size and below render decently fast (~3s).

---

For example, from [a 199MiB attachment](https://sentry-sdks.sentry.io/issues/7529263714/events/1e2089d5f58146eb82ecb78a2930baf8/?project=4509371203256320):

<img width="673" height="261" alt="Screenshot 2026-06-05 at 13 53 02" src="https://github.com/user-attachments/assets/f6f3af72-0740-40bb-a88b-12c22fc03b0e" />


[Link to events with different sized attachments](https://sentry-sdks.sentry.io/issues/7529263714/events/ef22d84b6981437181572e3d23ed74c6/events/?project=4509371203256320) (20-199MiB) 