### PR TITLE
feat(cmdk): Suggest auth token destinations

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
@@ -334,6 +334,12 @@ describe('GlobalCommandPaletteActions - search recall', () => {
 
   it.each([
     ['auth tok', /Organization Tokens/, /Personal Tokens/],
+    [
+      'SENTRY_AUTH_TOKEN',
+      /Settings.*Organization Tokens/,
+      /Settings.*Custom Integrations/,
+      /Settings.*Personal Tokens/,
+    ],
     ['source map', /Project Settings.*Source Maps/],
     ['codeowners', /Project Settings.*Ownership Rules/],
     ['inbound', /Project Settings.*Inbound Filters/],

--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -282,6 +282,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
             t('internal integration'),
             t('developer settings'),
             t('webhooks'),
+            'SENTRY_AUTH_TOKEN',
           ],
           description: t('Manage custom integrations'),
           id: 'developer-settings',
@@ -303,6 +304,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
             t('token'),
             t('credentials'),
             t('user auth tokens'),
+            'SENTRY_AUTH_TOKEN',
           ],
           description: t('Manage organization tokens'),
           id: 'auth-tokens',
@@ -318,6 +320,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
             t('token'),
             t('credentials'),
             t('user auth tokens'),
+            'SENTRY_AUTH_TOKEN',
           ],
           description: t(
             "Personal tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."


### PR DESCRIPTION
Command+K now surfaces product destinations when users paste `SENTRY_AUTH_TOKEN` into the palette. The existing settings actions for organization tokens, custom integrations, and personal tokens get the env-var keyword so the search lands on the same product pages users already see for auth-token queries.

The docs result is intentionally left out of this PR. A better follow-up is to add `SENTRY_AUTH_TOKEN` as a synonym or search term in the docs search index so Help can return the Auth Tokens page through the same path as other docs results.