### PR TITLE
feat(agents): Warn about wrongly reported tokens in span details

### DIFF
--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -241,5 +241,8 @@ function getShortSpanOperationDescription(operation?: string) {
 }
 
 export function formatDollars(value: number) {
+  if (value < 0) {
+    return `-$${formatAbbreviatedNumberWithDynamicPrecision(Math.abs(value))}`;
+  }
   return `$${formatAbbreviatedNumberWithDynamicPrecision(value)}`;
 }

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -241,8 +241,5 @@ function getShortSpanOperationDescription(operation?: string) {
 }
 
 export function formatDollars(value: number) {
-  if (value < 0) {
-    return `-$${formatAbbreviatedNumberWithDynamicPrecision(Math.abs(value))}`;
-  }
   return `$${formatAbbreviatedNumberWithDynamicPrecision(value)}`;
 }

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -47,10 +47,10 @@ import {Thresholds} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plott
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {getExploreUrl} from 'sentry/views/explore/utils';
-import {NegativeCostWarning} from 'sentry/views/insights/common/components/tableCells/currencyCell';
 import {TextAlignRight} from 'sentry/views/insights/common/components/textAlign';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
+import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
 import {
   SeriesColorIndicator,
   WidgetFooterTable,
@@ -378,9 +378,7 @@ function VisualizationWidgetContent({
             </Tooltip>
             <TextAlignRight>
               {dataType === 'currency' && value !== null && value < 0 ? (
-                <NegativeCostWarning>
-                  {formatBreakdownLegendValue(value, dataType, dataUnit)}
-                </NegativeCostWarning>
+                <NegativeCostInfo cost={value} />
               ) : (
                 formatBreakdownLegendValue(value, dataType, dataUnit)
               )}

--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -13,12 +13,11 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {ExternalLink} from 'sentry/components/links/externalLink';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Placeholder} from 'sentry/components/placeholder';
 import {TimeSince} from 'sentry/components/timeSince';
-import {IconCopy, IconWarning} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {IconCopy} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isUUID} from 'sentry/utils/string/isUUID';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
@@ -26,6 +25,7 @@ import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {getTimeBoundsFromNodes} from 'sentry/views/explore/conversations/utils/timeBounds';
 import {getExploreUrl} from 'sentry/views/explore/utils';
+import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
 import {
   getNumberAttr,
   getStringAttr,
@@ -156,7 +156,7 @@ export function ConversationAggregatesBar({
         label={t('Cost')}
         value={
           aggregates.totalCost < 0 ? (
-            <NegativeCostValue cost={aggregates.totalCost} />
+            <NegativeCostInfo cost={aggregates.totalCost} />
           ) : (
             formatLLMCosts(aggregates.totalCost)
           )
@@ -344,26 +344,6 @@ export function ConversationSummary({
           })
         }
       />
-    </Flex>
-  );
-}
-
-const TOKEN_TROUBLESHOOTING_URL =
-  'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
-
-function NegativeCostValue({cost}: {cost: number}) {
-  return (
-    <Flex align="center" gap="xs">
-      <IconWarning legacySize="1em" variant="warning" />
-      <InfoText
-        variant="warning"
-        title={tct(
-          'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
-          {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
-        )}
-      >
-        {formatLLMCosts(cost)}
-      </InfoText>
     </Flex>
   );
 }

--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -13,11 +13,12 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {ExternalLink} from 'sentry/components/links/externalLink';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Placeholder} from 'sentry/components/placeholder';
 import {TimeSince} from 'sentry/components/timeSince';
-import {IconCopy} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {IconCopy, IconWarning} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isUUID} from 'sentry/utils/string/isUUID';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
@@ -153,7 +154,13 @@ export function ConversationAggregatesBar({
       />
       <AggregateItem
         label={t('Cost')}
-        value={formatLLMCosts(aggregates.totalCost)}
+        value={
+          aggregates.totalCost < 0 ? (
+            <NegativeCostValue cost={aggregates.totalCost} />
+          ) : (
+            formatLLMCosts(aggregates.totalCost)
+          )
+        }
         isLoading={isLoading}
       />
       {lastMessageDate !== undefined && (
@@ -337,6 +344,26 @@ export function ConversationSummary({
           })
         }
       />
+    </Flex>
+  );
+}
+
+const TOKEN_TROUBLESHOOTING_URL =
+  'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
+
+function NegativeCostValue({cost}: {cost: number}) {
+  return (
+    <Flex align="center" gap="xs">
+      <IconWarning legacySize="1em" variant="warning" />
+      <InfoText
+        variant="warning"
+        title={tct(
+          'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
+          {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
+        )}
+      >
+        {formatLLMCosts(cost)}
+      </InfoText>
     </Flex>
   );
 }

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -36,6 +36,7 @@ import {
 import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/explore/conversations/settings';
 import {hasGenAiConversationsFeature} from 'sentry/views/explore/conversations/utils/features';
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
+import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
 import {AIContentRenderer} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer';
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
@@ -325,7 +326,12 @@ const BodyCell = memo(function BodyCell({
     case 'tokensAndCost':
       return (
         <Text as="div" align="right">
-          <Count value={dataRow.totalTokens} /> / <LLMCosts cost={dataRow.totalCost} />
+          <Count value={dataRow.totalTokens} /> /{' '}
+          {dataRow.totalCost !== null && dataRow.totalCost < 0 ? (
+            <NegativeCostInfo cost={dataRow.totalCost} />
+          ) : (
+            <LLMCosts cost={dataRow.totalCost} />
+          )}
         </Text>
       );
     case 'timestamp':

--- a/static/app/views/insights/common/components/tableCells/currencyCell.spec.tsx
+++ b/static/app/views/insights/common/components/tableCells/currencyCell.spec.tsx
@@ -23,18 +23,14 @@ describe('CurrencyCell', () => {
     expect(screen.getByText('$0')).toBeInTheDocument();
   });
 
-  it('renders negative value with warning icon', async () => {
+  it('renders negative value with warning tooltip', async () => {
     render(<CurrencyCell value={-5.5} />);
 
     // The negative value should be rendered
     expect(screen.getByText('$-5.5')).toBeInTheDocument();
 
-    // Warning icon should be present
-    const warningIcon = screen.getByRole('img', {hidden: true});
-    expect(warningIcon).toBeInTheDocument();
-
-    // Hover over the wrapper to see tooltip
-    await userEvent.hover(warningIcon);
+    // Hover over the value to see tooltip
+    await userEvent.hover(screen.getByText('$-5.5'));
     expect(
       await screen.findByText(/Negative costs indicate an error/)
     ).toBeInTheDocument();

--- a/static/app/views/insights/common/components/tableCells/currencyCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/currencyCell.tsx
@@ -1,38 +1,10 @@
-import {Flex} from '@sentry/scraps/layout';
-import {Tooltip} from '@sentry/scraps/tooltip';
-
-import {ExternalLink} from 'sentry/components/links/externalLink';
-import {IconWarning} from 'sentry/icons';
-import {tct} from 'sentry/locale';
 import {NumberContainer} from 'sentry/utils/discover/styles';
 import {formatDollars} from 'sentry/utils/formatters';
+import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
 
 type Props = {
   value: number | null;
 };
-
-const NEGATIVE_COST_DOCS_URL =
-  'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
-
-export function NegativeCostWarning({children}: {children: React.ReactNode}) {
-  return (
-    <Tooltip
-      title={tct(
-        'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
-        {
-          link: <ExternalLink href={NEGATIVE_COST_DOCS_URL} />,
-        }
-      )}
-      skipWrapper
-      isHoverable
-    >
-      <Flex as="span" display="inline-flex" align="center" gap="xs">
-        <IconWarning legacySize="1em" variant="warning" />
-        {children}
-      </Flex>
-    </Tooltip>
-  );
-}
 
 export function CurrencyCell({value}: Props) {
   if (value === null || value === undefined) {
@@ -42,7 +14,7 @@ export function CurrencyCell({value}: Props) {
   if (value < 0) {
     return (
       <NumberContainer>
-        <NegativeCostWarning>{formatDollars(value)}</NegativeCostWarning>
+        <NegativeCostInfo cost={value} />
       </NumberContainer>
     );
   }

--- a/static/app/views/insights/pages/agents/components/negativeCostWarning.tsx
+++ b/static/app/views/insights/pages/agents/components/negativeCostWarning.tsx
@@ -19,8 +19,8 @@ interface NegativeCostInfoProps {
  */
 export function NegativeCostInfo({cost}: NegativeCostInfoProps) {
   return (
-    <Flex display="inline-flex" align="center" gap="xs">
-      <IconWarning legacySize="1em" variant="warning" />
+    <Flex as="span" display="inline-flex" align="center" gap="xs">
+      <IconWarning size="xs" variant="warning" />
       <InfoText
         variant="warning"
         title={tct(

--- a/static/app/views/insights/pages/agents/components/negativeCostWarning.tsx
+++ b/static/app/views/insights/pages/agents/components/negativeCostWarning.tsx
@@ -1,0 +1,35 @@
+import {InfoText} from '@sentry/scraps/info';
+import {Flex} from '@sentry/scraps/layout';
+
+import {ExternalLink} from 'sentry/components/links/externalLink';
+import {IconWarning} from 'sentry/icons';
+import {tct} from 'sentry/locale';
+import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
+
+const TOKEN_TROUBLESHOOTING_URL =
+  'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
+
+interface NegativeCostInfoProps {
+  cost: number | string;
+}
+
+/**
+ * Warning indicator for negative LLM costs. Shows a warning icon + the cost
+ * value with an InfoText tooltip linking to troubleshooting docs.
+ */
+export function NegativeCostInfo({cost}: NegativeCostInfoProps) {
+  return (
+    <Flex align="center" gap="xs">
+      <IconWarning legacySize="1em" variant="warning" />
+      <InfoText
+        variant="warning"
+        title={tct(
+          'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
+          {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
+        )}
+      >
+        {formatLLMCosts(cost)}
+      </InfoText>
+    </Flex>
+  );
+}

--- a/static/app/views/insights/pages/agents/components/negativeCostWarning.tsx
+++ b/static/app/views/insights/pages/agents/components/negativeCostWarning.tsx
@@ -6,7 +6,7 @@ import {IconWarning} from 'sentry/icons';
 import {tct} from 'sentry/locale';
 import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
 
-const TOKEN_TROUBLESHOOTING_URL =
+export const TOKEN_TROUBLESHOOTING_URL =
   'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
 
 interface NegativeCostInfoProps {
@@ -19,7 +19,7 @@ interface NegativeCostInfoProps {
  */
 export function NegativeCostInfo({cost}: NegativeCostInfoProps) {
   return (
-    <Flex align="center" gap="xs">
+    <Flex display="inline-flex" align="center" gap="xs">
       <IconWarning legacySize="1em" variant="warning" />
       <InfoText
         variant="warning"

--- a/static/app/views/insights/pages/agents/components/negativeCostWarning.tsx
+++ b/static/app/views/insights/pages/agents/components/negativeCostWarning.tsx
@@ -1,8 +1,6 @@
 import {InfoText} from '@sentry/scraps/info';
-import {Flex} from '@sentry/scraps/layout';
 
 import {ExternalLink} from 'sentry/components/links/externalLink';
-import {IconWarning} from 'sentry/icons';
 import {tct} from 'sentry/locale';
 import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
 
@@ -14,22 +12,19 @@ interface NegativeCostInfoProps {
 }
 
 /**
- * Warning indicator for negative LLM costs. Shows a warning icon + the cost
- * value with an InfoText tooltip linking to troubleshooting docs.
+ * Warning indicator for negative LLM costs. Shows the cost value with
+ * a warning-styled InfoText tooltip linking to troubleshooting docs.
  */
 export function NegativeCostInfo({cost}: NegativeCostInfoProps) {
   return (
-    <Flex as="span" display="inline-flex" align="center" gap="xs">
-      <IconWarning size="xs" variant="warning" />
-      <InfoText
-        variant="warning"
-        title={tct(
-          'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
-          {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
-        )}
-      >
-        {formatLLMCosts(cost)}
-      </InfoText>
-    </Flex>
+    <InfoText
+      variant="warning"
+      title={tct(
+        'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
+        {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
+      )}
+    >
+      {formatLLMCosts(cost)}
+    </InfoText>
   );
 }

--- a/static/app/views/insights/pages/agents/utils/formatLLMCosts.tsx
+++ b/static/app/views/insights/pages/agents/utils/formatLLMCosts.tsx
@@ -6,6 +6,9 @@ export function formatLLMCosts(cost: string | number | null) {
   }
   const number = Number(cost);
 
+  if (number < 0) {
+    return formatDollars(number);
+  }
   if (number < 0.01) {
     return `<$${(0.01).toLocaleString()}`;
   }

--- a/static/app/views/insights/pages/agents/utils/tokenBreakdown.spec.ts
+++ b/static/app/views/insights/pages/agents/utils/tokenBreakdown.spec.ts
@@ -1,4 +1,4 @@
-import {getTokenBreakdown} from './tokenBreakdown';
+import {getTokenBreakdown, hasTokenMismatch} from './tokenBreakdown';
 
 describe('getTokenBreakdown', () => {
   it('returns input as netNewInput when there are no cached tokens', () => {
@@ -156,5 +156,79 @@ describe('getTokenBreakdown', () => {
       output: 50,
       total: 150,
     });
+  });
+});
+
+describe('hasTokenMismatch', () => {
+  it('returns false when tokens add up correctly', () => {
+    expect(
+      hasTokenMismatch({
+        inputTokens: 100,
+        cachedTokens: 0,
+        outputTokens: 50,
+        reasoningTokens: 0,
+        totalTokens: 150,
+      })
+    ).toBe(false);
+  });
+
+  it('returns false when tokens add up with cached included', () => {
+    expect(
+      hasTokenMismatch({
+        inputTokens: 100,
+        cachedTokens: 80,
+        outputTokens: 50,
+        reasoningTokens: 0,
+        totalTokens: 150,
+      })
+    ).toBe(false);
+  });
+
+  it('returns true when any token value is negative', () => {
+    expect(
+      hasTokenMismatch({
+        inputTokens: -10,
+        cachedTokens: 0,
+        outputTokens: 50,
+        reasoningTokens: 0,
+        totalTokens: 40,
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when total tokens is negative', () => {
+    expect(
+      hasTokenMismatch({
+        inputTokens: 100,
+        cachedTokens: 0,
+        outputTokens: 50,
+        reasoningTokens: 0,
+        totalTokens: -50,
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when total does not match input + output', () => {
+    expect(
+      hasTokenMismatch({
+        inputTokens: 100,
+        cachedTokens: 0,
+        outputTokens: 50,
+        reasoningTokens: 0,
+        totalTokens: 500,
+      })
+    ).toBe(true);
+  });
+
+  it('returns false within small rounding tolerance', () => {
+    expect(
+      hasTokenMismatch({
+        inputTokens: 100,
+        cachedTokens: 0,
+        outputTokens: 50,
+        reasoningTokens: 0,
+        totalTokens: 151,
+      })
+    ).toBe(false);
   });
 });

--- a/static/app/views/insights/pages/agents/utils/tokenBreakdown.spec.ts
+++ b/static/app/views/insights/pages/agents/utils/tokenBreakdown.spec.ts
@@ -245,4 +245,19 @@ describe('hasTokenMismatch', () => {
       })
     ).toBe(false);
   });
+
+  it('returns true when displayed values do not add up due to clamping', () => {
+    // input=5796, cached=9500, output=4, total=5800
+    // Raw: adjustedInput(5796) + output(4) = 5800 = total ✓
+    // Display: netNewInput=max(0, 5796-9500)=0, so 0+9500+4=9504 ≠ 5800 ✗
+    expect(
+      hasTokenMismatch({
+        inputTokens: 5796,
+        cachedTokens: 9500,
+        outputTokens: 4,
+        reasoningTokens: 0,
+        totalTokens: 5800,
+      })
+    ).toBe(true);
+  });
 });

--- a/static/app/views/insights/pages/agents/utils/tokenBreakdown.spec.ts
+++ b/static/app/views/insights/pages/agents/utils/tokenBreakdown.spec.ts
@@ -231,4 +231,18 @@ describe('hasTokenMismatch', () => {
       })
     ).toBe(false);
   });
+
+  it('returns false when cached exceeds input but total still matches', () => {
+    // OTel: input=100 includes cached=80, output=50, total=150
+    // netNewInput would be clamped to 20, but adjusted input (100) + output (50) = total
+    expect(
+      hasTokenMismatch({
+        inputTokens: 100,
+        cachedTokens: 80,
+        outputTokens: 50,
+        reasoningTokens: 0,
+        totalTokens: 150,
+      })
+    ).toBe(false);
+  });
 });

--- a/static/app/views/insights/pages/agents/utils/tokenBreakdown.ts
+++ b/static/app/views/insights/pages/agents/utils/tokenBreakdown.ts
@@ -48,6 +48,51 @@ export function getTokenBreakdown({
 }
 
 /**
+ * Checks whether the reported token counts look wrong.
+ *
+ * Returns `true` when any value is negative or when the breakdown
+ * (input + output, after adjustments for cached/reasoning) doesn't
+ * add up to `total` within a small tolerance.
+ */
+export function hasTokenMismatch({
+  inputTokens,
+  cachedTokens,
+  outputTokens,
+  reasoningTokens,
+  totalTokens,
+}: {
+  cachedTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  totalTokens: number;
+}): boolean {
+  if (
+    inputTokens < 0 ||
+    outputTokens < 0 ||
+    totalTokens < 0 ||
+    cachedTokens < 0 ||
+    reasoningTokens < 0
+  ) {
+    return true;
+  }
+
+  const breakdown = getTokenBreakdown({
+    inputTokens,
+    cachedTokens,
+    outputTokens,
+    reasoningTokens,
+    totalTokens,
+  });
+
+  const sum = breakdown.netNewInput + breakdown.cached + breakdown.output;
+
+  // Allow a small tolerance for rounding
+  const tolerance = Math.max(1, totalTokens * 0.01);
+  return Math.abs(sum - breakdown.total) > tolerance;
+}
+
+/**
  * Some providers report `inputTokens` exclusive of cached; others inclusive.
  * We pick whichever interpretation makes `input + output` closest to `total`.
  */

--- a/static/app/views/insights/pages/agents/utils/tokenBreakdown.ts
+++ b/static/app/views/insights/pages/agents/utils/tokenBreakdown.ts
@@ -90,9 +90,18 @@ export function hasTokenMismatch({
 
   const sum = adjustedInput + adjustedOutput;
 
+  // Also check if the displayed values (after clamping) don't add up.
+  // netNewInput is clamped to 0 when cached > adjustedInput, so the
+  // displayed sum can differ from total even when raw values match.
+  const netNewInput = cached > 0 ? Math.max(0, adjustedInput - cached) : adjustedInput;
+  const displayedSum = netNewInput + cached + adjustedOutput;
+
   // Allow a small tolerance for rounding
   const tolerance = Math.max(1, totalTokens * 0.01);
-  return Math.abs(sum - totalTokens) > tolerance;
+  return (
+    Math.abs(sum - totalTokens) > tolerance ||
+    Math.abs(displayedSum - totalTokens) > tolerance
+  );
 }
 
 /**

--- a/static/app/views/insights/pages/agents/utils/tokenBreakdown.ts
+++ b/static/app/views/insights/pages/agents/utils/tokenBreakdown.ts
@@ -77,19 +77,22 @@ export function hasTokenMismatch({
     return true;
   }
 
-  const breakdown = getTokenBreakdown({
-    inputTokens,
-    cachedTokens,
-    outputTokens,
-    reasoningTokens,
-    totalTokens,
-  });
+  const cached = isNaN(cachedTokens) ? 0 : cachedTokens;
+  const reasoning = isNaN(reasoningTokens) ? 0 : reasoningTokens;
 
-  const sum = breakdown.netNewInput + breakdown.cached + breakdown.output;
+  const adjustedInput = getAdjustedInput(inputTokens, cached, outputTokens, totalTokens);
+  const adjustedOutput = getAdjustedOutput(
+    adjustedInput,
+    outputTokens,
+    reasoning,
+    totalTokens
+  );
+
+  const sum = adjustedInput + adjustedOutput;
 
   // Allow a small tolerance for rounding
   const tolerance = Math.max(1, totalTokens * 0.01);
-  return Math.abs(sum - breakdown.total) > tolerance;
+  return Math.abs(sum - totalTokens) > tolerance;
 }
 
 /**

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
@@ -162,4 +162,34 @@ describe('getHighlightedSpanAttributes', () => {
 
     expect(result.find(attr => attr.name === 'Context Utilization')).toBeUndefined();
   });
+
+  it('should include cost attribute when cost is negative', () => {
+    const attributes = {
+      'gen_ai.operation.type': 'ai_client',
+      'gen_ai.cost.total_tokens': '-0.05',
+    };
+
+    const result = getHighlightedSpanAttributes({
+      spanId: '123',
+      attributes,
+    });
+
+    expect(result.find(attr => attr.name === 'Cost')).toBeDefined();
+  });
+
+  it('should include tokens attribute when values are present', () => {
+    const attributes = {
+      'gen_ai.operation.type': 'ai_client',
+      'gen_ai.usage.input_tokens': '100',
+      'gen_ai.usage.output_tokens': '50',
+      'gen_ai.usage.total_tokens': '150',
+    };
+
+    const result = getHighlightedSpanAttributes({
+      spanId: '123',
+      attributes,
+    });
+
+    expect(result.find(attr => attr.name === 'Tokens')).toBeDefined();
+  });
 });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -157,7 +157,7 @@ function getAISpanAttributes({
       value:
         costValue < 0 ? (
           <Flex align="center" gap="xs">
-            <TokenReportingWarningIcon />
+            <TokenReportingWarningIcon reason="negative_cost" />
             <LLMCosts cost={totalCosts.toString()} />
           </Flex>
         ) : (
@@ -402,7 +402,7 @@ function HighlightedTokenAttributes({
   if (mismatch) {
     return (
       <Flex align="center" gap="xs">
-        <TokenReportingWarningIcon />
+        <TokenReportingWarningIcon reason="token_mismatch" />
         {tokenDisplay}
       </Flex>
     );
@@ -468,18 +468,24 @@ function HighlightedContextUtilization({
 const TOKEN_TROUBLESHOOTING_URL =
   'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
 
-function TokenReportingWarningIcon() {
+function TokenReportingWarningIcon({
+  reason,
+}: {
+  reason: 'token_mismatch' | 'negative_cost';
+}) {
+  const title =
+    reason === 'token_mismatch'
+      ? tct(
+          'Input and output token counts do not add up to the reported total. This may indicate an error in token reporting. [link:Learn more].',
+          {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
+        )
+      : tct(
+          'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
+          {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
+        );
+
   return (
-    <Tooltip
-      title={tct(
-        'This may indicate an error in token reporting. [link:Follow this guide] to troubleshoot.',
-        {
-          link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />,
-        }
-      )}
-      skipWrapper
-      isHoverable
-    >
+    <Tooltip title={title} skipWrapper isHoverable>
       <Flex align="center">
         <IconWarning legacySize="1em" variant="warning" />
       </Flex>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -7,10 +7,13 @@ import {Container, Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
+import {ExternalLink} from 'sentry/components/links/externalLink';
 import {StructuredData} from 'sentry/components/structuredEventData';
-import {t, tn} from 'sentry/locale';
+import {IconWarning} from 'sentry/icons';
+import {t, tct, tn} from 'sentry/locale';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {NegativeCostWarning} from 'sentry/views/insights/common/components/tableCells/currencyCell';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
@@ -20,7 +23,10 @@ import {
   getToolSpansFilter,
 } from 'sentry/views/insights/pages/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
-import {getTokenBreakdown} from 'sentry/views/insights/pages/agents/utils/tokenBreakdown';
+import {
+  getTokenBreakdown,
+  hasTokenMismatch,
+} from 'sentry/views/insights/pages/agents/utils/tokenBreakdown';
 import {SpanFields} from 'sentry/views/insights/types';
 import {tryParseJsonRecursive} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 
@@ -145,10 +151,18 @@ function getAISpanAttributes({
   }
 
   const totalCosts = attributes['gen_ai.cost.total_tokens'];
-  if (totalCosts && Number(totalCosts) > 0) {
+  if (totalCosts && Number(totalCosts) !== 0) {
+    const costValue = Number(totalCosts);
     highlightedAttributes.push({
       name: t('Cost'),
-      value: <LLMCosts cost={totalCosts.toString()} />,
+      value:
+        costValue < 0 ? (
+          <NegativeCostWarning>
+            <LLMCosts cost={totalCosts.toString()} />
+          </NegativeCostWarning>
+        ) : (
+          <LLMCosts cost={totalCosts.toString()} />
+        ),
     });
   }
 
@@ -329,13 +343,15 @@ function HighlightedTokenAttributes({
   reasoningTokens: number;
   totalTokens: number;
 }) {
-  const breakdown = getTokenBreakdown({
+  const tokenArgs = {
     inputTokens,
     cachedTokens,
     outputTokens,
     reasoningTokens,
     totalTokens,
-  });
+  };
+  const breakdown = getTokenBreakdown(tokenArgs);
+  const mismatch = hasTokenMismatch(tokenArgs);
 
   const hasCached = breakdown.cached > 0;
 
@@ -379,6 +395,7 @@ function HighlightedTokenAttributes({
           {' = '}
           <Count value={breakdown.total} /> {t('total')}
         </Container>
+        {mismatch && <TokenMismatchIcon />}
       </TokensSpan>
     </Tooltip>
   );
@@ -434,6 +451,32 @@ function HighlightedContextUtilization({
   return (
     <Tooltip title={tooltipContent}>
       <TokensSpan>{inlineValue}</TokensSpan>
+    </Tooltip>
+  );
+}
+
+const TOKEN_TROUBLESHOOTING_URL =
+  'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
+
+function TokenMismatchIcon() {
+  return (
+    <Tooltip
+      title={tct(
+        'Token counts do not add up correctly, which may indicate an error in token reporting. [link:Follow this guide] to troubleshoot.',
+        {
+          link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />,
+        }
+      )}
+      skipWrapper
+      isHoverable
+    >
+      <Container
+        as="span"
+        display="inline-flex"
+        style={{verticalAlign: 'middle', marginLeft: 4}}
+      >
+        <IconWarning legacySize="1em" variant="warning" />
+      </Container>
     </Tooltip>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -3,8 +3,7 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import {Tag} from '@sentry/scraps/badge';
-import {InfoText} from '@sentry/scraps/info';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
@@ -157,13 +156,10 @@ function getAISpanAttributes({
       name: t('Cost'),
       value:
         costValue < 0 ? (
-          <Stack gap="xs">
-            <Flex align="center" gap="xs">
-              <IconWarning legacySize="1em" variant="warning" />
-              <LLMCosts cost={totalCosts.toString()} />
-            </Flex>
-            <TokenReportingWarningText />
-          </Stack>
+          <Flex align="center" gap="xs">
+            <TokenReportingWarningIcon />
+            <LLMCosts cost={totalCosts.toString()} />
+          </Flex>
         ) : (
           <LLMCosts cost={totalCosts.toString()} />
         ),
@@ -405,13 +401,10 @@ function HighlightedTokenAttributes({
 
   if (mismatch) {
     return (
-      <Stack gap="xs">
-        <Flex align="center" gap="xs">
-          <IconWarning legacySize="1em" variant="warning" />
-          {tokenDisplay}
-        </Flex>
-        <TokenReportingWarningText />
-      </Stack>
+      <Flex align="center" gap="xs">
+        <TokenReportingWarningIcon />
+        {tokenDisplay}
+      </Flex>
     );
   }
 
@@ -475,20 +468,22 @@ function HighlightedContextUtilization({
 const TOKEN_TROUBLESHOOTING_URL =
   'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
 
-function TokenReportingWarningText() {
+function TokenReportingWarningIcon() {
   return (
-    <InfoText
-      size="sm"
-      variant="warning"
+    <Tooltip
       title={tct(
-        'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
+        'This may indicate an error in token reporting. [link:Follow this guide] to troubleshoot.',
         {
           link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />,
         }
       )}
+      skipWrapper
+      isHoverable
     >
-      {t('This may indicate an error in token reporting.')}
-    </InfoText>
+      <Flex align="center">
+        <IconWarning legacySize="1em" variant="warning" />
+      </Flex>
+    </Tooltip>
   );
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -136,7 +136,7 @@ function getAISpanAttributes({
   const reasoningTokens = attributes['gen_ai.usage.output_tokens.reasoning'];
   const totalTokens = attributes['gen_ai.usage.total_tokens'];
 
-  if (inputTokens && outputTokens && totalTokens && Number(totalTokens) > 0) {
+  if (inputTokens && outputTokens && totalTokens && Number(totalTokens) !== 0) {
     highlightedAttributes.push({
       name: t('Tokens'),
       value: (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import {Tag} from '@sentry/scraps/badge';
+import {InfoText} from '@sentry/scraps/info';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -157,8 +158,16 @@ function getAISpanAttributes({
       value:
         costValue < 0 ? (
           <Flex align="center" gap="xs">
-            <TokenReportingWarningIcon reason="negative_cost" />
-            <LLMCosts cost={totalCosts.toString()} />
+            <IconWarning legacySize="1em" variant="warning" />
+            <InfoText
+              variant="warning"
+              title={tct(
+                'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
+                {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
+              )}
+            >
+              <LLMCosts cost={totalCosts.toString()} />
+            </InfoText>
           </Flex>
         ) : (
           <LLMCosts cost={totalCosts.toString()} />
@@ -355,7 +364,49 @@ function HighlightedTokenAttributes({
 
   const hasCached = breakdown.cached > 0;
 
-  const tokenDisplay = (
+  const tokenSummary = (
+    <Fragment>
+      <Container as="span" display="inline-block">
+        <Count value={breakdown.netNewInput} /> {t('in')}
+      </Container>
+      {hasCached && (
+        <Fragment>
+          {' '}
+          <Container as="span" display="inline-block">
+            {' + '}
+            <Count value={breakdown.cached} /> {t('cached')}
+          </Container>
+        </Fragment>
+      )}{' '}
+      <Container as="span" display="inline-block">
+        {' + '}
+        <Count value={breakdown.output} /> {t('out')}
+      </Container>{' '}
+      <Container as="span" display="inline-block">
+        {' = '}
+        <Count value={breakdown.total} /> {t('total')}
+      </Container>
+    </Fragment>
+  );
+
+  if (mismatch) {
+    return (
+      <Flex align="center" gap="xs">
+        <IconWarning legacySize="1em" variant="warning" />
+        <InfoText
+          variant="warning"
+          title={tct(
+            'Input and output token counts do not add up to the reported total. This may indicate an error in token reporting. [link:Learn more].',
+            {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
+          )}
+        >
+          {tokenSummary}
+        </InfoText>
+      </Flex>
+    );
+  }
+
+  return (
     <Tooltip
       title={
         <TokensTooltipTitle>
@@ -374,41 +425,9 @@ function HighlightedTokenAttributes({
         </TokensTooltipTitle>
       }
     >
-      <TokensSpan>
-        <Container as="span" display="inline-block">
-          <Count value={breakdown.netNewInput} /> {t('in')}
-        </Container>
-        {hasCached && (
-          <Fragment>
-            {' '}
-            <Container as="span" display="inline-block">
-              {' + '}
-              <Count value={breakdown.cached} /> {t('cached')}
-            </Container>
-          </Fragment>
-        )}{' '}
-        <Container as="span" display="inline-block">
-          {' + '}
-          <Count value={breakdown.output} /> {t('out')}
-        </Container>{' '}
-        <Container as="span" display="inline-block">
-          {' = '}
-          <Count value={breakdown.total} /> {t('total')}
-        </Container>
-      </TokensSpan>
+      <TokensSpan>{tokenSummary}</TokensSpan>
     </Tooltip>
   );
-
-  if (mismatch) {
-    return (
-      <Flex align="center" gap="xs">
-        <TokenReportingWarningIcon reason="token_mismatch" />
-        {tokenDisplay}
-      </Flex>
-    );
-  }
-
-  return tokenDisplay;
 }
 
 function HighlightedContextUtilization({
@@ -467,31 +486,6 @@ function HighlightedContextUtilization({
 
 const TOKEN_TROUBLESHOOTING_URL =
   'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
-
-function TokenReportingWarningIcon({
-  reason,
-}: {
-  reason: 'token_mismatch' | 'negative_cost';
-}) {
-  const title =
-    reason === 'token_mismatch'
-      ? tct(
-          'Input and output token counts do not add up to the reported total. This may indicate an error in token reporting. [link:Learn more].',
-          {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
-        )
-      : tct(
-          'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
-          {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
-        );
-
-  return (
-    <Tooltip title={title} skipWrapper isHoverable>
-      <Flex align="center">
-        <IconWarning legacySize="1em" variant="warning" />
-      </Flex>
-    </Tooltip>
-  );
-}
 
 const TokensTooltipTitle = styled('div')`
   display: grid;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -17,7 +17,10 @@ import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTra
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
-import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
+import {
+  NegativeCostInfo,
+  TOKEN_TROUBLESHOOTING_URL,
+} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
 import {resolveAgentName} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import {
   getIsAiAgentSpan,
@@ -435,9 +438,6 @@ function HighlightedContextUtilization({
 
   return <InfoText title={tooltipContent}>{inlineText}</InfoText>;
 }
-
-const TOKEN_TROUBLESHOOTING_URL =
-  'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
 
 const TokensTooltipTitle = styled('div')`
   display: grid;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -382,7 +382,7 @@ function HighlightedTokenAttributes({
   if (mismatch) {
     return (
       <Flex align="center" gap="xs">
-        <IconWarning legacySize="1em" variant="warning" />
+        <IconWarning size="xs" variant="warning" />
         <InfoText
           variant="warning"
           title={tct(

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -9,7 +9,6 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {ExternalLink} from 'sentry/components/links/externalLink';
 import {StructuredData} from 'sentry/components/structuredEventData';
-import {IconWarning} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
@@ -381,18 +380,15 @@ function HighlightedTokenAttributes({
 
   if (mismatch) {
     return (
-      <Flex align="center" gap="xs">
-        <IconWarning size="xs" variant="warning" />
-        <InfoText
-          variant="warning"
-          title={tct(
-            'Input and output token counts do not add up to the reported total. This may indicate an error in token reporting. [link:Learn more].',
-            {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
-          )}
-        >
-          {tokenSummary}
-        </InfoText>
-      </Flex>
+      <InfoText
+        variant="warning"
+        title={tct(
+          'Input and output token counts do not add up to the reported total. This may indicate an error in token reporting. [link:Learn more].',
+          {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
+        )}
+      >
+        {tokenSummary}
+      </InfoText>
     );
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/react';
 
 import {Tag} from '@sentry/scraps/badge';
 import {InfoText} from '@sentry/scraps/info';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
@@ -12,6 +12,7 @@ import {ExternalLink} from 'sentry/components/links/externalLink';
 import {StructuredData} from 'sentry/components/structuredEventData';
 import {IconWarning} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
@@ -295,7 +296,9 @@ function HighlightedTools({
   const hasToolNames = toolNames.length > 0;
   const toolSpansQuery = useSpans(
     {
-      search: `parent_span:${spanId} has:${SpanFields.GEN_AI_TOOL_NAME} ${getToolSpansFilter()}`,
+      search: `parent_span:${spanId} has:${
+        SpanFields.GEN_AI_TOOL_NAME
+      } ${getToolSpansFilter()}`,
       fields: [SpanFields.GEN_AI_TOOL_NAME],
       enabled: hasToolNames,
     },
@@ -364,29 +367,24 @@ function HighlightedTokenAttributes({
 
   const hasCached = breakdown.cached > 0;
 
-  const tokenSummary = (
-    <Fragment>
-      <Container as="span" display="inline-block">
-        <Count value={breakdown.netNewInput} /> {t('in')}
-      </Container>
+  const abbr = formatAbbreviatedNumber;
+  const tokenSummary = `${abbr(breakdown.netNewInput)} ${t('in')}${hasCached ? ` + ${abbr(breakdown.cached)} ${t('cached')}` : ''} + ${abbr(breakdown.output)} ${t('out')} = ${abbr(breakdown.total)} ${t('total')}`;
+
+  const breakdownTooltip = (
+    <TokensTooltipTitle>
+      <span>{t('Input')}</span>
+      <span>{breakdown.netNewInput.toLocaleString()}</span>
       {hasCached && (
         <Fragment>
-          {' '}
-          <Container as="span" display="inline-block">
-            {' + '}
-            <Count value={breakdown.cached} /> {t('cached')}
-          </Container>
+          <span>{t('Cached')}</span>
+          <span>{breakdown.cached.toLocaleString()}</span>
         </Fragment>
-      )}{' '}
-      <Container as="span" display="inline-block">
-        {' + '}
-        <Count value={breakdown.output} /> {t('out')}
-      </Container>{' '}
-      <Container as="span" display="inline-block">
-        {' = '}
-        <Count value={breakdown.total} /> {t('total')}
-      </Container>
-    </Fragment>
+      )}
+      <span>{t('Output')}</span>
+      <span>{breakdown.output.toLocaleString()}</span>
+      <span>{t('Total')}</span>
+      <span>{breakdown.total.toLocaleString()}</span>
+    </TokensTooltipTitle>
   );
 
   if (mismatch) {
@@ -406,28 +404,7 @@ function HighlightedTokenAttributes({
     );
   }
 
-  return (
-    <Tooltip
-      title={
-        <TokensTooltipTitle>
-          <span>{t('Input')}</span>
-          <span>{breakdown.netNewInput.toLocaleString()}</span>
-          {hasCached && (
-            <Fragment>
-              <span>{t('Cached')}</span>
-              <span>{breakdown.cached.toLocaleString()}</span>
-            </Fragment>
-          )}
-          <span>{t('Output')}</span>
-          <span>{breakdown.output.toLocaleString()}</span>
-          <span>{t('Total')}</span>
-          <span>{breakdown.total.toLocaleString()}</span>
-        </TokensTooltipTitle>
-      }
-    >
-      <TokensSpan>{tokenSummary}</TokensSpan>
-    </Tooltip>
-  );
+  return <InfoText title={breakdownTooltip}>{tokenSummary}</InfoText>;
 }
 
 function HighlightedContextUtilization({

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -375,6 +375,7 @@ function HighlightedTokenAttributes({
       }
     >
       <TokensSpan>
+        {mismatch && <TokenMismatchIcon />}
         <Container as="span" display="inline-block">
           <Count value={breakdown.netNewInput} /> {t('in')}
         </Container>
@@ -395,7 +396,6 @@ function HighlightedTokenAttributes({
           {' = '}
           <Count value={breakdown.total} /> {t('total')}
         </Container>
-        {mismatch && <TokenMismatchIcon />}
       </TokensSpan>
     </Tooltip>
   );

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -3,7 +3,8 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import {Tag} from '@sentry/scraps/badge';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {InfoText} from '@sentry/scraps/info';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
@@ -13,7 +14,6 @@ import {IconWarning} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
-import {NegativeCostWarning} from 'sentry/views/insights/common/components/tableCells/currencyCell';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
@@ -157,9 +157,13 @@ function getAISpanAttributes({
       name: t('Cost'),
       value:
         costValue < 0 ? (
-          <NegativeCostWarning>
-            <LLMCosts cost={totalCosts.toString()} />
-          </NegativeCostWarning>
+          <Stack gap="xs">
+            <Flex align="center" gap="xs">
+              <IconWarning legacySize="1em" variant="warning" />
+              <LLMCosts cost={totalCosts.toString()} />
+            </Flex>
+            <TokenReportingWarningText />
+          </Stack>
         ) : (
           <LLMCosts cost={totalCosts.toString()} />
         ),
@@ -355,7 +359,7 @@ function HighlightedTokenAttributes({
 
   const hasCached = breakdown.cached > 0;
 
-  return (
+  const tokenDisplay = (
     <Tooltip
       title={
         <TokensTooltipTitle>
@@ -375,7 +379,6 @@ function HighlightedTokenAttributes({
       }
     >
       <TokensSpan>
-        {mismatch && <TokenMismatchIcon />}
         <Container as="span" display="inline-block">
           <Count value={breakdown.netNewInput} /> {t('in')}
         </Container>
@@ -399,6 +402,20 @@ function HighlightedTokenAttributes({
       </TokensSpan>
     </Tooltip>
   );
+
+  if (mismatch) {
+    return (
+      <Stack gap="xs">
+        <Flex align="center" gap="xs">
+          <IconWarning legacySize="1em" variant="warning" />
+          {tokenDisplay}
+        </Flex>
+        <TokenReportingWarningText />
+      </Stack>
+    );
+  }
+
+  return tokenDisplay;
 }
 
 function HighlightedContextUtilization({
@@ -458,26 +475,20 @@ function HighlightedContextUtilization({
 const TOKEN_TROUBLESHOOTING_URL =
   'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
 
-function TokenMismatchIcon() {
+function TokenReportingWarningText() {
   return (
-    <Tooltip
+    <InfoText
+      size="sm"
+      variant="warning"
       title={tct(
-        'Token counts do not add up correctly, which may indicate an error in token reporting. [link:Follow this guide] to troubleshoot.',
+        'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
         {
           link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />,
         }
       )}
-      skipWrapper
-      isHoverable
     >
-      <Container
-        as="span"
-        display="inline-flex"
-        style={{verticalAlign: 'middle', marginLeft: 4}}
-      >
-        <IconWarning legacySize="1em" variant="warning" />
-      </Container>
-    </Tooltip>
+      {t('This may indicate an error in token reporting.')}
+    </InfoText>
   );
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -7,7 +7,6 @@ import {InfoText} from '@sentry/scraps/info';
 import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {Count} from 'sentry/components/count';
 import {ExternalLink} from 'sentry/components/links/externalLink';
 import {StructuredData} from 'sentry/components/structuredEventData';
 import {IconWarning} from 'sentry/icons';
@@ -420,20 +419,10 @@ function HighlightedContextUtilization({
   const tokensUsed =
     windowSize === undefined ? totalTokens : Math.round(utilization * windowSize);
 
-  const inlineValue = (
-    <Fragment>
-      {percentage}%
-      {tokensUsed !== undefined && windowSize !== undefined && (
-        <Fragment>
-          {' ('}
-          <Count value={tokensUsed} />
-          {' / '}
-          <Count value={windowSize} />
-          {')'}
-        </Fragment>
-      )}
-    </Fragment>
-  );
+  const inlineText =
+    tokensUsed !== undefined && windowSize !== undefined
+      ? `${percentage}% (${formatAbbreviatedNumber(tokensUsed)} / ${formatAbbreviatedNumber(windowSize)})`
+      : `${percentage}%`;
 
   const tooltipContent = (
     <TokensTooltipTitle>
@@ -454,11 +443,7 @@ function HighlightedContextUtilization({
     </TokensTooltipTitle>
   );
 
-  return (
-    <Tooltip title={tooltipContent}>
-      <TokensSpan>{inlineValue}</TokensSpan>
-    </Tooltip>
-  );
+  return <InfoText title={tooltipContent}>{inlineText}</InfoText>;
 }
 
 const TOKEN_TROUBLESHOOTING_URL =
@@ -474,10 +459,4 @@ const TokensTooltipTitle = styled('div')`
     text-align: right;
   }
   gap: ${p => p.theme.space.xs};
-`;
-
-const TokensSpan = styled('span')`
-  border-bottom: 1px dashed ${p => p.theme.tokens.border.primary};
-  -webkit-box-decoration-break: clone;
-  box-decoration-break: clone;
 `;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -17,8 +17,8 @@ import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTra
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
+import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
 import {resolveAgentName} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
-import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
 import {
   getIsAiAgentSpan,
   getToolSpansFilter,
@@ -158,18 +158,7 @@ function getAISpanAttributes({
       name: t('Cost'),
       value:
         costValue < 0 ? (
-          <Flex align="center" gap="xs">
-            <IconWarning legacySize="1em" variant="warning" />
-            <InfoText
-              variant="warning"
-              title={tct(
-                'Negative costs indicate an error in token count reporting. [link:Follow this guide] to troubleshoot.',
-                {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
-              )}
-            >
-              {formatLLMCosts(totalCosts.toString())}
-            </InfoText>
-          </Flex>
+          <NegativeCostInfo cost={totalCosts.toString()} />
         ) : (
           <LLMCosts cost={totalCosts.toString()} />
         ),

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -18,6 +18,7 @@ import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
 import {resolveAgentName} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
+import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
 import {
   getIsAiAgentSpan,
   getToolSpansFilter,
@@ -166,7 +167,7 @@ function getAISpanAttributes({
                 {link: <ExternalLink href={TOKEN_TROUBLESHOOTING_URL} />}
               )}
             >
-              <LLMCosts cost={totalCosts.toString()} />
+              {formatLLMCosts(totalCosts.toString())}
             </InfoText>
           </Flex>
         ) : (


### PR DESCRIPTION
Add warning indicators to the promoted token and cost attributes in the span detail view when values look incorrect.

**Token mismatch**: When token counts don't add up (total ≠ input + output after adjustments for cached/reasoning tokens) or any value is negative, token summary has a warning-styled `InfoText` tooltip explaining the mismatch and linking to troubleshooting docs.

**Negative cost**: Negative costs now display the actual negative value (e.g. `-$0.03`) instead of being hidden or showing `<$0.01`. `InfoText` tooltip explains the issue.

**Consistent InfoText usage**: All promoted attributes with tooltips (tokens, cost, context utilization) now use the `InfoText` component from scraps for accessible, discoverable tooltips with underline decoration.

Changes:
- `tokenBreakdown.ts`: new `hasTokenMismatch` helper that detects negative values or sum mismatches
- `formatLLMCosts.ts`: show actual negative values instead of `<$0.01`
- `highlightedAttributes.tsx`: migrate all promoted attribute tooltips to `InfoText`, add warning states for token mismatch and negative cost

Before:
<img width="900" height="356" alt="CleanShot 2026-06-09 at 10 15 45@2x" src="https://github.com/user-attachments/assets/aee563ae-aefc-4282-b781-210db7898662" />

After:
<img width="900" height="356" alt="CleanShot 2026-06-09 at 10 14 50@2x" src="https://github.com/user-attachments/assets/d5e77457-f066-46ae-8223-fbbc8d50a0f0" />


Closes TET-2444