### PR TITLE
fix(explore): reset cursor when searching saved queries

### DIFF
--- a/static/app/views/explore/savedQueries/savedQueriesLandingContent.spec.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesLandingContent.spec.tsx
@@ -73,9 +73,11 @@ describe('SavedQueriesTable', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
         pathname: '/organizations/org-slug/explore/saved-queries/',
-        query: {
+        query: expect.objectContaining({
           query: 'Query Name',
-        },
+          ownedCursor: undefined,
+          sharedCursor: undefined,
+        }),
       })
     );
 
@@ -103,6 +105,31 @@ describe('SavedQueriesTable', () => {
         query: expect.objectContaining({
           query: 'Query Name',
           exclude: 'owned',
+        }),
+      })
+    );
+  });
+
+  it('resets cursors when searching from a paginated page', async () => {
+    const mockNavigate = jest.fn();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+    mockUseLocation.mockReturnValue(
+      LocationFixture({
+        pathname: '/organizations/org-slug/explore/saved-queries/',
+        query: {ownedCursor: 'abc123', sharedCursor: 'def456'},
+      })
+    );
+    render(<SavedQueriesLandingContent />);
+    await screen.findByText('Created by Me');
+    await userEvent.type(screen.getByPlaceholderText('Search for a query'), 'My Query');
+    await userEvent.keyboard('{enter}');
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: 'My Query',
+          ownedCursor: undefined,
+          sharedCursor: undefined,
         }),
       })
     );

--- a/static/app/views/explore/savedQueries/savedQueriesLandingContent.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesLandingContent.tsx
@@ -46,7 +46,12 @@ export function SavedQueriesLandingContent() {
             onSearch={newQuery => {
               navigate({
                 pathname: location.pathname,
-                query: {...location.query, query: newQuery},
+                query: {
+                  ...location.query,
+                  query: newQuery,
+                  ownedCursor: undefined,
+                  sharedCursor: undefined,
+                },
               });
             }}
             defaultQuery={searchQuery}


### PR DESCRIPTION
When a user typed a search query while on page 2+ of saved queries, the stale `ownedCursor`/`sharedCursor` values were carried forward in the URL. The next page fetch then started from the wrong offset, so results appeared empty.

**Fix:** clear both cursor keys in the `onSearch` navigate call.

**Verified:** updated the existing search test to assert cursor keys are set to `undefined`, and added a dedicated test that starts with cursor values in `location.query` and confirms they're cleared on search.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC08SBFDKBKJ%3A1781015029.670489%22)