### PR TITLE
feat(config-issues): Add beta badge to Sentry Configuration

### DIFF
--- a/static/app/views/issueList/taxonomies.tsx
+++ b/static/app/views/issueList/taxonomies.tsx
@@ -1,5 +1,7 @@
 import type {ReactNode} from 'react';
 
+import type {FeatureBadgeProps} from '@sentry/scraps/badge';
+
 import {t} from 'sentry/locale';
 import {IssueCategory} from 'sentry/types/group';
 
@@ -22,6 +24,7 @@ export const ISSUE_TAXONOMY_CONFIG: Record<
     description: ReactNode;
     key: string;
     label: string;
+    badge?: FeatureBadgeProps['type'];
     featureFlags?: string[];
   }
 > = {
@@ -58,6 +61,7 @@ export const ISSUE_TAXONOMY_CONFIG: Record<
     categories: [IssueCategory.CONFIGURATION],
     label: t('Sentry Configuration'),
     key: 'sentry-configuration',
+    badge: 'beta',
     description: t(
       'Issues detected from SDK or tooling configuration problems that degrade your ability to debug telemetry using Sentry.'
     ),

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Badge} from '@sentry/scraps/badge';
+import {Badge, FeatureBadge} from '@sentry/scraps/badge';
 import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -44,12 +44,13 @@ export function IssuesSecondaryNavigation() {
                   !featureFlags ||
                   featureFlags.some(feature => organization.features.includes(feature))
               )
-              .map(({key, label}) => (
+              .map(({key, label, badge}) => (
                 <SecondaryNavigation.ListItem key={key}>
                   <SecondaryNavigation.Link
                     to={`${baseUrl}/${key}/`}
                     end
                     analyticsItemName={`issues_types_${key}`}
+                    trailingItems={badge ? <FeatureBadge type={badge} /> : null}
                   >
                     {label}
                   </SecondaryNavigation.Link>


### PR DESCRIPTION
Add a beta badge to the Sentry Configuration taxonomy item in the Issues secondary navigation. The taxonomy config now carries an optional badge value so the secondary nav can render the existing feature badge alongside the label.

Closes TET-2439