### PR TITLE
feat(pr-metrics): Add merge_commit_id to the PR close/merge event

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -31,6 +31,11 @@ class PrCloseMetricsEvent(analytics.Event):
     opened_at: str | None = None
     # Null for a closed-but-unmerged PR (no merge commit / merge time).
     merge_commit_sha: str | None = None
+    # Sentry Commit.id for the merge commit, resolved from merge_commit_sha via
+    # the (repository_id, key) unique key. Null when the PR wasn't merged or
+    # Sentry never recorded the landed commit (release tracking, not pr_metrics,
+    # populates Commit rows).
+    merge_commit_id: int | None = None
     merged_at: str | None = None
     draft: bool = False
     # Structural counters read straight from the close/merge webhook payload (no

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -13,6 +13,7 @@ from typing import Any, Final, Literal
 
 from sentry import analytics
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
+from sentry.models.commit import Commit
 from sentry.models.grouplink import GroupLink
 from sentry.models.pullrequest import PullRequest, PullRequestAttribution, PullRequestMetrics
 from sentry.pr_metrics.attribution import SIGNAL_TYPE_CONFIDENCE
@@ -76,6 +77,25 @@ def _resolved_group_ids(pull_request: PullRequest) -> list[int]:
     )
 
 
+def _merge_commit_id(pull_request: PullRequest) -> int | None:
+    """The Sentry Commit row id for the PR's merge commit, if Sentry tracks it.
+
+    Resolved from merge_commit_sha via the (repository_id, key) unique key. Null
+    when the PR wasn't merged or Sentry never recorded the landed commit — the
+    pr_metrics module never creates Commit rows, so a match isn't guaranteed.
+    """
+    if pull_request.merge_commit_sha is None:
+        return None
+    return (
+        Commit.objects.filter(
+            repository_id=pull_request.repository_id,
+            key=pull_request.merge_commit_sha,
+        )
+        .values_list("id", flat=True)
+        .first()
+    )
+
+
 def build_pr_metrics_row(
     *,
     pull_request: PullRequest,
@@ -114,6 +134,7 @@ def build_pr_metrics_row(
         head_commit_sha=head_commit_sha,
         closed_at=closed_at.isoformat(),
         merge_commit_sha=pull_request.merge_commit_sha,
+        merge_commit_id=_merge_commit_id(pull_request),
         merged_at=_iso(pull_request.merged_at),
         opened_at=_iso(pull_request.opened_at),
         draft=bool(pull_request.draft),

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -189,6 +189,40 @@ class PrMetricsEmissionTest(TestCase):
         assert row.head_commit_sha == HEAD_SHA
         assert row.closed_at == CLOSED_AT.isoformat()
 
+    def test_build_row_resolves_merge_commit_id(self) -> None:
+        # When Sentry tracks the landed commit, the row carries its Commit.id.
+        commit = self.create_commit(repo=self.repo, key=MERGE_SHA)
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.merge_commit_id == commit.id
+
+    def test_build_row_merge_commit_id_null_when_commit_untracked(self) -> None:
+        # No Commit row matches the merge sha (pr_metrics never creates them), so
+        # the id resolves to null rather than erroring.
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.merge_commit_id is None
+
+    def test_build_row_merge_commit_id_null_when_unmerged(self) -> None:
+        # A closed-but-unmerged PR has no merge commit sha, so no id to resolve.
+        self.pull_request.merge_commit_sha = None
+        self.pull_request.merged_at = None
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="closed",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.merge_commit_id is None
+
     def test_active_attributions_only_includes_valid_signals(self) -> None:
         self._track(PullRequestAttributionSignalType.SENTRY_APP)
         self._track(


### PR DESCRIPTION
Adds `merge_commit_id` to the `PrCloseMetricsEvent` analytics row emitted when a tracked PR is closed or merged.

The row previously carried only the merge commit SHA, which can't be joined to Sentry's own commit/release data downstream (BigQuery). We now resolve the merge commit's Sentry `Commit.id` from `merge_commit_sha` via the `(repository_id, key)` unique key and emit it on the event, so consumers can connect a merged PR to the commit Sentry tracks.

The field is nullable: `null` when the PR wasn't merged (`merge_commit_sha` is `None`) or when Sentry never recorded the landed commit — the pr_metrics module never creates `Commit` rows, so a match isn't guaranteed and we don't fail loud.

We resolve the **merge** commit rather than the head commit because the merge commit is what GitHub lands on the base branch (the squashed commit for squash-and-merge, the merge commit for a regular merge, the last rebased commit for a rebase merge). That's the commit Sentry's release tracking is most likely to have recorded; the head SHA points at the pre-merge branch tip, which is frequently squashed away and untracked.

The lookup is an equality match on `(repository_id, key)`, fully covered by the unique composite index that `unique_together = (("repository_id", "key"),)` creates on `sentry_commit` — a single unique index lookup, no new index needed.