### PR TITLE
feat(autofix): Add pr_iteration endpoint step and operator activity

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import re
 from enum import StrEnum

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 import re
 from enum import StrEnum

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -71,8 +71,12 @@ class UserUIFeedbackSource(TypedDict):
     # use the same stable key (`user_id`) that `GroupSeen` uses to track which
     # users have viewed an issue.
     user_id: int
-    # The serialized user, resolved at write time so the read path doesn't have
-    # to hydrate it. ``None`` if the user could not be serialized.
+    # The publicly serialized user, resolved at write time so the read path
+    # doesn't have to hydrate it. ``None`` if the user could not be serialized.
+    # This is serialized as an anonymous viewer (never as the requester) so the
+    # payload never includes the user's full email list, options, or flags: it
+    # is embedded in Seer prompt metadata and round-tripped back to any org
+    # member with group-read access.
     user: NotRequired[Any]
 
 
@@ -91,6 +95,10 @@ class NoSeerQuotaException(Exception):
 
 
 class PrIterationNoPullRequestException(Exception):
+    pass
+
+
+class PrIterationNotEnabledException(Exception):
     pass
 
 
@@ -387,6 +395,8 @@ def trigger_autofix_agent(
 
     iteration_index: int | None = None
     if step == AutofixStep.PR_ITERATION:
+        if not pr_iteration_enabled:
+            raise PrIterationNotEnabledException()
         if run_state is None or not run_state.repo_pr_states:
             raise PrIterationNoPullRequestException()
         if insert_index is not None:

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -87,6 +87,10 @@ class NoSeerQuotaException(Exception):
     pass
 
 
+class PrIterationNoPullRequestException(Exception):
+    pass
+
+
 class AutofixStep(StrEnum):
     """Available autofix steps."""
 
@@ -379,7 +383,9 @@ def trigger_autofix_agent(
         pr_iteration_enabled = run_state.metadata.get("pr_iteration_enabled", pr_iteration_enabled)
 
     iteration_index: int | None = None
-    if step == AutofixStep.PR_ITERATION and run_state is not None:
+    if step == AutofixStep.PR_ITERATION:
+        if run_state is None or not run_state.repo_pr_states:
+            raise PrIterationNoPullRequestException()
         if insert_index is not None:
             iteration_index = get_iteration_for_insert_index(run_state, insert_index)
         else:

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -274,6 +274,11 @@ def get_autofix_agent_client(
     )
 
 
+def get_autofix_run_state(group: Group, run_id: int) -> SeerRunState:
+    client = get_autofix_agent_client(group)
+    return _get_group_run_state(client, group, run_id)
+
+
 def _validate_run_belongs_to_group(state: SeerRunState, group: Group) -> None:
     group_id = state.metadata.get("group_id") if state.metadata else None
     if group_id != group.id:

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict, cast
 
 from django.utils import timezone
 from pydantic import BaseModel
@@ -71,6 +71,9 @@ class UserUIFeedbackSource(TypedDict):
     # use the same stable key (`user_id`) that `GroupSeen` uses to track which
     # users have viewed an issue.
     user_id: int
+    # The serialized user, resolved at write time so the read path doesn't have
+    # to hydrate it. ``None`` if the user could not be serialized.
+    user: NotRequired[Any]
 
 
 # Discriminated on ``type``. Add new TypedDict variants to this union as more

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -372,7 +372,11 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                 group,
             )
             if decision is not None:
-                iteration_index = get_latest_iteration_index(state)
+                iteration_index = (
+                    get_latest_iteration_index(state)
+                    if current_step == AutofixStep.PR_ITERATION
+                    else None
+                )
                 analytics.record(
                     AiAutofixIntrospectionEvent(
                         organization_id=organization.id,

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -43,8 +43,10 @@ from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.autofix_agent import (
     UNKNOWN_RUN_ID_FOR_GROUP,
     AutofixStep,
+    Feedback,
     NoSeerQuotaException,
     get_autofix_agent_state,
+    get_autofix_run_state,
     trigger_autofix_agent,
     trigger_coding_agent_handoff,
     trigger_push_changes,
@@ -309,12 +311,12 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             try:
-                state = get_autofix_agent_state(group.organization, group.id)
+                state = get_autofix_run_state(group, run_id)
             except SeerPermissionError as e:
                 if _is_unknown_run_id_error(e):
                     return Response(status=status.HTTP_404_NOT_FOUND)
                 raise PermissionDenied(SEER_PERMISSION_DENIED)
-            if state is None or not state.repo_pr_states:
+            if not state.repo_pr_states:
                 return Response(
                     {"detail": "Cannot iterate on a PR before one has been created"},
                     status=status.HTTP_400_BAD_REQUEST,
@@ -323,6 +325,21 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         # Handle all built-in Seer steps. A missing run_id means this call starts a new
         # autofix run (the kickoff); a provided run_id is advancing an existing run.
         is_autofix_kickoff = resolved_run_id is None
+        user_context = data.get("user_context")
+        feedback = None
+        if (
+            step == "pr_iteration"
+            and user_context is not None
+            and request.user
+            and request.user.is_authenticated
+        ):
+            feedback = Feedback(
+                message=user_context,
+                source={
+                    "type": "user-ui",
+                    "user_id": request.user.id,
+                },
+            )
         try:
             run_id = trigger_autofix_agent(
                 group=group,
@@ -330,8 +347,9 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 referrer=_parse_autofix_referrer(data.get("referrer")),
                 stopping_point=AutofixStoppingPoint(stopping_point) if stopping_point else None,
                 run_id=resolved_run_id,
-                user_context=data.get("user_context"),
+                user_context=user_context,
                 insert_index=data.get("insert_index"),
+                feedback=feedback,
             )
             if is_autofix_kickoff:
                 # Record the trigger action only on kickoff, not on each subsequent

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -94,6 +95,7 @@ class ExplorerAutofixRequestSerializer(CamelSnakeSerializer):
             "root_cause",
             "solution",
             "code_changes",
+            "pr_iteration",
             "open_pr",
             "coding_agent_handoff",
         ],
@@ -294,6 +296,29 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 "sentry_run_id": resolved_sentry_run_id,
             }
             return Response(open_pr_body, status=status.HTTP_202_ACCEPTED)
+
+        if step == "pr_iteration":
+            if not features.has("organizations:autofix-pr-iteration", group.organization):
+                return Response(
+                    {"detail": "PR iteration is not enabled for this organization"},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+            if not run_id:
+                return Response(
+                    {"detail": "run_id is required for pr_iteration"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            try:
+                state = get_autofix_agent_state(group.organization, group.id)
+            except SeerPermissionError as e:
+                if _is_unknown_run_id_error(e):
+                    return Response(status=status.HTTP_404_NOT_FOUND)
+                raise PermissionDenied(SEER_PERMISSION_DENIED)
+            if state is None or not state.repo_pr_states:
+                return Response(
+                    {"detail": "Cannot iterate on a PR before one has been created"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
         # Handle all built-in Seer steps. A missing run_id means this call starts a new
         # autofix run (the kickoff); a provided run_id is advancing an existing run.

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -70,7 +70,6 @@ from sentry.seer.models import SeerPermissionError
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -89,41 +88,6 @@ def _parse_autofix_referrer(raw: str | None) -> AutofixReferrer:
     except ValueError:
         logger.warning("group_ai_autofix.unknown_referrer", extra={"referrer": raw})
         return AutofixReferrer.UNKNOWN
-
-
-def _hydrate_feedback_users(blocks: list[dict[str, Any]], request_user: Any) -> None:
-    parsed_by_index: dict[int, dict[str, Any]] = {}
-    user_ids: set[int] = set()
-    for index, block in enumerate(blocks):
-        metadata = (block.get("message") or {}).get("metadata") or {}
-        raw = metadata.get("feedback")
-        if not raw:
-            continue
-        try:
-            feedback = json.loads(raw)
-        except (ValueError, TypeError):
-            continue
-        user_id = (feedback.get("source") or {}).get("user_id")
-        if not isinstance(user_id, int):
-            continue
-        parsed_by_index[index] = feedback
-        user_ids.add(user_id)
-
-    if not user_ids:
-        return
-
-    users = {
-        u["id"]: u
-        for u in user_service.serialize_many(
-            filter={"user_ids": list(user_ids)},
-            as_user=serialize_generic_user(request_user),
-        )
-    }
-
-    for index, feedback in parsed_by_index.items():
-        user_id = feedback["source"]["user_id"]
-        feedback["source"]["user"] = users.get(user_id)
-        blocks[index]["message"]["metadata"]["feedback"] = json.dumps(feedback)
 
 
 class ExplorerAutofixRequestSerializer(CamelSnakeSerializer):
@@ -360,11 +324,18 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
             and request.user
             and request.user.is_authenticated
         ):
+            # Serialize the user here on write so the read path (GET) doesn't have
+            # to hydrate it from the stored user_id on every fetch.
+            serialized_users = user_service.serialize_many(
+                filter={"user_ids": [request.user.id]},
+                as_user=serialize_generic_user(request.user),
+            )
             feedback = Feedback(
                 message=user_context,
                 source={
                     "type": "user-ui",
                     "user_id": request.user.id,
+                    "user": serialized_users[0] if serialized_users else None,
                 },
             )
         try:
@@ -469,7 +440,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
 
         run = get_seer_run(state.run_id, group.organization)
         blocks = [block.dict() for block in state.blocks]
-        _hydrate_feedback_users(blocks, request.user)
         return Response(
             {
                 "autofix": {

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -68,6 +68,9 @@ from sentry.seer.autofix.utils import (
 from sentry.seer.endpoints.utils import get_seer_run, resolve_seer_run
 from sentry.seer.models import SeerPermissionError
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.users.services.user.serial import serialize_generic_user
+from sentry.users.services.user.service import user_service
+from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +89,40 @@ def _parse_autofix_referrer(raw: str | None) -> AutofixReferrer:
     except ValueError:
         logger.warning("group_ai_autofix.unknown_referrer", extra={"referrer": raw})
         return AutofixReferrer.UNKNOWN
+
+
+def _hydrate_feedback_users(blocks: list[dict[str, Any]], request_user: Any) -> None:
+    parsed_by_index: dict[int, dict[str, Any]] = {}
+    user_ids: set[int] = set()
+    for index, block in enumerate(blocks):
+        raw = (block.get("message") or {}).get("metadata", {}).get("feedback")
+        if not raw:
+            continue
+        try:
+            feedback = json.loads(raw)
+        except (ValueError, TypeError):
+            continue
+        user_id = (feedback.get("source") or {}).get("user_id")
+        if not isinstance(user_id, int):
+            continue
+        parsed_by_index[index] = feedback
+        user_ids.add(user_id)
+
+    if not user_ids:
+        return
+
+    users = {
+        u["id"]: u
+        for u in user_service.serialize_many(
+            filter={"user_ids": list(user_ids)},
+            as_user=serialize_generic_user(request_user),
+        )
+    }
+
+    for index, feedback in parsed_by_index.items():
+        user_id = feedback["source"]["user_id"]
+        feedback["source"]["user"] = users.get(user_id)
+        blocks[index]["message"]["metadata"]["feedback"] = json.dumps(feedback)
 
 
 class ExplorerAutofixRequestSerializer(CamelSnakeSerializer):
@@ -305,13 +342,13 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                     {"detail": "PR iteration is not enabled for this organization"},
                     status=status.HTTP_403_FORBIDDEN,
                 )
-            if not run_id:
+            if resolved_run_id is None:
                 return Response(
                     {"detail": "run_id is required for pr_iteration"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             try:
-                state = get_autofix_run_state(group, run_id)
+                state = get_autofix_run_state(group, resolved_run_id)
             except SeerPermissionError as e:
                 if _is_unknown_run_id_error(e):
                     return Response(status=status.HTTP_404_NOT_FOUND)
@@ -436,13 +473,15 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 )
 
         run = get_seer_run(state.run_id, group.organization)
+        blocks = [block.dict() for block in state.blocks]
+        _hydrate_feedback_users(blocks, request.user)
         return Response(
             {
                 "autofix": {
                     "run_id": state.run_id,
                     "sentry_run_id": str(run.uuid) if run else None,
                     "status": state.status,
-                    "blocks": [block.dict() for block in state.blocks],
+                    "blocks": blocks,
                     "updated_at": state.updated_at,
                     "pending_user_input": (
                         state.pending_user_input.dict() if state.pending_user_input else None

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -487,6 +487,9 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                     "coding_agents": {
                         agent_id: agent.dict() for agent_id, agent in state.coding_agents.items()
                     },
+                    "pr_iteration_enabled": bool(
+                        state.metadata.get("pr_iteration_enabled") if state.metadata else False
+                    ),
                 }
             }
         )

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -10,7 +10,6 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -46,6 +45,7 @@ from sentry.seer.autofix.autofix_agent import (
     Feedback,
     NoSeerQuotaException,
     PrIterationNoPullRequestException,
+    PrIterationNotEnabledException,
     get_autofix_agent_state,
     trigger_autofix_agent,
     trigger_coding_agent_handoff,
@@ -68,7 +68,6 @@ from sentry.seer.autofix.utils import (
 from sentry.seer.endpoints.utils import get_seer_run, resolve_seer_run
 from sentry.seer.models import SeerPermissionError
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
 
 logger = logging.getLogger(__name__)
@@ -302,11 +301,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
             return Response(open_pr_body, status=status.HTTP_202_ACCEPTED)
 
         if step == "pr_iteration":
-            if not features.has("organizations:autofix-pr-iteration", group.organization):
-                return Response(
-                    {"detail": "PR iteration is not enabled for this organization"},
-                    status=status.HTTP_403_FORBIDDEN,
-                )
             if resolved_run_id is None:
                 return Response(
                     {"detail": "run_id is required for pr_iteration"},
@@ -325,10 +319,14 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
             and request.user.is_authenticated
         ):
             # Serialize the user here on write so the read path (GET) doesn't have
-            # to hydrate it from the stored user_id on every fetch.
+            # to hydrate it from the stored user_id on every fetch. Serialize as
+            # an anonymous viewer (no ``as_user``) so the result is the public
+            # user representation rather than the self representation, which would
+            # leak the user's full email list, options, and flags. This payload is
+            # embedded in Seer prompt metadata and readable by any org member with
+            # group-read access.
             serialized_users = user_service.serialize_many(
                 filter={"user_ids": [request.user.id]},
-                as_user=serialize_generic_user(request.user),
             )
             feedback = Feedback(
                 message=user_context,
@@ -375,6 +373,11 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
             return Response(kickoff_body, status=status.HTTP_202_ACCEPTED)
         except NoSeerQuotaException:
             return Response("No budget for Seer Autofix.", status=status.HTTP_402_PAYMENT_REQUIRED)
+        except PrIterationNotEnabledException:
+            return Response(
+                {"detail": "PR iteration is not enabled for this organization"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         except PrIterationNoPullRequestException:
             return Response(
                 {"detail": "Cannot iterate on a PR before one has been created"},

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -45,8 +45,8 @@ from sentry.seer.autofix.autofix_agent import (
     AutofixStep,
     Feedback,
     NoSeerQuotaException,
+    PrIterationNoPullRequestException,
     get_autofix_agent_state,
-    get_autofix_run_state,
     trigger_autofix_agent,
     trigger_coding_agent_handoff,
     trigger_push_changes,
@@ -348,17 +348,6 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                     {"detail": "run_id is required for pr_iteration"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
-            try:
-                state = get_autofix_run_state(group, resolved_run_id)
-            except SeerPermissionError as e:
-                if _is_unknown_run_id_error(e):
-                    return Response(status=status.HTTP_404_NOT_FOUND)
-                raise PermissionDenied(SEER_PERMISSION_DENIED)
-            if not state.repo_pr_states:
-                return Response(
-                    {"detail": "Cannot iterate on a PR before one has been created"},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
 
         # Handle all built-in Seer steps. A missing run_id means this call starts a new
         # autofix run (the kickoff); a provided run_id is advancing an existing run.
@@ -415,6 +404,11 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
             return Response(kickoff_body, status=status.HTTP_202_ACCEPTED)
         except NoSeerQuotaException:
             return Response("No budget for Seer Autofix.", status=status.HTTP_402_PAYMENT_REQUIRED)
+        except PrIterationNoPullRequestException:
+            return Response(
+                {"detail": "Cannot iterate on a PR before one has been created"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except SeerPermissionError as e:
             if _is_unknown_run_id_error(e):
                 return Response(status=status.HTTP_404_NOT_FOUND)

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -95,7 +95,8 @@ def _hydrate_feedback_users(blocks: list[dict[str, Any]], request_user: Any) -> 
     parsed_by_index: dict[int, dict[str, Any]] = {}
     user_ids: set[int] = set()
     for index, block in enumerate(blocks):
-        raw = (block.get("message") or {}).get("metadata", {}).get("feedback")
+        metadata = (block.get("message") or {}).get("metadata") or {}
+        raw = metadata.get("feedback")
         if not raw:
             continue
         try:

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -587,6 +587,16 @@ def _create_seer_activity(
         pull_requests = event_payload.get("pull_requests", [])
         if pull_requests:
             activity_data["pull_requests"] = pull_requests
+    elif event_type == SentryAppEventType.SEER_ITERATION_COMPLETED:
+        pull_requests = event_payload.get("pull_requests", [])
+        if pull_requests:
+            activity_data["pull_requests"] = pull_requests
+        code_changes = event_payload.get("code_changes")
+        if code_changes:
+            activity_data["code_changes"] = code_changes
+        iteration_index = event_payload.get("iteration_index")
+        if iteration_index is not None:
+            activity_data["iteration_index"] = iteration_index
 
     Activity.objects.create_group_activity(
         group,

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -475,12 +475,13 @@ class TestTriggerAutofixAgent(TestCase):
         )
         mock_client.continue_run.return_value = 67890
 
-        trigger_autofix_agent(
-            group=self.group,
-            step=AutofixStep.PR_ITERATION,
-            referrer=AutofixReferrer.UNKNOWN,
-            run_id=67890,
-        )
+        with self.feature("organizations:autofix-pr-iteration"):
+            trigger_autofix_agent(
+                group=self.group,
+                step=AutofixStep.PR_ITERATION,
+                referrer=AutofixReferrer.UNKNOWN,
+                run_id=67890,
+            )
 
         call_kwargs = mock_broadcast.call_args.kwargs
         assert call_kwargs["event_name"] == SeerActionType.ITERATION_STARTED.value
@@ -493,7 +494,10 @@ class TestTriggerAutofixAgent(TestCase):
         mock_client_class.return_value = mock_client
         mock_client.get_run.return_value = _state_with_blocks([], group_id=self.group.id)
 
-        with pytest.raises(PrIterationNoPullRequestException):
+        with (
+            self.feature("organizations:autofix-pr-iteration"),
+            pytest.raises(PrIterationNoPullRequestException),
+        ):
             trigger_autofix_agent(
                 group=self.group,
                 step=AutofixStep.PR_ITERATION,

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -15,6 +15,7 @@ from sentry.seer.autofix.autofix_agent import (
     STEP_CONFIGS,
     AutofixStep,
     NoSeerQuotaException,
+    PrIterationNoPullRequestException,
     build_step_prompt,
     generate_autofix_handoff_prompt,
     get_iteration_for_insert_index,
@@ -256,12 +257,17 @@ def _iteration_block(iteration_index: int | None = None) -> MemoryBlock:
     )
 
 
-def _state_with_blocks(blocks: list[MemoryBlock], group_id: int | None = None) -> SeerRunState:
+def _state_with_blocks(
+    blocks: list[MemoryBlock],
+    group_id: int | None = None,
+    repo_pr_states: dict[str, RepoPRState] | None = None,
+) -> SeerRunState:
     return SeerRunState(
         run_id=67890,
         blocks=blocks,
         status="completed",
         updated_at="2024-01-01T00:00:00Z",
+        repo_pr_states=repo_pr_states or {},
         metadata={"group_id": group_id} if group_id is not None else None,
     )
 
@@ -459,7 +465,13 @@ class TestTriggerAutofixAgent(TestCase):
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.get_run.return_value = _state_with_blocks(
-            [_iteration_block(1)], group_id=self.group.id
+            [_iteration_block(1)],
+            group_id=self.group.id,
+            repo_pr_states={
+                "owner/repo": RepoPRState(
+                    repo_name="owner/repo", pr_url="https://example.com/pull/7"
+                )
+            },
         )
         mock_client.continue_run.return_value = 67890
 
@@ -473,6 +485,24 @@ class TestTriggerAutofixAgent(TestCase):
         call_kwargs = mock_broadcast.call_args.kwargs
         assert call_kwargs["event_name"] == SeerActionType.ITERATION_STARTED.value
         assert call_kwargs["payload"]["iteration_index"] == 2
+
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_pr_iteration_requires_existing_pr(self, mock_client_class, mock_broadcast):
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_run.return_value = _state_with_blocks([], group_id=self.group.id)
+
+        with pytest.raises(PrIterationNoPullRequestException):
+            trigger_autofix_agent(
+                group=self.group,
+                step=AutofixStep.PR_ITERATION,
+                referrer=AutofixReferrer.UNKNOWN,
+                run_id=67890,
+            )
+
+        mock_client.continue_run.assert_not_called()
+        mock_broadcast.assert_not_called()
 
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=False)

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -2,7 +2,7 @@ import uuid
 from unittest.mock import Mock, patch
 
 from sentry.issues.action_log.types import TriggerAutofixAction
-from sentry.seer.agent.client_models import SeerRunState
+from sentry.seer.agent.client_models import RepoPRState, SeerRunState
 from sentry.seer.autofix.autofix_agent import AutofixStep, NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.utils import AutofixStoppingPoint
@@ -253,6 +253,93 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 202, response.data
         mock_publish.assert_not_called()
+
+    @with_feature("organizations:autofix-pr-iteration")
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    def test_pr_iteration(self, mock_trigger_explorer, mock_get_state):
+        group = self.create_group()
+        mock_trigger_explorer.return_value = 123
+        mock_get_state.return_value = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                "owner/repo": RepoPRState(
+                    repo_name="owner/repo", pr_url="https://example.com/pull/7"
+                )
+            },
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "pr_iteration", "run_id": 123},
+            format="json",
+        )
+
+        assert response.status_code == 202, response.data
+        mock_trigger_explorer.assert_called_once_with(
+            group=group,
+            step=AutofixStep.PR_ITERATION,
+            referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
+            stopping_point=None,
+            run_id=123,
+            user_context=None,
+            insert_index=None,
+        )
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    def test_pr_iteration_requires_feature_flag(self, mock_trigger_explorer):
+        group = self.create_group()
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "pr_iteration", "run_id": 123},
+            format="json",
+        )
+
+        assert response.status_code == 403, response.data
+        mock_trigger_explorer.assert_not_called()
+
+    @with_feature("organizations:autofix-pr-iteration")
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    def test_pr_iteration_requires_run_id(self, mock_trigger_explorer):
+        group = self.create_group()
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "pr_iteration"},
+            format="json",
+        )
+
+        assert response.status_code == 400, response.data
+        mock_trigger_explorer.assert_not_called()
+
+    @with_feature("organizations:autofix-pr-iteration")
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    def test_pr_iteration_requires_existing_pr(self, mock_trigger_explorer, mock_get_state):
+        group = self.create_group()
+        mock_get_state.return_value = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "pr_iteration", "run_id": 123},
+            format="json",
+        )
+
+        assert response.status_code == 400, response.data
+        mock_trigger_explorer.assert_not_called()
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_post_continue_unknown_run_returns_404(self, mock_trigger_explorer):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -196,6 +196,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             run_id=None,
             user_context=None,
             insert_index=None,
+            feedback=None,
         )
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
@@ -220,6 +221,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             run_id=42,
             user_context=None,
             insert_index=3,
+            feedback=None,
         )
 
     @patch("sentry.seer.endpoints.group_ai_autofix.publish_action", autospec=True)
@@ -277,7 +279,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         mock_publish.assert_not_called()
 
     @with_feature("organizations:autofix-pr-iteration")
-    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_pr_iteration(self, mock_trigger_explorer, mock_get_state):
         group = self.create_group()
@@ -310,6 +312,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             run_id=123,
             user_context=None,
             insert_index=None,
+            feedback=None,
         )
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
@@ -342,7 +345,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         mock_trigger_explorer.assert_not_called()
 
     @with_feature("organizations:autofix-pr-iteration")
-    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_pr_iteration_requires_existing_pr(self, mock_trigger_explorer, mock_get_state):
         group = self.create_group()

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -2,7 +2,7 @@ import uuid
 from unittest.mock import Mock, patch
 
 from sentry.issues.action_log.types import TriggerAutofixAction
-from sentry.seer.agent.client_models import RepoPRState, SeerRunState
+from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
 from sentry.seer.autofix.autofix_agent import AutofixStep, NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.utils import AutofixStoppingPoint
@@ -57,6 +57,28 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.data
         assert response.data["autofix"]["run_id"] == 888
         assert response.data["autofix"]["sentry_run_id"] == str(run.uuid)
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
+    def test_get_handles_block_with_null_metadata(self, mock_get_explorer_state):
+        group = self.create_group()
+        mock_get_explorer_state.return_value = SeerRunState(
+            run_id=888,
+            blocks=[
+                MemoryBlock(
+                    id="block-1",
+                    message=Message(role="assistant", content="No metadata", metadata=None),
+                    timestamp="2023-07-18T12:00:00Z",
+                )
+            ],
+            status="completed",
+            updated_at="2023-07-18T12:00:00Z",
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.get(self._get_url(group.id), format="json")
+
+        assert response.status_code == 200, response.data
+        assert response.data["autofix"]["blocks"][0]["message"]["metadata"] is None
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_post_triggers_autofix_agent(self, mock_trigger_explorer):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -2,8 +2,12 @@ import uuid
 from unittest.mock import Mock, patch
 
 from sentry.issues.action_log.types import TriggerAutofixAction
-from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
-from sentry.seer.autofix.autofix_agent import AutofixStep, NoSeerQuotaException
+from sentry.seer.agent.client_models import MemoryBlock, Message, SeerRunState
+from sentry.seer.autofix.autofix_agent import (
+    AutofixStep,
+    NoSeerQuotaException,
+    PrIterationNoPullRequestException,
+)
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models import SeerPermissionError
@@ -279,22 +283,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         mock_publish.assert_not_called()
 
     @with_feature("organizations:autofix-pr-iteration")
-    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
-    def test_pr_iteration(self, mock_trigger_explorer, mock_get_state):
+    def test_pr_iteration(self, mock_trigger_explorer):
         group = self.create_group()
         mock_trigger_explorer.return_value = 123
-        mock_get_state.return_value = SeerRunState(
-            run_id=123,
-            blocks=[],
-            status="completed",
-            updated_at="2024-01-01T00:00:00Z",
-            repo_pr_states={
-                "owner/repo": RepoPRState(
-                    repo_name="owner/repo", pr_url="https://example.com/pull/7"
-                )
-            },
-        )
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -345,16 +337,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         mock_trigger_explorer.assert_not_called()
 
     @with_feature("organizations:autofix-pr-iteration")
-    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
-    def test_pr_iteration_requires_existing_pr(self, mock_trigger_explorer, mock_get_state):
+    def test_pr_iteration_requires_existing_pr(self, mock_trigger_explorer):
         group = self.create_group()
-        mock_get_state.return_value = SeerRunState(
-            run_id=123,
-            blocks=[],
-            status="completed",
-            updated_at="2024-01-01T00:00:00Z",
-        )
+        mock_trigger_explorer.side_effect = PrIterationNoPullRequestException()
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -364,7 +350,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         )
 
         assert response.status_code == 400, response.data
-        mock_trigger_explorer.assert_not_called()
+        mock_trigger_explorer.assert_called_once()
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_post_continue_unknown_run_returns_404(self, mock_trigger_explorer):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -307,9 +307,19 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             feedback=None,
         )
 
-    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
-    def test_pr_iteration_requires_feature_flag(self, mock_trigger_explorer):
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_pr_iteration_requires_feature_flag(self, mock_client_class):
         group = self.create_group()
+        mock_client = mock_client_class.return_value
+        # Run state with no ``pr_iteration_enabled`` metadata so, with the flag
+        # off, trigger_autofix_agent raises PrIterationNotEnabledException.
+        mock_client.get_run.return_value = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            metadata={"group_id": group.id},
+        )
 
         self.login_as(user=self.user)
         response = self.client.post(
@@ -319,7 +329,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         )
 
         assert response.status_code == 403, response.data
-        mock_trigger_explorer.assert_not_called()
+        mock_client.continue_run.assert_not_called()
 
     @with_feature("organizations:autofix-pr-iteration")
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -644,6 +644,36 @@ class SeerOperatorTest(TestCase):
             == "https://github.com/owner/repo/pull/42"
         )
 
+    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
+    def test_create_seer_activity_iteration_completed(self, _mock_has_access):
+        event_payload = {
+            "run_id": MOCK_RUN_ID,
+            "group_id": self.group.id,
+            "code_changes": {"owner/repo": [{"diff": "...", "path": "foo.py"}]},
+            "pull_requests": [
+                {
+                    "pull_request": {
+                        "pr_number": 42,
+                        "pr_url": "https://github.com/owner/repo/pull/42",
+                    },
+                    "repo_name": "owner/repo",
+                    "provider": "github",
+                }
+            ],
+        }
+
+        process_autofix_updates(
+            event_type=SentryAppEventType.SEER_ITERATION_COMPLETED,
+            event_payload=event_payload,
+            organization_id=self.organization.id,
+        )
+
+        activity = Activity.objects.get(
+            group=self.group, type=ActivityType.SEER_ITERATION_COMPLETED.value
+        )
+        assert activity.data["pull_requests"][0]["repo_name"] == "owner/repo"
+        assert activity.data["code_changes"]["owner/repo"][0]["path"] == "foo.py"
+
     @patch("sentry.models.activity.invoke_workflow_activity_handlers")
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)
     def test_create_seer_activity_invokes_workflow_activity_handlers(


### PR DESCRIPTION
Accept the pr_iteration step in the explorer autofix endpoint, gated behind
the autofix-pr-iteration feature flag. The step requires an existing run with
at least one created pull request, otherwise it returns a 400. Map the
SEER_ITERATION_COMPLETED webhook to a SEER_ITERATION_COMPLETED group activity
in the operator, carrying the pull requests and iteration index.

Also, transform user IDs stored in run state feedback into serialized users for frontend