### PR TITLE
feat(issues): Add optional project scoping to qualified short id lookups

### DIFF
--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Collection, Sequence
 from datetime import datetime
 from typing import Any
 
@@ -174,15 +174,19 @@ def get_by_short_id(
     organization_id: int,
     is_short_id_lookup: str,
     query: str,
+    project_ids: Collection[int] | None = None,
 ) -> Group | None:
     if is_short_id_lookup != "1":
         return None
     # A short id token anywhere in the query is treated as a direct hit,
-    # so it composes with filters.
+    # so it composes with filters. When project_ids is provided, the lookup is scoped to
+    # those projects so a short id for a project the caller cannot access does not resolve.
     for token in query.split():
         if looks_like_short_id(token):
             try:
-                return Group.objects.by_qualified_short_id(organization_id, token)
+                return Group.objects.by_qualified_short_id(
+                    organization_id, token, project_ids=project_ids
+                )
             except Group.DoesNotExist:
                 continue
     return None

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from collections import defaultdict, namedtuple
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from datetime import datetime, timedelta
 from enum import Enum
 from functools import reduce
@@ -368,12 +368,33 @@ class GroupManager(BaseManager["Group"]):
             .with_post_update_signal(options.get("groups.enable-post-update-signal"))
         )
 
-    def by_qualified_short_id(self, organization_id: int, short_id: str):
-        return self.by_qualified_short_id_bulk(organization_id, [short_id])[0]
+    def by_qualified_short_id(
+        self,
+        organization_id: int,
+        short_id: str,
+        project_ids: Collection[int] | None = None,
+    ):
+        return self.by_qualified_short_id_bulk(
+            organization_id, [short_id], project_ids=project_ids
+        )[0]
 
     def by_qualified_short_id_bulk(
-        self, organization_id: int, short_ids_raw: list[str]
+        self,
+        organization_id: int,
+        short_ids_raw: list[str],
+        project_ids: Collection[int] | None = None,
     ) -> Sequence[Group]:
+        """
+        Resolve qualified short ids (e.g. ``PROJECT-123``) to groups.
+
+        Always scoped to ``organization_id``. When ``project_ids`` is provided (including an
+        empty collection), the lookup is additionally scoped to those projects so that a short
+        id referencing a project the caller cannot access does not resolve. Callers that have
+        an authorized-project set (the projects the actor is allowed to see) should pass it to
+        enforce project-level permissions at the query layer rather than via a post-hoc check.
+        ``project_ids=None`` (the default) means "no project restriction" and must only be used
+        by callers that legitimately operate organization-wide.
+        """
         short_ids = []
         for short_id_raw in short_ids_raw:
             parsed_short_id = parse_short_id(short_id_raw)
@@ -402,6 +423,9 @@ class GroupManager(BaseManager["Group"]):
                 GroupStatus.PENDING_MERGE,
             ]
         ).filter(project__organization=organization_id)
+
+        if project_ids is not None:
+            base_group_queryset = base_group_queryset.filter(project_id__in=project_ids)
 
         groups = list(base_group_queryset.filter(short_id_lookup).select_related("project"))
         # Key the lookup by ShortId(project_slug, short_id): short ids are only unique per

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -196,6 +196,50 @@ class GroupTest(TestCase, SnubaTestCase):
         with pytest.raises(Group.DoesNotExist):
             Group.objects.by_qualified_short_id_bulk(org_id, [a_short_id, b_short_id])
 
+    def test_by_qualified_short_id_scoped_to_projects(self) -> None:
+        project_a = self.create_project(name="proj a")
+        project_b = self.create_project(name="proj b")
+        group_a = self.create_group(project=project_a, short_id=project_a.next_short_id())
+        group_b = self.create_group(project=project_b, short_id=project_b.next_short_id())
+        org_id = self.organization.id
+
+        # In-scope short id resolves.
+        assert (
+            Group.objects.by_qualified_short_id(
+                org_id, group_a.qualified_short_id, project_ids=[project_a.id]
+            )
+            == group_a
+        )
+
+        # Out-of-scope short id does not resolve.
+        with pytest.raises(Group.DoesNotExist):
+            Group.objects.by_qualified_short_id(
+                org_id, group_b.qualified_short_id, project_ids=[project_a.id]
+            )
+
+        # An empty collection restricts to no projects (distinct from None = no restriction).
+        with pytest.raises(Group.DoesNotExist):
+            Group.objects.by_qualified_short_id(org_id, group_a.qualified_short_id, project_ids=[])
+
+    def test_by_qualified_short_id_bulk_scoped_to_projects(self) -> None:
+        project_a = self.create_project(name="proj a")
+        project_b = self.create_project(name="proj b")
+        group_a = self.create_group(project=project_a, short_id=project_a.next_short_id())
+        group_b = self.create_group(project=project_b, short_id=project_b.next_short_id())
+        org_id = self.organization.id
+
+        assert Group.objects.by_qualified_short_id_bulk(
+            org_id, [group_a.qualified_short_id], project_ids=[project_a.id]
+        ) == [group_a]
+
+        # If any requested short id falls outside the project scope, the bulk lookup raises.
+        with pytest.raises(Group.DoesNotExist):
+            Group.objects.by_qualified_short_id_bulk(
+                org_id,
+                [group_a.qualified_short_id, group_b.qualified_short_id],
+                project_ids=[project_a.id],
+            )
+
     def test_by_qualified_short_id_bulk_case_insensitive_project_slug(self) -> None:
         project = self.create_project(slug="mixedcaseslug")
         group = self.create_group(project=project, short_id=project.next_short_id())


### PR DESCRIPTION
> Stacked on #117046 — review/merge that first. The diff below is incremental on top of it.

Adds an optional `project_ids` argument to `Group.objects.by_qualified_short_id` / `by_qualified_short_id_bulk` and to the `get_by_short_id` helper. When provided, the lookup is additionally scoped to those projects **at the query layer**, so a short id referencing a project the caller cannot access does not resolve.

A qualified short id (e.g. `PROJECT-123`) embeds a project *slug*, so resolution always returned the correct group in the correct project — but it was only scoped by organization and never verified that the caller may access that project. Callers that hold an authorized-project set (the projects the actor is allowed to see) can now enforce project-level permissions in the query itself rather than via a post-hoc `group.project_id in project_ids` check.

`project_ids` defaults to `None` (no restriction), so this change is **non-breaking** and changes no behavior on its own — callers are migrated in follow-up PRs. An empty collection is intentionally distinct from `None`: it restricts to no projects (nothing resolves), whereas `None` means "operate organization-wide."

This is the API-core step of a stacked series hardening short-id → group resolution against in-org IDOR; subsequent PRs thread `project_ids` through the issue endpoints/helpers, search `issue:` resolvers, and Seer tools, and finally make the argument required.