### PR TITLE
feat(vsts): Accept the Marketplace account as API pipeline initial data

### DIFF
--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -11,10 +11,12 @@ from django import forms
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 from django.utils.translation import gettext as _
+from rest_framework import serializers
 from rest_framework.fields import CharField
 from rest_framework.serializers import Serializer
 
 from sentry import features, http, options
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
 from sentry.identity.oauth2 import OAuth2ApiStep
@@ -450,6 +452,28 @@ class VstsIntegration(RepositoryIntegration[VstsApiClient], VstsIssuesSpec):
             return None
 
 
+class VstsInitialDataSerializer(CamelSnakeSerializer[dict[str, Any]]):
+    """Optional initial pipeline data for Azure DevOps Marketplace installs.
+
+    The Marketplace redirects to the configure link with `targetId`
+    identifying the Azure DevOps organization the install was started from. We
+    bind it as a pre-selected account so the account-selection step can
+    auto-advance -- but it is still verified against the user's actual Azure
+    DevOps memberships before it's accepted (see VstsAccountSelectionApiStep),
+    so it is only a hint, not a trusted value. In-app installs send no initial
+    data and fall through to the normal picker.
+    """
+
+    target_id = serializers.CharField(required=False)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        target_id = attrs.get("target_id")
+        if not target_id:
+            return {}
+
+        return {"preselected_account_id": target_id}
+
+
 class VstsAccountSelectionSerializer(Serializer):
     account = CharField(required=True)
 
@@ -469,9 +493,7 @@ class VstsAccountSelectionApiStep:
     def get_serializer_cls(self) -> type:
         return VstsAccountSelectionSerializer
 
-    def get_step_data(
-        self, pipeline: IntegrationPipeline, request: HttpRequest
-    ) -> VstsAccountSelectionStepData:
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
         with IntegrationPipelineViewEvent(
             IntegrationPipelineViewType.ACCOUNT_CONFIG,
             IntegrationDomain.SOURCE_CODE_MANAGEMENT,
@@ -495,12 +517,23 @@ class VstsAccountSelectionApiStep:
 
             accounts_list = accounts["value"]
             pipeline.bind_state("accounts", accounts_list)
-            return {
+            step_data: dict[str, Any] = {
                 "accounts": [
                     {"accountId": account["accountId"], "accountName": account["accountName"]}
                     for account in accounts_list
                 ]
             }
+
+            # Marketplace installs pre-select an account via initialData. When
+            # the user is actually a member of it, surface it as the chosen
+            # account so the frontend can advance without prompting; otherwise
+            # fall through to the normal picker. The selection is still verified
+            # in handle_post, so this is purely a UX shortcut.
+            preselected_id = pipeline.fetch_state("preselected_account_id")
+            if preselected_id and get_account_from_id(preselected_id, accounts_list) is not None:
+                step_data["account"] = preselected_id
+
+            return step_data
 
     def handle_post(
         self,
@@ -521,6 +554,9 @@ class VstsAccountSelectionApiStep:
 class VstsIntegrationProvider(IntegrationProvider):
     key = IntegrationProviderSlug.AZURE_DEVOPS.value
     name = "Azure DevOps"
+    # Installs can also be initiated from the Azure DevOps Marketplace, which
+    # drives this same pipeline with the account supplied as initial data.
+    can_add_externally = True
     metadata = metadata
     api_version = "4.1"
     oauth_redirect_url = "/extensions/vsts/setup/"
@@ -595,6 +631,9 @@ class VstsIntegrationProvider(IntegrationProvider):
             self._make_oauth_api_step(),
             VstsAccountSelectionApiStep(),
         ]
+
+    def get_initial_data_serializer_cls(self) -> type[VstsInitialDataSerializer]:
+        return VstsInitialDataSerializer
 
     def _make_oauth_api_step(self) -> OAuth2ApiStep:
         provider = VSTSNewIdentityProvider(

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 from urllib.parse import parse_qs, urlparse
 
+import orjson
 import pytest
 import responses
 from django.http import HttpRequest
@@ -339,6 +340,17 @@ class VstsIntegrationApiPipelineTest(VstsIntegrationTestCase):
             format="json",
         )
 
+    def _initialize_with_initial_data(self, initial_data: dict[str, Any]) -> Any:
+        # Nested initialData must be sent as real JSON; the Django test client
+        # ignores format="json" and would form-encode it.
+        return self.client.post(
+            self._get_pipeline_url(),
+            data=orjson.dumps(
+                {"action": "initialize", "provider": "vsts", "initialData": initial_data}
+            ),
+            content_type="application/json",
+        )
+
     def _advance_step(self, data: dict[str, Any]) -> Any:
         return self.client.post(self._get_pipeline_url(), data=data, format="json")
 
@@ -428,6 +440,54 @@ class VstsIntegrationApiPipelineTest(VstsIntegrationTestCase):
             organization_id=self.organization.id,
             integration=integration,
         ).exists()
+
+    def test_marketplace_install_auto_advances_account_selection(self) -> None:
+        # Marketplace installs supply the account up front as initialData. Since
+        # the user is a member of it, the account-selection step signals
+        # auto-advance with the pre-selected account.
+        resp = self._initialize_with_initial_data({"targetId": self.vsts_account_id})
+        assert resp.status_code == 200, resp.content
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        resp = self._advance_step({"code": "oauth-code", "state": pipeline_signature})
+        assert resp.status_code == 200, resp.content
+        assert resp.data["step"] == "account_selection"
+        # The pre-selected account is surfaced so the frontend can advance
+        # without prompting; its presence is the auto-advance signal.
+        assert resp.data["data"]["account"] == self.vsts_account_id
+
+        # The pre-selected account still goes through the normal verification.
+        resp = self._advance_step({"account": self.vsts_account_id})
+        assert resp.status_code == 200, resp.content
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider="vsts")
+        assert integration.external_id == self.vsts_account_id
+        assert integration.name == self.vsts_account_name
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()
+
+    def test_marketplace_install_does_not_trust_unverified_account(self) -> None:
+        # A targetId the user is not a member of must not auto-advance, and must
+        # be rejected if submitted -- the supplied account is only a hint, never
+        # trusted without membership verification.
+        resp = self._initialize_with_initial_data(
+            {"targetId": "00000000-0000-0000-0000-000000000000"}
+        )
+        assert resp.status_code == 200, resp.content
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        resp = self._advance_step({"code": "oauth-code", "state": pipeline_signature})
+        assert resp.status_code == 200, resp.content
+        assert resp.data["step"] == "account_selection"
+        # No pre-selected account is surfaced, so the frontend shows the picker.
+        assert "account" not in resp.data["data"]
+
+        resp = self._advance_step({"account": "00000000-0000-0000-0000-000000000000"})
+        assert resp.status_code == 400, resp.content
+        assert resp.data["data"]["detail"] == "Invalid Azure DevOps account"
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_account_selection_get_with_no_accounts(self, mock_record: MagicMock) -> None:


### PR DESCRIPTION
First step of folding the Azure DevOps Marketplace install into the main `vsts` provider, replacing the separate `vsts-extension` provider. The historical reason for that second provider was a legacy-pipeline limitation (key-based class lookup, no DI) that the API pipeline removes — and nothing is stored in the DB under `vsts-extension` (the integration and identities are already `vsts`), so collapsing it needs no migration.

This PR teaches the `vsts` API pipeline to accept the pre-known account up front, the same way GitHub/Discord accept their provider-initiated install params.

- Add an optional `VstsInitialDataSerializer`: when the Marketplace supplies `targetId`/`targetName` it validates the org name (`RegexField`) and binds the account to top-level pipeline state. In-app installs send no initial data and are unaffected.
- `VstsAccountSelectionApiStep` auto-advances when an account is already bound: `get_step_data` signals the frontend (`autoAdvance` + `state`) and skips the account lookup, and `handle_post` advances on the echoed state. The interactive picker path is unchanged.
- Mark the provider `can_add_externally` for the Marketplace-initiated install (a no-op while `can_add` stays `True`, matching GitHub/Discord).

No entry-point changes yet: the Marketplace still uses the legacy configure view until the frontend can drive the modal (next PR) and the legacy views + `vsts-extension` provider are removed (final PR).

Refs [VDY-32](https://linear.app/getsentry/issue/VDY-32/migrate-integration-setup-pipelines-to-api-driven-flows)

Part of [VDY-102](https://linear.app/getsentry/issue/VDY-102/azure-devops-extension-api-driven-integration-setup).