### PR TITLE
feat(jira-server): Add API-driven pipeline backend for integration setup

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -17,11 +17,15 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
+from rest_framework import serializers
+from rest_framework.fields import BooleanField, CharField, URLField
 
 from sentry import features
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationData,
+    IntegrationDomain,
     IntegrationFeatures,
     IntegrationMetadata,
     IntegrationProvider,
@@ -36,9 +40,14 @@ from sentry.integrations.models.integration_external_project import IntegrationE
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import ExternalProviders, IntegrationProviderSlug
+from sentry.integrations.utils.metrics import (
+    IntegrationPipelineViewEvent,
+    IntegrationPipelineViewType,
+)
 from sentry.models.group import Group
 from sentry.organizations.services.organization.service import organization_service
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiHostError,
@@ -308,6 +317,151 @@ class OAuthCallbackView:
         except ApiError as error:
             logger.info("identity.jira-server.access-token", extra={"error": error})
             return pipeline.error("Could not fetch an access token from Jira")
+
+
+class InstallationConfigData(TypedDict):
+    url: str
+    consumer_key: str
+    private_key: str
+    verify_ssl: bool
+
+
+class InstallationConfigSerializer(CamelSnakeSerializer[InstallationConfigData]):
+    url = URLField(required=True)
+    consumer_key = CharField(required=True, max_length=200)
+    private_key = CharField(required=True)
+    verify_ssl = BooleanField(required=False, default=True)
+
+    def validate_private_key(self, value: str) -> str:
+        try:
+            load_pem_private_key(value.encode("utf-8"), None, default_backend())
+        except Exception:
+            raise serializers.ValidationError(
+                "Private key must be a valid SSH private key encoded in a PEM format."
+            )
+        return value
+
+
+class InstallationConfigApiStep:
+    """
+    Collect the Jira Server consumer credentials and verify them by fetching an
+    OAuth 1.0a request token. The token is stored on pipeline state so the next
+    step can build an authorize URL and exchange it for an access token.
+    """
+
+    step_name = "installation_config"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
+        return {}
+
+    def get_serializer_cls(self) -> type:
+        return InstallationConfigSerializer
+
+    def handle_post(
+        self,
+        validated_data: InstallationConfigData,
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        validated_data["url"] = validated_data["url"].rstrip("/")
+
+        client = JiraServerSetupClient(
+            validated_data["url"],
+            validated_data["consumer_key"],
+            validated_data["private_key"],
+            validated_data["verify_ssl"],
+        )
+
+        with IntegrationPipelineViewEvent(
+            IntegrationPipelineViewType.OAUTH_LOGIN,
+            IntegrationDomain.PROJECT_MANAGEMENT,
+            JiraServerIntegrationProvider.key,
+        ).capture() as lifecycle:
+            try:
+                request_token = client.get_request_token()
+            except ApiError as error:
+                lifecycle.record_failure(str(error), extra={"url": validated_data["url"]})
+                return PipelineStepResult.error(
+                    f"Could not fetch a request token from Jira. {error}"
+                )
+
+            if not request_token.get("oauth_token") or not request_token.get("oauth_token_secret"):
+                lifecycle.record_failure(
+                    "missing oauth_token", extra={"url": validated_data["url"]}
+                )
+                return PipelineStepResult.error("Missing oauth_token")
+
+        pipeline.bind_state("installation_data", validated_data)
+        pipeline.bind_state("request_token", request_token)
+        return PipelineStepResult.advance()
+
+
+class OAuthCallbackData(TypedDict):
+    oauth_token: str
+
+
+class OAuthCallbackSerializer(CamelSnakeSerializer[OAuthCallbackData]):
+    oauth_token = CharField(required=True)
+
+
+class OAuthStepData(TypedDict):
+    oauthUrl: str
+
+
+class OAuthApiStep:
+    """
+    Build the Jira Server authorize URL from the previously-fetched request
+    token, then exchange the callback's oauth_token (which Jira Server uses as
+    the verifier) for an access token.
+    """
+
+    step_name = "oauth_callback"
+
+    def _client(self, pipeline: IntegrationPipeline) -> JiraServerSetupClient:
+        installation = pipeline.fetch_state("installation_data")
+        if installation is None:
+            raise AssertionError("pipeline called out of order")
+        return JiraServerSetupClient(
+            installation["url"],
+            installation["consumer_key"],
+            installation["private_key"],
+            installation["verify_ssl"],
+        )
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> OAuthStepData:
+        request_token = pipeline.fetch_state("request_token")
+        if request_token is None:
+            raise AssertionError("pipeline called out of order")
+        return {"oauthUrl": self._client(pipeline).get_authorize_url(request_token)}
+
+    def get_serializer_cls(self) -> type:
+        return OAuthCallbackSerializer
+
+    def handle_post(
+        self,
+        validated_data: OAuthCallbackData,
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        request_token = pipeline.fetch_state("request_token")
+        if request_token is None:
+            raise AssertionError("pipeline called out of order")
+
+        with IntegrationPipelineViewEvent(
+            IntegrationPipelineViewType.OAUTH_CALLBACK,
+            IntegrationDomain.PROJECT_MANAGEMENT,
+            JiraServerIntegrationProvider.key,
+        ).capture() as lifecycle:
+            try:
+                access_token = self._client(pipeline).get_access_token(
+                    request_token, validated_data["oauth_token"]
+                )
+            except ApiError as error:
+                lifecycle.record_failure(str(error))
+                return PipelineStepResult.error("Could not fetch an access token from Jira")
+
+        pipeline.bind_state("access_token", access_token)
+        return PipelineStepResult.advance()
 
 
 # Hide linked issues fields because we don't have the necessary UI for fully specifying
@@ -1402,6 +1556,9 @@ class JiraServerIntegrationProvider(IntegrationProvider):
 
     def get_pipeline_views(self) -> list[PipelineView[IntegrationPipeline]]:
         return [InstallationConfigView(), OAuthLoginView(), OAuthCallbackView()]
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return [InstallationConfigApiStep(), OAuthApiStep()]
 
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
         install = state["installation_data"]

--- a/tests/sentry/integrations/jira_server/test_installation.py
+++ b/tests/sentry/integrations/jira_server/test_installation.py
@@ -1,18 +1,26 @@
+from typing import Any
 from unittest import mock
+from unittest.mock import MagicMock, patch
 
 import orjson
 import responses
+from django.urls import reverse
 from requests.exceptions import ReadTimeout
 
 from sentry.integrations.jira_server import JiraServerIntegrationProvider
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
-from sentry.testutils.cases import IntegrationTestCase
+from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.testutils.asserts import assert_failure_metric
+from sentry.testutils.cases import APITestCase, IntegrationTestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.identity import Identity, IdentityProvider
 from sentry.utils import jwt
 
 from . import EXAMPLE_PRIVATE_KEY
+
+REQUEST_TOKEN_BODY = "oauth_token=req-token&oauth_token_secret=req-token-secret"
+ACCESS_TOKEN_BODY = "oauth_token=valid-token&oauth_token_secret=valid-secret"
 
 
 @control_silo_test
@@ -552,5 +560,306 @@ class JiraServerInstallationTest(IntegrationTestCase):
         resp = self.install_integration()
         self.assertContains(resp, "You do not have permission to create")
         self.assertContains(resp, "Could not create issue webhook")
+
+        assert Integration.objects.count() == 0
+
+
+@control_silo_test
+class JiraServerApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+
+    jira_url = "https://jira.example.com"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+
+    def tearDown(self) -> None:
+        responses.reset()
+        super().tearDown()
+
+    def _pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize(self) -> Any:
+        return self.client.post(
+            self._pipeline_url(),
+            data={"action": "initialize", "provider": "jira_server"},
+            format="json",
+        )
+
+    def _advance(self, data: dict[str, Any]) -> Any:
+        return self.client.post(self._pipeline_url(), data=data, format="json")
+
+    def _submit_config(self, **overrides: Any) -> Any:
+        data = {
+            "url": self.jira_url,
+            "consumerKey": "sentry-bot",
+            "privateKey": EXAMPLE_PRIVATE_KEY,
+            "verifySsl": False,
+        }
+        data.update(overrides)
+        return self._advance(data)
+
+    def _stub_request_token(self, **kwargs: Any) -> None:
+        responses.add(
+            responses.POST,
+            f"{self.jira_url}/plugins/servlet/oauth/request-token",
+            status=kwargs.pop("status", 200),
+            content_type="text/plain",
+            body=kwargs.pop("body", REQUEST_TOKEN_BODY),
+            **kwargs,
+        )
+
+    def _stub_access_token(self, **kwargs: Any) -> None:
+        responses.add(
+            responses.POST,
+            f"{self.jira_url}/plugins/servlet/oauth/access-token",
+            status=kwargs.pop("status", 200),
+            content_type="text/plain",
+            body=kwargs.pop("body", ACCESS_TOKEN_BODY),
+            **kwargs,
+        )
+
+    def _stub_install_endpoints(self, **kwargs: Any) -> None:
+        responses.add(
+            responses.GET,
+            f"{self.jira_url}/rest/api/2/serverInfo",
+            status=200,
+            json={"baseUrl": self.jira_url, "version": "9.9.9"},
+        )
+        responses.add(
+            responses.POST,
+            f"{self.jira_url}/rest/webhooks/1.0/webhook",
+            status=kwargs.pop("webhook_status", 204),
+            body=kwargs.pop("webhook_body", ""),
+            json=kwargs.pop("webhook_json", None),
+        )
+
+    @responses.activate
+    def test_initialize_pipeline(self) -> None:
+        resp = self._initialize()
+        assert resp.status_code == 200
+        assert resp.data["provider"] == "jira_server"
+        assert resp.data["step"] == "installation_config"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 2
+        assert resp.data["data"] == {}
+
+    @responses.activate
+    def test_config_step_validation_missing_required_fields(self) -> None:
+        self._initialize()
+        resp = self._advance({"url": self.jira_url})
+        assert resp.status_code == 400
+        for field in ("consumerKey", "privateKey"):
+            assert resp.data[field] == ["This field is required."]
+
+    @responses.activate
+    def test_config_step_validation_invalid_url(self) -> None:
+        self._initialize()
+        resp = self._submit_config(url="jira.example.com")
+        assert resp.status_code == 400
+        assert resp.data["url"] == ["Enter a valid URL."]
+
+    @responses.activate
+    def test_config_step_validation_invalid_private_key(self) -> None:
+        self._initialize()
+        resp = self._submit_config(privateKey="hot-garbage")
+        assert resp.status_code == 400
+        assert "PEM format" in resp.data["privateKey"][0]
+
+    @responses.activate
+    def test_config_step_validation_consumer_key_too_long(self) -> None:
+        self._initialize()
+        resp = self._submit_config(consumerKey="x" * 201)
+        assert resp.status_code == 400
+        assert "200 characters" in resp.data["consumerKey"][0]
+
+    @responses.activate
+    def test_config_step_advance(self) -> None:
+        self._stub_request_token()
+        self._initialize()
+        resp = self._submit_config()
+        assert resp.status_code == 200
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "oauth_callback"
+        assert resp.data["stepIndex"] == 1
+        assert resp.data["data"]["oauthUrl"] == (
+            f"{self.jira_url}/plugins/servlet/oauth/authorize?oauth_token=req-token"
+        )
+
+    @responses.activate
+    def test_config_step_strips_trailing_slash(self) -> None:
+        self._stub_request_token()
+        self._initialize()
+        resp = self._submit_config(url=f"{self.jira_url}//")
+        assert resp.status_code == 200
+        assert resp.data["status"] == "advance"
+        assert resp.data["data"]["oauthUrl"] == (
+            f"{self.jira_url}/plugins/servlet/oauth/authorize?oauth_token=req-token"
+        )
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_config_step_request_token_timeout(self, mock_record: MagicMock) -> None:
+        responses.add(
+            responses.POST,
+            f"{self.jira_url}/plugins/servlet/oauth/request-token",
+            body=ReadTimeout("Read timed out. (read timeout=30)"),
+        )
+        self._initialize()
+        resp = self._submit_config()
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+        assert "request token from Jira" in resp.data["data"]["detail"]
+        assert_failure_metric(mock_record, "Timed out attempting to reach host: jira.example.com")
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_config_step_request_token_fails(self, mock_record: MagicMock) -> None:
+        self._stub_request_token(status=503, body="")
+        self._initialize()
+        resp = self._submit_config()
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+        assert "request token from Jira" in resp.data["data"]["detail"]
+
+    @responses.activate
+    def test_config_step_missing_oauth_token(self) -> None:
+        self._stub_request_token(body="no_token=oops&foo=bar")
+        self._initialize()
+        resp = self._submit_config()
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+        assert resp.data["data"]["detail"] == "Missing oauth_token"
+
+    @responses.activate
+    def test_config_step_missing_oauth_token_secret(self) -> None:
+        # A response with a token but no secret must fail here rather than
+        # raising a KeyError later when the access token is exchanged.
+        self._stub_request_token(body="oauth_token=req-token")
+        self._initialize()
+        resp = self._submit_config()
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+        assert resp.data["data"]["detail"] == "Missing oauth_token"
+
+    @responses.activate
+    def test_oauth_step_validation_missing_token(self) -> None:
+        self._stub_request_token()
+        self._initialize()
+        self._submit_config()
+        resp = self._advance({})
+        assert resp.status_code == 400
+        assert resp.data["oauthToken"] == ["This field is required."]
+
+    @responses.activate
+    def test_oauth_step_passes_callback_token_as_verifier(self) -> None:
+        # Jira Server uses the callback's oauth_token as the OAuth 1.0a verifier
+        # when exchanging for an access token. Confirm the access-token request
+        # signature contains the value from the callback.
+        self._stub_request_token()
+        self._stub_access_token()
+        self._stub_install_endpoints()
+        self._initialize()
+        self._submit_config()
+        self._advance({"oauthToken": "callback-token"})
+
+        access_token_calls = [
+            call
+            for call in responses.calls
+            if call.request.url == f"{self.jira_url}/plugins/servlet/oauth/access-token"
+        ]
+        assert len(access_token_calls) == 1
+        assert (
+            'oauth_verifier="callback-token"'
+            in access_token_calls[0].request.headers["Authorization"]
+        )
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_oauth_step_access_token_failure(self, mock_record: MagicMock) -> None:
+        self._stub_request_token()
+        error_msg = "<html>it broke</html>"
+        self._stub_access_token(status=500, body=error_msg)
+        self._initialize()
+        self._submit_config()
+
+        resp = self._advance({"oauthToken": "callback-token"})
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+        assert "access token from Jira" in resp.data["data"]["detail"]
+        assert_failure_metric(mock_record, error_msg)
+
+    @responses.activate
+    def test_full_pipeline_flow(self) -> None:
+        self._stub_request_token()
+        self._stub_access_token()
+        self._stub_install_endpoints()
+
+        resp = self._initialize()
+        assert resp.data["step"] == "installation_config"
+
+        resp = self._submit_config()
+        assert resp.data["step"] == "oauth_callback"
+
+        resp = self._advance({"oauthToken": "callback-token"})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider="jira_server")
+        assert integration.name == "sentry-bot"
+        assert integration.external_id == "jira.example.com:sentry-bot"
+        assert integration.metadata["base_url"] == self.jira_url
+        assert integration.metadata["domain_name"] == "jira.example.com"
+        assert integration.metadata["verify_ssl"] is False
+        assert integration.metadata["webhook_secret"]
+
+        assert OrganizationIntegration.objects.filter(
+            integration=integration, organization_id=self.organization.id
+        ).exists()
+
+        idp = IdentityProvider.objects.get(type="jira_server")
+        identity = Identity.objects.get(
+            idp=idp, user=self.user, external_id="jira.example.com:sentry-bot"
+        )
+        assert identity.data["consumer_key"] == "sentry-bot"
+        assert identity.data["access_token"] == "valid-token"
+        assert identity.data["access_token_secret"] == "valid-secret"
+        assert identity.data["private_key"] == EXAMPLE_PRIVATE_KEY
+
+    @responses.activate
+    def test_full_pipeline_truncates_external_id(self) -> None:
+        self._stub_request_token()
+        self._stub_access_token()
+        self._stub_install_endpoints()
+
+        self._initialize()
+        long_key = "a-very-long-consumer-key-that-when-combined-with-host-would-overflow"
+        self._submit_config(consumerKey=long_key)
+        self._advance({"oauthToken": "callback-token"})
+
+        integration = Integration.objects.get(provider="jira_server")
+        assert (
+            integration.external_id
+            == "jira.example.com:a-very-long-consumer-key-that-when-combined-wit"
+        )
+
+    @responses.activate
+    def test_full_pipeline_webhook_failure(self) -> None:
+        self._stub_request_token()
+        self._stub_access_token()
+        self._stub_install_endpoints(webhook_status=502, webhook_body="Bad things")
+
+        self._initialize()
+        self._submit_config()
+        resp = self._advance({"oauthToken": "callback-token"})
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+        assert "webhook" in resp.data["data"]["detail"]
 
         assert Integration.objects.count() == 0


### PR DESCRIPTION
Migrate the Jira Server integration setup to the API-driven pipeline, mirroring the work already shipped for Bitbucket Server (which shares the same OAuth 1.0a flow and the same URL + consumer key + RSA private key + verify SSL credential set).

This PR adds the backend machinery alongside the existing flow:

- `InstallationConfigApiStep` — validates the instance URL, RSA private key (PEM), and consumer key length, then fetches an OAuth 1.0a request token from the Jira Server instance and stashes it on pipeline state.
- `OAuthApiStep` — builds the authorize URL from the request token and exchanges the callback's `oauth_token` (which Jira Server uses as the verifier) for an access token.
- `get_pipeline_api_steps()` returns `[InstallationConfigApiStep(), OAuthApiStep()]`. `build_integration()` already reads `installation_data`/`access_token` from top-level pipeline state, so it is unchanged and continues to create the issue webhook before persisting the integration.

The legacy `InstallationConfigView`, `OAuthLoginView`, and `OAuthCallbackView` remain in place so in-flight installs can complete via the existing server-rendered flow. They will be removed in a follow-up once the API flow has been validated in production.

The frontend pipeline modal that drives these steps lands in a separate PR.

Part of [VDY-100](https://linear.app/getsentry/issue/VDY-100/jira-server-api-driven-integration-setup).