### PR TITLE
ref: Type PUBLIC delete endpoints via helper return types

### DIFF
--- a/src/sentry/core/endpoints/organization_member_details.py
+++ b/src/sentry/core/endpoints/organization_member_details.py
@@ -27,6 +27,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.auth.services.auth import auth_service
 from sentry.auth.superuser import is_active_superuser
 from sentry.core.endpoints.organization_member_index import OrganizationMemberRequestSerializer
@@ -432,7 +433,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         organization: Organization,
         member: OrganizationMember,
         acting_member: OrganizationMember,
-    ) -> Response:
+    ) -> Response[None] | Response[DetailResponse]:
         # Members can only delete invitations
         if not member.is_pending:
             return Response({"detail": ERR_INSUFFICIENT_SCOPE}, status=400)
@@ -470,7 +471,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         request: Request,
         organization: Organization,
         member: OrganizationMember,
-    ) -> Response:
+    ) -> Response[None] | Response[DetailResponse]:
         """
         Remove an organization member.
         """

--- a/src/sentry/monitors/endpoints/base_monitor_details.py
+++ b/src/sentry/monitors/endpoints/base_monitor_details.py
@@ -68,7 +68,9 @@ class MonitorDetailsMixin(BaseEndpointMixin):
 
         return self.respond(serialize(updated_monitor, request.user))
 
-    def delete_monitor(self, request: Request, project: Project, monitor: Monitor) -> Response:
+    def delete_monitor(
+        self, request: Request, project: Project, monitor: Monitor
+    ) -> Response[None]:
         """
         Delete a monitor or monitor environments.
         """

--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -89,7 +89,7 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint, MonitorDetailsMixin):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def delete(self, request: Request, organization, project, monitor) -> Response:
+    def delete(self, request: Request, organization, project, monitor) -> Response[None]:
         """
         Delete a monitor or monitor environments.
         """

--- a/src/sentry/monitors/endpoints/project_monitor_details.py
+++ b/src/sentry/monitors/endpoints/project_monitor_details.py
@@ -91,7 +91,7 @@ class ProjectMonitorDetailsEndpoint(ProjectMonitorEndpoint, MonitorDetailsMixin)
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def delete(self, request: Request, project, monitor) -> Response:
+    def delete(self, request: Request, project, monitor) -> Response[None]:
         """
         Delete a monitor or monitor environments.
         """

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -67,7 +67,9 @@ def _check_metric_detector_allowed(detector: Detector, organization: Organizatio
         raise ResourceDoesNotExist
 
 
-def remove_detector(request: Request, organization: Organization, detector: Detector) -> Response:
+def remove_detector(
+    request: Request, organization: Organization, detector: Detector
+) -> Response[None]:
     """
     Delete a given detector. This method is used by the OrganizationAlertRuleDetailsEndpoint DELETE method
     for backwards compatibility and can be moved back under DELETE after API deprecation.
@@ -232,7 +234,9 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def delete(self, request: Request, organization: Organization, detector: Detector) -> Response:
+    def delete(
+        self, request: Request, organization: Organization, detector: Detector
+    ) -> Response[None]:
         """
         Delete a monitor
         """


### PR DESCRIPTION
Tightens 4 more PUBLIC `delete` methods by first typing their shared helpers:

- `delete_monitor` → `Response[None]` (project + organization monitor deletes)
- `remove_detector` → `Response[None]` (detector_details delete)
- `_handle_deletion_by_member` → `Response[None] | Response[DetailResponse]` (organization_member_details delete)

No body changes; declares the existing runtime shapes.