### PR TITLE
feat(dev): Suppress mypy unused configs warnings when running via prek

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         require_serial: true
       - id: mypy
         name: mypy
-        entry: bash -c 'if [ -n "${SENTRY_MYPY_PRE_PUSH:-}" ]; then exec .venv/bin/mypy "$@"; fi' --
+        entry: bash -c 'if [ -n "${SENTRY_MYPY_PRE_PUSH:-}" ]; then exec .venv/bin/mypy --no-warn-unused-configs "$@"; fi' --
         language: system
         stages: [pre-push]
         types: [python]


### PR DESCRIPTION
The pre-push hook runs mypy on changed files only, which causes `warn_unused_configs` to report every unmatched override section in `pyproject.toml` as noise. 
Pass `--no-warn-unused-configs` in the hook so full-project runs still benefit from the check.
