### PR TITLE
fix(teams): Guard team avatar serializer on `avatar_type` instead of `file_id`

### DIFF
--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -295,10 +295,11 @@ class BaseTeamSerializer(Serializer):
     ) -> BaseTeamSerializerResponse:
         if attrs.get("avatar"):
             avatar_obj = attrs["avatar"]
+            is_upload = avatar_obj.get_avatar_type_display() == "upload"
             avatar: SerializedAvatarFields = {
                 "avatarType": avatar_obj.get_avatar_type_display(),
-                "avatarUuid": avatar_obj.ident if avatar_obj.file_id else None,
-                "avatarUrl": avatar_obj.absolute_url() if avatar_obj.file_id else None,
+                "avatarUuid": avatar_obj.ident if is_upload else None,
+                "avatarUrl": avatar_obj.absolute_url() if is_upload else None,
             }
         else:
             avatar = {"avatarType": "letter_avatar", "avatarUuid": None, "avatarUrl": None}

--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -64,6 +64,21 @@ class TeamSerializerTest(TestCase):
         assert result["avatar"]["avatarUuid"] == avatar.ident
         assert avatar.ident in result["avatar"]["avatarUrl"]
 
+    def test_avatar_letter_avatar_with_stale_file(self) -> None:
+        user = self.create_user(username="foo")
+        organization = self.create_organization()
+        team = self.create_team(organization=organization)
+        photo = File.objects.create(name="test.png", type="avatar.file")
+        photo.putfile(BytesIO(b"test"))
+        TeamAvatar.objects.create(team=team, file_id=photo.id, avatar_type=0)
+
+        result = serialize(team, user)
+        assert result["avatar"] == {
+            "avatarType": "letter_avatar",
+            "avatarUuid": None,
+            "avatarUrl": None,
+        }
+
     def test_member_count(self) -> None:
         user = self.create_user(username="foo")
         other_user = self.create_user(username="bar")


### PR DESCRIPTION
The team serializer was guarding `avatarUuid` and `avatarUrl` on `file_id`, which caused letter_avatar responses to incorrectly include a UUID and photo URL from any stale files that persist. We should check `avatar_type` instead of `file_id` to determine whether or not to populate these fields.