### PR TITLE
ref(api): tighten group_details.put() return to Response[T]

### DIFF
--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -2,7 +2,7 @@ import functools
 import logging
 from collections.abc import Sequence
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 
 from django.utils import timezone
 from drf_spectacular.utils import extend_schema
@@ -37,6 +37,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.issue_examples import IssueExamples
 from sentry.apidocs.parameters import GlobalParams, IssueParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.integrations.api.serializers.models.external_issue import ExternalIssueSerializer
@@ -392,7 +393,9 @@ class GroupDetailsEndpoint(GroupEndpoint):
         },
     )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-details"])
-    def put(self, request: Request, group: Group) -> Response:
+    def put(
+        self, request: Request, group: Group
+    ) -> Response[BaseGroupSerializerResponse] | Response[DetailResponse]:
         """
         Update an individual issue's attributes. Only the attributes submitted
         are modified.
@@ -418,7 +421,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
             # for mutation.
             group = Group.objects.get(id=group.id)
 
-            serialized = serialize(
+            serialized: BaseGroupSerializerResponse = serialize(
                 group,
                 request.user,
                 GroupSerializer(
@@ -440,7 +443,10 @@ class GroupDetailsEndpoint(GroupEndpoint):
             logger.exception(
                 "group_details:put client.ApiError",
             )
-            return Response(e.body, status=e.status_code)
+            # client.ApiError.body is opaque (proxied from another service);
+            # cast is sanctioned for this opaque-body cohort per the spec.
+            body = cast(BaseGroupSerializerResponse, e.body)
+            return Response(body, status=e.status_code)
 
     @extend_schema(
         operation_id="Remove an Issue",


### PR DESCRIPTION
Tighten the `PUT /issues/{id}/` return annotation from bare `Response` to `Response[BaseGroupSerializerResponse] | Response[DetailResponse]`. No body changes.

The success path uses the typed-variable trick: `GroupSerializer` is on the autoderive denylist, so `serialize()` flows `Any` and a local annotation pins it to `BaseGroupSerializerResponse`. The early-return pass-through from `update_groups_with_search_fn` (which can be a DetailResponse on errors) is covered by the union arm. The exception path returns `e.body` from a proxied `client.ApiError` — genuinely opaque at the source, so `cast()` is the sanctioned approach for this single line per the opaque-body cohort of the response-typing spec.