### PR TITLE
ref(onboarding): Extract project-details form into a reusable hook and core

### DIFF
--- a/static/app/views/onboarding/components/scmProjectDetailsCore.spec.tsx
+++ b/static/app/views/onboarding/components/scmProjectDetailsCore.spec.tsx
@@ -1,0 +1,60 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import * as analytics from 'sentry/utils/analytics';
+import {DEFAULT_ISSUE_ALERT_OPTIONS_VALUES} from 'sentry/views/projectInstall/issueAlertOptions';
+
+import {ScmProjectDetailsCore} from './scmProjectDetailsCore';
+
+type CoreProps = React.ComponentProps<typeof ScmProjectDetailsCore>;
+
+function renderCore(overrides: Partial<CoreProps> = {}) {
+  const props: CoreProps = {
+    analyticsFlow: 'project-creation',
+    projectName: 'my-project',
+    onProjectNameChange: jest.fn(),
+    onProjectNameBlur: jest.fn(),
+    teamSlug: 'my-team',
+    onTeamChange: jest.fn(),
+    alertRuleConfig: DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
+    onAlertChange: jest.fn(),
+    isOrgMemberWithNoAccess: false,
+    ...overrides,
+  };
+
+  render(<ScmProjectDetailsCore {...props} />, {organization: OrganizationFixture()});
+  return props;
+}
+
+describe('ScmProjectDetailsCore', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders the project name, team, and alert-frequency fields', () => {
+    renderCore();
+
+    expect(screen.getByText('Give your project a name')).toBeInTheDocument();
+    expect(screen.getByText('Assign a team')).toBeInTheDocument();
+    expect(screen.getByText('Alert frequency')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('project-name')).toHaveValue('my-project');
+  });
+
+  it('fires step_viewed analytics for the given flow on mount', () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    renderCore({analyticsFlow: 'project-creation'});
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.scm_project_details_step_viewed',
+      expect.anything()
+    );
+  });
+
+  it('hides the team selector for a no-access member', () => {
+    renderCore({isOrgMemberWithNoAccess: true});
+
+    expect(screen.getByText('Give your project a name')).toBeInTheDocument();
+    expect(screen.queryByText('Assign a team')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
+++ b/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
@@ -1,0 +1,128 @@
+import {useEffect} from 'react';
+
+import {Input} from '@sentry/scraps/input';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {TeamSelector} from 'sentry/components/teamSelector';
+import {IconGroup, IconProject, IconSiren} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Team} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {AlertRuleOptions} from 'sentry/views/projectInstall/issueAlertOptions';
+
+import {ScmAlertFrequency} from './scmAlertFrequency';
+import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
+
+const STEP_VIEWED_EVENT = {
+  onboarding: 'onboarding.scm_project_details_step_viewed',
+  'project-creation': 'project_creation.scm_project_details_step_viewed',
+} as const;
+
+interface ScmProjectDetailsCoreProps {
+  alertRuleConfig: AlertRuleOptions;
+  analyticsFlow: ScmAnalyticsFlow;
+  /** Hides the team selector for a no-access member (see useScmProjectDetails). */
+  isOrgMemberWithNoAccess: boolean;
+  onAlertChange: <K extends keyof AlertRuleOptions>(
+    key: K,
+    value: AlertRuleOptions[K]
+  ) => void;
+  onProjectNameBlur: () => void;
+  onProjectNameChange: (value: string) => void;
+  onTeamChange: (option: {value: string}) => void;
+  projectName: string;
+  teamSlug: string;
+  /** Max width of the field column. Hosts pass their own step/section width. */
+  contentMaxWidth?: string;
+}
+
+/**
+ * Presentational project name / team / alert-frequency form shared by the SCM
+ * onboarding project-details step and the SCM-first project-creation surface.
+ * Form state, the create flow, and field analytics live in `useScmProjectDetails`;
+ * the host wires that hook to this component and renders its own Create button.
+ * This component owns only the rendering and the `step_viewed` analytics, which
+ * fires when the step becomes visible.
+ */
+export function ScmProjectDetailsCore({
+  alertRuleConfig,
+  analyticsFlow,
+  isOrgMemberWithNoAccess,
+  onAlertChange,
+  onProjectNameBlur,
+  onProjectNameChange,
+  onTeamChange,
+  projectName,
+  teamSlug,
+  contentMaxWidth,
+}: ScmProjectDetailsCoreProps) {
+  const organization = useOrganization();
+
+  useEffect(() => {
+    trackAnalytics(STEP_VIEWED_EVENT[analyticsFlow], {organization});
+  }, [organization, analyticsFlow]);
+
+  return (
+    <Stack gap="3xl" width="100%" maxWidth={contentMaxWidth}>
+      <Stack gap="md">
+        <Flex gap="md" align="center" justify="center">
+          <IconProject size="md" variant="secondary" />
+          <Container>
+            <Text bold size="lg" density="comfortable">
+              {t('Give your project a name')}
+            </Text>
+          </Container>
+        </Flex>
+        <Input
+          type="text"
+          placeholder={t('project-name')}
+          value={projectName}
+          onChange={e => onProjectNameChange(e.target.value)}
+          onBlur={onProjectNameBlur}
+        />
+      </Stack>
+
+      {!isOrgMemberWithNoAccess && (
+        <Stack gap="md">
+          <Flex gap="md" align="center" justify="center">
+            <IconGroup size="md" />
+            <Container>
+              <Text bold size="lg" density="comfortable">
+                {t('Assign a team')}
+              </Text>
+            </Container>
+          </Flex>
+          <TeamSelector
+            allowCreate
+            name="team"
+            aria-label={t('Select a Team')}
+            clearable={false}
+            placeholder={t('Select a Team')}
+            teamFilter={(tm: Team) => tm.access.includes('team:admin')}
+            value={teamSlug}
+            onChange={onTeamChange}
+          />
+        </Stack>
+      )}
+
+      <Stack gap="md">
+        <Flex gap="md" align="center" justify="center">
+          <IconSiren size="md" />
+          <Container>
+            <Text bold size="lg" density="comfortable">
+              {t('Alert frequency')}
+            </Text>
+          </Container>
+        </Flex>
+        <Container>
+          <Text variant="muted" size="lg" density="comfortable" align="center">
+            {t('Get notified when things go wrong')}
+          </Text>
+        </Container>
+        <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
+      </Stack>
+    </Stack>
+  );
+}

--- a/static/app/views/onboarding/components/useScmProjectDetails.ts
+++ b/static/app/views/onboarding/components/useScmProjectDetails.ts
@@ -1,0 +1,305 @@
+import {useCallback, useState} from 'react';
+import * as Sentry from '@sentry/react';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import type {ProjectDetailsFormState} from 'sentry/components/onboarding/onboardingContext';
+import {useCreateProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
+import {t} from 'sentry/locale';
+import type {Repository} from 'sentry/types/integrations';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import type {Team} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import type {RequestError} from 'sentry/utils/requestError/requestError';
+import {slugify} from 'sentry/utils/slugify';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
+import {useTeams} from 'sentry/utils/useTeams';
+import type {ScmAnalyticsFlow} from 'sentry/views/onboarding/components/scmAnalyticsFlow';
+import {
+  DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
+  getRequestDataFragment,
+  type AlertRuleOptions,
+  RuleAction,
+} from 'sentry/views/projectInstall/issueAlertOptions';
+
+// The project-details analytics events, routed by the active flow (new-org
+// onboarding vs SCM-first project creation). The project_creation.* events are
+// registered in projectCreationAnalyticsEvents.tsx. STEP_VIEWED is fired by the
+// presentational component when the step is rendered, not here.
+const NAME_EDITED_EVENT = {
+  onboarding: 'onboarding.scm_project_details_name_edited',
+  'project-creation': 'project_creation.scm_project_details_name_edited',
+} as const;
+const TEAM_SELECTED_EVENT = {
+  onboarding: 'onboarding.scm_project_details_team_selected',
+  'project-creation': 'project_creation.scm_project_details_team_selected',
+} as const;
+const ALERT_SELECTED_EVENT = {
+  onboarding: 'onboarding.scm_project_details_alert_selected',
+  'project-creation': 'project_creation.scm_project_details_alert_selected',
+} as const;
+const CREATE_CLICKED_EVENT = {
+  onboarding: 'onboarding.scm_project_details_create_clicked',
+  'project-creation': 'project_creation.scm_project_details_create_clicked',
+} as const;
+const CREATE_SUCCEEDED_EVENT = {
+  onboarding: 'onboarding.scm_project_details_create_succeeded',
+  'project-creation': 'project_creation.scm_project_details_create_succeeded',
+} as const;
+const CREATE_FAILED_EVENT = {
+  onboarding: 'onboarding.scm_project_details_create_failed',
+  'project-creation': 'project_creation.scm_project_details_create_failed',
+} as const;
+
+interface UseScmProjectDetailsOptions {
+  analyticsFlow: ScmAnalyticsFlow;
+  /** Called after a project is created (or an unchanged one reused). */
+  onComplete: () => void;
+  onProjectCreated: (slug: string | undefined) => void;
+  onProjectDetailsFormChange: (form: ProjectDetailsFormState) => void;
+  selectedPlatform: OnboardingSelectedSDK | undefined;
+  selectedRepository: Repository | undefined;
+  /**
+   * Mirror classic project creation: when the viewer has no admin team and
+   * can't create one, drop the team requirement and create with no team (the
+   * backend assigns one). Off by default so onboarding keeps requiring a team.
+   */
+  allowMemberWithoutTeam?: boolean;
+  /** Slug of an already-created project, used for the back-nav reuse check. */
+  createdProjectSlug?: string;
+  projectDetailsForm?: ProjectDetailsFormState;
+}
+
+interface ScmProjectDetailsForm {
+  alertRuleConfig: AlertRuleOptions;
+  /** Whether the form is complete enough to submit. */
+  canSubmit: boolean;
+  /** The most recent create error, for hosts that surface it inline. */
+  error: RequestError | null;
+  /** Whether a create is in flight. */
+  isBusy: boolean;
+  /** Whether the team selector should be hidden (no-access member). */
+  isOrgMemberWithNoAccess: boolean;
+  onAlertChange: <K extends keyof AlertRuleOptions>(
+    key: K,
+    value: AlertRuleOptions[K]
+  ) => void;
+  onProjectNameBlur: () => void;
+  onProjectNameChange: (value: string) => void;
+  onTeamChange: (option: {value: string}) => void;
+  /** Resolved project name (user edit, falling back to the platform default). */
+  projectName: string;
+  /** Creates the project (or reuses an unchanged one) and reports completion. */
+  submit: () => void;
+  /** Resolved team slug (user selection, falling back to first admin team). */
+  teamSlug: string;
+}
+
+/**
+ * Owns the SCM project-details form state, the create-project + repo-link flow,
+ * and the field/create analytics (routed by `analyticsFlow`). Returned to the
+ * host so it can render the presentational `ScmProjectDetailsCore` form and
+ * place its own Create button (onboarding's fixed footer, project creation's
+ * page-level footer) independent of where the form fields render.
+ */
+export function useScmProjectDetails({
+  analyticsFlow,
+  onComplete,
+  onProjectCreated,
+  onProjectDetailsFormChange,
+  selectedPlatform,
+  selectedRepository,
+  createdProjectSlug,
+  projectDetailsForm,
+  allowMemberWithoutTeam,
+}: UseScmProjectDetailsOptions): ScmProjectDetailsForm {
+  const organization = useOrganization();
+  const {teams, fetching: isLoadingTeams} = useTeams();
+  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
+  const createProjectAndRules = useCreateProjectAndRules();
+
+  const accessTeams = teams.filter((team: Team) => team.access.includes('team:admin'));
+  const firstAdminTeam = accessTeams[0];
+  // A member with no admin team who also can't create one: with
+  // allowMemberWithoutTeam we let them create a project anyway (backend assigns
+  // a new team), matching classic project creation.
+  const isOrgMemberWithNoAccess =
+    !!allowMemberWithoutTeam &&
+    accessTeams.length === 0 &&
+    !organization.access.includes('project:admin');
+  const defaultName = slugify(selectedPlatform?.key ?? '');
+
+  // State tracks user edits. When the host restores a persisted
+  // projectDetailsForm (e.g. back-navigation in onboarding) it seeds the inputs.
+  const [projectName, setProjectName] = useState(projectDetailsForm?.projectName ?? null);
+  const [teamSlug, setTeamSlug] = useState(projectDetailsForm?.teamSlug ?? null);
+  const [alertRuleConfig, setAlertRuleConfig] = useState(
+    projectDetailsForm?.alertRuleConfig ?? DEFAULT_ISSUE_ALERT_OPTIONS_VALUES
+  );
+
+  const projectNameResolved = projectName ?? defaultName;
+  const teamSlugResolved = teamSlug ?? firstAdminTeam?.slug ?? '';
+
+  const onProjectNameChange = useCallback((value: string) => {
+    setProjectName(slugify(value));
+  }, []);
+
+  const onProjectNameBlur = useCallback(() => {
+    if (projectName !== null) {
+      trackAnalytics(NAME_EDITED_EVENT[analyticsFlow], {
+        organization,
+        custom: projectName !== defaultName,
+      });
+    }
+  }, [projectName, defaultName, organization, analyticsFlow]);
+
+  const onTeamChange = useCallback(
+    ({value}: {value: string}) => {
+      setTeamSlug(value);
+      trackAnalytics(TEAM_SELECTED_EVENT[analyticsFlow], {organization, team: value});
+    },
+    [organization, analyticsFlow]
+  );
+
+  const onAlertChange = useCallback(
+    <K extends keyof AlertRuleOptions>(key: K, value: AlertRuleOptions[K]) => {
+      setAlertRuleConfig(prev => ({...prev, [key]: value}));
+      if (key === 'alertSetting') {
+        const optionMap: Record<number, string> = {
+          [RuleAction.DEFAULT_ALERT]: 'high_priority',
+          [RuleAction.CUSTOMIZED_ALERTS]: 'custom',
+          [RuleAction.CREATE_ALERT_LATER]: 'create_later',
+        };
+        trackAnalytics(ALERT_SELECTED_EVENT[analyticsFlow], {
+          organization,
+          option: optionMap[value as number] ?? String(value),
+        });
+      }
+    },
+    [organization, analyticsFlow]
+  );
+
+  // Block submission until teams and the projects store have loaded so the
+  // reuse check below can't be bypassed by a race.
+  const canSubmit =
+    projectNameResolved.length > 0 &&
+    (isOrgMemberWithNoAccess || teamSlugResolved.length > 0) &&
+    !!selectedPlatform &&
+    !createProjectAndRules.isPending &&
+    !isLoadingTeams &&
+    projectsLoaded;
+
+  const existingProject = createdProjectSlug
+    ? projects.find(p => p.slug === createdProjectSlug)
+    : undefined;
+
+  // Platform is compared against the project record rather than a form-state
+  // snapshot because the Project model tracks it; alert fields are not on the
+  // Project record so we compare those against the context snapshot.
+  const samePlatform = existingProject?.platform === selectedPlatform?.key;
+  const savedAlert = projectDetailsForm?.alertRuleConfig;
+  const nothingChanged =
+    samePlatform &&
+    !!projectDetailsForm &&
+    projectNameResolved === projectDetailsForm.projectName &&
+    teamSlugResolved === projectDetailsForm.teamSlug &&
+    alertRuleConfig.alertSetting === savedAlert?.alertSetting &&
+    alertRuleConfig.interval === savedAlert?.interval &&
+    alertRuleConfig.metric === savedAlert?.metric &&
+    alertRuleConfig.threshold === savedAlert?.threshold;
+
+  const submit = useCallback(async () => {
+    if (!selectedPlatform || !canSubmit) {
+      return;
+    }
+
+    trackAnalytics(CREATE_CLICKED_EVENT[analyticsFlow], {organization});
+
+    // User navigated back and clicked Create without changing anything; skip
+    // to completion without creating a duplicate. Any actual change abandons
+    // the previous project and creates a new one, matching legacy onboarding.
+    if (existingProject && nothingChanged) {
+      trackAnalytics(CREATE_SUCCEEDED_EVENT[analyticsFlow], {
+        organization,
+        project_slug: existingProject.slug,
+      });
+      onComplete();
+      return;
+    }
+
+    try {
+      const {project} = await createProjectAndRules.mutateAsync({
+        projectName: projectNameResolved,
+        platform: selectedPlatform,
+        team: isOrgMemberWithNoAccess ? undefined : teamSlugResolved,
+        alertRuleConfig: getRequestDataFragment(alertRuleConfig),
+        createNotificationAction: () => {},
+      });
+
+      // Store the project slug separately so the host can find the project
+      // without corrupting selectedPlatform.key.
+      onProjectCreated(project.slug);
+
+      if (selectedRepository?.id) {
+        try {
+          await fetchMutation({
+            url: `/projects/${organization.slug}/${project.slug}/repo/`,
+            method: 'POST',
+            data: {repositoryId: selectedRepository.id},
+          });
+        } catch (error) {
+          Sentry.captureException(error);
+        }
+      }
+
+      onProjectDetailsFormChange({
+        projectName: projectNameResolved,
+        teamSlug: teamSlugResolved,
+        alertRuleConfig,
+      });
+
+      trackAnalytics(CREATE_SUCCEEDED_EVENT[analyticsFlow], {
+        organization,
+        project_slug: project.slug,
+      });
+
+      onComplete();
+    } catch (error) {
+      trackAnalytics(CREATE_FAILED_EVENT[analyticsFlow], {organization});
+      addErrorMessage(t('Failed to create project'));
+      Sentry.captureException(error);
+    }
+  }, [
+    analyticsFlow,
+    alertRuleConfig,
+    canSubmit,
+    createProjectAndRules,
+    existingProject,
+    isOrgMemberWithNoAccess,
+    nothingChanged,
+    onComplete,
+    onProjectCreated,
+    onProjectDetailsFormChange,
+    organization,
+    projectNameResolved,
+    selectedPlatform,
+    selectedRepository,
+    teamSlugResolved,
+  ]);
+
+  return {
+    projectName: projectNameResolved,
+    onProjectNameChange,
+    onProjectNameBlur,
+    teamSlug: teamSlugResolved,
+    onTeamChange,
+    alertRuleConfig,
+    onAlertChange,
+    isOrgMemberWithNoAccess,
+    canSubmit,
+    isBusy: createProjectAndRules.isPending,
+    error: createProjectAndRules.error,
+    submit,
+  };
+}

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -1,37 +1,17 @@
-import {useEffect, useState} from 'react';
-import * as Sentry from '@sentry/react';
-
 import {Button} from '@sentry/scraps/button';
-import {Input} from '@sentry/scraps/input';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
+import {Flex} from '@sentry/scraps/layout';
 
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {ProjectDetailsFormState} from 'sentry/components/onboarding/onboardingContext';
-import {useCreateProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
-import {TeamSelector} from 'sentry/components/teamSelector';
-import {IconGroup, IconProject, IconSiren} from 'sentry/icons';
+import {IconProject} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
-import type {Team} from 'sentry/types/organization';
-import {trackAnalytics} from 'sentry/utils/analytics';
-import {fetchMutation} from 'sentry/utils/queryClient';
-import {slugify} from 'sentry/utils/slugify';
-import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjects} from 'sentry/utils/useProjects';
-import {useTeams} from 'sentry/utils/useTeams';
 import {GenericFooter} from 'sentry/views/onboarding/components/genericFooter';
+import {ScmProjectDetailsCore} from 'sentry/views/onboarding/components/scmProjectDetailsCore';
+import {useScmProjectDetails} from 'sentry/views/onboarding/components/useScmProjectDetails';
 import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
-import {
-  DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
-  getRequestDataFragment,
-  type AlertRuleOptions,
-  RuleAction,
-} from 'sentry/views/projectInstall/issueAlertOptions';
 
-import {ScmAlertFrequency} from './components/scmAlertFrequency';
 import {ScmStepHeader} from './components/scmStepHeader';
 import type {StepProps} from './types';
 
@@ -58,156 +38,17 @@ export function ScmProjectDetails({
   selectedRepository,
   genBackButton,
 }: ScmProjectDetailsProps) {
-  const organization = useOrganization();
-  const {teams, fetching: isLoadingTeams} = useTeams();
-  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
-  const createProjectAndRules = useCreateProjectAndRules();
-  useEffect(() => {
-    trackAnalytics('onboarding.scm_project_details_step_viewed', {organization});
-  }, [organization]);
-
-  const firstAdminTeam = teams.find((team: Team) => team.access.includes('team:admin'));
-  const defaultName = slugify(selectedPlatform?.key ?? '');
-
-  // State tracks user edits. When the user navigates back from setup-docs
-  // the persisted projectDetailsForm restores their previous inputs.
-  const [projectName, setProjectName] = useState(projectDetailsForm?.projectName ?? null);
-  const [teamSlug, setTeamSlug] = useState(projectDetailsForm?.teamSlug ?? null);
-
-  const projectNameResolved = projectName ?? defaultName;
-  const teamSlugResolved = teamSlug ?? firstAdminTeam?.slug ?? '';
-
-  const [alertRuleConfig, setAlertRuleConfig] = useState(
-    projectDetailsForm?.alertRuleConfig ?? DEFAULT_ISSUE_ALERT_OPTIONS_VALUES
-  );
-
-  function handleAlertChange<K extends keyof AlertRuleOptions>(
-    key: K,
-    value: AlertRuleOptions[K]
-  ) {
-    setAlertRuleConfig(prev => ({...prev, [key]: value}));
-    if (key === 'alertSetting') {
-      const optionMap: Record<number, string> = {
-        [RuleAction.DEFAULT_ALERT]: 'high_priority',
-        [RuleAction.CUSTOMIZED_ALERTS]: 'custom',
-        [RuleAction.CREATE_ALERT_LATER]: 'create_later',
-      };
-      trackAnalytics('onboarding.scm_project_details_alert_selected', {
-        organization,
-        option: optionMap[value as number] ?? String(value),
-      });
-    }
-  }
-
-  function handleProjectNameBlur() {
-    if (projectName !== null) {
-      trackAnalytics('onboarding.scm_project_details_name_edited', {
-        organization,
-        custom: projectName !== defaultName,
-      });
-    }
-  }
-
-  function handleTeamChange({value}: {value: string}) {
-    setTeamSlug(value);
-    trackAnalytics('onboarding.scm_project_details_team_selected', {
-      organization,
-      team: value,
-    });
-  }
-
-  // Block submission until teams and the projects store have loaded so the
-  // reuse check below can't be bypassed by a race.
-  const canSubmit =
-    projectNameResolved.length > 0 &&
-    teamSlugResolved.length > 0 &&
-    !!selectedPlatform &&
-    !createProjectAndRules.isPending &&
-    !isLoadingTeams &&
-    projectsLoaded;
-
-  const existingProject = createdProjectSlug
-    ? projects.find(p => p.slug === createdProjectSlug)
-    : undefined;
-
-  // Platform is compared against the project record rather than a form-state
-  // snapshot because the Project model tracks it; alert fields are not on the
-  // Project record so we compare those against the context snapshot.
-  const samePlatform = existingProject?.platform === selectedPlatform?.key;
-  const savedAlert = projectDetailsForm?.alertRuleConfig;
-  const nothingChanged =
-    samePlatform &&
-    !!projectDetailsForm &&
-    projectNameResolved === projectDetailsForm.projectName &&
-    teamSlugResolved === projectDetailsForm.teamSlug &&
-    alertRuleConfig.alertSetting === savedAlert?.alertSetting &&
-    alertRuleConfig.interval === savedAlert?.interval &&
-    alertRuleConfig.metric === savedAlert?.metric &&
-    alertRuleConfig.threshold === savedAlert?.threshold;
-
-  async function handleCreateProject() {
-    if (!selectedPlatform || !canSubmit) {
-      return;
-    }
-
-    trackAnalytics('onboarding.scm_project_details_create_clicked', {organization});
-
-    // User navigated back and clicked Create without changing anything; skip
-    // to setup-docs without creating a duplicate. Any actual change abandons
-    // the previous project and creates a new one, matching legacy onboarding.
-    if (existingProject && nothingChanged) {
-      trackAnalytics('onboarding.scm_project_details_create_succeeded', {
-        organization,
-        project_slug: existingProject.slug,
-      });
-      onComplete(undefined, selectedFeatures ? {product: selectedFeatures} : undefined);
-      return;
-    }
-
-    try {
-      const {project} = await createProjectAndRules.mutateAsync({
-        projectName: projectNameResolved,
-        platform: selectedPlatform,
-        team: teamSlugResolved,
-        alertRuleConfig: getRequestDataFragment(alertRuleConfig),
-        createNotificationAction: () => {},
-      });
-
-      // Store the project slug separately so onboarding.tsx can find
-      // the project via useRecentCreatedProject without corrupting
-      // selectedPlatform.key (which the platform features step needs).
-      onProjectCreated(project.slug);
-
-      if (selectedRepository?.id) {
-        try {
-          await fetchMutation({
-            url: `/projects/${organization.slug}/${project.slug}/repo/`,
-            method: 'POST',
-            data: {repositoryId: selectedRepository.id},
-          });
-        } catch (error) {
-          Sentry.captureException(error);
-        }
-      }
-
-      onProjectDetailsFormChange({
-        projectName: projectNameResolved,
-        teamSlug: teamSlugResolved,
-        alertRuleConfig,
-      });
-
-      trackAnalytics('onboarding.scm_project_details_create_succeeded', {
-        organization,
-        project_slug: project.slug,
-      });
-
-      onComplete(undefined, selectedFeatures ? {product: selectedFeatures} : undefined);
-    } catch (error) {
-      trackAnalytics('onboarding.scm_project_details_create_failed', {organization});
-      addErrorMessage(t('Failed to create project'));
-      Sentry.captureException(error);
-    }
-  }
+  const form = useScmProjectDetails({
+    analyticsFlow: 'onboarding',
+    selectedPlatform,
+    selectedRepository,
+    createdProjectSlug,
+    projectDetailsForm,
+    onProjectCreated,
+    onProjectDetailsFormChange,
+    onComplete: () =>
+      onComplete(undefined, selectedFeatures ? {product: selectedFeatures} : undefined),
+  });
 
   return (
     <Flex direction="column" align="center" gap="2xl" flexGrow={1}>
@@ -218,72 +59,27 @@ export function ScmProjectDetails({
         )}
       />
 
-      <Stack gap="3xl" width="100%" maxWidth={SCM_STEP_CONTENT_WIDTH}>
-        <Stack gap="md">
-          <Flex gap="md" align="center" justify="center">
-            <IconProject size="md" variant="secondary" />
-            <Container>
-              <Text bold size="lg" density="comfortable">
-                {t('Give your project a name')}
-              </Text>
-            </Container>
-          </Flex>
-          <Input
-            type="text"
-            placeholder={t('project-name')}
-            value={projectNameResolved}
-            onChange={e => setProjectName(slugify(e.target.value))}
-            onBlur={handleProjectNameBlur}
-          />
-        </Stack>
-
-        <Stack gap="md">
-          <Flex gap="md" align="center" justify="center">
-            <IconGroup size="md" />
-            <Container>
-              <Text bold size="lg" density="comfortable">
-                {t('Assign a team')}
-              </Text>
-            </Container>
-          </Flex>
-          <TeamSelector
-            allowCreate
-            name="team"
-            aria-label={t('Select a Team')}
-            clearable={false}
-            placeholder={t('Select a Team')}
-            teamFilter={(tm: Team) => tm.access.includes('team:admin')}
-            value={teamSlugResolved}
-            onChange={handleTeamChange}
-          />
-        </Stack>
-
-        <Stack gap="md">
-          <Flex gap="md" align="center" justify="center">
-            <IconSiren size="md" />
-            <Container>
-              <Text bold size="lg" density="comfortable">
-                {t('Alert frequency')}
-              </Text>
-            </Container>
-          </Flex>
-          <Container>
-            <Text variant="muted" size="lg" density="comfortable" align="center">
-              {t('Get notified when things go wrong')}
-            </Text>
-          </Container>
-          <ScmAlertFrequency {...alertRuleConfig} onFieldChange={handleAlertChange} />
-        </Stack>
-      </Stack>
+      <ScmProjectDetailsCore
+        analyticsFlow="onboarding"
+        projectName={form.projectName}
+        onProjectNameChange={form.onProjectNameChange}
+        onProjectNameBlur={form.onProjectNameBlur}
+        teamSlug={form.teamSlug}
+        onTeamChange={form.onTeamChange}
+        alertRuleConfig={form.alertRuleConfig}
+        onAlertChange={form.onAlertChange}
+        isOrgMemberWithNoAccess={form.isOrgMemberWithNoAccess}
+        contentMaxWidth={SCM_STEP_CONTENT_WIDTH}
+      />
 
       <GenericFooter gap="3xl" padding="0 3xl">
         <Flex align="center">{genBackButton?.()}</Flex>
         <Flex align="center" gap="md">
           <Button
             variant="primary"
-            onClick={handleCreateProject}
-            disabled={!canSubmit}
-            busy={createProjectAndRules.isPending}
+            onClick={form.submit}
+            disabled={!form.canSubmit}
+            busy={form.isBusy}
             icon={<IconProject />}
           >
             {t('Create project')}


### PR DESCRIPTION
## TLDR

Splits the SCM onboarding project-details step into a reusable `useScmProjectDetails` hook plus a presentational `ScmProjectDetailsCore`, so the SCM-first project-creation flow can reuse it and place its own Create button. No behavior change; the existing spec passes unchanged.

## Details

- `useScmProjectDetails` owns the form state, the create-project + repo-link flow, the reuse ("nothing changed") short-circuit, and the field/create analytics, routed by an `analyticsFlow` prop. It also supports a no-access member path (`allowMemberWithoutTeam`), off by default.
- `ScmProjectDetailsCore` is the presentational name / team / alert-frequency form. It fires the `step_viewed` analytics when shown and hides the team selector for no-access members. Keeping the submit handler in the hook (rather than a render-prop) means each host renders its own Create button wherever it wants, decoupled from where the fields render.
- `ScmProjectDetails` (onboarding) is now a thin wrapper: the step header plus the fixed footer with the Back and Create buttons.

This is the VDY-76 equivalent of the `ScmPlatformFeaturesCore` extraction (#116624).

## Stack

- **PR 1 (this):** Extract project-details form into a hook and core
- [PR 2](https://github.com/getsentry/sentry/pull/117325): Keep getting-started rendered while back nav deletes
- [PR 3](https://github.com/getsentry/sentry/pull/117333): Drive the project-details form from host state
- [PR 4](https://github.com/getsentry/sentry/pull/117213): Wire into single-view project creation
- [PR 5](https://github.com/getsentry/sentry/pull/117341): Commit the auto-detected platform to the host
- [PR 6](https://github.com/getsentry/sentry/pull/117342): Explain the disabled Create CTA in the SCM wizard

Refs VDY-76