### PR TITLE
fix(attachments): Disable preview for `prosperodmp` attachments

### DIFF
--- a/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
+++ b/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
@@ -50,9 +50,15 @@ export const getImageAttachmentRenderer = (
   return undefined;
 };
 
+const nonPreviewableExtensions = ['.prosperodmp', '.prosperomemdmp'];
+
 export const getInlineAttachmentRenderer = (
   attachment: IssueAttachment
 ): AttachmentRenderer | undefined => {
+  if (nonPreviewableExtensions.some(ext => attachment.name.endsWith(ext))) {
+    return undefined;
+  }
+
   const imageAttachmentRenderer = getImageAttachmentRenderer(attachment);
   if (imageAttachmentRenderer) {
     return imageAttachmentRenderer;


### PR DESCRIPTION
These binary crash dump formats get application/octet-stream as their MIME type, which incorrectly matches the image preview allow-list.

Example event with PlayStation crash data:
 https://sentry-sdks.sentry.io/issues/7539423639/?project=4510979762487296&query=is%3Aunresolved&referrer=issue-stream

With preview disabled for these specific file types:
<img width="1367" height="916" alt="Screenshot 2026-06-09 at 17 48 16" src="https://github.com/user-attachments/assets/394acb93-9a2c-4531-af6e-33ed0c23f5d4" />
