### PR TITLE
ref(api): tighten 2 more endpoint returns to Response[T]

### DIFF
--- a/src/sentry/apidocs/examples/replay_examples.py
+++ b/src/sentry/apidocs/examples/replay_examples.py
@@ -45,7 +45,7 @@ class ReplayExamples:
     GET_REPLAYS = [
         OpenApiExample(
             "Get list of replays",
-            value=[replay_example],
+            value={"data": [replay_example]},
             status_codes=["200"],
             response_only=True,
         )

--- a/src/sentry/core/endpoints/project_environments.py
+++ b/src/sentry/core/endpoints/project_environments.py
@@ -21,7 +21,11 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.environment_examples import EnvironmentExamples
 from sentry.apidocs.parameters import EnvironmentParams, GlobalParams
-from sentry.apidocs.response_types import DetailResponse
+from sentry.apidocs.response_types import (
+    DetailResponse,
+    ValidationErrorResponse,
+    as_validation_errors,
+)
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.environment import EnvironmentProject
 
@@ -113,13 +117,15 @@ class ProjectEnvironmentsEndpoint(ProjectEndpoint):
         },
         examples=EnvironmentExamples.GET_PROJECT_ENVIRONMENTS,
     )
-    def put(self, request: Request, project) -> Response:
+    def put(
+        self, request: Request, project
+    ) -> Response[list[EnvironmentProjectSerializerResponse]] | Response[ValidationErrorResponse]:
         """
         Bulk update the visibility for a project's environments.
         """
         serializer = BulkEnvironmentSerializer(data=request.data)
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer), status=400)
 
         data = serializer.validated_data
         environment_names = data["environmentNames"]
@@ -135,4 +141,5 @@ class ProjectEnvironmentsEndpoint(ProjectEndpoint):
 
         queryset = base_queryset.select_related("environment").order_by("environment__name")
 
-        return Response(serialize(list(queryset), request.user))
+        items: list[EnvironmentProject] = list(queryset)
+        return Response(serialize(items, request.user, EnvironmentProjectSerializer()))

--- a/src/sentry/replays/endpoints/organization_replay_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_index.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import cast
+from typing import TypedDict, cast
 
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import ParseError
@@ -25,6 +25,10 @@ from sentry.replays.validators import ReplayValidator
 from sentry.utils.cursors import Cursor, CursorResult
 
 
+class _ListReplaysResponse(TypedDict):
+    data: list[ReplayDetailsResponse]
+
+
 @cell_silo_endpoint
 @extend_schema(tags=["Replays"])
 class OrganizationReplayIndexEndpoint(OrganizationReplayEndpoint):
@@ -36,14 +40,14 @@ class OrganizationReplayIndexEndpoint(OrganizationReplayEndpoint):
         operation_id="List an Organization's Replays",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, ReplayValidator],
         responses={
-            200: inline_sentry_response_serializer("ListReplays", list[ReplayDetailsResponse]),
+            200: inline_sentry_response_serializer("ListReplays", _ListReplaysResponse),
             400: RESPONSE_BAD_REQUEST,
             403: RESPONSE_FORBIDDEN,
         },
         examples=ReplayExamples.GET_REPLAYS,
     )
     @handled_snuba_exceptions
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response[_ListReplaysResponse]:
         """
         Return a list of replays belonging to an organization.
         """


### PR DESCRIPTION
Tighten two endpoint return annotations from bare `Response` to the typed unions declared by their `@extend_schema` decorators.

- `project_environments.put()` — the bulk-update method added recently still had the bare `Response`. Use the same `EnvironmentProjectSerializerResponse` shape as the existing `get` on this endpoint; route validation errors through `as_validation_errors`.
- `organization_replay_index.get()` — the decorator declared `list[ReplayDetailsResponse]` but the runtime has always wrapped the list in `{"data": [...]}`. Replace both the decorator schema and the annotation with a small local `_ListReplaysResponse` TypedDict that matches the actual wire shape. No JSON output change — the schema documentation now accurately describes what clients receive.

Update the openapi schema diff tracker for the replay index correction (📝 doc-only; no wire change).