### PR TITLE
feat(eap): Add OTel GenAI token usage attributes

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -231,6 +231,21 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="integer",
         ),
         ResolvedAttribute(
+            public_alias="gen_ai.usage.reasoning.output_tokens",
+            internal_name="gen_ai.usage.reasoning.output_tokens",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
+            public_alias="gen_ai.usage.cache_read.input_tokens",
+            internal_name="gen_ai.usage.cache_read.input_tokens",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
+            public_alias="gen_ai.usage.cache_creation.input_tokens",
+            internal_name="gen_ai.usage.cache_creation.input_tokens",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
             public_alias="gen_ai.usage.total_tokens",
             internal_name="gen_ai.usage.total_tokens",
             search_type="integer",


### PR DESCRIPTION
Add resolved attributes for the OpenTelemetry GenAI semantic conventions token usage fields:

- `gen_ai.usage.reasoning.output_tokens`
- `gen_ai.usage.cache_read.input_tokens`
- `gen_ai.usage.cache_creation.input_tokens`

These follow the OTel naming conventions for reasoning tokens, cached input tokens, and cache creation input tokens.