### PR TITLE
ref(dashboards): Remove dashboards-revisions feature flag (frontend)

### DIFF
--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -368,11 +368,7 @@ export function Controls({
               />
             )}
             {!hasPageFrameFeature && renderEditButton(hasFeature)}
-            {hasFeature && (
-              <Feature features="dashboards-revisions">
-                <DashboardRevisionsButton dashboard={dashboard} />
-              </Feature>
-            )}
+            {hasFeature && <DashboardRevisionsButton dashboard={dashboard} />}
             {hasFeature && !isPrebuiltDashboard && !hideAddWidget && (
               <Tooltip
                 title={tooltipMessage}

--- a/static/app/views/dashboards/dashboardRevisions.spec.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.spec.tsx
@@ -57,7 +57,7 @@ function makeSnapshot(overrides = {}) {
 }
 
 function renderButton(dashboardOverrides = {}) {
-  const organization = OrganizationFixture({features: ['dashboards-revisions']});
+  const organization = OrganizationFixture();
   const dashboard = DashboardFixture([], {
     id: '1',
     title: 'My Dashboard',


### PR DESCRIPTION
Dashboard revisions is rolled out to 100%, so this removes the `dashboards-revisions` gate on the frontend. The revisions button now renders whenever the user has dashboard edit access.

## Changes
- Drop the `<Feature features="dashboards-revisions">` wrapper around `DashboardRevisionsButton` in `controls.tsx`.
- Drop the flag from the `dashboardRevisions.spec.tsx` org fixture.

## Notes
The backend flag removal is in a **separate PR** (#116969) since frontend and backend are not atomically deployed. Either order is deploy-safe because the flag is already at 100%.

DAIN-1702