### PR TITLE
fix(search): Treat Seer datetimes as plain UTC instead of Z-stripping

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
@@ -189,10 +189,10 @@ describe('buildSeerDateTimeSelection', () => {
     start: '2024-01-01T00:00:00',
     end: '2024-01-02T00:00:00',
     period: '24h',
-    utc: true,
+    utc: false,
   };
 
-  it('strips Z suffix and converts to ISO when both start and end provided', () => {
+  it('treats Seer UTC datetimes as plain UTC when both start and end provided', () => {
     const result = buildSeerDateTimeSelection(
       '2024-06-01T00:00:00Z',
       '2024-06-02T00:00:00Z',
@@ -200,9 +200,11 @@ describe('buildSeerDateTimeSelection', () => {
       pageFiltersDatetime
     );
 
-    expect(result.start).toBe(new Date('2024-06-01T00:00:00').toISOString());
-    expect(result.end).toBe(new Date('2024-06-02T00:00:00').toISOString());
+    expect(result.start).toBe('2024-06-01T00:00:00');
+    expect(result.end).toBe('2024-06-02T00:00:00');
     expect(result.period).toBeNull();
+    // Forces UTC display so the picker matches the UTC suggestion preview,
+    // even though the page filter is not in UTC.
     expect(result.utc).toBe(true);
   });
 
@@ -212,7 +214,8 @@ describe('buildSeerDateTimeSelection', () => {
     expect(result.start).toBe('2024-01-01T00:00:00');
     expect(result.end).toBe('2024-01-02T00:00:00');
     expect(result.period).toBe('24h');
-    expect(result.utc).toBe(true);
+    // Inherits the page filter's utc flag when falling back.
+    expect(result.utc).toBe(false);
   });
 
   it('uses statsPeriod when no start/end', () => {
@@ -234,7 +237,7 @@ describe('buildSeerDateTimeSelection', () => {
     expect(result.period).toBeNull();
   });
 
-  it('handles dates without Z suffix', () => {
+  it('does not shift dates without a Z suffix', () => {
     const result = buildSeerDateTimeSelection(
       '2024-06-01T12:00:00',
       '2024-06-02T12:00:00',
@@ -242,8 +245,8 @@ describe('buildSeerDateTimeSelection', () => {
       pageFiltersDatetime
     );
 
-    expect(result.start).toBe(new Date('2024-06-01T12:00:00').toISOString());
-    expect(result.end).toBe(new Date('2024-06-02T12:00:00').toISOString());
+    expect(result.start).toBe('2024-06-01T12:00:00');
+    expect(result.end).toBe('2024-06-02T12:00:00');
   });
 });
 

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -9,6 +9,7 @@ import {Token} from 'sentry/components/searchSyntax/parser';
 import {stringifyToken} from 'sentry/components/searchSyntax/utils';
 import type {DateString} from 'sentry/types/core';
 import type {PageFilters} from 'sentry/types/core';
+import {getUtcDateString} from 'sentry/utils/dates';
 import {useProjects} from 'sentry/utils/useProjects';
 import {isChartType} from 'sentry/views/insights/common/components/chart';
 
@@ -141,11 +142,8 @@ export function buildSeerDateTimeSelection(
   let end: DateString = null;
 
   if (resultStart && resultEnd) {
-    // Strip 'Z' suffix to treat UTC dates as local time
-    const startLocal = resultStart.endsWith('Z') ? resultStart.slice(0, -1) : resultStart;
-    const endLocal = resultEnd.endsWith('Z') ? resultEnd.slice(0, -1) : resultEnd;
-    start = new Date(startLocal).toISOString();
-    end = new Date(endLocal).toISOString();
+    start = getUtcDateString(resultStart);
+    end = getUtcDateString(resultEnd);
   } else {
     start = pageFiltersDatetime.start;
     end = pageFiltersDatetime.end;
@@ -154,7 +152,9 @@ export function buildSeerDateTimeSelection(
   return {
     start,
     end,
-    utc: pageFiltersDatetime.utc,
+    // Seer returns absolute ranges as UTC, so display them in UTC to match the
+    // suggestion preview the user accepted.
+    utc: resultStart && resultEnd ? true : pageFiltersDatetime.utc,
     period: resultStart && resultEnd ? null : statsPeriod || pageFiltersDatetime.period,
   };
 }

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -152,14 +152,9 @@ export function formatQueryToNaturalLanguage(query: string): string {
 }
 
 /**
- * Formats a date range for display.
- *
- * The endpoint returns times in UTC format, but the values represent what the user
- * intended in their local context. E.g., if user asks for "9pm", endpoint returns
- * "T21:00:00Z" - we want to display "9:00 PM", not convert to local timezone.
+ * Formats a UTC date range for display.
  */
 export function formatDateRange(start: string, end: string, separator = ' to '): string {
-  // Parse as UTC but display the UTC values directly (without timezone conversion)
   const startMoment = moment.utc(start);
   const endMoment = moment.utc(end);
 

--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -156,10 +156,14 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
         newQueryParams.start = typeof start === 'string' ? start : start?.toISOString();
         newQueryParams.end = typeof end === 'string' ? end : end?.toISOString();
         newQueryParams.statsPeriod = undefined;
+        // Seer absolute ranges are UTC; carry the flag so Discover charts
+        // display them in UTC instead of the page's local timezone.
+        newQueryParams.utc = dt.utc ? 'true' : undefined;
       } else if (statsPeriod) {
         newQueryParams.statsPeriod = statsPeriod;
         newQueryParams.start = undefined;
         newQueryParams.end = undefined;
+        newQueryParams.utc = dt.utc ? 'true' : undefined;
       }
 
       if (runId !== undefined) {

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -106,6 +106,9 @@ export function IssueListSeerComboBox() {
           statsPeriod,
           start: undefined,
           end: undefined,
+          // Clear any utc flag left over from a prior absolute range; a relative
+          // window has no UTC display semantics to preserve.
+          utc: undefined,
         };
       }
 

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -18,6 +18,7 @@ import {
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {getUtcDateString} from 'sentry/utils/dates';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -92,15 +93,13 @@ export function IssueListSeerComboBox() {
       let timeParams: Record<string, string | undefined> = {};
 
       if (resultStart && resultEnd) {
-        // Strip 'Z' suffix to treat UTC dates as local time
-        const startLocal = resultStart.endsWith('Z')
-          ? resultStart.slice(0, -1)
-          : resultStart;
-        const endLocal = resultEnd.endsWith('Z') ? resultEnd.slice(0, -1) : resultEnd;
         timeParams = {
-          start: new Date(startLocal).toISOString(),
-          end: new Date(endLocal).toISOString(),
+          start: getUtcDateString(resultStart),
+          end: getUtcDateString(resultEnd),
           statsPeriod: undefined,
+          // Seer returns absolute ranges as UTC, so display them in UTC to match
+          // the suggestion preview the user accepted.
+          utc: 'true',
         };
       } else if (statsPeriod) {
         timeParams = {


### PR DESCRIPTION
## Summary

When a user accepted a Seer suggestion with an absolute time range, the returned `start`/`end` were "Z-stripped" and re-parsed via `new Date(...)`, reinterpreting them in the browser's local timezone. For non-UTC users this double-shifted the range and sent the **wrong instant** to the API.

Seer already returns real UTC instants — the `assisted_query` prompt interprets relative dates in the user's timezone (passed from `collect_user_org_context`) and converts to UTC server-side. So the frontend should treat these values as plain UTC.

This PR:
- Replaces the Z-strip in `buildSeerDateTimeSelection` and the duplicate in `issueListSeerComboBox.tsx` with `getUtcDateString`, which parses as UTC and emits the bare `YYYY-MM-DDTHH:mm:ss` format the page filters expect.
- Forces `utc: true` for Seer **absolute** ranges so the picker displays the same UTC wall-clock as the accepted suggestion preview (rendered via `moment.utc`). Fallback / statsPeriod paths still inherit the existing `utc` flag.

### Behavior change

Not behavior-preserving for non-UTC users — that's the point. Old behavior queried the wrong instant but displayed Seer's literal digits; new behavior queries the correct instant and preserves that displayed wall-clock.

## Test plan

- [x] `pnpm test-ci .../useSeerComboBoxSetup.spec.tsx static/app/views/explore/seerQuery.spec.tsx` (20 passed)
- [x] `pnpm run lint:js` on changed files
- [x] Manual: in a non-UTC timezone, accept a Seer suggestion with an explicit range (Explore or Issues) and confirm the URL `start`/`end` are plain UTC and the picker matches the suggestion preview.