### PR TITLE
feat(values): Add a way to start deprecating this api

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABC, abstractmethod
 from datetime import timedelta
 from typing import Literal
@@ -34,6 +35,8 @@ from sentry.search.events.types import SnubaParams
 from sentry.snuba.referrer import Referrer
 from sentry.tagstore.types import TagValue
 from sentry.utils import snuba_rpc
+
+logger = logging.getLogger(__name__)
 
 
 def as_tag_key(name: str, search_type: Literal["string", "number", "boolean"]):
@@ -147,6 +150,12 @@ class OrganizationSpansFieldsEndpoint(OrganizationSpansFieldsEndpointBase):
 @cell_silo_endpoint
 class OrganizationSpansFieldValuesEndpoint(OrganizationSpansFieldsEndpointBase):
     def get(self, request: Request, organization: Organization, key: str) -> Response:
+        logger.info("a request to span-fields was made")
+        if features.has(
+            "organizations:explore-span-fields-removal", organization, actor=request.user
+        ):
+            return Response(status=404)
+
         if not features.has(
             "organizations:visibility-explore-view", organization, actor=request.user
         ):

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -105,6 +105,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:explore-errors", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable removing the schema hints section to declutter the explore UI
     manager.add("organizations:explore-schema-hints-removal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable to disable the span-fields endpoint
+    manager.add("organizations:explore-span-fields-removal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enable returning the migrated discover queries in explore saved queries
     manager.add("organizations:expose-migrated-discover-queries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GenAI features such as Autofix and Issue Summary


### PR DESCRIPTION
- This api is replaced by the more dataset agnostic TraceItemAttributeValuesEndpoint. as far as i can tell, this endpoint isn't being hit anymore, but add a log and a feature flag so I can turn this off safely