### PR TITLE
feat(onboarding): Wire ScmProjectDetailsCore into single-view project creation

### DIFF
--- a/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
+++ b/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
@@ -67,7 +67,7 @@ export function ScmProjectDetailsCore({
   return (
     <Stack gap="3xl" width="100%" maxWidth={contentMaxWidth}>
       <Stack gap="md">
-        <Flex gap="md" align="center" justify="center">
+        <Flex gap="md" align="center">
           <IconProject size="md" variant="secondary" />
           <Container>
             <Text bold size="lg" density="comfortable">
@@ -86,7 +86,7 @@ export function ScmProjectDetailsCore({
 
       {!isOrgMemberWithNoAccess && (
         <Stack gap="md">
-          <Flex gap="md" align="center" justify="center">
+          <Flex gap="md" align="center">
             <IconGroup size="md" />
             <Container>
               <Text bold size="lg" density="comfortable">
@@ -108,7 +108,7 @@ export function ScmProjectDetailsCore({
       )}
 
       <Stack gap="md">
-        <Flex gap="md" align="center" justify="center">
+        <Flex gap="md" align="center">
           <IconSiren size="md" />
           <Container>
             <Text bold size="lg" density="comfortable">
@@ -117,7 +117,7 @@ export function ScmProjectDetailsCore({
           </Container>
         </Flex>
         <Container>
-          <Text variant="muted" size="lg" density="comfortable" align="center">
+          <Text variant="muted" size="lg" density="comfortable">
             {t('Get notified when things go wrong')}
           </Text>
         </Container>

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -140,6 +140,38 @@ describe('ScmCreateProject', () => {
     expect(screen.getByPlaceholderText('project-name')).toHaveValue('my-restored-name');
   });
 
+  it('restores the wizard when the return params arrive after mount', async () => {
+    const projectDetailsForm: ProjectDetailsFormState = {
+      projectName: 'my-restored-name',
+      teamSlug: adminTeam.slug,
+    };
+    persistRevealedWizard({projectDetailsForm});
+
+    // The back nav from getting-started can land here bare before its replace
+    // navigation appends the referrer/project params (see ScmCreateProject).
+    const {router} = render(<ScmCreateProject />, {
+      organization,
+      initialRouterConfig: {
+        location: {pathname: '/organizations/org-slug/projects/new/'},
+      },
+    });
+
+    await screen.findByRole('button', {name: 'Create project'});
+    expect(
+      screen.queryByRole('heading', {name: 'Project details'})
+    ).not.toBeInTheDocument();
+
+    router.navigate(
+      `/organizations/org-slug/projects/new/?referrer=getting-started&project=${CREATED_PROJECT_ID}`,
+      {replace: true}
+    );
+
+    expect(
+      await screen.findByRole('heading', {name: 'Project details'})
+    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('project-name')).toHaveValue('my-restored-name');
+  });
+
   it('navigates to the new project getting-started on creation', async () => {
     persistRevealedWizard();
 

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -1,0 +1,210 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {TeamFixture} from 'sentry-fixture/team';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {ProjectDetailsFormState} from 'sentry/components/onboarding/onboardingContext';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {TeamStore} from 'sentry/stores/teamStore';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import {DEFAULT_ISSUE_ALERT_OPTIONS_VALUES} from 'sentry/views/projectInstall/issueAlertOptions';
+
+import {ScmCreateProject} from './scmCreateProject';
+
+// Mock the virtualizer so the platform-features manual-picker Select renders.
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: jest.fn(({count}) => ({
+    getVirtualItems: () =>
+      Array.from({length: count}, (_, i) => ({
+        key: i,
+        index: i,
+        start: i * 36,
+        size: 36,
+      })),
+    getTotalSize: () => count * 36,
+    measureElement: jest.fn(),
+  })),
+}));
+
+jest.mock('sentry/data/platforms', () => {
+  const actual = jest.requireActual('sentry/data/platforms');
+  return {
+    ...actual,
+    platforms: actual.platforms.filter(
+      (p: {id: string}) => p.id === 'python' || p.id === 'javascript'
+    ),
+  };
+});
+
+const WIZARD_KEY = 'project-creation-wizard';
+const CREATED_PROJECT_ID = 'created-1';
+
+const pythonPlatform: OnboardingSelectedSDK = {
+  key: 'python',
+  name: 'Python',
+  language: 'python',
+  type: 'language',
+  link: 'https://docs.sentry.io/platforms/python/',
+  category: 'popular',
+};
+
+describe('ScmCreateProject', () => {
+  const organization = OrganizationFixture();
+  const adminTeam = TeamFixture({slug: 'admin-team', access: ['team:admin']});
+
+  // Seed a persisted wizard advanced to the revealed/project-selected state, as
+  // if the user had created a project in this session.
+  function persistRevealedWizard(overrides: Partial<Record<string, unknown>> = {}) {
+    window.sessionStorage.setItem(
+      WIZARD_KEY,
+      JSON.stringify({
+        repoStepCompleted: true,
+        selectedPlatform: pythonPlatform,
+        createdProjectId: CREATED_PROJECT_ID,
+        ...overrides,
+      })
+    );
+  }
+
+  // A return from getting-started for the created project: referrer + matching id.
+  const returningRouterConfig = {
+    location: {
+      pathname: '/organizations/org-slug/projects/new/',
+      query: {referrer: 'getting-started', project: CREATED_PROJECT_ID},
+    },
+  };
+
+  beforeEach(() => {
+    TeamStore.reset();
+    TeamStore.loadInitialData([adminTeam]);
+    ProjectsStore.loadInitialData([]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/config/integrations/`,
+      body: {providers: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/user-teams/`,
+      body: [adminTeam],
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    window.sessionStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('keeps the Create CTA available (disabled) before any steps are revealed', async () => {
+    render(<ScmCreateProject />, {organization});
+
+    expect(
+      screen.queryByRole('heading', {name: 'Project details'})
+    ).not.toBeInTheDocument();
+    const createButton = await screen.findByRole('button', {name: 'Create project'});
+    expect(createButton).toBeDisabled();
+  });
+
+  it('resets a persisted wizard on a fresh visit (no return from getting-started)', async () => {
+    persistRevealedWizard();
+
+    // No referrer/project query: not a return, so the persisted state is dropped.
+    render(<ScmCreateProject />, {organization});
+
+    await screen.findByRole('button', {name: 'Create project'});
+    expect(
+      screen.queryByRole('heading', {name: 'Project details'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('restores the wizard on a valid return from getting-started', async () => {
+    const projectDetailsForm: ProjectDetailsFormState = {
+      projectName: 'my-restored-name',
+      teamSlug: adminTeam.slug,
+    };
+    persistRevealedWizard({projectDetailsForm});
+
+    render(<ScmCreateProject />, {
+      organization,
+      initialRouterConfig: returningRouterConfig,
+    });
+
+    expect(
+      await screen.findByRole('heading', {name: 'Project details'})
+    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('project-name')).toHaveValue('my-restored-name');
+  });
+
+  it('navigates to the new project getting-started on creation', async () => {
+    persistRevealedWizard();
+
+    const createRequest = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      method: 'POST',
+      body: ProjectFixture({slug: 'python', name: 'python'}),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [adminTeam],
+    });
+
+    const {router} = render(<ScmCreateProject />, {
+      organization,
+      initialRouterConfig: returningRouterConfig,
+    });
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
+
+    await waitFor(() => {
+      expect(createRequest).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(router.location.pathname).toContain('/python/getting-started/');
+    });
+  });
+
+  it('reuses the existing project on an unchanged return instead of duplicating', async () => {
+    ProjectsStore.loadInitialData([
+      ProjectFixture({slug: 'python', name: 'python', platform: 'python'}),
+    ]);
+    persistRevealedWizard({
+      createdProjectSlug: 'python',
+      projectDetailsForm: {
+        projectName: 'python',
+        teamSlug: adminTeam.slug,
+        alertRuleConfig: DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
+      },
+    });
+
+    const createRequest = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      method: 'POST',
+      body: ProjectFixture({slug: 'python', name: 'python'}),
+    });
+
+    const {router} = render(<ScmCreateProject />, {
+      organization,
+      initialRouterConfig: returningRouterConfig,
+    });
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
+
+    await waitFor(() => {
+      expect(router.location.pathname).toContain('/python/getting-started/');
+    });
+    expect(createRequest).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useRef} from 'react';
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
 import {LayoutGroup, motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
@@ -9,20 +9,42 @@ import {Heading, Text} from '@sentry/scraps/text';
 import {Access} from 'sentry/components/acl/access';
 import * as Layout from 'sentry/components/layouts/thirds';
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {ProjectDetailsFormState} from 'sentry/components/onboarding/onboardingContext';
+import {ProjectCreationErrorAlert} from 'sentry/components/onboarding/projectCreationErrorAlert';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {IconProject} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import type {Project} from 'sentry/types/project';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {useCanCreateProject} from 'sentry/utils/useCanCreateProject';
-import {useSessionStorage} from 'sentry/utils/useSessionStorage';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  readStorageValue,
+  removeStorageValue,
+  useSessionStorage,
+} from 'sentry/utils/useSessionStorage';
 import {ScmIntegrationConnect} from 'sentry/views/onboarding/components/scmIntegrationConnect';
 import {ScmPlatformFeaturesCore} from 'sentry/views/onboarding/components/scmPlatformFeaturesCore';
+import {ScmProjectDetailsCore} from 'sentry/views/onboarding/components/scmProjectDetailsCore';
 import {useScmPlatformDetection} from 'sentry/views/onboarding/components/useScmPlatformDetection';
+import {useScmProjectDetails} from 'sentry/views/onboarding/components/useScmProjectDetails';
 import {useScmProviders} from 'sentry/views/onboarding/components/useScmProviders';
+import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
 const CREATE_PROJECT_MAX_WIDTH = '760px';
+const WIZARD_STORAGE_KEY = 'project-creation-wizard';
 
 interface WizardState {
+  // Id/slug of the project created in this wizard session. The id validates a
+  // return from getting-started (see the mount gate); the slug drives the
+  // getting-started navigation and the project-details reuse check.
+  createdProjectId: string | undefined;
+  createdProjectSlug: string | undefined;
+  projectDetailsForm: ProjectDetailsFormState | undefined;
   // Flips true on the first meaningful action in section 1 (repo selected
   // or "Continue without connecting a repo" clicked). Sections 2 and 3
   // reveal together when this is true. Decoupled from selection state so
@@ -37,6 +59,9 @@ interface WizardState {
 
 const INITIAL_STATE: WizardState = {
   repoStepCompleted: false,
+  createdProjectId: undefined,
+  createdProjectSlug: undefined,
+  projectDetailsForm: undefined,
   selectedFeatures: undefined,
   selectedIntegration: undefined,
   selectedPlatform: undefined,
@@ -44,38 +69,43 @@ const INITIAL_STATE: WizardState = {
 };
 
 export function ScmCreateProject() {
-  // Session-storage backed so a refresh restores how far the user has
-  // progressed. Separate key from new-org onboarding's 'onboarding' key.
+  const organization = useOrganization();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // Decide once, before reading the persisted state, whether this mount is a
+  // legitimate return from the created project's getting-started page (mirrors
+  // createProject's autofill condition). If so, keep the persisted wizard so
+  // the user's selections are restored; otherwise reset it so a fresh visit (or
+  // a reload) starts clean. Doing this before useSessionStorage avoids a flash
+  // of stale state.
+  const didResolveEntry = useRef(false);
+  if (!didResolveEntry.current) {
+    didResolveEntry.current = true;
+    const persisted = readStorageValue(WIZARD_STORAGE_KEY, INITIAL_STATE);
+    const isReturnFromGettingStarted =
+      decodeScalar(location.query.referrer) === 'getting-started' &&
+      !!persisted.createdProjectId &&
+      decodeScalar(location.query.project) === persisted.createdProjectId;
+    if (!isReturnFromGettingStarted) {
+      removeStorageValue(WIZARD_STORAGE_KEY);
+    }
+  }
+
+  // Session-storage backed so a return from getting-started restores how far the
+  // user progressed. Separate key from new-org onboarding's 'onboarding' key.
   const [
     {
       repoStepCompleted,
+      createdProjectSlug,
+      projectDetailsForm,
       selectedFeatures,
       selectedIntegration,
       selectedPlatform,
       selectedRepository,
     },
     setState,
-  ] = useSessionStorage('project-creation-wizard', INITIAL_STATE);
-
-  // An optimistic repo (empty id, see useScmRepoSelection) persisted by a
-  // refresh mid-resolution can never fetch detection and would hold the
-  // platform step in a permanent spinner. Drop it once on load, also clearing
-  // the repo-derived platform/features so section 2 doesn't show a platform
-  // with no connected repo (mirrors handleClearDerivedState on a repo change).
-  // Live in-session optimistic selections arrive after mount and keep their
-  // loading state.
-  const hadStaleRepoOnLoad = useRef(!!selectedRepository && !selectedRepository.id);
-  useEffect(() => {
-    if (hadStaleRepoOnLoad.current) {
-      hadStaleRepoOnLoad.current = false;
-      setState(s => ({
-        ...s,
-        selectedRepository: undefined,
-        selectedPlatform: undefined,
-        selectedFeatures: undefined,
-      }));
-    }
-  }, [setState]);
+  ] = useSessionStorage(WIZARD_STORAGE_KEY, INITIAL_STATE);
 
   const canUserCreateProject = useCanCreateProject();
   // Subscribe so the parent re-renders when integration state changes inside
@@ -85,6 +115,12 @@ export function ScmCreateProject() {
   useScmProviders();
 
   useScmPlatformDetection(selectedRepository);
+
+  // Slug of the project to land on. Seeded from a restored session (reuse path)
+  // and updated when a new project is created. Held in a ref so the deferred
+  // navigation reads the latest value without a stale closure.
+  const createdProjectSlugRef = useRef(createdProjectSlug);
+  const [pendingNavigation, setPendingNavigation] = useState(false);
 
   const completeRepoStep = () => {
     setState(s => ({...s, repoStepCompleted: true}));
@@ -125,20 +161,74 @@ export function ScmCreateProject() {
     [setState]
   );
 
-  // Clear state derived from the repository when the repo changes. Platform
-  // and features are repo-dependent (auto-detection seeds them). VDY-76 will
-  // extend this to clear the project-details form too.
+  // Clear state derived from the repository when the repo changes. Platform,
+  // features, and the project-details form are repo-dependent (auto-detection
+  // seeds the platform, which in turn seeds the project name).
   const handleClearDerivedState = useCallback(() => {
     setState(s => ({
       ...s,
       selectedPlatform: undefined,
       selectedFeatures: undefined,
+      projectDetailsForm: undefined,
     }));
   }, [setState]);
 
-  // Clear the project-details form when the platform changes. VDY-76 will
-  // wire this up to actual project-details state.
-  const handleClearProjectDetailsForm = useCallback(() => {}, []);
+  // Clear the persisted project-details form when the platform changes, since
+  // the project name defaults from the platform key.
+  const handleClearProjectDetailsForm = useCallback(() => {
+    setState(s => ({...s, projectDetailsForm: undefined}));
+  }, [setState]);
+
+  const handleProjectDetailsFormChange = useCallback(
+    (projectDetailsFormState: ProjectDetailsFormState | undefined) => {
+      setState(s => ({...s, projectDetailsForm: projectDetailsFormState}));
+    },
+    [setState]
+  );
+
+  const handleProjectCreated = useCallback(
+    (project: Project) => {
+      createdProjectSlugRef.current = project.slug;
+      // Persist id + slug so a return from getting-started is recognized (id)
+      // and the reuse check has the slug. Committed before navigation runs
+      // (see the deferred-navigation effect below).
+      setState(s => ({
+        ...s,
+        createdProjectId: project.id,
+        createdProjectSlug: project.slug,
+      }));
+    },
+    [setState]
+  );
+
+  // Defer the getting-started navigation to an effect so the create-time state
+  // writes above commit (to session storage) before this component unmounts.
+  const handleComplete = useCallback(() => {
+    setPendingNavigation(true);
+  }, []);
+
+  useEffect(() => {
+    if (pendingNavigation && createdProjectSlugRef.current) {
+      navigate(
+        makeProjectsPathname({
+          path: `/${createdProjectSlugRef.current}/getting-started/`,
+          organization,
+        })
+      );
+    }
+  }, [pendingNavigation, navigate, organization]);
+
+  const form = useScmProjectDetails({
+    analyticsFlow: 'project-creation',
+    allowMemberWithoutTeam: true,
+    selectedPlatform,
+    selectedRepository,
+    createdProjectSlug,
+    projectDetailsForm,
+    onProjectCreated: handleProjectCreated,
+    onProjectDetailsFormChange: handleProjectDetailsFormChange,
+    onComplete: handleComplete,
+  });
 
   const showContinueWithoutRepo = !selectedRepository && !repoStepCompleted;
   const showAllSteps = repoStepCompleted;
@@ -234,25 +324,58 @@ export function ScmCreateProject() {
                     onClearProjectDetailsForm={handleClearProjectDetailsForm}
                   />
                 </MotionStack>
-                <ProjectDetailsSection />
+
+                <MotionStack
+                  layout="position"
+                  gap="lg"
+                  border="primary"
+                  radius="md"
+                  padding="lg"
+                >
+                  <Stack gap="md">
+                    <Heading as="h2" size="xl">
+                      {t('Project details')}
+                    </Heading>
+                    <Text variant="muted">
+                      {t('Name your project, assign a team, and set up issue alerts.')}
+                    </Text>
+                  </Stack>
+                  <ScmProjectDetailsCore
+                    analyticsFlow="project-creation"
+                    projectName={form.projectName}
+                    onProjectNameChange={form.onProjectNameChange}
+                    onProjectNameBlur={form.onProjectNameBlur}
+                    teamSlug={form.teamSlug}
+                    onTeamChange={form.onTeamChange}
+                    alertRuleConfig={form.alertRuleConfig}
+                    onAlertChange={form.onAlertChange}
+                    isOrgMemberWithNoAccess={form.isOrgMemberWithNoAccess}
+                  />
+                </MotionStack>
               </Fragment>
             )}
           </LayoutGroup>
+
+          {/* Page-level CTA: always present so the primary action is available
+              regardless of which steps are currently revealed. Disabled until a
+              platform and project details are ready. */}
+          <Stack gap="md">
+            <ProjectCreationErrorAlert error={form.error} />
+            <Flex justify="end">
+              <Button
+                variant="primary"
+                onClick={form.submit}
+                disabled={!form.canSubmit}
+                busy={form.isBusy}
+                icon={<IconProject />}
+              >
+                {t('Create project')}
+              </Button>
+            </Flex>
+          </Stack>
         </Stack>
       </Access>
     </SentryDocumentTitle>
-  );
-}
-
-// Placeholder for VDY-76. Will be replaced with <ScmProjectDetails />.
-function ProjectDetailsSection() {
-  return (
-    <MotionStack gap="lg" border="primary" radius="md" padding="lg" layout="position">
-      <Heading as="h2" size="xl">
-        {t('Project details')}
-      </Heading>
-      <Text variant="muted">{t('Project details step content goes here (VDY-76).')}</Text>
-    </MotionStack>
   );
 }
 

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -197,6 +197,12 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
     ({project, projectDetailsForm: submittedForm}: ScmProjectDetailsCompletion) => {
       writeStorageValue(WIZARD_STORAGE_KEY, {
         ...wizardState,
+        // An optimistic repo (empty id, see useScmRepoSelection) can never
+        // fetch detection; restoring one would strand the platform section in
+        // a permanent spinner, so it is not worth persisting.
+        selectedRepository: wizardState.selectedRepository?.id
+          ? wizardState.selectedRepository
+          : undefined,
         createdProjectId: project.id,
         createdProjectSlug: project.slug,
         projectDetailsForm: submittedForm,

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -174,11 +174,19 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
     }));
   }, [setState]);
 
-  // Clear the persisted project-details form when the platform changes, since
-  // the project name defaults from the platform key.
+  // Clear the project-details form when the platform changes, since the
+  // project name defaults from the platform key; the hook re-derives cleared
+  // fields.
   const handleClearProjectDetailsForm = useCallback(() => {
     setState(s => ({...s, projectDetailsForm: undefined}));
   }, [setState]);
+
+  const handleProjectDetailsFormChange = useCallback(
+    (projectDetailsFormState: ProjectDetailsFormState) => {
+      setState(s => ({...s, projectDetailsForm: projectDetailsFormState}));
+    },
+    [setState]
+  );
 
   // Snapshot the completed session (the created project's id validates the
   // return from getting-started, the slug feeds the reuse check, and the form
@@ -210,6 +218,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
     selectedRepository,
     createdProjectSlug,
     projectDetailsForm,
+    onProjectDetailsFormChange: handleProjectDetailsFormChange,
     onComplete: handleComplete,
   });
 

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
+import {Fragment, useCallback, useState} from 'react';
 import {LayoutGroup, motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
@@ -16,7 +16,6 @@ import {IconProject} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
-import type {Project} from 'sentry/types/project';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useCanCreateProject} from 'sentry/utils/useCanCreateProject';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -27,7 +26,10 @@ import {ScmIntegrationConnect} from 'sentry/views/onboarding/components/scmInteg
 import {ScmPlatformFeaturesCore} from 'sentry/views/onboarding/components/scmPlatformFeaturesCore';
 import {ScmProjectDetailsCore} from 'sentry/views/onboarding/components/scmProjectDetailsCore';
 import {useScmPlatformDetection} from 'sentry/views/onboarding/components/useScmPlatformDetection';
-import {useScmProjectDetails} from 'sentry/views/onboarding/components/useScmProjectDetails';
+import {
+  type ScmProjectDetailsCompletion,
+  useScmProjectDetails,
+} from 'sentry/views/onboarding/components/useScmProjectDetails';
 import {useScmProviders} from 'sentry/views/onboarding/components/useScmProviders';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
@@ -71,7 +73,7 @@ export function ScmCreateProject() {
   const projectId = decodeScalar(location.query.project);
 
   // Snapshot of the last completed wizard session, written when a project is
-  // created (see the navigation effect below). Restored when this mount is a
+  // created (see handleComplete in the wizard). Restored when this mount is a
   // return from that project's getting-started page, whose back nav tags the
   // URL with referrer + project id (mirrors createProject's autofill
   // condition). Computed reactively rather than once at mount because the tag
@@ -120,12 +122,6 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
   useScmProviders();
 
   useScmPlatformDetection(selectedRepository);
-
-  // Slug of the project to land on. Seeded from a restored session (reuse path)
-  // and updated when a new project is created. Held in a ref so the deferred
-  // navigation reads the latest value without a stale closure.
-  const createdProjectSlugRef = useRef(createdProjectSlug);
-  const [pendingNavigation, setPendingNavigation] = useState(false);
 
   const completeRepoStep = () => {
     setState(s => ({...s, repoStepCompleted: true}));
@@ -184,47 +180,28 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
     setState(s => ({...s, projectDetailsForm: undefined}));
   }, [setState]);
 
-  const handleProjectDetailsFormChange = useCallback(
-    (projectDetailsFormState: ProjectDetailsFormState | undefined) => {
-      setState(s => ({...s, projectDetailsForm: projectDetailsFormState}));
-    },
-    [setState]
-  );
-
-  const handleProjectCreated = useCallback(
-    (project: Project) => {
-      createdProjectSlugRef.current = project.slug;
-      // Persist id + slug so a return from getting-started is recognized (id)
-      // and the reuse check has the slug. Committed before navigation runs
-      // (see the deferred-navigation effect below).
-      setState(s => ({
-        ...s,
+  // Snapshot the completed session (the created project's id validates the
+  // return from getting-started, the slug feeds the reuse check, and the form
+  // seeds the fields) so it can be restored later (see ScmCreateProject), then
+  // leave for the project's getting-started page. Live wizard state never
+  // holds the created project, so there is nothing to commit before unmount.
+  const handleComplete = useCallback(
+    ({project, projectDetailsForm: submittedForm}: ScmProjectDetailsCompletion) => {
+      writeStorageValue(WIZARD_STORAGE_KEY, {
+        ...wizardState,
         createdProjectId: project.id,
         createdProjectSlug: project.slug,
-      }));
-    },
-    [setState]
-  );
-
-  // Defer the getting-started navigation to an effect so the create-time state
-  // writes above commit before the session is snapshotted here.
-  const handleComplete = useCallback(() => {
-    setPendingNavigation(true);
-  }, []);
-
-  useEffect(() => {
-    if (pendingNavigation && createdProjectSlugRef.current) {
-      // Snapshot the completed session so a return from getting-started can
-      // restore it (see ScmCreateProject).
-      writeStorageValue(WIZARD_STORAGE_KEY, wizardState);
+        projectDetailsForm: submittedForm,
+      });
       navigate(
         makeProjectsPathname({
-          path: `/${createdProjectSlugRef.current}/getting-started/`,
+          path: `/${project.slug}/getting-started/`,
           organization,
         })
       );
-    }
-  }, [pendingNavigation, wizardState, navigate, organization]);
+    },
+    [wizardState, navigate, organization]
+  );
 
   const form = useScmProjectDetails({
     analyticsFlow: 'project-creation',
@@ -233,8 +210,6 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
     selectedRepository,
     createdProjectSlug,
     projectDetailsForm,
-    onProjectCreated: handleProjectCreated,
-    onProjectDetailsFormChange: handleProjectDetailsFormChange,
     onComplete: handleComplete,
   });
 

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -22,11 +22,7 @@ import {useCanCreateProject} from 'sentry/utils/useCanCreateProject';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {
-  readStorageValue,
-  removeStorageValue,
-  useSessionStorage,
-} from 'sentry/utils/useSessionStorage';
+import {useSessionStorage, writeStorageValue} from 'sentry/utils/useSessionStorage';
 import {ScmIntegrationConnect} from 'sentry/views/onboarding/components/scmIntegrationConnect';
 import {ScmPlatformFeaturesCore} from 'sentry/views/onboarding/components/scmPlatformFeaturesCore';
 import {ScmProjectDetailsCore} from 'sentry/views/onboarding/components/scmProjectDetailsCore';
@@ -40,8 +36,9 @@ const WIZARD_STORAGE_KEY = 'project-creation-wizard';
 
 interface WizardState {
   // Id/slug of the project created in this wizard session. The id validates a
-  // return from getting-started (see the mount gate); the slug drives the
-  // getting-started navigation and the project-details reuse check.
+  // return from getting-started (see the entry resolution in ScmCreateProject);
+  // the slug drives the getting-started navigation and the project-details
+  // reuse check.
   createdProjectId: string | undefined;
   createdProjectSlug: string | undefined;
   projectDetailsForm: ProjectDetailsFormState | undefined;
@@ -69,43 +66,51 @@ const INITIAL_STATE: WizardState = {
 };
 
 export function ScmCreateProject() {
+  const location = useLocation();
+  const referrer = decodeScalar(location.query.referrer);
+  const projectId = decodeScalar(location.query.project);
+
+  // Snapshot of the last completed wizard session, written when a project is
+  // created (see the navigation effect below). Restored when this mount is a
+  // return from that project's getting-started page, whose back nav tags the
+  // URL with referrer + project id (mirrors createProject's autofill
+  // condition). Computed reactively rather than once at mount because the tag
+  // can arrive late: deleting an inactive project redirects here bare before
+  // the back nav's replace navigation appends the query params (browser-back
+  // POPs race the same way).
+  const [savedSession] = useSessionStorage<WizardState | null>(WIZARD_STORAGE_KEY, null);
+  const isReturnFromGettingStarted =
+    referrer === 'getting-started' &&
+    !!savedSession?.createdProjectId &&
+    projectId === savedSession.createdProjectId;
+  const restoredSession = isReturnFromGettingStarted ? savedSession : null;
+
+  // Keyed so a restore arriving after mount remounts the wizard and
+  // mount-seeded form state re-reads the restored session.
+  return (
+    <ScmCreateProjectWizard
+      key={restoredSession ? 'restored' : 'fresh'}
+      initialState={restoredSession ?? INITIAL_STATE}
+    />
+  );
+}
+
+function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
   const organization = useOrganization();
   const navigate = useNavigate();
-  const location = useLocation();
 
-  // Decide once, before reading the persisted state, whether this mount is a
-  // legitimate return from the created project's getting-started page (mirrors
-  // createProject's autofill condition). If so, keep the persisted wizard so
-  // the user's selections are restored; otherwise reset it so a fresh visit (or
-  // a reload) starts clean. Doing this before useSessionStorage avoids a flash
-  // of stale state.
-  const didResolveEntry = useRef(false);
-  if (!didResolveEntry.current) {
-    didResolveEntry.current = true;
-    const persisted = readStorageValue(WIZARD_STORAGE_KEY, INITIAL_STATE);
-    const isReturnFromGettingStarted =
-      decodeScalar(location.query.referrer) === 'getting-started' &&
-      !!persisted.createdProjectId &&
-      decodeScalar(location.query.project) === persisted.createdProjectId;
-    if (!isReturnFromGettingStarted) {
-      removeStorageValue(WIZARD_STORAGE_KEY);
-    }
-  }
-
-  // Session-storage backed so a return from getting-started restores how far the
-  // user progressed. Separate key from new-org onboarding's 'onboarding' key.
-  const [
-    {
-      repoStepCompleted,
-      createdProjectSlug,
-      projectDetailsForm,
-      selectedFeatures,
-      selectedIntegration,
-      selectedPlatform,
-      selectedRepository,
-    },
-    setState,
-  ] = useSessionStorage(WIZARD_STORAGE_KEY, INITIAL_STATE);
+  // In-memory while in progress, so a fresh visit or reload starts clean; the
+  // session is only persisted once a project is created.
+  const [wizardState, setState] = useState(initialState);
+  const {
+    repoStepCompleted,
+    createdProjectSlug,
+    projectDetailsForm,
+    selectedFeatures,
+    selectedIntegration,
+    selectedPlatform,
+    selectedRepository,
+  } = wizardState;
 
   const canUserCreateProject = useCanCreateProject();
   // Subscribe so the parent re-renders when integration state changes inside
@@ -202,13 +207,16 @@ export function ScmCreateProject() {
   );
 
   // Defer the getting-started navigation to an effect so the create-time state
-  // writes above commit (to session storage) before this component unmounts.
+  // writes above commit before the session is snapshotted here.
   const handleComplete = useCallback(() => {
     setPendingNavigation(true);
   }, []);
 
   useEffect(() => {
     if (pendingNavigation && createdProjectSlugRef.current) {
+      // Snapshot the completed session so a return from getting-started can
+      // restore it (see ScmCreateProject).
+      writeStorageValue(WIZARD_STORAGE_KEY, wizardState);
       navigate(
         makeProjectsPathname({
           path: `/${createdProjectSlugRef.current}/getting-started/`,
@@ -216,7 +224,7 @@ export function ScmCreateProject() {
         })
       );
     }
-  }, [pendingNavigation, navigate, organization]);
+  }, [pendingNavigation, wizardState, navigate, organization]);
 
   const form = useScmProjectDetails({
     analyticsFlow: 'project-creation',


### PR DESCRIPTION
## TLDR

Wires the SCM project-details form into the single-view project-creation flow: a Project details section plus an always-present, page-level Create CTA that creates the project and navigates to its getting-started page. Includes parity with classic project creation for members with no admin team. Messaging-integration alerts are deferred to VDY-50.

## Details

- Drives the Project details section with `useScmProjectDetails` and the presentational `ScmProjectDetailsCore`.
- The Create CTA is a page-level footer, available regardless of which steps are currently revealed (disabled until a platform and details are ready), alongside `ProjectCreationErrorAlert`.
- Adds `projectDetailsForm` to the wizard state and clears it when the platform or repository changes (resolving the two standing TODOs).
- On success, navigates to the created project's getting-started page via `makeProjectsPathname`.
- In-progress wizard state is in-memory, so a fresh visit or reload starts clean. A completed session is snapshotted to session storage when the project is created and restored when returning from its getting-started page, with the return condition computed reactively from the `referrer`/`project` query params (mirroring classic `createProject` autofill) since the back nav can deliver them after mount.
- On a restored return, clicking Create with nothing changed reuses the existing project instead of creating a duplicate; any edit abandons it and creates a new one, matching legacy onboarding.
- `allowMemberWithoutTeam`: when the viewer has no admin team and can't create one, the team selector is hidden and the project is created with no team (backend assigns one), matching classic `createProject`. Off in onboarding.

## Stack

- [PR 1](https://github.com/getsentry/sentry/pull/117209): Extract project-details form into a hook and core (merged)
- [PR 2](https://github.com/getsentry/sentry/pull/117325): Keep getting-started rendered while back nav deletes (merged)
- [PR 3](https://github.com/getsentry/sentry/pull/117333): Drive the project-details form from host state
- **PR 4 (this):** Wire into single-view project creation
- [PR 5](https://github.com/getsentry/sentry/pull/117341): Commit the auto-detected platform to the host
- [PR 6](https://github.com/getsentry/sentry/pull/117342): Explain the disabled Create CTA in the SCM wizard

Refs VDY-76
