### PR TITLE
fix(tracemetrics): Switching to equation mode clears aliases

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.spec.tsx
@@ -4,7 +4,10 @@ import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLib
 
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
-import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {
+  useWidgetBuilderContext,
+  WidgetBuilderProvider,
+} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {
   type EquationModeSnapshot,
   useTraceMetricsVisualizeModeState,
@@ -266,7 +269,13 @@ describe('useTraceMetricsVisualizeModeState', () => {
   });
 
   it('clears legend aliases when switching to equation mode and restores them on return', async () => {
-    const {result} = renderHookWithProviders(useTraceMetricsVisualizeModeState, {
+    function useCombinedStateHooks() {
+      const modeState = useTraceMetricsVisualizeModeState();
+      const {state} = useWidgetBuilderContext();
+      return {visualizeModeState: modeState, widgetBuilderState: state};
+    }
+
+    const {result} = renderHookWithProviders(useCombinedStateHooks, {
       organization: OrganizationFixture({features: EQUATION_FEATURES}),
       additionalWrapper: WidgetBuilderProvider,
       initialRouterConfig: {
@@ -283,37 +292,21 @@ describe('useTraceMetricsVisualizeModeState', () => {
     });
 
     // Switch to equation mode — aliases should be cleared
-    mockNavigate.mockClear();
     act(() => {
-      result.current.handleModeToggle(true);
+      result.current.visualizeModeState.handleModeToggle(true);
     });
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          query: expect.objectContaining({
-            legendAlias: [],
-          }),
-        }),
-        expect.anything()
-      );
+      expect(result.current.widgetBuilderState.legendAlias).toEqual([]);
     });
 
     // Switch back to series mode — aliases should be restored
-    mockNavigate.mockClear();
     act(() => {
-      result.current.handleModeToggle(false);
+      result.current.visualizeModeState.handleModeToggle(false);
     });
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          query: expect.objectContaining({
-            legendAlias: ['my alias'],
-          }),
-        }),
-        expect.anything()
-      );
+      expect(result.current.widgetBuilderState.legendAlias).toEqual(['my alias']);
     });
   });
 

--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.spec.tsx
@@ -265,6 +265,58 @@ describe('useTraceMetricsVisualizeModeState', () => {
     });
   });
 
+  it('clears legend aliases when switching to equation mode and restores them on return', async () => {
+    const {result} = renderHookWithProviders(useTraceMetricsVisualizeModeState, {
+      organization: OrganizationFixture({features: EQUATION_FEATURES}),
+      additionalWrapper: WidgetBuilderProvider,
+      initialRouterConfig: {
+        location: {
+          pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+          query: {
+            dataset: WidgetType.TRACEMETRICS,
+            displayType: DisplayType.LINE,
+            yAxis: ['sum(value,alpha_metric,counter,none)'],
+            legendAlias: ['my alias'],
+          },
+        },
+      },
+    });
+
+    // Switch to equation mode — aliases should be cleared
+    mockNavigate.mockClear();
+    act(() => {
+      result.current.handleModeToggle(true);
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            legendAlias: [],
+          }),
+        }),
+        expect.anything()
+      );
+    });
+
+    // Switch back to series mode — aliases should be restored
+    mockNavigate.mockClear();
+    act(() => {
+      result.current.handleModeToggle(false);
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            legendAlias: ['my alias'],
+          }),
+        }),
+        expect.anything()
+      );
+    });
+  });
+
   it('restores equation yAxis when toggling to equation mode with a cached snapshot', async () => {
     const {result} = renderHookWithProviders(useTraceMetricsVisualizeModeState, {
       organization: OrganizationFixture({features: EQUATION_FEATURES}),

--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
@@ -28,6 +28,7 @@ import {
 
 interface SeriesModeSnapshot {
   fields: QueryFieldValue[];
+  legendAlias: string[];
   query: string[];
 }
 
@@ -83,6 +84,10 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
         type: BuilderStateAction.SET_QUERY,
         payload: seriesSnapshot.current.query,
       });
+      dispatch({
+        type: BuilderStateAction.SET_LEGEND_ALIAS,
+        payload: seriesSnapshot.current.legendAlias,
+      });
       return;
     }
 
@@ -109,11 +114,15 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
       derivedFields = [getDatasetConfig(WidgetType.TRACEMETRICS).defaultField];
     }
 
-    seriesSnapshot.current = {fields: derivedFields, query: []};
+    seriesSnapshot.current = {fields: derivedFields, legendAlias: [], query: []};
     const actionType = getTraceMetricAggregateActionType(state.displayType);
     dispatch({type: actionType, payload: derivedFields});
     dispatch({
       type: BuilderStateAction.SET_QUERY,
+      payload: [],
+    });
+    dispatch({
+      type: BuilderStateAction.SET_LEGEND_ALIAS,
       payload: [],
     });
   }, [state.displayType, dispatch]);
@@ -179,6 +188,10 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
       type: BuilderStateAction.SET_QUERY,
       payload: [selected.queryParams.query],
     });
+    dispatch({
+      type: BuilderStateAction.SET_LEGEND_ALIAS,
+      payload: [],
+    });
   }, [state.displayType, state.yAxis, state.fields, dispatch]);
 
   // Auto-restore the previous visualize mode when the dataset returns
@@ -212,6 +225,8 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
 
   const handleModeToggle = useCallback(
     (nextIsEquation: boolean) => {
+      const currentLegendAlias = state.legendAlias ? [...state.legendAlias] : [];
+
       if (nextIsEquation) {
         const currentFields = getTraceMetricAggregateSource(
           state.displayType,
@@ -220,6 +235,7 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
         );
         seriesSnapshot.current = {
           fields: currentFields ? structuredClone(currentFields) : [],
+          legendAlias: currentLegendAlias,
           query: state.query ? [...state.query] : [],
         };
         restoreEquationState();
@@ -235,6 +251,7 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
       state.yAxis,
       state.fields,
       state.query,
+      state.legendAlias,
       restoreSeriesState,
       restoreEquationState,
     ]


### PR DESCRIPTION
We don't support aliases yet for equations mode, so clear them when switching. They are cached in the series mode so when flipped back, they will still apply.
