### PR TITLE
ref(segments): Refresh last_seen every 30 minutes

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -124,13 +124,13 @@ def _process_segment(
         cache[cache_key] = timestamp
         metrics.incr(cache_metric_name, tags={"outcome": "miss"})
     # If a cached value was found and the timestamp specified by the current event exceeds
-    # the previously cached timestamp by at least `LAST_SEEN_INTERVAL_SECONDS * 15` then we
+    # the previously cached timestamp by at least `LAST_SEEN_INTERVAL_SECONDS * 30` then we
     # perform small mutations on select models. From the code in this module this may appear
     # to only save one or two cache lookups, however, certain billing logic tied to the
     # feature flag check runs when this program is executed in getsentry. In the minimal
     # case its three extra saved queries but up to six additional cache lookups have been
     # observed.
-    elif timestamp - (LAST_SEEN_INTERVAL_SECONDS * 15) >= cached_timestamp:
+    elif timestamp - (LAST_SEEN_INTERVAL_SECONDS * 30) >= cached_timestamp:
         _bump_release_last_seen(project, environment_name, release_name, date)
         cache[cache_key] = timestamp
         metrics.incr(cache_metric_name, tags={"action": "bump", "outcome": "hit"})

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -124,13 +124,13 @@ def _process_segment(
         cache[cache_key] = timestamp
         metrics.incr(cache_metric_name, tags={"outcome": "miss"})
     # If a cached value was found and the timestamp specified by the current event exceeds
-    # the previously cached timestamp by at least `LAST_SEEN_INTERVAL_SECONDS` then we
+    # the previously cached timestamp by at least `LAST_SEEN_INTERVAL_SECONDS * 15` then we
     # perform small mutations on select models. From the code in this module this may appear
     # to only save one or two cache lookups, however, certain billing logic tied to the
     # feature flag check runs when this program is executed in getsentry. In the minimal
     # case its three extra saved queries but up to six additional cache lookups have been
     # observed.
-    elif timestamp - LAST_SEEN_INTERVAL_SECONDS >= cached_timestamp:
+    elif timestamp - (LAST_SEEN_INTERVAL_SECONDS * 15) >= cached_timestamp:
         _bump_release_last_seen(project, environment_name, release_name, date)
         cache[cache_key] = timestamp
         metrics.incr(cache_metric_name, tags={"action": "bump", "outcome": "hit"})

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -509,7 +509,7 @@ class TestProcessSegmentCaching(TestCase):
         later = build_mock_span(
             project_id=self.project.id,
             is_segment=True,
-            end_timestamp=self.base_ts + 901,
+            end_timestamp=self.base_ts + 1801,
         )
         process_segment([later])
 
@@ -524,7 +524,7 @@ class TestProcessSegmentCaching(TestCase):
         mock_create.reset_mock()
 
         # Trigger a bump at T+61.
-        bump_ts = self.base_ts + 901
+        bump_ts = self.base_ts + 1801
         process_segment(
             [build_mock_span(project_id=self.project.id, is_segment=True, end_timestamp=bump_ts)]
         )

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -509,7 +509,7 @@ class TestProcessSegmentCaching(TestCase):
         later = build_mock_span(
             project_id=self.project.id,
             is_segment=True,
-            end_timestamp=self.base_ts + 61,
+            end_timestamp=self.base_ts + 901,
         )
         process_segment([later])
 
@@ -524,7 +524,7 @@ class TestProcessSegmentCaching(TestCase):
         mock_create.reset_mock()
 
         # Trigger a bump at T+61.
-        bump_ts = self.base_ts + 61
+        bump_ts = self.base_ts + 901
         process_segment(
             [build_mock_span(project_id=self.project.id, is_segment=True, end_timestamp=bump_ts)]
         )

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -523,29 +523,29 @@ class TestProcessSegmentCaching(TestCase):
         process_segment([segment])
         mock_create.reset_mock()
 
-        # Trigger a bump at T+61.
+        # Trigger a bump just past the interval, advancing the cached timestamp.
         bump_ts = self.base_ts + 1801
         process_segment(
             [build_mock_span(project_id=self.project.id, is_segment=True, end_timestamp=bump_ts)]
         )
         mock_bump.reset_mock()
 
-        # T+90 is only 29s after the bump — should be noop.
+        # 1799s after the bump is within the interval — should be noop.
         process_segment(
             [
                 build_mock_span(
-                    project_id=self.project.id, is_segment=True, end_timestamp=self.base_ts + 90
+                    project_id=self.project.id, is_segment=True, end_timestamp=bump_ts + 1799
                 )
             ]
         )
         mock_create.assert_not_called()
         mock_bump.assert_not_called()
 
-        # T+122 is 61s after the bump — should trigger another bump.
+        # 1800s after the bump exceeds the interval — should trigger another bump.
         process_segment(
             [
                 build_mock_span(
-                    project_id=self.project.id, is_segment=True, end_timestamp=bump_ts + 61
+                    project_id=self.project.id, is_segment=True, end_timestamp=bump_ts + 1800
                 )
             ]
         )


### PR DESCRIPTION
Because each cache is unique to a large number of processes, and because message distribution is random, we make requests more frequently than once per minute when considering the system as a whole. We can debounce more often and not lose any fidelity.

In the worst case scenario, there is a >96% chance the `last_seen` value is updated at least once per minute. Given rosier assumptions (higher or lower message volume, bigger cluster size) there is a >99% chance of accurate recording in the worst case. This fidelity decrease is not a real concern given the usage of the `last_seen` column (that is to say its lack of usage).

You can prove to yourself this works by using this formula:

```python
def emitted_rpm(rpm, interval, numprocs):
     return rpm / (1 + (rpm * interval / numprocs))
```

`numprocs` can be extracted from the kubernetes configuration. `rpm` is requests per minute. `interval` is in minutes.