### PR TITLE
fix(onboarding): Keep getting-started rendered while back nav deletes

### DIFF
--- a/static/app/views/projectInstall/gettingStarted.tsx
+++ b/static/app/views/projectInstall/gettingStarted.tsx
@@ -1,3 +1,4 @@
+import {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Stack} from '@sentry/scraps/layout';
@@ -5,6 +6,7 @@ import {Stack} from '@sentry/scraps/layout';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Redirect} from 'sentry/components/redirect';
 import {allPlatforms} from 'sentry/data/platforms';
+import type {Project} from 'sentry/types/project';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useProjects} from 'sentry/utils/useProjects';
@@ -23,9 +25,24 @@ export default function GettingStarted() {
 
   const loadingProjects = !initiallyLoaded;
 
-  const project = loadingProjects
+  const projectInStore = loadingProjects
     ? undefined
     : projects.find(proj => proj.slug === params.projectId);
+
+  // Keep rendering a project that disappears from the store mid-session: the
+  // back nav deletes inactive projects before navigating (see
+  // PlatformDocHeader's handleGoBack), and bouncing to the create-project page
+  // here would race that navigation's referrer/project query params. The
+  // redirect below is only for projects that were never found.
+  const lastFoundProjectRef = useRef<Project | undefined>(undefined);
+  if (projectInStore) {
+    lastFoundProjectRef.current = projectInStore;
+  }
+  const project =
+    projectInStore ??
+    (lastFoundProjectRef.current?.slug === params.projectId
+      ? lastFoundProjectRef.current
+      : undefined);
 
   const currentPlatformKey = project?.platform ?? 'other';
   const currentPlatform = allPlatforms.find(p => p.id === currentPlatformKey);


### PR DESCRIPTION
## TLDR

Keeps the getting-started page rendered when its project disappears from the projects store mid-session, reserving the not-found redirect for projects that were never found. This stops the back nav's project deletion from bouncing to the create-project page without the referrer and project query params.

## Details

- The back nav from getting-started (`PlatformDocHeader.handleGoBack`) deletes inactive projects before navigating to the create-project page tagged with `?referrer=getting-started&project=<id>`. The deletion order is deliberate: downstream flows rely on the projects store being updated before they mount (see the equivalent comment in onboarding's `useBackActions`).
- The DELETE updates the store while getting-started is still mounted, so its project-not-found fallback fired first and redirected to the create-project page bare, racing the tagged replace navigation. Classic project creation tolerates this reactively (see the delayed route replace regression test in `createProject.spec.tsx`), but the params still arrive a full request roundtrip late, and the single-view flow in PR 3 restores a saved wizard session from them, which made the race visible as a flash of reset state.
- Getting-started now latches the last project found for the current slug and keeps rendering it if it vanishes from the store, so the only navigation away is the back nav's own tagged replace. A project deleted from another tab now leaves the docs page in place instead of bouncing immediately, which seems less surprising.

## Stack

- [PR 1](https://github.com/getsentry/sentry/pull/117209): Extract project-details form into a hook and core (merged)
- **PR 2 (this):** Keep getting-started rendered while back nav deletes
- [PR 3](https://github.com/getsentry/sentry/pull/117333): Drive the project-details form from host state
- [PR 4](https://github.com/getsentry/sentry/pull/117213): Wire into single-view project creation
- [PR 5](https://github.com/getsentry/sentry/pull/117341): Commit the auto-detected platform to the host
- [PR 6](https://github.com/getsentry/sentry/pull/117342): Explain the disabled Create CTA in the SCM wizard

Refs VDY-76