### PR TITLE
ref: Type 8 Goal #1 PUBLIC endpoints (trace, profiling, replay, releases)

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -19,6 +19,7 @@ from sentry.api.utils import handle_query_errors
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.profiling_examples import ProfilingExamples
 from sentry.apidocs.parameters import GlobalParams, OrganizationParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.profiles.flamegraph import FlamegraphExecutor
@@ -138,7 +139,9 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
         },
         examples=ProfilingExamples.FLAMEGRAPH,
     )
-    def get(self, request: Request, organization: Organization) -> HttpResponse:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[None] | Response[ValidationErrorResponse] | HttpResponse:
         """
         Retrieve an aggregated flamegraph for the organization, built from the
         requested data source (transactions, profiles, functions, or spans).
@@ -157,7 +160,7 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
 
         serializer = OrganizationProfilingFlamegraphSerializer(data=request.GET)
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer), status=400)
         serialized = serializer.validated_data
 
         sentry_sdk.set_tag("query.dataSource", serialized["dataSource"])
@@ -228,7 +231,7 @@ class OrganizationProfilingChunksEndpoint(OrganizationProfilingBaseEndpoint):
         },
         examples=ProfilingExamples.PROFILE_CHUNKS,
     )
-    def get(self, request: Request, organization: Organization) -> HttpResponse:
+    def get(self, request: Request, organization: Organization) -> Response[None] | HttpResponse:
         """
         Retrieve continuous profiling data for a profiler over a time range.
 

--- a/src/sentry/api/endpoints/organization_stats_summary.py
+++ b/src/sentry/api/endpoints/organization_stats_summary.py
@@ -142,7 +142,9 @@ class OrganizationStatsSummaryEndpoint(OrganizationEndpoint):
         },
         examples=OrganizationExamples.RETRIEVE_SUMMARY_EVENT_COUNT,
     )
-    def get(self, request: Request, organization: Organization) -> HttpResponse:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[StatsSummaryApiResponse] | HttpResponse:
         """
         Query summarized event counts by project for your Organization. Also see https://docs.sentry.io/api/organizations/retrieve-event-counts-for-an-organization-v2/ for reference.
         """

--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -1,5 +1,4 @@
 import sentry_sdk
-from django.http import HttpResponse
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
@@ -149,7 +148,9 @@ class OrganizationTraceEndpoint(OrganizationEventsEndpointBase):
         },
         examples=TraceExamples.TRACE,
     )
-    def get(self, request: Request, organization: Organization, trace_id: str) -> HttpResponse:
+    def get(
+        self, request: Request, organization: Organization, trace_id: str
+    ) -> Response[list[SerializedSpan | SerializedIssue | SerializedUptimeCheck]] | Response[None]:
         """
         Retrieve the spans, errors, and (optionally) uptime checks that make up a single trace.
 

--- a/src/sentry/api/endpoints/organization_trace_meta.py
+++ b/src/sentry/api/endpoints/organization_trace_meta.py
@@ -1,7 +1,6 @@
 import logging
 
 import sentry_sdk
-from django.http import HttpResponse
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -241,7 +240,9 @@ class OrganizationTraceMetaEndpoint(OrganizationEventsEndpointBase):
         },
         examples=TraceExamples.TRACE_META,
     )
-    def get(self, request: Request, organization: Organization, trace_id: str) -> HttpResponse:
+    def get(
+        self, request: Request, organization: Organization, trace_id: str
+    ) -> Response[OrganizationTraceMetaResponse] | Response[None]:
         """
         Retrieve aggregate metadata for a single trace, including counts of spans,
         errors, performance issues, logs, and metrics, along with per-span-operation

--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -60,7 +60,9 @@ class ProjectProfilingProfileEndpoint(ProjectProfilingBaseEndpoint):
         },
         examples=ProfilingExamples.PROFILE_DETAILS,
     )
-    def get(self, request: Request, project: Project, profile_id: str) -> HttpResponse:
+    def get(
+        self, request: Request, project: Project, profile_id: str
+    ) -> Response[dict[str, Any]] | Response[None] | HttpResponse:
         """
         Retrieve a single profile by its ID.
 
@@ -79,7 +81,7 @@ class ProjectProfilingProfileEndpoint(ProjectProfilingBaseEndpoint):
         )
 
         if response.status == 200:
-            profile = orjson.loads(response.data)
+            profile: dict[str, Any] = orjson.loads(response.data)
 
             if "release" in profile:
                 profile["release"] = get_release(project, profile["release"])

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from django.db.models import F, Q
-from django.http import HttpResponse
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.request import Request
@@ -33,6 +32,7 @@ from sentry.api.serializers import serialize
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST
 from sentry.apidocs.examples.release_threshold_examples import ReleaseThresholdExamples
 from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.release import Release
 from sentry.models.release_threshold.constants import ReleaseThresholdType
@@ -118,7 +118,9 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
         },
         examples=ReleaseThresholdExamples.THRESHOLD_STATUS_RESPONSE,
     )
-    def get(self, request: Request, organization: Organization | RpcOrganization) -> HttpResponse:
+    def get(
+        self, request: Request, organization: Organization | RpcOrganization
+    ) -> Response[dict[str, list[EnrichedThreshold]]] | Response[ValidationErrorResponse]:
         r"""
         **`[WARNING]`**: This API is an experimental Alpha feature and is subject to change!
 
@@ -138,7 +140,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
             data=request.query_params,
         )
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer), status=400)
 
         environments_list = serializer.validated_data.get(
             "environment"
@@ -308,7 +310,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
         # ========================================================================
         # Step 4: Determine threshold status per threshold type and return results
         # ========================================================================
-        release_threshold_health = defaultdict(list)
+        release_threshold_health: dict[str, list[EnrichedThreshold]] = defaultdict(list)
         for threshold_type, filter_list in thresholds_by_type.items():
             project_id_list = [proj_id for proj_id in filter_list["project_ids"]]
             release_value_list = [release_version for release_version in filter_list["releases"]]

--- a/src/sentry/apidocs/examples/replay_examples.py
+++ b/src/sentry/apidocs/examples/replay_examples.py
@@ -164,28 +164,14 @@ class ReplayExamples:
     GET_REPLAY_SEGMENT = [
         OpenApiExample(
             "Retrieve a replay segment",
-            value=[
-                {
-                    "type": 5,
-                    "timestamp": 1658770772.902,
-                    "data": {
-                        "tag": "performanceSpan",
-                        "payload": {
-                            "op": "memory",
-                            "description": "",
-                            "startTimestamp": 1658770772.902,
-                            "endTimestamp": 1658770772.902,
-                            "data": {
-                                "memory": {
-                                    "jsHeapSizeLimit": 4294705152,
-                                    "totalJSHeapSize": 10204109,
-                                    "usedJSHeapSize": 9131621,
-                                }
-                            },
-                        },
-                    },
-                }
-            ],
+            value={
+                "data": {
+                    "replayId": "7e07485f6c25420c87f5a0ec3a8db3a3",
+                    "segmentId": 0,
+                    "projectId": "4505321021243392",
+                    "dateAdded": "2024-01-15T22:23:15+00:00",
+                },
+            },
             status_codes=["200"],
             response_only=True,
         )

--- a/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
@@ -1,21 +1,33 @@
 from io import BytesIO
-from typing import Any
+from typing import TypedDict
 
 import sentry_sdk
 from django.http import StreamingHttpResponse
-from django.http.response import HttpResponseBase
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.replay_examples import ReplayExamples
 from sentry.apidocs.parameters import GlobalParams, ReplayParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.replays.endpoints.project_replay_endpoint import ProjectReplayEndpoint
 from sentry.replays.lib.storage import RecordingSegmentStorageMeta, make_recording_filename
 from sentry.replays.usecases.reader import download_segment, fetch_segment_metadata
+
+
+class _SegmentMetadataResponse(TypedDict):
+    replayId: str
+    segmentId: int
+    projectId: str
+    dateAdded: str | None
+
+
+class _SegmentDetailsResponse(TypedDict):
+    data: _SegmentMetadataResponse
 
 
 @cell_silo_endpoint
@@ -35,7 +47,7 @@ class ProjectReplayRecordingSegmentDetailsEndpoint(ProjectReplayEndpoint):
         ],
         responses={
             200: inline_sentry_response_serializer(
-                "GetReplayRecordingSegment", list[dict[str, Any]]
+                "GetReplayRecordingSegment", _SegmentDetailsResponse
             ),
             400: RESPONSE_BAD_REQUEST,
             403: RESPONSE_FORBIDDEN,
@@ -43,7 +55,9 @@ class ProjectReplayRecordingSegmentDetailsEndpoint(ProjectReplayEndpoint):
         },
         examples=ReplayExamples.GET_REPLAY_SEGMENT,
     )
-    def get(self, request: Request, project, replay_id, segment_id) -> HttpResponseBase:
+    def get(
+        self, request: Request, project, replay_id, segment_id
+    ) -> Response[_SegmentDetailsResponse] | Response[DetailResponse] | StreamingHttpResponse:
         """Return a replay recording segment."""
         self.check_replay_access(request, project)
 
@@ -54,20 +68,19 @@ class ProjectReplayRecordingSegmentDetailsEndpoint(ProjectReplayEndpoint):
         if request.GET.get("download") is not None:
             return self.download(segment)
         else:
-            return self.respond(
-                {
-                    "data": {
-                        "replayId": segment.replay_id,
-                        "segmentId": segment.segment_id,
-                        "projectId": str(segment.project_id),
-                        "dateAdded": (
-                            segment.date_added.replace(microsecond=0).isoformat()
-                            if segment.date_added
-                            else None
-                        ),
-                    }
+            body: _SegmentDetailsResponse = {
+                "data": {
+                    "replayId": segment.replay_id,
+                    "segmentId": segment.segment_id,
+                    "projectId": str(segment.project_id),
+                    "dateAdded": (
+                        segment.date_added.replace(microsecond=0).isoformat()
+                        if segment.date_added
+                        else None
+                    ),
                 }
-            )
+            }
+            return self.respond(body)
 
     def download(self, segment: RecordingSegmentStorageMeta) -> StreamingHttpResponse:
         with sentry_sdk.start_span(

--- a/src/sentry/replays/endpoints/project_replay_video_details.py
+++ b/src/sentry/replays/endpoints/project_replay_video_details.py
@@ -7,12 +7,14 @@ from django.http import HttpResponse, StreamingHttpResponse
 from django.http.response import HttpResponseBase
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.replay_examples import ReplayExamples
 from sentry.apidocs.parameters import GlobalParams, ReplayParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.replays.endpoints.project_replay_endpoint import ProjectReplayEndpoint
 from sentry.replays.lib.http import (
@@ -51,7 +53,9 @@ class ProjectReplayVideoDetailsEndpoint(ProjectReplayEndpoint):
         },
         examples=ReplayExamples.GET_REPLAY_VIDEO,
     )
-    def get(self, request: Request, project, replay_id, segment_id) -> HttpResponseBase:
+    def get(
+        self, request: Request, project, replay_id, segment_id
+    ) -> Response[DetailResponse] | HttpResponseBase:
         """Return a replay video."""
         self.check_replay_access(request, project)
 


### PR DESCRIPTION
Tightens 8 of the 14 Goal #1 untyped PUBLIC endpoints:

- `release_threshold_status_index.get` → typed against existing `dict[str, list[EnrichedThreshold]]` decorator T
- `organization_trace_meta.get` → `Response[OrganizationTraceMetaResponse]` via existing helper return type
- `organization_trace.get` → `Response[list[SerializedSpan | SerializedIssue | SerializedUptimeCheck]]` matching the decorator
- `organization_profiling_profiles` flamegraph + chunks endpoints → `Response[None] | Response[ValidationErrorResponse] | HttpResponse` (the success path is the proxy_profiling_service HttpResponse)
- `project_profiling_profile.get` → `Response[dict[str, Any]] | Response[None] | HttpResponse`
- `project_replay_recording_segment_details.get` → corrects the decorator from `list[dict[str, Any]]` to a structured `{"data": ...}` envelope via new local `_SegmentDetailsResponse` + `_SegmentMetadataResponse` TypedDicts. Spec-only correction; runtime has always emitted the envelope.
- `project_replay_video_details.get` → `Response[DetailResponse] | HttpResponseBase`
- `organization_stats_summary.get` → `Response[StatsSummaryApiResponse] | HttpResponse`

Validation paths route through `as_validation_errors()`. No wire changes.