### PR TITLE
test(snapshots): Add diff mode toolbar snapshots

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
@@ -190,10 +190,10 @@ describe('SnapshotsToolbar', () => {
       {tags: {area: 'snapshots'}}
     );
 
-    describe.each(['split', 'wipe', 'onion'] as const)('diff mode %s', diffMode => {
-      it.snapshot(
-        'toolbar',
-        () => (
+    describe('diff mode', () => {
+      it.snapshot.each<DiffMode>(['split', 'wipe', 'onion'])(
+        '%s',
+        diffMode => (
           <ThemeProvider theme={themes[themeName]}>
             <div style={{width: 960}}>
               <SnapshotsToolbarWithControls
@@ -210,7 +210,7 @@ describe('SnapshotsToolbar', () => {
             </div>
           </ThemeProvider>
         ),
-        {tags: {area: 'snapshots', diffMode}}
+        diffMode => ({tags: {area: 'snapshots', diffMode}})
       );
     });
   });

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
@@ -189,5 +189,29 @@ describe('SnapshotsToolbar', () => {
       ),
       {tags: {area: 'snapshots'}}
     );
+
+    describe.each(['split', 'wipe', 'onion'] as const)('diff mode %s', diffMode => {
+      it.snapshot(
+        'toolbar',
+        () => (
+          <ThemeProvider theme={themes[themeName]}>
+            <div style={{width: 960}}>
+              <SnapshotsToolbarWithControls
+                viewMode="single"
+                onViewModeChange={noop}
+                diff={{
+                  mode: diffMode,
+                  onModeChange: noop,
+                  overlayColor: '#f55459',
+                  onOverlayColorChange: noop,
+                }}
+                solo={{isActive: false, onToggle: noop}}
+              />
+            </div>
+          </ThemeProvider>
+        ),
+        {tags: {area: 'snapshots', diffMode}}
+      );
+    });
   });
 });


### PR DESCRIPTION
Add per-theme snapshot coverage for the snapshots toolbar across its three diff modes.

A nested `describe.each(['split', 'wipe', 'onion'])` inside the existing light/dark theme block produces six snapshots (theme × diff mode), exercising `DiffModeToggle` in each state. The `split` case additionally renders the `ColorPickerButton`, which only appears in split mode, so regressions in that conditional are caught too.