### PR TITLE
ref(api): tighten 4 more paginate-based endpoint returns

### DIFF
--- a/src/sentry/core/endpoints/organization_member_requests_invite_index.py
+++ b/src/sentry/core/endpoints/organization_member_requests_invite_index.py
@@ -65,7 +65,9 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[OrganizationMemberWithTeamsResponse]]:
         """
         Return a list of pending invite and join requests for an organization.
         """

--- a/src/sentry/core/endpoints/organization_projects.py
+++ b/src/sentry/core/endpoints/organization_projects.py
@@ -2,7 +2,7 @@ import logging
 import random
 import string
 from email.headerregistry import Address
-from typing import Any, TypeIs
+from typing import Any, TypedDict, TypeIs
 
 from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError, router, transaction
@@ -44,6 +44,7 @@ from sentry.apidocs.parameters import (
     OrganizationParams,
     VisibilityParams,
 )
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.core.endpoints.team_projects import (
@@ -65,6 +66,13 @@ from sentry.utils.snowflake import MaxSnowflakeRetryError
 ERR_INVALID_STATS_PERIOD = (
     "Invalid stats_period. Valid choices are '', '1h', '24h', '7d', '14d', '30d', and '90d'"
 )
+
+
+class _LegacyParamErrorResponse(TypedDict):
+    # Legacy nested error envelope used by this endpoint's stats_period / id
+    # validation; kept as-is for wire compatibility.
+    error: dict[str, dict[str, dict[str, str]]]
+
 
 DATASETS = {
     "": discover,  # in case they pass an empty query string fall back on default
@@ -132,7 +140,13 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint):
         },
         examples=OrganizationExamples.LIST_PROJECTS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> (
+        Response[list[OrganizationProjectResponse]]
+        | Response[DetailResponse]
+        | Response[_LegacyParamErrorResponse]
+    ):
         """
         Return a list of projects bound to a organization.
         """

--- a/src/sentry/core/endpoints/team_projects.py
+++ b/src/sentry/core/endpoints/team_projects.py
@@ -42,6 +42,12 @@ from sentry.utils.snowflake import MaxSnowflakeRetryError
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '14d', and '30d'"
 
 
+class _StatsPeriodErrorResponse(TypedDict):
+    # Legacy nested error envelope used only by this endpoint's stats_period
+    # validation; kept as-is for wire compatibility.
+    error: dict[str, dict[str, dict[str, str]]]
+
+
 def apply_default_project_settings(organization: Organization, project: Project) -> None:
     if project.platform and project.platform.startswith("javascript"):
         set_default_inbound_filters(project, organization)
@@ -157,7 +163,9 @@ class TeamProjectsEndpoint(TeamEndpoint):
         },
         examples=TeamExamples.LIST_TEAM_PROJECTS,
     )
-    def get(self, request: Request, team) -> Response:
+    def get(
+        self, request: Request, team
+    ) -> Response[list[OrganizationProjectResponse]] | Response[_StatsPeriodErrorResponse]:
         """
         Return a list of projects bound to a team.
         """

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_installations.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_installations.py
@@ -55,7 +55,9 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[SentryAppInstallationResult]]:
         """
         Return a list of an organization's installations of custom integrations (Sentry Apps).
         """


### PR DESCRIPTION
Tighten four `paginate()`-based endpoint return annotations from bare `Response` to `Response[T]` (matching the typed `@extend_schema` decorator each endpoint already declares).

`paginate()` returns an untyped `Response` (defaults to `Any`), which mypy accepts for any specific `Response[T]` annotation, so this is annotation-only — no body changes. Two endpoints needed a small local TypedDict to declare a legacy nested error envelope (`{"error": {"params": ...}}`) that doesn't match `DetailResponse`; that shape is preserved verbatim.

Endpoints touched: `team_projects.get`, `organization_projects.get`, `organization_member_requests_invite_index.get`, `sentry_app_installations.get`.