### PR TITLE
fix(aci): Add better condition validation

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -486,7 +486,9 @@ class WorkflowEngineRuleSerializer(Serializer):
                 except NoRegistrationExistsError:
                     raise serializers.ValidationError(f"Invalid condition type: {condition_type}")
 
-            condition_data["name"] = handler.render_label(condition_data)
+            condition_data["name"] = handler.render_label(
+                condition_data, organization_id=project.organization_id
+            )
             return condition_data
 
         def generate_condition_filters(conditions: list[DataCondition], is_filter: bool):

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/email_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/email_metric_alert_handler.py
@@ -131,7 +131,10 @@ def get_target(
 
     elif notification_context.target_type == ActionTarget.TEAM:
         try:
-            return Team.objects.get(id=int(notification_context.target_identifier))
+            return Team.objects.get(
+                id=int(notification_context.target_identifier),
+                organization=organization,
+            )
         except Team.DoesNotExist:
             pass
 

--- a/src/sentry/rules/filters/assigned_to.py
+++ b/src/sentry/rules/filters/assigned_to.py
@@ -7,6 +7,7 @@ from django import forms
 from sentry.mail.forms.assigned_to import AssignedToForm
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
+from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.notifications.types import ASSIGNEE_CHOICES, AssigneeTargetType
 from sentry.rules import EventState
@@ -69,14 +70,19 @@ class AssignedToFilter(EventFilter):
     def render_label(self) -> str:
         target_type = AssigneeTargetType(self.get_option("targetType"))
         target_identifer = self.get_option("targetIdentifier")
+        organization_id = self.project.organization_id
         if target_type == AssigneeTargetType.TEAM:
             try:
-                team = Team.objects.get(id=target_identifer)
+                team = Team.objects.get(id=target_identifer, organization_id=organization_id)
             except Team.DoesNotExist:
                 return self.label.format(**self.data)
             return self.label.format(targetType=f"team #{team.slug}")
 
         elif target_type == AssigneeTargetType.MEMBER:
+            if not OrganizationMember.objects.filter(
+                user_id=target_identifer, organization_id=organization_id
+            ).exists():
+                return self.label.format(**self.data)
             user = user_service.get_user(user_id=target_identifer)
             if user is not None:
                 return self.label.format(targetType=user.username)

--- a/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
+from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.notifications.types import AssigneeTargetType
 from sentry.users.services.user.service import user_service
@@ -65,7 +66,7 @@ class AssignedToConditionHandler(DataConditionHandler[WorkflowEventData]):
             return any(assignee.user_id and assignee.user_id == target_id for assignee in assignees)
 
     @classmethod
-    def render_label(cls, condition_data: dict[str, Any]) -> str:
+    def render_label(cls, condition_data: dict[str, Any], organization_id: int) -> str:
         target_type: str | None = condition_data.get("targetType")
         if target_type is None:
             return cls.label_template.format(**condition_data)
@@ -75,7 +76,7 @@ class AssignedToConditionHandler(DataConditionHandler[WorkflowEventData]):
             if target_identifer is None:
                 return cls.label_template.format(**condition_data)
             try:
-                team = Team.objects.get(id=target_identifer)
+                team = Team.objects.get(id=target_identifer, organization_id=organization_id)
             except Team.DoesNotExist:
                 return cls.label_template.format(**condition_data)
             return cls.label_template.format(targetType=f"team #{team.slug}")
@@ -84,10 +85,16 @@ class AssignedToConditionHandler(DataConditionHandler[WorkflowEventData]):
             if target_identifer is None:
                 return cls.label_template.format(**condition_data)
             try:
-                user = user_service.get_user(user_id=int(target_identifer))
+                user_id = int(target_identifer)
             except (ValueError, TypeError):
                 return cls.label_template.format(**condition_data)
 
+            if not OrganizationMember.objects.filter(
+                user_id=user_id, organization_id=organization_id
+            ).exists():
+                return cls.label_template.format(**condition_data)
+
+            user = user_service.get_user(user_id=user_id)
             if user is not None:
                 return cls.label_template.format(targetType=user.username)
             else:

--- a/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
@@ -104,7 +104,7 @@ class EventAttributeConditionHandler(DataConditionHandler[WorkflowEventData]):
         )
 
     @classmethod
-    def render_label(cls, condition_data: dict[str, Any]) -> str:
+    def render_label(cls, condition_data: dict[str, Any], organization_id: int) -> str:
         data = {
             "attribute": condition_data["attribute"],
             "value": condition_data["value"],

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -78,7 +78,7 @@ class BaseEventFrequencyQueryHandler(ABC):
     label_template = ""
 
     @classmethod
-    def render_label(cls, condition_data: dict[str, Any]) -> str:
+    def render_label(cls, condition_data: dict[str, Any], organization_id: int) -> str:
         return cls.label_template.format(**condition_data)
 
     def get_query_window(self, end: datetime, duration: timedelta) -> tuple[datetime, datetime]:
@@ -410,7 +410,7 @@ class EventUniqueUserFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
     )
 
     @classmethod
-    def render_label(cls, condition_data: dict[str, Any]) -> str:
+    def render_label(cls, condition_data: dict[str, Any], organization_id: int) -> str:
         from sentry.rules.conditions.event_frequency import (
             EventUniqueUserFrequencyConditionWithConditions,
         )
@@ -465,7 +465,7 @@ class PercentSessionsQueryHandler(BaseEventFrequencyQueryHandler):
     label_template = "The issue affects more than {value} percent of sessions in {interval}"
 
     @classmethod
-    def render_label(cls, condition_data: dict[str, Any]) -> str:
+    def render_label(cls, condition_data: dict[str, Any], organization_id: int) -> str:
         data = dict(condition_data)
         value = data.get("value")
         if isinstance(value, float) and value.is_integer():

--- a/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
@@ -55,7 +55,7 @@ class IssueCategoryConditionHandler(DataConditionHandler[WorkflowEventData]):
         return bool(category_matches if include else not category_matches)
 
     @classmethod
-    def render_label(cls, condition_data: dict[str, Any]) -> str:
+    def render_label(cls, condition_data: dict[str, Any], organization_id: int) -> str:
         value = condition_data["value"]
         title = CATEGORY_CHOICES.get(value)
         group_category_name = title.title() if title else ""

--- a/src/sentry/workflow_engine/handlers/condition/issue_type_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_type_handler.py
@@ -51,7 +51,7 @@ class IssueTypeConditionHandler(DataConditionHandler[WorkflowEventData]):
         return group.issue_type == value if include else group.issue_type != value
 
     @classmethod
-    def render_label(cls, condition_data: dict[str, Any]) -> str:
+    def render_label(cls, condition_data: dict[str, Any], organization_id: int) -> str:
         value = condition_data["value"]
         group_type = grouptype.registry.get_by_slug(value)
         issue_type_name = (getattr(group_type, "description", None) or value) if group_type else ""

--- a/src/sentry/workflow_engine/handlers/condition/level_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/level_handler.py
@@ -58,7 +58,7 @@ class LevelConditionHandler(DataConditionHandler[WorkflowEventData]):
         return False
 
     @classmethod
-    def render_label(cls, condition_data: dict[str, Any]) -> str:
+    def render_label(cls, condition_data: dict[str, Any], organization_id: int) -> str:
         data = {
             "level": LEVEL_CHOICES[condition_data["level"]],
             "match": LEVEL_MATCH_CHOICES[condition_data["match"]],

--- a/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
@@ -110,7 +110,7 @@ class TaggedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
         return result
 
     @classmethod
-    def render_label(cls, condition_data: dict[str, Any]) -> str:
+    def render_label(cls, condition_data: dict[str, Any], organization_id: int) -> str:
         data = {
             "key": condition_data["key"],
             "value": condition_data["value"],

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -406,7 +406,7 @@ class DataConditionHandler(Generic[T]):
         raise NotImplementedError
 
     @classmethod
-    def render_label(cls, condition_data: dict[str, Any]) -> str:
+    def render_label(cls, condition_data: dict[str, Any], organization_id: int) -> str:
         return cls.label_template.format(**condition_data)
 
 

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -11,8 +11,12 @@ from sentry.incidents.typings.metric_detector import (
     OpenPeriodContext,
 )
 from sentry.models.activity import Activity
+from sentry.models.team import Team
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.metric_alert_registry import EmailMetricAlertHandler
+from sentry.notifications.notification_action.metric_alert_registry.handlers.email_metric_alert_handler import (
+    get_target,
+)
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
     get_detector_serializer,
 )
@@ -38,6 +42,29 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
         )
 
         self.handler = EmailMetricAlertHandler()
+
+    def test_get_target_team_in_org(self) -> None:
+        organization = self.detector.project.organization
+        team = self.create_team(organization=organization)
+        notification_context = NotificationContext(
+            id=self.action.id,
+            target_identifier=str(team.id),
+            target_type=ActionTarget.TEAM,
+        )
+        assert get_target(organization, notification_context) == team
+
+    def test_get_target_team_foreign_org(self) -> None:
+        organization = self.detector.project.organization
+        other_org = self.create_organization()
+        other_team = self.create_team(organization=other_org)
+        notification_context = NotificationContext(
+            id=self.action.id,
+            target_identifier=str(other_team.id),
+            target_type=ActionTarget.TEAM,
+        )
+        assert get_target(organization, notification_context) is None
+        # The foreign team still exists; it simply isn't reachable cross-org.
+        assert Team.objects.filter(id=other_team.id).exists()
 
     @mock.patch(
         "sentry.notifications.notification_action.metric_alert_registry.handlers.email_metric_alert_handler.email_users"

--- a/tests/sentry/rules/filters/test_assigned_to.py
+++ b/tests/sentry/rules/filters/test_assigned_to.py
@@ -73,3 +73,29 @@ class AssignedToFilterTest(RuleTestCase):
         }
         rule = self.get_rule(data=data)
         self.assertDoesNotPass(rule, event)
+
+    def test_render_label_team_in_org(self) -> None:
+        rule = self.get_rule(data={"targetType": "Team", "targetIdentifier": self.team.id})
+        assert rule.render_label() == f"The issue is assigned to team #{self.team.slug}"
+
+    def test_render_label_team_foreign_org(self) -> None:
+        other_org = self.create_organization()
+        other_team = self.create_team(organization=other_org)
+        rule = self.get_rule(data={"targetType": "Team", "targetIdentifier": other_team.id})
+        label = rule.render_label()
+        assert other_team.slug not in label
+        assert label == "The issue is assigned to Team"
+
+    def test_render_label_member_in_org(self) -> None:
+        rule = self.get_rule(data={"targetType": "Member", "targetIdentifier": self.user.id})
+        assert rule.render_label() == f"The issue is assigned to {self.user.username}"
+
+    def test_render_label_member_foreign_org(self) -> None:
+        other_org = self.create_organization()
+        other_user = self.create_user(email="foreign@example.com")
+        self.create_member(user=other_user, organization=other_org)
+        rule = self.get_rule(data={"targetType": "Member", "targetIdentifier": other_user.id})
+        label = rule.render_label()
+        assert other_user.username not in label
+        assert other_user.email not in label
+        assert label == "The issue is assigned to Member"

--- a/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
@@ -5,6 +5,7 @@ from jsonschema import ValidationError
 
 from sentry.models.groupassignee import GroupAssignee
 from sentry.rules.filters.assigned_to import AssignedToFilter
+from sentry.workflow_engine.handlers.condition.assigned_to_handler import AssignedToConditionHandler
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase
@@ -105,3 +106,39 @@ class TestAssignedToCondition(ConditionTestCase):
         GroupAssignee.objects.create(user_id=self.user.id, group=self.group, project=self.project)
         self.dc.update(comparison={"target_type": "Unassigned"})
         self.assert_does_not_pass(self.dc, self.event_data)
+
+    def test_render_label_team_in_org(self) -> None:
+        label = AssignedToConditionHandler.render_label(
+            {"targetType": "Team", "targetIdentifier": self.team.id},
+            organization_id=self.organization.id,
+        )
+        assert label == f"The issue is assigned to team #{self.team.slug}"
+
+    def test_render_label_team_foreign_org(self) -> None:
+        other_org = self.create_organization()
+        other_team = self.create_team(organization=other_org)
+        label = AssignedToConditionHandler.render_label(
+            {"targetType": "Team", "targetIdentifier": other_team.id},
+            organization_id=self.organization.id,
+        )
+        assert other_team.slug not in label
+        assert label == "The issue is assigned to Team"
+
+    def test_render_label_member_in_org(self) -> None:
+        label = AssignedToConditionHandler.render_label(
+            {"targetType": "Member", "targetIdentifier": self.user.id},
+            organization_id=self.organization.id,
+        )
+        assert label == f"The issue is assigned to {self.user.username}"
+
+    def test_render_label_member_foreign_org(self) -> None:
+        other_org = self.create_organization()
+        other_user = self.create_user(email="foreign@example.com")
+        self.create_member(user=other_user, organization=other_org)
+        label = AssignedToConditionHandler.render_label(
+            {"targetType": "Member", "targetIdentifier": other_user.id},
+            organization_id=self.organization.id,
+        )
+        assert other_user.username not in label
+        assert other_user.email not in label
+        assert label == "The issue is assigned to Member"


### PR DESCRIPTION
Most of the changes here are due to needing to thread `organization_id` through to `render_label` which changes many of the callsites. If you have any better ways of accessing the organization data without doing this lmk, but since `render_label` is only used for the legacy alert APIs, this will all be deleted soon anyway.