### PR TITLE
feat(onboarding): Complete SCM task when Perforce integration is added

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -159,6 +159,7 @@ INTEGRATION_TYPE_TO_PROVIDER = {
         IntegrationProviderSlug.BITBUCKET,
         IntegrationProviderSlug.BITBUCKET_SERVER,
         IntegrationProviderSlug.AZURE_DEVOPS,
+        IntegrationProviderSlug.PERFORCE,
     ],
     IntegrationDomain.ON_CALL_SCHEDULING: [
         IntegrationProviderSlug.PAGERDUTY,

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -809,6 +809,33 @@ class OrganizationOnboardingTaskTest(TestCase):
             ),
         )
 
+    @patch("sentry.analytics.record", wraps=record)
+    def test_perforce_source_code_management_added(self, record_analytics: MagicMock) -> None:
+        integration_id = self._create_integration("perforce", 123).id
+        integration_added.send(
+            integration_id=integration_id,
+            organization_id=self.organization.id,
+            user_id=self.user.id,
+            sender=None,
+        )
+        task = OrganizationOnboardingTask.objects.get(
+            organization=self.organization,
+            task=OnboardingTask.LINK_SENTRY_TO_SOURCE_CODE,
+            status=OnboardingTaskStatus.COMPLETE,
+        )
+        assert task is not None
+
+        assert_last_analytics_event(
+            record_analytics,
+            IntegrationAddedEvent(
+                user_id=self.user.id,
+                default_user_id=self.organization.default_owner_id,
+                organization_id=self.organization.id,
+                id=integration_id,
+                provider="perforce",
+            ),
+        )
+
     def test_second_platform_complete(self) -> None:
         now = timezone.now()
         project = self.create_project(first_event=now)


### PR DESCRIPTION
## Summary

Adds `IntegrationProviderSlug.PERFORCE` to the `SOURCE_CODE_MANAGEMENT` provider list in `INTEGRATION_TYPE_TO_PROVIDER` so that installing a Perforce integration completes the **"Link Sentry to Source Code"** onboarding task — the same as GitHub, GitLab, Bitbucket, and Azure DevOps.

## Why

When an integration is added, the `integration_added` signal handler in `src/sentry/receivers/onboarding.py` calls `get_integration_types(provider)` and only completes `LINK_SENTRY_TO_SOURCE_CODE` if the provider maps to `IntegrationDomain.SOURCE_CODE_MANAGEMENT`.

Perforce was absent from that mapping, so `get_integration_types("perforce")` returned an empty list and the task was never recorded — even though Perforce is a fully supported SCM integration (`STACKTRACE_LINK` + `COMMITS`). Perforce customers were left with a permanently incomplete "Getting Started" checklist (the 5/6 reported in the issue).

## Analytics

No analytics changes are required. The `integration_added` signal already drives provider-agnostic analytics in `src/sentry/receivers/features.py` — `IntegrationAddedEvent(provider=...)` plus the `integration.added` metric fire identically for Perforce today. There is no SCM-task-specific event; the only onboarding event (`OnboardingCompleteEvent`) fires when all required tasks complete, independent of provider. So Perforce now behaves exactly like GitHub.

## Tests

Adds `test_perforce_source_code_management_added`, mirroring the existing `test_source_code_management_added` (GitHub) test — asserts the task is marked complete and the `IntegrationAddedEvent` is recorded with `provider="perforce"`. Both pass locally.

## Related

The companion frontend PR (#116998) gives Perforce a popularity weight so it sorts alongside the other SCM providers in the integrations directory. Frontend and backend are split per the non-atomic-deploy rule.

Fixes https://github.com/getsentry/sentry/issues/91428