### PR TITLE
fix(intercom): Remove intercom double boot

### DIFF
--- a/static/app/utils/intercom.tsx
+++ b/static/app/utils/intercom.tsx
@@ -78,8 +78,7 @@ async function initIntercom(orgSlug: string): Promise<void> {
       shutdown();
       boot(intercomSettings);
 
-      const nextIntercomState = {orgSlug, settings: intercomSettings};
-      intercomState = nextIntercomState;
+      intercomState = {orgSlug, settings: intercomSettings};
     } catch (error) {
       // Reset so user can retry on next click
       bootPromise = null;

--- a/static/app/utils/intercom.tsx
+++ b/static/app/utils/intercom.tsx
@@ -74,36 +74,12 @@ async function initIntercom(orgSlug: string): Promise<void> {
       // hard navigation between org subdomains, so a plain boot resumes the
       // previous org's session. Load the SDK, drop the stale session cookie,
       // then boot clean with this org's identity.
-      const {
-        boot,
-        default: Intercom,
-        show,
-        onShow,
-        shutdown,
-      } = await import('@intercom/messenger-js-sdk');
-      Intercom(intercomSettings);
+      const {boot, shutdown} = await import('@intercom/messenger-js-sdk');
       shutdown();
       boot(intercomSettings);
 
       const nextIntercomState = {orgSlug, settings: intercomSettings};
       intercomState = nextIntercomState;
-      let hasRebootedAfterShow = false;
-
-      // After Intercom is opened, reboot with the same settings. Intercom needs
-      // the cookie to be cleared again after showing so the company updates
-      // correctly after switching orgs.
-      onShow(() => {
-        if (intercomState !== nextIntercomState || hasRebootedAfterShow) {
-          return;
-        }
-
-        hasRebootedAfterShow = true;
-        setTimeout(() => {
-          shutdown();
-          boot(intercomSettings);
-          show();
-        }, 2000);
-      });
     } catch (error) {
       // Reset so user can retry on next click
       bootPromise = null;


### PR DESCRIPTION
After talking with intercom team it sounds like we want to just call shutdown and boot and the problem might be that we called boot implicitly via Intercom()
