### PR TITLE
test(snapshots): Add diff mode snapshots for toolbar

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
@@ -192,50 +192,26 @@ describe('SnapshotsToolbar', () => {
       {tags: {area: 'snapshots'}}
     );
 
-    it.snapshot(
-      'split',
-      () => (
+    it.snapshot.each<DiffMode>(['split', 'wipe', 'onion'])(
+      '%s',
+      diffMode => (
         <ThemeProvider theme={themes[themeName]}>
           <div style={{width: 960}}>
             <SnapshotsToolbarWithControls
-              viewMode="list"
+              viewMode="single"
               onViewModeChange={noop}
               progress={{current: 1, total: 5, percent: 20}}
               diff={{
-                mode: 'split',
+                mode: diffMode,
                 onModeChange: noop,
                 overlayColor: '#f55459',
                 onOverlayColorChange: noop,
-                showSplit: true,
               }}
             />
           </div>
         </ThemeProvider>
       ),
-      {tags: {area: 'snapshots'}}
-    );
-
-    it.snapshot(
-      'wipe',
-      () => (
-        <ThemeProvider theme={themes[themeName]}>
-          <div style={{width: 960}}>
-            <SnapshotsToolbarWithControls
-              viewMode="list"
-              onViewModeChange={noop}
-              progress={{current: 1, total: 5, percent: 20}}
-              diff={{
-                mode: 'wipe',
-                onModeChange: noop,
-                overlayColor: '#f55459',
-                onOverlayColorChange: noop,
-                showSplit: true,
-              }}
-            />
-          </div>
-        </ThemeProvider>
-      ),
-      {tags: {area: 'snapshots'}}
+      diffMode => ({tags: {area: 'snapshots', diffMode}})
     );
   });
 });

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
@@ -191,5 +191,51 @@ describe('SnapshotsToolbar', () => {
       ),
       {tags: {area: 'snapshots'}}
     );
+
+    it.snapshot(
+      'split',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{width: 960}}>
+            <SnapshotsToolbarWithControls
+              viewMode="list"
+              onViewModeChange={noop}
+              progress={{current: 1, total: 5, percent: 20}}
+              diff={{
+                mode: 'split',
+                onModeChange: noop,
+                overlayColor: '#f55459',
+                onOverlayColorChange: noop,
+                showSplit: true,
+              }}
+            />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {area: 'snapshots'}}
+    );
+
+    it.snapshot(
+      'wipe',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{width: 960}}>
+            <SnapshotsToolbarWithControls
+              viewMode="list"
+              onViewModeChange={noop}
+              progress={{current: 1, total: 5, percent: 20}}
+              diff={{
+                mode: 'wipe',
+                onModeChange: noop,
+                overlayColor: '#f55459',
+                onOverlayColorChange: noop,
+                showSplit: true,
+              }}
+            />
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {area: 'snapshots'}}
+    );
   });
 });


### PR DESCRIPTION
Add snapshot tests for all three diff modes (split, wipe, onion) in the
snapshots toolbar using it.snapshot.each. Each mode is now captured
independently, making it easy to visually verify diff mode UI without the
complexity of other controls.

**Diff Mode Snapshots**

- Split mode with color picker button
- Wipe mode
- Onion mode

Generated for all theme variants (light and dark).