### PR TITLE
fix(dashboards): Hide internal error messages from widget error state

### DIFF
--- a/static/app/views/dashboards/widgetCard/widgetFrame.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetFrame.spec.tsx
@@ -21,7 +21,7 @@ describe('WidgetFrame', () => {
       expect(await screen.findByText('Number of events per second')).toBeInTheDocument();
     });
 
-    it('Catches errors in the visualization', async () => {
+    it('Catches errors in the visualization and hides the internal message', async () => {
       render(
         <WidgetFrame title="Uh Oh">
           <UhOh />
@@ -30,7 +30,12 @@ describe('WidgetFrame', () => {
 
       expect(screen.getByText('Uh Oh')).toBeInTheDocument();
 
-      expect(await screen.findByText(/cannot read properties/i)).toBeInTheDocument();
+      // The raw error is caught and reported to Sentry, but not surfaced to the
+      // user — a friendly message is shown instead.
+      expect(
+        await screen.findByText('Something went wrong displaying this widget.')
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/cannot read properties/i)).not.toBeInTheDocument();
     });
   });
 

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.spec.tsx
@@ -15,7 +15,7 @@ describe('BigNumberWidgetVisualization', () => {
       jest.resetAllMocks();
     });
 
-    it('Explains non-numeric data', () => {
+    it('Hides the internal error behind a friendly message for non-numeric data', () => {
       render(
         <Widget
           Visualization={
@@ -29,7 +29,13 @@ describe('BigNumberWidgetVisualization', () => {
         />
       );
 
-      expect(screen.getByText('Value is not a finite number.')).toBeInTheDocument();
+      // The non-finite value throws during render. We don't surface the raw
+      // (non-actionable) error message to the user; the Widget's ErrorBoundary
+      // shows a friendly message instead.
+      expect(
+        screen.getByText('Something went wrong displaying this widget.')
+      ).toBeInTheDocument();
+      expect(screen.queryByText('Value is not a finite number.')).not.toBeInTheDocument();
     });
 
     it('Formats dates', () => {

--- a/static/app/views/dashboards/widgets/widget/widget.spec.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.spec.tsx
@@ -1,0 +1,47 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+
+const INTERNAL_ERROR_MESSAGE = 'Cannot read properties of undefined (reading "secret")';
+
+function ExplodingVisualization(): React.ReactNode {
+  throw new Error(INTERNAL_ERROR_MESSAGE);
+}
+
+describe('Widget', () => {
+  it('renders the visualization when it does not error', () => {
+    render(<Widget Visualization={<div>Chart contents</div>} />);
+
+    expect(screen.getByText('Chart contents')).toBeInTheDocument();
+  });
+
+  it('hides the internal error and shows a friendly message when the visualization throws', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<Widget Visualization={<ExplodingVisualization />} />);
+
+    expect(
+      screen.getByText('Something went wrong displaying this widget.')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(new RegExp(INTERNAL_ERROR_MESSAGE))
+    ).not.toBeInTheDocument();
+
+    errorSpy.mockRestore();
+  });
+
+  it('hides the internal error in the footer when it throws', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<Widget Footer={<ExplodingVisualization />} />);
+
+    expect(
+      screen.getByText('Something went wrong displaying this widget.')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(new RegExp(INTERNAL_ERROR_MESSAGE))
+    ).not.toBeInTheDocument();
+
+    errorSpy.mockRestore();
+  });
+});

--- a/static/app/views/dashboards/widgets/widget/widget.stories.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.stories.tsx
@@ -15,6 +15,10 @@ import {Widget} from './widget';
 export const documentation =
   import('!!type-loader!sentry/views/dashboards/widgets/widget/widget');
 
+function BrokenVisualization(): React.ReactNode {
+  throw new Error('Cannot read properties of undefined (reading "series")');
+}
+
 export default Storybook.story('Widget', story => {
   story('Getting Started', () => {
     return (
@@ -296,6 +300,25 @@ function InsightsLineChart() {
 
                 `}
         </CodeBlock>
+      </Fragment>
+    );
+  });
+
+  story('Error states', () => {
+    return (
+      <Fragment>
+        <p>
+          If the visualization (or footer) throws while rendering, the Widget's
+          ErrorBoundary hides the raw error from the user and shows a friendly message
+          plus a "Give Feedback" button. The underlying error is still reported to Sentry.
+        </p>
+
+        <SmallStorybookSizingWindow>
+          <Widget
+            Title={<Widget.WidgetTitle title="epm() : /insights/frontend/assets" />}
+            Visualization={<BrokenVisualization />}
+          />
+        </SmallStorybookSizingWindow>
       </Fragment>
     );
   });

--- a/static/app/views/dashboards/widgets/widget/widget.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.tsx
@@ -5,6 +5,8 @@ import styled from '@emotion/styled';
 import {Container, Flex} from '@sentry/scraps/layout';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
+import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
+import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils/defined';
 import {MIN_HEIGHT, MIN_WIDTH} from 'sentry/views/dashboards/widgets/common/settings';
 
@@ -12,6 +14,25 @@ import {WidgetDescription} from './widgetDescription';
 import {WidgetError} from './widgetError';
 import {WidgetTitle} from './widgetTitle';
 import {WidgetToolbar} from './widgetToolbar';
+
+const RENDER_ERROR_MESSAGE = t('Something went wrong displaying this widget.');
+
+function FeedbackAction() {
+  return (
+    <FeedbackButton
+      size="xs"
+      feedbackOptions={{
+        messagePlaceholder: t('What were you doing when this widget broke?'),
+        tags: {
+          ['feedback.source']: 'dashboards-widget-render-error',
+          ['feedback.owner']: 'dashboards',
+        },
+      }}
+    >
+      {t('Give Feedback')}
+    </FeedbackButton>
+  );
+}
 
 export interface Widget {
   /**
@@ -85,9 +106,13 @@ function WidgetLayout(props: Widget) {
       {props.Visualization && (
         <VisualizationWrapper noPadding={props.noVisualizationPadding}>
           <ErrorBoundary
-            customComponent={({error}) => (
+            // The error itself is reported to Sentry by the ErrorBoundary. We
+            // deliberately don't surface the raw error to the user — it's an
+            // internal code/render error that isn't actionable for them — and
+            // instead show a friendly message with a way to send us feedback.
+            customComponent={() => (
               <Container position="absolute" inset={0}>
-                <WidgetError error={error ?? undefined} />
+                <WidgetError error={RENDER_ERROR_MESSAGE} action={<FeedbackAction />} />
               </Container>
             )}
           >
@@ -99,7 +124,7 @@ function WidgetLayout(props: Widget) {
       {props.Footer && (
         <FooterWrapper noPadding={props.noFooterPadding}>
           <ErrorBoundary
-            customComponent={({error}) => <WidgetError error={error ?? undefined} />}
+            customComponent={() => <WidgetError error={RENDER_ERROR_MESSAGE} />}
           >
             {props.Footer}
           </ErrorBoundary>

--- a/static/app/views/dashboards/widgets/widget/widgetError.tsx
+++ b/static/app/views/dashboards/widgets/widget/widgetError.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import {Flex} from '@sentry/scraps/layout';
+
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {DEEMPHASIS_VARIANT} from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
@@ -10,19 +12,27 @@ import type {
 
 interface WidgetErrorProps {
   error: StateProps['error'];
+  /**
+   * Optional content rendered beneath the error message, e.g. a button that
+   * lets the user retry or send feedback.
+   */
+  action?: React.ReactNode;
 }
 
-export function WidgetError({error}: WidgetErrorProps) {
+export function WidgetError({error, action}: WidgetErrorProps) {
   return (
     <Panel>
       <NonShrinkingWarningIcon variant={DEEMPHASIS_VARIANT} size="md" />
-      <ErrorText>
-        {typeof error === 'string'
-          ? error
-          : ((error as ErrorPropWithResponseJSON)?.responseJSON?.detail.toString() ??
-            error?.message ??
-            t('Error loading data.'))}
-      </ErrorText>
+      <Flex direction="column" align="start" gap="md">
+        <ErrorText>
+          {typeof error === 'string'
+            ? error
+            : ((error as ErrorPropWithResponseJSON)?.responseJSON?.detail?.toString() ??
+              error?.message ??
+              t('Error loading data.'))}
+        </ErrorText>
+        {action}
+      </Flex>
     </Panel>
   );
 }


### PR DESCRIPTION
## Summary

When a dashboard/insights widget threw an error during render, the inner `ErrorBoundary` in the `Widget` component caught it and rendered the **raw `error.message`** directly to the user via `WidgetError`. These are internal, non-actionable code/render errors that shouldn't be exposed.

This shows a friendly message instead — _"Something went wrong displaying this widget."_ — plus a **Give Feedback** button so users can report these non-actionable errors (per discussion on DAIN-1297). The error is still reported to Sentry by the `ErrorBoundary`, so we lose no observability.

The data-loading path (API errors, "no data", invalid-query messages) is intentionally **unchanged** — those messages are deliberate and actionable, so they continue to render as before.

Before
<img width="707" height="283" alt="image" src="https://github.com/user-attachments/assets/323d296c-971e-4150-b0a7-8ec9812cb0fe" />



After
<img width="707" height="283" alt="image" src="https://github.com/user-attachments/assets/065f1ac6-2936-4e60-b0ca-95e0a4d792e6" />

## Changes

- **`widgets/widget/widget.tsx`** — the inner `ErrorBoundary` around `Visualization`/`Footer` no longer forwards the caught error; it renders the generic friendly message. The visualization fallback adds a `FeedbackButton` (tagged `feedback.source: dashboards-widget-render-error`).
- **`widgets/widget/widgetError.tsx`** — added an optional `action` slot rendered beneath the message (used for the feedback button); guarded `responseJSON?.detail?.toString()` so a missing detail can't itself throw.
- **`widgets/widget/widget.spec.tsx`** (new) — verifies the raw error is hidden and the friendly message shown for both `Visualization` and `Footer` throws.
- **`bigNumberWidget/bigNumberWidgetVisualization.spec.tsx`** — this widget throws `Error('Value is not a finite number.')` for non-finite values and relied on the old leak to display it; that non-actionable message now correctly falls behind the friendly message. Updated the test accordingly.

Refs DAIN-1297
