### PR TITLE
ref(ACI): Remove `workflow_status_update_handler` and use generic handler

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -378,6 +378,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:workflow-engine-metric-detector-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable seer activities to be evaluated in workflow engine
     manager.add("organizations:workflow-engine-evaluate-seer-activities", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Route group status change activities through the workflow activity registry (replaces group_status_update_registry)
+    manager.add("organizations:workflow-engine-status-change-via-activity", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable our logs product (known internally as ourlogs) in UI and backend
     manager.add("organizations:ourlogs-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product to be ingested via Relay.

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -562,6 +562,7 @@ class GroupManager(BaseManager["Group"]):
                 data=activity_data,
                 send_notification=send_activity_notification,
                 datetime=update_date,
+                detector_id=detector_id,
             )
             record_group_history_from_activity_type(group, activity_type.value)
 
@@ -584,6 +585,7 @@ class GroupManager(BaseManager["Group"]):
                         "reason": PriorityChangeReason.ONGOING,
                     },
                     datetime=update_date,
+                    detector_id=detector_id,
                 )
                 record_group_history(group, PRIORITY_TO_GROUP_HISTORY_STATUS[new_priority])
 

--- a/src/sentry/workflow_engine/handlers/workflow/__init__.py
+++ b/src/sentry/workflow_engine/handlers/workflow/__init__.py
@@ -1,7 +1,6 @@
-from .workflow_activity_handlers import seer_activity_handler
-from .workflow_status_update_handler import workflow_status_update_handler
+from .workflow_activity_handlers import activity_handler, seer_activity_handler
 
 __all__ = [
+    "activity_handler",
     "seer_activity_handler",
-    "workflow_status_update_handler",
 ]

--- a/src/sentry/workflow_engine/handlers/workflow/__init__.py
+++ b/src/sentry/workflow_engine/handlers/workflow/__init__.py
@@ -1,6 +1,8 @@
 from .workflow_activity_handlers import activity_handler, seer_activity_handler
+from .workflow_status_update_handler import workflow_status_update_handler
 
 __all__ = [
     "activity_handler",
     "seer_activity_handler",
+    "workflow_status_update_handler",
 ]

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -26,9 +26,11 @@ SEER_WORKFLOW_ACTIVITIES = [
 # Activity types handled by the generic activity_handler. This replaces the
 # group_status_update_registry path (see workflow_status_update_handler) once the
 # organizations:workflow-engine-status-change-via-activity flag is fully rolled out.
-STATUS_CHANGE_WORKFLOW_ACTIVITIES = [
+SUPPORTED_ACTIVITIES = [
     ActivityType.SET_RESOLVED,
 ]
+
+STATUS_CHANGE_VIA_ACTIVITY_FLAG = "organizations:workflow-engine-status-change-via-activity"
 
 
 @workflow_activity_registry.register("seer_activity")
@@ -97,10 +99,11 @@ def activity_handler(
     """
     Generic handler for group status change activities.
 
-    This handler replaces the ``group_status_update_registry`` path. Because it is
-    invoked from ``create_group_activity``, it processes the relevant status change
-    activities regardless of where they originate (issue platform, integration sync,
-    direct API resolves, etc.) rather than only the issue platform consumer.
+    To add a new activity, add it to SUPPORTED_ACTIVITIES.
+    Then, add a roll out flag after the supported activity filter.
+
+    If there's a need for greater flexibility, create a new handler in the registry.
+    But, these custom handlers will not have the platform metrics or logging.
     """
     logging_ctx = {
         "activity_type": activity.type,
@@ -112,24 +115,27 @@ def activity_handler(
         activity_type = ActivityType(activity.type)
     except ValueError:
         logger.exception(
-            "workflow_engine.activity_handler.invalid_activity_type", extra=logging_ctx
+            "workflow_engine.activity_handler.invalid_activity_type",
+            extra=logging_ctx,
         )
         return
+
     logging_ctx["activity_name"] = activity_type.name
 
-    # Record every activity that reaches this handler (before any filtering) so we
-    # can measure the full volume and distribution of activity types flowing through
-    # create_group_activity.
+    # Record every activity that reaches this handler, before any filtering.
+    # This allows us to track all of the registered activities that could be
+    # supported by the platform.
     metrics.incr(
         "workflow_engine.activity_handler.received",
         tags={"activity_name": activity_type.name},
     )
 
-    if activity_type not in STATUS_CHANGE_WORKFLOW_ACTIVITIES:
+    if activity_type not in SUPPORTED_ACTIVITIES:
         return
 
     if not features.has(
-        "organizations:workflow-engine-status-change-via-activity", group.organization
+        STATUS_CHANGE_VIA_ACTIVITY_FLAG,
+        group.organization,
     ):
         return
 
@@ -141,7 +147,10 @@ def activity_handler(
         else:
             detector = get_preferred_detector(event_data=event_data)
     except Detector.DoesNotExist:
-        logger.exception("workflow_engine.activity_handler.missing_detector", extra=logging_ctx)
+        logger.exception(
+            "workflow_engine.activity_handler.missing_detector",
+            extra=logging_ctx,
+        )
         return
 
     logging_ctx["detector_id"] = detector.id
@@ -152,8 +161,12 @@ def activity_handler(
         group_id=group.id,
         detector_id=detector.id,
     )
+
     metrics.incr(
         "workflow_engine.activity_handler.complete",
         tags={"activity_name": activity_type.name},
     )
-    logger.info("workflow_engine.activity_handler.complete", extra=logging_ctx)
+    logger.info(
+        "workflow_engine.activity_handler.complete",
+        extra=logging_ctx,
+    )

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -122,7 +122,7 @@ def activity_handler(
 
     logging_ctx["activity_name"] = activity_type.name
 
-    # Record every activity that reaches this handler, before any filtering.
+    # Record every activity that reaches this handler, before filtering for support.
     # This allows us to track all of the registered activities that could be
     # supported by the platform.
     metrics.incr(

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -23,6 +23,13 @@ SEER_WORKFLOW_ACTIVITIES = [
     ActivityType.SEER_PR_CREATED,
 ]
 
+# Activity types handled by the generic activity_handler. This replaces the
+# group_status_update_registry path (see workflow_status_update_handler) once the
+# organizations:workflow-engine-status-change-via-activity flag is fully rolled out.
+STATUS_CHANGE_WORKFLOW_ACTIVITIES = [
+    ActivityType.SET_RESOLVED,
+]
+
 
 @workflow_activity_registry.register("seer_activity")
 def seer_activity_handler(
@@ -79,3 +86,74 @@ def seer_activity_handler(
         tags={"activity_name": activity_type.name},
     )
     logger.info("workflow_engine.seer_activity_handler.complete", extra=logging_ctx)
+
+
+@workflow_activity_registry.register("generic_activity")
+def activity_handler(
+    group: Group,
+    activity: Activity,
+    detector_id: DetectorId | None = None,
+) -> None:
+    """
+    Generic handler for group status change activities.
+
+    This handler replaces the ``group_status_update_registry`` path. Because it is
+    invoked from ``create_group_activity``, it processes the relevant status change
+    activities regardless of where they originate (issue platform, integration sync,
+    direct API resolves, etc.) rather than only the issue platform consumer.
+    """
+    logging_ctx = {
+        "activity_type": activity.type,
+        "group_id": group.id,
+        "project_id": group.project_id,
+    }
+
+    try:
+        activity_type = ActivityType(activity.type)
+    except ValueError:
+        logger.exception(
+            "workflow_engine.activity_handler.invalid_activity_type", extra=logging_ctx
+        )
+        return
+    logging_ctx["activity_name"] = activity_type.name
+
+    # Record every activity that reaches this handler (before any filtering) so we
+    # can measure the full volume and distribution of activity types flowing through
+    # create_group_activity.
+    metrics.incr(
+        "workflow_engine.activity_handler.received",
+        tags={"activity_name": activity_type.name},
+    )
+
+    if activity_type not in STATUS_CHANGE_WORKFLOW_ACTIVITIES:
+        return
+
+    if not features.has(
+        "organizations:workflow-engine-status-change-via-activity", group.organization
+    ):
+        return
+
+    event_data = WorkflowEventData(event=activity, group=group)
+
+    try:
+        if detector_id is not None:
+            detector = Detector.objects.get(pk=detector_id)
+        else:
+            detector = get_preferred_detector(event_data=event_data)
+    except Detector.DoesNotExist:
+        logger.exception("workflow_engine.activity_handler.missing_detector", extra=logging_ctx)
+        return
+
+    logging_ctx["detector_id"] = detector.id
+    logging_ctx["detector_type"] = detector.type
+
+    process_workflow_activity.delay(
+        activity_id=activity.id,
+        group_id=group.id,
+        detector_id=detector.id,
+    )
+    metrics.incr(
+        "workflow_engine.activity_handler.complete",
+        tags={"activity_name": activity_type.name},
+    )
+    logger.info("workflow_engine.activity_handler.complete", extra=logging_ctx)

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -122,14 +122,6 @@ def activity_handler(
 
     logging_ctx["activity_name"] = activity_type.name
 
-    # Record every activity that reaches this handler, before filtering for support.
-    # This allows us to track all of the registered activities that could be
-    # supported by the platform.
-    metrics.incr(
-        "workflow_engine.activity_handler.received",
-        tags={"activity_name": activity_type.name},
-    )
-
     if activity_type not in SUPPORTED_ACTIVITIES:
         return
 

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
@@ -62,6 +62,14 @@ def workflow_status_update_handler(
         return
 
     organization = Organization.objects.get_from_cache(pk=activity.project.organization_id)
+
+    if activity.type == ActivityType.SET_RESOLVED.value and features.has(
+        "organizations:workflow-engine-status-change-via-activity", organization
+    ):
+        # The generic activity_handler (invoked via create_group_activity) now owns
+        # status change activities. Skip here to avoid queuing the task twice.
+        return
+
     can_process_seer_activities = features.has(
         "organizations:workflow-engine-evaluate-seer-activities", organization
     )

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
@@ -8,6 +8,9 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.types.activity import ActivityType
 from sentry.utils import metrics
+from sentry.workflow_engine.handlers.workflow.workflow_activity_handlers import (
+    STATUS_CHANGE_VIA_ACTIVITY_FLAG,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +67,7 @@ def workflow_status_update_handler(
     organization = Organization.objects.get_from_cache(pk=activity.project.organization_id)
 
     if activity.type == ActivityType.SET_RESOLVED.value and features.has(
-        "organizations:workflow-engine-status-change-via-activity", organization
+        STATUS_CHANGE_VIA_ACTIVITY_FLAG, organization
     ):
         # The generic activity_handler (invoked via create_group_activity) now owns
         # status change activities. Skip here to avoid queuing the task twice.

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -141,23 +141,6 @@ class GenericActivityHandlerTest(TestCase):
         mock_process_workflow_activity.delay.assert_not_called()
 
     @mock.patch("sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.metrics")
-    @mock.patch(
-        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
-    )
-    def test_received_metric_recorded_before_filtering(
-        self, mock_process_workflow_activity: MagicMock, mock_metrics: MagicMock
-    ) -> None:
-        # An unsupported, un-flagged activity type should still record the received metric.
-        activity = self.create_group_activity(group=self.group, type=ActivityType.NOTE.value)
-        activity_handler(self.group, activity, None)
-
-        mock_metrics.incr.assert_any_call(
-            "workflow_engine.activity_handler.received",
-            tags={"activity_name": ActivityType.NOTE.name},
-        )
-        mock_process_workflow_activity.delay.assert_not_called()
-
-    @mock.patch("sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.metrics")
     def test_invalid_activity_type(self, mock_metrics: MagicMock) -> None:
         self.activity.type = -1
         activity_handler(self.group, self.activity, self.detector.id)

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -8,6 +8,7 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.handlers.workflow.workflow_activity_handlers import (
     SEER_WORKFLOW_ACTIVITIES,
+    STATUS_CHANGE_VIA_ACTIVITY_FLAG,
     activity_handler,
     seer_activity_handler,
 )
@@ -162,7 +163,7 @@ class GenericActivityHandlerTest(TestCase):
         activity_handler(self.group, self.activity, self.detector.id)
         mock_metrics.incr.assert_not_called()
 
-    @with_feature("organizations:workflow-engine-status-change-via-activity")
+    @with_feature(STATUS_CHANGE_VIA_ACTIVITY_FLAG)
     @mock.patch(
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
     )
@@ -174,7 +175,7 @@ class GenericActivityHandlerTest(TestCase):
 
         mock_process_workflow_activity.delay.assert_not_called()
 
-    @with_feature("organizations:workflow-engine-status-change-via-activity")
+    @with_feature(STATUS_CHANGE_VIA_ACTIVITY_FLAG)
     @mock.patch(
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
     )
@@ -189,7 +190,7 @@ class GenericActivityHandlerTest(TestCase):
             detector_id=self.detector.id,
         )
 
-    @with_feature("organizations:workflow-engine-status-change-via-activity")
+    @with_feature(STATUS_CHANGE_VIA_ACTIVITY_FLAG)
     @mock.patch(
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
     )
@@ -205,7 +206,7 @@ class GenericActivityHandlerTest(TestCase):
             detector_id=self.detector.id,
         )
 
-    @with_feature("organizations:workflow-engine-status-change-via-activity")
+    @with_feature(STATUS_CHANGE_VIA_ACTIVITY_FLAG)
     @mock.patch(
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
     )

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -8,6 +8,7 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.handlers.workflow.workflow_activity_handlers import (
     SEER_WORKFLOW_ACTIVITIES,
+    activity_handler,
     seer_activity_handler,
 )
 from sentry.workflow_engine.models import Detector
@@ -18,7 +19,8 @@ from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 class WorkflowActivityRegistryTest(TestCase):
     def test_registrants(self) -> None:
         assert "seer_activity" in workflow_activity_registry.registrations
-        assert len(workflow_activity_registry.registrations) == 1
+        assert "generic_activity" in workflow_activity_registry.registrations
+        assert len(workflow_activity_registry.registrations) == 2
 
 
 class SeerActivityHandlerTest(TestCase):
@@ -120,3 +122,100 @@ class SeerActivityHandlerTest(TestCase):
             group_id=self.group.id,
             detector_id=issue_stream_detector.id,
         )
+
+
+class GenericActivityHandlerTest(TestCase):
+    def setUp(self) -> None:
+        self.group = self.create_group()
+        self.activity = self.create_group_activity(
+            group=self.group, type=ActivityType.SET_RESOLVED.value
+        )
+        self.detector = Detector.objects.get(project=self.project, type=ErrorGroupType.slug)
+
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
+    def test_feature_flag_disabled(self, mock_process_workflow_activity: MagicMock) -> None:
+        activity_handler(self.group, self.activity, self.detector.id)
+        mock_process_workflow_activity.delay.assert_not_called()
+
+    @mock.patch("sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.metrics")
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
+    def test_received_metric_recorded_before_filtering(
+        self, mock_process_workflow_activity: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        # An unsupported, un-flagged activity type should still record the received metric.
+        activity = self.create_group_activity(group=self.group, type=ActivityType.NOTE.value)
+        activity_handler(self.group, activity, None)
+
+        mock_metrics.incr.assert_any_call(
+            "workflow_engine.activity_handler.received",
+            tags={"activity_name": ActivityType.NOTE.name},
+        )
+        mock_process_workflow_activity.delay.assert_not_called()
+
+    @mock.patch("sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.metrics")
+    def test_invalid_activity_type(self, mock_metrics: MagicMock) -> None:
+        self.activity.type = -1
+        activity_handler(self.group, self.activity, self.detector.id)
+        mock_metrics.incr.assert_not_called()
+
+    @with_feature("organizations:workflow-engine-status-change-via-activity")
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
+    def test_skips_unsupported_activity_type(
+        self, mock_process_workflow_activity: MagicMock
+    ) -> None:
+        activity = self.create_group_activity(group=self.group, type=ActivityType.NOTE.value)
+        activity_handler(self.group, activity, self.detector.id)
+
+        mock_process_workflow_activity.delay.assert_not_called()
+
+    @with_feature("organizations:workflow-engine-status-change-via-activity")
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
+    def test_dispatches_with_provided_detector_id(
+        self, mock_process_workflow_activity: MagicMock
+    ) -> None:
+        activity_handler(self.group, self.activity, self.detector.id)
+
+        mock_process_workflow_activity.delay.assert_called_once_with(
+            activity_id=self.activity.id,
+            group_id=self.group.id,
+            detector_id=self.detector.id,
+        )
+
+    @with_feature("organizations:workflow-engine-status-change-via-activity")
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
+    def test_falls_back_to_preferred_detector(
+        self, mock_process_workflow_activity: MagicMock
+    ) -> None:
+        # No detector_id provided (e.g. a non-issue-platform resolve) -> resolve from the group.
+        activity_handler(self.group, self.activity, None)
+
+        mock_process_workflow_activity.delay.assert_called_once_with(
+            activity_id=self.activity.id,
+            group_id=self.group.id,
+            detector_id=self.detector.id,
+        )
+
+    @with_feature("organizations:workflow-engine-status-change-via-activity")
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.get_preferred_detector",
+        side_effect=Detector.DoesNotExist,
+    )
+    def test_skips_when_no_detector(
+        self, mock_get_detector: MagicMock, mock_process_workflow_activity: MagicMock
+    ) -> None:
+        activity_handler(self.group, self.activity, None)
+
+        mock_process_workflow_activity.delay.assert_not_called()

--- a/tests/sentry/workflow_engine/test_task_integration.py
+++ b/tests/sentry/workflow_engine/test_task_integration.py
@@ -7,6 +7,7 @@ from sentry.issues.status_change_message import StatusChangeMessageData
 from sentry.models.group import GroupStatus
 from sentry.models.grouphash import GroupHash
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 from tests.sentry.issues.test_status_change_consumer import get_test_message_status_change
@@ -71,3 +72,40 @@ class IssuePlatformIntegrationTests(TestCase):
                 "workflow_engine.tasks.process_workflows.activity_update",
                 tags={"activity_type": ActivityType.SET_RESOLVED.value},
             )
+
+    def _resolved_message(self) -> StatusChangeMessageData:
+        return StatusChangeMessageData(
+            id="test_message_id",
+            project_id=self.project.id,
+            new_status=GroupStatus.RESOLVED,
+            new_substatus=None,
+            fingerprint=[self.fingerprint],
+            detector_id=self.detector.id,
+            activity_data={"test": "test"},
+        )
+
+    @mock.patch("sentry.workflow_engine.tasks.workflows.process_workflow_activity.delay")
+    def test_single_dispatch__flag_off(self, mock_delay: mock.MagicMock) -> None:
+        """
+        With the flag off, only the legacy group_status_update_registry path dispatches
+        the task. The generic activity_handler bails at the flag check, so we get exactly
+        one dispatch (no double-processing).
+        """
+        update_status(self.group, self._resolved_message())
+        assert mock_delay.call_count == 1
+
+    @with_feature("organizations:workflow-engine-status-change-via-activity")
+    @mock.patch("sentry.workflow_engine.tasks.workflows.process_workflow_activity.delay")
+    def test_single_dispatch__flag_on(self, mock_delay: mock.MagicMock) -> None:
+        """
+        With the flag on, the generic activity_handler (via create_group_activity) owns
+        the dispatch and the legacy handler bails for SET_RESOLVED, so we still get
+        exactly one dispatch.
+        """
+        update_status(self.group, self._resolved_message())
+        assert mock_delay.call_count == 1
+        mock_delay.assert_called_once_with(
+            activity_id=mock.ANY,
+            group_id=self.group.id,
+            detector_id=self.detector.id,
+        )

--- a/tests/sentry/workflow_engine/test_task_integration.py
+++ b/tests/sentry/workflow_engine/test_task_integration.py
@@ -8,8 +8,11 @@ from sentry.models.group import GroupStatus
 from sentry.models.grouphash import GroupHash
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
-from sentry.types.activity import STATUS_CHANGE_VIA_ACTIVITY_FLAG, ActivityType
+from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
+from sentry.workflow_engine.handlers.workflow.workflow_activity_handlers import (
+    STATUS_CHANGE_VIA_ACTIVITY_FLAG,
+)
 from tests.sentry.issues.test_status_change_consumer import get_test_message_status_change
 
 

--- a/tests/sentry/workflow_engine/test_task_integration.py
+++ b/tests/sentry/workflow_engine/test_task_integration.py
@@ -8,7 +8,7 @@ from sentry.models.group import GroupStatus
 from sentry.models.grouphash import GroupHash
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
-from sentry.types.activity import ActivityType
+from sentry.types.activity import STATUS_CHANGE_VIA_ACTIVITY_FLAG, ActivityType
 from sentry.types.group import GroupSubStatus
 from tests.sentry.issues.test_status_change_consumer import get_test_message_status_change
 
@@ -94,7 +94,7 @@ class IssuePlatformIntegrationTests(TestCase):
         update_status(self.group, self._resolved_message())
         assert mock_delay.call_count == 1
 
-    @with_feature("organizations:workflow-engine-status-change-via-activity")
+    @with_feature(STATUS_CHANGE_VIA_ACTIVITY_FLAG)
     @mock.patch("sentry.workflow_engine.tasks.workflows.process_workflow_activity.delay")
     def test_single_dispatch__flag_on(self, mock_delay: mock.MagicMock) -> None:
         """


### PR DESCRIPTION
# Description
Create a generic `activity_handler` handler for activity updates. This will allow us to have a single hook for activities, but for now it will only handle the resolved activities.

This should also fix the issue where only metric issues were getting a resolution case, as this is a more generic call site.