### PR TITLE
feat(seer): Add issue troubleshooting context

### DIFF
--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -2,7 +2,7 @@ import logging
 import time
 import uuid
 from datetime import UTC, datetime, timedelta, timezone
-from typing import Any, cast
+from typing import Any, TypedDict, cast
 
 from django.core.exceptions import BadRequest
 from django.db import models
@@ -34,6 +34,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey, ProjectKeyStatus, UseCase
 from sentry.models.repository import Repository
+from sentry.processing_errors.grouptype import LowValueSpanConfigurationType
 from sentry.replays.post_process import process_raw_response
 from sentry.replays.query import (
     query_replay_id_by_prefix,
@@ -1129,6 +1130,50 @@ _SEER_EXPLORER_ACTIVITY_TYPES = [
 ]
 
 
+class _IssueTroubleshootingContext(TypedDict):
+    # These fields are added to serialized group data, which uses camelCase API keys.
+    detectionContext: str | None
+    troubleshootingHint: str | None
+
+
+def _get_issue_troubleshooting_context(
+    group: Group, event: Event | GroupEvent | None = None
+) -> _IssueTroubleshootingContext:
+    if group.type == LowValueSpanConfigurationType.type_id:
+        occurrence = getattr(event, "occurrence", None)
+        evidence_data = occurrence.evidence_data if occurrence else {}
+        span_origin = evidence_data.get("span_origin")
+
+        troubleshooting_hint = (
+            "If the span is manually instrumented, remove the instrumentation that creates "
+            "it. Otherwise, filter the automatically created span before sending, typically "
+            "in Sentry SDK initialization."
+        )
+        if span_origin == "manual":
+            troubleshooting_hint = (
+                "Remove the manually instrumented span code that creates this span."
+            )
+        elif span_origin:
+            troubleshooting_hint = (
+                "Filter this automatically created span before sending, typically in Sentry SDK "
+                "initialization."
+            )
+
+        return {
+            "detectionContext": (
+                "This issue was created by a Sentry detector, not by an exception in the "
+                "application. It reports a high-volume span with low telemetry value so the "
+                "project can reduce noisy telemetry."
+            ),
+            "troubleshootingHint": troubleshooting_hint,
+        }
+
+    return {
+        "detectionContext": None,
+        "troubleshootingHint": None,
+    }
+
+
 def get_issue_and_event_response(
     event: Event | GroupEvent,
     group: Group | None,
@@ -1151,6 +1196,7 @@ def get_issue_and_event_response(
         serialized_group = dict(serialize(group, user=None, serializer=GroupSerializer()))
         # Add issueTypeDescription as it provides better context for LLMs. Note the initial type should be BaseGroupSerializerResponse.
         serialized_group["issueTypeDescription"] = group.issue_type.description
+        serialized_group.update(_get_issue_troubleshooting_context(group, event))
 
         logger.info(
             "get_issue_and_event_details_v2: Querying for tags overview",
@@ -1275,6 +1321,7 @@ def get_issue_details(
     serialized_group = dict(serialize(group, user=None, serializer=GroupSerializer()))
     # Add issueTypeDescription as it provides better context for LLMs. Note the initial type should be BaseGroupSerializerResponse.
     serialized_group["issueTypeDescription"] = group.issue_type.description
+    serialized_group.update(_get_issue_troubleshooting_context(group))
 
     # Get aggregate tag and event data and activity.
     try:

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -15,6 +15,7 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.repository import Repository
+from sentry.processing_errors.grouptype import LowValueSpanConfigurationType
 from sentry.replays.testutils import mock_replay, mock_replay_click
 from sentry.search.utils import parse_iso_timestamp
 from sentry.seer.agent.tools import (
@@ -982,6 +983,8 @@ class _IssueMetadata(BaseModel):
     type: str
     issueType: str
     issueTypeDescription: str  # Extra field added by get_issue_and_event_details.
+    detectionContext: str | None  # Extra field added by get_issue_and_event_details.
+    troubleshootingHint: str | None  # Extra field added by get_issue_and_event_details.
     issueCategory: str
     hasSeen: bool
     project: _Project
@@ -1498,6 +1501,8 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, SearchIssueTest
         self._assert_issue_response_shape(result)
         assert result["issue"]["id"] == str(group.id)
         assert result["issue"]["issueTypeDescription"] == group.issue_type.description
+        assert result["issue"]["detectionContext"] is None
+        assert result["issue"]["troubleshootingHint"] is None
         assert result["project_id"] == group.project_id
         assert result["project_slug"] == group.project.slug
 
@@ -1522,6 +1527,28 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, SearchIssueTest
         assert result["issue"]["id"] == str(group.id)
         assert result["project_id"] == group.project_id
         assert result["project_slug"] == group.project.slug
+
+    @patch("sentry.seer.agent.tools._get_issue_event_timeseries")
+    @patch("sentry.seer.agent.tools.get_all_tags_overview")
+    def test_low_value_span_issue_context(self, mock_tags, mock_ts):
+        mock_ts.return_value = ({"count()": {"data": []}}, "6h", "15m")
+        mock_tags.return_value = {"tags_overview": []}
+        group = self.create_group(
+            project=self.project,
+            type=LowValueSpanConfigurationType.type_id,
+        )
+
+        result = get_issue_details(
+            organization_id=self.organization.id,
+            issue_id=str(group.id),
+        )
+
+        assert isinstance(result, dict)
+        self._assert_issue_response_shape(result)
+        assert "Sentry detector" in result["issue"]["detectionContext"]
+        assert "low telemetry value" in result["issue"]["detectionContext"]
+        assert "manually instrumented" in result["issue"]["troubleshootingHint"]
+        assert "filter the automatically created span" in result["issue"]["troubleshootingHint"]
 
     # --- timeseries ---
 


### PR DESCRIPTION
Add detector-aware troubleshooting context to Seer issue details. Seer now receives nullable `detectionContext` and `troubleshootingHint` fields alongside `issueTypeDescription`, giving issue-type-specific guidance without changing the Autofix step flow.

Currently root cause analysis can treat detector-created issues as if they are exceptions in the user's codebase. Low-value span issues now explain that they come from a Sentry detector and identify high-volume, low telemetry value spans as optimization opportunities.

**Low-Value Span Guidance**

Low-value span issues include a generic remediation hint by default. When the latest event occurrence evidence has `span_origin`, the hint is simplified to either remove manually instrumented span code or filter automatically created spans before sending. Other issue types leave both new fields unset.