### PR TITLE
feat(seer): pass `enable_embeds` option to Seer agent runs

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -425,6 +425,13 @@ class SeerAgentClient:
         ):
             agent_run_options["use_agent_sandbox"] = True
 
+        if features.has(
+            "organizations:seer-explorer-embeds",
+            self.organization,
+            actor=self.user,
+        ):
+            agent_run_options["enable_embeds"] = True
+
         user_id = (
             self.user.id
             if self.user and hasattr(self.user, "id") and self.user.id is not None
@@ -564,6 +571,13 @@ class SeerAgentClient:
             actor=self.user,
         ):
             agent_run_options["use_agent_sandbox"] = True
+
+        if features.has(
+            "organizations:seer-explorer-embeds",
+            self.organization,
+            actor=self.user,
+        ):
+            agent_run_options["enable_embeds"] = True
 
         response = make_agent_chat_request(chat_body, viewer_context=self.viewer_context)
 


### PR DESCRIPTION
Gates the forthcoming `enable_embeds` capability behind the [`seer-explorer-embeds` feature flag](https://github.com/getsentry/sentry-options-automator/pull/8050) for both `start_run` and `send_chat_message` paths.

Follow-up to #116780 which registered the flag

Seer-side PR [#6866](https://github.com/getsentry/seer/pull/6866)
