### PR TITLE
ref(buffers): Handle none value in non-pickle dump

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -99,7 +99,9 @@ class PendingBufferRouter:
         """
         pending_buffer = PendingBuffer(self.incr_batch_size)
         self.pending_buffer_router[model_key] = PendingBufferValue(
-            model_key=model_key, pending_buffer=pending_buffer, generate_queue=generate_queue
+            model_key=model_key,
+            pending_buffer=pending_buffer,
+            generate_queue=generate_queue,
         )
 
     def get_pending_buffer(self, model_key: str | None) -> PendingBuffer:
@@ -126,7 +128,9 @@ class PendingBufferRouter:
         pending_buffers = list(self.pending_buffer_router.values())
         pending_buffers.append(
             PendingBufferValue(
-                model_key=None, pending_buffer=self.default_pending_buffer, generate_queue=None
+                model_key=None,
+                pending_buffer=self.default_pending_buffer,
+                generate_queue=None,
             )
         )
         return pending_buffers
@@ -264,11 +268,15 @@ class RedisBuffer(Buffer):
 
     @classmethod
     def _dump_value(
-        cls, value: str | datetime | date | int | float | dict[str, Any], depth: int = 0
+        cls,
+        value: str | datetime | date | int | float | dict[str, Any] | None,
+        depth: int = 0,
     ) -> tuple[str, str]:
         if depth > 3:
             raise Exception("Depth limit exceeded in _dump_value")
-        if isinstance(value, str):
+        if value is None:
+            type_ = "n"
+        elif isinstance(value, str):
             type_ = "s"
         elif isinstance(value, datetime):
             type_ = "dt"
@@ -299,9 +307,11 @@ class RedisBuffer(Buffer):
     @classmethod
     def _load_value(
         cls, payload: tuple[str, Any]
-    ) -> dict[str, Any] | str | datetime | date | int | float:
+    ) -> dict[str, Any] | str | datetime | date | int | float | None:
         (type_, value) = payload
-        if type_ == "s":
+        if type_ == "n":
+            return None
+        elif type_ == "s":
             return force_str(value)
         elif type_ == "dt":
             return datetime.fromtimestamp(float(value)).replace(tzinfo=timezone.utc)

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -298,7 +298,7 @@ class RedisBuffer(Buffer):
     @classmethod
     def _load_values(
         cls, payload: dict[str, tuple[str, Any]]
-    ) -> dict[str, str | datetime | date | int | float | dict[str, Any]]:
+    ) -> dict[str, str | datetime | date | int | float | dict[str, Any] | None]:
         result = {}
         for k, (t, v) in payload.items():
             result[k] = cls._load_value((t, v))


### PR DESCRIPTION
<!-- Describe your PR here. -->

```
Traceback (most recent call last):
  File "/.venv/lib/python3.13/site-packages/taskbroker_client/worker/workerchild.py", line 371, in run_worker
    _execute_activation(task_func, inflight.activation, app.context_hooks)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.13/site-packages/taskbroker_client/worker/workerchild.py", line 551, in _execute_activation
    task_func(*args, **kwargs)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/src/sentry/src/sentry/silo/base.py", line 157, in override
    return original_method(*args, **kwargs)
  File "/.venv/lib/python3.13/site-packages/taskbroker_client/task.py", line 157, in __call__
    return self._func(*args, **kwargs)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/src/sentry/src/sentry/tasks/store.py", line 651, in save_event
    _do_save_event(
    ~~~~~~~~~~~~~~^
        cache_key,
        ^^^^^^^^^^
    ...<5 lines>...
        **kwargs,
        ^^^^^^^^^
    )
    ^
  File "/usr/src/sentry/src/sentry/tasks/store.py", line 585, in _do_save_event
    manager.save(
    ~~~~~~~~~~~~^
        project=project,
        ^^^^^^^^^^^^^^^^
    ...<3 lines>...
        attachments=attachments,
        ^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/.venv/lib/python3.13/site-packages/sentry_sdk/tracing_utils.py", line 1109, in sync_wrapper
    result = f(*args, **kwargs)
  File "/usr/src/sentry/src/sentry/event_manager.py", line 513, in save
    return self.save_error_events(
           ~~~~~~~~~~~~~~~~~~~~~~^
        project, job, projects, metric_tags, attachments or [], raw, cache_key
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/.venv/lib/python3.13/site-packages/sentry_sdk/tracing_utils.py", line 1109, in sync_wrapper
    result = f(*args, **kwargs)
  File "/usr/src/sentry/src/sentry/event_manager.py", line 547, in save_error_events
    group_info = assign_event_to_group(event=job["event"], job=job, metric_tags=metric_tags)
  File "/.venv/lib/python3.13/site-packages/sentry_sdk/tracing_utils.py", line 1109, in sync_wrapper
    result = f(*args, **kwargs)
  File "/usr/src/sentry/src/sentry/event_manager.py", line 1328, in assign_event_to_group
    group_info = handle_existing_grouphash(job, primary.existing_grouphash, primary.grouphashes)
  File "/.venv/lib/python3.13/site-packages/sentry_sdk/tracing_utils.py", line 1109, in sync_wrapper
    result = f(*args, **kwargs)
  File "/usr/src/sentry/src/sentry/event_manager.py", line 1462, in handle_existing_grouphash
    is_regression = _process_existing_aggregate(
        group=group,
    ...<2 lines>...
        release=job["release"],
    )
  File "/usr/src/sentry/src/sentry/event_manager.py", line 1951, in _process_existing_aggregate
    buffer_incr(Group, {"times_seen": times_seen}, {"id": group.id}, updated_group_values)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/sentry/src/sentry/tasks/process_buffer.py", line 82, in buffer_incr
    buffer.backend.incr(model, *args, **kwargs)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/sentry/src/sentry/buffer/redis.py", line 390, in incr
    pipe.hset(key, "e+" + column, json.dumps(self._dump_value(value)))
                                             ~~~~~~~~~~~~~~~~^^^^^^^
  File "/usr/src/sentry/src/sentry/buffer/redis.py", line 285, in _dump_value
    value = json.dumps({k: cls._dump_value(v, depth + 1) for k, v in value.items()})
                           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/usr/src/sentry/src/sentry/buffer/redis.py", line 285, in _dump_value
    value = json.dumps({k: cls._dump_value(v, depth + 1) for k, v in value.items()})
                           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/usr/src/sentry/src/sentry/buffer/redis.py", line 287, in _dump_value
    raise TypeError(type(value))
TypeError: <class 'NoneType'>
```

Adding clause for None in dump and load value

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
