### PR TITLE
fix(smartSearchBar): Handle prototype filter keys

### DIFF
--- a/static/app/components/searchSyntax/mutableSearch.spec.tsx
+++ b/static/app/components/searchSyntax/mutableSearch.spec.tsx
@@ -294,6 +294,15 @@ describe('MutableSearch', () => {
       expect(results.getFilterValues('nonexistent')).toEqual([]);
     });
 
+    it('getFilters handles keys that match Object prototype properties', () => {
+      const filters = new MutableSearch(
+        'constructor:value constructor:other tag:value'
+      ).getFilters();
+
+      expect(filters.constructor).toEqual(['value', 'other']);
+      expect(filters.tag).toEqual(['value']);
+    });
+
     it('getFilterValues splits bracket list into items', () => {
       const results = new MutableSearch('event.type:[error, default]');
       expect(results.getFilterValues('event.type')).toEqual(['error', 'default']);

--- a/static/app/components/searchSyntax/mutableSearch.tsx
+++ b/static/app/components/searchSyntax/mutableSearch.tsx
@@ -691,7 +691,7 @@ export class MutableSearch {
         t.listValues && t.listValues.length > 0 ? t.listValues : [t.value ?? ''];
       (acc[t.key] ??= []).push(...values);
       return acc;
-    }, {});
+    }, Object.create(null));
   }
 
   getFilterValues(key: string): string[] {


### PR DESCRIPTION
Follow-up from #116996 prevents a page crash when typing `constructor:`