### PR TITLE
ref(webhooks): Restructure project sidebar and add dedicated legacy-webhooks route

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -738,6 +738,13 @@ function buildRoutes(): RouteObject[] {
       redirectTo: '/settings/:orgId/projects/:projectId/security-headers/csp/',
     },
     {
+      path: 'legacy-webhooks/',
+      name: t('Webhooks'),
+      component: make(
+        () => import('sentry/views/settings/projectPlugins/legacyWebhookDetails')
+      ),
+    },
+    {
       path: 'plugins/',
       name: t('Legacy Integrations'),
       children: [

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -215,29 +215,20 @@ export function getNavigationConfiguration({
       id: 'settings-legacy-integrations',
       name: t('Legacy Integrations'),
       items: [
-        ...(hasLegacyWebhookUI
-          ? []
-          : [
-              {
-                path: `${pathPrefix}/plugins/`,
-                title: t('Legacy Integrations'),
-                description: t(
-                  'View, enable, and disable all integrations for a project'
-                ),
-                id: 'legacy_integrations',
-                recordAnalytics: true,
-              },
-            ]),
-        ...(hasLegacyWebhookUI
-          ? [
-              {
-                path: `${pathPrefix}/legacy-webhooks/`,
-                title: t('Webhooks (Legacy)'),
-                id: 'webhook_details',
-                recordAnalytics: true,
-              },
-            ]
-          : []),
+        hasLegacyWebhookUI
+          ? {
+              path: `${pathPrefix}/legacy-webhooks/`,
+              title: t('Webhooks (Legacy)'),
+              id: 'webhook_details',
+              recordAnalytics: true,
+            }
+          : {
+              path: `${pathPrefix}/plugins/`,
+              title: t('Legacy Integrations'),
+              description: t('View, enable, and disable all integrations for a project'),
+              id: 'legacy_integrations',
+              recordAnalytics: true,
+            },
         ...plugins
           .filter(plugin => !hasLegacyWebhookUI || plugin.id !== 'webhooks')
           .map(plugin => ({

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -21,6 +21,8 @@ export function getNavigationConfiguration({
   const plugins = (
     'plugins' in (project ?? {}) ? ((project as DetailedProject)?.plugins ?? []) : []
   ).filter(plugin => plugin.enabled);
+  const hasLegacyWebhookUI =
+    organization?.features?.includes('legacy-webhook-ui') ?? false;
   const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
   const isSelfHosted = ConfigStore.get('isSelfHosted');
   return [
@@ -213,20 +215,39 @@ export function getNavigationConfiguration({
       id: 'settings-legacy-integrations',
       name: t('Legacy Integrations'),
       items: [
-        {
-          path: `${pathPrefix}/plugins/`,
-          title: t('Legacy Integrations'),
-          description: t('View, enable, and disable all integrations for a project'),
-          id: 'legacy_integrations',
-          recordAnalytics: true,
-        },
-        ...plugins.map(plugin => ({
-          path: `${pathPrefix}/plugins/${plugin.id}/`,
-          title: plugin.name,
-          show: (opts: any) => opts?.access?.has('project:write') && !plugin.isDeprecated,
-          id: 'plugin_details',
-          recordAnalytics: true,
-        })),
+        ...(hasLegacyWebhookUI
+          ? []
+          : [
+              {
+                path: `${pathPrefix}/plugins/`,
+                title: t('Legacy Integrations'),
+                description: t(
+                  'View, enable, and disable all integrations for a project'
+                ),
+                id: 'legacy_integrations',
+                recordAnalytics: true,
+              },
+            ]),
+        ...(hasLegacyWebhookUI
+          ? [
+              {
+                path: `${pathPrefix}/legacy-webhooks/`,
+                title: t('Webhooks (Legacy)'),
+                id: 'webhook_details',
+                recordAnalytics: true,
+              },
+            ]
+          : []),
+        ...plugins
+          .filter(plugin => !hasLegacyWebhookUI || plugin.id !== 'webhooks')
+          .map(plugin => ({
+            path: `${pathPrefix}/plugins/${plugin.id}/`,
+            title: plugin.name,
+            show: (opts: any) =>
+              opts?.access?.has('project:write') && !plugin.isDeprecated,
+            id: 'plugin_details',
+            recordAnalytics: true,
+          })),
       ],
     },
   ];

--- a/static/app/views/settings/projectPlugins/details.spec.tsx
+++ b/static/app/views/settings/projectPlugins/details.spec.tsx
@@ -114,42 +114,31 @@ describe('ProjectPluginDetails - webhook routing', () => {
     MockApiClient.clearMockResponses();
   });
 
-  it('renders webhook details page for pluginId=webhooks', async () => {
-    MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
-      method: 'GET',
-      body: {urls: ['https://example.com/hook'], enabled: true},
-    });
-
-    render(<ProjectPluginDetails />, {
+  it('redirects to legacy-webhooks route for pluginId=webhooks', () => {
+    const {router} = render(<ProjectPluginDetails />, {
       organization,
       outletContext: {project},
       initialRouterConfig: webhookRouterConfig,
     });
 
-    expect(await screen.findByText(/strongly recommend using an/)).toBeInTheDocument();
+    expect(router.location.pathname).toBe(
+      `/settings/${organization.slug}/projects/${project.slug}/legacy-webhooks/`
+    );
   });
 
-  it('does not call plugin API for webhooks route', async () => {
+  it('does not call plugin API for webhooks route', () => {
     const pluginsMock = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/plugins/`,
       method: 'GET',
       body: [],
     });
 
-    MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/legacy-webhooks/`,
-      method: 'GET',
-      body: {urls: [], enabled: false},
-    });
-
     render(<ProjectPluginDetails />, {
       organization,
       outletContext: {project},
       initialRouterConfig: webhookRouterConfig,
     });
 
-    await screen.findByText(/strongly recommend using an/);
     expect(pluginsMock).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/settings/projectPlugins/details.tsx
+++ b/static/app/views/settings/projectPlugins/details.tsx
@@ -14,26 +14,33 @@ import {
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {PluginConfig} from 'sentry/components/pluginConfig';
+import {Redirect} from 'sentry/components/redirect';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import type {Plugin} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchMutation, useApiQuery} from 'sentry/utils/queryClient';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
-import {LegacyWebhookDetails} from './legacyWebhookDetails';
 import {useTogglePluginMutation} from './useTogglePluginMutation';
 
 export default function ProjectPluginDetails() {
   const organization = useOrganization();
-  const {pluginId} = useParams<{pluginId: string; projectId: string}>();
+  const {pluginId, projectId} = useParams<{pluginId: string; projectId: string}>();
 
   if (pluginId === 'webhooks' && organization.features.includes('legacy-webhook-ui')) {
-    return <LegacyWebhookDetails />;
+    return (
+      <Redirect
+        to={normalizeUrl(
+          `/settings/${organization.slug}/projects/${projectId}/legacy-webhooks/`
+        )}
+      />
+    );
   }
 
   return <PluginDetails />;

--- a/static/app/views/settings/projectPlugins/legacyWebhookDetails.spec.tsx
+++ b/static/app/views/settings/projectPlugins/legacyWebhookDetails.spec.tsx
@@ -4,7 +4,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import * as indicators from 'sentry/actionCreators/indicator';
-import {LegacyWebhookDetails} from 'sentry/views/settings/projectPlugins/legacyWebhookDetails';
+import LegacyWebhookDetails from 'sentry/views/settings/projectPlugins/legacyWebhookDetails';
 
 describe('LegacyWebhookDetails', () => {
   const organization = OrganizationFixture();

--- a/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
+++ b/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
@@ -146,8 +146,8 @@ export default function LegacyWebhookDetails() {
 
   return (
     <div>
-      <SentryDocumentTitle title="WebHooks" projectSlug={project.slug} />
-      <SettingsPageHeader title="WebHooks" />
+      <SentryDocumentTitle title="Webhooks" projectSlug={project.slug} />
+      <SettingsPageHeader title="Webhooks" />
       <Alert.Container>
         <Alert variant="warning">
           {tct(

--- a/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
+++ b/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
@@ -32,7 +32,7 @@ interface LegacyWebhookResponse {
   urls: string[];
 }
 
-export function LegacyWebhookDetails() {
+export default function LegacyWebhookDetails() {
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
   const queryClient = useQueryClient();


### PR DESCRIPTION
## Summary
- Add legacy-webhook url/route so we don't use the plugin one (also redirect the plugin route to the new route)
- When flag is on
  - Adds hardcoded webhooks (legacy) entry
  - hides the plugin list page

### Flag on


### Flag off
(get rid of this page)
<img width="738" height="1147" alt="image" src="https://github.com/user-attachments/assets/d6ba25ac-5085-4f80-bb13-df187afb0ccf" />


