### PR TITLE
feat(events): Wire up TagDerivers behind feature flag

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -806,8 +806,10 @@ def _partition_jobs_by_tag_deriver_flag(
 def _derive_tags_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
     new_jobs, legacy_jobs = _partition_jobs_by_tag_deriver_flag(jobs, projects)
     if new_jobs:
+        metrics.incr("event_manager.derive_tags.new_path", amount=len(new_jobs))
         _derive_tags_many_new(new_jobs, projects)
     if legacy_jobs:
+        metrics.incr("event_manager.derive_tags.legacy_path", amount=len(legacy_jobs))
         _derive_tags_many_legacy(legacy_jobs, projects)
 
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -49,6 +49,7 @@ from sentry.constants import (
 )
 from sentry.culprit import generate_culprit
 from sentry.dynamic_sampling import record_latest_release
+from sentry.event_manager_auto_tags import get_enabled_derivers
 from sentry.eventstream.base import GroupState
 from sentry.eventtypes.base import BaseEvent as EventType
 from sentry.eventtypes.transaction import TransactionEvent
@@ -781,22 +782,40 @@ def _get_event_user_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None
         job["user"] = user
 
 
+def _partition_jobs_by_tag_deriver_flag(
+    jobs: Sequence[Job], projects: ProjectsMapping
+) -> tuple[list[Job], list[Job]]:
+    org_flag_mapping: dict[int, bool] = {}
+    new_jobs: list[Job] = []
+    legacy_jobs: list[Job] = []
+    for job in jobs:
+        project = projects[job["project_id"]]
+        org_id = project.organization_id
+        if org_id not in org_flag_mapping:
+            org_flag_mapping[org_id] = features.has(
+                "organizations:derive-tags-without-plugins", project.organization
+            )
+        if org_flag_mapping[org_id]:
+            new_jobs.append(job)
+        else:
+            legacy_jobs.append(job)
+    return new_jobs, legacy_jobs
+
+
 @sentry_sdk.tracing.trace
 def _derive_tags_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
-    sample_project = next(iter(projects.values()))
-    if features.has("organizations:derive-tags-without-plugins", sample_project.organization):
-        _derive_tags_many_new(jobs, projects)
-    else:
-        _derive_tags_many_legacy(jobs, projects)
+    new_jobs, legacy_jobs = _partition_jobs_by_tag_deriver_flag(jobs, projects)
+    if new_jobs:
+        _derive_tags_many_new(new_jobs, projects)
+    if legacy_jobs:
+        _derive_tags_many_legacy(legacy_jobs, projects)
 
 
 def _derive_tags_many_new(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
-    from sentry.event_manager_auto_tags import get_enabled_derivers
-
-    derivers_for_projects = {p.id: get_enabled_derivers(p) for p in projects.values()}
+    derivers = get_enabled_derivers()
     for job in jobs:
         data = job["data"]
-        for deriver in derivers_for_projects[job["project_id"]]:
+        for deriver in derivers:
             try:
                 for key, value in deriver.get_tags(job["event"]):
                     if get_tag(data, key) is None:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -539,7 +539,7 @@ class EventManager:
             except ProjectKey.DoesNotExist:
                 pass
 
-        _derive_plugin_tags_many(jobs, projects)
+        _derive_tags_many(jobs, projects)
         _derive_interface_tags_many(jobs)
         _derive_client_error_sampling_rate(jobs, projects)
 
@@ -782,8 +782,30 @@ def _get_event_user_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None
 
 
 @sentry_sdk.tracing.trace
-def _derive_plugin_tags_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
-    # XXX: We ought to inline or remove this one for sure
+def _derive_tags_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
+    sample_project = next(iter(projects.values()))
+    if features.has("organizations:derive-tags-without-plugins", sample_project.organization):
+        _derive_tags_many_new(jobs, projects)
+    else:
+        _derive_tags_many_legacy(jobs, projects)
+
+
+def _derive_tags_many_new(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
+    from sentry.event_manager_auto_tags import get_enabled_derivers
+
+    derivers_for_projects = {p.id: get_enabled_derivers(p) for p in projects.values()}
+    for job in jobs:
+        data = job["data"]
+        for deriver in derivers_for_projects[job["project_id"]]:
+            try:
+                for key, value in deriver.get_tags(job["event"]):
+                    if get_tag(data, key) is None:
+                        set_tag(data, key, value)
+            except Exception:
+                logger.exception("auto_tag.derive_error")
+
+
+def _derive_tags_many_legacy(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
     plugins_for_projects = {p.id: plugins.for_project(p, version=None) for p in projects.values()}
 
     for job in jobs:
@@ -2742,7 +2764,7 @@ def save_transaction_events(
 
     _get_or_create_release_many(jobs, projects)
     _get_event_user_many(jobs, projects)
-    _derive_plugin_tags_many(jobs, projects)
+    _derive_tags_many(jobs, projects)
     _derive_interface_tags_many(jobs)
     _calculate_span_grouping(jobs, projects)
     _materialize_metadata_many(jobs)
@@ -2781,7 +2803,7 @@ def save_generic_events(jobs: Sequence[Job], projects: ProjectsMapping) -> Seque
 
     _get_or_create_release_many(jobs, projects)
     _get_event_user_many(jobs, projects)
-    _derive_plugin_tags_many(jobs, projects)
+    _derive_tags_many(jobs, projects)
     _derive_interface_tags_many(jobs)
     _materialize_metadata_many(jobs)
     _get_or_create_environment_many(jobs, projects)

--- a/src/sentry/event_manager_auto_tags.py
+++ b/src/sentry/event_manager_auto_tags.py
@@ -9,8 +9,6 @@ if TYPE_CHECKING:
     from ua_parser.user_agent_parser import _ParseResult
 
 from sentry.constants import MAX_TAG_VALUE_LENGTH
-from sentry.models.options.project_option import ProjectOption
-from sentry.models.project import Project
 
 
 class TagDeriver(abc.ABC):
@@ -126,14 +124,5 @@ ALL_TAG_DERIVERS: list[TagDeriver] = [
 ]
 
 
-def get_enabled_derivers(project: Project) -> list[TagDeriver]:
-    all_options = ProjectOption.objects.get_all_values(project)
-    enabled: list[TagDeriver] = []
-    for deriver in ALL_TAG_DERIVERS:
-        opt_value = all_options.get(deriver.option_key)
-        if opt_value is not None:
-            if opt_value:
-                enabled.append(deriver)
-        elif deriver.default_enabled:
-            enabled.append(deriver)
-    return enabled
+def get_enabled_derivers() -> list[TagDeriver]:
+    return [deriver for deriver in ALL_TAG_DERIVERS if deriver.default_enabled]

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -89,6 +89,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:intercom-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable default anomaly detection metric monitor for new projects
     manager.add("organizations:default-anomaly-detector", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:derive-tags-without-plugins", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the discover saved queries deprecation warnings
     manager.add("organizations:discover-saved-queries-deprecation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable migration of transaction widgets and queries to spans

--- a/tests/sentry/event_manager/test_auto_tags.py
+++ b/tests/sentry/event_manager/test_auto_tags.py
@@ -14,8 +14,8 @@ from sentry.event_manager_auto_tags import (
     UrlTagDeriver,
     get_enabled_derivers,
 )
-from sentry.models.options.project_option import ProjectOption
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 
 
 def _make_event(
@@ -246,10 +246,9 @@ class TestDictHeaders:
         assert tags == [("browser", "Googlebot 2.1")]
 
 
-class TestGetEnabledDerivers(TestCase):
-    def test_default_returns_default_enabled(self) -> None:
-        project = self.create_project()
-        derivers = get_enabled_derivers(project)
+class TestGetEnabledDerivers:
+    def test_returns_all_default_enabled(self) -> None:
+        derivers = get_enabled_derivers()
         tags = {d.tag for d in derivers}
         assert "browser" in tags
         assert "os" in tags
@@ -257,33 +256,8 @@ class TestGetEnabledDerivers(TestCase):
         assert "url" in tags
         assert "interface_type" in tags
 
-    def test_disabling_default_on_deriver(self) -> None:
-        project = self.create_project()
-        ProjectOption.objects.set_value(project, "auto_tag:_browsers:enabled", False)
-        derivers = get_enabled_derivers(project)
-        tags = {d.tag for d in derivers}
-        assert "browser" not in tags
-        assert "os" in tags
-
-    def test_disabling_interface_type_deriver(self) -> None:
-        project = self.create_project()
-        ProjectOption.objects.set_value(project, "auto_tag:_interface_types:enabled", False)
-        derivers = get_enabled_derivers(project)
-        tags = {d.tag for d in derivers}
-        assert "interface_type" not in tags
-
-    def test_all_disabled(self) -> None:
-        project = self.create_project()
-        for deriver in ALL_TAG_DERIVERS:
-            ProjectOption.objects.set_value(project, deriver.option_key, False)
-        derivers = get_enabled_derivers(project)
-        assert derivers == []
-
-    def test_all_enabled(self) -> None:
-        project = self.create_project()
-        for deriver in ALL_TAG_DERIVERS:
-            ProjectOption.objects.set_value(project, deriver.option_key, True)
-        derivers = get_enabled_derivers(project)
+    def test_returns_all_derivers(self) -> None:
+        derivers = get_enabled_derivers()
         assert len(derivers) == len(ALL_TAG_DERIVERS)
 
 
@@ -313,13 +287,13 @@ class TestDeriveTagsMany(TestCase):
         http = _make_http_interface(url=url)
         return _make_event(interfaces={"request": http})
 
+    @with_feature("organizations:derive-tags-without-plugins")
     def test_new_path_derives_tags(self) -> None:
         project = self.create_project()
         event = self._make_url_event()
         job = _make_job(event, project.id)
 
-        with self.feature("organizations:derive-tags-without-plugins"):
-            _derive_tags_many([job], {project.id: project})
+        _derive_tags_many([job], {project.id: project})
 
         assert get_tag(job["data"], "url") == "https://example.com/path"
 
@@ -332,33 +306,22 @@ class TestDeriveTagsMany(TestCase):
 
         assert get_tag(job["data"], "url") == "https://example.com/path"
 
+    @with_feature("organizations:derive-tags-without-plugins")
     def test_new_path_does_not_override_user_tags(self) -> None:
         project = self.create_project()
         event = self._make_url_event()
         job = _make_job(event, project.id)
         job["data"]["tags"] = [("url", "https://user-provided.com")]
 
-        with self.feature("organizations:derive-tags-without-plugins"):
-            _derive_tags_many([job], {project.id: project})
+        _derive_tags_many([job], {project.id: project})
 
         assert get_tag(job["data"], "url") == "https://user-provided.com"
 
-    def test_new_path_respects_project_option_disable(self) -> None:
-        project = self.create_project()
-        ProjectOption.objects.set_value(project, "auto_tag:_urls:enabled", False)
-        event = self._make_url_event()
-        job = _make_job(event, project.id)
-
-        with self.feature("organizations:derive-tags-without-plugins"):
-            _derive_tags_many([job], {project.id: project})
-
-        assert get_tag(job["data"], "url") is None
-
+    @with_feature("organizations:derive-tags-without-plugins")
     def test_new_path_handles_deriver_exception(self) -> None:
         project = self.create_project()
         event = _make_event(interfaces={"request": MagicMock(side_effect=Exception("boom"))})
         event.interfaces.get = MagicMock(side_effect=Exception("boom"))
         job = _make_job(event, project.id)
 
-        with self.feature("organizations:derive-tags-without-plugins"):
-            _derive_tags_many([job], {project.id: project})
+        _derive_tags_many([job], {project.id: project})

--- a/tests/sentry/event_manager/test_auto_tags.py
+++ b/tests/sentry/event_manager/test_auto_tags.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from sentry.constants import MAX_TAG_VALUE_LENGTH
+from sentry.event_manager import _derive_tags_many, get_tag
 from sentry.event_manager_auto_tags import (
     ALL_TAG_DERIVERS,
     BrowserTagDeriver,
@@ -297,3 +298,67 @@ class TestAllTagDerivers:
 
     def test_deriver_count(self) -> None:
         assert len(ALL_TAG_DERIVERS) == 5
+
+
+def _make_job(event: MagicMock, project_id: int) -> dict[str, Any]:
+    return {
+        "data": {"tags": []},
+        "event": event,
+        "project_id": project_id,
+    }
+
+
+class TestDeriveTagsMany(TestCase):
+    def _make_url_event(self, url: str = "https://example.com/path") -> MagicMock:
+        http = _make_http_interface(url=url)
+        return _make_event(interfaces={"request": http})
+
+    def test_new_path_derives_tags(self) -> None:
+        project = self.create_project()
+        event = self._make_url_event()
+        job = _make_job(event, project.id)
+
+        with self.feature("organizations:derive-tags-without-plugins"):
+            _derive_tags_many([job], {project.id: project})
+
+        assert get_tag(job["data"], "url") == "https://example.com/path"
+
+    def test_legacy_path_derives_tags(self) -> None:
+        project = self.create_project()
+        event = self._make_url_event()
+        job = _make_job(event, project.id)
+
+        _derive_tags_many([job], {project.id: project})
+
+        assert get_tag(job["data"], "url") == "https://example.com/path"
+
+    def test_new_path_does_not_override_user_tags(self) -> None:
+        project = self.create_project()
+        event = self._make_url_event()
+        job = _make_job(event, project.id)
+        job["data"]["tags"] = [("url", "https://user-provided.com")]
+
+        with self.feature("organizations:derive-tags-without-plugins"):
+            _derive_tags_many([job], {project.id: project})
+
+        assert get_tag(job["data"], "url") == "https://user-provided.com"
+
+    def test_new_path_respects_project_option_disable(self) -> None:
+        project = self.create_project()
+        ProjectOption.objects.set_value(project, "auto_tag:_urls:enabled", False)
+        event = self._make_url_event()
+        job = _make_job(event, project.id)
+
+        with self.feature("organizations:derive-tags-without-plugins"):
+            _derive_tags_many([job], {project.id: project})
+
+        assert get_tag(job["data"], "url") is None
+
+    def test_new_path_handles_deriver_exception(self) -> None:
+        project = self.create_project()
+        event = _make_event(interfaces={"request": MagicMock(side_effect=Exception("boom"))})
+        event.interfaces.get = MagicMock(side_effect=Exception("boom"))
+        job = _make_job(event, project.id)
+
+        with self.feature("organizations:derive-tags-without-plugins"):
+            _derive_tags_many([job], {project.id: project})

--- a/tests/sentry/event_manager/test_auto_tags.py
+++ b/tests/sentry/event_manager/test_auto_tags.py
@@ -316,12 +316,3 @@ class TestDeriveTagsMany(TestCase):
         _derive_tags_many([job], {project.id: project})
 
         assert get_tag(job["data"], "url") == "https://user-provided.com"
-
-    @with_feature("organizations:derive-tags-without-plugins")
-    def test_new_path_handles_deriver_exception(self) -> None:
-        project = self.create_project()
-        event = _make_event(interfaces={"request": MagicMock(side_effect=Exception("boom"))})
-        event.interfaces.get = MagicMock(side_effect=Exception("boom"))
-        job = _make_job(event, project.id)
-
-        _derive_tags_many([job], {project.id: project})


### PR DESCRIPTION
- Adds the tag deriver logic to event manager behind a feature flag
- Apparently the projectmapping dict could have many projects from different organizations in it (????????) 💀 so we need to check each one's org individually for the feature flag. I'm not sure since this is a hot path how much performance hit this will be.