### PR TITLE
fix(low-value-spans): Correct typo in problem description

### DIFF
--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
@@ -120,7 +120,7 @@ export function ProblemSection({evidenceData}: ProblemSectionProps) {
     <Stack gap="lg">
       <Alert variant="muted" showIcon>
         {t(
-          'Sentry found a frequently created span that adds little value. It can make traces harder to read and increase stored span volume.'
+          'Sentry found a frequently created span that adds little value. It can make traces harder to read and increases stored span volume.'
         )}
       </Alert>
       <Grid columns="fit-content(50%) 1fr" border="primary" radius="md" padding="sm">


### PR DESCRIPTION
Fix typo: "increase" → "increases" in the low-value span configuration issue description.

Fixes [TET-2467](https://linear.app/getsentry/issue/TET-2467/fix-typo)