### PR TITLE
fix(explore): setting metrics heat map visualization with previous groupby

### DIFF
--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -50,8 +50,8 @@ import {MetricsHeatMap} from 'sentry/views/explore/metrics/metricsHeatMap';
 import {
   useMetricVisualize,
   useMetricVisualizes,
+  useSetMetricAggregateFields,
   useSetMetricVisualizes,
-  useSetMetricVisualizesAndGroupBys,
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 import {MetricToolbar} from 'sentry/views/explore/metrics/metricToolbar';
 import {STACKED_GRAPH_HEIGHT} from 'sentry/views/explore/metrics/settings';
@@ -124,7 +124,7 @@ export function MetricPanel({
   const visualize = useMetricVisualize();
   const visualizes = useMetricVisualizes();
   const setVisualizes = useSetMetricVisualizes();
-  const setVisualizesAndGroupBys = useSetMetricVisualizesAndGroupBys();
+  const setAggregateFields = useSetMetricAggregateFields();
   // use the biggest interval for the heat map as this produces better patterns
   const [interval, setInterval, intervalOptions] = useChartInterval({
     unspecifiedStrategy:
@@ -210,15 +210,14 @@ export function MetricPanel({
   function handleChartTypeChange(newChartType: ChartType) {
     if (newChartType === ChartType.HEATMAP) {
       // Heatmap always uses count() with no group by
-      setVisualizesAndGroupBys(
+      setAggregateFields(
         visualizes.map(v =>
           isVisualizeFunction(v)
             ? updateVisualizeYAxis(v, 'count', traceMetric).replace({
                 chartType: ChartType.HEATMAP,
               })
             : v.replace({chartType: ChartType.HEATMAP})
-        ),
-        []
+        )
       );
     } else if (isHeatmap) {
       // Switching away from heatmap — restore the default aggregate

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -51,6 +51,7 @@ import {
   useMetricVisualize,
   useMetricVisualizes,
   useSetMetricVisualizes,
+  useSetMetricVisualizesAndGroupBys,
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 import {MetricToolbar} from 'sentry/views/explore/metrics/metricToolbar';
 import {STACKED_GRAPH_HEIGHT} from 'sentry/views/explore/metrics/settings';
@@ -60,11 +61,9 @@ import {
 } from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsAggregateSortBys,
-  useQueryParamsGroupBys,
   useQueryParamsMode,
   useQueryParamsQuery,
   useQueryParamsSortBys,
-  useSetQueryParamsGroupBys,
 } from 'sentry/views/explore/queryParams/context';
 import {
   isVisualizeEquation,
@@ -121,12 +120,11 @@ export function MetricPanel({
   const mode = useQueryParamsMode();
   const sortBys = useQueryParamsSortBys();
   const aggregateSortBys = useQueryParamsAggregateSortBys();
-  const groupBys = useQueryParamsGroupBys();
-  const setGroupBys = useSetQueryParamsGroupBys();
   const topEvents = useTopEvents();
   const visualize = useMetricVisualize();
   const visualizes = useMetricVisualizes();
   const setVisualizes = useSetMetricVisualizes();
+  const setVisualizesAndGroupBys = useSetMetricVisualizesAndGroupBys();
   // use the biggest interval for the heat map as this produces better patterns
   const [interval, setInterval, intervalOptions] = useChartInterval({
     unspecifiedStrategy:
@@ -212,18 +210,16 @@ export function MetricPanel({
   function handleChartTypeChange(newChartType: ChartType) {
     if (newChartType === ChartType.HEATMAP) {
       // Heatmap always uses count() with no group by
-      setVisualizes(
+      setVisualizesAndGroupBys(
         visualizes.map(v =>
           isVisualizeFunction(v)
             ? updateVisualizeYAxis(v, 'count', traceMetric).replace({
                 chartType: ChartType.HEATMAP,
               })
             : v.replace({chartType: ChartType.HEATMAP})
-        )
+        ),
+        []
       );
-      if (groupBys.length > 0) {
-        setGroupBys([]);
-      }
     } else if (isHeatmap) {
       // Switching away from heatmap — restore the default aggregate
       const defaultAggregate = DEFAULT_YAXIS_BY_TYPE[traceMetric.type] ?? 'count';

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -15,8 +15,9 @@ import {
   QueryParamsContextProvider,
   useQueryParamsVisualizes,
   useSetQueryParamsVisualizes,
+  useSetQueryParamsVisualizesAndGroupBys,
 } from 'sentry/views/explore/queryParams/context';
-import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {isGroupBy, type GroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {
   isVisualizeEquation,
@@ -209,6 +210,20 @@ export function useSetMetricVisualizes() {
     [setVisualizes]
   );
   return setMetricVisualizes;
+}
+
+export function useSetMetricVisualizesAndGroupBys() {
+  const setVisualizesAndGroupBys = useSetQueryParamsVisualizesAndGroupBys();
+  const setMetricVisualizesAndGroupBys = useCallback(
+    (newVisualizes: Visualize[], newGroupBys: GroupBy[]) => {
+      setVisualizesAndGroupBys(
+        newVisualizes.map(v => v.serialize()),
+        newGroupBys
+      );
+    },
+    [setVisualizesAndGroupBys]
+  );
+  return setMetricVisualizesAndGroupBys;
 }
 
 function updateQueryParams(

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -14,12 +14,13 @@ import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateFie
 import {
   QueryParamsContextProvider,
   useQueryParamsVisualizes,
+  useSetQueryParamsAggregateFields,
   useSetQueryParamsVisualizes,
-  useSetQueryParamsVisualizesAndGroupBys,
 } from 'sentry/views/explore/queryParams/context';
 import {isGroupBy, type GroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 import {
+  isVisualize,
   isVisualizeEquation,
   isVisualizeFunction,
   parseVisualize,
@@ -212,18 +213,19 @@ export function useSetMetricVisualizes() {
   return setMetricVisualizes;
 }
 
-export function useSetMetricVisualizesAndGroupBys() {
-  const setVisualizesAndGroupBys = useSetQueryParamsVisualizesAndGroupBys();
-  const setMetricVisualizesAndGroupBys = useCallback(
-    (newVisualizes: Visualize[], newGroupBys: GroupBy[]) => {
-      setVisualizesAndGroupBys(
-        newVisualizes.map(v => v.serialize()),
-        newGroupBys
+export function useSetMetricAggregateFields() {
+  const setAggregateFields = useSetQueryParamsAggregateFields();
+  const setMetricAggregateFields = useCallback(
+    (newAggregateFields: Array<Visualize | GroupBy>) => {
+      setAggregateFields(
+        newAggregateFields.map(aggregateField =>
+          isVisualize(aggregateField) ? aggregateField.serialize() : aggregateField
+        )
       );
     },
-    [setVisualizesAndGroupBys]
+    [setAggregateFields]
   );
-  return setMetricVisualizesAndGroupBys;
+  return setMetricAggregateFields;
 }
 
 function updateQueryParams(

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -18,7 +18,7 @@ import type {
   WritableAggregateField,
 } from 'sentry/views/explore/queryParams/aggregateField';
 import type {CrossEvent} from 'sentry/views/explore/queryParams/crossEvent';
-import {isGroupBy, type GroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {deriveUpdatedManagedFields} from 'sentry/views/explore/queryParams/managedFields';
 import type {Mode} from 'sentry/views/explore/queryParams/mode';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
@@ -324,47 +324,6 @@ export function useSetQueryParamsVisualizes() {
 
       for (const visualize of iter) {
         aggregateFields.push(visualize);
-      }
-
-      setQueryParams({aggregateFields});
-    },
-    [queryParams, setQueryParams]
-  );
-}
-
-export function useSetQueryParamsVisualizesAndGroupBys() {
-  const queryParams = useQueryParams();
-  const setQueryParams = useSetQueryParams();
-
-  return useCallback(
-    (visualizes: BaseVisualize[], groupBys: GroupBy[]) => {
-      const aggregateFields: WritableAggregateField[] = [];
-
-      const visualizeIter = visualizes[Symbol.iterator]();
-      const groupByIter = groupBys[Symbol.iterator]();
-
-      for (const aggregateField of queryParams.aggregateFields) {
-        if (isVisualize(aggregateField)) {
-          const {value: visualize, done} = visualizeIter.next();
-          if (!done) {
-            aggregateFields.push(visualize);
-          }
-        } else if (isGroupBy(aggregateField)) {
-          const {value: groupBy, done} = groupByIter.next();
-          if (!done) {
-            aggregateFields.push(groupBy);
-          }
-        } else {
-          throw new Error(`Unknown aggregate field: ${JSON.stringify(aggregateField)}`);
-        }
-      }
-
-      for (const visualize of visualizeIter) {
-        aggregateFields.push(visualize);
-      }
-
-      for (const groupBy of groupByIter) {
-        aggregateFields.push(groupBy);
       }
 
       setQueryParams({aggregateFields});

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -18,7 +18,7 @@ import type {
   WritableAggregateField,
 } from 'sentry/views/explore/queryParams/aggregateField';
 import type {CrossEvent} from 'sentry/views/explore/queryParams/crossEvent';
-import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {isGroupBy, type GroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {deriveUpdatedManagedFields} from 'sentry/views/explore/queryParams/managedFields';
 import type {Mode} from 'sentry/views/explore/queryParams/mode';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
@@ -324,6 +324,47 @@ export function useSetQueryParamsVisualizes() {
 
       for (const visualize of iter) {
         aggregateFields.push(visualize);
+      }
+
+      setQueryParams({aggregateFields});
+    },
+    [queryParams, setQueryParams]
+  );
+}
+
+export function useSetQueryParamsVisualizesAndGroupBys() {
+  const queryParams = useQueryParams();
+  const setQueryParams = useSetQueryParams();
+
+  return useCallback(
+    (visualizes: BaseVisualize[], groupBys: GroupBy[]) => {
+      const aggregateFields: WritableAggregateField[] = [];
+
+      const visualizeIter = visualizes[Symbol.iterator]();
+      const groupByIter = groupBys[Symbol.iterator]();
+
+      for (const aggregateField of queryParams.aggregateFields) {
+        if (isVisualize(aggregateField)) {
+          const {value: visualize, done} = visualizeIter.next();
+          if (!done) {
+            aggregateFields.push(visualize);
+          }
+        } else if (isGroupBy(aggregateField)) {
+          const {value: groupBy, done} = groupByIter.next();
+          if (!done) {
+            aggregateFields.push(groupBy);
+          }
+        } else {
+          throw new Error(`Unknown aggregate field: ${JSON.stringify(aggregateField)}`);
+        }
+      }
+
+      for (const visualize of visualizeIter) {
+        aggregateFields.push(visualize);
+      }
+
+      for (const groupBy of groupByIter) {
+        aggregateFields.push(groupBy);
       }
 
       setQueryParams({aggregateFields});


### PR DESCRIPTION
Previously, setting the visualization from any other metrics visualization with a group by to a heat map would result in the group by being cleared but the visualization staying the same. This is because the `setVisualize` and `setGroupBy` functions had a race condition. Both of them used the aggregate fields that were already present causing them to write over each other. I've created a new metric hook which sets the visualize and group by (AKA aggregate fields) in a single hook. It reformats the values to fit into the `setQueryParamsAggregateFields` explore hook. Now a metric chart with the group by will switch to a heat map properly.