### PR TITLE
feat(ourlogs): only re-query truncated logs on significant viewport width increases

### DIFF
--- a/static/app/views/explore/logs/useLogsQueryTruncate.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQueryTruncate.spec.tsx
@@ -9,21 +9,51 @@ jest.mock('sentry/utils/window/useWindowSize');
 const mockUseWindowSize = jest.mocked(useWindowSize);
 
 describe('useLogsQueryTruncate', () => {
-  it('returns 64 for narrow viewports when the formula yields less', () => {
+  it('returns 128 for narrow viewports when the formula yields less', () => {
     mockUseWindowSize.mockReturnValue({innerWidth: 800, innerHeight: 600});
     const {result} = renderHookWithProviders(() => useLogsQueryTruncate());
-    expect(result.current).toBe(64);
+    expect(result.current).toBe(128);
   });
 
-  it('returns the formula result when the viewport exceeds narrow width', () => {
+  it('rounds the formula result up to the next power of two', () => {
     mockUseWindowSize.mockReturnValue({innerWidth: 6400, innerHeight: 1080});
     const {result} = renderHookWithProviders(() => useLogsQueryTruncate());
-    expect(result.current).toBe(400);
+    expect(result.current).toBe(512);
   });
 
-  it('returns the formula result as a floored int when the viewport math would make it a float', () => {
-    mockUseWindowSize.mockReturnValue({innerWidth: 6412.3, innerHeight: 1080});
+  it('returns the exact value when the formula result is already a power of two', () => {
+    mockUseWindowSize.mockReturnValue({innerWidth: 4096, innerHeight: 1080});
     const {result} = renderHookWithProviders(() => useLogsQueryTruncate());
-    expect(result.current).toBe(400);
+    expect(result.current).toBe(256);
+  });
+
+  it('does not shrink the truncation length when the viewport shrinks', () => {
+    mockUseWindowSize.mockReturnValue({innerWidth: 6400, innerHeight: 1080});
+    const {result, rerender} = renderHookWithProviders(() => useLogsQueryTruncate());
+    expect(result.current).toBe(512);
+
+    mockUseWindowSize.mockReturnValue({innerWidth: 3200, innerHeight: 1080});
+    rerender();
+    expect(result.current).toBe(512);
+  });
+
+  it('does not recompute when the viewport grows within the same power of two', () => {
+    mockUseWindowSize.mockReturnValue({innerWidth: 3200, innerHeight: 1080});
+    const {result, rerender} = renderHookWithProviders(() => useLogsQueryTruncate());
+    expect(result.current).toBe(256);
+
+    mockUseWindowSize.mockReturnValue({innerWidth: 4096, innerHeight: 1080});
+    rerender();
+    expect(result.current).toBe(256);
+  });
+
+  it('grows the truncation length when the viewport grows past the next power of two', () => {
+    mockUseWindowSize.mockReturnValue({innerWidth: 4096, innerHeight: 1080});
+    const {result, rerender} = renderHookWithProviders(() => useLogsQueryTruncate());
+    expect(result.current).toBe(256);
+
+    mockUseWindowSize.mockReturnValue({innerWidth: 8192, innerHeight: 1080});
+    rerender();
+    expect(result.current).toBe(512);
   });
 });

--- a/static/app/views/explore/logs/useLogsQueryTruncate.tsx
+++ b/static/app/views/explore/logs/useLogsQueryTruncate.tsx
@@ -1,6 +1,20 @@
+import {useRef} from 'react';
+
 import {useWindowSize} from 'sentry/utils/window/useWindowSize';
 
 export function useLogsQueryTruncate(): number {
   const {innerWidth} = useWindowSize();
-  return Math.max(64, Math.floor(innerWidth / 16));
+  const target = Math.max(128, Math.floor(innerWidth / 16));
+
+  // Round up to the next power of two so small viewport changes don't shift the
+  // truncation length and trigger a re-query.
+  const truncate = 2 ** Math.ceil(Math.log2(target));
+
+  // Only ever grow the truncation length. Shrinking the viewport means the
+  // logs we already fetched are still long enough to display, so there is no
+  // reason to re-query for shorter messages.
+  const maxTruncate = useRef(truncate);
+  maxTruncate.current = Math.max(maxTruncate.current, truncate);
+
+  return maxTruncate.current;
 }


### PR DESCRIPTION
Logs query with a `truncate` parameter derived from the viewport width. Previously the value tracked `window.innerWidth` directly, so shrinking the viewport lowered `truncate`, changed the query key, and triggered an unnecessary re-query even though the messages already fetched were long enough to display. 😬 

This PR adds a monotonic, power-of-two truncation length. Meaning: truncation length is now rounded up to the next power of two and tracked as an increasing high-water mark (we never go down, only equal or up).

The truncation length steps up at these viewport widths:

| truncate | min `innerWidth` |
|----------|------------------|
| 256      | 2064px           |
| 512      | 4112px           |

This means we fetch a little bit more data for logs than we need. But it's not much more data and shouldn't change much.

Closes LOGS-839