### PR TITLE
fix(cell): Adds actor serialization fix for monitors

### DIFF
--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -214,7 +214,9 @@ class MonitorSerializer(Serializer[MonitorSerializerResponse]):
         )
         filtered_actors = list(filter(None, actors))
 
-        actors_serialized = serialize(Actor.resolve_many(filtered_actors), user, ActorSerializer())
+        actors_serialized = serialize(
+            Actor.resolve_many(filtered_actors, filter_none=False), user, ActorSerializer()
+        )
         actor_data = {
             actor: serialized_actor
             for actor, serialized_actor in zip(filtered_actors, actors_serialized)

--- a/tests/sentry/monitors/test_serializers.py
+++ b/tests/sentry/monitors/test_serializers.py
@@ -1,6 +1,10 @@
 from sentry.api.serializers import serialize
 from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorEnvironment
-from sentry.monitors.serializers import MonitorCheckInSerializer, MonitorEnvironmentSerializer
+from sentry.monitors.serializers import (
+    MonitorCheckInSerializer,
+    MonitorEnvironmentSerializer,
+    MonitorSerializer,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -26,6 +30,79 @@ class MonitorEnvironmentSerializerTest(TestCase):
         # When environment is missing, the serialization should still work
         # The name will be "[removed]" since the environment doesn't exist
         assert result[0]["name"] == "[removed]"
+
+
+class MonitorSerializerOwnerTest(TestCase):
+    def test_serialize_with_user_owner(self) -> None:
+        monitor = self.create_monitor(owner_user_id=self.user.id)
+
+        result = serialize(monitor, self.user, MonitorSerializer())
+
+        assert result["owner"] == {
+            "type": "user",
+            "id": str(self.user.id),
+            "name": self.user.get_display_name(),
+            "email": self.user.email,
+        }
+
+    def test_serialize_with_team_owner(self) -> None:
+        team = self.create_team(organization=self.organization)
+        monitor = self.create_monitor(owner_user_id=None, owner_team_id=team.id)
+
+        result = serialize(monitor, self.user, MonitorSerializer())
+
+        assert result["owner"] == {
+            "type": "team",
+            "id": str(team.id),
+            "name": team.slug,
+        }
+
+    def test_serialize_with_no_owner(self) -> None:
+        monitor = self.create_monitor(owner_user_id=None, owner_team_id=None)
+
+        result = serialize(monitor, self.user, MonitorSerializer())
+
+        assert result["owner"] is None
+
+    def test_serialize_with_unresolved_owner(self) -> None:
+        """
+        Tests a case where an invalid user ID is provided. While contrived
+        in this test, it can happen if a user is deleted in control, but
+        awaiting tombstone cleanup in cell.
+        """
+        monitor = self.create_monitor(owner_user_id=123456789)
+
+        result = serialize(monitor, self.user, MonitorSerializer())
+
+        assert result["owner"] is None
+
+    def test_serialize_mixed_resolved_and_unresolved_owners(self) -> None:
+        """
+        Regression test for a case where a monitor has an unresolvable actor,
+        which can cause misalignment in serialized actor data.
+        """
+        team = self.create_team(organization=self.organization)
+        user_owned = self.create_monitor(owner_user_id=self.user.id)
+        unresolved_owned = self.create_monitor(owner_user_id=123456789)
+        team_owned = self.create_monitor(owner_user_id=None, owner_team_id=team.id)
+
+        result = serialize(
+            [user_owned, unresolved_owned, team_owned], self.user, MonitorSerializer()
+        )
+
+        by_slug = {item["slug"]: item for item in result}
+        assert by_slug[user_owned.slug]["owner"] == {
+            "type": "user",
+            "id": str(self.user.id),
+            "name": self.user.get_display_name(),
+            "email": self.user.email,
+        }
+        assert by_slug[team_owned.slug]["owner"] == {
+            "type": "team",
+            "id": str(team.id),
+            "name": team.slug,
+        }
+        assert by_slug[unresolved_owned.slug]["owner"] is None
 
 
 class MonitorCheckInSerializerTest(TestCase):


### PR DESCRIPTION
Fixes a minor bug in monitor serialization, where missing users can result in mismatched owner properties in monitors. Adds regression tests to confirm this behavior is maintained going forward.
