### PR TITLE
fix(ourlogs): use dynamic back-to-top button offset

### DIFF
--- a/static/app/components/scrollCarousel.tsx
+++ b/static/app/components/scrollCarousel.tsx
@@ -8,6 +8,7 @@ import {Button} from '@sentry/scraps/button';
 
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {getOffsetRect} from 'sentry/utils/getOffsetRect';
 import type {SpaceSize} from 'sentry/utils/theme';
 import {useRefChildrenVisibility} from 'sentry/utils/useRefChildrenVisibility';
 
@@ -38,25 +39,6 @@ const DEFAULT_VISIBLE_RATIO = 0.85;
  * when the arrow buttons are clicked
  */
 const DEFAULT_JUMP_ITEM_COUNT = 2;
-
-/**
- * Calculates the offset rectangle of an element relative to another element.
- */
-const getOffsetRect = (el: HTMLElement, relativeTo: HTMLElement) => {
-  const rect = el.getBoundingClientRect();
-  if (!relativeTo) {
-    return rect;
-  }
-  const relativeRect = relativeTo.getBoundingClientRect();
-  return {
-    left: rect.left - relativeRect.left,
-    top: rect.top - relativeRect.top,
-    right: rect.right - relativeRect.left,
-    bottom: rect.bottom - relativeRect.top,
-    width: rect.width,
-    height: rect.height,
-  };
-};
 
 export function ScrollCarousel({
   children,

--- a/static/app/utils/getOffsetRect.tsx
+++ b/static/app/utils/getOffsetRect.tsx
@@ -1,0 +1,25 @@
+interface OffsetRect {
+  bottom: number;
+  height: number;
+  left: number;
+  right: number;
+  top: number;
+  width: number;
+}
+
+/**
+ * Calculates the bounding rectangle of an element expressed relative to another
+ * element's top-left corner, rather than relative to the viewport.
+ */
+export function getOffsetRect(el: HTMLElement, relativeTo: HTMLElement): OffsetRect {
+  const rect = el.getBoundingClientRect();
+  const relativeRect = relativeTo.getBoundingClientRect();
+  return {
+    left: rect.left - relativeRect.left,
+    top: rect.top - relativeRect.top,
+    right: rect.right - relativeRect.left,
+    bottom: rect.bottom - relativeRect.top,
+    width: rect.width,
+    height: rect.height,
+  };
+}

--- a/static/app/utils/useElementOffset.spec.tsx
+++ b/static/app/utils/useElementOffset.spec.tsx
@@ -1,0 +1,93 @@
+import {useRef} from 'react';
+
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {useElementOffset} from 'sentry/utils/useElementOffset';
+
+function rect(top: number, left: number): DOMRect {
+  return {
+    top,
+    left,
+    bottom: top,
+    right: left,
+    width: 0,
+    height: 0,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  };
+}
+
+function TestComponent() {
+  const elementRef = useRef<HTMLDivElement>(null);
+  const relativeToRef = useRef<HTMLDivElement>(null);
+  const {top, left} = useElementOffset(elementRef, relativeToRef);
+
+  return (
+    <div ref={relativeToRef} data-role="relative">
+      <div ref={elementRef} data-role="element" />
+      <span data-test-id="offset">{`${top},${left}`}</span>
+    </div>
+  );
+}
+
+describe('useElementOffset', () => {
+  let resizeCallback: ResizeObserverCallback | undefined;
+  const disconnect = jest.fn();
+  let elementRect = rect(0, 0);
+  let relativeRect = rect(0, 0);
+
+  beforeEach(() => {
+    resizeCallback = undefined;
+    elementRect = rect(0, 0);
+    relativeRect = rect(0, 0);
+
+    window.ResizeObserver = jest.fn().mockImplementation(callback => {
+      resizeCallback = callback;
+      return {observe: jest.fn(), unobserve: jest.fn(), disconnect};
+    });
+
+    jest
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        if (this.dataset.role === 'element') {
+          return elementRect;
+        }
+        if (this.dataset.role === 'relative') {
+          return relativeRect;
+        }
+        return rect(0, 0);
+      });
+  });
+
+  it('returns the offset of the element relative to the other element on mount', () => {
+    elementRect = rect(120, 40);
+    relativeRect = rect(50, 10);
+
+    render(<TestComponent />);
+
+    expect(screen.getByTestId('offset')).toHaveTextContent('70,30');
+  });
+
+  it('re-measures when the ResizeObserver fires', () => {
+    elementRect = rect(120, 40);
+    relativeRect = rect(50, 10);
+
+    render(<TestComponent />);
+
+    elementRect = rect(200, 40);
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver);
+    });
+
+    expect(screen.getByTestId('offset')).toHaveTextContent('150,30');
+  });
+
+  it('disconnects the observer on unmount', () => {
+    const {unmount} = render(<TestComponent />);
+
+    unmount();
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/utils/useElementOffset.tsx
+++ b/static/app/utils/useElementOffset.tsx
@@ -1,0 +1,44 @@
+import type {RefObject} from 'react';
+import {useLayoutEffect, useState} from 'react';
+
+import {getOffsetRect} from 'sentry/utils/getOffsetRect';
+
+interface ElementOffset {
+  left: number;
+  top: number;
+}
+
+/**
+ * Returns the offset of an element relative to another element (e.g. an
+ * element's top edge relative to a container). The offset is re-measured via a
+ * ResizeObserver on both elements, so it stays correct as either element
+ * resizes. Both elements are expected to be mounted while the hook is in use.
+ */
+export function useElementOffset(
+  elementRef: RefObject<HTMLElement | null>,
+  relativeToRef: RefObject<HTMLElement | null>
+): ElementOffset {
+  const [offset, setOffset] = useState({left: 0, top: 0});
+
+  useLayoutEffect(() => {
+    const element = elementRef.current;
+    const relativeTo = relativeToRef.current;
+    if (!element || !relativeTo) {
+      return () => {};
+    }
+
+    const measure = () => {
+      const {left, top} = getOffsetRect(element, relativeTo);
+      setOffset({left, top});
+    };
+
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    observer.observe(relativeTo);
+    return () => observer.disconnect();
+  }, [elementRef, relativeToRef]);
+
+  return offset;
+}

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -499,9 +499,7 @@ export const FloatingBackToTopContainer = styled('div')<{
   z-index: 1;
   opacity: ${p => (p.inReplay ? 1 : 0.9)};
   top: ${p =>
-    p.inReplay
-      ? p.theme.space.md
-      : `calc(${p.topOffset ?? 65}px + ${p.theme.space.xl})`};
+    p.inReplay ? p.theme.space.md : `calc(${p.topOffset ?? 65}px + ${p.theme.space.xl})`};
   width: var(--floatingWidth);
   display: flex;
   justify-content: center;

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -492,12 +492,13 @@ export const FloatingBackToTopContainer = styled('div')<{
   inReplay?: boolean;
   position?: 'absolute' | 'fixed';
   tableWidth?: number;
+  topOffset?: number;
 }>`
   --floatingWidth: ${p => (p.tableWidth ? `${p.tableWidth}px` : '100%')};
   position: ${p => p.position};
   z-index: 1;
   opacity: ${p => (p.inReplay ? 1 : 0.9)};
-  top: ${p => (p.inReplay ? p.theme.space.md : '65px')};
+  top: ${p => (p.inReplay ? p.theme.space.md : `${p.topOffset ?? 65}px`)};
   width: var(--floatingWidth);
   display: flex;
   justify-content: center;

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -498,7 +498,10 @@ export const FloatingBackToTopContainer = styled('div')<{
   position: ${p => p.position};
   z-index: 1;
   opacity: ${p => (p.inReplay ? 1 : 0.9)};
-  top: ${p => (p.inReplay ? p.theme.space.md : `${p.topOffset ?? 65}px`)};
+  top: ${p =>
+    p.inReplay
+      ? p.theme.space.md
+      : `calc(${p.topOffset ?? 65}px + ${p.theme.space.xl})`};
   width: var(--floatingWidth);
   display: flex;
   justify-content: center;

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -30,6 +30,7 @@ import type {TagCollection} from 'sentry/types/group';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {defined} from 'sentry/utils/defined';
 import {useDimensions} from 'sentry/utils/useDimensions';
+import {useElementOffset} from 'sentry/utils/useElementOffset';
 import {
   TableBodyCell,
   TableHead,
@@ -232,6 +233,7 @@ export function LogsInfiniteTable({
   const tableRef = useRef<HTMLTableElement>(null);
   const tableBodyRef = useRef<HTMLTableSectionElement>(null);
   const {width: tableWidth} = useDimensions({elementRef: tableRef});
+  const {top: backToTopOffset} = useElementOffset(tableBodyRef, tableRef);
   const [expandedLogRows, setExpandedLogRows] = useState(
     new Set(embeddedOptions?.openWithExpandedIds)
   );
@@ -629,6 +631,7 @@ export function LogsInfiniteTable({
         position="absolute"
         inReplay={!!embeddedOptions?.replay}
         tableWidth={tableWidth}
+        topOffset={backToTopOffset}
       >
         {!embeddedOptions?.replay && (
           <BackToTopButton


### PR DESCRIPTION
Switches the `LogsInfiniteTable`'s "back to top" button's vertical offset from a hardcoded 65px to a dynamic measurement of the table's `<tbody>`.

I tried extracting shared helpers to do this, since the logic got kind of nitty gritty... but ended up really only reusing `getOffsetRect`. Ah well. 🤷 

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="707" height="327" alt="image" src="https://github.com/user-attachments/assets/4b85111f-b6a5-43b9-a319-6ecf2c89c512" />
</td>
<td>
<img width="707" height="327" alt="image" src="https://github.com/user-attachments/assets/f4e92e95-592e-4a4f-b5f2-9e885d37906e" />
</td>
</tr>
</tbody>
</table>

Closes LOGS-837.