### PR TITLE
feat(seer): Add cross-event filter params to execute_table_query

### DIFF
--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -137,9 +137,17 @@ def execute_table_query(
     end: str | None = None,
     sampling_mode: SAMPLING_MODES = "NORMAL",
     case_insensitive: bool | None = None,
+    span_query: list[str] | None = None,
+    log_query: list[str] | None = None,
+    metric_query: list[str] | None = None,
 ) -> dict[str, Any] | None:
     """
     Execute a query to get table data by calling the events endpoint.
+
+    span_query/log_query/metric_query are optional cross-event (same-trace) filters:
+    when set, results are restricted to the primary dataset's rows whose trace also
+    contains a matching span/log/metric. Forwarded to the events endpoint as repeated
+    spanQuery/logQuery/metricQuery params (read server-side by get_additional_queries).
 
     Arg notes:
         project_ids: The IDs of the projects to query. Cannot be provided with project_slugs.
@@ -186,6 +194,14 @@ def execute_table_query(
     # Add boolean params only if provided.
     if case_insensitive is not None:
         params["caseInsensitive"] = "1" if case_insensitive else "0"
+
+    # Cross-event (same-trace) filters.
+    if span_query:
+        params["spanQuery"] = span_query
+    if log_query:
+        params["logQuery"] = log_query
+    if metric_query:
+        params["metricQuery"] = metric_query
 
     # Remove None values
     params = {k: v for k, v in params.items() if v is not None}

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -247,6 +247,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
             start={item?.start}
             end={item?.end}
             visualizations={item?.visualizations}
+            expandedProjectIds={item?.expandedProjectIds}
           />
         </Item>
       );

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -281,6 +281,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
             start={item?.start}
             end={item?.end}
             visualizations={item?.visualizations}
+            expandedProjectIds={item?.expandedProjectIds}
           />
         </Item>
       );

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -8,6 +8,9 @@ import {useSearchQueryBuilderConfig} from 'sentry/components/searchQueryBuilder/
 import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {t} from 'sentry/locale';
+import {useProjects} from 'sentry/utils/useProjects';
+
+const MAX_PROJECT_CHIPS = 3;
 
 export function QueryTokens({
   groupBys,
@@ -17,9 +20,11 @@ export function QueryTokens({
   start,
   end,
   visualizations,
+  expandedProjectIds,
 }: QueryTokensProps) {
   const tokens = [];
   const {getFieldDefinition} = useSearchQueryBuilderConfig();
+  const {projects} = useProjects();
   const parsedQuery = query ? parseQueryBuilderValue(query, getFieldDefinition) : null;
   if (query && parsedQuery?.length) {
     tokens.push(
@@ -94,6 +99,35 @@ export function QueryTokens({
       >
         <ExploreParamTitle>{t('Time Range')}</ExploreParamTitle>
         <ExploreGroupBys>{statsPeriod}</ExploreGroupBys>
+      </Flex>
+    );
+  }
+
+  // When the agent broadened the query beyond the user's selected projects,
+  // surface the scope it will run against. Chosen alongside the other tokens,
+  // so the user sees (and consents to) the expansion before applying.
+  if (expandedProjectIds && expandedProjectIds.length > 0) {
+    const slugs = expandedProjectIds.map(
+      id => projects.find(project => project.id === String(id))?.slug ?? String(id)
+    );
+    const shownSlugs = slugs.slice(0, MAX_PROJECT_CHIPS);
+    const overflowCount = slugs.length - shownSlugs.length;
+    tokens.push(
+      <Flex
+        as="span"
+        align="center"
+        wrap="wrap"
+        gap="xs"
+        overflow="hidden"
+        key="projects"
+      >
+        <ExploreParamTitle>{t('Projects')}</ExploreParamTitle>
+        {shownSlugs.map(slug => (
+          <ExploreGroupBys key={slug}>{slug}</ExploreGroupBys>
+        ))}
+        {overflowCount > 0 ? (
+          <ExploreGroupBys>{t('+%s more', overflowCount)}</ExploreGroupBys>
+        ) : null}
       </Flex>
     );
   }

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
@@ -14,6 +14,9 @@ export interface SeerRawResponseItem {
 export interface SeerRawResponse {
   responses: SeerRawResponseItem[];
   unsupported_reason: string | null;
+  // Projects Seer actually scoped the query to — a superset of the projects we
+  // sent when it broadens scope. `null`/absent when there's no expansion.
+  project_ids?: number[] | null;
 }
 
 export interface NoneOfTheseItem {
@@ -29,6 +32,12 @@ export type AskSeerSearchItems<T> = (AskSeerSearchItem<string> & T) | NoneOfThes
 
 export interface QueryTokensProps {
   end?: string | null;
+  /**
+   * Projects the agent broadened the query to, when it expanded scope beyond
+   * the user's selection. Set only when there is an actual expansion; drives
+   * the "Projects" chip and the projects applied when the suggestion is chosen.
+   */
+  expandedProjectIds?: number[];
   groupBys?: string[];
   query?: string;
   sort?: string;

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -73,6 +73,24 @@ export function isNoneOfTheseItem(
   return item.key === 'none-of-these';
 }
 
+/**
+ * Returns the agent's expanded project scope to apply when it broadened beyond
+ * the user's selection (Seer always returns a superset). Returns `undefined`
+ * when there's no expansion, so the "Projects" chip stays hidden and the user's
+ * selection is left untouched.
+ */
+export function getExpandedProjectIds(
+  returnedProjectIds: number[] | null | undefined,
+  selectedProjectIds: number[]
+): number[] | undefined {
+  if (!returnedProjectIds || returnedProjectIds.length === 0) {
+    return undefined;
+  }
+  const selectedSet = new Set(selectedProjectIds);
+  const hasExtraProjects = returnedProjectIds.some(id => !selectedSet.has(id));
+  return hasExtraProjects ? returnedProjectIds : undefined;
+}
+
 function formatToken(token: string): string {
   const isNegated = token.startsWith('!') && token.includes(':');
   const actualToken = isNegated ? token.slice(1) : token;

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -13,6 +13,7 @@ import {
   useSelectedProjectIds,
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import {getExpandedProjectIds} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -36,6 +37,7 @@ interface AskSeerSearchQuery {
   sort: string;
   start: string | null;
   statsPeriod: string;
+  expandedProjectIds?: number[];
 }
 
 export function LogsTabSeerComboBox() {
@@ -68,6 +70,11 @@ export function LogsTabSeerComboBox() {
         },
       });
 
+      const expandedProjectIds = getExpandedProjectIds(
+        data.project_ids,
+        selectedProjectIds
+      );
+
       return {
         status: 'ok',
         unsupported_reason: data.unsupported_reason,
@@ -79,6 +86,7 @@ export function LogsTabSeerComboBox() {
           start: r?.start ?? null,
           end: r?.end ?? null,
           mode: r?.mode ?? 'samples',
+          ...(expandedProjectIds ? {expandedProjectIds} : {}),
         })),
       };
     },
@@ -95,6 +103,7 @@ export function LogsTabSeerComboBox() {
         statsPeriod,
         start: resultStart,
         end: resultEnd,
+        expandedProjectIds,
       } = result;
 
       const dt = buildSeerDateTimeSelection(
@@ -159,6 +168,8 @@ export function LogsTabSeerComboBox() {
 
       const newQuery = {
         ...location.query,
+        // Widen to the agent's expanded scope when it broadened the query.
+        ...(expandedProjectIds ? {project: expandedProjectIds.map(String)} : {}),
         [LOGS_QUERY_KEY]: queryToUse,
         mode,
         [LOGS_AGGREGATE_FIELD_KEY]: aggregateFields.map(field => JSON.stringify(field)),
@@ -201,8 +212,12 @@ export function LogsTabSeerComboBox() {
   );
 
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
-      transformSeerResponse(response, r => ({
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
+      const expandedProjectIds = getExpandedProjectIds(
+        (response as unknown as SeerRawResponse).project_ids,
+        selectedProjectIds
+      );
+      return transformSeerResponse(response, r => ({
         query: r?.query ?? '',
         sort: r?.sort ?? '',
         groupBys: r?.group_by ?? [],
@@ -210,8 +225,10 @@ export function LogsTabSeerComboBox() {
         start: r?.start ?? null,
         end: r?.end ?? null,
         mode: r?.mode ?? 'samples',
-      })),
-    []
+        ...(expandedProjectIds ? {expandedProjectIds} : {}),
+      }));
+    },
+    [selectedProjectIds]
   );
 
   if (!enableAISearch) {

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -17,6 +17,7 @@ import {
   useSelectedProjectIds,
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import {getExpandedProjectIds} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {ConfigStore} from 'sentry/stores/configStore';
@@ -87,10 +88,18 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         },
       });
 
+      const expandedProjectIds = getExpandedProjectIds(
+        data.project_ids,
+        selectedProjectIds
+      );
+
       return {
         status: 'ok',
         unsupported_reason: data.unsupported_reason,
-        queries: data.responses.map(response => mapSeerResponseItem(response)),
+        queries: data.responses.map(response => ({
+          ...mapSeerResponseItem(response),
+          ...(expandedProjectIds ? {expandedProjectIds} : {}),
+        })),
       };
     },
   });
@@ -294,6 +303,10 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
           ...location,
           query: {
             ...location.query,
+            // Widen to the agent's expanded scope when it broadened the query.
+            ...(result.expandedProjectIds?.length
+              ? {project: result.expandedProjectIds.map(String)}
+              : {}),
             metric: newEncodedMetrics,
             start: seerQuery.datetime.start,
             end: seerQuery.datetime.end,
@@ -323,9 +336,17 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
     organization.features.includes('gen-ai-explore-metrics-search');
 
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
-      transformSeerResponse(response, responseItem => mapSeerResponseItem(responseItem)),
-    []
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
+      const expandedProjectIds = getExpandedProjectIds(
+        (response as unknown as SeerRawResponse).project_ids,
+        selectedProjectIds
+      );
+      return transformSeerResponse(response, responseItem => ({
+        ...mapSeerResponseItem(responseItem),
+        ...(expandedProjectIds ? {expandedProjectIds} : {}),
+      }));
+    },
+    [selectedProjectIds]
   );
 
   if (!enableAISearch) {

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -17,6 +17,7 @@ import {
   useSelectedProjectIds,
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
+import {getExpandedProjectIds} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {fetchMutation} from 'sentry/utils/queryClient';
@@ -70,10 +71,18 @@ export function SpansTabSeerComboBox() {
           },
         });
 
+        const expandedProjectIds = getExpandedProjectIds(
+          data.project_ids,
+          selectedProjectIds
+        );
+
         return {
           status: 'ok',
           unsupported_reason: data.unsupported_reason,
-          queries: data.responses.map(response => mapSeerResponseItem(response, 'spans')),
+          queries: data.responses.map(response => ({
+            ...mapSeerResponseItem(response, 'spans'),
+            ...(expandedProjectIds ? {expandedProjectIds} : {}),
+          })),
         };
       }
 
@@ -121,6 +130,10 @@ export function SpansTabSeerComboBox() {
 
       const selection = {
         ...pageFilters.selection,
+        // Widen to the agent's expanded scope when it broadened the query.
+        ...(result.expandedProjectIds?.length
+          ? {projects: result.expandedProjectIds}
+          : {}),
         datetime: seerQuery.datetime,
       };
 
@@ -170,11 +183,17 @@ export function SpansTabSeerComboBox() {
   });
 
   const transformResponse = useCallback(
-    (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
-      transformSeerResponse(response, responseItem =>
-        mapSeerResponseItem(responseItem, 'spans')
-      ),
-    []
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
+      const expandedProjectIds = getExpandedProjectIds(
+        (response as unknown as SeerRawResponse).project_ids,
+        selectedProjectIds
+      );
+      return transformSeerResponse(response, responseItem => ({
+        ...mapSeerResponseItem(responseItem, 'spans'),
+        ...(expandedProjectIds ? {expandedProjectIds} : {}),
+      }));
+    },
+    [selectedProjectIds]
   );
 
   if (useTranslateEndpoint) {

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -455,6 +455,57 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
 
         assert exc_info.value.status_code == 500
 
+    @patch("sentry.seer.agent.tools.client.get")
+    def test_table_query_forwards_cross_event_params(self, mock_client_get: Mock) -> None:
+        """Cross-event filters are forwarded to /events/ as repeated spanQuery/logQuery/metricQuery params."""
+        mock_resp = Mock()
+        mock_resp.data = {"data": []}
+        mock_client_get.return_value = mock_resp
+
+        execute_table_query(
+            org_id=self.organization.id,
+            dataset="spans",
+            fields=self.default_span_fields,
+            query="span.op:QueryBuilder",
+            stats_period="1h",
+            sort="-timestamp",
+            per_page=10,
+            span_query=["span.category:http"],
+            log_query=["severity:error"],
+            metric_query=["metric.name:checkout.latency"],
+        )
+
+        mock_client_get.assert_called_once()
+        params = mock_client_get.call_args.kwargs["params"]
+        assert params["spanQuery"] == ["span.category:http"]
+        assert params["logQuery"] == ["severity:error"]
+        assert params["metricQuery"] == ["metric.name:checkout.latency"]
+        # Primary query is unaffected by the cross-event filters.
+        assert params["query"] == "span.op:QueryBuilder"
+
+    @patch("sentry.seer.agent.tools.client.get")
+    def test_table_query_omits_cross_event_params_when_unset(self, mock_client_get: Mock) -> None:
+        """With no cross-event filters the request is unchanged — back-compat for existing callers."""
+        mock_resp = Mock()
+        mock_resp.data = {"data": []}
+        mock_client_get.return_value = mock_resp
+
+        execute_table_query(
+            org_id=self.organization.id,
+            dataset="spans",
+            fields=self.default_span_fields,
+            query="",
+            stats_period="1h",
+            sort="-timestamp",
+            per_page=10,
+        )
+
+        mock_client_get.assert_called_once()
+        params = mock_client_get.call_args.kwargs["params"]
+        assert "spanQuery" not in params
+        assert "logQuery" not in params
+        assert "metricQuery" not in params
+
     def test_spans_timeseries_with_groupby(self) -> None:
         """Test timeseries query with group_by parameter for aggregates"""
         result = execute_timeseries_query(
@@ -577,6 +628,90 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
         # Test with nonexistent organization
         result = get_organization_project_ids(org_id=99999)
         assert result == {"projects": []}
+
+
+class TestSpansCrossTraceQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase, OurLogTestCase):
+    """Integration test for the tool->API cross-event (same-trace) contract."""
+
+    span_fields = ["id", "span.op", "trace", "timestamp"]
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.ten_mins_ago = before_now(minutes=10)
+
+        self.trace_with_log = uuid.uuid4().hex
+        self.trace_without_log = uuid.uuid4().hex
+
+        # A matching log lives only in trace_with_log; the other trace gets an unrelated log.
+        self.store_eap_items(
+            [
+                self.create_ourlog(
+                    {
+                        "body": "crosseventneedle",
+                        "severity_text": "ERROR",
+                        "severity_number": 17,
+                        "trace_id": self.trace_with_log,
+                    },
+                    timestamp=self.ten_mins_ago,
+                ),
+                self.create_ourlog(
+                    {
+                        "body": "unrelatedlog",
+                        "severity_text": "INFO",
+                        "severity_number": 9,
+                        "trace_id": self.trace_without_log,
+                    },
+                    timestamp=self.ten_mins_ago,
+                ),
+            ]
+        )
+
+        # One db span in each trace; the primary query (span.op:db) matches both spans,
+        # so any narrowing in the assertions is attributable to the cross-event filter.
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "cross-event probe",
+                        "sentry_tags": {"op": "db"},
+                        "trace_id": self.trace_with_log,
+                    },
+                    start_ts=self.ten_mins_ago,
+                    duration=100,
+                ),
+                self.create_span(
+                    {
+                        "description": "cross-event probe",
+                        "sentry_tags": {"op": "db"},
+                        "trace_id": self.trace_without_log,
+                    },
+                    start_ts=self.ten_mins_ago,
+                    duration=100,
+                ),
+            ]
+        )
+
+    def test_log_cross_event_filter_restricts_to_matching_trace(self) -> None:
+        """log_query restricts spans to those whose trace also contains the matching log."""
+        result = execute_table_query(
+            org_id=self.organization.id,
+            dataset="spans",
+            fields=self.span_fields,
+            query="span.op:db",
+            stats_period="1h",
+            sort="-timestamp",
+            per_page=10,
+            project_slugs=[self.project.slug],
+            log_query=["message:crosseventneedle"],
+        )
+
+        assert result is not None
+        assert "error" not in result, result
+        rows = result["data"]
+        # Only the span whose trace also contains the matching log survives the join.
+        assert len(rows) == 1
+        assert rows[0]["trace"] == self.trace_with_log
 
 
 class TestGetTraceWaterfall(APITransactionTestCase, SpanTestCase, SnubaTestCase):


### PR DESCRIPTION
`execute_table_query` now accepts optional `span_query/log_query/metric_query` lists and forwards them to the events endpoint as repeated `spanQuery/logQuery/metricQuery` params. The endpoint reads these via `get_additional_queries`, so EAP restricts the primary spans result to traces that also contain a matching sibling item (the same-trace cross-event join). This lets Seer's Explorer agent express cross-event queries the product already supports instead of collapsing them into a structurally empty single-row conjunction.
