### PR TITLE
ref(seer): Add diagnostic logs to GitLab MR emoji reaction path

### DIFF
--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -260,6 +260,28 @@ def _delete_existing_reactions_and_add_reaction(
                 if (author := reaction.get("author")) is not None
                 and author["id"] == current_actor_id
             ]
+            # The add decision below hinges entirely on what this fetch returns: if the
+            # authenticated actor id is wrong (or pagination truncates the list) we can
+            # both fail to delete stale reactions and wrongly skip/duplicate the add.
+            # Log the resolved actor and our own reactions so a missing :eyes: can be
+            # traced to the actual reaction state we observed.
+            debug_log(
+                logger,
+                organization_id,
+                "gitlab.webhook.merge_request.reaction.existing_fetched",
+                {
+                    "organization_id": organization_id,
+                    "repo_id": repo.id,
+                    "mr_iid": mr_iid,
+                    "action": action_value,
+                    "current_actor_id": current_actor_id,
+                    "total_reaction_count": len(existing),
+                    "own_reaction_count": len(own_reactions),
+                    "own_reaction_contents": [
+                        reaction.get("content") for reaction in own_reactions
+                    ],
+                },
+            )
         except Exception:
             logger.warning("gitlab.webhook.merge_request.reaction.fetch_failed", exc_info=True)
             record_webhook_handler_error(
@@ -270,22 +292,63 @@ def _delete_existing_reactions_and_add_reaction(
         if reaction.get("content") in reactions_to_delete and reaction.get("id"):
             try:
                 scm_actions.delete_pull_request_reaction(scm, mr_iid, str(reaction["id"]))
+                debug_log(
+                    logger,
+                    organization_id,
+                    "gitlab.webhook.merge_request.reaction.deleted",
+                    {
+                        "organization_id": organization_id,
+                        "repo_id": repo.id,
+                        "mr_iid": mr_iid,
+                        "action": action_value,
+                        "reaction": reaction.get("content"),
+                    },
+                )
             except Exception:
                 logger.warning("gitlab.webhook.merge_request.reaction.delete_failed", exc_info=True)
                 record_webhook_handler_error(
                     GITLAB_WEBHOOK_EVENT, action_value, CodeReviewErrorType.REACTION_FAILED
                 )
 
-    if reaction_to_add and not any(
-        reaction.get("content") == reaction_to_add for reaction in own_reactions
-    ):
-        try:
-            scm_actions.create_pull_request_reaction(scm, mr_iid, reaction_to_add)
-        except Exception:
-            logger.warning("gitlab.webhook.merge_request.reaction.add_failed", exc_info=True)
-            record_webhook_handler_error(
-                GITLAB_WEBHOOK_EVENT, action_value, CodeReviewErrorType.REACTION_FAILED
-            )
+    if reaction_to_add is None:
+        return
+
+    # GitLab rejects a duplicate award_emoji POST, so we intentionally skip the add when
+    # our user already placed this reaction. This is the most common reason a re-review
+    # of an MR shows no *new* :eyes: — log it so the skip is not mistaken for a failure.
+    if any(reaction.get("content") == reaction_to_add for reaction in own_reactions):
+        debug_log(
+            logger,
+            organization_id,
+            "gitlab.webhook.merge_request.reaction.add_skipped_already_present",
+            {
+                "organization_id": organization_id,
+                "repo_id": repo.id,
+                "mr_iid": mr_iid,
+                "action": action_value,
+                "reaction": reaction_to_add,
+            },
+        )
+        return
+
+    try:
+        scm_actions.create_pull_request_reaction(scm, mr_iid, reaction_to_add)
+        debug_log(
+            logger,
+            organization_id,
+            "gitlab.webhook.merge_request.reaction.added",
+            {
+                "organization_id": organization_id,
+                "repo_id": repo.id,
+                "action": action_value,
+                "reaction": reaction_to_add,
+            },
+        )
+    except Exception:
+        logger.warning("gitlab.webhook.merge_request.reaction.add_failed", exc_info=True)
+        record_webhook_handler_error(
+            GITLAB_WEBHOOK_EVENT, action_value, CodeReviewErrorType.REACTION_FAILED
+        )
 
 
 def handle_merge_request_event(
@@ -453,6 +516,13 @@ def handle_merge_request_event(
                 action_value=action_value,
                 reactions_to_delete=["hooray"],
                 reaction_to_add="eyes",
+            )
+        else:
+            # A non-close MR event with no iid should not happen, but if it does the
+            # reaction is silently skipped; log it so a missing :eyes: is explainable.
+            logger.warning(
+                "gitlab.webhook.merge_request.reaction.skipped_missing_iid",
+                extra={"organization_id": org.id, "repo_id": repo.id, "action": action_value},
             )
 
     debug_log(logger, organization, "scheduling_seer_task", base_log)


### PR DESCRIPTION
## Summary

We've seen the :eyes: reaction not always get added to GitLab MRs when a Seer code review starts, and the reaction path was effectively a black box: `_delete_existing_reactions_and_add_reaction` only logged on **failure**, so the most common non-failure reasons for a missing reaction were invisible.

This adds `info`-level diagnostic logs at every decision point in the reaction helper so a missing :eyes: can be traced to the actual state we observed:

- **`…reaction.existing_fetched`** — resolved `current_actor_id`, total reaction count, and our own reactions + their contents. If the actor id is wrong or the list is truncated, this is where it shows up (and it drives every downstream decision).
- **`…reaction.deleted`** — each stale :tada: removed.
- **`…reaction.add_skipped_already_present`** — the big one. GitLab rejects a duplicate `award_emoji` POST, so we intentionally skip the add when our bot already placed the reaction. This was previously a **completely silent** skip and is the most likely explanation for "no *new* :eyes: on a re-review".
- **`…reaction.added`** — successful add (pre-existing log, retained).
- **`…reaction.skipped_missing_iid`** — `warning` for the (shouldn't-happen) case of a non-close MR event with no `iid`.

The add tail is restructured from a single nested `if` into explicit early returns (behavior preserving) so the already-present skip has somewhere to log.

All messages share the `gitlab.webhook.merge_request.reaction.*` prefix, so they flow into the existing **GitLab Seer Code Review — Webhook Flow** dashboard (the wildcard breakdown widget + the new Added / Add-Skipped / Failures KPIs).

## Notes

- No behavior change beyond logging; the control-flow refactor is verified against the existing `MergeRequestReactionTest` suite (16 passing).
- Backend-only change.

## Test plan

- `pytest tests/sentry/seer/code_review/webhooks/test_merge_request.py::MergeRequestReactionTest` — green.
- After deploy: filter logs on `gitlab.webhook.merge_request.reaction.*` and confirm `existing_fetched` / `add_skipped_already_present` populate; cross-check `current_actor_id` against reaction authors for MRs missing the :eyes:.