### PR TITLE
ref(mypy): remove ActorSerializer + GroupEventReleaseSerializer from autoderive denylist

### DIFF
--- a/src/sentry/issues/endpoints/event_owners.py
+++ b/src/sentry/issues/endpoints/event_owners.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -41,7 +43,8 @@ class EventOwnersEndpoint(ProjectEndpoint):
         ordered_owners = []
         owner_by_id = {(o["id"], o["type"]): o for o in serialized_owners}
         for o in owners:
-            key = (str(o.id), "team" if o.is_team else "user")
+            owner_type: Literal["user", "team"] = "team" if o.is_team else "user"
+            key = (str(o.id), owner_type)
             if owner_by_id.get(key):
                 ordered_owners.append(owner_by_id[key])
 

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -930,14 +930,20 @@ class GroupEventReleaseSerializerTest(TestCase, SnubaTestCase):
         assert result["dateReleased"] == release.date_released
         assert result["deployCount"] == release.total_deploys
         assert result["ref"] == release.ref
-        assert result["lastCommit"]["id"] == commit.key
-        assert result["lastDeploy"]["id"] == str(deploy.id)
+        last_commit = result["lastCommit"]
+        assert last_commit is not None
+        assert last_commit["id"] == commit.key
+        last_deploy = result["lastDeploy"]
+        assert last_deploy is not None
+        assert last_deploy["id"] == str(deploy.id)
 
         assert result["version"] == release.version
-        assert result["versionInfo"]["package"] is None
-        assert result["versionInfo"]["version"]["raw"] == release_version
-        assert result["versionInfo"]["buildHash"] == release_version
-        assert result["versionInfo"]["description"] == release_version[:12]
+        version_info = result["versionInfo"]
+        assert version_info is not None
+        assert version_info["package"] is None
+        assert version_info["version"]["raw"] == release_version
+        assert version_info["buildHash"] == release_version
+        assert version_info["description"] == release_version[:12]
 
 
 class GetUsersForAuthorsUserMappingsTest(TestCase):

--- a/tools/mypy_helpers/serializer_autoderive.py
+++ b/tools/mypy_helpers/serializer_autoderive.py
@@ -21,13 +21,11 @@ SERIALIZER_FULLNAME = "sentry.api.serializers.base.Serializer"
 # fixes its callers — landing the fix is more valuable than the exemption.
 _AUTODERIVE_DENYLIST: frozenset[str] = frozenset(
     {
-        "sentry.api.serializers.models.actor.ActorSerializer",
         "sentry.api.serializers.models.commit.CommitSerializer",
         "sentry.api.serializers.models.event.EventSerializer",
         "sentry.api.serializers.models.group.GroupSerializerBase",
         "sentry.api.serializers.models.organization_member.base.OrganizationMemberSerializer",
         "sentry.api.serializers.models.project.ProjectSerializer",
-        "sentry.api.serializers.models.release.GroupEventReleaseSerializer",
         "sentry.api.serializers.models.release.ReleaseSerializer",
         "sentry.api.serializers.models.team.BaseTeamSerializer",
         "sentry.users.api.serializers.user.UserSerializer",


### PR DESCRIPTION
Drains both from `_AUTODERIVE_DENYLIST` (10 → 8). With these out, the autoderive plugin rewrites their bare `Serializer` base to `Serializer[ActorSerializerResponse]` and `Serializer[GroupEventReleaseSerializerResponse]`, so the free `serialize(...)` call sites get the typed return.

- `event_owners.py` annotates `owner_type` as `Literal["user", "team"]` so the dict-lookup tuple matches the typed key shape.
- `test_release.py` narrows `lastCommit` / `lastDeploy` / `versionInfo` with `assert ... is not None` before indexing.

`UserSerializer` and `OrganizationMemberSerializer` were tried alongside but their subclasses (`DetailedUserSerializer`, `OrganizationMemberWithProjectsSerializer`, etc.) override `serialize()` with subtype returns, and the autoderive plugin only fires on classes whose direct base is bare `Serializer`. The subclasses keep the parent's `T` and ~40 test-side index errors result. Likely worth extending the plugin to handle this case rather than draining one-at-a-time.