### PR TITLE
fix(grouping): Match Dart bootstrap stub frames by trimmed function name

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2026-01-20.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/all-platforms@2026-01-20.txt
@@ -402,8 +402,8 @@ family:native stack.abs_path:dart:*/** -app
 family:native stack.abs_path:third_party/dart/sdk/** -app
 family:native package:**/Frameworks/FlutterMacOS.framework/** -app
 family:native package:**/Frameworks/Flutter.framework/** -app
-family:native function:"stub InvokeDartCode" -app
-family:native function:"stub CallBootstrapNative" -app
+family:native function:"InvokeDartCode" -app
+family:native function:"CallBootstrapNative" -app
 
 # sentry-dart SDK frames are not in app
 stack.abs_path:package:sentry/** -app -group

--- a/tests/sentry/grouping/test_enhancer_dart_flutter_native.py
+++ b/tests/sentry/grouping/test_enhancer_dart_flutter_native.py
@@ -253,14 +253,27 @@ class TestDartFlutterEnhancerNative(_BaseNativeDartFlutterEnhancerTest):
     def test_dart_bootstrap_stub_frames_not_in_app(self) -> None:
         """Dart VM bootstrap/invoke stub frames (no abs_path) are out-of-app.
 
-        Native frames carry `raw_function`, which makes the grouping matcher use
-        the untrimmed `function` value. Without it, `trim_native_function_name`
-        would strip the leading `stub ` token and the rule wouldn't match.
+        On real symbolicated native frames the `stub ` prefix is kept in
+        `raw_function`/`symbol` while `function` already holds the trimmed name
+        (e.g. `InvokeDartCode`). Because `raw_function` is set, the grouping
+        matcher uses `function` unchanged, so the rule must match the trimmed
+        name rather than the `stub ...` form.
         """
-        for stub_function in ("stub InvokeDartCode", "stub CallBootstrapNative"):
-            frame = {"function": stub_function, "raw_function": stub_function}
+        for function, raw_function in (
+            ("InvokeDartCode", "stub InvokeDartCode"),
+            ("CallBootstrapNative", "stub CallBootstrapNative"),
+        ):
+            frame = {
+                "function": function,
+                "raw_function": raw_function,
+                "symbol": raw_function,
+                "package": (
+                    "/data/app/~~HnUUEj6l01Oer6sOVEGsCQ==/"
+                    "io.sentry.flutter.sample-iQnuDrBoh7jPXpeiiy-THw==/lib/arm64/libapp.so"
+                ),
+            }
             result = self.apply_rules(frame)
-            assert result["in_app"] is False, f"{stub_function} should be out-of-app"
+            assert result["in_app"] is False, f"{function} should be out-of-app"
 
     def test_user_dart_frames_stay_in_app(self) -> None:
         """User application Dart frames must remain in-app (regression guard).


### PR DESCRIPTION
Dart VM bootstrap frames (`InvokeDartCode`, `CallBootstrapNative`) are now reliably marked out-of-app on the native platform.

On real symbolicated native frames the symbolicator keeps the `stub ` prefix in `raw_function`/`symbol` while `function` already holds the trimmed name (e.g. `InvokeDartCode`). Since `raw_function` is set, the grouping matcher uses `function` unchanged, so the previous `function:"stub ..."` rules never matched a production frame.

**Rule change**

The two rules now match the trimmed `function` value:

```
- family:native function:"stub InvokeDartCode" -app
- family:native function:"stub CallBootstrapNative" -app
+ family:native function:"InvokeDartCode" -app
+ family:native function:"CallBootstrapNative" -app
```

This is also robust when `raw_function` is absent: `trim_native_function_name("stub InvokeDartCode")` collapses to `InvokeDartCode`, so the rule still fires.

The regression test was updated to use the real frame shape (trimmed `function` plus `stub ...` in `raw_function`/`symbol`) instead of the previous artificial frame that put `stub ...` directly in `function`.

Made with [Cursor](https://cursor.com)