### PR TITLE
feat(ourlogs): sync hover state between pinned and tbody log rows

### DIFF
--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -89,6 +89,16 @@ export const LogTableRow = styled(TableRow)<LogTableRowProps>`
       }
     `}
 
+  &[data-row-hover-linked='true']:not(thead > &) {
+    background-color: ${p =>
+      p.theme.tokens.interactive.transparent.accent.selected.background.active};
+
+    &:hover {
+      background-color: ${p =>
+        p.theme.tokens.interactive.transparent.accent.selected.background.active};
+    }
+  }
+
   &.beforeHoverTime + &.afterHoverTime:before {
     border-top: 1px solid ${p => p.theme.tokens.border.accent.moderate};
     content: '';

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {LogFixture} from 'sentry-fixture/log';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
@@ -18,7 +17,6 @@ import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {OrganizationContext} from 'sentry/utils/organizationContext';
-import {useLocation} from 'sentry/utils/useLocation';
 import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {
   LOGS_FIELDS_KEY,
@@ -29,9 +27,6 @@ import {DEFAULT_TRACE_ITEM_HOVER_TIMEOUT} from 'sentry/views/explore/logs/consta
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {LogsInfiniteTable} from 'sentry/views/explore/logs/tables/logsInfiniteTable';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
-
-jest.mock('sentry/utils/useLocation');
-const mockUseLocation = jest.mocked(useLocation);
 
 jest.mock('@tanstack/react-virtual', () => {
   return {
@@ -125,6 +120,17 @@ describe('LogsInfiniteTable', () => {
 
   const frozenColumnFields = [OurLogKnownFieldKey.TIMESTAMP, OurLogKnownFieldKey.MESSAGE];
 
+  const defaultRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/explore/logs/`,
+      query: {
+        [LOGS_FIELDS_KEY]: visibleColumnFields,
+        [LOGS_SORT_BYS_KEY]: '-timestamp',
+        [LOGS_QUERY_KEY]: 'severity:error',
+      },
+    },
+  };
+
   beforeEach(() => {
     jest.restoreAllMocks();
     MockApiClient.clearMockResponses();
@@ -142,17 +148,6 @@ describe('LogsInfiniteTable', () => {
         utc: null,
       },
     });
-
-    mockUseLocation.mockReturnValue(
-      LocationFixture({
-        pathname: `/organizations/${organization.slug}/explore/logs/?end=2025-04-10T20%3A04%3A51&project=${project.id}&start=2025-04-10T14%3A37%3A55`,
-        query: {
-          [LOGS_FIELDS_KEY]: visibleColumnFields,
-          [LOGS_SORT_BYS_KEY]: '-timestamp',
-          [LOGS_QUERY_KEY]: 'severity:error',
-        },
-      })
-    );
 
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/releases/1.0.0/`,
@@ -223,7 +218,11 @@ describe('LogsInfiniteTable', () => {
   }
 
   const renderWithProviders = (children: React.ReactElement, options?: RenderOptions) => {
-    return render(children, {additionalWrapper: Wrapper, ...options});
+    return render(children, {
+      additionalWrapper: Wrapper,
+      initialRouterConfig: defaultRouterConfig,
+      ...options,
+    });
   };
 
   it('should render the table component', async () => {
@@ -430,19 +429,20 @@ describe('LogsInfiniteTable', () => {
       },
     });
 
-    mockUseLocation.mockReturnValue(
-      LocationFixture({
-        pathname: `/organizations/${organization.slug}/explore/logs/?end=2025-04-10T20%3A04%3A51&project=${project.id}&start=2025-04-10T14%3A37%3A55`,
-        query: {
-          [LOGS_FIELDS_KEY]: ['message', OurLogKnownFieldKey.REPLAY_ID],
-          [LOGS_SORT_BYS_KEY]: '-timestamp',
-          [LOGS_QUERY_KEY]: 'severity:error',
-        },
-      })
-    );
-
     renderWithProviders(
-      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />
+      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/logs/`,
+            query: {
+              [LOGS_FIELDS_KEY]: ['message', OurLogKnownFieldKey.REPLAY_ID],
+              [LOGS_SORT_BYS_KEY]: '-timestamp',
+              [LOGS_QUERY_KEY]: 'severity:error',
+            },
+          },
+        },
+      }
     );
 
     expect(eventsMock).toHaveBeenCalledWith(
@@ -492,20 +492,21 @@ describe('LogsInfiniteTable', () => {
   });
 
   it('renders a pin button on a hovered row when ourlogs-pinning is enabled', async () => {
-    mockUseLocation.mockReturnValue(
-      LocationFixture({
-        pathname: `/organizations/${organization.slug}/explore/logs/?end=2025-04-10T20%3A04%3A51&project=${project.id}&start=2025-04-10T14%3A37%3A55`,
-        query: {
-          [LOGS_FIELDS_KEY]: visibleColumnFields,
-          [LOGS_SORT_BYS_KEY]: '-timestamp',
-          [LOGS_QUERY_KEY]: 'severity:error',
-          logsPinning: 'true',
-        },
-      })
-    );
-
     renderWithProviders(
-      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />
+      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/logs/`,
+            query: {
+              [LOGS_FIELDS_KEY]: visibleColumnFields,
+              [LOGS_SORT_BYS_KEY]: '-timestamp',
+              [LOGS_QUERY_KEY]: 'severity:error',
+              logsPinning: 'true',
+            },
+          },
+        },
+      }
     );
 
     const [firstRow] = await screen.findAllByTestId('log-table-row');
@@ -530,22 +531,22 @@ describe('LogsInfiniteTable', () => {
   });
 
   it('marks the row as pinned when its id is in the logsPinned query', async () => {
-    mockUseLocation.mockReturnValue(
-      LocationFixture({
-        pathname: `/organizations/${organization.slug}/explore/logs/?end=2025-04-10T20%3A04%3A51&project=${project.id}&start=2025-04-10T14%3A37%3A55`,
-        search: '?logsPinned=1',
-        query: {
-          [LOGS_FIELDS_KEY]: visibleColumnFields,
-          [LOGS_SORT_BYS_KEY]: '-timestamp',
-          [LOGS_QUERY_KEY]: 'severity:error',
-          logsPinning: 'true',
-          logsPinned: '1',
-        },
-      })
-    );
-
     renderWithProviders(
-      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />
+      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/logs/`,
+            query: {
+              [LOGS_FIELDS_KEY]: visibleColumnFields,
+              [LOGS_SORT_BYS_KEY]: '-timestamp',
+              [LOGS_QUERY_KEY]: 'severity:error',
+              logsPinning: 'true',
+              logsPinned: '1',
+            },
+          },
+        },
+      }
     );
 
     const [firstRow] = await screen.findAllByTestId('log-table-row');
@@ -556,22 +557,22 @@ describe('LogsInfiniteTable', () => {
   });
 
   it('links the body instance hover state when the pinned instance is hovered', async () => {
-    mockUseLocation.mockReturnValue(
-      LocationFixture({
-        pathname: `/organizations/${organization.slug}/explore/logs/?end=2025-04-10T20%3A04%3A51&project=${project.id}&start=2025-04-10T14%3A37%3A55`,
-        search: '?logsPinned=1',
-        query: {
-          [LOGS_FIELDS_KEY]: visibleColumnFields,
-          [LOGS_SORT_BYS_KEY]: '-timestamp',
-          [LOGS_QUERY_KEY]: 'severity:error',
-          logsPinning: 'true',
-          logsPinned: '1',
-        },
-      })
-    );
-
     renderWithProviders(
-      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />
+      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/logs/`,
+            query: {
+              [LOGS_FIELDS_KEY]: visibleColumnFields,
+              [LOGS_SORT_BYS_KEY]: '-timestamp',
+              [LOGS_QUERY_KEY]: 'severity:error',
+              logsPinning: 'true',
+              logsPinned: '1',
+            },
+          },
+        },
+      }
     );
 
     const pinnedTableBody = await screen.findByTestId('pinned-logs-table-body');
@@ -590,22 +591,22 @@ describe('LogsInfiniteTable', () => {
   });
 
   it('links the pinned instance hover state when the body instance is hovered', async () => {
-    mockUseLocation.mockReturnValue(
-      LocationFixture({
-        pathname: `/organizations/${organization.slug}/explore/logs/?end=2025-04-10T20%3A04%3A51&project=${project.id}&start=2025-04-10T14%3A37%3A55`,
-        search: '?logsPinned=1',
-        query: {
-          [LOGS_FIELDS_KEY]: visibleColumnFields,
-          [LOGS_SORT_BYS_KEY]: '-timestamp',
-          [LOGS_QUERY_KEY]: 'severity:error',
-          logsPinning: 'true',
-          logsPinned: '1',
-        },
-      })
-    );
-
     renderWithProviders(
-      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />
+      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/logs/`,
+            query: {
+              [LOGS_FIELDS_KEY]: visibleColumnFields,
+              [LOGS_SORT_BYS_KEY]: '-timestamp',
+              [LOGS_QUERY_KEY]: 'severity:error',
+              logsPinning: 'true',
+              logsPinned: '1',
+            },
+          },
+        },
+      }
     );
 
     const pinnedTableBody = await screen.findByTestId('pinned-logs-table-body');
@@ -625,16 +626,6 @@ describe('LogsInfiniteTable', () => {
 
   it('cycles column sort: unsorted → desc → asc → reset to default timestamp desc', async () => {
     // Start with severity sorted ascending (second click has already happened)
-    mockUseLocation.mockReturnValue(
-      LocationFixture({
-        pathname: `/organizations/${organization.slug}/explore/logs/`,
-        query: {
-          [LOGS_FIELDS_KEY]: visibleColumnFields,
-          [LOGS_SORT_BYS_KEY]: 'severity',
-        },
-      })
-    );
-
     const {router} = renderWithProviders(
       <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
       {

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -555,6 +555,74 @@ describe('LogsInfiniteTable', () => {
     );
   });
 
+  it('links the body instance hover state when the pinned instance is hovered', async () => {
+    mockUseLocation.mockReturnValue(
+      LocationFixture({
+        pathname: `/organizations/${organization.slug}/explore/logs/?end=2025-04-10T20%3A04%3A51&project=${project.id}&start=2025-04-10T14%3A37%3A55`,
+        search: '?logsPinned=1',
+        query: {
+          [LOGS_FIELDS_KEY]: visibleColumnFields,
+          [LOGS_SORT_BYS_KEY]: '-timestamp',
+          [LOGS_QUERY_KEY]: 'severity:error',
+          logsPinning: 'true',
+          logsPinned: '1',
+        },
+      })
+    );
+
+    renderWithProviders(
+      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />
+    );
+
+    const pinnedTableBody = await screen.findByTestId('pinned-logs-table-body');
+    const rows = await screen.findAllByTestId('log-table-row');
+    const pinnedRow = rows.find(row => pinnedTableBody.contains(row))!;
+    const tbodyRow = rows.find(
+      row => !pinnedTableBody.contains(row) && within(row).queryByText('test log body 1')
+    )!;
+
+    await userEvent.hover(pinnedRow);
+
+    await waitFor(() => {
+      expect(tbodyRow).toHaveAttribute('data-row-hover-linked', 'true');
+    });
+    expect(pinnedRow).toHaveAttribute('data-row-hover-linked', 'true');
+  });
+
+  it('links the pinned instance hover state when the body instance is hovered', async () => {
+    mockUseLocation.mockReturnValue(
+      LocationFixture({
+        pathname: `/organizations/${organization.slug}/explore/logs/?end=2025-04-10T20%3A04%3A51&project=${project.id}&start=2025-04-10T14%3A37%3A55`,
+        search: '?logsPinned=1',
+        query: {
+          [LOGS_FIELDS_KEY]: visibleColumnFields,
+          [LOGS_SORT_BYS_KEY]: '-timestamp',
+          [LOGS_QUERY_KEY]: 'severity:error',
+          logsPinning: 'true',
+          logsPinned: '1',
+        },
+      })
+    );
+
+    renderWithProviders(
+      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />
+    );
+
+    const pinnedTableBody = await screen.findByTestId('pinned-logs-table-body');
+    const rows = await screen.findAllByTestId('log-table-row');
+    const pinnedRow = rows.find(row => pinnedTableBody.contains(row))!;
+    const tbodyRow = rows.find(
+      row => !pinnedTableBody.contains(row) && within(row).queryByText('test log body 1')
+    )!;
+
+    await userEvent.hover(tbodyRow);
+
+    await waitFor(() => {
+      expect(pinnedRow).toHaveAttribute('data-row-hover-linked', 'true');
+    });
+    expect(tbodyRow).toHaveAttribute('data-row-hover-linked', 'true');
+  });
+
   it('cycles column sort: unsorted → desc → asc → reset to default timestamp desc', async () => {
     // Start with severity sorted ascending (second click has already happened)
     mockUseLocation.mockReturnValue(

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -239,6 +239,7 @@ export function LogsInfiniteTable({
     Record<string, number>
   >({});
   const [isFunctionScrolling, setIsFunctionScrolling] = useState(false);
+  const [hoveredRowId, setHoveredRowId] = useState<string | null>(null);
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const scrollFetchDisabled = isFunctionScrolling || autorefreshEnabled;
 
@@ -468,6 +469,8 @@ export function LogsInfiniteTable({
           logStart={logStart}
           logEnd={logEnd}
           isPinned={logsPinning?.hasPinnedRow?.(rowId)}
+          isHoverLinked={hoveredRowId === rowId}
+          setHoveredRowId={setHoveredRowId}
           togglePinnedRow={logsPinning?.togglePinnedRow}
         />
       );
@@ -478,6 +481,7 @@ export function LogsInfiniteTable({
       handleExpand,
       handleExpandHeight,
       highlightTerms,
+      hoveredRowId,
       logEnd,
       logStart,
       logsPinning,
@@ -608,6 +612,8 @@ export function LogsInfiniteTable({
                   showCellActions={showCellActions}
                   showExploreSimilarSpansLink={showExploreSimilarSpansLink}
                   isPinned={logsPinning?.hasPinnedRow?.(rowId)}
+                  isHoverLinked={hoveredRowId === rowId}
+                  setHoveredRowId={setHoveredRowId}
                   togglePinnedRow={logsPinning?.togglePinnedRow}
                 />
               </Fragment>

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -129,6 +129,7 @@ type LogsRowProps = {
   };
   expansionKey?: string;
   isExpanded?: boolean;
+  isHoverLinked?: boolean;
   isPinned?: boolean;
   logEnd?: string;
   logStart?: string;
@@ -136,6 +137,7 @@ type LogsRowProps = {
   onEmbeddedRowClick?: (logItemId: string, event: React.MouseEvent) => void;
   onExpand?: (logItemId: string) => void;
   onExpandHeight?: (logItemId: string, estimatedHeight: number) => void;
+  setHoveredRowId?: (logItemId: string | null) => void;
   showCellActions?: boolean;
   showExploreSimilarSpansLink?: boolean;
   togglePinnedRow?: (logItemId: string) => void;
@@ -226,6 +228,8 @@ export const LogRowContent = memo(function LogRowContent({
   logStart,
   logEnd,
   isPinned,
+  isHoverLinked,
+  setHoveredRowId,
   togglePinnedRow,
   showCellActions,
   showExploreSimilarSpansLink,
@@ -418,6 +422,7 @@ export const LogRowContent = memo(function LogRowContent({
     <Fragment>
       <LogTableRow
         data-test-id="log-table-row"
+        data-row-hover-linked={isHoverLinked}
         highlighted={isPseudoRow}
         pinned={isPinned}
         {...omit(rowInteractProps, 'className')}
@@ -425,9 +430,15 @@ export const LogRowContent = memo(function LogRowContent({
         onMouseEnter={e => {
           setShouldRenderHoverElements(true);
           rowInteractProps.onMouseEnter?.(e);
+          if (isPinned) {
+            setHoveredRowId?.(rowId);
+          }
         }}
         onMouseLeave={e => {
           rowInteractProps.onMouseLeave?.(e);
+          if (isPinned) {
+            setHoveredRowId?.(null);
+          }
         }}
       >
         <LogsTableBodyFirstCell key="first">


### PR DESCRIPTION
A pinned log shows up twice: once in the pinned section at the top of the table and again in the tbody. Hovering either instance now highlights both so it's clear they're the same row.

https://github.com/user-attachments/assets/c397897a-e439-4c78-a53b-f28dd596d3d5

Closes LOGS-841