### PR TITLE
chore(code-review): Add flagged logging in gitlab note flow

### DIFF
--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -498,11 +498,47 @@ class NoteEventWebhook(GitlabWebhook):
 
         repo = self.get_repo(integration, organization, event)
         if repo is None:
+            debug_log(
+                logger,
+                organization,
+                "gitlab.note.repo_not_found",
+                {
+                    "integration_id": integration.id,
+                    "project_id": (event.get("project") or {}).get("id"),
+                },
+            )
             return
+
+        object_attributes = event.get("object_attributes") or {}
+        merge_request = event.get("merge_request") or {}
+        debug_log(
+            logger,
+            organization,
+            "gitlab.note.received",
+            {
+                "organization_slug": organization.slug,
+                "integration_id": integration.id,
+                "repo_id": repo.id,
+                "note_id": object_attributes.get("id"),
+                "noteable_type": object_attributes.get("noteable_type"),
+                "action": object_attributes.get("action"),
+                "mr_iid": merge_request.get("iid"),
+            },
+        )
 
         # Keep repo metadata fresh (url and path_with_namespace).
         self.update_repo_data(repo, event)
 
+        debug_log(
+            logger,
+            organization,
+            "gitlab.note.dispatching_processors",
+            {
+                "integration_id": integration.id,
+                "repo_id": repo.id,
+                "processor_count": len(self.WEBHOOK_EVENT_PROCESSORS),
+            },
+        )
         self._handle(
             integration=integration,
             event=event,

--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -799,7 +799,11 @@ def handle_merge_request_note_event(
         logger,
         organization,
         "note.review_command_matched",
-        {**base_log, "note_preview": (note_body or "")[:200]},
+        {
+            **base_log,
+            "review_command": SENTRY_REVIEW_COMMAND,
+            "note_length": len(note_body or ""),
+        },
     )
 
     try:

--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -683,8 +683,17 @@ def _schedule_note_task(
     try:
         validated = SeerCodeReviewTaskRequestForPrReview.parse_obj(payload)
         serialized_payload = json.loads(validated.json())
-    except ValidationError:
-        logger.warning("gitlab.webhook.note.validation_failed")
+    except ValidationError as e:
+        debug_log(
+            logger,
+            organization,
+            "note.validation_failed",
+            {
+                "mr_iid": mr_iid,
+                "validation_errors": e.errors(),
+            },
+            level=logging.WARNING,
+        )
         record_webhook_filtered(
             GITLAB_WEBHOOK_NOTE_EVENT,
             action_value,
@@ -692,6 +701,12 @@ def _schedule_note_task(
         )
         return
 
+    debug_log(
+        logger,
+        organization,
+        "note.seer_task_enqueued",
+        {"mr_iid": mr_iid, "target_commit_sha": target_commit_sha},
+    )
     process_github_webhook_event.delay(
         seer_path=SeerEndpoint.SCM_CODE_REVIEW_REVIEW_REQUEST.value,
         event_payload=serialized_payload,
@@ -724,19 +739,34 @@ def handle_merge_request_note_event(
     3. Adds :eyes: to the note to acknowledge the command.
     4. Enqueues a Seer review request with ``trigger: on_command_phrase``.
     """
+    object_attributes = event.get("object_attributes") or {}
+    merge_request = event.get("merge_request") or {}
+    base_log: dict[str, object] = {
+        "organization_id": organization.id,
+        "organization_slug": organization.slug,
+        "repo_id": repo.id,
+        "note_id": object_attributes.get("id"),
+        "noteable_type": object_attributes.get("noteable_type"),
+        "mr_iid": merge_request.get("iid"),
+    }
+
     if integration is None:
+        debug_log(logger, organization, "note.missing_integration", base_log)
         return
+
+    base_log["integration_id"] = integration.id
+    debug_log(logger, organization, "note.handler_started", base_log)
 
     if not features.has("organizations:seer-code-review-gitlab", organization):
         return
 
-    object_attributes = event.get("object_attributes", {})
     action_value = object_attributes.get("action", "")
-
+    base_log["action"] = action_value
     record_webhook_received(GITLAB_WEBHOOK_NOTE_EVENT, action_value)
 
     # Only process newly created notes; ignore edits and deletions.
     if action_value != "create":
+        debug_log(logger, organization, "note.unsupported_action", base_log)
         record_webhook_filtered(
             GITLAB_WEBHOOK_NOTE_EVENT,
             action_value,
@@ -746,6 +776,7 @@ def handle_merge_request_note_event(
 
     # Only handle notes on merge requests, not issues, commits, or snippets.
     if object_attributes.get("noteable_type") != "MergeRequest":
+        debug_log(logger, organization, "note.not_merge_request", base_log)
         record_webhook_filtered(
             GITLAB_WEBHOOK_NOTE_EVENT,
             action_value,
@@ -754,7 +785,9 @@ def handle_merge_request_note_event(
         return
 
     # Filter for the @sentry review command phrase.
-    if not _is_sentry_review_command(object_attributes.get("note")):
+    note_body = object_attributes.get("note")
+    if not _is_sentry_review_command(note_body):
+        debug_log(logger, organization, "note.not_review_command", base_log)
         record_webhook_filtered(
             GITLAB_WEBHOOK_NOTE_EVENT,
             action_value,
@@ -762,14 +795,22 @@ def handle_merge_request_note_event(
         )
         return
 
+    debug_log(
+        logger,
+        organization,
+        "note.review_command_matched",
+        {**base_log, "note_preview": (note_body or "")[:200]},
+    )
+
     try:
         org = Organization.objects.get_from_cache(id=organization.id)
     except Organization.DoesNotExist:
+        debug_log(logger, organization, "note.organization_not_found", base_log)
         return
 
     # Billing seat is keyed to the MR author, not the commenter.
-    merge_request = event.get("merge_request") or {}
     mr_author_id = merge_request.get("author_id")
+    base_log["mr_author_id"] = mr_author_id
     preflight = CodeReviewPreflightService(
         organization=org,
         repo=repo,
@@ -778,27 +819,45 @@ def handle_merge_request_note_event(
     ).check()
 
     if not preflight.allowed:
+        denial = preflight.denial_reason.value if preflight.denial_reason else None
+        debug_log(
+            logger,
+            organization,
+            "note.preflight_denied",
+            {**base_log, "denial_reason": denial},
+        )
         if preflight.denial_reason:
             record_webhook_filtered(
                 GITLAB_WEBHOOK_NOTE_EVENT, action_value, preflight.denial_reason
             )
         return
 
+    debug_log(logger, organization, "note.preflight_passed", base_log)
+
     last_commit = merge_request.get("last_commit") or {}
     target_commit_sha = last_commit.get("id")
     if not target_commit_sha:
+        debug_log(logger, organization, "note.missing_target_commit_sha", base_log)
         return
 
     mr_iid = merge_request.get("iid")
     if mr_iid is None:
+        debug_log(logger, organization, "note.missing_mr_iid", base_log)
         return
 
     note_id = object_attributes.get("id")
+    base_log["target_commit_sha"] = target_commit_sha
 
     # Dedup redeliveries: GitLab may resend the same note event on timeout.
     seen_key = f"{WEBHOOK_NOTE_SEEN_KEY_PREFIX}{org.id}:{repo.id}:{note_id}"
     if _is_duplicate_delivery(seen_key):
-        logger.warning("gitlab.webhook.note.duplicate_delivery_skipped")
+        debug_log(
+            logger,
+            organization,
+            "note.duplicate_delivery_skipped",
+            base_log,
+            level=logging.WARNING,
+        )
         return
 
     # Add :eyes: to the note to signal we received the command.
@@ -811,6 +870,7 @@ def handle_merge_request_note_event(
             reaction="eyes",
         )
 
+    debug_log(logger, organization, "note.scheduling_seer_task", base_log)
     _schedule_note_task(
         action_value=action_value,
         event=event,


### PR DESCRIPTION
Add some logging in gitlab note flow to debug the `@sentry review` use case in code review. Sits behind flag `organizations:seer-code-review-gitlab`