### PR TITLE
feat(issues): Instrument Sentry App platform external issue attach/unlink

### DIFF
--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -64,6 +64,9 @@ class GroupActionType(IntEnum):
     CREATE_EXTERNAL_ISSUE = 18
     LINK_EXTERNAL_ISSUE = 19
     UNLINK_EXTERNAL_ISSUE = 20
+    CREATE_PLATFORM_EXTERNAL_ISSUE = 21
+    LINK_PLATFORM_EXTERNAL_ISSUE = 22
+    UNLINK_PLATFORM_EXTERNAL_ISSUE = 23
 
 
 class GroupAction(BaseModel, abc.ABC):
@@ -225,3 +228,33 @@ class UnlinkExternalIssueAction(GroupAction):
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.UNLINK_EXTERNAL_ISSUE
+
+
+class CreatePlatformExternalIssueAction(GroupAction):
+    service_type: str
+    display_name: str
+    web_url: str
+
+    @classmethod
+    def get_type(cls) -> GroupActionType:
+        return GroupActionType.CREATE_PLATFORM_EXTERNAL_ISSUE
+
+
+class LinkPlatformExternalIssueAction(GroupAction):
+    service_type: str
+    display_name: str
+    web_url: str
+
+    @classmethod
+    def get_type(cls) -> GroupActionType:
+        return GroupActionType.LINK_PLATFORM_EXTERNAL_ISSUE
+
+
+class UnlinkPlatformExternalIssueAction(GroupAction):
+    service_type: str
+    display_name: str
+    web_url: str
+
+    @classmethod
+    def get_type(cls) -> GroupActionType:
+        return GroupActionType.UNLINK_PLATFORM_EXTERNAL_ISSUE

--- a/src/sentry/sentry_apps/api/endpoints/group_external_issue_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/group_external_issue_details.py
@@ -7,6 +7,13 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.helpers.deprecation import deprecated
 from sentry.constants import CELL_API_DEPRECATION_DATE
+from sentry.issues.action_log import (
+    SYSTEM_ACTOR,
+    GroupActionActor,
+    publish_action,
+    resolve_action_source,
+)
+from sentry.issues.action_log.types import UnlinkPlatformExternalIssueAction
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 
@@ -26,6 +33,23 @@ class GroupExternalIssueDetailsEndpoint(GroupEndpoint):
             )
         except PlatformExternalIssue.DoesNotExist:
             return Response(status=404)
+
+        publish_action(
+            UnlinkPlatformExternalIssueAction(
+                service_type=external_issue.service_type,
+                display_name=external_issue.display_name,
+                web_url=external_issue.web_url,
+            ),
+            source=resolve_action_source(request),
+            group_id=group.id,
+            organization_id=group.project.organization_id,
+            project_id=external_issue.project_id or group.project_id,
+            actor=(
+                GroupActionActor.user(request.user.id)
+                if request.user.is_authenticated
+                else SYSTEM_ACTOR
+            ),
+        )
 
         deletions.exec_sync(external_issue)
 

--- a/src/sentry/sentry_apps/services/cell/impl.py
+++ b/src/sentry/sentry_apps/services/cell/impl.py
@@ -6,6 +6,17 @@ from django.db import router, transaction
 from sentry import deletions, tsdb
 from sentry.auth.access import Access, OrganizationGlobalMembership, from_user
 from sentry.auth.services.auth.model import AuthenticationContext
+from sentry.issues.action_log import (
+    SYSTEM_ACTOR,
+    ActionSource,
+    GroupActionActor,
+    publish_action,
+)
+from sentry.issues.action_log.types import (
+    CreatePlatformExternalIssueAction,
+    LinkPlatformExternalIssueAction,
+    UnlinkPlatformExternalIssueAction,
+)
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -160,6 +171,24 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
         except (SentryAppIntegratorError, SentryAppSentryError) as e:
             return RpcPlatformExternalIssueResult(error=RpcSentryAppError.from_exc(e))
 
+        action_cls = (
+            CreatePlatformExternalIssueAction
+            if action == "create"
+            else LinkPlatformExternalIssueAction
+        )
+        publish_action(
+            action_cls(
+                service_type=external_issue.service_type,
+                display_name=external_issue.display_name,
+                web_url=external_issue.web_url,
+            ),
+            source=ActionSource.API,
+            group_id=group.id,
+            organization_id=organization_id,
+            project_id=external_issue.project_id or group.project_id,
+            actor=GroupActionActor.user(user.id),
+        )
+
         return RpcPlatformExternalIssueResult(
             external_issue=serialize_platform_external_issue(external_issue)
         )
@@ -224,6 +253,19 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
         except SentryAppSentryError as e:
             return RpcPlatformExternalIssueResult(error=RpcSentryAppError.from_exc(e))
 
+        publish_action(
+            CreatePlatformExternalIssueAction(
+                service_type=external_issue.service_type,
+                display_name=external_issue.display_name,
+                web_url=external_issue.web_url,
+            ),
+            source=ActionSource.API,
+            group_id=group.id,
+            organization_id=organization_id,
+            project_id=external_issue.project_id or group.project_id,
+            actor=GroupActionActor.user(user.id) if user is not None else SYSTEM_ACTOR,
+        )
+
         return RpcPlatformExternalIssueResult(
             external_issue=serialize_platform_external_issue(external_issue)
         )
@@ -285,6 +327,19 @@ class DatabaseBackedSentryAppCellService(SentryAppCellService):
                         status_code=403,
                     ),
                 )
+
+        publish_action(
+            UnlinkPlatformExternalIssueAction(
+                service_type=platform_external_issue.service_type,
+                display_name=platform_external_issue.display_name,
+                web_url=platform_external_issue.web_url,
+            ),
+            source=ActionSource.API,
+            group_id=platform_external_issue.group_id,
+            organization_id=organization_id,
+            project_id=issue_project.id,
+            actor=GroupActionActor.user(user.id) if user is not None else SYSTEM_ACTOR,
+        )
 
         deletions.exec_sync(platform_external_issue)
 

--- a/tests/sentry/sentry_apps/api/endpoints/test_group_external_issue_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_group_external_issue_details.py
@@ -1,3 +1,4 @@
+from sentry.issues.action_log import ActionSource
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.testutils.cases import APITestCase
 
@@ -21,6 +22,29 @@ class GroupExternalIssueDetailsEndpointTest(APITestCase):
 
         assert response.status_code == 204, response.content
         assert not PlatformExternalIssue.objects.filter(id=self.external_issue.id).exists()
+
+    def test_deletes_external_issue_records_action_log(self) -> None:
+        with self.assertLogs("sentry.issues.action_log", level="INFO") as logs:
+            response = self.client.delete(self.url, format="json")
+
+        assert response.status_code == 204, response.content
+
+        records = [
+            r
+            for r in logs.records
+            if r.message == "group.action_log"
+            and getattr(r, "action") == "unlink_platform_external_issue"
+        ]
+        assert len(records) == 1
+        record = records[0]
+        assert getattr(record, "source") == ActionSource.WEB
+        assert getattr(record, "actor_id") == str(self.user.id)
+        assert getattr(record, "group_id") == str(self.group.id)
+        assert getattr(record, "metadata") == {
+            "service_type": "sentry-app",
+            "display_name": "App#issue-1",
+            "web_url": "https://example.com/app/issues/1",
+        }
 
     def test_handles_non_existing_external_issue(self) -> None:
         url = f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/external-issues/99999/"

--- a/tests/sentry/sentry_apps/services/test_cell_service.py
+++ b/tests/sentry/sentry_apps/services/test_cell_service.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 
 import orjson
@@ -36,11 +37,11 @@ class TestSentryAppCellService(TestCase):
         self.rpc_installation = serialize_sentry_app_installation(self.install)
         self.auth_context = AuthenticationContext(user=serialize_rpc_user(self.user))
 
-    def _action_log_records(self, logs, action):
+    def _action_log_records(
+        self, records: list[logging.LogRecord], action: str
+    ) -> list[logging.LogRecord]:
         return [
-            r
-            for r in logs.records
-            if r.message == "group.action_log" and getattr(r, "action") == action
+            r for r in records if r.message == "group.action_log" and getattr(r, "action") == action
         ]
 
     @responses.activate
@@ -342,7 +343,7 @@ class TestSentryAppCellService(TestCase):
             )
 
         assert result.error is None
-        records = self._action_log_records(logs, "create_platform_external_issue")
+        records = self._action_log_records(logs.records, "create_platform_external_issue")
         assert len(records) == 1
         record = records[0]
         assert getattr(record, "source") == ActionSource.API
@@ -381,8 +382,8 @@ class TestSentryAppCellService(TestCase):
             )
 
         assert result.error is None
-        assert len(self._action_log_records(logs, "link_platform_external_issue")) == 1
-        assert self._action_log_records(logs, "create_platform_external_issue") == []
+        assert len(self._action_log_records(logs.records, "link_platform_external_issue")) == 1
+        assert self._action_log_records(logs.records, "create_platform_external_issue") == []
 
     def test_create_external_issue_records_action_log(self) -> None:
         with self.assertLogs("sentry.issues.action_log", level="INFO") as logs:
@@ -397,7 +398,7 @@ class TestSentryAppCellService(TestCase):
             )
 
         assert result.error is None
-        records = self._action_log_records(logs, "create_platform_external_issue")
+        records = self._action_log_records(logs.records, "create_platform_external_issue")
         assert len(records) == 1
         assert getattr(records[0], "source") == ActionSource.API
         assert getattr(records[0], "actor_type") == "user"
@@ -416,7 +417,7 @@ class TestSentryAppCellService(TestCase):
             )
 
         assert result.error is None
-        records = self._action_log_records(logs, "create_platform_external_issue")
+        records = self._action_log_records(logs.records, "create_platform_external_issue")
         assert len(records) == 1
         assert getattr(records[0], "actor_type") == "system"
         assert getattr(records[0], "actor_id") == "0"
@@ -440,7 +441,7 @@ class TestSentryAppCellService(TestCase):
             )
 
         assert result.success is True
-        records = self._action_log_records(logs, "unlink_platform_external_issue")
+        records = self._action_log_records(logs.records, "unlink_platform_external_issue")
         assert len(records) == 1
         record = records[0]
         assert getattr(record, "source") == ActionSource.API

--- a/tests/sentry/sentry_apps/services/test_cell_service.py
+++ b/tests/sentry/sentry_apps/services/test_cell_service.py
@@ -6,6 +6,7 @@ from django.utils.http import urlencode
 from responses.matchers import query_string_matcher
 
 from sentry.auth.services.auth.model import AuthenticationContext
+from sentry.issues.action_log import ActionSource
 from sentry.models.organization import Organization
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
@@ -34,6 +35,13 @@ class TestSentryAppCellService(TestCase):
         )
         self.rpc_installation = serialize_sentry_app_installation(self.install)
         self.auth_context = AuthenticationContext(user=serialize_rpc_user(self.user))
+
+    def _action_log_records(self, logs, action):
+        return [
+            r
+            for r in logs.records
+            if r.message == "group.action_log" and getattr(r, "action") == action
+        ]
 
     @responses.activate
     def test_get_select_options(self) -> None:
@@ -307,6 +315,142 @@ class TestSentryAppCellService(TestCase):
         assert result.success is False
         assert result.error is not None
         assert result.error.status_code == 404
+
+    @responses.activate
+    def test_create_issue_link_records_action_log(self) -> None:
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/link-issue",
+            json={
+                "project": "Projectname",
+                "webUrl": "https://example.com/project/issue-id",
+                "identifier": "issue-1",
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        with self.assertLogs("sentry.issues.action_log", level="INFO") as logs:
+            result = sentry_app_cell_service.create_issue_link(
+                organization_id=self.org.id,
+                installation=self.rpc_installation,
+                group_id=self.group.id,
+                action="create",
+                fields={"title": "An Issue"},
+                uri="/link-issue",
+                user=serialize_rpc_user(self.user),
+            )
+
+        assert result.error is None
+        records = self._action_log_records(logs, "create_platform_external_issue")
+        assert len(records) == 1
+        record = records[0]
+        assert getattr(record, "source") == ActionSource.API
+        assert getattr(record, "actor_type") == "user"
+        assert getattr(record, "actor_id") == str(self.user.id)
+        assert getattr(record, "group_id") == str(self.group.id)
+        assert getattr(record, "metadata") == {
+            "service_type": self.sentry_app.slug,
+            "display_name": "Projectname#issue-1",
+            "web_url": "https://example.com/project/issue-id",
+        }
+
+    @responses.activate
+    def test_create_issue_link_with_link_action_records_link_action_log(self) -> None:
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/link-issue",
+            json={
+                "project": "Projectname",
+                "webUrl": "https://example.com/project/issue-id",
+                "identifier": "issue-1",
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        with self.assertLogs("sentry.issues.action_log", level="INFO") as logs:
+            result = sentry_app_cell_service.create_issue_link(
+                organization_id=self.org.id,
+                installation=self.rpc_installation,
+                group_id=self.group.id,
+                action="link",
+                fields={"title": "An Issue"},
+                uri="/link-issue",
+                user=serialize_rpc_user(self.user),
+            )
+
+        assert result.error is None
+        assert len(self._action_log_records(logs, "link_platform_external_issue")) == 1
+        assert self._action_log_records(logs, "create_platform_external_issue") == []
+
+    def test_create_external_issue_records_action_log(self) -> None:
+        with self.assertLogs("sentry.issues.action_log", level="INFO") as logs:
+            result = sentry_app_cell_service.create_external_issue(
+                organization_id=self.org.id,
+                installation=self.rpc_installation,
+                group_id=self.group.id,
+                web_url="https://example.com/project/issue-1",
+                project="ProjectName",
+                identifier="issue-1",
+                user=serialize_rpc_user(self.user),
+            )
+
+        assert result.error is None
+        records = self._action_log_records(logs, "create_platform_external_issue")
+        assert len(records) == 1
+        assert getattr(records[0], "source") == ActionSource.API
+        assert getattr(records[0], "actor_type") == "user"
+        assert getattr(records[0], "actor_id") == str(self.user.id)
+
+    def test_create_external_issue_without_user_records_system_actor(self) -> None:
+        with self.assertLogs("sentry.issues.action_log", level="INFO") as logs:
+            result = sentry_app_cell_service.create_external_issue(
+                organization_id=self.org.id,
+                installation=self.rpc_installation,
+                group_id=self.group.id,
+                web_url="https://example.com/project/issue-1",
+                project="ProjectName",
+                identifier="issue-1",
+                user=None,
+            )
+
+        assert result.error is None
+        records = self._action_log_records(logs, "create_platform_external_issue")
+        assert len(records) == 1
+        assert getattr(records[0], "actor_type") == "system"
+        assert getattr(records[0], "actor_id") == "0"
+
+    def test_delete_external_issue_records_action_log(self) -> None:
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            external_issue = PlatformExternalIssue.objects.create(
+                group_id=self.group.id,
+                project_id=self.project.id,
+                service_type=self.sentry_app.slug,
+                display_name="Test#123",
+                web_url="https://example.com/issue/123",
+            )
+
+        with self.assertLogs("sentry.issues.action_log", level="INFO") as logs:
+            result = sentry_app_cell_service.delete_external_issue(
+                organization_id=self.org.id,
+                installation=self.rpc_installation,
+                external_issue_id=external_issue.id,
+                user=serialize_rpc_user(self.user),
+            )
+
+        assert result.success is True
+        records = self._action_log_records(logs, "unlink_platform_external_issue")
+        assert len(records) == 1
+        record = records[0]
+        assert getattr(record, "source") == ActionSource.API
+        assert getattr(record, "actor_type") == "user"
+        assert getattr(record, "actor_id") == str(self.user.id)
+        assert getattr(record, "metadata") == {
+            "service_type": self.sentry_app.slug,
+            "display_name": "Test#123",
+            "web_url": "https://example.com/issue/123",
+        }
 
     def test_create_external_issue_denied_without_project_access(self) -> None:
         with assume_test_silo_mode_of(Organization):


### PR DESCRIPTION
Instruments the Integration Platform / Sentry App external-issue subsystem (`PlatformExternalIssue`) to record Issue Action Log entries, mirroring the first-party external-issue instrumentation.

This is a separate subsystem from first-party external issues: it has no `external_issue_key` (it's a `(group, service_type)` upsert carrying `display_name`/`web_url`), and its attach/unlink flows cross the control→region silo boundary — so it gets its own action types rather than reusing the first-party ones.

**Action types** — `Create` / `Link` / `Unlink`, fields `{service_type, display_name, web_url}`.

**Instrumented paths:**

| path | action | actor |
|---|---|---|
| `create_issue_link` (cell) | Create / Link by `action` | user |
| `create_external_issue` (cell) | Create | user, else SYSTEM (token apps) |
| `delete_external_issue` (cell) | Unlink | user, else SYSTEM |
| group external-issue delete endpoint | Unlink | request.user, else SYSTEM |

**Source:** the region-side cell methods have no request in scope, so they pass `source=API` (token apps already resolve to `api` on the normal path); the endpoint uses `resolve_action_source`. Recording *which* Sentry App made the call is an Actor concern, deferred to a follow-up.

**Tests:** action-log assertions on each path — create/link mapping, token-app SYSTEM actor, both unlink paths.

Fixes ID-1611
