### PR TITLE
feat(pr-metrics): Add Seer judge callback update_pr_metrics

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -46,6 +46,9 @@ class PrCloseMetricsEvent(analytics.Event):
     # the active (is_valid=True) attributions, each {signal_type, source,
     # signal_details}, ordered by attribution priority (highest-confidence first).
     attributions: str = "[]"
+    # The Seer judge verdict (one of ``PullRequestVerdict``). Null on the no-judge
+    # path and until the judge callback lands a result for a forwarded PR.
+    verdict: str | None = None
 
 
 analytics.register(PrCloseMetricsEvent)

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -125,6 +125,7 @@ def build_pr_metrics_row(
         review_comments_count=metrics.review_comments_count,
         is_assigned=metrics.is_assigned,
         attributions=json.dumps(attributions),
+        verdict=metrics.verdict,
     )
 
 

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -1,0 +1,126 @@
+"""Seer judge path for the PR metrics pipeline.
+
+This module owns the Sentry side of the judge round-trip. Today it holds the
+inbound ``upsert_pr_metrics_summary`` handler — the callback Seer makes once it
+has judged a forwarded terminal PR event. The forward (Sentry → Seer) half lands
+later and will live here alongside it.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from django.db import router, transaction
+
+from sentry.models.pullrequest import (
+    PullRequest,
+    PullRequestAttributionSignalType,
+    PullRequestAttributionSource,
+    PullRequestMetrics,
+    PullRequestVerdict,
+)
+from sentry.pr_metrics.attribution import record_attribution_signal
+from sentry.pr_metrics.emit import emit_pr_metrics_row
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_attributions(
+    raw: Sequence[Mapping[str, Any]],
+) -> list[tuple[PullRequestAttributionSignalType, PullRequestAttributionSource, Any]]:
+    """Validate Seer-supplied attribution signals at the trust boundary.
+
+    Returns the parsed ``(signal_type, source, signal_details)`` tuples, or raises
+    ``ValueError`` if any entry names a signal type or source we don't recognize —
+    we reject the whole batch rather than silently drop malformed signals.
+    """
+    parsed = []
+    for entry in raw:
+        signal_type = PullRequestAttributionSignalType(entry["signal_type"])
+        source = PullRequestAttributionSource(entry["source"])
+        parsed.append((signal_type, source, entry.get("signal_details")))
+    return parsed
+
+
+def upsert_pr_metrics_summary(
+    *,
+    pull_request_id: int,
+    organization_id: int,
+    repository_id: int,
+    verdict: str | None = None,
+    participants_count: int | None = None,
+    reviews_count: int | None = None,
+    attributions: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Persist Seer's judge result for a PR and emit the enriched metrics row.
+
+    Inbound Seer RPC (Seer → Sentry), invoked once Seer has judged a forwarded
+    terminal PR event. Persists the ``verdict`` and the Seer-derived counters onto
+    ``PullRequestMetrics`` (leaving the webhook-sourced counters untouched),
+    records any Seer-derived ``PullRequestAttribution`` signals, then re-emits the
+    now judge-enriched ``pr_metrics.row``.
+
+    The PR is located by its Sentry id but constrained to the reported
+    ``organization_id``/``repository_id``, so a mismatched id can't reach another
+    tenant's PR. Returns ``{"success": bool}`` for the Seer caller.
+    """
+    log_extra = {
+        "pull_request_id": pull_request_id,
+        "organization_id": organization_id,
+        "repository_id": repository_id,
+    }
+
+    if verdict is not None and verdict not in PullRequestVerdict.values:
+        logger.warning("pr_metrics.upsert.invalid_verdict", extra={**log_extra, "verdict": verdict})
+        metrics.incr("pr_metrics.upsert.skipped", tags={"reason": "invalid_verdict"})
+        return {"success": False, "error": "invalid_verdict"}
+
+    try:
+        parsed_attributions = _parse_attributions(attributions or ())
+    except (KeyError, ValueError):
+        logger.warning("pr_metrics.upsert.invalid_attribution", extra=log_extra)
+        metrics.incr("pr_metrics.upsert.skipped", tags={"reason": "invalid_attribution"})
+        return {"success": False, "error": "invalid_attribution"}
+
+    # Scope the lookup to the reported org+repo: the id alone is attacker-influenced
+    # (it round-trips through Seer), so trusting it unscoped would be an IDOR.
+    try:
+        pull_request = PullRequest.objects.get(
+            id=pull_request_id,
+            organization_id=organization_id,
+            repository_id=repository_id,
+        )
+    except PullRequest.DoesNotExist:
+        logger.warning("pr_metrics.upsert.pull_request_not_found", extra=log_extra)
+        metrics.incr("pr_metrics.upsert.skipped", tags={"reason": "pr_not_found"})
+        return {"success": False, "error": "pull_request_not_found"}
+
+    # Only the judge-derived fields are written here; the webhook keeps the
+    # activity counters current, so we must not clobber them with a partial upsert.
+    seer_fields: dict[str, Any] = {"verdict": verdict}
+    if participants_count is not None:
+        seer_fields["participants_count"] = participants_count
+    if reviews_count is not None:
+        seer_fields["reviews_count"] = reviews_count
+
+    with transaction.atomic(using=router.db_for_write(PullRequestMetrics)):
+        PullRequestMetrics.objects.update_or_create(
+            pull_request=pull_request,
+            defaults=seer_fields,
+        )
+        for signal_type, source, signal_details in parsed_attributions:
+            record_attribution_signal(
+                pull_request=pull_request,
+                signal_type=signal_type,
+                source=source,
+                signal_details=signal_details,
+            )
+
+    emit_pr_metrics_row(pull_request=pull_request)
+
+    metrics.incr("pr_metrics.upsert.recorded", tags={"verdict": verdict or "none"})
+    logger.info("pr_metrics.upsert.recorded", extra={**log_extra, "verdict": verdict})
+    return {"success": True}

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -35,15 +35,20 @@ def _parse_attributions(
 
     Returns the parsed ``(signal_type, source, signal_details)`` tuples. Raises if
     the payload is the wrong shape (not a list of objects → ``TypeError``), is
-    missing a required key (``KeyError``), or names a signal type or source we
-    don't recognize (``ValueError``) — the caller rejects the whole batch rather
-    than silently dropping malformed signals.
+    missing a required key (``KeyError``), names a signal type or source we don't
+    recognize, or carries a non-object ``signal_details`` (``ValueError``) — the
+    caller rejects the whole batch rather than silently dropping malformed signals.
     """
     parsed = []
     for entry in raw:
         signal_type = PullRequestAttributionSignalType(entry["signal_type"])
         source = PullRequestAttributionSource(entry["source"])
-        parsed.append((signal_type, source, entry.get("signal_details")))
+        signal_details = entry.get("signal_details")
+        # signal_details is persisted as a JSON object; reject scalars/arrays here
+        # so record_attribution_signal's dict(...) can't raise mid-transaction.
+        if signal_details is not None and not isinstance(signal_details, Mapping):
+            raise ValueError("signal_details must be an object or null")
+        parsed.append((signal_type, source, signal_details))
     return parsed
 
 

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -33,9 +33,11 @@ def _parse_attributions(
 ) -> list[tuple[PullRequestAttributionSignalType, PullRequestAttributionSource, Any]]:
     """Validate Seer-supplied attribution signals at the trust boundary.
 
-    Returns the parsed ``(signal_type, source, signal_details)`` tuples, or raises
-    ``ValueError`` if any entry names a signal type or source we don't recognize —
-    we reject the whole batch rather than silently drop malformed signals.
+    Returns the parsed ``(signal_type, source, signal_details)`` tuples. Raises if
+    the payload is the wrong shape (not a list of objects → ``TypeError``), is
+    missing a required key (``KeyError``), or names a signal type or source we
+    don't recognize (``ValueError``) — the caller rejects the whole batch rather
+    than silently dropping malformed signals.
     """
     parsed = []
     for entry in raw:
@@ -81,7 +83,7 @@ def upsert_pr_metrics_summary(
 
     try:
         parsed_attributions = _parse_attributions(attributions or ())
-    except (KeyError, ValueError):
+    except (KeyError, TypeError, ValueError):
         logger.warning("pr_metrics.upsert.invalid_attribution", extra=log_extra)
         metrics.incr("pr_metrics.upsert.skipped", tags={"reason": "invalid_attribution"})
         return {"success": False, "error": "invalid_attribution"}

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -51,17 +51,15 @@ def upsert_pr_metrics_summary(
     organization_id: int,
     repository_id: int,
     verdict: str | None = None,
-    participants_count: int | None = None,
-    reviews_count: int | None = None,
     attributions: Sequence[Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Persist Seer's judge result for a PR and emit the enriched metrics row.
 
     Inbound Seer RPC (Seer → Sentry), invoked once Seer has judged a forwarded
-    terminal PR event. Persists the ``verdict`` and the Seer-derived counters onto
-    ``PullRequestMetrics`` (leaving the webhook-sourced counters untouched),
-    records any Seer-derived ``PullRequestAttribution`` signals, then re-emits the
-    now judge-enriched ``pr_metrics.row``.
+    terminal PR event. Persists the ``verdict`` onto ``PullRequestMetrics``
+    (leaving the webhook-sourced counters untouched), records any Seer-derived
+    ``PullRequestAttribution`` signals, then re-emits the now judge-enriched
+    ``pr_metrics.row``.
 
     The PR is located by its Sentry id but constrained to the reported
     ``organization_id``/``repository_id``, so a mismatched id can't reach another
@@ -98,18 +96,12 @@ def upsert_pr_metrics_summary(
         metrics.incr("pr_metrics.upsert.skipped", tags={"reason": "pr_not_found"})
         return {"success": False, "error": "pull_request_not_found"}
 
-    # Only the judge-derived fields are written here; the webhook keeps the
-    # activity counters current, so we must not clobber them with a partial upsert.
-    seer_fields: dict[str, Any] = {"verdict": verdict}
-    if participants_count is not None:
-        seer_fields["participants_count"] = participants_count
-    if reviews_count is not None:
-        seer_fields["reviews_count"] = reviews_count
-
+    # Only the verdict is written here; the webhook keeps the activity counters
+    # current, so we must not clobber them with a partial upsert.
     with transaction.atomic(using=router.db_for_write(PullRequestMetrics)):
         PullRequestMetrics.objects.update_or_create(
             pull_request=pull_request,
-            defaults=seer_fields,
+            defaults={"verdict": verdict},
         )
         for signal_type, source, signal_details in parsed_attributions:
             record_attribution_signal(

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -1,8 +1,8 @@
 """Seer judge path for the PR metrics pipeline.
 
 This module owns the Sentry side of the judge round-trip. Today it holds the
-inbound ``upsert_pr_metrics_summary`` handler — the callback Seer makes once it
-has judged a forwarded terminal PR event. The forward (Sentry → Seer) half lands
+inbound ``update_pr_metrics`` handler — the callback Seer makes once it has
+judged a forwarded terminal PR event. The forward (Sentry → Seer) half lands
 later and will live here alongside it.
 """
 
@@ -47,7 +47,7 @@ def _parse_attributions(
     return parsed
 
 
-def upsert_pr_metrics_summary(
+def update_pr_metrics(
     *,
     pull_request_id: int,
     organization_id: int,
@@ -58,15 +58,19 @@ def upsert_pr_metrics_summary(
     """Persist Seer's judge result for a PR and emit the enriched metrics row.
 
     Inbound Seer RPC (Seer → Sentry), invoked once Seer has judged a forwarded
-    terminal PR event. Persists the ``verdict`` onto ``PullRequestMetrics``
-    (leaving the webhook-sourced counters untouched), records any Seer-derived
-    ``PullRequestAttribution`` signals, then re-emits the now judge-enriched
-    ``pr_metrics.row``.
+    terminal PR event. Updates the ``verdict`` on the PR's ``PullRequestMetrics``
+    row (the webhook creates and keeps the row's activity counters current, so
+    this leaves them untouched), records any ``attributions`` Seer produced while
+    judging, then re-emits the now judge-enriched ``pr_metrics.row``.
+
+    ``attributions`` are new signals Seer surfaced during judging (recorded with
+    a ``seer_*`` source), additive to the ones the webhook already detected — not
+    an echo or filter of the attributions Sentry forwarded.
 
     The PR is located by its Sentry id but constrained to the reported
     ``organization_id``/``repository_id``, so a mismatched id can't reach another
-    tenant's PR. A missing or unrecognized ``verdict`` is rejected as invalid
-    input. Returns ``{"success": bool}`` for the Seer caller.
+    tenant's PR. A missing/unrecognized ``verdict`` or a non-terminal PR is
+    rejected up front. Returns ``{"success": bool}`` for the Seer caller.
     """
     log_extra = {
         "pull_request_id": pull_request_id,
@@ -75,17 +79,17 @@ def upsert_pr_metrics_summary(
     }
 
     # The verdict is the judge result this callback exists to deliver, so a
-    # missing one is malformed input — reject it rather than upserting a null.
+    # missing one is malformed input — reject it rather than writing a null.
     if verdict is None or verdict not in PullRequestVerdict.values:
-        logger.warning("pr_metrics.upsert.invalid_verdict", extra={**log_extra, "verdict": verdict})
-        metrics.incr("pr_metrics.upsert.skipped", tags={"reason": "invalid_verdict"})
+        logger.warning("pr_metrics.update.invalid_verdict", extra={**log_extra, "verdict": verdict})
+        metrics.incr("pr_metrics.update.skipped", tags={"reason": "invalid_verdict"})
         return {"success": False, "error": "invalid_verdict"}
 
     try:
         parsed_attributions = _parse_attributions(attributions or ())
     except (KeyError, TypeError, ValueError):
-        logger.warning("pr_metrics.upsert.invalid_attribution", extra=log_extra)
-        metrics.incr("pr_metrics.upsert.skipped", tags={"reason": "invalid_attribution"})
+        logger.warning("pr_metrics.update.invalid_attribution", extra=log_extra)
+        metrics.incr("pr_metrics.update.skipped", tags={"reason": "invalid_attribution"})
         return {"success": False, "error": "invalid_attribution"}
 
     # Scope the lookup to the reported org+repo: the id alone is attacker-influenced
@@ -97,12 +101,20 @@ def upsert_pr_metrics_summary(
             repository_id=repository_id,
         )
     except PullRequest.DoesNotExist:
-        logger.warning("pr_metrics.upsert.pull_request_not_found", extra=log_extra)
-        metrics.incr("pr_metrics.upsert.skipped", tags={"reason": "pr_not_found"})
+        logger.warning("pr_metrics.update.pull_request_not_found", extra=log_extra)
+        metrics.incr("pr_metrics.update.skipped", tags={"reason": "pr_not_found"})
         return {"success": False, "error": "pull_request_not_found"}
 
+    # Emit needs a terminal PR (closed_at + head_commit_sha). Validate it before
+    # writing so a non-terminal PR is rejected up front rather than committing the
+    # verdict and then failing in emit — i.e. no committed-but-errored state.
+    if pull_request.closed_at is None or pull_request.head_commit_sha is None:
+        logger.warning("pr_metrics.update.not_terminal", extra=log_extra)
+        metrics.incr("pr_metrics.update.skipped", tags={"reason": "not_terminal"})
+        return {"success": False, "error": "pull_request_not_terminal"}
+
     # Only the verdict is written here; the webhook keeps the activity counters
-    # current, so this partial upsert must not clobber them.
+    # current, so this partial update must not clobber them.
     with transaction.atomic(using=router.db_for_write(PullRequestMetrics)):
         PullRequestMetrics.objects.update_or_create(
             pull_request=pull_request,
@@ -118,6 +130,6 @@ def upsert_pr_metrics_summary(
 
     emit_pr_metrics_row(pull_request=pull_request)
 
-    metrics.incr("pr_metrics.upsert.recorded", tags={"verdict": verdict or "none"})
-    logger.info("pr_metrics.upsert.recorded", extra={**log_extra, "verdict": verdict})
+    metrics.incr("pr_metrics.update.recorded", tags={"verdict": verdict})
+    logger.info("pr_metrics.update.recorded", extra={**log_extra, "verdict": verdict})
     return {"success": True}

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -96,12 +96,15 @@ def upsert_pr_metrics_summary(
         metrics.incr("pr_metrics.upsert.skipped", tags={"reason": "pr_not_found"})
         return {"success": False, "error": "pull_request_not_found"}
 
-    # Only the verdict is written here; the webhook keeps the activity counters
-    # current, so we must not clobber them with a partial upsert.
+    # Only write the verdict, and only when reported: a None verdict means "not
+    # provided", so it must not clear a verdict already stored by an earlier call.
+    # The webhook keeps the activity counters current, so this partial upsert must
+    # not clobber them either.
+    defaults = {"verdict": verdict} if verdict is not None else {}
     with transaction.atomic(using=router.db_for_write(PullRequestMetrics)):
         PullRequestMetrics.objects.update_or_create(
             pull_request=pull_request,
-            defaults={"verdict": verdict},
+            defaults=defaults,
         )
         for signal_type, source, signal_details in parsed_attributions:
             record_attribution_signal(

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -63,7 +63,8 @@ def upsert_pr_metrics_summary(
 
     The PR is located by its Sentry id but constrained to the reported
     ``organization_id``/``repository_id``, so a mismatched id can't reach another
-    tenant's PR. Returns ``{"success": bool}`` for the Seer caller.
+    tenant's PR. A missing or unrecognized ``verdict`` is rejected as invalid
+    input. Returns ``{"success": bool}`` for the Seer caller.
     """
     log_extra = {
         "pull_request_id": pull_request_id,
@@ -71,7 +72,9 @@ def upsert_pr_metrics_summary(
         "repository_id": repository_id,
     }
 
-    if verdict is not None and verdict not in PullRequestVerdict.values:
+    # The verdict is the judge result this callback exists to deliver, so a
+    # missing one is malformed input — reject it rather than upserting a null.
+    if verdict is None or verdict not in PullRequestVerdict.values:
         logger.warning("pr_metrics.upsert.invalid_verdict", extra={**log_extra, "verdict": verdict})
         metrics.incr("pr_metrics.upsert.skipped", tags={"reason": "invalid_verdict"})
         return {"success": False, "error": "invalid_verdict"}
@@ -96,15 +99,12 @@ def upsert_pr_metrics_summary(
         metrics.incr("pr_metrics.upsert.skipped", tags={"reason": "pr_not_found"})
         return {"success": False, "error": "pull_request_not_found"}
 
-    # Only write the verdict, and only when reported: a None verdict means "not
-    # provided", so it must not clear a verdict already stored by an earlier call.
-    # The webhook keeps the activity counters current, so this partial upsert must
-    # not clobber them either.
-    defaults = {"verdict": verdict} if verdict is not None else {}
+    # Only the verdict is written here; the webhook keeps the activity counters
+    # current, so this partial upsert must not clobber them.
     with transaction.atomic(using=router.db_for_write(PullRequestMetrics)):
         PullRequestMetrics.objects.update_or_create(
             pull_request=pull_request,
-            defaults=defaults,
+            defaults={"verdict": verdict},
         )
         for signal_type, source, signal_details in parsed_attributions:
             record_attribution_signal(

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -53,6 +53,7 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
 from sentry.models.repository import Repository
+from sentry.pr_metrics.judge import upsert_pr_metrics_summary
 from sentry.replays.usecases.summarize import rpc_get_replay_summary_logs
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
@@ -965,6 +966,9 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     #
     # Issue Detection
     "create_issue_occurrence": create_issue_occurrence,
+    #
+    # PR metrics (judge path)
+    "upsert_pr_metrics_summary": upsert_pr_metrics_summary,
 }
 
 

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -53,7 +53,7 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
 from sentry.models.repository import Repository
-from sentry.pr_metrics.judge import upsert_pr_metrics_summary
+from sentry.pr_metrics.judge import update_pr_metrics
 from sentry.replays.usecases.summarize import rpc_get_replay_summary_logs
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
@@ -968,7 +968,7 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     "create_issue_occurrence": create_issue_occurrence,
     #
     # PR metrics (judge path)
-    "upsert_pr_metrics_summary": upsert_pr_metrics_summary,
+    "update_pr_metrics": update_pr_metrics,
 }
 
 

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -139,6 +139,26 @@ class UpdatePrMetricsTest(TestCase):
         assert mock_record.call_count == 0
 
     @patch("sentry.analytics.record")
+    def test_rejects_non_object_signal_details(self, mock_record: Any) -> None:
+        self._track()
+        # signal_details must be an object; a scalar would raise in
+        # record_attribution_signal, so it must be caught as invalid_attribution.
+        result = self._call(
+            verdict="merged_unchanged",
+            attributions=[
+                {
+                    "signal_type": "seer_delegated:claude_code",
+                    "source": "seer_llm_judge",
+                    "signal_details": "not-an-object",
+                }
+            ],
+        )
+
+        assert result == {"success": False, "error": "invalid_attribution"}
+        assert not PullRequestMetrics.objects.filter(pull_request=self.pull_request).exists()
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
     def test_does_not_clobber_webhook_counters(self, mock_record: Any) -> None:
         self._track()
         PullRequestMetrics.objects.create(

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -142,20 +142,16 @@ class UpsertPrMetricsSummaryTest(TestCase):
         assert metrics.is_assigned is True
 
     @patch("sentry.analytics.record")
-    def test_omitted_verdict_does_not_clear_existing(self, mock_record: Any) -> None:
+    def test_rejects_missing_verdict(self, mock_record: Any) -> None:
         self._track()
-        PullRequestMetrics.objects.create(
-            pull_request=self.pull_request, verdict="merged_unchanged"
-        )
 
-        # A later call with no verdict (e.g. an attribution-only update) must not
-        # null out the verdict a prior call stored.
+        # The verdict is the judge result; a call without one is malformed input
+        # and must not reach the upsert (which would otherwise store a null).
         result = self._call()
 
-        assert result == {"success": True}
-        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
-            "merged_unchanged"
-        )
+        assert result == {"success": False, "error": "invalid_verdict"}
+        assert not PullRequestMetrics.objects.filter(pull_request=self.pull_request).exists()
+        assert mock_record.call_count == 0
 
     @patch("sentry.analytics.record")
     def test_pull_request_not_found(self, mock_record: Any) -> None:

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -125,6 +125,20 @@ class UpsertPrMetricsSummaryTest(TestCase):
         assert mock_record.call_count == 0
 
     @patch("sentry.analytics.record")
+    def test_rejects_wrong_shape_attributions(self, mock_record: Any) -> None:
+        self._track()
+        # A single object instead of a list of objects: iterating it yields keys,
+        # which must surface as invalid_attribution rather than a generic error.
+        result = self._call(
+            verdict="merged_unchanged",
+            attributions={"signal_type": "seer_delegated:claude_code", "source": "seer_llm_judge"},
+        )
+
+        assert result == {"success": False, "error": "invalid_attribution"}
+        assert not PullRequestMetrics.objects.filter(pull_request=self.pull_request).exists()
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
     def test_does_not_clobber_webhook_counters(self, mock_record: Any) -> None:
         self._track()
         PullRequestMetrics.objects.create(

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -142,6 +142,22 @@ class UpsertPrMetricsSummaryTest(TestCase):
         assert metrics.is_assigned is True
 
     @patch("sentry.analytics.record")
+    def test_omitted_verdict_does_not_clear_existing(self, mock_record: Any) -> None:
+        self._track()
+        PullRequestMetrics.objects.create(
+            pull_request=self.pull_request, verdict="merged_unchanged"
+        )
+
+        # A later call with no verdict (e.g. an attribution-only update) must not
+        # null out the verdict a prior call stored.
+        result = self._call()
+
+        assert result == {"success": True}
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "merged_unchanged"
+        )
+
+    @patch("sentry.analytics.record")
     def test_pull_request_not_found(self, mock_record: Any) -> None:
         result = upsert_pr_metrics_summary(
             pull_request_id=self.pull_request.id + 1000,

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -10,7 +10,7 @@ from sentry.models.pullrequest import (
     PullRequestMetrics,
 )
 from sentry.pr_metrics.attribution import record_attribution_signal
-from sentry.pr_metrics.judge import upsert_pr_metrics_summary
+from sentry.pr_metrics.judge import update_pr_metrics
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.analytics import get_event_count
 from sentry.testutils.silo import cell_silo_test
@@ -25,7 +25,7 @@ def _last_row(mock_record: Any) -> PrCloseMetricsEvent:
 
 
 @cell_silo_test
-class UpsertPrMetricsSummaryTest(TestCase):
+class UpdatePrMetricsTest(TestCase):
     def setUp(self) -> None:
         self.repo = self.create_repo(
             self.project, name="getsentry/sentry", provider="integrations:github"
@@ -45,7 +45,7 @@ class UpsertPrMetricsSummaryTest(TestCase):
         )
 
     def _call(self, **kwargs: Any) -> dict[str, Any]:
-        return upsert_pr_metrics_summary(
+        return update_pr_metrics(
             pull_request_id=self.pull_request.id,
             organization_id=self.organization.id,
             repository_id=self.repo.id,
@@ -91,7 +91,7 @@ class UpsertPrMetricsSummaryTest(TestCase):
         self._track()
         other_org = self.create_organization()
 
-        result = upsert_pr_metrics_summary(
+        result = update_pr_metrics(
             pull_request_id=self.pull_request.id,
             organization_id=other_org.id,
             repository_id=self.repo.id,
@@ -169,7 +169,7 @@ class UpsertPrMetricsSummaryTest(TestCase):
 
     @patch("sentry.analytics.record")
     def test_pull_request_not_found(self, mock_record: Any) -> None:
-        result = upsert_pr_metrics_summary(
+        result = update_pr_metrics(
             pull_request_id=self.pull_request.id + 1000,
             organization_id=self.organization.id,
             repository_id=self.repo.id,
@@ -177,6 +177,19 @@ class UpsertPrMetricsSummaryTest(TestCase):
         )
 
         assert result == {"success": False, "error": "pull_request_not_found"}
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
+    def test_rejects_non_terminal_pr(self, mock_record: Any) -> None:
+        self._track()
+        # A PR that never reached a terminal state can't build a row. Reject up
+        # front so we don't commit the verdict and then fail in emit.
+        self.pull_request.update(closed_at=None, head_commit_sha=None)
+
+        result = self._call(verdict="merged_unchanged")
+
+        assert result == {"success": False, "error": "pull_request_not_terminal"}
+        assert not PullRequestMetrics.objects.filter(pull_request=self.pull_request).exists()
         assert mock_record.call_count == 0
 
     @patch("sentry.analytics.record")

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -131,13 +131,11 @@ class UpsertPrMetricsSummaryTest(TestCase):
             pull_request=self.pull_request, additions=10, deletions=5, is_assigned=True
         )
 
-        result = self._call(verdict="merged_unchanged", participants_count=3, reviews_count=2)
+        result = self._call(verdict="merged_unchanged")
 
         assert result == {"success": True}
         metrics = PullRequestMetrics.objects.get(pull_request=self.pull_request)
         assert metrics.verdict == "merged_unchanged"
-        assert metrics.participants_count == 3
-        assert metrics.reviews_count == 2
         # Webhook-sourced counters survive the judge upsert.
         assert metrics.additions == 10
         assert metrics.deletions == 5

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -1,0 +1,168 @@
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import patch
+
+from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
+from sentry.models.pullrequest import (
+    PullRequestAttribution,
+    PullRequestAttributionSignalType,
+    PullRequestAttributionSource,
+    PullRequestMetrics,
+)
+from sentry.pr_metrics.attribution import record_attribution_signal
+from sentry.pr_metrics.judge import upsert_pr_metrics_summary
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.analytics import get_event_count
+from sentry.testutils.silo import cell_silo_test
+
+HEAD_SHA = "a" * 40
+# Past year avoids the S015 future-date lint.
+CLOSED_AT = datetime(2020, 6, 4, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def _last_row(mock_record: Any) -> PrCloseMetricsEvent:
+    return mock_record.call_args_list[-1].args[0]
+
+
+@cell_silo_test
+class UpsertPrMetricsSummaryTest(TestCase):
+    def setUp(self) -> None:
+        self.repo = self.create_repo(
+            self.project, name="getsentry/sentry", provider="integrations:github"
+        )
+        self.pull_request = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id, key="42"
+        )
+        # Persisted so the handler's re-fetch + emit see a terminal PR.
+        self.pull_request.update(head_commit_sha=HEAD_SHA, closed_at=CLOSED_AT, merged_at=CLOSED_AT)
+
+    def _track(self) -> None:
+        # A valid attribution makes the PR "tracked" so emit isn't skipped.
+        record_attribution_signal(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+        )
+
+    def _call(self, **kwargs: Any) -> dict[str, Any]:
+        return upsert_pr_metrics_summary(
+            pull_request_id=self.pull_request.id,
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            **kwargs,
+        )
+
+    @patch("sentry.analytics.record")
+    def test_persists_verdict_and_emits_enriched_row(self, mock_record: Any) -> None:
+        self._track()
+        result = self._call(verdict="merged_with_iteration")
+
+        assert result == {"success": True}
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "merged_with_iteration"
+        )
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+        assert _last_row(mock_record).verdict == "merged_with_iteration"
+
+    @patch("sentry.analytics.record")
+    def test_records_seer_attributions(self, mock_record: Any) -> None:
+        result = self._call(
+            verdict="merged_unchanged",
+            attributions=[
+                {
+                    "signal_type": "seer_delegated:claude_code",
+                    "source": "seer_llm_judge",
+                    "signal_details": {"confidence": 0.9},
+                }
+            ],
+        )
+
+        assert result == {"success": True}
+        signal = PullRequestAttribution.objects.get(
+            pull_request=self.pull_request, source=PullRequestAttributionSource.SEER_LLM_JUDGE
+        )
+        assert signal.signal_type == "seer_delegated:claude_code"
+        assert signal.signal_details == {"confidence": 0.9}
+        # The recorded signal makes the PR tracked, so the row emits.
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+
+    @patch("sentry.analytics.record")
+    def test_scopes_lookup_to_org_and_repo(self, mock_record: Any) -> None:
+        self._track()
+        other_org = self.create_organization()
+
+        result = upsert_pr_metrics_summary(
+            pull_request_id=self.pull_request.id,
+            organization_id=other_org.id,
+            repository_id=self.repo.id,
+            verdict="merged_unchanged",
+        )
+
+        assert result == {"success": False, "error": "pull_request_not_found"}
+        assert not PullRequestMetrics.objects.filter(pull_request=self.pull_request).exists()
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
+    def test_rejects_invalid_verdict(self, mock_record: Any) -> None:
+        self._track()
+        result = self._call(verdict="not_a_verdict")
+
+        assert result == {"success": False, "error": "invalid_verdict"}
+        assert not PullRequestMetrics.objects.filter(pull_request=self.pull_request).exists()
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
+    def test_rejects_invalid_attribution(self, mock_record: Any) -> None:
+        self._track()
+        result = self._call(
+            verdict="merged_unchanged",
+            attributions=[{"signal_type": "bogus", "source": "seer_llm_judge"}],
+        )
+
+        assert result == {"success": False, "error": "invalid_attribution"}
+        # Rejected before any write — verdict not persisted.
+        assert not PullRequestMetrics.objects.filter(pull_request=self.pull_request).exists()
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
+    def test_does_not_clobber_webhook_counters(self, mock_record: Any) -> None:
+        self._track()
+        PullRequestMetrics.objects.create(
+            pull_request=self.pull_request, additions=10, deletions=5, is_assigned=True
+        )
+
+        result = self._call(verdict="merged_unchanged", participants_count=3, reviews_count=2)
+
+        assert result == {"success": True}
+        metrics = PullRequestMetrics.objects.get(pull_request=self.pull_request)
+        assert metrics.verdict == "merged_unchanged"
+        assert metrics.participants_count == 3
+        assert metrics.reviews_count == 2
+        # Webhook-sourced counters survive the judge upsert.
+        assert metrics.additions == 10
+        assert metrics.deletions == 5
+        assert metrics.is_assigned is True
+
+    @patch("sentry.analytics.record")
+    def test_pull_request_not_found(self, mock_record: Any) -> None:
+        result = upsert_pr_metrics_summary(
+            pull_request_id=self.pull_request.id + 1000,
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            verdict="merged_unchanged",
+        )
+
+        assert result == {"success": False, "error": "pull_request_not_found"}
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
+    def test_persists_but_skips_emit_for_untracked_pr(self, mock_record: Any) -> None:
+        # No attribution anywhere: the verdict is still stored, but the row is not
+        # emitted (untracked PRs are never emitted).
+        result = self._call(verdict="closed_unmerged")
+
+        assert result == {"success": True}
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "closed_unmerged"
+        )
+        assert mock_record.call_count == 0


### PR DESCRIPTION
> **Stacked on #117242** (`ref(pr-metrics): Derive close_action from the PR row in emit`). Review/merge that one first; this branch targets it as its base.

## What

The Sentry side of CORE-217's **response handling + emit** — the inbound `update_pr_metrics` seer-rpc handler Seer calls back into once it has judged a forwarded terminal PR event.

The handler:
- Locates the PR by its Sentry id, **constrained to the reported `organization_id`/`repository_id`** so a mismatched id can't cross tenants (the id round-trips through Seer, so it's a trust boundary).
- Persists `verdict` onto `PullRequestMetrics` via `update_or_create`, **leaving the webhook-sourced activity counters intact** (partial defaults only).
- Records any Seer-derived `PullRequestAttribution` signals through the existing idempotent `record_attribution_signal`.
- Re-emits the now judge-enriched `pr_metrics.row` via the payload-free `emit_pr_metrics_row(pull_request=pr)` seam (the thing PR #117242 unblocked).
- Validates `verdict` and attribution signals at the boundary; rejects the whole call on malformed input rather than silently dropping.

Also surfaces the verdict on the row: `PrCloseMetricsEvent` gains a nullable `verdict` (additive — null on the no-judge path), and `build_pr_metrics_row` reads it off the `PullRequestMetrics` row it already loads.

## Contract (shared with CW-1436, Seer side)

Seer calls `update_pr_metrics(pull_request_id, organization_id, repository_id, verdict=None, attributions=None)`. PR identity is the echoed Sentry `pull_request_id` (org/repo verified). The confirmed judge outputs are the `verdict` and any new attribution signals — that's all the handler accepts. `PullRequestMetrics.participants_count`/`reviews_count` are intentionally **not** threaded through: no confirmed Seer producer and no consumer yet, so they'd bake an unverified detail into the RPC signature. The columns stay; wire them when CW-1436 defines them and something reads them.

## Out of scope

The **forward** half (Sentry → Seer, gated on `needs_judge`) and the `needs_judge` criteria land separately — they depend on the Seer endpoint contract and CORE-227's `event_id`. `needs_judge` still returns `False`, so nothing forwards yet and this callback is currently exercised only by tests.

## Test plan

`tests/sentry/pr_metrics/test_judge.py` — persist+emit, Seer attribution recording, **IDOR org/repo scoping**, invalid verdict/attribution rejection, webhook-counter preservation, PR-not-found, and untracked-PR (persist but skip emit). mypy clean; full pr_metrics suite green.

Refs CORE-217
