### PR TITLE
fix(issues): serve org-prefixed public share links without login

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1192,6 +1192,12 @@ urlpatterns += [
                     DisabledMemberView.as_view(),
                     name="sentry-organization-disabled-member",
                 ),
+                # Need to serve the org-slug-prefixed share route for self-hosted
+                re_path(
+                    r"^(?P<organization_slug>[^/]+)/share/(?:group|issue)/(?P<share_id>[^/]+)/$",
+                    SharedGroupDetailsView.as_view(auth_required=False),
+                    name="sentry-customer-domain-group-shared",
+                ),
                 # need to force these to React and ensure organization_slug is captured
                 re_path(
                     r"^(?P<organization_slug>[^/]+)/(?P<sub_page>[\w_-]+)/",

--- a/tests/sentry/web/frontend/test_shared_group_details.py
+++ b/tests/sentry/web/frontend/test_shared_group_details.py
@@ -66,3 +66,11 @@ class SharedGroupDetailsTest(TestCase):
         response = self.client.get(f"/share/issue/{share.uuid}/", HTTP_HOST=self.org_domain)
         assert response.status_code == 200
         self.assert_group_metadata_present(response)
+
+    def test_get_org_prefixed_path_no_subdomain(self) -> None:
+        share = self.share_group()
+        response = self.client.get(
+            f"/organizations/{self.organization.slug}/share/issue/{share.uuid}/"
+        )
+        assert response.status_code == 200
+        self.assert_group_metadata_present(response)


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry/issues/117159

We currently serve an authless `/share/issue/{id}` route for shared issues, which is normalized using the organization slug (so e.g. `sentry.sentry.io/share/issue/123` can be served without auth). However, for self-hosted, we don't do this normalization, and instead serve `/{org_slug}/share/issue/{id}`, which requires auth. Add this as a non-auth-required URL for self-hosted.