### PR TITLE
ref(api): use token operationIds + summary for dashboard endpoints

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_details.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_details.py
@@ -105,7 +105,8 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
     }
 
     @extend_schema(
-        operation_id="Retrieve an Organization's Custom Dashboard",
+        operation_id="getOrganizationDashboard",
+        summary="Retrieve an Organization's Custom Dashboard",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, DashboardParams.DASHBOARD_ID],
         responses={
             200: DashboardDetailsModelSerializer,
@@ -127,7 +128,8 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
         return self.respond(body)
 
     @extend_schema(
-        operation_id="Delete an Organization's Custom Dashboard",
+        operation_id="deleteOrganizationDashboard",
+        summary="Delete an Organization's Custom Dashboard",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, DashboardParams.DASHBOARD_ID],
         responses={
             204: RESPONSE_NO_CONTENT,
@@ -154,7 +156,8 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
         return self.respond(status=204)
 
     @extend_schema(
-        operation_id="Edit an Organization's Custom Dashboard",
+        operation_id="updateOrganizationDashboard",
+        summary="Edit an Organization's Custom Dashboard",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, DashboardParams.DASHBOARD_ID],
         request=DashboardDetailsSerializer,
         responses={

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -348,7 +348,8 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationDashboardsPermission,)
 
     @extend_schema(
-        operation_id="List an Organization's Custom Dashboards",
+        operation_id="listOrganizationDashboards",
+        summary="List an Organization's Custom Dashboards",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, VisibilityParams.PER_PAGE, CursorQueryParam],
         request=None,
         responses={
@@ -542,7 +543,8 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         )
 
     @extend_schema(
-        operation_id="Create a New Dashboard for an Organization",
+        operation_id="createOrganizationDashboard",
+        summary="Create a New Dashboard for an Organization",
         parameters=[GlobalParams.ORG_ID_OR_SLUG],
         request=DashboardSerializer,
         responses={


### PR DESCRIPTION
## Summary

Second area of the operationId→token migration. OpenAPI `operationId` is meant to be a machine identifier, but Sentry uses the human sentence — which the generated `@sentry/api` SDK turns into function names and the API reference renders as the page title + URL slug.

This moves the sentence into `summary` and sets `operation_id` to a short camelCase REST token for the **dashboard** endpoints. The SDK gets clean names; paired with the merged docs change (title/slug derive from `summary`), the docs titles and SEO URLs stay byte-identical.

5 operations, 2 files, all textbook CRUD (no exceptions):
`listOrganizationDashboards` · `createOrganizationDashboard` · `getOrganizationDashboard` · `updateOrganizationDashboard` · `deleteOrganizationDashboard`

## Test plan
- `make build-api-docs` regenerates the spec and passes `--validate --fail-on-warn`; dashboard ops show token operationIds with the sentence preserved as `summary`.
- prek green (ruff/flake8/mypy + the `@extend_schema` response-type check).

## Related (operationId→token migration)
- Convention documented in `src/AGENTS.md`: #117285
- Replays pilot (first area): #117166
- Docs SEO foundation (title/slug from summary): getsentry/sentry-docs#18322 (merged)