### PR TITLE
ref(ourlogs): Rename PinnedLogs query prop to pinnedLogsQuery

### DIFF
--- a/static/app/views/explore/logs/pinning/PinnedLogs.spec.tsx
+++ b/static/app/views/explore/logs/pinning/PinnedLogs.spec.tsx
@@ -50,7 +50,7 @@ function PinnedLogsWrapper({
       <PinnedLogs
         allRows={allRows}
         logsPinning={logsPinning}
-        query={{
+        pinnedLogsQuery={{
           fetchedRows: fetchedPinnedRows,
           isPending: isFetchingPinnedRows,
         }}

--- a/static/app/views/explore/logs/pinning/PinnedLogs.tsx
+++ b/static/app/views/explore/logs/pinning/PinnedLogs.tsx
@@ -17,12 +17,13 @@ import type {LogTableRowItem} from 'sentry/views/explore/logs/utils';
 interface Props {
   allRows: LogTableRowItem[];
   logsPinning: LogsPinning;
-  query: ReturnType<typeof usePinnedLogsQuery>;
+  pinnedLogsQuery: ReturnType<typeof usePinnedLogsQuery>;
   renderRow: (dataRow: LogTableRowItem) => React.ReactNode;
 }
 
-export function PinnedLogs({allRows, logsPinning, query, renderRow}: Props) {
-  const {fetchedRows: fetchedPinnedRows, isPending: isFetchingPinnedRows} = query;
+export function PinnedLogs({allRows, logsPinning, pinnedLogsQuery, renderRow}: Props) {
+  const {fetchedRows: fetchedPinnedRows, isPending: isFetchingPinnedRows} =
+    pinnedLogsQuery;
   const [expanded, setExpanded] = useState(true);
   const pinnedRows = logsPinning.getPinnedRowIds();
 

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -536,7 +536,7 @@ export function LogsInfiniteTable({
           <PinnedLogs
             allRows={data}
             logsPinning={logsPinning}
-            query={pinnedLogsQuery}
+            pinnedLogsQuery={pinnedLogsQuery}
             renderRow={renderRow}
           />
         )}


### PR DESCRIPTION
Renames the `query` prop on `PinnedLogs` to `pinnedLogsQuery` so it reads clearly at the call site and isn't confused with other queries. Requested by @narsaynorath in https://github.com/getsentry/sentry/pull/116614#discussion_r3357891165.
