### PR TITLE
fix(seer): Handle prototype repo names

### DIFF
--- a/static/app/views/seerExplorer/components/prWidget.spec.tsx
+++ b/static/app/views/seerExplorer/components/prWidget.spec.tsx
@@ -1,0 +1,51 @@
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {DiffFileType} from 'sentry/components/events/autofix/types';
+import {usePRWidgetData} from 'sentry/views/seerExplorer/components/prWidget';
+import type {Block} from 'sentry/views/seerExplorer/types';
+
+describe('usePRWidgetData', () => {
+  it('handles repo names that match Object prototype properties', () => {
+    const blocks: Block[] = [
+      {
+        id: 'block-1',
+        message: {
+          content: null,
+          role: 'assistant',
+        },
+        timestamp: '2026-01-01T00:00:00Z',
+        merged_file_patches: [
+          {
+            diff: '',
+            repo_name: 'constructor',
+            patch: {
+              added: 3,
+              hunks: [],
+              path: 'src/example.ts',
+              removed: 1,
+              source_file: 'src/example.ts',
+              target_file: 'src/example.ts',
+              type: DiffFileType.MODIFIED,
+            },
+          },
+        ],
+      },
+    ];
+
+    const {result} = renderHook(() =>
+      usePRWidgetData({
+        blocks,
+        repoPRStates: {},
+        onCreatePR: jest.fn(),
+      })
+    );
+
+    expect(result.current.totalAdded).toBe(3);
+    expect(result.current.totalRemoved).toBe(1);
+    expect(result.current.menuItems).toHaveLength(1);
+    expect(result.current.menuItems[0]).toMatchObject({
+      key: 'constructor',
+      title: 'constructor',
+    });
+  });
+});

--- a/static/app/views/seerExplorer/components/prWidget.tsx
+++ b/static/app/views/seerExplorer/components/prWidget.tsx
@@ -78,19 +78,17 @@ export function usePRWidgetData({
       added += patch.added;
       removed += patch.removed;
 
-      if (!stats[patch.repoName]) {
+      if (!Object.hasOwn(stats, patch.repoName)) {
         stats[patch.repoName] = {added: 0, removed: 0};
       }
-      const repoStat = stats[patch.repoName];
-      if (repoStat) {
-        repoStat.added += patch.added;
-        repoStat.removed += patch.removed;
-      }
+      const repoStat = stats[patch.repoName]!;
+      repoStat.added += patch.added;
+      repoStat.removed += patch.removed;
 
-      if (!fileStats[patch.repoName]) {
+      if (!Object.hasOwn(fileStats, patch.repoName)) {
         fileStats[patch.repoName] = [];
       }
-      fileStats[patch.repoName]?.push({
+      fileStats[patch.repoName]!.push({
         added: patch.added,
         path: patch.path,
         removed: patch.removed,


### PR DESCRIPTION
Follow-up from #116996 while checking for other plain-object dynamic key indexes.\n\nThis updates the Seer PR widget aggregation to use own-property checks before reading repository-name buckets. That keeps repo names like constructor from resolving to Object.prototype.constructor before the bucket exists.\n\nTested with:\n\n`pnpm test-ci static/app/views/seerExplorer/components/prWidget.spec.tsx`

fixes JAVASCRIPT-39FP