### PR TITLE
feat(seer): Populate SeerAgentRun.group from the client's group

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -22,6 +22,7 @@ from sentry.hybridcloud.models.outbox import (
     outbox_context,
 )
 from sentry.hybridcloud.outbox.category import OutboxCategory, OutboxScope
+from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.agent.client_models import AgentRun, AgentRunWithPrs, SeerRunState
@@ -238,6 +239,7 @@ class SeerAgentClient:
             organization: Sentry organization
             user: User for permission checks and user-specific context (can be User, RpcUser, AnonymousUser, or None)
             project: Optional project for project-scoped runs (e.g. autofix for an issue)
+            group: Optional group/issue for issue-scoped runs (e.g. autofix for an issue)
             category_key: Optional category key for filtering/grouping runs (e.g., "bug-fixer", "trace-analyzer"). Must be provided together with category_value. Makes it easy to retrieve runs for your feature later.
             category_value: Optional category value for filtering/grouping runs (e.g., issue ID, trace ID). Must be provided together with category_key. Makes it easy to retrieve a specific run for your feature later.
             custom_tools: Optional list of `AgentTool` classes to make available as tools to the agent. Each tool must inherit from AgentTool, define a params_model (Pydantic BaseModel), and implement execute(). Tools are automatically given access to the organization context. Tool classes must be module-level (not nested classes).
@@ -254,6 +256,7 @@ class SeerAgentClient:
         organization: Organization,
         user: User | RpcUser | AnonymousUser | None = None,
         project: Project | None = None,
+        group: Group | None = None,
         category_key: str | None = None,
         category_value: str | None = None,
         custom_tools: list[type[AgentTool[Any]]] | None = None,
@@ -269,6 +272,7 @@ class SeerAgentClient:
         self.organization = organization
         self.user = user
         self.project = project
+        self.group = group
         self.custom_tools = custom_tools or []
         self.on_completion_hook = on_completion_hook
         self.intelligence_level = intelligence_level
@@ -325,7 +329,8 @@ class SeerAgentClient:
             on_page_context: Optional context from the user's screen
             artifact_key: Optional key to identify this artifact (required if artifact_schema is provided)
             artifact_schema: Optional Pydantic model to generate a structured artifact
-            metadata: Optional metadata to store with the run (e.g., stopping_point, group_id)
+            metadata: Optional metadata to store with the run (e.g., stopping_point). group_id is
+                added automatically when the client was constructed with a group.
             request: Optional rest_framework Request object from endpoints.
 
         Returns:
@@ -394,6 +399,9 @@ class SeerAgentClient:
             chat_body["category_key"] = self.category_key
             chat_body["category_value"] = self.category_value
 
+        if self.group:
+            metadata = {**(metadata or {}), "group_id": self.group.id}
+
         if metadata:
             chat_body["metadata"] = metadata
 
@@ -453,6 +461,7 @@ class SeerAgentClient:
                     title=prompt[:255] + "…" if len(prompt) > 256 else prompt,
                     source=source,
                     project=self.project,
+                    group=self.group,
                     extras=({"category_value": self.category_value} if self.category_value else {}),
                 )
                 CellOutbox(

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -197,6 +197,7 @@ def get_autofix_agent_client(
     return SeerAgentClient(
         organization=group.organization,
         project=group.project,
+        group=group,
         user=None,  # No user personalization for autofix
         category_key="autofix",
         category_value=str(group.id),
@@ -321,7 +322,7 @@ def trigger_autofix_agent(
     artifact_schema = config.artifact_schema
 
     if run_id is None:
-        metadata = {"group_id": group.id, "referrer": referrer.value}
+        metadata = {"referrer": referrer.value}
         if stopping_point:
             metadata["stopping_point"] = stopping_point.value
         run_id = client.start_run(

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -15,6 +15,7 @@ from sentry.seer.agent.client_models import (
     SeerRunState,
 )
 from sentry.seer.models import SeerApiError, SeerPermissionError
+from sentry.seer.models.run import SeerAgentRun
 from sentry.testutils.cases import TestCase
 from sentry.testutils.requests import make_request
 
@@ -71,14 +72,22 @@ class TestSeerAgentClient(TestCase):
         mock_response.status = 200
         mock_post.return_value = mock_response
 
-        client = SeerAgentClient(self.organization, self.user)
-        run_id = client.start_run("Test query").seer_run_state_id
+        project = self.create_project(organization=self.organization)
+        group = self.create_group(project=project)
 
-        assert run_id == 123
+        client = SeerAgentClient(self.organization, self.user, project=project, group=group)
+        run = client.start_run("Test query")
+
+        assert run.seer_run_state_id == 123
         mock_collect_context.assert_called_once_with(self.user, self.organization, request=None)
         assert mock_post.called
         body = mock_post.call_args[0][0]
         assert "enable_frontend_code_search" not in body["agent_run_options"]
+        assert body["metadata"]["group_id"] == group.id
+
+        agent_run = SeerAgentRun.objects.get(run=run)
+        assert agent_run.project_id == project.id
+        assert agent_run.group_id == group.id
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.receivers.outbox.cell.make_agent_chat_request")

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -318,10 +318,10 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_trigger_autofix_agent_passes_project_to_client(
+    def test_trigger_autofix_agent_passes_project_and_group_to_client(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
-        """SeerAgentClient is constructed with project from the group."""
+        """SeerAgentClient is constructed with project and group from the group."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.start_run.return_value = MagicMock(seer_run_state_id=123)
@@ -336,15 +336,16 @@ class TestTriggerAutofixAgent(TestCase):
         mock_client_class.assert_called_once()
         call_kwargs = mock_client_class.call_args.kwargs
         assert call_kwargs["project"] == self.group.project
+        assert call_kwargs["group"] == self.group
 
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_trigger_autofix_agent_passes_group_id_in_metadata(
+    def test_trigger_autofix_agent_metadata_omits_group_id(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
-        """start_run is called with metadata containing group_id even without stopping_point."""
+        """group_id is injected by the client from its group, not hand-built here."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.start_run.return_value = MagicMock(seer_run_state_id=123)
@@ -358,7 +359,7 @@ class TestTriggerAutofixAgent(TestCase):
 
         mock_client.start_run.assert_called_once()
         call_kwargs = mock_client.start_run.call_args.kwargs
-        assert call_kwargs["metadata"] == {"group_id": self.group.id, "referrer": "unknown"}
+        assert call_kwargs["metadata"] == {"referrer": "unknown"}
 
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=False)


### PR DESCRIPTION
`SeerAgentRun.group` was declared but never written. `start_run` only passed `project`, and `SeerAgentClient` had no way to receive a group, so the mirror column was always NULL. Autofix communicated the issue to Seer solely through `category_value` and a hand-built `metadata` group_id.

`SeerAgentClient` now takes a typed `group` param (sibling of `project`) that populates the column on run creation.

**Single source for group_id**

`start_run` injects `group_id` into the Seer metadata payload from `self.group`, mirroring how `project_id` is injected from `self.project`. Autofix no longer hand-builds `{"group_id": group.id}` — it passes `group=group` once, which feeds both the column and the Seer metadata.

Explorer chat, night-shift triage (spans many candidate groups), and the read-only `get_autofix_agent_state` correctly leave the column NULL.