### PR TITLE
fix(performance): Handle prototype query params

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -580,6 +580,17 @@ describe('SpanEvidenceKeyValueList', () => {
           filter: ['none'],
         });
       });
+
+      it('handles parameter names that match Object prototype properties', () => {
+        const URLs = [
+          new URL('http://service.io/items?constructor=4'),
+          new URL('http://service.io/items?constructor=5'),
+        ];
+
+        expect(extractQueryParameters(URLs)).toEqual({
+          constructor: ['4', '5'],
+        });
+      });
     });
   });
 

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -901,7 +901,7 @@ export const extractSpanURLString = (span: Span, baseURL?: string): URL | null =
 };
 
 export function extractQueryParameters(URLs: URL[]): ParameterLookup {
-  const parameterValuesByKey: ParameterLookup = {};
+  const parameterValuesByKey: ParameterLookup = Object.create(null);
 
   URLs.forEach(url => {
     for (const [key, value] of url.searchParams) {


### PR DESCRIPTION
Follow-up from #116996 while checking for other plain-object dynamic key indexes.\n\nThis keeps extractQueryParameters() returning the same Record shape, but uses a null-prototype accumulator while grouping URL query parameter names so constructor is treated as data.\n\nTested with:\n\n`pnpm test-ci static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx`