### PR TITLE
fix(issues): Guard memberList lookups against prototype-chain hits

### DIFF
--- a/static/app/views/issueList/groupListBody.spec.tsx
+++ b/static/app/views/issueList/groupListBody.spec.tsx
@@ -1,0 +1,77 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {GroupStore} from 'sentry/stores/groupStore';
+import {GroupListBody} from 'sentry/views/issueList/groupListBody';
+
+describe('GroupListBody', () => {
+  const organization = OrganizationFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    GroupStore.reset();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+  });
+
+  afterEach(() => {
+    GroupStore.reset();
+  });
+
+  function renderBody(group: ReturnType<typeof GroupFixture>) {
+    GroupStore.add([group]);
+    return render(
+      <GroupListBody
+        groupIds={[group.id]}
+        memberList={{}}
+        query=""
+        displayReprocessingLayout={false}
+        groupStatsPeriod="24h"
+        loading={false}
+        error={null}
+        pageSize={25}
+        refetchGroups={jest.fn()}
+        onActionTaken={jest.fn()}
+        selectedProjectIds={[]}
+      />,
+      {organization}
+    );
+  }
+
+  it('renders a group whose project slug collides with Object.prototype.constructor', async () => {
+    // Regression guard for JAVASCRIPT-39FS: `memberList['constructor']` used to
+    // resolve to Object.prototype.constructor via the prototype chain and crash
+    // AssigneeSelectorDropdown at `.find()`.
+    const group = GroupFixture({
+      id: '1',
+      project: ProjectFixture({id: '13', slug: 'constructor'}),
+    });
+
+    renderBody(group);
+
+    expect(await screen.findByTestId('group')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Modify issue assignee'})
+    ).toBeInTheDocument();
+  });
+
+  it('renders a group with a normal project slug not in the indexed memberList', async () => {
+    const group = GroupFixture({
+      id: '2',
+      project: ProjectFixture({id: '14', slug: 'foo-project'}),
+    });
+
+    renderBody(group);
+
+    expect(await screen.findByTestId('group')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -207,7 +207,11 @@ function GroupList({
         statsPeriod={groupStatsPeriod}
         query={query}
         hasGuideAnchor={id === topIssue}
-        memberList={group.project ? memberList[group.project.slug] : undefined}
+        memberList={
+          group.project && Object.hasOwn(memberList, group.project.slug)
+            ? memberList[group.project.slug]
+            : undefined
+        }
         displayReprocessingLayout={displayReprocessingLayout}
         useFilteredStats
         canSelect={!selectDisabled}

--- a/static/app/views/issueList/supergroups/supergroupDrawer.spec.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.spec.tsx
@@ -1,5 +1,6 @@
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 import {SupergroupDetailFixture} from 'sentry-fixture/supergroupDetail';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -74,5 +75,37 @@ describe('SupergroupDetailDrawer', () => {
     expect(await screen.findByText('MATCHED_MEMBER')).toBeInTheDocument();
     const rows = screen.getAllByTestId('group');
     expect(rows[0]).toHaveTextContent('MATCHED_MEMBER');
+  });
+
+  it('renders a group whose project slug collides with Object.prototype.constructor', async () => {
+    // Regression guard for JAVASCRIPT-39FS: `memberList['constructor']` used to
+    // resolve to Object.prototype.constructor via the prototype chain and crash
+    // AssigneeSelectorDropdown at `.find()`.
+    const group = GroupFixture({
+      id: '1',
+      project: ProjectFixture({id: '13', slug: 'constructor'}),
+    });
+
+    MockApiClient.addMockResponse({
+      url: issuesUrl,
+      method: 'GET',
+      body: [group],
+    });
+
+    render(
+      <SupergroupDetailDrawer
+        supergroup={SupergroupDetailFixture({group_ids: [Number(group.id)]})}
+        memberList={{}}
+      />,
+      {
+        organization,
+        initialRouterConfig: {
+          route: '/organizations/:orgId/issues/',
+          location: {pathname: '/organizations/:orgId/issues/'},
+        },
+      }
+    );
+
+    expect(await screen.findByTestId('group')).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -295,9 +295,12 @@ function SupergroupIssueList({
           <DrawerActionsBar groupIds={visibleGroupIds} />
           <PanelBody>
             {sortedGroups.map(group => {
-              const members = memberList?.[group.project?.slug]
-                ? memberList[group.project.slug]
-                : undefined;
+              const members =
+                memberList &&
+                group.project &&
+                Object.hasOwn(memberList, group.project.slug)
+                  ? memberList[group.project.slug]
+                  : undefined;
               return (
                 <IssueRow key={group.id}>
                   {matchedIds.has(group.id) && (


### PR DESCRIPTION
groupListBody and the supergroup drawer indexed an `IndexedMembersByProject` (`Record<string, User[]>`) directly by `group.project.slug`. With Sentry's lowercase slug rules the only `Object.prototype` names that can collide are `constructor` and `__proto__` and the failing customer had a project named `constructor`. `memberList['constructor']` resolved to Object's constructor function via the prototype chain, flowed into AssigneeSelectorDropdown's memberList prop, and crashed at `memList.find(...)`.

Use `Object.hasOwn` before reading the slug, matching the safe pattern already in components/issues/groupList.tsx.

Fixes [JAVASCRIPT-39FS](https://sentry.io/organizations/sentry/issues/?project=11276&query=JAVASCRIPT-39FS)