### PR TITLE
feat(issues): Send resolving commit id on issue_resolved signal

### DIFF
--- a/src/sentry/analytics/events/issue_resolved.py
+++ b/src/sentry/analytics/events/issue_resolved.py
@@ -13,6 +13,8 @@ class IssueResolvedEvent(analytics.Event):
     provider: str | None = None
     issue_category: str | None = None
     issue_type: str | None = None
+    # Only set for commit-based resolutions (in_commit / with_commit); None otherwise.
+    commit_id: int | None = None
 
 
 analytics.register(IssueResolvedEvent)

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -469,6 +469,7 @@ def handle_resolve_in_release(
             group=group,
             project=project_lookup[group.project_id],
             resolution_type=res_type_str,
+            commit_id=commit.id if commit else None,
             sender=update_groups,
         )
 

--- a/src/sentry/integrations/tasks/sync_status_inbound.py
+++ b/src/sentry/integrations/tasks/sync_status_inbound.py
@@ -292,6 +292,7 @@ def sync_status_inbound(
                 group=group,
                 project=group.project,
                 resolution_type=provider.key,
+                commit_id=None,
                 sender=f"resolved_with_{provider.key}",
             )
             try:

--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -250,6 +250,23 @@ def update_group_resolutions(release, commit_author_by_commit):
         if (repo_id := commit_repo_ids.get(commit_id)) is not None:
             provider_by_group[group_id] = normalize_provider_key(repo_providers.get(repo_id))
 
+    # Map each resolved group to the commit that resolved it, so the
+    # issue_resolved analytics event records the commit id. Commit resolutions
+    # carry the commit id directly; PR resolutions are mapped through the PR's
+    # merge_commit_sha to the matching release commit (no extra query needed,
+    # since PRs were already filtered by merge_commit_sha above). PRs are
+    # iterated first so a direct commit resolution wins when a group has both.
+    commit_id_by_group: dict[int, int] = {}
+    commit_id_by_commit_key = {rc["commit__key"]: rc["commit_id"] for rc in release_commits}
+    pr_merge_sha = {pra.id: pra.merge_commit_sha for pra in pr_authors}
+    for group_id, pr_id in pull_request_resolutions:
+        merge_sha = pr_merge_sha.get(pr_id)
+        pr_commit_id = commit_id_by_commit_key.get(merge_sha) if merge_sha is not None else None
+        if pr_commit_id is not None:
+            commit_id_by_group[group_id] = pr_commit_id
+    for group_id, commit_id in commit_resolutions:
+        commit_id_by_group[group_id] = commit_id
+
     user_by_author: dict[CommitAuthor | None, RpcUser | None] = {None: None}
 
     commits_and_prs = list(itertools.chain(commit_group_authors, pull_request_group_authors))
@@ -309,6 +326,7 @@ def update_group_resolutions(release, commit_author_by_commit):
             project=group.project,
             resolution_type="with_commit",
             provider=provider_by_group.get(group_id),
+            commit_id=commit_id_by_group.get(group_id),
             sender=type(release),
         )
 

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -246,7 +246,7 @@ def record_issue_assigned(project, group, user, **kwargs):
 
 @issue_resolved.connect(weak=False)
 def record_issue_resolved(
-    organization_id, project, group, user, resolution_type, provider=None, **kwargs
+    organization_id, project, group, user, resolution_type, provider=None, commit_id=None, **kwargs
 ):
     """There are three main types of ways to resolve issues
     1) via a release (current release, next release, or other)
@@ -279,6 +279,7 @@ def record_issue_resolved(
                 group_id=group.id,
                 resolution_type=resolution_type,
                 provider=provider,
+                commit_id=commit_id,
                 issue_type=group.issue_type.slug,
                 issue_category=group.issue_category.name.lower(),
             )

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -146,7 +146,7 @@ ownership_rule_created = BetterSignal()  # ["project"]
 issue_assigned = BetterSignal()  # ["project", "group", "user"]
 issue_unassigned = BetterSignal()  # ["project", "group", "user"]
 issue_deleted = BetterSignal()  # ["group", "user", "delete_type"]
-# ["organization_id", "project", "group", "user", "resolution_type"]
+# ["organization_id", "project", "group", "user", "resolution_type", "provider", "commit_id"]
 issue_resolved = BetterSignal()
 issue_unresolved = BetterSignal()  # ["project", "user", "group", "transition_type"]
 issue_ignored = BetterSignal()  # ["project", "user", "group_list", "activity_data"]

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -153,6 +153,7 @@ def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwar
                 group=group,
                 project=project,
                 resolution_type="autoresolve",
+                commit_id=None,
                 sender="auto_resolve_issues",
             )
 

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -158,6 +158,34 @@ class UpdateGroupsTest(TestCase):
         assert unresolved_group.status == GroupStatus.RESOLVED
         assert not GroupInbox.objects.filter(group=unresolved_group).exists()
         assert send_robust.called
+        # Resolving "now" has no commit associated with it.
+        assert send_robust.call_args.kwargs["commit_id"] is None
+
+    @patch("sentry.signals.issue_resolved.send_robust")
+    def test_resolving_group_in_commit(self, send_robust: Mock) -> None:
+        unresolved_group = self.create_group(status=GroupStatus.UNRESOLVED)
+        repo = self.create_repo(project=unresolved_group.project)
+        commit = self.create_commit(project=unresolved_group.project, repo=repo)
+
+        http_request = self.make_request(user=self.user, method="GET")
+        http_request.GET = QueryDict(query_string=f"id={unresolved_group.id}")
+        request = _wrap_request(
+            http_request,
+            data={
+                "status": "resolved",
+                "statusDetails": {"inCommit": {"commit": commit.key, "repository": repo.name}},
+            },
+        )
+
+        group_list = get_group_list(self.organization.id, [self.project], request.GET.getlist("id"))
+        update_groups(request, group_list)
+
+        unresolved_group.refresh_from_db()
+
+        assert unresolved_group.status == GroupStatus.RESOLVED
+        assert send_robust.called
+        assert send_robust.call_args.kwargs["resolution_type"] == "in_commit"
+        assert send_robust.call_args.kwargs["commit_id"] == commit.id
 
     @patch("sentry.signals.issue_ignored.send_robust")
     @patch("sentry.issues.status_change.post_save")

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -554,6 +554,7 @@ class SetCommitsTestCase(TestCase):
                 group_id=group.id,
                 resolution_type="with_commit",
                 provider="github",
+                commit_id=commit.id,
                 issue_type=group.issue_type.slug,
                 issue_category=group.issue_category.name.lower(),
             ),
@@ -576,6 +577,7 @@ class SetCommitsTestCase(TestCase):
         release.set_commits([{"id": "a" * 40, "message": "fixes %s" % (group.qualified_short_id)}])
 
         assert Group.objects.get(id=group.id).status == GroupStatus.RESOLVED
+        commit = Commit.objects.get(organization_id=org.id, key="a" * 40)
         assert_any_analytics_event(
             mock_record,
             IssueResolvedEvent(
@@ -586,6 +588,50 @@ class SetCommitsTestCase(TestCase):
                 group_id=group.id,
                 resolution_type="with_commit",
                 provider=None,
+                commit_id=commit.id,
+                issue_type=group.issue_type.slug,
+                issue_category=group.issue_category.name.lower(),
+            ),
+        )
+
+    @patch("sentry.analytics.record")
+    @receivers_raise_on_send()
+    def test_resolution_via_pull_request_records_merge_commit(self, mock_record: MagicMock) -> None:
+        """A group resolved by a pull request records the PR's merge commit id on
+        the IssueResolvedEvent, resolved through the release's matching commit."""
+        org = self.create_organization(owner=Factories.create_user())
+        project = self.create_project(organization=org, name="foo")
+        group = self.create_group(project=project)
+        add_group_to_inbox(group, GroupInboxReason.MANUAL)
+        repo = Repository.objects.create(
+            organization_id=org.id, name="test/repo", provider="integrations:github"
+        )
+        commit = Commit.objects.create(organization_id=org.id, repository_id=repo.id, key="b" * 40)
+        pull_request = self.create_pull_request(repository_id=repo.id, organization_id=org.id)
+        pull_request.update(merge_commit_sha=commit.key)
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.pull_request,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id=pull_request.id,
+        )
+
+        release = self.create_release(project=project, version="abcdabc")
+        release.set_commits([{"id": commit.key, "repository": repo.name}])
+
+        assert Group.objects.get(id=group.id).status == GroupStatus.RESOLVED
+        assert_any_analytics_event(
+            mock_record,
+            IssueResolvedEvent(
+                user_id=None,
+                project_id=project.id,
+                default_user_id=org.default_owner_id,
+                organization_id=org.id,
+                group_id=group.id,
+                resolution_type="with_commit",
+                provider="github",
+                commit_id=commit.id,
                 issue_type=group.issue_type.slug,
                 issue_category=group.issue_category.name.lower(),
             ),


### PR DESCRIPTION
Add a `commit_id` kwarg to the `issue_resolved` signal so the `IssueResolvedEvent` analytics event records which commit resolved an issue.

A commit only exists for genuinely commit-based resolutions, so `commit_id` is **not** always available. It is populated where a commit is in scope and left `None` otherwise:

| Call site | `resolution_type` | `commit_id` |
|---|---|---|
| `tasks/auto_resolve_issues.py` | `autoresolve` | `None` (resolved by age) |
| `integrations/tasks/sync_status_inbound.py` | `<provider.key>` | `None` (external integration state sync) |
| `api/helpers/group_index/update.py` | `in_commit` / `in_release` / `in_next_release` / `now` | `commit.id` only for `in_commit`, else `None` |
| `models/releases/set_commits.py` | `with_commit` | commit id for both commit- and PR-resolved groups |

For the release `with_commit` path, PR-resolved groups are mapped to a commit id through the PR's `merge_commit_sha` → matching release commit, reusing data already fetched (no extra query). Direct commit resolutions win over PR-derived ones when a group has both, mirroring the existing `provider_by_group` ordering.

`commit_id` is intentionally nullable on `IssueResolvedEvent` (same as the existing `provider` field), since most resolutions have no associated commit.

All three `issue_resolved` receivers accept `**kwargs`, so the new kwarg is backward compatible; only `record_issue_resolved` consumes it.