### PR TITLE
chore(autofix): gate "open in seer agent" button behind a option

### DIFF
--- a/static/app/components/events/autofix/v3/header.tsx
+++ b/static/app/components/events/autofix/v3/header.tsx
@@ -12,6 +12,7 @@ import {IconCopy} from 'sentry/icons/iconCopy';
 import {IconRefresh} from 'sentry/icons/iconRefresh';
 import {t} from 'sentry/locale';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface SeerDrawerHeaderProps {
   onCopyMarkdown?: () => void;
@@ -26,6 +27,8 @@ export function SeerDrawerHeader({
   onReset,
   referrer,
 }: SeerDrawerHeaderProps) {
+  const organization = useOrganization();
+  const hasDebugFlag = organization.features.includes('autofix-seer-agent-debug');
   const isSentryEmployee = useIsSentryEmployee();
   const tooltip = useMemo(() => {
     const config = getReferrerConfig(referrer);
@@ -58,7 +61,7 @@ export function SeerDrawerHeader({
             aria-label={t('Copy analysis as Markdown')}
             variant="transparent"
           />
-          {isSentryEmployee && onOpenSeerAgent && (
+          {isSentryEmployee && hasDebugFlag && onOpenSeerAgent && (
             <Button
               size="xs"
               icon={<IconBot />}


### PR DESCRIPTION
depends on https://github.com/getsentry/sentry-options-automator/pull/8156 being merged 

we don't want all internal users to see this, only the ones that are
actively working on autofix and have context that this is only meant for
debugging, having this show up all the time leads to worst dogfooding
as internal users aren't seeing the same version of the product that
external users would see

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.