### PR TITLE
feat(seer): Add autofix RCA and solution to issue details LLM context

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -597,7 +597,8 @@ function getIssueDetailContextHint(view: IssueView): string {
   const shortIdNote = 'shortId is the human-readable issue identifier (e.g. PROJ-123). ';
   const tools =
     'You can get issue details for aggregate stats and stack trace, get event details for a specific error event, ' +
-    'and search live telemetry for related spans/errors/logs/metrics.';
+    'and search live telemetry for related spans/errors/logs/metrics. ' +
+    "If an autofix section appears in the page context below, Sentry's Autofix has already analyzed this issue — use that analysis as a starting point if needed.";
   return `${preamble} ${shortIdNote}${tools}`;
 }
 

--- a/static/app/views/issueDetails/sidebar/autofixSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.spec.tsx
@@ -5,12 +5,17 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {DetailedProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {DiffFileType} from 'sentry/components/events/autofix/types';
 import {EntryType} from 'sentry/types/event';
 import {IssueCategory, type Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {
+  LLMContextProvider,
+  useLLMContext,
+} from 'sentry/views/seerExplorer/contexts/llmContext';
+import type {LLMContextSnapshot} from 'sentry/views/seerExplorer/contexts/llmContextTypes';
 
 import {AutofixSection} from './autofixSection';
 
@@ -599,5 +604,92 @@ describe('AutofixSection', () => {
     expect(screen.getByText('Outline a plan')).toBeInTheDocument();
     expect(screen.getByText('Create a code fix')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Start Analysis'})).toBeInTheDocument();
+  });
+
+  it('pushes autofix data into LLM context when results are available', async () => {
+    const snapshotRef: {current: (() => LLMContextSnapshot) | null} = {current: null};
+
+    function ContextCapture() {
+      const {getLLMContext} = useLLMContext();
+      snapshotRef.current = getLLMContext;
+      return null;
+    }
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
+      body: {
+        autofix: {
+          run_id: 1,
+          status: 'completed',
+          updated_at: new Date().toISOString(),
+          blocks: [
+            {
+              id: 'block-1',
+              message: {
+                content: 'Found root cause',
+                role: 'assistant',
+                metadata: {step: 'root_cause'},
+              },
+              timestamp: new Date().toISOString(),
+              artifacts: [
+                {
+                  key: 'root_cause',
+                  reason: 'Identified the issue',
+                  data: {
+                    one_line_description: 'Null pointer in user handler',
+                    five_whys: ['Missing guard clause'],
+                    reproduction_steps: ['Call /api/user with null id'],
+                  },
+                },
+              ],
+            },
+            {
+              id: 'block-2',
+              message: {
+                content: 'Made code changes',
+                role: 'assistant',
+                metadata: {step: 'code_changes'},
+              },
+              timestamp: new Date().toISOString(),
+              merged_file_patches: [
+                {
+                  diff: '--- a/src/handler.py\n+++ b/src/handler.py',
+                  repo_name: 'org/repo',
+                  patch: {
+                    path: 'src/handler.py',
+                    added: 2,
+                    removed: 1,
+                    hunks: [],
+                    source_file: 'src/handler.py',
+                    target_file: 'src/handler.py',
+                    type: DiffFileType.MODIFIED,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    render(
+      <LLMContextProvider>
+        <AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />
+        <ContextCapture />
+      </LLMContextProvider>,
+      {organization}
+    );
+
+    await waitFor(() => {
+      const node = snapshotRef.current?.().nodes.find(n => n.nodeType === 'autofix');
+      expect((node?.data as Record<string, string> | undefined)?.autofixStatus).toBe(
+        'completed'
+      );
+    });
+
+    const data = snapshotRef.current!().nodes.find(n => n.nodeType === 'autofix')!
+      .data as Record<string, string>;
+    expect(data.rootCause).toContain('Null pointer in user handler');
+    expect(data.codeChanges).toBe('org/repo: src/handler.py');
   });
 });

--- a/static/app/views/issueDetails/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.tsx
@@ -11,6 +11,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {
   type AutofixSection,
+  getAutofixArtifactFromSection,
   getOrderedAutofixSections,
   isCodeChangesArtifact,
   isCodeChangesSection,
@@ -31,6 +32,7 @@ import {
   SolutionPreview,
 } from 'sentry/components/events/autofix/v3/autofixPreviews';
 import {useAutoTriggerAutofix} from 'sentry/components/events/autofix/v3/useAutoTriggerAutofix';
+import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
 import {useGroupSummaryData} from 'sentry/components/group/groupSummary';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {OverrideOrDefault} from 'sentry/components/overrideOrDefault';
@@ -50,6 +52,8 @@ import {SidebarFoldSection} from 'sentry/views/issueDetails/foldSection';
 import {useAiConfig} from 'sentry/views/issueDetails/hooks/useAiConfig';
 import {Resources} from 'sentry/views/issueDetails/sidebar/resources';
 import {useOpenSeerDrawer} from 'sentry/views/issueDetails/sidebar/seerDrawer';
+import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
+import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
 interface AutofixSectionProps {
   group: Group;
@@ -111,10 +115,13 @@ export function AutofixSection({group, project, event}: AutofixSectionProps) {
   );
 }
 
-const AutofixContentHook = OverrideOrDefault({
-  overrideName: 'component:ai-configure-seer-quota-sidebar',
-  defaultComponent: AutofixContent,
-});
+const AutofixContentHook = registerLLMContext(
+  'autofix',
+  OverrideOrDefault({
+    overrideName: 'component:ai-configure-seer-quota-sidebar',
+    defaultComponent: AutofixContent,
+  })
+);
 
 export interface AutofixContentProps {
   aiConfig: ReturnType<typeof useAiConfig>;
@@ -131,6 +138,56 @@ export function AutofixContent({aiConfig, group, project, event}: AutofixContent
   );
 
   useAutoTriggerAutofix({autofix, group});
+
+  const autofixContextData = useMemo(() => {
+    if (!autofix.runState) {
+      return null;
+    }
+
+    const data: Record<string, string> = {
+      autofixStatus: autofix.runState.status,
+    };
+
+    const sections = getOrderedAutofixSections(autofix.runState);
+
+    for (const section of sections) {
+      const artifact = getAutofixArtifactFromSection(section);
+      if (!artifact) {
+        continue;
+      }
+
+      if (isCodeChangesArtifact(artifact)) {
+        // Summarize code changes as file names only to avoid bloating context with full diffs
+        const filesByRepo: Record<string, string[]> = {};
+        for (const filePatch of artifact) {
+          const files = filesByRepo[filePatch.repo_name] ?? [];
+          files.push(filePatch.patch.target_file);
+          filesByRepo[filePatch.repo_name] = files;
+        }
+        const parts = Object.entries(filesByRepo).map(
+          ([repo, files]) => `${repo}: ${files.join(', ')}`
+        );
+        data.codeChanges = parts.join('\n');
+      } else {
+        const md = artifactToMarkdown(artifact, 2);
+        if (md) {
+          if (isRootCauseSection(section)) {
+            data.rootCause = md;
+          } else if (isSolutionSection(section)) {
+            data.solution = md;
+          } else if (isPullRequestsSection(section)) {
+            data.pullRequests = md;
+          } else if (isCodingAgentsSection(section)) {
+            data.codingAgents = md;
+          }
+        }
+      }
+    }
+
+    return data;
+  }, [autofix.runState]);
+
+  useLLMContext(autofixContextData);
 
   if (
     // waiting on the onboarding checks to load

--- a/static/app/views/seerExplorer/contexts/llmContextTypes.ts
+++ b/static/app/views/seerExplorer/contexts/llmContextTypes.ts
@@ -18,6 +18,7 @@
  * Add new types here as new context-aware components are registered.
  */
 export type LLMContextNodeType =
+  | 'autofix'
   | 'chart'
   | 'dashboard'
   | 'issue-detail'


### PR DESCRIPTION
+ Register AutofixContent as a child LLM context node under issue-detail so the Seer Explorer agent can see autofix results (root cause, solution, code changes, PRs, coding agents) without additional tool calls.


