### PR TITLE
feat(pr-metrics): Scaffold delegated-agent PR detection from GitHub webhooks

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2950,19 +2950,6 @@ SENTRY_GITHUB_APP_USER_ID = 39604003
 
 SEER_AUTOFIX_FORCE_USE_REPOS: list[dict] = []
 
-# PR Merge Live Metrics: signals used to flag a freshly-opened PR as a possible
-# delegated coding-agent PR (created by a Seer Autofix session that handed off to
-# Claude Code or GitHub Copilot). Keyed by provider hint.
-PR_METRICS_DELEGATED_AGENT_BRANCH_PREFIXES: dict[str, str] = {
-    "claude_code": "claude/",
-    "github_copilot": "copilot/",
-}
-# GitHub bot login -> provider hint. Copilot opens PRs as a distinct bot user, so
-# the author login is a reliable signal; other providers rely on the branch prefix.
-PR_METRICS_DELEGATED_AGENT_AUTHOR_LOGINS: dict[str, str] = {
-    "copilot-swe-agent[bot]": "github_copilot",
-}
-
 # For encrypting the access token for the GHE integration
 SEER_GHE_ENCRYPT_KEY: str | None = os.getenv("SEER_GHE_ENCRYPT_KEY")
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2950,6 +2950,19 @@ SENTRY_GITHUB_APP_USER_ID = 39604003
 
 SEER_AUTOFIX_FORCE_USE_REPOS: list[dict] = []
 
+# PR Merge Live Metrics: signals used to flag a freshly-opened PR as a possible
+# delegated coding-agent PR (created by a Seer Autofix session that handed off to
+# Claude Code or GitHub Copilot). Keyed by provider hint.
+PR_METRICS_DELEGATED_AGENT_BRANCH_PREFIXES: dict[str, str] = {
+    "claude_code": "claude/",
+    "github_copilot": "copilot/",
+}
+# GitHub bot login -> provider hint. Copilot opens PRs as a distinct bot user, so
+# the author login is a reliable signal; other providers rely on the branch prefix.
+PR_METRICS_DELEGATED_AGENT_AUTHOR_LOGINS: dict[str, str] = {
+    "copilot-swe-agent[bot]": "github_copilot",
+}
+
 # For encrypting the access token for the GHE integration
 SEER_GHE_ENCRYPT_KEY: str | None = os.getenv("SEER_GHE_ENCRYPT_KEY")
 

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -25,6 +25,7 @@ from sentry.models.pullrequest import (
     PullRequestVerdict,
 )
 from sentry.pr_metrics.attribution import SIGNAL_TYPE_CONFIDENCE
+from sentry.pr_metrics.utils import resolved_group_ids
 from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
@@ -127,20 +128,6 @@ def _active_attributions(pull_request: PullRequest) -> list[dict[str, Any]]:
     ]
 
 
-def _resolved_group_ids(pull_request: PullRequest) -> list[int]:
-    """Group IDs this PR resolves, from the resolving GroupLink rows.
-
-    Sorted for a deterministic row; empty when the PR resolves no issues.
-    """
-    return sorted(
-        GroupLink.objects.filter(
-            linked_type=GroupLink.LinkedType.pull_request,
-            relationship=GroupLink.Relationship.resolves,
-            linked_id=pull_request.id,
-        ).values_list("group_id", flat=True)
-    )
-
-
 def _merge_commit_id(pull_request: PullRequest) -> int | None:
     """The Sentry Commit row id for the PR's merge commit, if Sentry tracks it.
 
@@ -158,6 +145,7 @@ def _merge_commit_id(pull_request: PullRequest) -> int | None:
         .values_list("id", flat=True)
         .first()
     )
+
 
 
 def build_pr_metrics_row(
@@ -241,7 +229,7 @@ def emit_pr_metrics_row(
         pull_request=pull_request,
         close_action=close_action,
         attributions=attributions,
-        group_ids=_resolved_group_ids(pull_request),
+        group_ids=resolved_group_ids(pull_request),
     )
     analytics.record(row)
     metrics.incr("pr_metrics.emit.recorded", tags={"close_action": close_action})

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -14,7 +14,6 @@ from typing import Any, Final, Literal
 from sentry import analytics, features
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
 from sentry.models.commit import Commit
-from sentry.models.grouplink import GroupLink
 from sentry.models.organization import Organization
 from sentry.models.pullrequest import (
     PullRequest,

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -147,7 +147,6 @@ def _merge_commit_id(pull_request: PullRequest) -> int | None:
     )
 
 
-
 def build_pr_metrics_row(
     *,
     pull_request: PullRequest,

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -1,0 +1,20 @@
+"""Shared utilities for the PR Merge Live Metrics pipeline."""
+
+from __future__ import annotations
+
+from sentry.models.grouplink import GroupLink
+from sentry.models.pullrequest import PullRequest
+
+
+def resolved_group_ids(pull_request: PullRequest) -> list[int]:
+    """Group IDs this PR resolves, from the resolving GroupLink rows.
+
+    Sorted for a deterministic ordering; empty when the PR resolves no issues.
+    """
+    return sorted(
+        GroupLink.objects.filter(
+            linked_type=GroupLink.LinkedType.pull_request,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id=pull_request.id,
+        ).values_list("group_id", flat=True)
+    )

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -5,6 +5,19 @@ from __future__ import annotations
 from sentry.models.grouplink import GroupLink
 from sentry.models.pullrequest import PullRequest
 
+# Branch-prefix → provider hint. Claude-delegated PRs are opened by the Sentry
+# GitHub app (no distinct author), so the branch prefix is the only usable signal.
+DELEGATED_AGENT_BRANCH_PREFIXES: dict[str, str] = {
+    "claude_code": "claude/",
+    "github_copilot": "copilot/",
+}
+
+# GitHub bot login → provider hint. Copilot opens PRs as a distinct bot user;
+# other providers rely on the branch prefix above.
+DELEGATED_AGENT_AUTHOR_LOGINS: dict[str, str] = {
+    "copilot-swe-agent[bot]": "github_copilot",
+}
+
 
 def resolved_group_ids(pull_request: PullRequest) -> list[int]:
     """Group IDs this PR resolves, from the resolving GroupLink rows.

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -65,6 +65,7 @@ from sentry.pr_metrics.emit import (
     is_pr_tracked,
     select_verdict,
 )
+from sentry.seer.seer_setup import has_seer_access
 from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.webhooks")
@@ -138,6 +139,15 @@ def handle_attribution(
     _write_author_attribution(pr, github_user)
     if features.has("organizations:mcp-issue-view-attribution", organization):
         _write_mcp_attribution(pr)
+    if pull_request is not None and has_seer_access(organization):
+        provider_hint = _is_delegated_agent_candidate(pull_request, github_user)
+        if provider_hint is not None:
+            # TODO: Fire-and-forget request to Seer when the match endpoint exists.
+            metrics.incr(
+                "pr_metrics.delegated_agent.seer_match.not_implemented",
+                tags={"provider_hint": provider_hint},
+                sample_rate=1.0,
+            )
 
 
 def _claim_terminal_event(pr: PullRequest, verdict: PullRequestVerdict) -> bool:
@@ -523,6 +533,27 @@ def _metrics_counters(pull_request: Mapping[str, Any]) -> dict[str, Any]:
         "review_comments_count": pull_request.get("review_comments") or 0,
         "is_assigned": bool(pull_request.get("assignees") or pull_request.get("assignee")),
     }
+
+
+def _is_delegated_agent_candidate(
+    pull_request: Mapping[str, Any], github_user: Mapping[str, Any]
+) -> str | None:
+    """Return a provider hint if a PR looks like a delegated coding-agent PR, else None.
+
+    Two payload-native signals are used. The head branch prefix is primary because
+    Claude-delegated PRs are opened by the Sentry GitHub app (no distinct author to
+    key on), so the ``claude/`` prefix is the only usable signal. The author login
+    covers Copilot, which opens PRs as a distinct bot user. The branch prefix wins
+    when both match. This is a cheap heuristic; the authoritative match happens in
+    Seer downstream.
+    """
+    head_ref = (pull_request.get("head") or {}).get("ref") or ""
+    for provider, prefix in settings.PR_METRICS_DELEGATED_AGENT_BRANCH_PREFIXES.items():
+        if prefix and head_ref.startswith(prefix):
+            return provider
+
+    login = github_user.get("login") or ""
+    return settings.PR_METRICS_DELEGATED_AGENT_AUTHOR_LOGINS.get(login)
 
 
 def _detect_app_signal(github_user_id: int) -> PullRequestAttributionSignalType | None:

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -65,7 +65,11 @@ from sentry.pr_metrics.emit import (
     is_pr_tracked,
     select_verdict,
 )
-from sentry.pr_metrics.utils import resolved_group_ids
+from sentry.pr_metrics.utils import (
+    DELEGATED_AGENT_AUTHOR_LOGINS,
+    DELEGATED_AGENT_BRANCH_PREFIXES,
+    resolved_group_ids,
+)
 from sentry.seer.seer_setup import has_seer_access
 from sentry.utils import metrics
 
@@ -550,12 +554,12 @@ def _is_delegated_agent_candidate(
     Seer downstream.
     """
     head_ref = (pull_request.get("head") or {}).get("ref") or ""
-    for provider, prefix in settings.PR_METRICS_DELEGATED_AGENT_BRANCH_PREFIXES.items():
+    for provider, prefix in DELEGATED_AGENT_BRANCH_PREFIXES.items():
         if prefix and head_ref.startswith(prefix):
             return provider
 
     login = github_user.get("login") or ""
-    return settings.PR_METRICS_DELEGATED_AGENT_AUTHOR_LOGINS.get(login)
+    return DELEGATED_AGENT_AUTHOR_LOGINS.get(login)
 
 
 def _detect_app_signal(github_user_id: int) -> PullRequestAttributionSignalType | None:

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -65,6 +65,7 @@ from sentry.pr_metrics.emit import (
     is_pr_tracked,
     select_verdict,
 )
+from sentry.pr_metrics.utils import resolved_group_ids
 from sentry.seer.seer_setup import has_seer_access
 from sentry.utils import metrics
 
@@ -139,15 +140,16 @@ def handle_attribution(
     _write_author_attribution(pr, github_user)
     if features.has("organizations:mcp-issue-view-attribution", organization):
         _write_mcp_attribution(pr)
-    if pull_request is not None and has_seer_access(organization):
+    if has_seer_access(organization):
         provider_hint = _is_delegated_agent_candidate(pull_request, github_user)
         if provider_hint is not None:
-            # TODO: Fire-and-forget request to Seer when the match endpoint exists.
-            metrics.incr(
-                "pr_metrics.delegated_agent.seer_match.not_implemented",
-                tags={"provider_hint": provider_hint},
-                sample_rate=1.0,
-            )
+            if resolved_group_ids(pr):
+                # TODO: Fire-and-forget request to Seer when the match endpoint exists.
+                metrics.incr(
+                    "pr_metrics.delegated_agent.seer_match.not_implemented",
+                    tags={"provider_hint": provider_hint},
+                    sample_rate=1.0,
+                )
 
 
 def _claim_terminal_event(pr: PullRequest, verdict: PullRequestVerdict) -> bool:

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -140,7 +140,7 @@ def handle_attribution(
     _write_author_attribution(pr, github_user)
     if features.has("organizations:mcp-issue-view-attribution", organization):
         _write_mcp_attribution(pr)
-    if has_seer_access(organization):
+    if pull_request is not None and has_seer_access(organization):
         provider_hint = _is_delegated_agent_candidate(pull_request, github_user)
         if provider_hint is not None:
             if resolved_group_ids(pr):

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -20,6 +20,7 @@ from collections.abc import Mapping
 from dataclasses import asdict
 from typing import Any
 
+import sentry_sdk
 from django.conf import settings
 from django.core.cache import cache
 from django.db import IntegrityError, router, transaction
@@ -75,10 +76,6 @@ from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.webhooks")
 
-# Actions that set attribution for who authored the PR. The PR author is fixed
-# at creation time and never changes, so app attribution is a one-shot write.
-_AUTHOR_ATTRIBUTION_ACTIONS = frozenset({"opened"})
-
 _ACTIVITY_ACTIONS = frozenset(
     {
         "opened",
@@ -131,9 +128,6 @@ def handle_attribution(
     if not (action and github_user):
         return
 
-    if action not in _AUTHOR_ATTRIBUTION_ACTIONS:
-        return
-
     if not features.has("organizations:pr-metrics-attribution", organization):
         return
 
@@ -141,19 +135,12 @@ def handle_attribution(
     if pr is None:
         return
 
-    _write_author_attribution(pr, github_user)
+    if action == "opened":
+        _write_author_attribution(pr, github_user)
     if features.has("organizations:mcp-issue-view-attribution", organization):
         _write_mcp_attribution(pr)
-    if pull_request is not None and has_seer_access(organization):
-        provider_hint = _is_delegated_agent_candidate(pull_request, github_user)
-        if provider_hint is not None:
-            if resolved_group_ids(pr):
-                # TODO: Fire-and-forget request to Seer when the match endpoint exists.
-                metrics.incr(
-                    "pr_metrics.delegated_agent.seer_match.not_implemented",
-                    tags={"provider_hint": provider_hint},
-                    sample_rate=1.0,
-                )
+    if action == "opened" and pull_request is not None and has_seer_access(organization):
+        _detect_delegated_agent(pr, pull_request)
 
 
 def _claim_terminal_event(pr: PullRequest, verdict: PullRequestVerdict) -> bool:
@@ -541,9 +528,7 @@ def _metrics_counters(pull_request: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
-def _is_delegated_agent_candidate(
-    pull_request: Mapping[str, Any], github_user: Mapping[str, Any]
-) -> str | None:
+def _is_delegated_agent_candidate(webhook_pull_request: Mapping[str, Any]) -> str | None:
     """Return a provider hint if a PR looks like a delegated coding-agent PR, else None.
 
     Two payload-native signals are used. The head branch prefix is primary because
@@ -553,13 +538,13 @@ def _is_delegated_agent_candidate(
     when both match. This is a cheap heuristic; the authoritative match happens in
     Seer downstream.
     """
-    head_ref = (pull_request.get("head") or {}).get("ref") or ""
+    head_ref = (webhook_pull_request.get("head") or {}).get("ref") or ""
     for provider, prefix in DELEGATED_AGENT_BRANCH_PREFIXES.items():
         if prefix and head_ref.startswith(prefix):
             return provider
 
-    login = github_user.get("login") or ""
-    return DELEGATED_AGENT_AUTHOR_LOGINS.get(login)
+    github_login = (webhook_pull_request or {}).get("user", {}).get("login") or ""
+    return DELEGATED_AGENT_AUTHOR_LOGINS.get(github_login)
 
 
 def _detect_app_signal(github_user_id: int) -> PullRequestAttributionSignalType | None:
@@ -582,6 +567,26 @@ def _write_author_attribution(pr: PullRequest, github_user: dict[str, Any]) -> N
         signal_type=signal_type,
         source=PullRequestAttributionSource.WEBHOOK_DATA,
     )
+
+
+def _detect_delegated_agent(pr: PullRequest, webhook_pull_request: Mapping[str, Any]) -> None:
+    """
+    Filter PRs that could have been delegated by Autofix to external coding agents,
+    and fire the matching request to Seer if it's a candidate.
+
+    Then Seer calls the RPC "record_pr_attribution" to write the attribution row async.
+    """
+    provider_hint = _is_delegated_agent_candidate(webhook_pull_request)
+    # Our candidates are PRs from delegated agents
+    # That explicitly address a Sentry issue
+    if provider_hint is not None and resolved_group_ids(pr):
+        # TODO: Fire-and-forget request to Seer when the match endpoint exists.
+        # We will send: provider_hint, github_login, head_ref
+        sentry_sdk.metrics.count(
+            "pr_metrics.delegated_agent.seer_match.not_implemented",
+            1,
+            attributes={"provider_hint": provider_hint},
+        )
 
 
 def _write_mcp_attribution(pr: PullRequest) -> None:

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -903,24 +903,23 @@ def deliver_feature_result(
     handler(organization_id, run_uuid, status, result, error)
 
 
-def record_delegated_pr_attribution(
+def record_pr_attribution(
     *,
     organization_id: int,
     pull_request_id: int,
     signal_type: str,
-    agent_id: str | None = None,
+    signal_details: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Record Seer's verdict on a delegated-agent PR candidate.
+    """Record a PR attribution signal on behalf of Seer.
 
-    Called by Seer after confirming that a PR was opened by a delegated coding
-    agent (Claude Code, GitHub Copilot, Cursor). Idempotent via the unique
-    constraint on PullRequestAttribution(pull_request, signal_type, source).
+    Idempotent via the unique constraint on
+    PullRequestAttribution(pull_request, signal_type, source).
 
     Args:
         organization_id: Sentry organization that owns the PR.
-        pull_request_id: Sentry-internal PullRequest.id passed to Seer at handoff.
-        signal_type: A PullRequestAttributionSignalType value (e.g. "seer_delegated_claude_code").
-        agent_id: Provider-specific agent identifier, if known.
+        pull_request_id: Sentry-internal PullRequest.id.
+        signal_type: A PullRequestAttributionSignalType value.
+        signal_details: Arbitrary provider-specific metadata to store on the row.
 
     Returns:
         {"attribution_id": int} on success, or {"attribution_id": None} when the
@@ -940,7 +939,7 @@ def record_delegated_pr_attribution(
 
     if not features.has("organizations:pr-metrics-attribution", organization):
         logger.info(
-            "seer.record_delegated_pr_attribution.feature_disabled",
+            "seer.record_pr_attribution.feature_disabled",
             extra={"organization_id": organization_id, "pull_request_id": pull_request_id},
         )
         return {"attribution_id": None}
@@ -959,10 +958,10 @@ def record_delegated_pr_attribution(
         pull_request=pull_request,
         signal_type=signal,
         source=PullRequestAttributionSource.SEER_DATA,
-        signal_details={"agent_id": agent_id} if agent_id else None,
+        signal_details=signal_details,
     )
     logger.info(
-        "seer.record_delegated_pr_attribution.recorded",
+        "seer.record_pr_attribution.recorded",
         extra={
             "organization_id": organization_id,
             "pull_request_id": pull_request_id,
@@ -1030,7 +1029,7 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     "call_custom_tool": call_custom_tool,
     "call_on_completion_hook": call_on_completion_hook,
     "deliver_feature_result": deliver_feature_result,
-    "record_delegated_pr_attribution": record_delegated_pr_attribution,
+    "record_pr_attribution": record_pr_attribution,
     "get_log_attributes_for_trace": get_log_attributes_for_trace,
     "get_metric_attributes_for_trace": get_metric_attributes_for_trace,
     "get_baseline_tag_distribution": get_baseline_tag_distribution,

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -52,7 +52,13 @@ from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
+from sentry.models.pullrequest import (
+    PullRequest,
+    PullRequestAttributionSignalType,
+    PullRequestAttributionSource,
+)
 from sentry.models.repository import Repository
+from sentry.pr_metrics.attribution import record_attribution_signal
 from sentry.pr_metrics.judge import update_pr_metrics
 from sentry.replays.usecases.summarize import rpc_get_replay_summary_logs
 from sentry.search.eap.resolver import SearchResolver
@@ -897,6 +903,76 @@ def deliver_feature_result(
     handler(organization_id, run_uuid, status, result, error)
 
 
+def record_delegated_pr_attribution(
+    *,
+    organization_id: int,
+    pull_request_id: int,
+    signal_type: str,
+    agent_id: str | None = None,
+) -> dict[str, Any]:
+    """Record Seer's verdict on a delegated-agent PR candidate.
+
+    Called by Seer after confirming that a PR was opened by a delegated coding
+    agent (Claude Code, GitHub Copilot, Cursor). Idempotent via the unique
+    constraint on PullRequestAttribution(pull_request, signal_type, source).
+
+    Args:
+        organization_id: Sentry organization that owns the PR.
+        pull_request_id: Sentry-internal PullRequest.id passed to Seer at handoff.
+        signal_type: A PullRequestAttributionSignalType value (e.g. "seer_delegated_claude_code").
+        agent_id: Provider-specific agent identifier, if known.
+
+    Returns:
+        {"attribution_id": int} on success, or {"attribution_id": None} when the
+        pr-metrics-attribution feature is disabled for the org.
+    """
+    try:
+        signal = PullRequestAttributionSignalType(signal_type)
+    except ValueError:
+        raise ParseError(detail=f"Unknown signal_type: {signal_type!r}")
+
+    try:
+        organization = Organization.objects.get(
+            id=organization_id, status=OrganizationStatus.ACTIVE
+        )
+    except Organization.DoesNotExist:
+        raise ObjectDoesNotExist(f"Organization {organization_id} not found or inactive")
+
+    if not features.has("organizations:pr-metrics-attribution", organization):
+        logger.info(
+            "seer.record_delegated_pr_attribution.feature_disabled",
+            extra={"organization_id": organization_id, "pull_request_id": pull_request_id},
+        )
+        return {"attribution_id": None}
+
+    try:
+        pull_request = PullRequest.objects.get(
+            id=pull_request_id,
+            organization_id=organization_id,
+        )
+    except PullRequest.DoesNotExist:
+        raise ObjectDoesNotExist(
+            f"PullRequest {pull_request_id} not found in org {organization_id}"
+        )
+
+    attribution = record_attribution_signal(
+        pull_request=pull_request,
+        signal_type=signal,
+        source=PullRequestAttributionSource.SEER_DATA,
+        signal_details={"agent_id": agent_id} if agent_id else None,
+    )
+    logger.info(
+        "seer.record_delegated_pr_attribution.recorded",
+        extra={
+            "organization_id": organization_id,
+            "pull_request_id": pull_request_id,
+            "signal_type": signal_type,
+            "attribution_id": attribution.id,
+        },
+    )
+    return {"attribution_id": attribution.id}
+
+
 seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     # Common to Seer features
     "get_github_enterprise_integration_config": get_github_enterprise_integration_config,
@@ -954,6 +1030,7 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     "call_custom_tool": call_custom_tool,
     "call_on_completion_hook": call_on_completion_hook,
     "deliver_feature_result": deliver_feature_result,
+    "record_delegated_pr_attribution": record_delegated_pr_attribution,
     "get_log_attributes_for_trace": get_log_attributes_for_trace,
     "get_metric_attributes_for_trace": get_metric_attributes_for_trace,
     "get_baseline_tag_distribution": get_baseline_tag_distribution,

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -17,12 +17,12 @@ from sentry.models.pullrequest import (
 )
 from sentry.pr_metrics.emit import (
     _active_attributions,
-    _resolved_group_ids,
     build_pr_metrics_row,
     emit_pr_metrics_row,
     is_pr_tracked,
     select_verdict,
 )
+from sentry.pr_metrics.utils import resolved_group_ids
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
@@ -343,17 +343,17 @@ class PrMetricsEmissionTest(TestCase):
             },
         ]
 
-    def test_resolved_group_ids_returns_sorted_resolving_links(self) -> None:
+    def testresolved_group_ids_returns_sorted_resolving_links(self) -> None:
         ids = sorted([self._link_group(), self._link_group()])
-        assert _resolved_group_ids(self.pull_request) == ids
+        assert resolved_group_ids(self.pull_request) == ids
 
-    def test_resolved_group_ids_excludes_non_resolving_links(self) -> None:
+    def testresolved_group_ids_excludes_non_resolving_links(self) -> None:
         # Only resolving links count; a "references" link is not a resolution.
         self._link_group(relationship=GroupLink.Relationship.references)
-        assert _resolved_group_ids(self.pull_request) == []
+        assert resolved_group_ids(self.pull_request) == []
 
-    def test_resolved_group_ids_empty_when_pr_resolves_nothing(self) -> None:
-        assert _resolved_group_ids(self.pull_request) == []
+    def testresolved_group_ids_empty_when_pr_resolves_nothing(self) -> None:
+        assert resolved_group_ids(self.pull_request) == []
 
     def test_build_row_carries_group_ids(self) -> None:
         row = build_pr_metrics_row(
@@ -365,7 +365,7 @@ class PrMetricsEmissionTest(TestCase):
         assert row.group_ids == [7, 9]
 
     @patch("sentry.analytics.record")
-    def test_emit_carries_resolved_group_ids(self, mock_record: Any) -> None:
+    def test_emit_carriesresolved_group_ids(self, mock_record: Any) -> None:
         self._track()
         group_ids = sorted([self._link_group(), self._link_group()])
         emit_pr_metrics_row(pull_request=self.pull_request)

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -343,16 +343,16 @@ class PrMetricsEmissionTest(TestCase):
             },
         ]
 
-    def testresolved_group_ids_returns_sorted_resolving_links(self) -> None:
+    def test_resolved_group_ids_returns_sorted_resolving_links(self) -> None:
         ids = sorted([self._link_group(), self._link_group()])
         assert resolved_group_ids(self.pull_request) == ids
 
-    def testresolved_group_ids_excludes_non_resolving_links(self) -> None:
+    def test_resolved_group_ids_excludes_non_resolving_links(self) -> None:
         # Only resolving links count; a "references" link is not a resolution.
         self._link_group(relationship=GroupLink.Relationship.references)
         assert resolved_group_ids(self.pull_request) == []
 
-    def testresolved_group_ids_empty_when_pr_resolves_nothing(self) -> None:
+    def test_resolved_group_ids_empty_when_pr_resolves_nothing(self) -> None:
         assert resolved_group_ids(self.pull_request) == []
 
     def test_build_row_carries_group_ids(self) -> None:
@@ -365,7 +365,7 @@ class PrMetricsEmissionTest(TestCase):
         assert row.group_ids == [7, 9]
 
     @patch("sentry.analytics.record")
-    def test_emit_carriesresolved_group_ids(self, mock_record: Any) -> None:
+    def test_emit_carries_resolved_group_ids(self, mock_record: Any) -> None:
         self._track()
         group_ids = sorted([self._link_group(), self._link_group()])
         emit_pr_metrics_row(pull_request=self.pull_request)

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -1271,3 +1271,121 @@ class HandleReviewThreadForPrMetricsTest(TestCase):
             extra={"repository_id": self.repo.id, "pr_number": 9999},
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+
+@with_feature(["organizations:pr-metrics-attribution", "organizations:gen-ai-features"])
+@cell_silo_test
+class HandleDelegatedAgentDetectionTest(TestCase):
+    def setUp(self) -> None:
+        self.project = self.create_project(organization=self.organization)
+        self.repo = self.create_repo(self.project, provider="integrations:github", external_id="99")
+        self.pr = self.create_pull_request(
+            repository_id=self.repo.id,
+            organization_id=self.organization.id,
+            key="42",
+        )
+
+    def _call(
+        self,
+        *,
+        action: str = "opened",
+        login: str = "a-human",
+        user_id: int = 999,
+        head_ref: str = "feature/x",
+        head_sha: str = "headsha123",
+        number: int = 42,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "number": number,
+            "user": {"id": user_id, "login": login},
+            "head": {"ref": head_ref, "sha": head_sha},
+        }
+        handle_attribution(
+            github_event=GithubWebhookType.PULL_REQUEST,
+            event={"action": action, "pull_request": payload},
+            organization=self.organization,
+            repo=self.repo,
+        )
+
+    def _mock_incr(self) -> Any:
+        return patch(f"{MODULE}.metrics.incr")
+
+    # --- Candidate detection fires the signal ---
+
+    def test_claude_branch_prefix_detects_candidate(self) -> None:
+        with self._mock_incr() as mock_incr:
+            self._call(head_ref="claude/fix-the-bug")
+
+        mock_incr.assert_called_once_with(
+            "pr_metrics.delegated_agent.seer_match.not_implemented",
+            tags={"provider_hint": "claude_code"},
+            sample_rate=1.0,
+        )
+
+    def test_copilot_branch_prefix_detects_candidate(self) -> None:
+        with self._mock_incr() as mock_incr:
+            self._call(head_ref="copilot/fix-the-bug")
+
+        assert mock_incr.call_count == 1
+        assert mock_incr.call_args.kwargs["tags"]["provider_hint"] == "github_copilot"
+
+    def test_copilot_author_login_detects_candidate(self) -> None:
+        # Copilot opens PRs from a non-prefixed branch but as a distinct bot user.
+        with self._mock_incr() as mock_incr:
+            self._call(login="copilot-swe-agent[bot]", head_ref="some-branch")
+
+        assert mock_incr.call_count == 1
+        assert mock_incr.call_args.kwargs["tags"]["provider_hint"] == "github_copilot"
+
+    def test_branch_prefix_takes_precedence_over_author(self) -> None:
+        with self._mock_incr() as mock_incr:
+            self._call(login="copilot-swe-agent[bot]", head_ref="claude/fix")
+
+        assert mock_incr.call_count == 1
+        assert mock_incr.call_args.kwargs["tags"]["provider_hint"] == "claude_code"
+
+    # --- Non-candidates do not fire ---
+
+    def test_non_candidate_branch_and_author_does_not_detect(self) -> None:
+        with self._mock_incr() as mock_incr:
+            self._call(login="a-human", head_ref="feature/x")
+
+        mock_incr.assert_not_called()
+
+    def test_non_opened_action_does_not_detect(self) -> None:
+        for action in ("synchronize", "closed", "reopened", "edited", "labeled"):
+            with self._mock_incr() as mock_incr:
+                self._call(action=action, head_ref="claude/fix")
+
+            mock_incr.assert_not_called()
+
+    # --- Gating ---
+
+    def test_attribution_flag_off_does_not_detect(self) -> None:
+        with self._mock_incr() as mock_incr:
+            with self.feature({"organizations:pr-metrics-attribution": False}):
+                self._call(head_ref="claude/fix")
+
+        mock_incr.assert_not_called()
+
+    def test_no_seer_access_via_flag_does_not_detect(self) -> None:
+        with self._mock_incr() as mock_incr:
+            with self.feature({"organizations:gen-ai-features": False}):
+                self._call(head_ref="claude/fix")
+
+        mock_incr.assert_not_called()
+
+    def test_no_seer_access_via_hidden_ai_features_does_not_detect(self) -> None:
+        self.organization.update_option("sentry:hide_ai_features", True)
+
+        with self._mock_incr() as mock_incr:
+            self._call(head_ref="claude/fix")
+
+        mock_incr.assert_not_called()
+
+    def test_missing_pr_does_not_detect(self) -> None:
+        # Candidate gate passes, but no PullRequest row exists for this number.
+        with self._mock_incr() as mock_incr:
+            self._call(head_ref="claude/fix", number=9999)
+
+        mock_incr.assert_not_called()

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -1284,6 +1284,14 @@ class HandleDelegatedAgentDetectionTest(TestCase):
             organization_id=self.organization.id,
             key="42",
         )
+        self.group = self.create_group(project=self.project)
+        GroupLink.objects.create(
+            group=self.group,
+            project=self.project,
+            linked_type=GroupLink.LinkedType.pull_request,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id=self.pr.id,
+        )
 
     def _call(
         self,
@@ -1356,8 +1364,7 @@ class HandleDelegatedAgentDetectionTest(TestCase):
         for action in ("synchronize", "closed", "reopened", "edited", "labeled"):
             with self._mock_incr() as mock_incr:
                 self._call(action=action, head_ref="claude/fix")
-
-            mock_incr.assert_not_called()
+                mock_incr.assert_not_called()
 
     # --- Gating ---
 
@@ -1387,5 +1394,16 @@ class HandleDelegatedAgentDetectionTest(TestCase):
         # Candidate gate passes, but no PullRequest row exists for this number.
         with self._mock_incr() as mock_incr:
             self._call(head_ref="claude/fix", number=9999)
+
+        mock_incr.assert_not_called()
+
+    def test_no_linked_groups_does_not_detect(self) -> None:
+        GroupLink.objects.filter(
+            linked_type=GroupLink.LinkedType.pull_request,
+            linked_id=self.pr.id,
+        ).delete()
+
+        with self._mock_incr() as mock_incr:
+            self._call(head_ref="claude/fix")
 
         mock_incr.assert_not_called()

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -1315,87 +1315,87 @@ class HandleDelegatedAgentDetectionTest(TestCase):
             repo=self.repo,
         )
 
-    def _mock_incr(self) -> Any:
-        return patch(f"{MODULE}.metrics.incr")
+    def _mock_count(self) -> Any:
+        return patch("sentry_sdk.metrics.count")
 
     # --- Candidate detection fires the signal ---
 
     def test_claude_branch_prefix_detects_candidate(self) -> None:
-        with self._mock_incr() as mock_incr:
+        with self._mock_count() as mock_count:
             self._call(head_ref="claude/fix-the-bug")
 
-        mock_incr.assert_called_once_with(
+        mock_count.assert_called_once_with(
             "pr_metrics.delegated_agent.seer_match.not_implemented",
-            tags={"provider_hint": "claude_code"},
-            sample_rate=1.0,
+            1,
+            attributes={"provider_hint": "claude_code"},
         )
 
     def test_copilot_branch_prefix_detects_candidate(self) -> None:
-        with self._mock_incr() as mock_incr:
+        with self._mock_count() as mock_count:
             self._call(head_ref="copilot/fix-the-bug")
 
-        assert mock_incr.call_count == 1
-        assert mock_incr.call_args.kwargs["tags"]["provider_hint"] == "github_copilot"
+        assert mock_count.call_count == 1
+        assert mock_count.call_args.kwargs["attributes"]["provider_hint"] == "github_copilot"
 
     def test_copilot_author_login_detects_candidate(self) -> None:
         # Copilot opens PRs from a non-prefixed branch but as a distinct bot user.
-        with self._mock_incr() as mock_incr:
+        with self._mock_count() as mock_count:
             self._call(login="copilot-swe-agent[bot]", head_ref="some-branch")
 
-        assert mock_incr.call_count == 1
-        assert mock_incr.call_args.kwargs["tags"]["provider_hint"] == "github_copilot"
+        assert mock_count.call_count == 1
+        assert mock_count.call_args.kwargs["attributes"]["provider_hint"] == "github_copilot"
 
     def test_branch_prefix_takes_precedence_over_author(self) -> None:
-        with self._mock_incr() as mock_incr:
+        with self._mock_count() as mock_count:
             self._call(login="copilot-swe-agent[bot]", head_ref="claude/fix")
 
-        assert mock_incr.call_count == 1
-        assert mock_incr.call_args.kwargs["tags"]["provider_hint"] == "claude_code"
+        assert mock_count.call_count == 1
+        assert mock_count.call_args.kwargs["attributes"]["provider_hint"] == "claude_code"
 
     # --- Non-candidates do not fire ---
 
     def test_non_candidate_branch_and_author_does_not_detect(self) -> None:
-        with self._mock_incr() as mock_incr:
+        with self._mock_count() as mock_count:
             self._call(login="a-human", head_ref="feature/x")
 
-        mock_incr.assert_not_called()
+        mock_count.assert_not_called()
 
     def test_non_opened_action_does_not_detect(self) -> None:
         for action in ("synchronize", "closed", "reopened", "edited", "labeled"):
-            with self._mock_incr() as mock_incr:
+            with self._mock_count() as mock_count:
                 self._call(action=action, head_ref="claude/fix")
-                mock_incr.assert_not_called()
+                mock_count.assert_not_called()
 
     # --- Gating ---
 
     def test_attribution_flag_off_does_not_detect(self) -> None:
-        with self._mock_incr() as mock_incr:
+        with self._mock_count() as mock_count:
             with self.feature({"organizations:pr-metrics-attribution": False}):
                 self._call(head_ref="claude/fix")
 
-        mock_incr.assert_not_called()
+        mock_count.assert_not_called()
 
     def test_no_seer_access_via_flag_does_not_detect(self) -> None:
-        with self._mock_incr() as mock_incr:
+        with self._mock_count() as mock_count:
             with self.feature({"organizations:gen-ai-features": False}):
                 self._call(head_ref="claude/fix")
 
-        mock_incr.assert_not_called()
+        mock_count.assert_not_called()
 
     def test_no_seer_access_via_hidden_ai_features_does_not_detect(self) -> None:
         self.organization.update_option("sentry:hide_ai_features", True)
 
-        with self._mock_incr() as mock_incr:
+        with self._mock_count() as mock_count:
             self._call(head_ref="claude/fix")
 
-        mock_incr.assert_not_called()
+        mock_count.assert_not_called()
 
     def test_missing_pr_does_not_detect(self) -> None:
         # Candidate gate passes, but no PullRequest row exists for this number.
-        with self._mock_incr() as mock_incr:
+        with self._mock_count() as mock_count:
             self._call(head_ref="claude/fix", number=9999)
 
-        mock_incr.assert_not_called()
+        mock_count.assert_not_called()
 
     def test_no_linked_groups_does_not_detect(self) -> None:
         GroupLink.objects.filter(
@@ -1403,7 +1403,7 @@ class HandleDelegatedAgentDetectionTest(TestCase):
             linked_id=self.pr.id,
         ).delete()
 
-        with self._mock_incr() as mock_incr:
+        with self._mock_count() as mock_count:
             self._call(head_ref="claude/fix")
 
-        mock_incr.assert_not_called()
+        mock_count.assert_not_called()

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -29,7 +29,7 @@ from sentry.seer.endpoints.seer_rpc import (
     get_project_preferences,
     get_repo_installation_id,
     has_repo_code_mappings,
-    record_delegated_pr_attribution,
+    record_pr_attribution,
     validate_repo,
 )
 from sentry.sentry_apps.metrics import SentryAppEventType
@@ -1683,7 +1683,7 @@ class TestGetOrganizationFeatures(APITestCase):
 
 @with_feature("organizations:pr-metrics-attribution")
 @cell_silo_test
-class TestRecordDelegatedPrAttribution(APITestCase):
+class TestRecordPrAttribution(APITestCase):
     def setUp(self) -> None:
         self.project = self.create_project(organization=self.organization)
         self.repo = self.create_repo(self.project, provider="integrations:github", external_id="1")
@@ -1700,7 +1700,7 @@ class TestRecordDelegatedPrAttribution(APITestCase):
             "signal_type": PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
         }
         kwargs.update(overrides)
-        return record_delegated_pr_attribution(**kwargs)
+        return record_pr_attribution(**kwargs)
 
     def test_creates_attribution(self) -> None:
         result = self._call()
@@ -1710,13 +1710,13 @@ class TestRecordDelegatedPrAttribution(APITestCase):
         assert attr.is_valid is True
         assert result == {"attribution_id": attr.id}
 
-    def test_stores_agent_id_in_signal_details(self) -> None:
-        self._call(agent_id="agent-abc-123")
+    def test_stores_signal_details(self) -> None:
+        self._call(signal_details={"agent_id": "agent-abc-123"})
 
         attr = PullRequestAttribution.objects.get(pull_request=self.pr)
         assert attr.signal_details == {"agent_id": "agent-abc-123"}
 
-    def test_no_agent_id_leaves_signal_details_null(self) -> None:
+    def test_no_signal_details_leaves_signal_details_null(self) -> None:
         self._call()
 
         attr = PullRequestAttribution.objects.get(pull_request=self.pr)

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -16,6 +16,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.project import Project
 from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
+from sentry.models.pullrequest import PullRequestAttribution, PullRequestAttributionSignalType
 from sentry.models.repository import Repository
 from sentry.seer.agent.tools import get_trace_item_attributes
 from sentry.seer.endpoints.seer_rpc import (
@@ -28,11 +29,13 @@ from sentry.seer.endpoints.seer_rpc import (
     get_project_preferences,
     get_repo_installation_id,
     has_repo_code_mappings,
+    record_delegated_pr_attribution,
     validate_repo,
 )
 from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import assume_test_silo_mode_of
+from sentry.testutils.helpers import with_feature
+from sentry.testutils.silo import assume_test_silo_mode_of, cell_silo_test
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 
 # Fernet key must be a base64 encoded string, exactly 32 bytes long
@@ -1676,3 +1679,94 @@ class TestGetOrganizationFeatures(APITestCase):
         with self.feature("organizations:seer-agent-source-code-search"):
             result = get_organization_features(org_id=self.organization.id, user_id=0)
         assert result == {"features": ["seer-agent-source-code-search"]}
+
+
+@with_feature("organizations:pr-metrics-attribution")
+@cell_silo_test
+class TestRecordDelegatedPrAttribution(APITestCase):
+    def setUp(self) -> None:
+        self.project = self.create_project(organization=self.organization)
+        self.repo = self.create_repo(self.project, provider="integrations:github", external_id="1")
+        self.pr = self.create_pull_request(
+            repository_id=self.repo.id,
+            organization_id=self.organization.id,
+            key="10",
+        )
+
+    def _call(self, **overrides: Any) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "organization_id": self.organization.id,
+            "pull_request_id": self.pr.id,
+            "signal_type": PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
+        }
+        kwargs.update(overrides)
+        return record_delegated_pr_attribution(**kwargs)
+
+    def test_creates_attribution(self) -> None:
+        result = self._call()
+
+        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.signal_type == PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE
+        assert attr.is_valid is True
+        assert result == {"attribution_id": attr.id}
+
+    def test_stores_agent_id_in_signal_details(self) -> None:
+        self._call(agent_id="agent-abc-123")
+
+        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.signal_details == {"agent_id": "agent-abc-123"}
+
+    def test_no_agent_id_leaves_signal_details_null(self) -> None:
+        self._call()
+
+        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.signal_details is None
+
+    def test_idempotent_on_repeat_call(self) -> None:
+        result1 = self._call()
+        result2 = self._call()
+
+        assert result1 == result2
+        assert PullRequestAttribution.objects.filter(pull_request=self.pr).count() == 1
+
+    def test_invalid_signal_type_raises(self) -> None:
+        from rest_framework.exceptions import ParseError
+
+        with pytest.raises(ParseError):
+            self._call(signal_type="not_a_real_signal")
+
+    def test_org_not_found_raises(self) -> None:
+        from django.core.exceptions import ObjectDoesNotExist
+
+        with pytest.raises(ObjectDoesNotExist):
+            self._call(organization_id=999999)
+
+    def test_pr_not_found_raises(self) -> None:
+        from django.core.exceptions import ObjectDoesNotExist
+
+        with pytest.raises(ObjectDoesNotExist):
+            self._call(pull_request_id=999999)
+
+    def test_pr_from_different_org_raises(self) -> None:
+        from django.core.exceptions import ObjectDoesNotExist
+
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        other_repo = self.create_repo(
+            other_project, provider="integrations:github", external_id="2"
+        )
+        other_pr = self.create_pull_request(
+            repository_id=other_repo.id,
+            organization_id=other_org.id,
+            key="20",
+        )
+
+        with pytest.raises(ObjectDoesNotExist):
+            self._call(pull_request_id=other_pr.id)
+
+    def test_feature_disabled_returns_null_attribution_id(self) -> None:
+        with self.feature({"organizations:pr-metrics-attribution": False}):
+            result = self._call()
+
+        assert result == {"attribution_id": None}
+        assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()


### PR DESCRIPTION
Tracks [CW-1485](https://linear.app/getsentry/issue/CW-1485) / [CW-1486](https://linear.app/getsentry/issue/CW-1486).

## What this does

Wires the GitHub \`pull_request\` webhook path to flag freshly-opened PRs that may have been created by a delegated coding agent (Claude Code / GitHub Copilot) from a Seer Autofix session, and provides a Seer RPC callback to confirm and record the attribution.

The pipeline follows a **fire-and-forget** pattern:

1. On \`opened\`, \`handle_attribution\` runs a cheap heuristic (branch prefix / bot author login). If the PR looks like a delegated-agent candidate **and** resolves at least one Sentry issue (via \`GroupLink\`), it will fire the handoff to Seer.
2. Seer confirms whether the PR was authored by a delegated agent and calls back to write a \`PullRequestAttribution\` row idempotently.

**The Seer match endpoint does not exist yet**, so step 1 currently records a \`not_implemented\` Sentry metric instead of contacting Seer. Step 2 is not wired yet either — both sides will be connected once Seer ships its endpoint.

## Key details

- Detection heuristic uses two constants in \`pr_metrics/utils.py\`: \`DELEGATED_AGENT_BRANCH_PREFIXES\` (branch prefix → provider hint) and \`DELEGATED_AGENT_AUTHOR_LOGINS\` (bot login → provider hint). Branch prefix takes precedence when both signals match.
- The GroupLink gate avoids noisy signals for PRs with no Sentry issue context.
- \`handle_attribution\` is now a router: each sub-handler (\`_write_author_attribution\`, \`_write_mcp_attribution\`, \`_detect_delegated_agent\`) owns its own action gate.
- \`resolved_group_ids()\` is extracted from \`emit.py\` into a shared \`pr_metrics/utils.py\` so both the emission path and the detection path reuse it.