### PR TITLE
fix(intercom): Wait before shutdown/restart

### DIFF
--- a/static/app/utils/intercom.tsx
+++ b/static/app/utils/intercom.tsx
@@ -98,9 +98,11 @@ async function initIntercom(orgSlug: string): Promise<void> {
         }
 
         hasRebootedAfterShow = true;
-        shutdown();
-        boot(intercomSettings);
-        show();
+        setTimeout(() => {
+          shutdown();
+          boot(intercomSettings);
+          show();
+        }, 2000);
       });
     } catch (error) {
       // Reset so user can retry on next click


### PR DESCRIPTION
onShow triggers too early, there isn't a hook for after everything has actually mounted.

refs #117127