### PR TITLE
chore(markdown): add more to copy to markdown for performance issues 

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -11,11 +11,8 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import type {EventTransaction} from 'sentry/types/event';
 import {IssueType} from 'sentry/types/group';
 
-import {
-  extractQueryParameters,
-  extractSpanURLString,
-  SpanEvidenceKeyValueList,
-} from './spanEvidenceKeyValueList';
+import {SpanEvidenceKeyValueList} from './spanEvidenceKeyValueList';
+import {extractQueryParameters, extractSpanURLString} from './spanMetrics';
 
 describe('SpanEvidenceKeyValueList', () => {
   const projectSlug = 'project';

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -4,7 +4,6 @@ import {useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 import kebabCase from 'lodash/kebabCase';
-import mapValues from 'lodash/mapValues';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
@@ -16,6 +15,8 @@ import {ClippedBox} from 'sentry/components/clippedBox';
 import {getKeyValueListData as getRegressionIssueKeyValueList} from 'sentry/components/events/eventStatisticalDetector/eventRegressionSummary';
 import {KeyValueList} from 'sentry/components/events/interfaces/keyValueList';
 import {
+  extractSpanURLString,
+  formatChangingQueryParameters,
   getSpanDuration,
   getSpanFieldBytes,
 } from 'sentry/components/events/interfaces/performance/spanMetrics';
@@ -45,7 +46,6 @@ import type {Organization} from 'sentry/types/organization';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {toRoundedPercent} from 'sentry/utils/number/toRoundedPercent';
 import {SQLishFormatter} from 'sentry/utils/sqlish';
-import {safeURL} from 'sentry/utils/url/safeURL';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
@@ -823,80 +823,6 @@ function formatDelay(durationAdded: number, totalDuration: number) {
 
 function getSingleSpanDurationImpact(event: EventTransaction, span: Span) {
   return getDurationImpact(event, getSpanDuration(span));
-}
-
-type ParameterLookup = Record<string, string[]>;
-
-/**
- * Extracts changing URL query parameters from a list of `http.client` spans.
- * e.g.,
- *
- * https://service.io/r?id=1&filter=none
- * https://service.io/r?id=2&filter=none
- * https://service.io/r?id=3&filter=none
- *
- * @returns A condensed string describing the query parameters changing
- * between the URLs of the given span. e.g., "id:{1,2,3}"
- */
-function formatChangingQueryParameters(spans: Span[], baseURL?: string): string[] {
-  const URLs = spans
-    .map(span => extractSpanURLString(span, baseURL))
-    .filter((url): url is URL => url instanceof URL);
-
-  const allQueryParameters = extractQueryParameters(URLs);
-
-  const pairs: string[] = [];
-  for (const key in allQueryParameters) {
-    const values = allQueryParameters[key]!;
-
-    // By definition, if the parameter only has one value that means it's not
-    // changing between calls, so omit it!
-    if (values.length > 1) {
-      pairs.push(`${key}:{${values.join(',')}}`);
-    }
-  }
-
-  return pairs;
-}
-
-/**
- * Parses the span data and pulls out the URL. Accounts for different SDKs and
- * different versions of SDKs formatting and parsing the URL contents
- * differently. Mirror of `get_url_from_span`. Ideally, this should not exist,
- * and instead it should use the data provided by the backend
- */
-export const extractSpanURLString = (span: Span, baseURL?: string): URL | null => {
-  let url = span?.data?.url;
-  if (url) {
-    const query = span.data['http.query'];
-    if (query) {
-      url += `?${query}`;
-    }
-
-    const parsedURL = safeURL(url, baseURL);
-    if (parsedURL) {
-      return parsedURL;
-    }
-  }
-
-  const [_method, _url] = (span?.description ?? '').split(' ', 2) as [string, string];
-
-  return safeURL(_url, baseURL) ?? null;
-};
-
-export function extractQueryParameters(URLs: URL[]): ParameterLookup {
-  const parameterValuesByKey: ParameterLookup = {};
-
-  URLs.forEach(url => {
-    for (const [key, value] of url.searchParams) {
-      parameterValuesByKey[key] ??= [];
-      parameterValuesByKey[key].push(value);
-    }
-  });
-
-  return mapValues(parameterValuesByKey, parameterList => {
-    return Array.from(new Set(parameterList));
-  });
 }
 
 function formatBasePath(span: Span, baseURL?: string): string {

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -15,6 +15,10 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {ClippedBox} from 'sentry/components/clippedBox';
 import {getKeyValueListData as getRegressionIssueKeyValueList} from 'sentry/components/events/eventStatisticalDetector/eventRegressionSummary';
 import {KeyValueList} from 'sentry/components/events/interfaces/keyValueList';
+import {
+  getSpanDuration,
+  getSpanFieldBytes,
+} from 'sentry/components/events/interfaces/performance/spanMetrics';
 import {getSpanInfoFromTransactionEvent} from 'sentry/components/events/interfaces/performance/utils';
 import type {
   ProcessedSpanType,
@@ -38,7 +42,6 @@ import {
   isTransactionBased,
 } from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {toRoundedPercent} from 'sentry/utils/number/toRoundedPercent';
 import {SQLishFormatter} from 'sentry/utils/sqlish';
@@ -144,8 +147,8 @@ function LargeHTTPPayloadSpanEvidence({
         makeRow(t('Large HTTP Payload Span'), getSpanEvidenceValue(offendingSpans[0]!)),
         makeRow(
           t('Payload Size'),
-          getSpanFieldBytes(offendingSpans[0]!, 'http.response_content_length') ??
-            getSpanFieldBytes(offendingSpans[0]!, 'Encoded Body Size')
+          getSpanFieldBytes(offendingSpans[0], 'http.response_content_length') ??
+            getSpanFieldBytes(offendingSpans[0], 'Encoded Body Size')
         ),
       ].filter(Boolean)}
     />
@@ -586,10 +589,7 @@ function RenderBlockingAssetSpanEvidence({
         makeRow(t('Slow Resource Span'), getSpanEvidenceValue(offendingSpan!)),
         makeRow(
           t('FCP Delay'),
-          formatDelay(
-            getSpanDuration(offendingSpan!),
-            event.measurements?.fcp?.value ?? 0
-          )
+          formatDelay(getSpanDuration(offendingSpan), event.measurements?.fcp?.value ?? 0)
         ),
         makeRow(t('Duration Impact'), getSingleSpanDurationImpact(event, offendingSpan!)),
       ]}
@@ -611,8 +611,8 @@ function UncompressedAssetSpanEvidence({
         makeRow(t('Slow Resource Span'), getSpanEvidenceValue(offendingSpans[0]!)),
         makeRow(
           t('Asset Size'),
-          getSpanFieldBytes(offendingSpans[0]!, 'http.response_content_length') ??
-            getSpanFieldBytes(offendingSpans[0]!, 'Encoded Body Size')
+          getSpanFieldBytes(offendingSpans[0], 'http.response_content_length') ??
+            getSpanFieldBytes(offendingSpans[0], 'Encoded Body Size')
         ),
         makeRow(
           t('Duration Impact'),
@@ -796,10 +796,6 @@ const sumSpanDurations = (spans: Span[]) => {
   return totalDuration;
 };
 
-const getSpanDuration = ({timestamp, start_timestamp}: Span) => {
-  return ((timestamp ?? 0) - (start_timestamp ?? 0)) * 1000;
-};
-
 function getDurationImpact(event: EventTransaction, durationAdded: number) {
   const transactionTime = (event.endTimestamp - event.startTimestamp) * 1000;
   if (!transactionTime) {
@@ -827,18 +823,6 @@ function formatDelay(durationAdded: number, totalDuration: number) {
 
 function getSingleSpanDurationImpact(event: EventTransaction, span: Span) {
   return getDurationImpact(event, getSpanDuration(span));
-}
-
-function getSpanDataField(span: Span, field: string) {
-  return span.data?.[field];
-}
-
-function getSpanFieldBytes(span: Span, field: string) {
-  const bytes = getSpanDataField(span, field);
-  if (!bytes) {
-    return null;
-  }
-  return `${formatBytesBase2(bytes)} (${bytes} B)`;
 }
 
 type ParameterLookup = Record<string, string[]>;

--- a/static/app/components/events/interfaces/performance/spanMetrics.tsx
+++ b/static/app/components/events/interfaces/performance/spanMetrics.tsx
@@ -1,0 +1,35 @@
+import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
+
+/**
+ * Minimal structural span shape these pure metric helpers need. Compatible with
+ * both the UI's `Span` (spanEvidenceKeyValueList) and the markdown formatter's
+ * `EvidenceSpan`, so the same helpers serve both and stay a single source of
+ * truth. Kept dependency-free (no React/emotion/theme) so it's cheap to import
+ * anywhere.
+ */
+type SpanMetricInput =
+  | {
+      data?: Record<string, any>;
+      start_timestamp?: number;
+      timestamp?: number;
+    }
+  | null
+  | undefined;
+
+/** Span duration in milliseconds. */
+export function getSpanDuration(span: SpanMetricInput): number {
+  return ((span?.timestamp ?? 0) - (span?.start_timestamp ?? 0)) * 1000;
+}
+
+export function getSpanDataField(span: SpanMetricInput, field: string): any {
+  return span?.data?.[field];
+}
+
+/** A `span.data` byte field formatted as e.g. "4.8 MiB (5000000 B)". */
+export function getSpanFieldBytes(span: SpanMetricInput, field: string): string | null {
+  const bytes = getSpanDataField(span, field);
+  if (!bytes) {
+    return null;
+  }
+  return `${formatBytesBase2(bytes)} (${bytes} B)`;
+}

--- a/static/app/components/events/interfaces/performance/spanMetrics.tsx
+++ b/static/app/components/events/interfaces/performance/spanMetrics.tsx
@@ -21,7 +21,7 @@ export function getSpanDuration(span: SpanMetricInput): number {
   return ((span?.timestamp ?? 0) - (span?.start_timestamp ?? 0)) * 1000;
 }
 
-export function getSpanDataField(span: SpanMetricInput, field: string): any {
+function getSpanDataField(span: SpanMetricInput, field: string): any {
   return span?.data?.[field];
 }
 

--- a/static/app/components/events/interfaces/performance/spanMetrics.tsx
+++ b/static/app/components/events/interfaces/performance/spanMetrics.tsx
@@ -1,4 +1,7 @@
+import mapValues from 'lodash/mapValues';
+
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
+import {safeURL} from 'sentry/utils/url/safeURL';
 
 /**
  * Minimal structural span shape these pure metric helpers need. Compatible with
@@ -9,12 +12,18 @@ import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
  */
 type SpanMetricInput =
   | {
+      // Allow the full span object (span_id, op, hash, etc.) — these helpers
+      // only read the fields below.
+      [key: string]: unknown;
       data?: Record<string, any>;
+      description?: string;
       start_timestamp?: number;
       timestamp?: number;
     }
   | null
   | undefined;
+
+type ParameterLookup = Record<string, string[]>;
 
 /** Span duration in milliseconds. */
 export function getSpanDuration(span: SpanMetricInput): number {
@@ -32,4 +41,76 @@ export function getSpanFieldBytes(span: SpanMetricInput, field: string): string 
     return null;
   }
   return `${formatBytesBase2(bytes)} (${bytes} B)`;
+}
+
+/**
+ * Parses the span data and pulls out the URL. Accounts for different SDKs and
+ * different versions of SDKs formatting and parsing the URL contents
+ * differently. Mirror of `get_url_from_span`. Ideally, this should not exist,
+ * and instead it should use the data provided by the backend.
+ */
+export function extractSpanURLString(
+  span: SpanMetricInput,
+  baseURL?: string
+): URL | null {
+  let url = span?.data?.url;
+  if (url) {
+    const query = span?.data?.['http.query'];
+    if (query) {
+      url += `?${query}`;
+    }
+
+    const parsedURL = safeURL(url, baseURL);
+    if (parsedURL) {
+      return parsedURL;
+    }
+  }
+
+  const [_method, _url] = (span?.description ?? '').split(' ', 2) as [string, string];
+
+  return safeURL(_url, baseURL) ?? null;
+}
+
+export function extractQueryParameters(URLs: URL[]): ParameterLookup {
+  const parameterValuesByKey: ParameterLookup = {};
+
+  URLs.forEach(url => {
+    for (const [key, value] of url.searchParams) {
+      parameterValuesByKey[key] ??= [];
+      parameterValuesByKey[key].push(value);
+    }
+  });
+
+  return mapValues(parameterValuesByKey, parameterList => {
+    return Array.from(new Set(parameterList));
+  });
+}
+
+/**
+ * Condensed description of the query parameters that change between the URLs of
+ * the given spans, e.g. "id:{1,2,3}". Used as the fallback for N+1 API calls
+ * when the backend didn't pre-compute `evidenceData.parameters`.
+ */
+export function formatChangingQueryParameters(
+  spans: SpanMetricInput[],
+  baseURL?: string
+): string[] {
+  const URLs = spans
+    .map(span => extractSpanURLString(span, baseURL))
+    .filter((url): url is URL => url instanceof URL);
+
+  const allQueryParameters = extractQueryParameters(URLs);
+
+  const pairs: string[] = [];
+  for (const key in allQueryParameters) {
+    const values = allQueryParameters[key]!;
+
+    // By definition, if the parameter only has one value that means it's not
+    // changing between calls, so omit it!
+    if (values.length > 1) {
+      pairs.push(`${key}:{${values.join(',')}}`);
+    }
+  }
+
+  return pairs;
 }

--- a/static/app/views/issueDetails/hooks/spanEvidenceMarkdown.tsx
+++ b/static/app/views/issueDetails/hooks/spanEvidenceMarkdown.tsx
@@ -2,12 +2,17 @@ import {
   getKeyValueListData,
   keyValueListDataToMarkdownLines,
 } from 'sentry/components/events/eventStatisticalDetector/eventRegressionSummary';
+import {
+  getSpanDuration,
+  getSpanFieldBytes,
+} from 'sentry/components/events/interfaces/performance/spanMetrics';
 import {getSpanInfoFromTransactionEvent} from 'sentry/components/events/interfaces/performance/utils';
 import type {Event, EventTransaction} from 'sentry/types/event';
 import {
   AI_DETECTED_ISSUE_TYPES,
   type Group,
   isTransactionBased,
+  IssueType,
 } from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
@@ -71,10 +76,6 @@ function getSpanCodeLocation(span: EvidenceSpan): string | null {
   return fn ? `${location} ${fn}` : location;
 }
 
-function getSpanDurationMs(span: EvidenceSpan): number {
-  return ((span?.timestamp ?? 0) - (span?.start_timestamp ?? 0)) * 1000;
-}
-
 /**
  * Formats total time for a span group, plus its share of the transaction
  * (Duration Impact) when the transaction duration is known. Same math as
@@ -122,7 +123,7 @@ function summarizeSpanGroup(
     const distinct = Array.from(
       new Set(group.map(normalizeSpanDescription).filter(Boolean))
     );
-    const totalMs = group.reduce((sum, span) => sum + getSpanDurationMs(span), 0);
+    const totalMs = group.reduce((sum, span) => sum + getSpanDuration(span), 0);
     const timing = formatGroupTiming(totalMs, event);
     const repeat = count > 1 ? `${count}×, ` : '';
 
@@ -157,6 +158,93 @@ function summarizeSpanGroup(
   });
 
   return {lines, remaining};
+}
+
+/** Pushes a labeled value, or a bulleted list when there are multiple items. */
+function pushList(lines: string[], label: string, items: string[]): void {
+  if (items.length === 0) {
+    return;
+  }
+  if (items.length === 1) {
+    lines.push(`**${label}:** ${items[0]}`);
+    return;
+  }
+  lines.push(`**${label}:**`);
+  items.forEach(item => lines.push(`- ${item}`));
+}
+
+/**
+ * Type-specific metrics the UI's Span Evidence panel shows but the generic span
+ * summary doesn't. These are additive (no overlap with the transaction/parent/
+ * offending/pattern rows) and sourced from evidenceData or the offending span's
+ * data — the same fields the per-type components in spanEvidenceKeyValueList use.
+ */
+function formatIssueTypeMetrics(
+  issueType: IssueType,
+  event: EventTransaction,
+  offendingSpans: EvidenceSpan[],
+  evidenceData: Record<string, any>
+): string[] {
+  const lines: string[] = [];
+  const offender = offendingSpans[0] ?? null;
+
+  switch (issueType) {
+    case IssueType.PERFORMANCE_LARGE_HTTP_PAYLOAD: {
+      const size =
+        getSpanFieldBytes(offender, 'http.response_content_length') ??
+        getSpanFieldBytes(offender, 'Encoded Body Size');
+      if (size) {
+        lines.push(`**Payload Size:** ${size}`);
+      }
+      break;
+    }
+    case IssueType.PERFORMANCE_UNCOMPRESSED_ASSET: {
+      const size =
+        getSpanFieldBytes(offender, 'http.response_content_length') ??
+        getSpanFieldBytes(offender, 'Encoded Body Size');
+      if (size) {
+        lines.push(`**Asset Size:** ${size}`);
+      }
+      break;
+    }
+    case IssueType.PERFORMANCE_RENDER_BLOCKING_ASSET: {
+      const fcp = event.measurements?.fcp?.value;
+      const duration = getSpanDuration(offender);
+      if (fcp && duration) {
+        lines.push(
+          `**FCP Delay:** ${getPerformanceDuration(duration)} (${toRoundedPercent(
+            duration / fcp
+          )} of FCP)`
+        );
+      }
+      break;
+    }
+    case IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS: {
+      pushList(lines, 'Query Parameters', evidenceData.parameters ?? []);
+      pushList(lines, 'Path Parameters', evidenceData.pathParameters ?? []);
+      break;
+    }
+    case IssueType.QUERY_INJECTION_VULNERABILITY: {
+      const vulnerable: Array<[string, unknown]> =
+        evidenceData.vulnerableParameters ?? [];
+      pushList(
+        lines,
+        'Vulnerable Parameters',
+        vulnerable.map(([name, value]) => {
+          const formatted = typeof value === 'string' ? value : JSON.stringify(value);
+          return `${name}: ${formatted}`;
+        })
+      );
+      if (evidenceData.requestUrl) {
+        lines.push(`**Request URL:** ${evidenceData.requestUrl}`);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
+  return lines;
 }
 
 /**
@@ -253,6 +341,11 @@ export function formatSpanEvidenceToMarkdown(
       sampleBudget
     );
     lines.push(...offending.lines);
+
+    // Type-specific metrics the UI shows beyond the generic span summary.
+    lines.push(
+      ...formatIssueTypeMetrics(issueType, eventTransaction, offendingSpans, evidenceData)
+    );
 
     // Surface the cache-miss → DB read shape when both appear (classic N+1).
     const hasCacheMiss = offendingSpans.some(span => span?.op?.startsWith('cache'));

--- a/static/app/views/issueDetails/hooks/spanEvidenceMarkdown.tsx
+++ b/static/app/views/issueDetails/hooks/spanEvidenceMarkdown.tsx
@@ -3,11 +3,17 @@ import {
   keyValueListDataToMarkdownLines,
 } from 'sentry/components/events/eventStatisticalDetector/eventRegressionSummary';
 import {
+  formatChangingQueryParameters,
   getSpanDuration,
   getSpanFieldBytes,
 } from 'sentry/components/events/interfaces/performance/spanMetrics';
 import {getSpanInfoFromTransactionEvent} from 'sentry/components/events/interfaces/performance/utils';
-import type {Event, EventTransaction} from 'sentry/types/event';
+import {
+  EntryType,
+  type EntryRequest,
+  type Event,
+  type EventTransaction,
+} from 'sentry/types/event';
 import {
   AI_DETECTED_ISSUE_TYPES,
   type Group,
@@ -220,7 +226,16 @@ function formatIssueTypeMetrics(
       break;
     }
     case IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS: {
-      pushList(lines, 'Query Parameters', evidenceData.parameters ?? []);
+      // Mirror the UI: fall back to deriving changing query params from the
+      // offending HTTP spans when the backend didn't provide them.
+      const baseURL = event.entries?.find(
+        (entry): entry is EntryRequest => entry.type === EntryType.REQUEST
+      )?.data?.url;
+      pushList(
+        lines,
+        'Query Parameters',
+        evidenceData.parameters ?? formatChangingQueryParameters(offendingSpans, baseURL)
+      );
       pushList(lines, 'Path Parameters', evidenceData.pathParameters ?? []);
       break;
     }

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
@@ -676,6 +676,32 @@ LIMIT 21`;
       expect(result).toContain('**Path Parameters:** /users/*');
     });
 
+    it('derives N+1 API query params from spans when evidenceData lacks them', () => {
+      const apiGroup = GroupFixture({
+        issueCategory: IssueCategory.PERFORMANCE,
+        issueType: IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
+      });
+      // No evidenceData.parameters — mirror the UI fallback that derives the
+      // changing query params from the offending spans' URLs.
+      const spans = [1, 2, 3].map(id => ({
+        span_id: `s${id}`,
+        op: 'http.client',
+        description: `GET https://api.example.com/users?id=${id}`,
+      }));
+      const apiEvent = EventFixture({
+        ...event,
+        occurrence: {
+          type: 1010,
+          evidenceData: {offenderSpanIds: spans.map(s => s.span_id)},
+          evidenceDisplay: [],
+        },
+        entries: [{type: EntryType.SPANS, data: spans}],
+      });
+
+      const result = formatSpanEvidenceToMarkdown(apiEvent, organization, apiGroup);
+      expect(result).toContain('**Query Parameters:** id:{1,2,3}');
+    });
+
     it('includes vulnerable parameters and request URL for query injection issues', () => {
       const injectionGroup = GroupFixture({
         issueCategory: IssueCategory.PERFORMANCE,

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
@@ -571,6 +571,162 @@ LIMIT 21`;
       expect(sampleLines).toBeLessThanOrEqual(10);
     });
 
+    it('includes payload size for large HTTP payload issues', () => {
+      const payloadGroup = GroupFixture({
+        issueCategory: IssueCategory.PERFORMANCE,
+        issueType: IssueType.PERFORMANCE_LARGE_HTTP_PAYLOAD,
+      });
+      const payloadEvent = EventFixture({
+        ...event,
+        occurrence: {
+          type: 1015,
+          evidenceData: {offenderSpanIds: ['s1']},
+          evidenceDisplay: [],
+        },
+        entries: [
+          {
+            type: EntryType.SPANS,
+            data: [
+              {
+                span_id: 's1',
+                op: 'http.client',
+                description: 'GET /big.json',
+                data: {'http.response_content_length': 5_000_000},
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = formatSpanEvidenceToMarkdown(
+        payloadEvent,
+        organization,
+        payloadGroup
+      );
+      expect(result).toContain('**Payload Size:**');
+      expect(result).toContain('5000000 B');
+    });
+
+    it('includes FCP delay for render-blocking asset issues', () => {
+      const renderBlockingGroup = GroupFixture({
+        issueCategory: IssueCategory.PERFORMANCE,
+        issueType: IssueType.PERFORMANCE_RENDER_BLOCKING_ASSET,
+      });
+      const renderBlockingEvent = EventFixture({
+        ...event,
+        startTimestamp: 0,
+        endTimestamp: 1,
+        measurements: {fcp: {value: 1000, unit: 'millisecond'}},
+        occurrence: {
+          type: 1004,
+          evidenceData: {offenderSpanIds: ['s1']},
+          evidenceDisplay: [],
+        },
+        entries: [
+          {
+            type: EntryType.SPANS,
+            data: [
+              {
+                span_id: 's1',
+                op: 'resource.script',
+                description: 'app.js',
+                start_timestamp: 0,
+                timestamp: 0.4,
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = formatSpanEvidenceToMarkdown(
+        renderBlockingEvent,
+        organization,
+        renderBlockingGroup
+      );
+      expect(result).toContain('**FCP Delay:**');
+      expect(result).toContain('of FCP');
+    });
+
+    it('includes query and path parameters for N+1 API call issues', () => {
+      const apiGroup = GroupFixture({
+        issueCategory: IssueCategory.PERFORMANCE,
+        issueType: IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS,
+      });
+      const apiEvent = EventFixture({
+        ...event,
+        occurrence: {
+          type: 1010,
+          evidenceData: {
+            offenderSpanIds: ['s1'],
+            parameters: ['id:{1,2,3}'],
+            pathParameters: ['/users/*'],
+          },
+          evidenceDisplay: [],
+        },
+        entries: [
+          {
+            type: EntryType.SPANS,
+            data: [{span_id: 's1', op: 'http.client', description: 'GET /users/1'}],
+          },
+        ],
+      });
+
+      const result = formatSpanEvidenceToMarkdown(apiEvent, organization, apiGroup);
+      expect(result).toContain('**Query Parameters:** id:{1,2,3}');
+      expect(result).toContain('**Path Parameters:** /users/*');
+    });
+
+    it('includes vulnerable parameters and request URL for query injection issues', () => {
+      const injectionGroup = GroupFixture({
+        issueCategory: IssueCategory.PERFORMANCE,
+        issueType: IssueType.QUERY_INJECTION_VULNERABILITY,
+      });
+      const injectionEvent = EventFixture({
+        ...event,
+        occurrence: {
+          type: 1021,
+          evidenceData: {
+            offenderSpanIds: ['s1'],
+            vulnerableParameters: [['username', "admin' OR '1'='1"]],
+            requestUrl: 'https://example.com/login',
+          },
+          evidenceDisplay: [],
+        },
+        entries: [
+          {
+            type: EntryType.SPANS,
+            data: [
+              {
+                span_id: 's1',
+                op: 'db',
+                description: 'SELECT * FROM users WHERE name = ?',
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = formatSpanEvidenceToMarkdown(
+        injectionEvent,
+        organization,
+        injectionGroup
+      );
+      expect(result).toContain("**Vulnerable Parameters:** username: admin' OR '1'='1");
+      expect(result).toContain('**Request URL:** https://example.com/login');
+    });
+
+    it('does not add type-specific metrics for N+1 DB issues', () => {
+      // N+1 DB has no extra per-type metric rows beyond the generic summary.
+      const result = formatSpanEvidenceToMarkdown(
+        nPlusOneEvent,
+        organization,
+        performanceGroup
+      );
+      expect(result).not.toContain('**Payload Size:**');
+      expect(result).not.toContain('**FCP Delay:**');
+      expect(result).not.toContain('**Query Parameters:**');
+    });
+
     it('includes evidence display rows for profiling issues', () => {
       // 2001 is the occurrence type for File I/O on Main Thread
       const profileEvent = EventFixture({


### PR DESCRIPTION

Extends the issue "copy as markdown" Span Evidence section with the type-specific metrics the UI panel shows but the generic span summary didn't, for transaction-based performance issues:

- **Payload Size** (Large HTTP Payload) / **Asset Size** (Uncompressed Asset)
- **FCP Delay** (Render-blocking Asset)
- **Query / Path Parameters** (N+1 API Calls)
- **Vulnerable Parameters** + **Request URL** (Query Injection)

Also extracts the shared, dependency-free span helpers (`getSpanDuration`, `getSpanFieldBytes`) into a new `performance/spanMetrics.tsx` so the markdown formatter and the UI panel (`spanEvidenceKeyValueList`) compute these from a single source of truth instead of duplicating logic.

