### PR TITLE
ref: Type PUBLIC monitor get/put endpoints via mixin

### DIFF
--- a/src/sentry/monitors/endpoints/base_monitor_details.py
+++ b/src/sentry/monitors/endpoints/base_monitor_details.py
@@ -11,6 +11,7 @@ from sentry import audit_log, quotas
 from sentry.api.base import BaseEndpointMixin
 from sentry.api.helpers.environments import get_environments
 from sentry.api.serializers import serialize
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.constants import ObjectStatus
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
@@ -18,7 +19,7 @@ from sentry.models.environment import Environment
 from sentry.models.project import Project
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
 from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorStatus
-from sentry.monitors.serializers import MonitorSerializer
+from sentry.monitors.serializers import MonitorSerializer, MonitorSerializerResponse
 from sentry.monitors.utils import ensure_cron_detector_deletion
 from sentry.monitors.validators import MonitorValidator
 from sentry.utils.auth import AuthenticatedHttpRequest
@@ -27,7 +28,9 @@ from sentry.workflow_engine.models import Detector
 
 
 class MonitorDetailsMixin(BaseEndpointMixin):
-    def get_monitor(self, request: Request, project: Project, monitor: Monitor) -> Response:
+    def get_monitor(
+        self, request: Request, project: Project, monitor: Monitor
+    ) -> Response[MonitorSerializerResponse]:
         """
         Retrieves details for a monitor.
         """
@@ -43,7 +46,7 @@ class MonitorDetailsMixin(BaseEndpointMixin):
 
     def update_monitor(
         self, request: AuthenticatedHttpRequest, project: Project, monitor: Monitor
-    ) -> Response:
+    ) -> Response[MonitorSerializerResponse] | Response[ValidationErrorResponse]:
         """
         Update a monitor.
         """
@@ -59,14 +62,18 @@ class MonitorDetailsMixin(BaseEndpointMixin):
             },
         )
         if not validator.is_valid():
-            return self.respond(validator.errors, status=400)
+            return self.respond(as_validation_errors(validator), status=400)
 
         try:
             updated_monitor = validator.save()
         except serializers.ValidationError as e:
-            return self.respond(e.detail, status=400)
+            errors: ValidationErrorResponse = (
+                dict(e.detail) if isinstance(e.detail, dict) else {"non_field_errors": e.detail}
+            )
+            return self.respond(errors, status=400)
 
-        return self.respond(serialize(updated_monitor, request.user))
+        body: MonitorSerializerResponse = serialize(updated_monitor, request.user)
+        return self.respond(body)
 
     def delete_monitor(
         self, request: Request, project: Project, monitor: Monitor

--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -15,7 +15,8 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import GlobalParams, MonitorParams
-from sentry.monitors.serializers import MonitorSerializer
+from sentry.apidocs.response_types import ValidationErrorResponse
+from sentry.monitors.serializers import MonitorSerializer, MonitorSerializerResponse
 from sentry.monitors.validators import MonitorValidator
 from sentry.utils.auth import AuthenticatedHttpRequest
 
@@ -47,7 +48,9 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint, MonitorDetailsMixin):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, organization, project, monitor) -> Response:
+    def get(
+        self, request: Request, organization, project, monitor
+    ) -> Response[MonitorSerializerResponse]:
         """
         Retrieves details for a monitor.
         """
@@ -68,7 +71,9 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint, MonitorDetailsMixin):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def put(self, request: AuthenticatedHttpRequest, organization, project, monitor) -> Response:
+    def put(
+        self, request: AuthenticatedHttpRequest, organization, project, monitor
+    ) -> Response[MonitorSerializerResponse] | Response[ValidationErrorResponse]:
         """
         Update a monitor.
         """

--- a/src/sentry/monitors/endpoints/project_monitor_details.py
+++ b/src/sentry/monitors/endpoints/project_monitor_details.py
@@ -15,7 +15,8 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import GlobalParams, MonitorParams
-from sentry.monitors.serializers import MonitorSerializer
+from sentry.apidocs.response_types import ValidationErrorResponse
+from sentry.monitors.serializers import MonitorSerializer, MonitorSerializerResponse
 from sentry.monitors.validators import MonitorValidator
 from sentry.utils.auth import AuthenticatedHttpRequest
 
@@ -47,7 +48,7 @@ class ProjectMonitorDetailsEndpoint(ProjectMonitorEndpoint, MonitorDetailsMixin)
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, project, monitor) -> Response:
+    def get(self, request: Request, project, monitor) -> Response[MonitorSerializerResponse]:
         """
         Retrieves details for a monitor.
         """
@@ -69,7 +70,9 @@ class ProjectMonitorDetailsEndpoint(ProjectMonitorEndpoint, MonitorDetailsMixin)
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def put(self, request: AuthenticatedHttpRequest, project, monitor) -> Response:
+    def put(
+        self, request: AuthenticatedHttpRequest, project, monitor
+    ) -> Response[MonitorSerializerResponse] | Response[ValidationErrorResponse]:
         """
         Update a monitor.
         """


### PR DESCRIPTION
Tightens 4 PUBLIC monitor methods (project + organization × get + put) by first typing the shared MonitorDetailsMixin helpers:
- `get_monitor` → `Response[MonitorSerializerResponse]`
- `update_monitor` → `Response[MonitorSerializerResponse] | Response[ValidationErrorResponse]`

Body shapes unchanged. `update_monitor` routes `validator.errors` through `as_validation_errors()` and normalizes the late-save `ValidationError` detail to a dict (or `{"non_field_errors": ...}` for list-shaped detail).