### PR TITLE
fix(api) Convert snuba RPC rate limit errors to 429

### DIFF
--- a/src/sentry/api/handlers.py
+++ b/src/sentry/api/handlers.py
@@ -5,6 +5,7 @@ from rest_framework.views import exception_handler
 from sentry.search.events.constants import RATE_LIMIT_ERROR_MESSAGE
 from sentry.types.ratelimit import SnubaRateLimitMeta
 from sentry.utils.snuba import RateLimitExceeded
+from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 
 
 def custom_exception_handler(exc, context):
@@ -32,6 +33,16 @@ def custom_exception_handler(exc, context):
                 level="warning",
             )
         # let the client know that they've been rate limited with details
+        exc = Throttled(detail=RATE_LIMIT_ERROR_MESSAGE)
+
+    if isinstance(exc, SnubaRPCRateLimitExceeded):
+        # capture the rate limited exception so we can see it in Sentry
+        with sentry_sdk.new_scope() as scope:
+            scope.fingerprint = ["snuba-rpc-rate-limit-exceeded"]
+            sentry_sdk.capture_exception(
+                exc,
+                level="warning",
+            )
         exc = Throttled(detail=RATE_LIMIT_ERROR_MESSAGE)
 
     response = exception_handler(exc, context)

--- a/tests/sentry/api/test_handlers.py
+++ b/tests/sentry/api/test_handlers.py
@@ -7,6 +7,7 @@ from sentry.search.events.constants import RATE_LIMIT_ERROR_MESSAGE
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.snuba import RateLimitExceeded
+from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 
 
 class RateLimitedEndpoint(Endpoint):
@@ -16,6 +17,9 @@ class RateLimitedEndpoint(Endpoint):
         raise RateLimitExceeded(
             "Rate limit exceeded. Please try your query with a smaller date range or fewer projects."
         )
+
+    def post(self, request):
+        raise SnubaRPCRateLimitExceeded("Snuba is tired")
 
 
 urlpatterns = [re_path(r"^/$", RateLimitedEndpoint.as_view(), name="sentry-test")]
@@ -28,7 +32,14 @@ class TestRateLimited(APITestCase):
 
     def test_simple(self) -> None:
         self.login_as(self.user)
-        resp = self.get_response()
+        resp = self.get_response(method="get")
+        assert resp.status_code == 429
+
+        assert resp.data["detail"] == RATE_LIMIT_ERROR_MESSAGE
+
+    def test_snuba_rpc(self) -> None:
+        self.login_as(self.user)
+        resp = self.get_response(method="post")
         assert resp.status_code == 429
 
         assert resp.data["detail"] == RATE_LIMIT_ERROR_MESSAGE

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -14,6 +14,7 @@ from sentry.testutils.cases import (
     TraceAttachmentTestCase,
 )
 from sentry.testutils.helpers.datetime import before_now
+from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 
 
 class ProjectTraceItemDetailsEndpointTest(
@@ -736,3 +737,17 @@ class ProjectTraceItemDetailsEndpointTest(
             trace_details_response = self.do_request("logs", item_id, extra_data=extra_data)
 
             assert trace_details_response.status_code == 400, trace_details_response.content
+
+    @mock.patch("sentry.api.endpoints.project_trace_item_details.trace_item_details_rpc")
+    def test_snuba_rate_limit_error_makes_429(self, mock_trace_item_details_rpc):
+        mock_trace_item_details_rpc.side_effect = SnubaRPCRateLimitExceeded("too much traffic")
+        log = self.create_ourlog(
+            {"body": "debug test", "trace_id": self.trace_uuid},
+            timestamp=self.one_min_ago,
+        )
+        self.store_eap_items([log])
+        item_id = log.item_id.hex()
+
+        response = self.do_request("logs", item_id)
+        assert response.status_code == 429
+        assert b"Rate limit exceeded" in response.content


### PR DESCRIPTION
When snuba raises a 429 error when it is overloaded, sentry should not raise a 500. Instead it should catch the error from snuba and respond with a 429.

Refs SENTRY-5FDT