### PR TITLE
feat(scm-multi-platform-detetion): Calling get_tree in new test endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -278,6 +278,9 @@ from sentry.integrations.api.endpoints.organization_repository_details import (
 from sentry.integrations.api.endpoints.organization_repository_platforms import (
     OrganizationRepositoryPlatformsEndpoint,
 )
+from sentry.integrations.api.endpoints.organization_repository_platforms_test import (
+    OrganizationRepositoryPlatformsTestEndpoint,
+)
 from sentry.integrations.api.endpoints.organization_repository_settings import (
     OrganizationRepositorySettingsEndpoint,
 )
@@ -2180,6 +2183,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/repos/(?P<repo_id>[^/]+)/platforms/$",
         OrganizationRepositoryPlatformsEndpoint.as_view(),
         name="sentry-api-0-organization-repository-platforms",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/repos/(?P<repo_id>[^/]+)/platforms-test/$",
+        OrganizationRepositoryPlatformsTestEndpoint.as_view(),
+        name="sentry-api-0-organization-repository-platforms-test",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/plugins/$",

--- a/src/sentry/integrations/api/endpoints/organization_repository_platforms_test.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_platforms_test.py
@@ -20,6 +20,7 @@ from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
+from sentry.shared_integrations.exceptions import ApiConflictError
 
 # Metric namespace for the candidate (tree-based) detector.
 _MULTI_METRICS_PREFIX = "onboarding-scm.platform_detection.multi"
@@ -116,9 +117,12 @@ class OrganizationRepositoryPlatformsTestEndpoint(OrganizationRepositoryEndpoint
                 repo_size_bytes,
                 unit="byte",
             )
-        except Exception:
+        except Exception as e:
+            # Empty repositories return a 409 (ApiConflictError) — an expected
+            # measurement failure, so log only. Surface anything else as an issue.
             sentry_logger.warning(
                 f"{_MULTI_METRICS_PREFIX}.failed",
                 attributes={"repo_id": repo.id, "repo_name": repo.name},
             )
-            sentry_sdk.capture_exception()
+            if not isinstance(e, ApiConflictError):
+                sentry_sdk.capture_exception()

--- a/src/sentry/integrations/api/endpoints/organization_repository_platforms_test.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_platforms_test.py
@@ -20,7 +20,6 @@ from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
-from sentry.shared_integrations.exceptions import ApiError
 
 # Metric namespace for the candidate (tree-based) detector.
 _MULTI_METRICS_PREFIX = "onboarding-scm.platform_detection.multi"
@@ -92,32 +91,34 @@ class OrganizationRepositoryPlatformsTestEndpoint(OrganizationRepositoryEndpoint
                 f"/repos/{repo.name}/git/trees/HEAD",
                 params={"recursive": 1},
             )
-        except ApiError:
-            # Includes empty repos (409), which are expected. Log and bail
-            # without emitting a completion, so failures don't skew the metrics.
+
+            tree: list[dict[str, Any]] = (
+                response.get("tree", []) if isinstance(response, dict) else []
+            )
+            is_truncated = bool(response.get("truncated")) if isinstance(response, dict) else False
+            repo_size_bytes = sum(
+                entry.get("size", 0) for entry in tree if entry.get("type") == "blob"
+            )
+
+            sentry_sdk.metrics.distribution(
+                f"{_MULTI_METRICS_PREFIX}.duration",
+                (time.monotonic() - start_time) * 1000,
+                unit="millisecond",
+            )
+            sentry_sdk.metrics.count(
+                f"{_MULTI_METRICS_PREFIX}.completed",
+                1,
+                attributes={"is_truncated": is_truncated},
+            )
+            sentry_sdk.metrics.distribution(f"{_MULTI_METRICS_PREFIX}.tree.entry_count", len(tree))
+            sentry_sdk.metrics.distribution(
+                f"{_MULTI_METRICS_PREFIX}.repo_size_bytes",
+                repo_size_bytes,
+                unit="byte",
+            )
+        except Exception:
             sentry_logger.warning(
                 f"{_MULTI_METRICS_PREFIX}.failed",
                 attributes={"repo_id": repo.id, "repo_name": repo.name},
             )
-            return
-
-        tree: list[dict[str, Any]] = response.get("tree", []) if isinstance(response, dict) else []
-        is_truncated = bool(response.get("truncated")) if isinstance(response, dict) else False
-        repo_size_bytes = sum(entry.get("size", 0) for entry in tree if entry.get("type") == "blob")
-
-        sentry_sdk.metrics.distribution(
-            f"{_MULTI_METRICS_PREFIX}.duration",
-            (time.monotonic() - start_time) * 1000,
-            unit="millisecond",
-        )
-        sentry_sdk.metrics.count(
-            f"{_MULTI_METRICS_PREFIX}.completed",
-            1,
-            attributes={"is_truncated": is_truncated},
-        )
-        sentry_sdk.metrics.distribution(f"{_MULTI_METRICS_PREFIX}.tree.entry_count", len(tree))
-        sentry_sdk.metrics.distribution(
-            f"{_MULTI_METRICS_PREFIX}.repo_size_bytes",
-            repo_size_bytes,
-            unit="byte",
-        )
+            sentry_sdk.capture_exception()

--- a/src/sentry/integrations/api/endpoints/organization_repository_platforms_test.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_platforms_test.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.integrations.api.bases.organization_repository import (
+    OrganizationRepositoryEndpoint,
+)
+from sentry.integrations.github.client import GitHubApiClient
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.organization import Organization
+from sentry.models.repository import Repository
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+# Metric namespace for the candidate (tree-based) detector. Kept separate from
+# the live single-platform detector's `.single.*` metrics so the two can be
+# compared and this measurement removed/relocated cleanly at cutover.
+_MULTI_METRICS_PREFIX = "onboarding-scm.platform_detection.multi"
+
+
+@cell_silo_endpoint
+class OrganizationRepositoryPlatformsTestEndpoint(OrganizationRepositoryEndpoint):
+    """Measurement-only endpoint for the tree-based detector.
+
+    Fetches the repository git tree in a single call and emits structural
+    metrics (`onboarding-scm.platform_detection.multi.*`). It returns 204 No
+    Content and has no effect on the live detector; the frontend fires it
+    fire-and-forget alongside the real detection request.
+    """
+
+    owner = ApiOwner.INTEGRATION_PLATFORM
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+
+    def get(self, request: Request, organization: Organization, repo: Repository) -> Response:
+        if not features.has(
+            "organizations:integrations-github-platform-detection",
+            organization,
+            actor=request.user,
+        ):
+            return Response(status=404)
+
+        if (
+            not repo.integration_id
+            or repo.provider != f"integrations:{IntegrationProviderSlug.GITHUB}"
+        ):
+            return Response(
+                {"detail": "Platform detection is only supported for GitHub repositories."},
+                status=400,
+            )
+
+        integration = integration_service.get_integration(integration_id=repo.integration_id)
+        if integration is None:
+            return Response({"detail": "GitHub integration not found."}, status=400)
+
+        org_integration = integration_service.get_organization_integration(
+            integration_id=repo.integration_id, organization_id=organization.id
+        )
+        if org_integration is None:
+            return Response(
+                {"detail": "GitHub integration is not configured for this organization."},
+                status=400,
+            )
+
+        client = GitHubApiClient(integration=integration, org_integration_id=org_integration.id)
+
+        self._measure_tree(client, repo)
+
+        # Measurement-only: no body. A top-level list would trip Sentry's
+        # MissingPaginationError guard, so return 204 No Content instead.
+        return Response(status=204)
+
+    def _measure_tree(self, client: GitHubApiClient, repo: Repository) -> None:
+        """Fetch the full git tree once and emit structural metrics.
+
+        Uses the ``HEAD`` ref so a single ``git/trees`` call suffices (no branch
+        resolution). The client's ``get_tree`` helper drops the ``truncated``
+        flag, so we call ``client.get`` directly to keep ``truncated`` and the
+        per-entry ``size``.
+        """
+        start_time = time.monotonic()
+        try:
+            response = client.get(
+                f"/repos/{repo.name}/git/trees/HEAD",
+                params={"recursive": 1},
+            )
+        except ApiError:
+            # Includes empty repos (409). Mirror the live path: log and bail
+            # without emitting a completion, so failures don't skew the metrics.
+            logger.exception(
+                "integrations.github.platform_detection_measurement_failed",
+                extra={"repo_id": repo.id, "repo_name": repo.name},
+            )
+            return
+
+        tree: list[dict[str, Any]] = response.get("tree", []) if isinstance(response, dict) else []
+        is_truncated = bool(response.get("truncated")) if isinstance(response, dict) else False
+        repo_size_bytes = sum(entry.get("size", 0) for entry in tree if entry.get("type") == "blob")
+
+        metrics.timing(f"{_MULTI_METRICS_PREFIX}.duration", time.monotonic() - start_time)
+        metrics.incr(
+            f"{_MULTI_METRICS_PREFIX}.completed",
+            tags={"is_truncated": "true" if is_truncated else "false"},
+        )
+        metrics.distribution(f"{_MULTI_METRICS_PREFIX}.tree.entry_count", len(tree))
+        metrics.distribution(f"{_MULTI_METRICS_PREFIX}.repo_size_bytes", repo_size_bytes)

--- a/src/sentry/integrations/api/endpoints/organization_repository_platforms_test.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_platforms_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from typing import Any
 
+import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import logger as sentry_logger
@@ -20,7 +21,6 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.utils import metrics
 
 # Metric namespace for the candidate (tree-based) detector.
 _MULTI_METRICS_PREFIX = "onboarding-scm.platform_detection.multi"
@@ -105,10 +105,19 @@ class OrganizationRepositoryPlatformsTestEndpoint(OrganizationRepositoryEndpoint
         is_truncated = bool(response.get("truncated")) if isinstance(response, dict) else False
         repo_size_bytes = sum(entry.get("size", 0) for entry in tree if entry.get("type") == "blob")
 
-        metrics.timing(f"{_MULTI_METRICS_PREFIX}.duration", time.monotonic() - start_time)
-        metrics.incr(
-            f"{_MULTI_METRICS_PREFIX}.completed",
-            tags={"is_truncated": "true" if is_truncated else "false"},
+        sentry_sdk.metrics.distribution(
+            f"{_MULTI_METRICS_PREFIX}.duration",
+            (time.monotonic() - start_time) * 1000,
+            unit="millisecond",
         )
-        metrics.distribution(f"{_MULTI_METRICS_PREFIX}.tree.entry_count", len(tree))
-        metrics.distribution(f"{_MULTI_METRICS_PREFIX}.repo_size_bytes", repo_size_bytes)
+        sentry_sdk.metrics.count(
+            f"{_MULTI_METRICS_PREFIX}.completed",
+            1,
+            attributes={"is_truncated": is_truncated},
+        )
+        sentry_sdk.metrics.distribution(f"{_MULTI_METRICS_PREFIX}.tree.entry_count", len(tree))
+        sentry_sdk.metrics.distribution(
+            f"{_MULTI_METRICS_PREFIX}.repo_size_bytes",
+            repo_size_bytes,
+            unit="byte",
+        )

--- a/src/sentry/integrations/api/endpoints/organization_repository_platforms_test.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_platforms_test.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import logging
 import time
 from typing import Any
 
 from rest_framework.request import Request
 from rest_framework.response import Response
+from sentry_sdk import logger as sentry_logger
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
@@ -22,11 +22,7 @@ from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import metrics
 
-logger = logging.getLogger(__name__)
-
-# Metric namespace for the candidate (tree-based) detector. Kept separate from
-# the live single-platform detector's `.single.*` metrics so the two can be
-# compared and this measurement removed/relocated cleanly at cutover.
+# Metric namespace for the candidate (tree-based) detector.
 _MULTI_METRICS_PREFIX = "onboarding-scm.platform_detection.multi"
 
 
@@ -79,8 +75,7 @@ class OrganizationRepositoryPlatformsTestEndpoint(OrganizationRepositoryEndpoint
 
         self._measure_tree(client, repo)
 
-        # Measurement-only: no body. A top-level list would trip Sentry's
-        # MissingPaginationError guard, so return 204 No Content instead.
+        # Measurement-only: no body.
         return Response(status=204)
 
     def _measure_tree(self, client: GitHubApiClient, repo: Repository) -> None:
@@ -89,7 +84,7 @@ class OrganizationRepositoryPlatformsTestEndpoint(OrganizationRepositoryEndpoint
         Uses the ``HEAD`` ref so a single ``git/trees`` call suffices (no branch
         resolution). The client's ``get_tree`` helper drops the ``truncated``
         flag, so we call ``client.get`` directly to keep ``truncated`` and the
-        per-entry ``size``.
+        per-entry ``size`` for now.
         """
         start_time = time.monotonic()
         try:
@@ -98,11 +93,11 @@ class OrganizationRepositoryPlatformsTestEndpoint(OrganizationRepositoryEndpoint
                 params={"recursive": 1},
             )
         except ApiError:
-            # Includes empty repos (409). Mirror the live path: log and bail
+            # Includes empty repos (409), which are expected. Log and bail
             # without emitting a completion, so failures don't skew the metrics.
-            logger.exception(
-                "integrations.github.platform_detection_measurement_failed",
-                extra={"repo_id": repo.id, "repo_name": repo.name},
+            sentry_logger.warning(
+                f"{_MULTI_METRICS_PREFIX}.failed",
+                attributes={"repo_id": repo.id, "repo_name": repo.name},
             )
             return
 

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -349,6 +349,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/repos/'
   | '/organizations/$organizationIdOrSlug/repos/$repoId/'
   | '/organizations/$organizationIdOrSlug/repos/$repoId/commits/'
+  | '/organizations/$organizationIdOrSlug/repos/$repoId/platforms-test/'
   | '/organizations/$organizationIdOrSlug/repos/$repoId/platforms/'
   | '/organizations/$organizationIdOrSlug/repos/settings/'
   | '/organizations/$organizationIdOrSlug/request-project-creation/'

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms_test.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms_test.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest import mock
+
+import responses
+from django.utils import timezone
+
+from sentry.models.repository import Repository
+from sentry.testutils.cases import APITestCase
+
+FEATURE_FLAG = "organizations:integrations-github-platform-detection"
+
+
+class OrganizationRepositoryPlatformsTestGetTest(APITestCase):
+    endpoint = "sentry-api-0-organization-repository-platforms-test"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+
+        ten_days = timezone.now() + timedelta(days=10)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="Github Test Org",
+            external_id="1",
+            metadata={
+                "access_token": "12345token",
+                "expires_at": ten_days.strftime("%Y-%m-%dT%H:%M:%S"),
+            },
+        )
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="integrations:github",
+            external_id="123",
+            integration_id=self.integration.id,
+        )
+
+    def test_feature_flag_required(self) -> None:
+        response = self.get_response(self.organization.slug, self.repo.id)
+        assert response.status_code == 404
+
+    def test_non_github_repo(self) -> None:
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="non-github-repo",
+            provider="integrations:bitbucket",
+            external_id="456",
+        )
+
+        with self.feature(FEATURE_FLAG):
+            response = self.get_response(self.organization.slug, repo.id)
+        assert response.status_code == 400
+        assert "only supported for GitHub" in response.data["detail"]
+
+    def test_repo_without_integration(self) -> None:
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="orphan-repo",
+            provider="integrations:github",
+            external_id="789",
+            integration_id=None,
+        )
+
+        with self.feature(FEATURE_FLAG):
+            response = self.get_response(self.organization.slug, repo.id)
+        assert response.status_code == 400
+
+    def test_repo_not_found(self) -> None:
+        with self.feature(FEATURE_FLAG):
+            response = self.get_response(self.organization.slug, 99999)
+        assert response.status_code == 404
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_returns_no_content(self, get_jwt: mock.MagicMock) -> None:
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/git/trees/HEAD",
+            json={
+                "sha": "abc",
+                "truncated": False,
+                "tree": [
+                    {"path": "src/app.py", "type": "blob", "size": 1234},
+                    {"path": "src", "type": "tree"},
+                ],
+            },
+            status=200,
+        )
+
+        with self.feature(FEATURE_FLAG):
+            response = self.get_response(self.organization.slug, self.repo.id)
+
+        assert response.status_code == 204
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_returns_no_content_on_github_error(self, get_jwt: mock.MagicMock) -> None:
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/git/trees/HEAD",
+            json={"message": "Git Repository is empty."},
+            status=409,
+        )
+
+        with self.feature(FEATURE_FLAG):
+            response = self.get_response(self.organization.slug, self.repo.id)
+
+        assert response.status_code == 204


### PR DESCRIPTION
Adds a measurement-only endpoint to size up the tree-based (multi-platform) detector before we build it, without touching the live detection path.

**Why a separate endpoint**: it runs in parallel with the current detection request, fully off the live path, so it can't slow down or break onboarding. Faster revert, we just remove the FE call. 

It reuses the existing endpoint's guarding, makes a single recursive git tree call off HEAD, and returns 204 (no body). We call the GitHub client directly instead of `get_tree` because that helper hides the truncated flag, which we need. 

Metrics (onboarding-scm.platform_detection.multi):

`duration`: tree fetch latency, to compare against the current detector.
`completed`: counter of successful runs, tagged is_truncated to see how often GitHub truncates the tree.
`tree.entry_count`: number of tree entries (repo size signal).
`repo_size_bytes`: total blob bytes (compute/cost signal).

On any GitHub error (incl. empty-repo 409) we log and bail without emitting completed, so failures don't skew the data.