### PR TITLE
ref(api): tighten 5 more endpoint returns to Response[T]

### DIFF
--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -21,6 +21,7 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -28,6 +29,12 @@ from sentry.models.promptsactivity import PromptsActivity
 from sentry.utils.prompts import prompt_config
 
 VALID_STATUSES = frozenset(("snoozed", "dismissed", "visible"))
+
+
+class _NoFeatureSpecifiedResponse(TypedDict):
+    # XXX: this is a legacy typo — the field is `details`, not the standard
+    # DRF `detail`. Kept as-is to preserve wire compatibility.
+    details: str
 
 
 class PromptsActivityResponse(TypedDict):
@@ -102,7 +109,13 @@ class PromptsActivityEndpoint(OrganizationEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, organization: Organization, **kwargs) -> Response:
+    def get(
+        self, request: Request, organization: Organization, **kwargs
+    ) -> (
+        Response[PromptsActivityResponse]
+        | Response[DetailResponse]
+        | Response[_NoFeatureSpecifiedResponse]
+    ):
         """
         Return whether feature prompts have been dismissed or are currently snoozed.
         """

--- a/src/sentry/core/endpoints/organization_member_requests_invite_index.py
+++ b/src/sentry/core/endpoints/organization_member_requests_invite_index.py
@@ -22,6 +22,11 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
+from sentry.apidocs.response_types import (
+    DetailResponse,
+    ValidationErrorResponse,
+    as_validation_errors,
+)
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.core.endpoints.organization_member_index import OrganizationMemberRequestSerializer
 from sentry.core.endpoints.organization_member_utils import save_team_assignments
@@ -95,7 +100,13 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def post(self, request: Request, organization: Organization) -> Response:
+    def post(
+        self, request: Request, organization: Organization
+    ) -> (
+        Response[OrganizationMemberResponse]
+        | Response[DetailResponse]
+        | Response[ValidationErrorResponse]
+    ):
         """
         Create an invite request for an organization given an email and suggested
         role / teams.
@@ -106,7 +117,7 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
         )
 
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer), status=400)
 
         if request.access.requires_sso:
             return Response(
@@ -146,4 +157,5 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
 
         async_send_notification(InviteRequestNotification, om, request.user)
 
-        return Response(serialize(om), status=201)
+        data: OrganizationMemberResponse = serialize(om)
+        return Response(data, status=201)

--- a/src/sentry/releases/endpoints/organization_release_assemble.py
+++ b/src/sentry/releases/endpoints/organization_release_assemble.py
@@ -49,6 +49,10 @@ class ReleaseAssembleResponse(TypedDict):
     missingChunks: list[str]
 
 
+class _AssembleErrorResponse(TypedDict):
+    error: str
+
+
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
@@ -71,7 +75,9 @@ class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def post(self, request: Request, organization, version) -> Response:
+    def post(
+        self, request: Request, organization, version
+    ) -> Response[ReleaseAssembleResponse] | Response[_AssembleErrorResponse]:
         """
         Assemble an artifact bundle from previously uploaded chunks and merge it into the
         release. Returns the current assembly state.

--- a/src/sentry/releases/endpoints/project_releases.py
+++ b/src/sentry/releases/endpoints/project_releases.py
@@ -28,6 +28,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.release_examples import ReleaseExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
@@ -124,7 +125,9 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
         },
         examples=ReleaseExamples.CREATE_RELEASE,
     )
-    def post(self, request: Request, project) -> Response:
+    def post(
+        self, request: Request, project
+    ) -> Response[ReleaseSerializerResponse] | Response[ValidationErrorResponse]:
         """
         Create a new release and/or associate a project with a release. Releases are used by
         Sentry to improve error reporting by correlating first-seen events with the release
@@ -228,9 +231,9 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
 
             # Disable snuba here as it often causes 429s when overloaded and
             # a freshly created release won't have health data anyways.
-            return Response(
-                serialize(release, request.user, no_snuba_for_release_creation=True),
-                status=status,
+            data: ReleaseSerializerResponse = serialize(
+                release, request.user, no_snuba_for_release_creation=True
             )
+            return Response(data, status=status)
         scope.set_tag("failure_reason", "serializer_error")
-        return Response(serializer.errors, status=400)
+        return Response(as_validation_errors(serializer), status=400)

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -27,6 +27,7 @@ from sentry.sentry_apps.services.cell.model import RpcSentryAppError
 from sentry.sentry_apps.utils.errors import (
     SentryAppError,
     SentryAppIntegratorError,
+    SentryAppPublicErrorBody,
     SentryAppSentryError,
 )
 from sentry.users.models.user import User
@@ -117,7 +118,9 @@ def _check_sentry_app_disabled(
 class IntegrationPlatformEndpoint(Endpoint):
     allow_disabled_sentry_app_for_methods: set[str] = set()
 
-    def respond_rpc_sentry_app_error(self, rpc_error: RpcSentryAppError) -> Response:
+    def respond_rpc_sentry_app_error(
+        self, rpc_error: RpcSentryAppError
+    ) -> Response[SentryAppPublicErrorBody]:
         """
         Surfaces errors from the cell-side Sentry App RPC to the client.
         """

--- a/src/sentry/sentry_apps/api/endpoints/installation_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_issues.py
@@ -14,6 +14,11 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import SentryAppParams
+from sentry.apidocs.response_types import (
+    DetailResponse,
+    ValidationErrorResponse,
+    as_validation_errors,
+)
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.sentry_apps.api.bases.sentryapps import (
     SentryAppInstallationExternalIssueBaseEndpoint as ExternalIssueBaseEndpoint,
@@ -26,6 +31,7 @@ from sentry.sentry_apps.api.serializers.platform_external_issue import (
     PlatformExternalIssueSerializerResponse,
 )
 from sentry.sentry_apps.services.cell import sentry_app_cell_service
+from sentry.sentry_apps.utils.errors import SentryAppPublicErrorBody
 
 
 class PlatformExternalIssueSerializer(serializers.Serializer):
@@ -60,7 +66,14 @@ class SentryAppInstallationExternalIssuesEndpoint(ExternalIssueBaseEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def post(self, request: Request, installation) -> Response:
+    def post(
+        self, request: Request, installation
+    ) -> (
+        Response[PlatformExternalIssueSerializerResponse]
+        | Response[DetailResponse]
+        | Response[ValidationErrorResponse]
+        | Response[SentryAppPublicErrorBody]
+    ):
         """
         Link a Sentry issue to a resource in an external service through a custom
         integration (Sentry App) installation.
@@ -69,7 +82,7 @@ class SentryAppInstallationExternalIssuesEndpoint(ExternalIssueBaseEndpoint):
 
         serializer = PlatformExternalIssueSerializer(data=request.data)
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer), status=400)
 
         try:
             group_id = int(data.pop("issueId"))
@@ -95,8 +108,7 @@ class SentryAppInstallationExternalIssuesEndpoint(ExternalIssueBaseEndpoint):
         if not result.external_issue:
             return Response({"detail": "Failed to create external issue"}, status=500)
 
-        return Response(
-            serialize(
-                objects=result.external_issue, serializer=ResponsePlatformExternalIssueSerializer()
-            )
+        body: PlatformExternalIssueSerializerResponse = serialize(
+            objects=result.external_issue, serializer=ResponsePlatformExternalIssueSerializer()
         )
+        return Response(body)


### PR DESCRIPTION
Five more Goal #1 endpoint methods. Typed-variable trick for denylisted serializers (Release, OrganizationMember) plus narrower union arms for the custom error shapes each endpoint emits.

- `organization_member_requests_invite_index.post()` → `Response[OrganizationMemberResponse] | Response[DetailResponse] | Response[ValidationErrorResponse]`.
- `project_releases.post()` → `Response[ReleaseSerializerResponse] | Response[ValidationErrorResponse]`.
- `organization_release_assemble.post()` → `Response[ReleaseAssembleResponse] | Response[_AssembleErrorResponse]`. New local TypedDict covers the existing `{"error": str}` wire shape verbatim.
- `installation_external_issues.post()` → 4-arm union: success + `DetailResponse` + `ValidationErrorResponse` + `SentryAppPublicErrorBody`. Also annotates `IntegrationPlatformEndpoint.respond_rpc_sentry_app_error` return as `Response[SentryAppPublicErrorBody]` (was bare).
- `prompts_activity.get()` → 3-arm union with a new local `_NoFeatureSpecifiedResponse` TypedDict that preserves the existing `{"details": ...}` typo wire shape verbatim.