### PR TITLE
fix(charts): restore chart drag-to-select

### DIFF
--- a/static/app/components/charts/barChartZoom.tsx
+++ b/static/app/components/charts/barChartZoom.tsx
@@ -2,6 +2,7 @@ import type {Location} from 'history';
 
 import {DataZoomInside} from 'sentry/components/charts/components/dataZoomInside';
 import {ToolBox} from 'sentry/components/charts/components/toolBox';
+import {activateZoomAreaSelect} from 'sentry/components/charts/utils';
 import type {
   EChartChartReadyHandler,
   EChartDataZoomHandler,
@@ -94,16 +95,7 @@ export function BarChartZoom({
    * Chart event when *any* rendering+animation finishes
    */
   const handleChartFinished = (_props: any, chart: any) => {
-    // This attempts to activate the area zoom toolbox feature
-    const zoom = chart._componentsViews?.find((c: any) => c._features?.dataZoom);
-    if (zoom && !zoom._features.dataZoom._isZoomActive) {
-      // Calling dispatchAction will re-trigger handleChartFinished
-      chart.dispatchAction({
-        type: 'takeGlobalCursor',
-        key: 'dataZoomSelect',
-        dataZoomSelectActive: true,
-      });
-    }
+    activateZoomAreaSelect(chart);
   };
 
   const handleDataZoom = (evt: any, chart: any) => {

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -11,6 +11,7 @@ import * as qs from 'query-string';
 
 import {DataZoomInside} from 'sentry/components/charts/components/dataZoomInside';
 import {ToolBox} from 'sentry/components/charts/components/toolBox';
+import {activateZoomAreaSelect} from 'sentry/components/charts/utils';
 import {updateDateTime} from 'sentry/components/pageFilters/actions';
 import type {DateString} from 'sentry/types/core';
 import type {
@@ -292,16 +293,7 @@ class ChartZoom extends Component<Props> {
    * Chart event when *any* rendering+animation finishes
    */
   handleChartFinished = (_props: any, chart: any) => {
-    // This attempts to activate the area zoom toolbox feature
-    const zoom = chart._componentsViews?.find((c: any) => c._features?.dataZoom);
-    if (zoom && !zoom._features.dataZoom._isZoomActive) {
-      // Calling dispatchAction will re-trigger handleChartFinished
-      chart.dispatchAction({
-        type: 'takeGlobalCursor',
-        key: 'dataZoomSelect',
-        dataZoomSelectActive: true,
-      });
-    }
+    activateZoomAreaSelect(chart);
 
     if (typeof this.props.onFinished === 'function') {
       this.props.onFinished(_props, chart);

--- a/static/app/components/charts/useChartZoom.tsx
+++ b/static/app/components/charts/useChartZoom.tsx
@@ -4,6 +4,7 @@ import * as qs from 'query-string';
 
 import {DataZoomInside} from 'sentry/components/charts/components/dataZoomInside';
 import {ToolBox} from 'sentry/components/charts/components/toolBox';
+import {activateZoomAreaSelect} from 'sentry/components/charts/utils';
 import {updateDateTime} from 'sentry/components/pageFilters/actions';
 import type {DateString} from 'sentry/types/core';
 import type {
@@ -222,16 +223,7 @@ export function useChartZoom({
    * before we update URL state and re-render
    */
   const handleChartFinished = useCallback<EChartFinishedHandler>((_props, chart) => {
-    // This attempts to activate the area zoom toolbox feature
-    const zoom = (chart as any)._componentsViews?.find((c: any) => c._features?.dataZoom);
-    if (zoom && !zoom._features.dataZoom._isZoomActive) {
-      // Calling dispatchAction will re-trigger handleChartFinished
-      chart.dispatchAction({
-        type: 'takeGlobalCursor',
-        key: 'dataZoomSelect',
-        dataZoomSelectActive: true,
-      });
-    }
+    activateZoomAreaSelect(chart);
   }, []);
 
   const dataZoomProp = useMemo<DataZoomComponentOption[]>(() => {

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -6,7 +6,7 @@ import moment from 'moment-timezone';
 
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import type {PageFilters} from 'sentry/types/core';
-import type {ReactEchartsRef, Series} from 'sentry/types/echarts';
+import type {ECharts, ReactEchartsRef, Series} from 'sentry/types/echarts';
 import type {
   EventsStats,
   GroupedMultiSeriesEventsStats,
@@ -459,4 +459,25 @@ export function isEmptySeries(series: Series) {
 export function isChartHovered(chartRef: ReactEchartsRef | null) {
   const hoveredEchartElement = document.querySelector('.echarts-for-react:hover');
   return hoveredEchartElement === chartRef?.ele;
+}
+
+/**
+ * Auto-activates the toolbox area-zoom cursor so users can drag-to-select a range
+ * without first clicking the (hidden) toolbox icon. Reaches into echarts internals:
+ * in echarts 6.1 `ToolboxView._features` became a HashMap, so the dataZoom feature
+ * must be read via `.get('dataZoom')` rather than as a plain property.
+ */
+export function activateZoomAreaSelect(chart: ECharts) {
+  const toolboxView = (chart as any)._componentsViews?.find((view: any) =>
+    view._features?.get?.('dataZoom')
+  );
+  const dataZoomFeature = toolboxView?._features.get('dataZoom');
+  if (dataZoomFeature && !dataZoomFeature._isZoomActive) {
+    // dispatchAction re-triggers `finished`; the _isZoomActive guard prevents a loop
+    chart.dispatchAction({
+      type: 'takeGlobalCursor',
+      key: 'dataZoomSelect',
+      dataZoomSelectActive: true,
+    });
+  }
 }

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -462,10 +462,10 @@ export function isChartHovered(chartRef: ReactEchartsRef | null) {
 }
 
 /**
+ * Chart event when *any* rendering+animation finishes.
+ *
  * Auto-activates the toolbox area-zoom cursor so users can drag-to-select a range
- * without first clicking the (hidden) toolbox icon. Reaches into echarts internals:
- * in echarts 6.1 `ToolboxView._features` became a HashMap, so the dataZoom feature
- * must be read via `.get('dataZoom')` rather than as a plain property.
+ * without first clicking the (hidden) toolbox icon.
  */
 export function activateZoomAreaSelect(chart: ECharts) {
   const toolboxView = (chart as any)._componentsViews?.find((view: any) =>
@@ -473,7 +473,7 @@ export function activateZoomAreaSelect(chart: ECharts) {
   );
   const dataZoomFeature = toolboxView?._features.get('dataZoom');
   if (dataZoomFeature && !dataZoomFeature._isZoomActive) {
-    // dispatchAction re-triggers `finished`; the _isZoomActive guard prevents a loop
+    // Calling dispatchAction will re-trigger handleChartFinished
     chart.dispatchAction({
       type: 'takeGlobalCursor',
       key: 'dataZoomSelect',


### PR DESCRIPTION
Gets the "drag to select time range" feature working again on charts (Errors, Logs, etc.).

The regression happened because echarts 6.1 changed `ToolboxView._features` from a plain object to a zrender `HashMap`. The shared\* drag-to-select activation logic read `_features.dataZoom` as a plain property, which now always returns `undefined`. We now need to instead do `_feature.get('dataZoom')`.

\*Shared, sort of - there were three places that copy & pasted the same code that got broken by echarts 6.1. I unified them into a shared `activateZoomAreaSelect` helper.

Closes LOGS-850.