### PR TITLE
feat(GAL): Add handling of GALEs during group merge

### DIFF
--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -5,10 +5,12 @@ from typing import Any
 import sentry_sdk
 from django.db import DataError, IntegrityError, router, transaction
 from django.db.models import F
+from django.db.models.functions import Coalesce
 from taskbroker_client.retry import Retry
 
 from sentry import eventstream, similarity, tsdb
 from sentry.db.models.base import Model
+from sentry.issues.groupactionlogentry import GroupActionLogEntry
 from sentry.models.group import Group
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, track_group_async_operation
@@ -101,6 +103,7 @@ def merge_groups(
             UserReport,
             GroupRedirect,
             GroupMeta,
+            GroupActionLogEntry,
         )
 
         has_more = merge_objects(
@@ -241,6 +244,10 @@ def merge_objects(
         else:
             queryset = project_qs.filter(group_id=group.id)  # type: ignore[misc]
             update_kwargs["group_id"] = new_group.id
+
+        if "original_group_id" in all_fields:
+            # Only set original_group_id if not already set.
+            update_kwargs["original_group_id"] = Coalesce(F("original_group_id"), group.id)
 
         for obj in queryset[:limit]:
             try:

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -75,6 +75,8 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.types import ExternalProviders
 from sentry.issue_detection.performance_problem import PerformanceProblem
+from sentry.issues.action_log.types import GroupActionType, GroupActorType
+from sentry.issues.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.grouptype import get_group_type_by_type_id
 from sentry.models.activity import Activity
 from sentry.models.apikey import ApiKey
@@ -1266,6 +1268,34 @@ class Factories:
     @assume_test_silo_mode(SiloMode.CELL)
     def create_group_activity(group, *args, **kwargs):
         return Activity.objects.create(group=group, project=group.project, *args, **kwargs)
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_group_action_log_entry(
+        group, type=None, actor_type=None, actor_id=None, source=None, data=None, *args, **kwargs
+    ) -> GroupActionLogEntry:
+        if type is None:
+            type = GroupActionType.VIEW
+        if actor_type is None:
+            actor_type = GroupActorType.SYSTEM
+        if actor_id is None:
+            actor_id = 1234
+        if source is None:
+            source = "testutils.factories"
+        if data is None:
+            data = {}
+
+        return GroupActionLogEntry.objects.create(
+            group_id=group.id,
+            project_id=group.project.id,
+            type=type,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            source=source,
+            data=data,
+            *args,
+            **kwargs,
+        )
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CELL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -20,6 +20,7 @@ from sentry.incidents.models.alert_rule import AlertRule
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.issues.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.environment import Environment
@@ -359,6 +360,11 @@ class Fixtures:
         if group is None:
             group = self.group
         return Factories.create_group_activity(group, *args, **kwargs)
+
+    def create_group_action_log_entry(self, group=None, *args, **kwargs) -> GroupActionLogEntry:
+        if group is None:
+            group = self.group
+        return Factories.create_group_action_log_entry(group, *args, **kwargs)
 
     def create_n_groups_with_hashes(
         self, number_of_groups: int, project: Project, group_type: int | None = None

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -221,3 +221,20 @@ class MergeGroupTest(TestCase, SnubaTestCase):
         fetch_buffered_group_stats(new_group)
         assert new_group.times_seen_pending == 3
         assert new_group.times_seen_with_pending == 168
+
+    @mock_redis_buffer()
+    def test_merge_original_group_id(self) -> None:
+        project = self.create_project()
+        old_group = self.create_group(project)
+        new_group = self.create_group(project)
+
+        gale = self.create_group_action_log_entry(group=old_group)
+
+        with self.tasks():
+            merge_groups([old_group.id], new_group.id)
+
+        assert Group.objects.filter(id=old_group.id).exists() is False
+
+        gale.refresh_from_db()
+        assert gale.group_id == new_group.id
+        assert gale.original_group_id == old_group.id


### PR DESCRIPTION
GroupActionLogEntries need custom handling during group merge to handle the "original_group_id" field. 