### PR TITLE
chore(cell): Updates apigateway metrics with method, removes old resolution code

### DIFF
--- a/src/sentry/hybridcloud/apigateway/apigateway.py
+++ b/src/sentry/hybridcloud/apigateway/apigateway.py
@@ -8,12 +8,10 @@ from django.conf import settings
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
 
-from sentry import options
 from sentry.api.base import CellSiloEndpoint
 from sentry.hybridcloud.apigateway.cell_request_resolvers import CellRequestResolver
 from sentry.hybridcloud.apigateway.proxy import (
     proxy_cell_request,
-    proxy_error_embed_request,
     proxy_request,
 )
 from sentry.silo.base import SiloLimit, SiloMode
@@ -75,7 +73,7 @@ def proxy_request_if_needed(
         return proxy_request(request, org_id_or_slug, url_name)
 
     resolver = _get_view_cell_resolver(view_func)
-    if options.get("apigateway.cell_resolver.enabled") and resolver is not None:
+    if resolver is not None:
         cell = resolver.resolve(request, view_func, view_kwargs)
 
         if cell:
@@ -84,17 +82,6 @@ def proxy_request_if_needed(
             )
             return proxy_cell_request(request, cell, url_name)
         # If no cell resolved, we drop through to the default resolution method
-    elif url_name == "sentry-error-page-embed" and "dsn" in request.GET:
-        # Error embed modal is special as customers can't easily use cell URLs.
-        dsn = request.GET["dsn"]
-        metrics.incr(
-            "apigateway.proxy_request",
-            tags={
-                **shared_metric_tags,
-                "kind": "error-embed",
-            },
-        )
-        return proxy_error_embed_request(request, dsn, url_name)
 
     if (
         request.resolver_match

--- a/src/sentry/hybridcloud/apigateway/apigateway.py
+++ b/src/sentry/hybridcloud/apigateway/apigateway.py
@@ -64,6 +64,10 @@ def proxy_request_if_needed(
     if request.resolver_match:
         url_name = request.resolver_match.url_name or url_name
 
+    shared_metric_tags = {
+        "url_name": url_name,
+        "request_method": request.method,
+    }
     if "organization_slug" in view_kwargs or "organization_id_or_slug" in view_kwargs:
         org_id_or_slug = str(
             view_kwargs.get("organization_slug") or view_kwargs.get("organization_id_or_slug", "")
@@ -76,7 +80,7 @@ def proxy_request_if_needed(
 
         if cell:
             metrics.incr(
-                "apigateway.proxy_request", tags={"url_name": url_name, "kind": "cell_resolver"}
+                "apigateway.proxy_request", tags={**shared_metric_tags, "kind": "cell_resolver"}
             )
             return proxy_cell_request(request, cell, url_name)
         # If no cell resolved, we drop through to the default resolution method
@@ -86,7 +90,7 @@ def proxy_request_if_needed(
         metrics.incr(
             "apigateway.proxy_request",
             tags={
-                "url_name": url_name,
+                **shared_metric_tags,
                 "kind": "error-embed",
             },
         )
@@ -100,7 +104,7 @@ def proxy_request_if_needed(
         metrics.incr(
             "apigateway.proxy_request",
             tags={
-                "url_name": url_name,
+                **shared_metric_tags,
                 "kind": "regionpin",
             },
         )
@@ -114,7 +118,7 @@ def proxy_request_if_needed(
             "apigateway.proxy_request",
             tags={
                 "kind": "noop",
-                "url_name": url_name,
+                **shared_metric_tags,
             },
         )
         logger.info("apigateway.unknown_url", extra={"url": request.path})

--- a/src/sentry/hybridcloud/apigateway/cell_request_resolvers.py
+++ b/src/sentry/hybridcloud/apigateway/cell_request_resolvers.py
@@ -11,10 +11,24 @@ logger = logging.getLogger(__name__)
 
 
 class CellRequestResolver:
+    """
+    Base class for Cell request resolvers. Implement the resolve method, and
+    pass this method to a @cell_silo_endpoint decorator to use on cell-silo
+    endpoints that should be routed through Control silo.
+    """
+
     def resolve(
         self,
         request: Request,
         view_func: Callable[..., HttpResponseBase],
         view_kwargs: dict[str, Any],
     ) -> Cell | None:
+        """
+        Given a request, returns the relevant cell if one can be determined. If
+        the request cannot immediately be routed, but is region-pinned (meaning
+        it only goes to the monolith cell as a fallback), return None.
+
+        Otherwise, raise an exception with details on why the request cannot be
+        properly routed.
+        """
         raise NotImplementedError

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -121,6 +121,7 @@ def proxy_request(request: HttpRequest, org_id_or_slug: str, url_name: str) -> H
             "url_name": url_name,
             "kind": "orgslug",
             "target": cell.name,
+            "request_method": request.method,
         },
     )
     return proxy_cell_request(request, cell, url_name)

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -165,7 +165,12 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
     if cell.api_gateway_address and in_random_rollout("apigateway.proxy.use_gateway_address"):
         host = cell.api_gateway_address
 
-    metric_tags = {"destination_cell": cell.name, "url_name": url_name, "destination_host": host}
+    metric_tags = {
+        "destination_cell": cell.name,
+        "url_name": url_name,
+        "destination_host": host,
+        "request_method": request.method,
+    }
     circuit_breaker: CircuitBreaker | None = None
     use_pooling = in_random_rollout("hybridcloud.apigateway.use_pooling.rate")
 

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Generator
 from http.cookiejar import Cookie
 from threading import local
 from typing import Any
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin
 from wsgiref.util import is_hop_by_hop
 
 from django.conf import settings
@@ -34,7 +34,6 @@ from sentry.silo.util import (
 from sentry.types.cell import (
     Cell,
     CellResolutionError,
-    get_cell_by_name,
     get_cell_for_organization,
 )
 from sentry.utils import metrics
@@ -124,37 +123,6 @@ def proxy_request(request: HttpRequest, org_id_or_slug: str, url_name: str) -> H
             "request_method": request.method,
         },
     )
-    return proxy_cell_request(request, cell, url_name)
-
-
-def proxy_error_embed_request(
-    request: HttpRequest, dsn: str, url_name: str
-) -> HttpResponseBase | None:
-    try:
-        parsed = urlparse(dsn)
-    except Exception as err:
-        logger.info("apigateway.error_embed.invalid_dsn", extra={"dsn": dsn, "error": err})
-        return None
-    host = parsed.netloc
-    app_host = urlparse(options.get("system.url-prefix")).netloc
-    if not host.endswith(app_host):
-        # Don't further parse URLs that aren't for us.
-        return None
-
-    app_segments = app_host.split(".")
-    host_segments = host.split(".")
-    if len(host_segments) - len(app_segments) < 3:
-        # If we don't have a o123.ingest.{cell}.{app_host} style domain
-        # we forward to the monolith cell
-        cell = get_cell_by_name(settings.SENTRY_MONOLITH_REGION)
-        return proxy_cell_request(request, cell, url_name)
-    try:
-        cell_offset = len(app_segments) + 1
-        cell_segment = host_segments[cell_offset * -1]
-        cell = get_cell_by_name(cell_segment)
-    except Exception:
-        return None
-
     return proxy_cell_request(request, cell, url_name)
 
 

--- a/src/sentry/hybridcloud/apigateway_async/apigateway.py
+++ b/src/sentry/hybridcloud/apigateway_async/apigateway.py
@@ -67,6 +67,10 @@ async def proxy_request_if_needed(
     if request.resolver_match:
         url_name = request.resolver_match.url_name or url_name
 
+    shared_metric_tags = {
+        "url_name": url_name,
+        "request_method": request.method,
+    }
     if "organization_slug" in view_kwargs or "organization_id_or_slug" in view_kwargs:
         org_id_or_slug = str(
             view_kwargs.get("organization_slug") or view_kwargs.get("organization_id_or_slug", "")
@@ -75,7 +79,7 @@ async def proxy_request_if_needed(
         metrics.incr(
             "apigateway.proxy_request",
             tags={
-                "url_name": url_name,
+                **shared_metric_tags,
                 "kind": "orgslug",
             },
         )
@@ -89,7 +93,7 @@ async def proxy_request_if_needed(
         if cell:
             metrics.incr(
                 "apigateway.proxy_request",
-                tags={"url_name": url_name, "kind": "cell_resolver"},
+                tags={**shared_metric_tags, "kind": "cell_resolver"},
             )
             return await proxy_cell_request(request, cell, url_name)
         # If no cell resolved, we drop through to the default resolution method
@@ -99,7 +103,7 @@ async def proxy_request_if_needed(
         metrics.incr(
             "apigateway.proxy_request",
             tags={
-                "url_name": url_name,
+                **shared_metric_tags,
                 "kind": "error-embed",
             },
         )
@@ -113,7 +117,7 @@ async def proxy_request_if_needed(
         metrics.incr(
             "apigateway.proxy_request",
             tags={
-                "url_name": url_name,
+                **shared_metric_tags,
                 "kind": "regionpin",
             },
         )
@@ -126,8 +130,8 @@ async def proxy_request_if_needed(
         metrics.incr(
             "apigateway.proxy_request",
             tags={
+                **shared_metric_tags,
                 "kind": "noop",
-                "url_name": url_name,
             },
         )
         logger.info("apigateway.unknown_url", extra={"url": request.path})

--- a/src/sentry/hybridcloud/apigateway_async/apigateway.py
+++ b/src/sentry/hybridcloud/apigateway_async/apigateway.py
@@ -9,7 +9,6 @@ from django.conf import settings
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
 
-from sentry import options
 from sentry.api.base import CellSiloEndpoint
 from sentry.hybridcloud.apigateway.cell_request_resolvers import CellRequestResolver
 from sentry.silo.base import SiloLimit, SiloMode
@@ -19,7 +18,6 @@ from sentry.web.frontend.base import CellSiloView
 
 from .proxy import (
     proxy_cell_request,
-    proxy_error_embed_request,
     proxy_request,
 )
 
@@ -85,9 +83,8 @@ async def proxy_request_if_needed(
         )
         return await proxy_request(request, org_id_or_slug, url_name)
 
-    resolvers_enabled = await sync_to_async(options.get)("apigateway.cell_resolver.enabled")
     resolver = _get_view_cell_resolver(view_func)
-    if resolvers_enabled and resolver is not None:
+    if resolver is not None:
         cell = await sync_to_async(resolver.resolve)(request, view_func, view_kwargs)
 
         if cell:
@@ -97,17 +94,6 @@ async def proxy_request_if_needed(
             )
             return await proxy_cell_request(request, cell, url_name)
         # If no cell resolved, we drop through to the default resolution method
-    elif url_name == "sentry-error-page-embed" and "dsn" in request.GET:
-        # Error embed modal is special as customers can't easily use cell URLs.
-        dsn = request.GET["dsn"]
-        metrics.incr(
-            "apigateway.proxy_request",
-            tags={
-                **shared_metric_tags,
-                "kind": "error-embed",
-            },
-        )
-        return await proxy_error_embed_request(request, dsn, url_name)
 
     if (
         request.resolver_match

--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -160,6 +160,7 @@ async def proxy_cell_request(
         "destination_cell": cell.name,
         "url_name": url_name,
         "destination_host": host,
+        "request_method": request.method,
     }
     target_url = urljoin(host, request.path)
 

--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import AsyncGenerator, AsyncIterator
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin
 
 import httpx
 from asgiref.sync import sync_to_async
@@ -15,7 +15,6 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse, JsonResponse, StreamingHttpResponse
 from django.http.response import HttpResponseBase
 
-from sentry import options
 from sentry.api.exceptions import RequestTimeout
 from sentry.objectstore.endpoints.organization import get_raw_body_async
 from sentry.options.rollout import in_random_rollout
@@ -28,7 +27,6 @@ from sentry.silo.util import (
 from sentry.types.cell import (
     Cell,
     CellResolutionError,
-    get_cell_by_name,
     get_cell_for_organization,
 )
 from sentry.utils import metrics
@@ -111,37 +109,6 @@ async def proxy_request(
     except CellResolutionError as e:
         logger.info("region_resolution_error", extra={"org_slug": org_id_or_slug, "error": str(e)})
         return HttpResponse(status=404)
-
-    return await proxy_cell_request(request, cell, url_name)
-
-
-async def proxy_error_embed_request(
-    request: HttpRequest, dsn: str, url_name: str
-) -> HttpResponseBase | None:
-    try:
-        parsed = urlparse(dsn)
-    except Exception as err:
-        logger.info("apigateway.error_embed.invalid_dsn", extra={"dsn": dsn, "error": err})
-        return None
-    host = parsed.netloc
-    app_host = urlparse(options.get("system.url-prefix")).netloc
-    if not host.endswith(app_host):
-        # Don't further parse URLs that aren't for us.
-        return None
-
-    app_segments = app_host.split(".")
-    host_segments = host.split(".")
-    if len(host_segments) - len(app_segments) < 3:
-        # If we don't have a o123.ingest.{cell}.{app_host} style domain
-        # we forward to the monolith cell
-        cell = get_cell_by_name(settings.SENTRY_MONOLITH_REGION)
-        return await proxy_cell_request(request, cell, url_name)
-    try:
-        cell_offset = len(app_segments) + 1
-        cell_segment = host_segments[cell_offset * -1]
-        cell = get_cell_by_name(cell_segment)
-    except Exception:
-        return None
 
     return await proxy_cell_request(request, cell, url_name)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3714,14 +3714,6 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Enables cell resolver in APIGateway, should be removed after rollout
-register(
-    "apigateway.cell_resolver.enabled",
-    default=False,
-    type=Bool,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # When True, auto-link-repos-by-name logs matches but does not create ProjectRepository rows.
 register(
     "repository.auto-link-by-name-dry-run",

--- a/src/sentry/testutils/helpers/apigateway.py
+++ b/src/sentry/testutils/helpers/apigateway.py
@@ -18,6 +18,7 @@ from rest_framework.response import Response
 import sentry.api.urls as api_urls
 from sentry.api.base import Endpoint, cell_silo_endpoint, control_silo_endpoint
 from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrganizationEndpoint
+from sentry.feedback.endpoints.error_page_embed import ErrorEmbedResolver
 from sentry.testutils.cases import APITestCase
 from sentry.types.cell import Cell, RegionCategory
 from sentry.utils import json
@@ -50,6 +51,15 @@ class NoOrgRegionEndpoint(Endpoint):
         return Response({"proxy": False})
 
 
+@cell_silo_endpoint(cell_resolver=ErrorEmbedResolver())
+class MockErrorEmbedEndpoint(Endpoint):
+    # Mock embed endpoint to e2e test the resolver logic in apigateway tests
+    permission_classes: tuple[type[BasePermission], ...] = (AllowAny,)
+
+    def get(self, request: Request) -> Response:
+        return Response({"proxy": False, "name": "error-embed"})
+
+
 urlpatterns = [
     re_path(
         r"^organizations/(?P<organization_slug>[^/]+)/control/$",
@@ -73,7 +83,7 @@ urlpatterns = [
     ),
     re_path(
         r"^api/embed/error-page/$",
-        RegionEndpoint.as_view(),
+        MockErrorEmbedEndpoint.as_view(),
         name="sentry-error-page-embed",
     ),
 ] + api_urls.urlpatterns

--- a/tests/sentry/feedback/endpoints/test_error_page_embed.py
+++ b/tests/sentry/feedback/endpoints/test_error_page_embed.py
@@ -23,7 +23,6 @@ from sentry.silo.base import SiloLimit, SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.apigateway import ApiGatewayTestCase
 from sentry.testutils.helpers.datetime import before_now
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.response import close_streaming_response
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
@@ -303,7 +302,6 @@ class ErrorEmbedCellProxyTest(ApiGatewayTestCase):
 
         return project_key
 
-    @override_options({"apigateway.cell_resolver.enabled": True})
     def test_proxy_error_embed_dsn(self) -> None:
         self.httpx_router.add(
             "GET",

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -7,10 +7,8 @@ from django.urls import reverse
 
 from sentry.loader.dynamic_sdk_options import DynamicSdkLoaderOption
 from sentry.models.projectkey import ProjectKey
-from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.apigateway import ApiGatewayTestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.response import close_streaming_response
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
@@ -715,7 +713,6 @@ class JavaScriptSdkLoaderProxyTest(ApiGatewayTestCase):
 
         return project_key
 
-    @override_options({"apigateway.cell_resolver.enabled": True})
     def test_proxy_js_sdk_loader(self) -> None:
         project_key = self._create_project_key_with_mapping()
         self.httpx_router.add(
@@ -733,10 +730,13 @@ class JavaScriptSdkLoaderProxyTest(ApiGatewayTestCase):
             assert resp_json["proxy"] is True
             mock_metrics.incr.assert_called_with(
                 "apigateway.proxy_request",
-                tags={"url_name": "sentry-js-sdk-loader", "kind": "cell_resolver"},
+                tags={
+                    "url_name": "sentry-js-sdk-loader",
+                    "kind": "cell_resolver",
+                    "request_method": "GET",
+                },
             )
 
-    @override_options({"apigateway.cell_resolver.enabled": True})
     def test_proxy_js_sdk_loader_minified(self) -> None:
         project_key = self._create_project_key_with_mapping()
         self.httpx_router.add(
@@ -754,10 +754,13 @@ class JavaScriptSdkLoaderProxyTest(ApiGatewayTestCase):
             assert resp_json["proxy"] is True
             mock_metrics.incr.assert_called_with(
                 "apigateway.proxy_request",
-                tags={"url_name": "sentry-js-sdk-loader", "kind": "cell_resolver"},
+                tags={
+                    "url_name": "sentry-js-sdk-loader",
+                    "kind": "cell_resolver",
+                    "request_method": "GET",
+                },
             )
 
-    @override_options({"apigateway.cell_resolver.enabled": True})
     def test_proxy_js_sdk_loader_no_mapping_falls_through_to_regionpin(self) -> None:
         unmapped_key = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
         self.httpx_router.add(
@@ -778,14 +781,21 @@ class JavaScriptSdkLoaderProxyTest(ApiGatewayTestCase):
             incr_calls = _get_incr_calls(mock_metrics)
             assert (
                 "apigateway.proxy_request",
-                (("kind", "regionpin"), ("url_name", "sentry-js-sdk-loader")),
+                (
+                    ("kind", "regionpin"),
+                    ("request_method", "GET"),
+                    ("url_name", "sentry-js-sdk-loader"),
+                ),
             ) in incr_calls
             assert (
                 "apigateway.proxy_request",
-                (("kind", "cell_resolver"), ("url_name", "sentry-js-sdk-loader")),
+                (
+                    ("kind", "cell_resolver"),
+                    ("request_method", "GET"),
+                    ("url_name", "sentry-js-sdk-loader"),
+                ),
             ) not in incr_calls
 
-    @override_options({"apigateway.cell_resolver.enabled": True})
     def test_proxy_js_sdk_loader_invalid_key_falls_through_to_regionpin(self) -> None:
         self.httpx_router.add(
             "GET",
@@ -804,38 +814,17 @@ class JavaScriptSdkLoaderProxyTest(ApiGatewayTestCase):
             incr_calls = _get_incr_calls(mock_metrics)
             assert (
                 "apigateway.proxy_request",
-                (("kind", "cell_resolver"), ("url_name", "sentry-js-sdk-loader")),
+                (
+                    ("kind", "cell_resolver"),
+                    ("request_method", "GET"),
+                    ("url_name", "sentry-js-sdk-loader"),
+                ),
             ) not in incr_calls
             assert (
                 "apigateway.proxy_request",
-                (("kind", "regionpin"), ("url_name", "sentry-js-sdk-loader")),
+                (
+                    ("kind", "regionpin"),
+                    ("request_method", "GET"),
+                    ("url_name", "sentry-js-sdk-loader"),
+                ),
             ) in incr_calls
-
-    @override_options({"apigateway.cell_resolver.enabled": False})
-    def test_proxy_js_sdk_loader_option_disabled_falls_through_to_regionpin(self) -> None:
-        project_key = self._create_project_key_with_mapping()
-        self.httpx_router.add(
-            "GET",
-            f"{self.CELL.address}/js-sdk-loader/{project_key.public_key}.js",
-            json_data={"proxy": True, "region_pinned": True},
-        )
-        with (
-            override_settings(SILO_MODE=SiloMode.CONTROL, MIDDLEWARE=tuple(self.middleware)),
-            override_settings(ROOT_URLCONF="sentry.web.urls"),
-            mock.patch("sentry.hybridcloud.apigateway_async.apigateway.metrics") as mock_metrics,
-        ):
-            resp = self.client.get(f"/js-sdk-loader/{project_key.public_key}.js")
-            assert resp.status_code == 200
-            resp_json = json.loads(close_streaming_response(resp))
-            assert resp_json["proxy"] is True
-            assert resp_json["region_pinned"] is True
-            # Only regionpin — cell_resolver should never fire
-            incr_calls = _get_incr_calls(mock_metrics)
-            assert (
-                "apigateway.proxy_request",
-                (("kind", "regionpin"), ("url_name", "sentry-js-sdk-loader")),
-            ) in incr_calls
-            assert (
-                "apigateway.proxy_request",
-                (("kind", "cell_resolver"), ("url_name", "sentry-js-sdk-loader")),
-            ) not in incr_calls


### PR DESCRIPTION
- Adds new `request_method` tag to apigateway metrics, to help determine which types of requests are being handled by the gateway.

Also removes the old error-embed logic, and resolver option checks as this has been stable in production for the last week.
