### PR TITLE
ref(scm): Pass timeouts through the internal hybrid-cloud proxying

### DIFF
--- a/src/sentry/integrations/api/endpoints/integration_proxy.py
+++ b/src/sentry/integrations/api/endpoints/integration_proxy.py
@@ -40,7 +40,9 @@ from sentry.silo.util import (
     PROXY_OI_HEADER,
     PROXY_PATH,
     PROXY_SIGNATURE_HEADER,
+    PROXY_TIMEOUT_HEADER,
     clean_outbound_headers,
+    decode_proxy_timeout,
     trim_leading_slashes,
     verify_subnet_signature,
 )
@@ -266,6 +268,11 @@ class InternalIntegrationProxyEndpoint(Endpoint):
             method=request.method, url=full_url, headers=headers, data=request.body
         ).prepare()
 
+        # Honor the timeout the original caller forwarded so the downstream
+        # request can stay open as long as intended. Falls back to the client's
+        # default timeout when the header is absent or unparseable.
+        timeout = decode_proxy_timeout(request.headers.get(PROXY_TIMEOUT_HEADER))
+
         resp: Response = self.client.request(
             request.method,
             self.proxy_path,
@@ -273,6 +280,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
             prepared_request=prepared_request,
             raw_response=True,
             stream=True,
+            timeout=timeout,
         )
 
         def iter_response(response: Response) -> Generator[bytes]:

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -152,6 +152,18 @@ class BaseApiClient:
         """
         return prepared_request
 
+    def set_proxy_request_options(
+        self,
+        prepared_request: PreparedRequest,
+        timeout: int | float | tuple[float, float] | None,
+    ) -> None:
+        """
+        Allows subclasses to annotate the outgoing request with per-call options
+        (such as the resolved timeout) that aren't otherwise part of the prepared
+        request. No-op by default.
+        """
+        return None
+
     def is_response_fatal(self, resp: Response) -> bool:
         return False
 
@@ -335,6 +347,7 @@ class BaseApiClient:
         try:
             with self.build_session() as session:
                 finalized_request = self.finalize_request(_prepared_request)
+                self.set_proxy_request_options(finalized_request, timeout)
                 environment_settings = session.merge_environment_settings(
                     url=finalized_request.url,
                     proxies={},

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -31,6 +31,8 @@ from sentry.silo.util import (
     PROXY_OI_HEADER,
     PROXY_PATH,
     PROXY_SIGNATURE_HEADER,
+    PROXY_TIMEOUT_HEADER,
+    encode_proxy_timeout,
     encode_subnet_signature,
     trim_leading_slashes,
 )
@@ -243,3 +245,21 @@ class IntegrationProxyClient(ApiClient):
         )
         prepared_request.url = url
         return prepared_request
+
+    def set_proxy_request_options(
+        self,
+        prepared_request: PreparedRequest,
+        timeout: int | float | tuple[float, float] | None,
+    ) -> None:
+        """
+        Forward the resolved per-call timeout to the Control Silo proxy so the
+        downstream request to the service provider stays open as long as the
+        caller intended, instead of falling back to the Control Silo client's
+        default timeout.
+        """
+        if not self._should_proxy_to_control:
+            return
+
+        encoded = encode_proxy_timeout(timeout)
+        if encoded is not None:
+            prepared_request.headers[PROXY_TIMEOUT_HEADER] = encoded

--- a/src/sentry/silo/util.py
+++ b/src/sentry/silo/util.py
@@ -13,6 +13,7 @@ PROXY_BASE_URL_HEADER = "X-Sentry-Subnet-Base-URL"
 PROXY_SIGNATURE_HEADER = "X-Sentry-Subnet-Signature"
 PROXY_PATH = "X-Sentry-Subnet-Path"
 PROXY_KEYID_HEADER = "X-Sentry-Subnet-Keyid"
+PROXY_TIMEOUT_HEADER = "X-Sentry-Subnet-Timeout"
 PROXY_DIRECT_LOCATION_HEADER = "X-Sentry-Proxy-URL"
 PROXY_APIGATEWAY_HEADER = "X-Apigateway"
 
@@ -22,6 +23,7 @@ INVALID_OUTBOUND_HEADERS = INVALID_PROXY_HEADERS | {
     PROXY_SIGNATURE_HEADER,
     PROXY_BASE_URL_HEADER,
     PROXY_PATH,
+    PROXY_TIMEOUT_HEADER,
 }
 
 DEFAULT_REQUEST_BODY = b""
@@ -53,6 +55,38 @@ def clean_proxy_headers(headers: Mapping[str, str] | None) -> MutableMapping[str
 
 def clean_outbound_headers(headers: Mapping[str, str] | None) -> MutableMapping[str, str]:
     return clean_headers(headers, invalid_headers=INVALID_OUTBOUND_HEADERS)
+
+
+def encode_proxy_timeout(timeout: float | tuple[float, float] | None) -> str | None:
+    """Serialize a requests-style timeout for transport in a proxy header.
+
+    A scalar is encoded as a single value; a (connect, read) tuple is encoded as
+    two comma-separated values. ``None`` returns ``None`` so callers can skip the
+    header entirely and let the downstream client fall back to its default.
+    """
+    if timeout is None:
+        return None
+    if isinstance(timeout, tuple):
+        connect, read = timeout
+        return f"{connect},{read}"
+    return str(timeout)
+
+
+def decode_proxy_timeout(value: str | None) -> float | tuple[float, float] | None:
+    """Parse the value produced by :func:`encode_proxy_timeout`.
+
+    Returns ``None`` for a missing or unparseable header so the downstream client
+    falls back to its own default timeout rather than failing the request.
+    """
+    if not value:
+        return None
+    try:
+        if "," in value:
+            connect, read = value.split(",", 1)
+            return (float(connect), float(read))
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def encode_subnet_signature(

--- a/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
+++ b/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
@@ -47,6 +47,7 @@ class SiloHttpHeaders(TypedDict, total=False):
     HTTP_X_SENTRY_SUBNET_SIGNATURE: str
     HTTP_X_SENTRY_SUBNET_BASE_URL: str
     HTTP_X_SENTRY_SUBNET_PATH: str
+    HTTP_X_SENTRY_SUBNET_TIMEOUT: str
 
 
 def test_ensure_http_headers_match() -> None:
@@ -221,6 +222,71 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
             mock_metrics=mock_metrics,
             kwargs_to_match={"sample_rate": 1.0, "tags": {"status": 400}},
         )
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(ExampleIntegration, "get_client")
+    @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
+    @patch.object(metrics, "incr")
+    def test_proxy_forwards_timeout(
+        self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
+    ) -> None:
+        signature_path = f"/{self.proxy_path}"
+        headers = self.create_request_headers(
+            signature_path=signature_path,
+            integration_id=self.org_integration.id,
+        )
+        headers["HTTP_X_SENTRY_SUBNET_TIMEOUT"] = "90.0"
+
+        content = b"{}"
+        mock_response = MagicMock(spec=Response)
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.content = content
+        mock_response.status_code = 200
+        mock_response.reason = "OK"
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.iter_content = MagicMock(return_value=iter([content]))
+
+        mock_client.base_url = "https://example.com/api"
+        mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
+        mock_client.request = MagicMock(return_value=mock_response)
+        mock_get_client.return_value = mock_client
+
+        self.client.get(self.path, **headers)
+
+        # The caller's timeout is decoded and forwarded to the downstream request.
+        assert mock_client.request.call_args.kwargs["timeout"] == 90.0
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(ExampleIntegration, "get_client")
+    @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
+    @patch.object(metrics, "incr")
+    def test_proxy_without_timeout_header(
+        self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
+    ) -> None:
+        signature_path = f"/{self.proxy_path}"
+        headers = self.create_request_headers(
+            signature_path=signature_path,
+            integration_id=self.org_integration.id,
+        )
+
+        content = b"{}"
+        mock_response = MagicMock(spec=Response)
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.content = content
+        mock_response.status_code = 200
+        mock_response.reason = "OK"
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.iter_content = MagicMock(return_value=iter([content]))
+
+        mock_client.base_url = "https://example.com/api"
+        mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
+        mock_client.request = MagicMock(return_value=mock_response)
+        mock_get_client.return_value = mock_client
+
+        self.client.get(self.path, **headers)
+
+        # Absent header -> None, so the client falls back to its own default timeout.
+        assert mock_client.request.call_args.kwargs["timeout"] is None
 
     @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
     @patch.object(ExampleIntegration, "get_client")

--- a/tests/sentry/shared_integrations/client/test_proxy.py
+++ b/tests/sentry/shared_integrations/client/test_proxy.py
@@ -14,7 +14,12 @@ from sentry.shared_integrations.client.proxy import (
 )
 from sentry.shared_integrations.exceptions import ApiHostError
 from sentry.silo.base import SiloMode
-from sentry.silo.util import PROXY_OI_HEADER, PROXY_PATH, PROXY_SIGNATURE_HEADER
+from sentry.silo.util import (
+    PROXY_OI_HEADER,
+    PROXY_PATH,
+    PROXY_SIGNATURE_HEADER,
+    PROXY_TIMEOUT_HEADER,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
 
@@ -119,6 +124,33 @@ class IntegrationProxyClientTest(TestCase):
         for header in [PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER, PROXY_PATH]:
             assert header in prepared_request.headers
         assert prepared_request.headers[PROXY_PATH] == "get?query=1&user=me"
+
+    def test_set_proxy_request_options_forwards_timeout(self) -> None:
+        """When proxying to control, the per-call timeout is forwarded as a header."""
+        prepared_request = Request(method="GET", url=self.test_url).prepare()
+        client = self.client_cls(org_integration_id=self.oi_id)
+        client._should_proxy_to_control = True
+
+        client.set_proxy_request_options(prepared_request, timeout=60.0)
+        assert prepared_request.headers[PROXY_TIMEOUT_HEADER] == "60.0"
+
+    def test_set_proxy_request_options_no_timeout(self) -> None:
+        """A ``None`` timeout omits the header so control falls back to its default."""
+        prepared_request = Request(method="GET", url=self.test_url).prepare()
+        client = self.client_cls(org_integration_id=self.oi_id)
+        client._should_proxy_to_control = True
+
+        client.set_proxy_request_options(prepared_request, timeout=None)
+        assert PROXY_TIMEOUT_HEADER not in prepared_request.headers
+
+    def test_set_proxy_request_options_noop_without_proxy(self) -> None:
+        """Outside the proxy-to-control path the header is never added."""
+        prepared_request = Request(method="GET", url=self.test_url).prepare()
+        client = self.client_cls(org_integration_id=self.oi_id)
+        client._should_proxy_to_control = False
+
+        client.set_proxy_request_options(prepared_request, timeout=60.0)
+        assert PROXY_TIMEOUT_HEADER not in prepared_request.headers
 
     @patch("sentry.shared_integrations.client.proxy.get_control_silo_ip_address")
     @patch("socket.getaddrinfo")

--- a/tests/sentry/silo/test_util.py
+++ b/tests/sentry/silo/test_util.py
@@ -13,9 +13,12 @@ from sentry.silo.util import (
     PROXY_OI_HEADER,
     PROXY_PATH,
     PROXY_SIGNATURE_HEADER,
+    PROXY_TIMEOUT_HEADER,
     clean_headers,
     clean_outbound_headers,
     clean_proxy_headers,
+    decode_proxy_timeout,
+    encode_proxy_timeout,
     encode_subnet_signature,
     trim_leading_slashes,
     verify_subnet_signature,
@@ -34,6 +37,7 @@ class SiloUtilityTest(TestCase):
             PROXY_SIGNATURE_HEADER: "-leander(but-in-cursive)",
             PROXY_BASE_URL_HEADER: "https://api.integration.com/",
             PROXY_PATH: "additional/path/params",
+            PROXY_TIMEOUT_HEADER: "30.0",
             "X-Test-Header-1": "One",
             "X-Test-Header-2": "Two",
             "X-Test-Header-3": "Three",
@@ -80,6 +84,26 @@ class SiloUtilityTest(TestCase):
         retained_headers = filter(lambda k: k not in INVALID_OUTBOUND_HEADERS, self.headers.keys())
         for header in retained_headers:
             assert self.headers[header] == cleaned[header]
+
+    def test_encode_decode_proxy_timeout(self) -> None:
+        # Scalar timeouts round-trip.
+        assert encode_proxy_timeout(30) == "30"
+        assert decode_proxy_timeout("30") == 30.0
+        assert encode_proxy_timeout(45.5) == "45.5"
+        assert decode_proxy_timeout("45.5") == 45.5
+
+        # Tuple (connect, read) timeouts round-trip.
+        assert encode_proxy_timeout((3.0, 60.0)) == "3.0,60.0"
+        assert decode_proxy_timeout("3.0,60.0") == (3.0, 60.0)
+
+        # None means "no header", so downstream falls back to its own default.
+        assert encode_proxy_timeout(None) is None
+        assert decode_proxy_timeout(None) is None
+        assert decode_proxy_timeout("") is None
+
+        # Unparseable values are treated as absent rather than raising.
+        assert decode_proxy_timeout("not-a-number") is None
+        assert decode_proxy_timeout("1,2,3") is None
 
     def test_clean_hop_by_hop_headers(self) -> None:
         headers = {


### PR DESCRIPTION
Pass timeouts through the internal hybrid-cloud proxying.