### PR TITLE
feat(taskbroker): Add `TASKWORKER_INGEST_PUSH` to `Topic` Enum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dependencies = [
   "sentry-arroyo>=2.39.2",
   "sentry-conventions>=0.10.0",
   "sentry-forked-email-reply-parser>=0.5.12.post1",
-  "sentry-kafka-schemas>=2.1.27",
+  "sentry-kafka-schemas>=2.1.32",
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.0.13",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2725,6 +2725,7 @@ KAFKA_TOPIC_TO_CLUSTER: Mapping[str, str] = {
     "taskworker-example": "default",
     "taskworker-ingest": "default",
     "taskworker-ingest-dlq": "default",
+    "taskworker-ingest-push": "default",
     "taskworker-ingest-errors": "default",
     "taskworker-ingest-errors-dlq": "default",
     "taskworker-ingest-errors-postprocess": "default",

--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -83,6 +83,7 @@ class Topic(Enum):
     TASKWORKER_EXAMPLE = "taskworker-example"
     TASKWORKER_INGEST = "taskworker-ingest"
     TASKWORKER_INGEST_DLQ = "taskworker-ingest-dlq"
+    TASKWORKER_INGEST_PUSH = "taskworker-ingest-push"
     TASKWORKER_INGEST_ERRORS = "taskworker-ingest-errors"
     TASKWORKER_INGEST_ERRORS_DLQ = "taskworker-ingest-errors-dlq"
     TASKWORKER_INGEST_ERRORS_POSTPROCESS = "taskworker-ingest-errors-postprocess"

--- a/uv.lock
+++ b/uv.lock
@@ -2421,7 +2421,7 @@ requires-dist = [
     { name = "sentry-arroyo", specifier = ">=2.39.2" },
     { name = "sentry-conventions", specifier = ">=0.10.0" },
     { name = "sentry-forked-email-reply-parser", specifier = ">=0.5.12.post1" },
-    { name = "sentry-kafka-schemas", specifier = ">=2.1.27" },
+    { name = "sentry-kafka-schemas", specifier = ">=2.1.32" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.0.13" },
     { name = "sentry-protos", specifier = ">=0.26.0" },
@@ -2571,7 +2571,7 @@ wheels = [
 
 [[package]]
 name = "sentry-kafka-schemas"
-version = "2.1.27"
+version = "2.1.32"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "fastjsonschema", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2582,7 +2582,7 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_kafka_schemas-2.1.27-py2.py3-none-any.whl", hash = "sha256:c9f2ad159702623c9e5e2b33e19033f5d0f1ff2ccd1e50ad864d0f99d41c5714" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_kafka_schemas-2.1.32-py2.py3-none-any.whl", hash = "sha256:21e8f0d12568390672854a7a2a4d3adb83bf08f06c24a339b27a7f7c061c77e3" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Linear
Refs [STREAM-967](https://linear.app/getsentry/issue/STREAM-967/create-ingest-push-alloydb-pool)

## Description
Add `TASKWORKER_INGEST_PUSH = "taskworker-ingest-push` to the `Topic` enum so it can be used by taskworkers.