### PR TITLE
chore(autofix): Remove legacy autofix state from PR

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -253,19 +253,6 @@ def make_get_autofix_state_request(
     )
 
 
-def make_get_autofix_state_pr_request(
-    body: GetAutofixStatePrRequest,
-    connection_pool: HTTPConnectionPool | None = None,
-    viewer_context: SeerViewerContext | None = None,
-) -> BaseHTTPResponse:
-    return make_signed_seer_api_request(
-        connection_pool or autofix_connection_pool,
-        "/v1/automation/autofix/state/pr",
-        body=orjson.dumps(body),
-        viewer_context=viewer_context,
-    )
-
-
 def make_get_autofix_prompt_request(
     body: GetAutofixPromptRequest,
     connection_pool: HTTPConnectionPool | None = None,
@@ -958,24 +945,6 @@ def get_autofix_state(
             return state
 
     return None
-
-
-def get_autofix_state_from_pr_id(provider: str, pr_id: int) -> AutofixState | None:
-    body = GetAutofixStatePrRequest(provider=provider, pr_id=pr_id)
-    response = make_get_autofix_state_pr_request(body)
-
-    if response.status >= 400:
-        raise Exception(f"Seer request failed with status {response.status}")
-    result = response.json()
-
-    if not result:
-        return None
-
-    state = result.get("state", None)
-    if state is None:
-        return None
-
-    return AutofixState.validate(state)
 
 
 def is_seer_scanner_rate_limited(project: Project, organization: Organization) -> bool:

--- a/src/sentry/seer/autofix/webhooks.py
+++ b/src/sentry/seer/autofix/webhooks.py
@@ -15,7 +15,6 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.seer.agent.client_utils import get_agent_state_from_pr_id
-from sentry.seer.autofix.utils import get_autofix_state_from_pr_id
 from sentry.utils import metrics
 
 AnalyticAction = Literal["opened", "closed", "merged"]
@@ -66,23 +65,6 @@ def record_pr_action_analytic(
         analytic_action = "merged"
 
     sent_at = _get_pr_timestamp_ms(pull_request, analytic_action)
-
-    autofix_state = get_autofix_state_from_pr_id("integrations:github", pull_request["id"])
-    if autofix_state:
-        analytics.record(
-            ACTION_TO_EVENTS[analytic_action](
-                organization_id=org.id,
-                integration=IntegrationProviderSlug.GITHUB.value,
-                project_id=autofix_state.request.project_id,
-                group_id=autofix_state.request.issue["id"],
-                run_id=autofix_state.run_id,
-                github_app=github_app,
-                sent_at=sent_at,
-            )
-        )
-
-        metrics.incr(f"ai.autofix.pr.{analytic_action}")
-        return
 
     agent_state = get_agent_state_from_pr_id(org.id, "integrations:github", pull_request["id"])
     if agent_state:

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -13,7 +13,6 @@ from sentry.seer.autofix.utils import (
     _get_autofix_rate_limit_config,
     get_autofix_repos_from_project_code_mappings,
     get_autofix_state,
-    get_autofix_state_from_pr_id,
     is_seer_autotriggered_autofix_rate_limited,
     is_seer_autotriggered_autofix_rate_limited_and_increment,
     is_seer_scanner_rate_limited,
@@ -182,66 +181,6 @@ class TestGetRepoFromCodeMappings(TestCase):
         repos = get_autofix_repos_from_project_code_mappings(project)
         assert len(repos) == 1
         assert repos[0]["repository_id"] == repo_with_external_id.id
-
-
-class TestGetAutofixStateFromPrId(TestCase):
-    @patch("sentry.seer.autofix.utils.make_signed_seer_api_request")
-    def test_get_autofix_state_from_pr_id_success(self, mock_request: MagicMock) -> None:
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_response.json.return_value = {
-            "state": {
-                "run_id": 123,
-                "request": {
-                    "project_id": 456,
-                    "organization_id": 999,
-                    "issue": {"id": 789, "title": "Test Issue"},
-                    "repos": [],
-                },
-                "updated_at": "2023-07-18T12:00:00Z",
-                "status": "PROCESSING",
-            }
-        }
-        mock_request.return_value = mock_response
-
-        result = get_autofix_state_from_pr_id("github", 1)
-
-        assert result is not None
-        assert result.run_id == 123
-        assert result.request == {
-            "project_id": 456,
-            "organization_id": 999,
-            "issue": {"id": 789, "title": "Test Issue"},
-            "repos": [],
-        }
-        assert result.updated_at == datetime(2023, 7, 18, 12, 0, tzinfo=timezone.utc)
-        assert result.status == AutofixStatus.PROCESSING
-
-        mock_request.assert_called_once()
-        path = mock_request.call_args[0][1]
-        assert path == "/v1/automation/autofix/state/pr"
-        body = orjson.loads(mock_request.call_args[1]["body"])
-        assert body == {"provider": "github", "pr_id": 1}
-
-    @patch("sentry.seer.autofix.utils.make_signed_seer_api_request")
-    def test_get_autofix_state_from_pr_id_no_state(self, mock_request: MagicMock) -> None:
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_response.json.return_value = {}
-        mock_request.return_value = mock_response
-
-        result = get_autofix_state_from_pr_id("github", 1)
-
-        assert result is None
-
-    @patch("sentry.seer.autofix.utils.make_signed_seer_api_request")
-    def test_get_autofix_state_from_pr_id_http_error(self, mock_request: MagicMock) -> None:
-        mock_response = Mock()
-        mock_response.status = 500
-        mock_request.return_value = mock_response
-
-        with pytest.raises(Exception, match="Seer request failed with status 500"):
-            get_autofix_state_from_pr_id("github", 1)
 
 
 class TestGetAutofixState(TestCase):

--- a/tests/sentry/autofix/test_webhooks.py
+++ b/tests/sentry/autofix/test_webhooks.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timezone
 from unittest.mock import call, patch
 
 from django.conf import settings
@@ -9,8 +8,7 @@ from sentry.analytics.events.ai_autofix_pr_events import (
     AiAutofixPrMergedEvent,
     AiAutofixPrOpenedEvent,
 )
-from sentry.seer.autofix.constants import AutofixStatus
-from sentry.seer.autofix.utils import AutofixState
+from sentry.seer.agent.client_models import SeerRunState
 from sentry.seer.autofix.webhooks import handle_github_pr_webhook_for_autofix
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.analytics import (
@@ -21,28 +19,21 @@ from sentry.testutils.helpers.analytics import (
 
 class AutofixPrWebhookTest(APITestCase):
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
-    @patch(
-        "sentry.seer.autofix.webhooks.get_autofix_state_from_pr_id",
-        return_value=AutofixState(
-            run_id=1,
-            request={
-                "project_id": 2,
-                "organization_id": 4,
-                "issue": {"id": 3, "title": "Test issue"},
-                "repos": [
-                    {"provider": "github", "owner": "test", "name": "test", "external_id": "123"}
-                ],
-            },
-            updated_at=datetime.now(timezone.utc),
-            status=AutofixStatus.PROCESSING,
-            steps=[],
-        ),
-    )
+    @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
     @patch("sentry.seer.autofix.webhooks.analytics.record")
     @patch("sentry.seer.autofix.webhooks.metrics.incr")
     def test_opened(
-        self, mock_metrics_incr, mock_analytics_record, mock_get_autofix_state_from_pr_id
+        self, mock_metrics_incr, mock_analytics_record, mock_get_agent_state_from_pr_id
     ):
+        group = self.create_group(project=self.project)
+        mock_get_agent_state_from_pr_id.return_value = SeerRunState(
+            run_id=1,
+            blocks=[],
+            status="processing",
+            updated_at="2025-01-15T10:30:00Z",
+            metadata={"group_id": group.id},
+        )
+
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "opened",
@@ -55,14 +46,14 @@ class AutofixPrWebhookTest(APITestCase):
             {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
         )
 
-        mock_metrics_incr.assert_called_with("ai.autofix.pr.opened")
+        mock_metrics_incr.assert_called_with("ai.autofix.pr.opened", tags={"mode": "explorer"})
         assert_last_analytics_event(
             mock_analytics_record,
             AiAutofixPrOpenedEvent(
                 organization_id=self.organization.id,
                 integration="github",
-                project_id=2,
-                group_id=3,
+                project_id=group.project.id,
+                group_id=group.id,
                 run_id=1,
                 github_app="seer",
                 sent_at=1736937000000,
@@ -70,28 +61,21 @@ class AutofixPrWebhookTest(APITestCase):
         )
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345", SENTRY_GITHUB_APP_USER_ID="67890")
-    @patch(
-        "sentry.seer.autofix.webhooks.get_autofix_state_from_pr_id",
-        return_value=AutofixState(
-            run_id=1,
-            request={
-                "project_id": 2,
-                "organization_id": 4,
-                "issue": {"id": 3, "title": "Test issue"},
-                "repos": [
-                    {"provider": "github", "owner": "test", "name": "test", "external_id": "123"}
-                ],
-            },
-            updated_at=datetime.now(timezone.utc),
-            status=AutofixStatus.PROCESSING,
-            steps=[],
-        ),
-    )
+    @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
     @patch("sentry.seer.autofix.webhooks.analytics.record")
     @patch("sentry.seer.autofix.webhooks.metrics.incr")
     def test_opened_sentry_app(
-        self, mock_metrics_incr, mock_analytics_record, mock_get_autofix_state_from_pr_id
+        self, mock_metrics_incr, mock_analytics_record, mock_get_agent_state_from_pr_id
     ):
+        group = self.create_group(project=self.project)
+        mock_get_agent_state_from_pr_id.return_value = SeerRunState(
+            run_id=1,
+            blocks=[],
+            status="processing",
+            updated_at="2025-01-15T10:30:00Z",
+            metadata={"group_id": group.id},
+        )
+
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "opened",
@@ -104,14 +88,14 @@ class AutofixPrWebhookTest(APITestCase):
             {"id": settings.SENTRY_GITHUB_APP_USER_ID},
         )
 
-        mock_metrics_incr.assert_called_with("ai.autofix.pr.opened")
+        mock_metrics_incr.assert_called_with("ai.autofix.pr.opened", tags={"mode": "explorer"})
         assert_last_analytics_event(
             mock_analytics_record,
             AiAutofixPrOpenedEvent(
                 organization_id=self.organization.id,
                 integration="github",
-                project_id=2,
-                group_id=3,
+                project_id=group.project.id,
+                group_id=group.id,
                 run_id=1,
                 github_app="sentry",
                 sent_at=1736937000000,
@@ -119,28 +103,21 @@ class AutofixPrWebhookTest(APITestCase):
         )
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
-    @patch(
-        "sentry.seer.autofix.webhooks.get_autofix_state_from_pr_id",
-        return_value=AutofixState(
-            run_id=1,
-            request={
-                "project_id": 2,
-                "organization_id": 4,
-                "issue": {"id": 3, "title": "Test issue"},
-                "repos": [
-                    {"provider": "github", "owner": "test", "name": "test", "external_id": "123"}
-                ],
-            },
-            updated_at=datetime.now(timezone.utc),
-            status=AutofixStatus.PROCESSING,
-            steps=[],
-        ),
-    )
+    @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
     @patch("sentry.seer.autofix.webhooks.analytics.record")
     @patch("sentry.seer.autofix.webhooks.metrics.incr")
     def test_closed(
-        self, mock_metrics_incr, mock_analytics_record, mock_get_autofix_state_from_pr_id
+        self, mock_metrics_incr, mock_analytics_record, mock_get_agent_state_from_pr_id
     ):
+        group = self.create_group(project=self.project)
+        mock_get_agent_state_from_pr_id.return_value = SeerRunState(
+            run_id=1,
+            blocks=[],
+            status="processing",
+            updated_at="2025-01-15T12:00:00Z",
+            metadata={"group_id": group.id},
+        )
+
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "closed",
@@ -153,14 +130,14 @@ class AutofixPrWebhookTest(APITestCase):
             {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
         )
 
-        mock_metrics_incr.assert_called_with("ai.autofix.pr.closed")
+        mock_metrics_incr.assert_called_with("ai.autofix.pr.closed", tags={"mode": "explorer"})
         assert_last_analytics_event(
             mock_analytics_record,
             AiAutofixPrClosedEvent(
                 organization_id=self.organization.id,
                 integration="github",
-                project_id=2,
-                group_id=3,
+                project_id=group.project.id,
+                group_id=group.id,
                 run_id=1,
                 github_app="seer",
                 sent_at=1736942400000,
@@ -168,28 +145,21 @@ class AutofixPrWebhookTest(APITestCase):
         )
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
-    @patch(
-        "sentry.seer.autofix.webhooks.get_autofix_state_from_pr_id",
-        return_value=AutofixState(
-            run_id=1,
-            request={
-                "project_id": 2,
-                "organization_id": 4,
-                "issue": {"id": 3, "title": "Test issue"},
-                "repos": [
-                    {"provider": "github", "owner": "test", "name": "test", "external_id": "123"}
-                ],
-            },
-            updated_at=datetime.now(timezone.utc),
-            status=AutofixStatus.PROCESSING,
-            steps=[],
-        ),
-    )
+    @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
     @patch("sentry.seer.autofix.webhooks.analytics.record")
     @patch("sentry.seer.autofix.webhooks.metrics.incr")
     def test_merged(
-        self, mock_metrics_incr, mock_analytics_record, mock_get_autofix_state_from_pr_id
+        self, mock_metrics_incr, mock_analytics_record, mock_get_agent_state_from_pr_id
     ):
+        group = self.create_group(project=self.project)
+        mock_get_agent_state_from_pr_id.return_value = SeerRunState(
+            run_id=1,
+            blocks=[],
+            status="processing",
+            updated_at="2025-01-15T14:00:00Z",
+            metadata={"group_id": group.id},
+        )
+
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "closed",
@@ -201,14 +171,14 @@ class AutofixPrWebhookTest(APITestCase):
             },
             {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
         )
-        mock_metrics_incr.assert_called_with("ai.autofix.pr.merged")
+        mock_metrics_incr.assert_called_with("ai.autofix.pr.merged", tags={"mode": "explorer"})
         assert_last_analytics_event(
             mock_analytics_record,
             AiAutofixPrMergedEvent(
                 organization_id=self.organization.id,
                 integration="github",
-                project_id=2,
-                group_id=3,
+                project_id=group.project.id,
+                group_id=group.id,
                 run_id=1,
                 github_app="seer",
                 sent_at=1736949600000,
@@ -217,13 +187,13 @@ class AutofixPrWebhookTest(APITestCase):
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
     @patch(
-        "sentry.seer.autofix.webhooks.get_autofix_state_from_pr_id",
+        "sentry.seer.autofix.webhooks.get_agent_state_from_pr_id",
         return_value=None,
     )
     @patch("sentry.seer.autofix.webhooks.analytics.record")
     @patch("sentry.seer.autofix.webhooks.metrics.incr")
     def test_no_run(
-        self, mock_metrics_incr, mock_analytics_record, mock_get_autofix_state_from_pr_id
+        self, mock_metrics_incr, mock_analytics_record, mock_get_agent_state_from_pr_id
     ):
         handle_github_pr_webhook_for_autofix(
             self.organization,
@@ -246,13 +216,13 @@ class AutofixPrWebhookTest(APITestCase):
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID=None)
     @patch(
-        "sentry.seer.autofix.webhooks.get_autofix_state_from_pr_id",
+        "sentry.seer.autofix.webhooks.get_agent_state_from_pr_id",
         return_value=None,
     )
     @patch("sentry.seer.autofix.webhooks.analytics.record")
     @patch("sentry.seer.autofix.webhooks.metrics.incr")
     def test_no_settings_github_app_id_set(
-        self, mock_metrics_incr, mock_analytics_record, mock_get_autofix_state_from_pr_id
+        self, mock_metrics_incr, mock_analytics_record, mock_get_agent_state_from_pr_id
     ):
         handle_github_pr_webhook_for_autofix(
             self.organization,
@@ -272,13 +242,13 @@ class AutofixPrWebhookTest(APITestCase):
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
     @patch(
-        "sentry.seer.autofix.webhooks.get_autofix_state_from_pr_id",
+        "sentry.seer.autofix.webhooks.get_agent_state_from_pr_id",
         return_value=None,
     )
     @patch("sentry.seer.autofix.webhooks.analytics.record")
     @patch("sentry.seer.autofix.webhooks.metrics.incr")
     def test_no_different_github_app(
-        self, mock_metrics_incr, mock_analytics_record, mock_get_autofix_state_from_pr_id
+        self, mock_metrics_incr, mock_analytics_record, mock_get_agent_state_from_pr_id
     ):
         handle_github_pr_webhook_for_autofix(
             self.organization,


### PR DESCRIPTION
This is only receiving pr closed/merged events now as no new prs are being opened through the legacy code path.