### PR TITLE
feat(autofix): Trigger PR iteration runs and surface PR links in prompts

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -286,6 +286,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-autofix-high-intelligence-high-reasoning", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Expose the code review tool to autofix coding runs
     manager.add("organizations:seer-autofix-code-review", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable the PR iteration feedback flow in the explorer autofix drawer
+    manager.add("organizations:autofix-pr-iteration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Show Seer run ID in Slack notification footers
     manager.add("organizations:seer-run-id-in-slack", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Gate display of Seer action events in the issue activity timeline

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Callable
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
@@ -34,6 +33,7 @@ from sentry.seer.autofix.artifact_schemas import (
 )
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.prompts import (
+    PromptBuilder,
     code_changes_prompt,
     pr_iteration_prompt,
     root_cause_prompt,
@@ -121,7 +121,7 @@ class StepConfig:
     def __init__(
         self,
         artifact_schema: type[BaseModel] | None,
-        prompt_fn: Callable[..., str],
+        prompt_fn: PromptBuilder,
         enable_coding: bool = False,
         reasoning_effort: Literal["low", "medium", "high"] | None = None,
         started_event: type[AiAutofixPhaseEvent] | None = None,

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -4,8 +4,9 @@ import logging
 import re
 from collections.abc import Callable
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
+from django.utils import timezone
 from pydantic import BaseModel
 from rest_framework.exceptions import PermissionDenied
 
@@ -50,7 +51,7 @@ from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
 from sentry.sentry_apps.utils.webhooks import SeerActionType
-from sentry.utils import metrics
+from sentry.utils import json, metrics
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
@@ -60,6 +61,26 @@ logger = logging.getLogger(__name__)
 
 _UNSET: Any = object()
 UNKNOWN_RUN_ID_FOR_GROUP = "Unknown run id for group"
+
+
+class UserUIFeedbackSource(TypedDict):
+    """Feedback submitted by a user through the Sentry UI."""
+
+    type: Literal["user-ui"]
+    # Identify the user by id rather than username: usernames are mutable, so we
+    # use the same stable key (`user_id`) that `GroupSeen` uses to track which
+    # users have viewed an issue.
+    user_id: int
+
+
+# Discriminated on ``type``. Add new TypedDict variants to this union as more
+# feedback sources are introduced.
+FeedbackSource = UserUIFeedbackSource
+
+
+class Feedback(BaseModel):
+    message: str
+    source: FeedbackSource
 
 
 class NoSeerQuotaException(Exception):
@@ -234,7 +255,11 @@ def recover_iteration_feedback(state: SeerRunState, insert_index: int) -> str | 
     metadata = state.blocks[insert_index].message.metadata
     if metadata is None:
         return None
-    return metadata.get("feedback")
+    raw = metadata.get("feedback")
+    if raw is None:
+        return None
+    # Feedback is stored as a JSON object (``{"text", "username", "timestamp"}``).
+    return json.loads(raw).get("text")
 
 
 def get_autofix_agent_client(
@@ -310,6 +335,7 @@ def trigger_autofix_agent(
     reasoning_effort: Literal["low", "medium", "high"] | None = _UNSET,
     user_context: str | None = None,
     insert_index: int | None = None,
+    feedback: Feedback | None = None,
 ) -> int:
     """
     Start or continue an agent-based autofix run.
@@ -386,8 +412,17 @@ def trigger_autofix_agent(
         "has_user_context": "no" if user_context is None else "yes",
         "is_retry": "no" if insert_index is None else "yes",
     }
-    if step == AutofixStep.PR_ITERATION and user_context is not None:
-        prompt_metadata["feedback"] = user_context
+    if step == AutofixStep.PR_ITERATION and feedback is not None:
+        # Stored as a JSON object so the UI can attribute the feedback to its
+        # source and show when it was submitted. See ``recover_iteration_feedback``
+        # for the read side.
+        prompt_metadata["feedback"] = json.dumps(
+            {
+                "text": feedback.message,
+                "source": feedback.source,
+                "timestamp": timezone.now().isoformat(),
+            }
+        )
     if iteration_index is not None:
         prompt_metadata["iteration_index"] = str(iteration_index)
     artifact_key = step.value if config.artifact_schema else None

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -14,6 +14,8 @@ from sentry.analytics.events.autofix_events import (
     AiAutofixAgentHandoffEvent,
     AiAutofixCodeChangesCompletedEvent,
     AiAutofixCodeChangesStartedEvent,
+    AiAutofixIterationCompletedEvent,
+    AiAutofixIterationStartedEvent,
     AiAutofixPhaseEvent,
     AiAutofixPrCreatedStartedEvent,
     AiAutofixRootCauseCompletedEvent,
@@ -32,6 +34,7 @@ from sentry.seer.autofix.artifact_schemas import (
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.prompts import (
     code_changes_prompt,
+    pr_iteration_prompt,
     root_cause_prompt,
     solution_prompt,
 )
@@ -133,16 +136,29 @@ STEP_CONFIGS: dict[AutofixStep, StepConfig] = {
         started_event=AiAutofixCodeChangesStartedEvent,
         completed_event=AiAutofixCodeChangesCompletedEvent,
     ),
+    AutofixStep.PR_ITERATION: StepConfig(
+        artifact_schema=None,  # Iteration changes read from file_patches
+        prompt_fn=pr_iteration_prompt,
+        enable_coding=True,
+        started_event=AiAutofixIterationStartedEvent,
+        completed_event=AiAutofixIterationCompletedEvent,
+    ),
 }
 
 
-def build_step_prompt(step: AutofixStep, group: Group, user_context: str | None = None) -> str:
+def build_step_prompt(
+    step: AutofixStep,
+    group: Group,
+    user_context: str | None = None,
+    run_state: SeerRunState | None = None,
+) -> str:
     """
     Build the prompt for a step using issue details.
 
     Args:
         step: The autofix step to build prompt for
         group: The Sentry group (issue) being analyzed
+        run_state: The current run state, used to surface PR links for iteration
 
     Returns:
         Formatted prompt string
@@ -153,6 +169,7 @@ def build_step_prompt(step: AutofixStep, group: Group, user_context: str | None 
         title=group.title or "Unknown error",
         culprit=group.culprit or "unknown",
         artifact_key=step.value,
+        run_state=run_state,
     )
 
     parts = [prompt]
@@ -187,6 +204,37 @@ def get_step_webhook_action_type(step: AutofixStep, is_completed: bool) -> SeerA
         },
     }
     return step_to_action_type[step][is_completed]
+
+
+def get_latest_iteration_index(state: SeerRunState) -> int:
+    for block in reversed(state.blocks):
+        metadata = block.message.metadata or {}
+        if metadata.get("step") == AutofixStep.PR_ITERATION.value:
+            return int(metadata["iteration_index"])
+    return 0
+
+
+def get_iteration_for_insert_index(state: SeerRunState, insert_index: int) -> int:
+    block = state.blocks[insert_index]
+    metadata = block.message.metadata or {}
+    return int(metadata["iteration_index"])
+
+
+def recover_iteration_feedback(state: SeerRunState, insert_index: int) -> str | None:
+    """
+    Recover the user feedback that originally triggered a PR iteration.
+
+    When a PR iteration is retried, the frontend truncates the run at the
+    iteration's first block (``insert_index``). That block carries the original
+    feedback in its metadata, so we reuse it to retry with the same feedback
+    rather than dropping it.
+    """
+    if insert_index < 0 or insert_index >= len(state.blocks):
+        return None
+    metadata = state.blocks[insert_index].message.metadata
+    if metadata is None:
+        return None
+    return metadata.get("feedback")
 
 
 def get_autofix_agent_client(
@@ -297,6 +345,8 @@ def trigger_autofix_agent(
         else reasoning_effort
     )
 
+    pr_iteration_enabled = features.has("organizations:autofix-pr-iteration", group.organization)
+
     client = get_autofix_agent_client(
         group,
         intelligence_level=resolved_intelligence_level,
@@ -304,8 +354,19 @@ def trigger_autofix_agent(
         enable_coding=config.enable_coding,
         code_review_enabled=_code_review_enabled(group.organization, config.enable_coding),
     )
+    run_state: SeerRunState | None = None
     if run_id is not None:
-        _get_group_run_state(client, group, run_id)
+        run_state = _get_group_run_state(client, group, run_id)
+
+    if run_state is not None and run_state.metadata:
+        pr_iteration_enabled = run_state.metadata.get("pr_iteration_enabled", pr_iteration_enabled)
+
+    iteration_index: int | None = None
+    if step == AutofixStep.PR_ITERATION and run_state is not None:
+        if insert_index is not None:
+            iteration_index = get_iteration_for_insert_index(run_state, insert_index)
+        else:
+            iteration_index = get_latest_iteration_index(run_state) + 1
 
     if config.started_event is not None:
         analytics.record(
@@ -314,21 +375,30 @@ def trigger_autofix_agent(
                 project_id=group.project_id,
                 group_id=group.id,
                 referrer=referrer.value,
+                iteration_index=iteration_index,
             )
         )
 
-    prompt = build_step_prompt(step, group, user_context)
+    prompt = build_step_prompt(step, group, user_context, run_state=run_state)
     prompt_metadata = {
         "step": step.value,
         "referrer": referrer.value,
         "has_user_context": "no" if user_context is None else "yes",
         "is_retry": "no" if insert_index is None else "yes",
     }
+    if step == AutofixStep.PR_ITERATION and user_context is not None:
+        prompt_metadata["feedback"] = user_context
+    if iteration_index is not None:
+        prompt_metadata["iteration_index"] = str(iteration_index)
     artifact_key = step.value if config.artifact_schema else None
     artifact_schema = config.artifact_schema
 
     if run_id is None:
-        metadata = {"referrer": referrer.value}
+        metadata: dict[str, Any] = {
+            "group_id": group.id,
+            "referrer": referrer.value,
+            "pr_iteration_enabled": pr_iteration_enabled,  # value of the option since we're creating a new one
+        }
         if stopping_point:
             metadata["stopping_point"] = stopping_point.value
         run_id = client.start_run(
@@ -353,10 +423,12 @@ def trigger_autofix_agent(
             insert_index=insert_index,
         )
 
-    payload = {
+    payload: dict[str, Any] = {
         "run_id": run_id,
         "group_id": group.id,
     }
+    if iteration_index is not None:
+        payload["iteration_index"] = iteration_index
 
     webhook_action_type = get_step_webhook_action_type(step, is_completed=False)
     event_name = webhook_action_type.value
@@ -398,7 +470,14 @@ def trigger_autofix_agent(
             },
         )
 
-    metrics.incr("autofix.explorer.trigger", tags={"step": step.value, "referrer": referrer.value})
+    metrics.incr(
+        "autofix.explorer.trigger",
+        tags={
+            "step": step.value,
+            "referrer": referrer.value,
+            "iteration_index": iteration_index,
+        },
+    )
 
     return run_id
 

--- a/src/sentry/seer/autofix/prompts.py
+++ b/src/sentry/seer/autofix/prompts.py
@@ -3,9 +3,20 @@ Prompts for Explorer-based Autofix steps.
 """
 
 from textwrap import dedent
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sentry.seer.agent.client_models import SeerRunState
 
 
-def root_cause_prompt(*, short_id: str, title: str, culprit: str, artifact_key: str | None) -> str:
+def root_cause_prompt(
+    *,
+    short_id: str,
+    title: str,
+    culprit: str,
+    artifact_key: str | None,
+    run_state: "SeerRunState | None" = None,
+) -> str:
     return dedent(
         f"""\
         Analyze issue {short_id}: "{title}" (culprit: {culprit})
@@ -30,7 +41,14 @@ def root_cause_prompt(*, short_id: str, title: str, culprit: str, artifact_key: 
     )
 
 
-def solution_prompt(*, short_id: str, title: str, culprit: str, artifact_key: str | None) -> str:
+def solution_prompt(
+    *,
+    short_id: str,
+    title: str,
+    culprit: str,
+    artifact_key: str | None,
+    run_state: "SeerRunState | None" = None,
+) -> str:
     return dedent(
         f"""\
         Plan a solution for issue {short_id}: "{title}" (culprit: {culprit})
@@ -58,7 +76,12 @@ def solution_prompt(*, short_id: str, title: str, culprit: str, artifact_key: st
 
 
 def code_changes_prompt(
-    *, short_id: str, title: str, culprit: str, artifact_key: str | None
+    *,
+    short_id: str,
+    title: str,
+    culprit: str,
+    artifact_key: str | None,
+    run_state: "SeerRunState | None" = None,
 ) -> str:
     return dedent(
         f"""\
@@ -76,6 +99,55 @@ def code_changes_prompt(
         Use your coding tools to make changes directly to the codebase.
         """
     )
+
+
+def pr_iteration_prompt(
+    *,
+    short_id: str,
+    title: str,
+    culprit: str,
+    artifact_key: str | None,
+    run_state: "SeerRunState | None" = None,
+) -> str:
+    prompt = dedent(
+        f"""\
+        Iterate on the pull request for issue {short_id}: "{title}" (culprit: {culprit})
+
+        Review the existing pull request, previous code changes, and any available feedback. Update the codebase to address the requested revisions while preserving the original fix.
+
+        Steps:
+        1. Inspect the existing pull request and prior file patches
+        2. Identify the smallest set of follow-up changes needed
+        3. Use the code editing tools to revise the implementation
+
+        Use your coding tools to make changes directly to the codebase.
+        """
+    )
+
+    pr_links = pr_links_section(run_state)
+    if pr_links:
+        prompt = f"{prompt}\n{pr_links}"
+
+    return prompt
+
+
+def pr_links_section(run_state: "SeerRunState | None") -> str:
+    """Render a section linking the open pull request URLs for the run, if any."""
+    if run_state is None:
+        return ""
+
+    lines = [
+        f"- {pr.repo_name}: {pr.pr_url}" for pr in run_state.repo_pr_states.values() if pr.pr_url
+    ]
+    if not lines:
+        return ""
+
+    header = (
+        "We've created/updated the following pull request(s) as a result of your changes. "
+        "Review each one — including its description, diff, and review comments — "
+        "before making further changes:"
+    )
+    return "\n".join([header, *lines])
 
 
 def artifact_tool_str(artifact_key: str | None) -> str:

--- a/src/sentry/seer/autofix/prompts.py
+++ b/src/sentry/seer/autofix/prompts.py
@@ -3,10 +3,24 @@ Prompts for Explorer-based Autofix steps.
 """
 
 from textwrap import dedent
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from sentry.seer.agent.client_models import SeerRunState
+
+
+class PromptBuilder(Protocol):
+    """Signature shared by all autofix step prompt builders."""
+
+    def __call__(
+        self,
+        *,
+        short_id: str,
+        title: str,
+        culprit: str,
+        artifact_key: str | None,
+        run_state: "SeerRunState | None" = None,
+    ) -> str: ...
 
 
 def root_cause_prompt(

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -28,6 +28,7 @@ from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.models import SeerPermissionError
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
+from sentry.utils import json
 
 
 class TestGenerateAutofixHandoffPrompt(TestCase):
@@ -253,7 +254,13 @@ def _iteration_block(
     if iteration_index is not None:
         metadata["iteration_index"] = str(iteration_index)
     if feedback is not None:
-        metadata["feedback"] = feedback
+        metadata["feedback"] = json.dumps(
+            {
+                "text": feedback,
+                "source": "user",
+                "timestamp": "2024-01-01T00:00:00Z",
+            }
+        )
     return MemoryBlock(
         id=f"block-{iteration_index}",
         message=Message(role="assistant", content="iteration", metadata=metadata),

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -8,6 +8,7 @@ from sentry.seer.agent.client_models import (
     Artifact,
     MemoryBlock,
     Message,
+    RepoPRState,
     SeerRunState,
 )
 from sentry.seer.autofix.autofix_agent import (
@@ -16,6 +17,9 @@ from sentry.seer.autofix.autofix_agent import (
     NoSeerQuotaException,
     build_step_prompt,
     generate_autofix_handoff_prompt,
+    get_iteration_for_insert_index,
+    get_latest_iteration_index,
+    recover_iteration_feedback,
     trigger_autofix_agent,
     trigger_coding_agent_handoff,
     trigger_push_changes,
@@ -242,6 +246,86 @@ class TestBuildStepPrompt(TestCase):
             assert not prompt.startswith("\t"), f"{step} prompt starts with tab"
 
 
+def _iteration_block(
+    iteration_index: int | None = None, feedback: str | None = None
+) -> MemoryBlock:
+    metadata: dict[str, str] = {"step": AutofixStep.PR_ITERATION.value}
+    if iteration_index is not None:
+        metadata["iteration_index"] = str(iteration_index)
+    if feedback is not None:
+        metadata["feedback"] = feedback
+    return MemoryBlock(
+        id=f"block-{iteration_index}",
+        message=Message(role="assistant", content="iteration", metadata=metadata),
+        timestamp="2024-01-01T00:00:00Z",
+    )
+
+
+def _state_with_blocks(blocks: list[MemoryBlock], group_id: int | None = None) -> SeerRunState:
+    return SeerRunState(
+        run_id=67890,
+        blocks=blocks,
+        status="completed",
+        updated_at="2024-01-01T00:00:00Z",
+        metadata={"group_id": group_id} if group_id is not None else None,
+    )
+
+
+class TestIterationHelpers(TestCase):
+    def test_get_latest_iteration_index_returns_zero_without_iterations(self) -> None:
+        state = _state_with_blocks([])
+        assert get_latest_iteration_index(state) == 0
+
+    def test_get_latest_iteration_index_returns_most_recent(self) -> None:
+        state = _state_with_blocks([_iteration_block(1), _iteration_block(2)])
+        assert get_latest_iteration_index(state) == 2
+
+    def test_get_iteration_for_insert_index(self) -> None:
+        state = _state_with_blocks([_iteration_block(1), _iteration_block(2)])
+        assert get_iteration_for_insert_index(state, 1) == 2
+
+    def test_recover_iteration_feedback_returns_feedback(self) -> None:
+        state = _state_with_blocks([_iteration_block(1, feedback="please fix the tests")])
+        assert recover_iteration_feedback(state, 0) == "please fix the tests"
+
+    def test_recover_iteration_feedback_out_of_range(self) -> None:
+        state = _state_with_blocks([])
+        assert recover_iteration_feedback(state, 0) is None
+        assert recover_iteration_feedback(state, -1) is None
+
+    def test_recover_iteration_feedback_no_metadata(self) -> None:
+        block = MemoryBlock(
+            id="block-none",
+            message=Message(role="assistant", content="x", metadata=None),
+            timestamp="2024-01-01T00:00:00Z",
+        )
+        state = _state_with_blocks([block])
+        assert recover_iteration_feedback(state, 0) is None
+
+
+class TestPrIterationPrompt(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group(project=self.project, message="Test error message")
+
+    def test_pr_iteration_prompt_includes_pr_links(self) -> None:
+        state = _state_with_blocks([])
+        state.repo_pr_states = {
+            "owner/repo": RepoPRState(repo_name="owner/repo", pr_url="https://example.com/pull/7")
+        }
+        prompt = build_step_prompt(AutofixStep.PR_ITERATION, self.group, run_state=state)
+
+        assert "Iterate on the pull request" in prompt
+        assert "owner/repo" in prompt
+        assert "https://example.com/pull/7" in prompt
+
+    def test_pr_iteration_prompt_without_run_state_omits_pr_links(self) -> None:
+        prompt = build_step_prompt(AutofixStep.PR_ITERATION, self.group)
+
+        assert "Iterate on the pull request" in prompt
+        assert "pull request(s)" not in prompt
+
+
 class TestTriggerAutofixAgent(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -359,7 +443,59 @@ class TestTriggerAutofixAgent(TestCase):
 
         mock_client.start_run.assert_called_once()
         call_kwargs = mock_client.start_run.call_args.kwargs
-        assert call_kwargs["metadata"] == {"referrer": "unknown"}
+        assert call_kwargs["metadata"] == {
+            "group_id": self.group.id,
+            "referrer": "unknown",
+            "pr_iteration_enabled": False,
+        }
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_new_run_records_pr_iteration_enabled_in_metadata(
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        """The pr_iteration feature flag value is persisted in the run metadata."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.start_run.return_value = MagicMock(seer_run_state_id=123)
+
+        with self.feature("organizations:autofix-pr-iteration"):
+            trigger_autofix_agent(
+                group=self.group,
+                step=AutofixStep.ROOT_CAUSE,
+                referrer=AutofixReferrer.UNKNOWN,
+                run_id=None,
+            )
+
+        assert mock_client.start_run.call_args.kwargs["metadata"]["pr_iteration_enabled"] is True
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_pr_iteration_continued_run_increments_iteration_index(
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        """Continuing a PR iteration run computes the next iteration index and surfaces it."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_run.return_value = _state_with_blocks(
+            [_iteration_block(1)], group_id=self.group.id
+        )
+        mock_client.continue_run.return_value = 67890
+
+        trigger_autofix_agent(
+            group=self.group,
+            step=AutofixStep.PR_ITERATION,
+            referrer=AutofixReferrer.UNKNOWN,
+            run_id=67890,
+        )
+
+        call_kwargs = mock_broadcast.call_args.kwargs
+        assert call_kwargs["event_name"] == SeerActionType.ITERATION_STARTED.value
+        assert call_kwargs["payload"]["iteration_index"] == 2
 
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=False)


### PR DESCRIPTION
Add the autofix-pr-iteration feature flag and wire the trigger path for the
PR_ITERATION step. trigger_autofix_agent now persists the flag value in run
metadata on creation, computes the iteration index (from the insert index on
retry, otherwise the latest + 1), and includes it in the started webhook
payload, prompt metadata, and trigger metric. build_step_prompt threads the
run state into the prompt builders so pr_iteration_prompt can surface the open
pull request links. Adds get_latest_iteration_index, get_iteration_for_insert_index,
and recover_iteration_feedback helpers.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
