### PR TITLE
feat(explore): Use heatmap icon for Heat Map chart type

### DIFF
--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -75,11 +75,11 @@ import {ChartType} from 'sentry/views/insights/common/components/chart';
 const RESULT_LIMIT = 50;
 const TWO_MINUTE_DELAY = 120;
 
-const CHART_TYPE_TO_ICON: Record<ChartType, 'line' | 'area' | 'bar' | 'scatter'> = {
+const CHART_TYPE_TO_ICON: Record<ChartType, 'line' | 'area' | 'bar' | 'heatmap'> = {
   [ChartType.LINE]: 'line',
   [ChartType.AREA]: 'area',
   [ChartType.BAR]: 'bar',
-  [ChartType.HEATMAP]: 'scatter',
+  [ChartType.HEATMAP]: 'heatmap',
 };
 
 interface MetricPanelProps extends React.HTMLAttributes<HTMLDivElement> {


### PR DESCRIPTION
Use the new `IconGraphHeatmap` icon for the Heat Map chart type option in Explore, replacing the scatter icon that was used as a placeholder.

The heatmap icon was recently added in #116977 — this wires it up in the metric panel's chart type selector.

DAIN-1709