### PR TITLE
feat(seer): Move troubleshooting context to the serialized event

### DIFF
--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -1155,7 +1155,7 @@ class _EventTroubleshootingContext(TypedDict):
 def _get_event_troubleshooting_context(
     event: Event | GroupEvent,
 ) -> _EventTroubleshootingContext:
-    group = getattr(event, "group", None)
+    group = event.group
     if group is None:
         return {"detectionContext": None, "troubleshootingHint": None}
 

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -1146,15 +1146,19 @@ _SEER_EXPLORER_ACTIVITY_TYPES = [
 ]
 
 
-class _IssueTroubleshootingContext(TypedDict):
-    # These fields are added to serialized group data, which uses camelCase API keys.
+class _EventTroubleshootingContext(TypedDict):
+    # These fields are added to the serialized event, which uses camelCase API keys.
     detectionContext: str | None
     troubleshootingHint: str | None
 
 
-def _get_issue_troubleshooting_context(
-    group: Group, event: Event | GroupEvent | None = None
-) -> _IssueTroubleshootingContext:
+def _get_event_troubleshooting_context(
+    event: Event | GroupEvent,
+) -> _EventTroubleshootingContext:
+    group = getattr(event, "group", None)
+    if group is None:
+        return {"detectionContext": None, "troubleshootingHint": None}
+
     if group.type == LowValueSpanConfigurationType.type_id:
         occurrence = getattr(event, "occurrence", None)
         evidence_data = occurrence.evidence_data if occurrence else {}
@@ -1197,7 +1201,8 @@ def get_issue_and_event_response(
     start: datetime | None = None,
     end: datetime | None = None,
 ) -> dict[str, Any]:
-    serialized_event = serialize(event, user=None, serializer=EventSerializer())
+    serialized_event = dict(serialize(event, user=None, serializer=EventSerializer()))
+    serialized_event.update(_get_event_troubleshooting_context(event))
 
     result = {
         "event": serialized_event,
@@ -1212,7 +1217,6 @@ def get_issue_and_event_response(
         serialized_group = dict(serialize(group, user=None, serializer=GroupSerializer()))
         # Add issueTypeDescription as it provides better context for LLMs. Note the initial type should be BaseGroupSerializerResponse.
         serialized_group["issueTypeDescription"] = group.issue_type.description
-        serialized_group.update(_get_issue_troubleshooting_context(group, event))
 
         logger.info(
             "get_issue_and_event_details_v2: Querying for tags overview",
@@ -1337,7 +1341,6 @@ def get_issue_details(
     serialized_group = dict(serialize(group, user=None, serializer=GroupSerializer()))
     # Add issueTypeDescription as it provides better context for LLMs. Note the initial type should be BaseGroupSerializerResponse.
     serialized_group["issueTypeDescription"] = group.issue_type.description
-    serialized_group.update(_get_issue_troubleshooting_context(group))
 
     # Get aggregate tag and event data and activity.
     try:
@@ -1499,7 +1502,8 @@ def get_event_details(
         )
         return None
 
-    serialized_event = serialize(event, user=None, serializer=EventSerializer())
+    serialized_event = dict(serialize(event, user=None, serializer=EventSerializer()))
+    serialized_event.update(_get_event_troubleshooting_context(event))
 
     return {
         "event": serialized_event,

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -1147,7 +1147,7 @@ _SEER_EXPLORER_ACTIVITY_TYPES = [
 
 
 class _EventTroubleshootingContext(TypedDict):
-    # These fields are added to the serialized event, which uses camelCase API keys.
+    # These fields are added to the serialized event, which uses camelCase keys.
     detectionContext: str | None
     troubleshootingHint: str | None
 

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -1118,8 +1118,6 @@ class _IssueMetadata(BaseModel):
     type: str
     issueType: str
     issueTypeDescription: str  # Extra field added by get_issue_and_event_details.
-    detectionContext: str | None  # Extra field added by get_issue_and_event_details.
-    troubleshootingHint: str | None  # Extra field added by get_issue_and_event_details.
     issueCategory: str
     hasSeen: bool
     project: _Project
@@ -1594,6 +1592,36 @@ class TestGetIssueAndEventDetailsV2(
             assert serialized["value"] == original.value
             assert serialized["important"] == original.important
 
+    @patch("sentry.seer.agent.tools._get_issue_event_timeseries")
+    @patch("sentry.seer.agent.tools.get_all_tags_overview")
+    def test_low_value_span_event_context(self, mock_get_tags, mock_get_timeseries) -> None:
+        """Troubleshooting context lives on the serialized event, not the issue."""
+        mock_get_timeseries.return_value = ({"count()": {"data": []}}, "6h", "15m")
+        mock_get_tags.return_value = {"tags_overview": []}
+
+        occurrence, _ = self.process_occurrence(
+            event_data={
+                "timestamp": before_now(minutes=5).isoformat(),
+                "project_id": self.project.id,
+                "platform": "python",
+            },
+            project_id=self.project.id,
+            type=LowValueSpanConfigurationType.type_id,
+            evidence_data={"span_origin": "manual"},
+        )
+
+        result = get_issue_and_event_details_v2(
+            organization_id=self.organization.id,
+            event_id=occurrence.event_id,
+            project_slug=self.project.slug,
+            include_issue=True,
+        )
+
+        assert result is not None
+        event_dict = result["event"]
+        assert "Sentry detector" in event_dict["detectionContext"]
+        assert "Remove the manually instrumented span" in event_dict["troubleshootingHint"]
+
 
 class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, SearchIssueTestMixin):
     """Tests for get_issue_details — fetching issue-level metadata, timeseries, tags, and activity."""
@@ -1636,8 +1664,6 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, SearchIssueTest
         self._assert_issue_response_shape(result)
         assert result["issue"]["id"] == str(group.id)
         assert result["issue"]["issueTypeDescription"] == group.issue_type.description
-        assert result["issue"]["detectionContext"] is None
-        assert result["issue"]["troubleshootingHint"] is None
         assert result["project_id"] == group.project_id
         assert result["project_slug"] == group.project.slug
 
@@ -1662,28 +1688,6 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, SearchIssueTest
         assert result["issue"]["id"] == str(group.id)
         assert result["project_id"] == group.project_id
         assert result["project_slug"] == group.project.slug
-
-    @patch("sentry.seer.agent.tools._get_issue_event_timeseries")
-    @patch("sentry.seer.agent.tools.get_all_tags_overview")
-    def test_low_value_span_issue_context(self, mock_tags, mock_ts):
-        mock_ts.return_value = ({"count()": {"data": []}}, "6h", "15m")
-        mock_tags.return_value = {"tags_overview": []}
-        group = self.create_group(
-            project=self.project,
-            type=LowValueSpanConfigurationType.type_id,
-        )
-
-        result = get_issue_details(
-            organization_id=self.organization.id,
-            issue_id=str(group.id),
-        )
-
-        assert isinstance(result, dict)
-        self._assert_issue_response_shape(result)
-        assert "Sentry detector" in result["issue"]["detectionContext"]
-        assert "low telemetry value" in result["issue"]["detectionContext"]
-        assert "manually instrumented" in result["issue"]["troubleshootingHint"]
-        assert "filter the automatically created span" in result["issue"]["troubleshootingHint"]
 
     # --- timeseries ---
 
@@ -2124,6 +2128,47 @@ class TestGetEventDetails(
         )
 
         assert result is None
+
+    # --- troubleshooting context on the serialized event ---
+
+    def test_low_value_span_event_context(self) -> None:
+        """Low-value-span events surface detector context on the serialized event."""
+        occurrence, _ = self.process_occurrence(
+            event_data={
+                "timestamp": before_now(minutes=5).isoformat(),
+                "project_id": self.project.id,
+                "platform": "python",
+            },
+            project_id=self.project.id,
+            type=LowValueSpanConfigurationType.type_id,
+            evidence_data={"span_origin": "manual"},
+        )
+
+        result = get_event_details(
+            organization_id=self.organization.id,
+            event_id=occurrence.event_id,
+            project_slug=self.project.slug,
+        )
+
+        assert result is not None
+        event_dict = result["event"]
+        assert "Sentry detector" in event_dict["detectionContext"]
+        assert "Remove the manually instrumented span" in event_dict["troubleshootingHint"]
+
+    def test_non_detector_event_has_null_context(self) -> None:
+        """Non-detector events expose the keys with null values."""
+        event = self._make_error_event()
+
+        result = get_event_details(
+            organization_id=self.organization.id,
+            event_id=event.event_id,
+            project_slug=self.project.slug,
+        )
+
+        assert result is not None
+        event_dict = result["event"]
+        assert event_dict["detectionContext"] is None
+        assert event_dict["troubleshootingHint"] is None
 
 
 class TestGetIssueAndEventResponse(APITransactionTestCase, SnubaTestCase, SearchIssueTestMixin):


### PR DESCRIPTION
Autofix on Low-Value Spans was missing the detector context that explains why a span was flagged. The `detectionContext` and `troubleshootingHint` fields were only added to the issue payload, so the event-only `get_event_details` tool — which never sees the issue — rendered events without any of that guidance. The combined `get_issue_and_event_details_v2` tool exposed them on the issue object too, which was the wrong layer.

Move both fields onto the serialized event in `get_event_details` and `get_issue_and_event_details_v2`, and drop them from the issue side everywhere (including `get_issue_details`). The hint variant depends on `span_origin` from the event's occurrence, so the event is the natural home for this data.

Closes TET-2487