### PR TITLE
fix(settings): Fix the layout of the integrations page after a search

### DIFF
--- a/static/app/views/settings/components/settingsPageHeader.tsx
+++ b/static/app/views/settings/components/settingsPageHeader.tsx
@@ -9,12 +9,11 @@ import {BreadcrumbTitle} from 'sentry/views/settings/components/settingsBreadcru
 type Props = {
   title: React.ReactNode;
   action?: React.ReactNode;
-  body?: React.ReactNode;
   subtitle?: React.ReactNode;
   tabs?: React.ReactNode;
 };
 
-export function SettingsPageHeader({title, subtitle, action, body, tabs}: Props) {
+export function SettingsPageHeader({title, subtitle, action, tabs}: Props) {
   return (
     <Fragment>
       {typeof title === 'string' ? (
@@ -28,7 +27,6 @@ export function SettingsPageHeader({title, subtitle, action, body, tabs}: Props)
           {action}
         </Flex>
       )}
-      {body && <BodyWrapper>{body}</BodyWrapper>}
       {tabs && <TabsWrapper>{tabs}</TabsWrapper>}
     </Fragment>
   );
@@ -42,10 +40,6 @@ const Subtitle = styled('div')`
   font-size: ${p => p.theme.font.size.md};
 `;
 
-const BodyWrapper = styled('div')`
-  flex: 1;
-  margin: 0 0 ${p => p.theme.space['2xl']};
-`;
 const TabsWrapper = styled('div')`
   flex: 1;
   margin: 0;

--- a/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
@@ -455,25 +455,29 @@ export default function IntegrationListDirectory() {
   return (
     <Fragment>
       <SentryDocumentTitle title={title} orgSlug={organization.slug} />
-      <IntegrationSettingsHeader
-        title={title}
-        list={list}
-        category={category}
-        onChangeCategory={onCategoryChange}
-        search={search}
-        onChangeSearch={onSearchChange}
-      />
-      <OrganizationPermissionAlert access={['org:integrations']} />
-      <ReinstallAlert integrations={integrations} />
-      <Panel>
-        <PanelBody data-test-id="integration-panel">
-          {displayList.length ? (
-            displayList.map(renderIntegration)
-          ) : (
-            <IntegrationResultsEmpty searchTerm={search} />
-          )}
-        </PanelBody>
-      </Panel>
+      <Stack gap="xl">
+        <IntegrationSettingsHeader
+          title={title}
+          list={list}
+          category={category}
+          onChangeCategory={onCategoryChange}
+          search={search}
+          onChangeSearch={onSearchChange}
+        />
+        <Stack>
+          <OrganizationPermissionAlert access={['org:integrations']} />
+          <ReinstallAlert integrations={integrations} />
+          <Panel>
+            <PanelBody data-test-id="integration-panel">
+              {displayList.length ? (
+                displayList.map(renderIntegration)
+              ) : (
+                <IntegrationResultsEmpty searchTerm={search} />
+              )}
+            </PanelBody>
+          </Panel>
+        </Stack>
+      </Stack>
     </Fragment>
   );
 }
@@ -505,35 +509,33 @@ function IntegrationSettingsHeader({
   }, [list, getCategoryLabel]);
 
   return (
-    <SettingsPageHeader
-      title={title}
-      body={
-        <Flex align="center" gap="md">
-          <Container width="240px">
-            <Select
-              name="select-categories"
-              onChange={onChangeCategory}
-              value={category}
-              options={categoryOptions}
+    <Fragment>
+      <SettingsPageHeader title={title} />
+      <Flex align="center" gap="md">
+        <Container width="240px">
+          <Select
+            name="select-categories"
+            onChange={onChangeCategory}
+            value={category}
+            options={categoryOptions}
+          />
+        </Container>
+        <Container flex={1}>
+          {({className}) => (
+            <SearchBar
+              className={className}
+              query={search}
+              onSearch={onChangeSearch}
+              placeholder={t('Filter Integrations\u2026')}
+              aria-label={t('Filter')}
+              width="100%"
+              data-test-id="search-bar"
             />
-          </Container>
-          <Container flex={1}>
-            {({className}) => (
-              <SearchBar
-                className={className}
-                query={search}
-                onSearch={onChangeSearch}
-                placeholder={t('Filter Integrations\u2026')}
-                aria-label={t('Filter')}
-                width="100%"
-                data-test-id="search-bar"
-              />
-            )}
-          </Container>
-          <CreateIntegrationButton analyticsView="integrations_directory" size="md" />
-        </Flex>
-      }
-    />
+          )}
+        </Container>
+        <CreateIntegrationButton analyticsView="integrations_directory" size="md" />
+      </Flex>
+    </Fragment>
   );
 }
 


### PR DESCRIPTION
I broke this a few minutes ago with https://github.com/getsentry/sentry/pull/117099/changes

**Before**
<img width="1546" height="598" alt="SCR-20260608-lchs" src="https://github.com/user-attachments/assets/7dea7232-bbca-4b28-9f64-e3e1682df825" />


**After**
<img width="1598" height="343" alt="SCR-20260608-lcbq" src="https://github.com/user-attachments/assets/f6949bc5-fb07-4765-aee8-bb78dfb67ff3" />

