### PR TITLE
feat(developer-settings): Add webhook headers field to custom integrations

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -267,6 +267,9 @@ export type SentryApp = {
     id: number;
     slug: string;
   };
+  // Each entry is a "Header-Name: value" line. Values are masked by the API for
+  // viewers without elevated access.
+  webhookHeaders?: string[];
 };
 
 // Minimal Sentry App representation for use with avatars

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -267,8 +267,7 @@ export type SentryApp = {
     id: number;
     slug: string;
   };
-  // Each entry is a "Header-Name: value" line. Values are masked by the API for
-  // viewers without elevated access.
+  // Each entry is a "Header-Name: value" line. Saved values are masked by the API
   webhookHeaders?: string[];
 };
 

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -124,6 +124,7 @@ describe('Sentry Application Details', () => {
         verifyInstall: true,
         isAlertable: true,
         allowedOrigins: [],
+        webhookHeaders: [],
         schema: {},
         overview: '',
       };
@@ -132,6 +133,33 @@ describe('Sentry Application Details', () => {
         '/sentry-apps/',
         expect.objectContaining({
           data,
+          method: 'POST',
+        })
+      );
+    });
+
+    it('saves webhook headers', async () => {
+      renderComponent();
+
+      await userEvent.type(screen.getByRole('textbox', {name: 'Name'}), 'Test App');
+      await userEvent.type(screen.getByRole('textbox', {name: 'Author'}), 'Sentry');
+      await userEvent.type(
+        screen.getByRole('textbox', {name: 'Webhook URL'}),
+        'https://webhook.com'
+      );
+      await userEvent.type(
+        screen.getByRole('textbox', {name: 'Webhook Headers'}),
+        'X-Example: value'
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
+
+      expect(createAppRequest).toHaveBeenCalledWith(
+        '/sentry-apps/',
+        expect.objectContaining({
+          data: expect.objectContaining({
+            webhookHeaders: ['X-Example: value'],
+          }),
           method: 'POST',
         })
       );
@@ -228,6 +256,20 @@ describe('Sentry Application Details', () => {
       await screen.findByRole('button', {name: 'Save Changes'});
       expect(screen.getByRole('textbox', {name: 'Client ID'})).toBeInTheDocument();
       expect(screen.getByRole('textbox', {name: 'Client Secret'})).toBeInTheDocument();
+    });
+
+    it('prefills webhook headers from the app', async () => {
+      sentryApp.webhookHeaders = ['X-Example: value', 'Another-Header: thing'];
+      MockApiClient.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/`,
+        body: sentryApp,
+      });
+
+      renderComponent();
+
+      expect(await screen.findByRole('textbox', {name: 'Webhook Headers'})).toHaveValue(
+        'X-Example: value\nAnother-Header: thing'
+      );
     });
   });
 

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -139,7 +139,12 @@ describe('Sentry Application Details', () => {
     });
 
     it('saves webhook headers', async () => {
-      renderComponent();
+      render(<SentryApplicationDetails />, {
+        initialRouterConfig,
+        organization: OrganizationFixture({
+          features: ['sentry-apps-custom-webhook-headers'],
+        }),
+      });
 
       await userEvent.type(screen.getByRole('textbox', {name: 'Name'}), 'Test App');
       await userEvent.type(screen.getByRole('textbox', {name: 'Author'}), 'Sentry');
@@ -265,7 +270,12 @@ describe('Sentry Application Details', () => {
         body: sentryApp,
       });
 
-      renderComponent();
+      render(<SentryApplicationDetails />, {
+        initialRouterConfig,
+        organization: OrganizationFixture({
+          features: ['sentry-apps-custom-webhook-headers'],
+        }),
+      });
 
       expect(await screen.findByRole('textbox', {name: 'Webhook Headers'})).toHaveValue(
         'X-Example: value\nAnother-Header: thing'

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -700,7 +700,7 @@ function SentryApplicationForm({
             <field.Layout.Row
               label={t('Webhook Headers')}
               hintText={t(
-                'Custom headers to include with every webhook request. Enter one header per line in the format: Header-Name: value. Saved header values are masked.'
+                'Custom headers to include with every webhook request. Only certain headers are allowed, such as Authorization or X-* custom headers. Enter one header per line in the format: Header-Name: value. Saved header values are masked.'
               )}
             >
               <field.TextArea

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -700,16 +700,14 @@ function SentryApplicationForm({
             <field.Layout.Row
               label={t('Webhook Headers')}
               hintText={t(
-                'Custom headers to include with every webhook request. Enter one header per line in the format: Header-Name: value'
+                'Custom headers to include with every webhook request. Enter one header per line in the format: Header-Name: value. Saved header values are masked.'
               )}
             >
               <field.TextArea
                 autosize
                 value={field.state.value}
                 onChange={field.handleChange}
-                placeholder={
-                  'anthropic-version: 2023-06-01\nauthorization: Bearer token123'
-                }
+                placeholder={'Authorization: Bearer <token>\nX-Custom-Header: value'}
               />
             </field.Layout.Row>
           )}

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -86,6 +86,7 @@ const sentryAppFormSchema = z
     name: z.string(),
     author: z.string(),
     webhookUrl: z.string(),
+    webhookHeaders: z.string(),
     redirectUrl: z.string(),
     verifyInstall: z.boolean(),
     isAlertable: z.boolean(),
@@ -197,6 +198,7 @@ type SaveSentryAppPayload = {
   author?: string | null;
   overview?: string;
   redirectUrl?: string;
+  webhookHeaders?: string[];
   webhookUrl?: string;
 };
 
@@ -514,6 +516,9 @@ function SentryApplicationForm({
     schema: getSchemaFieldValue(app?.schema),
     overview: app?.overview ?? '',
     allowedOrigins: convertMultilineFieldValue(app?.allowedOrigins ?? []),
+    // Masked values (Header-Name: ***) round-trip safely: the backend preserves
+    // the stored value for any entry resubmitted with the mask sentinel.
+    webhookHeaders: convertMultilineFieldValue(app?.webhookHeaders ?? []),
     organization: organization.slug,
     isInternal,
     scopes: app ? [...app.scopes] : [],
@@ -553,6 +558,7 @@ function SentryApplicationForm({
         scopes: value.scopes,
         events: value.events,
         allowedOrigins: extractMultilineFields(value.allowedOrigins),
+        webhookHeaders: extractMultilineFields(value.webhookHeaders),
         schema: value.schema.trim() === '' ? {} : JSON.parse(value.schema),
         // The author parser doesn't allow_blank, so send null for empty
         // (covers internal apps with no author).
@@ -684,6 +690,26 @@ function SentryApplicationForm({
                 value={field.state.value}
                 onChange={field.handleChange}
                 placeholder={t('e.g. https://example.com/sentry/webhook/')}
+              />
+            </field.Layout.Row>
+          )}
+        </form.AppField>
+
+        <form.AppField name="webhookHeaders">
+          {field => (
+            <field.Layout.Row
+              label={t('Webhook Headers')}
+              hintText={t(
+                'Custom headers to include with every webhook request. Enter one header per line in the format: Header-Name: value'
+              )}
+            >
+              <field.TextArea
+                autosize
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder={
+                  'anthropic-version: 2023-06-01\nauthorization: Bearer token123'
+                }
               />
             </field.Layout.Row>
           )}

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -695,23 +695,25 @@ function SentryApplicationForm({
           )}
         </form.AppField>
 
-        <form.AppField name="webhookHeaders">
-          {field => (
-            <field.Layout.Row
-              label={t('Webhook Headers')}
-              hintText={t(
-                'Custom headers to include with every webhook request. Only certain headers are allowed, such as Authorization or X-* custom headers. Enter one header per line in the format: Header-Name: value. Saved header values are masked.'
-              )}
-            >
-              <field.TextArea
-                autosize
-                value={field.state.value}
-                onChange={field.handleChange}
-                placeholder={'Authorization: Bearer <token>\nX-Custom-Header: value'}
-              />
-            </field.Layout.Row>
-          )}
-        </form.AppField>
+        {organization.features.includes('sentry-apps-custom-webhook-headers') && (
+          <form.AppField name="webhookHeaders">
+            {field => (
+              <field.Layout.Row
+                label={t('Webhook Headers')}
+                hintText={t(
+                  'Custom headers to include with every webhook request. Only certain headers are allowed, such as Authorization or X-* custom headers. Enter one header per line in the format: Header-Name: value. Saved header values are masked.'
+                )}
+              >
+                <field.TextArea
+                  autosize
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                  placeholder={'Authorization: Bearer <token>\nX-Custom-Header: value'}
+                />
+              </field.Layout.Row>
+            )}
+          </form.AppField>
+        )}
 
         {!isInternal && (
           <form.AppField name="redirectUrl">


### PR DESCRIPTION
Add a Webhook Headers textarea to the Integration Details form for internal
and public custom integrations, directly below Webhook URL. Each line is a
'Header-Name: value' pair sent with every outgoing webhook request.

Mirrors the allowedOrigins field exactly (convert/extract multiline helpers).
Note that API always returns masked values for the headers. They will be updated if the values are changed. You can also add new headers while having the existing/masked header un the textarea.

<img width="1280" height="577" alt="image" src="https://github.com/user-attachments/assets/beadf366-9a49-47cd-b0c3-1cef04c2de9c" />


Supersedes #116732, which split out this UI ahead of the backend.

Co-Authored-By: Claude <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>