### PR TITLE
feat(explore): Surface and apply Seer's expanded project scope

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -247,6 +247,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
             start={item?.start}
             end={item?.end}
             visualizations={item?.visualizations}
+            expandedProjectIds={item?.expandedProjectIds}
           />
         </Item>
       );

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -281,6 +281,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
             start={item?.start}
             end={item?.end}
             visualizations={item?.visualizations}
+            expandedProjectIds={item?.expandedProjectIds}
           />
         </Item>
       );

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -103,9 +103,6 @@ export function QueryTokens({
     );
   }
 
-  // When the agent broadened the query beyond the user's selected projects,
-  // surface the scope it will run against. Chosen alongside the other tokens,
-  // so the user sees (and consents to) the expansion before applying.
   if (expandedProjectIds && expandedProjectIds.length > 0) {
     const shownSlugs = expandedProjectIds
       .slice(0, MAX_PROJECT_CHIPS)

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -8,6 +8,9 @@ import {useSearchQueryBuilderConfig} from 'sentry/components/searchQueryBuilder/
 import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {t} from 'sentry/locale';
+import {useProjects} from 'sentry/utils/useProjects';
+
+const MAX_PROJECT_CHIPS = 3;
 
 export function QueryTokens({
   groupBys,
@@ -17,9 +20,11 @@ export function QueryTokens({
   start,
   end,
   visualizations,
+  expandedProjectIds,
 }: QueryTokensProps) {
   const tokens = [];
   const {getFieldDefinition} = useSearchQueryBuilderConfig();
+  const {projects} = useProjects();
   const parsedQuery = query ? parseQueryBuilderValue(query, getFieldDefinition) : null;
   if (query && parsedQuery?.length) {
     tokens.push(
@@ -94,6 +99,35 @@ export function QueryTokens({
       >
         <ExploreParamTitle>{t('Time Range')}</ExploreParamTitle>
         <ExploreGroupBys>{statsPeriod}</ExploreGroupBys>
+      </Flex>
+    );
+  }
+
+  // When the agent broadened the query beyond the user's selected projects,
+  // surface the scope it will run against. Chosen alongside the other tokens,
+  // so the user sees (and consents to) the expansion before applying.
+  if (expandedProjectIds && expandedProjectIds.length > 0) {
+    const slugs = expandedProjectIds.map(
+      id => projects.find(project => project.id === String(id))?.slug ?? String(id)
+    );
+    const shownSlugs = slugs.slice(0, MAX_PROJECT_CHIPS);
+    const overflowCount = slugs.length - shownSlugs.length;
+    tokens.push(
+      <Flex
+        as="span"
+        align="center"
+        wrap="wrap"
+        gap="xs"
+        overflow="hidden"
+        key="projects"
+      >
+        <ExploreParamTitle>{t('Projects')}</ExploreParamTitle>
+        {shownSlugs.map(slug => (
+          <ExploreGroupBys key={slug}>{slug}</ExploreGroupBys>
+        ))}
+        {overflowCount > 0 ? (
+          <ExploreGroupBys>{t('+%s more', overflowCount)}</ExploreGroupBys>
+        ) : null}
       </Flex>
     );
   }

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -107,11 +107,10 @@ export function QueryTokens({
   // surface the scope it will run against. Chosen alongside the other tokens,
   // so the user sees (and consents to) the expansion before applying.
   if (expandedProjectIds && expandedProjectIds.length > 0) {
-    const slugs = expandedProjectIds.map(
-      id => projects.find(project => project.id === String(id))?.slug ?? String(id)
-    );
-    const shownSlugs = slugs.slice(0, MAX_PROJECT_CHIPS);
-    const overflowCount = slugs.length - shownSlugs.length;
+    const shownSlugs = expandedProjectIds
+      .slice(0, MAX_PROJECT_CHIPS)
+      .map(id => projects.find(project => project.id === String(id))?.slug ?? String(id));
+    const overflowCount = expandedProjectIds.length - shownSlugs.length;
     tokens.push(
       <Flex
         as="span"

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
@@ -14,6 +14,9 @@ export interface SeerRawResponseItem {
 export interface SeerRawResponse {
   responses: SeerRawResponseItem[];
   unsupported_reason: string | null;
+  // Projects Seer actually scoped the query to — a superset of the projects we
+  // sent when it broadens scope. `null`/absent when there's no expansion.
+  project_ids?: number[] | null;
 }
 
 export interface NoneOfTheseItem {
@@ -29,6 +32,12 @@ export type AskSeerSearchItems<T> = (AskSeerSearchItem<string> & T) | NoneOfThes
 
 export interface QueryTokensProps {
   end?: string | null;
+  /**
+   * Projects the agent broadened the query to, when it expanded scope beyond
+   * the user's selection. Set only when there is an actual expansion; drives
+   * the "Projects" chip and the projects applied when the suggestion is chosen.
+   */
+  expandedProjectIds?: number[];
   groupBys?: string[];
   query?: string;
   sort?: string;

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
@@ -129,6 +129,48 @@ describe('transformSeerResponse', () => {
       },
     ]);
   });
+
+  it('attaches expandedProjectIds when Seer broadened beyond the selection', () => {
+    const rawResponse = {
+      project_ids: [1, 2, 3],
+      responses: [
+        {
+          query: 'is:unresolved',
+          sort: '',
+          group_by: [],
+          stats_period: '24h',
+          start: null,
+          end: null,
+          mode: 'samples',
+        },
+      ],
+    };
+
+    const result = transformSeerResponse(rawResponse as any, mapItem, [1, 2]);
+
+    expect(result[0]).toEqual(expect.objectContaining({expandedProjectIds: [1, 2, 3]}));
+  });
+
+  it('omits expandedProjectIds when the scope matches the selection', () => {
+    const rawResponse = {
+      project_ids: [1, 2],
+      responses: [
+        {
+          query: 'is:unresolved',
+          sort: '',
+          group_by: [],
+          stats_period: '24h',
+          start: null,
+          end: null,
+          mode: 'samples',
+        },
+      ],
+    };
+
+    const result = transformSeerResponse(rawResponse as any, mapItem, [1, 2]);
+
+    expect(result[0]).not.toHaveProperty('expandedProjectIds');
+  });
 });
 
 describe('mapSeerResponseItem', () => {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -91,6 +91,22 @@ export function useSelectedProjectIdsForMutation(): Array<number | string> {
   }, [pageFilters.selection.projects, projects]);
 }
 
+function mapResponsesWithExpansion<T extends QueryTokensProps>(
+  responses: SeerRawResponseItem[],
+  projectIds: number[] | null | undefined,
+  selectedProjectIds: number[] | undefined,
+  mapItem: (item: SeerRawResponseItem) => T
+): T[] {
+  const expandedProjectIds = selectedProjectIds
+    ? getExpandedProjectIds(projectIds, selectedProjectIds)
+    : undefined;
+
+  return responses.map(item => ({
+    ...mapItem(item),
+    ...(expandedProjectIds ? {expandedProjectIds} : {}),
+  }));
+}
+
 export function transformSeerResponse<T extends QueryTokensProps>(
   response: T,
   mapItem: (item: SeerRawResponseItem) => T,
@@ -105,16 +121,29 @@ export function transformSeerResponse<T extends QueryTokensProps>(
     return [response];
   }
 
-  // Surface the scope Seer broadened to (a superset of the user's selection)
-  // on each suggestion, so the "Projects" chip and apply-on-accept can use it.
-  const expandedProjectIds = selectedProjectIds
-    ? getExpandedProjectIds(envelope.project_ids, selectedProjectIds)
-    : undefined;
+  return mapResponsesWithExpansion(
+    envelope.responses,
+    envelope.project_ids,
+    selectedProjectIds,
+    mapItem
+  );
+}
 
-  return envelope.responses.map(item => ({
-    ...mapItem(item),
-    ...(expandedProjectIds ? {expandedProjectIds} : {}),
-  }));
+export function buildSeerMutationResult<T extends QueryTokensProps>(
+  data: SeerRawResponse,
+  selectedProjectIds: number[],
+  mapItem: (item: SeerRawResponseItem) => T
+): {queries: T[]; status: string; unsupported_reason: string | null} {
+  return {
+    status: 'ok',
+    unsupported_reason: data.unsupported_reason,
+    queries: mapResponsesWithExpansion(
+      data.responses,
+      data.project_ids,
+      selectedProjectIds,
+      mapItem
+    ),
+  };
 }
 
 export function mapSeerResponseItem(

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -114,7 +114,7 @@ export function transformSeerResponse<T extends QueryTokensProps>(
 ): T[] {
   // The polling `final_response` is a serialized `SeerRawResponse` envelope at
   // runtime, even though the combobox types it as a single item. We reconcile
-  // that narrowing here once, rather than casting in every ComboBox.
+  // that narrowing here once, rather than asserting in every ComboBox.
   const envelope = response as unknown as SeerRawResponse;
 
   if (!Array.isArray(envelope.responses)) {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -12,7 +12,13 @@ import type {PageFilters} from 'sentry/types/core';
 import {useProjects} from 'sentry/utils/useProjects';
 import {isChartType} from 'sentry/views/insights/common/components/chart';
 
-import type {AskSeerSearchQuery, SeerRawResponseItem} from './types';
+import type {
+  AskSeerSearchQuery,
+  QueryTokensProps,
+  SeerRawResponse,
+  SeerRawResponseItem,
+} from './types';
+import {getExpandedProjectIds} from './utils';
 
 export function useInitialSeerQuery(): string {
   const {query, committedQuery, parseQuery} = useSearchQueryBuilderState();
@@ -85,19 +91,30 @@ export function useSelectedProjectIdsForMutation(): Array<number | string> {
   }, [pageFilters.selection.projects, projects]);
 }
 
-export function transformSeerResponse<T>(
+export function transformSeerResponse<T extends QueryTokensProps>(
   response: T,
-  mapItem: (item: SeerRawResponseItem) => T
+  mapItem: (item: SeerRawResponseItem) => T,
+  selectedProjectIds?: number[]
 ): T[] {
-  const seerResponse = response as unknown as {
-    responses?: SeerRawResponseItem[];
-  };
+  // The polling `final_response` is a serialized `SeerRawResponse` envelope at
+  // runtime, even though the combobox types it as a single item. We reconcile
+  // that narrowing here once, rather than casting in every ComboBox.
+  const envelope = response as unknown as SeerRawResponse;
 
-  if (seerResponse.responses && Array.isArray(seerResponse.responses)) {
-    return seerResponse.responses.map(mapItem);
+  if (!Array.isArray(envelope.responses)) {
+    return [response];
   }
 
-  return [response];
+  // Surface the scope Seer broadened to (a superset of the user's selection)
+  // on each suggestion, so the "Projects" chip and apply-on-accept can use it.
+  const expandedProjectIds = selectedProjectIds
+    ? getExpandedProjectIds(envelope.project_ids, selectedProjectIds)
+    : undefined;
+
+  return envelope.responses.map(item => ({
+    ...mapItem(item),
+    ...(expandedProjectIds ? {expandedProjectIds} : {}),
+  }));
 }
 
 export function mapSeerResponseItem(

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.spec.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.spec.ts
@@ -1,22 +1,29 @@
 import {generateQueryTokensString, getExpandedProjectIds} from './utils';
 
 describe('getExpandedProjectIds', () => {
-  it('returns undefined when no projects are returned', () => {
-    expect(getExpandedProjectIds(null, [1, 2])).toBeUndefined();
-    expect(getExpandedProjectIds(undefined, [1, 2])).toBeUndefined();
-    expect(getExpandedProjectIds([], [1, 2])).toBeUndefined();
+  it.each([null, undefined, []])('returns undefined when projects is %s', input => {
+    expect(getExpandedProjectIds(input, [1, 2])).toBeUndefined();
   });
 
-  it('returns undefined when the returned scope does not exceed the selection', () => {
-    expect(getExpandedProjectIds([1, 2], [1, 2])).toBeUndefined();
-    // The selection already covers everything returned -> no expansion.
-    expect(getExpandedProjectIds([1], [1, 2])).toBeUndefined();
-  });
+  it.each([
+    {returned: [1, 2], selected: [1, 2]},
+    {returned: [1], selected: [1, 2]},
+  ])(
+    'returns undefined when returned $returned does not exceed selection $selected',
+    ({returned, selected}) => {
+      expect(getExpandedProjectIds(returned, selected)).toBeUndefined();
+    }
+  );
 
-  it('returns the full returned scope when it includes unselected projects', () => {
-    expect(getExpandedProjectIds([1, 2, 3], [1, 2])).toEqual([1, 2, 3]);
-    expect(getExpandedProjectIds([5], [])).toEqual([5]);
-  });
+  it.each([
+    {returned: [1, 2, 3], selected: [1, 2], expected: [1, 2, 3]},
+    {returned: [5], selected: [], expected: [5]},
+  ])(
+    'returns $returned when it includes projects beyond the selection',
+    ({returned, selected, expected}) => {
+      expect(getExpandedProjectIds(returned, selected)).toEqual(expected);
+    }
+  );
 });
 
 describe('generateQueryTokensString', () => {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.spec.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.spec.ts
@@ -1,0 +1,38 @@
+import {generateQueryTokensString, getExpandedProjectIds} from './utils';
+
+describe('getExpandedProjectIds', () => {
+  it('returns undefined when no projects are returned', () => {
+    expect(getExpandedProjectIds(null, [1, 2])).toBeUndefined();
+    expect(getExpandedProjectIds(undefined, [1, 2])).toBeUndefined();
+    expect(getExpandedProjectIds([], [1, 2])).toBeUndefined();
+  });
+
+  it('returns undefined when the returned scope does not exceed the selection', () => {
+    expect(getExpandedProjectIds([1, 2], [1, 2])).toBeUndefined();
+    // The selection already covers everything returned -> no expansion.
+    expect(getExpandedProjectIds([1], [1, 2])).toBeUndefined();
+  });
+
+  it('returns the full returned scope when it includes unselected projects', () => {
+    expect(getExpandedProjectIds([1, 2, 3], [1, 2])).toEqual([1, 2, 3]);
+    expect(getExpandedProjectIds([5], [])).toEqual([5]);
+  });
+});
+
+describe('generateQueryTokensString', () => {
+  it('omits the projects clause when there is no expansion', () => {
+    expect(generateQueryTokensString({query: 'is:unresolved'})).not.toContain('expanded');
+  });
+
+  it('announces the expanded project scope for screen readers', () => {
+    expect(
+      generateQueryTokensString({query: 'is:unresolved', expandedProjectIds: [1, 2, 3]})
+    ).toContain('search expanded to 3 projects');
+  });
+
+  it('uses the singular form for a single expanded project', () => {
+    expect(generateQueryTokensString({expandedProjectIds: [1]})).toBe(
+      'search expanded to 1 project'
+    );
+  });
+});

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -242,8 +242,6 @@ export function generateQueryTokensString(args: QueryTokensProps): string {
     parts.push(`sort is '${sortText}'`);
   }
 
-  // Announce when the agent broadened the query to projects beyond the user's
-  // selection, so screen reader users hear the widened scope the chip shows.
   if (args?.expandedProjectIds && args.expandedProjectIds.length > 0) {
     const count = args.expandedProjectIds.length;
     parts.push(`search expanded to ${count} ${count === 1 ? 'project' : 'projects'}`);

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -242,5 +242,12 @@ export function generateQueryTokensString(args: QueryTokensProps): string {
     parts.push(`sort is '${sortText}'`);
   }
 
+  // Announce when the agent broadened the query to projects beyond the user's
+  // selection, so screen reader users hear the widened scope the chip shows.
+  if (args?.expandedProjectIds && args.expandedProjectIds.length > 0) {
+    const count = args.expandedProjectIds.length;
+    parts.push(`search expanded to ${count} ${count === 1 ? 'project' : 'projects'}`);
+  }
+
   return parts.length > 0 ? parts.join(', ') : 'No query parameters set';
 }

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -73,6 +73,24 @@ export function isNoneOfTheseItem(
   return item.key === 'none-of-these';
 }
 
+/**
+ * Returns the agent's expanded project scope to apply when it broadened beyond
+ * the user's selection (Seer always returns a superset). Returns `undefined`
+ * when there's no expansion, so the "Projects" chip stays hidden and the user's
+ * selection is left untouched.
+ */
+export function getExpandedProjectIds(
+  returnedProjectIds: number[] | null | undefined,
+  selectedProjectIds: number[]
+): number[] | undefined {
+  if (!returnedProjectIds || returnedProjectIds.length === 0) {
+    return undefined;
+  }
+  const selectedSet = new Set(selectedProjectIds);
+  const hasExtraProjects = returnedProjectIds.some(id => !selectedSet.has(id));
+  return hasExtraProjects ? returnedProjectIds : undefined;
+}
+
 function formatToken(token: string): string {
   const isNegated = token.startsWith('!') && token.includes(':');
   const actualToken = isNegated ? token.slice(1) : token;

--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -11,13 +11,13 @@ import type {
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
   buildSeerDateTimeSelection,
+  buildSeerMutationResult,
   mapSeerResponseItem,
   transformSeerResponse,
   useInitialSeerQuery,
   useSelectedProjectIds,
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
-import {getExpandedProjectIds} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -70,19 +70,9 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
         },
       });
 
-      const expandedProjectIds = getExpandedProjectIds(
-        data.project_ids,
-        selectedProjectIds
+      return buildSeerMutationResult(data, selectedProjectIds, response =>
+        mapSeerResponseItem(response)
       );
-
-      return {
-        status: 'ok',
-        unsupported_reason: data.unsupported_reason,
-        queries: data.responses.map(response => ({
-          ...mapSeerResponseItem(response),
-          ...(expandedProjectIds ? {expandedProjectIds} : {}),
-        })),
-      };
     },
   });
 
@@ -150,7 +140,6 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
         query: queryToUse,
       };
 
-      // Widen to the agent's expanded scope when it broadened the query.
       if (expandedProjectIds) {
         newQueryParams.project = expandedProjectIds.map(String);
       }

--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -45,16 +45,12 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
   const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
 
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
-      const expandedProjectIds = getExpandedProjectIds(
-        (response as unknown as SeerRawResponse).project_ids,
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
+      transformSeerResponse(
+        response,
+        responseItem => mapSeerResponseItem(responseItem),
         selectedProjectIds
-      );
-      return transformSeerResponse(response, responseItem => ({
-        ...mapSeerResponseItem(responseItem),
-        ...(expandedProjectIds ? {expandedProjectIds} : {}),
-      }));
-    },
+      ),
     [selectedProjectIds]
   );
 

--- a/static/app/views/discover/results/issueListSeerComboBox.tsx
+++ b/static/app/views/discover/results/issueListSeerComboBox.tsx
@@ -17,6 +17,7 @@ import {
   useSelectedProjectIds,
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import {getExpandedProjectIds} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -44,9 +45,17 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
   const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
 
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
-      transformSeerResponse(response, responseItem => mapSeerResponseItem(responseItem)),
-    []
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
+      const expandedProjectIds = getExpandedProjectIds(
+        (response as unknown as SeerRawResponse).project_ids,
+        selectedProjectIds
+      );
+      return transformSeerResponse(response, responseItem => ({
+        ...mapSeerResponseItem(responseItem),
+        ...(expandedProjectIds ? {expandedProjectIds} : {}),
+      }));
+    },
+    [selectedProjectIds]
   );
 
   const issueListAskSeerMutationOptions = mutationOptions({
@@ -65,10 +74,18 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
         },
       });
 
+      const expandedProjectIds = getExpandedProjectIds(
+        data.project_ids,
+        selectedProjectIds
+      );
+
       return {
         status: 'ok',
         unsupported_reason: data.unsupported_reason,
-        queries: data.responses.map(response => mapSeerResponseItem(response)),
+        queries: data.responses.map(response => ({
+          ...mapSeerResponseItem(response),
+          ...(expandedProjectIds ? {expandedProjectIds} : {}),
+        })),
       };
     },
   });
@@ -86,6 +103,7 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
         start: resultStart,
         end: resultEnd,
         visualizations,
+        expandedProjectIds,
       } = result;
 
       const dt = buildSeerDateTimeSelection(
@@ -135,6 +153,11 @@ export function IssueListSeerComboBox({onSearch}: IssueListSeerComboBoxProps) {
         ...location.query,
         query: queryToUse,
       };
+
+      // Widen to the agent's expanded scope when it broadened the query.
+      if (expandedProjectIds) {
+        newQueryParams.project = expandedProjectIds.map(String);
+      }
 
       // Convert to aliased format for Discover (e.g., "-count()" -> "-count")
       if (sort) {

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -8,12 +8,12 @@ import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSe
 import type {SeerRawResponse} from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
   buildSeerDateTimeSelection,
+  buildSeerMutationResult,
   transformSeerResponse,
   useInitialSeerQuery,
   useSelectedProjectIds,
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
-import {getExpandedProjectIds} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -70,25 +70,15 @@ export function LogsTabSeerComboBox() {
         },
       });
 
-      const expandedProjectIds = getExpandedProjectIds(
-        data.project_ids,
-        selectedProjectIds
-      );
-
-      return {
-        status: 'ok',
-        unsupported_reason: data.unsupported_reason,
-        queries: data.responses.map(r => ({
-          query: r?.query ?? '',
-          sort: r?.sort ?? '',
-          groupBys: r?.group_by ?? [],
-          statsPeriod: r?.stats_period ?? '',
-          start: r?.start ?? null,
-          end: r?.end ?? null,
-          mode: r?.mode ?? 'samples',
-          ...(expandedProjectIds ? {expandedProjectIds} : {}),
-        })),
-      };
+      return buildSeerMutationResult(data, selectedProjectIds, r => ({
+        query: r?.query ?? '',
+        sort: r?.sort ?? '',
+        groupBys: r?.group_by ?? [],
+        statsPeriod: r?.stats_period ?? '',
+        start: r?.start ?? null,
+        end: r?.end ?? null,
+        mode: r?.mode ?? 'samples',
+      }));
     },
   });
 
@@ -168,7 +158,6 @@ export function LogsTabSeerComboBox() {
 
       const newQuery = {
         ...location.query,
-        // Widen to the agent's expanded scope when it broadened the query.
         ...(expandedProjectIds ? {project: expandedProjectIds.map(String)} : {}),
         [LOGS_QUERY_KEY]: queryToUse,
         mode,

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -13,6 +13,7 @@ import {
   useSelectedProjectIds,
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import {getExpandedProjectIds} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -36,6 +37,7 @@ interface AskSeerSearchQuery {
   sort: string;
   start: string | null;
   statsPeriod: string;
+  expandedProjectIds?: number[];
 }
 
 export function LogsTabSeerComboBox() {
@@ -68,6 +70,11 @@ export function LogsTabSeerComboBox() {
         },
       });
 
+      const expandedProjectIds = getExpandedProjectIds(
+        data.project_ids,
+        selectedProjectIds
+      );
+
       return {
         status: 'ok',
         unsupported_reason: data.unsupported_reason,
@@ -79,6 +86,7 @@ export function LogsTabSeerComboBox() {
           start: r?.start ?? null,
           end: r?.end ?? null,
           mode: r?.mode ?? 'samples',
+          ...(expandedProjectIds ? {expandedProjectIds} : {}),
         })),
       };
     },
@@ -95,6 +103,7 @@ export function LogsTabSeerComboBox() {
         statsPeriod,
         start: resultStart,
         end: resultEnd,
+        expandedProjectIds,
       } = result;
 
       const dt = buildSeerDateTimeSelection(
@@ -159,6 +168,8 @@ export function LogsTabSeerComboBox() {
 
       const newQuery = {
         ...location.query,
+        // Widen to the agent's expanded scope when it broadened the query.
+        ...(expandedProjectIds ? {project: expandedProjectIds.map(String)} : {}),
         [LOGS_QUERY_KEY]: queryToUse,
         mode,
         [LOGS_AGGREGATE_FIELD_KEY]: aggregateFields.map(field => JSON.stringify(field)),
@@ -201,8 +212,12 @@ export function LogsTabSeerComboBox() {
   );
 
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
-      transformSeerResponse(response, r => ({
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
+      const expandedProjectIds = getExpandedProjectIds(
+        (response as unknown as SeerRawResponse).project_ids,
+        selectedProjectIds
+      );
+      return transformSeerResponse(response, r => ({
         query: r?.query ?? '',
         sort: r?.sort ?? '',
         groupBys: r?.group_by ?? [],
@@ -210,8 +225,10 @@ export function LogsTabSeerComboBox() {
         start: r?.start ?? null,
         end: r?.end ?? null,
         mode: r?.mode ?? 'samples',
-      })),
-    []
+        ...(expandedProjectIds ? {expandedProjectIds} : {}),
+      }));
+    },
+    [selectedProjectIds]
   );
 
   if (!enableAISearch) {

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -212,22 +212,20 @@ export function LogsTabSeerComboBox() {
   );
 
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
-      const expandedProjectIds = getExpandedProjectIds(
-        (response as unknown as SeerRawResponse).project_ids,
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
+      transformSeerResponse(
+        response,
+        r => ({
+          query: r?.query ?? '',
+          sort: r?.sort ?? '',
+          groupBys: r?.group_by ?? [],
+          statsPeriod: r?.stats_period ?? '',
+          start: r?.start ?? null,
+          end: r?.end ?? null,
+          mode: r?.mode ?? 'samples',
+        }),
         selectedProjectIds
-      );
-      return transformSeerResponse(response, r => ({
-        query: r?.query ?? '',
-        sort: r?.sort ?? '',
-        groupBys: r?.group_by ?? [],
-        statsPeriod: r?.stats_period ?? '',
-        start: r?.start ?? null,
-        end: r?.end ?? null,
-        mode: r?.mode ?? 'samples',
-        ...(expandedProjectIds ? {expandedProjectIds} : {}),
-      }));
-    },
+      ),
     [selectedProjectIds]
   );
 

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -11,13 +11,13 @@ import type {
   SeerRawResponse,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
+  buildSeerMutationResult,
   mapSeerResponseItem,
   transformSeerResponse,
   useInitialSeerQuery,
   useSelectedProjectIds,
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
-import {getExpandedProjectIds} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {ConfigStore} from 'sentry/stores/configStore';
@@ -88,19 +88,9 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         },
       });
 
-      const expandedProjectIds = getExpandedProjectIds(
-        data.project_ids,
-        selectedProjectIds
+      return buildSeerMutationResult(data, selectedProjectIds, response =>
+        mapSeerResponseItem(response)
       );
-
-      return {
-        status: 'ok',
-        unsupported_reason: data.unsupported_reason,
-        queries: data.responses.map(response => ({
-          ...mapSeerResponseItem(response),
-          ...(expandedProjectIds ? {expandedProjectIds} : {}),
-        })),
-      };
     },
   });
 
@@ -303,7 +293,6 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
           ...location,
           query: {
             ...location.query,
-            // Widen to the agent's expanded scope when it broadened the query.
             ...(result.expandedProjectIds?.length
               ? {project: result.expandedProjectIds.map(String)}
               : {}),

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -336,16 +336,12 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
     organization.features.includes('gen-ai-explore-metrics-search');
 
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
-      const expandedProjectIds = getExpandedProjectIds(
-        (response as unknown as SeerRawResponse).project_ids,
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
+      transformSeerResponse(
+        response,
+        responseItem => mapSeerResponseItem(responseItem),
         selectedProjectIds
-      );
-      return transformSeerResponse(response, responseItem => ({
-        ...mapSeerResponseItem(responseItem),
-        ...(expandedProjectIds ? {expandedProjectIds} : {}),
-      }));
-    },
+      ),
     [selectedProjectIds]
   );
 

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -17,6 +17,7 @@ import {
   useSelectedProjectIds,
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import {getExpandedProjectIds} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {ConfigStore} from 'sentry/stores/configStore';
@@ -87,10 +88,18 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         },
       });
 
+      const expandedProjectIds = getExpandedProjectIds(
+        data.project_ids,
+        selectedProjectIds
+      );
+
       return {
         status: 'ok',
         unsupported_reason: data.unsupported_reason,
-        queries: data.responses.map(response => mapSeerResponseItem(response)),
+        queries: data.responses.map(response => ({
+          ...mapSeerResponseItem(response),
+          ...(expandedProjectIds ? {expandedProjectIds} : {}),
+        })),
       };
     },
   });
@@ -294,6 +303,10 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
           ...location,
           query: {
             ...location.query,
+            // Widen to the agent's expanded scope when it broadened the query.
+            ...(result.expandedProjectIds?.length
+              ? {project: result.expandedProjectIds.map(String)}
+              : {}),
             metric: newEncodedMetrics,
             start: seerQuery.datetime.start,
             end: seerQuery.datetime.end,
@@ -323,9 +336,17 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
     organization.features.includes('gen-ai-explore-metrics-search');
 
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
-      transformSeerResponse(response, responseItem => mapSeerResponseItem(responseItem)),
-    []
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
+      const expandedProjectIds = getExpandedProjectIds(
+        (response as unknown as SeerRawResponse).project_ids,
+        selectedProjectIds
+      );
+      return transformSeerResponse(response, responseItem => ({
+        ...mapSeerResponseItem(responseItem),
+        ...(expandedProjectIds ? {expandedProjectIds} : {}),
+      }));
+    },
+    [selectedProjectIds]
   );
 
   if (!enableAISearch) {

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -11,13 +11,13 @@ import type {
   SeerRawResponse,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
+  buildSeerMutationResult,
   mapSeerResponseItem,
   transformSeerResponse,
   useInitialSeerQuery,
   useSelectedProjectIds,
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
-import {getExpandedProjectIds} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {fetchMutation} from 'sentry/utils/queryClient';
@@ -71,19 +71,9 @@ export function SpansTabSeerComboBox() {
           },
         });
 
-        const expandedProjectIds = getExpandedProjectIds(
-          data.project_ids,
-          selectedProjectIds
+        return buildSeerMutationResult(data, selectedProjectIds, response =>
+          mapSeerResponseItem(response, 'spans')
         );
-
-        return {
-          status: 'ok',
-          unsupported_reason: data.unsupported_reason,
-          queries: data.responses.map(response => ({
-            ...mapSeerResponseItem(response, 'spans'),
-            ...(expandedProjectIds ? {expandedProjectIds} : {}),
-          })),
-        };
       }
 
       const data = await fetchMutation<TraceAskSeerSearchResponse>({
@@ -130,7 +120,6 @@ export function SpansTabSeerComboBox() {
 
       const selection = {
         ...pageFilters.selection,
-        // Widen to the agent's expanded scope when it broadened the query.
         ...(result.expandedProjectIds?.length
           ? {projects: result.expandedProjectIds}
           : {}),

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -183,16 +183,12 @@ export function SpansTabSeerComboBox() {
   });
 
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
-      const expandedProjectIds = getExpandedProjectIds(
-        (response as unknown as SeerRawResponse).project_ids,
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
+      transformSeerResponse(
+        response,
+        responseItem => mapSeerResponseItem(responseItem, 'spans'),
         selectedProjectIds
-      );
-      return transformSeerResponse(response, responseItem => ({
-        ...mapSeerResponseItem(responseItem, 'spans'),
-        ...(expandedProjectIds ? {expandedProjectIds} : {}),
-      }));
-    },
+      ),
     [selectedProjectIds]
   );
 

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -17,6 +17,7 @@ import {
   useSelectedProjectIds,
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import {getExpandedProjectIds} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {fetchMutation} from 'sentry/utils/queryClient';
@@ -70,10 +71,18 @@ export function SpansTabSeerComboBox() {
           },
         });
 
+        const expandedProjectIds = getExpandedProjectIds(
+          data.project_ids,
+          selectedProjectIds
+        );
+
         return {
           status: 'ok',
           unsupported_reason: data.unsupported_reason,
-          queries: data.responses.map(response => mapSeerResponseItem(response, 'spans')),
+          queries: data.responses.map(response => ({
+            ...mapSeerResponseItem(response, 'spans'),
+            ...(expandedProjectIds ? {expandedProjectIds} : {}),
+          })),
         };
       }
 
@@ -121,6 +130,10 @@ export function SpansTabSeerComboBox() {
 
       const selection = {
         ...pageFilters.selection,
+        // Widen to the agent's expanded scope when it broadened the query.
+        ...(result.expandedProjectIds?.length
+          ? {projects: result.expandedProjectIds}
+          : {}),
         datetime: seerQuery.datetime,
       };
 
@@ -170,11 +183,17 @@ export function SpansTabSeerComboBox() {
   });
 
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
-      transformSeerResponse(response, responseItem =>
-        mapSeerResponseItem(responseItem, 'spans')
-      ),
-    []
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
+      const expandedProjectIds = getExpandedProjectIds(
+        (response as unknown as SeerRawResponse).project_ids,
+        selectedProjectIds
+      );
+      return transformSeerResponse(response, responseItem => ({
+        ...mapSeerResponseItem(responseItem, 'spans'),
+        ...(expandedProjectIds ? {expandedProjectIds} : {}),
+      }));
+    },
+    [selectedProjectIds]
   );
 
   if (useTranslateEndpoint) {

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -10,13 +10,13 @@ import type {
   SeerRawResponse,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
 import {
+  buildSeerMutationResult,
   mapSeerResponseItem,
   transformSeerResponse,
   useInitialSeerQuery,
   useSelectedProjectIds,
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
-import {getExpandedProjectIds} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {fetchMutation} from 'sentry/utils/queryClient';
@@ -58,19 +58,9 @@ export function IssueListSeerComboBox() {
         },
       });
 
-      const expandedProjectIds = getExpandedProjectIds(
-        data.project_ids,
-        selectedProjectIds
+      return buildSeerMutationResult(data, selectedProjectIds, response =>
+        mapSeerResponseItem(response)
       );
-
-      return {
-        status: 'ok',
-        unsupported_reason: data.unsupported_reason,
-        queries: data.responses.map(response => ({
-          ...mapSeerResponseItem(response),
-          ...(expandedProjectIds ? {expandedProjectIds} : {}),
-        })),
-      };
     },
   });
 
@@ -126,7 +116,6 @@ export function IssueListSeerComboBox() {
 
       const queryParams = {
         ...omit(location.query, ['page', 'cursor']),
-        // Widen to the agent's expanded scope when it broadened the query.
         ...(expandedProjectIds ? {project: expandedProjectIds.map(String)} : {}),
         referrer: 'issue-list',
         query: queryToUse,

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -37,16 +37,12 @@ export function IssueListSeerComboBox() {
   const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
 
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
-      const expandedProjectIds = getExpandedProjectIds(
-        (response as unknown as SeerRawResponse).project_ids,
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
+      transformSeerResponse(
+        response,
+        responseItem => mapSeerResponseItem(responseItem),
         selectedProjectIds
-      );
-      return transformSeerResponse(response, responseItem => ({
-        ...mapSeerResponseItem(responseItem),
-        ...(expandedProjectIds ? {expandedProjectIds} : {}),
-      }));
-    },
+      ),
     [selectedProjectIds]
   );
 

--- a/static/app/views/issueList/issueListSeerComboBox.tsx
+++ b/static/app/views/issueList/issueListSeerComboBox.tsx
@@ -16,6 +16,7 @@ import {
   useSelectedProjectIds,
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import {getExpandedProjectIds} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {fetchMutation} from 'sentry/utils/queryClient';
@@ -36,9 +37,17 @@ export function IssueListSeerComboBox() {
   const selectedProjectIdsForMutation = useSelectedProjectIdsForMutation();
 
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
-      transformSeerResponse(response, responseItem => mapSeerResponseItem(responseItem)),
-    []
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
+      const expandedProjectIds = getExpandedProjectIds(
+        (response as unknown as SeerRawResponse).project_ids,
+        selectedProjectIds
+      );
+      return transformSeerResponse(response, responseItem => ({
+        ...mapSeerResponseItem(responseItem),
+        ...(expandedProjectIds ? {expandedProjectIds} : {}),
+      }));
+    },
+    [selectedProjectIds]
   );
 
   const issueListAskSeerMutationOptions = mutationOptions({
@@ -53,10 +62,18 @@ export function IssueListSeerComboBox() {
         },
       });
 
+      const expandedProjectIds = getExpandedProjectIds(
+        data.project_ids,
+        selectedProjectIds
+      );
+
       return {
         status: 'ok',
         unsupported_reason: data.unsupported_reason,
-        queries: data.responses.map(response => mapSeerResponseItem(response)),
+        queries: data.responses.map(response => ({
+          ...mapSeerResponseItem(response),
+          ...(expandedProjectIds ? {expandedProjectIds} : {}),
+        })),
       };
     },
   });
@@ -73,6 +90,7 @@ export function IssueListSeerComboBox() {
         statsPeriod,
         start: resultStart,
         end: resultEnd,
+        expandedProjectIds,
       } = result;
 
       askSeerSuggestedQueryRef.current = JSON.stringify({
@@ -112,6 +130,8 @@ export function IssueListSeerComboBox() {
 
       const queryParams = {
         ...omit(location.query, ['page', 'cursor']),
+        // Widen to the agent's expanded scope when it broadened the query.
+        ...(expandedProjectIds ? {project: expandedProjectIds.map(String)} : {}),
         referrer: 'issue-list',
         query: queryToUse,
         ...(sort ? {sort} : {}),


### PR DESCRIPTION
When Ask Seer broadens an assisted query beyond the user's selected projects (it returns a superset, never a smaller set), the suggestion row now shows a "Projects" chip and accepting the suggestion widens the project selection to match; consistent with how the suggested time range already previews and applies.

Previously the expanded projects were invisible and the applied query ran only against the originally selected projects, so results could miss the very projects Seer found most relevant.

Rolled out to the Traces, Logs, and Metrics, Issues and Discover.

DSL looks like below:
<img width="1804" height="862" alt="image" src="https://github.com/user-attachments/assets/d1261bd8-318f-4a03-a8f1-eba907b66f3e" />

After DSL selection
<img width="1569" height="745" alt="image" src="https://github.com/user-attachments/assets/5d512b2d-b4bf-4587-ad6d-d529a58ef67f" />

Created with Claude