### PR TITLE
chore(cells): Adds Error Embed pages to metric allowed paths

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2807,6 +2807,7 @@ SENTRY_REQUEST_METRIC_ALLOWED_PATHS = (
     "sentry.sentry_apps.api.endpoints",
     "sentry.preprod.api.endpoints",
     "sentry.workflow_engine.endpoints",
+    "sentry.feedback.endpoints",
 )
 SENTRY_MAIL_ADAPTER_BACKEND = "sentry.mail.adapter.MailAdapter"
 


### PR DESCRIPTION
I realized we were missing metrics on the error-embed pages, which I need to monitor for POST requests going directly to different localities
