### PR TITLE
feat(autofix): Add PR iteration variants to enums and type registrations

### DIFF
--- a/src/sentry/analytics/events/autofix_events.py
+++ b/src/sentry/analytics/events/autofix_events.py
@@ -7,6 +7,7 @@ class AiAutofixPhaseEvent(analytics.Event):
     project_id: int
     group_id: int
     referrer: str | None
+    iteration_index: int | None = None
 
 
 @analytics.eventclass("ai.autofix.root_cause.started")
@@ -24,6 +25,11 @@ class AiAutofixCodeChangesStartedEvent(AiAutofixPhaseEvent):
     pass
 
 
+@analytics.eventclass("ai.autofix.pr_iteration.started")
+class AiAutofixIterationStartedEvent(AiAutofixPhaseEvent):
+    pass
+
+
 @analytics.eventclass("ai.autofix.root_cause.completed")
 class AiAutofixRootCauseCompletedEvent(AiAutofixPhaseEvent):
     pass
@@ -36,6 +42,11 @@ class AiAutofixSolutionCompletedEvent(AiAutofixPhaseEvent):
 
 @analytics.eventclass("ai.autofix.code_changes.completed")
 class AiAutofixCodeChangesCompletedEvent(AiAutofixPhaseEvent):
+    pass
+
+
+@analytics.eventclass("ai.autofix.pr_iteration.completed")
+class AiAutofixIterationCompletedEvent(AiAutofixPhaseEvent):
     pass
 
 
@@ -64,9 +75,11 @@ class AiAutofixIntrospectionEvent(AiAutofixPhaseEvent):
 analytics.register(AiAutofixRootCauseStartedEvent)
 analytics.register(AiAutofixSolutionStartedEvent)
 analytics.register(AiAutofixCodeChangesStartedEvent)
+analytics.register(AiAutofixIterationStartedEvent)
 analytics.register(AiAutofixRootCauseCompletedEvent)
 analytics.register(AiAutofixSolutionCompletedEvent)
 analytics.register(AiAutofixCodeChangesCompletedEvent)
+analytics.register(AiAutofixIterationCompletedEvent)
 analytics.register(AiAutofixPrCreatedStartedEvent)
 analytics.register(AiAutofixPrCreatedCompletedEvent)
 analytics.register(AiAutofixAgentHandoffEvent)

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -69,6 +69,7 @@ class AutofixStep(StrEnum):
     ROOT_CAUSE = "root_cause"
     SOLUTION = "solution"
     CODE_CHANGES = "code_changes"
+    PR_ITERATION = "pr_iteration"
 
     @staticmethod
     def from_autofix_stopping_point(
@@ -179,6 +180,10 @@ def get_step_webhook_action_type(step: AutofixStep, is_completed: bool) -> SeerA
         AutofixStep.CODE_CHANGES: {
             False: SeerActionType.CODING_STARTED,
             True: SeerActionType.CODING_COMPLETED,
+        },
+        AutofixStep.PR_ITERATION: {
+            False: SeerActionType.ITERATION_STARTED,
+            True: SeerActionType.ITERATION_COMPLETED,
         },
     }
     return step_to_action_type[step][is_completed]

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -452,6 +452,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             return introspect_solution(organization, run_id, state, group)
         elif step == AutofixStep.CODE_CHANGES:
             return introspect_code_changes(organization, run_id, state, group)
+        return None
 
     @classmethod
     def _push_changes(cls, group: Group, run_id: int, state: SeerRunState) -> None:

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -45,6 +45,8 @@ SEER_EVENT_TO_ACTIVITY_TYPE: dict[SentryAppEventType, ActivityType] = {
     SentryAppEventType.SEER_CODING_STARTED: ActivityType.SEER_CODING_STARTED,
     SentryAppEventType.SEER_CODING_COMPLETED: ActivityType.SEER_CODING_COMPLETED,
     SentryAppEventType.SEER_PR_CREATED: ActivityType.SEER_PR_CREATED,
+    SentryAppEventType.SEER_ITERATION_STARTED: ActivityType.SEER_ITERATION_STARTED,
+    SentryAppEventType.SEER_ITERATION_COMPLETED: ActivityType.SEER_ITERATION_COMPLETED,
 }
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -151,6 +151,8 @@ class SentryAppEventType(StrEnum):
     SEER_CODING_STARTED = "seer.coding_started"
     SEER_CODING_COMPLETED = "seer.coding_completed"
     SEER_PR_CREATED = "seer.pr_created"
+    SEER_ITERATION_STARTED = "seer.iteration_started"
+    SEER_ITERATION_COMPLETED = "seer.iteration_completed"
 
     # preprod artifact webhooks
     PREPROD_ARTIFACT_SIZE_ANALYSIS_COMPLETED = "preprod_artifact.size_analysis_completed"

--- a/src/sentry/sentry_apps/utils/webhooks.py
+++ b/src/sentry/sentry_apps/utils/webhooks.py
@@ -53,6 +53,8 @@ class SeerActionType(SentryAppActionType):
     CODING_STARTED = "coding_started"
     CODING_COMPLETED = "coding_completed"
     PR_CREATED = "pr_created"
+    ITERATION_STARTED = "iteration_started"
+    ITERATION_COMPLETED = "iteration_completed"
 
 
 class PreprodArtifactActionType(SentryAppActionType):

--- a/src/sentry/types/activity.py
+++ b/src/sentry/types/activity.py
@@ -41,6 +41,8 @@ class ActivityType(Enum):
     SEER_CODING_STARTED = 33
     SEER_CODING_COMPLETED = 34
     SEER_PR_CREATED = 35
+    SEER_ITERATION_STARTED = 36
+    SEER_ITERATION_COMPLETED = 37
 
 
 # Warning: This must remain in this EXACT order.
@@ -82,6 +84,8 @@ CHOICES = tuple(
         ActivityType.SEER_CODING_STARTED,  # 33
         ActivityType.SEER_CODING_COMPLETED,  # 34
         ActivityType.SEER_PR_CREATED,  # 35
+        ActivityType.SEER_ITERATION_STARTED,  # 36
+        ActivityType.SEER_ITERATION_COMPLETED,  # 37
     ]
 )
 

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -21,6 +21,8 @@ SEER_WORKFLOW_ACTIVITIES = [
     ActivityType.SEER_CODING_STARTED,
     ActivityType.SEER_CODING_COMPLETED,
     ActivityType.SEER_PR_CREATED,
+    ActivityType.SEER_ITERATION_STARTED,
+    ActivityType.SEER_ITERATION_COMPLETED,
 ]
 
 # Activity types handled by the generic activity_handler. This replaces the

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_status_update_handler.py
@@ -22,6 +22,8 @@ SEER_ACTIVITIES = [
     ActivityType.SEER_CODING_STARTED.value,
     ActivityType.SEER_CODING_COMPLETED.value,
     ActivityType.SEER_PR_CREATED.value,
+    ActivityType.SEER_ITERATION_STARTED.value,
+    ActivityType.SEER_ITERATION_COMPLETED.value,
 ]
 
 SUPPORTED_ACTIVITIES = [

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -235,7 +235,7 @@ class TestBuildStepPrompt(TestCase):
         assert "unknown" in prompt
 
     def test_all_prompts_are_dedented(self) -> None:
-        for step in AutofixStep:
+        for step in STEP_CONFIGS:
             prompt = build_step_prompt(step, self.group)
             # Dedented prompts should not start with whitespace
             assert not prompt.startswith(" "), f"{step} prompt starts with whitespace"

--- a/tests/sentry/sentry_apps/test_webhooks.py
+++ b/tests/sentry/sentry_apps/test_webhooks.py
@@ -183,6 +183,8 @@ class BroadcastWebhooksForOrganizationTest(TestCase):
             ("metric_alert", "resolved"),
             ("metric_alert", "critical"),
             ("metric_alert", "warning"),
+            ("seer", "iteration_started"),
+            ("seer", "iteration_completed"),
         ]
 
         for resource_name, event_name in valid_combinations:


### PR DESCRIPTION
Register ITERATION_STARTED and ITERATION_COMPLETED across
SeerActionType, SentryAppEventType, ActivityType, workflow activity
handlers, and the operator event-to-activity mapping.

EDIT: PR iteration step config defined in a later PR on this stack, just getting defining all these enum variants out of the way for now

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
