### PR TITLE
chore(billing): Bump sentry-protos to 0.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.0.13",
-  "sentry-protos>=0.22.3",
+  "sentry-protos>=0.24.0",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm==0.22.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2424,7 +2424,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.1.27" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.0.13" },
-    { name = "sentry-protos", specifier = ">=0.22.3" },
+    { name = "sentry-protos", specifier = ">=0.24.0" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = "==0.22.0" },
@@ -2608,7 +2608,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.22.3"
+version = "0.24.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2616,7 +2616,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.22.3-py3-none-any.whl", hash = "sha256:aaf1e2e81e2551c8ffb4ebc90e5aaae86cb6e28625a46f9d344e3a623acd9897" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.24.0-py3-none-any.whl", hash = "sha256:11367d578ef46f002f376546ff193b86a4e925f4eb92626c7fed74813207ac69" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps the `sentry-protos` pin from **0.22.3 → 0.24.0** (latest). This is a routine dependency bump that touches only `pyproject.toml` and the `uv.lock` lockfile.

## What's included

Going from 0.22.3 to 0.24.0 picks up two billing proto additions:

| Version | Change | Upstream |
|---------|--------|----------|
| 0.23.0 | Add optional `type` to `InvoiceLineItem` | [sentry-protos#293](https://github.com/getsentry/sentry-protos/pull/293) |
| 0.24.0 | Add `tax_number` to `BillingDetails` | [sentry-protos#286](https://github.com/getsentry/sentry-protos/pull/286) |

Release: https://github.com/getsentry/sentry-protos/releases/tag/0.24.0

## Why

These new proto fields are consumed by in-flight getsentry billing work and need the bump to land in `sentry` first:

- `getsentry#20568` — persist invoice line item `type` on platform invoices (uses `InvoiceLineItem.type`, 0.23.0)
- `getsentry#20532` — make platform contract invoices tax-inclusive / REVENG-15 (uses `tax_number`, 0.24.0)
- `getsentry#20549` — degrade platform tax on a provider outage and backfill it
- `getsentry#20556` — classify Stripe infra errors at the charge seam

## Notes

- Lockfile regenerated with `uv lock --upgrade-package sentry-protos`; only the `sentry-protos` entry changed (version + wheel URL + sha256).
- Backend-only change; no frontend impact.