### PR TITLE
test(preprod): Hide overlay color picker at xs in toolbar snapshot

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
@@ -119,27 +119,29 @@ describe('SnapshotsToolbar', () => {
     it.snapshot.breakpoints(
       ['xs', 'sm', 'md'],
       'all controls',
-      width => (
-        <ThemeProvider theme={themes[themeName]}>
-          <div style={{width: '100%'}}>
-            <SnapshotsToolbarWithControls
-              viewMode="list"
-              onViewModeChange={noop}
-              progress={{current: 3, total: 12, percent: 25}}
-              sort={{value: 'diff', onChange: noop}}
-              diff={{
-                mode: 'split',
-                onModeChange: noop,
-                overlayColor: '#f55459',
-                onOverlayColorChange: noop,
-                // Mirror production's `showSplit={breakpoints.sm}`.
-                showSplit: width >= parseInt(themes[themeName].breakpoints.sm, 10),
-              }}
-              solo={{isActive: false, onToggle: noop}}
-            />
-          </div>
-        </ThemeProvider>
-      ),
+      width => {
+        const isSm = width >= parseInt(themes[themeName].breakpoints.sm, 10);
+        return (
+          <ThemeProvider theme={themes[themeName]}>
+            <div style={{width: '100%'}}>
+              <SnapshotsToolbarWithControls
+                viewMode="list"
+                onViewModeChange={noop}
+                progress={{current: 3, total: 12, percent: 25}}
+                sort={{value: 'diff', onChange: noop}}
+                diff={{
+                  mode: isSm ? 'split' : 'wipe',
+                  onModeChange: noop,
+                  overlayColor: '#f55459',
+                  onOverlayColorChange: noop,
+                  showSplit: isSm,
+                }}
+                solo={{isActive: false, onToggle: noop}}
+              />
+            </div>
+          </ThemeProvider>
+        );
+      },
       {tags: {area: 'snapshots'}}
     );
 


### PR DESCRIPTION
The `all controls` breakpoint snapshot for `SnapshotsToolbar` hardcoded `diffMode='split'`, which rendered the overlay `ColorPickerButton` at the `xs` breakpoint. Production never reaches this state, so the baseline was capturing an unreachable UI.

**Why the xs state was wrong**

`snapshots.tsx` derives `effectiveDiffMode`, coercing `'split'` to `'wipe'` below the `sm` breakpoint before passing the mode down. The color picker is gated on `diffMode === 'split'`, so in production it is hidden at `xs`. The snapshot skipped this coercion and showed the picker anyway.

The snapshot now derives the mode the same way (`split` at/above `sm`, `wipe` below), so the `xs` baseline matches real behavior. No production code changes; `sm`/`md` snapshots are unchanged.