### PR TITLE
feat(search-query-builder): Convert to filter key on comparison ops

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1341,18 +1341,6 @@ describe('SearchQueryBuilder', () => {
       }
     );
 
-    it('adds default value for pasted multi-character numeric comparison operators', async () => {
-      render(<SearchQueryBuilder {...defaultProps} />);
-      await userEvent.click(getLastInput());
-
-      await userEvent.paste('timesSeen>=');
-      await userEvent.keyboard('{Escape}');
-
-      expect(
-        await screen.findByRole('row', {name: 'timesSeen:>=100'})
-      ).toBeInTheDocument();
-    });
-
     it('adds default value for numeric tag filters from filter key metadata', async () => {
       render(<SearchQueryBuilder {...defaultProps} />);
       await userEvent.click(getLastInput());

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1,6 +1,7 @@
 import type {ComponentProps} from 'react';
 import {destroyAnnouncer} from '@react-aria/live-announcer';
 import {mutationOptions} from '@tanstack/react-query';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {
   act,
@@ -138,6 +139,10 @@ const FILTER_KEY_SECTIONS: FilterKeySection[] = [
     children: ['custom_tag_name'],
   },
 ];
+
+const numberOperatorConversionOrganization = OrganizationFixture({
+  features: ['search-query-builder-number-operator-conversion'],
+});
 
 function getLastInput() {
   const input = screen.getAllByRole('combobox', {name: 'Add a search term'}).at(-1);
@@ -1332,7 +1337,9 @@ describe('SearchQueryBuilder', () => {
     ])(
       'adds default value for numeric filter when typing <filter>%s',
       async (operator, expectedQuery) => {
-        render(<SearchQueryBuilder {...defaultProps} />);
+        render(<SearchQueryBuilder {...defaultProps} />, {
+          organization: numberOperatorConversionOrganization,
+        });
         await userEvent.click(getLastInput());
 
         await userEvent.keyboard(`timesSeen${operator}{Escape}`);
@@ -1341,8 +1348,19 @@ describe('SearchQueryBuilder', () => {
       }
     );
 
-    it('adds default value for numeric tag filters from filter key metadata', async () => {
+    it('does not add a default value for numeric filters without the feature flag', async () => {
       render(<SearchQueryBuilder {...defaultProps} />);
+      await userEvent.click(getLastInput());
+
+      await userEvent.keyboard('timesSeen>');
+
+      expect(getLastInput()).toHaveValue('timesSeen>');
+    });
+
+    it('adds default value for numeric tag filters from filter key metadata', async () => {
+      render(<SearchQueryBuilder {...defaultProps} />, {
+        organization: numberOperatorConversionOrganization,
+      });
       await userEvent.click(getLastInput());
 
       await userEvent.paste('tags[bar,number]>');
@@ -5683,7 +5701,9 @@ describe('SearchQueryBuilder', () => {
     });
 
     it('replaces number key with suggestion when typing comparison operator', async () => {
-      render(<SearchQueryBuilder {...builderProps} />);
+      render(<SearchQueryBuilder {...builderProps} />, {
+        organization: numberOperatorConversionOrganization,
+      });
 
       await userEvent.click(getLastInput());
       await userEvent.keyboard('bar>{Escape}');

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1325,6 +1325,58 @@ describe('SearchQueryBuilder', () => {
       expect(mockOnChange).toHaveBeenCalledWith('is:unresolved', expect.anything());
     });
 
+    it.each([
+      ['>', 'timesSeen:>100'],
+      ['<', 'timesSeen:<100'],
+      ['=', 'timesSeen:=100'],
+    ])(
+      'adds default value for numeric filter when typing <filter>%s',
+      async (operator, expectedQuery) => {
+        render(<SearchQueryBuilder {...defaultProps} />);
+        await userEvent.click(getLastInput());
+
+        await userEvent.keyboard(`timesSeen${operator}{Escape}`);
+
+        expect(await screen.findByRole('row', {name: expectedQuery})).toBeInTheDocument();
+      }
+    );
+
+    it('adds default value for pasted multi-character numeric comparison operators', async () => {
+      render(<SearchQueryBuilder {...defaultProps} />);
+      await userEvent.click(getLastInput());
+
+      await userEvent.paste('timesSeen>=');
+      await userEvent.keyboard('{Escape}');
+
+      expect(
+        await screen.findByRole('row', {name: 'timesSeen:>=100'})
+      ).toBeInTheDocument();
+    });
+
+    it('adds default value for numeric tag filters from filter key metadata', async () => {
+      render(<SearchQueryBuilder {...defaultProps} />);
+      await userEvent.click(getLastInput());
+
+      await userEvent.paste('tags[bar,number]>');
+      await userEvent.keyboard('{Escape}');
+
+      expect(
+        await screen.findByRole('row', {name: 'tags[bar,number]:>100'})
+      ).toBeInTheDocument();
+    });
+
+    it('does not automatically create a filter for non-numeric keys with comparison operators', async () => {
+      render(<SearchQueryBuilder {...defaultProps} />);
+      await userEvent.click(getLastInput());
+
+      await userEvent.keyboard('browser.name>');
+
+      expect(getLastInput()).toHaveValue('browser.name>');
+      expect(
+        screen.queryByRole('button', {name: 'Edit key for filter: browser.name'})
+      ).not.toBeInTheDocument();
+    });
+
     it('does not automatically create a filter if the user intends to wrap in quotes', async () => {
       render(<SearchQueryBuilder {...defaultProps} />);
       await userEvent.click(getLastInput());
@@ -5640,6 +5692,32 @@ describe('SearchQueryBuilder', () => {
       expect(
         screen.getByRole('button', {name: 'Edit key for filter: tags[bar,number]'})
       ).toHaveTextContent('bar');
+    });
+
+    it('replaces number key with suggestion when typing comparison operator', async () => {
+      render(<SearchQueryBuilder {...builderProps} />);
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('bar>{Escape}');
+
+      expect(
+        screen.getByRole('button', {name: 'Edit key for filter: tags[bar,number]'})
+      ).toHaveTextContent('bar');
+      expect(
+        screen.getByRole('row', {name: 'tags[bar,number]:>100'})
+      ).toBeInTheDocument();
+    });
+
+    it('does not replace string key with suggestion when typing comparison operator', async () => {
+      render(<SearchQueryBuilder {...builderProps} />);
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('foo>');
+
+      expect(getLastInput()).toHaveValue('foo>');
+      expect(
+        screen.queryByRole('button', {name: 'Edit key for filter: tags[foo,string]'})
+      ).not.toBeInTheDocument();
     });
 
     it('replaces string key with suggestion on enter', async () => {

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -332,6 +332,9 @@ function SearchQueryBuilderInputInternal({
   const [selectionIndex, setSelectionIndex] = useState(0);
 
   const organization = useOrganization();
+  const enableNumberOperatorConversion = organization.features.includes(
+    'search-query-builder-number-operator-conversion'
+  );
 
   const updateSelectionIndex = useCallback(() => {
     setSelectionIndex(inputRef.current?.selectionStart ?? 0);
@@ -481,7 +484,7 @@ function SearchQueryBuilderInputInternal({
         filterKeys,
       });
 
-      if (comparisonShortcut) {
+      if (enableNumberOperatorConversion && comparisonShortcut) {
         dispatch({
           type: 'UPDATE_FREE_TEXT_ON_COLON',
           tokens: [token],
@@ -505,6 +508,7 @@ function SearchQueryBuilderInputInternal({
     },
     [
       dispatch,
+      enableNumberOperatorConversion,
       filterKeys,
       getFieldDefinition,
       getSuggestedFilterKey,
@@ -765,7 +769,7 @@ function SearchQueryBuilderInputInternal({
             filterKeys,
           });
 
-          if (comparisonShortcut) {
+          if (enableNumberOperatorConversion && comparisonShortcut) {
             const {fieldDefinition, filterKey, text} = comparisonShortcut;
             const key = filterKeys[filterKey];
             dispatch({

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -129,8 +129,6 @@ const NUMERIC_COMPARISON_VALUE_TYPES = new Set<FieldValueType>([
 ]);
 
 const COMPARISON_SHORTCUT_OPERATORS = [
-  TermOperator.GREATER_THAN_EQUAL,
-  TermOperator.LESS_THAN_EQUAL,
   TermOperator.GREATER_THAN,
   TermOperator.LESS_THAN,
   TermOperator.EQUAL,

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -29,17 +29,20 @@ import type {
 } from 'sentry/components/searchQueryBuilder/types';
 import {
   collapseTextTokens,
+  getFieldDefinitionForFilterKey,
   parseTokenKey,
   recentSearchTypeToLabel,
 } from 'sentry/components/searchQueryBuilder/utils';
 import {
   InvalidReason,
   parseSearch,
+  TermOperator,
   Token,
   type ParseResultToken,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
 import {t} from 'sentry/locale';
+import type {TagCollection} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {FieldDefinition} from 'sentry/utils/fields';
 import {FieldKind, FieldValueType} from 'sentry/utils/fields';
@@ -106,13 +109,84 @@ function replaceFocusedWordWithFilter(
   value: string,
   cursorPosition: number,
   key: string,
-  getFieldDefinition: FieldDefinitionGetter
+  getFieldDefinition: FieldDefinitionGetter,
+  operator?: TermOperator
 ) {
   return replaceFocusedWord(
     value,
     cursorPosition,
-    getInitialFilterText(key, getFieldDefinition(key))
+    getInitialFilterText(key, getFieldDefinition(key), operator)
   );
+}
+
+const NUMERIC_COMPARISON_VALUE_TYPES = new Set<FieldValueType>([
+  FieldValueType.INTEGER,
+  FieldValueType.NUMBER,
+  FieldValueType.CURRENCY,
+  FieldValueType.DURATION,
+  FieldValueType.SIZE,
+  FieldValueType.PERCENTAGE,
+]);
+
+const COMPARISON_SHORTCUT_OPERATORS = [
+  TermOperator.GREATER_THAN_EQUAL,
+  TermOperator.LESS_THAN_EQUAL,
+  TermOperator.GREATER_THAN,
+  TermOperator.LESS_THAN,
+  TermOperator.EQUAL,
+] as const;
+
+function getNumericComparisonFilterShortcut({
+  value,
+  cursorPosition,
+  getSuggestedFilterKey,
+  getFieldDefinition,
+  filterKeys,
+}: {
+  cursorPosition: number;
+  filterKeys: TagCollection;
+  getFieldDefinition: FieldDefinitionGetter;
+  getSuggestedFilterKey: (key: string) => string | null;
+  value: string;
+}) {
+  const word = getWordAtCursorPosition(value, cursorPosition);
+  const operator = COMPARISON_SHORTCUT_OPERATORS.find(op => word.endsWith(op));
+
+  if (!operator) {
+    return null;
+  }
+
+  const key = word.slice(0, -operator.length);
+  if (!key || key.endsWith('!')) {
+    return null;
+  }
+
+  const filterKey = getSuggestedFilterKey(key) ?? key;
+  const fieldDefinition = getFieldDefinitionForFilterKey(
+    filterKey,
+    getFieldDefinition,
+    filterKeys
+  );
+  const valueType = fieldDefinition?.valueType;
+  if (
+    !fieldDefinition ||
+    fieldDefinition.kind === FieldKind.FUNCTION ||
+    !valueType ||
+    !NUMERIC_COMPARISON_VALUE_TYPES.has(valueType)
+  ) {
+    return null;
+  }
+
+  return {
+    fieldDefinition,
+    filterKey,
+    operator,
+    text: replaceFocusedWord(
+      value,
+      cursorPosition,
+      getInitialFilterText(filterKey, fieldDefinition, operator)
+    ),
+  };
 }
 
 function countPreviousItemsOfType({
@@ -401,6 +475,29 @@ function SearchQueryBuilderInputInternal({
         .replace('\n', '')
         .trim();
 
+      const comparisonShortcut = getNumericComparisonFilterShortcut({
+        value: clipboardText,
+        cursorPosition: clipboardText.length,
+        getSuggestedFilterKey,
+        getFieldDefinition,
+        filterKeys,
+      });
+
+      if (comparisonShortcut) {
+        dispatch({
+          type: 'UPDATE_FREE_TEXT_ON_COLON',
+          tokens: [token],
+          text: comparisonShortcut.text,
+          focusOverride: calculateNextFocusForFilter(
+            state,
+            comparisonShortcut.fieldDefinition
+          ),
+          shouldCommitQuery: false,
+        });
+        resetInputValue();
+        return;
+      }
+
       dispatch({
         type: 'REPLACE_TOKENS_WITH_TEXT_ON_PASTE',
         tokens: [token],
@@ -408,7 +505,15 @@ function SearchQueryBuilderInputInternal({
       });
       resetInputValue();
     },
-    [dispatch, resetInputValue, token]
+    [
+      dispatch,
+      filterKeys,
+      getFieldDefinition,
+      getSuggestedFilterKey,
+      resetInputValue,
+      state,
+      token,
+    ]
   );
 
   const onClick = useCallback(() => {
@@ -650,6 +755,38 @@ function SearchQueryBuilderInputInternal({
               shouldCommitQuery: false,
             });
             resetInputValue();
+            return;
+          }
+
+          const cursorPosition = e.target.selectionStart ?? rawValue.length;
+          const comparisonShortcut = getNumericComparisonFilterShortcut({
+            value: rawValue,
+            cursorPosition,
+            getSuggestedFilterKey,
+            getFieldDefinition,
+            filterKeys,
+          });
+
+          if (comparisonShortcut) {
+            const {fieldDefinition, filterKey, text} = comparisonShortcut;
+            const key = filterKeys[filterKey];
+            dispatch({
+              type: 'UPDATE_FREE_TEXT_ON_COLON',
+              tokens: [token],
+              text,
+              focusOverride: calculateNextFocusForFilter(state, fieldDefinition),
+              shouldCommitQuery: false,
+            });
+            resetInputValue();
+            trackAnalytics('search.key_manually_typed', {
+              organization,
+              search_type: recentSearchTypeToLabel(recentSearches),
+              search_source: searchSource,
+              item_name: filterKey,
+              item_kind: key?.kind ?? FieldKind.FIELD,
+              item_value_type: fieldDefinition.valueType ?? FieldValueType.STRING,
+              new_experience: true,
+            });
             return;
           }
 

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -10,6 +10,7 @@ import type {
 
 import {areWildcardOperatorsAllowed} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {
+  TermOperator,
   WildcardOperators,
   type ParseResultToken,
 } from 'sentry/components/searchSyntax/parser';
@@ -244,7 +245,8 @@ function getInitialValueType(fieldDefinition: FieldDefinition | null) {
 
 export function getInitialFilterText(
   key: string,
-  fieldDefinition: FieldDefinition | null
+  fieldDefinition: FieldDefinition | null,
+  operator: TermOperator = TermOperator.GREATER_THAN
 ) {
   const defaultValue = getDefaultFilterValue({fieldDefinition});
 
@@ -258,7 +260,7 @@ export function getInitialFilterText(
     case FieldValueType.DURATION:
     case FieldValueType.SIZE:
     case FieldValueType.PERCENTAGE:
-      return `${keyText}:>${defaultValue}`;
+      return `${keyText}:${operator}${defaultValue}`;
     case FieldValueType.STRING: {
       return areWildcardOperatorsAllowed(fieldDefinition, valueType)
         ? `${keyText}:${WildcardOperators.CONTAINS}${defaultValue}`

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -16,7 +16,7 @@ import {
 import {getKeyName} from 'sentry/components/searchSyntax/utils';
 import {t} from 'sentry/locale';
 import {SavedSearchType, type TagCollection} from 'sentry/types/group';
-import {FieldValueType} from 'sentry/utils/fields';
+import {FieldKind, FieldValueType, type FieldDefinition} from 'sentry/utils/fields';
 
 function getFilterKeysFromQuery(value: string | undefined): string[] {
   if (!value) {
@@ -35,12 +35,36 @@ function getFilterKeysFromQuery(value: string | undefined): string[] {
   return Array.from(keys);
 }
 
+export function getFieldDefinitionForFilterKey(
+  key: string,
+  getFieldDefinition: FieldDefinitionGetter,
+  filterKeys?: TagCollection
+): FieldDefinition | null {
+  const fieldDef = getFieldDefinition(key);
+  if (fieldDef) {
+    return fieldDef;
+  }
+
+  switch (filterKeys?.[key]?.kind) {
+    case FieldKind.MEASUREMENT:
+    case FieldKind.NUMERIC_METRICS:
+      return {kind: FieldKind.FIELD, valueType: FieldValueType.NUMBER};
+    case FieldKind.BOOLEAN:
+      return {kind: FieldKind.FIELD, valueType: FieldValueType.BOOLEAN};
+    case FieldKind.TAG:
+      return {kind: FieldKind.FIELD, valueType: FieldValueType.STRING};
+    default:
+      return null;
+  }
+}
+
 function addKeyToSearchConfig(
   config: Partial<SearchConfig>,
   key: string,
-  getFieldDefinition: FieldDefinitionGetter
+  getFieldDefinition: FieldDefinitionGetter,
+  filterKeys: TagCollection
 ) {
-  const fieldDef = getFieldDefinition(key);
+  const fieldDef = getFieldDefinitionForFilterKey(key, getFieldDefinition, filterKeys);
   if (!fieldDef) {
     return;
   }
@@ -93,11 +117,11 @@ function getSearchConfigFromKeys({
   } satisfies Partial<SearchConfig>;
 
   for (const key of Object.keys(keys)) {
-    addKeyToSearchConfig(config, key, getFieldDefinition);
+    addKeyToSearchConfig(config, key, getFieldDefinition, keys);
   }
 
   for (const key of queryKeys) {
-    addKeyToSearchConfig(config, key, getFieldDefinition);
+    addKeyToSearchConfig(config, key, getFieldDefinition, keys);
   }
 
   return config;


### PR DESCRIPTION
This PR modifies how the search query builder handles comparison operators, and will recognize them and automatically convert from free text to filter key setup.

Closes EXP-990