### PR TITLE
ref(flags): Graduate organizations:processing-errors-eap

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -213,7 +213,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-snapshots", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the playstation ingestion in relay
     manager.add("organizations:relay-playstation-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    manager.add("organizations:processing-errors-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:sourcemap-issue-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable profiling
     manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1272,9 +1272,6 @@ def process_processing_errors_eap(job: PostProcessJob) -> None:
 
     event = job["event"]
 
-    if not features.has("organizations:processing-errors-eap", event.project.organization):
-        return
-
     processing_errors = event.data.get("errors", [])
     if not processing_errors:
         return

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2196,25 +2196,6 @@ class ProcessingErrorsEAPTestMixin(BasePostProcessGroupMixin):
         assert args[0].id == self.project.id
         assert args[2] == [{"type": "js_no_source", "symbolicator_type": "missing_sourcemap"}]
 
-    def test_processing_errors_eap_not_called_without_feature(
-        self, mock_produce: MagicMock
-    ) -> None:
-        event = self.create_event(
-            data={"message": "testing"},
-            project_id=self.project.id,
-            assert_no_errors=False,
-        )
-        event.data["errors"] = [{"type": "js_no_source"}]
-
-        self.call_post_process_group(
-            is_new=True,
-            is_regression=False,
-            is_new_group_environment=True,
-            event=event,
-        )
-
-        mock_produce.assert_not_called()
-
     def test_processing_errors_eap_not_called_without_errors(self, mock_produce: MagicMock) -> None:
         event = self.create_event(
             data={"message": "testing"},

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2172,7 +2172,6 @@ class SDKCrashMonitoringTestMixin(BasePostProcessGroupMixin):
 
 @patch("sentry.processing_errors.eap.producer.produce_processing_errors_to_eap")
 class ProcessingErrorsEAPTestMixin(BasePostProcessGroupMixin):
-    @with_feature("organizations:processing-errors-eap")
     def test_processing_errors_eap_called_with_errors(self, mock_produce: MagicMock) -> None:
         event = self.create_event(
             data={
@@ -2216,7 +2215,6 @@ class ProcessingErrorsEAPTestMixin(BasePostProcessGroupMixin):
 
         mock_produce.assert_not_called()
 
-    @with_feature("organizations:processing-errors-eap")
     def test_processing_errors_eap_not_called_without_errors(self, mock_produce: MagicMock) -> None:
         event = self.create_event(
             data={"message": "testing"},


### PR DESCRIPTION
## Summary
- Removes the `organizations:processing-errors-eap` feature flag, which has been rolled out to all organizations via flagpole
- Processing errors are now unconditionally stored in EAP

## Test plan
- [x] Existing tests pass without the `@with_feature` decorator
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)