### PR TITLE
fix(project-install): Handle prototype provider slugs

### DIFF
--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -2,12 +2,19 @@ import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegration
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderHookWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {
   IssueAlertNotificationOptions,
   type IssueAlertNotificationProps,
+  useCreateNotificationAction,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
 describe('MessagingIntegrationAlertRule', () => {
@@ -92,5 +99,31 @@ describe('MessagingIntegrationAlertRule', () => {
     await screen.findByText(/notify via integration/i);
     await userEvent.click(screen.getByText(/notify via integration/i));
     expect(mockSetAction).toHaveBeenCalled();
+  });
+
+  it('groups integrations with provider slugs that match Object prototype properties', async () => {
+    const constructorIntegration = OrganizationIntegrationsFixture({
+      provider: {
+        ...OrganizationIntegrationsFixture().provider,
+        slug: 'constructor',
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body: [constructorIntegration],
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+    });
+
+    const {result} = renderHookWithProviders(() => useCreateNotificationAction(), {
+      organization,
+    });
+
+    await waitFor(() => {
+      expect(result.current.notificationProps.querySuccess).toBe(true);
+    });
+
+    expect(result.current.notificationProps.providersToIntegrations.constructor).toEqual([
+      constructorIntegration,
+    ]);
   });
 });

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -107,8 +107,10 @@ export function useCreateNotificationAction({
       for (const i of messagingIntegrationsQuery.data) {
         if (i.status === 'active') {
           const providerSlug = i.provider.slug;
-          map[providerSlug] = map[providerSlug] ?? [];
-          map[providerSlug].push(i);
+          if (!Object.hasOwn(map, providerSlug)) {
+            map[providerSlug] = [];
+          }
+          map[providerSlug]!.push(i);
         }
       }
     }


### PR DESCRIPTION
Follow-up from #116996 while checking for other plain-object dynamic key indexes.\n\nThis updates messaging integration grouping to use own-property checks before reading provider-slug buckets. That keeps provider slugs like constructor from resolving to Object.prototype.constructor before the bucket exists.\n\nTested with:\n\n`pnpm test-ci static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx`