### PR TITLE
ref(issues): Scope issue endpoint short id lookups to authorized projects

### DIFF
--- a/src/sentry/api/helpers/group_index/lookup.py
+++ b/src/sentry/api/helpers/group_index/lookup.py
@@ -31,14 +31,17 @@ def get_group_list(
             ).select_related("project")
         )
     else:
-        project_ids = {p.id for p in projects}
+        project_ids = [p.id for p in projects]
         for group_id in group_ids:
             if isinstance(group_id, str):
                 try:
-                    group = Group.objects.by_qualified_short_id(organization_id, group_id)
+                    # Scope the short id lookup to the authorized projects so a short id
+                    # referencing a project the caller cannot access does not resolve.
+                    group = Group.objects.by_qualified_short_id(
+                        organization_id, group_id, project_ids=project_ids
+                    )
                 except Group.DoesNotExist:
                     continue
-                if group.project_id in project_ids:
-                    groups.append(group)
+                groups.append(group)
 
     return groups

--- a/src/sentry/api/helpers/group_index/lookup.py
+++ b/src/sentry/api/helpers/group_index/lookup.py
@@ -35,8 +35,6 @@ def get_group_list(
         for group_id in group_ids:
             if isinstance(group_id, str):
                 try:
-                    # Scope the short id lookup to the authorized projects so a short id
-                    # referencing a project the caller cannot access does not resolve.
                     group = Group.objects.by_qualified_short_id(
                         organization_id, group_id, project_ids=project_ids
                     )

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -401,7 +401,15 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
                     )
                     return Response(by_event)
 
-            group = get_by_short_id(organization.id, request.GET.get("shortIdLookup") or "0", query)
+            # project_ids=None: resolve org-wide, then gate on the actor's project access
+            # below via has_project_access (the authoritative check, which also handles
+            # global/superuser access that a raw project-id filter would not).
+            group = get_by_short_id(
+                organization.id,
+                request.GET.get("shortIdLookup") or "0",
+                query,
+                project_ids=None,
+            )
             if group is not None:
                 # check all projects user has access to
                 if request.access.has_project_access(group.project):

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -401,9 +401,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
                     )
                     return Response(by_event)
 
-            # project_ids=None: resolve org-wide, then gate on the actor's project access
-            # below via has_project_access (the authoritative check, which also handles
-            # global/superuser access that a raw project-id filter would not).
             group = get_by_short_id(
                 organization.id,
                 request.GET.get("shortIdLookup") or "0",

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -171,8 +171,6 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
                 else:
                     matching_event = eventstore.backend.get_event_by_id(project.id, event_id)
             elif matching_group is None:
-                # Scope the short id lookup to this project so a short id for another
-                # project in the org does not resolve here.
                 matching_group = get_by_short_id(
                     project.organization_id,
                     request.GET.get("shortIdLookup", "0"),

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -171,11 +171,14 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
                 else:
                     matching_event = eventstore.backend.get_event_by_id(project.id, event_id)
             elif matching_group is None:
+                # Scope the short id lookup to this project so a short id for another
+                # project in the org does not resolve here.
                 matching_group = get_by_short_id(
-                    project.organization_id, request.GET.get("shortIdLookup", "0"), query
+                    project.organization_id,
+                    request.GET.get("shortIdLookup", "0"),
+                    query,
+                    project_ids=[project.id],
                 )
-                if matching_group is not None and matching_group.project_id != project.id:
-                    matching_group = None
 
             if matching_group is not None:
                 matching_event_environment = None


### PR DESCRIPTION
> Draft, stacked on #117047 (which is stacked on the merged #117046). Showcase of the call-site adoption pattern; review/merge the parents first.

Threads project scope into the short-id resolution used by the issue endpoints, moving enforcement from post-hoc checks to the query layer. Demonstrates the three adoption shapes:

- **`get_group_list`** (the reported IDOR path) — passes the authorized projects that `get_projects()` already resolved and drops the redundant `group.project_id in project_ids` post-check.
- **`ProjectGroupIndexEndpoint`** — scopes the short-id direct hit to the URL project (`project_ids=[project.id]`) and drops the redundant `project_id` mismatch check.
- **`OrganizationGroupIndexEndpoint`** — resolves org-wide (`project_ids=None`) and keeps `request.access.has_project_access`, which correctly handles global/superuser access that a raw project-id filter would not.

No behavior change (post-check → query-level scoping); the existing endpoint/IDOR tests pass unchanged. This is the issues-area slice of the stacked series; search (`filter.py`/`discover.py`/`resolver.py`) and Seer adopt the same param in sibling PRs, and a final PR makes `project_ids` required keyword-only.