### PR TITLE
fix(configuration-issues): Show event header in details

### DIFF
--- a/static/app/views/issueDetails/eventDetails.tsx
+++ b/static/app/views/issueDetails/eventDetails.tsx
@@ -6,7 +6,6 @@ import {Sticky} from 'sentry/components/sticky';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
-import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {useIssueDetails} from 'sentry/views/issueDetails/context';
 import {EventMissingBanner} from 'sentry/views/issueDetails/eventMissingBanner';
 import {EventTitle} from 'sentry/views/issueDetails/eventTitle';
@@ -27,14 +26,10 @@ export function EventDetails({group, event, project}: EventDetailsContentProps) 
     );
   }
 
-  const issueTypeConfig = getConfigForIssueType(group, project);
-
   return (
     <PageErrorBoundary mini message={t('There was an error loading the event content')}>
       <GroupContent role="main">
-        {issueTypeConfig.header.eventNavigation.enabled && (
-          <StickyEventNav event={event} group={group} />
-        )}
+        <StickyEventNav event={event} group={group} />
         <ContentPadding>
           <EventDetailsContent group={group} event={event} project={project} />
         </ContentPadding>


### PR DESCRIPTION
Show the shared event metadata header on configuration issue detail pages.

Configuration issue details now render the same event ID, timestamp, and JSON link header as other event detail surfaces. The issue-specific navigation actions remain disabled by the issue type config, so this only restores the metadata header needed by the refreshed configuration issue designs.

Closes TET-2460