### PR TITLE
fix(apps): Fix theme issues with a divider

### DIFF
--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -270,7 +270,7 @@ const Footer = styled('div')`
   display: flex;
   align-items: center;
   padding: 20px 30px;
-  border-top: 1px solid #e2dee6;
+  border-top: 1px solid ${p => p.theme.tokens.border.secondary};
   margin: 20px -30px -30px;
   justify-content: space-between;
 `;


### PR DESCRIPTION
Fixes theme issues with a divider inside the `sentryAppDetailsModal` which used a static white color for its border. Basically replace it with the theme-aware `p.theme.tokens.border.secondary` to reflect this change.

Closes #112440.

*Starting to get active with contributing here, so I'm taking small tasks here and there that I don't see anyone else working on*

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
