### PR TITLE
fix(tagstore): Skip array meta-columns in tag value paginator

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -2038,10 +2038,16 @@ class SnubaTagStorage(TagStorage):
         # time:         This is a column computed from timestamp so it suffers the same issues
         if snuba_key in {"group_id"}:
             snuba_key = f"tags[{snuba_key}]"
+        # tags.key/tags.value are array meta-columns (the list of all tag keys/values on an
+        # event). They have no arrayjoin (see snuba.get_arrayjoin), so grouping by them returns
+        # an array per row which is unhashable in snuba.nest_groups. They are not real tags and
+        # have no meaningful values to suggest, so we disable them here.
         if snuba_key in {"event_id", "timestamp", "time", "profile_id", "replay_id"} or key in {
             "trace",
             "trace.span",
             "trace.parent_span",
+            "tags.key",
+            "tags.value",
         }:
             return SequencePaginator([])
 

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -759,6 +759,33 @@ class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceI
             )
         ]
 
+    def test_get_tag_value_paginator_array_meta_columns(self) -> None:
+        # tags.key/tags.value are array meta-columns that previously crashed with
+        # "TypeError: unhashable type: 'list'" in nest_groups (SENTRY-5PD7). They should
+        # short-circuit to an empty result instead.
+        assert (
+            list(
+                self.ts.get_tag_value_paginator(
+                    self.proj1.id,
+                    self.proj1env1.id,
+                    "tags.key",
+                    tenant_ids={"referrer": "r", "organization_id": 1234},
+                ).get_result(10)
+            )
+            == []
+        )
+        assert (
+            list(
+                self.ts.get_tag_value_paginator(
+                    self.proj1.id,
+                    self.proj1env1.id,
+                    "tags.value",
+                    tenant_ids={"referrer": "r", "organization_id": 1234},
+                ).get_result(10)
+            )
+            == []
+        )
+
     def test_get_tag_value_paginator_with_dates(self) -> None:
         from sentry.tagstore.types import TagValue
 


### PR DESCRIPTION
## Summary

Fixes **SENTRY-5PD7**: `TypeError: unhashable type: 'list'`.

Querying tag values for the array meta-columns `tags.key` / `tags.value` crashed in
`snuba.nest_groups`. These columns map to themselves in the snuba column map and have no
arrayjoin (`get_arrayjoin` only matches `exception_stacks|exception_frames|contexts`), so the
backend issued a `GROUP BY tags.key` query and snuba returned an array per row. `nest_groups`
then used that list as a dict key → crash.

The trigger in production was the Seer public RPC `get_event_filter_key_values`, which forwarded
`filter_key="tags.key"` to the tags-values endpoint, but any caller of that endpoint was affected.

## Fix

`tags.key` / `tags.value` are array meta-columns, not real tags, and have no meaningful values to
suggest. They now short-circuit to an empty paginator in `get_tag_value_paginator_for_projects`,
using the same early-return blacklist that already handles `trace.*`, `event_id`, `timestamp`, etc.

## Testing

- Added `test_get_tag_value_paginator_array_meta_columns` asserting both keys return `[]` instead
  of raising.
- Verified the new test fails without the fix (reproduces the `GROUP BY tags.key` crash path) and
  passes with it.
- `prek` lint clean on both files.

Fixes SENTRY-5PD7
