### PR TITLE
ref: Create ListItemSelectedState to declaratively render

### DIFF
--- a/static/app/components/feedback/list/feedbackListHeader.tsx
+++ b/static/app/components/feedback/list/feedbackListHeader.tsx
@@ -12,17 +12,12 @@ import {useFeedbackHasNewItems} from 'sentry/components/feedback/useFeedbackHasN
 import {useMailbox} from 'sentry/components/feedback/useMailbox';
 import {IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {ListItemSelectedState} from 'sentry/utils/list/listItemSelectedState';
 import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
 
 export function FeedbackListHeader() {
-  const {
-    countSelected,
-    deselectAll,
-    isAllSelected,
-    isAnySelected,
-    selectAll,
-    selectedIds,
-  } = useListItemCheckboxContext();
+  const {countSelected, deselectAll, isAllSelected, selectAll, selectedIds} =
+    useListItemCheckboxContext();
   const [mailbox, setMailbox] = useMailbox();
 
   const {listPrefetchApiOptions, resetListHeadTime} = useFeedbackApiOptions();
@@ -42,16 +37,17 @@ export function FeedbackListHeader() {
             }
           }}
         />
-        {isAnySelected ? (
+        <ListItemSelectedState selected="none">
+          <MailboxPicker value={mailbox} onChange={setMailbox} />
+        </ListItemSelectedState>
+        <ListItemSelectedState selected="indeterminate-or-all">
           <FeedbackListBulkSelection
             mailbox={mailbox}
             countSelected={countSelected}
             selectedIds={selectedIds}
             deselectAll={deselectAll}
           />
-        ) : (
-          <MailboxPicker value={mailbox} onChange={setMailbox} />
-        )}
+        </ListItemSelectedState>
       </HeaderPanelItem>
       {hasNewItems ? (
         <Flex justify="center" align="center" flexGrow={1} padding="xs">

--- a/static/app/components/replays/table/replayTableHeader.tsx
+++ b/static/app/components/replays/table/replayTableHeader.tsx
@@ -13,6 +13,7 @@ import {
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t, tct, tn} from 'sentry/locale';
 import type {Sort} from 'sentry/utils/discover/fields';
+import {ListItemSelectedState} from 'sentry/utils/list/listItemSelectedState';
 import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
 import type {ReplayListRecord} from 'sentry/views/explore/replays/types';
 
@@ -32,15 +33,8 @@ export function ReplayTableHeader({
   stickyHeader,
 }: Props) {
   const listItemCheckboxState = useListItemCheckboxContext();
-  const {
-    countSelected,
-    deselectAll,
-    isAllSelected,
-    isAnySelected,
-    endpointOptionsRef,
-    selectAll,
-    selectedIds,
-  } = listItemCheckboxState;
+  const {countSelected, deselectAll, endpointOptionsRef, selectAll, selectedIds} =
+    listItemCheckboxState;
   const endpointOptions = endpointOptionsRef.current;
   const rawQuery = endpointOptions?.query?.query;
   const queryString = typeof rawQuery === 'string' ? rawQuery : undefined;
@@ -67,7 +61,7 @@ export function ReplayTableHeader({
         ))}
       </TableHeader>
 
-      {isAnySelected ? (
+      <ListItemSelectedState selected="indeterminate-or-all">
         <TableHeader>
           <TableCellFirst>
             <ReplaySelectColumn.Header
@@ -99,9 +93,9 @@ export function ReplayTableHeader({
             />
           </Flex>
         </TableHeader>
-      ) : null}
+      </ListItemSelectedState>
 
-      {isAllSelected === 'indeterminate' ? (
+      <ListItemSelectedState selected="indeterminate">
         <FullGridAlert variant="info" system>
           <Flex justify="start" width="100%" wrap="wrap" gap="md">
             {tn(
@@ -118,9 +112,9 @@ export function ReplayTableHeader({
             </a>
           </Flex>
         </FullGridAlert>
-      ) : null}
+      </ListItemSelectedState>
 
-      {isAllSelected === true ? (
+      <ListItemSelectedState selected="all">
         <FullGridAlert variant="info" system>
           {queryString
             ? tct('Selected all replays matching: [queryString].', {
@@ -130,7 +124,7 @@ export function ReplayTableHeader({
               ? t('Selected all %s+ replays.', replays.length)
               : tn('Selected all %s replay.', 'Selected all %s replays.', countSelected)}
         </FullGridAlert>
-      ) : null}
+      </ListItemSelectedState>
     </Fragment>
   );
 }

--- a/static/app/utils/list/listItemSelectedState.spec.tsx
+++ b/static/app/utils/list/listItemSelectedState.spec.tsx
@@ -1,0 +1,155 @@
+import {type ComponentProps, type PropsWithChildren} from 'react';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {QueryKeyEndpointOptions} from 'sentry/utils/api/apiQueryKey';
+import {ListItemSelectedState} from 'sentry/utils/list/listItemSelectedState';
+import {
+  ListItemCheckboxProvider,
+  useListItemCheckboxContext,
+} from 'sentry/utils/list/useListItemCheckboxState';
+
+const endpointOptions: QueryKeyEndpointOptions = {query: {status: 'active'}};
+
+type ProviderProps = ComponentProps<typeof ListItemCheckboxProvider>;
+
+function SelectionControls() {
+  const {selectAll, toggleSelected, deselectAll} = useListItemCheckboxContext();
+  return (
+    <div>
+      <button onClick={selectAll}>Select All</button>
+      <button onClick={deselectAll}>Deselect All</button>
+      <button onClick={() => toggleSelected('1')}>Toggle 1</button>
+    </div>
+  );
+}
+
+function createWrapper(props: Omit<ProviderProps, 'children' | 'endpointOptions'>) {
+  return function Wrapper({children}: PropsWithChildren) {
+    return (
+      <ListItemCheckboxProvider {...props} endpointOptions={endpointOptions}>
+        <SelectionControls />
+        {children}
+      </ListItemCheckboxProvider>
+    );
+  };
+}
+
+function renderSelectedState({
+  selected,
+  ...providerProps
+}: {selected: ComponentProps<typeof ListItemSelectedState>['selected']} & Omit<
+  ProviderProps,
+  'children' | 'endpointOptions'
+>) {
+  const Wrapper = createWrapper(providerProps);
+  return render(
+    <Wrapper>
+      <ListItemSelectedState selected={selected}>
+        <span>visible</span>
+      </ListItemSelectedState>
+    </Wrapper>
+  );
+}
+
+describe('ListItemSelectedState', () => {
+  describe('selected="none"', () => {
+    it('renders when nothing is selected', () => {
+      renderSelectedState({selected: 'none', hits: 3, knownIds: ['1', '2', '3']});
+      expect(screen.getByText('visible')).toBeInTheDocument();
+    });
+
+    it('does not render when all are selected', async () => {
+      renderSelectedState({selected: 'none', hits: 3, knownIds: ['1', '2', '3']});
+      await userEvent.click(screen.getByRole('button', {name: 'Select All'}));
+      expect(screen.queryByText('visible')).not.toBeInTheDocument();
+    });
+
+    it('does not render when some are selected', async () => {
+      renderSelectedState({selected: 'none', hits: 3, knownIds: ['1', '2', '3']});
+      await userEvent.click(screen.getByRole('button', {name: 'Toggle 1'}));
+      expect(screen.queryByText('visible')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('selected="all"', () => {
+    it('renders when all are selected', async () => {
+      renderSelectedState({selected: 'all', hits: 3, knownIds: ['1', '2', '3']});
+      await userEvent.click(screen.getByRole('button', {name: 'Select All'}));
+      expect(screen.getByText('visible')).toBeInTheDocument();
+    });
+
+    it('does not render when nothing is selected', () => {
+      renderSelectedState({selected: 'all', hits: 3, knownIds: ['1', '2', '3']});
+      expect(screen.queryByText('visible')).not.toBeInTheDocument();
+    });
+
+    it('does not render when some are selected', async () => {
+      renderSelectedState({selected: 'all', hits: 3, knownIds: ['1', '2', '3']});
+      await userEvent.click(screen.getByRole('button', {name: 'Toggle 1'}));
+      expect(screen.queryByText('visible')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('selected="indeterminate"', () => {
+    it('renders when some are selected', async () => {
+      renderSelectedState({
+        selected: 'indeterminate',
+        hits: 3,
+        knownIds: ['1', '2', '3'],
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Toggle 1'}));
+      expect(screen.getByText('visible')).toBeInTheDocument();
+    });
+
+    it('does not render when nothing is selected', () => {
+      renderSelectedState({
+        selected: 'indeterminate',
+        hits: 3,
+        knownIds: ['1', '2', '3'],
+      });
+      expect(screen.queryByText('visible')).not.toBeInTheDocument();
+    });
+
+    it('does not render when all are selected', async () => {
+      renderSelectedState({
+        selected: 'indeterminate',
+        hits: 3,
+        knownIds: ['1', '2', '3'],
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Select All'}));
+      expect(screen.queryByText('visible')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('selected="indeterminate-or-all"', () => {
+    it('renders when all are selected', async () => {
+      renderSelectedState({
+        selected: 'indeterminate-or-all',
+        hits: 3,
+        knownIds: ['1', '2', '3'],
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Select All'}));
+      expect(screen.getByText('visible')).toBeInTheDocument();
+    });
+
+    it('renders when some are selected', async () => {
+      renderSelectedState({
+        selected: 'indeterminate-or-all',
+        hits: 3,
+        knownIds: ['1', '2', '3'],
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Toggle 1'}));
+      expect(screen.getByText('visible')).toBeInTheDocument();
+    });
+
+    it('does not render when nothing is selected', () => {
+      renderSelectedState({
+        selected: 'indeterminate-or-all',
+        hits: 3,
+        knownIds: ['1', '2', '3'],
+      });
+      expect(screen.queryByText('visible')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/utils/list/listItemSelectedState.tsx
+++ b/static/app/utils/list/listItemSelectedState.tsx
@@ -17,17 +17,20 @@ interface Props {
 export function ListItemSelectedState({children, selected}: Props) {
   const {isAllSelected} = useListItemCheckboxContext();
   if (selected === 'none' && isAllSelected === false) {
-    return null;
+    return children;
   }
+
   if (
     selected === 'indeterminate-or-all' &&
     (isAllSelected === true || isAllSelected === 'indeterminate')
   ) {
     return children;
   }
+
   if (selected === 'all' && isAllSelected === true) {
     return children;
   }
+
   if (selected === 'indeterminate' && isAllSelected === 'indeterminate') {
     return children;
   }

--- a/static/app/utils/list/listItemSelectedState.tsx
+++ b/static/app/utils/list/listItemSelectedState.tsx
@@ -1,0 +1,35 @@
+import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
+
+interface Props {
+  children: React.ReactNode;
+
+  /**
+   * The state of the list item selection
+   *
+   * - none: No items are selected
+   * - indeterminate-or-all: One or more items are selected
+   * - all: All items are selected
+   * - indeterminate: Some, but not all, items are selected
+   */
+  selected: 'none' | 'indeterminate-or-all' | 'all' | 'indeterminate';
+}
+
+export function ListItemSelectedState({children, selected}: Props) {
+  const {isAllSelected} = useListItemCheckboxContext();
+  if (selected === 'none' && isAllSelected === false) {
+    return null;
+  }
+  if (
+    selected === 'indeterminate-or-all' &&
+    (isAllSelected === true || isAllSelected === 'indeterminate')
+  ) {
+    return children;
+  }
+  if (selected === 'all' && isAllSelected === true) {
+    return children;
+  }
+  if (selected === 'indeterminate' && isAllSelected === 'indeterminate') {
+    return children;
+  }
+  return null;
+}

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -18,6 +18,7 @@ import {t, tct, tn} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {Sort} from 'sentry/utils/discover/fields';
+import {ListItemSelectedState} from 'sentry/utils/list/listItemSelectedState';
 import {
   useListItemCheckboxContext,
   type ListItemCheckboxState,
@@ -111,14 +112,8 @@ export function ProjectTableHeader({
   const organization = useOrganization();
   const canWrite = useCanWriteSettings();
   const listItemCheckboxState = useListItemCheckboxContext();
-  const {
-    countSelected,
-    isAllSelected,
-    isAnySelected,
-    endpointOptionsRef,
-    selectAll,
-    selectedIds,
-  } = listItemCheckboxState;
+  const {countSelected, endpointOptionsRef, selectAll, selectedIds} =
+    listItemCheckboxState;
   const endpointOptions = endpointOptionsRef.current;
   const rawQuery = endpointOptions?.query?.query;
   const queryString = typeof rawQuery === 'string' ? rawQuery : undefined;
@@ -163,7 +158,7 @@ export function ProjectTableHeader({
         ))}
       </TableHeader>
 
-      {isAnySelected ? (
+      <ListItemSelectedState selected="indeterminate-or-all">
         <TableHeader>
           <TableCellFirst>
             <SelectAllCheckbox
@@ -244,9 +239,9 @@ export function ProjectTableHeader({
             />
           </TableCellsRemainingContent>
         </TableHeader>
-      ) : null}
+      </ListItemSelectedState>
 
-      {isAllSelected === 'indeterminate' ? (
+      <ListItemSelectedState selected="indeterminate">
         <FullGridAlert variant="info" system>
           <Flex justify="start" width="100%" wrap="wrap" gap="md">
             {tn('Selected %s project.', 'Selected %s projects.', countSelected)}
@@ -260,9 +255,9 @@ export function ProjectTableHeader({
             </a>
           </Flex>
         </FullGridAlert>
-      ) : null}
+      </ListItemSelectedState>
 
-      {isAllSelected === true ? (
+      <ListItemSelectedState selected="all">
         <FullGridAlert variant="info" system>
           {queryString
             ? tct('Selected all [count] projects matching: [queryString].', {
@@ -273,7 +268,7 @@ export function ProjectTableHeader({
               ? t('Selected all %s+ projects.', projects.length)
               : tn('Selected %s project.', 'Selected all %s projects.', countSelected)}
         </FullGridAlert>
-      ) : null}
+      </ListItemSelectedState>
     </Fragment>
   );
 }

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
@@ -19,6 +19,7 @@ import {t, tct, tn} from 'sentry/locale';
 import type {RepositoryWithSettings} from 'sentry/types/integrations';
 import type {CodeReviewTrigger} from 'sentry/types/seer';
 import type {Sort} from 'sentry/utils/discover/fields';
+import {ListItemSelectedState} from 'sentry/utils/list/listItemSelectedState';
 import {
   useListItemCheckboxContext,
   type ListItemCheckboxState,
@@ -69,15 +70,8 @@ export function SeerRepoTableHeader({
 }: Props) {
   const canWrite = useCanWriteSettings();
   const listItemCheckboxState = useListItemCheckboxContext();
-  const {
-    countSelected,
-    isAllSelected,
-    isAnySelected,
-    endpointOptionsRef,
-    selectAll,
-    selectedIds,
-    knownIds,
-  } = listItemCheckboxState;
+  const {countSelected, endpointOptionsRef, selectAll, selectedIds, knownIds} =
+    listItemCheckboxState;
   const endpointOptions = endpointOptionsRef.current;
   const rawQuery = endpointOptions?.query?.query;
   const queryString = typeof rawQuery === 'string' ? rawQuery : undefined;
@@ -243,7 +237,7 @@ export function SeerRepoTableHeader({
 
   return (
     <Fragment>
-      {isAnySelected ? null : (
+      <ListItemSelectedState selected="none">
         <TableHeader gridColumns={gridColumns}>
           <SimpleTable.HeaderCell>
             <SelectAllCheckbox
@@ -275,9 +269,9 @@ export function SeerRepoTableHeader({
             </SimpleTable.HeaderCell>
           ))}
         </TableHeader>
-      )}
+      </ListItemSelectedState>
 
-      {isAnySelected ? (
+      <ListItemSelectedState selected="indeterminate-or-all">
         <TableHeader gridColumns={gridColumns}>
           <TableCellFirst>
             <SelectAllCheckbox
@@ -346,9 +340,9 @@ export function SeerRepoTableHeader({
             />
           </TableCellsRemainingContent>
         </TableHeader>
-      ) : null}
+      </ListItemSelectedState>
 
-      {isAllSelected === 'indeterminate' ? (
+      <ListItemSelectedState selected="indeterminate">
         <FullGridAlert variant="info" system>
           <Flex justify="start" width="100%" wrap="wrap" gap="md">
             {tn('Selected %s repository.', 'Selected %s repositories.', countSelected)}
@@ -362,9 +356,9 @@ export function SeerRepoTableHeader({
             </a>
           </Flex>
         </FullGridAlert>
-      ) : null}
+      </ListItemSelectedState>
 
-      {isAllSelected === true ? (
+      <ListItemSelectedState selected="all">
         <FullGridAlert variant="info" system>
           {queryString
             ? tct('Selected all [count] repositories matching: [queryString].', {
@@ -379,7 +373,7 @@ export function SeerRepoTableHeader({
                   countSelected
                 )}
         </FullGridAlert>
-      ) : null}
+      </ListItemSelectedState>
     </Fragment>
   );
 }


### PR DESCRIPTION
Within  `<ListItemCheckboxProvider>` you've usually got to manually create a sub-component so that it's possible to call the hook`useListItemCheckboxContext()` properly. That's kind of annoying sometimes, and looks like this:
```
function MyListWrapper() {
  return (
    <ListItemCheckboxProvider ...>
      <MyListHeader />
    </ListItemCheckboxProvider>
  );
}

function MyListHeader() {
  const {isAnySelected} = useListItemCheckboxContext();
  return isAnySelected ? <BulkActions /> : <NormalTableHeaders />;
}
```

Ideally we can have all my page-specific stuff in the same file/component, which means the ListItemCheckbox stuff needs a better interface. This is a step in that direction and looks like:
```
function MyList() {
  return (
    <ListItemCheckboxProvider ...>
      <ListItemSelectedState selected="none">
        <NormalTableHeaders />
      </ListItemSelectedState>
      <ListItemSelectedState selected="any">
        <BulkActions />
      </ListItemSelectedState>
    </ListItemCheckboxProvider>
  );
}