### PR TITLE
feat(preprod): Add odiff desync detection and unchanged-diff telemetry

### DIFF
--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -7,7 +7,7 @@ import threading
 from pathlib import Path
 
 from sentry.preprod.snapshots.image_diff.types import OdiffResponse
-from sentry.utils import json
+from sentry.utils import json, metrics
 
 
 def _find_odiff_binary() -> str:
@@ -125,6 +125,15 @@ class OdiffServer:
             except RuntimeError:
                 self._kill_process()
                 raise
+
+            # This server is one reused subprocess; if the stream desyncs, a comparison would
+            # silently inherit a prior pair's verdict. Fail loudly instead of corrupting results.
+            if response.requestId != self._request_id:
+                self._kill_process()
+                metrics.incr("preprod.snapshots.odiff.requestid_mismatch")
+                raise RuntimeError(
+                    f"odiff response id {response.requestId} != request id {self._request_id}"
+                )
 
         if response.error:
             raise RuntimeError(f"odiff error: {response.error}")

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -623,6 +623,22 @@ def _process_chunk(
 
             diff_mask_image_id = f"{head_artifact_id}/{base_artifact_id}/diff/{stem}.png"
 
+            if not is_changed:
+                metrics.incr("preprod.snapshots.odiff.unchanged_with_diff_hash")
+                logger.info(
+                    "preprod.snapshots.odiff.unchanged_with_diff_hash",
+                    extra={
+                        "name": name,
+                        "org_id": org_id,
+                        "head_artifact_id": head_artifact_id,
+                        "base_artifact_id": base_artifact_id,
+                        "head_hash": head_hash,
+                        "base_hash": base_hash,
+                        "changed_pixels": diff_result.changed_pixels,
+                        "threshold": threshold,
+                    },
+                )
+
             images[name] = ComparisonImageResult(
                 status="changed" if is_changed else "unchanged",
                 head_hash=head_hash,


### PR DESCRIPTION
Add lightweight instrumentation to the snapshot image-diff pipeline to detect and measure a rare, non-deterministic false `unchanged` verdict from odiff (a genuinely-changed image occasionally reported as unchanged).

Two pieces:

- **odiff response-id validation** (`OdiffServer.compare`): the server is a single reused subprocess; we write a request with an incrementing id and read back one line, assuming it answers that request. If the stdout stream ever desyncs (a stray/buffered line), every later comparison would silently inherit a prior pair's verdict (e.g. a changed pair reading an earlier `match` → false `unchanged`). We now validate `response.requestId`, and on mismatch kill the process, emit `preprod.snapshots.odiff.requestid_mismatch`, and raise — so the pair errors and the chunk retries with a fresh process (a loud, self-healing failure instead of silent corruption).
- **unchanged-verdict telemetry** (`_process_chunk`): every `unchanged` verdict — which always has differing content hashes, since equal-hash pairs short-circuit before odiff — now emits `preprod.snapshots.odiff.unchanged_with_diff_hash` (counter + structured log with org/artifact ids and hashes).

Motivation: the same comparison flagged a different number of changed images across two runs with **byte-identical inputs**, but the false `unchanged` was **not reproducible offline** across ~112k comparisons (including the exact prod Linux odiff binary, heavy concurrency, and reused/fresh processes). Since it can't be reproduced offline, production telemetry is the only way to measure how often this signature actually occurs.

Scope: instrumentation only. The diff results themselves are unchanged apart from the desync guard. A mitigation (e.g. re-checking an `unchanged` verdict in a fresh process) is a deliberate follow-up, gated on what the telemetry shows.

Refs EME-1192