### PR TITLE
feat(integrations): Set Perforce integration popularity weight

### DIFF
--- a/static/app/views/settings/organizationIntegrations/constants.tsx
+++ b/static/app/views/settings/organizationIntegrations/constants.tsx
@@ -19,6 +19,7 @@ export const POPULARITY_WEIGHT: Record<string, number> = {
   bitbucket: 10,
   discord: 15,
   gitlab: 10,
+  perforce: 10,
   pagerduty: 10,
   vsts: 9,
   jira_server: 9,


### PR DESCRIPTION
## Summary

Adds `perforce` to the `POPULARITY_WEIGHT` map with a weight of **10** — matching GitLab, Bitbucket, and GitHub Enterprise.

Previously Perforce had no entry in the map, so `getPopularityWeight()` fell back to the default weight of `1`, sorting Perforce to the very bottom of the integrations directory popularity tier. With a weight of 10 it now sorts alongside the other source code management providers.

## Why

Perforce is a fully supported SCM integration (stacktrace linking + commits), but it ranked below every other first-party integration in the directory because it had no explicit popularity weight.

## Notes

- The `POPULARITY_WEIGHT` map has no existing test coverage and this is a one-line data change, so no test is added.
- This is the frontend half of a two-part change; a separate backend PR adds Perforce to the integrations that complete the onboarding "Getting Started" checklist.

Refs https://github.com/getsentry/sentry/issues/91428