### PR TITLE
fix(sdk-crash): Suppress crashes when all SDK frames are conditional

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
@@ -123,21 +123,23 @@ class SDKCrashDetector:
 
         # Loop 3: Check if the only SDK frame is a "conditional" one (e.g., SentrySwizzleWrapper).
         # These are SDK instrumentation frames that intercept calls but are unlikely to cause
-        # crashes themselves. A single conditional frame is not reported, but multiple SDK frames
-        # (even if all conditional) are reported to prefer over-reporting over under-reporting.
-        conditional_sdk_frame_count = 0
+        # crashes themselves. When every SDK frame in the stack is conditional (e.g. swizzle
+        # wrappers), the crash is suppressed — regardless of how many conditional frames appear.
+        # The same instrumentation frame can appear multiple times (e.g. UIKit calling
+        # sendAction: twice in the responder chain), and that still isn't an SDK bug.
+        has_conditional_sdk_frame = False
         has_non_conditional_sdk_frame = False
         for frame in iter_frames:
             if self.is_sdk_frame(frame):
                 if self._matches_sdk_crash_ignore(frame):
                     continue
                 if self._matches_ignore_when_only_sdk_frame(frame):
-                    conditional_sdk_frame_count += 1
+                    has_conditional_sdk_frame = True
                 else:
                     has_non_conditional_sdk_frame = True
                     break
 
-        if conditional_sdk_frame_count == 1 and not has_non_conditional_sdk_frame:
+        if has_conditional_sdk_frame and not has_non_conditional_sdk_frame:
             return False
 
         # Passed all ignore checks: this is an SDK crash.

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_cocoa.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_cocoa.py
@@ -855,40 +855,55 @@ class CocoaSDKSwizzleWrapperTestMixin(BaseSDKCrashDetectionMixin):
             mock_sdk_crash_reporter,
         )
 
-    def test_multiple_swizzle_wrapper_frames_reported(
+    def test_multiple_swizzle_wrapper_frames_not_reported(
         self, mock_sdk_crash_reporter: MagicMock
     ) -> None:
         """
-        Multiple SentrySwizzleWrapper frames in the stack.
-        Even though each individual frame would be ignored when it's the only SDK frame,
-        having multiple SDK frames (even if all conditional) should be reported.
+        Multiple SentrySwizzleWrapperHelper frames in the stack from UIKit calling
+        sendAction: twice in the responder chain. All SDK frames are conditional
+        (instrumentation wrappers), so the crash is not an SDK bug.
+
+        Real stack trace from SDK-CRASHES-COCOA-8F8 event b2a5f61242a043caa60bac684bda7f28.
         """
-        # Frames ordered from oldest (caller) to youngest (exception)
         frames = [
             {
-                "function": "-[UIApplication sendEvent:]",
+                "function": "-[UIControl sendAction:to:forEvent:]",
                 "package": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
                 "in_app": False,
             },
             {
-                "function": "__49-[SentrySwizzleWrapper swizzleSendAction:forKey:]_block_invoke_2",
+                "function": "__38+[SentrySwizzleWrapperHelper swizzle:]_block_invoke_2",
                 "package": "/private/var/containers/Bundle/Application/59E988EF-46DB-4C75-8E08-10C27DC3E90E/iOS-Swift.app/Frameworks/Sentry.framework/Sentry",
                 "in_app": False,
             },
             {
-                "function": "-[UIGestureRecognizer _updateGestureForActiveEvents]",
+                "function": "-[UIApplication sendAction:to:from:forEvent:]",
                 "package": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
                 "in_app": False,
             },
             {
-                # Second SentrySwizzleWrapper frame
-                "function": "__49-[SentrySwizzleWrapper swizzleSendAction:forKey:]_block_invoke_3",
+                "function": "-[UIBarButtonItem _triggerActionForEvent:fallbackSender:]",
+                "package": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
+                "in_app": False,
+            },
+            {
+                "function": "__38+[SentrySwizzleWrapperHelper swizzle:]_block_invoke_2",
                 "package": "/private/var/containers/Bundle/Application/59E988EF-46DB-4C75-8E08-10C27DC3E90E/iOS-Swift.app/Frameworks/Sentry.framework/Sentry",
                 "in_app": False,
             },
             {
-                "function": "-[NSString substringWithRange:]",
+                "function": "-[UIApplication sendAction:to:from:forEvent:]",
+                "package": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
+                "in_app": False,
+            },
+            {
+                "function": "-[NSUndoManager undo]",
                 "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+                "in_app": False,
+            },
+            {
+                "function": "objc_exception_throw",
+                "package": "/usr/lib/libobjc.A.dylib",
                 "in_app": False,
             },
             {
@@ -900,7 +915,7 @@ class CocoaSDKSwizzleWrapperTestMixin(BaseSDKCrashDetectionMixin):
 
         self.execute_test(
             get_crash_event_with_frames(frames),
-            True,  # Should be reported - multiple SDK frames even if all conditional
+            False,
             mock_sdk_crash_reporter,
         )
 


### PR DESCRIPTION
## Summary

- Changes the conditional SDK frame suppression check from `== 1` to `>= 1` (boolean flag) so that crashes with **only** conditional SDK frames are suppressed regardless of how many times the instrumentation frame appears.
- Updates the existing multi-frame test to use a real stack trace from SDK-CRASHES-COCOA-8F8 and expect suppression.

## Context

[SDK-CRASHES-COCOA-8F8](https://sentry.sentry.io/issues/5492649506/) has 45K+ events where `SentrySwizzleWrapperHelper` appears twice in the stack because UIKit calls `sendAction:` twice in the responder chain. The `SentrySwizzleWrapper` pattern is already in `sdk_crash_ignore_when_only_sdk_frame_matchers`, but the old `== 1` check failed when the same wrapper appeared more than once — causing false-positive SDK crash reports.

Fixes getsentry/sentry-cocoa#8016

#skip-changelog