### PR TITLE
ref(replays): cut two type-only edges into the import cycle

### DIFF
--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -1,5 +1,5 @@
 import type {LayoutKey} from 'sentry/utils/replays/hooks/useReplayLayout';
-import type {Output} from 'sentry/views/explore/replays/detail/network/details/getOutputType';
+import type {Output} from 'sentry/views/explore/replays/detail/network/details/output';
 
 export type ReplayEventParameters = {
   'replay.ai-summary.chapter-clicked': {

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -13,8 +13,6 @@ import type {
 } from '@sentry/react';
 import invariant from 'invariant';
 
-import type {Event} from 'sentry/types/event';
-
 export type {serializedNodeWithId} from '@sentry-internal/rrweb-snapshot';
 export type {fullSnapshotEvent, incrementalSnapshotEvent} from '@sentry-internal/rrweb';
 
@@ -214,8 +212,13 @@ export function isFeedbackFrame(frame: ReplayFrame | undefined): frame is Feedba
   return Boolean(frame && 'category' in frame && frame.category === 'feedback');
 }
 
-export function isHydrateCrumb(item: BreadcrumbFrame | Event): item is BreadcrumbFrame {
-  return 'category' in item && item.category === 'replay.hydrate-error';
+export function isHydrateCrumb(item: unknown): item is BreadcrumbFrame {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    'category' in item &&
+    item.category === 'replay.hydrate-error'
+  );
 }
 
 export function isSpanFrame(frame: ReplayFrame | undefined): frame is SpanFrame {

--- a/static/app/views/explore/replays/detail/network/details/content.tsx
+++ b/static/app/views/explore/replays/detail/network/details/content.tsx
@@ -6,14 +6,12 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {getFrameMethod, getFrameStatus} from 'sentry/utils/replays/resourceFrame';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {FluidHeight} from 'sentry/views/explore/replays/detail/layout/fluidHeight';
-import {
-  getOutputType,
-  Output,
-} from 'sentry/views/explore/replays/detail/network/details/getOutputType';
+import {getOutputType} from 'sentry/views/explore/replays/detail/network/details/getOutputType';
 import {
   Setup,
   UnsupportedOp,
 } from 'sentry/views/explore/replays/detail/network/details/onboarding';
+import {Output} from 'sentry/views/explore/replays/detail/network/details/output';
 import type {SectionProps} from 'sentry/views/explore/replays/detail/network/details/sections';
 import {
   GeneralSection,

--- a/static/app/views/explore/replays/detail/network/details/getOutputType.tsx
+++ b/static/app/views/explore/replays/detail/network/details/getOutputType.tsx
@@ -1,17 +1,9 @@
 import {isRequestFrame} from 'sentry/utils/replays/resourceFrame';
+import {Output} from 'sentry/views/explore/replays/detail/network/details/output';
 import type {SectionProps} from 'sentry/views/explore/replays/detail/network/details/sections';
 import type {TabKey} from 'sentry/views/explore/replays/detail/network/details/tabs';
 
-export enum Output {
-  SETUP = 'setup',
-  UNSUPPORTED = 'unsupported',
-  URL_SKIPPED = 'url_skipped',
-  BODY_SKIPPED = 'body_skipped',
-  BODY_PARSE_ERROR = 'body_parse_error',
-  BODY_PARSE_TIMEOUT = 'body_parse_timeout',
-  UNPARSEABLE_BODY_TYPE = 'unparseable_body_type',
-  DATA = 'data',
-}
+export {Output};
 
 type Args = {
   isCaptureBodySetup: boolean;

--- a/static/app/views/explore/replays/detail/network/details/getOutputType.tsx
+++ b/static/app/views/explore/replays/detail/network/details/getOutputType.tsx
@@ -3,8 +3,6 @@ import {Output} from 'sentry/views/explore/replays/detail/network/details/output
 import type {SectionProps} from 'sentry/views/explore/replays/detail/network/details/sections';
 import type {TabKey} from 'sentry/views/explore/replays/detail/network/details/tabs';
 
-export {Output};
-
 type Args = {
   isCaptureBodySetup: boolean;
   isSetup: boolean;

--- a/static/app/views/explore/replays/detail/network/details/onboarding.spec.tsx
+++ b/static/app/views/explore/replays/detail/network/details/onboarding.spec.tsx
@@ -6,8 +6,8 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {hydrateSpans} from 'sentry/utils/replays/hydrateSpans';
 import {useProjectSdkNeedsUpdate} from 'sentry/utils/useProjectSdkNeedsUpdate';
-import {Output} from 'sentry/views/explore/replays/detail/network/details/getOutputType';
 import {Setup} from 'sentry/views/explore/replays/detail/network/details/onboarding';
+import {Output} from 'sentry/views/explore/replays/detail/network/details/output';
 
 jest.mock('sentry/utils/useProjectSdkNeedsUpdate');
 

--- a/static/app/views/explore/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/explore/replays/detail/network/details/onboarding.tsx
@@ -16,7 +16,7 @@ import type {SpanFrame} from 'sentry/utils/replays/types';
 import {useDismissAlert} from 'sentry/utils/useDismissAlert';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectSdkNeedsUpdate} from 'sentry/utils/useProjectSdkNeedsUpdate';
-import {Output} from 'sentry/views/explore/replays/detail/network/details/getOutputType';
+import {Output} from 'sentry/views/explore/replays/detail/network/details/output';
 import type {TabKey} from 'sentry/views/explore/replays/detail/network/details/tabs';
 
 export const useDismissReqRespBodiesAlert = () => {

--- a/static/app/views/explore/replays/detail/network/details/output.tsx
+++ b/static/app/views/explore/replays/detail/network/details/output.tsx
@@ -1,0 +1,10 @@
+export enum Output {
+  SETUP = 'setup',
+  UNSUPPORTED = 'unsupported',
+  URL_SKIPPED = 'url_skipped',
+  BODY_SKIPPED = 'body_skipped',
+  BODY_PARSE_ERROR = 'body_parse_error',
+  BODY_PARSE_TIMEOUT = 'body_parse_timeout',
+  UNPARSEABLE_BODY_TYPE = 'unparseable_body_type',
+  DATA = 'data',
+}

--- a/static/app/views/insights/pages/mcp/onboarding.tsx
+++ b/static/app/views/insights/pages/mcp/onboarding.tsx
@@ -415,7 +415,7 @@ const BulletList = styled('ul')`
 const HeaderWrapper = styled('div')`
   display: flex;
   justify-content: space-between;
-  gap: $${p => p.theme.space['2xl']};
+  gap:  ${p => p.theme.space['2xl']};
   border-radius: ${p => p.theme.radius.md};
   padding: ${p => p.theme.space['3xl']};
 `;

--- a/static/app/views/insights/pages/mcp/onboarding.tsx
+++ b/static/app/views/insights/pages/mcp/onboarding.tsx
@@ -415,7 +415,7 @@ const BulletList = styled('ul')`
 const HeaderWrapper = styled('div')`
   display: flex;
   justify-content: space-between;
-  gap:  ${p => p.theme.space['2xl']};
+  gap: ${p => p.theme.space['2xl']};
   border-radius: ${p => p.theme.radius.md};
   padding: ${p => p.theme.space['3xl']};
 `;

--- a/static/app/views/insights/pages/mcp/onboarding.tsx
+++ b/static/app/views/insights/pages/mcp/onboarding.tsx
@@ -415,7 +415,7 @@ const BulletList = styled('ul')`
 const HeaderWrapper = styled('div')`
   display: flex;
   justify-content: space-between;
-  gap: ${p => p.theme.space['2xl']};
+  gap: $${p => p.theme.space['2xl']};
   border-radius: ${p => p.theme.radius.md};
   padding: ${p => p.theme.space['3xl']};
 `;


### PR DESCRIPTION
## Why

A batch of **source-side, type-only bridge cuts** — like #117029, each severs a single high-leverage type edge by editing the *importer*, not by relocating a widely-used symbol. Type-only change, no runtime behavior difference.

## What

- **`utils/replays/types` → `types/event` (~−24).** The file imported `Event` solely to type one type-guard parameter (`isHydrateCrumb`). The guard only reads `.category`, so it now takes `unknown` and narrows structurally — dropping the `types/event` edge entirely.
- **`replayAnalyticsEvents` → `getOutputType` (~−6).** The `Output` enum lived in `getOutputType` (a runtime util with its own deps), so the analytics event-map pulled that whole module in for one type. Move `Output` into a dependency-free leaf (`details/output`) and re-export it from `getOutputType` so existing consumers are untouched.

## Impact

Largest type-import SCC drops **1681 → 1651 (−30)** across **5 files**.

### Scope note (the other "cheap cut" candidates)

From the ranked type-only-edge list, the rest aren't independent of work already in flight:
- `types/core` → `charts/utils` (−30) is **#116853**.
- `types/system` → `exportGlobals` (−26) is **#117029**.
- `uptime/types`→`core`, `deprecatedforms/formField`→`group`, `issueTypeConfig`→`group` (−19/−10/−8) are **relocation-style** — those importers get repointed to the new leaves by the leaf-extraction PR, so doing them here would duplicate/conflict.
- `configStore` → `system` (−13) genuinely stores the `Config` type; not cheaply cuttable.

So this PR is the remaining *independent, source-side* type cuts.
