### PR TITLE
feat(pr-metrics): Attribute PRs opened by Seer-delegated coding agents

### DIFF
--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -23,6 +23,8 @@ from sentry.api.utils import to_valid_int_id
 from sentry.integrations.cursor.integration import CursorAgentIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.utils.webhook_viewer_context import webhook_viewer_context
+from sentry.models.pullrequest import PullRequestAttributionSignalType
+from sentry.pr_metrics.attribution import attribute_delegated_agent_pull_request
 from sentry.seer.autofix.utils import (
     CodingAgentResult,
     CodingAgentStatus,
@@ -40,6 +42,9 @@ class CursorWebhookEndpoint(Endpoint):
     }
     authentication_classes = ()
     permission_classes = ()
+
+    # Set per-request in post(); a fresh endpoint instance is created per request.
+    organization_id: int
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
@@ -61,6 +66,7 @@ class CursorWebhookEndpoint(Endpoint):
             logger.warning("cursor_webhook.invalid_signature")
             raise PermissionDenied("Invalid signature")
 
+        self.organization_id = org_id
         with webhook_viewer_context(org_id):
             self._process_webhook(payload)
         logger.info("cursor_webhook.success", extra={"event_type": event_type})
@@ -227,6 +233,22 @@ class CursorWebhookEndpoint(Endpoint):
             agent_url=agent_url,
             result=result,
         )
+
+        if status == CodingAgentStatus.COMPLETED and pr_url:
+            try:
+                attribute_delegated_agent_pull_request(
+                    organization_id=self.organization_id,
+                    signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_CURSOR,
+                    repo_full_name=repo_full_name,
+                    repo_provider=repo_provider,
+                    pr_url=pr_url,
+                    agent_id=agent_id,
+                )
+            except Exception:
+                logger.exception(
+                    "cursor_webhook.pr_attribution_failed",
+                    extra={"agent_id": agent_id, "pr_url": pr_url},
+                )
 
     def _update_coding_agent_status(
         self,

--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -227,14 +227,14 @@ class CursorWebhookEndpoint(Endpoint):
             pr_url=pr_url if status == CodingAgentStatus.COMPLETED else None,
         )
 
-        self._update_coding_agent_status(
+        known_to_seer = self._update_coding_agent_status(
             agent_id=agent_id,
             status=status,
             agent_url=agent_url,
             result=result,
         )
 
-        if status == CodingAgentStatus.COMPLETED and pr_url:
+        if known_to_seer and status == CodingAgentStatus.COMPLETED and pr_url:
             try:
                 attribute_delegated_agent_pull_request(
                     organization_id=self.organization_id,
@@ -256,8 +256,8 @@ class CursorWebhookEndpoint(Endpoint):
         status: CodingAgentStatus,
         agent_url: str | None = None,
         result: CodingAgentResult | None = None,
-    ):
-        update_coding_agent_state(
+    ) -> bool:
+        known_to_seer = update_coding_agent_state(
             agent_id=agent_id,
             status=status,
             agent_url=agent_url,
@@ -271,3 +271,4 @@ class CursorWebhookEndpoint(Endpoint):
                 "has_result": result is not None,
             },
         )
+        return known_to_seer

--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -10,11 +10,13 @@ than collapsed into a single field.
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Mapping, Sequence
 from typing import Any
 
 from django.db.models import Q
 
+from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
@@ -107,6 +109,67 @@ def recompute_pull_request_attribution(pull_request: PullRequest) -> str | None:
     )
 
 
+def _attribute_pull_request(
+    *,
+    organization_id: int,
+    repo_name: str,
+    provider: str | None,
+    pr_number: int | str,
+    signal_type: PullRequestAttributionSignalType,
+    source: PullRequestAttributionSource,
+    signal_details: Mapping[str, Any] | None,
+    log_context: Mapping[str, Any],
+) -> None:
+    """Resolve the org-scoped ``Repository`` for a reported PR, find-or-create the
+    canonical ``PullRequest`` row (keyed on PR number), and idempotently record one
+    attribution signal. Shared by the Seer-native and delegated-agent paths.
+
+    A find-or-create here may run before the SCM ``opened`` webhook arrives, so the
+    ``PullRequest`` row can be a shell (no title/body); the GitHub webhook fills
+    those in later. We never overwrite them from this path.
+
+    Failures are logged and swallowed rather than raised, so a batch caller's
+    remaining PRs are unaffected.
+    """
+    normalized_provider = _normalize_provider(provider)
+    # A present-but-unrecognized provider means the source sent something we don't
+    # map — warn so it can be corrected upstream, but still attempt to resolve.
+    if normalized_provider is not None and normalized_provider not in _KNOWN_SCM_PROVIDERS:
+        logger.warning("seer.pr_attribution.unrecognized_provider", extra=log_context)
+
+    repository, resolution = _resolve_repository(
+        organization_id=organization_id,
+        repo_name=repo_name,
+        normalized_provider=normalized_provider,
+    )
+    if repository is None:
+        if resolution == "ambiguous":
+            logger.warning("seer.pr_attribution.repo_ambiguous", extra=log_context)
+        else:
+            logger.warning("seer.pr_attribution.repo_not_found", extra=log_context)
+        return
+
+    # get_or_create is race-safe via the unique constraints — Django retries the
+    # get on IntegrityError.
+    try:
+        pull_request, _ = PullRequest.objects.get_or_create(
+            organization_id=organization_id,
+            repository_id=repository.id,
+            key=str(pr_number),
+        )
+        record_attribution_signal(
+            pull_request=pull_request,
+            signal_type=signal_type,
+            source=source,
+            signal_details=signal_details,
+        )
+    except Exception:
+        logger.exception("seer.pr_attribution.record_failed", extra=log_context)
+        return
+
+    logger.info("seer.pr_attribution.recorded", extra=log_context)
+
+
 def attribute_seer_created_pull_requests(
     *,
     organization: Organization,
@@ -116,13 +179,11 @@ def attribute_seer_created_pull_requests(
 ) -> None:
     """Attribute PRs reported by Seer's ``seer.pr_created`` event to the Seer app.
 
-    For each reported PR: resolve the org-scoped ``Repository`` by name and
-    provider, find-or-create the canonical ``PullRequest`` row (keyed on the PR
-    number), and idempotently record a ``sentry_app`` attribution signal.
-
-    A find-or-create here may run before the SCM ``opened`` webhook arrives, so
-    the ``PullRequest`` row can be a shell (no title/body); the GitHub webhook
-    fills those in later. We never overwrite them from this path.
+    For each reported PR, record a ``sentry_app`` attribution signal. SENTRY_APP
+    covers both of our GitHub apps: Seer chooses between the Sentry and Seer apps
+    at push time (its write client falls back to the Seer app only when the Sentry
+    app lacks write access), but we don't distinguish them — both are
+    internal-agent authorship.
     """
     for entry in pull_requests:
         repo_name = entry.get("repo_name")
@@ -144,48 +205,16 @@ def attribute_seer_created_pull_requests(
             logger.warning("seer.pr_attribution.missing_fields", extra=log_context)
             continue
 
-        normalized_provider = _normalize_provider(provider)
-        # A present-but-unrecognized provider means Seer sent something we don't
-        # map — warn so it can be corrected upstream, but still attempt to resolve.
-        if normalized_provider is not None and normalized_provider not in _KNOWN_SCM_PROVIDERS:
-            logger.warning("seer.pr_attribution.unrecognized_provider", extra=log_context)
-
-        repository, resolution = _resolve_repository(
+        _attribute_pull_request(
             organization_id=organization.id,
             repo_name=repo_name,
-            normalized_provider=normalized_provider,
+            provider=provider,
+            pr_number=pr_number,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.SEER_DATA,
+            signal_details={"run_id": run_id, "group_id": group_id, "pr_url": pr_url},
+            log_context=log_context,
         )
-        if repository is None:
-            if resolution == "ambiguous":
-                logger.warning("seer.pr_attribution.repo_ambiguous", extra=log_context)
-            else:
-                logger.warning("seer.pr_attribution.repo_not_found", extra=log_context)
-            continue
-
-        # Isolate each PR: one entry's write failure must not drop the rest of
-        # the batch. (get_or_create itself is race-safe via the unique
-        # constraints — Django retries the get on IntegrityError.)
-        try:
-            pull_request, _ = PullRequest.objects.get_or_create(
-                organization_id=organization.id,
-                repository_id=repository.id,
-                key=str(pr_number),
-            )
-            # SENTRY_APP covers both of our GitHub apps: Seer chooses between the
-            # Sentry and Seer apps at push time (its write client falls back to
-            # the Seer app only when the Sentry app lacks write access), but we
-            # don't distinguish them — both are internal-agent authorship.
-            record_attribution_signal(
-                pull_request=pull_request,
-                signal_type=PullRequestAttributionSignalType.SENTRY_APP,
-                source=PullRequestAttributionSource.SEER_DATA,
-                signal_details={"run_id": run_id, "group_id": group_id, "pr_url": pr_url},
-            )
-        except Exception:
-            logger.exception("seer.pr_attribution.record_failed", extra=log_context)
-            continue
-
-        logger.info("seer.pr_attribution.recorded", extra=log_context)
 
 
 def _resolve_repository(
@@ -221,6 +250,73 @@ def _resolve_repository(
     if len(matches) == 1:
         return matches[0], "resolved"
     return None, "ambiguous" if matches else "not_found"
+
+
+def attribute_delegated_agent_pull_request(
+    *,
+    organization_id: int,
+    signal_type: PullRequestAttributionSignalType,
+    repo_full_name: str,
+    repo_provider: str,
+    pr_url: str,
+    agent_id: str | None = None,
+) -> None:
+    """Attribute a PR opened by a Seer-delegated coding agent (Cursor/Copilot/Claude).
+
+    Sentry learns of these PRs directly — by polling the agent (GitHub Copilot,
+    Claude Code) or via the agent's webhook (Cursor) — rather than from Seer's
+    ``seer.pr_created`` event, so attribution is recorded here at the detection
+    point. Callers pass the ``SEER_DELEGATED_*`` signal type for the authoring
+    agent; unlike Seer-native PRs we never attribute these to ``SENTRY_APP``.
+
+    Gated behind ``organizations:pr-metrics-attribution``. Best-effort: callers run
+    this inside the polling/webhook flow, so any failure is logged and swallowed
+    rather than allowed to interrupt that flow.
+    """
+    try:
+        organization = Organization.objects.get(id=organization_id, status=ObjectStatus.ACTIVE)
+    except Organization.DoesNotExist:
+        return
+
+    if not features.has("organizations:pr-metrics-attribution", organization):
+        return
+
+    pr_number = _parse_pr_number(pr_url)
+
+    log_context = {
+        "organization_id": organization_id,
+        "signal_type": signal_type,
+        "agent_id": agent_id,
+        "repo_name": repo_full_name,
+        "pr_url": pr_url,
+        "pr_number": pr_number,
+    }
+
+    if pr_number is None:
+        logger.warning("seer.pr_attribution.invalid_pr_url", extra=log_context)
+        return
+
+    _attribute_pull_request(
+        organization_id=organization_id,
+        repo_name=repo_full_name,
+        provider=repo_provider,
+        pr_number=pr_number,
+        signal_type=signal_type,
+        source=PullRequestAttributionSource.SEER_DATA,
+        signal_details={"agent_id": agent_id, "pr_url": pr_url},
+        log_context=log_context,
+    )
+
+
+def _parse_pr_number(pr_url: str) -> int | None:
+    """Extract the PR/MR number from a pull-request URL, or None if there isn't one.
+
+    Matches the number after a ``/pull/`` (GitHub) or ``/merge_requests/`` (GitLab)
+    segment specifically — a delegated agent can report a branch/``tree`` URL as its
+    result, and we must not mistake a trailing branch-name segment for a PR number.
+    """
+    match = re.search(r"/(?:pull|pulls|merge_requests)/(\d+)", pr_url)
+    return int(match.group(1)) if match else None
 
 
 def _normalize_provider(provider: str | None) -> str | None:

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -24,6 +24,8 @@ from sentry.integrations.coding_agent.utils import get_coding_agent_providers
 from sentry.integrations.github_copilot.client import GithubCopilotAgentClient
 from sentry.integrations.services.github_copilot_identity import github_copilot_identity_service
 from sentry.integrations.services.integration import integration_service
+from sentry.models.pullrequest import PullRequestAttributionSignalType
+from sentry.pr_metrics.attribution import attribute_delegated_agent_pull_request
 from sentry.seer.autofix.utils import (
     AutofixState,
     CodingAgentProviderType,
@@ -145,10 +147,17 @@ def poll_github_copilot_agents(
     autofix_state: AutofixState | None = None,
     user_id: int = 0,
     coding_agents: dict[str, Any] | None = None,
+    organization_id: int = 0,
 ) -> None:
     agents = coding_agents or (autofix_state.coding_agents if autofix_state else None)
     if not agents:
         return
+
+    # Mirror poll_claude_code_agents: fall back to the run's org when a caller
+    # passes autofix_state without an explicit organization_id.
+    organization_id = organization_id or (
+        autofix_state.request.organization_id if autofix_state else 0
+    )
 
     user_access_token: str | None = None
 
@@ -215,6 +224,22 @@ def poll_github_copilot_agents(
                         status=new_status,
                         result=result,
                     )
+
+                    if is_task_done and pr_url:
+                        try:
+                            attribute_delegated_agent_pull_request(
+                                organization_id=organization_id,
+                                signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_GITHUB_COPILOT,
+                                repo_full_name=f"{owner}/{repo}",
+                                repo_provider="github",
+                                pr_url=pr_url,
+                                agent_id=agent_id,
+                            )
+                        except Exception:
+                            logger.exception(
+                                "coding_agent.github_copilot.pr_attribution_failed",
+                                extra={"agent_id": agent_id, "pr_url": pr_url},
+                            )
 
                     logger.info(
                         "coding_agent.github_copilot.pr_update",
@@ -314,6 +339,22 @@ def poll_claude_agent(clients, agent_id, org_id, agent_state: CodingAgentState) 
                 status=new_status,
                 result=result,
             )
+
+            if new_status == CodingAgentStatus.COMPLETED and result is not None and result.pr_url:
+                try:
+                    attribute_delegated_agent_pull_request(
+                        organization_id=org_id,
+                        signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
+                        repo_full_name=result.repo_full_name,
+                        repo_provider=result.repo_provider,
+                        pr_url=result.pr_url,
+                        agent_id=agent_id,
+                    )
+                except Exception:
+                    logger.exception(
+                        "coding_agent.claude_code.pr_attribution_failed",
+                        extra={"agent_id": agent_id, "pr_url": result.pr_url},
+                    )
 
         logger.info(
             "coding_agent.claude_code.poll_update",

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -1029,9 +1029,10 @@ def update_coding_agent_state(
     status: CodingAgentStatus,
     agent_url: str | None = None,
     result: CodingAgentResult | None = None,
-) -> None:
+) -> bool:
     """Send coding agent state update to Seer.
 
+    Returns True if Seer accepted the update (2xx), False otherwise.
     Errors are logged and swallowed so that callers iterating over
     multiple agents are never interrupted by a single failed update.
     """
@@ -1053,7 +1054,7 @@ def update_coding_agent_state(
             "coding_agent.state_update_error",
             extra={"agent_id": agent_id},
         )
-        return
+        return False
 
     if response.status >= 400:
         logger.error(
@@ -1064,3 +1065,6 @@ def update_coding_agent_state(
                 "response": response.data.decode("utf-8"),
             },
         )
+        return False
+
+    return True

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -324,7 +324,9 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
             agent_providers = {a.provider for a in state.coding_agents.values()}
             if CodingAgentProviderType.GITHUB_COPILOT_AGENT in agent_providers:
                 poll_github_copilot_agents(
-                    coding_agents=state.coding_agents, user_id=request.user.id
+                    coding_agents=state.coding_agents,
+                    user_id=request.user.id,
+                    organization_id=group.organization.id,
                 )
             if CodingAgentProviderType.CLAUDE_CODE_AGENT in agent_providers:
                 poll_claude_code_agents(

--- a/tests/sentry/integrations/cursor/test_webhook.py
+++ b/tests/sentry/integrations/cursor/test_webhook.py
@@ -73,6 +73,7 @@ class TestCursorWebhook(APITestCase):
 
     @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
     def test_happy_path_finished(self, mock_update_state):
+        mock_update_state.return_value = True
         payload = self._build_status_payload(status="FINISHED")
         body = orjson.dumps(payload)
         headers = self._signed_headers(body)
@@ -93,6 +94,7 @@ class TestCursorWebhook(APITestCase):
 
     @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
     def test_finished_records_pr_attribution(self, mock_update_state):
+        mock_update_state.return_value = True
         repo = self.create_repo(
             self.project, name="testorg/testrepo", provider="integrations:github"
         )
@@ -108,6 +110,21 @@ class TestCursorWebhook(APITestCase):
         assert attribution.source == PullRequestAttributionSource.SEER_DATA
         assert attribution.pull_request.repository_id == repo.id
         assert attribution.pull_request.key == "1"
+
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_unknown_agent_records_no_attribution(self, mock_update_state):
+        # Seer returns False (e.g. 404) for agent_ids it doesn't know about —
+        # these are Cursor sessions not delegated by Seer, and must not be attributed.
+        mock_update_state.return_value = False
+        self.create_repo(self.project, name="testorg/testrepo", provider="integrations:github")
+        body = orjson.dumps(self._build_status_payload(status="FINISHED"))
+        headers = self._signed_headers(body)
+
+        with self.feature("organizations:pr-metrics-attribution"):
+            response = self._post_with_headers(body, headers)
+
+        assert response.status_code == 204
+        assert not PullRequestAttribution.objects.exists()
 
     @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
     def test_error_status_records_no_attribution(self, mock_update_state):

--- a/tests/sentry/integrations/cursor/test_webhook.py
+++ b/tests/sentry/integrations/cursor/test_webhook.py
@@ -8,6 +8,11 @@ import pytest
 from django.urls import reverse
 from rest_framework.exceptions import MethodNotAllowed
 
+from sentry.models.pullrequest import (
+    PullRequestAttribution,
+    PullRequestAttributionSignalType,
+    PullRequestAttributionSource,
+)
 from sentry.testutils.cases import APITestCase
 
 
@@ -85,6 +90,62 @@ class TestCursorWebhook(APITestCase):
         assert result.repo_full_name == "testorg/testrepo"
         assert result.repo_provider == "github"
         assert result.pr_url == "https://github.com/testorg/testrepo/pull/1"
+
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_finished_records_pr_attribution(self, mock_update_state):
+        repo = self.create_repo(
+            self.project, name="testorg/testrepo", provider="integrations:github"
+        )
+        body = orjson.dumps(self._build_status_payload(status="FINISHED"))
+        headers = self._signed_headers(body)
+
+        with self.feature("organizations:pr-metrics-attribution"):
+            response = self._post_with_headers(body, headers)
+
+        assert response.status_code == 204
+        attribution = PullRequestAttribution.objects.get()
+        assert attribution.signal_type == PullRequestAttributionSignalType.SEER_DELEGATED_CURSOR
+        assert attribution.source == PullRequestAttributionSource.SEER_DATA
+        assert attribution.pull_request.repository_id == repo.id
+        assert attribution.pull_request.key == "1"
+
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_error_status_records_no_attribution(self, mock_update_state):
+        self.create_repo(self.project, name="testorg/testrepo", provider="integrations:github")
+        body = orjson.dumps(self._build_status_payload(status="ERROR", pr_url=None))
+        headers = self._signed_headers(body)
+
+        with self.feature("organizations:pr-metrics-attribution"):
+            response = self._post_with_headers(body, headers)
+
+        assert response.status_code == 204
+        assert not PullRequestAttribution.objects.exists()
+
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_finished_without_pr_url_records_no_attribution(self, mock_update_state):
+        # Isolates the ``and pr_url`` half of the attribution guard: a completed
+        # agent that produced no PR must not be attributed.
+        self.create_repo(self.project, name="testorg/testrepo", provider="integrations:github")
+        body = orjson.dumps(self._build_status_payload(status="FINISHED", pr_url=None))
+        headers = self._signed_headers(body)
+
+        with self.feature("organizations:pr-metrics-attribution"):
+            response = self._post_with_headers(body, headers)
+
+        assert response.status_code == 204
+        assert not PullRequestAttribution.objects.exists()
+
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_finished_records_no_attribution_when_flag_disabled(self, mock_update_state):
+        self.create_repo(self.project, name="testorg/testrepo", provider="integrations:github")
+        body = orjson.dumps(self._build_status_payload(status="FINISHED"))
+        headers = self._signed_headers(body)
+
+        with self.feature({"organizations:pr-metrics-attribution": False}):
+            response = self._post_with_headers(body, headers)
+
+        assert response.status_code == 204
+        assert not PullRequestAttribution.objects.exists()
 
     def test_invalid_method(self) -> None:
         with pytest.raises(MethodNotAllowed):

--- a/tests/sentry/pr_metrics/test_attribution.py
+++ b/tests/sentry/pr_metrics/test_attribution.py
@@ -193,7 +193,7 @@ class AttributeDelegatedAgentPullRequestTest(TestCase):
     def _attribute(
         self,
         *,
-        signal_type: str = PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
+        signal_type: PullRequestAttributionSignalType = PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
         repo_full_name: str = REPO_NAME,
         repo_provider: str = "github",
         pr_url: str = "https://github.com/getsentry/sentry/pull/42",

--- a/tests/sentry/pr_metrics/test_attribution.py
+++ b/tests/sentry/pr_metrics/test_attribution.py
@@ -9,6 +9,7 @@ from sentry.models.pullrequest import (
     PullRequestAttributionSource,
 )
 from sentry.pr_metrics.attribution import (
+    attribute_delegated_agent_pull_request,
     attribute_seer_created_pull_requests,
     recompute_pull_request_attribution,
     record_attribution_signal,
@@ -183,6 +184,109 @@ class AttributeSeerCreatedPullRequestsTest(TestCase):
         )
 
         assert not PullRequestAttribution.objects.exists()
+
+
+class AttributeDelegatedAgentPullRequestTest(TestCase):
+    def setUp(self) -> None:
+        self.repo = self.create_repo(self.project, name=REPO_NAME, provider="integrations:github")
+
+    def _attribute(
+        self,
+        *,
+        signal_type: str = PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
+        repo_full_name: str = REPO_NAME,
+        repo_provider: str = "github",
+        pr_url: str = "https://github.com/getsentry/sentry/pull/42",
+        agent_id: str | None = "agent-1",
+        organization_id: int | None = None,
+        has_feature: bool = True,
+    ) -> None:
+        with self.feature({"organizations:pr-metrics-attribution": has_feature}):
+            attribute_delegated_agent_pull_request(
+                organization_id=(
+                    self.organization.id if organization_id is None else organization_id
+                ),
+                signal_type=signal_type,
+                repo_full_name=repo_full_name,
+                repo_provider=repo_provider,
+                pr_url=pr_url,
+                agent_id=agent_id,
+            )
+
+    def test_records_the_given_signal_type(self) -> None:
+        signal_types = [
+            PullRequestAttributionSignalType.SEER_DELEGATED_CURSOR,
+            PullRequestAttributionSignalType.SEER_DELEGATED_GITHUB_COPILOT,
+            PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
+        ]
+        for index, signal_type in enumerate(signal_types):
+            pr_number = 100 + index
+            self._attribute(
+                signal_type=signal_type,
+                pr_url=f"https://github.com/getsentry/sentry/pull/{pr_number}",
+            )
+
+            pull_request = PullRequest.objects.get(repository_id=self.repo.id, key=str(pr_number))
+            attribution = PullRequestAttribution.objects.get(pull_request=pull_request)
+            assert attribution.signal_type == signal_type
+            assert attribution.source == PullRequestAttributionSource.SEER_DATA
+            assert attribution.signal_details == {
+                "agent_id": "agent-1",
+                "pr_url": f"https://github.com/getsentry/sentry/pull/{pr_number}",
+            }
+
+    def test_noop_when_feature_disabled(self) -> None:
+        self._attribute(has_feature=False)
+
+        assert not PullRequest.objects.exists()
+        assert not PullRequestAttribution.objects.exists()
+
+    def test_is_idempotent_on_redelivery(self) -> None:
+        self._attribute()
+        self._attribute()
+
+        assert PullRequest.objects.filter(repository_id=self.repo.id, key="42").count() == 1
+        assert PullRequestAttribution.objects.count() == 1
+
+    def test_noop_when_organization_missing(self) -> None:
+        self._attribute(organization_id=99999999)
+
+        assert not PullRequest.objects.exists()
+        assert not PullRequestAttribution.objects.exists()
+
+    def test_skips_when_pr_url_has_no_number(self) -> None:
+        with patch("sentry.pr_metrics.attribution.logger") as mock_logger:
+            self._attribute(pr_url="https://github.com/getsentry/sentry/pulls")
+
+        assert not PullRequestAttribution.objects.exists()
+        assert "seer.pr_attribution.invalid_pr_url" in _warning_events(mock_logger)
+
+    def test_skips_branch_url(self) -> None:
+        # A delegated agent can report a branch/tree URL; its trailing segment must
+        # not be mistaken for a PR number.
+        with patch("sentry.pr_metrics.attribution.logger") as mock_logger:
+            self._attribute(pr_url="https://github.com/getsentry/sentry/tree/123")
+
+        assert not PullRequestAttribution.objects.exists()
+        assert "seer.pr_attribution.invalid_pr_url" in _warning_events(mock_logger)
+
+    def test_skips_when_repository_not_found(self) -> None:
+        with patch("sentry.pr_metrics.attribution.logger") as mock_logger:
+            self._attribute(repo_full_name="getsentry/does-not-exist")
+
+        assert not PullRequestAttribution.objects.exists()
+        assert "seer.pr_attribution.repo_not_found" in _warning_events(mock_logger)
+
+    def test_attributes_against_the_given_org_only(self) -> None:
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        other_repo = self.create_repo(other_project, name=REPO_NAME, provider="integrations:github")
+
+        self._attribute(organization_id=other_org.id)
+
+        # Scoped to the given org's same-named repo — never this org's.
+        assert not PullRequest.objects.filter(repository_id=self.repo.id).exists()
+        assert PullRequest.objects.filter(repository_id=other_repo.id).exists()
 
 
 class RecordAttributionSignalTest(TestCase):

--- a/tests/sentry/pr_metrics/test_attribution.py
+++ b/tests/sentry/pr_metrics/test_attribution.py
@@ -9,6 +9,7 @@ from sentry.models.pullrequest import (
     PullRequestAttributionSource,
 )
 from sentry.pr_metrics.attribution import (
+    _parse_pr_number,
     attribute_delegated_agent_pull_request,
     attribute_seer_created_pull_requests,
     recompute_pull_request_attribution,
@@ -287,6 +288,28 @@ class AttributeDelegatedAgentPullRequestTest(TestCase):
         # Scoped to the given org's same-named repo — never this org's.
         assert not PullRequest.objects.filter(repository_id=self.repo.id).exists()
         assert PullRequest.objects.filter(repository_id=other_repo.id).exists()
+
+
+class ParsePrNumberTest(TestCase):
+    def test_extracts_number_from_supported_url_shapes(self) -> None:
+        # Each provider segment the regex recognizes must yield the trailing number.
+        cases = [
+            ("https://github.com/getsentry/sentry/pull/42", 42),
+            ("https://github.com/getsentry/sentry/pulls/7", 7),
+            ("https://gitlab.com/getsentry/sentry/merge_requests/13", 13),
+        ]
+        for url, expected in cases:
+            assert _parse_pr_number(url) == expected
+
+    def test_returns_none_when_no_pr_segment(self) -> None:
+        # A branch/tree URL or a number-less path must not be mistaken for a PR.
+        cases = [
+            "https://github.com/getsentry/sentry/tree/123",
+            "https://github.com/getsentry/sentry/pulls",
+            "https://github.com/getsentry/sentry",
+        ]
+        for url in cases:
+            assert _parse_pr_number(url) is None
 
 
 class RecordAttributionSignalTest(TestCase):

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -2,11 +2,13 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 from sentry.integrations.claude_code.utils import ClaudeSessionEvent, ClaudeSessionEventStatus
+from sentry.integrations.github_copilot.client import GithubCopilotAgentClient
 from sentry.integrations.github_copilot.models import (
     GithubCopilotArtifact,
     GithubCopilotArtifactData,
     GithubCopilotTask,
 )
+from sentry.models.pullrequest import PullRequestAttributionSignalType
 from sentry.seer.autofix.coding_agent import (
     extract_result_from_events,
     poll_claude_code_agents,
@@ -172,6 +174,117 @@ class TestPollGithubCopilotAgents(TestCase):
         assert call_kwargs["result"].pr_url == "https://github.com/getsentry/sentry/pull/12345"
         assert call_kwargs["result"].description == "Fix the bug"
         assert call_kwargs["result"].repo_full_name == "getsentry/sentry"
+
+    @patch("sentry.seer.autofix.coding_agent.attribute_delegated_agent_pull_request")
+    @patch("sentry.seer.autofix.coding_agent.update_coding_agent_state")
+    @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")
+    def test_poll_attributes_pr_when_task_complete(
+        self, mock_identity_service, mock_update_state, mock_attribute
+    ):
+        """A completed Copilot task with a PR is attributed to the Copilot agent."""
+        mock_identity_service.get_access_token_for_user.return_value = "test_token"
+
+        mock_client = MagicMock()
+        mock_client.get_task_status.return_value = GithubCopilotTask(
+            id="task-123",
+            state="completed",
+            artifacts=[
+                GithubCopilotArtifact(
+                    provider="github",
+                    type="pull_request",
+                    data=GithubCopilotArtifactData(id=456, type="pull", global_id="PR_abc123"),
+                )
+            ],
+        )
+        mock_pr_info = MagicMock()
+        mock_pr_info.url = "https://github.com/getsentry/sentry/pull/12345"
+        mock_pr_info.title = "Fix the bug"
+        mock_client.get_pr_from_graphql.return_value = mock_pr_info
+
+        agents = {
+            "getsentry:sentry:task-123": CodingAgentState(
+                id="getsentry:sentry:task-123",
+                status=CodingAgentStatus.RUNNING,
+                provider=CodingAgentProviderType.GITHUB_COPILOT_AGENT,
+                name="GitHub Copilot",
+                started_at=datetime.now(UTC),
+            )
+        }
+        autofix_state = self._create_autofix_state_with_agents(agents)
+
+        with patch.object(GithubCopilotAgentClient, "__init__", return_value=None):
+            with patch.object(
+                GithubCopilotAgentClient, "get_task_status", mock_client.get_task_status
+            ):
+                with patch.object(
+                    GithubCopilotAgentClient, "get_pr_from_graphql", mock_client.get_pr_from_graphql
+                ):
+                    poll_github_copilot_agents(
+                        autofix_state,
+                        user_id=self.user.id,
+                        organization_id=self.organization.id,
+                    )
+
+        mock_attribute.assert_called_once_with(
+            organization_id=self.organization.id,
+            signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_GITHUB_COPILOT,
+            repo_full_name="getsentry/sentry",
+            repo_provider="github",
+            pr_url="https://github.com/getsentry/sentry/pull/12345",
+            agent_id="getsentry:sentry:task-123",
+        )
+
+    @patch("sentry.seer.autofix.coding_agent.attribute_delegated_agent_pull_request")
+    @patch("sentry.seer.autofix.coding_agent.update_coding_agent_state")
+    @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")
+    def test_poll_does_not_attribute_when_task_not_done(
+        self, mock_identity_service, mock_update_state, mock_attribute
+    ):
+        """A PR seen while the task is still running is not attributed yet."""
+        mock_identity_service.get_access_token_for_user.return_value = "test_token"
+
+        mock_client = MagicMock()
+        mock_client.get_task_status.return_value = GithubCopilotTask(
+            id="task-123",
+            state="in_progress",
+            artifacts=[
+                GithubCopilotArtifact(
+                    provider="github",
+                    type="pull_request",
+                    data=GithubCopilotArtifactData(id=456, type="pull", global_id="PR_abc123"),
+                )
+            ],
+        )
+        mock_pr_info = MagicMock()
+        mock_pr_info.url = "https://github.com/getsentry/sentry/pull/12345"
+        mock_pr_info.title = "WIP"
+        mock_client.get_pr_from_graphql.return_value = mock_pr_info
+
+        agents = {
+            "getsentry:sentry:task-123": CodingAgentState(
+                id="getsentry:sentry:task-123",
+                status=CodingAgentStatus.RUNNING,
+                provider=CodingAgentProviderType.GITHUB_COPILOT_AGENT,
+                name="GitHub Copilot",
+                started_at=datetime.now(UTC),
+            )
+        }
+        autofix_state = self._create_autofix_state_with_agents(agents)
+
+        with patch.object(GithubCopilotAgentClient, "__init__", return_value=None):
+            with patch.object(
+                GithubCopilotAgentClient, "get_task_status", mock_client.get_task_status
+            ):
+                with patch.object(
+                    GithubCopilotAgentClient, "get_pr_from_graphql", mock_client.get_pr_from_graphql
+                ):
+                    poll_github_copilot_agents(
+                        autofix_state,
+                        user_id=self.user.id,
+                        organization_id=self.organization.id,
+                    )
+
+        mock_attribute.assert_not_called()
 
     @patch("sentry.seer.autofix.coding_agent.update_coding_agent_state")
     @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")
@@ -526,6 +639,70 @@ class TestPollClaudeCodeAgents(TestCase):
         call_kwargs = mock_update_state.call_args[1]
         assert call_kwargs["agent_id"] == "claude-session-123"
         assert call_kwargs["status"] == CodingAgentStatus.COMPLETED
+
+    @patch("sentry.seer.autofix.coding_agent.attribute_delegated_agent_pull_request")
+    @patch(MOCK_UPDATE_STATE_PATH)
+    @patch(MOCK_CLIENT_CLASS_PATH)
+    @patch(MOCK_INTEGRATION_SERVICE_PATH)
+    def test_attributes_pr_on_completion(
+        self, mock_integration_service, mock_import_string, mock_update_state, mock_attribute
+    ):
+        """A completed Claude session with a PR is attributed to the Claude agent."""
+        self._mock_integration(mock_integration_service)
+        mock_client = MagicMock()
+        mock_client.list_session_events.return_value = [
+            {
+                "type": "agent.message",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "PR created: https://github.com/getsentry/sentry/pull/999",
+                    }
+                ],
+            },
+            {"type": ClaudeSessionEventStatus.IDLE},
+        ]
+        mock_client.build_result_from_session.return_value = MagicMock(
+            pr_url="https://github.com/getsentry/sentry/pull/999",
+            repo_full_name="getsentry/sentry",
+            repo_provider="github",
+        )
+        mock_import_string.return_value = lambda **kwargs: mock_client
+
+        agents = {"claude-session-123": self._create_claude_agent()}
+        autofix_state = self._create_autofix_state_with_agents(agents)
+        poll_claude_code_agents(autofix_state=autofix_state)
+
+        mock_attribute.assert_called_once_with(
+            organization_id=self.organization.id,
+            signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
+            repo_full_name="getsentry/sentry",
+            repo_provider="github",
+            pr_url="https://github.com/getsentry/sentry/pull/999",
+            agent_id="claude-session-123",
+        )
+
+    @patch("sentry.seer.autofix.coding_agent.attribute_delegated_agent_pull_request")
+    @patch(MOCK_UPDATE_STATE_PATH)
+    @patch(MOCK_CLIENT_CLASS_PATH)
+    @patch(MOCK_INTEGRATION_SERVICE_PATH)
+    def test_does_not_attribute_when_no_pr_url(
+        self, mock_integration_service, mock_import_string, mock_update_state, mock_attribute
+    ):
+        """A completed session without a PR is not attributed."""
+        self._mock_integration(mock_integration_service)
+        mock_client = MagicMock()
+        mock_client.list_session_events.return_value = [
+            {"type": "agent.message", "content": [{"type": "text", "text": "Done, no PR."}]},
+            {"type": ClaudeSessionEventStatus.IDLE},
+        ]
+        mock_import_string.return_value = lambda **kwargs: mock_client
+
+        agents = {"claude-session-123": self._create_claude_agent()}
+        autofix_state = self._create_autofix_state_with_agents(agents)
+        poll_claude_code_agents(autofix_state=autofix_state)
+
+        mock_attribute.assert_not_called()
 
     @patch(MOCK_UPDATE_STATE_PATH)
     @patch(MOCK_CLIENT_CLASS_PATH)


### PR DESCRIPTION
Record a `SEER_DELEGATED_*` `PullRequestAttribution` when a delegated coding agent (Cursor, GitHub Copilot, or Claude Code) opens a PR from an autofix session.

Attribution happens directly in Sentry where it already learns of the PR — the Cursor webhook and the Copilot/Claude polls — rather than via the `seer.pr_created` event, so no Seer round-trip is needed. Only fires on a completed agent with a PR URL, and gated behind `organizations:pr-metrics-attribution`.

Please read "Delegated agents & Sentry" below. The conclusion to me is that this is the best we can do with how the system is today, and I'll explore how we can improve next, but it should be considered follow-up work. (follow up ticket CW-1485)

Closes CW-1438

---

**Delegated agents & Sentry**
Read the ticket for more details.

* Launching agents happens in Sentry (unused here)
* Checking agent results also happens in Sentry (good for us)
  * For Claude and Copilot it's a POLL mechanism but it requires the frontend to be pointing at an Autofix session (bad for us)
  * For Cursor it's a webhook (good for us)

So as-is we can get some attribution but Claude and Copilot will be "best-effort". 