### PR TITLE
fix(tracemetrics): Read equation for total count in widget

### DIFF
--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.spec.tsx
@@ -148,6 +148,77 @@ describe('useWidgetRawCounts', () => {
     await waitFor(() => expect(totalCountRequest).toHaveBeenCalled());
   });
 
+  it('derives the trace metrics count aggregate from equations in the widget', async () => {
+    const selection = PageFiltersFixture({
+      projects: [2],
+      environments: ['prod'],
+      datetime: {
+        start: '2025-01-01T00:00:00',
+        end: '2025-01-02T00:00:00',
+        period: null,
+        utc: null,
+      },
+    });
+    const widget = WidgetFixture({
+      widgetType: WidgetType.TRACEMETRICS,
+      queries: [
+        {
+          name: '',
+          aggregates: [
+            'equation|sum(value,metricA,counter,none) + count(value,metricB,distribution,millisecond)',
+          ],
+          fields: [
+            'equation|sum(value,metricA,counter,none) + count(value,metricB,distribution,millisecond)',
+          ],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const normalRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(value)': 11}]},
+      match: [
+        MockApiClient.matchQuery({
+          sampling: 'NORMAL',
+          dataset: 'tracemetrics',
+          field: ['count(value)'],
+          query:
+            '( metric.name:metricA metric.type:counter ( !has:metric.unit OR metric.unit:none ) ) OR ( metric.name:metricB metric.type:distribution metric.unit:millisecond )',
+          project: [2],
+          environment: ['prod'],
+        }),
+      ],
+    });
+
+    const totalCountRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(value)': 13}]},
+      match: [
+        MockApiClient.matchQuery({
+          sampling: 'NORMAL',
+          dataset: 'tracemetrics',
+          field: ['count(value)'],
+          project: [2],
+          environment: ['prod'],
+          query:
+            '( metric.name:metricA metric.type:counter ( !has:metric.unit OR metric.unit:none ) ) OR ( metric.name:metricB metric.type:distribution metric.unit:millisecond )',
+          extrapolationMode: 'serverOnly',
+          disableAggregateExtrapolation: undefined,
+        }),
+      ],
+    });
+
+    renderHookWithProviders(useWidgetRawCounts, {
+      initialProps: {selection, widget},
+    });
+
+    await waitFor(() => expect(normalRequest).toHaveBeenCalled());
+    await waitFor(() => expect(totalCountRequest).toHaveBeenCalled());
+  });
+
   it('does not fetch raw counts for non-timeseries display types', async () => {
     const selection = PageFiltersFixture();
     const widget = WidgetFixture({

--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
@@ -2,11 +2,14 @@ import {useMemo} from 'react';
 
 import type {PageFilters} from 'sentry/types/core';
 import {defined} from 'sentry/utils/defined';
-import {explodeFieldString} from 'sentry/utils/discover/fields';
+import {explodeFieldString, isEquation} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
-import {createTraceMetricEventsFilter} from 'sentry/views/explore/metrics/utils';
+import {
+  createTraceMetricEventsFilter,
+  getEquationMetricsTotalFilter,
+} from 'sentry/views/explore/metrics/utils';
 import {useRawCounts, type RawCounts} from 'sentry/views/explore/useRawCounts';
 
 type Props = {
@@ -18,6 +21,8 @@ type RawCountConfig = {
   dataset: DiscoverDatasets;
   enabled: boolean;
   supported: boolean;
+  normalModeExtrapolated?: boolean;
+  query?: string;
 };
 
 export function useWidgetRawCounts({selection, widget}: Props): RawCounts | null {
@@ -36,12 +41,32 @@ export function useWidgetRawCounts({selection, widget}: Props): RawCounts | null
           enabled: isSupportedDisplayType,
         };
       case WidgetType.TRACEMETRICS: {
-        const traceMetrics = widget.queries?.[0]?.aggregates
-          ?.map(aggregate => explodeFieldString(aggregate))
-          ?.map(extractTraceMetricFromColumn)
-          ?.filter(defined);
+        // Process all function aggregates and equations to ensure the total count
+        // query can be derived from either
+        // In the current set up, we should only have one or the other being
+        // processed for this raw count
+        const aggregates = widget.queries?.[0]?.aggregates ?? [];
+        const functionAggregates = aggregates.filter(agg => !isEquation(agg));
+        const equationAggregates = aggregates.filter(agg => isEquation(agg));
 
-        if (!defined(traceMetrics) || traceMetrics.length === 0) {
+        const traceMetrics = functionAggregates
+          .map(aggregate => extractTraceMetricFromColumn(explodeFieldString(aggregate)))
+          .filter(defined);
+
+        const filters: string[] = [];
+
+        if (traceMetrics.length > 0) {
+          filters.push(createTraceMetricEventsFilter(traceMetrics));
+        }
+
+        for (const equation of equationAggregates) {
+          const equationFilter = getEquationMetricsTotalFilter(equation);
+          if (equationFilter) {
+            filters.push(equationFilter);
+          }
+        }
+
+        if (filters.length === 0) {
           return {
             supported: true,
             dataset: DiscoverDatasets.TRACEMETRICS,
@@ -53,7 +78,7 @@ export function useWidgetRawCounts({selection, widget}: Props): RawCounts | null
           supported: true,
           dataset: DiscoverDatasets.TRACEMETRICS,
           enabled: isSupportedDisplayType,
-          query: createTraceMetricEventsFilter(traceMetrics),
+          query: filters.join(' OR '),
           normalModeExtrapolated: true,
         };
       }


### PR DESCRIPTION
Process equations to get their total count as well for the confidence footer in dashboard widgets. We were gathering the filter with `extractTraceMetricFromColumn` but this only handles functions. We need to add a branch to handle equations using the helper. There's a chance I can combine the functionality of these, but for now I will push this to patch the behaviour.