### PR TITLE
fix(issues): Key bulk short id lookup on (project, short id) pairs

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -386,11 +386,11 @@ class GroupManager(BaseManager["Group"]):
         ).filter(project__organization=organization_id)
 
         groups = list(base_group_queryset.filter(short_id_lookup).select_related("project"))
-        # Key the lookup on (project_slug, short_id): short ids are only unique per project,
-        # so the integer short_id alone collides across projects (e.g. PROJ-A-1 and PROJ-B-1).
+        # Key the lookup by ShortId(project_slug, short_id): short ids are only unique per
+        # project, so the integer short_id alone collides across projects (PROJ-A-1 vs PROJ-B-1).
         # parse_short_id lowercases the slug, so lowercase the project slug to match.
-        group_lookup: set[tuple[str, int]] = {
-            (group.project.slug.lower(), group.short_id) for group in groups
+        group_lookup: set[ShortId] = {
+            ShortId(group.project.slug.lower(), group.short_id) for group in groups
         }
 
         # If any requested short_ids are missing after the exact slug match,
@@ -398,7 +398,7 @@ class GroupManager(BaseManager["Group"]):
         # Handles legacy project slugs that may not be entirely lowercase.
         missing_by_slug = defaultdict(list)
         for sid in short_ids:
-            if (sid.project_slug, sid.short_id) not in group_lookup:
+            if sid not in group_lookup:
                 missing_by_slug[sid.project_slug].append(sid.short_id)
 
         if len(missing_by_slug) > 0:
@@ -416,11 +416,12 @@ class GroupManager(BaseManager["Group"]):
 
             groups.extend(fallback_groups)
             group_lookup.update(
-                (group.project.slug.lower(), group.short_id) for group in fallback_groups
+                ShortId(group.project.slug.lower(), group.short_id) for group in fallback_groups
             )
 
+        # Throw an error if we cannot find a group for any short id requested
         for short_id in short_ids:
-            if (short_id.project_slug, short_id.short_id) not in group_lookup:
+            if short_id not in group_lookup:
                 raise Group.DoesNotExist()
         return groups
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -386,14 +386,19 @@ class GroupManager(BaseManager["Group"]):
         ).filter(project__organization=organization_id)
 
         groups = list(base_group_queryset.filter(short_id_lookup).select_related("project"))
-        group_lookup: set[int] = {group.short_id for group in groups}
+        # Key the lookup on (project_slug, short_id): short ids are only unique per project,
+        # so the integer short_id alone collides across projects (e.g. PROJ-A-1 and PROJ-B-1).
+        # parse_short_id lowercases the slug, so lowercase the project slug to match.
+        group_lookup: set[tuple[str, int]] = {
+            (group.project.slug.lower(), group.short_id) for group in groups
+        }
 
         # If any requested short_ids are missing after the exact slug match,
         # fallback to a case-insensitive slug lookup to handle legacy/mixed-case slugs.
         # Handles legacy project slugs that may not be entirely lowercase.
         missing_by_slug = defaultdict(list)
         for sid in short_ids:
-            if sid.short_id not in group_lookup:
+            if (sid.project_slug, sid.short_id) not in group_lookup:
                 missing_by_slug[sid.project_slug].append(sid.short_id)
 
         if len(missing_by_slug) > 0:
@@ -405,13 +410,17 @@ class GroupManager(BaseManager["Group"]):
                 ],
             )
 
-            fallback_groups = list(base_group_queryset.filter(ci_short_id_lookup))
+            fallback_groups = list(
+                base_group_queryset.filter(ci_short_id_lookup).select_related("project")
+            )
 
             groups.extend(fallback_groups)
-            group_lookup.update(group.short_id for group in fallback_groups)
+            group_lookup.update(
+                (group.project.slug.lower(), group.short_id) for group in fallback_groups
+            )
 
         for short_id in short_ids:
-            if short_id.short_id not in group_lookup:
+            if (short_id.project_slug, short_id.short_id) not in group_lookup:
                 raise Group.DoesNotExist()
         return groups
 

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -174,6 +174,28 @@ class GroupTest(TestCase, SnubaTestCase):
                 group.organization.id, [group_short_id, group_2_short_id]
             )
 
+    def test_by_qualified_short_id_bulk_missing_id_colliding_short_id_across_projects(
+        self,
+    ) -> None:
+        # short ids are only unique per project, so two projects can share the integer
+        # short_id 1 (PROJ-A-1 and PROJ-B-1). A requested short id that does not resolve must
+        # raise even when another project owns the same integer short_id.
+        project_a = self.create_project(name="proj a")
+        project_b = self.create_project(name="proj b")
+        group_a = self.create_group(project=project_a, short_id=project_a.next_short_id())
+        group_b = self.create_group(project=project_b, short_id=project_b.next_short_id())
+        assert group_a.short_id == group_b.short_id  # both 1
+        org_id = self.organization.id
+
+        a_short_id = group_a.qualified_short_id
+        b_short_id = group_b.qualified_short_id
+
+        # Make PROJ-B-1 unresolvable while PROJ-A-1 still resolves to the colliding short_id.
+        group_b.update(status=GroupStatus.PENDING_DELETION, substatus=None)
+
+        with pytest.raises(Group.DoesNotExist):
+            Group.objects.by_qualified_short_id_bulk(org_id, [a_short_id, b_short_id])
+
     def test_by_qualified_short_id_bulk_case_insensitive_project_slug(self) -> None:
         project = self.create_project(slug="mixedcaseslug")
         group = self.create_group(project=project, short_id=project.next_short_id())


### PR DESCRIPTION
`Group.objects.by_qualified_short_id_bulk` tracked which requested short ids had resolved using only their integer `short_id`. Short ids are unique per *project*, so the integer collides across projects — `PROJ-A-1` and `PROJ-B-1` both have `short_id` 1.

Because of that, a requested short id that did not resolve could be treated as found whenever any other project owned the same integer. The bulk lookup then returned partial results instead of raising `Group.DoesNotExist`, and the case-insensitive slug fallback was skipped for the genuinely-missing id.

This keys the resolved set on `(project_slug, short_id)` pairs across the exact-match, fallback, and completeness checks, and adds `select_related("project")` to the fallback query so slug access doesn't issue extra queries. Pure correctness fix; no API change.

First of a stacked series hardening short-id → group resolution; the follow-ups add optional project scoping to the lookup API and thread it through callers to enforce project-level permissions at the query layer.