### PR TITLE
docs(agents): Fix prek mypy run command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ cd /path/to/sentry && .venv/bin/prek run -q
 prek detects changed files automatically. To run a specific hook:
 
 ```bash
-.venv/bin/prek run -q mypy --files src/sentry/foo/bar.py
+SENTRY_MYPY_PRE_PUSH=1 .venv/bin/prek run -q mypy --files src/sentry/foo/bar.py --stage pre-push
 .venv/bin/prek run -q ruff --files src/sentry/foo/bar.py
 ```
 


### PR DESCRIPTION
My clanker was running mypy via the documented
```bash
.venv/bin/prek run -q mypy --files src/sentry/foo/bar.py
```
this would do nothing and exit with 0.

That command doesn't work because apparently in prek you have to pass `--stage pre-push` (I think pre-commit would run it regardless, so this is arguably a bug in prek) and also the definition of the step itself requires you to set `SENTRY_MYPY_PRE_PUSH=1` to do anything.