### PR TITLE
fix(issue-detection): Exclude cached queries from N+1 DB detection

### DIFF
--- a/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
@@ -88,9 +88,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
                 self.potential_parents[span_id] = span
             return
 
-        # Cached queries (e.g. ActiveRecord QueryCache hits) never touch the
-        # database, so they shouldn't count toward an N+1. Ignore them without
-        # disrupting any sequence we're currently tracking.
+        # Cached queries never touch the database, so they shouldn't count toward an N+1.
         if is_cached_span(span):
             return
 
@@ -268,9 +266,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
 def is_cached_span(span: Span) -> bool:
     """
     Returns True if the span was served from a query cache rather than hitting
-    the database. SDKs (e.g. sentry-rails for ActiveRecord QueryCache) mark
-    these with a `cached` flag, which lands in span tags on transaction events
-    and in span data on the span-first pipeline.
+    the database.
     """
     for source in (span.get("data"), span.get("tags")):
         if not source:

--- a/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/n_plus_one_db_span_detector.py
@@ -88,6 +88,12 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
                 self.potential_parents[span_id] = span
             return
 
+        # Cached queries (e.g. ActiveRecord QueryCache hits) never touch the
+        # database, so they shouldn't count toward an N+1. Ignore them without
+        # disrupting any sequence we're currently tracking.
+        if is_cached_span(span):
+            return
+
         if not self.source_span:
             # We aren't currently tracking an N+1. Maybe this span triggers one!
             self._maybe_use_as_source(span)
@@ -257,6 +263,25 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
             (str(parent_op) + str(parent_hash) + str(source_hash) + str(n_hash)).encode("utf8"),
         ).hexdigest()
         return f"1-{problem_class}-{full_fingerprint}"
+
+
+def is_cached_span(span: Span) -> bool:
+    """
+    Returns True if the span was served from a query cache rather than hitting
+    the database. SDKs (e.g. sentry-rails for ActiveRecord QueryCache) mark
+    these with a `cached` flag, which lands in span tags on transaction events
+    and in span data on the span-first pipeline.
+    """
+    for source in (span.get("data"), span.get("tags")):
+        if not source:
+            continue
+        value = source.get("cached")
+        if isinstance(value, str):
+            if value.lower() == "true":
+                return True
+        elif value:
+            return True
+    return False
 
 
 def contains_complete_query(span: Span, is_source: bool | None = False) -> bool:

--- a/src/sentry/issue_detection/types.py
+++ b/src/sentry/issue_detection/types.py
@@ -17,6 +17,7 @@ class Span(TypedDict, total=False):
     hash: str
     parent_span_id: str
     data: dict[str, Any] | None
+    tags: dict[str, Any] | None
     sentry_tags: SentryTags
 
 

--- a/tests/sentry/issue_detection/test_n_plus_one_db_span_detector.py
+++ b/tests/sentry/issue_detection/test_n_plus_one_db_span_detector.py
@@ -396,6 +396,37 @@ class NPlusOneDBSpanDetectorTest(unittest.TestCase):
 
         assert self.find_problems(event) == []
 
+    def test_does_not_detect_n_plus_one_with_cached_queries(self) -> None:
+        source_span = create_span(
+            "db",
+            100,
+            "SELECT * FROM features WHERE key = 'a'",
+            hash="source_hash",
+        )
+
+        # Repeats look like an N+1 but are served from the query cache, so they
+        # never touch the database and shouldn't be flagged.
+        repeating_spans = [
+            create_span(
+                "db",
+                100,
+                "SELECT * FROM features WHERE key = 'b'",
+                hash="repeating_hash",
+                data={"cached": True},
+            )
+            for _ in range(11)
+        ]
+
+        event = create_event([source_span] + repeating_spans)
+        event["contexts"] = {
+            "trace": {
+                "span_id": "a" * 16,
+                "op": "http.server",
+            }
+        }
+
+        assert self.find_problems(event) == []
+
 
 @pytest.mark.django_db
 class NPlusOneDbSettingTest(TestCase):


### PR DESCRIPTION
Cached queries (e.g. ActiveRecord QueryCache hits) never touch the database, but the N+1 DB detector counted them as offenders. This produced false-positive N+1 issues for the common Rails pattern of one real query followed by cache hits within a single request.

SDKs already mark these spans with a `cached` flag — it arrives in span `tags` on transaction events and in span `data` on the span-first pipeline. The detector now ignores cached DB spans without disrupting any sequence it's currently tracking, so a run of `1 real query + N cached repeats` no longer fires, while genuinely repeated real queries still do.

Reviewer notes:

* `cached` is the first span-level tag any detector reads, so `tags` was added to the `Span` TypedDict (it's a real, commonly-present span field — confirmed against captured-event fixtures — that simply hadn't been consumed before).
* For the span-first pipeline, the shim flattens span attributes into `data[<key>]`. The helper checks `data["cached"]`; if Relay emits the SDK tag under a prefixed attribute key, that key would need adding.

Refs getsentry/sentry#117164<br>Fixes getsentry/sentry#117164