### PR TITLE
ref(seer): Wrap settings pages with a Stack and hoist seer specific settings wrappers

### DIFF
--- a/static/app/views/settings/components/settingsLayout.tsx
+++ b/static/app/views/settings/components/settingsLayout.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Stack, Flex} from '@sentry/scraps/layout';
 
 import {useParams} from 'sentry/utils/useParams';
 import {TopBar} from 'sentry/views/navigation/topBar';
@@ -20,9 +20,9 @@ export function SettingsLayout({children}: Props) {
         <StyledSettingsBreadcrumb params={params} />
       </TopBar.Slot>
       <Flex flex="1">
-        <Container flex="1" padding="xl" minWidth="0">
+        <Stack flex="1" padding="xl" minWidth="0">
           {children}
-        </Container>
+        </Stack>
       </Flex>
     </SettingsColumn>
   );

--- a/static/gsApp/views/seerAutomation/advanced.tsx
+++ b/static/gsApp/views/seerAutomation/advanced.tsx
@@ -1,11 +1,12 @@
-import {Fragment} from 'react';
 import {mutationOptions} from '@tanstack/react-query';
 import {z} from 'zod';
 
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {updateOrganization} from 'sentry/actionCreators/organizations';
+import {AnalyticsArea} from 'sentry/components/analyticsArea';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
@@ -13,7 +14,7 @@ import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
-import {SeerSettingsPageContent} from 'getsentry/views/seerAutomation/components/seerSettingsPageContent';
+import {SeerSettingsPageBanners} from 'getsentry/views/seerAutomation/components/seerSettingsPageBanners';
 import {useCanWriteSettings} from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
 
 const schema = z.object({
@@ -32,7 +33,7 @@ export default function SeerAutomationAdvancedSettings() {
   });
 
   return (
-    <Fragment>
+    <AnalyticsArea name="advanced">
       <SentryDocumentTitle title={t('Advanced Settings')} />
       <SettingsPageHeader
         title={t('Advanced Settings')}
@@ -51,7 +52,8 @@ export default function SeerAutomationAdvancedSettings() {
           }
         )}
       />
-      <SeerSettingsPageContent>
+      <Stack gap="lg" flex="1" minHeight="0">
+        <SeerSettingsPageBanners />
         <FieldGroup>
           <AutoSaveForm
             name="enableSeerCoding"
@@ -84,7 +86,7 @@ export default function SeerAutomationAdvancedSettings() {
             )}
           </AutoSaveForm>
         </FieldGroup>
-      </SeerSettingsPageContent>
-    </Fragment>
+      </Stack>
+    </AnalyticsArea>
   );
 }

--- a/static/gsApp/views/seerAutomation/components/seerSettingsPageBanners.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerSettingsPageBanners.tsx
@@ -1,5 +1,6 @@
+import {Fragment} from 'react';
+
 import {Alert} from '@sentry/scraps/alert';
-import {Stack} from '@sentry/scraps/layout';
 
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -8,11 +9,7 @@ import {useSubscription} from 'getsentry/hooks/useSubscription';
 import {NoActiveSeerSubscriptionBanner} from 'getsentry/views/seerAutomation/components/noActiveSeerSubscriptionBanner';
 import {useCanWriteSettings} from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
 
-interface Props {
-  children: React.ReactNode;
-}
-
-export function SeerSettingsPageContent({children}: Props) {
+export function SeerSettingsPageBanners() {
   const subscription = useSubscription();
   const organization = useOrganization();
   const canWrite = useCanWriteSettings();
@@ -25,7 +22,7 @@ export function SeerSettingsPageContent({children}: Props) {
     subscription?.canSelfServe;
 
   return (
-    <Stack gap="lg">
+    <Fragment>
       {showNoActiveSeerSubscriptionBanner ? <NoActiveSeerSubscriptionBanner /> : null}
 
       {canWrite ? null : (
@@ -35,8 +32,6 @@ export function SeerSettingsPageContent({children}: Props) {
           )}
         </Alert>
       )}
-
-      {children}
-    </Stack>
+    </Fragment>
   );
 }

--- a/static/gsApp/views/seerAutomation/projects.tsx
+++ b/static/gsApp/views/seerAutomation/projects.tsx
@@ -1,6 +1,7 @@
 import {Outlet} from 'react-router-dom';
 
 import {LinkButton} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
@@ -12,7 +13,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
 import {SeerProjectTable} from 'getsentry/views/seerAutomation/components/projectTable/seerProjectTable';
-import {SeerSettingsPageContent} from 'getsentry/views/seerAutomation/components/seerSettingsPageContent';
+import {SeerSettingsPageBanners} from 'getsentry/views/seerAutomation/components/seerSettingsPageBanners';
 
 export default function SeerAutomationProjects() {
   const location = useLocation();
@@ -47,9 +48,10 @@ export default function SeerAutomationProjects() {
           }
         )}
       />
-      <SeerSettingsPageContent>
+      <Stack gap="lg" flex="1" minHeight="0" contain="size">
+        <SeerSettingsPageBanners />
         <SeerProjectTable />
-      </SeerSettingsPageContent>
+      </Stack>
       <Outlet />
     </AnalyticsArea>
   );

--- a/static/gsApp/views/seerAutomation/repos.tsx
+++ b/static/gsApp/views/seerAutomation/repos.tsx
@@ -1,6 +1,7 @@
 import {Outlet} from 'react-router-dom';
 
 import {LinkButton} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
@@ -13,7 +14,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
 import {SeerRepoTable} from 'getsentry/views/seerAutomation/components/repoTable/seerRepoTable';
-import {SeerSettingsPageContent} from 'getsentry/views/seerAutomation/components/seerSettingsPageContent';
+import {SeerSettingsPageBanners} from 'getsentry/views/seerAutomation/components/seerSettingsPageBanners';
 import {orgHasCodeReviewFeature} from 'getsentry/views/seerAutomation/utils';
 
 export default function SeerAutomationRepos() {
@@ -58,9 +59,10 @@ export default function SeerAutomationRepos() {
           }
         )}
       />
-      <SeerSettingsPageContent>
+      <Stack gap="lg" flex="1" minHeight="0" contain="size">
+        <SeerSettingsPageBanners />
         <SeerRepoTable />
-      </SeerSettingsPageContent>
+      </Stack>
       <Outlet />
     </AnalyticsArea>
   );


### PR DESCRIPTION
The big change here is swapping from Container to Stack in [settingsLayout.tsx](https://github.com/getsentry/sentry/compare/ryan953/ref-SeerSettingsPageBanners?expand=1#diff-af63da572b4af2552e84103519e1e8fd1b1c4d8ce0c56d03cb6a33bdf86a6563). That's just adding `display: flex; flex-direction: column` to the html. 

I also pulled the Stack out of SeerSettingsPageContent and into the callsites, with some prop changes for the future. no big impact here.

# Testing
I tested by rendering pages side-by-side, scrolling arond.
| page | scenario |
| --- | --- |
| /settings/organization/ | basic form page
| /settings/stats/issues/ | complex layout
| /settings/seer/projects/ | long scrolling table
| /settings/seer/repos/ | virtual list w/ constrained height
| /settings/seer/advanced/ | short, non-scrolling page

