### PR TITLE
ref(ingest): Add taskbroker raw task for ingest-events

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -889,6 +889,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.hybridcloud.tasks.deliver_from_outbox",
     "sentry.hybridcloud.tasks.deliver_webhooks",
     "sentry.incidents.tasks",
+    "sentry.ingest.consumer.simple_event",
     "sentry.ingest.transaction_clusterer.tasks",
     "sentry.integrations.data_forwarding.tasks",
     "sentry.integrations.github.tasks.link_all_repos",

--- a/src/sentry/ingest/consumer/simple_event.py
+++ b/src/sentry/ingest/consumer/simple_event.py
@@ -4,8 +4,14 @@ import msgpack
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.dlq import InvalidMessage
 from arroyo.types import BrokerValue, Message
+from taskbroker_client.constants import CompressionType
+from taskbroker_client.retry import Retry
 
+from sentry.ingest.types import ConsumerType
 from sentry.models.project import Project
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import ingest_events_passthrough_tasks
 from sentry.utils import metrics
 
 from .processors import IngestMessage, Retriable, process_event
@@ -70,3 +76,42 @@ def process_simple_event_message(
         raw_value = raw_message.value
         assert isinstance(raw_value, BrokerValue)
         raise InvalidMessage(raw_value.partition, raw_value.offset) from exc
+
+
+@instrumented_task(
+    name="sentry.ingest.consumer.simple_event.process_event_from_kafka",
+    namespace=ingest_events_passthrough_tasks,
+    processing_deadline_duration=60,
+    retry=Retry(times=2, delay=5, on=(Retriable,)),
+    compression_type=CompressionType.ZSTD,
+    silo_mode=SiloMode.CELL,
+)
+def process_event_from_kafka(message_bytes: bytes) -> None:
+    """Process an event from raw Kafka message bytes (taskbroker raw mode)."""
+    metrics.distribution(
+        "ingest_consumer.payload_size",
+        len(message_bytes),
+        tags={"consumer": ConsumerType.Events},
+        unit="byte",
+    )
+
+    message: IngestMessage = msgpack.unpackb(message_bytes, use_list=False)
+
+    message_type = message["type"]
+    project_id = message["project_id"]
+
+    if message_type != "event":
+        raise ValueError(f"Unsupported message type: {message_type}")
+
+    try:
+        with metrics.timer("ingest_consumer.fetch_project"):
+            project = Project.objects.get_from_cache(id=project_id)
+    except Project.DoesNotExist:
+        return
+
+    return process_event(
+        ConsumerType.Events,
+        message,
+        project,
+        reprocess_only_stuck_events=False,
+    )

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -102,6 +102,11 @@ ingest_attachments_tasks = app.taskregistry.create_namespace(
     app_feature="attachments",
 )
 
+ingest_events_passthrough_tasks = app.taskregistry.create_namespace(
+    "ingest.events.passthrough",
+    app_feature="errors",
+)
+
 ingest_errors_tasks = app.taskregistry.create_namespace(
     "ingest.errors",
     app_feature="errors",

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -8,6 +8,7 @@ from io import BytesIO
 from typing import Any
 from unittest.mock import patch
 
+import msgpack
 import orjson
 import pytest
 from arroyo.backends.kafka.consumer import KafkaPayload
@@ -24,6 +25,7 @@ from sentry.ingest.consumer.processors import (
     process_individual_attachment,
     process_userreport,
 )
+from sentry.ingest.consumer.simple_event import process_event_from_kafka
 from sentry.ingest.types import ConsumerType
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 from sentry.models.debugfile import create_files_from_dif_zip
@@ -102,6 +104,37 @@ def test_deduplication_works(default_project, task_runner, preprocess_event) -> 
             },
             project=default_project,
         )
+
+    (kwargs,) = preprocess_event
+    assert kwargs == {
+        "cache_key": f"e:{event_id}:{project_id}",
+        "data": payload,
+        "event_id": event_id,
+        "project": default_project,
+        "start_time": start_time,
+        "has_attachments": False,
+    }
+
+
+@django_db_all
+def test_process_event_from_kafka(default_project, preprocess_event) -> None:
+    payload = get_normalized_event({"message": "hello world"}, default_project)
+    event_id = payload["event_id"]
+    project_id = default_project.id
+    start_time = time.time() - 3600
+
+    message = msgpack.packb(
+        {
+            "payload": orjson.dumps(payload).decode(),
+            "start_time": start_time,
+            "event_id": event_id,
+            "project_id": project_id,
+            "remote_addr": "127.0.0.1",
+            "type": "event",
+        }
+    )
+
+    process_event_from_kafka(message)
 
     (kwargs,) = preprocess_event
     assert kwargs == {


### PR DESCRIPTION
Refs STREAM-1113

Port `ingest-events` to taskbroker raw mode by adding a raw Kafka task entrypoint `sentry.ingest.consumer.simple_event.process_event_from_kafka`.

Adds the `ingest.events.passthrough` namespace for raw `ingest-events` tasks.

The existing Arroyo `process_simple_event_message` path remains unchanged instead of refactored to be shared between consumer and taskbroker paths. Since `ingest-events`, `ingest-feedback-events`, and `ingest-transactions` all uses `process_simple_event_message` this would be safer.

