### PR TITLE
ref: Type 12 PUBLIC endpoints via local error TypedDicts and serializer typing

### DIFF
--- a/src/sentry/api/endpoints/project_symbol_sources.py
+++ b/src/sentry/api/endpoints/project_symbol_sources.py
@@ -1,3 +1,4 @@
+from typing import Any, TypeAlias, TypedDict
 from uuid import uuid4
 
 import orjson
@@ -230,6 +231,21 @@ class SourceSerializer(serializers.Serializer):
         return data
 
 
+_SymbolSource: TypeAlias = dict[str, Any]
+"""A custom symbol source entry. Shape varies by `type` (gcs, http, s3, …);
+the parsed/redacted representation is a loose dict whose key set depends on
+the source kind. Kept as `dict[str, Any]` rather than a closed TypedDict to
+preserve current wire flexibility."""
+
+
+class _SymbolSourceErrorResponse(TypedDict):
+    """`{"error": "..."}` envelope used by symbol-source endpoints in place of
+    the DRF-standard `{"detail": ...}`. Retained for backward compatibility
+    with existing API consumers."""
+
+    error: str
+
+
 @extend_schema(tags=["Projects"])
 @cell_silo_endpoint
 class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
@@ -258,14 +274,16 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         },
         examples=ProjectExamples.GET_SYMBOL_SOURCES,
     )
-    def get(self, request: Request, project: Project) -> Response:
+    def get(
+        self, request: Request, project: Project
+    ) -> Response[list[_SymbolSource]] | Response[_SymbolSourceErrorResponse]:
         """
         List custom symbol sources configured for a project.
         """
         id = request.GET.get("id")
         custom_symbol_sources_json = project.get_option("sentry:symbol_sources") or []
         sources = parse_sources(custom_symbol_sources_json, filter_appconnect=False)
-        redacted = redact_source_secrets(sources)
+        redacted: list[_SymbolSource] = redact_source_secrets(sources)
 
         if id:
             for source in redacted:
@@ -289,7 +307,9 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         },
         examples=ProjectExamples.DELETE_SYMBOL_SOURCE,
     )
-    def delete(self, request: Request, project: Project) -> Response:
+    def delete(
+        self, request: Request, project: Project
+    ) -> Response[None] | Response[_SymbolSourceErrorResponse]:
         """
         Delete a custom symbol source from a project.
         """
@@ -320,7 +340,7 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         },
         examples=ProjectExamples.ADD_SYMBOL_SOURCE,
     )
-    def post(self, request: Request, project: Project) -> Response:
+    def post(self, request: Request, project: Project) -> Response[_SymbolSource] | Response[None]:
         """
         Add a custom symbol source to a project.
         """
@@ -345,8 +365,8 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         serialized = orjson.dumps(sources).decode()
         project.update_option("sentry:symbol_sources", serialized)
 
-        redacted = redact_source_secrets([source])
-        return Response(data=redacted[0], status=201)
+        redacted_single: list[_SymbolSource] = redact_source_secrets([source])
+        return Response(data=redacted_single[0], status=201)
 
     @extend_schema(
         operation_id="Update a Project's Symbol Source",
@@ -364,7 +384,9 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         },
         examples=ProjectExamples.UPDATE_SYMBOL_SOURCE,
     )
-    def put(self, request: Request, project: Project) -> Response:
+    def put(
+        self, request: Request, project: Project
+    ) -> Response[_SymbolSource] | Response[None] | Response[_SymbolSourceErrorResponse]:
         """
         Update a custom symbol source in a project.
         """
@@ -406,5 +428,5 @@ class ProjectSymbolSourcesEndpoint(ProjectEndpoint):
         serialized = orjson.dumps(sources).decode()
         project.update_option("sentry:symbol_sources", serialized)
 
-        redacted = redact_source_secrets([source])
-        return Response(data=redacted[0], status=200)
+        redacted_put: list[_SymbolSource] = redact_source_secrets([source])
+        return Response(data=redacted_put[0], status=200)

--- a/src/sentry/api/serializers/models/deploy.py
+++ b/src/sentry/api/serializers/models/deploy.py
@@ -1,11 +1,30 @@
+from collections.abc import Mapping, MutableMapping, Sequence
+from datetime import datetime
+from typing import Any, TypedDict
+
+from django.contrib.auth.models import AnonymousUser
+
 from sentry.api.serializers import Serializer, register
 from sentry.models.deploy import Deploy
 from sentry.models.environment import Environment
+from sentry.users.models.user import User
+from sentry.users.services.user.model import RpcUser
+
+
+class DeploySerializerResponse(TypedDict):
+    id: str
+    environment: str | None
+    dateStarted: datetime | None
+    dateFinished: datetime
+    name: str | None
+    url: str | None
 
 
 @register(Deploy)
 class DeploySerializer(Serializer):
-    def get_attrs(self, item_list, user, **kwargs):
+    def get_attrs(
+        self, item_list: Sequence[Deploy], user: User | RpcUser | AnonymousUser, **kwargs: Any
+    ) -> MutableMapping[Any, Any]:
         environments = {
             id: name
             for id, name in Environment.objects.filter(
@@ -19,7 +38,13 @@ class DeploySerializer(Serializer):
 
         return result
 
-    def serialize(self, obj, attrs, user, **kwargs):
+    def serialize(
+        self,
+        obj: Deploy,
+        attrs: Mapping[str, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> DeploySerializerResponse:
         return {
             "id": str(obj.id),
             "environment": attrs.get("environment"),

--- a/src/sentry/apidocs/examples/notification_examples.py
+++ b/src/sentry/apidocs/examples/notification_examples.py
@@ -1,8 +1,10 @@
 from drf_spectacular.utils import OpenApiExample
 
 NOTIFICATION_ACTION_ONE = {
-    "id": "836501735",
-    "organizationId": "62848264",
+    "id": 836501735,
+    "organizationId": 62848264,
+    "integrationId": None,
+    "sentryAppId": None,
     "serviceType": "sentry_notification",
     "targetDisplay": "default",
     "targetIdentifier": "default",
@@ -12,8 +14,10 @@ NOTIFICATION_ACTION_ONE = {
 }
 
 NOTIFICATION_ACTION_TWO = {
-    "id": "73847650",
-    "organizationId": "62848264",
+    "id": 73847650,
+    "organizationId": 62848264,
+    "integrationId": None,
+    "sentryAppId": None,
     "serviceType": "sentry_notification",
     "targetDisplay": "default",
     "targetIdentifier": "default",

--- a/src/sentry/core/endpoints/organization_projects.py
+++ b/src/sentry/core/endpoints/organization_projects.py
@@ -74,6 +74,14 @@ class _LegacyParamErrorResponse(TypedDict):
     error: dict[str, dict[str, dict[str, str]]]
 
 
+class _OrganizationProjectCreateResponse(OrganizationProjectResponse):
+    """Project-creation response: the base `OrganizationProjectResponse` shape
+    plus a `team_slug` key that the endpoint appends post-serialize to surface
+    the auto-created personal team."""
+
+    team_slug: str
+
+
 DATASETS = {
     "": discover,  # in case they pass an empty query string fall back on default
     "discover": discover,
@@ -302,7 +310,9 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint):
             "(`disable_member_project_creation`), `org:write` scope is required."
         ),
     )
-    def post(self, request: Request, organization: Organization) -> Response:
+    def post(
+        self, request: Request, organization: Organization
+    ) -> Response[_OrganizationProjectCreateResponse]:
         """
         Create a new project for an organization.
 
@@ -438,11 +448,13 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint):
             "created team through project creation flow",
             extra={"team_slug": default_team_slug, "project_slug": project_name},
         )
-        serialized_response = serialize(
+        base: OrganizationProjectResponse = serialize(
             project, request.user, ProjectSummarySerializer(collapse=["unusedFeatures"])
         )
-        serialized_response["team_slug"] = team.slug
-
+        serialized_response: _OrganizationProjectCreateResponse = {
+            **base,
+            "team_slug": team.slug,
+        }
         return Response(serialized_response, status=201)
 
 

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -29,6 +29,7 @@ from sentry.api.paginator import ChainPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.dashboard import (
     DashboardDetailsModelSerializer,
+    DashboardDetailsResponse,
     DashboardListResponse,
     DashboardListSerializer,
 )
@@ -41,6 +42,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.dashboard_examples import DashboardExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, VisibilityParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.db.models.fields.text import CharField
@@ -552,7 +554,14 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         },
         examples=DashboardExamples.DASHBOARD_POST_RESPONSE,
     )
-    def post(self, request: Request, organization: Organization, retry: int = 0) -> Response:
+    def post(
+        self, request: Request, organization: Organization, retry: int = 0
+    ) -> (
+        Response[DashboardDetailsResponse]
+        | Response[None]
+        | Response[ValidationErrorResponse]
+        | Response[str]
+    ):
         """
         Create a new dashboard for the given Organization
         """
@@ -573,7 +582,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         )
 
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer), status=400)
 
         if request.GET.get("validateOnly"):
             return Response(status=200)
@@ -603,7 +612,8 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
 
                 dashboard = serializer.save()
 
-            return Response(serialize(dashboard, request.user), status=201)
+            body: DashboardDetailsResponse = serialize(dashboard, request.user)
+            return Response(body, status=201)
         except IntegrityError:
             if retry >= MAX_RETRIES:
                 return Response("Dashboard title already taken", status=409)

--- a/src/sentry/notifications/api/endpoints/notification_actions_details.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_details.py
@@ -17,6 +17,7 @@ from sentry.api.utils import to_valid_int_id
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_NO_CONTENT
 from sentry.apidocs.examples.notification_examples import NotificationActionExamples
 from sentry.apidocs.parameters import GlobalParams, NotificationParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.models.organization import Organization
 from sentry.notifications.api.endpoints.notification_actions_index import (
     NotificationActionsPermission,
@@ -25,6 +26,7 @@ from sentry.notifications.api.serializers.notification_action_request import (
     NotificationActionSerializer,
 )
 from sentry.notifications.api.serializers.notification_action_response import (
+    OutgoingNotificationActionResponse,
     OutgoingNotificationActionSerializer,
 )
 from sentry.notifications.models.notificationaction import NotificationAction
@@ -105,7 +107,7 @@ class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
     )
     def get(
         self, request: Request, organization: Organization, action: NotificationAction
-    ) -> Response:
+    ) -> Response[OutgoingNotificationActionResponse]:
         """
         Returns a serialized Spike Protection Notification Action object.
 
@@ -116,7 +118,8 @@ class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
             "notification_action.get_one",
             extra={"organization_id": organization.id, "action_id": action.id},
         )
-        return Response(serialize(action, request.user))
+        body: OutgoingNotificationActionResponse = serialize(action, request.user)
+        return Response(body)
 
     @extend_schema(
         operation_id="Update a Spike Protection Notification Action",
@@ -133,7 +136,7 @@ class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
     )
     def put(
         self, request: Request, organization: Organization, action: NotificationAction
-    ) -> Response:
+    ) -> Response[OutgoingNotificationActionResponse] | Response[ValidationErrorResponse]:
         """
         Updates a Spike Protection Notification Action.
 
@@ -150,7 +153,7 @@ class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
             data=request.data,
         )
         if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            return Response(as_validation_errors(serializer), status=status.HTTP_400_BAD_REQUEST)
 
         action = serializer.save()
         logger.info(
@@ -164,7 +167,8 @@ class NotificationActionsDetailsEndpoint(OrganizationEndpoint):
             event=audit_log.get_event_id("NOTIFICATION_ACTION_EDIT"),
             data=action.get_audit_log_data(),
         )
-        return Response(serialize(action, user=request.user), status=status.HTTP_202_ACCEPTED)
+        put_body: OutgoingNotificationActionResponse = serialize(action, user=request.user)
+        return Response(put_body, status=status.HTTP_202_ACCEPTED)
 
     @extend_schema(
         operation_id="Delete a Spike Protection Notification Action",

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -17,11 +17,13 @@ from sentry.api.serializers.base import serialize
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
 from sentry.apidocs.examples.notification_examples import NotificationActionExamples
 from sentry.apidocs.parameters import GlobalParams, NotificationParams, OrganizationParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.models.organization import Organization
 from sentry.notifications.api.serializers.notification_action_request import (
     NotificationActionSerializer,
 )
 from sentry.notifications.api.serializers.notification_action_response import (
+    OutgoingNotificationActionResponse,
     OutgoingNotificationActionSerializer,
 )
 from sentry.notifications.models.notificationaction import NotificationAction
@@ -70,7 +72,9 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         },
         examples=NotificationActionExamples.CREATE_NOTIFICATION_ACTION,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[list[OutgoingNotificationActionResponse]]:
         """
         Returns all Spike Protection Notification Actions for an organization.
 
@@ -121,7 +125,9 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         },
         examples=NotificationActionExamples.CREATE_NOTIFICATION_ACTION,
     )
-    def post(self, request: Request, organization: Organization) -> Response:
+    def post(
+        self, request: Request, organization: Organization
+    ) -> Response[OutgoingNotificationActionResponse] | Response[ValidationErrorResponse]:
         """
         Creates a new Notification Action for Spike Protection.
 
@@ -154,7 +160,7 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
             data=request.data,
         )
         if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            return Response(as_validation_errors(serializer), status=status.HTTP_400_BAD_REQUEST)
         action = serializer.save()
         logger.info(
             "notification_action.create",
@@ -167,4 +173,5 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
             event=audit_log.get_event_id("NOTIFICATION_ACTION_ADD"),
             data=action.get_audit_log_data(),
         )
-        return Response(serialize(action, request.user), status=status.HTTP_201_CREATED)
+        body: OutgoingNotificationActionResponse = serialize(action, request.user)
+        return Response(body, status=status.HTTP_201_CREATED)

--- a/src/sentry/notifications/api/serializers/notification_action_response.py
+++ b/src/sentry/notifications/api/serializers/notification_action_response.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any
+from typing import TypedDict
 
 from django.contrib.auth.models import AnonymousUser
 
@@ -14,8 +14,21 @@ from sentry.notifications.models.notificationaction import (
 from sentry.utils.serializers import manytoone_to_dict
 
 
+class OutgoingNotificationActionResponse(TypedDict):
+    id: int
+    organizationId: int
+    integrationId: int | None
+    sentryAppId: int | None
+    projects: list[int]
+    serviceType: str | None
+    triggerType: str
+    targetType: str | None
+    targetIdentifier: str | None
+    targetDisplay: str | None
+
+
 @register(NotificationAction)
-class OutgoingNotificationActionSerializer(Serializer[dict[str, Any]]):
+class OutgoingNotificationActionSerializer(Serializer[OutgoingNotificationActionResponse]):
     """
     Model serializer for outgoing NotificationAction API payloads
     """
@@ -35,7 +48,9 @@ class OutgoingNotificationActionSerializer(Serializer[dict[str, Any]]):
             for item in item_list
         }
 
-    def serialize(self, obj: NotificationAction, attrs, user, **kwargs) -> dict[str, Any]:
+    def serialize(
+        self, obj: NotificationAction, attrs, user, **kwargs
+    ) -> OutgoingNotificationActionResponse:
         return {
             "id": obj.id,
             "organizationId": obj.organization_id,

--- a/src/sentry/releases/endpoints/release_deploys.py
+++ b/src/sentry/releases/endpoints/release_deploys.py
@@ -14,9 +14,12 @@ from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
 from sentry.api.exceptions import ParameterValidationError, ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.deploy import DeploySerializer as DeployModelSerializer
+from sentry.api.serializers.models.deploy import DeploySerializerResponse
 from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.models.deploy import Deploy
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
@@ -148,7 +151,9 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
         parameters=[GlobalParams.ORG_ID_OR_SLUG, ReleaseParams.VERSION, CursorQueryParam],
         responses={200: DeployResponseSerializer(many=True)},
     )
-    def get(self, request: Request, organization, version) -> Response:
+    def get(
+        self, request: Request, organization, version
+    ) -> Response[list[DeploySerializerResponse]]:
         """
         Returns a list of deploys based on the organization, version, and project.
         """
@@ -188,7 +193,9 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
         request=DeploySerializer,
         responses={201: DeployResponseSerializer, 400: RESPONSE_BAD_REQUEST},
     )
-    def post(self, request: Request, organization, version) -> Response:
+    def post(
+        self, request: Request, organization, version
+    ) -> Response[DeploySerializerResponse] | Response[ValidationErrorResponse]:
         """
         Create a deploy for a given release.
         """
@@ -230,7 +237,6 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
 
         if serializer.is_valid():
             deploy = create_deploy(organization, release, serializer)
+            return Response(serialize(deploy, request.user, DeployModelSerializer()), status=201)
 
-            return Response(serialize(deploy, request.user), status=201)
-
-        return Response(serializer.errors, status=400)
+        return Response(as_validation_errors(serializer), status=400)

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TypedDict
 
 import orjson
 import sentry_sdk
@@ -49,6 +50,13 @@ from sentry.utils.audit import create_audit_entry
 
 logger = logging.getLogger(__name__)
 PARTNERSHIP_RESTRICTED_ERROR_MESSAGE = "This integration is managed by an active partnership and cannot be modified until the end of the partnership."
+
+
+class _PublishedAppErrorResponse(TypedDict):
+    """`{"detail": ["Published apps cannot be removed."]}` — list-shaped detail
+    retained for backward compat with existing API consumers."""
+
+    detail: list[str]
 
 
 class SentryAppDetailsEndpointPermission(SentryAppAndStaffPermission):
@@ -224,7 +232,9 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
         ],
         responses={204: RESPONSE_NO_CONTENT, 403: RESPONSE_FORBIDDEN},
     )
-    def delete(self, request: Request, sentry_app) -> Response:
+    def delete(
+        self, request: Request, sentry_app
+    ) -> Response[None] | Response[DetailResponse] | Response[_PublishedAppErrorResponse]:
         """
         Delete a custom integration.
         """


### PR DESCRIPTION
Tightens 12 more PUBLIC endpoints across 9 files:

- `sentry_app_details` delete: new local `_PublishedAppErrorResponse` for `{"detail": list[str]}` shape
- `project_symbol_sources` get/post/put/delete: new local `_SymbolSourceErrorResponse` for `{"error": str}` envelope + `_SymbolSource` TypeAlias for variable source-dict shape
- `organization_projects` post: new local `_OrganizationProjectCreateResponse` extending `OrganizationProjectResponse` with `team_slug`
- `organization_dashboards` post: typed against existing `DashboardDetailsResponse` plus a `Response[str]` arm for raw-string error bodies retained for backward compat
- `release_deploys` get + post: typed Deploy serializer with new `DeploySerializerResponse` TypedDict
- `notification_actions_index` get + post and `notification_actions_details` get + put: typed `OutgoingNotificationActionSerializer` with new `OutgoingNotificationActionResponse` TypedDict

Validation paths route through `as_validation_errors()`. No body changes.

`scim/teams.patch` is excluded — its SCIM error envelope path passes `exception.detail` through directly, which mypy can't structurally match against an `SCIMErrorResponse` arm without restructuring the method.