### PR TITLE
feat(seer): Tag Ask Seer UI conversations with ask_seer category

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -249,6 +249,8 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
             client = SeerAgentClient(
                 organization,
                 request.user,
+                category_key="ask_seer",
+                category_value="ui",
                 is_interactive=True,
                 enable_coding=enable_coding,
                 enable_code_mode_tools=enable_code_mode_tools,

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -115,6 +115,8 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client_class.assert_called_once_with(
             self.organization,
             ANY,
+            category_key="ask_seer",
+            category_value="ui",
             is_interactive=True,
             enable_coding=False,
             enable_code_mode_tools="off",
@@ -153,6 +155,8 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             mock_client_class.assert_called_with(
                 self.organization,
                 ANY,
+                category_key="ask_seer",
+                category_value="ui",
                 is_interactive=True,
                 enable_coding=feature_enabled and option_enabled,
                 enable_code_mode_tools="off",
@@ -176,6 +180,8 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client_class.assert_called_once_with(
             self.organization,
             ANY,
+            category_key="ask_seer",
+            category_value="ui",
             is_interactive=True,
             enable_coding=False,
             enable_code_mode_tools="off",
@@ -210,6 +216,8 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             mock_client_class.assert_called_with(
                 self.organization,
                 ANY,
+                category_key="ask_seer",
+                category_value="ui",
                 is_interactive=True,
                 enable_coding=feature_enabled and option_enabled,
                 enable_code_mode_tools="off",


### PR DESCRIPTION
Explorer chats started from the UI 'Ask Seer' feature were created without a `category_key`, so the local `SeerAgentRun` mirror stored an empty `source` and emitted a `seer_agent_run.missing_source` warning. Every other entrypoint (autofix, slack_thread, night_shift, etc.) attributes its runs via `category_key`.

This passes `category_key="ask_seer"` from `OrganizationSeerAgentChatEndpoint` so UI-originated conversations are attributed to their surface. A constant `category_value="ui"` is supplied to satisfy the client's all-or-nothing pair contract (`category_key` and `category_value` must be set together).

Only new runs are affected — `continue_run` does not forward the category, so continued/dashboard-generate runs are unchanged.


Agent transcript: https://claudescope.sentry.dev/share/e9n5Znpbydv4UZQ5BP2-r9OGRjWvWmspqN2nhbUhscE