### PR TITLE
chore(cells) Remove RPC methods for org slug reservations

### DIFF
--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -3,7 +3,6 @@ from collections.abc import Iterator, Mapping
 from typing import Any
 
 from django.db import IntegrityError, router, transaction
-from django.db.models import Q
 
 from sentry.auth.services.auth import RpcApiKey, RpcApiToken, RpcAuthIdentity, RpcAuthProvider
 from sentry.auth.services.orgauthtoken.model import RpcOrgAuthToken
@@ -18,9 +17,6 @@ from sentry.hybridcloud.models import (
 )
 from sentry.hybridcloud.outbox.base import ReplicatedCellModel, ReplicatedControlModel
 from sentry.hybridcloud.outbox.category import OutboxCategory
-from sentry.hybridcloud.services.control_organization_provisioning import (
-    RpcOrganizationSlugReservation,
-)
 from sentry.hybridcloud.services.project_key_mapping import RpcProjectKeyMapping
 from sentry.hybridcloud.services.replica.service import CellReplicaService, ControlReplicaService
 from sentry.integrations.models.external_actor import ExternalActor
@@ -35,7 +31,6 @@ from sentry.models.organization import Organization
 from sentry.models.organizationavatarreplica import OrganizationAvatarReplica
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
-from sentry.models.organizationslugreservationreplica import OrganizationSlugReservationReplica
 from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.models.projectkeymapping import ProjectKeyMapping
 from sentry.models.team import Team
@@ -273,48 +268,6 @@ class DatabaseBackedCellReplicaService(CellReplicaService):
         )
 
         handle_replication(ApiKey, destination)
-
-    def upsert_replicated_org_slug_reservation(
-        self,
-        *,
-        slug_reservation: RpcOrganizationSlugReservation,
-        cell_name: str,
-    ) -> None:
-        with enforce_constraints(
-            transaction.atomic(router.db_for_write(OrganizationSlugReservationReplica))
-        ):
-            # Delete any slug reservation that can possibly conflict, it's likely stale
-            OrganizationSlugReservationReplica.objects.filter(
-                Q(organization_slug_reservation_id=slug_reservation.id)
-                | Q(
-                    organization_id=slug_reservation.organization_id,
-                    reservation_type=slug_reservation.reservation_type,
-                )
-                | Q(slug=slug_reservation.slug)
-            ).delete()
-
-            OrganizationSlugReservationReplica.objects.create(
-                slug=slug_reservation.slug,
-                organization_id=slug_reservation.organization_id,
-                user_id=slug_reservation.user_id,
-                cell_name=slug_reservation.cell_name,
-                reservation_type=slug_reservation.reservation_type,
-                organization_slug_reservation_id=slug_reservation.id,
-            )
-
-    def delete_replicated_org_slug_reservation(
-        self,
-        *,
-        organization_slug_reservation_id: int,
-        cell_name: str,
-    ) -> None:
-        with enforce_constraints(
-            transaction.atomic(router.db_for_write(OrganizationSlugReservationReplica))
-        ):
-            org_slug_qs = OrganizationSlugReservationReplica.objects.filter(
-                organization_slug_reservation_id=organization_slug_reservation_id
-            )
-            org_slug_qs.delete()
 
     def delete_replicated_auth_provider(
         self,

--- a/src/sentry/hybridcloud/services/replica/service.py
+++ b/src/sentry/hybridcloud/services/replica/service.py
@@ -4,9 +4,6 @@ from sentry.auth.services.auth import RpcApiKey, RpcApiToken, RpcAuthIdentity, R
 from sentry.auth.services.orgauthtoken.model import RpcOrgAuthToken
 from sentry.hybridcloud.rpc.resolvers import ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, cell_rpc_method, rpc_method
-from sentry.hybridcloud.services.control_organization_provisioning import (
-    RpcOrganizationSlugReservation,
-)
 from sentry.hybridcloud.services.project_key_mapping import RpcProjectKeyMapping
 from sentry.notifications.services import RpcExternalActor
 from sentry.organizations.services.organization import RpcOrganizationMemberTeam, RpcTeam
@@ -134,28 +131,6 @@ class CellReplicaService(RpcService):
         token: RpcOrgAuthToken,
         cell_name: str,
     ) -> None:
-        pass
-
-    @cell_rpc_method(resolve=ByCellName())
-    @abc.abstractmethod
-    def upsert_replicated_org_slug_reservation(
-        self,
-        *,
-        slug_reservation: RpcOrganizationSlugReservation,
-        cell_name: str,
-    ) -> None:
-        """Deprecated will be removed in an upcoming change"""
-        pass
-
-    @cell_rpc_method(resolve=ByCellName())
-    @abc.abstractmethod
-    def delete_replicated_org_slug_reservation(
-        self,
-        *,
-        organization_slug_reservation_id: int,
-        cell_name: str,
-    ) -> None:
-        """Deprecated will be removed in an upcoming change"""
         pass
 
     @cell_rpc_method(resolve=ByCellName())


### PR DESCRIPTION
Now that we aren't replicating this OrgSlugReservation into cells we don't need the RPC methods either.

Refs INFRENG-317