### PR TITLE
fix(onboarding): Gate experiment exposure to recently created orgs

### DIFF
--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -46,6 +46,11 @@ import {SetupDocs} from './setupDocs';
 import {OnboardingStepId, type StepDescriptor, type StepProps} from './types';
 import {TargetedOnboardingWelcome} from './welcome';
 
+// Genuine new-org onboarding happens shortly after org creation. Existing orgs
+// only reach /onboarding via stale links + login replay and are far older than
+// this window, so gating exposure on org age keeps them out of the experiment.
+const NEW_ORG_ONBOARDING_WINDOW_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
+
 const legacyOnboardingSteps: StepDescriptor[] = [
   {
     id: OnboardingStepId.WELCOME,
@@ -263,16 +268,26 @@ export function OnboardingWithoutContext() {
     onboardingContext.createdProjectSlug ?? onboardingContext.selectedPlatform?.key;
 
   const hasNewWelcomeUI = useHasNewWelcomeUI();
+
+  // Only report experiment exposure for genuine new-org onboarding. Existing
+  // orgs can land on /onboarding via stale links, which would
+  // otherwise contaminate the experiment population. reportExposure does not
+  // affect the returned `inExperiment` assignment, so step selection below still
+  // works for everyone.
+  const isNewOrgOnboarding =
+    Date.now() - new Date(organization.dateCreated).getTime() <
+    NEW_ORG_ONBOARDING_WINDOW_MS;
+
   const {inExperiment: hasScmOnboarding} = useExperiment({
     feature: 'onboarding-scm-experiment',
-    reportExposure: true,
+    reportExposure: isNewOrgOnboarding,
   });
 
   // Only report exposure for users who are actually in SCM onboarding —
   // the assignment is irrelevant for legacy onboarding.
   const {inExperiment: hasProjectDetailsStep} = useExperiment({
     feature: 'onboarding-scm-project-details-experiment',
-    reportExposure: hasScmOnboarding,
+    reportExposure: hasScmOnboarding && isNewOrgOnboarding,
   });
 
   const scmSteps = hasProjectDetailsStep


### PR DESCRIPTION
## TL;DR
Existing orgs were firing onboarding experiment exposure after landing on `/onboarding` via stale links. Exposure now only fires for orgs created within the last 7 days, so the experiment population reflects genuine new-org onboarding.
##
`onboarding-scm-experiment` and `onboarding-scm-project-details-experiment` reported exposure on every onboarding mount. Existing orgs reach `/onboarding` via stale or legacy-format bookmarks (confirmed in api-access and load balancer logs; an auth bug and the onboarding continuation email were ruled out), which contaminated the experiment. Gating on `organization.dateCreated` is fully synchronous and cleanly excludes the contaminating orgs, which are years old. `reportExposure` does not change the returned `inExperiment` assignment, so onboarding step selection is unchanged.

`NEW_ORG_ONBOARDING_WINDOW_MS` (7 days) is tunable, and exposure volume is worth confirming after deploy. A project-count alternative was also prototyped.