### PR TITLE
test: Stop a leaked transaction from poisoning the whole xdist worker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,30 +103,60 @@ def setup_enforce_monotonic_transactions(request: pytest.FixtureRequest) -> Gene
 
 
 @pytest.fixture(autouse=True)
-def repair_leaked_transactions() -> Generator[None]:
-    """Prevent a single transaction leak from poisoning the whole xdist worker.
+def repair_leaked_transactions(request: pytest.FixtureRequest) -> Generator[None]:
+    """Contain (and surface) a transaction leak so it can't poison the worker.
 
     When a test fails partway through a multi-database operation it can leave a
     savepoint open on the (process-shared) connection that Django's rollback
-    does not unwind. Because the cross-transaction guard compares each
-    connection's transaction depth against a watermark that is re-baselined at
-    the start of every test, the leftover savepoint makes every subsequent test
-    on that worker raise CrossTransactionAssertionError (or "pop from empty
-    list") in setUp/teardown -- turning one flake into hundreds of failures.
+    does not unwind. The cross-transaction guard compares each connection's
+    transaction depth against a watermark that is re-baselined at the start of
+    every test (hardcoded to 2 for a Django ``TestCase``), so the leftover
+    savepoint leaves the connection permanently "above watermark". Every
+    subsequent test on that worker then fails in setUp/teardown with
+    ``CrossTransactionAssertionError`` (or "pop from empty list") -- turning a
+    single flake into hundreds of failures attributed to innocent tests.
 
-    After each test, close any connection still left above its watermark so the
-    next test gets a clean connection. On a healthy test there is nothing above
-    the watermark, so this is a no-op and adds no latency.
+    Note that ``connection.close()`` does NOT fix this: while the connection is
+    still inside the ``TestCase`` class-level atomic block, Django's ``close()``
+    only sets ``closed_in_transaction`` and leaves ``savepoint_ids`` /
+    ``in_atomic_block`` (and therefore the inflated depth) intact. So we reset
+    the connection's transaction bookkeeping ourselves -- mirroring what
+    ``connect()`` does -- to guarantee the next test starts clean.
+
+    On a healthy test nothing is above the watermark, so this is a no-op and
+    adds no latency. When a leak IS found we fail loudly, naming the offending
+    test and database(s): a leaked open transaction is a real bug that should be
+    fixed at the source, not silently swallowed.
     """
     from sentry.testutils.hybrid_cloud import simulated_transaction_watermarks
 
     yield
 
+    leaked = simulated_transaction_watermarks.connections_above_watermark()
+    if not leaked:
+        return
+
+    # Force each leaked connection back to a pristine, transaction-free state so
+    # the leak cannot cascade into the next test on this worker.
     for conn in connections.all():
-        if simulated_transaction_watermarks.connection_transaction_depth_above_watermark(
-            connection=conn
-        ):
+        if conn.alias not in leaked:
+            continue
+        try:
             conn.close()
+        finally:
+            conn.connection = None
+            conn.savepoint_ids = []
+            conn.atomic_blocks = []
+            conn.in_atomic_block = False
+            conn.closed_in_transaction = False
+            conn.needs_rollback = False
+
+    pytest.fail(
+        f"{request.node.nodeid} leaked an open transaction on db(s) "
+        f"{sorted(leaked)}. This corrupts transaction state for the rest of the "
+        f"xdist worker; the test must close its transactions before returning.",
+        pytrace=False,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,33 @@ def setup_enforce_monotonic_transactions(request: pytest.FixtureRequest) -> Gene
 
 
 @pytest.fixture(autouse=True)
+def repair_leaked_transactions() -> Generator[None]:
+    """Prevent a single transaction leak from poisoning the whole xdist worker.
+
+    When a test fails partway through a multi-database operation it can leave a
+    savepoint open on the (process-shared) connection that Django's rollback
+    does not unwind. Because the cross-transaction guard compares each
+    connection's transaction depth against a watermark that is re-baselined at
+    the start of every test, the leftover savepoint makes every subsequent test
+    on that worker raise CrossTransactionAssertionError (or "pop from empty
+    list") in setUp/teardown -- turning one flake into hundreds of failures.
+
+    After each test, close any connection still left above its watermark so the
+    next test gets a clean connection. On a healthy test there is nothing above
+    the watermark, so this is a no-op and adds no latency.
+    """
+    from sentry.testutils.hybrid_cloud import simulated_transaction_watermarks
+
+    yield
+
+    for conn in connections.all():
+        if simulated_transaction_watermarks.connection_transaction_depth_above_watermark(
+            connection=conn
+        ):
+            conn.close()
+
+
+@pytest.fixture(autouse=True)
 def audit_hybrid_cloud_writes_and_deletes(request: pytest.FixtureRequest) -> Generator[None]:
     """
     Ensure that write operations on hybrid cloud foreign keys are recorded


### PR DESCRIPTION
## Problem

A single flaky test can cascade into **100-300 failures on one xdist worker**. Examples:
- https://github.com/getsentry/sentry/actions/runs/27165458550/job/80191393478
- https://github.com/getsentry/sentry/actions/runs/26755815625/job/78855358796
- https://github.com/getsentry/sentry/actions/runs/26913824985/job/79398595299

In each, every failure is on a single worker (e.g. `[gw2]`) and almost all are the same error raised in `setUp`/teardown, not in the test body:
```
CrossTransactionAssertionError: Transaction opened for db {'secondary'}, but command running against db control
```
(plus a few `IndexError: pop from empty list` / `TransactionManagementError`).

## Root cause

The cross-transaction guard flags a connection when its transaction depth is **above the per-test watermark** (`simulated_transaction_watermarks`). For a Django `TestCase`, `simulate_on_commit` re-baselines that watermark to a **hardcoded 2** at the start of every test (class-level + per-test atomic).

When a test fails partway through a **multi-database** operation it can leave an extra **savepoint open on the process-shared connection** that Django's rollback doesn't unwind, leaving depth at 3. The next test starts at `3 - 2 = 1` above watermark, so the guard raises on the first query of `setUp` — and keeps raising for every subsequent test on that worker. One flake → whole-worker cascade. (Independent of *which* test flakes first.)

## Why not just `conn.close()`

An earlier version closed the connection. **That doesn't work** (verified against Django 5.2.8): while the connection is still inside the `TestCase` class-level atomic block, Django's `close()` only sets `closed_in_transaction` and leaves `savepoint_ids` / `in_atomic_block` (and thus the inflated depth) intact, so the next test stays poisoned.

## Fix

An autouse teardown that, **only when a connection is left above its watermark** (the leak signature):
1. Resets that connection's transaction bookkeeping (mirroring `connect()`) so the next test on the worker starts clean — actually containing the blast radius.
2. `pytest.fail`s naming the offending test and db(s). A leaked open transaction is a real bug; it should be surfaced on the culprit, not silently swallowed across the worker.

```python
leaked = simulated_transaction_watermarks.connections_above_watermark()
if not leaked:
    return
for conn in connections.all():
    if conn.alias not in leaked:
        continue
    try:
        conn.close()
    finally:
        conn.connection = None
        conn.savepoint_ids = []
        conn.atomic_blocks = []
        conn.in_atomic_block = False
        conn.closed_in_transaction = False
        conn.needs_rollback = False
pytest.fail(f"{request.node.nodeid} leaked an open transaction on db(s) {sorted(leaked)} ...", pytrace=False)
```

## Latency

None on the happy path: for a passing test nothing is above the watermark, so the body is skipped entirely. Only an actual leak pays the reset.

## Verification

Reproduced the depth math + `close()` semantics against Django 5.2.8: a surviving leak yields depth 3 vs watermark 2 (`above_watermark = 1`); `close()` inside the class atomic leaves it poisoned; the explicit reset returns the next test to depth 2 / clean.

## Notes
This is the systemic mitigation. Fixing the individual triggering flakes is complementary and tracked separately.