### PR TITLE
feat(api): Accept project slugs in project params

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -750,18 +750,16 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         elif request.auth is not None:
             actor_id = "apikey:%s" % request.auth.entity_id
         if actor_id is not None:
-            requested_project_ids = project_ids
-            requested_project_slugs: set[str] = set()
-            query_slugs = set(filter(None, request.GET.getlist("projectSlug")))
-            if requested_project_ids is not None:
-                requested_project_slugs = set()
-            elif query_slugs:
-                requested_project_ids = set()
-                requested_project_slugs = query_slugs
+            # Match get_projects() precedence: explicit ids, projectSlug, then project.
+            project_slug_params = set(filter(None, request.GET.getlist("projectSlug")))
+            if project_ids is not None:
+                requested_projects = ParsedProjectIdOrSlugParams(ids=project_ids, slugs=set())
+            elif project_slug_params:
+                requested_projects = ParsedProjectIdOrSlugParams(
+                    ids=set(), slugs=project_slug_params
+                )
             else:
                 requested_projects = self.get_requested_project_ids_and_slugs_unchecked(request)
-                requested_project_ids = requested_projects.ids
-                requested_project_slugs = requested_projects.slugs
             key = "release_perms:1:%s" % hash_values(
                 [
                     actor_id,
@@ -769,8 +767,8 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
                     release.id if release is not None else 0,
                     int(require_all_projects),
                 ]
-                + sorted(requested_project_ids)
-                + sorted(requested_project_slugs)
+                + sorted(requested_projects.ids)
+                + sorted(requested_projects.slugs)
             )
             has_perms = cache.get(key)
         if has_perms is None:

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -740,7 +740,7 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         they cannot access. The all-projects check respects Open Membership
         via has_global_access.
 
-        Results are cached for 60s per actor/org/release/project-ids/mode.
+        Results are cached for 60s per actor/org/release/effective-project-scope/mode.
         """
         actor_id = None
         has_perms = None
@@ -751,11 +751,17 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
             actor_id = "apikey:%s" % request.auth.entity_id
         if actor_id is not None:
             requested_project_ids = project_ids
-            requested_project_slugs = set(filter(None, request.GET.getlist("projectSlug")))
-            if requested_project_ids is None:
+            requested_project_slugs: set[str] = set()
+            query_slugs = set(filter(None, request.GET.getlist("projectSlug")))
+            if requested_project_ids is not None:
+                requested_project_slugs = set()
+            elif query_slugs:
+                requested_project_ids = set()
+                requested_project_slugs = query_slugs
+            else:
                 requested_projects = self.get_requested_project_ids_and_slugs_unchecked(request)
                 requested_project_ids = requested_projects.ids
-                requested_project_slugs |= requested_projects.slugs
+                requested_project_slugs = requested_projects.slugs
             key = "release_perms:1:%s" % hash_values(
                 [
                     actor_id,

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -6,6 +6,7 @@ from typing import Any, Literal, NotRequired, TypedDict, overload
 
 import sentry_sdk
 from django.core.cache import cache
+from django.db.models import Q
 from django.http.request import HttpRequest
 from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.permissions import BasePermission
@@ -15,6 +16,7 @@ from rest_framework.views import APIView
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
+from sentry.api.helpers.projects import ParsedProjectIdOrSlugParams, parse_id_or_slug_params
 from sentry.api.permissions import DemoSafePermission, StaffPermissionMixin
 from sentry.api.utils import get_date_range_from_params, is_member_disabled_from_limit
 from sentry.auth.staff import is_active_staff
@@ -349,8 +351,11 @@ def _validate_fetched_projects(
     """
     Validates that user has access to the specific projects they are requesting.
     """
-    missing_project_ids = ids and ids != {p.id for p in filtered_projects}
-    missing_project_slugs = slugs and slugs != {p.slug for p in filtered_projects}
+    fetched_ids = {p.id for p in filtered_projects}
+    fetched_slugs = {p.slug for p in filtered_projects}
+
+    missing_project_ids = ids and not ids.issubset(fetched_ids)
+    missing_project_slugs = slugs and not slugs.issubset(fetched_slugs)
 
     if missing_project_ids or missing_project_slugs:
         raise PermissionDenied
@@ -389,32 +394,35 @@ class OrganizationEndpoint(Endpoint):
         :return: A list of Project objects, or raises PermissionDenied. When project_ids or project_slugs
         are explicitly provided, the returned list is guaranteed non-empty (or PermissionDenied is raised).
 
-        NOTE: If both project_ids and project_slugs are passed, we will default
-        to fetching projects via project_id list.
+        NOTE: Passing both project_ids and project_slugs raises ``ParseError``.
         """
         qs = Project.objects.filter(organization_id=organization.id, status=ObjectStatus.ACTIVE)
         if project_slugs and project_ids:
             raise ParseError(detail="Cannot query for both ids and slugs")
 
-        slugs = project_slugs or set(filter(None, request.GET.getlist("projectSlug")))
-        ids = project_ids or self.get_requested_project_ids_unchecked(request)
-
-        if project_ids is None and slugs:
-            # If we're querying for project slugs specifically
-            if ALL_ACCESS_PROJECTS_SLUG in slugs:
-                # All projects I have access to
-                include_all_accessible = True
-            else:
-                qs = qs.filter(slug__in=slugs)
+        query_slugs = set(filter(None, request.GET.getlist("projectSlug")))
+        if project_ids is not None:
+            ids = project_ids
+            slugs: set[str] = set()
+        elif project_slugs is not None or query_slugs:
+            # Preserve existing projectSlug behavior: explicit slug filters take
+            # precedence over the project query param.
+            ids = set()
+            slugs = set(project_slugs or query_slugs)
         else:
-            # If we are explicitly querying for projects via id
-            # Or we're querying for an empty set of ids
-            if ALL_ACCESS_PROJECT_ID in ids:
-                # All projects i have access to
-                include_all_accessible = True
-            elif ids:
-                qs = qs.filter(id__in=ids)
-            # No project ids === `all projects I am a member of`
+            requested_projects = self.get_requested_project_ids_and_slugs_unchecked(request)
+            ids = requested_projects.ids
+            slugs = requested_projects.slugs
+
+        if ALL_ACCESS_PROJECT_ID in ids or ALL_ACCESS_PROJECTS_SLUG in slugs:
+            include_all_accessible = True
+        elif ids and slugs:
+            qs = qs.filter(Q(id__in=ids) | Q(slug__in=slugs))
+        elif slugs:
+            qs = qs.filter(slug__in=slugs)
+        elif ids:
+            qs = qs.filter(id__in=ids)
+        # No project ids or slugs === `all projects I am a member of`
 
         with sentry_sdk.start_span(op="fetch_organization_projects") as span:
             projects = list(qs)
@@ -474,15 +482,24 @@ class OrganizationEndpoint(Endpoint):
 
     def get_requested_project_ids_unchecked(self, request: HttpRequest) -> set[int]:
         """
-        Returns the project ids that were requested by the request.
+        Returns the numeric project ids that were requested by the request.
+        Non-numeric values (slugs) are silently ignored.
 
         To determine the projects to filter this endpoint by with full
         permission checking, use ``get_projects``, instead.
         """
-        try:
-            return set(map(int, request.GET.getlist("project")))
-        except ValueError:
-            raise ParseError(detail="Invalid project parameter. Values must be numbers.")
+        return self.get_requested_project_ids_and_slugs_unchecked(request).ids
+
+    def get_requested_project_ids_and_slugs_unchecked(
+        self, request: HttpRequest
+    ) -> ParsedProjectIdOrSlugParams:
+        """
+        Returns the project ids and slugs requested via the project query param.
+
+        To determine the projects to filter this endpoint by with full
+        permission checking, use ``get_projects``, instead.
+        """
+        return parse_id_or_slug_params(request.GET.getlist("project"))
 
     def get_environments(
         self, request: Request, organization: Organization | RpcOrganization
@@ -734,8 +751,11 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
             actor_id = "apikey:%s" % request.auth.entity_id
         if actor_id is not None:
             requested_project_ids = project_ids
+            requested_project_slugs = set(filter(None, request.GET.getlist("projectSlug")))
             if requested_project_ids is None:
-                requested_project_ids = self.get_requested_project_ids_unchecked(request)
+                requested_projects = self.get_requested_project_ids_and_slugs_unchecked(request)
+                requested_project_ids = requested_projects.ids
+                requested_project_slugs |= requested_projects.slugs
             key = "release_perms:1:%s" % hash_values(
                 [
                     actor_id,
@@ -744,6 +764,7 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
                     int(require_all_projects),
                 ]
                 + sorted(requested_project_ids)
+                + sorted(requested_project_slugs)
             )
             has_perms = cache.get(key)
         if has_perms is None:

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -404,7 +404,7 @@ class OrganizationEndpoint(Endpoint):
         if project_ids is not None:
             ids = project_ids
             slugs: set[str] = set()
-        elif project_slugs is not None or query_slugs:
+        elif project_slugs or query_slugs:
             # Preserve existing projectSlug behavior: explicit slug filters take
             # precedence over the project query param.
             ids = set()

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -21,7 +21,7 @@ from sentry.api.permissions import DemoSafePermission, StaffPermissionMixin
 from sentry.api.utils import get_date_range_from_params, is_member_disabled_from_limit
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
-from sentry.constants import ALL_ACCESS_PROJECT_ID, ALL_ACCESS_PROJECTS_SLUG, ObjectStatus
+from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidParams
 from sentry.models.apikey import is_api_key_auth
 from sentry.models.apitoken import is_api_token_auth
@@ -402,19 +402,19 @@ class OrganizationEndpoint(Endpoint):
 
         query_slugs = set(filter(None, request.GET.getlist("projectSlug")))
         if project_ids is not None:
-            ids = project_ids
-            slugs: set[str] = set()
+            requested_projects = ParsedProjectIdOrSlugParams(ids=project_ids, slugs=set())
         elif project_slugs or query_slugs:
             # Preserve existing projectSlug behavior: explicit slug filters take
             # precedence over the project query param.
-            ids = set()
-            slugs = set(project_slugs or query_slugs)
+            requested_projects = ParsedProjectIdOrSlugParams(
+                ids=set(), slugs=set(project_slugs or query_slugs)
+            )
         else:
             requested_projects = self.get_requested_project_ids_and_slugs_unchecked(request)
-            ids = requested_projects.ids
-            slugs = requested_projects.slugs
+        ids = requested_projects.ids
+        slugs = requested_projects.slugs
 
-        if ALL_ACCESS_PROJECT_ID in ids or ALL_ACCESS_PROJECTS_SLUG in slugs:
+        if requested_projects.has_all_projects_sentinel:
             include_all_accessible = True
         elif ids and slugs:
             qs = qs.filter(Q(id__in=ids) | Q(slug__in=slugs))

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -8,6 +8,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
 from sentry.api.endpoints.organization_events_spans_performance import EventID, get_span_description
+from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.api.utils import handle_query_errors
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.types import QueryBuilderConfig
@@ -35,7 +36,7 @@ RESPONSE_KEYS = [
 
 class RootCauseAnalysisQuerySerializer(serializers.Serializer):
     transaction = serializers.CharField(max_length=200)
-    project = serializers.IntegerField()
+    project = ProjectField(scope="project:read")
     breakpoint = serializers.CharField()
     per_page = serializers.IntegerField(min_value=1, max_value=MAX_LIMIT, default=DEFAULT_LIMIT)
     span_score_threshold = serializers.IntegerField(
@@ -203,13 +204,16 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
     }
 
     def get(self, request, organization):
-        serializer = RootCauseAnalysisQuerySerializer(data=request.GET)
+        serializer = RootCauseAnalysisQuerySerializer(
+            data=request.GET,
+            context={"access": request.access, "organization": organization},
+        )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
         validated = serializer.validated_data
         transaction_name = validated["transaction"]
-        project_id = validated["project"]
+        project_id = validated["project"].id
         regression_breakpoint = validated["breakpoint"]
         limit = validated["per_page"]
         span_score_threshold = validated["span_score_threshold"]

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -36,7 +36,7 @@ RESPONSE_KEYS = [
 
 class RootCauseAnalysisQuerySerializer(serializers.Serializer):
     transaction = serializers.CharField(max_length=200)
-    project = ProjectField(scope="project:read")
+    project = ProjectField(scope="project:read", id_allowed=True)
     breakpoint = serializers.CharField()
     per_page = serializers.IntegerField(min_value=1, max_value=MAX_LIMIT, default=DEFAULT_LIMIT)
     span_score_threshold = serializers.IntegerField(

--- a/src/sentry/api/endpoints/organization_stats_summary.py
+++ b/src/sentry/api/endpoints/organization_stats_summary.py
@@ -16,12 +16,12 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.helpers.projects import ProjectIdOrSlugField
 from sentry.api.utils import handle_query_errors
 from sentry.apidocs.constants import RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.exceptions import InvalidParams
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -83,7 +83,8 @@ class OrgStatsSummaryQueryParamsSerializer(serializers.Serializer):
 
     project = serializers.ListField(
         required=False,
-        help_text="The ID of the projects to filter by.",
+        child=ProjectIdOrSlugField(),
+        help_text="The ID or slug of the projects to filter by.",
     )
 
     category = serializers.ChoiceField(
@@ -186,18 +187,13 @@ class OrganizationStatsSummaryEndpoint(OrganizationEndpoint):
         return QueryDefinition.from_query_dict(query_dict, params)
 
     def _get_projects_for_orgstats_query(self, request: Request, organization):
-        req_proj_ids = self.get_requested_project_ids_unchecked(request)
-
         # the projects table always filters by project
         # the projects in the table should be those the user has access to
 
-        projects = self.get_projects(request, organization, project_ids=req_proj_ids)
+        projects = self.get_projects(request, organization)
         if not projects:
             raise NoProjects("No projects available")
         return [p.id for p in projects]
-
-    def _is_org_total_query(self, project_ids):
-        return all([not project_ids or project_ids == ALL_ACCESS_PROJECTS])
 
     def _generate_csv(self, projects):
         if not len(projects):

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -12,12 +12,16 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects
 from sentry.api.bases.organization import OrganizationAndStaffPermission, OrganizationEndpoint
+from sentry.api.helpers.projects import (
+    ParsedProjectIdOrSlugParams,
+    ProjectIdOrSlugField,
+)
 from sentry.api.utils import handle_query_errors
 from sentry.apidocs.constants import RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.constants import ALL_ACCESS_PROJECTS
+from sentry.constants import ALL_ACCESS_PROJECTS, ALL_ACCESS_PROJECTS_SLUG
 from sentry.exceptions import InvalidParams
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
@@ -97,7 +101,8 @@ class OrgStatsQueryParamsSerializer(serializers.Serializer):
 
     project = serializers.ListField(
         required=False,
-        help_text="The ID of the projects to filter by.\n\nUse `-1` to include all accessible projects.",
+        child=ProjectIdOrSlugField(),
+        help_text="The ID or slug of the projects to filter by.\n\nUse `-1` to include all accessible projects.",
     )
 
     category = serializers.ChoiceField(
@@ -205,21 +210,24 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
         # look at the raw project_id filter passed in, if its empty
         # and project_id is not in groupBy filter, treat it as an
         # org wide query and don't pass project_id in to QueryDefinition
-        req_proj_ids = self.get_requested_project_ids_unchecked(request)
-        if self._is_org_total_query(request, req_proj_ids):
+        requested_projects = self.get_requested_project_ids_and_slugs_unchecked(request)
+        if self._is_org_total_query(request, requested_projects):
             return None
         else:
-            projects = self.get_projects(request, organization, project_ids=req_proj_ids)
+            projects = self.get_projects(request, organization)
             if not projects:
                 raise NoProjects("No projects available")
             return [p.id for p in projects]
 
-    def _is_org_total_query(self, request: Request, project_ids):
-        return all(
-            [
-                not project_ids or project_ids == ALL_ACCESS_PROJECTS,
-                "project" not in request.GET.get("groupBy", []),
-            ]
+    def _is_org_total_query(
+        self, request: Request, requested_projects: ParsedProjectIdOrSlugParams
+    ) -> bool:
+        no_project_filter = not requested_projects.has_values
+        all_access_filter = (
+            requested_projects.ids == ALL_ACCESS_PROJECTS and not requested_projects.slugs
+        ) or (requested_projects.slugs == {ALL_ACCESS_PROJECTS_SLUG} and not requested_projects.ids)
+        return (no_project_filter or all_access_filter) and "project" not in request.GET.getlist(
+            "groupBy"
         )
 
     @contextmanager

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
@@ -37,8 +37,13 @@ class ReleaseThresholdIndexEndpoint(OrganizationEndpoint):
     }
 
     def get(self, request: Request, organization: Organization) -> HttpResponse:
+        query_params = request.query_params.copy()
+        if "project" in query_params:
+            query_params.setlist(
+                "project", [project for project in query_params.getlist("project") if project]
+            )
         validator = ReleaseThresholdIndexGETValidator(
-            data=request.query_params,
+            data=query_params,
         )
         if not validator.is_valid():
             return Response(validator.errors, status=400)

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
@@ -10,6 +10,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.helpers.projects import ProjectIdOrSlug, ProjectIdOrSlugField
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models.organization import Organization
@@ -18,16 +19,14 @@ from sentry.models.release_threshold.release_threshold import ReleaseThreshold
 
 class ReleaseThresholdIndexGETData(TypedDict, total=False):
     environment: list[str]
-    project: list[int]
+    project: list[ProjectIdOrSlug]
 
 
 class ReleaseThresholdIndexGETValidator(serializers.Serializer[ReleaseThresholdIndexGETData]):
     environment = serializers.ListField(
         required=False, allow_empty=True, child=serializers.CharField()
     )
-    project = serializers.ListField(
-        required=True, allow_empty=False, child=serializers.IntegerField()
-    )
+    project = serializers.ListField(required=True, allow_empty=False, child=ProjectIdOrSlugField())
 
 
 @cell_silo_endpoint

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -84,7 +84,7 @@ class ReleaseThresholdStatusIndexSerializer(
     projectSlug = serializers.ListField(
         required=False,
         allow_empty=True,
-        child=serializers.CharField(),
+        child=serializers.CharField(allow_blank=True),
         help_text=("A list of project slugs to filter your results by."),
     )
     project = serializers.ListField(
@@ -151,7 +151,9 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
         environments_list = serializer.validated_data.get(
             "environment"
         )  # list of environment names
-        project_slug_list = serializer.validated_data.get("projectSlug")
+        project_slug_list = [
+            slug for slug in serializer.validated_data.get("projectSlug", []) if slug
+        ] or None
         releases_list = serializer.validated_data.get("release")  # list of release versions
         try:
             filter_params = self.get_filter_params(

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -29,6 +29,7 @@ from sentry.api.endpoints.release_thresholds.utils import (
     get_errors_counts_timeseries_by_project_and_release,
     get_new_issue_counts,
 )
+from sentry.api.helpers.projects import ProjectIdOrSlug, ProjectIdOrSlugField
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST
 from sentry.apidocs.examples.release_threshold_examples import ReleaseThresholdExamples
@@ -54,6 +55,7 @@ class ReleaseThresholdStatusIndexData(TypedDict, total=False):
     start: datetime
     end: datetime
     environment: list[str]
+    project: list[ProjectIdOrSlug]
     projectSlug: list[str]
     release: list[str]
 
@@ -84,6 +86,12 @@ class ReleaseThresholdStatusIndexSerializer(
         allow_empty=True,
         child=serializers.CharField(),
         help_text=("A list of project slugs to filter your results by."),
+    )
+    project = serializers.ListField(
+        required=False,
+        allow_empty=True,
+        child=ProjectIdOrSlugField(),
+        help_text=("A list of project IDs or slugs to filter your results by."),
     )
     release = serializers.ListField(
         required=False,

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -29,7 +29,11 @@ from sentry.api.endpoints.release_thresholds.utils import (
     get_errors_counts_timeseries_by_project_and_release,
     get_new_issue_counts,
 )
-from sentry.api.helpers.projects import ProjectIdOrSlug, ProjectIdOrSlugField
+from sentry.api.helpers.projects import (
+    ProjectIdOrSlug,
+    ProjectIdOrSlugField,
+    parse_id_or_slug_params,
+)
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST
 from sentry.apidocs.examples.release_threshold_examples import ReleaseThresholdExamples
@@ -142,9 +146,18 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
         # NOTE: start/end parameters determine window to query for releases
         # This is NOT the window to query snuba for event data - nor the individual threshold windows
         # ========================================================================
-        serializer = ReleaseThresholdStatusIndexSerializer(
-            data=request.query_params,
-        )
+        query_params = request.query_params.copy()
+        project_slug_params = [slug for slug in query_params.getlist("projectSlug") if slug]
+        if "projectSlug" in query_params:
+            query_params.setlist("projectSlug", project_slug_params)
+        if project_slug_params:
+            query_params.pop("project", None)
+        elif "project" in query_params:
+            query_params.setlist(
+                "project", [project for project in query_params.getlist("project") if project]
+            )
+
+        serializer = ReleaseThresholdStatusIndexSerializer(data=query_params)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
@@ -154,10 +167,15 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
         project_slug_list = [
             slug for slug in serializer.validated_data.get("projectSlug", []) if slug
         ] or None
+        requested_project = parse_id_or_slug_params(serializer.validated_data.get("project", []))
         releases_list = serializer.validated_data.get("release")  # list of release versions
         try:
             filter_params = self.get_filter_params(
-                request, organization, date_filter_optional=True, project_slugs=project_slug_list
+                request,
+                organization,
+                date_filter_optional=True,
+                project_ids=requested_project.ids or None,
+                project_slugs=project_slug_list or requested_project.slugs or None,
             )
         except NoProjects:
             raise NoProjects("No projects available")

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -169,13 +169,21 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
         ] or None
         requested_project = parse_id_or_slug_params(serializer.validated_data.get("project", []))
         releases_list = serializer.validated_data.get("release")  # list of release versions
+        project_ids: set[int] | None = None
+        project_slugs: list[str] | set[str] | None = project_slug_list
+        if project_slug_list is None:
+            if requested_project.ids and not requested_project.slugs:
+                project_ids = requested_project.ids
+            elif requested_project.slugs and not requested_project.ids:
+                project_slugs = requested_project.slugs
+
         try:
             filter_params = self.get_filter_params(
                 request,
                 organization,
                 date_filter_optional=True,
-                project_ids=requested_project.ids or None,
-                project_slugs=project_slug_list or requested_project.slugs or None,
+                project_ids=project_ids,
+                project_slugs=project_slugs,
             )
         except NoProjects:
             raise NoProjects("No projects available")

--- a/src/sentry/api/helpers/projects.py
+++ b/src/sentry/api/helpers/projects.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import NamedTuple, TypeAlias
+
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+from sentry.constants import ALL_ACCESS_PROJECTS_SLUG
+from sentry.utils.slug import DEFAULT_SLUG_ERROR_MESSAGE, MIXED_SLUG_REGEX
+
+ProjectIdOrSlug: TypeAlias = int | str
+
+
+class ParsedProjectIdOrSlugParams(NamedTuple):
+    ids: set[int]
+    slugs: set[str]
+
+    @property
+    def has_values(self) -> bool:
+        return bool(self.ids or self.slugs)
+
+
+def _is_int_string(value: str) -> bool:
+    return value.isdecimal() or (len(value) > 1 and value[0] == "-" and value[1:].isdecimal())
+
+
+def parse_id_or_slug_params(
+    values: Iterable[ProjectIdOrSlug | None],
+) -> ParsedProjectIdOrSlugParams:
+    """
+    Partition project identifier values into numeric IDs and slugs.
+
+    All-digit values are treated as IDs, everything else as slugs. A single
+    leading ``-`` is allowed so the ``-1`` all-access project sigil remains a
+    project ID.
+    """
+    ids: set[int] = set()
+    slugs: set[str] = set()
+    for value in values:
+        if value is None or value == "":
+            continue
+        if isinstance(value, int) and not isinstance(value, bool):
+            ids.add(value)
+            continue
+
+        value_str = str(value)
+        if _is_int_string(value_str):
+            ids.add(int(value_str))
+        else:
+            slugs.add(value_str)
+    return ParsedProjectIdOrSlugParams(ids=ids, slugs=slugs)
+
+
+@extend_schema_field(field=OpenApiTypes.STR)
+class ProjectIdOrSlugField(serializers.Field[ProjectIdOrSlug]):
+    default_error_messages = {
+        "invalid": "Expected a project ID or slug.",
+        "invalid_slug": DEFAULT_SLUG_ERROR_MESSAGE,
+    }
+
+    def to_internal_value(self, data: object) -> ProjectIdOrSlug:
+        if data is None or isinstance(data, bool):
+            self.fail("invalid")
+        if isinstance(data, int):
+            return data
+        if not isinstance(data, str) or data == "":
+            self.fail("invalid")
+        if _is_int_string(data):
+            return int(data)
+        if data == ALL_ACCESS_PROJECTS_SLUG:
+            return data
+        if MIXED_SLUG_REGEX.match(data) is None:
+            self.fail("invalid_slug")
+        return data
+
+    def to_representation(self, value: ProjectIdOrSlug) -> ProjectIdOrSlug:
+        return value

--- a/src/sentry/api/helpers/projects.py
+++ b/src/sentry/api/helpers/projects.py
@@ -7,7 +7,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from sentry.constants import ALL_ACCESS_PROJECTS_SLUG
+from sentry.constants import ALL_ACCESS_PROJECT_ID, ALL_ACCESS_PROJECTS_SLUG
 from sentry.utils.slug import DEFAULT_SLUG_ERROR_MESSAGE, MIXED_SLUG_REGEX
 
 ProjectIdOrSlug: TypeAlias = int | str
@@ -20,6 +20,10 @@ class ParsedProjectIdOrSlugParams(NamedTuple):
     @property
     def has_values(self) -> bool:
         return bool(self.ids or self.slugs)
+
+    @property
+    def has_all_projects_sentinel(self) -> bool:
+        return ALL_ACCESS_PROJECT_ID in self.ids or ALL_ACCESS_PROJECTS_SLUG in self.slugs
 
 
 def _is_int_string(value: str) -> bool:

--- a/src/sentry/api/helpers/projects.py
+++ b/src/sentry/api/helpers/projects.py
@@ -54,7 +54,7 @@ def parse_id_or_slug_params(
 
 
 @extend_schema_field(field=OpenApiTypes.STR)
-class ProjectIdOrSlugField(serializers.Field[ProjectIdOrSlug]):
+class ProjectIdOrSlugField(serializers.Field[ProjectIdOrSlug, object, ProjectIdOrSlug, object]):
     default_error_messages = {
         "invalid": "Expected a project ID or slug.",
         "invalid_slug": DEFAULT_SLUG_ERROR_MESSAGE,

--- a/src/sentry/api/serializers/rest_framework/project.py
+++ b/src/sentry/api/serializers/rest_framework/project.py
@@ -13,12 +13,14 @@ ValidationError = serializers.ValidationError
 @extend_schema_field(field=OpenApiTypes.STR)
 class ProjectField(serializers.Field):
     def __init__(
-        self, scope: str | Collection[str] = "project:write", id_allowed: bool = True, **kwags
+        self, scope: str | Collection[str] = "project:write", id_allowed: bool = False, **kwags
     ):
         """
         The scope parameter specifies which permissions are required to access the project field.
         If multiple scopes are provided, the project can be accessed when the user is authenticated with
         any of the scopes.
+
+        If id_allowed is true, the field accepts a project ID or slug. Otherwise, it accepts slugs only.
         """
         self.scope = scope
         self.id_allowed = id_allowed

--- a/src/sentry/api/serializers/rest_framework/project.py
+++ b/src/sentry/api/serializers/rest_framework/project.py
@@ -4,6 +4,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
+from sentry.api.helpers.projects import ProjectIdOrSlugField
 from sentry.models.project import Project
 
 ValidationError = serializers.ValidationError
@@ -12,7 +13,7 @@ ValidationError = serializers.ValidationError
 @extend_schema_field(field=OpenApiTypes.STR)
 class ProjectField(serializers.Field):
     def __init__(
-        self, scope: str | Collection[str] = "project:write", id_allowed: bool = False, **kwags
+        self, scope: str | Collection[str] = "project:write", id_allowed: bool = True, **kwags
     ):
         """
         The scope parameter specifies which permissions are required to access the project field.
@@ -26,14 +27,18 @@ class ProjectField(serializers.Field):
     def to_representation(self, value):
         return value
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data: object) -> Project:
         try:
             if self.id_allowed:
+                project_id_or_slug = ProjectIdOrSlugField().to_internal_value(data)
                 project = Project.objects.get(
-                    organization=self.context["organization"], slug__id_or_slug=data
+                    organization=self.context["organization"], slug__id_or_slug=project_id_or_slug
                 )
             else:
-                project = Project.objects.get(organization=self.context["organization"], slug=data)
+                project_slug = self._validate_slug(data)
+                project = Project.objects.get(
+                    organization=self.context["organization"], slug=project_slug
+                )
         except Project.DoesNotExist:
             raise ValidationError("Invalid project")
 
@@ -41,3 +46,11 @@ class ProjectField(serializers.Field):
         if not self.context["access"].has_any_project_scope(project, scopes):
             raise ValidationError("Insufficient access to project")
         return project
+
+    def _validate_slug(self, data: object) -> str:
+        if not isinstance(data, str):
+            raise ValidationError("Invalid project")
+        project_id_or_slug = ProjectIdOrSlugField().to_internal_value(data)
+        if not isinstance(project_id_or_slug, str):
+            raise ValidationError("Invalid project")
+        return project_id_or_slug

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -255,7 +255,7 @@ class ReleaseParams:
         description="Case-insensitive substring match against the release version.",
     )
     PROJECT_ID = OpenApiParameter(
-        name="project_id",
+        name="project",
         location="query",
         required=False,
         type=str,

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -153,10 +153,11 @@ class OrganizationParams:
         location="query",
         required=False,
         many=True,
-        type=int,
-        description="""The IDs of projects to filter by. `-1` means all available projects.
+        type=str,
+        description="""The IDs or slugs of projects to filter by. `-1` means all available projects.
 For example, the following are valid parameters:
 - `/?project=1234&project=56789`
+- `/?project=android&project=javascript-react`
 - `/?project=-1`
 """,
     )
@@ -258,7 +259,7 @@ class ReleaseParams:
         location="query",
         required=False,
         type=str,
-        description="The project ID to filter by.",
+        description="The project ID or slug to filter by.",
     )
     HEALTH = OpenApiParameter(
         name="health",

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -44,7 +44,7 @@ class GlobalParams:
     )
     PROJECT_ID_OR_SLUG = OpenApiParameter(
         name="project_id_or_slug",
-        description="The ID or slug of the project the resource belongs to.",
+        description="The ID or slug of the project the resource belongs to. Project slugs are unique within each organization.",
         required=True,
         type=str,
         location="path",
@@ -137,13 +137,13 @@ class EnvironmentParams:
 
 
 class OrganizationParams:
-    PROJECT_ID_OR_SLUG = OpenApiParameter(
-        name="project_id_or_slug",
+    PROJECT_SLUG = OpenApiParameter(
+        name="projectSlug",
         location="query",
         required=False,
         many=True,
         type=str,
-        description="""The project slugs to filter by. Use `$all` to include all available projects. For example, the following are valid parameters:
+        description="""The project slugs to filter by. This legacy parameter takes precedence over `project` if both are provided. Use `$all` to include all available projects. For example, the following are valid parameters:
 - `/?projectSlug=$all`
 - `/?projectSlug=android&projectSlug=javascript-react`
 """,
@@ -154,7 +154,7 @@ class OrganizationParams:
         required=False,
         many=True,
         type=str,
-        description="""The IDs or slugs of projects to filter by. `-1` means all available projects.
+        description="""The IDs or slugs of projects to filter by. Project slugs are unique within each organization. `-1` means all available projects.
 For example, the following are valid parameters:
 - `/?project=1234&project=56789`
 - `/?project=android&project=javascript-react`

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -67,7 +67,6 @@ from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
 from sentry.middleware import is_frontend_request
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
-from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.monitors.models import (
@@ -525,31 +524,10 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         """
         Fetches metric, issue, crons, and uptime alert rules for an organization
         """
-        # Common setup: project resolution
-        project_ids = self.get_requested_project_ids_unchecked(request) or None
-        if project_ids == {-1}:  # All projects for org:
-            project_ids = set(
-                Project.objects.filter(
-                    organization=organization, status=ObjectStatus.ACTIVE
-                ).values_list("id", flat=True)
-            )
-        elif project_ids is None:  # All projects for user
-            org_team_list = Team.objects.filter(organization=organization).values_list(
-                "id", flat=True
-            )
-            user_team_list = OrganizationMemberTeam.objects.filter(
-                organizationmember__user_id=request.user.id, team__in=org_team_list
-            ).values_list("team", flat=True)
-            project_ids = set(
-                Project.objects.filter(
-                    teams__in=user_team_list, status=ObjectStatus.ACTIVE
-                ).values_list("id", flat=True)
-            )
-
         # Materialize the project ids here. This helps us to not overwhelm the query planner with
         # overcomplicated subqueries. Previously, this was causing Postgres to use a suboptimal
         # index to filter on. Also enforces permission checks.
-        projects = self.get_projects(request, organization, project_ids=project_ids)
+        projects = self.get_projects(request, organization)
 
         # Common setup: team parsing
         teams = request.GET.getlist("team", [])

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.db import IntegrityError, router, transaction
+from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -13,6 +14,7 @@ from sentry.api.bases.organization import (
     OrganizationCodeMappingsBulkPermission,
     OrganizationEndpoint,
 )
+from sentry.api.helpers.projects import ProjectIdOrSlugField, parse_id_or_slug_params
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.constants import ObjectStatus
 from sentry.integrations.api.endpoints.organization_code_mappings import (
@@ -42,7 +44,7 @@ class MappingItemSerializer(serializers.Serializer[dict[str, object]]):
 
 
 class BulkCodeMappingsRequestSerializer(CamelSnakeSerializer[dict[str, object]]):
-    project = serializers.CharField(required=True)
+    project = ProjectIdOrSlugField(required=True)
     repository = serializers.CharField(required=True)
     provider = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     default_branch = serializers.RegexField(
@@ -165,13 +167,16 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
 
         data = serializer.validated_data
 
-        # Resolve project by slug
+        # Resolve project by ID or slug.
+        parsed_project = parse_id_or_slug_params([data["project"]])
+        project_filter = Q(organization=organization, status=ObjectStatus.ACTIVE)
+        if parsed_project.ids:
+            project_filter &= Q(id__in=parsed_project.ids)
+        else:
+            project_filter &= Q(slug__in=parsed_project.slugs)
+
         try:
-            project = Project.objects.get(
-                organization=organization,
-                slug=data["project"],
-                status=ObjectStatus.ACTIVE,
-            )
+            project = Project.objects.get(project_filter)
         except Project.DoesNotExist:
             return Response(
                 {"detail": f"Project not found or not active: {data['project']}"},

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -313,8 +313,9 @@ class ConfigValidator(serializers.Serializer):
 class MonitorValidator(CamelSnakeSerializer):
     project = ProjectField(
         scope="project:read",
+        id_allowed=True,
         required=True,
-        help_text="The project slug to associate the monitor to.",
+        help_text="The project ID or slug to associate the monitor to.",
     )
     name = serializers.CharField(
         max_length=128,

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -60,7 +60,7 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             OrganizationParams.PROJECT,
-            OrganizationParams.PROJECT_ID_OR_SLUG,
+            OrganizationParams.PROJECT_SLUG,
             NotificationParams.TRIGGER_TYPE,
         ],
         responses={

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -82,8 +82,9 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         queryset = NotificationAction.objects.filter(organization_id=organization.id)
         # If a project query is specified, filter out non-project-specific actions
         # otherwise, include them but still ensure project permissions are enforced
+        query_slugs = set(filter(None, request.GET.getlist("projectSlug")))
         has_project_query = bool(
-            request.GET.getlist("project") or request.GET.getlist("projectSlug")
+            query_slugs or self.get_requested_project_ids_and_slugs_unchecked(request).has_values
         )
         projects = self.get_projects(request, organization)
         project_query = (

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -82,10 +82,14 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         queryset = NotificationAction.objects.filter(organization_id=organization.id)
         # If a project query is specified, filter out non-project-specific actions
         # otherwise, include them but still ensure project permissions are enforced
+        has_project_query = bool(
+            request.GET.getlist("project") or request.GET.getlist("projectSlug")
+        )
+        projects = self.get_projects(request, organization)
         project_query = (
-            Q(projects__in=self.get_projects(request, organization))
-            if self.get_requested_project_ids_unchecked(request)
-            else Q(projects=None) | Q(projects__in=self.get_projects(request, organization))
+            Q(projects__in=projects)
+            if has_project_query
+            else Q(projects=None) | Q(projects__in=projects)
         )
         queryset = queryset.filter(project_query).distinct()
         trigger_type_query = request.GET.getlist("triggerType")
@@ -98,7 +102,7 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
             extra={
                 "organization_id": organization.id,
                 "trigger_type_query": trigger_type_query,
-                "project_query": self.get_requested_project_ids_unchecked(request),
+                "project_query": self.get_requested_project_ids_and_slugs_unchecked(request),
             },
         )
         return self.paginate(

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -12,6 +12,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.helpers.projects import parse_id_or_slug_params
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers.base import serialize
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
@@ -136,10 +137,13 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         # team admins and regular org members don't have project:write on an org level
         if not request.access.has_scope("project:write"):
             # check if user has access to create notification actions for all requested projects
-            requested_projects = request.data.get("projects", [])
+            requested_projects = parse_id_or_slug_params(request.data.get("projects") or [])
             projects = self.get_projects(request, organization)
-            project_slugs = [project.slug for project in projects]
-            missing_access_projects = set(requested_projects).difference(set(project_slugs))
+            project_ids = {project.id for project in projects}
+            project_slugs = {project.slug for project in projects}
+            missing_access_projects = requested_projects.ids.difference(
+                project_ids
+            ) | requested_projects.slugs.difference(project_slugs)
 
             if missing_access_projects:
                 raise PermissionDenied(

--- a/src/sentry/notifications/api/serializers/notification_action_request.py
+++ b/src/sentry/notifications/api/serializers/notification_action_request.py
@@ -87,8 +87,8 @@ Required if **service_type** is `slack` or `opsgenie`.
         required=False,
     )
     projects = serializers.ListField(
-        help_text="""List of projects slugs that the Notification Action is created for.""",
-        child=ProjectField(scope="project:write"),
+        help_text="""List of project IDs or slugs that the Notification Action is created for.""",
+        child=ProjectField(scope="project:write", id_allowed=True),
         required=False,
     )
     # Optional and not needed for spike protection so not documenting

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -165,6 +165,8 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
             except ValidationError:
                 return Response({"detail": "Invalid project parameter"}, status=400)
             requested_project = parse_id_or_slug_params([project_id_or_slug])
+            if requested_project.has_all_projects_sentinel:
+                return Response({"detail": "Invalid project parameter"}, status=400)
             if requested_project.ids:
                 project_id = next(iter(requested_project.ids))
             elif requested_project.slugs:

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -157,7 +157,9 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
 
         project_id = None
         project_slug = None
-        if project_param := request.GET.get("project"):
+        if project_slug_param := request.GET.get("projectSlug"):
+            project_slug = project_slug_param
+        elif project_param := request.GET.get("project"):
             try:
                 project_id_or_slug = ProjectIdOrSlugField().run_validation(project_param)
             except ValidationError:
@@ -167,8 +169,6 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
                 project_id = next(iter(requested_project.ids))
             elif requested_project.slugs:
                 project_slug = next(iter(requested_project.slugs))
-        elif project_slug_param := request.GET.get("projectSlug"):
-            project_slug = project_slug_param
 
         qs = (
             PreprodArtifact.objects.filter(

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -158,6 +158,8 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
         project_id = None
         project_slug = None
         if project_slug_param := request.GET.get("projectSlug"):
+            if parse_id_or_slug_params([project_slug_param]).has_all_projects_sentinel:
+                return Response({"detail": "Invalid project parameter"}, status=400)
             project_slug = project_slug_param
         elif project_param := request.GET.get("project"):
             try:

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -7,6 +7,7 @@ import orjson
 from django.conf import settings
 from django.db.models import Q
 from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -18,6 +19,7 @@ from sentry.api.bases.organization import (
     OrganizationEndpoint,
     OrganizationReleasePermission,
 )
+from sentry.api.helpers.projects import ProjectIdOrSlugField, parse_id_or_slug_params
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.preprod_examples import PreprodExamples
 from sentry.apidocs.parameters import GlobalParams
@@ -50,9 +52,9 @@ LATEST_BASE_SNAPSHOT_GET_QUERY_PARAMS: dict[str, Any] = {
         "description": "Set to '1' or 'true' to strip image metadata to display_name, image_file_name, group, description",
     },
     "project": {
-        "type": "integer",
+        "type": "string",
         "required": False,
-        "description": "Project ID to scope the lookup. Use either project or projectSlug when app_id is not unique across projects or project inference is unavailable.",
+        "description": "Project ID or slug to scope the lookup. Use either project or projectSlug when app_id is not unique across projects or project inference is unavailable.",
     },
     "projectSlug": {
         "type": "string",
@@ -91,10 +93,17 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
             ),
             OpenApiParameter(
                 name="project",
-                type=int,
+                type=str,
                 location="query",
                 required=False,
-                description="Project ID to scope the lookup.",
+                description="Project ID or slug to scope the lookup.",
+            ),
+            OpenApiParameter(
+                name="projectSlug",
+                type=str,
+                location="query",
+                required=False,
+                description="Project slug to scope the lookup.",
             ),
             OpenApiParameter(
                 name="compact_metadata",
@@ -146,10 +155,20 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
         branch = request.GET.get("branch")
         compact = request.GET.get("compact_metadata", "0") in ("1", "true")
 
-        try:
-            project_id = int(request.GET["project"]) if "project" in request.GET else None
-        except (ValueError, TypeError):
-            return Response({"detail": "Invalid project parameter"}, status=400)
+        project_id = None
+        project_slug = None
+        if project_param := request.GET.get("project"):
+            try:
+                project_id_or_slug = ProjectIdOrSlugField().run_validation(project_param)
+            except ValidationError:
+                return Response({"detail": "Invalid project parameter"}, status=400)
+            requested_project = parse_id_or_slug_params([project_id_or_slug])
+            if requested_project.ids:
+                project_id = next(iter(requested_project.ids))
+            elif requested_project.slugs:
+                project_slug = next(iter(requested_project.slugs))
+        elif project_slug_param := request.GET.get("projectSlug"):
+            project_slug = project_slug_param
 
         qs = (
             PreprodArtifact.objects.filter(
@@ -171,6 +190,8 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
 
         if project_id is not None:
             qs = qs.filter(project_id=project_id)
+        if project_slug is not None:
+            qs = qs.filter(project__slug=project_slug)
         if branch:
             qs = qs.filter(commit_comparison__head_ref=branch)
 

--- a/src/sentry/releases/endpoints/organization_release_details.py
+++ b/src/sentry/releases/endpoints/organization_release_details.py
@@ -1,7 +1,7 @@
 import sentry_sdk
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
-from rest_framework.exceptions import ParseError
+from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import ListField
@@ -17,6 +17,7 @@ from sentry.api.endpoints.organization_releases import (
     get_stats_period_detail,
 )
 from sentry.api.exceptions import ConflictError, InvalidRepository, ResourceDoesNotExist
+from sentry.api.helpers.projects import ProjectIdOrSlugField, parse_id_or_slug_params
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import (
     ReleaseHeadCommitSerializer,
@@ -366,11 +367,17 @@ class OrganizationReleaseDetailsEndpoint(
         project = None
         if project_id:
             try:
-                project_id_int = int(project_id)
-            except ValueError:
+                project_id_or_slug = ProjectIdOrSlugField().run_validation(project_id)
+            except ValidationError:
+                raise ParseError(detail="Invalid project")
+            requested_project = parse_id_or_slug_params([project_id_or_slug])
+            if not requested_project.has_values:
                 raise ParseError(detail="Invalid project")
             validated_projects = self.get_projects(
-                request, organization, project_ids={project_id_int}
+                request,
+                organization,
+                project_ids=requested_project.ids or None,
+                project_slugs=requested_project.slugs or None,
             )
             if not validated_projects:
                 raise ResourceDoesNotExist

--- a/src/sentry/releases/endpoints/organization_release_details.py
+++ b/src/sentry/releases/endpoints/organization_release_details.py
@@ -363,7 +363,7 @@ class OrganizationReleaseDetailsEndpoint(
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        # Validate project access when project_id is provided
+        # Validate project access when a project identifier is provided.
         project = None
         if project_id:
             try:

--- a/src/sentry/releases/endpoints/organization_release_details.py
+++ b/src/sentry/releases/endpoints/organization_release_details.py
@@ -371,7 +371,7 @@ class OrganizationReleaseDetailsEndpoint(
             except ValidationError:
                 raise ParseError(detail="Invalid project")
             requested_project = parse_id_or_slug_params([project_id_or_slug])
-            if not requested_project.has_values:
+            if not requested_project.has_values or requested_project.has_all_projects_sentinel:
                 raise ParseError(detail="Invalid project")
             validated_projects = self.get_projects(
                 request,

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -81,7 +81,7 @@ class OrganizationReplayCountEndpoint(OrganizationEventsEndpointBase):
             GlobalParams.END,
             GlobalParams.STATS_PERIOD,
             OrganizationParams.PROJECT,
-            OrganizationParams.PROJECT_ID_OR_SLUG,
+            OrganizationParams.PROJECT_SLUG,
             VisibilityParams.QUERY,
             ReplayParams.DATA_SOURCE,
             ReplayParams.RETURN_IDS,

--- a/src/sentry/replays/endpoints/organization_replay_selector_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_selector_index.py
@@ -117,7 +117,18 @@ class OrganizationReplaySelectorIndexEndpoint(OrganizationReplayEndpoint):
         except NoProjects:
             return Response({"data": []}, status=200)
 
-        result = ReplaySelectorValidator(data=request.GET)
+        query_params = request.GET.copy()
+        project_slug_params = [slug for slug in query_params.getlist("projectSlug") if slug]
+        if "projectSlug" in query_params:
+            query_params.setlist("projectSlug", project_slug_params)
+        if project_slug_params:
+            query_params.pop("project", None)
+        elif "project" in query_params:
+            query_params.setlist(
+                "project", [project for project in query_params.getlist("project") if project]
+            )
+
+        result = ReplaySelectorValidator(data=query_params)
         if not result.is_valid():
             raise ParseError(result.errors)
 

--- a/src/sentry/replays/validators.py
+++ b/src/sentry/replays/validators.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from sentry.api.helpers.projects import ProjectIdOrSlugField
+
 VALID_FIELD_SET = (
     "activity",
     "browser",
@@ -66,8 +68,8 @@ UTC ISO8601 or epoch seconds. Use along with `start` instead of `statsPeriod`.
     )
     project = serializers.ListField(
         required=False,
-        help_text="The ID of the projects to filter by.",
-        child=serializers.IntegerField(),
+        help_text="The ID or slug of the projects to filter by.",
+        child=ProjectIdOrSlugField(),
     )
     projectSlug = serializers.ListField(
         required=False,
@@ -115,8 +117,8 @@ class ReplaySelectorValidator(serializers.Serializer):
     )
     project = serializers.ListField(
         required=False,
-        help_text="The ID of the projects to filter by.",
-        child=serializers.IntegerField(),
+        help_text="The ID or slug of the projects to filter by.",
+        child=ProjectIdOrSlugField(),
     )
     projectSlug = serializers.ListField(
         required=False,

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -683,6 +683,14 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
 
         assert {p.id for p in result} == {self.project_2.id}
 
+    def test_empty_explicit_project_slugs_falls_back_to_project_param(self) -> None:
+        self.create_team_membership(user=self.user, team=self.team_1)
+        request = self.build_request(project=[str(self.project_1.id)])
+
+        result = self.endpoint.get_projects(request, self.org, project_slugs=set())
+
+        assert {p.id for p in result} == {self.project_1.id}
+
     @mock.patch("sentry.api.bases.organization.cache")
     def test_release_permission_cache_key_uses_project_slug_precedence(
         self, mock_cache: mock.MagicMock

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -17,6 +17,7 @@ from sentry.api.bases.organization import (
     OrganizationAndStaffPermission,
     OrganizationEndpoint,
     OrganizationPermission,
+    OrganizationReleasesBaseEndpoint,
 )
 from sentry.api.exceptions import (
     MemberDisabledOverLimit,
@@ -681,6 +682,28 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
         result = self.endpoint.get_projects(request, self.org)
 
         assert {p.id for p in result} == {self.project_2.id}
+
+    @mock.patch("sentry.api.bases.organization.cache")
+    def test_release_permission_cache_key_uses_project_slug_precedence(
+        self, mock_cache: mock.MagicMock
+    ) -> None:
+        self.create_team_membership(user=self.user, team=self.team_3)
+        mock_cache.get.return_value = None
+        endpoint = OrganizationReleasesBaseEndpoint()
+
+        endpoint.has_release_permission(
+            self.build_request(project=[self.project_1.slug], projectSlug=[self.project_2.slug]),
+            self.org,
+        )
+        first_cache_key = mock_cache.get.call_args.args[0]
+
+        endpoint.has_release_permission(
+            self.build_request(project=[self.project_2.slug], projectSlug=[self.project_1.slug]),
+            self.org,
+        )
+        second_cache_key = mock_cache.get.call_args.args[0]
+
+        assert first_cache_key != second_cache_key
 
     def test_get_requested_project_ids_unchecked_ignores_slugs(self) -> None:
         request = self.build_request(project=["1", "my-slug", "42"])

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -556,15 +556,8 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
     @mock.patch(
         "sentry.api.bases.organization.OrganizationEndpoint._filter_projects_by_permissions"
     )
-    @mock.patch(
-        "sentry.api.bases.organization.OrganizationEndpoint.get_requested_project_ids_unchecked"
-    )
-    def test_get_projects_no_slug_fallsback_to_ids(
-        self, mock_get_project_ids_unchecked, mock__filter_projects_by_permissions
-    ):
-        project_slugs = [""]
-        request = self.build_request(projectSlug=project_slugs)
-        mock_get_project_ids_unchecked.return_value = {self.project_1.id}
+    def test_get_projects_no_slug_fallsback_to_ids(self, mock__filter_projects_by_permissions):
+        request = self.build_request(projectSlug=[""], project=[str(self.project_1.id)])
 
         def side_effect(
             projects,
@@ -579,7 +572,6 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
             self.org,
         )
 
-        mock_get_project_ids_unchecked.assert_called_with(request)
         mock__filter_projects_by_permissions.assert_called_with(
             projects=[self.project_1],
             request=request,
@@ -656,6 +648,54 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
 
         with pytest.raises(PermissionDenied):
             self.endpoint.get_projects(request, self.org)
+
+    def test_project_param_with_slug(self) -> None:
+        self.create_team_membership(user=self.user, team=self.team_1)
+        request = self.build_request(project=[self.project_1.slug])
+
+        result = self.endpoint.get_projects(request, self.org)
+
+        assert {p.id for p in result} == {self.project_1.id}
+
+    def test_project_param_with_mixed_ids_and_slugs(self) -> None:
+        self.create_team_membership(user=self.user, team=self.team_3)
+        request = self.build_request(project=[str(self.project_1.id), self.project_2.slug])
+
+        result = self.endpoint.get_projects(request, self.org)
+
+        assert {p.id for p in result} == {self.project_1.id, self.project_2.id}
+
+    def test_project_param_with_nonexistent_slug(self) -> None:
+        self.create_team_membership(user=self.user, team=self.team_1)
+        request = self.build_request(project=["nonexistent-slug"])
+
+        with pytest.raises(PermissionDenied):
+            self.endpoint.get_projects(request, self.org)
+
+    def test_project_slug_param_takes_precedence_over_project_param(self) -> None:
+        self.create_team_membership(user=self.user, team=self.team_3)
+        request = self.build_request(
+            project=[str(self.project_1.id)], projectSlug=[self.project_2.slug]
+        )
+
+        result = self.endpoint.get_projects(request, self.org)
+
+        assert {p.id for p in result} == {self.project_2.id}
+
+    def test_get_requested_project_ids_unchecked_ignores_slugs(self) -> None:
+        request = self.build_request(project=["1", "my-slug", "42"])
+
+        result = self.endpoint.get_requested_project_ids_unchecked(request)
+
+        assert result == {1, 42}
+
+    def test_get_requested_project_ids_and_slugs_unchecked(self) -> None:
+        request = self.build_request(project=["1", "my-slug", "42"])
+
+        result = self.endpoint.get_requested_project_ids_and_slugs_unchecked(request)
+
+        assert result.ids == {1, 42}
+        assert result.slugs == {"my-slug"}
 
 
 class GetEnvironmentsTest(BaseOrganizationEndpointTest):

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -425,6 +425,48 @@ class ReleaseThresholdStatusTest(APITestCase):
     @patch(
         "sentry.api.endpoints.release_thresholds.release_threshold_status_index.is_new_issue_count_healthy"
     )
+    def test_get_success_project_param_slug_filter(
+        self,
+        mock_is_new_issue_count_healthy: MagicMock,
+        mock_get_new_issue_counts: MagicMock,
+        mock_is_error_count_healthy: MagicMock,
+        mock_get_error_counts: MagicMock,
+        mock_is_crash_free_rate_healthy: MagicMock,
+        mock_fetch_sessions_data: MagicMock,
+    ) -> None:
+        now = datetime.now(UTC)
+        yesterday = now - timedelta(hours=24)
+        mock_is_error_count_healthy.return_value = True, 100
+        mock_is_new_issue_count_healthy.return_value = True, 100
+        mock_is_crash_free_rate_healthy.return_value = True, 100
+
+        project_slug_response = self.get_success_response(
+            self.organization.slug, start=yesterday, end=now, projectSlug=[self.project2.slug]
+        )
+        project_response = self.get_success_response(
+            self.organization.slug, start=yesterday, end=now, project=[self.project2.slug]
+        )
+
+        assert project_response.data == project_slug_response.data
+
+    @patch(
+        "sentry.api.endpoints.release_thresholds.release_threshold_status_index.fetch_sessions_data"
+    )
+    @patch(
+        "sentry.api.endpoints.release_thresholds.release_threshold_status_index.is_crash_free_rate_healthy_check"
+    )
+    @patch(
+        "sentry.api.endpoints.release_thresholds.release_threshold_status_index.get_errors_counts_timeseries_by_project_and_release"
+    )
+    @patch(
+        "sentry.api.endpoints.release_thresholds.release_threshold_status_index.is_error_count_healthy"
+    )
+    @patch(
+        "sentry.api.endpoints.release_thresholds.release_threshold_status_index.get_new_issue_counts"
+    )
+    @patch(
+        "sentry.api.endpoints.release_thresholds.release_threshold_status_index.is_new_issue_count_healthy"
+    )
     def test_fetches_relevant_stats(
         self,
         mock_is_new_issue_count_healthy: MagicMock,

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -449,6 +449,28 @@ class ReleaseThresholdStatusTest(APITestCase):
 
         assert project_response.data == project_slug_response.data
 
+    def test_get_success_empty_project_slug_falls_back_to_project_filter(self) -> None:
+        now = datetime.now(UTC)
+        yesterday = datetime.now(UTC) - timedelta(hours=24)
+        response = self.get_success_response(
+            self.organization.slug,
+            start=yesterday,
+            end=now,
+            projectSlug=[""],
+            project=[self.project2.slug],
+        )
+
+        assert len(response.data.keys()) == 1
+        data = response.data
+        r1_keys = [k for k, v in data.items() if k.split("-")[1] == self.release1.version]
+        assert len(r1_keys) == 1
+
+        project1_key = f"{self.project1.slug}-{self.release1.version}"
+        assert project1_key not in r1_keys
+        project2_key = f"{self.project2.slug}-{self.release1.version}"
+        assert project2_key in r1_keys
+        assert len(data[project2_key]) == 1
+
     @patch(
         "sentry.api.endpoints.release_thresholds.release_threshold_status_index.fetch_sessions_data"
     )

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -420,6 +420,37 @@ class ReleaseThresholdStatusTest(APITestCase):
 
         assert project_response.data == project_slug_response.data
 
+    def test_get_success_project_param_mixed_id_and_slug_filter(self) -> None:
+        now = datetime.now(UTC)
+        yesterday = now - timedelta(hours=24)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            start=yesterday,
+            end=now,
+            project=[str(self.project1.id), self.project2.slug],
+        )
+
+        assert set(response.data.keys()) == {
+            f"{self.project1.slug}-{self.release1.version}",
+            f"{self.project1.slug}-{self.release2.version}",
+            f"{self.project2.slug}-{self.release1.version}",
+        }
+
+    def test_get_success_project_slug_takes_precedence_over_project_id(self) -> None:
+        now = datetime.now(UTC)
+        yesterday = now - timedelta(hours=24)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            start=yesterday,
+            end=now,
+            projectSlug=[self.project2.slug],
+            project=[str(self.project1.id)],
+        )
+
+        assert set(response.data.keys()) == {f"{self.project2.slug}-{self.release1.version}"}
+
     def test_get_success_empty_project_slug_falls_back_to_project_filter(self) -> None:
         now = datetime.now(UTC)
         yesterday = datetime.now(UTC) - timedelta(hours=24)

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -407,38 +407,9 @@ class ReleaseThresholdStatusTest(APITestCase):
         r2_keys = [k for k, v in data.items() if k.split("-")[1] == self.release2.version]
         assert len(r2_keys) == 0
 
-    @patch(
-        "sentry.api.endpoints.release_thresholds.release_threshold_status_index.fetch_sessions_data"
-    )
-    @patch(
-        "sentry.api.endpoints.release_thresholds.release_threshold_status_index.is_crash_free_rate_healthy_check"
-    )
-    @patch(
-        "sentry.api.endpoints.release_thresholds.release_threshold_status_index.get_errors_counts_timeseries_by_project_and_release"
-    )
-    @patch(
-        "sentry.api.endpoints.release_thresholds.release_threshold_status_index.is_error_count_healthy"
-    )
-    @patch(
-        "sentry.api.endpoints.release_thresholds.release_threshold_status_index.get_new_issue_counts"
-    )
-    @patch(
-        "sentry.api.endpoints.release_thresholds.release_threshold_status_index.is_new_issue_count_healthy"
-    )
-    def test_get_success_project_param_slug_filter(
-        self,
-        mock_is_new_issue_count_healthy: MagicMock,
-        mock_get_new_issue_counts: MagicMock,
-        mock_is_error_count_healthy: MagicMock,
-        mock_get_error_counts: MagicMock,
-        mock_is_crash_free_rate_healthy: MagicMock,
-        mock_fetch_sessions_data: MagicMock,
-    ) -> None:
+    def test_get_success_project_param_slug_filter(self) -> None:
         now = datetime.now(UTC)
         yesterday = now - timedelta(hours=24)
-        mock_is_error_count_healthy.return_value = True, 100
-        mock_is_new_issue_count_healthy.return_value = True, 100
-        mock_is_crash_free_rate_healthy.return_value = True, 100
 
         project_slug_response = self.get_success_response(
             self.organization.slug, start=yesterday, end=now, projectSlug=[self.project2.slug]

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_thresholds_index.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_thresholds_index.py
@@ -49,6 +49,21 @@ class ReleaseThresholdTest(APITestCase):
         assert created_threshold["environment"]["id"] == str(self.canary_environment.id)
         assert created_threshold["environment"]["name"] == self.canary_environment.name
 
+    def test_get_valid_project_slug(self) -> None:
+        ReleaseThreshold.objects.create(
+            threshold_type=0,
+            trigger_type=0,
+            value=100,
+            window_in_seconds=1800,
+            project=self.project,
+            environment=self.canary_environment,
+        )
+
+        response = self.get_success_response(self.organization.slug, project=self.project.slug)
+
+        assert len(response.data) == 1
+        assert response.data[0]["project"]["id"] == str(self.project.id)
+
     def test_get_invalid_environment(self) -> None:
         self.get_error_response(self.organization.slug, environment="foo bar", project="-1")
 

--- a/tests/sentry/api/endpoints/test_organization_events_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_events_root_cause_analysis.py
@@ -39,3 +39,21 @@ class RootCauseAnalysisQuerySerializerTest(APITestCase):
 
         assert serializer.is_valid(), serializer.errors
         assert serializer.validated_data["project"] == self.project
+
+    def test_rejects_project_id_from_another_organization(self) -> None:
+        other_project = self.create_project(organization=self.create_organization())
+        serializer = RootCauseAnalysisQuerySerializer(
+            data=self._data(str(other_project.id)), context=self._context()
+        )
+
+        assert not serializer.is_valid()
+        assert str(serializer.errors["project"][0]) == "Invalid project"
+
+    def test_rejects_project_id_without_scope(self) -> None:
+        self.access.has_any_project_scope.return_value = False
+        serializer = RootCauseAnalysisQuerySerializer(
+            data=self._data(str(self.project.id)), context=self._context()
+        )
+
+        assert not serializer.is_valid()
+        assert str(serializer.errors["project"][0]) == "Insufficient access to project"

--- a/tests/sentry/api/endpoints/test_organization_events_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_events_root_cause_analysis.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock
+
+from sentry.api.endpoints.organization_events_root_cause_analysis import (
+    RootCauseAnalysisQuerySerializer,
+)
+from sentry.testutils.cases import APITestCase
+
+
+class RootCauseAnalysisQuerySerializerTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.create_project(organization=self.organization)
+        self.access = MagicMock()
+        self.access.has_any_project_scope.return_value = True
+
+    def _data(self, project):
+        return {
+            "transaction": "GET /api/0/issues/",
+            "project": project,
+            "breakpoint": "2024-01-01T00:00:00Z",
+        }
+
+    def _context(self):
+        return {"access": self.access, "organization": self.organization}
+
+    def test_accepts_project_id(self) -> None:
+        serializer = RootCauseAnalysisQuerySerializer(
+            data=self._data(str(self.project.id)), context=self._context()
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["project"] == self.project
+
+    def test_accepts_project_slug(self) -> None:
+        serializer = RootCauseAnalysisQuerySerializer(
+            data=self._data(self.project.slug), context=self._context()
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["project"] == self.project

--- a/tests/sentry/api/endpoints/test_organization_events_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_events_root_cause_analysis.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock
 
 from sentry.api.endpoints.organization_events_root_cause_analysis import (
@@ -13,14 +14,14 @@ class RootCauseAnalysisQuerySerializerTest(APITestCase):
         self.access = MagicMock()
         self.access.has_any_project_scope.return_value = True
 
-    def _data(self, project):
+    def _data(self, project: str) -> dict[str, str]:
         return {
             "transaction": "GET /api/0/issues/",
             "project": project,
             "breakpoint": "2024-01-01T00:00:00Z",
         }
 
-    def _context(self):
+    def _context(self) -> dict[str, Any]:
         return {"access": self.access, "organization": self.organization}
 
     def test_accepts_project_id(self) -> None:

--- a/tests/sentry/api/helpers/test_projects.py
+++ b/tests/sentry/api/helpers/test_projects.py
@@ -1,0 +1,62 @@
+import pytest
+from rest_framework import serializers
+
+from sentry.api.helpers.projects import ProjectIdOrSlugField, parse_id_or_slug_params
+
+
+class TestParseIdOrSlugParams:
+    def test_empty_input(self) -> None:
+        params = parse_id_or_slug_params([])
+        assert params.ids == set()
+        assert params.slugs == set()
+
+    def test_numeric_values(self) -> None:
+        params = parse_id_or_slug_params(["1", "2", "3"])
+        assert params.ids == {1, 2, 3}
+        assert params.slugs == set()
+
+    def test_slug_values(self) -> None:
+        params = parse_id_or_slug_params(["my-project", "another-proj"])
+        assert params.ids == set()
+        assert params.slugs == {"my-project", "another-proj"}
+
+    def test_mixed_values(self) -> None:
+        params = parse_id_or_slug_params(["1", "my-project", 42])
+        assert params.ids == {1, 42}
+        assert params.slugs == {"my-project"}
+
+    def test_empty_values_are_skipped(self) -> None:
+        params = parse_id_or_slug_params(["", None, "1", "foo"])
+        assert params.ids == {1}
+        assert params.slugs == {"foo"}
+
+    def test_negative_numbers_are_ids(self) -> None:
+        params = parse_id_or_slug_params(["-1"])
+        assert params.ids == {-1}
+        assert params.slugs == set()
+
+    def test_all_access_sigil_is_slug(self) -> None:
+        params = parse_id_or_slug_params(["$all"])
+        assert params.ids == set()
+        assert params.slugs == {"$all"}
+
+    def test_deduplication(self) -> None:
+        params = parse_id_or_slug_params(["1", "1", "foo", "foo"])
+        assert params.ids == {1}
+        assert params.slugs == {"foo"}
+
+
+class TestProjectIdOrSlugField:
+    def test_accepts_ids_and_slugs(self) -> None:
+        field = ProjectIdOrSlugField()
+        assert field.to_internal_value("1") == 1
+        assert field.to_internal_value(2) == 2
+        assert field.to_internal_value("my-project") == "my-project"
+
+    def test_rejects_invalid_slug(self) -> None:
+        field = ProjectIdOrSlugField()
+
+        with pytest.raises(serializers.ValidationError) as error:
+            field.to_internal_value("foo bar")
+
+        assert "Enter a valid slug" in str(error.value)

--- a/tests/sentry/api/helpers/test_projects.py
+++ b/tests/sentry/api/helpers/test_projects.py
@@ -40,6 +40,11 @@ class TestParseIdOrSlugParams:
         assert params.ids == set()
         assert params.slugs == {"$all"}
 
+    def test_detects_all_access_sentinels(self) -> None:
+        assert parse_id_or_slug_params(["-1"]).has_all_projects_sentinel
+        assert parse_id_or_slug_params(["$all"]).has_all_projects_sentinel
+        assert not parse_id_or_slug_params(["1", "my-project"]).has_all_projects_sentinel
+
     def test_deduplication(self) -> None:
         params = parse_id_or_slug_params(["1", "1", "foo", "foo"])
         assert params.ids == {1}

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -369,6 +369,30 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
         assert len(resp.data) == 1
         assert resp.data[0]["name"] == self.detector.name
 
+    def test_workflow_engine_serializer_filters_by_project_slug(self) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
+
+        other_project = self.create_project(organization=self.organization)
+        self.create_detector(
+            project=other_project,
+            type=MetricIssue.slug,
+            name="Other Project Detector",
+        )
+
+        self.login_as(self.user)
+        with self.feature(
+            ["organizations:incidents", "organizations:workflow-engine-rule-serializers"]
+        ):
+            id_response = self.get_success_response(self.organization.slug, project=self.project.id)
+            slug_response = self.get_success_response(
+                self.organization.slug, project=self.project.slug
+            )
+
+        assert slug_response.data == id_response.data
+        assert len(slug_response.data) == 1
+        assert slug_response.data[0]["name"] == self.detector.name
+
     def test_workflow_engine_serializer_gte_lte_condition_types(self) -> None:
         team = self.create_team(organization=self.organization, members=[self.user])
         ProjectTeam.objects.create(project=self.project, team=team)

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -72,6 +72,12 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
             project=self.project1, repository=self.repo1
         ).exists()
 
+    def test_create_single_mapping_with_project_id(self) -> None:
+        response = self.make_post({"project": self.project1.id})
+
+        assert response.status_code == 200, response.content
+        assert response.data["created"] == 1
+
     def test_create_multiple_mappings(self) -> None:
         response = self.make_post(
             {

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -1,7 +1,11 @@
 from collections.abc import Iterable
 from unittest.mock import MagicMock, patch
 
+import pytest
+from django.core.exceptions import ValidationError
+
 from sentry.constants import ObjectStatus
+from sentry.db.models.fields.slug import SentrySlugField
 from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.deletions.tasks.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs_control
 from sentry.grouping.grouptype import ErrorGroupType
@@ -48,6 +52,13 @@ from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 
 class ProjectTest(APITestCase, TestCase):
+    def test_slug_rejects_numeric_values(self) -> None:
+        slug_field = Project._meta.get_field("slug")
+
+        assert isinstance(slug_field, SentrySlugField)
+        with pytest.raises(ValidationError):
+            slug_field.run_validators("123")
+
     def test_member_set_simple(self) -> None:
         user = self.create_user()
         org = self.create_organization(owner=user)

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -494,6 +494,19 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
             ),
         )
 
+    def test_create_with_project_id(self) -> None:
+        data = {
+            "project": self.project.id,
+            "name": "My Monitor",
+            "type": "cron_job",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+        }
+
+        response = self.get_success_response(self.organization.slug, **data)
+
+        monitor = Monitor.objects.get(slug=response.data["slug"])
+        assert monitor.project_id == self.project.id
+
     def test_slug(self) -> None:
         data = {
             "project": self.project.slug,

--- a/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
+++ b/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
@@ -28,6 +28,7 @@ ActionRegistrationT = TypeVar("ActionRegistrationT", bound=ActionRegistration)
 class _Query(TypedDict, total=False):
     triggerType: str
     project: int | str
+    projectSlug: str
 
 
 class _QueryResult(TypedDict):
@@ -136,6 +137,11 @@ class NotificationActionsIndexEndpointTest(APITestCase):
             "regular project slug": {
                 "query": {"project": project.slug},
                 "result": {na2, na3},
+            },
+            "empty project": {"query": {"project": ""}, "result": {na1, na2, na3, na4}},
+            "empty project slug": {
+                "query": {"projectSlug": ""},
+                "result": {na1, na2, na3, na4},
             },
             "regular trigger": {
                 "query": {"triggerType": "teacher"},

--- a/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
+++ b/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
@@ -526,3 +526,44 @@ class NotificationActionsIndexEndpointTest(APITestCase):
             "You do not have permission to create notification actions for projects"
             in response.data["detail"]
         )
+
+    @patch.dict(NotificationAction._registry, {})
+    def test_post_team_admin__missing_access_with_project_id(self) -> None:
+        user = self.create_user()
+        member = self.create_member(organization=self.organization, user=user, role="member")
+        OrganizationMemberTeam.objects.create(
+            team=self.team, organizationmember=member, role="admin"
+        )
+        self.login_as(user)
+
+        non_admin_project = self.create_project(
+            organization=self.organization, teams=[self.create_team()]
+        )
+
+        class MockActionRegistration(ActionRegistration):
+            validate_action = MagicMock()
+
+            def fire(self, data: Any) -> None:
+                raise NotImplementedError
+
+        registration = MockActionRegistration
+        _mock_register(self.base_data)(registration)
+
+        data = {
+            **self.base_data,
+            "projects": [self.projects[0].id, non_admin_project.id],
+        }
+
+        assert not registration.validate_action.called
+        response = self.get_error_response(
+            self.organization.slug,
+            status_code=status.HTTP_403_FORBIDDEN,
+            method="POST",
+            **data,
+        )
+
+        assert not registration.validate_action.called
+        assert (
+            "You do not have permission to create notification actions for projects"
+            in response.data["detail"]
+        )

--- a/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
+++ b/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
@@ -27,7 +27,7 @@ ActionRegistrationT = TypeVar("ActionRegistrationT", bound=ActionRegistration)
 
 class _Query(TypedDict, total=False):
     triggerType: str
-    project: int
+    project: int | str
 
 
 class _QueryResult(TypedDict):
@@ -131,6 +131,10 @@ class NotificationActionsIndexEndpointTest(APITestCase):
             "checks projects by default": {"query": {}, "result": {na1, na2, na3, na4}},
             "regular project": {
                 "query": {"project": project.id},
+                "result": {na2, na3},
+            },
+            "regular project slug": {
+                "query": {"project": project.slug},
                 "result": {na2, na3},
             },
             "regular trigger": {

--- a/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
+++ b/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
@@ -451,6 +451,43 @@ class NotificationActionsIndexEndpointTest(APITestCase):
         self.test_post_simple()
 
     @patch.dict(NotificationAction._registry, {})
+    def test_post_team_admin__success_with_project_ids(self) -> None:
+        user = self.create_user()
+        member = self.create_member(organization=self.organization, user=user, role="member")
+        OrganizationMemberTeam.objects.create(
+            team=self.team, organizationmember=member, role="admin"
+        )
+        self.login_as(user)
+
+        class MockActionRegistration(ActionRegistration):
+            validate_action = MagicMock()
+
+            def fire(self, data: Any) -> None:
+                raise NotImplementedError
+
+        registration = MockActionRegistration
+        _mock_register(self.base_data)(registration)
+
+        data = {
+            **self.base_data,
+            "projects": [self.projects[0].id, str(self.projects[1].id)],
+        }
+        response = self.get_success_response(
+            self.organization.slug,
+            status_code=status.HTTP_201_CREATED,
+            method="POST",
+            **data,
+        )
+
+        registration.validate_action.assert_called()
+        notif_action_projects = NotificationActionProject.objects.filter(
+            action_id=response.data["id"]
+        )
+        assert {action_project.project_id for action_project in notif_action_projects} == {
+            project.id for project in self.projects
+        }
+
+    @patch.dict(NotificationAction._registry, {})
     def test_post_team_admin__missing_access(self) -> None:
         user = self.create_user()
         member = self.create_member(organization=self.organization, user=user, role="member")

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -906,6 +906,26 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         assert response.data["project_slug"] == "other-project"
         mock_get_session.assert_called_once_with(self.org.id, other_project.id)
 
+    def test_get_latest_base_snapshot_rejects_all_project_id_sentinel(self):
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {"app_id": "com.example.app", "project": "-1"},
+            )
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project parameter"
+
+    def test_get_latest_base_snapshot_rejects_all_project_slug_sentinel(self):
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {"app_id": "com.example.app", "project": "$all"},
+            )
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project parameter"
+
 
 class ProjectPreprodSnapshotDeleteTest(APITestCase):
     def setUp(self) -> None:

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -812,6 +812,11 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         return mock_session
 
     def test_query_params_document_project_slug(self):
+        assert LATEST_BASE_SNAPSHOT_GET_QUERY_PARAMS["project"] == {
+            "type": "string",
+            "required": False,
+            "description": "Project ID or slug to scope the lookup. Use either project or projectSlug when app_id is not unique across projects or project inference is unavailable.",
+        }
         assert LATEST_BASE_SNAPSHOT_GET_QUERY_PARAMS["projectSlug"] == {
             "type": "string",
             "required": False,
@@ -836,6 +841,42 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         assert response.data["project_slug"] == "sausage"
         assert response.data["image_count"] == 1
         assert response.data["images"][0]["image_file_name"] == "components/button.png"
+        mock_get_session.assert_called_once_with(self.org.id, self.project.id)
+
+    @patch(
+        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_preprod_session"
+    )
+    def test_get_latest_base_snapshot_scoped_by_project_param_slug(self, mock_get_session):
+        artifact, manifest_key, manifest_json = self._create_base_snapshot()
+        mock_get_session.return_value = self._create_mock_session(manifest_json)
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {"app_id": "com.example.app", "project": self.project.slug},
+            )
+
+        assert response.status_code == 200
+        assert response.data["head_artifact_id"] == str(artifact.id)
+        assert response.data["project_slug"] == "sausage"
+        mock_get_session.assert_called_once_with(self.org.id, self.project.id)
+
+    @patch(
+        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_preprod_session"
+    )
+    def test_get_latest_base_snapshot_scoped_by_project_param_id(self, mock_get_session):
+        artifact, manifest_key, manifest_json = self._create_base_snapshot()
+        mock_get_session.return_value = self._create_mock_session(manifest_json)
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {"app_id": "com.example.app", "project": str(self.project.id)},
+            )
+
+        assert response.status_code == 200
+        assert response.data["head_artifact_id"] == str(artifact.id)
+        assert response.data["project_slug"] == "sausage"
         mock_get_session.assert_called_once_with(self.org.id, self.project.id)
 
 

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -782,7 +782,8 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
             args=[self.org.slug],
         )
 
-    def _create_base_snapshot(self):
+    def _create_base_snapshot(self, project=None):
+        project = project or self.project
         images = {
             "components/button.png": {
                 "content_hash": "hash_button",
@@ -792,11 +793,11 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
             }
         }
         artifact = PreprodArtifact.objects.create(
-            project=self.project,
+            project=project,
             state=PreprodArtifact.ArtifactState.UPLOADED,
             app_id="com.example.app",
         )
-        manifest_key = f"{self.org.id}/{self.project.id}/{artifact.id}/manifest.json"
+        manifest_key = f"{self.org.id}/{project.id}/{artifact.id}/manifest.json"
         PreprodSnapshotMetrics.objects.create(
             preprod_artifact=artifact,
             image_count=len(images),
@@ -878,6 +879,32 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         assert response.data["head_artifact_id"] == str(artifact.id)
         assert response.data["project_slug"] == "sausage"
         mock_get_session.assert_called_once_with(self.org.id, self.project.id)
+
+    @patch(
+        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_preprod_session"
+    )
+    def test_get_latest_base_snapshot_project_slug_takes_precedence_over_project(
+        self, mock_get_session
+    ):
+        self._create_base_snapshot()
+        other_project = self.create_project(organization=self.org, slug="other-project")
+        artifact, _, manifest_json = self._create_base_snapshot(project=other_project)
+        mock_get_session.return_value = self._create_mock_session(manifest_json)
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {
+                    "app_id": "com.example.app",
+                    "project": self.project.slug,
+                    "projectSlug": other_project.slug,
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.data["head_artifact_id"] == str(artifact.id)
+        assert response.data["project_slug"] == "other-project"
+        mock_get_session.assert_called_once_with(self.org.id, other_project.id)
 
 
 class ProjectPreprodSnapshotDeleteTest(APITestCase):

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -926,6 +926,26 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid project parameter"
 
+    def test_get_latest_base_snapshot_rejects_project_slug_all_sentinel(self):
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {"app_id": "com.example.app", "projectSlug": "$all"},
+            )
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project parameter"
+
+    def test_get_latest_base_snapshot_rejects_project_slug_id_sentinel(self):
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {"app_id": "com.example.app", "projectSlug": "-1"},
+            )
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project parameter"
+
 
 class ProjectPreprodSnapshotDeleteTest(APITestCase):
     def setUp(self) -> None:

--- a/tests/sentry/releases/endpoints/test_organization_release_details.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_details.py
@@ -174,6 +174,38 @@ class ReleaseDetailsTest(APITestCase):
         response = self.client.get(url, {"project": no_access_project.id})
         assert response.status_code in (403, 404)
 
+    def test_all_project_id_sentinel_is_rejected(self) -> None:
+        release = Release.objects.create(organization_id=self.organization.id, version="abcabcabc")
+        release.add_project(self.project1)
+
+        self.create_member(teams=[self.team1], user=self.user1, organization=self.organization)
+        self.login_as(user=self.user1)
+
+        url = reverse(
+            "sentry-api-0-organization-release-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "version": release.version},
+        )
+
+        response = self.client.get(url, {"project": "-1"})
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project"
+
+    def test_all_project_slug_sentinel_is_rejected(self) -> None:
+        release = Release.objects.create(organization_id=self.organization.id, version="abcabcabc")
+        release.add_project(self.project1)
+
+        self.create_member(teams=[self.team1], user=self.user1, organization=self.organization)
+        self.login_as(user=self.user1)
+
+        url = reverse(
+            "sentry-api-0-organization-release-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "version": release.version},
+        )
+
+        response = self.client.get(url, {"project": "$all"})
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project"
+
     def test_correct_project_contains_current_project_meta(self) -> None:
         """
         Test that shows when correct project id is passed to the request, `sessionsLowerBound`,

--- a/tests/sentry/releases/endpoints/test_organization_release_details.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_details.py
@@ -130,6 +130,9 @@ class ReleaseDetailsTest(APITestCase):
         response = self.client.get(url, {"project": self.project1.id})
         assert response.status_code == 200
 
+        response = self.client.get(url, {"project": self.project1.slug})
+        assert response.status_code == 200
+
     def test_project_from_another_org_is_rejected(self) -> None:
         """Supplying a project_id belonging to a different organization must not
         leak session health data (IDOR check)."""

--- a/tests/sentry/replays/endpoints/test_organization_replay_index.py
+++ b/tests/sentry/replays/endpoints/test_organization_replay_index.py
@@ -12,6 +12,7 @@ from sentry.replays.testutils import (
     mock_replay_tap,
     mock_replay_viewed,
 )
+from sentry.replays.validators import ReplaySelectorValidator, ReplayValidator
 from sentry.testutils.cases import APITestCase, ReplaysSnubaTestCase
 from sentry.utils.cursors import Cursor
 from sentry.utils.snuba import QueryMemoryLimitExceeded
@@ -24,6 +25,13 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
         super().setUp()
         self.login_as(user=self.user)
         self.url = reverse(self.endpoint, args=(self.organization.slug,))
+
+    def test_replay_validators_accept_project_slugs(self) -> None:
+        replay_validator = ReplayValidator(data={"project": ["my-project"]})
+        selector_validator = ReplaySelectorValidator(data={"project": ["my-project"]})
+
+        assert replay_validator.is_valid(), replay_validator.errors
+        assert selector_validator.is_valid(), selector_validator.errors
 
     @property
     def features(self) -> dict[str, bool]:

--- a/tests/snuba/api/endpoints/test_organization_stats_summary.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_summary.py
@@ -288,6 +288,20 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
         assert response.data == {"detail": "You do not have permission to perform this action."}
 
     @freeze_time(_now)
+    def test_project_slug_filter_matches_project_id_filter(self) -> None:
+        query = {
+            "statsPeriod": "1d",
+            "interval": "1d",
+            "field": ["sum(quantity)"],
+            "category": ["error"],
+        }
+
+        id_response = self.do_request({**query, "project": self.project2.id})
+        slug_response = self.do_request({**query, "project": self.project2.slug})
+
+        assert slug_response.data == id_response.data
+
+    @freeze_time(_now)
     def test_open_membership_semantics(self) -> None:
         self.org.flags.allow_joinleave = True
         self.org.save()

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -701,6 +701,20 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
         }
 
     @freeze_time(_now)
+    def test_project_slug_filter_matches_project_id_filter(self) -> None:
+        query = {
+            "statsPeriod": "1d",
+            "interval": "1d",
+            "field": ["sum(quantity)"],
+            "category": ["error"],
+        }
+
+        id_response = self.do_request({**query, "project": self.project2.id}, org=self.org)
+        slug_response = self.do_request({**query, "project": self.project2.slug}, org=self.org)
+
+        assert slug_response.data == id_response.data
+
+    @freeze_time(_now)
     def test_staff_project_filter(self) -> None:
         staff_user = self.create_user(is_staff=True, is_superuser=True)
         self.login_as(user=staff_user, superuser=True)


### PR DESCRIPTION
Allow API project inputs to use project slugs anywhere they already accept project IDs. This lets callers use the same org-scoped project identifier they already see in URLs while keeping the existing `projectSlug` precedence intact.

**Shared Project Reference Field**

`ProjectIdOrSlugField` and `parse_id_or_slug_params` normalize project identifiers for serializers and repeated query params. `OrganizationEndpoint.get_projects()` now resolves mixed IDs and slugs through the same central path instead of duplicating integer-only parsing in individual endpoints.

**Permission Safety**

Project slugs are unique within an organization, and every slug lookup in this PR remains scoped to the current organization. The central resolver starts from active projects in the organization, applies the existing project permission filter, then validates that every requested ID or slug resolved to an accessible project.

**Project Filter Edge Cases**

Empty `project` and `projectSlug` values are treated as absent. Empty explicit `project_slugs` overrides no longer suppress `project` parsing, avoiding accidental widening to all membership projects. Single-project parameters reject the all-project sentinels `-1` and `$all` so they cannot silently resolve to an arbitrary accessible project.

**Release Permission Cache**

Release permission cache keys now use the same effective project scope as `get_projects()`. When `projectSlug` is present, ignored `project` params are no longer included in the cache key, avoiding swapped-parameter cache collisions.

**Notification Action Filters**

Notification action listing now treats empty `project` and `projectSlug` query values as absent so organization-wide actions are preserved unless an effective project filter is provided.

**OpenAPI Project Params**

The API docs now distinguish path-level `project_id_or_slug`, repeated `project` filters that accept IDs or slugs, and the legacy `projectSlug` filter that takes precedence when both are present.

**Endpoint Updates**

Integer-only project parsing now uses the shared resolver across stats, release thresholds, releases, notifications, alert-rule listing, code mappings, preprod snapshots, monitors, replays, and root-cause-analysis.

Dedicated endpoint and serializer tests cover ID and slug inputs for the updated resolver paths.