### PR TITLE
feat(integrations): Add PathMapping component for repo code mappings

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -24,6 +24,8 @@ const productionEntryPoints = [
   'static/app/chartcuterie/**/*.{js,ts,tsx}',
   // TODO: Remove when used
   'static/app/views/seerExplorer/contexts/**/*.{js,ts,tsx}',
+  // TODO: Remove when wired into the connect repository modal
+  'static/app/components/connectRepository/**/*.{ts,tsx}',
 ];
 
 const testingEntryPoints = [

--- a/static/app/components/connectRepository/pathMapping.spec.tsx
+++ b/static/app/components/connectRepository/pathMapping.spec.tsx
@@ -1,0 +1,164 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {PathMapping} from 'sentry/components/connectRepository/pathMapping';
+
+interface OverrideProps {
+  branch?: string;
+  editing?: boolean;
+  isNew?: boolean;
+  onChange?: (value: {branch: string; sourceRoot: string; stackRoot: string}) => void;
+  onDelete?: () => void;
+  onExpandToggle?: () => void;
+  sourceRoot?: string;
+  stackRoot?: string;
+}
+
+function renderPathMapping(props: OverrideProps = {}) {
+  return render(
+    <PathMapping
+      stackRoot="app/"
+      sourceRoot="static/app/"
+      branch="main"
+      editing={false}
+      isNew={false}
+      onChange={() => {}}
+      onDelete={() => {}}
+      onExpandToggle={() => {}}
+      {...props}
+    />
+  );
+}
+
+describe('PathMapping', () => {
+  describe('collapsed summary', () => {
+    it('renders the rewritten path and branch without the form', () => {
+      renderPathMapping();
+
+      expect(screen.getByText('app/')).toBeInTheDocument();
+      expect(screen.getByText('static/app/')).toBeInTheDocument();
+      expect(screen.getByText('main')).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('textbox', {name: 'Stack trace root'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows an [empty] placeholder for an unset path', () => {
+      renderPathMapping({stackRoot: ''});
+
+      expect(screen.getByText('[empty]')).toBeInTheDocument();
+    });
+
+    it('defaults the branch to main when none is set', () => {
+      renderPathMapping({branch: ''});
+
+      expect(screen.getByText('main')).toBeInTheDocument();
+    });
+
+    it('calls onExpandToggle when the expand control is clicked', async () => {
+      const onExpandToggle = jest.fn();
+      renderPathMapping({onExpandToggle});
+
+      await userEvent.click(screen.getByRole('button', {name: 'Expand path mapping'}));
+
+      expect(onExpandToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onDelete when the delete control is clicked', async () => {
+      const onDelete = jest.fn();
+      renderPathMapping({onDelete});
+
+      await userEvent.click(screen.getByRole('button', {name: 'Delete path mapping'}));
+
+      expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('editing', () => {
+    it('shows the form pre-filled and keeps the summary for existing mappings', () => {
+      renderPathMapping({editing: true, isNew: false});
+
+      expect(screen.getByRole('textbox', {name: 'Stack trace root'})).toHaveValue('app/');
+      expect(screen.getByRole('textbox', {name: 'Source code root'})).toHaveValue(
+        'static/app/'
+      );
+      expect(screen.getByRole('textbox', {name: 'Branch'})).toHaveValue('main');
+
+      expect(
+        screen.getByRole('button', {name: 'Collapse path mapping'})
+      ).toBeInTheDocument();
+    });
+
+    it('hides the summary while editing a new mapping', () => {
+      renderPathMapping({editing: true, isNew: true});
+
+      expect(screen.getByRole('textbox', {name: 'Stack trace root'})).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Collapse path mapping'})
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Delete path mapping'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('reports edits through onChange', async () => {
+      const onChange = jest.fn();
+      renderPathMapping({editing: true, onChange});
+
+      const stackTraceRoot = screen.getByRole('textbox', {name: 'Stack trace root'});
+      await userEvent.clear(stackTraceRoot);
+      await userEvent.type(stackTraceRoot, 'lib/');
+
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({stackRoot: 'lib/'})
+      );
+    });
+
+    it('sanitizes invalid characters in the branch but keeps valid ones', async () => {
+      const onChange = jest.fn();
+      renderPathMapping({editing: true, branch: '', onChange});
+
+      const branch = screen.getByRole('textbox', {name: 'Branch'});
+      await userEvent.type(branch, 'feature/my branch');
+
+      // Slashes are valid in git branches and are preserved; the space becomes
+      // a dash.
+      expect(branch).toHaveValue('feature/my-branch');
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({branch: 'feature/my-branch'})
+      );
+    });
+
+    it('keeps a trailing dash (valid in git branch names)', async () => {
+      const onChange = jest.fn();
+      renderPathMapping({editing: true, branch: '', onChange});
+
+      const branch = screen.getByRole('textbox', {name: 'Branch'});
+      await userEvent.type(branch, 'wip-');
+
+      expect(branch).toHaveValue('wip-');
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({branch: 'wip-'})
+      );
+    });
+
+    it('does not rewrite a valid existing branch when editing other fields', async () => {
+      const onChange = jest.fn();
+      renderPathMapping({editing: true, branch: 'feature/foo_bar.1', onChange});
+
+      const stackTraceRoot = screen.getByRole('textbox', {name: 'Stack trace root'});
+      await userEvent.type(stackTraceRoot, 'x');
+
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({branch: 'feature/foo_bar.1'})
+      );
+    });
+
+    it('renders the preview example', () => {
+      renderPathMapping({editing: true});
+
+      expect(screen.getByText('In your stack trace')).toBeInTheDocument();
+      expect(screen.getByText('Sentry opens in your repo')).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/components/connectRepository/pathMapping.stories.tsx
+++ b/static/app/components/connectRepository/pathMapping.stories.tsx
@@ -1,0 +1,65 @@
+import {useState} from 'react';
+
+import {PathMapping} from 'sentry/components/connectRepository/pathMapping';
+import * as Storybook from 'sentry/stories';
+
+export default Storybook.story('PathMapping', story => {
+  story('New (editing)', () => {
+    const [value, setValue] = useState({
+      stackRoot: '',
+      sourceRoot: '',
+      branch: '',
+    });
+
+    return (
+      <PathMapping
+        {...value}
+        editing
+        isNew
+        onChange={setValue}
+        onDelete={() => {}}
+        onExpandToggle={() => {}}
+      />
+    );
+  });
+
+  story('Collapsed existing', () => {
+    const [editing, setEditing] = useState(false);
+    const [value, setValue] = useState({
+      stackRoot: 'app/',
+      sourceRoot: 'static/app/',
+      branch: 'main',
+    });
+
+    return (
+      <PathMapping
+        {...value}
+        editing={editing}
+        isNew={false}
+        onChange={setValue}
+        onDelete={() => {}}
+        onExpandToggle={() => setEditing(current => !current)}
+      />
+    );
+  });
+
+  story('Editing existing', () => {
+    const [editing, setEditing] = useState(true);
+    const [value, setValue] = useState({
+      stackRoot: 'app/',
+      sourceRoot: 'static/app/',
+      branch: 'main',
+    });
+
+    return (
+      <PathMapping
+        {...value}
+        editing={editing}
+        isNew={false}
+        onChange={setValue}
+        onDelete={() => {}}
+        onExpandToggle={() => setEditing(current => !current)}
+      />
+    );
+  });
+});

--- a/static/app/components/connectRepository/pathMapping.tsx
+++ b/static/app/components/connectRepository/pathMapping.tsx
@@ -1,0 +1,379 @@
+import styled from '@emotion/styled';
+import {z} from 'zod';
+
+import {Button} from '@sentry/scraps/button';
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+import {InputGroup} from '@sentry/scraps/input';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {IconArrow, IconBranch, IconChevron, IconDelete} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+interface PathMappingValue {
+  branch: string;
+  sourceRoot: string;
+  stackRoot: string;
+}
+
+interface PathMappingProps extends PathMappingValue {
+  /**
+   * When true, renders the editable form. Existing mappings keep their summary
+   * pinned above the form; new mappings (see `isNew`) hide it.
+   */
+  editing: boolean;
+  /**
+   * Marks a not-yet-persisted mapping. New mappings hide the summary while
+   * editing since there is nothing to collapse back to yet.
+   */
+  isNew: boolean;
+  onChange: (value: PathMappingValue) => void;
+  onDelete: () => void;
+  onExpandToggle: () => void;
+}
+
+const DEFAULT_BRANCH = 'main';
+
+/**
+ * Normalizes branch input as the user types. Git branch names (see
+ * `git check-ref-format`) allow slashes, underscores, dots and dashes, so we
+ * preserve those and only replace genuinely invalid characters (whitespace,
+ * `~^:?*[\` etc.) with a dash. Repeated slashes are collapsed and a leading
+ * slash/dot — both invalid at the start of a ref — is stripped. Trailing
+ * characters are left untouched here so a dash typed as a word separator
+ * survives mid-typing; `resolveBranch` cleans up the committed value.
+ */
+const sanitizeBranch = (value: string) =>
+  value
+    .replace(/[^\w/.-]+/g, '-')
+    .replace(/\/{2,}/g, '/')
+    .replace(/^[./]+/, '');
+
+/**
+ * The effective branch for a mapping. A ref can't end with a slash or dot, so
+ * those are trimmed, but a trailing dash is valid and kept. Falls back to the
+ * default when empty. Used for the reported value and summary display.
+ */
+const resolveBranch = (branch: string) =>
+  sanitizeBranch(branch).replace(/[./]+$/, '') || DEFAULT_BRANCH;
+
+const schema = z.object({
+  stackRoot: z.string(),
+  sourceRoot: z.string(),
+  branch: z.string(),
+});
+
+/**
+ * Sample stack frame path used to illustrate how the stack trace root is
+ * rewritten to the source code root in the preview.
+ */
+const PREVIEW_SUFFIX = 'views/index.tsx';
+
+/**
+ * Ensures a root reads as a path prefix in the preview so it joins cleanly with
+ * the example suffix (e.g. `app` -> `app/`, avoiding `appviews/index.tsx`).
+ */
+const withTrailingSlash = (root: string) => (root.endsWith('/') ? root : `${root}/`);
+
+/**
+ * Flex-grow weights for how the summary row divides between the two paths and
+ * the branch name when everything overflows (35% / 35% / 30%). `max-content`
+ * caps on each item let unused space be reclaimed by the others.
+ */
+const PATH_RATIO = 35;
+const BRANCH_RATIO = 30;
+
+export function PathMapping({
+  editing,
+  isNew,
+  onChange,
+  onDelete,
+  onExpandToggle,
+  ...value
+}: PathMappingProps) {
+  const showSummary = !(editing && isNew);
+
+  return (
+    <Stack border="muted" radius="md">
+      {showSummary && (
+        <PathMappingSummary
+          {...value}
+          expanded={editing}
+          onDelete={onDelete}
+          onExpandToggle={onExpandToggle}
+        />
+      )}
+      {showSummary && editing && <Container borderTop="muted" />}
+      {editing && <PathMappingEdit {...value} onChange={onChange} />}
+    </Stack>
+  );
+}
+
+interface PathMappingEditProps extends PathMappingValue {
+  onChange: (value: PathMappingValue) => void;
+}
+
+function PathMappingEdit({
+  branch,
+  sourceRoot,
+  stackRoot,
+  onChange,
+}: PathMappingEditProps) {
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {stackRoot, sourceRoot, branch},
+    validators: {onDynamic: schema},
+    listeners: {
+      onChange: ({formApi}) => {
+        const values = formApi.state.values;
+        onChange({...values, branch: resolveBranch(values.branch)});
+      },
+    },
+    onSubmit: () => {},
+  });
+
+  return (
+    <form.AppForm form={form}>
+      <Container padding="xl">
+        <Stack gap="xl">
+          <Grid columns="1fr 1fr" gap="xl">
+            <form.AppField name="stackRoot">
+              {field => (
+                <field.Layout.Stack
+                  label={t('Stack trace root')}
+                  hintText={t('The start of the path in an error')}
+                >
+                  <field.Input value={field.state.value} onChange={field.handleChange} />
+                </field.Layout.Stack>
+              )}
+            </form.AppField>
+
+            <form.AppField name="sourceRoot">
+              {field => (
+                <field.Layout.Stack
+                  label={t('Source code root')}
+                  hintText={t('What to look for in your repository')}
+                >
+                  <field.Input value={field.state.value} onChange={field.handleChange} />
+                </field.Layout.Stack>
+              )}
+            </form.AppField>
+          </Grid>
+
+          <form.AppField name="branch">
+            {field => (
+              <field.Layout.Stack
+                label={t('Branch')}
+                hintText={t('Which branch does this mapping apply to')}
+              >
+                <field.Base<HTMLInputElement>>
+                  {(baseProps, {indicator}) => (
+                    <InputGroup style={{flex: 1}}>
+                      <InputGroup.LeadingItems disablePointerEvents>
+                        <IconBranch />
+                      </InputGroup.LeadingItems>
+                      <InputGroup.Input
+                        {...baseProps}
+                        value={field.state.value}
+                        placeholder={DEFAULT_BRANCH}
+                        onChange={e => field.handleChange(sanitizeBranch(e.target.value))}
+                      />
+                      <InputGroup.TrailingItems>{indicator}</InputGroup.TrailingItems>
+                    </InputGroup>
+                  )}
+                </field.Base>
+              </field.Layout.Stack>
+            )}
+          </form.AppField>
+
+          <Stack gap="md">
+            <Text bold>{t('Preview example')}</Text>
+            <form.Subscribe
+              selector={state => ({
+                stackRoot: state.values.stackRoot,
+                sourceRoot: state.values.sourceRoot,
+              })}
+            >
+              {previewValue => (
+                <PathMappingPreview
+                  stackRoot={previewValue.stackRoot}
+                  sourceRoot={previewValue.sourceRoot}
+                />
+              )}
+            </form.Subscribe>
+          </Stack>
+        </Stack>
+      </Container>
+    </form.AppForm>
+  );
+}
+
+interface SummaryContentProps extends PathMappingValue {
+  expanded: boolean;
+  onDelete: () => void;
+  onExpandToggle: () => void;
+}
+
+/**
+ * The inner row of a mapping summary: the rewritten path, the branch, and the
+ * expand/delete controls. Kept separate from the bordered box so it can also
+ * be rendered as the header of the editing view.
+ */
+function SummaryContent({
+  branch,
+  sourceRoot,
+  stackRoot,
+  expanded,
+  onDelete,
+  onExpandToggle,
+}: SummaryContentProps) {
+  const branchName = resolveBranch(branch);
+
+  return (
+    <Flex align="center" gap="md" minWidth={0}>
+      <PathSegment value={stackRoot} />
+      <Container flexShrink={0}>
+        {props => <IconArrow direction="right" size="xs" {...props} />}
+      </Container>
+      <PathSegment value={sourceRoot} />
+
+      {/* Absorbs leftover space so the branch + actions stay right-anchored
+          when the paths don't overflow, and collapses when they do. */}
+      <Container flex="1 0 0%" />
+
+      <Flex
+        align="center"
+        gap="xs"
+        flex={`${BRANCH_RATIO} 0 0%`}
+        minWidth={0}
+        maxWidth="max-content"
+      >
+        <Container flexShrink={0}>{props => <IconBranch {...props} />}</Container>
+        <Tooltip title={branchName} showOnlyOnOverflow skipWrapper>
+          <Text variant="muted" ellipsis>
+            {branchName}
+          </Text>
+        </Tooltip>
+      </Flex>
+
+      <Flex align="center" gap="xs" flexShrink={0}>
+        <Button
+          size="zero"
+          variant="transparent"
+          icon={<IconChevron direction={expanded ? 'up' : 'down'} />}
+          aria-label={expanded ? t('Collapse path mapping') : t('Expand path mapping')}
+          onClick={onExpandToggle}
+        />
+        <Button
+          size="zero"
+          variant="transparent"
+          icon={<IconDelete />}
+          aria-label={t('Delete path mapping')}
+          onClick={onDelete}
+        />
+      </Flex>
+    </Flex>
+  );
+}
+
+function PathMappingSummary(props: SummaryContentProps) {
+  return (
+    <Container padding="md xl">
+      <SummaryContent {...props} />
+    </Container>
+  );
+}
+
+/**
+ * A single path in the summary. Grows to its share of the row but never past
+ * its own content (`max-content`), so a short path yields its space to the
+ * others. Truncates with an overflow tooltip when it does fill its share.
+ */
+function PathSegment({value}: {value: string}) {
+  return (
+    <Flex flex={`${PATH_RATIO} 0 0%`} minWidth={0} maxWidth="max-content">
+      {value ? (
+        <AccentPathSegment value={value} ellipsis />
+      ) : (
+        <Text monospace variant="muted">
+          {t('[empty]')}
+        </Text>
+      )}
+    </Flex>
+  );
+}
+
+const AccentHighlight = styled(Container)`
+  background: ${p => p.theme.tokens.background.transparent.accent.muted};
+`;
+
+interface AccentPathSegmentProps {
+  value: string;
+  ellipsis?: boolean;
+}
+
+/**
+ * An accent-colored path with the highlighted background that hugs the text.
+ * The background comes from a `Container` whose className is spread onto the
+ * `Text` (the accent token isn't expressible through `Container`'s `background`
+ * prop, so it lives on the styled wrapper). Pass `ellipsis` where the row can
+ * truncate; it switches to `inline-block` and adds an overflow tooltip.
+ */
+function AccentPathSegment({value, ellipsis}: AccentPathSegmentProps) {
+  return (
+    <AccentHighlight
+      display={ellipsis ? 'inline-block' : 'inline'}
+      radius="xs"
+      padding="0 xs"
+      maxWidth={ellipsis ? '100%' : undefined}
+    >
+      {props => {
+        const text = (
+          <Text {...props} monospace variant="accent" ellipsis={ellipsis || undefined}>
+            {value}
+          </Text>
+        );
+
+        return ellipsis ? (
+          <Tooltip title={value} showOnlyOnOverflow skipWrapper>
+            {text}
+          </Tooltip>
+        ) : (
+          text
+        );
+      }}
+    </AccentHighlight>
+  );
+}
+
+interface PathMappingPreviewProps {
+  sourceRoot: string;
+  stackRoot: string;
+}
+
+function PathMappingPreview({stackRoot, sourceRoot}: PathMappingPreviewProps) {
+  return (
+    <Container background="secondary" radius="md" padding="xl">
+      <Grid columns="1fr auto 1fr" gap="lg xl" align="center">
+        <Text bold variant="muted">
+          {t('In your stack trace')}
+        </Text>
+        <span />
+        <Text bold variant="muted">
+          {t('Sentry opens in your repo')}
+        </Text>
+
+        <Text monospace variant="muted">
+          {stackRoot && <AccentPathSegment value={withTrailingSlash(stackRoot)} />}
+          {PREVIEW_SUFFIX}
+        </Text>
+        <IconArrow direction="right" />
+        <Text monospace variant="muted">
+          {sourceRoot && <AccentPathSegment value={withTrailingSlash(sourceRoot)} />}
+          {PREVIEW_SUFFIX}
+        </Text>
+      </Grid>
+    </Container>
+  );
+}


### PR DESCRIPTION
Introduces a self-contained `PathMapping` component (in `components/connectRepository`) for editing a single repository code mapping — the stack trace root, source code root, and branch override that tell Sentry how to translate a stack frame path to a line in your repo.

It renders a collapsed summary that rewrites the path inline (`app/` → `static/app/`) and expands into an editable form with a live preview example. Existing mappings keep their summary pinned above the form when expanded; new (not-yet-persisted) mappings hide it.

Built on the new scraps form system. A few behaviors worth calling out:

- The branch slugifies non-alphanumerics to dashes as you type and defaults to `main`.
- The summary truncates long paths/branches with overflow tooltips, dividing the row 35/35/30 between the two paths and the branch while reclaiming space that isn't used (via flex-grow weights + `max-content` caps).
- Unset paths render an `[empty]` placeholder in the summary.

This is a standalone component with a story and tests; wiring it into the connect-repository modal will come in a follow-up.

Preview https://sentry-dyb9rhfsk.sentry.dev/stories/product/components/connectrepository/pathmapping/