### PR TITLE
fix(low-value-spans): Improve troubleshooting docs links

### DIFF
--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
@@ -48,26 +48,7 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
     expect(screen.queryByText('before_send_transaction')).not.toBeInTheDocument();
   });
 
-  it('links to platform custom instrumentation docs for manual spans', () => {
-    render(
-      <TroubleshootingSection
-        evidenceData={{
-          ...baseEvidenceData,
-          spanOrigin: 'manual',
-        }}
-        projectPlatform="python-django"
-      />
-    );
-
-    expect(
-      screen.getByRole('link', {name: 'Read the custom instrumentation docs'})
-    ).toHaveAttribute(
-      'href',
-      'https://docs.sentry.io/platforms/python/guides/django/tracing/instrumentation/custom-instrumentation/'
-    );
-  });
-
-  it('omits the custom instrumentation link when the platform is unknown', () => {
+  it('links to the platform-redirect custom instrumentation docs for manual spans', () => {
     render(
       <TroubleshootingSection
         evidenceData={{
@@ -79,11 +60,14 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
     );
 
     expect(
-      screen.queryByRole('link', {name: 'Read the custom instrumentation docs'})
-    ).not.toBeInTheDocument();
+      screen.getByRole('link', {name: 'Read the custom instrumentation docs'})
+    ).toHaveAttribute(
+      'href',
+      'https://docs.sentry.io/platform-redirect/?next=/tracing/instrumentation/custom-instrumentation/'
+    );
   });
 
-  it('links to the platform-specific filtering docs for non-JS/Python platforms', () => {
+  it('uses the platform-redirect filtering docs as a fallback', () => {
     render(
       <TroubleshootingSection
         evidenceData={baseEvidenceData}
@@ -95,7 +79,7 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
       screen.getByRole('link', {name: 'Read the SDK filtering docs'})
     ).toHaveAttribute(
       'href',
-      'https://docs.sentry.io/platforms/ruby/guides/rails/configuration/filtering/'
+      'https://docs.sentry.io/platform-redirect/?next=/configuration/filtering/'
     );
   });
 

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
@@ -48,6 +48,57 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
     expect(screen.queryByText('before_send_transaction')).not.toBeInTheDocument();
   });
 
+  it('links to platform custom instrumentation docs for manual spans', () => {
+    render(
+      <TroubleshootingSection
+        evidenceData={{
+          ...baseEvidenceData,
+          spanOrigin: 'manual',
+        }}
+        projectPlatform="python-django"
+      />
+    );
+
+    expect(
+      screen.getByRole('link', {name: 'Read the custom instrumentation docs'})
+    ).toHaveAttribute(
+      'href',
+      'https://docs.sentry.io/platforms/python/guides/django/tracing/instrumentation/custom-instrumentation/'
+    );
+  });
+
+  it('omits the custom instrumentation link when the platform is unknown', () => {
+    render(
+      <TroubleshootingSection
+        evidenceData={{
+          ...baseEvidenceData,
+          spanOrigin: 'manual',
+        }}
+        projectPlatform={null}
+      />
+    );
+
+    expect(
+      screen.queryByRole('link', {name: 'Read the custom instrumentation docs'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('links to the platform-specific filtering docs for non-JS/Python platforms', () => {
+    render(
+      <TroubleshootingSection
+        evidenceData={baseEvidenceData}
+        projectPlatform="ruby-rails"
+      />
+    );
+
+    expect(
+      screen.getByRole('link', {name: 'Read the SDK filtering docs'})
+    ).toHaveAttribute(
+      'href',
+      'https://docs.sentry.io/platforms/ruby/guides/rails/configuration/filtering/'
+    );
+  });
+
   it('recommends JavaScript span filtering and mentions beforeSendSpan', () => {
     render(
       <TroubleshootingSection

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.tsx
@@ -78,13 +78,9 @@ function AutomaticInstrumentationFix({
 
 function ManualInstrumentationFix({
   evidenceData,
-  projectPlatform,
 }: {
   evidenceData: LowValueSpanEvidenceData;
-  projectPlatform?: PlatformKey | null;
 }) {
-  const customInstrumentationDocsUrl = getCustomInstrumentationDocsUrl(projectPlatform);
-
   return (
     <Stack gap="md">
       <Text>{t('This appears to come from custom instrumentation in your code.')}</Text>
@@ -104,14 +100,12 @@ function ManualInstrumentationFix({
           )}
         </Text>
       </Stack>
-      {customInstrumentationDocsUrl && (
-        <Flex align="center" gap="xs">
-          <IconDocs size="xs" />
-          <ExternalLink href={customInstrumentationDocsUrl}>
-            {t('Read the custom instrumentation docs')}
-          </ExternalLink>
-        </Flex>
-      )}
+      <Flex align="center" gap="xs">
+        <IconDocs size="xs" />
+        <ExternalLink href={getCustomInstrumentationDocsUrl()}>
+          {t('Read the custom instrumentation docs')}
+        </ExternalLink>
+      </Flex>
     </Stack>
   );
 }
@@ -154,10 +148,7 @@ export function TroubleshootingSection({
     <Stack gap="lg" padding="lg">
       <Heading as="h3">{t('Troubleshooting')}</Heading>
       {isManualInstrumentation ? (
-        <ManualInstrumentationFix
-          evidenceData={evidenceData}
-          projectPlatform={projectPlatform}
-        />
+        <ManualInstrumentationFix evidenceData={evidenceData} />
       ) : (
         <AutomaticInstrumentationTroubleshooting
           evidenceData={evidenceData}

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.tsx
@@ -1,8 +1,8 @@
 import {CodeBlock, InlineCode} from '@sentry/scraps/code';
 import {Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 
-import {ExternalLink} from 'sentry/components/links/externalLink';
 import {IconDocs} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {PlatformKey} from 'sentry/types/platform';
@@ -10,6 +10,7 @@ import type {PlatformKey} from 'sentry/types/platform';
 import {SpanCode} from './spanCode';
 import type {LowValueSpanEvidenceData} from './types';
 import {
+  getCustomInstrumentationDocsUrl,
   getJavaScriptSpanFilterSnippet,
   getPythonSpanFilterSnippet,
   getSpanFilteringDocsUrl,
@@ -77,9 +78,13 @@ function AutomaticInstrumentationFix({
 
 function ManualInstrumentationFix({
   evidenceData,
+  projectPlatform,
 }: {
   evidenceData: LowValueSpanEvidenceData;
+  projectPlatform?: PlatformKey | null;
 }) {
+  const customInstrumentationDocsUrl = getCustomInstrumentationDocsUrl(projectPlatform);
+
   return (
     <Stack gap="md">
       <Text>{t('This appears to come from custom instrumentation in your code.')}</Text>
@@ -99,6 +104,14 @@ function ManualInstrumentationFix({
           )}
         </Text>
       </Stack>
+      {customInstrumentationDocsUrl && (
+        <Flex align="center" gap="xs">
+          <IconDocs size="xs" />
+          <ExternalLink href={customInstrumentationDocsUrl}>
+            {t('Read the custom instrumentation docs')}
+          </ExternalLink>
+        </Flex>
+      )}
     </Stack>
   );
 }
@@ -141,7 +154,10 @@ export function TroubleshootingSection({
     <Stack gap="lg" padding="lg">
       <Heading as="h3">{t('Troubleshooting')}</Heading>
       {isManualInstrumentation ? (
-        <ManualInstrumentationFix evidenceData={evidenceData} />
+        <ManualInstrumentationFix
+          evidenceData={evidenceData}
+          projectPlatform={projectPlatform}
+        />
       ) : (
         <AutomaticInstrumentationTroubleshooting
           evidenceData={evidenceData}

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
@@ -1,13 +1,15 @@
+import {allPlatforms} from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
 import type {PlatformKey} from 'sentry/types/platform';
 
 import type {LowValueSpanEvidenceData} from './types';
 
 const JAVASCRIPT_SPAN_FILTERING_DOCS_URL =
-  'https://docs.sentry.io/platforms/javascript/configuration/options/#ignorespans';
+  'https://docs.sentry.io/platforms/javascript/configuration/options/#ignoreSpans';
 const PYTHON_SPAN_FILTERING_DOCS_URL =
   'https://docs.sentry.io/platforms/python/configuration/filtering/#filtering-transaction-events';
-const GENERIC_SPAN_FILTERING_DOCS_URL = 'https://docs.sentry.io/product/explore/traces/';
+const GENERIC_FILTERING_DOCS_URL =
+  'https://docs.sentry.io/concepts/data-management/filtering/';
 const JAVASCRIPT_PROJECT_PLATFORMS = new Set<PlatformKey>([
   'bun',
   'capacitor',
@@ -85,6 +87,17 @@ export function isJavaScriptProjectPlatform(
   );
 }
 
+function getPlatformDocsBaseUrl(projectPlatform?: PlatformKey | null): string | null {
+  if (!projectPlatform) {
+    return null;
+  }
+  const platform = allPlatforms.find(({id}) => id === projectPlatform);
+  if (!platform?.link) {
+    return null;
+  }
+  return platform.link.endsWith('/') ? platform.link.slice(0, -1) : platform.link;
+}
+
 export function getSpanFilteringDocsUrl(projectPlatform?: PlatformKey | null): string {
   if (isPythonProjectPlatform(projectPlatform)) {
     return PYTHON_SPAN_FILTERING_DOCS_URL;
@@ -92,7 +105,21 @@ export function getSpanFilteringDocsUrl(projectPlatform?: PlatformKey | null): s
   if (isJavaScriptProjectPlatform(projectPlatform)) {
     return JAVASCRIPT_SPAN_FILTERING_DOCS_URL;
   }
-  return GENERIC_SPAN_FILTERING_DOCS_URL;
+  const platformBase = getPlatformDocsBaseUrl(projectPlatform);
+  if (platformBase) {
+    return `${platformBase}/configuration/filtering/`;
+  }
+  return GENERIC_FILTERING_DOCS_URL;
+}
+
+export function getCustomInstrumentationDocsUrl(
+  projectPlatform?: PlatformKey | null
+): string | null {
+  const platformBase = getPlatformDocsBaseUrl(projectPlatform);
+  if (!platformBase) {
+    return null;
+  }
+  return `${platformBase}/tracing/instrumentation/custom-instrumentation/`;
 }
 
 function toCodeString(value: string | null, fallback: string): string {

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
@@ -1,4 +1,3 @@
-import {allPlatforms} from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
 import type {PlatformKey} from 'sentry/types/platform';
 
@@ -9,7 +8,9 @@ const JAVASCRIPT_SPAN_FILTERING_DOCS_URL =
 const PYTHON_SPAN_FILTERING_DOCS_URL =
   'https://docs.sentry.io/platforms/python/configuration/filtering/#filtering-transaction-events';
 const GENERIC_FILTERING_DOCS_URL =
-  'https://docs.sentry.io/concepts/data-management/filtering/';
+  'https://docs.sentry.io/platform-redirect/?next=/configuration/filtering/';
+const CUSTOM_INSTRUMENTATION_DOCS_URL =
+  'https://docs.sentry.io/platform-redirect/?next=/tracing/instrumentation/custom-instrumentation/';
 const JAVASCRIPT_PROJECT_PLATFORMS = new Set<PlatformKey>([
   'bun',
   'capacitor',
@@ -87,17 +88,6 @@ export function isJavaScriptProjectPlatform(
   );
 }
 
-function getPlatformDocsBaseUrl(projectPlatform?: PlatformKey | null): string | null {
-  if (!projectPlatform) {
-    return null;
-  }
-  const platform = allPlatforms.find(({id}) => id === projectPlatform);
-  if (!platform?.link) {
-    return null;
-  }
-  return platform.link.endsWith('/') ? platform.link.slice(0, -1) : platform.link;
-}
-
 export function getSpanFilteringDocsUrl(projectPlatform?: PlatformKey | null): string {
   if (isPythonProjectPlatform(projectPlatform)) {
     return PYTHON_SPAN_FILTERING_DOCS_URL;
@@ -105,21 +95,11 @@ export function getSpanFilteringDocsUrl(projectPlatform?: PlatformKey | null): s
   if (isJavaScriptProjectPlatform(projectPlatform)) {
     return JAVASCRIPT_SPAN_FILTERING_DOCS_URL;
   }
-  const platformBase = getPlatformDocsBaseUrl(projectPlatform);
-  if (platformBase) {
-    return `${platformBase}/configuration/filtering/`;
-  }
   return GENERIC_FILTERING_DOCS_URL;
 }
 
-export function getCustomInstrumentationDocsUrl(
-  projectPlatform?: PlatformKey | null
-): string | null {
-  const platformBase = getPlatformDocsBaseUrl(projectPlatform);
-  if (!platformBase) {
-    return null;
-  }
-  return `${platformBase}/tracing/instrumentation/custom-instrumentation/`;
+export function getCustomInstrumentationDocsUrl(): string {
+  return CUSTOM_INSTRUMENTATION_DOCS_URL;
 }
 
 function toCodeString(value: string | null, fallback: string): string {


### PR DESCRIPTION
Improve the docs links shown in the troubleshooting section of the low-value spans issue details.

- **Generic auto-instrumentation fallback was wrong.** Previously pointed at the Traces product overview (`/product/explore/traces/`), which has nothing to do with span filtering. Now points at the platform-redirect endpoint (`/platform-redirect/?next=/configuration/filtering/`), which prompts the user to pick a platform and lands them on the right SDK filtering page.
- **Manual instrumentation had no docs link at all.** Added a "Read the custom instrumentation docs" link via the same platform-redirect pattern (`/platform-redirect/?next=/tracing/instrumentation/custom-instrumentation/`).
- **Swap deprecated `ExternalLink`** import from `sentry/components/links/externalLink` to `@sentry/scraps/link`.

The JavaScript (`ignoreSpans`) and Python (`before_send_transaction`) links are unchanged — both still point to the most relevant available documentation.