### PR TITLE
ref(sentry-apps): tighten sentry_app_details + installation_details to Response[T]

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/installation_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_details.py
@@ -19,6 +19,7 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import SentryAppParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import SentryAppInstallationStatus
 from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
@@ -60,7 +61,7 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, installation) -> Response:
+    def get(self, request: Request, installation) -> Response[SentryAppInstallationResult]:
         """
         Return details about a single custom integration (Sentry App) installation.
         """
@@ -140,7 +141,9 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def put(self, request: Request, installation) -> Response:
+    def put(
+        self, request: Request, installation
+    ) -> Response[SentryAppInstallationResult] | Response[ValidationErrorResponse]:
         """
         Update a custom integration (Sentry App) installation, for example to mark a
         pending installation as installed.
@@ -161,4 +164,4 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
                     serializer=SentryAppInstallationSerializer(),
                 )
             )
-        return Response(serializer.errors, status=400)
+        return Response(as_validation_errors(serializer), status=400)

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
@@ -20,6 +20,11 @@ from sentry.api.serializers import serialize
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NO_CONTENT
 from sentry.apidocs.examples.sentry_app_examples import SentryAppExamples
 from sentry.apidocs.parameters import SentryAppParams
+from sentry.apidocs.response_types import (
+    DetailResponse,
+    ValidationErrorResponse,
+    as_validation_errors,
+)
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.staff import is_active_staff
 from sentry.constants import SentryAppStatus
@@ -76,7 +81,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
         },
         examples=SentryAppExamples.RETRIEVE_SENTRY_APP,
     )
-    def get(self, request: Request, sentry_app) -> Response:
+    def get(self, request: Request, sentry_app: SentryApp) -> Response[SentryAppSerializerResponse]:
         """
         Retrieve a custom integration.
         """
@@ -104,7 +109,13 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
         },
         examples=SentryAppExamples.UPDATE_SENTRY_APP,
     )
-    def put(self, request: Request, sentry_app) -> Response:
+    def put(
+        self, request: Request, sentry_app: SentryApp
+    ) -> (
+        Response[SentryAppSerializerResponse]
+        | Response[DetailResponse]
+        | Response[ValidationErrorResponse]
+    ):
         """
         Update an existing custom integration.
         """
@@ -204,7 +215,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                     )
                 )
 
-        return Response(serializer.errors, status=400)
+        return Response(as_validation_errors(serializer), status=400)
 
     @extend_schema(
         operation_id="Delete a custom integration.",


### PR DESCRIPTION
Four endpoint methods with typed `@extend_schema` responses but bare `-> Response` annotations.

- `sentry_app_details.get()`: annotate `sentry_app: SentryApp` so `serialize()` flows as `SentryAppSerializerResponse`. `put()` gains three union arms (success, `DetailResponse` for partnership/non-field errors, `ValidationErrorResponse` via `as_validation_errors`).
- `installation_details.get()`: tighten to `Response[SentryAppInstallationResult]`. `put()`: two union arms (success, `ValidationErrorResponse`).