### PR TITLE
ref(preprod): Use file_path as React key for duplicate file rows

### DIFF
--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -300,8 +300,8 @@ function DuplicateGroupFileRow({
             </Button>
           )}
         >
-          {group.files.map((duplicateFile, index) => (
-            <Flex key={`${duplicateFile.file_path}-${index}`} align="center" gap="sm">
+          {group.files.map(duplicateFile => (
+            <Flex key={duplicateFile.file_path} align="center" gap="sm">
               <Text size="xs" variant="muted" ellipsis style={{flex: 1, minWidth: 0}}>
                 {duplicateFile.file_path}
               </Text>


### PR DESCRIPTION
Follow-up to review on #116815: key duplicate-file rows on `file_path` alone instead of `${file_path}-${index}`, removing the array-index-in-key anti-pattern.

`file_path` is unique within a duplicate group by construction (launchpad's `DuplicateFilesInsight` groups distinct bundle-tree nodes; see [here](https://github.com/getsentry/launchpad/blob/8d57061773982949ebaa61c60f7a49c834e43180/src/launchpad/size/insights/common/duplicate_files.py#L21)), so the index was never needed.

Refs https://github.com/getsentry/sentry/pull/116815#discussion_r3357019512