### PR TITLE
meta: Add JS SDK teams as codeowners for initializeSdk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -832,6 +832,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/views/settings/                           @getsentry/design-engineering
 /static/app/views/nav/                                @getsentry/design-engineering
 /static/app/bootstrap/                                @getsentry/design-engineering
+/static/app/bootstrap/initializeSdk.tsx               @getsentry/team-javascript-sdks-browser @getsentry/team-javascript-sdks-framework
 /static/app/components/commandPalette/                @getsentry/design-engineering
 # Config files
 /figma.config.json                                     @getsentry/design-engineering


### PR DESCRIPTION
Add `team-javascript-sdks-browser` and `team-javascript-sdks-framework` as codeowners for `static/app/bootstrap/initializeSdk.tsx` so SDK configuration changes get reviewed by the JS SDK teams. The entry is placed after the broader `/static/app/bootstrap/` rule to take precedence via last-match-wins.