### PR TITLE
feat(seer): Return and accept SeerRun UUID in explorer chat

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -479,8 +479,14 @@ class SeerAgentClient:
             run.save(update_fields=["mirror_status"])
             raise SeerApiError("Outbox flush failed for explorer SeerRun", 500)
         run.refresh_from_db()
-        if run.mirror_status == SeerRunMirrorStatus.FAILED:
-            raise SeerApiError("Seer run failed during outbox drain", 500)
+        if run.mirror_status != SeerRunMirrorStatus.LIVE:
+            if run.mirror_status == SeerRunMirrorStatus.FAILED:
+                detail = "Seer run failed during outbox drain"
+            elif run.seer_run_state_id is None:
+                detail = "Seer run did not mirror during outbox drain"
+            else:
+                detail = f"Seer run in unexpected state after outbox drain: {run.mirror_status}"
+            raise SeerApiError(detail, 500)
         return run
 
     def continue_run(

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -479,7 +479,7 @@ class SeerAgentClient:
             run.save(update_fields=["mirror_status"])
             raise SeerApiError("Outbox flush failed for explorer SeerRun", 500)
         run.refresh_from_db()
-        if run.mirror_status != SeerRunMirrorStatus.LIVE:
+        if run.mirror_status != SeerRunMirrorStatus.LIVE or run.seer_run_state_id is None:
             if run.mirror_status == SeerRunMirrorStatus.FAILED:
                 detail = "Seer run failed during outbox drain"
             elif run.seer_run_state_id is None:

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -157,9 +157,9 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         if not run_id:
             return Response({"session": None}, status=404)
 
-        seer_run_state_id = resolve_seer_run_state_id(run_id, organization)
-        if seer_run_state_id is None:
-            return Response({"session": None}, status=404)
+        seer_run_state_id, error_response = resolve_seer_run_state_id(run_id, organization)
+        if error_response is not None:
+            return error_response
 
         try:
             client = SeerAgentClient(organization, request.user)
@@ -260,7 +260,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                 reasoning_effort="medium",
             )
             if run_id:
-                seer_run_state_id = resolve_seer_run_state_id(run_id, organization)
+                seer_run_state_id, _ = resolve_seer_run_state_id(run_id, organization)
                 if seer_run_state_id is None:
                     return Response({"detail": "Invalid run_id"}, status=400)
                 # Continue existing conversation

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -157,9 +157,10 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         if not run_id:
             return Response({"session": None}, status=404)
 
-        seer_run_state_id = resolve_seer_run_state_id(run_id, organization)
-        if isinstance(seer_run_state_id, Response):
-            return seer_run_state_id
+        seer_run_id_or_response = resolve_seer_run_state_id(run_id, organization)
+        if isinstance(seer_run_id_or_response, Response):
+            return seer_run_id_or_response
+        seer_run_state_id = seer_run_id_or_response
 
         try:
             client = SeerAgentClient(organization, request.user)
@@ -260,9 +261,10 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                 reasoning_effort="medium",
             )
             if run_id:
-                seer_run_state_id = resolve_seer_run_state_id(run_id, organization)
-                if isinstance(seer_run_state_id, Response):
+                seer_run_id_or_response = resolve_seer_run_state_id(run_id, organization)
+                if isinstance(seer_run_id_or_response, Response):
                     return Response({"detail": "Invalid run_id"}, status=400)
+                seer_run_state_id = seer_run_id_or_response
                 # Continue existing conversation
                 result_run_id = client.continue_run(
                     run_id=seer_run_state_id,

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -261,7 +261,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                 reasoning_effort="medium",
             )
             if run_id:
-                resolved = resolve_seer_run(run_id, organization)
+                resolved = resolve_seer_run(run_id, organization, for_continue=True)
                 if isinstance(resolved, Response):
                     return resolved
                 # Continue existing conversation

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -193,7 +193,8 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         - on_page_context: Optional context from the user's screen.
 
         Returns:
-        - run_id: The run ID.
+        - run_id: The numeric Seer run id.
+        - sentry_run_id: The run's UUID (new runs only).
         """
         has_access, error = has_seer_agent_access_with_detail(organization, request.user)
 

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -20,9 +20,8 @@ from sentry.seer.agent.client_utils import (
     has_seer_agent_access_with_detail,
     snapshot_to_markdown,
 )
-from sentry.seer.endpoints.utils import resolve_seer_run_state_id
+from sentry.seer.endpoints.utils import resolve_seer_run
 from sentry.seer.models import SeerApiError, SeerPermissionError
-from sentry.seer.models.run import SeerRun
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import json
@@ -158,14 +157,13 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         if not run_id:
             return Response({"session": None}, status=404)
 
-        seer_run_id_or_response = resolve_seer_run_state_id(run_id, organization)
-        if isinstance(seer_run_id_or_response, Response):
-            return seer_run_id_or_response
-        seer_run_state_id = seer_run_id_or_response
+        resolved = resolve_seer_run(run_id, organization)
+        if isinstance(resolved, Response):
+            return resolved
 
         try:
             client = SeerAgentClient(organization, request.user)
-            state = client.get_run(run_id=seer_run_state_id)
+            state = client.get_run(run_id=resolved.seer_run_state_id)
             return Response({"session": state.dict()})
         except SeerPermissionError as e:
             raise PermissionDenied(e.message) from e
@@ -263,13 +261,12 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                 reasoning_effort="medium",
             )
             if run_id:
-                seer_run_id_or_response = resolve_seer_run_state_id(run_id, organization)
-                if isinstance(seer_run_id_or_response, Response):
-                    return seer_run_id_or_response
-                seer_run_state_id = seer_run_id_or_response
+                resolved = resolve_seer_run(run_id, organization)
+                if isinstance(resolved, Response):
+                    return resolved
                 # Continue existing conversation
-                result_run_id = client.continue_run(
-                    run_id=seer_run_state_id,
+                client.continue_run(
+                    run_id=resolved.seer_run_state_id,
                     prompt=query,
                     insert_index=insert_index,
                     on_page_context=on_page_context,
@@ -277,13 +274,9 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                     ui_tools=ui_tools,
                     request=request,
                 )
-                response_data: dict[str, str | int] = {"run_id": result_run_id}
-                run = SeerRun.objects.filter(
-                    seer_run_state_id=result_run_id, organization=organization
-                ).first()
-                if run is not None:
-                    response_data["sentry_run_id"] = str(run.uuid)
-                return Response(response_data)
+                return Response(
+                    {"run_id": resolved.seer_run_state_id, "sentry_run_id": resolved.uuid}
+                )
 
             # Start new conversation
             run = client.start_run(

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -264,11 +264,6 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
             if run_id:
                 seer_run_id_or_response = resolve_seer_run_state_id(run_id, organization)
                 if isinstance(seer_run_id_or_response, Response):
-                    # Pass through the resolver's 4xx (unknown / malformed id). A
-                    # 2xx poll status means the run exists but isn't mirrored yet
-                    # (or its mirror failed), which isn't a continuable state.
-                    if seer_run_id_or_response.status_code < 400:
-                        return Response({"detail": "Run is not ready"}, status=409)
                     return seer_run_id_or_response
                 seer_run_state_id = seer_run_id_or_response
                 # Continue existing conversation

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -264,6 +264,11 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
             if run_id:
                 seer_run_id_or_response = resolve_seer_run_state_id(run_id, organization)
                 if isinstance(seer_run_id_or_response, Response):
+                    # Pass through the resolver's 4xx (unknown / malformed id). A
+                    # 2xx poll status means the run exists but isn't mirrored yet
+                    # (or its mirror failed), which isn't a continuable state.
+                    if seer_run_id_or_response.status_code < 400:
+                        return Response({"detail": "Run is not ready"}, status=409)
                     return seer_run_id_or_response
                 seer_run_state_id = seer_run_id_or_response
                 # Continue existing conversation

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -264,7 +264,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
             if run_id:
                 seer_run_id_or_response = resolve_seer_run_state_id(run_id, organization)
                 if isinstance(seer_run_id_or_response, Response):
-                    return Response({"detail": "Invalid run_id"}, status=400)
+                    return seer_run_id_or_response
                 seer_run_state_id = seer_run_id_or_response
                 # Continue existing conversation
                 result_run_id = client.continue_run(

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -22,6 +22,7 @@ from sentry.seer.agent.client_utils import (
 )
 from sentry.seer.endpoints.utils import resolve_seer_run_state_id
 from sentry.seer.models import SeerApiError, SeerPermissionError
+from sentry.seer.models.run import SeerRun
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import json
@@ -194,7 +195,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
 
         Returns:
         - run_id: The numeric Seer run id.
-        - sentry_run_id: The run's UUID (new runs only).
+        - sentry_run_id: The run's UUID (when a mirror row exists).
         """
         has_access, error = has_seer_agent_access_with_detail(organization, request.user)
 
@@ -276,7 +277,13 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                     ui_tools=ui_tools,
                     request=request,
                 )
-                return Response({"run_id": result_run_id})
+                response_data: dict[str, str | int] = {"run_id": result_run_id}
+                run = SeerRun.objects.filter(
+                    seer_run_state_id=result_run_id, organization=organization
+                ).first()
+                if run is not None:
+                    response_data["sentry_run_id"] = str(run.uuid)
+                return Response(response_data)
 
             # Start new conversation
             run = client.start_run(

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -157,9 +157,9 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         if not run_id:
             return Response({"session": None}, status=404)
 
-        seer_run_state_id, error_response = resolve_seer_run_state_id(run_id, organization)
-        if error_response is not None:
-            return error_response
+        seer_run_state_id = resolve_seer_run_state_id(run_id, organization)
+        if isinstance(seer_run_state_id, Response):
+            return seer_run_state_id
 
         try:
             client = SeerAgentClient(organization, request.user)
@@ -260,8 +260,8 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                 reasoning_effort="medium",
             )
             if run_id:
-                seer_run_state_id, _ = resolve_seer_run_state_id(run_id, organization)
-                if seer_run_state_id is None:
+                seer_run_state_id = resolve_seer_run_state_id(run_id, organization)
+                if isinstance(seer_run_state_id, Response):
                     return Response({"detail": "Invalid run_id"}, status=400)
                 # Continue existing conversation
                 result_run_id = client.continue_run(

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -20,6 +20,7 @@ from sentry.seer.agent.client_utils import (
     has_seer_agent_access_with_detail,
     snapshot_to_markdown,
 )
+from sentry.seer.endpoints.utils import resolve_seer_run_state_id
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -138,7 +139,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationSeerAgentChatPermission,)
 
     def get(
-        self, request: Request, organization: Organization, run_id: int | None = None
+        self, request: Request, organization: Organization, run_id: str | None = None
     ) -> Response:
         """
         Get the current state of a Seer Agent session.
@@ -156,9 +157,13 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         if not run_id:
             return Response({"session": None}, status=404)
 
+        seer_run_state_id = resolve_seer_run_state_id(run_id, organization)
+        if seer_run_state_id is None:
+            return Response({"session": None}, status=404)
+
         try:
             client = SeerAgentClient(organization, request.user)
-            state = client.get_run(run_id=int(run_id))
+            state = client.get_run(run_id=seer_run_state_id)
             return Response({"session": state.dict()})
         except SeerPermissionError as e:
             raise PermissionDenied(e.message) from e
@@ -175,7 +180,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
             return Response({"session": None}, status=404)
 
     def post(
-        self, request: Request, organization: Organization, run_id: int | None = None
+        self, request: Request, organization: Organization, run_id: str | None = None
     ) -> Response:
         """
         Start a new chat session or continue an existing one.
@@ -255,9 +260,12 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                 reasoning_effort="medium",
             )
             if run_id:
+                seer_run_state_id = resolve_seer_run_state_id(run_id, organization)
+                if seer_run_state_id is None:
+                    return Response({"detail": "Invalid run_id"}, status=400)
                 # Continue existing conversation
                 result_run_id = client.continue_run(
-                    run_id=int(run_id),
+                    run_id=seer_run_state_id,
                     prompt=query,
                     insert_index=insert_index,
                     on_page_context=on_page_context,
@@ -265,18 +273,18 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                     ui_tools=ui_tools,
                     request=request,
                 )
-            else:
-                # Start new conversation
-                result_run_id = client.start_run(
-                    prompt=query,
-                    on_page_context=on_page_context,
-                    page_name=page_name,
-                    ui_tools=ui_tools,
-                    override_ce_enable=override_ce_enable,
-                    request=request,
-                ).seer_run_state_id
+                return Response({"run_id": result_run_id})
 
-            return Response({"run_id": result_run_id})
+            # Start new conversation
+            run = client.start_run(
+                prompt=query,
+                on_page_context=on_page_context,
+                page_name=page_name,
+                ui_tools=ui_tools,
+                override_ce_enable=override_ce_enable,
+                request=request,
+            )
+            return Response({"run_id": run.seer_run_state_id, "sentry_run_id": str(run.uuid)})
         except SeerPermissionError as e:
             raise PermissionDenied(e.message) from e
         except SeerApiError as e:

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -106,9 +106,9 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
-        seer_run_id, error_response = resolve_seer_run_state_id(run_id, organization)
-        if error_response is not None:
-            return error_response
+        seer_run_id = resolve_seer_run_state_id(run_id, organization)
+        if isinstance(seer_run_id, Response):
+            return seer_run_id
 
         try:
             viewer_context = SeerViewerContext(

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import uuid
 from typing import Any
 
 from django.conf import settings
@@ -16,8 +15,8 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
+from sentry.seer.endpoints.utils import SeerRunResolutionStatus, resolve_seer_run
 from sentry.seer.models import SeerApiError
-from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import (
     SearchAgentStateRequest,
@@ -107,32 +106,16 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
-        # Numeric run_id: legacy path, forward directly to Seer.
-        try:
-            seer_run_id = int(run_id)
-        except ValueError:
-            seer_run_id = None
-
-        # UUID run_id: look up the SeerRun to get the Seer-side ID.
-        if seer_run_id is None:
-            try:
-                uuid.UUID(run_id)
-            except ValueError:
-                return Response(
-                    {"detail": "Invalid run_id"},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-            try:
-                run = SeerRun.objects.get(uuid=run_id, organization=organization)
-            except SeerRun.DoesNotExist:
-                return Response({"session": None}, status=status.HTTP_404_NOT_FOUND)
-
-            if run.mirror_status == SeerRunMirrorStatus.FAILED:
-                return Response({"session": {"status": "error"}})
-            if run.seer_run_state_id is None:
-                return Response({"session": {"status": "processing"}})
-            seer_run_id = run.seer_run_state_id
+        resolution = resolve_seer_run(run_id, organization)
+        if resolution.status is SeerRunResolutionStatus.INVALID:
+            return Response({"detail": "Invalid run_id"}, status=status.HTTP_400_BAD_REQUEST)
+        if resolution.status is SeerRunResolutionStatus.NOT_FOUND:
+            return Response({"session": None}, status=status.HTTP_404_NOT_FOUND)
+        if resolution.status is SeerRunResolutionStatus.FAILED:
+            return Response({"session": {"status": "error"}})
+        if resolution.status is SeerRunResolutionStatus.PENDING:
+            return Response({"session": {"status": "processing"}})
+        seer_run_id = resolution.seer_run_state_id
 
         try:
             viewer_context = SeerViewerContext(

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -106,9 +106,10 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
-        seer_run_id = resolve_seer_run_state_id(run_id, organization)
-        if isinstance(seer_run_id, Response):
-            return seer_run_id
+        seer_run_id_or_response = resolve_seer_run_state_id(run_id, organization)
+        if isinstance(seer_run_id_or_response, Response):
+            return seer_run_id_or_response
+        seer_run_id = seer_run_id_or_response
 
         try:
             viewer_context = SeerViewerContext(

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -15,7 +15,7 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
-from sentry.seer.endpoints.utils import resolve_seer_run_state_id
+from sentry.seer.endpoints.utils import resolve_seer_run
 from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import (
@@ -106,10 +106,10 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
-        seer_run_id_or_response = resolve_seer_run_state_id(run_id, organization)
-        if isinstance(seer_run_id_or_response, Response):
-            return seer_run_id_or_response
-        seer_run_id = seer_run_id_or_response
+        resolved = resolve_seer_run(run_id, organization)
+        if isinstance(resolved, Response):
+            return resolved
+        seer_run_id = resolved.seer_run_state_id
 
         try:
             viewer_context = SeerViewerContext(

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -15,7 +15,7 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
-from sentry.seer.endpoints.utils import SeerRunResolutionStatus, resolve_seer_run
+from sentry.seer.endpoints.utils import resolve_seer_run_state_id
 from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import (
@@ -106,16 +106,9 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
-        resolution = resolve_seer_run(run_id, organization)
-        if resolution.status is SeerRunResolutionStatus.INVALID:
-            return Response({"detail": "Invalid run_id"}, status=status.HTTP_400_BAD_REQUEST)
-        if resolution.status is SeerRunResolutionStatus.NOT_FOUND:
-            return Response({"session": None}, status=status.HTTP_404_NOT_FOUND)
-        if resolution.status is SeerRunResolutionStatus.FAILED:
-            return Response({"session": {"status": "error"}})
-        if resolution.status is SeerRunResolutionStatus.PENDING:
-            return Response({"session": {"status": "processing"}})
-        seer_run_id = resolution.seer_run_state_id
+        seer_run_id, error_response = resolve_seer_run_state_id(run_id, organization)
+        if error_response is not None:
+            return error_response
 
         try:
             viewer_context = SeerViewerContext(

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -8,6 +8,7 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus
+from sentry.utils.numbers import validate_bigint
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
@@ -37,6 +38,8 @@ def resolve_seer_run(
         seer_run_state_id = None
 
     if seer_run_state_id is not None:
+        if not validate_bigint(seer_run_state_id):
+            return Response({"detail": "Invalid run_id"}, status=status.HTTP_400_BAD_REQUEST)
         run = SeerRun.objects.filter(
             seer_run_state_id=seer_run_state_id, organization=organization
         ).first()

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -1,5 +1,36 @@
+from __future__ import annotations
+
+import uuid as uuid_module
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from sentry.seer.models.run import SeerRun
+
+if TYPE_CHECKING:
+    from sentry.models.organization import Organization
+
+
+def resolve_seer_run_state_id(run_id: str, organization: Organization) -> int | None:
+    """Translate a client-facing run id (numeric ``seer_run_state_id`` or a
+    ``SeerRun.uuid``) into the Seer-side ``seer_run_state_id``.
+
+    A UUID is looked up scoped to ``organization``; returns ``None`` when it
+    can't be resolved to a live run. Numeric ids pass straight through.
+    """
+    try:
+        return int(run_id)
+    except (TypeError, ValueError):
+        pass
+
+    try:
+        run_uuid = uuid_module.UUID(str(run_id))
+    except (TypeError, ValueError):
+        return None
+
+    run = SeerRun.objects.filter(uuid=run_uuid, organization=organization).first()
+    if run is None:
+        return None
+    return run.seer_run_state_id
 
 
 def map_org_id_param(func: Callable) -> Callable:

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import enum
 import uuid as uuid_module
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+
+from rest_framework import status
+from rest_framework.response import Response
 
 from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus
 
@@ -12,55 +13,36 @@ if TYPE_CHECKING:
     from sentry.models.organization import Organization
 
 
-class SeerRunResolutionStatus(enum.Enum):
-    RESOLVED = "resolved"
-    INVALID = "invalid"
-    NOT_FOUND = "not_found"
-    PENDING = "pending"
-    FAILED = "failed"
-
-
-@dataclass(frozen=True)
-class SeerRunResolution:
-    status: SeerRunResolutionStatus
-    seer_run_state_id: int | None = None
-
-
-def resolve_seer_run(run_id: str | int, organization: Organization) -> SeerRunResolution:
+def resolve_seer_run_state_id(
+    run_id: str | int, organization: Organization
+) -> tuple[int | None, Response | None]:
     """Resolve a client-facing run id (numeric ``seer_run_state_id`` or a
     ``SeerRun.uuid``) to the Seer-side ``seer_run_state_id``.
 
-    Numeric ids pass straight through (legacy/internal). A UUID is looked up
-    scoped to ``organization``; the result distinguishes an unparseable id, a
-    missing run, a run whose Seer id isn't mirrored yet, and a failed mirror so
-    callers can map each to their own response.
+    Returns ``(seer_run_state_id, None)`` when resolved. Otherwise returns
+    ``(None, error_response)`` following the ``{"session": ...}`` poll contract:
+    400 for an unparseable id, 404 for an unknown run, and a ``processing`` /
+    ``error`` session status while the run's Seer id isn't mirrored yet or its
+    mirror failed. Numeric ids pass straight through.
     """
     try:
-        return SeerRunResolution(SeerRunResolutionStatus.RESOLVED, int(run_id))
+        return int(run_id), None
     except (TypeError, ValueError):
         pass
 
     try:
         run_uuid = uuid_module.UUID(str(run_id))
     except (TypeError, ValueError):
-        return SeerRunResolution(SeerRunResolutionStatus.INVALID)
+        return None, Response({"detail": "Invalid run_id"}, status=status.HTTP_400_BAD_REQUEST)
 
     run = SeerRun.objects.filter(uuid=run_uuid, organization=organization).first()
     if run is None:
-        return SeerRunResolution(SeerRunResolutionStatus.NOT_FOUND)
+        return None, Response({"session": None}, status=status.HTTP_404_NOT_FOUND)
     if run.mirror_status == SeerRunMirrorStatus.FAILED:
-        return SeerRunResolution(SeerRunResolutionStatus.FAILED)
+        return None, Response({"session": {"status": "error"}})
     if run.seer_run_state_id is None:
-        return SeerRunResolution(SeerRunResolutionStatus.PENDING)
-    return SeerRunResolution(SeerRunResolutionStatus.RESOLVED, run.seer_run_state_id)
-
-
-def resolve_seer_run_state_id(run_id: str | int, organization: Organization) -> int | None:
-    """Resolve to the Seer-side ``seer_run_state_id``, or ``None`` when the run
-    id can't be resolved to a live run. Thin wrapper over :func:`resolve_seer_run`
-    for callers that don't need to distinguish why resolution failed.
-    """
-    return resolve_seer_run(run_id, organization).seer_run_state_id
+        return None, Response({"session": {"status": "processing"}})
+    return run.seer_run_state_id, None
 
 
 def map_org_id_param(func: Callable) -> Callable:

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -1,36 +1,66 @@
 from __future__ import annotations
 
+import enum
 import uuid as uuid_module
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from sentry.seer.models.run import SeerRun
+from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
 
 
-def resolve_seer_run_state_id(run_id: str, organization: Organization) -> int | None:
-    """Translate a client-facing run id (numeric ``seer_run_state_id`` or a
-    ``SeerRun.uuid``) into the Seer-side ``seer_run_state_id``.
+class SeerRunResolutionStatus(enum.Enum):
+    RESOLVED = "resolved"
+    INVALID = "invalid"
+    NOT_FOUND = "not_found"
+    PENDING = "pending"
+    FAILED = "failed"
 
-    A UUID is looked up scoped to ``organization``; returns ``None`` when it
-    can't be resolved to a live run. Numeric ids pass straight through.
+
+@dataclass(frozen=True)
+class SeerRunResolution:
+    status: SeerRunResolutionStatus
+    seer_run_state_id: int | None = None
+
+
+def resolve_seer_run(run_id: str | int, organization: Organization) -> SeerRunResolution:
+    """Resolve a client-facing run id (numeric ``seer_run_state_id`` or a
+    ``SeerRun.uuid``) to the Seer-side ``seer_run_state_id``.
+
+    Numeric ids pass straight through (legacy/internal). A UUID is looked up
+    scoped to ``organization``; the result distinguishes an unparseable id, a
+    missing run, a run whose Seer id isn't mirrored yet, and a failed mirror so
+    callers can map each to their own response.
     """
     try:
-        return int(run_id)
+        return SeerRunResolution(SeerRunResolutionStatus.RESOLVED, int(run_id))
     except (TypeError, ValueError):
         pass
 
     try:
         run_uuid = uuid_module.UUID(str(run_id))
     except (TypeError, ValueError):
-        return None
+        return SeerRunResolution(SeerRunResolutionStatus.INVALID)
 
     run = SeerRun.objects.filter(uuid=run_uuid, organization=organization).first()
     if run is None:
-        return None
-    return run.seer_run_state_id
+        return SeerRunResolution(SeerRunResolutionStatus.NOT_FOUND)
+    if run.mirror_status == SeerRunMirrorStatus.FAILED:
+        return SeerRunResolution(SeerRunResolutionStatus.FAILED)
+    if run.seer_run_state_id is None:
+        return SeerRunResolution(SeerRunResolutionStatus.PENDING)
+    return SeerRunResolution(SeerRunResolutionStatus.RESOLVED, run.seer_run_state_id)
+
+
+def resolve_seer_run_state_id(run_id: str | int, organization: Organization) -> int | None:
+    """Resolve to the Seer-side ``seer_run_state_id``, or ``None`` when the run
+    id can't be resolved to a live run. Thin wrapper over :func:`resolve_seer_run`
+    for callers that don't need to distinguish why resolution failed.
+    """
+    return resolve_seer_run(run_id, organization).seer_run_state_id
 
 
 def map_org_id_param(func: Callable) -> Callable:

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -15,7 +15,8 @@ if TYPE_CHECKING:
 
 class ResolvedSeerRun(NamedTuple):
     seer_run_state_id: int
-    uuid: str
+    # None for legacy runs created before SeerRun mirroring, which have no row.
+    uuid: str | None
 
 
 def resolve_seer_run(run_id: str | int, organization: Organization) -> ResolvedSeerRun | Response:
@@ -28,6 +29,9 @@ def resolve_seer_run(run_id: str | int, organization: Organization) -> ResolvedS
     ``processing`` / ``error`` session status while the run's Seer id isn't
     mirrored yet or its mirror failed. Callers narrow with
     ``isinstance(result, Response)``.
+
+    A numeric id with no mirror row falls back to a bare passthrough (UUID
+    ``None``) so runs predating mirroring still resolve.
     """
     try:
         seer_run_state_id = int(run_id)
@@ -38,9 +42,7 @@ def resolve_seer_run(run_id: str | int, organization: Organization) -> ResolvedS
         run = SeerRun.objects.filter(
             seer_run_state_id=seer_run_state_id, organization=organization
         ).first()
-        if run is None:
-            return Response({"session": None}, status=status.HTTP_404_NOT_FOUND)
-        return ResolvedSeerRun(seer_run_state_id, str(run.uuid))
+        return ResolvedSeerRun(seer_run_state_id, str(run.uuid) if run else None)
 
     try:
         run_uuid = uuid_module.UUID(str(run_id))

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -13,36 +13,35 @@ if TYPE_CHECKING:
     from sentry.models.organization import Organization
 
 
-def resolve_seer_run_state_id(
-    run_id: str | int, organization: Organization
-) -> tuple[int | None, Response | None]:
+def resolve_seer_run_state_id(run_id: str | int, organization: Organization) -> int | Response:
     """Resolve a client-facing run id (numeric ``seer_run_state_id`` or a
     ``SeerRun.uuid``) to the Seer-side ``seer_run_state_id``.
 
-    Returns ``(seer_run_state_id, None)`` when resolved. Otherwise returns
-    ``(None, error_response)`` following the ``{"session": ...}`` poll contract:
-    400 for an unparseable id, 404 for an unknown run, and a ``processing`` /
-    ``error`` session status while the run's Seer id isn't mirrored yet or its
-    mirror failed. Numeric ids pass straight through.
+    Returns the ``seer_run_state_id`` when resolved, otherwise an error
+    ``Response`` following the ``{"session": ...}`` poll contract: 400 for an
+    unparseable id, 404 for an unknown run, and a ``processing`` / ``error``
+    session status while the run's Seer id isn't mirrored yet or its mirror
+    failed. Callers narrow with ``isinstance(result, Response)``. Numeric ids
+    pass straight through.
     """
     try:
-        return int(run_id), None
+        return int(run_id)
     except (TypeError, ValueError):
         pass
 
     try:
         run_uuid = uuid_module.UUID(str(run_id))
     except (TypeError, ValueError):
-        return None, Response({"detail": "Invalid run_id"}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({"detail": "Invalid run_id"}, status=status.HTTP_400_BAD_REQUEST)
 
     run = SeerRun.objects.filter(uuid=run_uuid, organization=organization).first()
     if run is None:
-        return None, Response({"session": None}, status=status.HTTP_404_NOT_FOUND)
+        return Response({"session": None}, status=status.HTTP_404_NOT_FOUND)
     if run.mirror_status == SeerRunMirrorStatus.FAILED:
-        return None, Response({"session": {"status": "error"}})
+        return Response({"session": {"status": "error"}})
     if run.seer_run_state_id is None:
-        return None, Response({"session": {"status": "processing"}})
-    return run.seer_run_state_id, None
+        return Response({"session": {"status": "processing"}})
+    return run.seer_run_state_id
 
 
 def map_org_id_param(func: Callable) -> Callable:

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid as uuid_module
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from rest_framework import status
 from rest_framework.response import Response
@@ -13,21 +13,34 @@ if TYPE_CHECKING:
     from sentry.models.organization import Organization
 
 
-def resolve_seer_run_state_id(run_id: str | int, organization: Organization) -> int | Response:
-    """Resolve a client-facing run id (numeric ``seer_run_state_id`` or a
-    ``SeerRun.uuid``) to the Seer-side ``seer_run_state_id``.
+class ResolvedSeerRun(NamedTuple):
+    seer_run_state_id: int
+    uuid: str
 
-    Returns the ``seer_run_state_id`` when resolved, otherwise an error
-    ``Response`` following the ``{"session": ...}`` poll contract: 400 for an
-    unparseable id, 404 for an unknown run, and a ``processing`` / ``error``
-    session status while the run's Seer id isn't mirrored yet or its mirror
-    failed. Callers narrow with ``isinstance(result, Response)``. Numeric ids
-    pass straight through.
+
+def resolve_seer_run(run_id: str | int, organization: Organization) -> ResolvedSeerRun | Response:
+    """Resolve a client-facing run id (numeric ``seer_run_state_id`` or a
+    ``SeerRun.uuid``) to its :class:`SeerRun`, scoped to ``organization``.
+
+    Returns a :class:`ResolvedSeerRun` (the Seer-side id and the run's UUID) in
+    a single lookup, or an error ``Response`` following the ``{"session": ...}``
+    poll contract: 400 for an unparseable id, 404 for an unknown run, and a
+    ``processing`` / ``error`` session status while the run's Seer id isn't
+    mirrored yet or its mirror failed. Callers narrow with
+    ``isinstance(result, Response)``.
     """
     try:
-        return int(run_id)
+        seer_run_state_id = int(run_id)
     except (TypeError, ValueError):
-        pass
+        seer_run_state_id = None
+
+    if seer_run_state_id is not None:
+        run = SeerRun.objects.filter(
+            seer_run_state_id=seer_run_state_id, organization=organization
+        ).first()
+        if run is None:
+            return Response({"session": None}, status=status.HTTP_404_NOT_FOUND)
+        return ResolvedSeerRun(seer_run_state_id, str(run.uuid))
 
     try:
         run_uuid = uuid_module.UUID(str(run_id))
@@ -41,7 +54,7 @@ def resolve_seer_run_state_id(run_id: str | int, organization: Organization) -> 
         return Response({"session": {"status": "error"}})
     if run.seer_run_state_id is None:
         return Response({"session": {"status": "processing"}})
-    return run.seer_run_state_id
+    return ResolvedSeerRun(run.seer_run_state_id, str(run.uuid))
 
 
 def map_org_id_param(func: Callable) -> Callable:

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -19,19 +19,17 @@ class ResolvedSeerRun(NamedTuple):
     uuid: str | None
 
 
-def resolve_seer_run(run_id: str | int, organization: Organization) -> ResolvedSeerRun | Response:
-    """Resolve a client-facing run id (numeric ``seer_run_state_id`` or a
-    ``SeerRun.uuid``) to its :class:`SeerRun`, scoped to ``organization``.
-
-    Returns a :class:`ResolvedSeerRun` (the Seer-side id and the run's UUID) in
-    a single lookup, or an error ``Response`` following the ``{"session": ...}``
-    poll contract: 400 for an unparseable id, 404 for an unknown run, and a
-    ``processing`` / ``error`` session status while the run's Seer id isn't
-    mirrored yet or its mirror failed. Callers narrow with
-    ``isinstance(result, Response)``.
-
-    A numeric id with no mirror row falls back to a bare passthrough (UUID
-    ``None``) so runs predating mirroring still resolve.
+def resolve_seer_run(
+    run_id: str | int,
+    organization: Organization,
+    *,
+    for_continue: bool = False,
+) -> ResolvedSeerRun | Response:
+    """Resolve a client-facing run id (numeric ``seer_run_state_id`` or
+    ``SeerRun.uuid``) to a :class:`ResolvedSeerRun`, or an error ``Response``
+    (narrow with ``isinstance``). For a not-ready run, a poll gets the 200
+    ``{"session": {"status": ...}}`` shape; ``for_continue`` instead gets 409
+    (still mirroring) or 422 (mirror failed).
     """
     try:
         seer_run_state_id = int(run_id)
@@ -53,8 +51,18 @@ def resolve_seer_run(run_id: str | int, organization: Organization) -> ResolvedS
     if run is None:
         return Response({"session": None}, status=status.HTTP_404_NOT_FOUND)
     if run.mirror_status == SeerRunMirrorStatus.FAILED:
+        if for_continue:
+            return Response(
+                {"detail": "This run failed to start and cannot be continued."},
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
         return Response({"session": {"status": "error"}})
     if run.seer_run_state_id is None:
+        if for_continue:
+            return Response(
+                {"detail": "This run is still being created; retry shortly."},
+                status=status.HTTP_409_CONFLICT,
+            )
         return Response({"session": {"status": "processing"}})
     return ResolvedSeerRun(run.seer_run_state_id, str(run.uuid))
 

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -130,6 +130,18 @@ class TestSeerAgentClient(TestCase):
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    def test_start_run_raises_when_seer_rejects_creation(self, mock_post, mock_access):
+        """A 4xx from Seer marks the run FAILED during the synchronous drain, so
+        start_run raises instead of returning an unmirrored run."""
+        mock_access.return_value = (True, None)
+        mock_post.return_value = MagicMock(status=400)
+
+        client = SeerAgentClient(self.organization, self.user)
+        with pytest.raises(SeerApiError, match="failed during outbox drain"):
+            client.start_run("Test query")
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_start_run_with_categories(self, mock_collect_context, mock_post, mock_access):
         """Test starting a run with category fields"""

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -250,7 +250,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         response = self.client.post(f"{self.url}{run.uuid}/", {"query": "More"}, format="json")
 
         assert response.status_code == 200
-        assert response.data == {"run_id": 555}
+        assert response.data == {"run_id": 555, "sentry_run_id": str(run.uuid)}
         assert mock_client.continue_run.call_args.kwargs["run_id"] == 555
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -254,13 +254,26 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         assert mock_client.continue_run.call_args.kwargs["run_id"] == 555
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
-    def test_post_continue_with_unknown_uuid_returns_400(
+    def test_post_continue_with_unknown_uuid_returns_404(
         self, mock_client_class: MagicMock
     ) -> None:
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
 
         response = self.client.post(f"{self.url}{uuid.uuid4()}/", {"query": "More"}, format="json")
+
+        assert response.status_code == 404
+        assert response.data == {"session": None}
+        mock_client.continue_run.assert_not_called()
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_post_continue_with_garbage_run_id_returns_400(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        response = self.client.post(f"{self.url}not-a-real-id/", {"query": "More"}, format="json")
 
         assert response.status_code == 400
         mock_client.continue_run.assert_not_called()

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any
 from unittest.mock import ANY, MagicMock, Mock, patch
 
@@ -103,15 +104,16 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_post_new_conversation_calls_client(self, mock_client_class: MagicMock):
+        run_uuid = uuid.uuid4()
         mock_client = MagicMock()
-        mock_client.start_run.return_value = MagicMock(seer_run_state_id=456)
+        mock_client.start_run.return_value = MagicMock(seer_run_state_id=456, uuid=run_uuid)
         mock_client_class.return_value = mock_client
 
         data = {"query": "What is this error about?"}
         response = self.client.post(self.url, data, format="json")
 
         assert response.status_code == 200
-        assert response.data == {"run_id": 456}
+        assert response.data == {"run_id": 456, "sentry_run_id": str(run_uuid)}
         mock_client_class.assert_called_once_with(
             self.organization,
             ANY,
@@ -190,6 +192,78 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             ui_tools=None,
             request=ANY,
         )
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_get_with_uuid_resolves_to_seer_run_state_id(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        from sentry.seer.agent.client_models import SeerRunState
+
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+        mock_client = MagicMock()
+        mock_client.get_run.return_value = SeerRunState(
+            run_id=555,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+        mock_client_class.return_value = mock_client
+
+        response = self.client.get(f"{self.url}{run.uuid}/")
+
+        assert response.status_code == 200
+        mock_client.get_run.assert_called_once_with(run_id=555)
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_get_with_unknown_uuid_returns_null_session(self, mock_client_class: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        response = self.client.get(f"{self.url}{uuid.uuid4()}/")
+
+        assert response.status_code == 404
+        assert response.data == {"session": None}
+        mock_client.get_run.assert_not_called()
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_get_with_uuid_from_other_org_is_not_resolved(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        other_org = self.create_organization()
+        run = self.create_seer_run(organization=other_org, seer_run_state_id=555)
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        response = self.client.get(f"{self.url}{run.uuid}/")
+
+        assert response.status_code == 404
+        assert response.data == {"session": None}
+        mock_client.get_run.assert_not_called()
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_post_continue_with_uuid_resolves(self, mock_client_class: MagicMock) -> None:
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+        mock_client = MagicMock()
+        mock_client.continue_run.return_value = 555
+        mock_client_class.return_value = mock_client
+
+        response = self.client.post(f"{self.url}{run.uuid}/", {"query": "More"}, format="json")
+
+        assert response.status_code == 200
+        assert response.data == {"run_id": 555}
+        assert mock_client.continue_run.call_args.kwargs["run_id"] == 555
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_post_continue_with_unknown_uuid_returns_400(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        response = self.client.post(f"{self.url}{uuid.uuid4()}/", {"query": "More"}, format="json")
+
+        assert response.status_code == 400
+        mock_client.continue_run.assert_not_called()
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_post_continue_conversation_enable_coding(self, mock_client_class: MagicMock) -> None:

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -279,19 +279,6 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client.continue_run.assert_not_called()
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
-    def test_post_continue_with_unmirrored_run_returns_409(
-        self, mock_client_class: MagicMock
-    ) -> None:
-        run = self.create_seer_run(organization=self.organization, seer_run_state_id=None)
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
-
-        response = self.client.post(f"{self.url}{run.uuid}/", {"query": "More"}, format="json")
-
-        assert response.status_code == 409
-        mock_client.continue_run.assert_not_called()
-
-    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_post_continue_conversation_enable_coding(self, mock_client_class: MagicMock) -> None:
         for i, (feature_enabled, option_enabled) in enumerate(
             [(True, True), (True, False), (False, True), (False, False)]

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -4,6 +4,13 @@ from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest
 
+from sentry.seer.agent.client_models import (
+    MemoryBlock,
+    Message,
+    SeerRunState,
+    Usage,
+    UsageAccumulator,
+)
 from sentry.seer.endpoints.organization_seer_agent_chat import SeerAgentChatSerializer
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunMirrorStatus, SeerRunType
 from sentry.testutils.cases import APITestCase
@@ -30,8 +37,6 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_get_with_run_id_calls_client(self, mock_client_class: MagicMock) -> None:
-        from sentry.seer.agent.client_models import SeerRunState
-
         # Mock client response
         mock_state = SeerRunState(
             run_id=123,
@@ -52,14 +57,6 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_get_excludes_private_fields(self, mock_client_class: MagicMock) -> None:
-        from sentry.seer.agent.client_models import (
-            MemoryBlock,
-            Message,
-            SeerRunState,
-            Usage,
-            UsageAccumulator,
-        )
-
         mock_state = SeerRunState(
             run_id=123,
             blocks=[
@@ -197,8 +194,6 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
     def test_get_with_uuid_resolves_to_seer_run_state_id(
         self, mock_client_class: MagicMock
     ) -> None:
-        from sentry.seer.agent.client_models import SeerRunState
-
         run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
         mock_client = MagicMock()
         mock_client.get_run.return_value = SeerRunState(
@@ -308,8 +303,6 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         self, mock_client_class: MagicMock
     ) -> None:
         """GET with run_id should succeed with dashboards-ai-generate flag even without seer-explorer."""
-        from sentry.seer.agent.client_models import SeerRunState
-
         mock_state = SeerRunState(
             run_id=123,
             blocks=[],

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -42,6 +42,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client = MagicMock()
         mock_client.get_run.return_value = mock_state
         mock_client_class.return_value = mock_client
+        self.create_seer_run(organization=self.organization, seer_run_state_id=123)
 
         response = self.client.get(f"{self.url}123/")
 
@@ -79,6 +80,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client = MagicMock()
         mock_client.get_run.return_value = mock_state
         mock_client_class.return_value = mock_client
+        self.create_seer_run(organization=self.organization, seer_run_state_id=123)
 
         response = self.client.get(f"{self.url}123/")
 
@@ -166,6 +168,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client = MagicMock()
         mock_client.continue_run.return_value = 789
         mock_client_class.return_value = mock_client
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=789)
 
         data = {
             "query": "Follow up question",
@@ -174,7 +177,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         response = self.client.post(f"{self.url}789/", data, format="json")
 
         assert response.status_code == 200
-        assert response.data == {"run_id": 789}
+        assert response.data == {"run_id": 789, "sentry_run_id": str(run.uuid)}
         mock_client_class.assert_called_once_with(
             self.organization,
             ANY,
@@ -280,6 +283,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_post_continue_conversation_enable_coding(self, mock_client_class: MagicMock) -> None:
+        self.create_seer_run(organization=self.organization, seer_run_state_id=789)
         for i, (feature_enabled, option_enabled) in enumerate(
             [(True, True), (True, False), (False, True), (False, False)]
         ):
@@ -319,6 +323,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client = MagicMock()
         mock_client.get_run.return_value = mock_state
         mock_client_class.return_value = mock_client
+        self.create_seer_run(organization=self.organization, seer_run_state_id=123)
 
         with self.feature(
             {
@@ -339,6 +344,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client = MagicMock()
         mock_client.continue_run.return_value = 789
         mock_client_class.return_value = mock_client
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=789)
 
         data = {"query": "Follow up question"}
         with self.feature(
@@ -350,7 +356,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             response = self.client.post(f"{self.url}789/", data, format="json")
 
         assert response.status_code == 200
-        assert response.data == {"run_id": 789}
+        assert response.data == {"run_id": 789, "sentry_run_id": str(run.uuid)}
 
     def test_new_run_denied_without_seer_explorer_flag(self) -> None:
         """POST without run_id should be denied with only dashboards-ai-generate flag."""

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -42,7 +42,6 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client = MagicMock()
         mock_client.get_run.return_value = mock_state
         mock_client_class.return_value = mock_client
-        self.create_seer_run(organization=self.organization, seer_run_state_id=123)
 
         response = self.client.get(f"{self.url}123/")
 
@@ -80,7 +79,6 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client = MagicMock()
         mock_client.get_run.return_value = mock_state
         mock_client_class.return_value = mock_client
-        self.create_seer_run(organization=self.organization, seer_run_state_id=123)
 
         response = self.client.get(f"{self.url}123/")
 
@@ -168,7 +166,6 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client = MagicMock()
         mock_client.continue_run.return_value = 789
         mock_client_class.return_value = mock_client
-        run = self.create_seer_run(organization=self.organization, seer_run_state_id=789)
 
         data = {
             "query": "Follow up question",
@@ -177,7 +174,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         response = self.client.post(f"{self.url}789/", data, format="json")
 
         assert response.status_code == 200
-        assert response.data == {"run_id": 789, "sentry_run_id": str(run.uuid)}
+        assert response.data == {"run_id": 789, "sentry_run_id": None}
         mock_client_class.assert_called_once_with(
             self.organization,
             ANY,
@@ -283,7 +280,6 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_post_continue_conversation_enable_coding(self, mock_client_class: MagicMock) -> None:
-        self.create_seer_run(organization=self.organization, seer_run_state_id=789)
         for i, (feature_enabled, option_enabled) in enumerate(
             [(True, True), (True, False), (False, True), (False, False)]
         ):
@@ -323,7 +319,6 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client = MagicMock()
         mock_client.get_run.return_value = mock_state
         mock_client_class.return_value = mock_client
-        self.create_seer_run(organization=self.organization, seer_run_state_id=123)
 
         with self.feature(
             {
@@ -344,7 +339,6 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client = MagicMock()
         mock_client.continue_run.return_value = 789
         mock_client_class.return_value = mock_client
-        run = self.create_seer_run(organization=self.organization, seer_run_state_id=789)
 
         data = {"query": "Follow up question"}
         with self.feature(
@@ -356,7 +350,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             response = self.client.post(f"{self.url}789/", data, format="json")
 
         assert response.status_code == 200
-        assert response.data == {"run_id": 789, "sentry_run_id": str(run.uuid)}
+        assert response.data == {"run_id": 789, "sentry_run_id": None}
 
     def test_new_run_denied_without_seer_explorer_flag(self) -> None:
         """POST without run_id should be denied with only dashboards-ai-generate flag."""

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -279,6 +279,19 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client.continue_run.assert_not_called()
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_post_continue_with_unmirrored_run_returns_409(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=None)
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        response = self.client.post(f"{self.url}{run.uuid}/", {"query": "More"}, format="json")
+
+        assert response.status_code == 409
+        mock_client.continue_run.assert_not_called()
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_post_continue_conversation_enable_coding(self, mock_client_class: MagicMock) -> None:
         for i, (feature_enabled, option_enabled) in enumerate(
             [(True, True), (True, False), (False, True), (False, False)]

--- a/tests/sentry/seer/endpoints/test_search_agent_state.py
+++ b/tests/sentry/seer/endpoints/test_search_agent_state.py
@@ -23,9 +23,11 @@ class SearchAgentStateEndpointTest(APITestCase):
         mock_request.return_value = Mock(
             status=200, json=Mock(return_value={"session": {"status": "completed"}})
         )
+        self.create_seer_run(type=SeerRunType.ASSISTED_QUERY, seer_run_state_id=42)
         with self.feature(self.features):
             response = self.get_success_response(self.organization.slug, "42")
         assert response.data["session"]["status"] == "completed"
+        assert mock_request.call_args[0][0]["run_id"] == 42
 
     def test_uuid_returns_processing_when_outbox_not_drained(self) -> None:
         run = self.create_seer_run(type=SeerRunType.ASSISTED_QUERY)

--- a/tests/sentry/seer/endpoints/test_search_agent_state.py
+++ b/tests/sentry/seer/endpoints/test_search_agent_state.py
@@ -23,7 +23,6 @@ class SearchAgentStateEndpointTest(APITestCase):
         mock_request.return_value = Mock(
             status=200, json=Mock(return_value={"session": {"status": "completed"}})
         )
-        self.create_seer_run(type=SeerRunType.ASSISTED_QUERY, seer_run_state_id=42)
         with self.feature(self.features):
             response = self.get_success_response(self.organization.slug, "42")
         assert response.data["session"]["status"] == "completed"

--- a/tests/sentry/seer/endpoints/test_utils.py
+++ b/tests/sentry/seer/endpoints/test_utils.py
@@ -1,0 +1,106 @@
+import uuid
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from sentry.seer.endpoints.utils import ResolvedSeerRun, resolve_seer_run
+from sentry.seer.models.run import SeerRunMirrorStatus
+from sentry.testutils.cases import TestCase
+
+
+class ResolveSeerRunTest(TestCase):
+    """Branch matrix for ``resolve_seer_run``.
+
+    Owned here so the endpoints that call it (explorer chat, search-agent, and
+    soon explorer autofix) only need a thin integration smoke test for their own
+    response shape rather than re-testing every branch.
+    """
+
+    def test_numeric_id_with_row_returns_uuid(self) -> None:
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+
+        result = resolve_seer_run("555", self.organization)
+
+        assert result == ResolvedSeerRun(555, str(run.uuid))
+
+    def test_numeric_id_without_row_passes_through(self) -> None:
+        # Legacy run created before SeerRun mirroring: no row exists, so we fall
+        # back to a bare passthrough with a None uuid.
+        result = resolve_seer_run("555", self.organization)
+
+        assert result == ResolvedSeerRun(555, None)
+
+    def test_numeric_id_from_other_org_passes_through(self) -> None:
+        # A numeric id scoped to another org does NOT 404 here — the numeric path
+        # is the legacy passthrough and authz is enforced downstream in Seer. We
+        # just can't enrich it with the uuid, so it resolves with uuid None.
+        other_org = self.create_organization()
+        self.create_seer_run(organization=other_org, seer_run_state_id=555)
+
+        result = resolve_seer_run("555", self.organization)
+
+        assert result == ResolvedSeerRun(555, None)
+
+    def test_uuid_resolves_when_mirrored(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization,
+            seer_run_state_id=555,
+            mirror_status=SeerRunMirrorStatus.LIVE,
+        )
+
+        result = resolve_seer_run(str(run.uuid), self.organization)
+
+        assert result == ResolvedSeerRun(555, str(run.uuid))
+
+    def test_uuid_with_failed_mirror_returns_error_session(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization,
+            mirror_status=SeerRunMirrorStatus.FAILED,
+        )
+
+        result = resolve_seer_run(str(run.uuid), self.organization)
+
+        assert isinstance(result, Response)
+        assert result.data == {"session": {"status": "error"}}
+
+    def test_uuid_pending_mirror_returns_processing_session(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization,
+            seer_run_state_id=None,
+            mirror_status=SeerRunMirrorStatus.PENDING,
+        )
+
+        result = resolve_seer_run(str(run.uuid), self.organization)
+
+        assert isinstance(result, Response)
+        assert result.data == {"session": {"status": "processing"}}
+
+    def test_unknown_uuid_returns_404(self) -> None:
+        result = resolve_seer_run(str(uuid.uuid4()), self.organization)
+
+        assert isinstance(result, Response)
+        assert result.status_code == status.HTTP_404_NOT_FOUND
+        assert result.data == {"session": None}
+
+    def test_uuid_from_other_org_returns_404(self) -> None:
+        other_org = self.create_organization()
+        run = self.create_seer_run(organization=other_org, seer_run_state_id=555)
+
+        result = resolve_seer_run(str(run.uuid), self.organization)
+
+        assert isinstance(result, Response)
+        assert result.status_code == status.HTTP_404_NOT_FOUND
+        assert result.data == {"session": None}
+
+    def test_garbage_id_returns_400(self) -> None:
+        result = resolve_seer_run("not-a-real-id", self.organization)
+
+        assert isinstance(result, Response)
+        assert result.status_code == status.HTTP_400_BAD_REQUEST
+        assert result.data == {"detail": "Invalid run_id"}
+
+    def test_none_id_returns_400(self) -> None:
+        result = resolve_seer_run(None, self.organization)  # type: ignore[arg-type]
+
+        assert isinstance(result, Response)
+        assert result.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/sentry/seer/endpoints/test_utils.py
+++ b/tests/sentry/seer/endpoints/test_utils.py
@@ -75,6 +75,29 @@ class ResolveSeerRunTest(TestCase):
         assert isinstance(result, Response)
         assert result.data == {"session": {"status": "processing"}}
 
+    def test_uuid_pending_mirror_for_continue_returns_409(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization,
+            seer_run_state_id=None,
+            mirror_status=SeerRunMirrorStatus.PENDING,
+        )
+
+        result = resolve_seer_run(str(run.uuid), self.organization, for_continue=True)
+
+        assert isinstance(result, Response)
+        assert result.status_code == status.HTTP_409_CONFLICT
+
+    def test_uuid_failed_mirror_for_continue_returns_422(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization,
+            mirror_status=SeerRunMirrorStatus.FAILED,
+        )
+
+        result = resolve_seer_run(str(run.uuid), self.organization, for_continue=True)
+
+        assert isinstance(result, Response)
+        assert result.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
     def test_unknown_uuid_returns_404(self) -> None:
         result = resolve_seer_run(str(uuid.uuid4()), self.organization)
 

--- a/tests/sentry/seer/endpoints/test_utils.py
+++ b/tests/sentry/seer/endpoints/test_utils.py
@@ -115,6 +115,12 @@ class ResolveSeerRunTest(TestCase):
         assert result.status_code == status.HTTP_404_NOT_FOUND
         assert result.data == {"session": None}
 
+    def test_oversized_numeric_id_returns_400(self) -> None:
+        result = resolve_seer_run("99999999999999999999", self.organization)
+
+        assert isinstance(result, Response)
+        assert result.status_code == status.HTTP_400_BAD_REQUEST
+
     def test_garbage_id_returns_400(self) -> None:
         result = resolve_seer_run("not-a-real-id", self.organization)
 


### PR DESCRIPTION
`/explorer-chat` start now returns `sentry_run_id` (the `SeerRun.uuid`) alongside `run_id`, and the GET (poll) and continue paths accept either the numeric `seer_run_state_id` or the UUID, translating to the Seer-side id at the boundary.

Moves the chat frontend<->backend contract onto the UUID, mirroring the search-agent flow. Backward compatible — numeric ids still pass through. Autofix follows in a separate PR.