### PR TITLE
fix(low-value-spans): Clarify extrapolation window in tooltips

### DIFF
--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
@@ -76,7 +76,7 @@ export function ProblemSection({evidenceData}: ProblemSectionProps) {
               <InfoTip
                 size="xs"
                 title={t(
-                  'This monthly volume is extrapolated from a recent sample of this span, so it may not match the final span volume for the billing period.'
+                  'Projected 30-day volume based on a recent sample. Actual volume may differ.'
                 )}
               />
             )}
@@ -98,7 +98,7 @@ export function ProblemSection({evidenceData}: ProblemSectionProps) {
                 <InfoTip
                   size="xs"
                   title={t(
-                    'This estimate is based on a recent sample of this span, so it may not match your final bill for the billing period.'
+                    'Projected 30-day cost based on a recent sample. Actual cost may differ.'
                   )}
                 />
               </Flex>


### PR DESCRIPTION
Reword the span count and estimated cost info tooltips on the low-value span configuration issue so they explicitly state that the values are projected over a 30-day window from a recent sample. The new copy is also shorter and drops the "billing period" framing.

Closes TET-2468