### PR TITLE
ref(issues): Use group naming for action log events and stringify IDs

### DIFF
--- a/src/sentry/issues/action_log/base.py
+++ b/src/sentry/issues/action_log/base.py
@@ -81,7 +81,7 @@ def resolve_action_source(request: Request) -> str:
         if family and family not in MCP_CATCHALL_CLIENT_FAMILIES:
             # Values outside this set are logged so we know to add new ones
             logger.warning(
-                "issue.action_log.unrecognized_mcp_client_family",
+                "group.action_log.unrecognized_mcp_client_family",
                 extra={"client_family": family},
             )
         return ActionSource.MCP
@@ -157,17 +157,19 @@ def publish_action(
     prefer publish_action_from_context().
     """
     action_name = action.get_type().name.lower()
-    metrics.incr("issue.action_log", tags={"action": action_name, "source": source})
+    metrics.incr("issues.action_log", tags={"action": action_name, "source": source})
     logger.info(
-        "issue.action_log",
+        "group.action_log",
         extra={
             "action": action_name,
             "source": source,
-            "group_id": group_id,
-            "organization_id": organization_id,
-            "project_id": project_id,
+            # IDs are stringified so large values aren't rendered in scientific
+            # notation by downstream log tooling.
+            "group_id": str(group_id),
+            "organization_id": str(organization_id),
+            "project_id": str(project_id),
             "actor_type": actor.actor_type.name.lower(),
-            "actor_id": actor.actor_id,
+            "actor_id": str(actor.actor_id),
             "metadata": action.dict(),
             "idempotency_key": idempotency_key,
         },
@@ -223,7 +225,7 @@ def publish_action_from_context(
     if ctx is None:
         logger.error(
             "publish_action_from_context called without ActionContext",
-            extra={"action": action.get_type().name.lower(), "group_id": group_id},
+            extra={"action": action.get_type().name.lower(), "group_id": str(group_id)},
         )
         source: str = ActionSource.UNKNOWN
         actor = SYSTEM_ACTOR

--- a/tests/sentry/issues/test_action_log.py
+++ b/tests/sentry/issues/test_action_log.py
@@ -175,10 +175,10 @@ class TestPublishAction(TestCase):
         assert len(logs.records) == 1
         record = logs.records[0]
         extra = record.__dict__
-        assert record.message == "issue.action_log"
+        assert record.message == "group.action_log"
         assert extra["action"] == "resolve"
         assert extra["source"] == "mcp:claude-code"
-        assert extra["actor_id"] == 4
+        assert extra["actor_id"] == "4"
 
     def test_actor_type_derived_from_actor(self) -> None:
         with self.assertLogs("sentry.issues.action_log", level="INFO") as logs:
@@ -216,7 +216,7 @@ class TestPublishActionFromContext(TestCase):
             )
         error_records = [r for r in logs.records if r.levelname == "ERROR"]
         assert any("without ActionContext" in r.message for r in error_records)
-        info_record = [r for r in logs.records if r.message == "issue.action_log"][0]
+        info_record = [r for r in logs.records if r.message == "group.action_log"][0]
         assert info_record.__dict__["source"] == "unknown"
 
 

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -208,7 +208,7 @@ class ResolvedInCommitTest(TestCase):
         # The self-assign is attributed to the commit author, not logged as a system action.
         assign_records = [r for r in logs.records if r.__dict__.get("action") == "assign"]
         assert len(assign_records) == 1
-        assert assign_records[0].__dict__["actor_id"] == user.id
+        assert assign_records[0].__dict__["actor_id"] == str(user.id)
         assert assign_records[0].__dict__["actor_type"] == "user"
         assert assign_records[0].__dict__["source"] == "system"
 


### PR DESCRIPTION
Follow-up corrections to the `GroupActionLogEntry` instrumentation backbone, now that the model is named with the **group** vocabulary:

- **Log event name** → `group.action_log` (and the MCP catch-all warning → `group.action_log.unrecognized_mcp_client_family`), matching the renamed model.
- **Metric stays plural** under `issues.action_log` — consistent with our other `issues.*` metrics.
- **IDs stringified** in the structured log extra (`group_id`, `organization_id`, `project_id`, `actor_id`) so large values aren't rendered in scientific notation by downstream log tooling.