### PR TITLE
fix(seer): Allow null tool_call_id in frontend ToolResult type

### DIFF
--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -72,7 +72,7 @@ export interface ToolLink {
 export interface ToolResult {
   content: string;
   tool_call_function: string;
-  tool_call_id: string;
+  tool_call_id: string | null;
 }
 
 export interface ToolCall {


### PR DESCRIPTION
Relax the seerExplorer `ToolResult.tool_call_id` frontend type from `string`
to `string | null`, mirroring the backend change in #117327.

Gemini omits `function_call.id` for non-parallel function calls, so a tool
result can carry a null `tool_call_id`. Existing consumers already guard with
truthy checks (`result?.tool_call_id`, `toolCallId ? …`), so this is a
type-only change with no behavior impact.

Refs SENTRY-5QH8