### PR TITLE
ref: Type 9 more PUBLIC endpoints incl. multi-shape & drift cases

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 from sentry import audit_log
 from sentry.api.base import audit_logger
 from sentry.api.utils import to_valid_int_id_list
+from sentry.apidocs.response_types import ValidationErrorResponse
 from sentry.deletions.defaults.group import GROUP_CHUNK_SIZE
 from sentry.deletions.tasks.groups import delete_groups_for_project
 from sentry.models.group import Group, GroupStatus
@@ -145,7 +146,7 @@ def schedule_tasks_to_delete_groups(
     projects: Sequence[Project],
     organization_id: int,
     search_fn: SearchFunction | None = None,
-) -> Response:
+) -> Response[None] | Response[ValidationErrorResponse]:
     """
     `search_fn` refers to the `search.query` method with the appropriate
     project, org, environment, and search params already bound

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -966,7 +966,7 @@ class DetailedProjectResponse(ProjectWithTeamResponseDict):
     defaultEnvironment: str | None
     relayPiiConfig: str | None
     builtinSymbolSources: list[str]
-    dynamicSamplingBiases: list[dict[str, str | bool]]
+    dynamicSamplingBiases: list[dict[str, str | bool]] | None
     symbolSources: str
     isDynamicallySampled: bool
     tempestFetchScreenshots: NotRequired[bool]

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -26,7 +26,10 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models import organization as org_serializers
 from sentry.api.serializers.models.organization import (
     BaseOrganizationSerializer,
+    OrganizationSerializerResponse,
+    OrganizationSummarySerializerResponse,
     OrganizationWithProjectsAndTeamsSerializer,
+    OrganizationWithProjectsAndTeamsSerializerResponse,
     TrustedRelaySerializer,
 )
 from sentry.apidocs.constants import (
@@ -38,6 +41,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams, OrganizationParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.auth.services.auth import auth_service
 from sentry.auth.staff import is_active_staff
 from sentry.constants import (
@@ -1088,7 +1092,13 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         },
         examples=OrganizationExamples.RETRIEVE_ORGANIZATION,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> (
+        Response[OrganizationSummarySerializerResponse]
+        | Response[OrganizationSerializerResponse]
+        | Response[OrganizationWithProjectsAndTeamsSerializerResponse]
+    ):
         """
         Return details on an individual organization, including various details
         such as membership access and teams.
@@ -1132,7 +1142,12 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         },
         examples=OrganizationExamples.UPDATE_ORGANIZATION,
     )
-    def put(self, request: Request, organization: Organization) -> Response:
+    def put(
+        self, request: Request, organization: Organization
+    ) -> (
+        Response[OrganizationWithProjectsAndTeamsSerializerResponse]
+        | Response[ValidationErrorResponse]
+    ):
         """
         Update various attributes and configurable settings for the given organization.
         """
@@ -1171,10 +1186,10 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                         organization_id=organization.id, slug=slug
                     )
                 except RpcValidationException:
-                    return self.respond(
-                        {"slug": [f'The slug "{slug}" is in use by another organization.']},
-                        status=status.HTTP_400_BAD_REQUEST,
-                    )
+                    slug_err: ValidationErrorResponse = {
+                        "slug": [f'The slug "{slug}" is in use by another organization.'],
+                    }
+                    return self.respond(slug_err, status=status.HTTP_400_BAD_REQUEST)
             with transaction.atomic(router.db_for_write(Organization)):
                 organization, changed_data = serializer.save()
 
@@ -1279,7 +1294,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
             )
 
             return self.respond(context)
-        return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        return self.respond(as_validation_errors(serializer), status=status.HTTP_400_BAD_REQUEST)
 
     def _compute_project_target_sample_rates(self, request: Request, organization: Organization):
         # TODO: this will take a long time for organizations with a lot of projects

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import timedelta
+from typing import NotRequired
 from uuid import uuid4
 
 import orjson
@@ -21,12 +22,17 @@ from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.fields.sentry_slug import SentrySerializerSlugField
 from sentry.api.permissions import StaffPermissionMixin
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.project import DetailedProjectSerializer
+from sentry.api.serializers.models.project import DetailedProjectResponse, DetailedProjectSerializer
 from sentry.api.serializers.rest_framework.list import EmptyListField
 from sentry.api.serializers.rest_framework.origin import OriginField
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NO_CONTENT, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.project_examples import ProjectExamples
 from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.response_types import (
+    DetailResponse,
+    ValidationErrorResponse,
+    as_validation_errors,
+)
 from sentry.constants import (
     PROJECT_SLUG_MAX_LENGTH,
     RESERVED_PROJECT_SLUGS,
@@ -512,6 +518,13 @@ class RelaxedProjectAndStaffPermission(StaffPermissionMixin, RelaxedProjectPermi
     pass
 
 
+class _ProjectDetailsResponse(DetailedProjectResponse):
+    """`DetailedProjectResponse` plus the endpoint-level extra the handler
+    appends post-serialize via `?expand=hasAlertIntegration`."""
+
+    hasAlertIntegrationInstalled: NotRequired[bool]
+
+
 @extend_schema(tags=["Projects"])
 @cell_silo_endpoint
 class ProjectDetailsEndpoint(ProjectEndpoint):
@@ -544,12 +557,16 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         },
         examples=ProjectExamples.DETAILED_PROJECT,
     )
-    def get(self, request: Request, project: Project) -> Response:
+    def get(
+        self, request: Request, project: Project
+    ) -> Response[_ProjectDetailsResponse] | Response[ValidationErrorResponse]:
         """
         Return details on an individual project.
         """
         collapse = request.GET.getlist("collapse", [])
-        data = serialize(project, request.user, DetailedProjectSerializer(collapse=collapse))
+        data: _ProjectDetailsResponse = serialize(
+            project, request.user, DetailedProjectSerializer(collapse=collapse)
+        )
 
         # TODO: should switch to expand and move logic into the serializer
         include = set(filter(bool, request.GET.get("include", "").split(",")))
@@ -567,8 +584,9 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 many=True,
             )
             if not ds_bias_serializer.is_valid():
-                return Response(ds_bias_serializer.errors, status=400)
-            data["dynamicSamplingBiases"] = ds_bias_serializer.data
+                return Response(as_validation_errors(ds_bias_serializer), status=400)
+            biases: list[dict[str, str | bool]] = list(ds_bias_serializer.data)
+            data["dynamicSamplingBiases"] = biases
         else:
             data["dynamicSamplingBiases"] = None
 
@@ -591,7 +609,14 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         },
         examples=ProjectExamples.DETAILED_PROJECT,
     )
-    def put(self, request: Request, project) -> Response:
+    def put(
+        self, request: Request, project
+    ) -> (
+        Response[_ProjectDetailsResponse]
+        | Response[None]
+        | Response[DetailResponse]
+        | Response[ValidationErrorResponse]
+    ):
         """
         Update various attributes and configurable settings for the given project.
 
@@ -630,7 +655,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 status=403,
             )
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer), status=400)
 
         if not has_elevated_scopes:
             for key in ProjectAdminSerializer().fields.keys():
@@ -1134,8 +1159,10 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                     result.get("dynamicSamplingBiases"),
                 )
                 if len(changed_proj_settings) == 1:
-                    data = serialize(project, request.user, DetailedProjectSerializer())
-                    return Response(data)
+                    body_partial: _ProjectDetailsResponse = serialize(
+                        project, request.user, DetailedProjectSerializer()
+                    )
+                    return Response(body_partial)
 
             if "sentry:uptime_autodetection" in options:
                 project.update_option(
@@ -1150,13 +1177,15 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             data={**changed_proj_settings, **project.get_audit_log_data()},
         )
 
-        data = serialize(project, request.user, DetailedProjectSerializer())
+        body: _ProjectDetailsResponse = serialize(
+            project, request.user, DetailedProjectSerializer()
+        )
         if not has_dynamic_sampling(project.organization):
-            data["dynamicSamplingBiases"] = None
+            body["dynamicSamplingBiases"] = None
         # If here because the case of when no dynamic sampling is enabled at all, you would want to kick
         # out both keys actually
 
-        return Response(data)
+        return Response(body)
 
     @extend_schema(
         operation_id="Delete a Project",
@@ -1167,7 +1196,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def delete(self, request: Request, project: Project) -> Response:
+    def delete(self, request: Request, project: Project) -> Response[None] | Response[str]:
         """
         Schedules a project for deletion.
 

--- a/src/sentry/core/endpoints/scim/constants.py
+++ b/src/sentry/core/endpoints/scim/constants.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import TypedDict
 
 SCIM_API_LIST = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
 SCIM_SCHEMA_USER = "urn:ietf:params:scim:schemas:core:2.0:User"
@@ -8,6 +9,17 @@ ERR_ONLY_OWNER = "You cannot remove the only remaining owner of the organization
 SCIM_API_ERROR = "urn:ietf:params:scim:api:messages:2.0:Error"
 SCIM_API_PATCH = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
 SCIM_COUNT = 100
+
+
+class SCIMErrorResponse(TypedDict, total=False):
+    """SCIM-specific error envelope: `{"schemas": [...], "detail": "..."}`
+    plus optional `scimType` per RFC 7644. The shape diverges from DRF's
+    `{"detail": ...}` because SCIM clients (IDPs) expect this exact format."""
+
+    schemas: list[str]
+    detail: str
+    scimType: str
+
 
 SCIM_404_USER_RES = {
     "schemas": [SCIM_API_ERROR],

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -662,7 +662,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         metrics.incr("sentry.scim.team.delete")
         return super().delete(request, team)
 
-    def put(self, request: Request, organization: Organization, team: Team) -> Response:  # type: ignore[override]  # convert_args changed shape from baseclass
+    def put(self, request: Request, organization: Organization, team: Team) -> HttpResponseBase:  # type: ignore[override]  # convert_args changed shape from baseclass
         # override parent's put since we don't have puts
         # in SCIM Team routes
         return self.http_method_not_allowed(request)

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -52,7 +52,7 @@ from sentry.apidocs.parameters import (
     IssueParams,
     OrganizationParams,
 )
-from sentry.apidocs.response_types import DetailResponse
+from sentry.apidocs.response_types import DetailResponse, ValidationErrorResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ALLOWED_FUTURE_DELTA
 from sentry.exceptions import InvalidSearchQuery
@@ -538,7 +538,9 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
         },
     )
     @track_slo_response("workflow")
-    def delete(self, request: Request, organization: Organization) -> Response:
+    def delete(
+        self, request: Request, organization: Organization
+    ) -> Response[None] | Response[DetailResponse] | Response[ValidationErrorResponse]:
         projects = self.get_projects(request, organization)
 
         search_fn = functools.partial(

--- a/src/sentry/issues/endpoints/project_ownership.py
+++ b/src/sentry/issues/endpoints/project_ownership.py
@@ -281,7 +281,7 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
         responses={200: ProjectOwnershipSerializer},
         examples=ownership_examples.GET_PROJECT_OWNERSHIP,
     )
-    def get(self, request: Request, project) -> Response:
+    def get(self, request: Request, project) -> Response[ProjectOwnershipResponse]:
         """
         Returns details on a project's ownership configuration.
         """
@@ -291,7 +291,8 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
             self.refresh_ownership_schema(ownership, project)
             self.rename_schema_identifier_for_parsing(ownership)
 
-        return Response(serialize(ownership, request.user))
+        body: ProjectOwnershipResponse = serialize(ownership, request.user)
+        return Response(body)
 
     @extend_schema(
         operation_id="Update Ownership Configuration for a Project",

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_download.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_download.py
@@ -14,7 +14,6 @@ from io import BytesIO
 import orjson
 from django.conf import settings
 from django.http import StreamingHttpResponse
-from django.http.response import HttpResponseBase
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -29,6 +28,7 @@ from sentry.api.bases.organization import (
 )
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.auth.staff import is_active_staff
 from sentry.models.organization import Organization
 from sentry.objectstore import get_preprod_session
@@ -115,7 +115,7 @@ class OrganizationPreprodSnapshotDownloadEndpoint(OrganizationEndpoint):
     )
     def get(
         self, request: Request, organization: Organization, snapshot_id: str
-    ) -> HttpResponseBase:
+    ) -> Response[DetailResponse] | StreamingHttpResponse:
         """
         Download all images in a snapshot as a ZIP archive.
 


### PR DESCRIPTION
Tightens 9 more PUBLIC endpoints:

- `project_ownership.get` → typed against existing `ProjectOwnershipResponse`
- `organization_group_index.delete` + `schedule_tasks_to_delete_groups` helper: typed for the async-deletion path
- `preprod_artifact_snapshot_download.get` → `Response[DetailResponse] | StreamingHttpResponse` (the success path is the ZIP archive stream)
- `organization_details.get` → three-arm union (`OrganizationSummary`, `Organization`, `OrganizationWithProjectsAndTeams`) matching the runtime branching by scope/`detailed` param
- `organization_details.put` → typed with `as_validation_errors()` routing
- `project_details.get/put` → new local `_ProjectDetailsResponse` extending `DetailedProjectResponse` with the `hasAlertIntegrationInstalled` key the endpoint appends post-serialize. `DetailedProjectResponse.dynamicSamplingBiases` widened to `list[...] | None` matching the runtime emission when dynamic sampling is disabled.
- `project_details.delete` → `Response[None] | Response[str]` for the raw-string error body retained for backward compat
- `scim/teams.put` → `HttpResponseBase` (returns `http_method_not_allowed`)
- `SCIMErrorResponse` TypedDict added to `scim/constants` for future use

`scim/teams.patch` left untyped: its exception-detail flow passes through DRF's `_APIExceptionInput` which can't be reconciled with `SCIMErrorResponse` without a deeper restructure.