### PR TITLE
chore(autofix): Remove get_autofix_state function

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -37,7 +37,6 @@ from sentry.seer.autofix.prompts import (
 )
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
-    get_autofix_state,
     read_preference_from_sentry_db,
 )
 from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
@@ -576,27 +575,6 @@ def trigger_coding_agent_handoff(
     state = _get_group_run_state(client, group, run_id)
 
     repo = _get_relevant_repo(state, repo_definitions, run_id, group)
-
-    # If branch_name is unset in preferences, resolve it from the autofix run state
-    if not repo.branch_name:
-        try:
-            autofix_state = get_autofix_state(run_id=run_id, organization_id=group.organization.id)
-            if autofix_state:
-                state_repo = next(
-                    (
-                        r
-                        for r in autofix_state.request.repos
-                        if r.owner == repo.owner and r.name == repo.name
-                    ),
-                    None,
-                )
-                if state_repo and state_repo.branch_name:
-                    repo = repo.copy(update={"branch_name": state_repo.branch_name})
-        except Exception:
-            logger.exception(
-                "autofix.coding_agent_handoff.get_branch_name_error",
-                extra={"owner": repo.owner, "repo": repo.name, "run_id": run_id},
-            )
 
     short_id = group.qualified_short_id
 

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -22,6 +22,7 @@ from sentry.seer.autofix.autofix import get_trace_tree_for_event
 from sentry.seer.autofix.autofix_agent import (
     AutofixStep,
     NoSeerQuotaException,
+    get_autofix_agent_state,
     trigger_autofix_agent,
 )
 from sentry.seer.autofix.constants import (
@@ -32,7 +33,6 @@ from sentry.seer.autofix.constants import (
 )
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
-    get_autofix_state,
     is_seer_autotriggered_autofix_rate_limited,
     is_seer_autotriggered_autofix_rate_limited_and_increment,
     is_seer_seat_based_tier_enabled,
@@ -386,7 +386,7 @@ def run_automation(
         }
     )
 
-    autofix_state = get_autofix_state(group_id=group.id, organization_id=group.organization.id)
+    autofix_state = get_autofix_agent_state(group.organization, group.id)
     if autofix_state:
         return  # already have an autofix on this issue
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -38,7 +38,6 @@ from sentry.seer.models import (
     AutofixHandoffPoint,
     BranchOverride,
     SeerAutomationHandoffConfiguration,
-    SeerPermissionError,
     SeerProjectPreference,
     SeerRepoDefinition,
 )
@@ -211,34 +210,9 @@ autofix_connection_pool = connection_from_url(
 )
 
 
-class GetAutofixStateRequest(TypedDict):
-    group_id: int | None
-    run_id: int | None
-    check_repo_access: bool
-    is_user_fetching: bool
-
-
-class GetAutofixStatePrRequest(TypedDict):
-    provider: str
-    pr_id: int
-
-
 class StoreCodingAgentStatesRequest(TypedDict):
     run_id: int
     coding_agent_states: list[dict[str, Any]]
-
-
-def make_get_autofix_state_request(
-    body: GetAutofixStateRequest,
-    connection_pool: HTTPConnectionPool | None = None,
-    viewer_context: SeerViewerContext | None = None,
-) -> BaseHTTPResponse:
-    return make_signed_seer_api_request(
-        connection_pool or autofix_connection_pool,
-        "/v1/automation/autofix/state",
-        body=orjson.dumps(body),
-        viewer_context=viewer_context,
-    )
 
 
 def make_update_coding_agent_state_request(
@@ -879,45 +853,6 @@ def get_autofix_repos_from_project_code_mappings(
             repos[repo_key] = repo_dict
 
     return list(repos.values())
-
-
-def get_autofix_state(
-    *,
-    group_id: int | None = None,
-    run_id: int | None = None,
-    check_repo_access: bool = False,
-    is_user_fetching: bool = False,
-    organization_id: int,
-) -> AutofixState | None:
-    body = GetAutofixStateRequest(
-        group_id=group_id,
-        run_id=run_id,
-        check_repo_access=check_repo_access,
-        is_user_fetching=is_user_fetching,
-    )
-    viewer_context = SeerViewerContext(organization_id=organization_id)
-    response = make_get_autofix_state_request(body, viewer_context=viewer_context)
-
-    if response.status >= 400:
-        raise Exception(f"Seer request failed with status {response.status}")
-
-    result = response.json()
-
-    if result:
-        if (
-            group_id is not None
-            and result["group_id"] == group_id
-            or run_id is not None
-            and result["run_id"] == run_id
-        ):
-            state = AutofixState.validate(result["state"])
-
-            if state.request.organization_id != organization_id:
-                raise SeerPermissionError("Different organization ID found in autofix state")
-
-            return state
-
-    return None
 
 
 def is_seer_scanner_rate_limited(project: Project, organization: Organization) -> bool:

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -1,23 +1,15 @@
-from datetime import datetime, timezone
-from unittest.mock import MagicMock, Mock, patch
-
-import orjson
-import pytest
+from unittest.mock import MagicMock, patch
 
 from sentry import ratelimits
 from sentry.constants import ObjectStatus
-from sentry.seer.autofix.constants import AutofixStatus
 from sentry.seer.autofix.utils import (
     AUTOFIX_AUTOTRIGGED_RATE_LIMIT_OPTION_MULTIPLIERS,
-    AutofixState,
     _get_autofix_rate_limit_config,
     get_autofix_repos_from_project_code_mappings,
-    get_autofix_state,
     is_seer_autotriggered_autofix_rate_limited,
     is_seer_autotriggered_autofix_rate_limited_and_increment,
     is_seer_scanner_rate_limited,
 )
-from sentry.seer.models import SeerPermissionError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
@@ -181,139 +173,6 @@ class TestGetRepoFromCodeMappings(TestCase):
         repos = get_autofix_repos_from_project_code_mappings(project)
         assert len(repos) == 1
         assert repos[0]["repository_id"] == repo_with_external_id.id
-
-
-class TestGetAutofixState(TestCase):
-    @patch("sentry.seer.autofix.utils.make_signed_seer_api_request")
-    def test_get_autofix_state_success_with_group_id(self, mock_request: MagicMock) -> None:
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_response.json.return_value = {
-            "group_id": 123,
-            "state": {
-                "run_id": 456,
-                "request": {
-                    "project_id": 789,
-                    "organization_id": 999,
-                    "issue": {"id": 123, "title": "Test Issue"},
-                    "repos": [],
-                },
-                "updated_at": "2023-07-18T12:00:00Z",
-                "status": "PROCESSING",
-            },
-        }
-        mock_request.return_value = mock_response
-
-        result = get_autofix_state(group_id=123, organization_id=999)
-
-        assert isinstance(result, AutofixState)
-        assert result.run_id == 456
-        assert result.request == {
-            "project_id": 789,
-            "organization_id": 999,
-            "issue": {"id": 123, "title": "Test Issue"},
-            "repos": [],
-        }
-        assert result.updated_at == datetime(2023, 7, 18, 12, 0, tzinfo=timezone.utc)
-        assert result.status == AutofixStatus.PROCESSING
-
-        mock_request.assert_called_once()
-        path = mock_request.call_args[0][1]
-        assert path == "/v1/automation/autofix/state"
-        body = orjson.loads(mock_request.call_args[1]["body"])
-        assert body == {
-            "group_id": 123,
-            "run_id": None,
-            "check_repo_access": False,
-            "is_user_fetching": False,
-        }
-
-    @patch("sentry.seer.autofix.utils.make_signed_seer_api_request")
-    def test_get_autofix_state_success_with_run_id(self, mock_request: MagicMock) -> None:
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_response.json.return_value = {
-            "run_id": 456,
-            "state": {
-                "run_id": 456,
-                "request": {
-                    "project_id": 789,
-                    "organization_id": 999,
-                    "issue": {"id": 123, "title": "Test Issue"},
-                    "repos": [],
-                },
-                "updated_at": "2023-07-18T12:00:00Z",
-                "status": "COMPLETED",
-            },
-        }
-        mock_request.return_value = mock_response
-
-        result = get_autofix_state(run_id=456, organization_id=999)
-
-        assert isinstance(result, AutofixState)
-        assert result.run_id == 456
-        assert result.request == {
-            "project_id": 789,
-            "organization_id": 999,
-            "issue": {"id": 123, "title": "Test Issue"},
-            "repos": [],
-        }
-        assert result.updated_at == datetime(2023, 7, 18, 12, 0, tzinfo=timezone.utc)
-        assert result.status == AutofixStatus.COMPLETED
-
-        mock_request.assert_called_once()
-        path = mock_request.call_args[0][1]
-        assert path == "/v1/automation/autofix/state"
-        body = orjson.loads(mock_request.call_args[1]["body"])
-        assert body == {
-            "group_id": None,
-            "run_id": 456,
-            "check_repo_access": False,
-            "is_user_fetching": False,
-        }
-
-    @patch("sentry.seer.autofix.utils.make_signed_seer_api_request")
-    def test_get_autofix_state_no_result(self, mock_request: MagicMock) -> None:
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_response.json.return_value = {}
-        mock_request.return_value = mock_response
-
-        result = get_autofix_state(group_id=123, organization_id=999)
-
-        assert result is None
-
-    @patch("sentry.seer.autofix.utils.make_signed_seer_api_request")
-    def test_get_autofix_state_http_error(self, mock_request: MagicMock) -> None:
-        mock_response = Mock()
-        mock_response.status = 500
-        mock_request.return_value = mock_response
-
-        with pytest.raises(Exception, match="Seer request failed with status 500"):
-            get_autofix_state(group_id=123, organization_id=999)
-
-    @patch("sentry.seer.autofix.utils.make_signed_seer_api_request")
-    def test_get_autofix_state_raises_on_org_id_mismatch(self, mock_request: MagicMock) -> None:
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_response.json.return_value = {
-            "group_id": 123,
-            "state": {
-                "run_id": 456,
-                "request": {
-                    "project_id": 789,
-                    "organization_id": 111,  # mismatched org id
-                    "issue": {"id": 123, "title": "Test Issue"},
-                    "repos": [],
-                },
-                "updated_at": "2023-07-18T12:00:00Z",
-                "status": "PROCESSING",
-            },
-        }
-        mock_request.return_value = mock_response
-
-        with pytest.raises(SeerPermissionError):
-            get_autofix_state(group_id=123, organization_id=999)
 
 
 class TestAutomationRateLimiting(TestCase):

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,9 +20,8 @@ from sentry.seer.autofix.autofix_agent import (
     trigger_coding_agent_handoff,
     trigger_push_changes,
 )
-from sentry.seer.autofix.constants import AutofixReferrer, AutofixStatus
-from sentry.seer.autofix.utils import AutofixRequest, AutofixState
-from sentry.seer.models import SeerPermissionError, SeerRepoDefinition
+from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.models import SeerPermissionError
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
 
@@ -642,9 +640,8 @@ class TestTriggerCodingAgentHandoff(TestCase):
         self.project.update_option("sentry:seer_automation_handoff_integration_id", 456)
         self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", auto_create_pr)
 
-    @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_trigger_coding_agent_handoff_success(self, mock_client_class, mock_get_autofix_state):
+    def test_trigger_coding_agent_handoff_success(self, mock_client_class):
         """Test successful coding agent handoff."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
@@ -662,7 +659,6 @@ class TestTriggerCodingAgentHandoff(TestCase):
             "failures": [],
         }
         self._make_repo_and_projectrepo()
-        mock_get_autofix_state.return_value = None
 
         result = trigger_coding_agent_handoff(
             group=self.group,
@@ -683,11 +679,8 @@ class TestTriggerCodingAgentHandoff(TestCase):
         assert call_kwargs["issue_short_id"] == self.group.qualified_short_id
 
     @patch("sentry.seer.autofix.autofix_agent.analytics.record")
-    @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_trigger_coding_agent_handoff_records_referrer(
-        self, mock_client_class, mock_get_autofix_state, mock_record
-    ):
+    def test_trigger_coding_agent_handoff_records_referrer(self, mock_client_class, mock_record):
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.get_run.return_value = self._make_run_state()
@@ -696,7 +689,6 @@ class TestTriggerCodingAgentHandoff(TestCase):
             "failures": [],
         }
         self._make_repo_and_projectrepo()
-        mock_get_autofix_state.return_value = None
 
         trigger_coding_agent_handoff(
             group=self.group,
@@ -743,11 +735,8 @@ class TestTriggerCodingAgentHandoff(TestCase):
 
         mock_client.launch_coding_agents.assert_not_called()
 
-    @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_trigger_coding_agent_handoff_generates_prompt_from_artifacts(
-        self, mock_client_class, mock_get_autofix_state
-    ):
+    def test_trigger_coding_agent_handoff_generates_prompt_from_artifacts(self, mock_client_class):
         """Test that prompt is generated from run state artifacts."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
@@ -770,7 +759,6 @@ class TestTriggerCodingAgentHandoff(TestCase):
             "failures": [],
         }
         self._make_repo_and_projectrepo()
-        mock_get_autofix_state.return_value = None
 
         trigger_coding_agent_handoff(
             group=self.group,
@@ -785,11 +773,8 @@ class TestTriggerCodingAgentHandoff(TestCase):
         assert "Memory leak in cache" in prompt
         assert "Add TTL to cache" in prompt
 
-    @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_trigger_coding_agent_handoff_uses_group_title_for_branch(
-        self, mock_client_class, mock_get_autofix_state
-    ):
+    def test_trigger_coding_agent_handoff_uses_group_title_for_branch(self, mock_client_class):
         """Test that branch_name_base is set to the group title."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
@@ -799,7 +784,6 @@ class TestTriggerCodingAgentHandoff(TestCase):
             "failures": [],
         }
         self._make_repo_and_projectrepo()
-        mock_get_autofix_state.return_value = None
 
         # Set a specific title on the group
         self.group.message = "NullPointerException in UserService"
@@ -815,10 +799,9 @@ class TestTriggerCodingAgentHandoff(TestCase):
         call_kwargs = mock_client.launch_coding_agents.call_args.kwargs
         assert call_kwargs["branch_name_base"] == self.group.title
 
-    @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_trigger_coding_agent_handoff_fetches_auto_create_pr_from_preferences(
-        self, mock_client_class, mock_get_autofix_state
+        self, mock_client_class
     ):
         """Test that auto_create_pr is fetched from project preferences."""
         mock_client = MagicMock()
@@ -830,7 +813,6 @@ class TestTriggerCodingAgentHandoff(TestCase):
         }
         self._make_repo_and_projectrepo()
         self._make_handoff(auto_create_pr=True)
-        mock_get_autofix_state.return_value = None
 
         trigger_coding_agent_handoff(
             group=self.group,
@@ -842,11 +824,8 @@ class TestTriggerCodingAgentHandoff(TestCase):
         call_kwargs = mock_client.launch_coding_agents.call_args.kwargs
         assert call_kwargs["auto_create_pr"] is True
 
-    @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_trigger_coding_agent_handoff_defaults_auto_create_pr_false(
-        self, mock_client_class, mock_get_autofix_state
-    ):
+    def test_trigger_coding_agent_handoff_defaults_auto_create_pr_false(self, mock_client_class):
         """Test that auto_create_pr defaults to False when automation_handoff not configured."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
@@ -857,7 +836,6 @@ class TestTriggerCodingAgentHandoff(TestCase):
         }
         # Repos are set but auto_create_pr=False (no handoff config)
         self._make_repo_and_projectrepo()
-        mock_get_autofix_state.return_value = None
 
         trigger_coding_agent_handoff(
             group=self.group,
@@ -869,11 +847,8 @@ class TestTriggerCodingAgentHandoff(TestCase):
         call_kwargs = mock_client.launch_coding_agents.call_args.kwargs
         assert call_kwargs["auto_create_pr"] is False
 
-    @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_trigger_coding_agent_handoff_uses_auto_create_pr_override(
-        self, mock_client_class, mock_get_autofix_state
-    ):
+    def test_trigger_coding_agent_handoff_uses_auto_create_pr_override(self, mock_client_class):
         """Test that manual handoff can force PR creation independent of automation settings."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
@@ -884,7 +859,6 @@ class TestTriggerCodingAgentHandoff(TestCase):
         }
         self._make_repo_and_projectrepo()
         self._make_handoff(auto_create_pr=False)
-        mock_get_autofix_state.return_value = None
 
         trigger_coding_agent_handoff(
             group=self.group,
@@ -897,11 +871,8 @@ class TestTriggerCodingAgentHandoff(TestCase):
         call_kwargs = mock_client.launch_coding_agents.call_args.kwargs
         assert call_kwargs["auto_create_pr"] is True
 
-    @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_trigger_coding_agent_handoff_filters_to_relevant_repo(
-        self, mock_client_class, mock_get_autofix_state
-    ):
+    def test_trigger_coding_agent_handoff_filters_to_relevant_repo(self, mock_client_class):
         """Test that only the repo named in relevant_repo is passed to launch_coding_agents."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
@@ -917,7 +888,6 @@ class TestTriggerCodingAgentHandoff(TestCase):
         mock_client.launch_coding_agents.return_value = {"successes": [], "failures": []}
         self._make_repo_and_projectrepo(name="relevant-repo", external_id="1")
         self._make_repo_and_projectrepo(name="other-repo", external_id="2")
-        mock_get_autofix_state.return_value = None
 
         trigger_coding_agent_handoff(
             group=self.group,
@@ -930,11 +900,10 @@ class TestTriggerCodingAgentHandoff(TestCase):
         assert len(repos) == 1
         assert repos[0].name == "relevant-repo"
 
-    @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
     @patch("sentry.seer.autofix.autofix_agent.logger")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_trigger_coding_agent_handoff_falls_back_to_first_repo_when_no_relevant_repo(
-        self, mock_client_class, mock_logger, mock_get_autofix_state
+        self, mock_client_class, mock_logger
     ):
         """Test that when relevant_repo is absent, first configured repo is used and a warning is logged."""
         mock_client = MagicMock()
@@ -945,7 +914,6 @@ class TestTriggerCodingAgentHandoff(TestCase):
         mock_client.launch_coding_agents.return_value = {"successes": [], "failures": []}
         self._make_repo_and_projectrepo(name="first-repo", external_id="1")
         self._make_repo_and_projectrepo(name="second-repo", external_id="2")
-        mock_get_autofix_state.return_value = None
 
         trigger_coding_agent_handoff(
             group=self.group,
@@ -966,11 +934,10 @@ class TestTriggerCodingAgentHandoff(TestCase):
             },
         )
 
-    @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
     @patch("sentry.seer.autofix.autofix_agent.logger")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_trigger_coding_agent_handoff_falls_back_when_relevant_repo_doesnt_match(
-        self, mock_client_class, mock_logger, mock_get_autofix_state
+        self, mock_client_class, mock_logger
     ):
         """Test that when relevant_repo doesn't match any configured repo, first repo is used."""
         mock_client = MagicMock()
@@ -987,7 +954,6 @@ class TestTriggerCodingAgentHandoff(TestCase):
         mock_client.launch_coding_agents.return_value = {"successes": [], "failures": []}
         self._make_repo_and_projectrepo(name="first-repo", external_id="1")
         self._make_repo_and_projectrepo(name="second-repo", external_id="2")
-        mock_get_autofix_state.return_value = None
 
         trigger_coding_agent_handoff(
             group=self.group,
@@ -1020,56 +986,9 @@ class TestTriggerCodingAgentHandoff(TestCase):
                 integration_id=456,
             )
 
-    @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_trigger_coding_agent_handoff_enriches_branch_name_from_autofix_state(
-        self, mock_client_class, mock_get_autofix_state
-    ):
-        """Test that branch_name is resolved from autofix state when unset in preferences."""
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
-        mock_client.get_run.return_value = self._make_run_state()
-        mock_client.launch_coding_agents.return_value = {"successes": [], "failures": []}
-        self._make_repo_and_projectrepo(external_id="1")
-        mock_get_autofix_state.return_value = AutofixState(
-            run_id=123,
-            request=AutofixRequest(
-                organization_id=self.organization.id,
-                project_id=self.project.id,
-                issue={
-                    "id": 1,
-                    "title": "Bug",
-                    "short_id": "PROJ-1",
-                    "first_seen": "2024-01-01T00:00:00Z",
-                },
-                repos=[
-                    SeerRepoDefinition(
-                        provider="integrations:github",
-                        owner="owner",
-                        name="repo",
-                        external_id="1",
-                        branch_name="main",
-                    )
-                ],
-            ),
-            updated_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
-            status=AutofixStatus.COMPLETED,
-        )
-
-        trigger_coding_agent_handoff(
-            group=self.group,
-            run_id=123,
-            referrer=AutofixReferrer.UNKNOWN,
-            integration_id=456,
-        )
-
-        repos = mock_client.launch_coding_agents.call_args.kwargs["repos"]
-        assert repos[0].branch_name == "main"
-
-    @patch("sentry.seer.autofix.autofix_agent.get_autofix_state")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_trigger_coding_agent_handoff_keeps_branch_name_from_preferences_when_set(
-        self, mock_client_class, mock_get_autofix_state
+        self, mock_client_class
     ):
         """Test that branch_name from preferences is used as-is when already set."""
         mock_client = MagicMock()
@@ -1085,7 +1004,6 @@ class TestTriggerCodingAgentHandoff(TestCase):
             integration_id=456,
         )
 
-        mock_get_autofix_state.assert_not_called()
         repos = mock_client.launch_coding_agents.call_args.kwargs["repos"]
         assert repos[0].branch_name == "release/v2"
 

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -474,7 +474,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_serialize.assert_called_once()
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
+    @patch("sentry.seer.autofix.issue_summary.get_autofix_agent_state")
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.seer.autofix.issue_summary.get_trace_tree_for_event")
@@ -487,10 +487,10 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_get_trace_tree,
         mock_record_seer_run,
         mock_generate_fixability_score,
-        mock_get_autofix_state,
+        mock_get_autofix_agent_state,
         mock_trigger_autofix_task,
     ):
-        mock_get_autofix_state.return_value = None
+        mock_get_autofix_agent_state.return_value = None
         mock_fixability_response = SummarizeIssueResponse(
             group_id=str(self.group.id),
             headline="some headline",
@@ -861,7 +861,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
         return_value=False,
     )
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
+    @patch("sentry.seer.autofix.issue_summary.get_autofix_agent_state", return_value=None)
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_high_fixability_code_changes(
@@ -885,7 +885,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
         return_value=False,
     )
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
+    @patch("sentry.seer.autofix.issue_summary.get_autofix_agent_state", return_value=None)
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_medium_fixability_solution(
@@ -910,7 +910,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary.is_group_triggering_automation", return_value=True)
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
+    @patch("sentry.seer.autofix.issue_summary.get_autofix_agent_state", return_value=None)
     def test_without_seat_based_tier(
         self,
         mock_state,
@@ -928,7 +928,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch("sentry.seer.autofix.issue_summary.is_group_triggering_automation", return_value=True)
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
+    @patch("sentry.seer.autofix.issue_summary.get_autofix_agent_state")
     def test_skips_when_autofix_in_progress(
         self, mock_state, mock_triggering, mock_trigger, mock_seat_based_tier
     ):
@@ -1018,7 +1018,7 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
         "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
         return_value=False,
     )
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
+    @patch("sentry.seer.autofix.issue_summary.get_autofix_agent_state", return_value=None)
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_user_preference_limits_high_fixability(
@@ -1053,7 +1053,7 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
         "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
         return_value=False,
     )
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
+    @patch("sentry.seer.autofix.issue_summary.get_autofix_agent_state", return_value=None)
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_fixability_limits_permissive_user_preference(


### PR DESCRIPTION
Legacy autofix runs are nearly all deleted already and we should be using get_autofix_agent_state where possible.