### PR TITLE
fix(search-query-builder): Handle explicit tagged attributes properly

### DIFF
--- a/static/app/components/arithmeticBuilder/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/index.spec.tsx
@@ -16,7 +16,7 @@ const getSpanFieldDefinition = (key: string) => {
   const argument = functionArguments.find(
     functionArgument => functionArgument.name === key
   );
-  return getFieldDefinition(key, 'span', argument?.kind);
+  return getFieldDefinition(key, {type: 'span', kind: argument?.kind});
 };
 
 function ArithmeticBuilderWrapper({

--- a/static/app/components/arithmeticBuilder/token/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/token/index.spec.tsx
@@ -34,7 +34,7 @@ const getSpanFieldDefinition = (key: string) => {
     functionArgument => functionArgument.name === key
   );
 
-  return getFieldDefinition(key, 'span', argument?.kind);
+  return getFieldDefinition(key, {type: 'span', kind: argument?.kind});
 };
 
 const getSuggestedKey = (key: string) => {

--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -61,7 +61,8 @@ const NON_TAG_FIELDS: string[] = [
   FieldKey.MESSAGE,
 ];
 
-const getFeedbackFieldDefinition = (key: string) => getFieldDefinition(key, 'feedback');
+const getFeedbackFieldDefinition = (key: string) =>
+  getFieldDefinition(key, {type: 'feedback'});
 
 function getHasFieldValues(supportedTags: TagCollection): string[] {
   const customTagKeys = Object.values(supportedTags)

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -22,6 +22,7 @@ import {
   type QueryBuilderActions,
 } from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderState';
 import type {
+  FieldDefinitionGetter,
   FilterKeySection,
   FocusOverride,
 } from 'sentry/components/searchQueryBuilder/types';
@@ -29,7 +30,6 @@ import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils
 import type {ParseResult} from 'sentry/components/searchSyntax/parser';
 import type {SavedSearchType, TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils/defined';
-import type {FieldDefinition, FieldKind} from 'sentry/utils/fields';
 import {getFieldDefinition} from 'sentry/utils/fields';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -55,7 +55,7 @@ interface SearchQueryBuilderConfigContextData {
   filterKeyAliases: TagCollection | undefined;
   filterKeySections: FilterKeySection[];
   filterKeys: TagCollection;
-  getFieldDefinition: (key: string, kind?: FieldKind) => FieldDefinition | null;
+  getFieldDefinition: FieldDefinitionGetter;
   getSuggestedFilterKey: (key: string) => string | null;
   getTagKeys: GetTagKeys | undefined;
   getTagValues: GetTagValues;

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -5192,7 +5192,10 @@ describe('SearchQueryBuilder', () => {
     const builderProps = {
       ...defaultProps,
       fieldDefinitionGetter: (key: string) =>
-        getFieldDefinition(key, 'span', defaultProps.filterKeys[key]?.kind),
+        getFieldDefinition(key, {
+          type: 'span',
+          kind: defaultProps.filterKeys[key]?.kind,
+        }),
     };
 
     it('renders explicit string tag filter', async () => {
@@ -5333,7 +5336,10 @@ describe('SearchQueryBuilder', () => {
     const builderProps = {
       ...defaultProps,
       fieldDefinitionGetter: (key: string) =>
-        getFieldDefinition(key, 'span', defaultProps.filterKeys[key]?.kind),
+        getFieldDefinition(key, {
+          type: 'span',
+          kind: defaultProps.filterKeys[key]?.kind,
+        }),
       getSuggestedFilterKey,
     };
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -5318,6 +5318,54 @@ describe('SearchQueryBuilder', () => {
       await userEvent.keyboard('bar');
       expect(screen.getByRole('option', {name: 'bar'})).toBeInTheDocument();
     });
+
+    it('re-keys to explicit tag syntax for undocumented number attributes', async () => {
+      // A plain (non-explicit) user-created number attribute. Re-keying an
+      // existing number filter to this attribute preserves the value type, so
+      // it takes the "swap key, keep value" path which must still emit explicit
+      // tag syntax rather than the ambiguous plain key.
+      const filterKeys: TagCollection = {
+        ...defaultProps.filterKeys,
+        'eap.custom_number': {
+          key: 'eap.custom_number',
+          name: 'eap.custom_number',
+          kind: FieldKind.MEASUREMENT,
+        },
+      };
+      const mockOnChange = jest.fn();
+
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          filterKeys={filterKeys}
+          fieldDefinitionGetter={(key: string) =>
+            getFieldDefinition(key, {type: 'span', kind: filterKeys[key]?.kind})
+          }
+          initialQuery="tags[bar,number]:>100"
+          onChange={mockOnChange}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit key for filter: tags[bar,number]'})
+      );
+      await userEvent.clear(screen.getByRole('combobox', {name: 'Edit filter key'}));
+      await userEvent.keyboard('eap.custom_number');
+      await userEvent.click(screen.getByRole('option', {name: 'eap.custom_number'}));
+
+      // The key is wrapped in explicit tag syntax and the existing value is kept.
+      expect(
+        screen.getByRole('button', {
+          name: 'Edit key for filter: tags[eap.custom_number,number]',
+        })
+      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith(
+          'tags[eap.custom_number,number]:>100',
+          expect.anything()
+        );
+      });
+    });
   });
 
   describe('autocomplete using suggestions', () => {

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -5320,10 +5320,6 @@ describe('SearchQueryBuilder', () => {
     });
 
     it('re-keys to explicit tag syntax for undocumented number attributes', async () => {
-      // A plain (non-explicit) user-created number attribute. Re-keying an
-      // existing number filter to this attribute preserves the value type, so
-      // it takes the "swap key, keep value" path which must still emit explicit
-      // tag syntax rather than the ambiguous plain key.
       const filterKeys: TagCollection = {
         ...defaultProps.filterKeys,
         'eap.custom_number': {
@@ -5353,7 +5349,6 @@ describe('SearchQueryBuilder', () => {
       await userEvent.keyboard('eap.custom_number');
       await userEvent.click(screen.getByRole('option', {name: 'eap.custom_number'}));
 
-      // The key is wrapped in explicit tag syntax and the existing value is kept.
       expect(
         screen.getByRole('button', {
           name: 'Edit key for filter: tags[eap.custom_number,number]',

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -18,7 +18,10 @@ import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/t
 import {getFilterValueType} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import type {SearchKeyItem} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
 import {useSortedFilterKeyItems} from 'sentry/components/searchQueryBuilder/tokens/useSortedFilterKeyItems';
-import {getInitialFilterText} from 'sentry/components/searchQueryBuilder/tokens/utils';
+import {
+  getInitialFilterText,
+  maybeWrapKeyWithExplicitType,
+} from 'sentry/components/searchQueryBuilder/tokens/utils';
 import type {
   ParseResultToken,
   Token,
@@ -106,7 +109,10 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
         dispatch({
           type: 'UPDATE_FILTER_KEY',
           token,
-          key: keyName,
+          // Preserve the existing value, but ensure undocumented number/boolean
+          // attributes are written in explicit tag syntax so the re-keyed query
+          // stays unambiguously typed (matching the filter-creation path).
+          key: maybeWrapKeyWithExplicitType(keyName, newFieldDef, kind),
         });
         onCommit();
         return;

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -27,7 +27,7 @@ import type {
 import {getKeyLabel, getKeyName} from 'sentry/components/searchSyntax/utils';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {FieldKey} from 'sentry/utils/fields';
+import {FieldKey, type FieldKind} from 'sentry/utils/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 type KeyComboboxProps = {
@@ -60,8 +60,8 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
   );
 
   const handleSelectKey = useCallback(
-    (keyName: string) => {
-      const newFieldDef = getFieldDefinition(keyName);
+    (keyName: string, kind?: FieldKind) => {
+      const newFieldDef = getFieldDefinition(keyName, {kind});
       const newFilterValueType = getFilterValueType(token, newFieldDef);
 
       if (keyName === ASK_SEER_ITEM_KEY) {
@@ -115,7 +115,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       dispatch({
         type: 'REPLACE_TOKENS_WITH_TEXT_ON_SELECT',
         tokens: [token],
-        text: getInitialFilterText(keyName, newFieldDef),
+        text: getInitialFilterText(keyName, newFieldDef, kind),
         focusOverride: {
           itemKey: item.key.toString(),
           part: 'value',
@@ -142,7 +142,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
 
   const onOptionSelected = useCallback(
     (option: SearchKeyItem) => {
-      handleSelectKey(option.value);
+      handleSelectKey(option.value, option.type === 'item' ? option.kind : undefined);
     },
     [handleSelectKey]
   );

--- a/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
@@ -185,7 +185,7 @@ function useParameterSuggestions({
             : field => columnTypes.includes(field.valueType);
 
         return potentialColumns
-          .map(col => [col, getFieldDefinition(col.key, col.kind)] as const)
+          .map(col => [col, getFieldDefinition(col.key, {kind: col.kind})] as const)
           .filter(([col, definition]) =>
             filterFn({
               key: col.key,

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/keyDescription.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/keyDescription.tsx
@@ -35,7 +35,7 @@ export function ValueType({
 export function KeyDescription({size = 'sm', tag}: KeyDescriptionProps) {
   const {getFieldDefinition} = useSearchQueryBuilderConfig();
 
-  const fieldDefinition = getFieldDefinition(tag.key);
+  const fieldDefinition = getFieldDefinition(tag.key, {kind: tag.kind});
 
   const description =
     fieldDefinition?.desc ??

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -5,6 +5,8 @@ import type {
   SelectSectionWithKey,
 } from '@sentry/scraps/compactSelect';
 
+import type {FieldKind} from 'sentry/utils/fields';
+
 export interface KeyItem extends SelectOptionWithKey<string> {
   description: string;
   hideCheck: boolean;
@@ -12,6 +14,7 @@ export interface KeyItem extends SelectOptionWithKey<string> {
   textValue: string;
   type: 'item';
   value: string;
+  kind?: FieldKind;
 }
 
 export interface KeySectionItem extends SelectSectionWithKey<string> {

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -120,6 +120,7 @@ export function createItem(
     description: description ?? '',
     value: tag.key,
     textValue: tag.key,
+    kind: tag.kind,
     hideCheck: true,
     showDetailsInOverlay: true,
     details: () => <KeyDescription tag={tag} />,

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -104,12 +104,13 @@ function replaceFocusedWordWithFilter(
   value: string,
   cursorPosition: number,
   key: string,
-  getFieldDefinition: FieldDefinitionGetter
+  getFieldDefinition: FieldDefinitionGetter,
+  kind?: FieldKind
 ) {
   return replaceFocusedWord(
     value,
     cursorPosition,
-    getInitialFilterText(key, getFieldDefinition(key))
+    getInitialFilterText(key, getFieldDefinition(key, {kind}), kind)
   );
 }
 
@@ -501,6 +502,7 @@ function SearchQueryBuilderInputInternal({
           }
 
           const value = option.value;
+          const kind = option.type === 'item' ? option.kind : undefined;
 
           dispatch({
             type: 'UPDATE_FREE_TEXT_ON_SELECT',
@@ -509,9 +511,13 @@ function SearchQueryBuilderInputInternal({
               inputValue,
               selectionIndex,
               value,
-              getFieldDefinition
+              getFieldDefinition,
+              kind
             ),
-            focusOverride: calculateNextFocusForFilter(state, getFieldDefinition(value)),
+            focusOverride: calculateNextFocusForFilter(
+              state,
+              getFieldDefinition(value, {kind})
+            ),
             shouldCommitQuery: false,
           });
           resetInputValue();
@@ -652,11 +658,12 @@ function SearchQueryBuilderInputInternal({
                 inputValue,
                 selectionIndex,
                 filterKey,
-                getFieldDefinition
+                getFieldDefinition,
+                key?.kind
               ),
               focusOverride: calculateNextFocusForFilter(
                 state,
-                getFieldDefinition(filterKey)
+                getFieldDefinition(filterKey, {kind: key?.kind})
               ),
               shouldCommitQuery: false,
             });

--- a/static/app/components/searchQueryBuilder/tokens/utils.spec.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.spec.tsx
@@ -1,7 +1,7 @@
 import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
 import {FieldKind, FieldValueType, type FieldDefinition} from 'sentry/utils/fields';
 
-import {getInitialFilterText} from './utils';
+import {getInitialFilterText, maybeWrapKeyWithExplicitType} from './utils';
 
 describe('getInitialFilterText', () => {
   it('defaults missing field definitions to contains', () => {
@@ -83,5 +83,37 @@ describe('getInitialFilterText', () => {
     expect(
       getInitialFilterText('span.duration', fieldDefinition, FieldKind.MEASUREMENT)
     ).toBe('span.duration:>10ms');
+  });
+
+  it('keeps Discover measurement keys in plain measurement syntax', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.NUMBER,
+    };
+
+    expect(
+      getInitialFilterText(
+        'measurements.custom.measurement',
+        fieldDefinition,
+        FieldKind.MEASUREMENT
+      )
+    ).toBe('measurements.custom.measurement:>100');
+  });
+});
+
+describe('maybeWrapKeyWithExplicitType', () => {
+  it('keeps Discover measurement keys in plain measurement syntax when re-keying', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.NUMBER,
+    };
+
+    expect(
+      maybeWrapKeyWithExplicitType(
+        'measurements.custom.measurement',
+        fieldDefinition,
+        FieldKind.MEASUREMENT
+      )
+    ).toBe('measurements.custom.measurement');
   });
 });

--- a/static/app/components/searchQueryBuilder/tokens/utils.spec.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.spec.tsx
@@ -30,4 +30,58 @@ describe('getInitialFilterText', () => {
 
     expect(getInitialFilterText('message', fieldDefinition)).toBe('message:""');
   });
+
+  it('emits explicit number tag syntax for undocumented measurement attributes', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.NUMBER,
+    };
+
+    expect(
+      getInitialFilterText(
+        'my.custom.number.attribute',
+        fieldDefinition,
+        FieldKind.MEASUREMENT
+      )
+    ).toBe('tags[my.custom.number.attribute,number]:>100');
+  });
+
+  it('emits explicit boolean tag syntax for undocumented boolean attributes', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.BOOLEAN,
+    };
+
+    expect(
+      getInitialFilterText('my.custom.flag', fieldDefinition, FieldKind.BOOLEAN)
+    ).toBe('tags[my.custom.flag,boolean]:true');
+  });
+
+  it('does not double-wrap keys already in explicit tag syntax', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.NUMBER,
+    };
+
+    expect(
+      getInitialFilterText(
+        'tags[my.custom.number.attribute,number]',
+        fieldDefinition,
+        FieldKind.MEASUREMENT
+      )
+    ).toBe('tags[my.custom.number.attribute,number]:>100');
+  });
+
+  it('does not wrap documented numeric fields', () => {
+    // Documented fields carry a description; these should keep their plain key.
+    const fieldDefinition: FieldDefinition = {
+      desc: 'The duration of the span',
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.DURATION,
+    };
+
+    expect(
+      getInitialFilterText('span.duration', fieldDefinition, FieldKind.MEASUREMENT)
+    ).toBe('span.duration:>10ms');
+  });
 });

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -98,11 +98,20 @@ function isExplicitlyTypedTagKey(key: string) {
   return prettifyTagKey(key) !== key;
 }
 
+const DISCOVER_MEASUREMENT_KEY_PATTERN = /^measurements\.[\w-.]+$/;
+
+function isDiscoverMeasurementKey(key: string) {
+  return DISCOVER_MEASUREMENT_KEY_PATTERN.test(key);
+}
+
 // User-created number/boolean attributes (e.g. EAP span/log attributes) are
 // not in the documented field definitions, so we can't infer their type from
 // the key alone. Emit explicit tag syntax (`tags[key,number]`) so the query
 // is unambiguously typed. Documented fields always carry a `desc`, so we use
 // its absence to detect undocumented attributes.
+//
+// Discover measurements are also undocumented numeric fields, but their valid
+// search syntax is the plain `measurements.*` key, not EAP tag syntax.
 //
 // Returns the key unchanged when it doesn't need (or already has) explicit
 // typing. Shared between filter creation and key re-keying so both paths stay
@@ -115,6 +124,7 @@ export function maybeWrapKeyWithExplicitType(
   if (
     !fieldDefinition?.desc &&
     !isExplicitlyTypedTagKey(key) &&
+    !(kind === FieldKind.MEASUREMENT && isDiscoverMeasurementKey(key)) &&
     (kind === FieldKind.MEASUREMENT || kind === FieldKind.BOOLEAN)
   ) {
     const explicitType = kind === FieldKind.MEASUREMENT ? 'number' : 'boolean';

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -14,7 +14,12 @@ import {
   type ParseResultToken,
 } from 'sentry/components/searchSyntax/parser';
 import {defined} from 'sentry/utils/defined';
-import {FieldKind, FieldValueType, type FieldDefinition} from 'sentry/utils/fields';
+import {
+  FieldKind,
+  FieldValueType,
+  prettifyTagKey,
+  type FieldDefinition,
+} from 'sentry/utils/fields';
 
 export function shiftFocusToChild(
   element: HTMLElement,
@@ -87,7 +92,17 @@ export function getDefaultFilterValue({
   return getDefaultValueForValueType(fieldDefinition.valueType);
 }
 
-function getInitialFilterKeyText(key: string, fieldDefinition: FieldDefinition | null) {
+// A key is already in explicit tag syntax when prettifying it changes the
+// value, e.g. `tags[foo,number]` -> `foo`.
+function isExplicitlyTypedTagKey(key: string) {
+  return prettifyTagKey(key) !== key;
+}
+
+function getInitialFilterKeyText(
+  key: string,
+  fieldDefinition: FieldDefinition | null,
+  kind?: FieldKind
+) {
   if (fieldDefinition?.kind === FieldKind.FUNCTION) {
     if (fieldDefinition.parameters) {
       const parametersText = fieldDefinition.parameters
@@ -99,6 +114,20 @@ function getInitialFilterKeyText(key: string, fieldDefinition: FieldDefinition |
     }
 
     return `${key}()`;
+  }
+
+  // User-created number/boolean attributes (e.g. EAP span/log attributes) are
+  // not in the documented field definitions, so we can't infer their type from
+  // the key alone. Emit explicit tag syntax (`tags[key,number]`) so the query
+  // is unambiguously typed. Documented fields always carry a `desc`, so we use
+  // its absence to detect undocumented attributes.
+  if (
+    !fieldDefinition?.desc &&
+    !isExplicitlyTypedTagKey(key) &&
+    (kind === FieldKind.MEASUREMENT || kind === FieldKind.BOOLEAN)
+  ) {
+    const explicitType = kind === FieldKind.MEASUREMENT ? 'number' : 'boolean';
+    return `tags[${key},${explicitType}]`;
   }
 
   return key;
@@ -120,11 +149,12 @@ function getInitialValueType(fieldDefinition: FieldDefinition | null) {
 
 export function getInitialFilterText(
   key: string,
-  fieldDefinition: FieldDefinition | null
+  fieldDefinition: FieldDefinition | null,
+  kind?: FieldKind
 ) {
   const defaultValue = getDefaultFilterValue({fieldDefinition});
 
-  const keyText = getInitialFilterKeyText(key, fieldDefinition);
+  const keyText = getInitialFilterKeyText(key, fieldDefinition, kind);
   const valueType = getInitialValueType(fieldDefinition);
 
   switch (valueType) {

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -98,6 +98,32 @@ function isExplicitlyTypedTagKey(key: string) {
   return prettifyTagKey(key) !== key;
 }
 
+// User-created number/boolean attributes (e.g. EAP span/log attributes) are
+// not in the documented field definitions, so we can't infer their type from
+// the key alone. Emit explicit tag syntax (`tags[key,number]`) so the query
+// is unambiguously typed. Documented fields always carry a `desc`, so we use
+// its absence to detect undocumented attributes.
+//
+// Returns the key unchanged when it doesn't need (or already has) explicit
+// typing. Shared between filter creation and key re-keying so both paths stay
+// consistent.
+export function maybeWrapKeyWithExplicitType(
+  key: string,
+  fieldDefinition: FieldDefinition | null,
+  kind?: FieldKind
+) {
+  if (
+    !fieldDefinition?.desc &&
+    !isExplicitlyTypedTagKey(key) &&
+    (kind === FieldKind.MEASUREMENT || kind === FieldKind.BOOLEAN)
+  ) {
+    const explicitType = kind === FieldKind.MEASUREMENT ? 'number' : 'boolean';
+    return `tags[${key},${explicitType}]`;
+  }
+
+  return key;
+}
+
 function getInitialFilterKeyText(
   key: string,
   fieldDefinition: FieldDefinition | null,
@@ -116,21 +142,7 @@ function getInitialFilterKeyText(
     return `${key}()`;
   }
 
-  // User-created number/boolean attributes (e.g. EAP span/log attributes) are
-  // not in the documented field definitions, so we can't infer their type from
-  // the key alone. Emit explicit tag syntax (`tags[key,number]`) so the query
-  // is unambiguously typed. Documented fields always carry a `desc`, so we use
-  // its absence to detect undocumented attributes.
-  if (
-    !fieldDefinition?.desc &&
-    !isExplicitlyTypedTagKey(key) &&
-    (kind === FieldKind.MEASUREMENT || kind === FieldKind.BOOLEAN)
-  ) {
-    const explicitType = kind === FieldKind.MEASUREMENT ? 'number' : 'boolean';
-    return `tags[${key},${explicitType}]`;
-  }
-
-  return key;
+  return maybeWrapKeyWithExplicitType(key, fieldDefinition, kind);
 }
 
 function getInitialValueType(fieldDefinition: FieldDefinition | null) {

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -1,7 +1,7 @@
 import type {ReactNode} from 'react';
 
 import type {ParseResult} from 'sentry/components/searchSyntax/parser';
-import type {FieldDefinition} from 'sentry/utils/fields';
+import type {FieldDefinition, FieldKind} from 'sentry/utils/fields';
 
 export type FilterKeySection = {
   children: string[];
@@ -19,7 +19,10 @@ export type FocusOverride = {
   part?: 'value' | 'key' | 'op';
 };
 
-export type FieldDefinitionGetter = (key: string) => FieldDefinition | null;
+export type FieldDefinitionGetter = (
+  key: string,
+  options?: {kind?: FieldKind}
+) => FieldDefinition | null;
 
 export type CallbackSearchState = {
   parsedQuery: ParseResult | null;

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -3717,9 +3717,9 @@ export type GetFieldDefinitionType =
 
 export const getFieldDefinition = (
   key: string,
-  type: GetFieldDefinitionType = 'event',
-  kind?: FieldKind
+  options: {kind?: FieldKind; type?: GetFieldDefinitionType} = {}
 ): FieldDefinition | null => {
+  const {type = 'event', kind} = options;
   return _getFieldFromMappings(type, key, kind) ?? null;
 };
 

--- a/static/app/views/alerts/rules/metric/eapField.tsx
+++ b/static/app/views/alerts/rules/metric/eapField.tsx
@@ -233,10 +233,9 @@ export function EAPField({aggregate, onChange, eventTypes, project}: Props) {
     traceItemType === TraceItemDataset.LOGS ? LOG_OPERATIONS : SPAN_OPERATIONS;
 
   const aggregateDefinition = aggregation
-    ? getFieldDefinition(
-        aggregation,
-        traceItemType === TraceItemDataset.LOGS ? 'log' : 'span'
-      )
+    ? getFieldDefinition(aggregation, {
+        type: traceItemType === TraceItemDataset.LOGS ? 'log' : 'span',
+      })
     : undefined;
 
   return (

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -69,7 +69,7 @@ export function getFieldDefinitionForDataset(
         return 'event';
     }
   };
-  return getFieldDefinition(tag.key, fieldType(), tag.kind);
+  return getFieldDefinition(tag.key, {type: fieldType(), kind: tag.kind});
 }
 
 export function parseFilterValue(

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -192,7 +192,7 @@ function getAggregateArguments(yAxis: string): string[] {
   if (!parsedFunction) {
     return [];
   }
-  const definition = getFieldDefinition(parsedFunction.name, 'span');
+  const definition = getFieldDefinition(parsedFunction.name, {type: 'span'});
   if (definition?.kind !== FieldKind.FUNCTION) {
     return [];
   }

--- a/static/app/views/dashboards/widgetBuilder/components/exploreArithmeticBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/exploreArithmeticBuilder.tsx
@@ -59,7 +59,7 @@ export function ExploreArithmeticBuilder({equation, onUpdate}: Props) {
   const getSpanFieldDefinition = useCallback(
     (key: string) => {
       const tag = numberTags[key] ?? stringTags[key];
-      return getFieldDefinition(key, 'span', tag?.kind);
+      return getFieldDefinition(key, {type: 'span', kind: tag?.kind});
     },
     [numberTags, stringTags]
   );

--- a/static/app/views/detectors/components/forms/metric/visualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/visualize.tsx
@@ -287,10 +287,9 @@ function GenericVisualize() {
     // For Spans dataset, use span-specific options from the provider
     if (dataset === DetectorDataset.SPANS || dataset === DetectorDataset.LOGS) {
       // Use field definition to determine what options should be displayed
-      const fieldDefinition = getFieldDefinition(
-        aggregate,
-        dataset === DetectorDataset.SPANS ? 'span' : 'log'
-      );
+      const fieldDefinition = getFieldDefinition(aggregate, {
+        type: dataset === DetectorDataset.SPANS ? 'span' : 'log',
+      });
       let isTypeAllowed = (_valueType: FieldValueType) => true;
       if (fieldDefinition?.parameters?.[0]?.kind === 'column') {
         const columnTypes = fieldDefinition?.parameters[0]?.columnTypes;

--- a/static/app/views/detectors/datasetConfig/spans.tsx
+++ b/static/app/views/detectors/datasetConfig/spans.tsx
@@ -42,7 +42,7 @@ function getAggregateOptions(
 ): Record<string, SelectValue<FieldValue>> {
   const base = SpansConfig.getTableFieldOptions(organization, tags, customMeasurements);
 
-  const apdexDefinition = getFieldDefinition(AggregationKey.APDEX, 'span');
+  const apdexDefinition = getFieldDefinition(AggregationKey.APDEX, {type: 'span'});
 
   if (apdexDefinition?.parameters) {
     // Convert field definition parameters to discover field format

--- a/static/app/views/explore/components/attributeDetails.tsx
+++ b/static/app/views/explore/components/attributeDetails.tsx
@@ -20,7 +20,7 @@ export function AttributeDetails({
   traceItemType,
 }: AttributeDetailsProps) {
   const type = traceItemTypeToType(traceItemType);
-  const definition = getFieldDefinition(column, type, kind);
+  const definition = getFieldDefinition(column, {type, kind});
   const description = definition?.desc ?? t('An attribute sent with one or more events');
   return (
     <Details>

--- a/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
@@ -116,7 +116,10 @@ export function SchemaHintsDrawer({
       filterQuery.removeFilter(keyToRemove);
       filterQuery.removeFilter(`!${keyToRemove}`);
     } else {
-      const hintFieldDefinition = getFieldDefinition(hint.key, 'span', hint.kind);
+      const hintFieldDefinition = getFieldDefinition(hint.key, {
+        type: 'span',
+        kind: hint.kind,
+      });
       addFilterToQuery(filterQuery, hint, hintFieldDefinition);
     }
 
@@ -148,7 +151,10 @@ export function SchemaHintsDrawer({
   );
 
   function HintItem({hint, index}: {hint: Tag; index: number}) {
-    const hintFieldDefinition = getFieldDefinition(hint.key, 'span', hint.kind);
+    const hintFieldDefinition = getFieldDefinition(hint.key, {
+      type: 'span',
+      kind: hint.kind,
+    });
 
     return (
       <div ref={virtualizer.measureElement} data-index={index}>

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -408,7 +408,10 @@ export function SchemaHintsList({
     }
 
     const newSearchQuery = new MutableSearch(query);
-    const fieldDefinition = getFieldDefinition(hint.key, 'span', hint.kind);
+    const fieldDefinition = getFieldDefinition(hint.key, {
+      type: 'span',
+      kind: hint.kind,
+    });
     addFilterToQuery(newSearchQuery, hint, fieldDefinition);
 
     const newQuery = newSearchQuery.formatString();

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -73,7 +73,7 @@ export function ToolbarVisualizeDropdown({
 
   const aggregateFunc = parsedFunction?.name;
   const aggregateDefinition = aggregateFunc
-    ? getFieldDefinition(aggregateFunc, 'span')
+    ? getFieldDefinition(aggregateFunc, {type: 'span'})
     : undefined;
 
   return (

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
@@ -65,7 +65,7 @@ export function VisualizeEquation({
   const getSpanFieldDefinition = useCallback(
     (key: string) => {
       const tag = numberTags[key] ?? stringTags[key];
-      return getFieldDefinition(key, 'span', tag?.kind);
+      return getFieldDefinition(key, {type: 'span', kind: tag?.kind});
     },
     [numberTags, stringTags]
   );

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
@@ -3,7 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
-import {FieldKind} from 'sentry/utils/fields';
+import {FieldKind, FieldValueType} from 'sentry/utils/fields';
 import {
   useTraceItemSearchQueryBuilderProps,
   type TraceItemSearchQueryBuilderProps,
@@ -120,6 +120,40 @@ describe('useTraceItemSearchQueryBuilderProps', () => {
 
     expect(result.current.filterKeys['log.message']).toBeDefined();
     expect(result.current.filterKeyAliases?.['log.message_alias']).toBeDefined();
+  });
+
+  describe('fieldDefinitionGetter', () => {
+    it('resolves number value type from a passed kind for undocumented attributes', () => {
+      const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {
+        initialProps: defaultInitialProps,
+        organization,
+      });
+
+      // A user-created attribute that is not in the static collection and not in
+      // the documented field definitions (e.g. dynamically fetched while typing).
+      // Without the kind it resolves to null, letting callers (e.g. the type
+      // badge) fall back to the attribute's own kind.
+      expect(
+        result.current.fieldDefinitionGetter('my.custom.number.attribute')
+      ).toBeNull();
+      expect(
+        result.current.fieldDefinitionGetter('my.custom.number.attribute', {
+          kind: FieldKind.MEASUREMENT,
+        })?.valueType
+      ).toBe(FieldValueType.NUMBER);
+    });
+
+    it('resolves value type from explicit tag syntax embedded in the key', () => {
+      const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {
+        initialProps: defaultInitialProps,
+        organization,
+      });
+
+      expect(
+        result.current.fieldDefinitionGetter('tags[my.custom.number.attribute,number]')
+          ?.valueType
+      ).toBe(FieldValueType.NUMBER);
+    });
   });
 
   it('merges all secondary alias types into filterKeyAliases', () => {

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
@@ -129,10 +129,6 @@ describe('useTraceItemSearchQueryBuilderProps', () => {
         organization,
       });
 
-      // A user-created attribute that is not in the static collection and not in
-      // the documented field definitions (e.g. dynamically fetched while typing).
-      // Without the kind it resolves to null, letting callers (e.g. the type
-      // badge) fall back to the attribute's own kind.
       expect(
         result.current.fieldDefinitionGetter('my.custom.number.attribute')
       ).toBeNull();

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -79,12 +79,11 @@ function getTraceItemFieldDefinitionFunction(
   tags: TagCollection
 ) {
   const getter: FieldDefinitionGetter = (key, options) => {
-    // User-created span/log attributes aren't in the documented field
-    // definitions, so we derive their kind from (in order): the kind passed by
-    // the caller (the attribute's tag), the static tag collection, or the
-    // explicit tag syntax embedded in the key itself (e.g. `tags[key,number]`).
-    // Without this, dynamically-fetched number/boolean attributes fall back to
-    // a string value type.
+    // User-created attributes aren't in the documented field definitions, so we derive
+    // their kind from (in order): the kind passed by the caller (the attribute's tag),
+    // the static tag collection, or the explicit tag syntax embedded in the key itself
+    // (e.g. `tags[key,number]`). Without this, dynamically-fetched number/boolean
+    // attributes fall back to a string value type.
     //
     // `classifyTagKey` returns `TAG` for keys without explicit tag syntax, so we
     // only use it when it actually disambiguates the type. Otherwise we leave

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -7,10 +7,11 @@ import {
   type SearchQueryBuilderProps,
 } from 'sentry/components/searchQueryBuilder';
 import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
+import type {FieldDefinitionGetter} from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
 import {SavedSearchType, type TagCollection} from 'sentry/types/group';
 import type {AggregationKey} from 'sentry/utils/fields';
-import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
+import {classifyTagKey, FieldKind, getFieldDefinition} from 'sentry/utils/fields';
 import {getHasTag} from 'sentry/utils/tag';
 import {useAttributeValidation} from 'sentry/views/explore/hooks/useAttributeValidation';
 import {useExploreSuggestedAttribute} from 'sentry/views/explore/hooks/useExploreSuggestedAttribute';
@@ -77,9 +78,28 @@ function getTraceItemFieldDefinitionFunction(
   itemType: TraceItemDataset,
   tags: TagCollection
 ) {
-  return (key: string) => {
-    return getFieldDefinition(key, typeMap[itemType], tags[key]?.kind);
+  const getter: FieldDefinitionGetter = (key, options) => {
+    // User-created span/log attributes aren't in the documented field
+    // definitions, so we derive their kind from (in order): the kind passed by
+    // the caller (the attribute's tag), the static tag collection, or the
+    // explicit tag syntax embedded in the key itself (e.g. `tags[key,number]`).
+    // Without this, dynamically-fetched number/boolean attributes fall back to
+    // a string value type.
+    //
+    // `classifyTagKey` returns `TAG` for keys without explicit tag syntax, so we
+    // only use it when it actually disambiguates the type. Otherwise we leave
+    // the kind undefined so undocumented plain keys resolve to `null` (callers
+    // fall back to the attribute's own kind, e.g. for the type badge).
+    const classifiedKind = classifyTagKey(key);
+    return getFieldDefinition(key, {
+      type: typeMap[itemType],
+      kind:
+        options?.kind ??
+        tags[key]?.kind ??
+        (classifiedKind === FieldKind.TAG ? undefined : classifiedKind),
+    });
   };
+  return getter;
 }
 
 export function useTraceItemSearchQueryBuilderProps({

--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
@@ -108,9 +108,9 @@ export function updateVisualizeAggregate({
     return `${newAggregate}()`;
   }
 
-  const newFieldDefinition = getFieldDefinition(newAggregate, 'span');
+  const newFieldDefinition = getFieldDefinition(newAggregate, {type: 'span'});
   const oldFieldDefinition = oldAggregate
-    ? getFieldDefinition(oldAggregate, 'span')
+    ? getFieldDefinition(oldAggregate, {type: 'span'})
     : undefined;
 
   if (newFieldDefinition?.parameters?.length !== oldFieldDefinition?.parameters?.length) {

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -118,7 +118,7 @@ function getSupportedAttributes({
       functionName === AggregationKey.PERFORMANCE_SCORE ||
       functionName === AggregationKey.OPPORTUNITY_SCORE
     ) {
-      const fieldDef = getFieldDefinition(functionName, 'span');
+      const fieldDef = getFieldDefinition(functionName, {type: 'span'});
       const param = fieldDef?.parameters?.[0];
       if (param?.kind === 'column' && typeof param.columnTypes === 'function') {
         const filtered: TagCollection = {};

--- a/static/app/views/explore/replays/list/replaySearchBar.tsx
+++ b/static/app/views/explore/replays/list/replaySearchBar.tsx
@@ -26,7 +26,8 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useApi} from 'sentry/utils/useApi';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 
-const getReplayFieldDefinition = (key: string) => getFieldDefinition(key, 'replay');
+const getReplayFieldDefinition = (key: string) =>
+  getFieldDefinition(key, {type: 'replay'});
 
 function fieldDefinitionsToTagCollection(fieldKeys: string[]): TagCollection {
   return Object.fromEntries(

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -426,7 +426,7 @@ function AggregateSelector({
   const parsedFunction = useMemo(() => parseFunction(yAxis), [yAxis]);
   const aggregateFunc = parsedFunction?.name;
   const aggregateDefinition = aggregateFunc
-    ? getFieldDefinition(aggregateFunc, 'span')
+    ? getFieldDefinition(aggregateFunc, {type: 'span'})
     : undefined;
 
   const aggregateOptions: Array<SelectOption<string>> = useMemo(() => {
@@ -699,7 +699,7 @@ function EquationSelector({
   const getSpanFieldDefinition = useCallback(
     (key: string) => {
       const tag = numberTags[key] ?? stringTags[key];
-      return getFieldDefinition(key, 'span', tag?.kind);
+      return getFieldDefinition(key, {type: 'span', kind: tag?.kind});
     },
     [numberTags, stringTags]
   );

--- a/static/app/views/explore/utils/sortSearchedAttributes.tsx
+++ b/static/app/views/explore/utils/sortSearchedAttributes.tsx
@@ -44,10 +44,9 @@ export function sortSearchedAttributes<Value extends SelectKey>({
   }
 
   const isKnown =
-    getFieldDefinition(
-      String(option.value),
-      getFieldDefinitionType(fieldDefinitionType)
-    ) !== null;
+    getFieldDefinition(String(option.value), {
+      type: getFieldDefinitionType(fieldDefinitionType),
+    }) !== null;
 
   const prefixBoost =
     result.start === 0 && result.end === normalizedSearch.length ? 8 : 0;
@@ -90,9 +89,9 @@ export function sortKnownAttributes<Value extends SelectOption<string>>(
   traceItemType: TraceItemDataset
 ) {
   const aKnown =
-    getFieldDefinition(a.value, getFieldDefinitionType(traceItemType)) !== null;
+    getFieldDefinition(a.value, {type: getFieldDefinitionType(traceItemType)}) !== null;
   const bKnown =
-    getFieldDefinition(b.value, getFieldDefinitionType(traceItemType)) !== null;
+    getFieldDefinition(b.value, {type: getFieldDefinitionType(traceItemType)}) !== null;
   if (aKnown !== bKnown) {
     return aKnown ? -1 : 1;
   }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
@@ -175,7 +175,7 @@ export function getTraceKeyValueActions(params: KeyValueActionParams): MenuItemP
     },
   ];
 
-  const valueType = getFieldDefinition(rowKey, 'span')?.valueType;
+  const valueType = getFieldDefinition(rowKey, {type: 'span'})?.valueType;
   const isNumeric =
     typeof rowValue === 'number' ||
     (valueType &&


### PR DESCRIPTION
The search query builder now preserves the type of undocumented attributes when users add or re-key filters. Custom number and boolean attributes are written with explicit tag syntax, like `tags[custom.attr,number]`, so they do not fall back to ambiguous string-style queries.

This threads `FieldKind` through field definition lookup and autocomplete selections, updates `getFieldDefinition` to take an options object instead of positional `type`/`kind` arguments, and adds regression coverage for creating and re-keying typed custom attributes.

Closes EXP-995