### PR TITLE
feat(issues): Add issue.progress search filter

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -952,7 +952,7 @@ SKIP_SNUBA_FIELDS = frozenset(
         "issue.type",
         "issue.seer_actionability",
         "issue.seer_last_run",
-        "issue.agent",
+        "issue.progress",
     )
 )
 

--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from enum import StrEnum
 from functools import partial
 from typing import overload
 
@@ -263,15 +264,21 @@ def convert_seer_actionability_value(
     return results
 
 
-ISSUE_PROGRESS_VALUES = {"identified", "triaged", "diagnosed", "fix_proposed", "fix_applied"}
+class IssueProgressState(StrEnum):
+    IDENTIFIED = "identified"
+    TRIAGED = "triaged"
+    DIAGNOSED = "diagnosed"
+    FIX_PROPOSED = "fix_proposed"
+    FIX_APPLIED = "fix_applied"
 
-ISSUE_PROGRESS_TO_ACTIVITY_TYPES: dict[str, list[int]] = {
-    "diagnosed": [ActivityType.SEER_RCA_COMPLETED.value],
-    "fix_proposed": [
+
+ISSUE_PROGRESS_TO_ACTIVITY_TYPES: dict[IssueProgressState, list[int]] = {
+    IssueProgressState.DIAGNOSED: [ActivityType.SEER_RCA_COMPLETED.value],
+    IssueProgressState.FIX_PROPOSED: [
         ActivityType.SEER_PR_CREATED.value,
         ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value,
     ],
-    "fix_applied": [
+    IssueProgressState.FIX_APPLIED: [
         ActivityType.REFERENCED_IN_COMMIT.value,
         ActivityType.SET_RESOLVED_IN_COMMIT.value,
         ActivityType.SET_RESOLVED_IN_RELEASE.value,
@@ -289,7 +296,9 @@ def convert_issue_progress_value(
 ) -> list[str]:
     results: list[str] = []
     for status in value:
-        if status not in ISSUE_PROGRESS_VALUES:
+        try:
+            IssueProgressState(status)
+        except ValueError:
             raise InvalidSearchQuery(f"Invalid issue.progress value of '{status}'")
         results.append(status)
     return results

--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -263,26 +263,35 @@ def convert_seer_actionability_value(
     return results
 
 
-ISSUE_AGENT_TO_ACTIVITY_TYPES: dict[str, list[int]] = {
-    "has_root_cause": [ActivityType.SEER_RCA_COMPLETED.value],
-    "has_plan": [ActivityType.SEER_SOLUTION_COMPLETED.value],
-    "has_code_changes": [ActivityType.SEER_CODING_COMPLETED.value],
-    "pr_created": [ActivityType.SEER_PR_CREATED.value],
+ISSUE_PROGRESS_VALUES = {"identified", "triaged", "diagnosed", "fix_proposed", "fix_applied"}
+
+ISSUE_PROGRESS_TO_ACTIVITY_TYPES: dict[str, list[int]] = {
+    "diagnosed": [ActivityType.SEER_RCA_COMPLETED.value],
+    "fix_proposed": [
+        ActivityType.SEER_PR_CREATED.value,
+        ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value,
+    ],
+    "fix_applied": [
+        ActivityType.REFERENCED_IN_COMMIT.value,
+        ActivityType.SET_RESOLVED_IN_COMMIT.value,
+        ActivityType.SET_RESOLVED_IN_RELEASE.value,
+        ActivityType.SET_RESOLVED_BY_AGE.value,
+        ActivityType.SET_RESOLVED.value,
+    ],
 }
 
 
-def convert_issue_agent_value(
+def convert_issue_progress_value(
     value: Iterable[str],
     projects: Sequence[Project],
     user: User,
     environments: Sequence[Environment] | None,
-) -> list[int]:
-    results: list[int] = []
+) -> list[str]:
+    results: list[str] = []
     for status in value:
-        activity_types = ISSUE_AGENT_TO_ACTIVITY_TYPES.get(status)
-        if not activity_types:
-            raise InvalidSearchQuery(f"Invalid issue.agent value of '{status}'")
-        results.extend(activity_types)
+        if status not in ISSUE_PROGRESS_VALUES:
+            raise InvalidSearchQuery(f"Invalid issue.progress value of '{status}'")
+        results.append(status)
     return results
 
 
@@ -311,7 +320,7 @@ value_converters: Mapping[str, ValueConverter] = {
     "device.class": convert_device_class_value,
     "substatus": convert_substatus_value,
     "issue.seer_actionability": convert_seer_actionability_value,
-    "issue.agent": convert_issue_agent_value,
+    "issue.progress": convert_issue_progress_value,
     "detector": convert_detector_value,  # TODO - delete this once the UI has been updated
     "monitor": convert_detector_value,
 }

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -253,7 +253,7 @@ def issue_activity_type_filter(activity_types: list[int], projects: Sequence[Pro
     group_ids = (
         Activity.objects.filter(
             project__in=projects,
-            type__in=activity_types + [ActivityType.SET_REGRESSION.value],
+            type__in=set(activity_types) | {ActivityType.SET_REGRESSION.value},
         )
         .values("group_id")
         .annotate(

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -287,7 +287,7 @@ def issue_progress_filter(progress_values: list[str], projects: Sequence[Project
     survives regressions — an issue that was assigned, progressed, then regressed
     remains triaged as long as it's still assigned.
     """
-    from sentry.issues.issue_search import ISSUE_PROGRESS_TO_ACTIVITY_TYPES
+    from sentry.issues.issue_search import ISSUE_PROGRESS_TO_ACTIVITY_TYPES, IssueProgressState
 
     all_progress_activity_types = [
         t for types in ISSUE_PROGRESS_TO_ACTIVITY_TYPES.values() for t in types
@@ -301,12 +301,13 @@ def issue_progress_filter(progress_values: list[str], projects: Sequence[Project
 
     q = Q()
     for value in progress_values:
-        if value == "identified":
+        progress = IssueProgressState(value)
+        if progress is IssueProgressState.IDENTIFIED:
             q |= ~assigned_q & ~has_progress_q
-        elif value == "triaged":
+        elif progress is IssueProgressState.TRIAGED:
             q |= assigned_q & ~has_progress_q
         else:
-            activity_types = ISSUE_PROGRESS_TO_ACTIVITY_TYPES[value]
+            activity_types = ISSUE_PROGRESS_TO_ACTIVITY_TYPES[progress]
             q |= issue_activity_type_filter(activity_types, projects)
     return q
 

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -8,7 +8,7 @@ from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime, timedelta
 from typing import Any
 
-from django.db.models import Q
+from django.db.models import F, Max, Q
 from django.utils import timezone
 from django.utils.functional import SimpleLazyObject
 
@@ -37,6 +37,7 @@ from sentry.search.snuba.executors import (
 )
 from sentry.seer.autofix.constants import FixabilityScoreThresholds
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
+from sentry.types.activity import ActivityType
 from sentry.users.models.user import User
 from sentry.utils import metrics
 from sentry.utils.cursors import Cursor, CursorResult
@@ -248,13 +249,66 @@ def regressed_in_release_filter(versions: Sequence[str], projects: Sequence[Proj
     )
 
 
-def issue_agent_filter(activity_types: list[int], projects: Sequence[Project]) -> Q:
-    return Q(
-        id__in=Activity.objects.filter(
+def issue_activity_type_filter(activity_types: list[int], projects: Sequence[Project]) -> Q:
+    group_ids = (
+        Activity.objects.filter(
             project__in=projects,
-            type__in=activity_types,
-        ).values_list("group_id", flat=True)
+            type__in=activity_types + [ActivityType.SET_REGRESSION.value],
+        )
+        .values("group_id")
+        .annotate(
+            _latest_match=Max("datetime", filter=Q(type__in=activity_types)),
+            _latest_regression=Max("datetime", filter=Q(type=ActivityType.SET_REGRESSION.value)),
+        )
+        .filter(_latest_match__isnull=False)
+        .filter(Q(_latest_regression__isnull=True) | Q(_latest_match__gte=F("_latest_regression")))
+        .values_list("group_id", flat=True)
     )
+
+    return Q(id__in=group_ids)
+
+
+def issue_progress_filter(progress_values: list[str], projects: Sequence[Project]) -> Q:
+    """
+    Filters issues by their position in the resolution lifecycle:
+
+      identified -> triaged -> diagnosed -> fix_proposed -> fix_applied
+
+    "diagnosed" and above are determined by seer/resolution activity types (see
+    ISSUE_PROGRESS_TO_ACTIVITY_TYPES). A regression (SET_REGRESSION) resets an issue
+    back, so only activities *after* the latest regression count.
+
+    "identified" and "triaged" are the two base states before any seer activity,
+    distinguished solely by whether the issue is currently assigned:
+      - identified: not assigned AND no post-regression seer activity
+      - triaged:    assigned (via GroupAssignee) AND no post-regression seer activity
+
+    Assignment is checked via GroupAssignee rather than ASSIGNED activity so that it
+    survives regressions — an issue that was assigned, progressed, then regressed
+    remains triaged as long as it's still assigned.
+    """
+    from sentry.issues.issue_search import ISSUE_PROGRESS_TO_ACTIVITY_TYPES
+
+    all_progress_activity_types = [
+        t for types in ISSUE_PROGRESS_TO_ACTIVITY_TYPES.values() for t in types
+    ]
+    has_progress_q = issue_activity_type_filter(all_progress_activity_types, projects)
+    assigned_q = Q(
+        id__in=GroupAssignee.objects.filter(project_id__in=[p.id for p in projects]).values_list(
+            "group_id", flat=True
+        )
+    )
+
+    q = Q()
+    for value in progress_values:
+        if value == "identified":
+            q |= ~assigned_q & ~has_progress_q
+        elif value == "triaged":
+            q |= assigned_q & ~has_progress_q
+        else:
+            activity_types = ISSUE_PROGRESS_TO_ACTIVITY_TYPES[value]
+            q |= issue_activity_type_filter(activity_types, projects)
+    return q
 
 
 def seer_actionability_filter(trigger_values: list[float]) -> Q:
@@ -605,8 +659,8 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             "issue.type": QCallbackCondition(lambda types: Q(type__in=types)),
             "issue.priority": QCallbackCondition(lambda priorities: Q(priority__in=priorities)),
             "issue.seer_actionability": QCallbackCondition(seer_actionability_filter),
-            "issue.agent": QCallbackCondition(
-                functools.partial(issue_agent_filter, projects=projects)
+            "issue.progress": QCallbackCondition(
+                functools.partial(issue_progress_filter, projects=projects)
             ),
             "issue.seer_last_run": ScalarCondition("seer_explorer_autofix_last_triggered"),
             "issue.id": QCallbackCondition(

--- a/tests/sentry/issues/test_issue_search.py
+++ b/tests/sentry/issues/test_issue_search.py
@@ -13,7 +13,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.grouptype import registry as GROUP_TYPE_REGISTRY
 from sentry.issues.issue_search import (
-    ISSUE_AGENT_TO_ACTIVITY_TYPES,
+    ISSUE_PROGRESS_VALUES,
     convert_actor_or_none_value,
     convert_category_value,
     convert_device_class_value,
@@ -348,21 +348,21 @@ class ConvertSeerActionabilityValueTest(TestCase):
             convert_query_values(filters, [self.project], self.user, None)
 
 
-class ConvertIssueAgentValueTest(TestCase):
+class ConvertIssueProgressValueTest(TestCase):
     def test_valid(self) -> None:
-        for status, activity_types in ISSUE_AGENT_TO_ACTIVITY_TYPES.items():
+        for status in ISSUE_PROGRESS_VALUES:
             filters = [
                 SearchFilter(
-                    SearchKey("issue.agent"),
+                    SearchKey("issue.progress"),
                     "=",
                     SearchValue([status]),
                 )
             ]
             result = convert_query_values(filters, [self.project], self.user, None)
-            assert result[0].value.raw_value == activity_types
+            assert result[0].value.raw_value == [status]
 
     def test_invalid(self) -> None:
-        filters = [SearchFilter(SearchKey("issue.agent"), "=", SearchValue("wrong"))]
+        filters = [SearchFilter(SearchKey("issue.progress"), "=", SearchValue("wrong"))]
         with pytest.raises(InvalidSearchQuery):
             convert_query_values(filters, [self.project], self.user, None)
 

--- a/tests/sentry/issues/test_issue_search.py
+++ b/tests/sentry/issues/test_issue_search.py
@@ -13,7 +13,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.grouptype import registry as GROUP_TYPE_REGISTRY
 from sentry.issues.issue_search import (
-    ISSUE_PROGRESS_VALUES,
+    IssueProgressState,
     convert_actor_or_none_value,
     convert_category_value,
     convert_device_class_value,
@@ -350,7 +350,7 @@ class ConvertSeerActionabilityValueTest(TestCase):
 
 class ConvertIssueProgressValueTest(TestCase):
     def test_valid(self) -> None:
-        for status in ISSUE_PROGRESS_VALUES:
+        for status in IssueProgressState:
             filters = [
                 SearchFilter(
                     SearchKey("issue.progress"),

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1074,31 +1074,74 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         assert set(results) == {linked_group2}
 
-    def test_issue_agent(self) -> None:
+    def test_issue_progress(self) -> None:
         self.create_group_activity(group=self.group1, type=ActivityType.SEER_RCA_COMPLETED.value)
         self.create_group_activity(group=self.group2, type=ActivityType.SEER_PR_CREATED.value)
 
-        results = self.make_query(search_filter_query="issue.agent:has_root_cause")
+        results = self.make_query(search_filter_query="issue.progress:diagnosed")
         assert set(results) == {self.group1}
 
-        results = self.make_query(search_filter_query="issue.agent:pr_created")
+        results = self.make_query(search_filter_query="issue.progress:fix_proposed")
         assert set(results) == {self.group2}
 
-        results = self.make_query(search_filter_query="issue.agent:has_plan")
+        results = self.make_query(search_filter_query="issue.progress:fix_applied")
         assert set(results) == set()
 
-    def test_issue_agent_multiple_values(self) -> None:
+    def test_issue_progress_multiple_values(self) -> None:
         self.create_group_activity(group=self.group1, type=ActivityType.SEER_RCA_COMPLETED.value)
         self.create_group_activity(group=self.group2, type=ActivityType.SEER_PR_CREATED.value)
 
-        results = self.make_query(search_filter_query="issue.agent:[has_root_cause, pr_created]")
+        results = self.make_query(search_filter_query="issue.progress:[diagnosed, fix_proposed]")
         assert set(results) == {self.group1, self.group2}
 
-    def test_issue_agent_negation(self) -> None:
+    def test_issue_progress_identified(self) -> None:
+        results = self.make_query(search_filter_query="issue.progress:identified")
+        assert self.group1 in set(results)
+        assert self.group2 not in set(results)
+
+    def test_issue_progress_triaged(self) -> None:
+        results = self.make_query(search_filter_query="issue.progress:triaged")
+        assert self.group2 in set(results)
+        assert self.group1 not in set(results)
+
+    def test_issue_progress_assigned_with_activity(self) -> None:
+        self.create_group_activity(group=self.group2, type=ActivityType.SEER_RCA_COMPLETED.value)
+
+        results = self.make_query(search_filter_query="issue.progress:diagnosed")
+        assert self.group2 in set(results)
+
+        results = self.make_query(search_filter_query="issue.progress:triaged")
+        assert self.group2 not in set(results)
+
+    def test_issue_progress_negation(self) -> None:
         self.create_group_activity(group=self.group1, type=ActivityType.SEER_RCA_COMPLETED.value)
 
-        results = self.make_query(search_filter_query="!issue.agent:has_root_cause")
-        assert set(results) == {self.group2}
+        results = self.make_query(search_filter_query="!issue.progress:diagnosed")
+        assert self.group2 in set(results)
+        assert self.group1 not in set(results)
+
+    def test_issue_progress_regression_resets(self) -> None:
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
+        self.create_group_activity(group=self.group1, type=ActivityType.SET_REGRESSION.value)
+
+        results = self.make_query(search_filter_query="issue.progress:identified")
+        assert self.group1 in set(results)
+
+        results = self.make_query(search_filter_query="issue.progress:fix_proposed")
+        assert self.group1 not in set(results)
+
+    def test_issue_progress_regression_preserves_triaged(self) -> None:
+        GroupAssignee.objects.create(
+            user_id=self.user.id, group=self.group1, project=self.group1.project
+        )
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
+        self.create_group_activity(group=self.group1, type=ActivityType.SET_REGRESSION.value)
+
+        results = self.make_query(search_filter_query="issue.progress:triaged")
+        assert self.group1 in set(results)
+
+        results = self.make_query(search_filter_query="issue.progress:fix_proposed")
+        assert self.group1 not in set(results)
 
     def test_unassigned(self) -> None:
         results = self.make_query(search_filter_query="is:unassigned")


### PR DESCRIPTION
Ref ISWF-2761

_Note: This is an experimental filter which will be used to unblock the new issue stream UI pieces. Once the issue action log is complete, we will use derived properties from there to power this._

See the [product spec](https://app.notion.com/p/sentry/Product-spec-Surfacing-Seer-Status-and-Actions-in-the-Issue-Stream-3798b10e4b5d81aba774e7860e4fad10?source=copy_link#dbc45d71f6ed4192a35b021d58e00cac) for an overview of issue progress.

This replaces the recently-added `issue.agent` filter with an `issue.progress` filter that is more generically useful for users who do and do not use Seer.

The valid progress values are:  `identified -> triaged -> diagnosed -> fix_proposed -> fix_applied`.

Here is an example of how an issue might progress:

  | Issue activity | Issue progress |
| :--- | :--- |
| **FIRST_SEEN** | Identified |
| **SEER_RCA_STARTED** | Identified |
| **SEER_RCA_COMPLETED** | Diagnosed |
| **SEER_SOLUTION_STARTED** | Diagnosed |
| **SEER_SOLUTION_COMPLETED** | Diagnosed |
| **SEER_CODING_STARTED** | Diagnosed |
| **SEER_CODING_COMPLETED** | Diagnosed |
| **SEER_PR_CREATED** | Fix Proposed |
| **PR_MERGED** | Fix Applied |
| **RESOLVED** | Fix Applied |
| **REGRESSED** | Identified |

Note that a regression will reset to the beginning of the cycle.

Usage:

```
issue.progress:diagnosed
issue.progress:[fix_proposed, fix_applied]
!issue.progress:identified
```

