### PR TITLE
ref(types): drop bootstrap/exportGlobals coupling from types/system

### DIFF
--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -1,6 +1,5 @@
 import type {FocusTrap} from 'focus-trap';
 
-import type {exportedGlobals} from 'sentry/bootstrap/exportGlobals';
 import type {ApiResult} from 'sentry/types/api';
 
 import type {ParntershipAgreementType} from './overrides';
@@ -27,7 +26,7 @@ export type OnSentryInitConfiguration =
     }
   | {
       name: 'onReady';
-      onReady: (globals: typeof exportedGlobals) => void;
+      onReady: (globals: Record<string, any>) => void;
     };
 
 declare global {


### PR DESCRIPTION
## Why

This is a **bridge cut**: instead of relocating a widely-imported symbol (which touches hundreds of files but barely moves the SCC), it severs a single high-leverage edge.

`types/system` defines `Config`, imported across a huge swath of the app. It also imported `exportedGlobals` from `bootstrap/exportGlobals` — purely for one callback signature, `onReady: (globals: typeof exportedGlobals)`.

`exportedGlobals` is declared `Record<string, any>`, so `typeof exportedGlobals` is *exactly* `Record<string, any>` — the import bought zero type information. But it dragged `bootstrap/exportGlobals` (and its `sentry/plugins` dependency) into the type-import closure of everything that touches `Config`.

## What

- Use `Record<string, any>` directly (already used in the sibling `renderReact` variant of this same union) and drop the `exportedGlobals` import.

Type-only change, no behavior difference.

## Impact

Largest type-import SCC drops **1681 → 1656 (−25)** — from a **single two-line edit in one file**.

For contrast, the sibling relocation PRs in this series move 170–500 files for −14 to −43. Bridge cuts trade breadth for leverage: tiny, surgical, high-impact, but they have to be found one at a time.

### Note on `bootstrap/exportGlobals`

While here: `exportGlobals` is already ~90% decoupled from the static graph — it pulls its heavy modules (`configStore`, `api`, `modal`, `forms/state`, …) via `require()` specifically so they don't count as static import edges. Its *only* remaining static intra-app import is `import {plugins} from 'sentry/plugins'`. So "splitting exportGlobals" wouldn't help much; the single `plugins` edge (or this consumer-side type coupling) is the whole story, and either one is worth the same ~−25/−26.
