### PR TITLE
feat(scraps): Add no-double-dollar-interpolation eslint rule

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -469,6 +469,7 @@ export default typescript.config([
     plugins: {'@sentry/scraps': sentryScrapsPlugin},
     rules: {
       '@sentry/scraps/no-core-import': 'error',
+      '@sentry/scraps/no-double-dollar-interpolation': 'error',
       '@sentry/scraps/no-token-import': 'error',
       '@sentry/scraps/prefer-info-text': 'error',
       '@sentry/scraps/use-semantic-token': [

--- a/static/app/views/insights/pages/mcp/onboarding.tsx
+++ b/static/app/views/insights/pages/mcp/onboarding.tsx
@@ -415,7 +415,6 @@ const BulletList = styled('ul')`
 const HeaderWrapper = styled('div')`
   display: flex;
   justify-content: space-between;
-  gap: $${p => p.theme.space['2xl']};
   border-radius: ${p => p.theme.radius.md};
   padding: ${p => p.theme.space['3xl']};
 `;

--- a/static/eslint/eslintPluginScraps/src/rules/index.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/index.ts
@@ -1,4 +1,5 @@
 import {noCoreImport} from './no-core-import';
+import {noDoubleDollarInterpolation} from './no-double-dollar-interpolation';
 import {noTokenImport} from './no-token-import';
 import {preferInfoText} from './prefer-info-text';
 import {restrictJsxSlotChildren} from './restrict-jsx-slot-children';
@@ -6,6 +7,7 @@ import {useSemanticToken} from './use-semantic-token';
 
 export const rules = {
   'no-core-import': noCoreImport,
+  'no-double-dollar-interpolation': noDoubleDollarInterpolation,
   'no-token-import': noTokenImport,
   'prefer-info-text': preferInfoText,
   'restrict-jsx-slot-children': restrictJsxSlotChildren,

--- a/static/eslint/eslintPluginScraps/src/rules/no-double-dollar-interpolation.spec.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/no-double-dollar-interpolation.spec.ts
@@ -1,0 +1,57 @@
+import {RuleTester} from '@typescript-eslint/rule-tester';
+
+import {noDoubleDollarInterpolation} from './no-double-dollar-interpolation';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-double-dollar-interpolation', noDoubleDollarInterpolation, {
+  valid: [
+    {
+      code: 'const C = styled.div`gap: ${p => p.theme.space.md};`;',
+      filename: 'file.tsx',
+    },
+    {
+      code: 'const c = css`color: ${p => p.theme.red};`;',
+      filename: 'file.tsx',
+    },
+    {
+      code: 'const C = styled(Base)`padding: ${gap} ${other};`;',
+      filename: 'file.tsx',
+    },
+    {
+      code: 'const price = `$${amount}`;',
+      filename: 'file.tsx',
+    },
+    {
+      code: 'const C = styled.div`content: "\\$"${x};`;',
+      filename: 'file.tsx',
+    },
+  ],
+
+  invalid: [
+    {
+      code: "const C = styled.div`gap: $${p => p.theme.space['2xl']};`;",
+      filename: 'file.tsx',
+      errors: [{messageId: 'doubleDollar'}],
+      output: "const C = styled.div`gap: ${p => p.theme.space['2xl']};`;",
+    },
+    {
+      code: 'const c = css`color: $${p => p.theme.red};`;',
+      filename: 'file.tsx',
+      errors: [{messageId: 'doubleDollar'}],
+      output: 'const c = css`color: ${p => p.theme.red};`;',
+    },
+    {
+      code: 'const C = styled(Base)`margin: ${a}; padding: $${b};`;',
+      filename: 'file.tsx',
+      errors: [{messageId: 'doubleDollar'}],
+      output: 'const C = styled(Base)`margin: ${a}; padding: ${b};`;',
+    },
+    {
+      code: 'const C = styled.div`gap: $${a}; width: $${b};`;',
+      filename: 'file.tsx',
+      errors: [{messageId: 'doubleDollar'}, {messageId: 'doubleDollar'}],
+      output: 'const C = styled.div`gap: ${a}; width: ${b};`;',
+    },
+  ],
+});

--- a/static/eslint/eslintPluginScraps/src/rules/no-double-dollar-interpolation.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/no-double-dollar-interpolation.ts
@@ -1,0 +1,57 @@
+import {ESLintUtils} from '@typescript-eslint/utils';
+
+import {shouldAnalyze} from '../ast/extractor/index';
+import {getStyledCallInfo} from '../ast/utils/styled';
+
+export const noDoubleDollarInterpolation = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+    docs: {
+      description:
+        'Disallow a doubled `$` before an interpolation in styled/css templates',
+    },
+    schema: [],
+    messages: {
+      doubleDollar:
+        'Doubled `$` before interpolation emits a literal "$" into the CSS, producing an invalid declaration. Use `${...}`.',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    if (!shouldAnalyze(context)) {
+      return {};
+    }
+
+    return {
+      TaggedTemplateExpression(node) {
+        if (!getStyledCallInfo(node)) {
+          return;
+        }
+
+        for (const quasi of node.quasi.quasis) {
+          if (
+            // A tail quasi has no following interpolation, so a trailing `$`
+            // cannot be the `$${...}` pattern.
+            quasi.tail ||
+            // Match a trailing `$` that is not itself escaped (`\$`).
+            !/(?<!\\)\$$/.test(quasi.value.raw)
+          ) {
+            continue;
+          }
+
+          // range[1] is the start of the following expression, so `${`
+          // occupies [range[1] - 2, range[1]) and the stray literal `$`
+          // sits immediately before it at range[1] - 3.
+          const dollarIndex = quasi.range[1] - 3;
+
+          context.report({
+            node: quasi,
+            messageId: 'doubleDollar',
+            fix: fixer => fixer.removeRange([dollarIndex, dollarIndex + 1]),
+          });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
Adds a `@sentry/scraps/no-double-dollar-interpolation` rule with a fixer. It catches cases like this one from https://github.com/getsentry/sentry/pull/117031#discussion_r3375417634:

```ts
gap: $${p => p.theme.space.md};
```

Since the existing code is invalid, I just removed it.