### PR TITLE
fix(metrics): sync trace metric from assisted query agent output

### DIFF
--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -294,23 +294,23 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
 
       // Apply Seer's visualizes. Seer should return metric-qualified y-axes
       // (e.g. p75(value, metric.name, distribution, millisecond)), which we pass
-      // through untouched — including conditional `_if` forms that carry a
-      // backtick filter argument. Defensively, if a plain (non-`_if`) y-axis
-      // comes back without a valid metric, we re-qualify it with the resolved
-      // metric so the chart stays aligned with the toolbar/samples. `_if` forms
-      // are never re-qualified since makeMetricsAggregate can't reconstruct the
-      // filter argument. In samples mode there's no visualize, so build a
-      // default one from the metric's type. When Seer didn't resolve a valid
-      // metric, leave the existing visualizes untouched so we don't clobber a
-      // customized aggregate.
+      // through untouched. Visualize aggregates are always in plain
+      // op(value,metric,type,unit) form — conditional `_if` aggregates are
+      // normalized to a plain aggregate plus a query filter before reaching a
+      // visualize (see parseAggregateExpression) — so re-qualifying never drops
+      // a filter argument. Defensively, if a y-axis comes back without a valid
+      // metric, we re-qualify it with the resolved metric so the chart stays
+      // aligned with the toolbar/samples. In samples mode there's no visualize,
+      // so build a default one from the metric's type. When Seer didn't resolve
+      // a valid metric, leave the existing visualizes untouched so we don't
+      // clobber a customized aggregate.
       if (seerVisualizes.length > 0) {
         for (const viz of seerVisualizes) {
           const {aggregation, traceMetric: vizMetric} = parseMetricAggregate(viz.yAxis);
           const isQualified = Boolean(
             vizMetric.name && vizMetric.type && isTraceMetricTypeValue(vizMetric.type)
           );
-          const isConditional = aggregation.endsWith('_if');
-          if (!isQualified && !isConditional && resolvedMetric) {
+          if (!isQualified && resolvedMetric) {
             aggregateFields.push(
               viz.replace({
                 yAxis: makeMetricsAggregate({

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -226,8 +226,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       // the metric name/type/unit out of the visualize aggregate (e.g.
       // p75(value, metric.name, distribution, millisecond)); if it's not there
       // we read metric.name/type/unit filters from the query (typically only
-      // present in samples mode), always stripping them from the outputted
-      // query since the metric is tracked on the panel rather than the query.
+      // present in samples mode).
       const search = new MutableSearch(queryToUse);
 
       const visualizationTraceMetric = visualizations
@@ -246,10 +245,6 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       const queryMetricUnit = search.getFilterValues(
         TraceMetricKnownFieldKey.METRIC_UNIT
       )[0];
-      search.removeFilter(TraceMetricKnownFieldKey.METRIC_NAME);
-      search.removeFilter(TraceMetricKnownFieldKey.METRIC_TYPE);
-      search.removeFilter(TraceMetricKnownFieldKey.METRIC_UNIT);
-      const cleanedQuery = search.formatString();
 
       // The metric Seer actually specified, if any. We require a valid metric
       // type and prefer the visualization metric, falling back to the query
@@ -278,6 +273,18 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       }
       const nextMetric = resolvedMetric ?? traceMetric;
 
+      // Only strip the metric filters from the query when we actually adopted a
+      // metric (it's then tracked on the panel, not the query). If we couldn't
+      // resolve one, leave the query untouched so it stays consistent with the
+      // unchanged panel metric.
+      let cleanedQuery = queryToUse;
+      if (resolvedMetric) {
+        search.removeFilter(TraceMetricKnownFieldKey.METRIC_NAME);
+        search.removeFilter(TraceMetricKnownFieldKey.METRIC_TYPE);
+        search.removeFilter(TraceMetricKnownFieldKey.METRIC_UNIT);
+        cleanedQuery = search.formatString();
+      }
+
       // Build aggregateFields: groupBys first, then visualizes
       const aggregateFields: AggregateField[] = [];
 
@@ -288,17 +295,22 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       // Apply Seer's visualizes. Seer should return metric-qualified y-axes
       // (e.g. p75(value, metric.name, distribution, millisecond)), which we pass
       // through untouched — including conditional `_if` forms that carry a
-      // filter argument. Defensively, if a y-axis comes back unqualified we
-      // re-qualify it with the resolved metric so the chart stays aligned with
-      // the toolbar/samples. In samples mode there's no visualize, so build a
+      // backtick filter argument. Defensively, if a plain (non-`_if`) y-axis
+      // comes back without a valid metric, we re-qualify it with the resolved
+      // metric so the chart stays aligned with the toolbar/samples. `_if` forms
+      // are never re-qualified since makeMetricsAggregate can't reconstruct the
+      // filter argument. In samples mode there's no visualize, so build a
       // default one from the metric's type. When Seer didn't resolve a valid
       // metric, leave the existing visualizes untouched so we don't clobber a
       // customized aggregate.
       if (seerVisualizes.length > 0) {
         for (const viz of seerVisualizes) {
           const {aggregation, traceMetric: vizMetric} = parseMetricAggregate(viz.yAxis);
-          const isQualified = Boolean(vizMetric.name && vizMetric.type);
-          if (!isQualified && resolvedMetric) {
+          const isQualified = Boolean(
+            vizMetric.name && vizMetric.type && isTraceMetricTypeValue(vizMetric.type)
+          );
+          const isConditional = aggregation.endsWith('_if');
+          if (!isQualified && !isConditional && resolvedMetric) {
             aggregateFields.push(
               viz.replace({
                 yAxis: makeMetricsAggregate({

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -254,16 +254,26 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       search.removeFilter(TraceMetricKnownFieldKey.METRIC_UNIT);
       const cleanedQuery = search.formatString();
 
-      let nextMetric = traceMetric;
+      // The metric Seer actually specified, if any. Left undefined when the
+      // response neither embeds a metric in a visualization nor names one in the
+      // query — in that case we keep the panel's existing metric untouched.
+      let resolvedMetric: TraceMetric | undefined;
       if (visualizationTraceMetric) {
-        nextMetric = visualizationTraceMetric;
+        // parseMetricAggregate leaves unit undefined when the aggregate omits
+        // the unit arg; normalize to NONE_UNIT so downstream sample queries keep
+        // the same unit scoping as the query-filter path below.
+        resolvedMetric = {
+          ...visualizationTraceMetric,
+          unit: visualizationTraceMetric.unit ?? NONE_UNIT,
+        };
       } else if (queryMetricName && queryMetricType) {
-        nextMetric = {
+        resolvedMetric = {
           name: queryMetricName,
           type: queryMetricType,
           unit: queryMetricUnit ?? NONE_UNIT,
-        } satisfies TraceMetric;
+        };
       }
+      const nextMetric = resolvedMetric ?? traceMetric;
 
       // Build aggregateFields: groupBys first, then visualizes
       const aggregateFields: AggregateField[] = [];
@@ -273,19 +283,23 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       }
 
       // Use Seer visualizes if provided. In samples mode Seer returns no
-      // visualization, so build a default visualize from the metric type (the
-      // metric came from the query filters above) to keep the chart in sync
-      // with the selected metric. Fall back to preserving existing visualizes
-      // only when we couldn't resolve a metric at all.
+      // visualization, so when it picked a new metric (via the query filters
+      // above) build a default visualize from that metric's type to keep the
+      // chart in sync. Otherwise preserve the existing visualizes — Seer didn't
+      // choose a metric, so we must not clobber a customized aggregate with the
+      // type default.
       if (seerVisualizes.length > 0) {
         for (const viz of seerVisualizes) {
           aggregateFields.push(viz);
         }
-      } else if (nextMetric.name && nextMetric.type) {
-        const defaultAggregate = DEFAULT_YAXIS_BY_TYPE[nextMetric.type] ?? 'count';
+      } else if (resolvedMetric) {
+        const defaultAggregate = DEFAULT_YAXIS_BY_TYPE[resolvedMetric.type] ?? 'count';
         aggregateFields.push(
           new VisualizeFunction(
-            makeMetricsAggregate({aggregate: defaultAggregate, traceMetric: nextMetric})
+            makeMetricsAggregate({
+              aggregate: defaultAggregate,
+              traceMetric: resolvedMetric,
+            })
           )
         );
       } else {

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -12,6 +12,7 @@ import {
   useSearchQueryBuilderState,
 } from 'sentry/components/searchQueryBuilder/context';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
+import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {Token} from 'sentry/components/searchSyntax/parser';
 import {stringifyToken} from 'sentry/components/searchSyntax/utils';
 import {ConfigStore} from 'sentry/stores/configStore';
@@ -24,7 +25,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
-import {NONE_UNIT} from 'sentry/views/explore/metrics/constants';
+import {DEFAULT_YAXIS_BY_TYPE, NONE_UNIT} from 'sentry/views/explore/metrics/constants';
 import {
   defaultAggregateSortBys,
   encodeMetricQueryParams,
@@ -33,6 +34,8 @@ import {
 } from 'sentry/views/explore/metrics/metricQuery';
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
+import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
+import {makeMetricsAggregate} from 'sentry/views/explore/metrics/utils';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {useQueryParams} from 'sentry/views/explore/queryParams/context';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
@@ -216,18 +219,51 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         viz.yAxes.map(yAxis => new VisualizeFunction(yAxis, {chartType: viz.chartType}))
       );
 
-      // The Seer response embeds the metric inside the visualization aggregate
-      // (e.g. p75(value, metric.name, distribution, millisecond)). Extract it
-      // so we can keep the panel's TraceMetric in sync with the aggregate —
-      // otherwise the toolbar, samples table, and timeseries queries keep
-      // using the previously-selected metric. We scan every y-axis we're about
-      // to encode (not just the first visualization's), since the
-      // metric-qualified aggregate may live in a later visualization.
-      const seerTraceMetric = visualizations
+      // Keep the panel's TraceMetric in sync with what Seer queried — otherwise
+      // the toolbar, samples table, and timeseries queries keep using the
+      // previously-selected metric.
+      //
+      // In aggregate mode the metric is embedded in the visualization aggregate
+      // (e.g. p75(value, metric.name, distribution, millisecond)), so we scan
+      // every y-axis we're about to encode (not just the first visualization's,
+      // since the metric-qualified aggregate may live in a later visualization).
+      //
+      // In samples mode there are no visualizations and the metric is expressed
+      // as `metric.name:...`/`metric.type:...`/`metric.unit:...` filters in the
+      // query instead. We pull them out of the query and always strip them from
+      // the outputted query, since the metric is tracked on the panel rather
+      // than the query.
+      const search = new MutableSearch(queryToUse);
+
+      const visualizationTraceMetric = visualizations
         .flatMap(viz => viz.yAxes)
         .map(yAxis => parseMetricAggregate(yAxis).traceMetric)
         .find(metric => metric.name && metric.type);
-      const nextMetric = seerTraceMetric ?? traceMetric;
+
+      const queryMetricName = search.getFilterValues(
+        TraceMetricKnownFieldKey.METRIC_NAME
+      )[0];
+      const queryMetricType = search.getFilterValues(
+        TraceMetricKnownFieldKey.METRIC_TYPE
+      )[0];
+      const queryMetricUnit = search.getFilterValues(
+        TraceMetricKnownFieldKey.METRIC_UNIT
+      )[0];
+      search.removeFilter(TraceMetricKnownFieldKey.METRIC_NAME);
+      search.removeFilter(TraceMetricKnownFieldKey.METRIC_TYPE);
+      search.removeFilter(TraceMetricKnownFieldKey.METRIC_UNIT);
+      const cleanedQuery = search.formatString();
+
+      let nextMetric = traceMetric;
+      if (visualizationTraceMetric) {
+        nextMetric = visualizationTraceMetric;
+      } else if (queryMetricName && queryMetricType) {
+        nextMetric = {
+          name: queryMetricName,
+          type: queryMetricType,
+          unit: queryMetricUnit ?? NONE_UNIT,
+        } satisfies TraceMetric;
+      }
 
       // Build aggregateFields: groupBys first, then visualizes
       const aggregateFields: AggregateField[] = [];
@@ -236,11 +272,22 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         aggregateFields.push({groupBy});
       }
 
-      // Use Seer visualizes if provided, otherwise preserve existing
+      // Use Seer visualizes if provided. In samples mode Seer returns no
+      // visualization, so build a default visualize from the metric type (the
+      // metric came from the query filters above) to keep the chart in sync
+      // with the selected metric. Fall back to preserving existing visualizes
+      // only when we couldn't resolve a metric at all.
       if (seerVisualizes.length > 0) {
         for (const viz of seerVisualizes) {
           aggregateFields.push(viz);
         }
+      } else if (nextMetric.name && nextMetric.type) {
+        const defaultAggregate = DEFAULT_YAXIS_BY_TYPE[nextMetric.type] ?? 'count';
+        aggregateFields.push(
+          new VisualizeFunction(
+            makeMetricsAggregate({aggregate: defaultAggregate, traceMetric: nextMetric})
+          )
+        );
       } else {
         for (const field of queryParams.aggregateFields) {
           if (isVisualize(field)) {
@@ -267,7 +314,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
 
       // Build updated ReadableQueryParams for this metric
       const newQueryParams = queryParams.replace({
-        query: queryToUse,
+        query: cleanedQuery,
         aggregateFields,
         aggregateSortBys,
         sortBys,
@@ -276,7 +323,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
 
       // Build encoded metric queries, updating the current metric's query params
       // and trace metric (the metric is parsed out of the agent's visualization
-      // aggregate above so the panel matches what was queried).
+      // aggregate or query filters above so the panel matches what was queried).
       const newEncodedMetrics = metricQueries
         .map((mq: BaseMetricQuery) => {
           if (mq.queryParams === queryParams) {
@@ -305,7 +352,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
 
       askSeerSuggestedQueryRef.current = JSON.stringify({
         selection,
-        query: queryToUse,
+        query: cleanedQuery,
         groupBys,
         mode,
       });
@@ -313,7 +360,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       trackAnalytics('ai_query.applied', {
         organization,
         area: analyticsArea,
-        query: queryToUse,
+        query: cleanedQuery,
         group_by_count: groupBys.length,
         visualize_count: visualizations?.length ?? 0,
       });

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -220,13 +220,14 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       // (e.g. p75(value, metric.name, distribution, millisecond)). Extract it
       // so we can keep the panel's TraceMetric in sync with the aggregate —
       // otherwise the toolbar, samples table, and timeseries queries keep
-      // using the previously-selected metric.
-      const firstSeerYAxis = visualizations[0]?.yAxes[0];
-      const seerTraceMetric = firstSeerYAxis
-        ? parseMetricAggregate(firstSeerYAxis).traceMetric
-        : undefined;
-      const nextMetric =
-        seerTraceMetric?.name && seerTraceMetric.type ? seerTraceMetric : traceMetric;
+      // using the previously-selected metric. We scan every y-axis we're about
+      // to encode (not just the first visualization's), since the
+      // metric-qualified aggregate may live in a later visualization.
+      const seerTraceMetric = visualizations
+        .flatMap(viz => viz.yAxes)
+        .map(yAxis => parseMetricAggregate(yAxis).traceMetric)
+        .find(metric => metric.name && metric.type);
+      const nextMetric = seerTraceMetric ?? traceMetric;
 
       // Build aggregateFields: groupBys first, then visualizes
       const aggregateFields: AggregateField[] = [];

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -32,6 +32,7 @@ import {
   type TraceMetric,
 } from 'sentry/views/explore/metrics/metricQuery';
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {useQueryParams} from 'sentry/views/explore/queryParams/context';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
@@ -215,6 +216,18 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         viz.yAxes.map(yAxis => new VisualizeFunction(yAxis, {chartType: viz.chartType}))
       );
 
+      // The Seer response embeds the metric inside the visualization aggregate
+      // (e.g. p75(value, metric.name, distribution, millisecond)). Extract it
+      // so we can keep the panel's TraceMetric in sync with the aggregate —
+      // otherwise the toolbar, samples table, and timeseries queries keep
+      // using the previously-selected metric.
+      const firstSeerYAxis = visualizations[0]?.yAxes[0];
+      const seerTraceMetric = firstSeerYAxis
+        ? parseMetricAggregate(firstSeerYAxis).traceMetric
+        : undefined;
+      const nextMetric =
+        seerTraceMetric?.name && seerTraceMetric.type ? seerTraceMetric : traceMetric;
+
       // Build aggregateFields: groupBys first, then visualizes
       const aggregateFields: AggregateField[] = [];
 
@@ -261,10 +274,16 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       });
 
       // Build encoded metric queries, updating the current metric's query params
+      // and trace metric (the metric is parsed out of the agent's visualization
+      // aggregate above so the panel matches what was queried).
       const newEncodedMetrics = metricQueries
         .map((mq: BaseMetricQuery) => {
           if (mq.queryParams === queryParams) {
-            return encodeMetricQueryParams({...mq, queryParams: newQueryParams});
+            return encodeMetricQueryParams({
+              ...mq,
+              metric: nextMetric,
+              queryParams: newQueryParams,
+            });
           }
           return encodeMetricQueryParams(mq);
         })
@@ -330,6 +349,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       pageFilters.selection,
       queryParams,
       setRunId,
+      traceMetric,
     ]
   );
 

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -219,20 +219,12 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         viz.yAxes.map(yAxis => new VisualizeFunction(yAxis, {chartType: viz.chartType}))
       );
 
-      // Keep the panel's TraceMetric in sync with what Seer queried — otherwise
-      // the toolbar, samples table, and timeseries queries keep using the
-      // previously-selected metric.
-      //
-      // In aggregate mode the metric is embedded in the visualization aggregate
-      // (e.g. p75(value, metric.name, distribution, millisecond)), so we scan
-      // every y-axis we're about to encode (not just the first visualization's,
-      // since the metric-qualified aggregate may live in a later visualization).
-      //
-      // In samples mode there are no visualizations and the metric is expressed
-      // as `metric.name:...`/`metric.type:...`/`metric.unit:...` filters in the
-      // query instead. We pull them out of the query and always strip them from
-      // the outputted query, since the metric is tracked on the panel rather
-      // than the query.
+      // Keep the panel's TraceMetric in sync with what Seer queried. We parse
+      // the metric name/type/unit out of the visualize aggregate (e.g.
+      // p75(value, metric.name, distribution, millisecond)); if it's not there
+      // we read metric.name/type/unit filters from the query (typically only
+      // present in samples mode), always stripping them from the outputted
+      // query since the metric is tracked on the panel rather than the query.
       const search = new MutableSearch(queryToUse);
 
       const visualizationTraceMetric = visualizations

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -34,7 +34,10 @@ import {
 } from 'sentry/views/explore/metrics/metricQuery';
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
-import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
+import {
+  isTraceMetricTypeValue,
+  TraceMetricKnownFieldKey,
+} from 'sentry/views/explore/metrics/types';
 import {makeMetricsAggregate} from 'sentry/views/explore/metrics/utils';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {useQueryParams} from 'sentry/views/explore/queryParams/context';
@@ -265,6 +268,13 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
           unit: queryMetricUnit ?? NONE_UNIT,
         };
       }
+
+      // We expect a valid metric type. If it's missing or unrecognized, leave
+      // the panel's metric and visualizes untouched rather than guessing a
+      // default aggregate.
+      if (resolvedMetric && !isTraceMetricTypeValue(resolvedMetric.type)) {
+        resolvedMetric = undefined;
+      }
       const nextMetric = resolvedMetric ?? traceMetric;
 
       // Build aggregateFields: groupBys first, then visualizes
@@ -274,26 +284,41 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         aggregateFields.push({groupBy});
       }
 
-      // Use Seer visualizes if provided. In samples mode Seer returns no
-      // visualization, so when it picked a new metric (via the query filters
-      // above) build a default visualize from that metric's type to keep the
-      // chart in sync. Otherwise preserve the existing visualizes — Seer didn't
-      // choose a metric, so we must not clobber a customized aggregate with the
-      // type default.
+      // Apply Seer's visualizes, re-qualifying each aggregate with the resolved
+      // metric so the chart targets the same metric as the toolbar/samples —
+      // Seer sometimes returns unqualified y-axes (e.g. p75(value)) while naming
+      // the metric only in the query. In samples mode there's no visualize, so
+      // build a default one from the metric's type. When Seer didn't resolve a
+      // valid metric, leave the existing visualizes untouched so we don't
+      // clobber a customized aggregate.
       if (seerVisualizes.length > 0) {
         for (const viz of seerVisualizes) {
-          aggregateFields.push(viz);
+          if (resolvedMetric) {
+            const {aggregation} = parseMetricAggregate(viz.yAxis);
+            aggregateFields.push(
+              viz.replace({
+                yAxis: makeMetricsAggregate({
+                  aggregate: aggregation,
+                  traceMetric: resolvedMetric,
+                }),
+              })
+            );
+          } else {
+            aggregateFields.push(viz);
+          }
         }
       } else if (resolvedMetric) {
-        const defaultAggregate = DEFAULT_YAXIS_BY_TYPE[resolvedMetric.type] ?? 'count';
-        aggregateFields.push(
-          new VisualizeFunction(
-            makeMetricsAggregate({
-              aggregate: defaultAggregate,
-              traceMetric: resolvedMetric,
-            })
-          )
-        );
+        const defaultAggregate = DEFAULT_YAXIS_BY_TYPE[resolvedMetric.type];
+        if (defaultAggregate) {
+          aggregateFields.push(
+            new VisualizeFunction(
+              makeMetricsAggregate({
+                aggregate: defaultAggregate,
+                traceMetric: resolvedMetric,
+              })
+            )
+          );
+        }
       } else {
         for (const field of queryParams.aggregateFields) {
           if (isVisualize(field)) {

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -233,7 +233,9 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       const visualizationTraceMetric = visualizations
         .flatMap(viz => viz.yAxes)
         .map(yAxis => parseMetricAggregate(yAxis).traceMetric)
-        .find(metric => metric.name && metric.type);
+        .find(
+          metric => metric.name && metric.type && isTraceMetricTypeValue(metric.type)
+        );
 
       const queryMetricName = search.getFilterValues(
         TraceMetricKnownFieldKey.METRIC_NAME
@@ -249,9 +251,11 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       search.removeFilter(TraceMetricKnownFieldKey.METRIC_UNIT);
       const cleanedQuery = search.formatString();
 
-      // The metric Seer actually specified, if any. Left undefined when the
-      // response neither embeds a metric in a visualization nor names one in the
-      // query — in that case we keep the panel's existing metric untouched.
+      // The metric Seer actually specified, if any. We require a valid metric
+      // type and prefer the visualization metric, falling back to the query
+      // filters. Left undefined when neither source yields a valid metric — in
+      // that case we keep the panel's existing metric untouched rather than
+      // guessing a default aggregate.
       let resolvedMetric: TraceMetric | undefined;
       if (visualizationTraceMetric) {
         // parseMetricAggregate leaves unit undefined when the aggregate omits
@@ -261,19 +265,16 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
           ...visualizationTraceMetric,
           unit: visualizationTraceMetric.unit ?? NONE_UNIT,
         };
-      } else if (queryMetricName && queryMetricType) {
+      } else if (
+        queryMetricName &&
+        queryMetricType &&
+        isTraceMetricTypeValue(queryMetricType)
+      ) {
         resolvedMetric = {
           name: queryMetricName,
           type: queryMetricType,
           unit: queryMetricUnit ?? NONE_UNIT,
         };
-      }
-
-      // We expect a valid metric type. If it's missing or unrecognized, leave
-      // the panel's metric and visualizes untouched rather than guessing a
-      // default aggregate.
-      if (resolvedMetric && !isTraceMetricTypeValue(resolvedMetric.type)) {
-        resolvedMetric = undefined;
       }
       const nextMetric = resolvedMetric ?? traceMetric;
 
@@ -284,17 +285,20 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         aggregateFields.push({groupBy});
       }
 
-      // Apply Seer's visualizes, re-qualifying each aggregate with the resolved
-      // metric so the chart targets the same metric as the toolbar/samples —
-      // Seer sometimes returns unqualified y-axes (e.g. p75(value)) while naming
-      // the metric only in the query. In samples mode there's no visualize, so
-      // build a default one from the metric's type. When Seer didn't resolve a
-      // valid metric, leave the existing visualizes untouched so we don't
-      // clobber a customized aggregate.
+      // Apply Seer's visualizes. Seer should return metric-qualified y-axes
+      // (e.g. p75(value, metric.name, distribution, millisecond)), which we pass
+      // through untouched — including conditional `_if` forms that carry a
+      // filter argument. Defensively, if a y-axis comes back unqualified we
+      // re-qualify it with the resolved metric so the chart stays aligned with
+      // the toolbar/samples. In samples mode there's no visualize, so build a
+      // default one from the metric's type. When Seer didn't resolve a valid
+      // metric, leave the existing visualizes untouched so we don't clobber a
+      // customized aggregate.
       if (seerVisualizes.length > 0) {
         for (const viz of seerVisualizes) {
-          if (resolvedMetric) {
-            const {aggregation} = parseMetricAggregate(viz.yAxis);
+          const {aggregation, traceMetric: vizMetric} = parseMetricAggregate(viz.yAxis);
+          const isQualified = Boolean(vizMetric.name && vizMetric.type);
+          if (!isQualified && resolvedMetric) {
             aggregateFields.push(
               viz.replace({
                 yAxis: makeMetricsAggregate({


### PR DESCRIPTION
Trying to make the explore ui more robust with agentic query outputs. For example we prioritize the 4 args format to extract metric.name and metric.type, but if somehow it's not there, we try to grab it from the query. We also always omit metric.name/type/unit from the search bar, as it's selected in the dropdown

## Ai Summary

The metrics assisted-query agent encodes which metric a query targets in two different places depending on mode:

- **Aggregate mode** → inside the visualization aggregate, e.g. `p75(value, db.duration, distribution, millisecond)`
- **Samples mode** → as `metric.name:` / `metric.type:` / `metric.unit:` filters in the query string

The previous apply path only updated the y-axis string and never updated the panel's `BaseMetricQuery.metric`, so the toolbar, samples table, and timeseries query kept pointing at the previously-selected metric — recreating a toolbar/chart mismatch.

This keeps the panel's `TraceMetric` in sync with whatever the agent actually queried:

- Scans **every** agent y-axis (not just `visualizations[0].yAxes[0]`) for the first metric-qualified aggregate.
- Falls back to parsing `metric.name` / `metric.type` / `metric.unit` out of the query when there's no visualization.
- **Always strips** `metric.name` / `metric.type` / `metric.unit` from the outputted query (the metric is tracked on the panel, not the query).
- When there's no visualization, synthesizes a default visualize from `DEFAULT_YAXIS_BY_TYPE` so the chart matches the resolved metric.
- Branches on whether a visualization/metric is actually present rather than the agent's `mode` flag, so a malformed response is handled the same way.

### Examples

| Agent returns | Resolved metric | Outputted query | Visualize |
| --- | --- | --- | --- |
| Aggregate w/ `p75(value, db.duration, distribution, ms)` | `db.duration` / distribution / ms | unchanged | agent's `p75(...)` |
| Multiple viz, metric only in a later y-axis | first metric-qualified y-axis wins | unchanged | agent's |
| Samples, query `metric.name:db.duration metric.type:distribution latency:>1s` | `db.duration` / distribution | `latency:>1s` | `sum(value, db.duration, ...)` (default for type) |
| Aggregate mode but no visualization, metric in query | resolved from query filters | filters stripped | default for type |
| No visualization and no metric anywhere | previous metric preserved | unchanged | existing visualizes preserved |

DAIN-1703

## Test plan

- [ ] In Explore → Metrics, type a natural-language query targeting a metric different from the currently selected one and confirm the toolbar, samples table, and chart all switch to the agent's chosen metric.
- [ ] Repeat in samples mode and verify the metric resolves from the query filters and those filters are stripped from the applied query.
- [ ] Verify behavior is unchanged when the agent returns no visualizations and no metric (existing metric/visualizes preserved).
