### PR TITLE
test(deletions): Fix flaky test_delete_error_events

### DIFF
--- a/tests/sentry/deletions/test_project.py
+++ b/tests/sentry/deletions/test_project.py
@@ -1,3 +1,4 @@
+import time
 from unittest import mock
 
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
@@ -226,10 +227,20 @@ class DeleteProjectTest(BaseWorkflowTest, TransactionTestCase, HybridCloudTestMi
         assert not GroupSeen.objects.filter(id=group_seen.id).exists()
         assert not Group.objects.filter(id=group.id).exists()
 
+        # While Snuba queries are synchronous, ClickHouse deletes are not, so the
+        # events may still be returned for a short window after the deletion task
+        # completes. Poll until they drain to avoid flakiness.
         conditions = eventstore.Filter(project_ids=[project.id, keeper.id], group_ids=[group.id])
         events = eventstore.backend.get_events(
             conditions, tenant_ids={"organization_id": 123, "referrer": "r"}
         )
+        for _ in range(10):
+            if len(events) == 0:
+                break
+            time.sleep(0.25)
+            events = eventstore.backend.get_events(
+                conditions, tenant_ids={"organization_id": 123, "referrer": "r"}
+            )
         assert len(events) == 0
 
     @mock.patch("sentry.quotas.backend.remove_seat")


### PR DESCRIPTION
## Summary

`tests/sentry/deletions/test_project.py::DeleteProjectTest::test_delete_error_events` is flaky. It deletes a project's error events via `run_scheduled_deletions()`, then immediately asserts the events are gone from Snuba:

```python
events = eventstore.backend.get_events(conditions, ...)
assert len(events) == 0
```

Snuba queries are synchronous, but ClickHouse **deletes** are asynchronous, so for a short window after the deletion task completes the event can still be returned. When that happens the test fails with:

```
assert 1 == 0
 +  where 1 = len([<Event ... event_id=...>])
```

### Why this matters beyond the one test
This test uses `TransactionTestCase` and touches multiple databases during deletion. When it fails mid-flight it can leave an open cross-DB transaction that poisons every subsequent test on the same xdist worker (cascading `CrossTransactionAssertionError`s — 100-300 failures from a single root cause). Examples:
- https://github.com/getsentry/sentry/actions/runs/27165458550/job/80191393478
- https://github.com/getsentry/sentry/actions/runs/26755815625/job/78855358796

## Fix
Poll until the events drain from Snuba before asserting (same approach as `wait_for_event_count`), with a bounded retry so a genuinely-undeleted event still fails.

## Notes
The worker-wide cascade is addressed separately; this PR removes one of the triggers.

🤖 Generated with [Droid](https://factory.ai)