### PR TITLE
ref(api): use token operationIds + summary for discover endpoints

### DIFF
--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -51,7 +51,8 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
         return features.has("organizations:discover-query", organization, actor=request.user)
 
     @extend_schema(
-        operation_id="List an Organization's Discover Saved Queries",
+        operation_id="listOrganizationDiscoverSavedQueries",
+        summary="List an Organization's Discover Saved Queries",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             VisibilityParams.PER_PAGE,
@@ -160,7 +161,8 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
         )
 
     @extend_schema(
-        operation_id="Create a New Saved Query",
+        operation_id="createOrganizationDiscoverSavedQuery",
+        summary="Create a New Saved Query",
         parameters=[GlobalParams.ORG_ID_OR_SLUG],
         request=DiscoverSavedQuerySerializer,
         responses={

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -63,7 +63,8 @@ class DiscoverSavedQueryDetailEndpoint(DiscoverSavedQueryBase):
         return features.has("organizations:discover-query", organization, actor=request.user)
 
     @extend_schema(
-        operation_id="Retrieve an Organization's Discover Saved Query",
+        operation_id="getOrganizationDiscoverSavedQuery",
+        summary="Retrieve an Organization's Discover Saved Query",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             DiscoverSavedQueryParams.DISCOVER_SAVED_QUERY_ID,
@@ -92,7 +93,8 @@ class DiscoverSavedQueryDetailEndpoint(DiscoverSavedQueryBase):
         )
 
     @extend_schema(
-        operation_id="Edit an Organization's Discover Saved Query",
+        operation_id="updateOrganizationDiscoverSavedQuery",
+        summary="Edit an Organization's Discover Saved Query",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, DiscoverSavedQueryParams.DISCOVER_SAVED_QUERY_ID],
         request=DiscoverSavedQuerySerializer,
         responses={
@@ -151,7 +153,8 @@ class DiscoverSavedQueryDetailEndpoint(DiscoverSavedQueryBase):
         )
 
     @extend_schema(
-        operation_id="Delete an Organization's Discover Saved Query",
+        operation_id="deleteOrganizationDiscoverSavedQuery",
+        summary="Delete an Organization's Discover Saved Query",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, DiscoverSavedQueryParams.DISCOVER_SAVED_QUERY_ID],
         responses={
             204: RESPONSE_NO_CONTENT,


### PR DESCRIPTION
## Summary

Third area of the operationId→token migration. Move the human sentence into `summary` and set `operation_id` to a short camelCase REST token, so the generated `@sentry/api` SDK gets clean names while docs titles/slugs stay byte-identical (derived from `summary`).

5 operations, 2 files. The path is `/discover/saved/`, so the pure structural token drops the resource noun (`…DiscoverSaved`). Overridden to the endpoint's own term — `DiscoverSavedQuery` (per `DiscoverSavedQuerySerializer`) — for clarity:

- `listOrganizationDiscoverSavedQueries`
- `createOrganizationDiscoverSavedQuery`
- `getOrganizationDiscoverSavedQuery`
- `updateOrganizationDiscoverSavedQuery`
- `deleteOrganizationDiscoverSavedQuery`

## Test plan
- `make build-api-docs` regenerates the spec and passes `--validate --fail-on-warn`; operations show token operationIds with the sentence preserved as `summary`.
- prek green (ruff/flake8/mypy + the `@extend_schema` response-type check).

## Related (operationId→token migration)
- Convention doc (`src/AGENTS.md`): #117285
- Replays pilot: #117166 · Dashboards: #117297
- Docs SEO foundation: getsentry/sentry-docs#18322 (merged)