### PR TITLE
fix(snuba): only tag snuba rejected queries 

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1229,11 +1229,10 @@ def _apply_cache_and_build_results(
 
 
 def _is_rejected_query(body: Any) -> bool:
-    return (
+    return bool(
         "quota_allowance" in body
         and "summary" in body["quota_allowance"]
-        and "rejected_by" in body["quota_allowance"]["summary"]
-        and body["quota_allowance"]["summary"]["rejected_by"] is not None
+        and body["quota_allowance"]["summary"].get("rejected_by")
     )
 
 

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -668,3 +668,89 @@ class SnubaQueryRateLimitTest(TestCase):
         assert exc_info.value.quota_unit == "bytes"
         assert exc_info.value.throttle_threshold == 1000000000000
         assert exc_info.value.rejection_threshold is None
+
+    @mock.patch("sentry_sdk.set_tag")
+    @mock.patch("sentry.utils.snuba._snuba_query")
+    def test_allocation_policy_tags_set_on_rejection(self, mock_snuba_query, mock_set_tag) -> None:
+        """A rejected query stamps its allocation_policy.* quota state onto the scope."""
+        mock_response = mock.Mock(spec=HTTPResponse)
+        mock_response.status = 429
+        mock_response.data = json.dumps(
+            {
+                "error": {"message": "rejected"},
+                "quota_allowance": {
+                    "summary": {
+                        "is_rejected": True,
+                        "rejected_by": {"policy": "ConcurrentRateLimitAllocationPolicy"},
+                        "throttled_by": {},
+                    }
+                },
+            }
+        ).encode()
+        mock_snuba_query.return_value = ("test_referrer", mock_response, lambda x: x, lambda x: x)
+
+        with pytest.raises(RateLimitExceeded):
+            _bulk_snuba_query([self.snuba_request])
+
+        mock_set_tag.assert_any_call("allocation_policy.is_rejected", True)
+        mock_set_tag.assert_any_call(
+            "allocation_policy.rejected_by.policy", "ConcurrentRateLimitAllocationPolicy"
+        )
+
+    @mock.patch("sentry_sdk.set_tag")
+    @mock.patch("sentry.utils.snuba._snuba_query")
+    def test_allocation_policy_tags_not_set_when_not_rejected(
+        self, mock_snuba_query, mock_set_tag
+    ) -> None:
+        mock_response = mock.Mock(spec=HTTPResponse)
+        mock_response.status = 200
+        mock_response.data = json.dumps(
+            {
+                "data": [],
+                "quota_allowance": {"summary": {"rejected_by": {}}},
+            }
+        ).encode()
+        mock_snuba_query.return_value = ("test_referrer", mock_response, lambda x: x, lambda x: x)
+
+        _bulk_snuba_query([self.snuba_request])
+
+        allocation_policy_tags = [
+            call
+            for call in mock_set_tag.call_args_list
+            if call.args[0].startswith("allocation_policy")
+        ]
+        assert allocation_policy_tags == []
+
+    @mock.patch("sentry_sdk.set_tag")
+    @mock.patch("sentry.utils.snuba._snuba_query")
+    def test_successful_query_does_not_leak_tags_onto_rate_limited_sibling(
+        self, mock_snuba_query, mock_set_tag
+    ) -> None:
+        ok_response = mock.Mock(spec=HTTPResponse)
+        ok_response.status = 200
+        ok_response.data = json.dumps(
+            {"data": [], "quota_allowance": {"summary": {"is_successful": True, "rejected_by": {}}}}
+        ).encode()
+        rate_limited_response = mock.Mock(spec=HTTPResponse)
+        rate_limited_response.status = 429
+        rate_limited_response.data = json.dumps({"error": {"message": "rate limited"}}).encode()
+
+        def snuba_query(params):
+            snuba_request = params[2]
+            response = ok_response if snuba_request.referrer == "ok" else rate_limited_response
+            return (snuba_request.referrer, response, lambda x: x, lambda x: x)
+
+        mock_snuba_query.side_effect = snuba_query
+
+        def make_request(referrer):
+            return SnubaRequest(
+                request=self.snuba_request.request,
+                referrer=referrer,
+                forward=lambda x: x,
+                reverse=lambda x: x,
+            )
+
+        with pytest.raises(RateLimitExceeded):
+            _bulk_snuba_query([make_request("ok"), make_request("rate_limited")])
+
+        assert mock.call("allocation_policy.is_successful", True) not in mock_set_tag.call_args_list


### PR DESCRIPTION
Check that `rejected_by` in snuba quota allowances is actually empty. It seems that sometimes, snuba will return `rejected_by = {}`, which is incorrectly interpreted as not None and thus a rejected query. I think this is leading to some tag clobbering in bulk snuba query, which is causing problems debugging. 