### PR TITLE
ref(api): tighten 3 more PUBLIC endpoint returns to Response[T]

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Any, Protocol, TypedDict, TypeGuard
+from typing import TYPE_CHECKING, Any, Protocol, TypedDict, TypeGuard
 
 import sentry_sdk
 from django.conf import settings
@@ -59,6 +59,13 @@ from sentry.users.services.user.service import user_service
 from sentry.utils.cache import cache
 from sentry.utils.safe import safe_execute
 from sentry.utils.snuba import aliased_query, get_snuba_column_name, raw_query
+
+if TYPE_CHECKING:
+    from sentry.models.groupinbox import InboxDetails
+    from sentry.models.groupowner import OwnersSerialized
+    from sentry.sentry_apps.api.serializers.platform_external_issue import (
+        PlatformExternalIssueSerializerResponse,
+    )
 
 # TODO(jess): remove when snuba is primary backend
 snuba_tsdb = SnubaTSDB(**settings.SENTRY_TSDB_OPTIONS)
@@ -149,11 +156,11 @@ class GroupDetailsResponseOptional(TypedDict, total=False):
     tags: list[dict[str, Any]]
     stats: dict[str, list[list[float]]]
     # Opt-in via `?expand=...`
-    inbox: dict[str, Any] | None
-    owners: list[dict[str, Any]] | None
+    inbox: InboxDetails | None
+    owners: list[OwnersSerialized] | None
     forecast: dict[str, Any]
     integrationIssues: list[dict[str, Any]]
-    sentryAppIssues: list[dict[str, Any]]
+    sentryAppIssues: list[PlatformExternalIssueSerializerResponse]
     latestEventHasAttachments: bool
 
 

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -329,6 +329,10 @@ class StreamGroupSerializerSnubaResponse(TypedDict):
     integrationIssues: NotRequired[list[dict[str, Any]]]
     sentryAppIssues: NotRequired[list[dict[str, Any]]]
     latestEventHasAttachments: NotRequired[bool]
+    # Added post-serialize at the direct-hit path in OrganizationGroupIndexEndpoint /
+    # ProjectGroupIndexEndpoint when a query resolves to a specific event.
+    matchingEventId: NotRequired[str | None]
+    matchingEventEnvironment: NotRequired[str | None]
 
 
 class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):

--- a/src/sentry/apidocs/examples/issue_examples.py
+++ b/src/sentry/apidocs/examples/issue_examples.py
@@ -93,6 +93,8 @@ SIMPLE_ISSUE: StreamGroupSerializerSnubaResponse = {
     "issueType": "performance_n_plus_one_db_queries",
     "sessionCount": 0,
     "latestEventHasAttachments": False,
+    "matchingEventId": None,
+    "matchingEventEnvironment": None,
 }
 
 MUTATE_ISSUE_RESULT: MutateIssueResponse = {

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -191,7 +191,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
         examples=IssueExamples.GROUP_DETAILS,
     )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-details"])
-    def get(self, request: Request, group: Group) -> Response:
+    def get(self, request: Request, group: Group) -> Response[GroupDetailsResponse]:
         """
         Return details on an individual issue, including its basic stats, comment
         and user-report counts, and a summary of the latest event.
@@ -209,7 +209,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
 
             # WARNING: the rest of this endpoint relies on this serializer
             # populating the cache SO don't move this :)
-            data = serialize(
+            data: GroupDetailsResponse = serialize(
                 group, request.user, GroupSerializerSnuba(environment_ids=environment_ids)
             )
 

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -52,6 +52,7 @@ from sentry.apidocs.parameters import (
     IssueParams,
     OrganizationParams,
 )
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ALLOWED_FUTURE_DELTA
 from sentry.exceptions import InvalidSearchQuery
@@ -312,7 +313,9 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
         examples=IssueExamples.ORGANIZATION_GROUP_INDEX_GET,
     )
     @track_slo_response("workflow")
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[StreamGroupSerializerSnubaResponse]] | Response[DetailResponse]:
         stats_period = request.GET.get("groupStatsPeriod")
         start, end = get_date_range_from_stats_period(request.GET)
 
@@ -384,7 +387,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
                     )
                 )
                 if len(groups) == 1:
-                    serialized_groups = serialize(
+                    serialized_groups: list[StreamGroupSerializerSnubaResponse] = serialize(
                         groups, request.user, serializer(), request=request
                     )
                     serialized_groups[0]["matchingEventId"] = event_id
@@ -393,15 +396,19 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
                     return response
 
                 if groups:
-                    return Response(serialize(groups, request.user, serializer(), request=request))
+                    by_event: list[StreamGroupSerializerSnubaResponse] = serialize(
+                        groups, request.user, serializer(), request=request
+                    )
+                    return Response(by_event)
 
             group = get_by_short_id(organization.id, request.GET.get("shortIdLookup") or "0", query)
             if group is not None:
                 # check all projects user has access to
                 if request.access.has_project_access(group.project):
-                    response = Response(
-                        serialize([group], request.user, serializer(), request=request)
+                    by_short_id: list[StreamGroupSerializerSnubaResponse] = serialize(
+                        [group], request.user, serializer(), request=request
                     )
+                    response = Response(by_short_id)
                     response["X-Sentry-Direct-Hit"] = "1"
                     return response
 
@@ -415,7 +422,10 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
             groups = list(Group.objects.filter(id__in=group_ids, project_id__in=project_ids))
             if any(g for g in groups if not request.access.has_project_access(g.project)):
                 raise PermissionDenied
-            return Response(serialize(groups, request.user, serializer(), request=request))
+            by_group_id: list[StreamGroupSerializerSnubaResponse] = serialize(
+                groups, request.user, serializer(), request=request
+            )
+            return Response(by_group_id)
 
         try:
             with handle_query_errors():

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -299,7 +299,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         examples=AutofixExamples.AUTOFIX_GET_RESPONSE,
     )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-autofix"])
-    def get(self, request: Request, group: Group) -> Response:
+    def get(self, request: Request, group: Group) -> Response[AutofixStateResponse]:
         """
         Retrieve the current detailed state of an issue fix process for a specific issue including:
 


### PR DESCRIPTION
Three more PUBLIC endpoints in the Goal #1 gap.

- `group_ai_autofix.get()` → `Response[AutofixStateResponse]`. Both return paths already match the existing TypedDict shape; no body change.
- `organization_group_index.get()` → `Response[list[StreamGroupSerializerSnubaResponse]] | Response[DetailResponse]`. Widen `StreamGroupSerializerSnubaResponse` with `NotRequired[matchingEventId / matchingEventEnvironment]` to declare the direct-hit mutations, then apply the typed-variable trick at four `serialize()` call sites (GroupSerializerBase is denylisted, so `serialize()` flows `Any`).
- `group_details.get()` → `Response[GroupDetailsResponse]`. Fix three TypedDict drifts so the declared shape matches runtime: `inbox: InboxDetails | None`, `owners: list[OwnersSerialized] | None`, `sentryAppIssues: list[PlatformExternalIssueSerializerResponse]`. No body changes.