### PR TITLE
ref: move system.logging-format to django settings as SENTRY_LOGGING_FORMAT

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -31,6 +31,7 @@ from sentry.conf.types.sdk_config import ServerSdkConfig
 from sentry.conf.types.sentry_config import SentryMode
 from sentry.conf.types.service_options import ServiceOptions
 from sentry.conf.types.uptime import UptimeRegionConfig
+from sentry.logging import LoggingFormat
 
 
 def gettext_noop(s: str) -> str:
@@ -1278,6 +1279,11 @@ else:
 # providing the cli with -l/--loglevel or the SENTRY_LOG_LEVEL env var.
 # The loggers that it overrides are root and any in LOGGING.overridable.
 # Be very careful with this in a production system
+# Output format for application logs. See sentry.logging.LoggingFormat for
+# valid values ("human" or "machine"). Set at deploy time via the
+# SENTRY_LOG_FORMAT environment variable.
+SENTRY_LOGGING_FORMAT = os.environ.get("SENTRY_LOG_FORMAT", LoggingFormat.HUMAN).lower()
+
 LOGGING: LoggingConfig = {
     "default_level": "INFO",
     "version": 1,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -31,7 +31,6 @@ from sentry.conf.types.sdk_config import ServerSdkConfig
 from sentry.conf.types.sentry_config import SentryMode
 from sentry.conf.types.service_options import ServiceOptions
 from sentry.conf.types.uptime import UptimeRegionConfig
-from sentry.logging import LoggingFormat
 
 
 def gettext_noop(s: str) -> str:
@@ -1279,11 +1278,6 @@ else:
 # providing the cli with -l/--loglevel or the SENTRY_LOG_LEVEL env var.
 # The loggers that it overrides are root and any in LOGGING.overridable.
 # Be very careful with this in a production system
-# Output format for application logs. See sentry.logging.LoggingFormat for
-# valid values ("human" or "machine"). Set at deploy time via the
-# SENTRY_LOG_FORMAT environment variable.
-SENTRY_LOGGING_FORMAT = os.environ.get("SENTRY_LOG_FORMAT", LoggingFormat.HUMAN).lower()
-
 LOGGING: LoggingConfig = {
     "default_level": "INFO",
     "version": 1,
@@ -2351,6 +2345,7 @@ DEAD = object()
 # This will eventually get set from values in SENTRY_OPTIONS during
 # sentry.runner.initializer:bootstrap_options
 SECRET_KEY = DEAD
+SENTRY_LOGGING_FORMAT = DEAD
 EMAIL_BACKEND = DEAD
 EMAIL_HOST = DEAD
 EMAIL_PORT = DEAD

--- a/src/sentry/logging/README.rst
+++ b/src/sentry/logging/README.rst
@@ -68,7 +68,7 @@ are defined in ``LOGGING.overridable``.
 Formats
 ```````
 The ``StructlogHandler`` has the ability to write its records based on a specified logging
-format defined in the options by ``system.logging-format``.
+format defined by the ``SENTRY_LOGGING_FORMAT`` Django setting.
 
 Human
 ~~~~~

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1,5 +1,6 @@
 import os
 
+from sentry.logging import LoggingFormat
 from sentry.options import register
 from sentry.options.manager import (
     FLAG_ALLOW_EMPTY,
@@ -45,6 +46,10 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register("system.secret-key", flags=FLAG_CREDENTIAL | FLAG_NOSTORE)
+# Read internally via the SENTRY_LOGGING_FORMAT Django setting, which
+# options_mapper populates from this option (see sentry.runner.initializer).
+# Registration supplies the default that gets promoted into the setting.
+register("system.logging-format", default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)
 # This is used for the chunk upload endpoint
 register("system.upload-url-prefix", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1,6 +1,5 @@
 import os
 
-from sentry.logging import LoggingFormat
 from sentry.options import register
 from sentry.options.manager import (
     FLAG_ALLOW_EMPTY,
@@ -46,7 +45,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register("system.secret-key", flags=FLAG_CREDENTIAL | FLAG_NOSTORE)
-register("system.logging-format", default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)
 # This is used for the chunk upload endpoint
 register("system.upload-url-prefix", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -210,7 +210,6 @@ def configure_structlog() -> None:
     import structlog
     from django.conf import settings
 
-    from sentry import options
     from sentry.logging import LoggingFormat
 
     kwargs: dict[str, Any] = {
@@ -223,11 +222,7 @@ def configure_structlog() -> None:
         ],
     }
 
-    fmt_from_env = os.environ.get("SENTRY_LOG_FORMAT")
-    if fmt_from_env:
-        settings.SENTRY_OPTIONS["system.logging-format"] = fmt_from_env.lower()
-
-    fmt = options.get("system.logging-format")
+    fmt = settings.SENTRY_LOGGING_FORMAT
 
     if fmt == LoggingFormat.HUMAN:
         from sentry.logging.handlers import HumanRenderer

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -117,6 +117,7 @@ options_mapper = {
     # 'system.databases': 'DATABASES',
     # 'system.debug': 'DEBUG',
     "system.secret-key": "SECRET_KEY",
+    "system.logging-format": "SENTRY_LOGGING_FORMAT",
     "mail.backend": "EMAIL_BACKEND",
     "mail.host": "EMAIL_HOST",
     "mail.port": "EMAIL_PORT",
@@ -292,6 +293,13 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
         )
 
     bootstrap_options(settings, config["options"])
+
+    # The SENTRY_LOG_FORMAT env var (e.g. the `--logformat` CLI flag) overrides
+    # the configured SENTRY_LOGGING_FORMAT (which options_mapper populated from
+    # the system.logging-format option in bootstrap_options).
+    fmt_from_env = os.environ.get("SENTRY_LOG_FORMAT")
+    if fmt_from_env:
+        settings.SENTRY_LOGGING_FORMAT = fmt_from_env.lower()
 
     logging.raiseExceptions = settings.DEBUG
 

--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -44,7 +44,6 @@ class SentryHTTPServer(Service):
     ) -> None:
         from django.conf import settings
 
-        from sentry import options as sentry_options
         from sentry.logging import LoggingFormat
 
         host = host or settings.SENTRY_WEB_HOST
@@ -85,7 +84,7 @@ class SentryHTTPServer(Service):
         # also an assumption that anyone operating at the scale of needing
         # machine formatted logs, they are also using nginx in front which
         # has it's own logs that can be formatted correctly.
-        if sentry_options.get("system.logging-format") == LoggingFormat.MACHINE:
+        if settings.SENTRY_LOGGING_FORMAT == LoggingFormat.MACHINE:
             options["disable-logging"] = True
 
         # Old options from uwsgi

--- a/src/sentry/utils/email/message_builder.py
+++ b/src/sentry/utils/email/message_builder.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import lxml.html
 import toronado
+from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.utils.encoding import force_str
 
@@ -262,7 +263,7 @@ class MessageBuilder:
     ) -> None:
         from sentry.tasks.email import send_email, send_email_control
 
-        fmt = options.get("system.logging-format")
+        fmt = settings.SENTRY_LOGGING_FORMAT
         messages = self.get_built_messages(to, reply_to, cc=cc, bcc=bcc)
         extra: MutableMapping[str, str | tuple[str]] = {"message_type": self.type}
         loggable = [v for k, v in self.context.items() if hasattr(v, "id")]

--- a/tests/sentry/services/test_http.py
+++ b/tests/sentry/services/test_http.py
@@ -35,9 +35,9 @@ class HTTPServiceTest(TestCase):
             assert server.options["proc-name"] == "LOL"
 
     def test_format_logs(self) -> None:
-        with self.options({"system.logging-format": "human"}):
+        with override_settings(SENTRY_LOGGING_FORMAT="human"):
             server = SentryHTTPServer()
             assert server.options["log-enabled"] is True
-        with self.options({"system.logging-format": "machine"}):
+        with override_settings(SENTRY_LOGGING_FORMAT="machine"):
             server = SentryHTTPServer()
             assert server.options["log-enabled"] is False


### PR DESCRIPTION
https://linear.app/getsentry/issue/DI-1999/migrate-systemlogging-format-as-a-poc

this is the first step in moving all FLAG_NOSTORE (file-only) options to
django settings to prove the shape + rollout

i'm leveraging the existing `options_mapper` machinery so `SENTRY_OPTIONS["system.logging-format"]` continues to work in getsentry - that's moved over in https://github.com/getsentry/getsentry/pull/20603 but merging this sentry PR by itself is safe and compatible with both

the full rollout would be:
- merge this (safe to do independent of below)
- merge https://github.com/getsentry/getsentry/pull/20603
- cleanup the`options_mapper` entry, `register()` call, and `SENTRY_LOGGING_FORMAT = DEAD`

verified locally with:

```python
import os
import warnings

os.environ.setdefault("SENTRY_CONF", "getsentry/settings.py")

from sentry.runner import configure

with warnings.catch_warnings(record=True) as caught:
    warnings.simplefilter("always")
    configure()

from django.conf import settings

from sentry.conf.server import DEAD
from sentry.runner.initializer import bootstrap_options, validate_options

logging_warnings = [str(w.message) for w in caught if "logging" in str(w.message).lower()]
print("[dev] SENTRY_LOGGING_FORMAT =", repr(settings.SENTRY_LOGGING_FORMAT))
print("[dev] option              =", repr(settings.SENTRY_OPTIONS.get("system.logging-format")))
print("[dev] logging warnings    =", logging_warnings)
assert settings.SENTRY_LOGGING_FORMAT == "human", settings.SENTRY_LOGGING_FORMAT
assert not logging_warnings, logging_warnings

# Simulate a deploy (e.g. cellsilo) that sets MACHINE via the option, resetting
# the setting to the DEAD sentinel that server.py starts from.
settings.SENTRY_LOGGING_FORMAT = DEAD
settings.SENTRY_OPTIONS["system.logging-format"] = "machine"
bootstrap_options(settings)
fmt_from_env = os.environ.get("SENTRY_LOG_FORMAT")
if fmt_from_env:
    settings.SENTRY_LOGGING_FORMAT = fmt_from_env.lower()

print("[machine] setting =", repr(settings.SENTRY_LOGGING_FORMAT))
print("[machine] option  =", repr(settings.SENTRY_OPTIONS.get("system.logging-format")))
assert settings.SENTRY_LOGGING_FORMAT == "machine", settings.SENTRY_LOGGING_FORMAT

validate_options(settings)
print("[machine] validate_options ok (no unknown-option warning/crash)")
print("\nOK")
```

```bash
SENTRY_CONF=getsentry/settings.py ../sentry/.venv/bin/python bin/verify-logging-format
```