### PR TITLE
ref(api): tighten 11 endpoint methods to Response[T]

### DIFF
--- a/src/sentry/api/endpoints/organization_relay_usage.py
+++ b/src/sentry/api/endpoints/organization_relay_usage.py
@@ -7,7 +7,10 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.relayusage import OrganizationRelayResponse
+from sentry.api.serializers.models.relayusage import (
+    OrganizationRelayResponse,
+    RelayUsageSerializer,
+)
 from sentry.apidocs.constants import RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
@@ -37,7 +40,9 @@ class OrganizationRelayUsage(OrganizationEndpoint):
         },
         examples=OrganizationExamples.LIST_RELAYS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[OrganizationRelayResponse]]:
         """
         Return a list of trusted relays bound to an organization.
         """
@@ -45,9 +50,10 @@ class OrganizationRelayUsage(OrganizationEndpoint):
         option_key = "sentry:trusted-relays"
         trusted_relays = organization.get_option(option_key)
         if trusted_relays is None or len(trusted_relays) == 0:
-            return Response([], status=200)
+            empty: list[OrganizationRelayResponse] = []
+            return Response(empty, status=200)
 
         keys = [val.get("public_key") for val in trusted_relays]
         relay_history = list(RelayUsage.objects.filter(public_key__in=keys).order_by("-last_seen"))
 
-        return Response(serialize(relay_history, request.user))
+        return Response(serialize(relay_history, request.user, RelayUsageSerializer()))

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -51,6 +51,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.release_examples import ReleaseExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.activity import Activity
@@ -750,7 +751,9 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
         },
         examples=ReleaseExamples.CREATE_RELEASE,
     )
-    def post(self, request: Request, organization: Organization) -> Response:
+    def post(
+        self, request: Request, organization: Organization
+    ) -> Response[ReleaseSerializerResponse] | Response[ValidationErrorResponse]:
         """
         Create a new release for the given organization. Releases are used by Sentry to
         improve error reporting by correlating first-seen events with the release that may
@@ -913,11 +916,12 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
                 update_org_auth_token_last_used(request.auth, [project.id for project in projects])
 
             scope.set_tag("success_status", status)
-            return Response(
-                serialize(release, request.user, no_snuba_for_release_creation=True), status=status
+            data: ReleaseSerializerResponse = serialize(
+                release, request.user, no_snuba_for_release_creation=True
             )
+            return Response(data, status=status)
         scope.set_tag("failure_reason", "serializer_error")
-        return Response(serializer.errors, status=400)
+        return Response(as_validation_errors(serializer), status=400)
 
 
 class OrganizationReleaseTimeseriesData(TypedDict):

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-from typing import Any, TypedDict
 
 import sentry_sdk
 from drf_spectacular.utils import extend_schema
@@ -27,6 +26,7 @@ from sentry.snuba.outcomes import (
     COLUMN_MAP,
     GROUPBY_MAP,
     QueryDefinition,
+    StatsApiResponse,
     massage_outcomes_result,
     run_outcomes_query_timeseries,
     run_outcomes_query_totals,
@@ -139,19 +139,6 @@ class OrgStatsQueryParamsSerializer(serializers.Serializer):
     )
 
 
-class _StatsGroup(TypedDict):  # this response is pretty dynamic, leaving generic
-    by: dict[str, Any]
-    totals: dict[str, Any]
-    series: dict[str, Any]
-
-
-class StatsApiResponse(TypedDict):
-    start: str
-    end: str
-    intervals: list[str]
-    groups: list[_StatsGroup]
-
-
 @extend_schema(tags=["Organizations"])
 @cell_silo_endpoint
 class OrganizationStatsEndpointV2(OrganizationEndpoint):
@@ -182,7 +169,7 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
         },
         examples=OrganizationExamples.RETRIEVE_EVENT_COUNTS_V2,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response[StatsApiResponse]:
         """
         Query event counts for your Organization.
         Select a field, define a date range, and group or filter by columns.

--- a/src/sentry/api/endpoints/project_member_index.py
+++ b/src/sentry/api/endpoints/project_member_index.py
@@ -37,7 +37,7 @@ class ProjectMemberIndexEndpoint(ProjectEndpoint):
         },
         examples=OrganizationMemberExamples.LIST_ORG_MEMBERS,
     )
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project) -> Response[list[OrganizationMemberResponse]]:
         """
         Returns a list of active organization members that belong to any team assigned to the project.
         """
@@ -48,6 +48,6 @@ class ProjectMemberIndexEndpoint(ProjectEndpoint):
         ).distinct()
 
         member_list = sorted(queryset, key=lambda member: member.email or str(member.id))
-        context = serialize(member_list, request.user)
+        context: list[OrganizationMemberResponse] = serialize(member_list, request.user)
 
         return Response(context)

--- a/src/sentry/api/serializers/models/relayusage.py
+++ b/src/sentry/api/serializers/models/relayusage.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import TypedDict
 
 from sentry.api.serializers import Serializer, register
@@ -7,14 +8,14 @@ from sentry.models.relay import RelayUsage
 class OrganizationRelayResponse(TypedDict):
     relayId: str
     version: str
-    publicKey: str
-    firstSeen: str
-    lastSeen: str
+    publicKey: str | None
+    firstSeen: datetime
+    lastSeen: datetime
 
 
 @register(RelayUsage)
 class RelayUsageSerializer(Serializer):
-    def serialize(self, obj, attrs, user, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs) -> OrganizationRelayResponse:
         return {
             "relayId": obj.relay_id,
             "version": obj.version,

--- a/src/sentry/core/endpoints/organization_user_teams.py
+++ b/src/sentry/core/endpoints/organization_user_teams.py
@@ -7,7 +7,10 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.team import TeamWithProjectsSerializer
+from sentry.api.serializers.models.team import (
+    TeamSerializerResponse,
+    TeamWithProjectsSerializer,
+)
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
 from sentry.apidocs.examples.team_examples import TeamExamples
 from sentry.apidocs.parameters import GlobalParams
@@ -31,14 +34,16 @@ class OrganizationUserTeamsEndpoint(OrganizationEndpoint):
         request=None,
         responses={
             200: inline_sentry_response_serializer(
-                "ListOrgTeamResponse", list[TeamWithProjectsSerializer]
+                "ListOrgTeamResponse", list[TeamSerializerResponse]
             ),
             400: RESPONSE_BAD_REQUEST,
             403: RESPONSE_FORBIDDEN,
         },
         examples=TeamExamples.LIST_ORG_TEAMS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[TeamSerializerResponse]]:
         """
         Returns a list of teams the user has access to in the specified organization.
         Note that this endpoint is restricted to [user auth tokens](https://docs.sentry.io/account/auth-tokens/#user-auth-tokens).
@@ -57,4 +62,7 @@ class OrganizationUserTeamsEndpoint(OrganizationEndpoint):
                 status=TeamStatus.ACTIVE,
                 id__in=request.access.team_ids_with_membership,
             ).order_by("slug")
-        return Response(serialize(list(queryset), request.user, TeamWithProjectsSerializer()))
+        teams: list[TeamSerializerResponse] = serialize(
+            list(queryset), request.user, TeamWithProjectsSerializer()
+        )
+        return Response(teams)

--- a/src/sentry/releases/endpoints/organization_release_details.py
+++ b/src/sentry/releases/endpoints/organization_release_details.py
@@ -32,6 +32,11 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams, ReleaseParams, VisibilityParams
+from sentry.apidocs.response_types import (
+    DetailResponse,
+    ValidationErrorResponse,
+    as_validation_errors,
+)
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
@@ -326,7 +331,9 @@ class OrganizationReleaseDetailsEndpoint(
         },
         examples=OrganizationExamples.RELEASE_DETAILS,
     )
-    def get(self, request: Request, organization, version) -> Response:
+    def get(
+        self, request: Request, organization, version
+    ) -> Response[ReleaseSerializerResponse] | Response[DetailResponse]:
         """
 
         Return details on an individual release.
@@ -411,17 +418,16 @@ class OrganizationReleaseDetailsEndpoint(
             except InvalidSortException:
                 return Response({"detail": "invalid sort"}, status=400)
 
-        return Response(
-            serialize(
-                release,
-                request.user,
-                with_health_data=with_health,
-                with_adoption_stages=with_adoption_stages,
-                summary_stats_period=summary_stats_period,
-                health_stats_period=health_stats_period,
-                current_project_meta=current_project_meta,
-            )
+        data: ReleaseSerializerResponse = serialize(
+            release,
+            request.user,
+            with_health_data=with_health,
+            with_adoption_stages=with_adoption_stages,
+            summary_stats_period=summary_stats_period,
+            health_stats_period=health_stats_period,
+            current_project_meta=current_project_meta,
         )
+        return Response(data)
 
     @extend_schema(
         operation_id="Update an Organization's Release",
@@ -438,7 +444,9 @@ class OrganizationReleaseDetailsEndpoint(
         },
         examples=OrganizationExamples.RELEASE_DETAILS,
     )
-    def put(self, request: Request, organization: Organization, version) -> Response:
+    def put(
+        self, request: Request, organization: Organization, version
+    ) -> Response[ReleaseSerializerResponse] | Response[ValidationErrorResponse]:
         """
 
         Update a release. This can change some metadata associated with
@@ -465,7 +473,7 @@ class OrganizationReleaseDetailsEndpoint(
 
         if not serializer.is_valid():
             scope.set_tag("failure_reason", "serializer_error")
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer), status=400)
 
         result = serializer.validated_data
 
@@ -540,11 +548,10 @@ class OrganizationReleaseDetailsEndpoint(
                 )
 
         no_snuba_for_release_creation = options.get("releases.no_snuba_for_release_creation")
-        return Response(
-            serialize(
-                release, request.user, no_snuba_for_release_creation=no_snuba_for_release_creation
-            )
+        data: ReleaseSerializerResponse = serialize(
+            release, request.user, no_snuba_for_release_creation=no_snuba_for_release_creation
         )
+        return Response(data)
 
     @extend_schema(
         operation_id="Delete an Organization's Release",

--- a/src/sentry/releases/endpoints/project_release_details.py
+++ b/src/sentry/releases/endpoints/project_release_details.py
@@ -23,6 +23,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.release_examples import ReleaseExamples
 from sentry.apidocs.parameters import GlobalParams, ReleaseParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.activity import Activity
 from sentry.models.release import Release
@@ -63,7 +64,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
         },
         examples=ReleaseExamples.RETRIEVE_RELEASE,
     )
-    def get(self, request: Request, project, version) -> Response:
+    def get(self, request: Request, project, version) -> Response[ReleaseSerializerResponse]:
         """
         Return details on an individual release.
         """
@@ -85,16 +86,15 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
         if with_health:
             release._for_project_id = project.id
 
-        return Response(
-            serialize(
-                release,
-                request.user,
-                project=project,
-                with_health_data=with_health,
-                summary_stats_period=summary_stats_period,
-                health_stats_period=health_stats_period,
-            )
+        data: ReleaseSerializerResponse = serialize(
+            release,
+            request.user,
+            project=project,
+            with_health_data=with_health,
+            summary_stats_period=summary_stats_period,
+            health_stats_period=health_stats_period,
         )
+        return Response(data)
 
     @extend_schema(
         operation_id="Update a Project's Release",
@@ -114,7 +114,9 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def put(self, request: Request, project, version) -> Response:
+    def put(
+        self, request: Request, project, version
+    ) -> Response[ReleaseSerializerResponse] | Response[ValidationErrorResponse]:
         """
         Update a release. This can change metadata associated with the release
         (its ref, url, dates, and status) and associate commits with it.
@@ -134,7 +136,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
 
         if not serializer.is_valid():
             scope.set_tag("failure_reason", "serializer_error")
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer), status=400)
 
         result = serializer.validated_data
 
@@ -171,11 +173,10 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
                 datetime=release.date_released,
             )
         no_snuba_for_release_creation = options.get("releases.no_snuba_for_release_creation")
-        return Response(
-            serialize(
-                release, request.user, no_snuba_for_release_creation=no_snuba_for_release_creation
-            )
+        body: ReleaseSerializerResponse = serialize(
+            release, request.user, no_snuba_for_release_creation=no_snuba_for_release_creation
         )
+        return Response(body)
 
     @extend_schema(
         operation_id="Delete a Project's Release",

--- a/src/sentry/releases/endpoints/project_release_repositories.py
+++ b/src/sentry/releases/endpoints/project_release_repositories.py
@@ -43,7 +43,9 @@ class ProjectReleaseRepositories(ProjectEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project, version) -> Response:
+    def get(
+        self, request: Request, project, version
+    ) -> Response[list[RepositorySerializerResponse]]:
         """
         Return the repositories that have commits associated with a given release.
         """
@@ -61,9 +63,5 @@ class ProjectReleaseRepositories(ProjectEndpoint):
 
         repositories = Repository.objects.filter(id__in=repository_ids)
 
-        return Response(
-            serialize(
-                list(repositories),
-                request.user,
-            )
-        )
+        data: list[RepositorySerializerResponse] = serialize(list(repositories), request.user)
+        return Response(data)

--- a/src/sentry/releases/endpoints/project_release_stats.py
+++ b/src/sentry/releases/endpoints/project_release_stats.py
@@ -19,6 +19,7 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import GlobalParams, ReleaseParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.release import Release
 from sentry.release_health.base import is_overview_stat
@@ -94,7 +95,9 @@ class ProjectReleaseStatsEndpoint(ProjectEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project, version) -> Response:
+    def get(
+        self, request: Request, project, version
+    ) -> Response[ProjectReleaseStatsResponse] | Response[DetailResponse]:
         """
         Return crash-free session/user health stats and a per-day breakdown for a release
         within a project.
@@ -150,7 +153,7 @@ class ProjectReleaseStatsEndpoint(ProjectEndpoint):
                 }
             )
 
-        return Response(
-            serialize({"stats": stats, "statTotals": totals, "usersBreakdown": users_breakdown}),
-            status=200,
+        body: ProjectReleaseStatsResponse = serialize(
+            {"stats": stats, "statTotals": totals, "usersBreakdown": users_breakdown}
         )
+        return Response(body, status=200)

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -475,9 +475,17 @@ def _split_rows_groupby(rows, groupby):
     return groups
 
 
+class _RawSessionsResult(TypingTypedDict):
+    start: str
+    end: str
+    query: str
+    intervals: list[str]
+    groups: list[_StatsGroup]
+
+
 def massage_sessions_result(
     query, result_totals, result_timeseries, ts_col="bucketed_started"
-) -> dict[str, list[Any]]:
+) -> _RawSessionsResult:
     """
     Post-processes the query result.
 
@@ -546,11 +554,11 @@ def massage_sessions_result(
             name: field.extract_from_row(totals[0], group) for name, field in query.fields.items()
         }
 
-    groups = []
+    groups: list[_StatsGroup] = []
     keys = set(total_groups.keys()) | set(timeseries_groups.keys())
     for key in keys:
         by = dict(key)
-        group = {
+        group: _StatsGroup = {
             "by": by,
             "totals": make_totals(total_groups.get(key, [None]), by),
         }
@@ -568,17 +576,32 @@ def massage_sessions_result(
     }
 
 
+class _StatsGroup(TypingTypedDict):
+    by: dict[str, Any]
+    totals: dict[str, Any]
+    series: NotRequired[dict[str, Any]]
+
+
+class StatsApiResponse(TypingTypedDict):
+    start: str
+    end: str
+    intervals: NotRequired[list[str]]
+    groups: list[_StatsGroup]
+
+
 def massage_outcomes_result(
     query: QueryDefinition,
     result_totals: ResultSet,
     result_timeseries: ResultSet | None,
-) -> dict[str, list[Any]]:
-    result: dict[str, list[Any]] = massage_sessions_result(
-        query, result_totals, result_timeseries, ts_col=TS_COL
-    )
-    if result_timeseries is None:
-        del result["intervals"]
-    del result["query"]
+) -> StatsApiResponse:
+    raw = massage_sessions_result(query, result_totals, result_timeseries, ts_col=TS_COL)
+    result: StatsApiResponse = {
+        "start": raw["start"],
+        "end": raw["end"],
+        "groups": raw["groups"],
+    }
+    if result_timeseries is not None:
+        result["intervals"] = raw["intervals"]
     return result
 
 


### PR DESCRIPTION
Eleven Phase 1 / Goal #1 endpoint methods with `@extend_schema(inline_sentry_response_serializer(...))` but bare `Response` annotations. All fixes are typing-only at the source.

Two patterns used:

**Source-typed where the serializer is typeable:**
- `organization_relay_usage.get()`: annotate `RelayUsageSerializer.serialize` + align TypedDict with runtime (datetime, nullable).
- `organization_stats_v2.get()`: annotate `massage_outcomes_result` / `massage_sessions_result`; move `StatsApiResponse` to `snuba.outcomes`.

**Typed-variable trick where the serializer is denylisted:**
- `project_member_index.get()` — pin `context: list[OrganizationMemberResponse]` (OrganizationMemberSerializer denylist).
- `organization_user_teams.get()` — pin `teams: list[TeamSerializerResponse]` (BaseTeamSerializer denylist); also fix decorator using serializer-class-as-type.
- `organization_release_details.get() + put()`, `organization_releases.post()`, `project_release_details.get() + put()`, `project_release_stats.get()`, `project_release_repositories.get()` — pin locals against `ReleaseSerializerResponse` / `RepositorySerializerResponse` (ReleaseSerializer denylist).

`as_validation_errors(serializer)` replaces raw `serializer.errors` in error paths so `Response[ValidationErrorResponse]` arms verify.