### PR TITLE
fix(issues): Handle prototype tag roots

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTree.spec.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.spec.tsx
@@ -256,6 +256,21 @@ describe('EventTagsTree', () => {
     expect(screen.queryByText('undefined tag')).not.toBeInTheDocument();
   });
 
+  it('renders tags rooted at object prototype property names', async () => {
+    const prototypeTagEvent = EventFixture({
+      tags: [{key: 'constructor.name', value: 'Event'}],
+    });
+
+    render(<EventTags projectSlug={project.slug} event={prototypeTagEvent} />, {
+      organization,
+    });
+
+    expect(mockDetailedProject).toHaveBeenCalled();
+    expect(await screen.findByText('constructor', {selector: 'div'})).toBeInTheDocument();
+    expect(screen.getByText('name', {selector: 'div'})).toBeInTheDocument();
+    expect(screen.getByText('Event')).toBeInTheDocument();
+  });
+
   it("renders 'Add to event highlights' option based on highlights", async () => {
     const highlightsEvent = EventFixture({
       tags: [

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -107,20 +107,23 @@ function getTagTreeRows({
   project,
   isLast,
 }: EventTagsTreeRowProps & {uniqueKey: string}): React.ReactNode[] {
-  const subtreeTags = Array.from(content.subtree.keys());
-  const subtreeRows = subtreeTags.reduce<React.ReactNode[]>((rows, tag, i) => {
-    const branchRows = getTagTreeRows({
-      event,
-      project,
-      tagKey: tag,
-      content: content.subtree.get(tag)!,
-      spacerCount: spacerCount + 1,
-      isLast: i === subtreeTags.length - 1,
-      // Encoding the trunk index with the branch index ensures uniqueness for the key
-      uniqueKey: `${uniqueKey}-${i}`,
-    });
-    return rows.concat(branchRows);
-  }, []);
+  const subtreeEntries = Array.from(content.subtree.entries());
+  const subtreeRows = subtreeEntries.reduce<React.ReactNode[]>(
+    (rows, [tag, tagContent], i) => {
+      const branchRows = getTagTreeRows({
+        event,
+        project,
+        tagKey: tag,
+        content: tagContent,
+        spacerCount: spacerCount + 1,
+        isLast: i === subtreeEntries.length - 1,
+        // Encoding the trunk index with the branch index ensures uniqueness for the key
+        uniqueKey: `${uniqueKey}-${i}`,
+      });
+      return rows.concat(branchRows);
+    },
+    []
+  );
   return [
     <EventTagsTreeRow
       key={`${tagKey}-${spacerCount}-${uniqueKey}`}

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -18,7 +18,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 const MAX_TREE_DEPTH = 4;
 const INVALID_BRANCH_REGEX = /\.{2,}/;
 
-type TagTree = Record<string, TagTreeContent>;
+type TagTree = Map<string, TagTreeContent>;
 
 export interface TagTreeContent {
   subtree: TagTree;
@@ -62,7 +62,12 @@ function addToTagTree({
 
   // Ignore tags with 0, or >4 branches, as well as sequential dots (e.g. 'some..tag')
   if (hasInvalidBranchCount || hasInvalidBranchSequence) {
-    tree[tag.key] = {value: tag.value, subtree: {}, meta: originalTag?.meta, originalTag};
+    tree.set(tag.key, {
+      value: tag.value,
+      subtree: new Map<string, TagTreeContent>(),
+      meta: originalTag?.meta,
+      originalTag,
+    });
     return tree;
   }
   // E.g. 'device.model.version'
@@ -70,16 +75,18 @@ function addToTagTree({
   const trunk = tag.key.slice(0, splitIndex); // 'device'
   const branch = tag.key.slice(splitIndex + 1); // 'model.version'
 
-  if (tree[trunk] === undefined) {
-    tree[trunk] = {value: '', subtree: {}};
+  let trunkNode = tree.get(trunk);
+  if (!trunkNode) {
+    trunkNode = {value: '', subtree: new Map<string, TagTreeContent>()};
+    tree.set(trunk, trunkNode);
   }
   // Recurse with a pseudo tag, e.g. 'model', to create nesting structure
   const pseudoTag = {
     key: branch,
     value: tag.value,
   };
-  tree[trunk].subtree = addToTagTree({
-    tree: tree[trunk].subtree,
+  trunkNode.subtree = addToTagTree({
+    tree: trunkNode.subtree,
     tag: pseudoTag,
     originalTag,
   });
@@ -100,13 +107,13 @@ function getTagTreeRows({
   project,
   isLast,
 }: EventTagsTreeRowProps & {uniqueKey: string}): React.ReactNode[] {
-  const subtreeTags = Object.keys(content.subtree);
+  const subtreeTags = Array.from(content.subtree.keys());
   const subtreeRows = subtreeTags.reduce<React.ReactNode[]>((rows, tag, i) => {
     const branchRows = getTagTreeRows({
       event,
       project,
       tagKey: tag,
-      content: content.subtree[tag]!,
+      content: content.subtree.get(tag)!,
       spacerCount: spacerCount + 1,
       isLast: i === subtreeTags.length - 1,
       // Encoding the trunk index with the branch index ensures uniqueness for the key
@@ -153,13 +160,13 @@ function TagTreeColumns({
       return [];
     }
     // Create the TagTree data structure using all the given tags
-    const tagTree = tags.reduce<TagTree>(
+    const tagTree = tags.reduce(
       (tree, tag) => addToTagTree({tree, tag, originalTag: tag}),
-      {}
+      new Map<string, TagTreeContent>()
     );
     // Create a list of TagTreeRow lists, containing every row to be rendered. They are grouped by
     // root parent so that we do not split up roots/branches when forming columns
-    const tagTreeRowGroups: React.ReactNode[][] = Object.entries(tagTree).map(
+    const tagTreeRowGroups: React.ReactNode[][] = Array.from(tagTree.entries()).map(
       ([tagKey, content], i) =>
         getTagTreeRows({tagKey, content, uniqueKey: `${i}`, project, event})
     );

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -18,7 +18,6 @@ import {IconEllipsis} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {DetailedProject} from 'sentry/types/project';
-import {isEmptyObject} from 'sentry/utils/object/isEmptyObject';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {escapeIssueTagKey, generateQueryWithTag} from 'sentry/utils/queryString';
 import {isValidUrl} from 'sentry/utils/string/isValidUrl';
@@ -68,7 +67,7 @@ export function EventTagsTreeRow({
   const originalTag = content.originalTag;
   const tagErrors = content.meta?.value?.['']?.err ?? [];
   const hasTagErrors = tagErrors.length > 0 && !config?.disableErrors;
-  const hasStem = !isLast && isEmptyObject(content.subtree);
+  const hasStem = !isLast && content.subtree.size === 0;
 
   if (!originalTag) {
     return (

--- a/static/app/components/events/highlights/util.tsx
+++ b/static/app/components/events/highlights/util.tsx
@@ -159,7 +159,7 @@ export function getHighlightTagData({
     return tm;
   }, {});
   return highlightTags.map(tagKey => ({
-    subtree: {},
+    subtree: new Map<string, TagTreeContent>(),
     meta: tagMap[tagKey]?.meta ?? {},
     value:
       tagMap[tagKey] && Object.hasOwn(tagMap[tagKey], 'value')


### PR DESCRIPTION
Event tag tree building used plain objects for arbitrary tag keys. Tags like `constructor.name` could walk through `Object.prototype` and blow up the tree render.

Use `Map` for the tag tree so tag names stay data, and add a regression test for the constructor root case.