### PR TITLE
feat(explore): Check attribute key and name for hidden values

### DIFF
--- a/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.spec.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.spec.tsx
@@ -185,6 +185,45 @@ describe('useGetTraceItemAttributeTagKeys', () => {
     expect(mockWithResults).toHaveBeenCalledTimes(2);
   });
 
+  it('filters hidden keys by both key and display name', async () => {
+    mockTraceItemAttributeKeysByType({
+      body: [
+        {
+          attributeType: 'string',
+          key: 'log.field',
+          name: 'log.field',
+          kind: FieldKind.TAG,
+        },
+        // Explicitly-typed key whose display name is the hidden field.
+        {
+          attributeType: 'number',
+          key: 'tags[project_id,number]',
+          name: 'project_id',
+          kind: FieldKind.MEASUREMENT,
+        },
+        // Plain hidden key.
+        {
+          attributeType: 'string',
+          key: 'project.id',
+          name: 'project.id',
+          kind: FieldKind.TAG,
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(useGetTraceItemAttributeTagKeys, {
+      initialProps: {
+        itemType: TraceItemDataset.LOGS,
+        hiddenKeys: ['project_id', 'project.id'],
+      },
+    });
+
+    const tags = await result.current('search-query');
+
+    expect(tags).toHaveLength(1);
+    expect(tags).toMatchObject([{key: 'log.field', name: 'log.field'}]);
+  });
+
   it('appends extraTags that are not in fetched results', async () => {
     mockTraceItemAttributeKeysByType({
       body: [

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
@@ -35,7 +35,7 @@ export function useGetTraceItemAttributeTagKeys({
         ...Object.values(keys.booleanAttributes),
       ];
       const filteredFetched = hiddenKeySet
-        ? fetched.filter(t => !hiddenKeySet.has(t.key))
+        ? fetched.filter(t => !hiddenKeySet.has(t.key) && !hiddenKeySet.has(t.name))
         : fetched;
       const fetchedKeySet = new Set(filteredFetched.map(t => t.key));
       return [

--- a/static/app/views/explore/utils.spec.tsx
+++ b/static/app/views/explore/utils.spec.tsx
@@ -1,9 +1,15 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {ProjectFixture} from 'sentry-fixture/project';
 
+import type {TagCollection} from 'sentry/types/group';
+import {FieldKind} from 'sentry/utils/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
-import {findSuggestedColumns, viewSamplesTarget} from 'sentry/views/explore/utils';
+import {
+  findSuggestedColumns,
+  removeHiddenKeys,
+  viewSamplesTarget,
+} from 'sentry/views/explore/utils';
 
 describe('viewSamplesTarget', () => {
   const project = ProjectFixture();
@@ -319,4 +325,59 @@ describe('findSuggestedColumns', () => {
       expect(new Set(suggestion)).toEqual(new Set(cols));
     }
   );
+});
+
+describe('removeHiddenKeys', () => {
+  it('removes keys that match the hidden list', () => {
+    const tags: TagCollection = {
+      'log.field': {key: 'log.field', name: 'log.field', kind: FieldKind.TAG},
+      project_id: {key: 'project_id', name: 'project_id', kind: FieldKind.TAG},
+    };
+
+    expect(removeHiddenKeys(tags, ['project_id'])).toEqual({
+      'log.field': {key: 'log.field', name: 'log.field', kind: FieldKind.TAG},
+    });
+  });
+
+  it('removes explicitly-typed keys by their display name', () => {
+    const tags: TagCollection = {
+      'log.duration': {
+        key: 'log.duration',
+        name: 'log.duration',
+        kind: FieldKind.MEASUREMENT,
+      },
+      // Number attributes are keyed by their explicit form but display the
+      // base name, which is what the hidden lists contain.
+      'tags[project_id,number]': {
+        key: 'tags[project_id,number]',
+        name: 'project_id',
+        kind: FieldKind.MEASUREMENT,
+      },
+    };
+
+    expect(removeHiddenKeys(tags, ['project_id'])).toEqual({
+      'log.duration': {
+        key: 'log.duration',
+        name: 'log.duration',
+        kind: FieldKind.MEASUREMENT,
+      },
+    });
+  });
+
+  it('keeps attributes whose name only partially matches a hidden key', () => {
+    const tags: TagCollection = {
+      prev_project_id: {
+        key: 'prev_project_id',
+        name: 'prev_project_id',
+        kind: FieldKind.MEASUREMENT,
+      },
+      'tags[message.parameter.project_id,number]': {
+        key: 'tags[message.parameter.project_id,number]',
+        name: 'message.parameter.project_id',
+        kind: FieldKind.MEASUREMENT,
+      },
+    };
+
+    expect(removeHiddenKeys(tags, ['project_id'])).toEqual(tags);
+  });
 });

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -641,11 +641,20 @@ export const removeHiddenKeys = (
   tagCollection: TagCollection,
   hiddenKeys: string[]
 ): TagCollection => {
+  const hiddenKeySet = new Set(hiddenKeys);
   const result: TagCollection = {};
   for (const key in tagCollection) {
-    if (key && !hiddenKeys.includes(key) && tagCollection[key]) {
-      result[key] = tagCollection[key];
+    const tag = tagCollection[key];
+    if (!key || !tag) {
+      continue;
     }
+    // Hide by both the raw key and the display name, matching the column
+    // editor. Explicitly-typed keys such as `tags[project_id,number]` carry a
+    // display name (`project_id`) that is what appears in the hidden lists.
+    if (hiddenKeySet.has(key) || (tag.name && hiddenKeySet.has(tag.name))) {
+      continue;
+    }
+    result[key] = tag;
   }
   return result;
 };


### PR DESCRIPTION
This PR tweaks the logic for how we check for hidden attributes to check both the key and name, as we were missing the removal of some.

Closes EXP-991