### PR TITLE
fix(heatmaps): change minimum duration unit to microsecond for small values

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.spec.tsx
@@ -41,7 +41,7 @@ describe('formatTooltipValue', () => {
 
   describe('duration', () => {
     it.each([
-      [0, 'millisecond', '0.00ms'],
+      [0, 'millisecond', '0.00μs'],
       [0.712, 'second', '712.00ms'],
       [1231, 'second', '20.52min'],
     ])('Formats %s as %s', (value, unit, formattedValue) => {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.tsx
@@ -7,7 +7,7 @@ import {
   type RateUnit,
 } from 'sentry/utils/discover/fields';
 import {getDuration} from 'sentry/utils/duration/getDuration';
-import {formatDollars, formatRate} from 'sentry/utils/formatters';
+import {formatDollars, formatRate, MICROSECOND} from 'sentry/utils/formatters';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {ECHARTS_MISSING_DATA_VALUE} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
 import {convertDuration} from 'sentry/utils/unitConversion/convertDuration';
@@ -57,7 +57,7 @@ export function formatTooltipValue(
       const durationUnit = isADurationUnit(unit) ? unit : DurationUnit.MILLISECOND;
       const durationInSeconds = convertDuration(value, durationUnit, DurationUnit.SECOND);
 
-      return getDuration(durationInSeconds, 2, true);
+      return getDuration(durationInSeconds, 2, true, false, false, MICROSECOND);
     }
     case 'size': {
       const sizeUnit = isASizeUnit(unit) ? unit : SizeUnit.BYTE;


### PR DESCRIPTION
this is mainly a change for heatmaps but touches all timeseries charts; for duration values in particular the formatter would only return the small values in ms which was showing a bunch of 0s. I've changed that minimum duration unit to be microseconds instead. I think this is probably good for all timeseries charts anyways but if anyone's got strong opinions otherwise i'm glad to put this in just for heatmaps.

| Before | After |
|--------|--------|
| <img width="368" height="228" alt="image" src="https://github.com/user-attachments/assets/c532712a-7282-4a77-91ca-f54350144bfe" /> | <img width="385" height="209" alt="image" src="https://github.com/user-attachments/assets/c62b7139-8ac9-4654-a6bb-96dee4f264c6" /> | 