### PR TITLE
feat(snapshots): Show label for active diff mode in toolbar

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
@@ -208,28 +208,38 @@ export function DiffModeToggle({
   onDiffModeChange: (mode: DiffMode) => void;
   showSplit: boolean;
 }) {
+  const splitLabel = t('Split');
+  const wipeLabel = t('Wipe');
+  const onionLabel = t('Onion');
+
   return (
     <SegmentedControl size="xs" value={diffMode} onChange={onDiffModeChange}>
       {showSplit ? (
         <SegmentedControl.Item
           key="split"
           icon={<IconPause />}
-          aria-label={t('Split')}
-          tooltip={t('Split')}
-        />
+          aria-label={splitLabel}
+          tooltip={splitLabel}
+        >
+          {diffMode === 'split' ? splitLabel : undefined}
+        </SegmentedControl.Item>
       ) : null}
       <SegmentedControl.Item
         key="wipe"
         icon={<IconInput />}
-        aria-label={t('Wipe')}
-        tooltip={t('Wipe')}
-      />
+        aria-label={wipeLabel}
+        tooltip={wipeLabel}
+      >
+        {diffMode === 'wipe' ? wipeLabel : undefined}
+      </SegmentedControl.Item>
       <SegmentedControl.Item
         key="onion"
         icon={<IconStack />}
-        aria-label={t('Onion')}
-        tooltip={t('Onion')}
-      />
+        aria-label={onionLabel}
+        tooltip={onionLabel}
+      >
+        {diffMode === 'onion' ? onionLabel : undefined}
+      </SegmentedControl.Item>
     </SegmentedControl>
   );
 }

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
@@ -268,7 +268,8 @@ const ColorTrigger = styled('button')<{color: string}>`
   height: 24px;
   border-radius: 50%;
   cursor: pointer;
-  border: 2px solid ${p => p.theme.tokens.border.primary};
+  border: 1px solid
+    ${p => p.theme.tokens.border.onVibrant[p.theme.type === 'dark' ? 'light' : 'dark']};
   background-color: ${p => (p.color === TRANSPARENT_COLOR ? 'transparent' : p.color)};
   padding: 0;
   ${p =>


### PR DESCRIPTION
## Summary

Regardless of diff type, show the text label next to the icon for the active snapshot diff view in `SnapshotsToolbar`'s `DiffModeToggle`. The selected mode (split, wipe, or onion) now renders its label alongside its icon, while inactive segments stay icon-only. This makes the active view easier to identify when scanning the toolbar.

## Notes

- Stacked on top of #117114 (`add-snapshot-diff-mode-states`). The per-mode (`split`/`wipe`/`onion`) and responsive `xs` snapshot coverage added there now exercises the label behavior, so no new snapshot cases were needed.

Refs [EME-1186](https://linear.app/getsentry/issue/EME-1186/show-labels-for-active-snapshot-diff-view)