### PR TITLE
feat(seer): Add cross-event filter params to execute_table_query

### DIFF
--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -137,9 +137,17 @@ def execute_table_query(
     end: str | None = None,
     sampling_mode: SAMPLING_MODES = "NORMAL",
     case_insensitive: bool | None = None,
+    span_query: list[str] | None = None,
+    log_query: list[str] | None = None,
+    metric_query: list[str] | None = None,
 ) -> dict[str, Any] | None:
     """
     Execute a query to get table data by calling the events endpoint.
+
+    span_query/log_query/metric_query are optional cross-event (same-trace) filters:
+    when set, results are restricted to the primary dataset's rows whose trace also
+    contains a matching span/log/metric. Forwarded to the events endpoint as repeated
+    spanQuery/logQuery/metricQuery params (read server-side by get_additional_queries).
 
     Arg notes:
         project_ids: The IDs of the projects to query. Cannot be provided with project_slugs.
@@ -186,6 +194,14 @@ def execute_table_query(
     # Add boolean params only if provided.
     if case_insensitive is not None:
         params["caseInsensitive"] = "1" if case_insensitive else "0"
+
+    # Cross-event (same-trace) filters.
+    if span_query:
+        params["spanQuery"] = span_query
+    if log_query:
+        params["logQuery"] = log_query
+    if metric_query:
+        params["metricQuery"] = metric_query
 
     # Remove None values
     params = {k: v for k, v in params.items() if v is not None}

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -455,6 +455,57 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
 
         assert exc_info.value.status_code == 500
 
+    @patch("sentry.seer.agent.tools.client.get")
+    def test_table_query_forwards_cross_event_params(self, mock_client_get: Mock) -> None:
+        """Cross-event filters are forwarded to /events/ as repeated spanQuery/logQuery/metricQuery params."""
+        mock_resp = Mock()
+        mock_resp.data = {"data": []}
+        mock_client_get.return_value = mock_resp
+
+        execute_table_query(
+            org_id=self.organization.id,
+            dataset="spans",
+            fields=self.default_span_fields,
+            query="span.op:QueryBuilder",
+            stats_period="1h",
+            sort="-timestamp",
+            per_page=10,
+            span_query=["span.category:http"],
+            log_query=["severity:error"],
+            metric_query=["metric.name:checkout.latency"],
+        )
+
+        mock_client_get.assert_called_once()
+        params = mock_client_get.call_args.kwargs["params"]
+        assert params["spanQuery"] == ["span.category:http"]
+        assert params["logQuery"] == ["severity:error"]
+        assert params["metricQuery"] == ["metric.name:checkout.latency"]
+        # Primary query is unaffected by the cross-event filters.
+        assert params["query"] == "span.op:QueryBuilder"
+
+    @patch("sentry.seer.agent.tools.client.get")
+    def test_table_query_omits_cross_event_params_when_unset(self, mock_client_get: Mock) -> None:
+        """With no cross-event filters the request is unchanged — back-compat for existing callers."""
+        mock_resp = Mock()
+        mock_resp.data = {"data": []}
+        mock_client_get.return_value = mock_resp
+
+        execute_table_query(
+            org_id=self.organization.id,
+            dataset="spans",
+            fields=self.default_span_fields,
+            query="",
+            stats_period="1h",
+            sort="-timestamp",
+            per_page=10,
+        )
+
+        mock_client_get.assert_called_once()
+        params = mock_client_get.call_args.kwargs["params"]
+        assert "spanQuery" not in params
+        assert "logQuery" not in params
+        assert "metricQuery" not in params
+
     def test_spans_timeseries_with_groupby(self) -> None:
         """Test timeseries query with group_by parameter for aggregates"""
         result = execute_timeseries_query(
@@ -577,6 +628,90 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
         # Test with nonexistent organization
         result = get_organization_project_ids(org_id=99999)
         assert result == {"projects": []}
+
+
+class TestSpansCrossTraceQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase, OurLogTestCase):
+    """Integration test for the tool->API cross-event (same-trace) contract."""
+
+    span_fields = ["id", "span.op", "trace", "timestamp"]
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.ten_mins_ago = before_now(minutes=10)
+
+        self.trace_with_log = uuid.uuid4().hex
+        self.trace_without_log = uuid.uuid4().hex
+
+        # A matching log lives only in trace_with_log; the other trace gets an unrelated log.
+        self.store_eap_items(
+            [
+                self.create_ourlog(
+                    {
+                        "body": "crosseventneedle",
+                        "severity_text": "ERROR",
+                        "severity_number": 17,
+                        "trace_id": self.trace_with_log,
+                    },
+                    timestamp=self.ten_mins_ago,
+                ),
+                self.create_ourlog(
+                    {
+                        "body": "unrelatedlog",
+                        "severity_text": "INFO",
+                        "severity_number": 9,
+                        "trace_id": self.trace_without_log,
+                    },
+                    timestamp=self.ten_mins_ago,
+                ),
+            ]
+        )
+
+        # One db span in each trace; the primary query (span.op:db) matches both spans,
+        # so any narrowing in the assertions is attributable to the cross-event filter.
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "cross-event probe",
+                        "sentry_tags": {"op": "db"},
+                        "trace_id": self.trace_with_log,
+                    },
+                    start_ts=self.ten_mins_ago,
+                    duration=100,
+                ),
+                self.create_span(
+                    {
+                        "description": "cross-event probe",
+                        "sentry_tags": {"op": "db"},
+                        "trace_id": self.trace_without_log,
+                    },
+                    start_ts=self.ten_mins_ago,
+                    duration=100,
+                ),
+            ]
+        )
+
+    def test_log_cross_event_filter_restricts_to_matching_trace(self) -> None:
+        """log_query restricts spans to those whose trace also contains the matching log."""
+        result = execute_table_query(
+            org_id=self.organization.id,
+            dataset="spans",
+            fields=self.span_fields,
+            query="span.op:db",
+            stats_period="1h",
+            sort="-timestamp",
+            per_page=10,
+            project_slugs=[self.project.slug],
+            log_query=["message:crosseventneedle"],
+        )
+
+        assert result is not None
+        assert "error" not in result, result
+        rows = result["data"]
+        # Only the span whose trace also contains the matching log survives the join.
+        assert len(rows) == 1
+        assert rows[0]["trace"] == self.trace_with_log
 
 
 class TestGetTraceWaterfall(APITransactionTestCase, SpanTestCase, SnubaTestCase):


### PR DESCRIPTION
### Context

This change would allow us to modify `telemetry_live_search` to support cross event queries

`execute_table_query` now accepts optional `span_query/log_query/metric_query` lists and forwards them to the events endpoint as repeated `spanQuery/logQuery/metricQuery` params. The endpoint reads these via `get_additional_queries`, so EAP restricts the primary spans result to traces that also contain a matching sibling item (the same-trace cross-event join). This lets Seer's Explorer agent express cross-event queries the product already supports instead of collapsing them into a structurally empty single-row conjunction.


