### PR TITLE
test(hybrid-cloud): Fix watermark drift causing spurious cross-transaction errors

### DIFF
--- a/src/sentry/db/postgres/transactions.py
+++ b/src/sentry/db/postgres/transactions.py
@@ -53,9 +53,13 @@ def django_test_transaction_water_mark(using: str | None = None) -> Generator[No
         yield
     finally:
         connection.run_on_commit = old_run_on_commit
-        hybrid_cloud.simulated_transaction_watermarks.state[using] = min(
-            hybrid_cloud.simulated_transaction_watermarks.get_transaction_depth(connection), prev
-        )
+        # Restore the watermark to the baseline that was in effect on entry. We
+        # intentionally do not take min() with the current depth: a transient drop
+        # below `prev` only happens when the connection's outer test transactions
+        # were reset (e.g. a connection close mid-block), and latching the watermark
+        # down to that value leaves the connection permanently "above watermark"
+        # once it re-enters its atomics, producing spurious CrossTransactionAssertionErrors.
+        hybrid_cloud.simulated_transaction_watermarks.state[using] = prev
 
 
 class InTestTransactionEnforcement(threading.local):

--- a/src/sentry/testutils/hybrid_cloud.py
+++ b/src/sentry/testutils/hybrid_cloud.py
@@ -121,13 +121,21 @@ class EnforceNoCrossTransactionWrapper:
         # when tasks fire synchronously, or other work is done in a test that would normally be separated by
         # different connections / processes.  If you believe this is the case, context the #project-hybrid-cloud channel
         # for assistance.
+        if open_transactions:
+            # Capture the watermark baseline and the actual per-connection
+            # transaction depths so a failure pinpoints which connection drifted
+            # rather than just naming the symptom.
+            diagnostics = (
+                f" (watermarks={dict(simulated_transaction_watermarks.state)}, "
+                f"depths={{{', '.join(f'{c.alias}={SimulatedTransactionWatermarks.get_transaction_depth(c)}' for c in connections.all())}}})"
+            )
         if len(open_transactions) >= 2:
             raise CrossTransactionAssertionError(
-                f"Found mixed open transactions between dbs {open_transactions}"
+                f"Found mixed open transactions between dbs {open_transactions}{diagnostics}"
             )
         if open_transactions and self.alias not in open_transactions:
             raise CrossTransactionAssertionError(
-                f"Transaction opened for db {open_transactions}, but command running against db {self.alias}"
+                f"Transaction opened for db {open_transactions}, but command running against db {self.alias}{diagnostics}"
             )
 
         return execute(*params)


### PR DESCRIPTION
The CrossTransactionAssertionError flaky cluster (SENTRY-TESTS-1DJ*, ~250k events) began exactly when pytest was bumped 8.1.2 -> 9.0.3 (#115057). The cross-transaction guard reads a per-connection transaction 'watermark' (baseline outer-transaction depth); a connection whose live depth exceeds its watermark is treated as having an open transaction. A connection is then flagged spuriously if its watermark drifts *below* the test's true baseline.

django_test_transaction_water_mark restored the watermark with min(current_depth, prev) on exit. current_depth only falls below prev when the connection's outer test transactions were reset mid-block (e.g. a connection close); min() then latches the watermark down to that transient value, leaving the connection permanently 'above watermark' once it re-enters its atomics -- surfacing as CrossTransactionAssertionError in unrelated later work (commonly setUp -> create_user, a control write, while the secondary/monitor connection shows a phantom open transaction). Restore to the entry baseline (prev) instead.

Also include the watermark state and actual per-connection depths in the guard's error message so any remaining occurrence pinpoints the drifting connection.

Validated against tests/sentry/db/test_transactions.py (watermark + on_commit simulation). The drift is cross-test/ordering-dependent and only reproduces under full-suite pytest-randomly ordering, so final confirmation is via CI.

Refs SENTRY-TESTS-1DJ3 SENTRY-TESTS-1DJ5 SENTRY-TESTS-1DJ7 SENTRY-TESTS-1DJ9 Refs SENTRY-TESTS-1DJH SENTRY-TESTS-1DJS SENTRY-TESTS-1DJ4 SENTRY-TESTS-1EY0
