### PR TITLE
ref(relay): Add option to disable internal ip auth bypass

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -111,7 +111,7 @@ def is_internal_relay(request, public_key):
         )
         return True
 
-    if is_internal_ip(request):
+    if is_internal_ip(request) and options.get("relay.allow_internal_ip_auth"):
         metrics.incr(
             "relay.is_internal_relay",
             tags={"reason": "internal_ip"},
@@ -131,7 +131,16 @@ def is_static_relay(request):
     relay_id = get_header_relay_id(request)
     static_relays = options.get("relay.static_auth")
     relay_info = static_relays.get(relay_id)
-    return relay_info is not None
+
+    if relay_info is not None:
+        metrics.incr(
+            "relay.is_internal_relay",
+            tags={"reason": "static_relay"},
+            sample_rate=1.0,
+        )
+        return True
+
+    return False
 
 
 def relay_from_id(request: Request, relay_id: str) -> tuple[Relay | None, bool]:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1305,6 +1305,9 @@ register(
 
 # All Relay options (statically authenticated Relays can be registered here)
 register("relay.static_auth", default={}, flags=FLAG_NOSTORE)
+# Whether Relay requests sent from internal ip addresses should be allowed even if the
+# credentials can not be verified.
+register("relay.allow_internal_ip_auth", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Tell Relay to stop extracting metrics from transaction payloads (see killswitches)
 # Example value: [{"project_id": 42}, {"project_id": 123}]


### PR DESCRIPTION
The internal auth bypass is a potential footgun and not required. Proper authentication should be preferred in all cases.

I plan on switching the default to `False` once self hosted is figured out.

Added another metric to cover an additional branch of authentication I missed before, the metric name doesn't really fit 100% but seems good enough for me.