### PR TITLE
Remove unused VSTS social auth feature flag

### DIFF
--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -8,7 +8,6 @@ from django.http.response import HttpResponseBase, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from sentry import options
 from sentry.identity.base import Provider
 from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.types import IntegrationProviderSlug
@@ -35,8 +34,6 @@ class IdentityPipeline(Pipeline[IdentityProvider, PipelineSessionStore]):
     def _get_provider(self, provider_key: str, organization: RpcOrganization | None) -> Provider:
         if provider_key == IntegrationProviderSlug.AZURE_DEVOPS.value:
             provider_key = "vsts_new"
-        if provider_key == "vsts_login" and options.get("vsts.social-auth-migration"):
-            provider_key = "vsts_login_new"
 
         return default_manager.get(provider_key)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -774,13 +774,6 @@ register("vsts_new.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("vsts-limited.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 register("vsts-limited.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 
-# Azure DevOps Integration Social Login Flow
-register(
-    "vsts.social-auth-migration",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Add consent prompt for Azure DevOps Integration
 register(


### PR DESCRIPTION
The Sentry Azure social auth has been using the prod version for a while. This is to clean up the feature flag once we default the provider to the new one. 

Depends on: https://github.com/getsentry/getsentry/pull/20579
