### PR TITLE
ref: Remove barely used tabs prop from SettingsPageHeader

### DIFF
--- a/static/app/views/organizationStats/header.tsx
+++ b/static/app/views/organizationStats/header.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {TabList} from '@sentry/scraps/tabs';
@@ -13,53 +14,47 @@ type Props = {
   organization: Organization;
 };
 
-function StatsHeaderTabs({organization}: Props) {
-  return (
-    <TabList>
-      <TabList.Item
-        key="stats"
-        to={makeStatsPathname({
-          path: '/',
-          organization,
-        })}
-      >
-        {t('Usage')}
-      </TabList.Item>
-      <TabList.Item
-        key="issues"
-        to={makeStatsPathname({
-          path: '/issues/',
-          organization,
-        })}
-      >
-        {t('Issues')}
-      </TabList.Item>
-      <TabList.Item
-        key="health"
-        to={makeStatsPathname({
-          path: '/health/',
-          organization,
-        })}
-      >
-        {t('Health')}
-      </TabList.Item>
-    </TabList>
-  );
-}
-
 export function StatsHeader({organization, activeTab}: Props) {
   return (
-    <SettingsPageHeader
-      title={t('Stats & Usage')}
-      subtitle={t(
-        'A view of the usage data that Sentry has received across your entire organization.'
-      )}
-      tabs={
-        <TabsContainer value={activeTab}>
-          <StatsHeaderTabs organization={organization} activeTab={activeTab} />
-        </TabsContainer>
-      }
-    />
+    <Fragment>
+      <SettingsPageHeader
+        title={t('Stats & Usage')}
+        subtitle={t(
+          'A view of the usage data that Sentry has received across your entire organization.'
+        )}
+      />
+      <TabsContainer value={activeTab}>
+        <TabList>
+          <TabList.Item
+            key="stats"
+            to={makeStatsPathname({
+              path: '/',
+              organization,
+            })}
+          >
+            {t('Usage')}
+          </TabList.Item>
+          <TabList.Item
+            key="issues"
+            to={makeStatsPathname({
+              path: '/issues/',
+              organization,
+            })}
+          >
+            {t('Issues')}
+          </TabList.Item>
+          <TabList.Item
+            key="health"
+            to={makeStatsPathname({
+              path: '/health/',
+              organization,
+            })}
+          >
+            {t('Health')}
+          </TabList.Item>
+        </TabList>
+      </TabsContainer>
+    </Fragment>
   );
 }
 

--- a/static/app/views/settings/account/accountSecurity/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.tsx
@@ -85,23 +85,19 @@ export default function AccountSecurity() {
   const routePrefix = '/settings/account/security/';
   return (
     <SentryDocumentTitle title={t('Security')}>
-      <SettingsPageHeader
-        title={t('Security')}
-        tabs={
-          <TabsContainer>
-            <Tabs value={activeTab}>
-              <TabList>
-                <TabList.Item key="settings" to={routePrefix}>
-                  {t('Settings')}
-                </TabList.Item>
-                <TabList.Item key="sessionHistory" to={`${routePrefix}session-history/`}>
-                  {t('Session History')}
-                </TabList.Item>
-              </TabList>
-            </Tabs>
-          </TabsContainer>
-        }
-      />
+      <SettingsPageHeader title={t('Security')} />
+      <TabsContainer>
+        <Tabs value={activeTab}>
+          <TabList>
+            <TabList.Item key="settings" to={routePrefix}>
+              {t('Settings')}
+            </TabList.Item>
+            <TabList.Item key="sessionHistory" to={`${routePrefix}session-history/`}>
+              {t('Session History')}
+            </TabList.Item>
+          </TabList>
+        </Tabs>
+      </TabsContainer>
 
       {!isEmpty && countEnrolled === 0 && <TwoFactorRequired />}
 

--- a/static/app/views/settings/account/accountSecurity/sessionHistory/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/sessionHistory/index.tsx
@@ -58,23 +58,19 @@ export default function SessionHistory() {
   const routePrefix = '/settings/account/security/';
   return (
     <SentryDocumentTitle title={t('Session History')}>
-      <SettingsPageHeader
-        title={t('Security')}
-        tabs={
-          <TabsContainer>
-            <Tabs value={activeTab}>
-              <TabList>
-                <TabList.Item key="settings" to={routePrefix}>
-                  {t('Settings')}
-                </TabList.Item>
-                <TabList.Item key="sessionHistory" to={`${routePrefix}session-history/`}>
-                  {t('Session History')}
-                </TabList.Item>
-              </TabList>
-            </Tabs>
-          </TabsContainer>
-        }
-      />
+      <SettingsPageHeader title={t('Security')} />
+      <TabsContainer>
+        <Tabs value={activeTab}>
+          <TabList>
+            <TabList.Item key="settings" to={routePrefix}>
+              {t('Settings')}
+            </TabList.Item>
+            <TabList.Item key="sessionHistory" to={`${routePrefix}session-history/`}>
+              {t('Session History')}
+            </TabList.Item>
+          </TabList>
+        </Tabs>
+      </TabsContainer>
 
       <Panel>
         <SessionPanelHeader>

--- a/static/app/views/settings/components/settingsPageHeader.tsx
+++ b/static/app/views/settings/components/settingsPageHeader.tsx
@@ -10,10 +10,9 @@ type Props = {
   title: React.ReactNode;
   action?: React.ReactNode;
   subtitle?: React.ReactNode;
-  tabs?: React.ReactNode;
 };
 
-export function SettingsPageHeader({title, subtitle, action, tabs}: Props) {
+export function SettingsPageHeader({title, subtitle, action}: Props) {
   return (
     <Fragment>
       {typeof title === 'string' ? (
@@ -27,7 +26,6 @@ export function SettingsPageHeader({title, subtitle, action, tabs}: Props) {
           {action}
         </Flex>
       )}
-      {tabs && <TabsWrapper>{tabs}</TabsWrapper>}
     </Fragment>
   );
 }
@@ -38,9 +36,4 @@ const Subtitle = styled('div')`
   color: ${p => p.theme.tokens.content.secondary};
   font-weight: ${p => p.theme.font.weight.sans.regular};
   font-size: ${p => p.theme.font.size.md};
-`;
-
-const TabsWrapper = styled('div')`
-  flex: 1;
-  margin: 0;
 `;

--- a/static/app/views/settings/project/projectEnvironments.tsx
+++ b/static/app/views/settings/project/projectEnvironments.tsx
@@ -197,29 +197,25 @@ export default function ProjectEnvironments() {
   return (
     <div>
       <SentryDocumentTitle title={t('Environments')} projectSlug={params.projectId} />
-      <SettingsPageHeader
-        title={t('Manage Environments')}
-        tabs={
-          <TabsContainer>
-            <Tabs value={isHidden ? 'hidden' : 'environments'}>
-              <TabList>
-                <TabList.Item
-                  key="environments"
-                  to={`/settings/${organization.slug}/projects/${params.projectId}/environments/`}
-                >
-                  {t('Environments')}
-                </TabList.Item>
-                <TabList.Item
-                  key="hidden"
-                  to={`/settings/${organization.slug}/projects/${params.projectId}/environments/hidden/`}
-                >
-                  {t('Hidden')}
-                </TabList.Item>
-              </TabList>
-            </Tabs>
-          </TabsContainer>
-        }
-      />
+      <SettingsPageHeader title={t('Manage Environments')} />
+      <TabsContainer>
+        <Tabs value={isHidden ? 'hidden' : 'environments'}>
+          <TabList>
+            <TabList.Item
+              key="environments"
+              to={`/settings/${organization.slug}/projects/${params.projectId}/environments/`}
+            >
+              {t('Environments')}
+            </TabList.Item>
+            <TabList.Item
+              key="hidden"
+              to={`/settings/${organization.slug}/projects/${params.projectId}/environments/hidden/`}
+            >
+              {t('Hidden')}
+            </TabList.Item>
+          </TabList>
+        </Tabs>
+      </TabsContainer>
       <ProjectPermissionAlert project={project} />
 
       <EnvironmentTable>


### PR DESCRIPTION
This removes an extra `<div style={{flex: 1}}>` wrapper that wasn't doing anything. 

Maybe we can say that it was helping to order tabs so they're in the correct position at the bottom under the subtitle/action.... but only 4 of 100 instances were using this. IMO it's not being helpful.

What i really want to target is the required marginBottom under the subtitle/action.. now that these tabs are out of the way that could be easier.