### PR TITLE
feat(jira-server): Add frontend pipeline steps for integration setup

### DIFF
--- a/static/app/components/pipeline/integrationJiraServer/index.spec.tsx
+++ b/static/app/components/pipeline/integrationJiraServer/index.spec.tsx
@@ -1,0 +1,166 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {
+  createMakeStepProps,
+  dispatchPipelineMessage,
+  setupMockPopup,
+} from 'sentry/components/pipeline/testUtils';
+
+import {jiraServerIntegrationPipeline} from '.';
+
+const InstallationConfigStep = jiraServerIntegrationPipeline.steps[0].component;
+const OAuthCallbackStep = jiraServerIntegrationPipeline.steps[1].component;
+
+const makeStepProps = createMakeStepProps({totalSteps: 2});
+
+let mockPopup: Window;
+
+beforeEach(() => {
+  mockPopup = setupMockPopup();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+async function fillRequiredConfigFields() {
+  await userEvent.type(
+    screen.getByRole('textbox', {name: 'Jira URL'}),
+    'https://jira.example.com'
+  );
+  await userEvent.type(
+    screen.getByRole('textbox', {name: 'Jira Consumer Key'}),
+    'sentry-bot'
+  );
+  await userEvent.type(
+    screen.getByRole('textbox', {name: 'Jira Consumer Private Key'}),
+    '-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----'
+  );
+}
+
+describe('Jira Server InstallationConfigStep', () => {
+  it('renders the config form fields', () => {
+    render(<InstallationConfigStep {...makeStepProps({stepData: {}})} />);
+
+    expect(screen.getByRole('textbox', {name: 'Jira URL'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Jira Consumer Key'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', {name: 'Jira Consumer Private Key'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeInTheDocument();
+  });
+
+  it('calls advance with form data on submit', async () => {
+    const advance = jest.fn();
+    render(<InstallationConfigStep {...makeStepProps({stepData: {}, advance})} />);
+
+    await fillRequiredConfigFields();
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith({
+        url: 'https://jira.example.com',
+        consumerKey: 'sentry-bot',
+        privateKey: '-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----',
+        verifySsl: true,
+      });
+    });
+  });
+
+  it('strips trailing slashes from the URL', async () => {
+    const advance = jest.fn();
+    render(<InstallationConfigStep {...makeStepProps({stepData: {}, advance})} />);
+
+    await fillRequiredConfigFields();
+    await userEvent.clear(screen.getByRole('textbox', {name: 'Jira URL'}));
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Jira URL'}),
+      'https://jira.example.com///'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith(
+        expect.objectContaining({url: 'https://jira.example.com'})
+      );
+    });
+  });
+
+  it('shows busy state when isAdvancing', () => {
+    render(
+      <InstallationConfigStep {...makeStepProps({stepData: {}, isAdvancing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Continue'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+  });
+});
+
+describe('Jira Server OAuthCallbackStep', () => {
+  const oauthUrl =
+    'https://jira.example.com/plugins/servlet/oauth/authorize?oauth_token=req-token';
+
+  it('renders the authorize button', () => {
+    render(<OAuthCallbackStep {...makeStepProps({stepData: {oauthUrl}})} />);
+
+    expect(
+      screen.getByRole('button', {name: 'Authorize Jira Server'})
+    ).toBeInTheDocument();
+  });
+
+  it('opens the popup and advances with oauthToken on callback', async () => {
+    const advance = jest.fn();
+    render(<OAuthCallbackStep {...makeStepProps({stepData: {oauthUrl}, advance})} />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Authorize Jira Server'}));
+
+    expect(window.open).toHaveBeenCalledWith(
+      oauthUrl,
+      'pipeline_popup',
+      expect.any(String)
+    );
+
+    dispatchPipelineMessage({
+      source: mockPopup,
+      data: {
+        _pipeline_source: 'sentry-pipeline',
+        oauth_token: 'callback-token',
+      },
+    });
+
+    expect(advance).toHaveBeenCalledWith({oauthToken: 'callback-token'});
+  });
+
+  it('disables the authorize button when oauthUrl is missing', () => {
+    render(<OAuthCallbackStep {...makeStepProps({stepData: {}})} />);
+
+    expect(screen.getByRole('button', {name: 'Authorize Jira Server'})).toBeDisabled();
+  });
+
+  it('shows popup-blocked notice when window.open returns null', async () => {
+    jest.spyOn(window, 'open').mockReturnValue(null);
+
+    render(<OAuthCallbackStep {...makeStepProps({stepData: {oauthUrl}})} />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Authorize Jira Server'}));
+
+    expect(
+      screen.getByText(
+        'The authorization popup was blocked by your browser. Please ensure popups are allowed and try again.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('shows busy state when isAdvancing', () => {
+    render(
+      <OAuthCallbackStep {...makeStepProps({stepData: {oauthUrl}, isAdvancing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Authorize Jira Server'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+  });
+});

--- a/static/app/components/pipeline/integrationJiraServer/index.tsx
+++ b/static/app/components/pipeline/integrationJiraServer/index.tsx
@@ -1,0 +1,237 @@
+import {useCallback, useEffect} from 'react';
+import {z} from 'zod';
+
+import {Button} from '@sentry/scraps/button';
+import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {useRedirectPopupStep} from 'sentry/components/pipeline/shared/useRedirectPopupStep';
+import type {
+  PipelineDefinition,
+  PipelineStepProps,
+} from 'sentry/components/pipeline/types';
+import {pipelineComplete} from 'sentry/components/pipeline/types';
+import {t, tct} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+const installationConfigSchema = z.object({
+  url: z
+    .string()
+    .min(1, t('Jira URL is required'))
+    .url(t('Enter a valid URL'))
+    .transform(v => v.replace(/\/+$/, '')),
+  consumerKey: z
+    .string()
+    .min(1, t('Consumer Key is required'))
+    .max(200, t('Consumer Key is limited to 200 characters')),
+  privateKey: z.string().min(1, t('Private Key is required')),
+  verifySsl: z.boolean(),
+});
+
+interface InstallationConfigAdvanceData {
+  consumerKey: string;
+  privateKey: string;
+  url: string;
+  verifySsl: boolean;
+}
+
+function InstallationConfigStep({
+  advance,
+  advanceError,
+  isAdvancing,
+  isInitializing,
+}: PipelineStepProps<Record<string, never>, InstallationConfigAdvanceData>) {
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {
+      url: '',
+      consumerKey: '',
+      privateKey: '',
+      verifySsl: true,
+    },
+    validators: {onDynamic: installationConfigSchema},
+    onSubmit: ({value}) => {
+      advance(installationConfigSchema.parse(value));
+    },
+  });
+
+  useEffect(() => {
+    if (advanceError) {
+      setFieldErrors(form, advanceError);
+    }
+  }, [advanceError, form]);
+
+  return (
+    <form.AppForm form={form}>
+      <Stack gap="lg">
+        <Text>
+          {tct(
+            'You must complete the [link:required steps] on your Jira Server instance before connecting it to Sentry, then enter the application credentials below.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/product/integrations/issue-tracking/jira/#jira-server" />
+              ),
+            }
+          )}
+        </Text>
+
+        <form.AppField name="url">
+          {field => (
+            <field.Layout.Stack
+              label={t('Jira URL')}
+              hintText={t(
+                'The base URL for your Jira Server instance, including the host and protocol.'
+              )}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="https://jira.example.com"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="consumerKey">
+          {field => (
+            <field.Layout.Stack
+              label={t('Jira Consumer Key')}
+              hintText={t('The consumer key configured on the Application Link.')}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="sentry-consumer-key"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="privateKey">
+          {field => (
+            <field.Layout.Stack
+              label={t('Jira Consumer Private Key')}
+              hintText={t('The RSA private key paired with the Application Link.')}
+              required
+            >
+              <field.TextArea
+                value={field.state.value}
+                onChange={field.handleChange}
+                rows={3}
+                placeholder={
+                  '-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----'
+                }
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="verifySsl">
+          {field => (
+            <field.Layout.Stack
+              label={t('Verify SSL')}
+              hintText={t(
+                'Verify SSL certificates when making requests to your Jira instance.'
+              )}
+            >
+              <field.Switch checked={field.state.value} onChange={field.handleChange} />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <Flex>
+          <form.SubmitButton busy={isAdvancing} disabled={isInitializing}>
+            {t('Continue')}
+          </form.SubmitButton>
+        </Flex>
+      </Stack>
+    </form.AppForm>
+  );
+}
+
+interface OAuthStepData {
+  oauthUrl?: string;
+}
+
+function OAuthCallbackStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<OAuthStepData, {oauthToken: string}>) {
+  const handleCallback = useCallback(
+    (data: Record<string, string>) => {
+      if (data.oauth_token) {
+        advance({oauthToken: data.oauth_token});
+      }
+    },
+    [advance]
+  );
+
+  const {openPopup, isWaitingForCallback, popupStatus} = useRedirectPopupStep({
+    redirectUrl: stepData?.oauthUrl,
+    onCallback: handleCallback,
+  });
+
+  return (
+    <Stack gap="lg" align="start">
+      <Stack gap="sm">
+        <Text>
+          {t(
+            'Authorize Sentry on your Jira Server instance to complete the integration setup.'
+          )}
+        </Text>
+        {isWaitingForCallback && (
+          <Text variant="muted" size="sm">
+            {t('A popup should have opened to authorize with Jira Server.')}
+          </Text>
+        )}
+        {popupStatus === 'failed-to-open' && (
+          <Text variant="danger" size="sm">
+            {t(
+              'The authorization popup was blocked by your browser. Please ensure popups are allowed and try again.'
+            )}
+          </Text>
+        )}
+      </Stack>
+      {isWaitingForCallback && !isAdvancing ? (
+        <Button size="sm" onClick={openPopup}>
+          {t('Reopen authorization window')}
+        </Button>
+      ) : (
+        <Button
+          size="sm"
+          variant="primary"
+          onClick={openPopup}
+          busy={isAdvancing}
+          disabled={!stepData?.oauthUrl}
+        >
+          {t('Authorize Jira Server')}
+        </Button>
+      )}
+    </Stack>
+  );
+}
+
+export const jiraServerIntegrationPipeline = {
+  type: 'integration',
+  provider: 'jira_server',
+  actionTitle: t('Installing Jira Server Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'installation_config',
+      shortDescription: t('Configuring Jira Server connection'),
+      component: InstallationConfigStep,
+    },
+    {
+      stepId: 'oauth_callback',
+      shortDescription: t('Authorizing via OAuth'),
+      component: OAuthCallbackStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -9,6 +9,7 @@ import {githubIntegrationPipeline} from './integrationGitHub';
 import {githubEnterpriseIntegrationPipeline} from './integrationGitHubEnterprise';
 import {gitlabIntegrationPipeline} from './integrationGitLab';
 import {jiraIntegrationPipeline} from './integrationJira';
+import {jiraServerIntegrationPipeline} from './integrationJiraServer';
 import {msTeamsIntegrationPipeline} from './integrationMsTeams';
 import {opsgenieIntegrationPipeline} from './integrationOpsgenie';
 import {pagerDutyIntegrationPipeline} from './integrationPagerDuty';
@@ -35,6 +36,7 @@ export const PIPELINE_REGISTRY = [
   githubEnterpriseIntegrationPipeline,
   gitlabIntegrationPipeline,
   jiraIntegrationPipeline,
+  jiraServerIntegrationPipeline,
   msTeamsIntegrationPipeline,
   opsgenieIntegrationPipeline,
   pagerDutyIntegrationPipeline,

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -54,6 +54,7 @@ const UNCONDITIONAL_API_PIPELINE_PROVIDERS = [
   'github_enterprise',
   'gitlab',
   'jira',
+  'jira_server',
   'msteams',
   'opsgenie',
   'pagerduty',


### PR DESCRIPTION
Add the API-driven pipeline modal definition for Jira Server, mirroring the Bitbucket Server pipeline it shares an OAuth 1.0a flow with.

The installation config step collects the instance URL, consumer key, RSA private key, and verify-SSL preference. The OAuth callback step opens the authorize URL in a popup and forwards the returned `oauth_token` back to the backend verifier exchange.

`jira_server` is added to the unconditional API pipeline providers so the install button drives the modal instead of the legacy server-rendered popup.

Depends on the backend pipeline steps in #117181. Kept as a draft until that PR is deployed, since frontend and backend deploy independently and the modal calls the new pipeline endpoints.

Part of [VDY-100](https://linear.app/getsentry/issue/VDY-100/jira-server-api-driven-integration-setup).