### PR TITLE
feat(cells): Route org listing through control silo if option is set

### DIFF
--- a/static/app/actionCreators/organizations.spec.tsx
+++ b/static/app/actionCreators/organizations.spec.tsx
@@ -11,6 +11,9 @@ describe('fetchOrganizations', () => {
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    // Reset between tests so the control-silo flag doesn't leak into the
+    // fan-out cases (and vice versa).
+    ConfigStore.set('features', new Set());
   });
 
   it('fetches from multiple regions', async () => {
@@ -42,6 +45,44 @@ describe('fetchOrganizations', () => {
     expect(organizations).toHaveLength(2);
     expect(usMock).toHaveBeenCalledTimes(1);
     expect(deMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches from the control silo when organizations:use-control-org-listing is enabled', async () => {
+    ConfigStore.set('features', new Set(['organizations:use-control-org-listing']));
+    ConfigStore.set('links', {
+      ...ConfigStore.get('links'),
+      sentryUrl: 'https://sentry.example.org',
+    });
+    ConfigStore.set('memberRegions', [
+      {name: 'us', url: 'https://us.example.org'},
+      {name: 'de', url: 'https://de.example.org'},
+    ]);
+
+    const controlMock = MockApiClient.addMockResponse({
+      url: '/organizations/',
+      body: [usorg, deorg],
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.host === 'https://sentry.example.org';
+        },
+      ],
+    });
+    const regionMock = MockApiClient.addMockResponse({
+      url: '/organizations/',
+      body: [usorg],
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.host !== 'https://sentry.example.org';
+        },
+      ],
+    });
+
+    const organizations = await fetchOrganizations(api);
+
+    // Single control-silo request, no per-region fan-out.
+    expect(organizations).toHaveLength(2);
+    expect(controlMock).toHaveBeenCalledTimes(1);
+    expect(regionMock).not.toHaveBeenCalled();
   });
 
   it('ignores 401 errors from a region', async () => {

--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -221,6 +221,18 @@ export async function fetchOrganizationDetails(
  * from /organizations can vary based on query parameters
  */
 export async function fetchOrganizations(api: Client, query?: Record<string, any>) {
+  // TODO(cells): Once this rollout completes, this becomes the only path and the
+  // cell fan-out below (plus the `memberRegions` plumbing) can be deleted.
+  if (ConfigStore.get('features').has('organizations:use-control-org-listing')) {
+    // The control silo endpoint returns the full cross-cell list in one call,
+    // so there's no fan-out to merge.
+    const controlUrl = ConfigStore.get('links').sentryUrl;
+    return api.requestPromise('/organizations/', {
+      host: controlUrl,
+      query,
+    });
+  }
+
   const regions = ConfigStore.get('memberRegions');
   const results = await Promise.all(
     regions.map(region =>


### PR DESCRIPTION
If `organizations:use-control-org-listing` is enabled, `fetchOrganizations` makes a single API call to the control silo GET /organizations/ endpoint, instead of fanning out to all cells and merging results in the UI.

The option behind this is registered in https://github.com/getsentry/sentry/pull/117115