### PR TITLE
ref(api): tighten 2 more Goal #1 endpoint methods

### DIFF
--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -20,7 +20,10 @@ from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.group_index import parse_and_convert_issue_search_query
 from sentry.api.helpers.group_index.validators import ValidationError
 from sentry.api.serializers import EventSerializer, serialize
-from sentry.api.serializers.models.event import GroupEventDetailsResponse
+from sentry.api.serializers.models.event import (
+    EventSerializerResponse,
+    GroupEventDetailsResponse,
+)
 from sentry.api.utils import get_date_range_from_params
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
@@ -30,6 +33,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.event_examples import EventExamples
 from sentry.apidocs.parameters import EventParams, GlobalParams, IssueParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
@@ -159,7 +163,13 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
         examples=EventExamples.GROUP_EVENT_DETAILS,
     )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-event-details"])
-    def get(self, request: Request, group: Group, event_id: str) -> Response:
+    def get(
+        self, request: Request, group: Group, event_id: str
+    ) -> (
+        Response[GroupEventDetailsResponse]
+        | Response[EventSerializerResponse]
+        | Response[DetailResponse]
+    ):
         """
         Retrieves the details of an issue event.
         """
@@ -196,7 +206,9 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
             conditions.append(Condition(Column("environment"), Op.IN, environment_names))
 
         metric = "api.endpoints.group_event_details.get"
-        error_response = {"detail": "Unable to apply query. Change or remove it and try again."}
+        error_response: DetailResponse = {
+            "detail": "Unable to apply query. Change or remove it and try again."
+        }
 
         event: Event | GroupEvent | None = None
 
@@ -239,7 +251,10 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
 
         collapse = request.GET.getlist("collapse", [])
         if "stacktraceOnly" in collapse:
-            return Response(serialize(event, request.user, EventSerializer()))
+            stacktrace_body: EventSerializerResponse = serialize(
+                event, request.user, EventSerializer()
+            )
+            return Response(stacktrace_body)
 
         data = wrap_event_response(
             request_user=request.user,

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -25,6 +25,7 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.preprod_examples import PreprodExamples
 from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.staff import is_active_staff
 from sentry.models.commitcomparison import CommitComparison
@@ -634,7 +635,9 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         },
         examples=PreprodExamples.CREATE_SNAPSHOT,
     )
-    def post(self, request: Request, project: Project) -> Response:
+    def post(
+        self, request: Request, project: Project
+    ) -> Response[SnapshotCreateResponseDict] | Response[DetailResponse]:
         """
         Upload a new snapshot with image metadata.
 


### PR DESCRIPTION
Two more Goal #1 method tightenings.

- `group_event_details.get()` → 3-arm union: `Response[GroupEventDetailsResponse] | Response[EventSerializerResponse] | Response[DetailResponse]`. The `stacktraceOnly` query-param path returns a stripped event shape (`EventSerializerResponse`) via the typed-variable trick — `EventSerializer` is denylisted, so `serialize()` flows `Any` and we pin the local to the typed shape. Normal path returns `GroupEventDetailsResponse` from `wrap_event_response`. Multiple error paths return `DetailResponse`; the shared `error_response` literal is pinned as `DetailResponse` so mypy reads it correctly.
- `preprod_artifact_snapshot.post()` → `Response[SnapshotCreateResponseDict] | Response[DetailResponse]`. The success-path dict literal already matches the TypedDict; many validation paths emit `{"detail": ...}`.

Branch name is stale — started by probing `release_file_details` endpoints but those have `FileResponse` paths I didn't want to touch in this PR.