### PR TITLE
fix(aci): Handle missing conditions in DataConditionGroup create

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
@@ -95,7 +95,8 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer[Any]):
 
     def create(self, validated_data: dict[str, Any]) -> DataConditionGroup:
         logic_type = validated_data.get("logic_type", DataConditionGroup.Type.ANY.value)
-        self._validate_logic_type(validated_data.get("conditions", []), logic_type)
+        conditions = validated_data.get("conditions", [])
+        self._validate_logic_type(conditions, logic_type)
 
         with transaction.atomic(router.db_for_write(DataConditionGroup)):
             condition_group = DataConditionGroup.objects.create(
@@ -103,7 +104,7 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer[Any]):
                 organization_id=self.context["organization"].id,
             )
 
-            for condition in validated_data["conditions"]:
+            for condition in conditions:
                 # Always set condition_group_id programmatically to prevent cross-org IDOR
                 condition["condition_group_id"] = condition_group.id
                 condition_validator = BaseDataConditionValidator()

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_data_condition_group.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_data_condition_group.py
@@ -155,6 +155,19 @@ class TestBaseDataConditionGroupValidatorCreate(TestBaseDataConditionGroupValida
         assert condition.comparison is True
         assert condition.condition_group == result
 
+    def test_create__missing_conditions(self) -> None:
+        data = {
+            "logicType": DataConditionGroup.Type.ANY,
+            "organizationId": self.organization.id,
+        }
+        validator = BaseDataConditionGroupValidator(data=data, context=self.context)
+        validator.is_valid(raise_exception=True)
+        result = validator.create(validator.validated_data)
+
+        assert result.logic_type == DataConditionGroup.Type.ANY
+        assert result.organization_id == self.organization.id
+        assert result.conditions.count() == 0
+
     def test_create_trigger__invalid_logic_type(self) -> None:
         valid_data = {
             "organizationId": self.organization.id,


### PR DESCRIPTION
Fixes SENTRY-5N9F

`BaseDataConditionGroupValidator.create()` was accessing `validated_data["conditions"]` directly, which raised a `KeyError` when a trigger/condition group was submitted without the optional `conditions` field. The `update()` method already handled this gracefully with `.get("conditions", [])`, so this just applies the same pattern to `create()`.