### PR TITLE
ref: Type final 4 PUBLIC endpoints, closing the Goal #1 gap

### DIFF
--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -15,6 +15,7 @@ from sentry.api.serializers.models.eventattachment import EventAttachmentSeriali
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.event_attachment_examples import EventAttachmentExamples
 from sentry.apidocs.parameters import EventParams, GlobalParams
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.superuser import superuser_has_permission
 from sentry.auth.system import is_system_auth
@@ -111,7 +112,12 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
     )
     def get(
         self, request: Request, project, event_id, attachment_id
-    ) -> Response | StreamingHttpResponse:
+    ) -> (
+        Response[EventAttachmentSerializerResponse]
+        | Response[None]
+        | Response[DetailResponse]
+        | StreamingHttpResponse
+    ):
         """
         Retrieve metadata for a single attachment on an event.
 

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Mapping
 from concurrent.futures import as_completed
-from typing import Any, NotRequired, TypedDict
+from typing import Any, TypedDict
 
 import sentry_sdk
 from drf_spectacular.utils import OpenApiResponse, extend_schema
@@ -29,6 +29,7 @@ from sentry.apidocs.parameters import (
     OrganizationParams,
     VisibilityParams,
 )
+from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
@@ -79,11 +80,24 @@ class DiscoverDatasetSplitException(Exception):
     pass
 
 
-class EventsMeta(TypedDict):
+class EventsMeta(TypedDict, total=False):
+    """Meta envelope emitted by `handle_results_with_meta` and the
+    empty-projects short-circuit. Every key is optional because the path
+    that emits it depends on flags (`standard_meta`, debug, dataset) — the
+    no-projects path only carries `tips`, the standard path carries
+    everything below."""
+
     fields: dict[str, str]
-    datasetReason: NotRequired[str]
-    isMetricsData: NotRequired[bool]
-    isMetricsExtractedData: NotRequired[bool]
+    units: dict[str, str | None]
+    tips: dict[str, str]
+    datasetReason: str
+    isMetricsData: bool
+    isMetricsExtractedData: bool
+    dataset: str
+    discoverSplitDecision: Any
+    dataScanned: str
+    bytesScanned: int
+    debug_info: Any
 
 
 # Only used for api docs
@@ -166,7 +180,9 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
         },
         examples=DiscoverAndPerformanceExamples.QUERY_DISCOVER_EVENTS,
     )
-    def get(self, request: Request, organization: Organization) -> Response:
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[EventsApiResponse] | Response[DetailResponse]:
         """
         Retrieves explore data for a given organization.
 
@@ -193,16 +209,15 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                 organization,
             )
         except NoProjects:
-            return Response(
-                {
-                    "data": [],
-                    "meta": {
-                        "tips": {
-                            "query": "Need at least one valid project to query.",
-                        },
+            empty_body: EventsApiResponse = {
+                "data": [],
+                "meta": {
+                    "tips": {
+                        "query": "Need at least one valid project to query.",
                     },
-                }
-            )
+                },
+            }
+            return Response(empty_body)
 
         batch_features = self.get_features(organization, request)
 
@@ -677,7 +692,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             if request.GET.get("noPagination"):
                 per_page = self.get_per_page(request)
                 result = paginator.get_result(limit=per_page, cursor=None)
-                return Response(_handle_results(result.results))
+                body: EventsApiResponse = _handle_results(result.results)
+                return Response(body)
             else:
                 return self.paginate(
                     request=request,

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -558,7 +558,9 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def patch(self, request: Request, organization, team):
+    def patch(
+        self, request: Request, organization, team
+    ) -> Response[None] | Response[ValidationErrorResponse]:
         """
         Update a team's attributes with a SCIM Group PATCH Request.
         """
@@ -606,9 +608,18 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                             user_ids_to_revoke_privileges.extend(revoked_users)
 
         except ParseError as e:
-            return Response(e.detail, status=400)
+            # Callers in this scope raise ParseError with a SCIM-shaped dict
+            # detail (`{"schemas": [...], "detail": str, "scimType"?: str}`).
+            # Coerce the rare non-dict branch so the union arm typechecks.
+            parse_detail: ValidationErrorResponse = (
+                dict(e.detail) if isinstance(e.detail, dict) else {"detail": str(e.detail)}
+            )
+            return Response(parse_detail, status=400)
         except UnsupportedAttributeError as e:
-            return Response(e.detail, status=400)
+            unsupported_detail: ValidationErrorResponse = (
+                dict(e.detail) if isinstance(e.detail, dict) else {"detail": str(e.detail)}
+            )
+            return Response(unsupported_detail, status=400)
         except OrganizationMember.DoesNotExist:
             raise ResourceDoesNotExist(detail=SCIM_404_USER_RES)
         except IntegrityError as e:

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -4,7 +4,7 @@ import logging
 import re
 from collections.abc import Callable
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic import BaseModel
 from rest_framework.exceptions import PermissionDenied
@@ -35,6 +35,7 @@ from sentry.seer.autofix.prompts import (
     root_cause_prompt,
     solution_prompt,
 )
+from sentry.seer.autofix.types import AutofixHandoffResponse
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     read_preference_from_sentry_db,
@@ -535,7 +536,7 @@ def trigger_coding_agent_handoff(
     provider: str | None = None,
     user_id: int | None = None,
     auto_create_pr: bool | None = None,
-) -> dict[str, list]:
+) -> AutofixHandoffResponse:
     """
     Trigger a coding agent handoff for an existing agent-based autofix run.
 
@@ -613,7 +614,10 @@ def trigger_coding_agent_handoff(
         },
     )
 
-    return coding_agents
+    # cast() sanctioned: `client.launch_coding_agents` returns loose
+    # dict[str, list]; the runtime shape is the `{successes, failures}`
+    # envelope captured by AutofixHandoffResponse.
+    return cast(AutofixHandoffResponse, coding_agents)
 
 
 def trigger_push_changes(

--- a/src/sentry/seer/autofix/types.py
+++ b/src/sentry/seer/autofix/types.py
@@ -4,9 +4,16 @@ from typing import Any, TypedDict
 
 
 class AutofixPostResponse(TypedDict):
-    """Response type for the POST endpoint"""
+    """Response type for the POST endpoint (default kickoff and step paths)."""
 
     run_id: int
+
+
+class AutofixHandoffResponse(TypedDict):
+    """Response type for the POST endpoint when `step=coding_agent_handoff`."""
+
+    successes: list[dict[str, Any]]
+    failures: list[dict[str, Any]]
 
 
 class AutofixStateResponse(TypedDict):

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -22,6 +22,11 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.autofix_examples import AutofixExamples
 from sentry.apidocs.parameters import GlobalParams, IssueParams
+from sentry.apidocs.response_types import (
+    DetailResponse,
+    ValidationErrorResponse,
+    as_validation_errors,
+)
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.action_log import (
@@ -48,7 +53,11 @@ from sentry.seer.autofix.coding_agent import (
     poll_github_copilot_agents,
 )
 from sentry.seer.autofix.constants import AutofixReferrer
-from sentry.seer.autofix.types import AutofixPostResponse, AutofixStateResponse
+from sentry.seer.autofix.types import (
+    AutofixHandoffResponse,
+    AutofixPostResponse,
+    AutofixStateResponse,
+)
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     CodingAgentProviderType,
@@ -176,7 +185,16 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         examples=AutofixExamples.AUTOFIX_POST_RESPONSE,
     )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-autofix"])
-    def post(self, request: Request, group: Group) -> Response:
+    def post(
+        self, request: Request, group: Group
+    ) -> (
+        Response[AutofixPostResponse]
+        | Response[AutofixHandoffResponse]
+        | Response[None]
+        | Response[DetailResponse]
+        | Response[ValidationErrorResponse]
+        | Response[str]
+    ):
         """
         Trigger a Seer Issue Fix run for a specific issue.
 
@@ -190,7 +208,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         """
         serializer = ExplorerAutofixRequestSerializer(data=request.data)
         if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            return Response(as_validation_errors(serializer), status=status.HTTP_400_BAD_REQUEST)
 
         data = serializer.validated_data
         step = data.get("step", "root_cause")
@@ -215,7 +233,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 )
 
             try:
-                result = trigger_coding_agent_handoff(
+                handoff_result: AutofixHandoffResponse = trigger_coding_agent_handoff(
                     group=group,
                     run_id=run_id,
                     referrer=_parse_autofix_referrer(data.get("referrer")),
@@ -228,7 +246,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 if _is_unknown_run_id_error(e):
                     return Response(status=status.HTTP_404_NOT_FOUND)
                 raise PermissionDenied(SEER_PERMISSION_DENIED)
-            return Response(result, status=status.HTTP_202_ACCEPTED)
+            return Response(handoff_result, status=status.HTTP_202_ACCEPTED)
 
         if step == "open_pr":
             if not run_id:
@@ -245,7 +263,8 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 )
             except SeerPermissionError:
                 return Response(status=status.HTTP_404_NOT_FOUND)
-            return Response({"run_id": run_id}, status=status.HTTP_202_ACCEPTED)
+            open_pr_body: AutofixPostResponse = {"run_id": run_id}
+            return Response(open_pr_body, status=status.HTTP_202_ACCEPTED)
 
         # Handle all built-in Seer steps. A missing run_id means this call starts a new
         # autofix run (the kickoff); a provided run_id is advancing an existing run.
@@ -275,7 +294,8 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                         else SYSTEM_ACTOR
                     ),
                 )
-            return Response({"run_id": run_id}, status=status.HTTP_202_ACCEPTED)
+            kickoff_body: AutofixPostResponse = {"run_id": run_id}
+            return Response(kickoff_body, status=status.HTTP_202_ACCEPTED)
         except NoSeerQuotaException:
             return Response("No budget for Seer Autofix.", status=status.HTTP_402_PAYMENT_REQUIRED)
         except SeerPermissionError as e:


### PR DESCRIPTION
Tightens the last 4 untyped PUBLIC endpoints, bringing the Goal #1 `@extend_schema` + typed-decorator gap to **zero**:

- `group_ai_autofix.post` → multi-shape union (`AutofixPostResponse | AutofixHandoffResponse | None | DetailResponse | ValidationErrorResponse | str`). New `AutofixHandoffResponse` TypedDict captures the `step=coding_agent_handoff` branch's `{successes, failures}` envelope. The decorator's 202 keeps `AutofixPostResponse` (the kickoff/step-advancement default) — the linter accepts annotation arms not declared by the decorator (subset semantics). `trigger_coding_agent_handoff()` now returns `AutofixHandoffResponse` via a cast at the source-of-truth boundary (`client.launch_coding_agents` still returns `dict[str, list]`).

- `organization_events.get` → `Response[EventsApiResponse] | Response[DetailResponse]`. `EventsMeta` widened to `total=False` with all keys `handle_results_with_meta` actually emits (`tips`, `units`, `dataset`, `dataScanned`, etc.) — the empty-projects short-circuit emits a meta with only `tips`, the standard path emits the full set.

- `scim/teams.patch` → `Response[None] | Response[ValidationErrorResponse]`. The `ParseError`/`UnsupportedAttributeError` detail attribute is coerced to a dict at each except site so the union arm typechecks; the in-scope raisers all use SCIM-shaped dict details.

- `event_attachment_details.get` → adds the missing `Response[EventAttachmentSerializerResponse] | Response[None] | Response[DetailResponse]` arms alongside the existing `StreamingHttpResponse` (the `?download` path).

No wire changes.