### PR TITLE
ref(api): rename trace item stats symbols and response key

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_stats.py
+++ b/src/sentry/api/endpoints/organization_trace_item_stats.py
@@ -113,7 +113,7 @@ class TraceItemStatsPaginator:
         )
 
 
-class OrganizationTraceItemsStatsSerializer(serializers.Serializer):
+class OrganizationTraceItemStatsSerializer(serializers.Serializer):
     query = serializers.CharField(required=False)
     statsType = serializers.ListField(
         child=serializers.ChoiceField(list(SUPPORTED_STATS_TYPES)), required=True
@@ -134,7 +134,7 @@ class OrganizationTraceItemsStatsSerializer(serializers.Serializer):
 
 
 @cell_silo_endpoint
-class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
+class OrganizationTraceItemStatsEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
@@ -146,7 +146,7 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
         except NoProjects:
             return Response({"data": []})
 
-        serializer = OrganizationTraceItemsStatsSerializer(data=request.GET)
+        serializer = OrganizationTraceItemStatsSerializer(data=request.GET)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
         serialized = serializer.validated_data
@@ -214,7 +214,7 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
             preflight_stats = run_stats_query_with_item_ids(f"id:[{item_id_list}]")
             try:
                 internal_alias_attr_keys = list(
-                    preflight_stats[0]["attribute_distributions"]["data"].keys()
+                    preflight_stats[0]["attributeDistributions"]["data"].keys()
                 )
             except (IndexError, KeyError):
                 return {"data": []}, 0

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -55,7 +55,7 @@ from sentry.api.endpoints.organization_trace_item_attributes_ranked import (
 from sentry.api.endpoints.organization_trace_item_metric_context import (
     OrganizationTraceItemMetricContextEndpoint,
 )
-from sentry.api.endpoints.organization_trace_item_stats import OrganizationTraceItemsStatsEndpoint
+from sentry.api.endpoints.organization_trace_item_stats import OrganizationTraceItemStatsEndpoint
 from sentry.api.endpoints.organization_unsubscribe import (
     OrganizationUnsubscribeIssue,
     OrganizationUnsubscribeProject,
@@ -1759,7 +1759,7 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/trace-items/stats/$",
-        OrganizationTraceItemsStatsEndpoint.as_view(),
+        OrganizationTraceItemStatsEndpoint.as_view(),
         name="sentry-api-0-organization-trace-item-stats",
     ),
     re_path(

--- a/src/sentry/snuba/occurrences_rpc.py
+++ b/src/sentry/snuba/occurrences_rpc.py
@@ -345,7 +345,7 @@ class Occurrences(rpc_dataset_common.RPCBase):
                             attrs[public_alias].append(
                                 {"label": bucket.label, "value": bucket.value}
                             )
-                stats.append({"attribute_distributions": {"data": attrs}})
+                stats.append({"attributeDistributions": {"data": attrs}})
 
         return stats
 

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -296,6 +296,6 @@ class Spans(rpc_dataset_common.RPCBase):
                             attrs[public_alias].append(
                                 {"label": bucket.label, "value": bucket.value}
                             )
-                stats.append({"attribute_distributions": {"data": attrs}})
+                stats.append({"attributeDistributions": {"data": attrs}})
 
         return stats

--- a/tests/sentry/snuba/test_occurrences_rpc.py
+++ b/tests/sentry/snuba/test_occurrences_rpc.py
@@ -371,8 +371,8 @@ class OccurrencesStatsRPCTest(TestCase, SnubaTestCase, OccurrenceTestCase):
 
         result = self._query_stats()
         assert len(result) == 1
-        assert "attribute_distributions" in result[0]
-        data = result[0]["attribute_distributions"]["data"]
+        assert "attributeDistributions" in result[0]
+        data = result[0]["attributeDistributions"]["data"]
         assert "level" in data
         level_buckets = data["level"]
         labels = {bucket["label"] for bucket in level_buckets}
@@ -391,7 +391,7 @@ class OccurrencesStatsRPCTest(TestCase, SnubaTestCase, OccurrenceTestCase):
 
         result = self._query_stats(query_string="level:error")
         assert len(result) == 1
-        data = result[0]["attribute_distributions"]["data"]
+        data = result[0]["attributeDistributions"]["data"]
         # With the filter, only error occurrences are included
         assert "level" in data
         labels = {bucket["label"] for bucket in data["level"]}
@@ -411,7 +411,7 @@ class OccurrencesStatsRPCTest(TestCase, SnubaTestCase, OccurrenceTestCase):
             attributes=[AttributeKey(name="level", type=AttributeKey.TYPE_STRING)],
         )
         assert len(result) == 1
-        data = result[0]["attribute_distributions"]["data"]
+        data = result[0]["attributeDistributions"]["data"]
         assert "level" in data
 
     def test_stats_excludes_private_attributes(self) -> None:
@@ -425,7 +425,7 @@ class OccurrencesStatsRPCTest(TestCase, SnubaTestCase, OccurrenceTestCase):
 
         result = self._query_stats()
         assert len(result) == 1
-        data = result[0]["attribute_distributions"]["data"]
+        data = result[0]["attributeDistributions"]["data"]
         # Private attributes should not appear
         assert "sentry.item_type" not in data
         assert "sentry.organization_id" not in data
@@ -452,7 +452,7 @@ class OccurrencesStatsRPCTest(TestCase, SnubaTestCase, OccurrenceTestCase):
         # Filter to only error category
         result = self._query_stats(occurrence_category=OccurrenceCategory.ERROR)
         assert len(result) == 1
-        data = result[0]["attribute_distributions"]["data"]
+        data = result[0]["attributeDistributions"]["data"]
         assert "level" in data
         labels = {bucket["label"] for bucket in data["level"]}
         assert "error" in labels
@@ -465,5 +465,5 @@ class OccurrencesStatsRPCTest(TestCase, SnubaTestCase, OccurrenceTestCase):
     def test_stats_empty_results(self) -> None:
         result = self._query_stats(query_string="level:nonexistent")
         assert len(result) == 1
-        data = result[0]["attribute_distributions"]["data"]
+        data = result[0]["attributeDistributions"]["data"]
         assert len(data) == 0

--- a/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
@@ -13,7 +13,7 @@ from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.options import override_options
 
 
-class OrganizationTraceItemsStatsEndpointTest(
+class OrganizationTraceItemStatsEndpointTest(
     APITransactionTestCase,
     SnubaTestCase,
     SpanTestCase,
@@ -127,7 +127,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         )
         assert response.status_code == 200, response.data
         assert len(response.data["data"]) == 1
-        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        attribute_distribution = response.data["data"][0]["attributeDistributions"]["data"]
         device_data = attribute_distribution["sentry.device"]
         assert {"label": "mobile", "value": 3.0} in device_data
         assert {"label": "desktop", "value": 1.0} in device_data
@@ -151,7 +151,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         )
         assert response.status_code == 200, response.data
         assert len(response.data["data"]) == 1
-        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        attribute_distribution = response.data["data"][0]["attributeDistributions"]["data"]
 
         assert "browser.name" in attribute_distribution
         assert "device" not in attribute_distribution
@@ -179,7 +179,7 @@ class OrganizationTraceItemsStatsEndpointTest(
 
         assert response.status_code == 200, response.data
         assert len(response.data["data"]) == 1
-        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        attribute_distribution = response.data["data"][0]["attributeDistributions"]["data"]
 
         assert "browser" in attribute_distribution
         assert "device" not in attribute_distribution
@@ -214,7 +214,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         )
         assert response.status_code == 200, response.data
         assert len(response.data["data"]) == 1
-        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        attribute_distribution = response.data["data"][0]["attributeDistributions"]["data"]
 
         assert "span.op" in attribute_distribution
         description_labels = [item["label"] for item in attribute_distribution["span.op"]]
@@ -242,7 +242,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         )
         assert response.status_code == 200, response.data
         assert len(response.data["data"]) == 1
-        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        attribute_distribution = response.data["data"][0]["attributeDistributions"]["data"]
 
         device_data = attribute_distribution.get("sentry.device", [])
         assert any(item["label"] == "desktop" for item in device_data)
@@ -266,7 +266,7 @@ class OrganizationTraceItemsStatsEndpointTest(
             }
         )
         assert response.status_code == 200, response.data
-        first_page = response.data["data"][0]["attribute_distributions"]["data"]
+        first_page = response.data["data"][0]["attributeDistributions"]["data"]
         assert len(first_page) == 2
 
         links = self._parse_links(response)
@@ -276,7 +276,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         # Second page: the remaining 2 attributes, with no further pages.
         next_response = self.client.get(links["next"]["href"], format="json")
         assert next_response.status_code == 200, next_response.content
-        second_page = next_response.data["data"][0]["attribute_distributions"]["data"]
+        second_page = next_response.data["data"][0]["attributeDistributions"]["data"]
         assert len(second_page) == 2
 
         next_links = self._parse_links(next_response)
@@ -309,7 +309,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         assert response.status_code == 200, response.data
 
         assert len(response.data["data"]) == 1
-        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        attribute_distribution = response.data["data"][0]["attributeDistributions"]["data"]
         assert len(attribute_distribution) == 1
 
         if "Link" in response:
@@ -328,7 +328,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         )
         assert response.status_code == 200, response.data
         assert len(response.data["data"]) == 1
-        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        attribute_distribution = response.data["data"][0]["attributeDistributions"]["data"]
         assert "level" in attribute_distribution
         level_buckets = attribute_distribution["level"]
         labels = {bucket["label"] for bucket in level_buckets}
@@ -343,7 +343,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         )
         assert response.status_code == 200, response.data
         assert len(response.data["data"]) == 1
-        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        attribute_distribution = response.data["data"][0]["attributeDistributions"]["data"]
         for excluded in ["id", "trace", "group_id", "issue_occurrence_id", "primary_hash"]:
             assert excluded not in attribute_distribution
 
@@ -360,7 +360,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         )
         assert response.status_code == 200, response.data
         assert len(response.data["data"]) == 1
-        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        attribute_distribution = response.data["data"][0]["attributeDistributions"]["data"]
         assert "level" in attribute_distribution
         labels = {bucket["label"] for bucket in attribute_distribution["level"]}
         assert "error" in labels
@@ -390,7 +390,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         )
         assert response.status_code == 200, response.data
         assert len(response.data["data"]) == 1
-        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        attribute_distribution = response.data["data"][0]["attributeDistributions"]["data"]
         city_data = attribute_distribution["tags[user.geo.city,string]"]
         assert {"label": "world", "value": 4.0} in city_data
         assert {"label": "foobar", "value": 3.0} in city_data


### PR DESCRIPTION
Renames the trace item stats endpoint's symbols and its response key ahead of publishing the endpoint (#117061):

- `OrganizationTraceItemsStats{Serializer,Endpoint}` → `OrganizationTraceItemStats{Serializer,Endpoint}` (drops the stray plural)
- Response key `attribute_distributions` → `attributeDistributions`, so the output matches the camelCase `statsType` input value and our `camelCase` response convention

To support the second change, we need https://github.com/getsentry/sentry/pull/117262 so both response keys can be accepted while we roll this out.