### PR TITLE
fix(conversations): Stop rendering raw tool call JSON as message content

### DIFF
--- a/static/app/views/explore/conversations/components/messagesPanel.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.tsx
@@ -126,21 +126,23 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
                   onSelectNode={onSelectNode}
                 />
               )}
-              <StyledClippedBox
-                clipHeight={200}
-                buttonProps={{variant: 'secondary', size: 'xs'}}
-                collapsible
-              >
-                <Container padding="md">
-                  <MessageText size="sm" align="left">
-                    <AIContentRenderer
-                      text={message.content}
-                      inline
-                      autoCollapseLimit={10}
-                    />
-                  </MessageText>
-                </Container>
-              </StyledClippedBox>
+              {message.content !== '' && (
+                <StyledClippedBox
+                  clipHeight={200}
+                  buttonProps={{variant: 'secondary', size: 'xs'}}
+                  collapsible
+                >
+                  <Container padding="md">
+                    <MessageText size="sm" align="left">
+                      <AIContentRenderer
+                        text={message.content}
+                        inline
+                        autoCollapseLimit={10}
+                      />
+                    </MessageText>
+                  </Container>
+                </StyledClippedBox>
+              )}
             </MessageBubble>
           );
         })}

--- a/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
@@ -340,6 +340,43 @@ describe('conversationMessages utilities', () => {
       });
       expect(parseAssistantContent(node as any)).toBe('fallback text');
     });
+
+    it('returns null when output.messages has tool calls but no text', () => {
+      const messages = JSON.stringify([
+        {
+          role: 'assistant',
+          parts: [{type: 'tool_call', toolCallId: 'tc-1', toolName: 'search', args: {}}],
+        },
+      ]);
+      const node = createMockNode({
+        id: 'node-1',
+        attributes: {
+          [SpanFields.GEN_AI_OUTPUT_MESSAGES]: messages,
+          [SpanFields.GEN_AI_RESPONSE_OBJECT]: '{"tool_calls": [{"name": "search"}]}',
+        },
+      });
+      // Should NOT fall through to gen_ai.response.object
+      expect(parseAssistantContent(node as any)).toBeNull();
+    });
+
+    it('returns text when output.messages has both text and tool calls', () => {
+      const messages = JSON.stringify([
+        {
+          role: 'assistant',
+          parts: [
+            {type: 'text', text: 'Let me search for that'},
+            {type: 'tool_call', toolCallId: 'tc-1', toolName: 'search', args: {}},
+          ],
+        },
+      ]);
+      const node = createMockNode({
+        id: 'node-1',
+        attributes: {
+          [SpanFields.GEN_AI_OUTPUT_MESSAGES]: messages,
+        },
+      });
+      expect(parseAssistantContent(node as any)).toBe('Let me search for that');
+    });
   });
 
   describe('partitionSpansByType', () => {
@@ -506,6 +543,32 @@ describe('conversationMessages utilities', () => {
         'tool-b',
         'tool-c',
       ]);
+    });
+
+    it('flushes pending tool calls onto last turn when no subsequent turn has content', () => {
+      const turns = [
+        {
+          generation: {id: 'gen-1'} as any,
+          userContent: 'Question',
+          assistantContent: 'Answer',
+          toolCalls: [],
+          userEmail: undefined,
+        },
+        {
+          generation: {id: 'gen-2'} as any,
+          userContent: null,
+          assistantContent: null,
+          toolCalls: [{name: 'search', nodeId: 'tool-1', hasError: false}],
+          userEmail: undefined,
+        },
+      ];
+
+      const merged = mergeEmptyTurns(turns);
+
+      // The pending tool call should be flushed onto the last result turn
+      expect(merged).toHaveLength(1);
+      expect(merged[0]?.toolCalls).toHaveLength(1);
+      expect(merged[0]?.toolCalls[0]?.name).toBe('search');
     });
 
     it('preserves user content turns even without assistant response', () => {
@@ -842,6 +905,49 @@ describe('conversationMessages utilities', () => {
       expect(messages[1]?.content).toBe('First response');
       expect(messages[2]?.content).toBe('Second');
       expect(messages[3]?.content).toBe('Second response');
+    });
+
+    it('creates assistant message for tool-call-only turns without text', () => {
+      const turns = [
+        {
+          generation: {
+            id: 'gen-1',
+            value: {start_timestamp: 1000, end_timestamp: 1100},
+          } as any,
+          userContent: 'Do something',
+          assistantContent: null,
+          toolCalls: [{name: 'search', nodeId: 'tool-1', hasError: false}],
+          userEmail: undefined,
+        },
+      ];
+
+      const messages = turnsToMessages(turns);
+
+      const assistantMessages = messages.filter(m => m.role === 'assistant');
+      expect(assistantMessages).toHaveLength(1);
+      expect(assistantMessages[0]?.content).toBe('');
+      expect(assistantMessages[0]?.toolCalls).toHaveLength(1);
+      expect(assistantMessages[0]?.toolCalls?.[0]?.name).toBe('search');
+    });
+
+    it('does not create assistant message when no content and no tool calls', () => {
+      const turns = [
+        {
+          generation: {
+            id: 'gen-1',
+            value: {start_timestamp: 1000, end_timestamp: 1100},
+          } as any,
+          userContent: 'Hello',
+          assistantContent: null,
+          toolCalls: [],
+          userEmail: undefined,
+        },
+      ];
+
+      const messages = turnsToMessages(turns);
+
+      const assistantMessages = messages.filter(m => m.role === 'assistant');
+      expect(assistantMessages).toHaveLength(0);
     });
 
     it('keeps user→assistant pairing across back-to-back turns under one second apart', () => {

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -145,6 +145,16 @@ export function mergeEmptyTurns(turns: ConversationTurn[]): ConversationTurn[] {
     }
   }
 
+  // Flush any remaining pending tool calls as a tool-call-only turn
+  if (pendingToolCalls.length > 0 && result.length > 0) {
+    const lastTurn = result[result.length - 1]!;
+    result[result.length - 1] = {
+      ...lastTurn,
+      toolCalls: [...lastTurn.toolCalls, ...pendingToolCalls],
+      toolSpanNodes: [...(lastTurn.toolSpanNodes ?? []), ...pendingToolSpanNodes],
+    };
+  }
+
   return result;
 }
 
@@ -172,12 +182,16 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
       });
     }
 
-    if (
+    const hasAssistantContent =
       turn.assistantContent &&
       (turn.assistantContent === FILTERED ||
-        !seenAssistantContent.has(turn.assistantContent))
-    ) {
-      seenAssistantContent.add(turn.assistantContent);
+        !seenAssistantContent.has(turn.assistantContent));
+    const hasToolCalls = turn.toolCalls.length > 0;
+
+    if (hasAssistantContent || hasToolCalls) {
+      if (turn.assistantContent) {
+        seenAssistantContent.add(turn.assistantContent);
+      }
 
       const toolSpanNodes = turn.toolSpanNodes ?? [];
       const lastToolEnd =
@@ -199,10 +213,10 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
       messages.push({
         id: `assistant-${turn.generation.id}`,
         role: 'assistant',
-        content: turn.assistantContent,
+        content: turn.assistantContent ?? '',
         timestamp: endTs,
         nodeId: turn.generation.id,
-        toolCalls: turn.toolCalls.length > 0 ? turn.toolCalls : undefined,
+        toolCalls: hasToolCalls ? turn.toolCalls : undefined,
         duration,
         agentName: agentName || undefined,
         modelName: modelName || undefined,
@@ -270,6 +284,11 @@ export function parseAssistantContent(node: AITraceSpanNode): string | null {
     });
     if (extracted.responseText) {
       return extracted.responseText;
+    }
+    // If tool calls were found but no text, don't fall through to response
+    // attributes — tool calls are rendered separately as badges
+    if (extracted.toolCalls) {
+      return null;
     }
   }
 

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -146,8 +146,8 @@ export function mergeEmptyTurns(turns: ConversationTurn[]): ConversationTurn[] {
   }
 
   // Flush any remaining pending tool calls as a tool-call-only turn
-  if (pendingToolCalls.length > 0 && result.length > 0) {
-    const lastTurn = result[result.length - 1]!;
+  const lastTurn = result.at(-1);
+  if (pendingToolCalls.length > 0 && lastTurn) {
     result[result.length - 1] = {
       ...lastTurn,
       toolCalls: [...lastTurn.toolCalls, ...pendingToolCalls],
@@ -294,10 +294,23 @@ export function parseAssistantContent(node: AITraceSpanNode): string | null {
 
   const responseText = getStringAttr(node, SpanFields.GEN_AI_RESPONSE_TEXT);
   if (responseText) {
+    if (isToolCallOnlyContent(responseText)) {
+      return null;
+    }
     return responseText;
   }
 
   return getStringAttr(node, SpanFields.GEN_AI_RESPONSE_OBJECT) ?? null;
+}
+
+/**
+ * Returns true if the string is JSON containing only tool_call parts
+ * and no actual text content (e.g. SDKs that stuff tool call output
+ * into gen_ai.response.text).
+ */
+function isToolCallOnlyContent(raw: string): boolean {
+  const extracted = extractAssistantOutput(raw, {defaultRole: 'assistant'});
+  return !extracted.responseText && extracted.toolCalls !== null;
 }
 
 export function getNodeTimestamp(node: AITraceSpanNode): number {


### PR DESCRIPTION
When an assistant response contains only tool calls without text, `parseAssistantContent` would fall through to `gen_ai.response.object`and render the raw tool call JSON as message content. This caused:

1. Raw JSON blobs appearing in conversation messages
2. Duplicate rendering of tool calls (badges + JSON content)

Fix by detecting tool-call-only outputs in `extractAssistantOutput` andreturning `null` instead of falling through to response attributes. Also creates assistant messages for tool-call-only turns so the tool call badges still render, and skips the content area when message content is empty.

Before:
<img width="597" height="506" alt="CleanShot 2026-06-08 at 13 07 55" src="https://github.com/user-attachments/assets/bb570ea4-c6cb-4202-a914-3e1baef1fc5a" />

After:
<img width="597" height="506" alt="CleanShot 2026-06-08 at 13 07 55" src="https://github.com/user-attachments/assets/53117082-8ccb-4b73-9678-828905cbb2da" />

Closes TET-2448