### PR TITLE
fix(onboarding): Skip locking write in record() when task is already complete

### DIFF
--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -57,6 +57,8 @@ class OnboardingTaskStatus(enum.IntEnum):
 
 
 class OrganizationOnboardingTaskManager(BaseManager["OrganizationOnboardingTask"]):
+    ONBOARDING_TASK_CACHE_TTL = 60 * 60 * 24 * 7  # 1 week
+
     def record(
         self,
         organization_id: int,
@@ -89,6 +91,16 @@ class OrganizationOnboardingTaskManager(BaseManager["OrganizationOnboardingTask"
                     },
                     sample_rate=1.0,
                 )
+
+            existing_status = (
+                self.filter(organization_id=organization_id, task=task)
+                .values_list("status", flat=True)
+                .first()
+            )
+            if existing_status == OnboardingTaskStatus.COMPLETE:
+                cache.set(cache_key, 1, self.ONBOARDING_TASK_CACHE_TTL)
+                return False
+
             defaults = {
                 **kwargs,
                 "status": status,
@@ -100,7 +112,7 @@ class OrganizationOnboardingTaskManager(BaseManager["OrganizationOnboardingTask"
             )
 
             # Store marker to prevent running all the time
-            cache.set(cache_key, 1, 60 * 60 * 24 * 7)  # 1 week
+            cache.set(cache_key, 1, self.ONBOARDING_TASK_CACHE_TTL)
             return created
         return False
 

--- a/tests/sentry/models/test_organizationonboardingtask.py
+++ b/tests/sentry/models/test_organizationonboardingtask.py
@@ -1,0 +1,122 @@
+from unittest.mock import patch
+
+import pytest
+from django.core.cache import cache
+from django.db import connections, router
+from django.test.utils import CaptureQueriesContext
+
+from sentry.models.organizationonboardingtask import (
+    OnboardingTask,
+    OnboardingTaskStatus,
+    OrganizationOnboardingTask,
+)
+from sentry.testutils.cases import TestCase
+
+
+class OrganizationOnboardingTaskRecordTest(TestCase):
+    _TASK = OnboardingTask.SOURCEMAPS
+
+    def _cache_key(self) -> str:
+        # Must match the key format in record().
+        return f"organizationonboardingtask:{self.organization.id}:{self._TASK}"
+
+    def _clear_marker(self) -> None:
+        cache.delete(self._cache_key())
+
+    def test_creates_task_when_row_missing(self) -> None:
+        """Cold start"""
+        self._clear_marker()
+        created = OrganizationOnboardingTask.objects.record(
+            organization_id=self.organization.id,
+            task=self._TASK,
+        )
+        assert created is True
+        row = OrganizationOnboardingTask.objects.get(
+            organization_id=self.organization.id,
+            task=self._TASK,
+        )
+        assert row.status == OnboardingTaskStatus.COMPLETE
+        assert cache.get(self._cache_key()) is not None
+
+    def test_cache_hit_makes_no_database_access(self) -> None:
+        """Warm cache: record() must return False before touching the ORM"""
+        cache.set(self._cache_key(), 1, 60)
+        with (
+            patch.object(
+                OrganizationOnboardingTask.objects, "update_or_create"
+            ) as mock_update_or_create,
+            patch.object(OrganizationOnboardingTask.objects, "filter") as mock_filter,
+        ):
+            created = OrganizationOnboardingTask.objects.record(
+                organization_id=self.organization.id,
+                task=self._TASK,
+            )
+            assert created is False
+            mock_update_or_create.assert_not_called()
+            mock_filter.assert_not_called()
+
+    def test_already_complete_row_short_circuits_locking_write(self) -> None:
+        """Cache miss with existing COMPLETE row - no write, cache key set."""
+        OrganizationOnboardingTask.objects.create(
+            organization=self.organization,
+            task=self._TASK,
+            status=OnboardingTaskStatus.COMPLETE,
+        )
+        self._clear_marker()
+
+        with patch.object(
+            OrganizationOnboardingTask.objects, "update_or_create"
+        ) as mock_update_or_create:
+            created = OrganizationOnboardingTask.objects.record(
+                organization_id=self.organization.id,
+                task=self._TASK,
+            )
+            assert created is False
+            mock_update_or_create.assert_not_called()
+            assert cache.get(self._cache_key()) is not None
+
+    def test_marker_eviction_after_record_does_not_lock_again(self) -> None:
+        """Task recorded once, marker later evicted, record() must not re-enter the write path."""
+        self._clear_marker()
+        created = OrganizationOnboardingTask.objects.record(
+            organization_id=self.organization.id,
+            task=self._TASK,
+        )
+        assert created is True
+        cache.delete(self._cache_key())
+
+        with CaptureQueriesContext(
+            connections[router.db_for_read(OrganizationOnboardingTask)]
+        ) as queries:
+            created = OrganizationOnboardingTask.objects.record(
+                organization_id=self.organization.id,
+                task=self._TASK,
+            )
+
+        assert created is False
+        assert not any("FOR UPDATE" in q["sql"] for q in queries.captured_queries)
+
+    def test_skipped_row_is_updated_to_complete(self) -> None:
+        """SKIPPED must still fall through to the write path and flip to COMPLETE."""
+        row = OrganizationOnboardingTask.objects.create(
+            organization=self.organization,
+            task=self._TASK,
+            status=OnboardingTaskStatus.SKIPPED,
+        )
+        self._clear_marker()
+        created = OrganizationOnboardingTask.objects.record(
+            organization_id=self.organization.id,
+            task=self._TASK,
+        )
+        assert created is False
+        row.refresh_from_db()
+        assert row.status == OnboardingTaskStatus.COMPLETE
+
+    def test_rejects_non_complete_status(self) -> None:
+        """record() only accepts status=COMPLETE."""
+        with pytest.raises(ValueError, match="unsupported"):
+            OrganizationOnboardingTask.objects.record(
+                organization_id=self.organization.id,
+                task=self._TASK,
+                status=OnboardingTaskStatus.SKIPPED,
+            )


### PR DESCRIPTION
`OrganizationOnboardingTask.objects.record()` now performs a non-locking status read on cache miss and returns early when the task row is already `COMPLETE`.

Adds tests for `record()`.

Fixes getsentry/self-hosted#4373

### Rationale

On a cache miss against an existing row, `update_or_create()` issues `SELECT ... FOR UPDATE` plus an unconditional `UPDATE` inside a transaction, and `complete_onboarding_task()` always passes a fresh `date_completed=timezone.now()`, so every miss writes a new row version. The hot path is the `event_processed`/`transaction_processed` receivers (`SOURCEMAPS`, `RELEASE_TRACKING`), which fire for every processed event. This caused incident in my self-hosted install: these queries consumed most of database CPU with many backends queued on tuple locks for a handful of `(organization, task)` rows.

Existing mitigations reduce the frequency but not the failure mode: the 7-day TTL (#100295) lowers the miss rate, and the `sentry:skip-record-onboarding-tasks-if-complete` option (#100180) is off by default and only engages once the `onboarding:complete` org option exists, which requires every required task to have `completion_seen` set via the quick-start UI.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
