### PR TITLE
feat(vsts): Drive Marketplace installs through the API pipeline modal

### DIFF
--- a/static/app/components/pipeline/integrationVsts/index.spec.tsx
+++ b/static/app/components/pipeline/integrationVsts/index.spec.tsx
@@ -110,4 +110,45 @@ describe('VstsAccountSelectionStep', () => {
 
     expect(advance).toHaveBeenCalledWith({account: 'acct-1'});
   });
+
+  it('auto-advances with the pre-selected account for Marketplace installs', () => {
+    const advance = jest.fn();
+    render(
+      <VstsAccountSelectionStep
+        {...makeStepProps({
+          stepData: {
+            account: 'acct-1',
+            accounts: [{accountId: 'acct-1', accountName: 'MyVSTSAccount'}],
+          },
+          advance,
+        })}
+      />
+    );
+
+    expect(advance).toHaveBeenCalledWith({account: 'acct-1'});
+    expect(advance).toHaveBeenCalledTimes(1);
+    // The picker is not shown while auto-advancing.
+    expect(
+      screen.queryByRole('button', {name: 'Select Azure DevOps organization'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not auto-advance without a pre-selected account', () => {
+    const advance = jest.fn();
+    render(
+      <VstsAccountSelectionStep
+        {...makeStepProps({
+          stepData: {
+            accounts: [{accountId: 'acct-1', accountName: 'MyVSTSAccount'}],
+          },
+          advance,
+        })}
+      />
+    );
+
+    expect(advance).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('button', {name: 'Select Azure DevOps organization'})
+    ).toBeInTheDocument();
+  });
 });

--- a/static/app/components/pipeline/integrationVsts/index.tsx
+++ b/static/app/components/pipeline/integrationVsts/index.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Stack} from '@sentry/scraps/layout';
@@ -21,6 +21,9 @@ interface VstsAccount {
 }
 
 interface VstsAccountSelectionStepData {
+  // Present for Marketplace installs: the pre-selected (and server-verified)
+  // account id. When set, the step advances without prompting.
+  account?: string;
   accounts?: VstsAccount[];
 }
 
@@ -55,8 +58,25 @@ function VstsAccountSelectionStep({
   advance,
   isAdvancing,
 }: PipelineStepProps<VstsAccountSelectionStepData, VstsAccountSelectionAdvanceData>) {
+  // Marketplace installs pre-select the account (verified server-side), which
+  // the backend surfaces as `account`. Advance immediately without prompting.
+  // The ref guards against React strict mode double-firing the effect.
+  const hasAutoAdvanced = useRef(false);
+  const preselectedAccount = stepData?.account;
+  useEffect(() => {
+    if (!preselectedAccount || hasAutoAdvanced.current) {
+      return;
+    }
+    hasAutoAdvanced.current = true;
+    advance({account: preselectedAccount});
+  }, [preselectedAccount, advance]);
+
   if (stepData === null) {
     return null;
+  }
+
+  if (preselectedAccount) {
+    return <Text>{t('Finishing up Azure DevOps integration installation...')}</Text>;
   }
 
   const accounts = stepData.accounts ?? [];

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -101,6 +101,11 @@ function trackExternalAnalytics({
  *    `/extensions/vercel/configure/`). Drives the pipeline with
  *    `vercelParams`.
  *
+ *  - Azure DevOps (VSTS Marketplace)
+ *    `/extensions/vsts/link/?targetId=...` (redirected from
+ *    `/extensions/vsts/configure/`). Drives the `vsts` pipeline with
+ *    `vstsParams`.
+ *
  *  - Anything else
  *    falls through to {@link finishLegacyInstallation}, which bounces to the
  *    legacy `/extensions/<slug>/configure/` backend endpoint.
@@ -276,6 +281,22 @@ export default function IntegrationOrganizationLink() {
     return {code};
   }, [integrationSlug, location.query]);
 
+  // Azure DevOps Marketplace installs arrive here with `targetId` in the URL
+  // query (forwarded from `/extensions/vsts/configure/`). It identifies the
+  // Azure DevOps organization to install; the `vsts` pipeline treats it as a
+  // pre-selected account (verified against the user's memberships) and
+  // auto-advances past account selection.
+  const vstsParams = useMemo<Record<string, string> | null>(() => {
+    if (integrationSlug !== 'vsts') {
+      return null;
+    }
+    const targetId = location.query.targetId;
+    if (typeof targetId !== 'string') {
+      return null;
+    }
+    return {targetId};
+  }, [integrationSlug, location.query]);
+
   // Legacy install path. Redirects to `/extensions/<slug>/configure/`, which
   // runs the Django-rendered `IntegrationExtensionConfigurationView` to drive
   // the install server-side via the legacy pipeline. Used by every provider
@@ -309,7 +330,8 @@ export default function IntegrationOrganizationLink() {
       discordAppDirectoryParams ??
       msTeamsParams ??
       jiraParams ??
-      vercelParams;
+      vercelParams ??
+      vstsParams;
     if (urlParams) {
       startFlow({provider, organization, onInstall, urlParams});
       return;
@@ -324,6 +346,7 @@ export default function IntegrationOrganizationLink() {
     msTeamsParams,
     jiraParams,
     vercelParams,
+    vstsParams,
     startFlow,
     onInstall,
     finishLegacyInstallation,


### PR DESCRIPTION
When a user installs Sentry from the Azure DevOps Marketplace, the configure link forwards `targetId` to the org-link page, which now drives the API pipeline modal instead of the legacy server-rendered flow.

This is the frontend half of folding the Marketplace install into the main `vsts` provider (replacing the old `vsts-extension` provider).

- The org-link view (`integrationOrganizationLink`) reads `targetId` and starts the install flow with the plain `vsts` provider. The slug already resolves to `vsts`, so no special provider handling is needed.
- The account-selection step auto-advances when the backend surfaces a pre-selected `account` — a Marketplace install where the user is a verified member of the org — rendering a brief "Finishing up..." message instead of the picker. A ref guards against React strict-mode double-firing.

Depends on the backend support (#116974) and must not deploy before it: the modal sends `targetId` as initial data, which only the new pipeline handles. The `/extensions/vsts/configure/` URL still routes through the legacy server-rendered view until the final PR swaps it to a redirect and removes the `vsts-extension` provider.

Refs [VDY-32](https://linear.app/getsentry/issue/VDY-32/migrate-integration-setup-pipelines-to-api-driven-flows)

Part of [VDY-102](https://linear.app/getsentry/issue/VDY-102/azure-devops-extension-api-driven-integration-setup).