### PR TITLE
chore(cells): Adds tag for apigateway proxied requests

### DIFF
--- a/src/sentry/middleware/stats.py
+++ b/src/sentry/middleware/stats.py
@@ -9,6 +9,7 @@ from django.utils.deprecation import MiddlewareMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.silo.util import PROXY_APIGATEWAY_HEADER
 from sentry.utils import metrics
 
 from . import ViewFunc, get_path, is_frontend_request
@@ -77,6 +78,10 @@ class RequestTimingMiddleware(MiddlewareMixin):
             ),
             "url_name": url_name,
         }
+
+        proxy_request_header = request.headers.get(PROXY_APIGATEWAY_HEADER, None) == "true"
+        tags["proxy_request"] = proxy_request_header
+
         metrics.incr("view.response", instance=view_path, tags=tags, skip_internal=False)
 
         start_time = getattr(request, "_start_time", None)

--- a/tests/sentry/middleware/test_stats.py
+++ b/tests/sentry/middleware/test_stats.py
@@ -9,6 +9,7 @@ from sentry.api.base import Endpoint
 from sentry.middleware.ratelimit import RatelimitMiddleware
 from sentry.middleware.stats import RequestTimingMiddleware
 from sentry.ratelimits.config import RateLimitConfig
+from sentry.silo.util import PROXY_APIGATEWAY_HEADER
 from sentry.testutils.cases import TestCase
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -50,6 +51,7 @@ class RequestTimingMiddlewareTest(TestCase):
                 "ui_request": False,
                 "rate_limit_type": None,
                 "url_name": "sentry",
+                "proxy_request": False,
             },
             skip_internal=False,
         )
@@ -76,6 +78,34 @@ class RequestTimingMiddlewareTest(TestCase):
                 "ui_request": False,
                 "rate_limit_type": "fixed_window",
                 "url_name": "sentry",
+                "proxy_request": False,
+            },
+            skip_internal=False,
+        )
+
+    @patch("sentry.utils.metrics.incr")
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    def test_records_proxy_request_metrics(self, incr: MagicMock) -> None:
+        rate_limit_middleware = RatelimitMiddleware(sentinel.callback)
+        test_endpoint = RateLimitedEndpoint.as_view()
+        request = self.factory.get("/", headers={PROXY_APIGATEWAY_HEADER: "true"})
+        request._view_path = "/"
+        request.resolver_match = resolve("/")
+        response = Mock(status_code=429)
+
+        rate_limit_middleware.process_view(request, test_endpoint, [], {})
+        self.middleware.process_response(request, response)
+
+        incr.assert_called_with(
+            "view.response",
+            instance=request._view_path,
+            tags={
+                "method": "GET",
+                "status_code": 429,
+                "ui_request": False,
+                "rate_limit_type": "fixed_window",
+                "url_name": "sentry",
+                "proxy_request": True,
             },
             skip_internal=False,
         )
@@ -101,6 +131,7 @@ class RequestTimingMiddlewareTest(TestCase):
                 "ui_request": True,
                 "rate_limit_type": None,
                 "url_name": "unreachable-unknown",
+                "proxy_request": False,
             },
             skip_internal=False,
         )


### PR DESCRIPTION
Filling another gap in reporting, our current API request metrics don't indicate whether the request is being proxied or not by Control. This adds a bool tag indicating whether or not this is the case.
