### PR TITLE
feat(search): Add recommended_v2 sort using the Postgres-data sort framework

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -890,20 +890,18 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# recommended_v2: additive boosts applied on top of the Snuba recommended score.
-# Each boost is weight * signal, where the signal is normalized to [0, 1].
 register(
-    "snuba.search.recommended-v2.assignment-weight",
+    "snuba.search.recommended.assignment-weight",
     default=0.30,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "snuba.search.recommended-v2.fixability-weight",
+    "snuba.search.recommended.fixability-weight",
     default=0.20,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "snuba.search.recommended-v2.agent-weight",
+    "snuba.search.recommended.agent-weight",
     default=0.20,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -890,6 +890,23 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# recommended_v2: additive boosts applied on top of the Snuba recommended score.
+# Each boost is weight * signal, where the signal is normalized to [0, 1].
+register(
+    "snuba.search.recommended-v2.assignment-weight",
+    default=0.30,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "snuba.search.recommended-v2.fixability-weight",
+    default=0.20,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "snuba.search.recommended-v2.agent-weight",
+    default=0.20,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # The percentage of tagkeys that we want to cache. Set to 1.0 in order to cache everything, <=0.0 to stop caching
 register(

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -945,9 +945,9 @@ def recommended_v2_strategy() -> PostgresSortStrategy:
     """Recommended sort v2: the Snuba recommended score (recency/spike/severity/user
     impact/event volume) plus additive boosts for viewer assignment, Seer fixability,
     and Seer agent progress."""
-    assignment_weight = options.get("snuba.search.recommended-v2.assignment-weight")
-    fixability_weight = options.get("snuba.search.recommended-v2.fixability-weight")
-    agent_weight = options.get("snuba.search.recommended-v2.agent-weight")
+    assignment_weight = options.get("snuba.search.recommended.assignment-weight")
+    fixability_weight = options.get("snuba.search.recommended.fixability-weight")
+    agent_weight = options.get("snuba.search.recommended.agent-weight")
 
     def score_fn(data: dict[str, Any]) -> float:
         return (

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -34,14 +34,18 @@ from sentry.issues.search import (
     group_categories_from,
     group_types_from,
 )
+from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.models.group import Group
+from sentry.models.groupassignee import GroupAssignee
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.models.team import Team
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.search.eap.occurrences.search_executor import EAP_SORT_STRATEGIES, run_eap_group_search
 from sentry.search.events.filter import convert_search_filter_to_snuba_query, format_search_filter
 from sentry.snuba.dataset import Dataset
+from sentry.types.activity import ActivityType
 from sentry.utils import json, metrics
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.snuba import (
@@ -889,6 +893,84 @@ def recommended_issue_platform_aggregation(
     )
 
 
+# Seer agent progress stages, mirroring the `issue.agent` search filter
+# (ISSUE_AGENT_TO_ACTIVITY_TYPES in sentry.issues.issue_search). A group's signal is
+# the furthest stage reached, normalized to [0, 1].
+ISSUE_AGENT_STAGE_SIGNALS: dict[int, float] = {
+    ActivityType.SEER_RCA_COMPLETED.value: 0.25,
+    ActivityType.SEER_SOLUTION_COMPLETED.value: 0.5,
+    ActivityType.SEER_CODING_COMPLETED.value: 0.75,
+    ActivityType.SEER_PR_CREATED.value: 1.0,
+}
+
+
+def resolve_assignment_signal(
+    actor: Any | None, organization: Organization, group_ids: list[int]
+) -> dict[int, float]:
+    """Assignment affinity for the viewer: 1.0 for groups assigned directly to them,
+    0.5 for groups assigned to one of their teams, absent otherwise."""
+    if actor is None or not getattr(actor, "is_authenticated", False):
+        return {}
+    assignments = list(
+        GroupAssignee.objects.filter(group_id__in=group_ids).values_list(
+            "group_id", "user_id", "team_id"
+        )
+    )
+    team_ids: set[int] = set()
+    if any(team_id is not None for _, _, team_id in assignments):
+        team_ids = {team.id for team in Team.objects.get_for_user(organization, actor)}
+    signal: dict[int, float] = {}
+    for group_id, user_id, team_id in assignments:
+        if user_id is not None and user_id == actor.id:
+            signal[group_id] = 1.0
+        elif team_id is not None and team_id in team_ids:
+            signal[group_id] = 0.5
+    return signal
+
+
+def resolve_issue_agent_signal(
+    actor: Any | None, organization: Organization, group_ids: list[int]
+) -> dict[int, float]:
+    """Furthest Seer agent stage reached per group, normalized to [0, 1]."""
+    activities = Activity.objects.filter(
+        group_id__in=group_ids, type__in=list(ISSUE_AGENT_STAGE_SIGNALS)
+    ).values_list("group_id", "type")
+    signal: dict[int, float] = {}
+    for group_id, activity_type in activities:
+        signal[group_id] = max(signal.get(group_id, 0.0), ISSUE_AGENT_STAGE_SIGNALS[activity_type])
+    return signal
+
+
+def recommended_v2_strategy() -> PostgresSortStrategy:
+    """Recommended sort v2: the Snuba recommended score (recency/spike/severity/user
+    impact/event volume) plus additive boosts for viewer assignment, Seer fixability,
+    and Seer agent progress."""
+    assignment_weight = options.get("snuba.search.recommended-v2.assignment-weight")
+    fixability_weight = options.get("snuba.search.recommended-v2.fixability-weight")
+    agent_weight = options.get("snuba.search.recommended-v2.agent-weight")
+
+    def score_fn(data: dict[str, Any]) -> float:
+        return (
+            (data.get("recommended") or 0.0)
+            + assignment_weight * data.get("assignment", 0.0)
+            + fixability_weight * (data.get("fixability") or 0.0)
+            + agent_weight * data.get("agent", 0.0)
+        )
+
+    return PostgresSortStrategy(
+        postgres_fields={"fixability": "seer_fixability_score"},
+        snuba_aggregations=["recommended"],
+        signal_resolvers={
+            "assignment": resolve_assignment_signal,
+            "agent": resolve_issue_agent_signal,
+        },
+        score_fn=score_fn,
+        # seer_fixability_score is null for most groups; score those as 0 rather
+        # than excluding them.
+        exclude_null_postgres=False,
+    )
+
+
 class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
     ISSUE_FIELD_NAME = "group_id"
 
@@ -905,6 +987,9 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         "new": "first_seen",
         "trends": "trends",
         "recommended": "recommended",
+        # Postgres-data sort; mapped to the recommended aggregation so the chunked
+        # Snuba path can take over when there are too many candidates to score in memory.
+        "recommended_v2": "recommended",
         "user": "user_count",
         # We don't need a corresponding snuba field here, since this sort only happens
         # in Postgres
@@ -930,7 +1015,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
 
     @property
     def postgres_sort_strategies(self) -> dict[str, PostgresSortStrategy]:
-        return {}
+        return {"recommended_v2": recommended_v2_strategy()}
 
     def _apply_type_visibility_filter(
         self,

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -931,12 +931,27 @@ def resolve_assignment_signal(
 def resolve_issue_agent_signal(
     actor: Any | None, organization: Organization, group_ids: list[int]
 ) -> dict[int, float]:
-    """Furthest Seer agent stage reached per group, normalized to [0, 1]."""
+    """Furthest Seer agent stage reached per group, normalized to [0, 1].
+
+    A regression resets progress: stages reached before the group's latest
+    SET_REGRESSION activity don't count, since that fix evidently didn't hold.
+    """
     activities = Activity.objects.filter(
-        group_id__in=group_ids, type__in=list(ISSUE_AGENT_STAGE_SIGNALS)
-    ).values_list("group_id", "type")
+        group_id__in=group_ids,
+        type__in=[*ISSUE_AGENT_STAGE_SIGNALS, ActivityType.SET_REGRESSION.value],
+    ).values_list("group_id", "type", "datetime")
+    last_regressed: dict[int, datetime] = {}
+    seer_activities: list[tuple[int, int, datetime]] = []
+    for group_id, activity_type, date in activities:
+        if activity_type == ActivityType.SET_REGRESSION.value:
+            if group_id not in last_regressed or date > last_regressed[group_id]:
+                last_regressed[group_id] = date
+        else:
+            seer_activities.append((group_id, activity_type, date))
     signal: dict[int, float] = {}
-    for group_id, activity_type in activities:
+    for group_id, activity_type, date in seer_activities:
+        if group_id in last_regressed and date < last_regressed[group_id]:
+            continue
         signal[group_id] = max(signal.get(group_id, 0.0), ISSUE_AGENT_STAGE_SIGNALS[activity_type])
     return signal
 

--- a/tests/snuba/search/test_postgres_sort_framework.py
+++ b/tests/snuba/search/test_postgres_sort_framework.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.issue_search import convert_query_values, parse_search_query
 from sentry.models.group import Group, GroupStatus
+from sentry.models.groupassignee import GroupAssignee
 from sentry.search.snuba.backend import EventsDatasetSnubaSearchBackend
 from sentry.search.snuba.executors import (
     DEFAULT_TRENDS_WEIGHTS,
@@ -21,6 +22,7 @@ from sentry.snuba.referrer import Referrer
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now
+from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus, PriorityLevel
 
 
@@ -376,6 +378,62 @@ class TestFallbackBehavior(PostgresSortTestBase):
         assert len(results) == 3
 
 
+class TestRecommendedV2Sort(PostgresSortTestBase):
+    """recommended_v2: Snuba recommended base score plus additive boosts for viewer
+    assignment, Seer fixability, and Seer agent progress.
+
+    The base fixture's groups have events ~8d, ~5d, and ~3d old, so the recency-driven
+    base score orders them [2, 1, 0] with small (<0.03) differences -- each boost below
+    is large enough to override that.
+    """
+
+    def _query(self, actor=None):
+        return list(
+            self.backend.query(
+                [self.project],
+                search_filters=[],
+                environments=None,
+                count_hits=False,
+                sort_by="recommended_v2",
+                date_from=None,
+                date_to=None,
+                cursor=None,
+                actor=actor,
+                referrer=Referrer.TESTING_TEST,
+            )
+        )
+
+    def test_assignment_ordering(self):
+        team = self.create_team(organization=self.organization, members=[self.user])
+        GroupAssignee.objects.assign(self.groups[0], self.user)
+        GroupAssignee.objects.assign(self.groups[1], team)
+
+        # Without a viewer, assignment contributes nothing and recency wins.
+        assert self._query(actor=None) == [self.groups[2], self.groups[1], self.groups[0]]
+        # Individual assignment outranks team assignment outranks unassigned.
+        assert self._query(actor=self.user) == [self.groups[0], self.groups[1], self.groups[2]]
+
+    def test_fixability_boost(self):
+        self.groups[0].update(seer_fixability_score=1.0)
+
+        results = self._query(actor=self.user)
+        assert results[0] == self.groups[0]
+        # Groups without a fixability score are still included, just unboosted.
+        assert set(results) == set(self.groups)
+
+    def test_agent_progress_boost(self):
+        # A later Seer stage outranks an earlier one, which outranks no agent activity.
+        self.create_group_activity(group=self.groups[0], type=ActivityType.SEER_PR_CREATED.value)
+        self.create_group_activity(group=self.groups[1], type=ActivityType.SEER_RCA_COMPLETED.value)
+
+        assert self._query(actor=self.user) == [self.groups[0], self.groups[1], self.groups[2]]
+
+
 class TestDefaultPostgresSortStrategies(TestCase):
-    def test_returns_empty(self):
-        assert PostgresSnubaQueryExecutor().postgres_sort_strategies == {}
+    def test_recommended_v2_registered(self):
+        strategies = PostgresSnubaQueryExecutor().postgres_sort_strategies
+        assert set(strategies) == {"recommended_v2"}
+        strategy = strategies["recommended_v2"]
+        assert strategy.snuba_aggregations == ["recommended"]
+        assert strategy.exclude_null_postgres is False
+        assert set(strategy.signal_resolvers) == {"assignment", "agent"}

--- a/tests/snuba/search/test_postgres_sort_framework.py
+++ b/tests/snuba/search/test_postgres_sort_framework.py
@@ -428,6 +428,32 @@ class TestRecommendedV2Sort(PostgresSortTestBase):
 
         assert self._query(actor=self.user) == [self.groups[0], self.groups[1], self.groups[2]]
 
+    def test_agent_boost_reset_by_regression(self):
+        # groups[0] reached PR-created but then regressed: that progress is stale.
+        self.create_group_activity(
+            group=self.groups[0],
+            type=ActivityType.SEER_PR_CREATED.value,
+            datetime=before_now(hours=2),
+        )
+        self.create_group_activity(
+            group=self.groups[0],
+            type=ActivityType.SET_REGRESSION.value,
+            datetime=before_now(hours=1),
+        )
+        # groups[1] reached a (lesser) stage after its regression: still counts.
+        self.create_group_activity(
+            group=self.groups[1],
+            type=ActivityType.SET_REGRESSION.value,
+            datetime=before_now(hours=2),
+        )
+        self.create_group_activity(
+            group=self.groups[1],
+            type=ActivityType.SEER_RCA_COMPLETED.value,
+            datetime=before_now(hours=1),
+        )
+
+        assert self._query(actor=self.user) == [self.groups[1], self.groups[2], self.groups[0]]
+
 
 class TestDefaultPostgresSortStrategies(TestCase):
     def test_recommended_v2_registered(self):


### PR DESCRIPTION
Adds a `recommended_v2` issue sort built on the Postgres-data sort framework (#116896). It keeps the Snuba `recommended` aggregation (recency / spike / severity / user impact / event volume) as the base score and layers on additive boosts for signals that live outside ClickHouse:

- **Assignment affinity**: issues assigned directly to the viewer get a full boost, issues assigned to one of the viewer's teams get half. Resolved in bulk from `GroupAssignee`; anonymous/absent viewers get no boost.
- **Seer fixability**: `Group.seer_fixability_score` ([0, 1], null scored as 0 — `exclude_null_postgres=False` so unscored groups aren't dropped).
- **Seer agent progress**: the furthest `issue.agent` stage reached per group (root cause < plan < code changes < PR created), resolved from `Activity` records and normalized to [0, 1].

Each boost is `weight * signal` with weights registered as options (`snuba.search.recommended.*`) so they can be tuned without a deploy, matching how the existing recommended weights work. 

These signals are an initial test of recommended_v2, more signals will be added and some of these might be taken away. 

The sort key is also mapped to the `recommended` aggregation in `sort_strategies`, so when there are too many candidates to score in memory the framework's overflow fallback degrades to the existing chunked Snuba recommended path rather than `date`.

The sort only activates when explicitly requested via `?sort=recommended_v2`, so it's inherently opt-in; this is to prevent anyone using the existed v1 implementation from being affected while we test it
