### PR TITLE
fix: adjust grid template columns values to constraint attribute tree text

### DIFF
--- a/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
@@ -555,7 +555,7 @@ const TreeValueTrunk = styled('div')`
   height: 100%;
   align-items: center;
   min-height: 22px;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   grid-column-gap: ${p => p.theme.space.xs};
 `;
 


### PR DESCRIPTION
The AttributeTree in the trace detail page displayed text weirdly when the trace drawer was resized to be very small: when texts were big, they disappeared off-screen - see image.

<img width="387" height="275" alt="Screenshot 2026-06-05 at 3 58 54 PM" src="https://github.com/user-attachments/assets/36eed50e-8c67-4073-93a2-e185e55716e2" />

This change basically makes it such that, when you resize, the content resizes until the trace drawer toggle min-width is reached, not prior to that (what it is currently doing).

Result:

<img width="402" height="291" alt="Screenshot 2026-06-05 at 3 59 58 PM" src="https://github.com/user-attachments/assets/7067b0bf-28bf-40c6-9daf-f78b040afeab" />

Closes EXP-951