### PR TITLE
fix(options): bump max option value length

### DIFF
--- a/src/sentry/runner/commands/presenters/webhookpresenter.py
+++ b/src/sentry/runner/commands/presenters/webhookpresenter.py
@@ -18,7 +18,7 @@ class WebhookPresenter(OptionsPresenter):
     be configured to your liking.
     """
 
-    MAX_OPTION_VALUE_LENGTH = 30
+    MAX_OPTION_VALUE_LENGTH = 100
 
     def __init__(self, source: str, timestamp: float | None = None) -> None:
         self.source = source


### PR DESCRIPTION
30 is really short considering options can have dict values. Let's try 100