### PR TITLE
feat(preprod): Add copy insight diff as JSON to clipboard

### DIFF
--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -22,6 +22,9 @@ export type BuildListPageSource =
   | 'releases_details_preprod_builds';
 
 export type PreprodBuildEventParameters = {
+  'preprod.builds.compare.copy_insight_diff': BasePreprodBuildEvent & {
+    insight_count: number;
+  };
   'preprod.builds.compare.go_to_build_details': BasePreprodBuildEvent & {
     slot?: 'head' | 'base';
   };
@@ -130,6 +133,8 @@ export const preprodBuildEventMap: Record<PreprodBuildAnalyticsKey, string | nul
   'preprod.builds.details.delete_build': 'Preprod Build Details: Delete Build',
   'preprod.builds.details.compare_build_clicked':
     'Preprod Build Details: Compare Clicked',
+  'preprod.builds.compare.copy_insight_diff':
+    'Preprod Build Comparison: Copy Insight Diff',
   'preprod.builds.compare.go_to_build_details':
     'Preprod Build Comparison: Go to Build Details',
   'preprod.builds.compare.select_base_build': 'Preprod Build Comparison: Base Selected',

--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -25,6 +25,9 @@ export type PreprodBuildEventParameters = {
   'preprod.builds.compare.copy_insight_diff': BasePreprodBuildEvent & {
     insight_count: number;
   };
+  'preprod.builds.compare.download_csv': BasePreprodBuildEvent & {
+    item_count: number;
+  };
   'preprod.builds.compare.go_to_build_details': BasePreprodBuildEvent & {
     slot?: 'head' | 'base';
   };
@@ -135,6 +138,7 @@ export const preprodBuildEventMap: Record<PreprodBuildAnalyticsKey, string | nul
     'Preprod Build Details: Compare Clicked',
   'preprod.builds.compare.copy_insight_diff':
     'Preprod Build Comparison: Copy Insight Diff',
+  'preprod.builds.compare.download_csv': 'Preprod Build Comparison: Download CSV',
   'preprod.builds.compare.go_to_build_details':
     'Preprod Build Comparison: Go to Build Details',
   'preprod.builds.compare.select_base_build': 'Preprod Build Comparison: Base Selected',

--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.spec.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.spec.tsx
@@ -1,0 +1,80 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {type InsightDiffItem, TreemapType} from 'sentry/views/preprod/types/appSizeTypes';
+
+import {InsightComparisonSection} from './insightComparisonSection';
+
+const mockInsightDiffItems: InsightDiffItem[] = [
+  {
+    insight_type: 'large_images',
+    status: 'new',
+    total_savings_change: 2_500_000,
+    file_diffs: [
+      {
+        path: '/assets/hero-banner.png',
+        type: 'added',
+        size_diff: 2_500_000,
+        head_size: 2_500_000,
+        base_size: null,
+        item_type: TreemapType.ASSETS,
+        diff_items: null,
+      },
+    ],
+    group_diffs: [],
+  },
+  {
+    insight_type: 'large_videos',
+    status: 'unresolved',
+    total_savings_change: 500_000,
+    file_diffs: [
+      {
+        path: '/assets/intro.mp4',
+        type: 'increased',
+        size_diff: 500_000,
+        head_size: 1_000_000,
+        base_size: 500_000,
+        item_type: TreemapType.ASSETS,
+        diff_items: null,
+      },
+    ],
+    group_diffs: [],
+  },
+];
+
+describe('InsightComparisonSection', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn().mockResolvedValue(''),
+      },
+    });
+  });
+
+  it('renders the section heading and copy button', () => {
+    render(
+      <InsightComparisonSection
+        insightDiffItems={mockInsightDiffItems}
+        totalInstallSizeBytes={50_000_000}
+      />
+    );
+
+    expect(screen.getByRole('heading', {name: 'Insight Diff'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Copy as JSON'})).toBeInTheDocument();
+  });
+
+  it('copies the entire insight diff as JSON to the clipboard', async () => {
+    render(
+      <InsightComparisonSection
+        insightDiffItems={mockInsightDiffItems}
+        totalInstallSizeBytes={50_000_000}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Copy as JSON'}));
+
+    // Copies all insights, not just the currently displayed/selected tab.
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      JSON.stringify(mockInsightDiffItems, null, 2)
+    );
+  });
+});

--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.spec.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.spec.tsx
@@ -1,5 +1,6 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import * as analytics from 'sentry/utils/analytics';
 import {type InsightDiffItem, TreemapType} from 'sentry/views/preprod/types/appSizeTypes';
 
 import {InsightComparisonSection} from './insightComparisonSection';
@@ -75,6 +76,24 @@ describe('InsightComparisonSection', () => {
     // Copies all insights, not just the currently displayed/selected tab.
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       JSON.stringify(mockInsightDiffItems, null, 2)
+    );
+  });
+
+  it('tracks an analytics event with the insight count when copying', async () => {
+    const analyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+
+    render(
+      <InsightComparisonSection
+        insightDiffItems={mockInsightDiffItems}
+        totalInstallSizeBytes={50_000_000}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Copy as JSON'}));
+
+    expect(analyticsSpy).toHaveBeenCalledWith(
+      'preprod.builds.compare.copy_insight_diff',
+      expect.objectContaining({insight_count: mockInsightDiffItems.length})
     );
   });
 });

--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -7,7 +7,9 @@ import {Heading} from '@sentry/scraps/text';
 
 import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {FileInsightItemDiffTable} from 'sentry/views/preprod/buildComparison/main/insights/fileInsightDiffTable';
 import {GroupInsightItemDiffTable} from 'sentry/views/preprod/buildComparison/main/insights/groupInsightDiffTable';
 import {InsightDiffRow} from 'sentry/views/preprod/buildComparison/main/insights/insightDiffRow';
@@ -117,6 +119,7 @@ export function InsightComparisonSection({
 }: InsightComparisonSectionProps) {
   type InsightTab = 'all' | InsightStatus;
   const [selectedTab, setSelectedTab] = useState<InsightTab>('all');
+  const organization = useOrganization();
 
   const tabbedInsights = useMemo(() => {
     const byTab: Record<InsightTab, InsightDiffItem[]> = {
@@ -187,7 +190,13 @@ export function InsightComparisonSection({
         <Button
           size="sm"
           icon={<IconCopy />}
-          onClick={() => copyToClipboard(JSON.stringify(insightDiffItems, null, 2))}
+          onClick={() => {
+            copyToClipboard(JSON.stringify(insightDiffItems, null, 2));
+            trackAnalytics('preprod.builds.compare.copy_insight_diff', {
+              organization,
+              insight_count: insightDiffItems.length,
+            });
+          }}
         >
           {t('Copy as JSON')}
         </Button>

--- a/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
+++ b/static/app/views/preprod/buildComparison/main/insightComparisonSection.tsx
@@ -1,9 +1,13 @@
 import {useMemo, useState} from 'react';
 
+import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
+import {Heading} from '@sentry/scraps/text';
 
+import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {FileInsightItemDiffTable} from 'sentry/views/preprod/buildComparison/main/insights/fileInsightDiffTable';
 import {GroupInsightItemDiffTable} from 'sentry/views/preprod/buildComparison/main/insights/groupInsightDiffTable';
 import {InsightDiffRow} from 'sentry/views/preprod/buildComparison/main/insights/insightDiffRow';
@@ -178,8 +182,22 @@ export function InsightComparisonSection({
 
   return (
     <Stack gap="md">
+      <Flex align="center" justify="between" gap="md">
+        <Heading as="h2">{t('Insight Diff')}</Heading>
+        <Button
+          size="sm"
+          icon={<IconCopy />}
+          onClick={() => copyToClipboard(JSON.stringify(insightDiffItems, null, 2))}
+        >
+          {t('Copy as JSON')}
+        </Button>
+      </Flex>
       <Flex align="center" gap="sm" wrap="wrap">
-        <SegmentedControl value={selectedTab} onChange={setSelectedTab}>
+        <SegmentedControl
+          aria-label={t('Filter insights by status')}
+          value={selectedTab}
+          onChange={setSelectedTab}
+        >
           {statusCounts.all > 0 ? (
             <SegmentedControl.Item key="all">
               {t('All (%s)', statusCounts.all)}

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -14,6 +14,7 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconChevron, IconDownload, IconRefresh, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {parseApiError} from 'sentry/utils/parseApiError';
 import {fetchMutation, useApiQuery} from 'sentry/utils/queryClient';
@@ -338,12 +339,16 @@ export function SizeCompareMainContent() {
               size="sm"
               icon={<IconDownload />}
               disabled={filteredDiffItems.length === 0}
-              onClick={() =>
+              onClick={() => {
                 downloadSizeCompareItemsAsCsv(
                   filteredDiffItems,
                   t('Size Compare Items Changed')
-                )
-              }
+                );
+                trackAnalytics('preprod.builds.compare.download_csv', {
+                  organization,
+                  item_count: filteredDiffItems.length,
+                });
+              }}
               aria-label={t('Download CSV')}
             >
               {t('Download CSV')}

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -301,15 +301,12 @@ export function SizeCompareMainContent() {
         comparisonDataQuery.data.insight_diff_items.length > 0 && (
           <Stack gap="xl">
             <Separator orientation="horizontal" border="primary" />
-            <Stack gap="md">
-              <Heading as="h2">{t('Insight Diff')}</Heading>
-              <InsightComparisonSection
-                totalInstallSizeBytes={
-                  comparisonDataQuery.data?.size_metric_diff_item.head_install_size
-                }
-                insightDiffItems={comparisonDataQuery.data.insight_diff_items}
-              />
-            </Stack>
+            <InsightComparisonSection
+              totalInstallSizeBytes={
+                comparisonDataQuery.data.size_metric_diff_item.head_install_size
+              }
+              insightDiffItems={comparisonDataQuery.data.insight_diff_items}
+            />
             <Separator orientation="horizontal" border="primary" />
           </Stack>
         )}


### PR DESCRIPTION
Adds a **"Copy as JSON"** button to the **Insight Diff** section of the build comparison view. Clicking it copies the entire insight diff payload — all insights, independent of the selected status tab — to the clipboard as formatted JSON.

### What changed
- `InsightComparisonSection` now owns its header: the "Insight Diff" heading plus the copy action live in the section, keeping it self-contained and unit-testable.
- The parent (`sizeCompareMainContent`) is simplified to render the section directly (removed the separate heading and a redundant single-child `Stack` wrapper).
- Added a missing `aria-label` to the status-filter `SegmentedControl` — a pre-existing accessibility warning that surfaced while adding the test.
- Added analytics tracking for both data-export actions in this view (see below).

### Why
Lets users grab the raw insight diff data (to paste into a ticket, a script, or an LLM) without scraping the UI.

### Analytics
Two new typed events under the `preprod.builds.compare.*` namespace, registered in `preprodBuildAnalyticsEvents.tsx`:

| Event key | Amplitude name | Params | Fires when |
| --- | --- | --- | --- |
| `preprod.builds.compare.copy_insight_diff` | `Preprod Build Comparison: Copy Insight Diff` | `insight_count` | User clicks the new "Copy as JSON" button |
| `preprod.builds.compare.download_csv` | `Preprod Build Comparison: Download CSV` | `item_count` | User clicks the existing "Download CSV" button |

Both flow through `trackAnalytics` to Reload + Amplitude. The CSV event was previously uninstrumented; adding it here so the two click-counts can be compared side by side. `item_count` reflects the filtered set actually written to the CSV (after search box + "hide <500B" toggle), not the full diff.

### Reviewer notes
- The copy button copies the **full** `insightDiffItems` array regardless of which status tab (All / New / Unresolved / Resolved) is selected — by design.
- Placement mirrors the sibling "Items Changed → Download CSV" header in the same view.
- Frontend-only change (`static/`), so it deploys independently of backend.

Looks like:

<img width="80%" alt="after" src="https://github.com/user-attachments/assets/6f62e4a4-0fcb-4fce-89c0-933229661f30" />


### Testing
- New unit test `insightComparisonSection.spec.tsx`: asserts the button renders, copies the entire payload as JSON, and fires the analytics event with the correct `insight_count`.
- The CSV analytics call has no unit test — the button lives in the data-fetching page component (`sizeCompareMainContent.tsx`) which has no existing spec; a heavyweight integration test isn't justified by a single instrumentation hook. Verified locally via `localStorage.setItem('DEBUG_ANALYTICS', '1')` and confirmed both events log on click.
- `pnpm typecheck`, `pnpm run lint:js`, and prek hooks all pass.

Refs EME-994
