### PR TITLE
feat(explore): Apply Seer-suggested interval to the metrics chart

### DIFF
--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -272,6 +272,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         query: cleanedQuery,
         groupBys: seerQuery.groupBys,
         mode: seerQuery.mode,
+        interval: seerQuery.interval,
       });
 
       trackAnalytics('ai_query.applied', {
@@ -299,6 +300,9 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
             end: seerQuery.datetime.end,
             statsPeriod: seerQuery.datetime.period,
             utc: seerQuery.datetime.utc,
+            // Only override the interval when Seer suggested one, otherwise
+            // leave the user's current interval untouched.
+            ...(seerQuery.interval ? {interval: seerQuery.interval} : {}),
           },
         },
         {replace: true, preventScrollReset: true}


### PR DESCRIPTION
Applies the Seer-suggested chart interval to the Explore metrics tab, completing interval support across the Explore tabs.

When a Seer suggestion is applied, the metrics tab now sets the `interval` URL param (read by `useChartInterval`) so the chart adopts Seer's interval. When Seer doesn't return an interval, the user's current interval is left untouched.

Stacked on #117196, which adds the shared interval plumbing (raw response shape, hoisting to a chart-level value, search bar preview) and wires up the spans and logs tabs. Review and merge that one first.

Refs BROWSE-546