### PR TITLE
ci: Post story preview links on PRs that change stories

### DIFF
--- a/.github/workflows/scripts/stories-preview-comment.test.ts
+++ b/.github/workflows/scripts/stories-preview-comment.test.ts
@@ -1,0 +1,199 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import {storyRoute, syncStoriesPreviewComment} from './stories-preview-comment.ts';
+
+// These expectations pin storyRoute to the slug/category logic it mirrors in
+// static/app/stories/view/storyTree.tsx. If that file's routing logic changes,
+// these will fail and the mirror must be re-synced (otherwise preview links
+// 404). Note camelCase names are only lowercased, not hyphenated, because
+// formatName only splits on existing hyphens.
+describe('storyRoute', () => {
+  const cases: Array<[string, string]> = [
+    // principles: app/styles, app/icons, components/core/principles
+    ['app/styles/colors.mdx', 'principles/colors'],
+    ['app/icons/iconAdd.stories.tsx', 'principles/iconadd'],
+    ['app/components/core/principles/spacing.mdx', 'principles/spacing'],
+    // patterns: components/core/patterns (hyphenated name stays hyphenated)
+    ['app/components/core/patterns/render-to-html.mdx', 'patterns/render-to-html'],
+    // core: components/core (no nesting in the slug)
+    ['app/components/core/button/button.stories.tsx', 'core/button'],
+    // product: nested dir segments are lowercased into the slug
+    [
+      'app/views/dashboards/widgetCard.stories.tsx',
+      'product/views/dashboards/widgetcard',
+    ],
+    [
+      'app/components/connectRepository/pathMapping.stories.tsx',
+      'product/components/connectrepository/pathmapping',
+    ],
+    // index.* files resolve to their containing directory's name
+    [
+      'app/components/connectRepository/index.stories.tsx',
+      'product/components/connectrepository/connectrepository',
+    ],
+    // use* hooks are lowercased like any other name
+    ['app/utils/useFoo.stories.tsx', 'product/utils/usefoo'],
+  ];
+
+  for (const [filesystemPath, expected] of cases) {
+    it(`maps ${filesystemPath} -> ${expected}`, () => {
+      assert.equal(storyRoute(filesystemPath), expected);
+    });
+  }
+});
+
+interface CommentCall {
+  body?: string;
+  comment_id?: number;
+  issue_number?: number;
+}
+
+interface Scenario {
+  prs?: Array<{number: number; state: string; head?: {sha: string}}>;
+  files?: Array<{filename: string; status: string}>;
+  comments?: Array<{id: number; body: string}>;
+  url?: string;
+}
+
+// The default open PR's head matches the deploy sha set in `run`, so the
+// out-of-order-deploy guard passes unless a scenario overrides it.
+const DEPLOY_SHA = 'deadbeef';
+
+// Fakes the one external boundary (the github-script client) so we can assert
+// the comment lifecycle effects: create, update, delete, or nothing at all.
+function run({
+  prs = [{number: 42, state: 'open', head: {sha: DEPLOY_SHA}}],
+  files = [],
+  comments = [],
+  url = 'https://sentry-abc.sentry.dev',
+}: Scenario) {
+  const calls = {
+    create: [] as CommentCall[],
+    update: [] as CommentCall[],
+    delete: [] as CommentCall[],
+  };
+  const core = {info: () => {}};
+  const github = {
+    rest: {
+      repos: {listPullRequestsAssociatedWithCommit: async () => ({data: prs})},
+      pulls: {listFiles: 'listFiles'},
+      issues: {
+        listComments: 'listComments',
+        createComment: async (params: CommentCall) => {
+          calls.create.push(params);
+        },
+        updateComment: async (params: CommentCall) => {
+          calls.update.push(params);
+        },
+        deleteComment: async (params: CommentCall) => {
+          calls.delete.push(params);
+        },
+      },
+    },
+    paginate: async (route: unknown) => (route === 'listComments' ? comments : files),
+  };
+  const context = {
+    repo: {owner: 'getsentry', repo: 'sentry'},
+    payload: {deployment: {sha: DEPLOY_SHA}, deployment_status: {environment_url: url}},
+  };
+
+  return syncStoriesPreviewComment({github, context, core} as any).then(() => calls);
+}
+
+const storyFile = {
+  filename: 'static/app/components/foo/foo.stories.tsx',
+  status: 'modified',
+};
+const marked = {id: 99, body: '<!-- STORIES_PREVIEW -->\nold'};
+
+describe('syncStoriesPreviewComment', () => {
+  it('creates a comment when stories changed and none exists', async () => {
+    const calls = await run({files: [storyFile]});
+    assert.equal(calls.create.length, 1);
+    assert.match(calls.create[0].body!, /<!-- STORIES_PREVIEW -->/);
+    assert.match(calls.create[0].body!, /stories\/product\/components\/foo\/foo\//);
+    assert.equal(calls.update.length, 0);
+    assert.equal(calls.delete.length, 0);
+  });
+
+  it('updates the existing comment when stories changed', async () => {
+    const calls = await run({files: [storyFile], comments: [marked]});
+    assert.equal(calls.update.length, 1);
+    assert.equal(calls.update[0].comment_id, 99);
+    assert.equal(calls.create.length, 0);
+    assert.equal(calls.delete.length, 0);
+  });
+
+  it('deletes a stale comment when an open PR no longer changes stories', async () => {
+    const calls = await run({files: [], comments: [marked]});
+    assert.equal(calls.delete.length, 1);
+    assert.equal(calls.delete[0].comment_id, 99);
+    assert.equal(calls.create.length, 0);
+    assert.equal(calls.update.length, 0);
+  });
+
+  it('does nothing when there are no stories and no existing comment', async () => {
+    const calls = await run({files: []});
+    assert.deepEqual(calls, {create: [], update: [], delete: []});
+  });
+
+  it('does nothing when the preview URL is not a trusted host', async () => {
+    const calls = await run({files: [storyFile], url: 'https://evil.example.com'});
+    assert.deepEqual(calls, {create: [], update: [], delete: []});
+  });
+
+  it('does nothing when there is no open PR', async () => {
+    const calls = await run({files: [storyFile], prs: [{number: 42, state: 'closed'}]});
+    assert.deepEqual(calls, {create: [], update: [], delete: []});
+  });
+
+  it('does nothing when no open PR has the deployed commit as its head', async () => {
+    const calls = await run({
+      files: [storyFile],
+      comments: [marked],
+      prs: [{number: 42, state: 'open', head: {sha: 'stale-older-sha'}}],
+    });
+    assert.deepEqual(calls, {create: [], update: [], delete: []});
+  });
+
+  it('selects the associated open PR whose head is the deployed commit', async () => {
+    const calls = await run({
+      files: [storyFile],
+      prs: [
+        {number: 1, state: 'open', head: {sha: 'another-shared-commit'}},
+        {number: 42, state: 'open', head: {sha: DEPLOY_SHA}},
+      ],
+    });
+    assert.equal(calls.create.length, 1);
+    assert.equal(calls.create[0].issue_number, 42);
+  });
+
+  it('escapes markdown brackets in story file labels', async () => {
+    const calls = await run({
+      files: [
+        {filename: 'static/app/components/foo]/bar.stories.tsx', status: 'modified'},
+      ],
+    });
+    assert.equal(calls.create.length, 1);
+    assert.match(calls.create[0].body!, /components\/foo\\\]\//);
+  });
+
+  it('neutralizes markdown-injecting paths in both the label and the URL', async () => {
+    const calls = await run({
+      files: [
+        {
+          filename:
+            'static/app/components/foo) [login](https://evil.example)/bar.stories.tsx',
+          status: 'modified',
+        },
+      ],
+    });
+    const body = calls.create[0].body!;
+    // URL segments are percent-encoded, so the raw `)` can't close the link.
+    assert.match(body, /foo%29/);
+    assert.doesNotMatch(body, /\)\/bar\//);
+    // Brackets in the label are escaped.
+    assert.match(body, /\\\[login\\\]/);
+  });
+});

--- a/.github/workflows/scripts/stories-preview-comment.ts
+++ b/.github/workflows/scripts/stories-preview-comment.ts
@@ -1,0 +1,303 @@
+/**
+ * Posts, updates, or deletes a PR comment linking to the stories changed in a
+ * PR on its Vercel preview deployment.
+ *
+ * Invoked from `.github/workflows/stories-preview.yml` via actions/github-script
+ * on the `deployment_status` event. Owns the whole comment lifecycle through the
+ * GitHub API so the workflow is a single step and the marker stays defined once.
+ *
+ * The slug/category helpers below are mirrored from
+ * `static/app/stories/view/storyTree.tsx` so the generated links resolve to the
+ * same semantic `/stories/<category>/<slug>/` route the app builds for a story.
+ * Keep them in sync if that file's slug/category logic changes. The routing
+ * category/slug is purely path-based for both `.stories.tsx` and `.mdx`;
+ * frontmatter only affects the core sidebar subcategory, which does not change
+ * the URL, so it is not needed here.
+ */
+
+type StoryCategory = 'principles' | 'patterns' | 'core' | 'product';
+
+interface PullRequestFile {
+  filename: string;
+  status: string;
+}
+
+interface IssueComment {
+  id: number;
+  body?: string;
+}
+
+/**
+ * The subset of the actions/github-script context we depend on. Typed locally
+ * because @actions/github is not a repo dependency; the github-script runtime
+ * supplies the full Octokit client and event context.
+ */
+interface SyncArgs {
+  github: {
+    rest: {
+      repos: {
+        listPullRequestsAssociatedWithCommit: (params: {
+          owner: string;
+          repo: string;
+          commit_sha: string;
+        }) => Promise<{
+          data: Array<{number: number; state: string; head: {sha: string}}>;
+        }>;
+      };
+      pulls: {listFiles: unknown};
+      issues: {
+        listComments: unknown;
+        createComment: (params: {
+          owner: string;
+          repo: string;
+          issue_number: number;
+          body: string;
+        }) => Promise<unknown>;
+        updateComment: (params: {
+          owner: string;
+          repo: string;
+          comment_id: number;
+          body: string;
+        }) => Promise<unknown>;
+        deleteComment: (params: {
+          owner: string;
+          repo: string;
+          comment_id: number;
+        }) => Promise<unknown>;
+      };
+    };
+    paginate: <T>(route: unknown, params: Record<string, unknown>) => Promise<T[]>;
+  };
+  context: {
+    repo: {owner: string; repo: string};
+    payload: {
+      deployment: {sha: string};
+      deployment_status: {environment_url?: string; target_url?: string};
+    };
+  };
+  core: {info: (message: string) => void};
+}
+
+// Invisible HTML marker that identifies our comment so we can find and update or
+// delete it on subsequent deploys.
+export const STORIES_COMMENT_MARKER = '<!-- STORIES_PREVIEW -->';
+
+// The stories loader globs both *.stories.tsx and *.mdx under static/app
+// (static/app/stories/view/useStoriesLoader.tsx).
+const STORY_FILE_RE = /^static\/app\/.*(\.stories\.tsx|\.mdx)$/;
+
+// `deployment_status` can be forged by any actor with `deployments` scope, who
+// could supply an arbitrary `environment_url` and have us post a link to it on a
+// real PR. Only trust HTTPS preview URLs on our known deploy domains.
+const ALLOWED_PREVIEW_HOST_SUFFIXES = ['.sentry.dev', '.vercel.app'];
+
+function isTrustedPreviewUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:') {
+    return false;
+  }
+  return ALLOWED_PREVIEW_HOST_SUFFIXES.some(suffix => parsed.hostname.endsWith(suffix));
+}
+
+// Mirror of inferComponentName (storyTree.tsx).
+function inferComponentName(path: string): string {
+  const parts = path.split('/');
+  let part = parts.pop();
+  while (part?.startsWith('index.')) {
+    part = parts.pop();
+  }
+  return (part ?? '').replace(/\.(stories\.tsx|mdx)$/, '');
+}
+
+// Mirror of formatName (storyTree.tsx).
+function formatName(name: string): string {
+  return name
+    .split('-')
+    .map(word =>
+      word === 'and' || word === 'or'
+        ? word
+        : word.charAt(0).toUpperCase() + word.slice(1)
+    )
+    .join(' ');
+}
+
+// Mirror of normalizeFilename (storyTree.tsx).
+function normalizeFilename(filename: string): string {
+  if (filename.startsWith('use')) {
+    return filename.replace('.stories.tsx', '');
+  }
+  return (
+    filename.charAt(0).toUpperCase() +
+    filename.slice(1).replace('.stories.tsx', '').replace('.mdx', '')
+  );
+}
+
+// Mirror of inferFileCategory (storyTree.tsx).
+function inferFileCategory(path: string): StoryCategory {
+  if (
+    path.includes('app/styles') ||
+    path.includes('app/icons') ||
+    path.includes('components/core/principles')
+  ) {
+    return 'principles';
+  }
+  if (path.includes('components/core/patterns')) {
+    return 'patterns';
+  }
+  if (path.includes('components/core')) {
+    return 'core';
+  }
+  return 'product';
+}
+
+/**
+ * Maps a story's filesystem path (in `app/...` form, i.e. with `static/`
+ * stripped) to its `<category>/<slug>` route, mirroring the StoryTreeNode
+ * constructor (storyTree.tsx).
+ */
+export function storyRoute(filesystemPath: string): string {
+  const label = normalizeFilename(formatName(inferComponentName(filesystemPath)));
+  const labelSlug = label.replaceAll(' ', '-').toLowerCase();
+  const category = inferFileCategory(filesystemPath);
+
+  if (category !== 'product') {
+    return `${category}/${labelSlug}`;
+  }
+
+  const segments = filesystemPath.split('/');
+  segments.shift(); // drop the leading `app`
+  segments.pop(); // drop the filename
+  const pathPrefix =
+    segments.length > 0
+      ? `${segments.map(segment => segment.toLowerCase()).join('/')}/`
+      : '';
+  return `${category}/${pathPrefix}${labelSlug}`;
+}
+
+// encodeURIComponent leaves parens unescaped, but `)` closes a markdown link,
+// so encode them explicitly.
+function encodeRouteSegment(segment: string): string {
+  return encodeURIComponent(segment).replace(/[()]/g, char =>
+    char === '(' ? '%28' : '%29'
+  );
+}
+
+function buildCommentBody(stories: string[], previewUrl: string): string {
+  const links = stories
+    .map(file => {
+      // The stories loader keys files as `app/...` (static/ stripped).
+      const filesystemPath = file.replace(/^static\//, '');
+      // Percent-encode each route segment so a path can't inject markdown link
+      // syntax (e.g. `)`) into the URL and forge an attacker-controlled link.
+      const route = storyRoute(filesystemPath)
+        .split('/')
+        .map(encodeRouteSegment)
+        .join('/');
+      const url = `${previewUrl}/stories/${route}/`;
+      // Escape backslashes and brackets so a path can't break out of the label.
+      const label = filesystemPath.replace(/[\\[\]]/g, '\\$&');
+      return `- [${label}](${url})`;
+    })
+    .join('\n');
+
+  return [
+    STORIES_COMMENT_MARKER,
+    '## Story previews',
+    '',
+    'Preview the stories changed in this PR on the Vercel deployment:',
+    '',
+    links,
+    '',
+    `<sub>Preview deployment: ${previewUrl}</sub>`,
+  ].join('\n');
+}
+
+export async function syncStoriesPreviewComment({
+  github,
+  context,
+  core,
+}: SyncArgs): Promise<void> {
+  const {owner, repo} = context.repo;
+  const sha = context.payload.deployment.sha;
+  const previewUrl = (
+    context.payload.deployment_status.environment_url ||
+    context.payload.deployment_status.target_url ||
+    ''
+  ).replace(/\/$/, '');
+
+  if (!previewUrl) {
+    core.info('No preview URL in deployment_status payload, skipping.');
+    return;
+  }
+
+  if (!isTrustedPreviewUrl(previewUrl)) {
+    core.info(`Preview URL is not a trusted deploy host (${previewUrl}), skipping.`);
+    return;
+  }
+
+  const {data: prs} = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+    owner,
+    repo,
+    commit_sha: sha,
+  });
+
+  // A commit can be associated with several open PRs (they share history), so
+  // select the one whose head is exactly the deployed commit. That is the PR
+  // this preview belongs to, and it also ignores delayed/out-of-order deploys
+  // of an older commit.
+  const pr = prs.find(
+    candidate => candidate.state === 'open' && candidate.head.sha === sha
+  );
+  if (!pr) {
+    core.info(`No open PR with head ${sha}, skipping.`);
+    return;
+  }
+
+  const files = await github.paginate<PullRequestFile>(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: pr.number,
+    per_page: 100,
+  });
+
+  const stories = files
+    .filter(file => file.status !== 'removed')
+    .filter(file => STORY_FILE_RE.test(file.filename))
+    .map(file => file.filename)
+    .sort();
+
+  const comments = await github.paginate<IssueComment>(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: pr.number,
+  });
+  const existing = comments.find(comment =>
+    comment.body?.includes(STORIES_COMMENT_MARKER)
+  );
+
+  if (stories.length === 0) {
+    if (existing) {
+      // The PR previously changed stories but no longer does; drop the stale links.
+      await github.rest.issues.deleteComment({owner, repo, comment_id: existing.id});
+      core.info(`Deleted stale stories preview comment on #${pr.number}.`);
+    } else {
+      core.info('No changed stories (*.stories.tsx / *.mdx) files, skipping.');
+    }
+    return;
+  }
+
+  const body = buildCommentBody(stories, previewUrl);
+
+  if (existing) {
+    await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body});
+    core.info(`Updated stories preview comment on #${pr.number}.`);
+  } else {
+    await github.rest.issues.createComment({owner, repo, issue_number: pr.number, body});
+    core.info(`Posted stories preview comment on #${pr.number}.`);
+  }
+}

--- a/.github/workflows/stories-preview.yml
+++ b/.github/workflows/stories-preview.yml
@@ -1,0 +1,43 @@
+name: '[NOT REQUIRED] stories preview links'
+
+# When Vercel finishes deploying a PR's preview, post (or update) a comment
+# linking directly to the stories that changed in that PR.
+#
+# Runs on `deployment_status` so it fires exactly when the preview is live, and
+# so it executes from the default branch with write permissions (fork PRs
+# included), the same trust model as `pull_request_target`.
+on:
+  deployment_status:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  stories-preview:
+    name: post stories preview links
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    # Only the successful Vercel preview deployment. Production deploys land on
+    # master and have no associated *open* PR, so they're filtered out below.
+    if: >
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment_status.creator.login == 'vercel[bot]'
+    steps:
+      # deployment_status checks out the deployment (PR head) SHA by default,
+      # which is untrusted fork code. Pin to the default branch so we only ever
+      # execute the trusted version of the comment script.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      # Posts, updates, or deletes the preview comment via the GitHub API.
+      - name: Sync stories preview comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { syncStoriesPreviewComment } = await import(
+              `${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/stories-preview-comment.ts`
+            );
+            await syncStoriesPreviewComment({github, context, core});


### PR DESCRIPTION
Reviewing a frontend story change today means finding the Vercel preview deploy and hunting through the sidebar for the component you changed. This wires up the last mile so the link comes to you.

When a PR's Vercel preview finishes deploying, this workflow posts (and keeps updated) a single comment linking each changed story straight to its rendered page on that preview:

> ## Story previews
> - [app/components/connectRepository/pathMapping.stories.tsx](https://sentry-xxxx.sentry.dev/stories/product/components/connectrepository/pathmapping/)

## How it works

- Triggers on `deployment_status` so it fires exactly when the preview is live, and runs from the default branch (pinned checkout) so we only ever execute the trusted version of the script — the same trust model as `pull_request_target`. The deployment SHA is used only as data to resolve the PR, never executed.
- Resolves the open PR for the deployed commit, collects its added/modified `*.stories.tsx` and `*.mdx` files, and builds the comment. Production/master deploys are skipped naturally (no associated open PR).
- The `<category>/<slug>` route is derived by mirroring the app's `storyTree.tsx` logic, so links land on the same pretty URL the sidebar produces. A colocated unit test pins this mapping and fails loudly if the routing logic drifts.
- Preview URLs are validated against an allowlist of `*.sentry.dev` / `*.vercel.app` HTTPS hosts before being used, so a forged `deployment_status` can't get us to post an arbitrary link.

Frontend-only; no app or API behavior changes.