### PR TITLE
fix(logs): Handle prototype buffer keys

### DIFF
--- a/static/app/views/explore/logs/useStreamingTimeseriesResult.spec.tsx
+++ b/static/app/views/explore/logs/useStreamingTimeseriesResult.spec.tsx
@@ -833,6 +833,52 @@ describe('useStreamingTimeseriesResult', () => {
       ]);
     });
 
+    it('handles group values that match Object prototype properties', async () => {
+      const mockTimeseriesData = getMockMultiGroupTimeseries();
+
+      const {result, rerender} = renderHook(
+        (tableData: UseInfiniteLogsQueryResult) =>
+          useStreamingTimeseriesResult(tableData, mockTimeseriesData, 0n),
+        {
+          initialProps: createMockTableData([]),
+          wrapper: createWrapper({
+            autoRefresh: 'enabled',
+            groupBy: [OurLogKnownFieldKey.SEVERITY],
+          }),
+        }
+      );
+
+      rerender(
+        createMockTableData([
+          LogFixture({
+            [OurLogKnownFieldKey.ID]: 'prototype-key',
+            [OurLogKnownFieldKey.PROJECT_ID]: project.id,
+            [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(logsOrganization.id),
+            [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: preciseTimestampFromMillis(9000),
+            [OurLogKnownFieldKey.SEVERITY]: 'constructor',
+          }),
+        ])
+      );
+
+      await waitFor(() => {
+        expect(
+          result.current.data['count(message)']?.some(
+            series => series.yAxis === 'constructor'
+          )
+        ).toBe(true);
+      });
+
+      const prototypeKeySeries = result.current.data['count(message)']?.find(
+        series => series.yAxis === 'constructor'
+      );
+
+      expect(prototypeKeySeries?.values.at(-1)).toEqual({
+        timestamp: 9000,
+        value: 1,
+        incomplete: true,
+      });
+    });
+
     it('should only update last bucket when ingest delay is at end of timeseries data', async () => {
       const mockTimeseriesData = getMockMultiGroupTimeseries();
       const ingestDelayMs = 8500n * 1_000_000n; // Set delay to match last bucket timestamp

--- a/static/app/views/explore/logs/useStreamingTimeseriesResult.tsx
+++ b/static/app/views/explore/logs/useStreamingTimeseriesResult.tsx
@@ -265,14 +265,14 @@ function createBufferFromTableData(
       continue;
     }
 
-    if (!groupBuffers[groupValue]) {
+    if (!Object.hasOwn(groupBuffers, groupValue)) {
       groupBuffers[groupValue] = {
         stableIndex: getStableIndex(groupValue, groupBuffers, originalTimeseries),
         values: [],
       };
     }
 
-    const buffer = groupBuffers[groupValue];
+    const buffer = groupBuffers[groupValue]!;
     const existingEntry = buffer.values.find(
       entry => entry.bucketIndex === rowBucketIndex
     );
@@ -486,8 +486,8 @@ function getStableIndex(
     }
   }
 
-  if (groupBuffers[groupValue]) {
-    return groupBuffers[groupValue].stableIndex;
+  if (Object.hasOwn(groupBuffers, groupValue)) {
+    return groupBuffers[groupValue]!.stableIndex;
   }
 
   const allYAxisValues = new Set([


### PR DESCRIPTION
Follow-up from #116996 while checking for other plain-object dynamic key indexes.\n\nThis updates the streamed logs timeseries buffer to use own-property checks before reading group values. That keeps group-by values like constructor from resolving to Object.prototype.constructor before the buffer entry exists.\n\nTested with:\n\n`pnpm test-ci static/app/views/explore/logs/useStreamingTimeseriesResult.spec.tsx`