### PR TITLE
chore(deps): Bump echarts from 6.0.0 to 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "diff": "8.0.3",
     "dompurify": "3.4.2",
     "downsample": "1.4.0",
-    "echarts": "6.0.0",
+    "echarts": "6.1.0",
     "echarts-for-react": "3.0.6",
     "esbuild": "0.25.10",
     "focus-trap": "7.6.5",
@@ -225,7 +225,7 @@
     "type-fest": "^5.2.0",
     "yaml": "2.8.3",
     "zod": "4.3.5",
-    "zrender": "6.0.0",
+    "zrender": "6.1.0",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,11 +359,11 @@ importers:
         specifier: 1.4.0
         version: 1.4.0
       echarts:
-        specifier: 6.0.0
-        version: 6.0.0
+        specifier: 6.1.0
+        version: 6.1.0
       echarts-for-react:
         specifier: 3.0.6
-        version: 3.0.6(echarts@6.0.0)(react@19.2.3)
+        version: 3.0.6(echarts@6.1.0)(react@19.2.3)
       esbuild:
         specifier: 0.25.10
         version: 0.25.10
@@ -539,8 +539,8 @@ importers:
         specifier: 4.3.5
         version: 4.3.5(patch_hash=2bb6d33b2c713a7a2c559c18ad0aa6cfb261f01d935ee1288dfec6c84411aa76)
       zrender:
-        specifier: 6.0.0
-        version: 6.0.0
+        specifier: 6.1.0
+        version: 6.1.0
       zxcvbn:
         specifier: ^4.4.2
         version: 4.4.2
@@ -5113,8 +5113,8 @@ packages:
       echarts: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
       react: ^15.0.0 || >=16.0.0
 
-  echarts@6.0.0:
-    resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
+  echarts@6.1.0:
+    resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
 
   editorconfig@1.0.4:
     resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
@@ -8961,8 +8961,8 @@ packages:
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
 
-  zrender@6.0.0:
-    resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
+  zrender@6.1.0:
+    resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -14002,17 +14002,17 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  echarts-for-react@3.0.6(echarts@6.0.0)(react@19.2.3):
+  echarts-for-react@3.0.6(echarts@6.1.0)(react@19.2.3):
     dependencies:
-      echarts: 6.0.0
+      echarts: 6.1.0
       fast-deep-equal: 3.1.3
       react: 19.2.3
       size-sensor: 1.0.3
 
-  echarts@6.0.0:
+  echarts@6.1.0:
     dependencies:
       tslib: 2.3.0
-      zrender: 6.0.0
+      zrender: 6.1.0
 
   editorconfig@1.0.4:
     dependencies:
@@ -19024,7 +19024,7 @@ snapshots:
 
   zod@4.3.5(patch_hash=2bb6d33b2c713a7a2c559c18ad0aa6cfb261f01d935ee1288dfec6c84411aa76): {}
 
-  zrender@6.0.0:
+  zrender@6.1.0:
     dependencies:
       tslib: 2.3.0
 

--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
@@ -169,9 +169,7 @@ export function CategoricalSeriesWidgetVisualization(
     axisLabel: {
       // Show the first/last category on the axis. We hide them by default
       // because on time series charts, this causes visual congestion.
-      // @ts-expect-error: ECharts types `showMinLabel` incorrect as a boolean, the documentation also allows `null`
       showMaxLabel: null,
-      // @ts-expect-error: ECharts types `showMaxLabel` incorrect as a boolean, the documentation also allows `null`
       showMinLabel: null,
       rotate: shouldRotate ? ROTATED_LABEL_ANGLE : 0,
       ...(shouldRotate ? {interval: 0} : {}),

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -28,6 +28,7 @@ import type {
   EChartDataZoomHandler,
   EChartDownplayHandler,
   EChartHighlightHandler,
+  ECharts,
   ReactEchartsRef,
 } from 'sentry/types/echarts';
 import {escape} from 'sentry/utils';
@@ -420,7 +421,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   );
 
   const handleChartReady = useCallback(
-    (instance: echarts.ECharts) => {
+    (instance: ECharts) => {
       onChartReadyZoom(instance);
       unregisterRef.current?.();
       unregisterRef.current = registerWithWidgetSyncContext(instance);


### PR DESCRIPTION
Bumps `echarts` and `zrender` from 6.0.0 to 6.1.0. This is pre-requisite for https://github.com/getsentry/sentry/pull/109881 which is a really annoying bug I've been chasing for a while.

I mostly used Claude to go through the code and the changelog, but verified its findings, and manually tested a bunch of charts in the UI. In short, the big breaking changes in 6.1.0 don't affect us.

1. The biggest change is `tooltip.valueFormatter` which we do not use, we always use `tooltip.formatter` which manually formats the entire tooltip including the value
2. We don't use `axis.startValue` so this doesn't affect us (but might be interesting)

There are two small typing changes since ECharts fixed a bit of silliness. Chartcuterie  bump is in https://github.com/getsentry/chartcuterie/pull/228

Closes DAIN-1707