### PR TITLE
feat(issues): Show linked pull requests in issue sidebar

### DIFF
--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -64,7 +64,7 @@ describe('LinkedPullRequests', () => {
       'https://github.com/example/widget-app/pull/123'
     );
     expect(linkedPullRequest).toHaveAccessibleName(
-      `Fix widget crash on startup, pull request #123, Merged, repository ${REPOSITORY_NAME}`
+      `Fix widget crash on startup, pull request #123, Merged in ${REPOSITORY_NAME}`
     );
     expect(within(list).getAllByRole('listitem')).toHaveLength(2);
     expect(within(list).getByText('#123')).toBeInTheDocument();

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -1,0 +1,85 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PullRequestFixture} from 'sentry-fixture/pullRequest';
+import {RepositoryFixture} from 'sentry-fixture/repository';
+
+import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+
+import {LinkedPullRequests} from './linkedPullRequests';
+
+const LINKED_PULL_REQUESTS_FEATURE = 'issue-details-linked-pull-requests';
+const REPOSITORY_NAME = 'example/widget-app';
+
+describe('LinkedPullRequests', () => {
+  const group = GroupFixture();
+  const organizationWithFeature = OrganizationFixture({
+    features: [LINKED_PULL_REQUESTS_FEATURE],
+  });
+  const repository = RepositoryFixture({
+    id: '42',
+    name: REPOSITORY_NAME,
+    provider: {id: 'integrations:github', name: 'GitHub'},
+  });
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders linked pull requests when the feature is enabled', async () => {
+    const pullRequestsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organizationWithFeature.slug}/issues/${group.id}/pull-requests/`,
+      body: {
+        pullRequests: [
+          {
+            ...PullRequestFixture({
+              id: '123',
+              title: 'Fix widget crash on startup',
+              repository,
+              externalUrl: 'https://github.com/example/widget-app/pull/123',
+            }),
+            dateLinked: '2026-06-08T23:11:32.000000Z',
+            status: 'merged',
+          },
+          {
+            ...PullRequestFixture({
+              id: '124',
+              title: 'Remove unused widget fallback',
+              repository,
+              externalUrl: 'https://github.com/example/widget-app/pull/124',
+            }),
+            dateLinked: '2026-06-08T23:10:32.000000Z',
+            status: 'closed',
+          },
+        ],
+      },
+    });
+
+    render(<LinkedPullRequests group={group} />, {
+      organization: organizationWithFeature,
+    });
+
+    const list = await screen.findByRole('list', {name: 'Linked pull requests'});
+    const linkedPullRequest = within(list).getByRole('link', {
+      name: /Fix widget crash on startup/,
+    });
+
+    expect(linkedPullRequest).toHaveAttribute(
+      'href',
+      'https://github.com/example/widget-app/pull/123'
+    );
+    expect(linkedPullRequest).toHaveAccessibleName(
+      `Fix widget crash on startup, pull request #123, Merged, repository ${REPOSITORY_NAME}`
+    );
+    expect(within(list).getAllByRole('listitem')).toHaveLength(2);
+    expect(within(list).getByText('#123')).toBeInTheDocument();
+    expect(within(list).getByText('#124')).toBeInTheDocument();
+    expect(within(list).getAllByText(REPOSITORY_NAME)).toHaveLength(2);
+    expect(
+      within(list).getByTestId('linked-pull-request-status-merged')
+    ).toBeInTheDocument();
+    expect(
+      within(list).getByTestId('linked-pull-request-status-closed')
+    ).toBeInTheDocument();
+    expect(pullRequestsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -21,10 +21,6 @@ describe('LinkedPullRequests', () => {
     provider: {id: 'integrations:github', name: 'GitHub'},
   });
 
-  beforeEach(() => {
-    MockApiClient.clearMockResponses();
-  });
-
   it('renders linked pull requests when the feature is enabled', async () => {
     const pullRequestsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organizationWithFeature.slug}/issues/${group.id}/pull-requests/`,

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -109,7 +109,7 @@ function LinkedPullRequestRow({pullRequest}: {pullRequest: LinkedPullRequest}) {
               </Text>
             </Flex>
             <Flex as="span" align="center" gap="xs" minWidth={0}>
-              <IconRepository size="xs" variant="muted" />
+              <RepositoryIcon size="xs" variant="muted" />
               <Text
                 as="span"
                 ellipsis
@@ -179,4 +179,8 @@ const PullRequestRow = styled(ExternalLink)`
     color: ${p => p.theme.tokens.content.primary};
     background: ${p => p.theme.tokens.background.secondary};
   }
+`;
+
+const RepositoryIcon = styled(IconRepository)`
+  transform: translateY(1px);
 `;

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -81,7 +81,7 @@ function LinkedPullRequestRow({pullRequest}: {pullRequest: LinkedPullRequest}) {
   return (
     <PullRequestRow
       aria-label={t(
-        '%s, pull request #%s, %s, repository %s',
+        '%s, pull request #%s, %s in %s',
         title,
         pullRequest.id,
         statusLabel,
@@ -98,9 +98,7 @@ function LinkedPullRequestRow({pullRequest}: {pullRequest: LinkedPullRequest}) {
           />
         </Flex>
         <Flex direction="column" gap="2xs" minWidth={0}>
-          <Text as="span" bold ellipsis>
-            {title}
-          </Text>
+          <PullRequestTitle>{title}</PullRequestTitle>
           <Flex align="center" gap="sm">
             <Flex as="span" align="center" gap="xs" minWidth={0}>
               {getStatusIcon(pullRequest.status)}
@@ -183,4 +181,15 @@ const PullRequestRow = styled(ExternalLink)`
 
 const RepositoryIcon = styled(IconRepository)`
   transform: translateY(1px);
+`;
+
+const PullRequestTitle = styled('span')`
+  display: block;
+  overflow: hidden;
+  width: 100%;
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+  font-variant-ligatures: no-common-ligatures;
+  font-feature-settings: 'liga' 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -1,0 +1,182 @@
+import styled from '@emotion/styled';
+import {skipToken, useQuery} from '@tanstack/react-query';
+
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
+import {
+  IconMerge,
+  IconPullRequest,
+  IconPullRequestClosed,
+  IconRepository,
+} from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
+import {t} from 'sentry/locale';
+import type {Group} from 'sentry/types/group';
+import type {PullRequest} from 'sentry/types/integrations';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+const LINKED_PULL_REQUESTS_FEATURE = 'issue-details-linked-pull-requests';
+
+type LinkedPullRequestStatus = 'closed' | 'draft' | 'merged' | 'open' | 'unknown';
+
+type LinkedPullRequest = PullRequest & {
+  dateLinked: string;
+  status: LinkedPullRequestStatus;
+};
+
+type LinkedPullRequestsResponse = {
+  pullRequests: LinkedPullRequest[];
+};
+
+type StatusIconConfig = {
+  Icon: React.ComponentType<SVGIconProps>;
+  variant: SVGIconProps['variant'];
+};
+
+const STATUS_ICON_CONFIG = {
+  closed: {Icon: IconPullRequestClosed, variant: 'danger'},
+  draft: {Icon: IconPullRequest, variant: 'muted'},
+  merged: {Icon: IconMerge, variant: 'accent'},
+  open: {Icon: IconPullRequest, variant: 'success'},
+  unknown: {Icon: IconPullRequest, variant: 'muted'},
+} satisfies Record<LinkedPullRequestStatus, StatusIconConfig>;
+
+function getStatusIcon(status: LinkedPullRequestStatus) {
+  const {Icon, variant} = STATUS_ICON_CONFIG[status];
+  return (
+    <Icon
+      aria-hidden
+      data-test-id={`linked-pull-request-status-${status}`}
+      size="xs"
+      variant={variant}
+    />
+  );
+}
+
+function getStatusLabel(status: LinkedPullRequestStatus) {
+  switch (status) {
+    case 'closed':
+      return t('Closed');
+    case 'draft':
+      return t('Draft');
+    case 'merged':
+      return t('Merged');
+    case 'open':
+      return t('Open');
+    case 'unknown':
+      return t('Unknown status');
+    default:
+      return status satisfies never;
+  }
+}
+
+function LinkedPullRequestRow({pullRequest}: {pullRequest: LinkedPullRequest}) {
+  const title = pullRequest.title ?? t('Pull request #%s', pullRequest.id);
+  const statusLabel = getStatusLabel(pullRequest.status);
+
+  return (
+    <PullRequestRow
+      aria-label={t(
+        '%s, pull request #%s, %s, repository %s',
+        title,
+        pullRequest.id,
+        statusLabel,
+        pullRequest.repository.name
+      )}
+      href={pullRequest.externalUrl}
+    >
+      <Grid columns="max-content minmax(0, 1fr)" gap="sm" padding="sm">
+        <Flex as="span" aria-hidden align="start" paddingTop="2xs">
+          <RepoProviderIcon
+            provider={pullRequest.repository.provider.id}
+            size="sm"
+            variant="muted"
+          />
+        </Flex>
+        <Flex direction="column" gap="2xs" minWidth={0}>
+          <Text as="span" bold ellipsis>
+            {title}
+          </Text>
+          <Flex align="center" gap="sm">
+            <Flex as="span" align="center" gap="xs" minWidth={0}>
+              {getStatusIcon(pullRequest.status)}
+              <Text as="span" textWrap="nowrap" variant="muted">
+                #{pullRequest.id}
+              </Text>
+            </Flex>
+            <Flex as="span" align="center" gap="xs" minWidth={0}>
+              <IconRepository size="xs" variant="muted" />
+              <Text
+                as="span"
+                ellipsis
+                title={pullRequest.repository.name}
+                variant="muted"
+              >
+                {pullRequest.repository.name}
+              </Text>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Grid>
+    </PullRequestRow>
+  );
+}
+
+export function LinkedPullRequests({group}: {group: Group}) {
+  const organization = useOrganization();
+  const hasFeature = organization.features.includes(LINKED_PULL_REQUESTS_FEATURE);
+
+  const {data, isError} = useQuery(
+    apiOptions.as<LinkedPullRequestsResponse>()(
+      '/organizations/$organizationIdOrSlug/issues/$issueId/pull-requests/',
+      {
+        path: hasFeature
+          ? {organizationIdOrSlug: organization.slug, issueId: group.id}
+          : skipToken,
+        staleTime: 30_000,
+      }
+    )
+  );
+
+  if (!hasFeature || isError || !data?.pullRequests.length) {
+    return null;
+  }
+
+  return (
+    <Flex
+      as="ul"
+      aria-label={t('Linked pull requests')}
+      direction="column"
+      border="primary"
+      radius="md"
+      overflow="hidden"
+      margin="0"
+      padding="0"
+    >
+      {data.pullRequests.map((pullRequest, index) => (
+        <Container
+          as="li"
+          key={`${pullRequest.repository.id}:${pullRequest.id}`}
+          borderTop={index === 0 ? undefined : 'primary'}
+          style={{listStyle: 'none'}}
+        >
+          <LinkedPullRequestRow pullRequest={pullRequest} />
+        </Container>
+      ))}
+    </Flex>
+  );
+}
+
+const PullRequestRow = styled(ExternalLink)`
+  display: block;
+  color: ${p => p.theme.tokens.content.primary};
+
+  &:hover {
+    color: ${p => p.theme.tokens.content.primary};
+    background: ${p => p.theme.tokens.background.secondary};
+  }
+`;

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
@@ -5,6 +5,8 @@ import {JiraIntegrationFixture} from 'sentry-fixture/jiraIntegration';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PlatformExternalIssueFixture} from 'sentry-fixture/platformExternalIssue';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {PullRequestFixture} from 'sentry-fixture/pullRequest';
+import {RepositoryFixture} from 'sentry-fixture/repository';
 import {SentryAppComponentFixture} from 'sentry-fixture/sentryAppComponent';
 import {SentryAppInstallationFixture} from 'sentry-fixture/sentryAppInstallation';
 
@@ -195,6 +197,81 @@ describe('ExternalIssueSidebarList', () => {
     expect(
       await screen.findByText('Track this issue in Jira, GitHub, etc.')
     ).toBeInTheDocument();
+  });
+
+  it('should not request linked pull requests when the feature is disabled', async () => {
+    const pullRequestsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
+      body: {pullRequests: []},
+    });
+
+    render(<ExternalIssueSidebarList event={event} group={group} project={project} />, {
+      organization,
+    });
+
+    expect(
+      await screen.findByText('Track this issue in Jira, GitHub, etc.')
+    ).toBeInTheDocument();
+    expect(pullRequestsMock).not.toHaveBeenCalled();
+  });
+
+  it('should render linked pull requests when the feature is enabled', async () => {
+    const organizationWithFeature = OrganizationFixture({
+      features: ['issue-details-linked-pull-requests'],
+    });
+    const repository = RepositoryFixture({
+      id: '42',
+      name: 'getsentry/sentry',
+      provider: {id: 'integrations:github', name: 'GitHub'},
+    });
+    const pullRequest = PullRequestFixture({
+      id: '115619',
+      title: 'fix(issues): Render assigned user linked pull requests',
+      repository,
+      externalUrl: 'https://github.com/getsentry/sentry/pull/115619',
+    });
+    const closedPullRequest = PullRequestFixture({
+      id: '115618',
+      title: 'fix(members): Ignore detail response',
+      repository,
+      externalUrl: 'https://github.com/getsentry/sentry/pull/115618',
+    });
+    const pullRequestsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organizationWithFeature.slug}/issues/${group.id}/pull-requests/`,
+      body: {
+        pullRequests: [
+          {
+            ...pullRequest,
+            dateLinked: '2026-06-08T23:11:32.000000Z',
+            status: 'merged',
+          },
+          {
+            ...closedPullRequest,
+            dateLinked: '2026-06-08T23:10:32.000000Z',
+            status: 'closed',
+          },
+        ],
+      },
+    });
+
+    render(<ExternalIssueSidebarList event={event} group={group} project={project} />, {
+      organization: organizationWithFeature,
+    });
+
+    const linkedPullRequest = await screen.findByRole('link', {
+      name: /fix\(issues\): Render assigned user linked pull requests/,
+    });
+
+    expect(linkedPullRequest).toHaveAttribute(
+      'href',
+      'https://github.com/getsentry/sentry/pull/115619'
+    );
+    expect(screen.getByText('#115619')).toBeInTheDocument();
+    expect(screen.getByText('#115618')).toBeInTheDocument();
+    expect(screen.getAllByText('getsentry/sentry')).toHaveLength(2);
+    expect(screen.getByTestId('linked-pull-request-status-merged')).toBeInTheDocument();
+    expect(screen.getByTestId('linked-pull-request-status-closed')).toBeInTheDocument();
+    expect(pullRequestsMock).toHaveBeenCalledTimes(1);
   });
 
   it('should render dropdown items with subtext correctly', async () => {

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
@@ -5,8 +5,6 @@ import {JiraIntegrationFixture} from 'sentry-fixture/jiraIntegration';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PlatformExternalIssueFixture} from 'sentry-fixture/platformExternalIssue';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {PullRequestFixture} from 'sentry-fixture/pullRequest';
-import {RepositoryFixture} from 'sentry-fixture/repository';
 import {SentryAppComponentFixture} from 'sentry-fixture/sentryAppComponent';
 import {SentryAppInstallationFixture} from 'sentry-fixture/sentryAppInstallation';
 
@@ -197,81 +195,6 @@ describe('ExternalIssueSidebarList', () => {
     expect(
       await screen.findByText('Track this issue in Jira, GitHub, etc.')
     ).toBeInTheDocument();
-  });
-
-  it('should not request linked pull requests when the feature is disabled', async () => {
-    const pullRequestsMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
-      body: {pullRequests: []},
-    });
-
-    render(<ExternalIssueSidebarList event={event} group={group} project={project} />, {
-      organization,
-    });
-
-    expect(
-      await screen.findByText('Track this issue in Jira, GitHub, etc.')
-    ).toBeInTheDocument();
-    expect(pullRequestsMock).not.toHaveBeenCalled();
-  });
-
-  it('should render linked pull requests when the feature is enabled', async () => {
-    const organizationWithFeature = OrganizationFixture({
-      features: ['issue-details-linked-pull-requests'],
-    });
-    const repository = RepositoryFixture({
-      id: '42',
-      name: 'getsentry/sentry',
-      provider: {id: 'integrations:github', name: 'GitHub'},
-    });
-    const pullRequest = PullRequestFixture({
-      id: '115619',
-      title: 'fix(issues): Render assigned user linked pull requests',
-      repository,
-      externalUrl: 'https://github.com/getsentry/sentry/pull/115619',
-    });
-    const closedPullRequest = PullRequestFixture({
-      id: '115618',
-      title: 'fix(members): Ignore detail response',
-      repository,
-      externalUrl: 'https://github.com/getsentry/sentry/pull/115618',
-    });
-    const pullRequestsMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organizationWithFeature.slug}/issues/${group.id}/pull-requests/`,
-      body: {
-        pullRequests: [
-          {
-            ...pullRequest,
-            dateLinked: '2026-06-08T23:11:32.000000Z',
-            status: 'merged',
-          },
-          {
-            ...closedPullRequest,
-            dateLinked: '2026-06-08T23:10:32.000000Z',
-            status: 'closed',
-          },
-        ],
-      },
-    });
-
-    render(<ExternalIssueSidebarList event={event} group={group} project={project} />, {
-      organization: organizationWithFeature,
-    });
-
-    const linkedPullRequest = await screen.findByRole('link', {
-      name: /fix\(issues\): Render assigned user linked pull requests/,
-    });
-
-    expect(linkedPullRequest).toHaveAttribute(
-      'href',
-      'https://github.com/getsentry/sentry/pull/115619'
-    );
-    expect(screen.getByText('#115619')).toBeInTheDocument();
-    expect(screen.getByText('#115618')).toBeInTheDocument();
-    expect(screen.getAllByText('getsentry/sentry')).toHaveLength(2);
-    expect(screen.getByTestId('linked-pull-request-status-merged')).toBeInTheDocument();
-    expect(screen.getByTestId('linked-pull-request-status-closed')).toBeInTheDocument();
-    expect(pullRequestsMock).toHaveBeenCalledTimes(1);
   });
 
   it('should render dropdown items with subtext correctly', async () => {

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
@@ -1,7 +1,9 @@
 import {Flex} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
+import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {ExternalIssueList} from 'sentry/components/group/externalIssuesList';
+import {LinkedPullRequests} from 'sentry/components/group/externalIssuesList/linkedPullRequests';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
@@ -28,6 +30,9 @@ export function ExternalIssueSidebarList({event, group, project}: Props) {
     >
       <Flex direction="column" gap="md">
         <ExternalIssueList group={group} event={event} project={project} />
+        <ErrorBoundary customComponent={null}>
+          <LinkedPullRequests group={group} />
+        </ErrorBoundary>
       </Flex>
     </SidebarFoldSection>
   );


### PR DESCRIPTION
Adds linked pull requests block under Issue Tracking from the new backend api #117249

<img width="335" height="267" alt="image" src="https://github.com/user-attachments/assets/21e454dc-300c-4a0c-acfc-c86dbcd38181" />

part of [ID-1614](https://linear.app/getsentry/issue/ID-1614)