### PR TITLE
ref: Type 3 preprod snapshot PUBLIC endpoints via cast() on pydantic .dict()

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 import jsonschema
 import orjson
@@ -311,7 +311,9 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         },
         examples=PreprodExamples.GET_SNAPSHOT_DETAILS,
     )
-    def get(self, request: Request, organization: Organization, snapshot_id: str) -> Response:
+    def get(
+        self, request: Request, organization: Organization, snapshot_id: str
+    ) -> Response[SnapshotDetailsResponseDict] | Response[DetailResponse]:
         """
         Retrieve full details for a snapshot, including categorized image lists
         and comparison status.
@@ -604,7 +606,11 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                     pair["base_image"] = _strip_to_compact(pair["base_image"])
                     pair["head_image"] = _strip_to_compact(pair["head_image"])
 
-        return Response(response_data)
+        # cast() sanctioned here: pydantic .dict() returns dict[str, Any] with no
+        # static link back to SnapshotDetailsResponseDict. The TypedDict and the
+        # Pydantic model are kept in sync by hand at the source of truth.
+        body = cast(SnapshotDetailsResponseDict, response_data)
+        return Response(body)
 
 
 @extend_schema(tags=["Snapshots"])

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_image_detail.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_image_detail.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 
 import orjson
 from django.conf import settings
@@ -19,6 +20,7 @@ from sentry.api.bases.organization import (
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.preprod_examples import PreprodExamples
 from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.staff import is_active_staff
 from sentry.models.organization import Organization
@@ -110,6 +112,13 @@ def _resolve_base_image_info(
     )
 
 
+def _to_response_dict(resp: SnapshotImageDetailResponse) -> SnapshotImageDetailResponseDict:
+    # cast() sanctioned here: pydantic .dict() returns dict[str, Any] with no
+    # static link back to SnapshotImageDetailResponseDict. The TypedDict and
+    # the Pydantic model are kept in sync by hand at the source of truth.
+    return cast(SnapshotImageDetailResponseDict, resp.dict())
+
+
 # Intentionally uses a flat response format (nullable fields, no conditional shapes)
 # rather than matching the details endpoint's SnapshotDiffPair/SnapshotImageResponse split.
 # This endpoint is designed for LLM/MCP consumers that benefit from a single uniform shape.
@@ -157,7 +166,7 @@ class OrganizationPreprodSnapshotImageDetailEndpoint(OrganizationEndpoint):
         organization: Organization,
         snapshot_id: str,
         image_identifier: str,
-    ) -> Response:
+    ) -> Response[SnapshotImageDetailResponseDict] | Response[DetailResponse]:
         """
         Retrieve detailed information for a single image within a snapshot.
 
@@ -266,7 +275,7 @@ class OrganizationPreprodSnapshotImageDetailEndpoint(OrganizationEndpoint):
                                 comp_file_name, base_manifest, org_slug, project_slug
                             ),
                         )
-                        return Response(resp.dict())
+                        return Response(_to_response_dict(resp))
 
                     if comp_result.status == "skipped":
                         base_image = _resolve_base_image_info(
@@ -278,7 +287,7 @@ class OrganizationPreprodSnapshotImageDetailEndpoint(OrganizationEndpoint):
                             head_image=base_image,
                             base_image=base_image,
                         )
-                        return Response(resp.dict())
+                        return Response(_to_response_dict(resp))
 
             return Response({"detail": "Image not found in snapshot"}, status=404)
 
@@ -294,7 +303,7 @@ class OrganizationPreprodSnapshotImageDetailEndpoint(OrganizationEndpoint):
                 image_file_name=image_file_name,
                 head_image=head_image,
             )
-            return Response(resp.dict())
+            return Response(_to_response_dict(resp))
 
         status = comp_result.status
 
@@ -328,4 +337,4 @@ class OrganizationPreprodSnapshotImageDetailEndpoint(OrganizationEndpoint):
             diff_percentage=diff_percentage,
             previous_image_file_name=previous_image_file_name,
         )
-        return Response(resp.dict())
+        return Response(_to_response_dict(resp))

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 import orjson
 from django.conf import settings
@@ -21,6 +21,7 @@ from sentry.api.bases.organization import (
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.preprod_examples import PreprodExamples
 from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.staff import is_active_staff
 from sentry.constants import ObjectStatus
@@ -119,7 +120,7 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
         self,
         request: Request,
         organization: Organization,
-    ) -> Response:
+    ) -> Response[LatestBaseSnapshotResponseDict] | Response[DetailResponse]:
         """
         Retrieve the most recent base snapshot for a given app.
 
@@ -234,4 +235,8 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
                 for img in response_data["images"]
             ]
 
-        return Response(response_data)
+        # cast() sanctioned: response_data is a hand-built dict[str, Any] whose
+        # shape mirrors LatestBaseSnapshotResponseDict. The TypedDict and the
+        # builder are kept in sync by hand at the source of truth.
+        body = cast(LatestBaseSnapshotResponseDict, response_data)
+        return Response(body)


### PR DESCRIPTION
Tightens the 3 remaining preprod snapshot PUBLIC endpoints:

- `preprod_artifact_snapshot.get` → `Response[SnapshotDetailsResponseDict] | Response[DetailResponse]`
- `preprod_artifact_snapshot_latest_base.get` → `Response[LatestBaseSnapshotResponseDict] | Response[DetailResponse]`
- `preprod_artifact_snapshot_image_detail.get` → `Response[SnapshotImageDetailResponseDict] | Response[DetailResponse]`

All three runtime success paths construct a pydantic BaseModel and call `.dict()` — pydantic v1's `.dict()` returns `dict[str, Any]` with no static link back to the response TypedDict declared by the decorator. The endpoint-level mutations (`compact_metadata`, `vcs_info` overlay) work against `dict[str, Any]` keys.

`cast()` is sanctioned here per the opaque-body cohort rule: `.dict()` genuinely has no type to lift. The TypedDicts and pydantic models are kept in sync by hand at the source of truth in `preprod/api/models/public/snapshots.py` and `preprod/api/models/snapshots/`. The image-detail endpoint factors the cast into a `_to_response_dict()` helper since it's used at 4 call sites.

No wire changes.