### PR TITLE
fix(seer): Make ToolResult.tool_call_id optional

### DIFF
--- a/src/sentry/seer/agent/client_models.py
+++ b/src/sentry/seer/agent/client_models.py
@@ -141,7 +141,7 @@ class ToolLink(BaseModel):
 class ToolResult(BaseModel):
     """The result of a tool call execution."""
 
-    tool_call_id: str
+    tool_call_id: str | None = None
     tool_call_function: str
     content: str | None = None
 


### PR DESCRIPTION
Relax `ToolResult.tool_call_id` from `str` to `str | None` so `SeerRunState`
parsing tolerates tool results without a tool-call id.

Seer's autofix run-status endpoint deserializes the run state into
`SeerRunState`. Runs routed to Gemini can produce tool results whose
`tool_call_id` is null — Gemini omits `function_call.id` for non-parallel
function calls — which made `SeerRunState(**session)` raise a `ValidationError`
and broke `GET /…/autofix/` for those runs (SENTRY-5QH8).

`tool_call_id` is declared but not read anywhere in Sentry today (only
`tool_call_function` and `content` are consumed, in `autofix/introspection.py`),
so accepting null here is functionally inert beyond unblocking parsing. It also
recovers already-persisted runs whose state was stored with null ids. Seer may
synthesize a local id at the source in a follow-up; this is the minimal,
immediate unblock.

Fixes SENTRY-5QH8