### PR TITLE
fix(onboarding): Hide trial and volume info outside onboarding

### DIFF
--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -24,6 +24,7 @@ interface ScmFeatureCardProps {
   disabled?: boolean;
   disabledReason?: ReactNode;
   isVolumeLoading?: boolean;
+  showVolume?: boolean;
 }
 
 export function ScmFeatureCard({
@@ -37,6 +38,7 @@ export function ScmFeatureCard({
   volume,
   volumeTooltip,
   isVolumeLoading,
+  showVolume = true,
 }: ScmFeatureCardProps) {
   return (
     <ScmCardButton
@@ -81,15 +83,16 @@ export function ScmFeatureCard({
             </Container>
 
             <Flex area="toggle" align="start" gap="sm">
-              {isVolumeLoading ? (
-                <Placeholder height="22px" width="100px" />
-              ) : (
-                <Tooltip title={volumeTooltip} delay={100}>
-                  <Tag variant="muted" icon={<IconInfo size="sm" />}>
-                    {volume}
-                  </Tag>
-                </Tooltip>
-              )}
+              {showVolume &&
+                (isVolumeLoading ? (
+                  <Placeholder height="22px" width="100px" />
+                ) : (
+                  <Tooltip title={volumeTooltip} delay={100}>
+                    <Tag variant="muted" icon={<IconInfo size="sm" />}>
+                      {volume}
+                    </Tag>
+                  </Tooltip>
+                ))}
 
               <Tooltip title={disabledReason} disabled={!disabledReason} delay={500}>
                 <Switch

--- a/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
@@ -16,6 +16,7 @@ interface ScmFeatureInfoCardsProps {
   featureMeta: Record<ProductSolution, FeatureMeta>;
   isVolumeLoading?: boolean;
   platformName?: string;
+  showVolume?: boolean;
 }
 
 // Informational variant of the SCM feature card list. Renders the products
@@ -29,6 +30,7 @@ export function ScmFeatureInfoCards({
   featureMeta,
   platformName,
   isVolumeLoading,
+  showVolume = true,
 }: ScmFeatureInfoCardsProps) {
   return (
     <Stack gap="xl" width="100%" justify="center">
@@ -101,26 +103,28 @@ export function ScmFeatureInfoCards({
                   >
                     {meta.description}
                   </Text>
-                  <Container>
-                    {isVolumeLoading ? (
-                      <Placeholder height="20px" width="100px" />
-                    ) : (
-                      <Tooltip
-                        title={meta.volumeTooltip}
-                        delay={100}
-                        disabled={isDisabled}
-                      >
-                        <Text
-                          variant="muted"
-                          underline="dotted"
-                          size="sm"
-                          density="comfortable"
+                  {showVolume ? (
+                    <Container>
+                      {isVolumeLoading ? (
+                        <Placeholder height="20px" width="100px" />
+                      ) : (
+                        <Tooltip
+                          title={meta.volumeTooltip}
+                          delay={100}
+                          disabled={isDisabled}
                         >
-                          {meta.volume}
-                        </Text>
-                      </Tooltip>
-                    )}
-                  </Container>
+                          <Text
+                            variant="muted"
+                            underline="dotted"
+                            size="sm"
+                            density="comfortable"
+                          >
+                            {meta.volume}
+                          </Text>
+                        </Tooltip>
+                      )}
+                    </Container>
+                  ) : null}
                 </Stack>
               </Grid>
             </Tooltip>

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -15,6 +15,7 @@ interface ScmFeatureSelectionCardsProps {
   onToggleFeature: (feature: ProductSolution) => void;
   selectedFeatures: ProductSolution[];
   isVolumeLoading?: boolean;
+  showVolume?: boolean;
 }
 
 export function ScmFeatureSelectionCards({
@@ -24,6 +25,7 @@ export function ScmFeatureSelectionCards({
   onToggleFeature,
   featureMeta,
   isVolumeLoading,
+  showVolume = true,
 }: ScmFeatureSelectionCardsProps) {
   return (
     <Stack gap="xl" width="100%" justify="center">
@@ -57,6 +59,7 @@ export function ScmFeatureSelectionCards({
               volume={meta.volume}
               volumeTooltip={meta.volumeTooltip}
               isVolumeLoading={isVolumeLoading}
+              showVolume={showVolume}
             />
           );
         })}

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
@@ -1,0 +1,100 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+
+import {ScmPlatformFeaturesCore} from './scmPlatformFeaturesCore';
+
+// Mock the virtualizer so the manual-picker Select renders in JSDOM (no layout
+// engine).
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: jest.fn(({count}) => ({
+    getVirtualItems: () =>
+      Array.from({length: count}, (_, i) => ({
+        key: i,
+        index: i,
+        start: i * 36,
+        size: 36,
+      })),
+    getTotalSize: () => count * 36,
+    measureElement: jest.fn(),
+  })),
+}));
+
+// Provide a small platform list so the Select dropdown renders a manageable
+// number of options in JSDOM.
+jest.mock('sentry/data/platforms', () => {
+  const actual = jest.requireActual('sentry/data/platforms');
+  return {
+    ...actual,
+    platforms: actual.platforms.filter(
+      (p: {id: string}) =>
+        p.id === 'javascript' || p.id === 'python' || p.id === 'python-django'
+    ),
+  };
+});
+
+const pythonPlatform: OnboardingSelectedSDK = {
+  key: 'python',
+  name: 'Python',
+  language: 'python',
+  type: 'language',
+  link: 'https://docs.sentry.io/platforms/python/',
+  category: 'popular',
+};
+
+function defaultProps(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    analyticsFlow: 'onboarding' as const,
+    selectedRepository: undefined,
+    selectedPlatform: pythonPlatform,
+    selectedFeatures: [ProductSolution.ERROR_MONITORING],
+    onPlatformChange: jest.fn(),
+    onFeaturesChange: jest.fn(),
+    onClearProjectDetailsForm: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('ScmPlatformFeaturesCore', () => {
+  const organization = OrganizationFixture({
+    features: ['performance-view', 'session-replay', 'profiling-view'],
+  });
+
+  describe('trial/billing framing', () => {
+    it('shows the trial banner and per-feature volumes during onboarding', async () => {
+      render(
+        <ScmPlatformFeaturesCore {...defaultProps({analyticsFlow: 'onboarding'})} />,
+        {
+          organization,
+        }
+      );
+
+      expect(
+        await screen.findByText('What do you want to instrument?')
+      ).toBeInTheDocument();
+      expect(screen.getByText(/unlimited volume for 14 days/)).toBeInTheDocument();
+      expect(screen.getByText('5,000 errors / mo')).toBeInTheDocument();
+    });
+
+    it('hides the trial banner and per-feature volumes outside onboarding', async () => {
+      render(
+        <ScmPlatformFeaturesCore
+          {...defaultProps({analyticsFlow: 'project-creation'})}
+        />,
+        {organization}
+      );
+
+      // Feature cards still render, just without the trial/billing framing.
+      expect(
+        await screen.findByText('What do you want to instrument?')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', {name: /Tracing/})).toBeInTheDocument();
+
+      expect(screen.queryByText(/unlimited volume for 14 days/)).not.toBeInTheDocument();
+      expect(screen.queryByText('5,000 errors / mo')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -94,6 +94,12 @@ export function ScmPlatformFeaturesCore({
 }: ScmPlatformFeaturesCoreProps) {
   const {openModal} = useModal();
   const organization = useOrganization();
+  // Trial/billing framing (the "unlimited volume" banner and per-feature volume
+  // limits) only makes sense during new-org onboarding, where a fresh trial is
+  // always active. In SCM-first project creation the viewer is an existing org
+  // on an unknown plan, so we hide that framing rather than show numbers that
+  // may not apply.
+  const isOnboarding = analyticsFlow === 'onboarding';
   // Fetch feature meta at step entry so billing-config is in flight (or cached)
   // before the user reaches the feature cards below.
   const {meta: featureMeta, isLoading: isFeatureMetaLoading} = useScmFeatureMeta();
@@ -498,27 +504,29 @@ export function ScmPlatformFeaturesCore({
       {featureMode !== 'none' && (
         <MotionStack layout="position" width="100%">
           <Stack gap="2xl" paddingTop="xs">
-            <Flex
-              padding="lg"
-              background="secondary"
-              border="secondary"
-              radius="md"
-              gap="lg"
-            >
-              <IconBusiness size="lg" variant="accent" />
-              <Text size="md" density="comfortable">
-                {tct(
-                  'You’ve got [bold:unlimited volume for 14 days] to try out everything. After that, free plan volumes apply ⋅ No credit card required',
-                  {
-                    bold: (
-                      <Text as="span" bold variant="accent">
-                        {null}
-                      </Text>
-                    ),
-                  }
-                )}
-              </Text>
-            </Flex>
+            {isOnboarding && (
+              <Flex
+                padding="lg"
+                background="secondary"
+                border="secondary"
+                radius="md"
+                gap="lg"
+              >
+                <IconBusiness size="lg" variant="accent" />
+                <Text size="md" density="comfortable">
+                  {tct(
+                    'You’ve got [bold:unlimited volume for 14 days] to try out everything. After that, free plan volumes apply ⋅ No credit card required',
+                    {
+                      bold: (
+                        <Text as="span" bold variant="accent">
+                          {null}
+                        </Text>
+                      ),
+                    }
+                  )}
+                </Text>
+              </Flex>
+            )}
             {featureMode === 'toggleable' ? (
               <ScmFeatureSelectionCards
                 availableFeatures={availableFeatures}
@@ -527,6 +535,7 @@ export function ScmPlatformFeaturesCore({
                 onToggleFeature={handleToggleFeature}
                 featureMeta={featureMeta}
                 isVolumeLoading={isFeatureMetaLoading}
+                showVolume={isOnboarding}
               />
             ) : (
               <ScmFeatureInfoCards
@@ -535,6 +544,7 @@ export function ScmPlatformFeaturesCore({
                 featureMeta={featureMeta}
                 platformName={currentPlatformName}
                 isVolumeLoading={isFeatureMetaLoading}
+                showVolume={isOnboarding}
               />
             )}
           </Stack>


### PR DESCRIPTION
## TLDR

In SCM-first project creation, hide the trial banner and the per-feature volume limits. Both are onboarding-only framing (fresh-trial assumptions). Onboarding is unchanged and no billing or quota data is computed.

## Details

ScmPlatformFeaturesCore is shared by new-org onboarding and SCM-first project creation. The trial banner ("unlimited volume for 14 days") and the per-feature volume limits assume a fresh trial, which only holds during onboarding. In project creation the viewer is an existing org on an unknown plan, so that framing can be misleading.

This gates the trial banner and the per-feature volume tags on the onboarding flow, via a derived isOnboarding flag and a showVolume prop threaded down to the feature cards. Onboarding is unchanged. No billing or quota data is computed: the alternative of computing real trial days and per-plan quotas (the prior approach in #116729) was considered and rejected as not worth the complexity for this surface.

Refs VDY-75