### PR TITLE
ref(webhooks): Route /integrations/webhooks/ to WebhookDetailedView

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1021,6 +1021,14 @@ function buildRoutes(): RouteObject[] {
           ),
         },
         {
+          path: 'webhooks/',
+          name: t('Webhooks'),
+          component: make(
+            () =>
+              import('sentry/views/settings/organizationIntegrations/webhookDetailedView')
+          ),
+        },
+        {
           path: ':integrationSlug',
           name: t('Integration Details'),
           component: make(

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1021,7 +1021,7 @@ function buildRoutes(): RouteObject[] {
           ),
         },
         {
-          path: 'webhooks/',
+          path: 'legacy-webhooks/',
           name: t('Webhooks'),
           component: make(
             () =>

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -47,6 +47,7 @@ import {IntegrationLayout} from 'sentry/views/settings/organizationIntegrations/
 import {InstalledIntegration} from 'sentry/views/settings/organizationIntegrations/installedIntegration';
 import {IntegrationButton} from 'sentry/views/settings/organizationIntegrations/integrationButton';
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
+import {WebhookDetailedView} from 'sentry/views/settings/organizationIntegrations/webhookDetailedView';
 
 // Show the features tab if the org has features for the integration
 const integrationFeatures = ['slack'];
@@ -103,7 +104,7 @@ function makeIntegrationQueryKey({
 
 const tabs: IntegrationTab[] = ['overview', 'configurations', 'features'];
 
-export default function IntegrationDetailedView() {
+function DefaultView() {
   const api = useApi({persistInFlight: true});
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useQueryState(
@@ -555,4 +556,18 @@ export default function IntegrationDetailedView() {
       />
     </SentryDocumentTitle>
   );
+}
+
+export default function IntegrationDetailedView() {
+  const {integrationSlug} = useParams<{integrationSlug: string}>();
+  const organization = useOrganization();
+
+  if (
+    integrationSlug === 'webhooks' &&
+    organization.features.includes('legacy-webhook-ui')
+  ) {
+    return <WebhookDetailedView />;
+  }
+
+  return <DefaultView />;
 }

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -47,7 +47,6 @@ import {IntegrationLayout} from 'sentry/views/settings/organizationIntegrations/
 import {InstalledIntegration} from 'sentry/views/settings/organizationIntegrations/installedIntegration';
 import {IntegrationButton} from 'sentry/views/settings/organizationIntegrations/integrationButton';
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
-import {WebhookDetailedView} from 'sentry/views/settings/organizationIntegrations/webhookDetailedView';
 
 // Show the features tab if the org has features for the integration
 const integrationFeatures = ['slack'];
@@ -104,7 +103,7 @@ function makeIntegrationQueryKey({
 
 const tabs: IntegrationTab[] = ['overview', 'configurations', 'features'];
 
-function DefaultView() {
+export default function IntegrationDetailedView() {
   const api = useApi({persistInFlight: true});
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useQueryState(
@@ -556,18 +555,4 @@ function DefaultView() {
       />
     </SentryDocumentTitle>
   );
-}
-
-export default function IntegrationDetailedView() {
-  const {integrationSlug} = useParams<{integrationSlug: string}>();
-  const organization = useOrganization();
-
-  if (
-    integrationSlug === 'webhooks' &&
-    organization.features.includes('legacy-webhook-ui')
-  ) {
-    return <WebhookDetailedView />;
-  }
-
-  return <DefaultView />;
 }

--- a/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
@@ -23,6 +23,7 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 import {setApiQueryData, useApiQuery, type ApiQueryKey} from 'sentry/utils/queryClient';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -373,6 +374,7 @@ const AddButton = styled(Button)`
 function PluginDetailedView() {
   const {integrationSlug} = useParams<{integrationSlug: string}>();
   const organization = useOrganization();
+  const location = useLocation();
 
   if (
     integrationSlug === 'webhooks' &&
@@ -380,7 +382,10 @@ function PluginDetailedView() {
   ) {
     return (
       <Redirect
-        to={normalizeUrl(`/settings/${organization.slug}/integrations/legacy-webhooks/`)}
+        to={
+          normalizeUrl(`/settings/${organization.slug}/integrations/legacy-webhooks/`) +
+          location.search
+        }
       />
     );
   }

--- a/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
@@ -380,7 +380,7 @@ function PluginDetailedView() {
   ) {
     return (
       <Redirect
-        to={normalizeUrl(`/settings/${organization.slug}/integrations/webhooks/`)}
+        to={normalizeUrl(`/settings/${organization.slug}/integrations/legacy-webhooks/`)}
       />
     );
   }

--- a/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/pluginDetailedView.tsx
@@ -11,6 +11,7 @@ import {hasEveryAccess} from 'sentry/components/acl/access';
 import {ContextPickerModalContainer as ContextPickerModal} from 'sentry/components/contextPickerModal';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {Redirect} from 'sentry/components/redirect';
 import {t} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import type {
@@ -35,7 +36,6 @@ import {IntegrationLayout} from 'sentry/views/settings/organizationIntegrations/
 import InstalledPlugin from 'sentry/views/settings/organizationIntegrations/installedPlugin';
 import {RequestIntegrationButton} from 'sentry/views/settings/organizationIntegrations/integrationRequest/RequestIntegrationButton';
 import {PluginDeprecationAlert} from 'sentry/views/settings/organizationIntegrations/pluginDeprecationAlert';
-import {WebhookDetailedView} from 'sentry/views/settings/organizationIntegrations/webhookDetailedView';
 
 // TODO @sentaur-athena: remove this once we have a solution to deprecate these plugins
 const TEMPORARY_PERMITTED_PLUGINS = new Set(['amazon-sqs']);
@@ -378,7 +378,11 @@ function PluginDetailedView() {
     integrationSlug === 'webhooks' &&
     organization.features.includes('legacy-webhook-ui')
   ) {
-    return <WebhookDetailedView />;
+    return (
+      <Redirect
+        to={normalizeUrl(`/settings/${organization.slug}/integrations/webhooks/`)}
+      />
+    );
   }
 
   return <DefaultView />;

--- a/static/app/views/settings/organizationIntegrations/webhookConfigurations.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/webhookConfigurations.spec.tsx
@@ -3,7 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import * as indicators from 'sentry/actionCreators/indicator';
-import {WebhookDetailedView} from 'sentry/views/settings/organizationIntegrations/webhookDetailedView';
+import WebhookDetailedView from 'sentry/views/settings/organizationIntegrations/webhookDetailedView';
 
 describe('WebhookConfigurations', () => {
   const organization = OrganizationFixture({features: ['legacy-webhook-ui']});

--- a/static/app/views/settings/organizationIntegrations/webhookDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/webhookDetailedView.spec.tsx
@@ -2,7 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {WebhookDetailedView} from 'sentry/views/settings/organizationIntegrations/webhookDetailedView';
+import WebhookDetailedView from 'sentry/views/settings/organizationIntegrations/webhookDetailedView';
 
 describe('WebhookDetailedView', () => {
   const organization = OrganizationFixture({features: ['legacy-webhook-ui']});

--- a/static/app/views/settings/organizationIntegrations/webhookDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/webhookDetailedView.tsx
@@ -196,3 +196,5 @@ export function WebhookDetailedView() {
     />
   );
 }
+
+export default WebhookDetailedView;

--- a/static/app/views/settings/organizationIntegrations/webhookDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/webhookDetailedView.tsx
@@ -10,6 +10,7 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {ContextPickerModalContainer as ContextPickerModal} from 'sentry/components/contextPickerModal';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {Redirect} from 'sentry/components/redirect';
 import {t, tct} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import type {Organization} from 'sentry/types/organization';
@@ -85,6 +86,12 @@ export default function WebhookDetailedView() {
   const {data, isPending, isError, refetch} = useQuery(
     legacyWebhooksQueryOptions(organization)
   );
+
+  if (!organization.features.includes('legacy-webhook-ui')) {
+    return (
+      <Redirect to={normalizeUrl(`/settings/${organization.slug}/plugins/webhooks/`)} />
+    );
+  }
 
   const webhookProjects = data?.projects ?? [];
   const installationStatus = webhookProjects.length ? INSTALLED : NOT_INSTALLED;

--- a/static/app/views/settings/organizationIntegrations/webhookDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/webhookDetailedView.tsx
@@ -71,7 +71,7 @@ export function legacyWebhooksQueryOptions(organization: Organization) {
   );
 }
 
-export function WebhookDetailedView() {
+export default function WebhookDetailedView() {
   const organization = useOrganization();
   const navigate = useNavigate();
   const {openModal} = useModal();
@@ -196,5 +196,3 @@ export function WebhookDetailedView() {
     />
   );
 }
-
-export default WebhookDetailedView;


### PR DESCRIPTION
- In preperation for plugins apis getting deprecated, we should get rid of mentions of the plugin route in our frontend too
- This PR adds new route for webhooks page and adds redirect from pluginsdetailedview/plugin router to the new route