### PR TITLE
fix(issues): Stop over-reporting status updates for already-matching groups

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -727,15 +727,10 @@ def handle_other_status_updates(
     new_substatus = infer_substatus(new_status, new_substatus, status_details, group_list)
 
     with transaction.atomic(router.db_for_write(Group)):
-        # Single UPDATE ... RETURNING id so the changed ids come straight from the rows the
-        # UPDATE actually touched -- no separate SELECT that could desync under a concurrent
-        # status change.
-        changed_group_ids = {
-            row[0]
-            for row in queryset.exclude(status=new_status).update_with_returning(
-                ["id"], status=new_status, substatus=new_substatus
-            )
-        }
+        status_updated = queryset.exclude(status=new_status).update_with_returning(
+            ["id"], status=new_status, substatus=new_substatus
+        )
+        changed_group_ids = {row[0] for row in status_updated}
         GroupResolution.objects.filter(group__in=group_ids).delete()
         # Also delete commit/PR resolution links when unresolving to prevent
         # showing old "resolved by commit" after manual re-resolution

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -727,9 +727,8 @@ def handle_other_status_updates(
     new_substatus = infer_substatus(new_status, new_substatus, status_details, group_list)
 
     with transaction.atomic(router.db_for_write(Group)):
-        status_updated = queryset.exclude(status=new_status).update(
-            status=new_status, substatus=new_substatus
-        )
+        changed_group_ids = set(queryset.exclude(status=new_status).values_list("id", flat=True))
+        queryset.exclude(status=new_status).update(status=new_status, substatus=new_substatus)
         GroupResolution.objects.filter(group__in=group_ids).delete()
         # Also delete commit/PR resolution links when unresolving to prevent
         # showing old "resolved by commit" after manual re-resolution
@@ -750,9 +749,10 @@ def handle_other_status_updates(
         else:
             result["statusDetails"] = {}
 
-    if group_list and status_updated:
+    changed_group_list = [group for group in group_list if group.id in changed_group_ids]
+    if changed_group_list:
         handle_status_update(
-            group_list=group_list,
+            group_list=changed_group_list,
             projects=projects,
             project_lookup=project_lookup,
             new_status=new_status,

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -727,8 +727,15 @@ def handle_other_status_updates(
     new_substatus = infer_substatus(new_status, new_substatus, status_details, group_list)
 
     with transaction.atomic(router.db_for_write(Group)):
-        changed_group_ids = set(queryset.exclude(status=new_status).values_list("id", flat=True))
-        queryset.exclude(status=new_status).update(status=new_status, substatus=new_substatus)
+        # Single UPDATE ... RETURNING id so the changed ids come straight from the rows the
+        # UPDATE actually touched -- no separate SELECT that could desync under a concurrent
+        # status change.
+        changed_group_ids = {
+            row[0]
+            for row in queryset.exclude(status=new_status).update_with_returning(
+                ["id"], status=new_status, substatus=new_substatus
+            )
+        }
         GroupResolution.objects.filter(group__in=group_ids).delete()
         # Also delete commit/PR resolution links when unresolving to prevent
         # showing old "resolved by commit" after manual re-resolution

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -163,6 +163,114 @@ class UpdateGroupsTest(TestCase):
         assert getattr(resolve_records[0], "source") == ActionSource.SLACK
         assert getattr(resolve_records[0], "actor_id") == str(self.user.id)
 
+    @patch("sentry.signals.issue_ignored.send_robust")
+    def test_bulk_ignore_skips_already_ignored(self, send_robust: Mock) -> None:
+        # One group needs to transition, one is already in the target status.
+        to_ignore = self.create_group(status=GroupStatus.UNRESOLVED)
+        already_ignored = self.create_group(status=GroupStatus.IGNORED)
+
+        http_request = self.make_request(user=self.user, method="GET")
+        http_request.GET = QueryDict(query_string=f"id={to_ignore.id}&id={already_ignored.id}")
+        request = _wrap_request(
+            http_request, data={"status": "ignored", "substatus": "archived_forever"}
+        )
+        group_list = get_group_list(self.organization.id, [self.project], request.GET.getlist("id"))
+
+        with self.assertLogs("sentry.issues.action_log", level="INFO") as logs:
+            update_groups(request, group_list)
+
+        # Activity is created only for the group that actually changed.
+        assert (
+            Activity.objects.filter(group=to_ignore, type=ActivityType.SET_IGNORED.value).count()
+            == 1
+        )
+        assert (
+            Activity.objects.filter(
+                group=already_ignored, type=ActivityType.SET_IGNORED.value
+            ).count()
+            == 0
+        )
+
+        # The action log records only the changed group.
+        archive_records = [
+            r
+            for r in logs.records
+            if r.message == "group.action_log" and getattr(r, "action") == "archive"
+        ]
+        assert len(archive_records) == 1
+        assert getattr(archive_records[0], "group_id") == str(to_ignore.id)
+
+        # The issue_ignored signal carries only the changed group.
+        assert send_robust.call_count == 1
+        assert send_robust.call_args.kwargs["group_list"] == [to_ignore]
+
+    @patch("sentry.signals.issue_unignored.send_robust")
+    @patch("sentry.signals.issue_unresolved.send_robust")
+    def test_bulk_unresolve_skips_already_unresolved(
+        self, send_unresolved: Mock, send_unignored: Mock
+    ) -> None:
+        to_unresolve = self.create_group(status=GroupStatus.RESOLVED)
+        already_unresolved = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        http_request = self.make_request(user=self.user, method="GET")
+        http_request.GET = QueryDict(
+            query_string=f"id={to_unresolve.id}&id={already_unresolved.id}"
+        )
+        request = _wrap_request(http_request, data={"status": "unresolved", "substatus": "ongoing"})
+        group_list = get_group_list(self.organization.id, [self.project], request.GET.getlist("id"))
+
+        with self.assertLogs("sentry.issues.action_log", level="INFO") as logs:
+            update_groups(request, group_list)
+
+        assert (
+            Activity.objects.filter(
+                group=to_unresolve, type=ActivityType.SET_UNRESOLVED.value
+            ).count()
+            == 1
+        )
+        assert (
+            Activity.objects.filter(
+                group=already_unresolved, type=ActivityType.SET_UNRESOLVED.value
+            ).count()
+            == 0
+        )
+
+        unresolve_records = [
+            r
+            for r in logs.records
+            if r.message == "group.action_log" and getattr(r, "action") == "unresolve"
+        ]
+        assert len(unresolve_records) == 1
+        assert getattr(unresolve_records[0], "group_id") == str(to_unresolve.id)
+
+        # RESOLVED -> UNRESOLVED fires issue_unresolved once; issue_unignored never fires.
+        assert send_unresolved.call_count == 1
+        assert send_unresolved.call_args.kwargs["group"] == to_unresolve
+        assert not send_unignored.called
+
+    @patch("sentry.signals.issue_ignored.send_robust")
+    def test_bulk_update_all_already_matching_emits_nothing(self, send_robust: Mock) -> None:
+        g1 = self.create_group(status=GroupStatus.IGNORED)
+        g2 = self.create_group(status=GroupStatus.IGNORED)
+
+        http_request = self.make_request(user=self.user, method="GET")
+        http_request.GET = QueryDict(query_string=f"id={g1.id}&id={g2.id}")
+        request = _wrap_request(
+            http_request, data={"status": "ignored", "substatus": "archived_forever"}
+        )
+        group_list = get_group_list(self.organization.id, [self.project], request.GET.getlist("id"))
+
+        # Nothing transitions, so handle_status_update is never called: no Activity,
+        # no action-log entry, and no signal.
+        with self.assertNoLogs("sentry.issues.action_log", level="INFO"):
+            update_groups(request, group_list)
+
+        assert (
+            Activity.objects.filter(group__in=[g1, g2], type=ActivityType.SET_IGNORED.value).count()
+            == 0
+        )
+        assert not send_robust.called
+
     @patch("sentry.signals.issue_resolved.send_robust")
     def test_resolving_unresolved_group(self, send_robust: Mock) -> None:
         unresolved_group = self.create_group(status=GroupStatus.UNRESOLVED)


### PR DESCRIPTION
`handle_other_status_updates()` skips already-matching groups at the DB level (`queryset.exclude(status=new_status).update(...)`), but then passed the **full `group_list`** to `handle_status_update()`. That loops over every group — Activity, GroupHistory, action-log entry, `issue_ignored`/`issue_unresolved`/`issue_unignored` signals, status syncs, `post_save` — so groups already in the target status got spurious side effects. The `status_updated` count gated *whether* to call it but not *which* groups; in a mixed bulk request the gate opens and the whole list is processed.

**Fix:** capture the genuinely-changed ids from the same `exclude(status=new_status)` predicate before the `UPDATE`, and pass only that subset to `handle_status_update()`. `if changed_group_list:` is equivalent to the old `status_updated > 0` guard. `is_bulk` still reflects the original request size. Single-group and all-changed bulk requests are unaffected; only the already-at-target subset of a mixed bulk request changes.

Out of scope (left on full list): resolution/link deletes (no-ops for unchanged groups) and `handle_ignored`/`handle_archived_until_escalating`.

**Tests:** three mixed-status `UpdateGroupsTest` cases (bulk ignore / unresolve / all-already-matching) asserting Activity, action-log, and signals fire only for changed groups. Regression: `test_status_change.py` and snuba `selective_status_update`/`bulk_resolve` pass.

Fixes ID-1577
