### PR TITLE
fix(attachments): Preserve screenshot aspect ratio on resize

### DIFF
--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/imageVisualization.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/imageVisualization.tsx
@@ -4,9 +4,7 @@ import {ImageViewer} from 'sentry/components/events/attachmentViewers/imageViewe
 
 export const ImageVisualization = styled(ImageViewer)`
   padding: 0;
+  width: 100%;
   height: 100%;
-  img {
-    width: auto;
-    height: 100%;
-  }
+  object-fit: cover;
 `;

--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -107,11 +107,9 @@ const StyledImageVisualization = styled(ImageVisualization)`
   border: 0;
   border-radius: ${p => p.theme.radius.md};
   overflow: hidden;
-  img {
-    width: auto;
-    height: auto;
-  }
+  width: auto;
   height: auto;
+  object-fit: unset;
 `;
 const FileDownload = styled('a')`
   cursor: pointer;


### PR DESCRIPTION
Screenshots in the attachments tab were squashed horizontally when the window was resized or the Seer Autofix sidebar opened. The root cause was a dead nested `img { ... }` CSS selector inside `styled(ImageViewer)` — since ImageViewer renders the `<img>` element directly, the className lands on the img itself and the nested selector never matched.

Move width, height, and object-fit to top-level styles so they apply to the actual element. Use `object-fit: cover` to crop instead of squash when the container is narrower than the image's natural width.

Example event with lots of screenshots: 
https://sentry-sdks.sentry.io/issues/7165181036/attachments/?attachmentFilter=screenshot&project=4508816831873030&query=is%3Aunresolved&referrer=issue-stream

**Before**
<img width="1511" height="865" alt="Screenshot 2026-06-09 at 18 02 08" src="https://github.com/user-attachments/assets/9e543181-2553-413f-9804-360ca8a9068c" />

**After**
<img width="1512" height="858" alt="Screenshot 2026-06-09 at 18 02 22" src="https://github.com/user-attachments/assets/018895e7-735e-4267-b1f7-39ee96132822" />
