### PR TITLE
feat(icons): Add heatmap visualization icon to IconGraph

### DIFF
--- a/static/app/icons/iconGraph.tsx
+++ b/static/app/icons/iconGraph.tsx
@@ -1,12 +1,13 @@
 import {IconGraphArea} from './iconGraphArea';
 import {IconGraphBar} from './iconGraphBar';
 import {IconGraphCircle} from './iconGraphCircle';
+import {IconGraphHeatmap} from './iconGraphHeatmap';
 import {IconGraphLine} from './iconGraphLine';
 import {IconGraphScatter} from './iconGraphScatter';
 import type {SVGIconProps} from './svgIcon';
 
 export interface IconGraphProps extends SVGIconProps {
-  type?: 'line' | 'circle' | 'bar' | 'area' | 'scatter';
+  type?: 'line' | 'circle' | 'bar' | 'area' | 'scatter' | 'heatmap';
 }
 
 export function IconGraph({type = 'line', ...props}: IconGraphProps) {
@@ -19,6 +20,8 @@ export function IconGraph({type = 'line', ...props}: IconGraphProps) {
       return <IconGraphArea {...props} />;
     case 'scatter':
       return <IconGraphScatter {...props} />;
+    case 'heatmap':
+      return <IconGraphHeatmap {...props} />;
     default:
       return <IconGraphLine {...props} />;
   }

--- a/static/app/icons/iconGraphHeatmap.tsx
+++ b/static/app/icons/iconGraphHeatmap.tsx
@@ -1,0 +1,11 @@
+import type {SVGIconProps} from './svgIcon';
+import {SvgIcon} from './svgIcon';
+
+export function IconGraphHeatmap(props: SVGIconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M1.75 1c.41 0 .75.34.75.75v11.5c0 .14.11.25.25.25h11.5a.75.75 0 0 1 0 1.5H2.75C1.78 15 1 14.22 1 13.25V1.75c0-.41.34-.75.75-.75" />
+      <path d="M8 9a1 1 0 0 1 1 1v1a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-1a1 1 0 0 1 1-1zm5-3a1 1 0 0 1 1 1v1a1 1 0 0 1-1 1h-3a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1zM8 3a1 1 0 0 1 1 1v1a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z" />
+    </SvgIcon>
+  );
+}

--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -1297,6 +1297,13 @@ const SECTIONS: TSection[] = [
         },
       },
       {
+        id: 'graph-type-heatmap',
+        name: 'Graph',
+        defaultProps: {
+          type: 'heatmap',
+        },
+      },
+      {
         id: 'stack',
         groups: ['chart'],
         keywords: ['group', 'combine', 'view', 'layers', 'pile'],


### PR DESCRIPTION
Add a new `IconGraphHeatmap` component.

**e.g.,**

<img width="190" height="44" alt="Screenshot 2026-06-05 at 12 26 07 PM" src="https://github.com/user-attachments/assets/ccb2323a-6e2f-44f1-b03d-d3e7f8c6b779" />
