### PR TITLE
docs(api): document operation_id naming convention

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -125,6 +125,12 @@ class DetailedSerializer(MySerializer):
 
 - OpenAPI spec generation: `make build-api-docs`
 - API ownership tracked in `src/sentry/apidocs/api_ownership_allowlist_dont_modify.py`
+- `@extend_schema(operation_id=...)`: use a short camelCase REST token, NOT a sentence.
+  Form is `<verb><Resource>` — verb is `list` (GET collection), `get` (GET one), `create`
+  (POST), `update` (PUT/PATCH), `delete` (DELETE); Resource comes from the path's nouns.
+  e.g. `listOrganizationIssues`, `getOrganizationIssue`, `createProjectKey`. Put the
+  human-readable title in `summary=` — that's what the API reference renders. Non-CRUD
+  actions use the real verb: `add`, `start`, `enable`, `upload`, `link`, `resolve`, etc.
 
 ### API Design Rules
 


### PR DESCRIPTION
## Summary

Records the `operation_id` naming convention for `@extend_schema` in the backend guide (`src/AGENTS.md`), so contributors know what to put — and so it matches the names the generated `@sentry/api` SDK produces.

`@extend_schema` is imported directly from drf-spectacular in ~250 files (no Sentry wrapper to host a docstring), so the convention lives in the in-repo guide that agents + humans already consult for API rules.

## Convention
`operation_id` = short camelCase REST token (`<verb><Resource>`): `list` (GET collection) / `get` (GET one) / `create` (POST) / `update` (PUT/PATCH) / `delete` (DELETE) + the path's nouns. Human title goes in `summary=`. Non-CRUD actions use the real verb (`add`, `start`, `enable`, …).

Part of the operationId→token + summary migration (docs SEO foundation already merged; replays pilot is #117166). When the apidocs enforcement hook lands, its failure message will quote this same convention.