### PR TITLE
fix(low-value-spans): Handle null op/description in explore link and snippets

### DIFF
--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.spec.tsx
@@ -67,4 +67,56 @@ describe('LowValueSpanIssues ProblemSection', () => {
 
     expect(screen.queryByText('Estimated cost')).not.toBeInTheDocument();
   });
+
+  it('links to explore filtering for missing description when description is null', () => {
+    render(
+      <ProblemSection
+        evidenceData={{
+          ...evidenceData,
+          description: null,
+        }}
+      />
+    );
+
+    const exploreLink = screen.getByRole('link', {name: 'function'});
+    expect(exploreLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('%21has%3Aspan.description')
+    );
+    expect(exploreLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('span.op%3Afunction')
+    );
+  });
+
+  it('links to explore filtering for missing op when op is null', () => {
+    render(
+      <ProblemSection
+        evidenceData={{
+          ...evidenceData,
+          op: null,
+        }}
+      />
+    );
+
+    const exploreLink = screen.getByRole('link', {name: 'compute_checksum'});
+    expect(exploreLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('%21has%3Aspan.op')
+    );
+  });
+
+  it('does not link to explore when both op and description are null', () => {
+    render(
+      <ProblemSection
+        evidenceData={{
+          ...evidenceData,
+          op: null,
+          description: null,
+        }}
+      />
+    );
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
@@ -11,7 +11,7 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils/defined';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {EMPTY_OPTION_VALUE, MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
@@ -26,13 +26,15 @@ interface ProblemSectionProps {
 const LOW_VALUE_SPAN_EXPLORE_REFERRER = 'low-value-span-configuration-issue';
 
 function getAffectedSpanQuery(evidenceData: LowValueSpanEvidenceData): string | null {
-  if (!evidenceData.op && !evidenceData.description) {
+  const {op, description} = evidenceData;
+
+  if (op === null && description === null) {
     return null;
   }
 
   return MutableSearch.fromQueryObject({
-    'span.op': evidenceData.op ?? undefined,
-    'span.description': evidenceData.description ?? undefined,
+    'span.op': op ?? EMPTY_OPTION_VALUE,
+    'span.description': description ?? EMPTY_OPTION_VALUE,
   }).formatString();
 }
 

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
@@ -158,4 +158,37 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
     expect(screen.getByText('ignoreSpans')).toBeInTheDocument();
     expect(screen.queryByText('1. Find the custom span')).not.toBeInTheDocument();
   });
+
+  it('emits op-only ignoreSpans with an over-match warning when description is null', () => {
+    render(
+      <TroubleshootingSection
+        evidenceData={{
+          ...baseEvidenceData,
+          description: null,
+        }}
+        projectPlatform="javascript-nextjs"
+      />
+    );
+
+    expect(screen.getByText(/op: "function"/)).toBeInTheDocument();
+    expect(screen.queryByText(/name:/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/will also drop other spans with this op/)
+    ).toBeInTheDocument();
+  });
+
+  it('uses `is None` in the Python snippet when description is null', () => {
+    render(
+      <TroubleshootingSection
+        evidenceData={{
+          ...baseEvidenceData,
+          description: null,
+        }}
+        projectPlatform="python-django"
+      />
+    );
+
+    expect(screen.getByText(/span.get\("op"\) == "function"/)).toBeInTheDocument();
+    expect(screen.getByText(/span.get\("description"\) is None/)).toBeInTheDocument();
+  });
 });

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
@@ -98,21 +98,27 @@ export function getCustomInstrumentationDocsUrl(): string {
   return CUSTOM_INSTRUMENTATION_DOCS_URL;
 }
 
-function toCodeString(value: string | null, fallback: string): string {
-  return JSON.stringify(value ?? fallback);
-}
-
 export function getJavaScriptSpanFilterSnippet(
   evidenceData: LowValueSpanEvidenceData
 ): string {
-  const spanOp = toCodeString(evidenceData.op, '<span.op>');
-  const spanDescription = toCodeString(evidenceData.description, '<span.description>');
+  const matcherLines: string[] = [];
+  if (evidenceData.description === null && evidenceData.op !== null) {
+    matcherLines.push(`      // NOTE: This span has no description, so it can only be`);
+    matcherLines.push(
+      `      // targeted by op. This will also drop other spans with this op.`
+    );
+  }
+  if (evidenceData.op !== null) {
+    matcherLines.push(`      op: ${JSON.stringify(evidenceData.op)},`);
+  }
+  if (evidenceData.description !== null) {
+    matcherLines.push(`      name: ${JSON.stringify(evidenceData.description)},`);
+  }
 
   return `Sentry.init({
   ignoreSpans: [
     {
-      op: ${spanOp},
-      name: ${spanDescription},
+${matcherLines.join('\n')}
     },
   ],
 });`;
@@ -121,8 +127,19 @@ export function getJavaScriptSpanFilterSnippet(
 export function getPythonSpanFilterSnippet(
   evidenceData: LowValueSpanEvidenceData
 ): string {
-  const spanOp = toCodeString(evidenceData.op, '<span.op>');
-  const spanDescription = toCodeString(evidenceData.description, '<span.description>');
+  const conditions: string[] = [];
+  if (evidenceData.op === null) {
+    conditions.push(`            span.get("op") is None`);
+  } else {
+    conditions.push(`            span.get("op") == ${JSON.stringify(evidenceData.op)}`);
+  }
+  if (evidenceData.description === null) {
+    conditions.push(`            and span.get("description") is None`);
+  } else {
+    conditions.push(
+      `            and span.get("description") == ${JSON.stringify(evidenceData.description)}`
+    );
+  }
 
   return `import sentry_sdk
 
@@ -131,8 +148,7 @@ def before_send_transaction(event, hint):
     event["spans"] = [
         span for span in event.get("spans", [])
         if not (
-            span.get("op") == ${spanOp}
-            and span.get("description") == ${spanDescription}
+${conditions.join('\n')}
         )
     ]
     return event


### PR DESCRIPTION
## Summary

A low-value span occurrence may arrive with a null `op` or `description`. The current details page handles this poorly:

- The Explore link silently drops the missing field from the query, broadening it to unrelated spans.
- The SDK filter snippets emit literal placeholder strings (`"<span.op>"`, `"<span.description>"`) that no SDK will ever match at runtime.

This PR makes the failure modes correct:

- **Explore link** now uses `!has:span.op` / `!has:span.description` so the query precisely targets the spans missing those fields.
- **Python `before_send_transaction` snippet** uses `is None` checks for null fields, which filters precisely.
- **JavaScript `ignoreSpans` snippet** omits the missing field from the matcher object and adds a code comment warning that op-only matching will also drop other spans with the same op.

## Caveat

This is symptom-fighting. The deeper issue is that low-value span occurrences with a null description shouldn't be surfaced to users in the first place — they're not actionable in JS without modifying the source integration, and they're hard to identify in any explore session. The fix here just makes the UI honest when these issues do reach the user.

Fixes TET-2466