### PR TITLE
fix(dashboards): Collapse Seer system prompt in dashboard chat

### DIFF
--- a/static/app/views/dashboards/createFromSeerLoading.tsx
+++ b/static/app/views/dashboards/createFromSeerLoading.tsx
@@ -4,8 +4,9 @@ import {Heading, Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
-import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
 import type {Block} from 'sentry/views/seerExplorer/types';
+
+import {DashboardChatBlock} from './dashboardChatBlock';
 
 interface CreateFromSeerLoadingProps {
   blocks: Block[];
@@ -33,7 +34,7 @@ export function CreateFromSeerLoading({blocks, seerRunId}: CreateFromSeerLoading
               background="primary"
             >
               {blocksToRender.map((block, index) => (
-                <BlockComponent
+                <DashboardChatBlock
                   key={block.id}
                   block={block}
                   blockIndex={index}

--- a/static/app/views/dashboards/createFromSeerUtils.spec.tsx
+++ b/static/app/views/dashboards/createFromSeerUtils.spec.tsx
@@ -1,6 +1,7 @@
 import {applySeerWidgetDefaults} from 'sentry/views/dashboards/createFromSeerUtils';
 import {
   extractDashboardFromSession,
+  splitDashboardPrompt,
   statusIsTerminal,
 } from 'sentry/views/dashboards/createFromSeerUtils';
 import type {Widget} from 'sentry/views/dashboards/types';
@@ -79,6 +80,29 @@ describe('statusIsTerminal', () => {
 
   it.each(['processing', 'pending', undefined, null])('returns false for %s', status => {
     expect(statusIsTerminal(status)).toBe(false);
+  });
+});
+
+describe('splitDashboardPrompt', () => {
+  it('splits instructions from the user query when the marker is present', () => {
+    const content =
+      'You are generating a Sentry dashboard. Follow these rules strictly:\n\nUser Query:\nShow me error rates by project\n';
+
+    const {instructions, query} = splitDashboardPrompt(content);
+
+    expect(instructions).toBe(
+      'You are generating a Sentry dashboard. Follow these rules strictly:'
+    );
+    expect(query).toBe('Show me error rates by project');
+  });
+
+  it('returns no instructions when the marker is absent', () => {
+    const content = 'Show me error rates by project';
+
+    const {instructions, query} = splitDashboardPrompt(content);
+
+    expect(instructions).toBeNull();
+    expect(query).toBe('Show me error rates by project');
   });
 });
 

--- a/static/app/views/dashboards/createFromSeerUtils.tsx
+++ b/static/app/views/dashboards/createFromSeerUtils.tsx
@@ -133,6 +133,28 @@ export function statusIsTerminal(status?: string | null) {
   return status === 'completed' || status === 'error' || status === 'awaiting_user_input';
 }
 
+/**
+ * The dashboard generation endpoint prepends a block of system instructions to
+ * the user's prompt before sending it to Seer, terminated by this marker (see
+ * `DASHBOARD_INSTRUCTIONS` in `organization_dashboard_generate.py`). Splitting on
+ * it lets the chat UI show only what the user actually typed and tuck the
+ * instructions behind a collapsible disclosure instead of leaking them inline.
+ */
+const DASHBOARD_INSTRUCTIONS_MARKER = 'User Query:\n';
+
+export function splitDashboardPrompt(content: string): {
+  instructions: string | null;
+  query: string;
+} {
+  const markerIndex = content.indexOf(DASHBOARD_INSTRUCTIONS_MARKER);
+  if (markerIndex === -1) {
+    return {instructions: null, query: content};
+  }
+  const instructions = content.slice(0, markerIndex).trim();
+  const query = content.slice(markerIndex + DASHBOARD_INSTRUCTIONS_MARKER.length).trim();
+  return {instructions: instructions || null, query};
+}
+
 export async function validateDashboardAndRecordMetrics({
   organization,
   dashboard,

--- a/static/app/views/dashboards/dashboardChatBlock.tsx
+++ b/static/app/views/dashboards/dashboardChatBlock.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Container, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
+import type {Block} from 'sentry/views/seerExplorer/types';
+
+import {splitDashboardPrompt} from './createFromSeerUtils';
+
+interface DashboardChatBlockProps {
+  block: Block;
+  blockIndex: number;
+  runId?: number;
+}
+
+/**
+ * Renders a Seer chat block for the dashboard generation/edit flows. The first
+ * user message has the generation instructions prepended to it server-side; we
+ * show only the user's query and collapse the instructions behind a disclosure
+ * so they don't clutter the conversation. All other blocks render normally.
+ */
+export function DashboardChatBlock({block, blockIndex, runId}: DashboardChatBlockProps) {
+  if (block.message.role === 'user' && typeof block.message.content === 'string') {
+    const {instructions, query} = splitDashboardPrompt(block.message.content);
+    if (instructions) {
+      const queryBlock: Block = {
+        ...block,
+        message: {...block.message, content: query},
+      };
+      return (
+        <Stack width="100%">
+          <BlockComponent block={queryBlock} blockIndex={blockIndex} runId={runId} />
+          <Container padding="0 xl xl">
+            <Disclosure size="xs">
+              <Disclosure.Title>{t('System instructions')}</Disclosure.Title>
+              <Disclosure.Content>
+                <InstructionsContainer maxHeight="240px" overflowY="auto">
+                  <Text as="div" variant="muted" size="sm">
+                    {instructions}
+                  </Text>
+                </InstructionsContainer>
+              </Disclosure.Content>
+            </Disclosure>
+          </Container>
+        </Stack>
+      );
+    }
+  }
+
+  return <BlockComponent block={block} blockIndex={blockIndex} runId={runId} />;
+}
+
+const InstructionsContainer = styled(Container)`
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+`;

--- a/static/app/views/dashboards/dashboardChatPanel.spec.tsx
+++ b/static/app/views/dashboards/dashboardChatPanel.spec.tsx
@@ -47,6 +47,34 @@ describe('DashboardChatPanel', () => {
     expect(screen.queryByText(/Hi there/)).not.toBeInTheDocument();
   });
 
+  it('hides prepended system instructions behind a disclosure', async () => {
+    const timestamp = new Date().toISOString();
+    const blocks: Block[] = [
+      {
+        id: '1',
+        message: {
+          content:
+            'You are generating a Sentry dashboard. Follow these rules strictly:\n\nUser Query:\nShow me error rates by project\n',
+          role: 'user',
+        },
+        timestamp,
+      },
+    ];
+
+    render(<DashboardChatPanel blocks={blocks} onSend={jest.fn()} isUpdating={false} />, {
+      organization: OrganizationFixture(),
+    });
+
+    // Only the user's query is visible; instructions are collapsed (hidden)
+    expect(screen.getByText('Show me error rates by project')).toBeInTheDocument();
+    expect(screen.getByText(/You are generating a Sentry dashboard/)).not.toBeVisible();
+
+    // Expanding the disclosure reveals the instructions
+    await userEvent.click(screen.getByRole('button', {name: 'System instructions'}));
+
+    expect(screen.getByText(/You are generating a Sentry dashboard/)).toBeVisible();
+  });
+
   it('calls onSend when submitting a message via Enter', async () => {
     const onSend = jest.fn();
     render(<DashboardChatPanel blocks={[]} onSend={onSend} isUpdating={false} />, {

--- a/static/app/views/dashboards/dashboardChatPanel.tsx
+++ b/static/app/views/dashboards/dashboardChatPanel.tsx
@@ -11,9 +11,10 @@ import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {IconChevron, IconClose, IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {MarkedText} from 'sentry/utils/marked/markedText';
-import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
 import type {PendingUserInput} from 'sentry/views/seerExplorer/types';
 import type {Block} from 'sentry/views/seerExplorer/types';
+
+import {DashboardChatBlock} from './dashboardChatBlock';
 
 const MAX_CHAT_HISTORY_HEIGHT = 500;
 
@@ -202,7 +203,7 @@ const ChatHistory = memo(function ChatHistoryInner({
     >
       <Stack>
         {blocks.map((block, index) => (
-          <BlockComponent key={block.id} block={block} blockIndex={index} />
+          <DashboardChatBlock key={block.id} block={block} blockIndex={index} />
         ))}
         {pendingUserInput && pendingUserInput.data.questions?.length > 0 && (
           <ChatMessageContainer padding="xl">


### PR DESCRIPTION
When generating or editing a dashboard with Seer, the dashboard generation endpoint prepends a block of generation instructions to the user's prompt before sending it to Seer. That combined string was rendered verbatim as the first user message in both the chat panel and the in-progress loading view, exposing the instructions ("system prompt") in the UI.

### Default state (collapsed)
<img width="800" height="228" alt="image" src="https://github.com/user-attachments/assets/2b87a58d-12d4-4e6f-9933-6fe5105accaf" />

### Uncollapsed
<img width="795" height="655" alt="image" src="https://github.com/user-attachments/assets/222fdedd-b00a-4691-b022-cce7d47e1ddf" />

## Changes

- Add `splitDashboardPrompt()`, which separates the prepended instructions from the user's actual query using the backend's `User Query:` marker.
- Add a `DashboardChatBlock` wrapper around the shared Seer `BlockComponent`. For the instructions-bearing user block, it renders only the user's query in the chat bubble and tucks the instructions behind a collapsed, expandable `Disclosure` ("System instructions"). All other blocks render unchanged.
- Route both the dashboard chat panel and the generation loading view through `DashboardChatBlock`.

The prompt sent to Seer is **unchanged**, so generation quality is preserved — this is a display-only change.

Fixes DAIN-1711