### PR TITLE
fix(search): Ignore prototype keys in recent filters

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -800,6 +800,8 @@ describe('SearchQueryBuilder', () => {
           body: [
             // Level is not a valid filter key
             {query: 'assigned:me level:error'},
+            // Prototype keys should be treated as invalid filter keys
+            {query: '__proto__:a'},
           ],
         });
 

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
@@ -93,7 +93,7 @@ function getFiltersFromRecentSearches(
       const filter = getKeyName(token.key);
       // We want to show recent filters that are not already in the current query
       // and are valid filter keys
-      return !filtersInCurrentQuery.has(filter) && !!filterKeys[filter];
+      return !filtersInCurrentQuery.has(filter) && Object.hasOwn(filterKeys, filter);
     })
     .reduce<FilterCounter>((acc, token) => {
       const filter = getKeyName(token.key);
@@ -106,7 +106,7 @@ function getFiltersFromRecentSearches(
         };
       }
       return acc;
-    }, {});
+    }, Object.create(null));
 
   return Object.entries(filterCounts)
     .sort((a, b) => b[1].count - a[1].count)


### PR DESCRIPTION
Follow-up to #116999 for recent search suggestions. `__proto__:a` could still come back from recent searches, and the filter-key list treated it as a real key through object prototype lookup before the recent-filter counter tried to mutate `Object.prototype`.

This uses own-property checks and a null-prototype counter so prototype-ish recent searches stay invalid like any other unknown filter key.