### PR TITLE
feat(explore): Apply Seer-suggested interval to Explore charts

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -248,6 +248,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
             end={item?.end}
             visualizations={item?.visualizations}
             expandedProjectIds={item?.expandedProjectIds}
+            interval={item?.interval}
           />
         </Item>
       );

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -282,6 +282,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
             end={item?.end}
             visualizations={item?.visualizations}
             expandedProjectIds={item?.expandedProjectIds}
+            interval={item?.interval}
           />
         </Item>
       );

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -14,6 +14,7 @@ const MAX_PROJECT_CHIPS = 3;
 
 export function QueryTokens({
   groupBys,
+  interval,
   query,
   sort,
   statsPeriod,
@@ -61,9 +62,6 @@ export function QueryTokens({
     );
   }
 
-  // The chart uses a single interval shared across all y-axes, so display the
-  // first interval Seer provided.
-  const interval = visualizations?.find(({interval: i}) => Boolean(i))?.interval;
   if (interval) {
     tokens.push(
       <Flex

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -61,6 +61,25 @@ export function QueryTokens({
     );
   }
 
+  // The chart uses a single interval shared across all y-axes, so display the
+  // first interval Seer provided.
+  const interval = visualizations?.find(({interval: i}) => Boolean(i))?.interval;
+  if (interval) {
+    tokens.push(
+      <Flex
+        as="span"
+        align="center"
+        wrap="wrap"
+        gap="xs"
+        overflow="hidden"
+        key="interval"
+      >
+        <ExploreParamTitle>{t('Interval')}</ExploreParamTitle>
+        <ExploreGroupBys>{interval}</ExploreGroupBys>
+      </Flex>
+    );
+  }
+
   if (groupBys && groupBys.length > 0) {
     tokens.push(
       <Flex as="span" align="center" wrap="wrap" gap="xs" overflow="hidden" key="groupBy">

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
@@ -43,15 +43,14 @@ export interface QueryTokensProps {
    */
   expandedProjectIds?: number[];
   groupBys?: string[];
+  // Seer returns the interval nested per-visualization, but the chart uses a
+  // single shared interval, so we hoist it to a chart-level field.
+  interval?: string | null;
   query?: string;
   sort?: string;
   start?: string | null;
   statsPeriod?: string;
-  visualizations?: Array<{
-    yAxes: string[];
-    chartType?: ChartType;
-    interval?: string | null;
-  }>;
+  visualizations?: Array<{yAxes: string[]; chartType?: ChartType}>;
 }
 
 export interface AskSeerSearchQuery extends QueryTokensProps {
@@ -62,11 +61,7 @@ export interface AskSeerSearchQuery extends QueryTokensProps {
   sort: string;
   start: string | null;
   statsPeriod: string;
-  visualizations: Array<{
-    yAxes: string[];
-    chartType?: ChartType;
-    interval?: string | null;
-  }>;
+  visualizations: Array<{yAxes: string[]; chartType?: ChartType}>;
 }
 
 /**

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
@@ -8,7 +8,11 @@ export interface SeerRawResponseItem {
   sort: string;
   start: string | null;
   stats_period: string;
-  visualization?: Array<{chart_type?: number; y_axes?: string[]}>;
+  visualization?: Array<{
+    chart_type?: number;
+    interval?: string | null;
+    y_axes?: string[];
+  }>;
 }
 
 export interface SeerRawResponse {
@@ -43,7 +47,11 @@ export interface QueryTokensProps {
   sort?: string;
   start?: string | null;
   statsPeriod?: string;
-  visualizations?: Array<{yAxes: string[]; chartType?: ChartType}>;
+  visualizations?: Array<{
+    yAxes: string[];
+    chartType?: ChartType;
+    interval?: string | null;
+  }>;
 }
 
 export interface AskSeerSearchQuery extends QueryTokensProps {
@@ -54,7 +62,11 @@ export interface AskSeerSearchQuery extends QueryTokensProps {
   sort: string;
   start: string | null;
   statsPeriod: string;
-  visualizations: Array<{yAxes: string[]; chartType?: ChartType}>;
+  visualizations: Array<{
+    yAxes: string[];
+    chartType?: ChartType;
+    interval?: string | null;
+  }>;
 }
 
 /**

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
@@ -198,7 +198,7 @@ describe('mapSeerResponseItem', () => {
     });
   });
 
-  it('maps the visualization interval when present', () => {
+  it('hoists the interval from the visualization to a top-level field', () => {
     expect(
       mapSeerResponseItem({
         query: 'span.op:db',
@@ -218,7 +218,8 @@ describe('mapSeerResponseItem', () => {
       start: null,
       end: null,
       mode: 'aggregates',
-      visualizations: [{chartType: ChartType.BAR, yAxes: ['count()'], interval: '1h'}],
+      visualizations: [{chartType: ChartType.BAR, yAxes: ['count()']}],
+      interval: '1h',
     });
   });
 

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
@@ -223,6 +223,35 @@ describe('mapSeerResponseItem', () => {
     });
   });
 
+  it('hoists the interval from a plotted visualization, ignoring axis-less entries', () => {
+    expect(
+      mapSeerResponseItem({
+        query: 'span.op:db',
+        sort: '',
+        group_by: [],
+        stats_period: '24h',
+        start: null,
+        end: null,
+        mode: 'aggregates',
+        visualization: [
+          // Dropped because it has no y-axes; its interval must not be used.
+          {y_axes: [], interval: '5m'},
+          {chart_type: ChartType.BAR, y_axes: ['count()'], interval: '1h'},
+        ],
+      })
+    ).toEqual({
+      query: 'span.op:db',
+      sort: '',
+      groupBys: [],
+      statsPeriod: '24h',
+      start: null,
+      end: null,
+      mode: 'aggregates',
+      visualizations: [{chartType: ChartType.BAR, yAxes: ['count()']}],
+      interval: '1h',
+    });
+  });
+
   it('leaves missing or invalid chart types undefined', () => {
     expect(
       mapSeerResponseItem(

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
@@ -198,6 +198,30 @@ describe('mapSeerResponseItem', () => {
     });
   });
 
+  it('maps the visualization interval when present', () => {
+    expect(
+      mapSeerResponseItem({
+        query: 'span.op:db',
+        sort: '',
+        group_by: [],
+        stats_period: '24h',
+        start: null,
+        end: null,
+        mode: 'aggregates',
+        visualization: [{chart_type: ChartType.BAR, y_axes: ['count()'], interval: '1h'}],
+      })
+    ).toEqual({
+      query: 'span.op:db',
+      sort: '',
+      groupBys: [],
+      statsPeriod: '24h',
+      start: null,
+      end: null,
+      mode: 'aggregates',
+      visualizations: [{chartType: ChartType.BAR, yAxes: ['count()'], interval: '1h'}],
+    });
+  });
+
   it('leaves missing or invalid chart types undefined', () => {
     expect(
       mapSeerResponseItem(

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -151,6 +151,7 @@ export function mapSeerResponseItem(
   item: SeerRawResponseItem,
   defaultMode = 'samples'
 ): AskSeerSearchQuery {
+  const interval = getRawSeerInterval(item);
   return {
     visualizations:
       item.visualization
@@ -158,7 +159,6 @@ export function mapSeerResponseItem(
           ...(isChartType(visualization.chart_type)
             ? {chartType: visualization.chart_type}
             : {}),
-          ...(visualization.interval ? {interval: visualization.interval} : {}),
           yAxes: visualization.y_axes ?? [],
         }))
         .filter(visualization => visualization.yAxes.length > 0) ?? [],
@@ -169,7 +169,16 @@ export function mapSeerResponseItem(
     start: item.start ?? null,
     end: item.end ?? null,
     mode: item.mode || defaultMode,
+    ...(interval ? {interval} : {}),
   };
+}
+
+// Seer returns the interval nested per-visualization, but the chart uses a
+// single shared interval. Hoist the first interval Seer provided.
+export function getRawSeerInterval(item: SeerRawResponseItem): string | undefined {
+  return (
+    item.visualization?.find(({interval}) => Boolean(interval))?.interval ?? undefined
+  );
 }
 
 export interface SeerDateTimeSelection {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -158,6 +158,7 @@ export function mapSeerResponseItem(
           ...(isChartType(visualization.chart_type)
             ? {chartType: visualization.chart_type}
             : {}),
+          ...(visualization.interval ? {interval: visualization.interval} : {}),
           yAxes: visualization.y_axes ?? [],
         }))
         .filter(visualization => visualization.yAxes.length > 0) ?? [],

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -174,10 +174,14 @@ export function mapSeerResponseItem(
 }
 
 // Seer returns the interval nested per-visualization, but the chart uses a
-// single shared interval. Hoist the first interval Seer provided.
+// single shared interval. Hoist the interval from the first plotted
+// visualization (one with y-axes, matching what `mapSeerResponseItem` keeps) so
+// we don't pick up an interval from a dropped, axis-less entry.
 export function getRawSeerInterval(item: SeerRawResponseItem): string | undefined {
   return (
-    item.visualization?.find(({interval}) => Boolean(interval))?.interval ?? undefined
+    item.visualization?.find(
+      ({interval, y_axes}) => Boolean(interval) && (y_axes?.length ?? 0) > 0
+    )?.interval ?? undefined
   );
 }
 

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -218,6 +218,10 @@ export function generateQueryTokensString(args: QueryTokensProps): string {
     }
   }
 
+  if (args?.interval) {
+    parts.push(`interval is '${args.interval}'`);
+  }
+
   if (args?.groupBys && args.groupBys.length > 0) {
     const groupByText =
       args.groupBys.length === 1 ? args.groupBys[0] : args.groupBys.join(', ');

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -9,6 +9,7 @@ import type {SeerRawResponse} from 'sentry/components/searchQueryBuilder/askSeer
 import {
   buildSeerDateTimeSelection,
   buildSeerMutationResult,
+  getRawSeerInterval,
   transformSeerResponse,
   useInitialSeerQuery,
   useSelectedProjectIds,
@@ -38,6 +39,7 @@ interface AskSeerSearchQuery {
   start: string | null;
   statsPeriod: string;
   expandedProjectIds?: number[];
+  interval?: string | null;
 }
 
 export function LogsTabSeerComboBox() {
@@ -78,6 +80,7 @@ export function LogsTabSeerComboBox() {
         start: r?.start ?? null,
         end: r?.end ?? null,
         mode: r?.mode ?? 'samples',
+        interval: getRawSeerInterval(r),
       }));
     },
   });
@@ -166,6 +169,9 @@ export function LogsTabSeerComboBox() {
         end: selection.datetime.end,
         statsPeriod: selection.datetime.period,
         utc: selection.datetime.utc,
+        // Only override the interval when Seer suggested one, otherwise leave
+        // the user's current interval untouched.
+        ...(result.interval ? {interval: result.interval} : {}),
       };
 
       askSeerSuggestedQueryRef.current = JSON.stringify({
@@ -173,6 +179,7 @@ export function LogsTabSeerComboBox() {
         query: queryToUse,
         groupBys,
         mode,
+        interval: result.interval,
       });
 
       trackAnalytics('ai_query.applied', {
@@ -212,6 +219,7 @@ export function LogsTabSeerComboBox() {
           start: r?.start ?? null,
           end: r?.end ?? null,
           mode: r?.mode ?? 'samples',
+          interval: getRawSeerInterval(r),
         }),
         selectedProjectIds
       ),

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -271,6 +271,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         query: cleanedQuery,
         groupBys: seerQuery.groupBys,
         mode: seerQuery.mode,
+        interval: seerQuery.interval,
       });
 
       trackAnalytics('ai_query.applied', {
@@ -301,6 +302,9 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
             end: seerQuery.datetime.end,
             statsPeriod: seerQuery.datetime.period,
             utc: seerQuery.datetime.utc,
+            // Only override the interval when Seer suggested one, otherwise
+            // leave the user's current interval untouched.
+            ...(seerQuery.interval ? {interval: seerQuery.interval} : {}),
           },
         },
         {replace: true, preventScrollReset: true}

--- a/static/app/views/explore/seerQuery.spec.tsx
+++ b/static/app/views/explore/seerQuery.spec.tsx
@@ -47,26 +47,19 @@ describe('getSeerExploreQuery', () => {
     });
   });
 
-  it('extracts the interval from the first visualization that provides one', () => {
+  it('passes through the interval', () => {
     const result = getSeerExploreQuery({
       pageDatetime,
-      result: seerResult({
-        visualizations: [
-          {yAxes: ['count()']},
-          {yAxes: ['p75(span.duration)'], interval: '1h'},
-        ],
-      }),
+      result: seerResult({interval: '1h'}),
     });
 
     expect(result.interval).toBe('1h');
   });
 
-  it('leaves interval undefined when no visualization provides one', () => {
+  it('leaves interval undefined when none is provided', () => {
     const result = getSeerExploreQuery({
       pageDatetime,
-      result: seerResult({
-        visualizations: [{yAxes: ['count()']}],
-      }),
+      result: seerResult({}),
     });
 
     expect(result.interval).toBeUndefined();

--- a/static/app/views/explore/seerQuery.spec.tsx
+++ b/static/app/views/explore/seerQuery.spec.tsx
@@ -46,6 +46,31 @@ describe('getSeerExploreQuery', () => {
       visualizes: [{chartType: ChartType.BAR, yAxes: ['count()']}],
     });
   });
+
+  it('extracts the interval from the first visualization that provides one', () => {
+    const result = getSeerExploreQuery({
+      pageDatetime,
+      result: seerResult({
+        visualizations: [
+          {yAxes: ['count()']},
+          {yAxes: ['p75(span.duration)'], interval: '1h'},
+        ],
+      }),
+    });
+
+    expect(result.interval).toBe('1h');
+  });
+
+  it('leaves interval undefined when no visualization provides one', () => {
+    const result = getSeerExploreQuery({
+      pageDatetime,
+      result: seerResult({
+        visualizations: [{yAxes: ['count()']}],
+      }),
+    });
+
+    expect(result.interval).toBeUndefined();
+  });
 });
 
 describe('getSeerSort', () => {

--- a/static/app/views/explore/seerQuery.ts
+++ b/static/app/views/explore/seerQuery.ts
@@ -37,15 +37,6 @@ function getSeerVisualizes(
   }));
 }
 
-// The chart uses a single interval (the `interval` URL param) shared across all
-// y-axes, but Seer returns it per visualization. Use the first interval Seer
-// provided.
-function getSeerInterval(
-  visualizations: readonly SeerVisualization[]
-): string | undefined {
-  return visualizations.find(({interval}) => Boolean(interval))?.interval ?? undefined;
-}
-
 export function getSeerExploreQuery({
   pageDatetime,
   result,
@@ -67,7 +58,7 @@ export function getSeerExploreQuery({
     query: result.query,
     sort: result.sort,
     visualizes: getSeerVisualizes(result.visualizations),
-    interval: getSeerInterval(result.visualizations),
+    interval: result.interval ?? undefined,
   };
 }
 

--- a/static/app/views/explore/seerQuery.ts
+++ b/static/app/views/explore/seerQuery.ts
@@ -17,6 +17,7 @@ interface SeerExploreQuery {
   query: string;
   sort: string;
   visualizes: BaseVisualize[];
+  interval?: string;
 }
 
 function getSeerExploreMode(result: AskSeerSearchQuery): Mode {
@@ -34,6 +35,15 @@ function getSeerVisualizes(
     chartType,
     yAxes,
   }));
+}
+
+// The chart uses a single interval (the `interval` URL param) shared across all
+// y-axes, but Seer returns it per visualization. Use the first interval Seer
+// provided.
+function getSeerInterval(
+  visualizations: readonly SeerVisualization[]
+): string | undefined {
+  return visualizations.find(({interval}) => Boolean(interval))?.interval ?? undefined;
 }
 
 export function getSeerExploreQuery({
@@ -57,6 +67,7 @@ export function getSeerExploreQuery({
     query: result.query,
     sort: result.sort,
     visualizes: getSeerVisualizes(result.visualizations),
+    interval: getSeerInterval(result.visualizations),
   };
 }
 

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -135,6 +135,7 @@ export function SpansTabSeerComboBox() {
         groupBy: seerQuery.groupBys,
         sort: seerQuery.sort,
         mode: seerQuery.mode,
+        interval: seerQuery.interval,
       });
 
       askSeerSuggestedQueryRef.current = JSON.stringify({
@@ -144,6 +145,7 @@ export function SpansTabSeerComboBox() {
         groupBy: seerQuery.groupBys,
         sort: seerQuery.sort,
         mode: seerQuery.mode,
+        interval: seerQuery.interval,
       });
       trackAnalytics('ai_query.applied', {
         organization,


### PR DESCRIPTION
The assisted query agent now optionally returns an `interval` per visualization. The Explore search bar preview surfaces that interval, and applying a Seer suggestion sets it on the chart via the `interval` URL param. This covers the spans, logs, and metrics tabs.

**Interval is hoisted to a single chart-level value**

Seer returns the interval nested per-visualization, but the Explore chart uses one `interval` shared across all y-axes. We hoist the first interval Seer provides to a chart-level field (`getRawSeerInterval` / `mapSeerResponseItem`), surface it in the search bar preview (`QueryTokens`), and pass it into the chart. `useChartInterval` already validates the URL value against the allowed options for the active time range, so an interval that isn't valid for the selected range is silently ignored rather than breaking the chart.

**Only overrides when Seer suggests one**

When Seer doesn't return an interval, the user's current interval is left untouched.

Refs BROWSE-546