### PR TITLE
fix(intercom): Scope messenger identity to org

### DIFF
--- a/src/sentry/api/endpoints/organization_intercom_jwt.py
+++ b/src/sentry/api/endpoints/organization_intercom_jwt.py
@@ -23,6 +23,10 @@ logger = logging.getLogger(__name__)
 JWT_VALIDITY_WINDOW_SECONDS = 300
 
 
+def get_intercom_user_id(user_id: int, organization_id: int) -> str:
+    return f"sentry:{user_id}:org:{organization_id}"
+
+
 @control_silo_endpoint
 class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
     """
@@ -63,10 +67,11 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
         user = request.user
         now = int(datetime.datetime.now(datetime.UTC).timestamp())
         exp = now + JWT_VALIDITY_WINDOW_SECONDS
+        intercom_user_id = get_intercom_user_id(user.id, organization.id)
 
         # Build JWT claims - user_id is required by Intercom
         claims = {
-            "user_id": str(user.id),
+            "user_id": intercom_user_id,
             "email": user.email,
             "iat": now,
             "exp": exp,
@@ -84,7 +89,7 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
             created_at = int(user.last_active.timestamp())
 
         user_data = {
-            "userId": str(user.id),
+            "userId": intercom_user_id,
             "email": user.email,
             "name": user.get_display_name(),
             "createdAt": created_at,

--- a/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
+++ b/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
@@ -1,3 +1,4 @@
+from sentry.api.endpoints.organization_intercom_jwt import get_intercom_user_id
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import jwt
@@ -21,8 +22,9 @@ class OrganizationIntercomJwtEndpointTest(APITestCase):
         assert "userData" in response.data
 
         # Verify user data
+        expected_user_id = get_intercom_user_id(self.user.id, self.organization.id)
         user_data = response.data["userData"]
-        assert user_data["userId"] == str(self.user.id)
+        assert user_data["userId"] == expected_user_id
         assert user_data["email"] == self.user.email
         assert user_data["organizationId"] == str(self.organization.id)
         assert user_data["organizationName"] == self.organization.name
@@ -32,10 +34,35 @@ class OrganizationIntercomJwtEndpointTest(APITestCase):
         token = response.data["jwt"]
         decoded = jwt.decode(token, test_secret, algorithms=["HS256"], audience=False)
 
-        assert decoded["user_id"] == str(self.user.id)
+        assert decoded["user_id"] == expected_user_id
         assert decoded["email"] == self.user.email
         assert "iat" in decoded
         assert "exp" in decoded
+
+    def test_get_jwt_user_id_is_scoped_to_organization(self) -> None:
+        test_secret = "test-intercom-secret-key"
+        other_organization = self.create_organization(owner=self.user)
+
+        with self.options({"intercom.sentry-api-secret": test_secret}):
+            response = self.get_success_response(self.organization.slug)
+            other_response = self.get_success_response(other_organization.slug)
+
+        user_id = response.data["userData"]["userId"]
+        other_user_id = other_response.data["userData"]["userId"]
+
+        assert user_id == get_intercom_user_id(self.user.id, self.organization.id)
+        assert other_user_id == get_intercom_user_id(self.user.id, other_organization.id)
+        assert user_id != other_user_id
+
+        decoded = jwt.decode(
+            response.data["jwt"], test_secret, algorithms=["HS256"], audience=False
+        )
+        other_decoded = jwt.decode(
+            other_response.data["jwt"], test_secret, algorithms=["HS256"], audience=False
+        )
+
+        assert decoded["user_id"] == user_id
+        assert other_decoded["user_id"] == other_user_id
 
     def test_get_jwt_unauthenticated(self) -> None:
         """Unauthenticated requests should return 401."""


### PR DESCRIPTION
Intercom keys Messenger users off the `user_id` we send and sign. We were using the raw Sentry user id, which means the same user gets one Intercom identity across every org.

This scopes the Intercom id to both the Sentry user and org, then uses that same value in the JWT claim and the boot payload. Adds a test so those do not drift apart.

This will create new Intercom identities instead of reusing the old raw user id, so previous conversations need a migration/linking plan if we care about carrying them over.
