### PR TITLE
chore(scm-multi-platform-detetion): Adding metrics for single platform detector.

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -278,6 +278,9 @@ from sentry.integrations.api.endpoints.organization_repository_details import (
 from sentry.integrations.api.endpoints.organization_repository_platforms import (
     OrganizationRepositoryPlatformsEndpoint,
 )
+from sentry.integrations.api.endpoints.organization_repository_platforms_test import (
+    OrganizationRepositoryPlatformsTestEndpoint,
+)
 from sentry.integrations.api.endpoints.organization_repository_settings import (
     OrganizationRepositorySettingsEndpoint,
 )
@@ -2180,6 +2183,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/repos/(?P<repo_id>[^/]+)/platforms/$",
         OrganizationRepositoryPlatformsEndpoint.as_view(),
         name="sentry-api-0-organization-repository-platforms",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/repos/(?P<repo_id>[^/]+)/platforms-test/$",
+        OrganizationRepositoryPlatformsTestEndpoint.as_view(),
+        name="sentry-api-0-organization-repository-platforms-test",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/plugins/$",

--- a/src/sentry/integrations/api/endpoints/organization_repository_platforms_test.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_platforms_test.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import sentry_sdk
+from rest_framework.request import Request
+from rest_framework.response import Response
+from sentry_sdk import logger as sentry_logger
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.integrations.api.bases.organization_repository import (
+    OrganizationRepositoryEndpoint,
+)
+from sentry.integrations.github.client import GitHubApiClient
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.organization import Organization
+from sentry.models.repository import Repository
+from sentry.shared_integrations.exceptions import ApiConflictError
+
+# Metric namespace for the candidate (tree-based) detector.
+_MULTI_METRICS_PREFIX = "onboarding-scm.platform_detection.multi"
+
+
+@cell_silo_endpoint
+class OrganizationRepositoryPlatformsTestEndpoint(OrganizationRepositoryEndpoint):
+    """Measurement-only endpoint for the tree-based detector.
+
+    Fetches the repository git tree in a single call and emits structural
+    metrics (`onboarding-scm.platform_detection.multi.*`). It returns 204 No
+    Content and has no effect on the live detector; the frontend fires it
+    fire-and-forget alongside the real detection request.
+    """
+
+    owner = ApiOwner.INTEGRATION_PLATFORM
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+
+    def get(self, request: Request, organization: Organization, repo: Repository) -> Response:
+        if not features.has(
+            "organizations:integrations-github-platform-detection",
+            organization,
+            actor=request.user,
+        ):
+            return Response(status=404)
+
+        if (
+            not repo.integration_id
+            or repo.provider != f"integrations:{IntegrationProviderSlug.GITHUB}"
+        ):
+            return Response(
+                {"detail": "Platform detection is only supported for GitHub repositories."},
+                status=400,
+            )
+
+        integration = integration_service.get_integration(integration_id=repo.integration_id)
+        if integration is None:
+            return Response({"detail": "GitHub integration not found."}, status=400)
+
+        org_integration = integration_service.get_organization_integration(
+            integration_id=repo.integration_id, organization_id=organization.id
+        )
+        if org_integration is None:
+            return Response(
+                {"detail": "GitHub integration is not configured for this organization."},
+                status=400,
+            )
+
+        client = GitHubApiClient(integration=integration, org_integration_id=org_integration.id)
+
+        self._measure_tree(client, repo)
+
+        # Measurement-only: no body.
+        return Response(status=204)
+
+    def _measure_tree(self, client: GitHubApiClient, repo: Repository) -> None:
+        """Fetch the full git tree once and emit structural metrics.
+
+        Uses the ``HEAD`` ref so a single ``git/trees`` call suffices (no branch
+        resolution). The client's ``get_tree`` helper drops the ``truncated``
+        flag, so we call ``client.get`` directly to keep ``truncated`` and the
+        per-entry ``size`` for now.
+        """
+        start_time = time.monotonic()
+        try:
+            response = client.get(
+                f"/repos/{repo.name}/git/trees/HEAD",
+                params={"recursive": 1},
+            )
+
+            tree: list[dict[str, Any]] = (
+                response.get("tree", []) if isinstance(response, dict) else []
+            )
+            is_truncated = bool(response.get("truncated")) if isinstance(response, dict) else False
+            repo_size_bytes = sum(
+                entry.get("size", 0) for entry in tree if entry.get("type") == "blob"
+            )
+
+            sentry_sdk.metrics.distribution(
+                f"{_MULTI_METRICS_PREFIX}.duration",
+                (time.monotonic() - start_time) * 1000,
+                unit="millisecond",
+            )
+            sentry_sdk.metrics.count(
+                f"{_MULTI_METRICS_PREFIX}.completed",
+                1,
+                attributes={"is_truncated": is_truncated},
+            )
+            sentry_sdk.metrics.distribution(f"{_MULTI_METRICS_PREFIX}.tree.entry_count", len(tree))
+            sentry_sdk.metrics.distribution(
+                f"{_MULTI_METRICS_PREFIX}.repo_size_bytes",
+                repo_size_bytes,
+                unit="byte",
+            )
+        except Exception as e:
+            # Empty repositories return a 409 (ApiConflictError) — an expected
+            # measurement failure, so log only. Surface anything else as an issue.
+            sentry_logger.warning(
+                f"{_MULTI_METRICS_PREFIX}.failed",
+                attributes={"repo_id": repo.id, "repo_name": repo.name},
+            )
+            if not isinstance(e, ApiConflictError):
+                sentry_sdk.capture_exception()

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -1281,6 +1281,7 @@ def detect_platforms(
         1,
         attributes={
             "confidence": results[0]["confidence"] if results else "none",
+            "detected_platforms_count": len(results),
             "languages_count": _bucket_languages_count(languages),
             "content_reads": _bucket_content_reads(needed_paths),
         },

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -1141,17 +1141,10 @@ def _bucket_languages_count(languages: dict[str, int]) -> str:
     return "4+" if count >= 4 else str(count)
 
 
-def _bucket_content_reads(count: int) -> str:
+def _bucket_content_reads(needed_paths: set[str]) -> str:
     """Bucket the number of content-fetch API calls into a metric tag."""
-    if count == 0:
-        return "0"
-    if count <= 2:
-        return "1-2"
-    if count <= 5:
-        return "3-5"
-    if count <= 10:
-        return "6-10"
-    return "11+"
+    count = len(needed_paths)
+    return "6+" if count >= 6 else str(count)
 
 
 def detect_platforms(
@@ -1286,7 +1279,7 @@ def detect_platforms(
         tags={
             "confidence": results[0]["confidence"] if results else "none",
             "languages_count": _bucket_languages_count(languages),
-            "content_reads": _bucket_content_reads(len(needed_paths)),
+            "content_reads": _bucket_content_reads(needed_paths),
         },
     )
 

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -8,10 +8,11 @@ from collections import defaultdict
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, NotRequired, TypedDict
 
+import sentry_sdk
 from yaml import YAMLError
 
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.utils import json, metrics
+from sentry.utils import json
 from sentry.utils.yaml import safe_load
 
 if TYPE_CHECKING:
@@ -1270,13 +1271,15 @@ def detect_platforms(
     results = [r for r in results if r["platform"] not in _NON_SELECTABLE_PLATFORMS]
     results.sort(key=lambda r: (r["bytes"], r["priority"]), reverse=True)
 
-    metrics.timing(
+    sentry_sdk.metrics.distribution(
         f"{_SINGLE_METRICS_PREFIX}.duration",
-        time.monotonic() - start_time,
+        (time.monotonic() - start_time) * 1000,
+        unit="millisecond",
     )
-    metrics.incr(
+    sentry_sdk.metrics.count(
         f"{_SINGLE_METRICS_PREFIX}.completed",
-        tags={
+        1,
+        attributes={
             "confidence": results[0]["confidence"] if results else "none",
             "languages_count": _bucket_languages_count(languages),
             "content_reads": _bucket_content_reads(needed_paths),

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -1122,37 +1122,22 @@ def _apply_supersession(results: list[DetectedPlatform]) -> list[DetectedPlatfor
 # Metric namespace for the single-platform detector.
 _SINGLE_METRICS_PREFIX = "onboarding-scm.platform_detection.single"
 
-# Minimum share of total repo bytes for a language's base platform to count
-# toward the multi-platform signal. Filters out incidental scripts (e.g. a small
-# JS helper in a Python repo) so they don't inflate the platform count.
-_MULTI_PLATFORM_BYTE_SHARE_THRESHOLD = 0.10
 
-
-def _count_base_platforms(languages: dict[str, int]) -> int:
-    """Count distinct Sentry base platforms among a repo's significant languages.
+def _bucket_languages_count(languages: dict[str, int]) -> str:
+    """Count distinct Sentry base platforms among a repo's languages and bucket
+    the result into a low-cardinality metric tag.
 
     SDK-less languages are ignored and related languages collapse to a single
-    base platform (e.g. TypeScript + JavaScript -> javascript). Only languages
-    above ``_MULTI_PLATFORM_BYTE_SHARE_THRESHOLD`` of total bytes are counted, so
-    incidental scripts in a second language don't inflate the result.
+    base platform (e.g. TypeScript + JavaScript -> javascript).
     """
-    total_bytes = sum(languages.values())
-    if total_bytes <= 0:
-        return 0
-    base_platforms: set[str] = set()
-    for language, byte_count in languages.items():
+    language_groups: set[str] = set()
+    for language in languages:
         if language in IGNORED_LANGUAGES:
             continue
         base_platform = GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.get(language)
-        if base_platform is None:
-            continue
-        if byte_count / total_bytes >= _MULTI_PLATFORM_BYTE_SHARE_THRESHOLD:
-            base_platforms.add(base_platform)
-    return len(base_platforms)
-
-
-def _bucket_base_platform_count(count: int) -> str:
-    """Bucket the base-platform count into a low-cardinality metric tag."""
+        if base_platform is not None:
+            language_groups.add(base_platform)
+    count = len(language_groups)
     return "4+" if count >= 4 else str(count)
 
 
@@ -1300,7 +1285,7 @@ def detect_platforms(
         f"{_SINGLE_METRICS_PREFIX}.completed",
         tags={
             "confidence": results[0]["confidence"] if results else "none",
-            "base_platform_count": _bucket_base_platform_count(_count_base_platforms(languages)),
+            "languages_count": _bucket_languages_count(languages),
             "content_reads": _bucket_content_reads(len(needed_paths)),
         },
     )

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -1156,6 +1156,19 @@ def _bucket_base_platform_count(count: int) -> str:
     return "4+" if count >= 4 else str(count)
 
 
+def _bucket_content_reads(count: int) -> str:
+    """Bucket the number of content-fetch API calls into a metric tag."""
+    if count == 0:
+        return "0"
+    if count <= 2:
+        return "1-2"
+    if count <= 5:
+        return "3-5"
+    if count <= 10:
+        return "6-10"
+    return "11+"
+
+
 def detect_platforms(
     client: GitHubBaseClient,
     repo: str,
@@ -1288,6 +1301,7 @@ def detect_platforms(
         tags={
             "confidence": results[0]["confidence"] if results else "none",
             "base_platform_count": _bucket_base_platform_count(_count_base_platforms(languages)),
+            "content_reads": _bucket_content_reads(len(needed_paths)),
         },
     )
 

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 from base64 import b64decode
 from collections import defaultdict
 from collections.abc import Sequence
@@ -10,7 +11,7 @@ from typing import TYPE_CHECKING, NotRequired, TypedDict
 from yaml import YAMLError
 
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.utils import json
+from sentry.utils import json, metrics
 from sentry.utils.yaml import safe_load
 
 if TYPE_CHECKING:
@@ -1118,6 +1119,43 @@ def _apply_supersession(results: list[DetectedPlatform]) -> list[DetectedPlatfor
     return [r for r in results if r["platform"] not in superseded]
 
 
+# Metric namespace for the single-platform detector.
+_SINGLE_METRICS_PREFIX = "onboarding-scm.platform_detection.single"
+
+# Minimum share of total repo bytes for a language's base platform to count
+# toward the multi-platform signal. Filters out incidental scripts (e.g. a small
+# JS helper in a Python repo) so they don't inflate the platform count.
+_MULTI_PLATFORM_BYTE_SHARE_THRESHOLD = 0.10
+
+
+def _count_base_platforms(languages: dict[str, int]) -> int:
+    """Count distinct Sentry base platforms among a repo's significant languages.
+
+    SDK-less languages are ignored and related languages collapse to a single
+    base platform (e.g. TypeScript + JavaScript -> javascript). Only languages
+    above ``_MULTI_PLATFORM_BYTE_SHARE_THRESHOLD`` of total bytes are counted, so
+    incidental scripts in a second language don't inflate the result.
+    """
+    total_bytes = sum(languages.values())
+    if total_bytes <= 0:
+        return 0
+    base_platforms: set[str] = set()
+    for language, byte_count in languages.items():
+        if language in IGNORED_LANGUAGES:
+            continue
+        base_platform = GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.get(language)
+        if base_platform is None:
+            continue
+        if byte_count / total_bytes >= _MULTI_PLATFORM_BYTE_SHARE_THRESHOLD:
+            base_platforms.add(base_platform)
+    return len(base_platforms)
+
+
+def _bucket_base_platform_count(count: int) -> str:
+    """Bucket the base-platform count into a low-cardinality metric tag."""
+    return "4+" if count >= 4 else str(count)
+
+
 def detect_platforms(
     client: GitHubBaseClient,
     repo: str,
@@ -1136,6 +1174,7 @@ def detect_platforms(
     Results are ranked by bytes (descending), then priority (descending).
     Superseded frameworks (e.g. React when Next.js is present) are removed.
     """
+    start_time = time.monotonic()
     languages = client.get_languages(repo)
     root_files, root_dirs = _get_root_entries(client, repo, ref)
 
@@ -1239,5 +1278,17 @@ def detect_platforms(
     results = _apply_supersession(results)
     results = [r for r in results if r["platform"] not in _NON_SELECTABLE_PLATFORMS]
     results.sort(key=lambda r: (r["bytes"], r["priority"]), reverse=True)
+
+    metrics.timing(
+        f"{_SINGLE_METRICS_PREFIX}.duration",
+        time.monotonic() - start_time,
+    )
+    metrics.incr(
+        f"{_SINGLE_METRICS_PREFIX}.completed",
+        tags={
+            "confidence": results[0]["confidence"] if results else "none",
+            "base_platform_count": _bucket_base_platform_count(_count_base_platforms(languages)),
+        },
+    )
 
     return results

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -349,6 +349,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/repos/'
   | '/organizations/$organizationIdOrSlug/repos/$repoId/'
   | '/organizations/$organizationIdOrSlug/repos/$repoId/commits/'
+  | '/organizations/$organizationIdOrSlug/repos/$repoId/platforms-test/'
   | '/organizations/$organizationIdOrSlug/repos/$repoId/platforms/'
   | '/organizations/$organizationIdOrSlug/repos/settings/'
   | '/organizations/$organizationIdOrSlug/request-project-creation/'

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms_test.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms_test.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest import mock
+
+import responses
+from django.utils import timezone
+
+from sentry.models.repository import Repository
+from sentry.testutils.cases import APITestCase
+
+FEATURE_FLAG = "organizations:integrations-github-platform-detection"
+
+
+class OrganizationRepositoryPlatformsTestGetTest(APITestCase):
+    endpoint = "sentry-api-0-organization-repository-platforms-test"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+
+        ten_days = timezone.now() + timedelta(days=10)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="Github Test Org",
+            external_id="1",
+            metadata={
+                "access_token": "12345token",
+                "expires_at": ten_days.strftime("%Y-%m-%dT%H:%M:%S"),
+            },
+        )
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="integrations:github",
+            external_id="123",
+            integration_id=self.integration.id,
+        )
+
+    def test_feature_flag_required(self) -> None:
+        response = self.get_response(self.organization.slug, self.repo.id)
+        assert response.status_code == 404
+
+    def test_non_github_repo(self) -> None:
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="non-github-repo",
+            provider="integrations:bitbucket",
+            external_id="456",
+        )
+
+        with self.feature(FEATURE_FLAG):
+            response = self.get_response(self.organization.slug, repo.id)
+        assert response.status_code == 400
+        assert "only supported for GitHub" in response.data["detail"]
+
+    def test_repo_without_integration(self) -> None:
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="orphan-repo",
+            provider="integrations:github",
+            external_id="789",
+            integration_id=None,
+        )
+
+        with self.feature(FEATURE_FLAG):
+            response = self.get_response(self.organization.slug, repo.id)
+        assert response.status_code == 400
+
+    def test_repo_not_found(self) -> None:
+        with self.feature(FEATURE_FLAG):
+            response = self.get_response(self.organization.slug, 99999)
+        assert response.status_code == 404
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_returns_no_content(self, get_jwt: mock.MagicMock) -> None:
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/git/trees/HEAD",
+            json={
+                "sha": "abc",
+                "truncated": False,
+                "tree": [
+                    {"path": "src/app.py", "type": "blob", "size": 1234},
+                    {"path": "src", "type": "tree"},
+                ],
+            },
+            status=200,
+        )
+
+        with self.feature(FEATURE_FLAG):
+            response = self.get_response(self.organization.slug, self.repo.id)
+
+        assert response.status_code == 204
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_returns_no_content_on_github_error(self, get_jwt: mock.MagicMock) -> None:
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/git/trees/HEAD",
+            json={"message": "Git Repository is empty."},
+            status=409,
+        )
+
+        with self.feature(FEATURE_FLAG):
+            response = self.get_response(self.organization.slug, self.repo.id)
+
+        assert response.status_code == 204


### PR DESCRIPTION
Adds Sentry metrics to the current single-platform detector

`.single.duration` (timing) measures detector wall-time from the first GitHub call through ranking, emitted on successful completion.

`.single.completed` (incr) counts detections and carries three tags:

`confidence`: the top result's confidence, high / medium / none (high means a framework matched, medium means base-language fallback).
`languages_count`: distinct Sentry base platforms across the repo's languages (SDK-less languages ignored, TypeScript+JavaScript collapsed to one), bucketed. This sizes how often repos are actually multi-platform even though today we only return the top one.
`content_reads`: number of file-content API calls made, bucketed. Excludes the two fixed calls (languages + root listing).