### PR TITLE
ref(dashboards): Remove dashboards-revisions feature flag (backend)

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_details.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_details.py
@@ -36,7 +36,6 @@ from sentry.models.organization import Organization
 
 EDIT_FEATURE = "organizations:dashboards-edit"
 READ_FEATURE = "organizations:dashboards-basic"
-REVISIONS_FEATURE = "organizations:dashboards-revisions"
 
 logger = logging.getLogger(__name__)
 
@@ -201,9 +200,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
                     {"detail": "Cannot change the title of prebuilt Dashboards."}, status=409
                 )
 
-        snapshot = None
-        if features.has(REVISIONS_FEATURE, organization, actor=request.user):
-            snapshot = _take_dashboard_snapshot(dashboard, request.user)
+        snapshot = _take_dashboard_snapshot(dashboard, request.user)
 
         revision_source = request.data.get("revisionSource", "edit")
         if revision_source not in ("edit", "edit-with-agent"):

--- a/src/sentry/dashboards/endpoints/organization_dashboard_revision_details.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_revision_details.py
@@ -5,13 +5,11 @@ from typing import Any
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.dashboards.endpoints.organization_dashboard_details import (
-    REVISIONS_FEATURE,
     OrganizationDashboardBase,
 )
 from sentry.models.dashboard import Dashboard, DashboardRevision
@@ -61,9 +59,6 @@ class OrganizationDashboardRevisionDetailsEndpoint(OrganizationDashboardBase):
         """
         Return the dashboard snapshot for a specific revision.
         """
-        if not features.has(REVISIONS_FEATURE, organization, actor=request.user):
-            return Response(status=404)
-
         if revision.snapshot_schema_version != DashboardRevision.SNAPSHOT_SCHEMA_VERSION:
             return Response(
                 {"detail": "This revision requires migration before it can be previewed."},

--- a/src/sentry/dashboards/endpoints/organization_dashboard_revision_restore.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_revision_restore.py
@@ -6,7 +6,6 @@ from django.db import IntegrityError, router, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -14,7 +13,6 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import DashboardDetailsSerializer
 from sentry.dashboards.endpoints.organization_dashboard_details import (
-    REVISIONS_FEATURE,
     OrganizationDashboardBase,
     _take_dashboard_snapshot,
 )
@@ -56,9 +54,6 @@ class OrganizationDashboardRevisionRestoreEndpoint(OrganizationDashboardBase):
         """
         Restore a dashboard to the state captured in the given revision.
         """
-        if not features.has(REVISIONS_FEATURE, organization, actor=request.user):
-            return Response(status=404)
-
         if not isinstance(dashboard, Dashboard):
             return Response(status=404)
 

--- a/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
@@ -5,14 +5,12 @@ from typing import Any
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.dashboards.endpoints.organization_dashboard_details import (
-    REVISIONS_FEATURE,
     OrganizationDashboardBase,
 )
 from sentry.models.dashboard import Dashboard, DashboardRevision
@@ -35,9 +33,6 @@ class OrganizationDashboardRevisionsEndpoint(OrganizationDashboardBase):
         """
         Return the revision history for an organization's custom dashboard.
         """
-        if not features.has(REVISIONS_FEATURE, organization, actor=request.user):
-            return Response(status=404)
-
         if not isinstance(dashboard, Dashboard):
             return Response(status=404)
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -81,8 +81,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-ai-generate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable AI-powered dashboard editing via Seer
     manager.add("organizations:dashboards-ai-generate-edit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable dashboard revisions (revision tracking and revert)
-    manager.add("organizations:dashboards-revisions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Data Secrecy
     manager.add("organizations:data-secrecy", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Data Secrecy v2 (with Break the Glass feature)

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -3898,24 +3898,15 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert "queries" in response.data["widgets"][1], response.data
         assert response.data["widgets"][1]["queries"][0] == "Text widgets don't have queries"
 
-    def test_put_creates_dashboard_revision_when_feature_enabled(self) -> None:
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.do_request(
-                "put", self.url(self.dashboard.id), data={"title": "Updated Title"}
-            )
-        assert response.status_code == 200, response.data
-        assert DashboardRevision.objects.filter(dashboard=self.dashboard).count() == 1
-
-    def test_put_does_not_create_revision_when_feature_disabled(self) -> None:
+    def test_put_creates_dashboard_revision(self) -> None:
         response = self.do_request(
             "put", self.url(self.dashboard.id), data={"title": "Updated Title"}
         )
         assert response.status_code == 200, response.data
-        assert DashboardRevision.objects.filter(dashboard=self.dashboard).count() == 0
+        assert DashboardRevision.objects.filter(dashboard=self.dashboard).count() == 1
 
     def test_put_snapshot_contains_pre_save_state(self) -> None:
-        with self.feature("organizations:dashboards-revisions"):
-            self.do_request("put", self.url(self.dashboard.id), data={"title": "New Title"})
+        self.do_request("put", self.url(self.dashboard.id), data={"title": "New Title"})
 
         revision = DashboardRevision.objects.get(dashboard=self.dashboard)
         # Snapshot reflects the state before the update
@@ -3926,8 +3917,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert self.dashboard.title == "New Title"
 
     def test_put_snapshot_includes_widgets_and_queries(self) -> None:
-        with self.feature("organizations:dashboards-revisions"):
-            self.do_request("put", self.url(self.dashboard.id), data={"title": "New Title"})
+        self.do_request("put", self.url(self.dashboard.id), data={"title": "New Title"})
 
         revision = DashboardRevision.objects.get(dashboard=self.dashboard)
         snapshot_widgets = revision.snapshot["widgets"]
@@ -3944,20 +3934,19 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
 
     def test_put_snapshot_captures_widget_state_before_widget_edit(self) -> None:
         original_widget_title = self.widget_1.title
-        with self.feature("organizations:dashboards-revisions"):
-            self.do_request(
-                "put",
-                self.url(self.dashboard.id),
-                data={
-                    "title": self.dashboard.title,
-                    "widgets": [
-                        {"id": str(self.widget_1.id), "title": "Updated Widget Title"},
-                        {"id": str(self.widget_2.id)},
-                        {"id": str(self.widget_3.id)},
-                        {"id": str(self.widget_4.id)},
-                    ],
-                },
-            )
+        self.do_request(
+            "put",
+            self.url(self.dashboard.id),
+            data={
+                "title": self.dashboard.title,
+                "widgets": [
+                    {"id": str(self.widget_1.id), "title": "Updated Widget Title"},
+                    {"id": str(self.widget_2.id)},
+                    {"id": str(self.widget_3.id)},
+                    {"id": str(self.widget_4.id)},
+                ],
+            },
+        )
 
         revision = DashboardRevision.objects.get(dashboard=self.dashboard)
         snapshot_widget = revision.snapshot["widgets"][0]
@@ -3969,30 +3958,27 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert self.widget_1.title == "Updated Widget Title"
 
     def test_put_revision_source_defaults_to_edit(self) -> None:
-        with self.feature("organizations:dashboards-revisions"):
-            self.do_request("put", self.url(self.dashboard.id), data={"title": "Updated"})
+        self.do_request("put", self.url(self.dashboard.id), data={"title": "Updated"})
 
         revision = DashboardRevision.objects.get(dashboard=self.dashboard)
         assert revision.source == "edit"
 
     def test_put_revision_source_edit_with_agent(self) -> None:
-        with self.feature("organizations:dashboards-revisions"):
-            self.do_request(
-                "put",
-                self.url(self.dashboard.id),
-                data={"title": "Updated", "revisionSource": "edit-with-agent"},
-            )
+        self.do_request(
+            "put",
+            self.url(self.dashboard.id),
+            data={"title": "Updated", "revisionSource": "edit-with-agent"},
+        )
 
         revision = DashboardRevision.objects.get(dashboard=self.dashboard)
         assert revision.source == "edit-with-agent"
 
     def test_put_revision_source_ignores_unknown_values(self) -> None:
-        with self.feature("organizations:dashboards-revisions"):
-            self.do_request(
-                "put",
-                self.url(self.dashboard.id),
-                data={"title": "Updated", "revisionSource": "malicious-value"},
-            )
+        self.do_request(
+            "put",
+            self.url(self.dashboard.id),
+            data={"title": "Updated", "revisionSource": "malicious-value"},
+        )
 
         revision = DashboardRevision.objects.get(dashboard=self.dashboard)
         assert revision.source == "edit"

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_revision_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_revision_details.py
@@ -34,13 +34,8 @@ class OrganizationDashboardRevisionDetailsTestCase(APITestCase):
 
 
 class GetOrganizationDashboardRevisionDetailsTest(OrganizationDashboardRevisionDetailsTestCase):
-    def test_returns_404_without_feature_flag(self) -> None:
-        response = self.client.get(self.url)
-        assert response.status_code == 404
-
     def test_returns_snapshot_with_expected_fields(self) -> None:
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(self.url)
+        response = self.client.get(self.url)
 
         assert response.status_code == 200
         assert response.data["id"] == str(self.dashboard.id)
@@ -64,8 +59,7 @@ class GetOrganizationDashboardRevisionDetailsTest(OrganizationDashboardRevisionD
                 "revision_id": old_revision.id,
             },
         )
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 422
 
@@ -78,8 +72,7 @@ class GetOrganizationDashboardRevisionDetailsTest(OrganizationDashboardRevisionD
                 "revision_id": "abc",
             },
         )
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 404
 
@@ -92,8 +85,7 @@ class GetOrganizationDashboardRevisionDetailsTest(OrganizationDashboardRevisionD
                 "revision_id": 99999,
             },
         )
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 404
 
@@ -106,8 +98,7 @@ class GetOrganizationDashboardRevisionDetailsTest(OrganizationDashboardRevisionD
                 "revision_id": self.revision.id,
             },
         )
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 404
 
@@ -133,8 +124,7 @@ class GetOrganizationDashboardRevisionDetailsTest(OrganizationDashboardRevisionD
                 "revision_id": other_revision.id,
             },
         )
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 404
 
@@ -161,7 +151,6 @@ class GetOrganizationDashboardRevisionDetailsTest(OrganizationDashboardRevisionD
                 "revision_id": other_revision.id,
             },
         )
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 404

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_revision_restore.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_revision_restore.py
@@ -71,11 +71,6 @@ class OrganizationDashboardRevisionRestoreTestCase(APITestCase):
 
 
 class PostOrganizationDashboardRevisionRestoreTest(OrganizationDashboardRevisionRestoreTestCase):
-    def test_returns_404_without_feature_flag(self) -> None:
-        revision = self._create_revision()
-        response = self.client.post(self._url(revision.id))
-        assert response.status_code == 404
-
     def test_returns_404_for_prebuilt_dashboard(self) -> None:
         revision = self._create_revision()
         url = reverse(
@@ -86,14 +81,12 @@ class PostOrganizationDashboardRevisionRestoreTest(OrganizationDashboardRevision
                 "revision_id": revision.id,
             },
         )
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.post(url)
+        response = self.client.post(url)
 
         assert response.status_code == 404
 
     def test_returns_404_for_nonexistent_revision(self) -> None:
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.post(self._url(99999))
+        response = self.client.post(self._url(99999))
 
         assert response.status_code == 404
 
@@ -112,8 +105,7 @@ class PostOrganizationDashboardRevisionRestoreTest(OrganizationDashboardRevision
             snapshot_schema_version=DashboardRevision.SNAPSHOT_SCHEMA_VERSION,
         )
 
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.post(self._url(other_revision.id))
+        response = self.client.post(self._url(other_revision.id))
 
         assert response.status_code == 404
 
@@ -126,8 +118,7 @@ class PostOrganizationDashboardRevisionRestoreTest(OrganizationDashboardRevision
         self.dashboard.title = "New Title"
         self.dashboard.save()
 
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.post(self._url(revision.id))
+        response = self.client.post(self._url(revision.id))
 
         assert response.status_code == 200
         assert response.data["title"] == "Old Title"
@@ -140,8 +131,7 @@ class PostOrganizationDashboardRevisionRestoreTest(OrganizationDashboardRevision
 
         initial_revision_count = DashboardRevision.objects.filter(dashboard=self.dashboard).count()
 
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.post(self._url(revision.id))
+        response = self.client.post(self._url(revision.id))
 
         assert response.status_code == 200
 
@@ -158,8 +148,7 @@ class PostOrganizationDashboardRevisionRestoreTest(OrganizationDashboardRevision
             snapshot={"title": "Restored Title", "widgets": [], "projects": []}
         )
 
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.post(self._url(revision.id))
+        response = self.client.post(self._url(revision.id))
 
         assert response.status_code == 200
         assert "id" in response.data
@@ -176,8 +165,7 @@ class PostOrganizationDashboardRevisionRestoreTest(OrganizationDashboardRevision
             snapshot_schema_version=DashboardRevision.SNAPSHOT_SCHEMA_VERSION + 1,
         )
 
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.post(self._url(revision.id))
+        response = self.client.post(self._url(revision.id))
 
         assert response.status_code == 400
         assert "detail" in response.data
@@ -193,8 +181,7 @@ class PostOrganizationDashboardRevisionRestoreTest(OrganizationDashboardRevision
         self.create_member(user=other_user, organization=self.organization, role="member")
         self.login_as(other_user)
 
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.post(self._url(revision.id))
+        response = self.client.post(self._url(revision.id))
 
         assert response.status_code == 403
 
@@ -209,8 +196,7 @@ class PostOrganizationDashboardRevisionRestoreTest(OrganizationDashboardRevision
             title="Conflicting Title",
         )
 
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.post(self._url(revision.id))
+        response = self.client.post(self._url(revision.id))
 
         assert response.status_code == 409
         assert "detail" in response.data
@@ -243,8 +229,7 @@ class PostOrganizationDashboardRevisionRestoreTest(OrganizationDashboardRevision
             }
         )
 
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.post(self._url(revision.id))
+        response = self.client.post(self._url(revision.id))
 
         assert response.status_code == 200
         assert len(response.data["widgets"]) == 1

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
@@ -37,22 +37,15 @@ class OrganizationDashboardRevisionsTestCase(APITestCase):
 
 
 class GetOrganizationDashboardRevisionsTest(OrganizationDashboardRevisionsTestCase):
-    def test_returns_404_without_feature_flag(self) -> None:
-        self._create_revision()
-        response = self.client.get(self.url)
-        assert response.status_code == 404
-
     def test_returns_empty_list_when_no_revisions(self) -> None:
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(self.url)
+        response = self.client.get(self.url)
 
         assert response.status_code == 200
         assert response.data == []
 
     def test_returns_revisions_with_expected_fields(self) -> None:
         revision = self._create_revision()
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(self.url)
+        response = self.client.get(self.url)
 
         assert response.status_code == 200
         assert len(response.data) == 1
@@ -72,8 +65,7 @@ class GetOrganizationDashboardRevisionsTest(OrganizationDashboardRevisionsTestCa
     def test_returns_gravatar_avatar_type(self) -> None:
         self.create_user_avatar(user=self.user, avatar_type=UserAvatarType.GRAVATAR)
         self._create_revision()
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(self.url)
+        response = self.client.get(self.url)
 
         assert response.status_code == 200
         created_by = response.data[0]["createdBy"]
@@ -83,8 +75,7 @@ class GetOrganizationDashboardRevisionsTest(OrganizationDashboardRevisionsTestCa
     def test_returns_upload_avatar_type(self) -> None:
         self.create_user_avatar(user=self.user, avatar_type=UserAvatarType.UPLOAD)
         self._create_revision()
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(self.url)
+        response = self.client.get(self.url)
 
         assert response.status_code == 200
         assert response.data[0]["createdBy"]["avatarType"] == "upload"
@@ -93,8 +84,7 @@ class GetOrganizationDashboardRevisionsTest(OrganizationDashboardRevisionsTestCa
         first = self._create_revision(title="First")
         second = self._create_revision(title="Second")
 
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(self.url)
+        response = self.client.get(self.url)
 
         assert response.status_code == 200
         assert len(response.data) == 2
@@ -109,8 +99,7 @@ class GetOrganizationDashboardRevisionsTest(OrganizationDashboardRevisionsTestCa
                 "dashboard_id": "default-overview",
             },
         )
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(prebuilt_url)
+        response = self.client.get(prebuilt_url)
 
         assert response.status_code == 404
 
@@ -130,8 +119,7 @@ class GetOrganizationDashboardRevisionsTest(OrganizationDashboardRevisionsTestCa
         )
         revision = self._create_revision()
 
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(self.url)
+        response = self.client.get(self.url)
 
         assert response.status_code == 200
         assert len(response.data) == 1
@@ -147,8 +135,7 @@ class GetOrganizationDashboardRevisionsTest(OrganizationDashboardRevisionsTestCa
             snapshot_schema_version=DashboardRevision.SNAPSHOT_SCHEMA_VERSION,
         )
 
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.client.get(self.url)
+        response = self.client.get(self.url)
 
         assert response.status_code == 200
         assert len(response.data) == 1


### PR DESCRIPTION
Dashboard revisions is rolled out to 100%, so this removes the `organizations:dashboards-revisions` feature flag on the backend and makes revision tracking, history, preview, and restore always-on.

## Changes
- Drop the flag registration from `features/temporary.py`.
- Remove the `REVISIONS_FEATURE` gate (the `features.has(...)` → 404 guard) from the revisions, revision-details, and revision-restore endpoints.
- Always take a dashboard snapshot on edit in the details endpoint (previously gated by the flag).
- Update tests to drop the `with self.feature(...)` context manager and remove the now-obsolete flag-disabled cases.

## Notes
The frontend gate removal is in a **separate PR** since frontend and backend are not atomically deployed. Either order is deploy-safe because the flag is already at 100%.

DAIN-1702