### PR TITLE
ref(api): tighten 3 endpoint returns to Response[T]

### DIFF
--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -24,7 +24,7 @@ from sentry.apidocs.parameters import GlobalParams, OrganizationParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.snuba.dataset import Dataset
-from sentry.tagstore.types import TagKeySerializerResponse
+from sentry.tagstore.types import TagKeySerializer, TagKeySerializerResponse
 from sentry.utils.numbers import format_grouped_length
 from sentry.utils.sdk import set_span_attribute
 
@@ -81,14 +81,17 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
         },
         examples=[TagsExamples.ORGANIZATION_TAGS],
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[TagKeySerializerResponse]]:
         """
         Return a list of tag keys for the given organization.
         """
         try:
             filter_params = self.get_filter_params(request, organization)
         except NoProjects:
-            return Response([])
+            empty: list[TagKeySerializerResponse] = []
+            return Response(empty)
 
         if request.GET.get("dataset"):
             try:
@@ -152,4 +155,4 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
                 sentry_sdk.set_tag("dataset_queried", dataset.value)
                 set_span_attribute("custom_tags.count", len(final_results))
 
-        return Response(serialize(final_results, request.user))
+        return Response(serialize(final_results, request.user, TagKeySerializer()))

--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -21,7 +21,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import PROTECTED_TAG_KEYS
 from sentry.models.environment import Environment
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.tagstore.types import TagKeySerializerResponse
+from sentry.tagstore.types import TagKeySerializer, TagKeySerializerResponse
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 _TAG_KEY_PARAM = OpenApiParameter(
@@ -68,7 +68,7 @@ class ProjectTagKeyDetailsEndpoint(ProjectEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project, key) -> Response:
+    def get(self, request: Request, project, key) -> Response[TagKeySerializerResponse]:
         """
         Return details about a tag key, including the number of unique and total values.
         """
@@ -90,7 +90,7 @@ class ProjectTagKeyDetailsEndpoint(ProjectEndpoint):
         except tagstore.TagKeyNotFound:
             raise ResourceDoesNotExist
 
-        return Response(serialize(tagkey, request.user))
+        return Response(serialize(tagkey, request.user, TagKeySerializer()))
 
     @extend_schema(
         operation_id="Delete a Tag Key",

--- a/src/sentry/core/endpoints/project_environments.py
+++ b/src/sentry/core/endpoints/project_environments.py
@@ -7,10 +7,14 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.environments import environment_visibility_filter_options
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.environment import EnvironmentProjectSerializerResponse
+from sentry.api.serializers.models.environment import (
+    EnvironmentProjectSerializer,
+    EnvironmentProjectSerializerResponse,
+)
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.environment_examples import EnvironmentExamples
 from sentry.apidocs.parameters import EnvironmentParams, GlobalParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.environment import EnvironmentProject
 
@@ -40,7 +44,9 @@ class ProjectEnvironmentsEndpoint(ProjectEndpoint):
         },
         examples=EnvironmentExamples.GET_PROJECT_ENVIRONMENTS,
     )
-    def get(self, request: Request, project) -> Response:
+    def get(
+        self, request: Request, project
+    ) -> Response[list[EnvironmentProjectSerializerResponse]] | Response[DetailResponse]:
         """
         Lists a project's environments.
         """
@@ -77,4 +83,5 @@ class ProjectEnvironmentsEndpoint(ProjectEndpoint):
         add_visibility_filters = environment_visibility_filter_options[visibility]
         queryset = add_visibility_filters(queryset)
 
-        return Response(serialize(list(queryset), request.user))
+        items: list[EnvironmentProject] = list(queryset)
+        return Response(serialize(items, request.user, EnvironmentProjectSerializer()))

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -104,7 +104,7 @@ class TagStorage(Service):
 
     def get_tag_key(
         self, project_id, environment_id, key: str, status=TagKeyStatus.ACTIVE, tenant_ids=None
-    ):
+    ) -> GroupTagKey | TagKey:
         """
         >>> get_tag_key(1, 2, "key1")
         """

--- a/tests/sentry/api/endpoints/test_project_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_details.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 
 from sentry import tagstore
 from sentry.tagstore.base import TagKeyStatus
+from sentry.tagstore.types import TagKey
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
@@ -99,13 +100,12 @@ class ProjectTagKeyDeleteTest(APITestCase):
 
         assert response.status_code == 403
 
-        assert (
-            tagstore.backend.get_tag_key(
-                project.id,
-                None,
-                "environment",
-                status=TagKeyStatus.ACTIVE,  # environment_id
-                tenant_ids={"referrer": "test_tagstore", "organization_id": 123},
-            ).status
-            == TagKeyStatus.ACTIVE
+        tag_key = tagstore.backend.get_tag_key(
+            project.id,
+            None,
+            "environment",
+            status=TagKeyStatus.ACTIVE,  # environment_id
+            tenant_ids={"referrer": "test_tagstore", "organization_id": 123},
         )
+        assert isinstance(tag_key, TagKey)
+        assert tag_key.status == TagKeyStatus.ACTIVE


### PR DESCRIPTION
Three endpoints with typed `@extend_schema` responses but bare `-> Response` annotations. Each tightening is a typing-only change at the source — no logic changes.

- `project_environments.get()`: type the local `items: list[EnvironmentProject]` so `serialize()` flows the typed result; add `| Response[DetailResponse]` for the visibility-error branch.
- `organization_tags.get()`: type the empty-result list; pass `TagKeySerializer()` explicitly so the registry path doesn't strip the typed return.
- `project_tagkey_details.get()`: annotate `TagStorageBackend.get_tag_key` return as `GroupTagKey | TagKey` (matches the snuba backend's existing override); pass `TagKeySerializer()` explicitly.