### PR TITLE
fix(seer-settings): scope Seer settings bulk PUT to all accessible projects

### DIFF
--- a/src/sentry/seer/endpoints/project_seer_settings.py
+++ b/src/sentry/seer/endpoints/project_seer_settings.py
@@ -484,7 +484,7 @@ class OrganizationSeerProjectSettingsEndpoint(OrganizationEndpoint):
         data = serializer.validated_data
         search_query = data.pop("query")
 
-        accessible_projects = self.get_projects(request, organization)
+        accessible_projects = self.get_projects(request, organization, include_all_accessible=True)
         queryset = _annotate_queryset(
             Project.objects.filter(id__in={p.id for p in accessible_projects})
         )


### PR DESCRIPTION
The bulk Seer settings PUT resolved projects by team membership while the GET used `include_all_accessible=True`, so org writers could see and select projects the update would silently skip. This passes `include_all_accessible=True` on the PUT so read and write resolve the same set, gated by the existing `org:write`/`org:admin` permission.