### PR TITLE
ref(onboarding): Drive the project-details form from host state

### DIFF
--- a/static/app/views/onboarding/components/useScmProjectDetails.ts
+++ b/static/app/views/onboarding/components/useScmProjectDetails.ts
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {Team} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
@@ -52,12 +53,22 @@ const CREATE_FAILED_EVENT = {
   'project-creation': 'project_creation.scm_project_details_create_failed',
 } as const;
 
+export interface ScmProjectDetailsCompletion {
+  /** The created project, or the reused one on the unchanged back-nav path. */
+  project: Project;
+  /** The form state the project was created with. */
+  projectDetailsForm: ProjectDetailsFormState;
+}
+
 interface UseScmProjectDetailsOptions {
   analyticsFlow: ScmAnalyticsFlow;
-  /** Called after a project is created (or an unchanged one reused). */
-  onComplete: () => void;
-  onProjectCreated: (slug: string | undefined) => void;
-  onProjectDetailsFormChange: (form: ProjectDetailsFormState) => void;
+  /**
+   * Called once the step is done: a project was created (or an unchanged one
+   * reused on the back-nav path) and the repo link attempted. Receives the
+   * project and the submitted form state together so the host can persist
+   * both and advance in one place.
+   */
+  onComplete: (completion: ScmProjectDetailsCompletion) => void;
   selectedPlatform: OnboardingSelectedSDK | undefined;
   selectedRepository: Repository | undefined;
   /**
@@ -106,8 +117,6 @@ interface ScmProjectDetailsForm {
 export function useScmProjectDetails({
   analyticsFlow,
   onComplete,
-  onProjectCreated,
-  onProjectDetailsFormChange,
   selectedPlatform,
   selectedRepository,
   createdProjectSlug,
@@ -216,6 +225,12 @@ export function useScmProjectDetails({
 
     trackAnalytics(CREATE_CLICKED_EVENT[analyticsFlow], {organization});
 
+    const submittedForm = {
+      projectName: projectNameResolved,
+      teamSlug: teamSlugResolved,
+      alertRuleConfig,
+    };
+
     // User navigated back and clicked Create without changing anything; skip
     // to completion without creating a duplicate. Any actual change abandons
     // the previous project and creates a new one, matching legacy onboarding.
@@ -224,7 +239,7 @@ export function useScmProjectDetails({
         organization,
         project_slug: existingProject.slug,
       });
-      onComplete();
+      onComplete({project: existingProject, projectDetailsForm: submittedForm});
       return;
     }
 
@@ -236,10 +251,6 @@ export function useScmProjectDetails({
         alertRuleConfig: getRequestDataFragment(alertRuleConfig),
         createNotificationAction: () => {},
       });
-
-      // Store the project slug separately so the host can find the project
-      // without corrupting selectedPlatform.key.
-      onProjectCreated(project.slug);
 
       if (selectedRepository?.id) {
         try {
@@ -253,18 +264,12 @@ export function useScmProjectDetails({
         }
       }
 
-      onProjectDetailsFormChange({
-        projectName: projectNameResolved,
-        teamSlug: teamSlugResolved,
-        alertRuleConfig,
-      });
-
       trackAnalytics(CREATE_SUCCEEDED_EVENT[analyticsFlow], {
         organization,
         project_slug: project.slug,
       });
 
-      onComplete();
+      onComplete({project, projectDetailsForm: submittedForm});
     } catch (error) {
       trackAnalytics(CREATE_FAILED_EVENT[analyticsFlow], {organization});
       addErrorMessage(t('Failed to create project'));
@@ -279,8 +284,6 @@ export function useScmProjectDetails({
     isOrgMemberWithNoAccess,
     nothingChanged,
     onComplete,
-    onProjectCreated,
-    onProjectDetailsFormChange,
     organization,
     projectNameResolved,
     selectedPlatform,

--- a/static/app/views/onboarding/components/useScmProjectDetails.ts
+++ b/static/app/views/onboarding/components/useScmProjectDetails.ts
@@ -1,4 +1,4 @@
-import {useCallback, useState} from 'react';
+import {useCallback, useRef} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -69,6 +69,13 @@ interface UseScmProjectDetailsOptions {
    * both and advance in one place.
    */
   onComplete: (completion: ScmProjectDetailsCompletion) => void;
+  /**
+   * Live form state, owned by the host. Fields absent from the form derive
+   * their defaults (platform-based name, first admin team, default alert
+   * config), so the host clearing the form makes the fields re-derive.
+   */
+  onProjectDetailsFormChange: (form: ProjectDetailsFormState) => void;
+  projectDetailsForm: ProjectDetailsFormState | undefined;
   selectedPlatform: OnboardingSelectedSDK | undefined;
   selectedRepository: Repository | undefined;
   /**
@@ -79,7 +86,6 @@ interface UseScmProjectDetailsOptions {
   allowMemberWithoutTeam?: boolean;
   /** Slug of an already-created project, used for the back-nav reuse check. */
   createdProjectSlug?: string;
-  projectDetailsForm?: ProjectDetailsFormState;
 }
 
 interface ScmProjectDetailsForm {
@@ -108,19 +114,22 @@ interface ScmProjectDetailsForm {
 }
 
 /**
- * Owns the SCM project-details form state, the create-project + repo-link flow,
- * and the field/create analytics (routed by `analyticsFlow`). Returned to the
- * host so it can render the presentational `ScmProjectDetailsCore` form and
- * place its own Create button (onboarding's fixed footer, project creation's
- * page-level footer) independent of where the form fields render.
+ * Drives the SCM project-details form (state owned by the host via
+ * `projectDetailsForm`/`onProjectDetailsFormChange`), the create-project +
+ * repo-link flow, and the field/create analytics (routed by `analyticsFlow`).
+ * Returned to the host so it can render the presentational
+ * `ScmProjectDetailsCore` form and place its own Create button (onboarding's
+ * fixed footer, project creation's page-level footer) independent of where
+ * the form fields render.
  */
 export function useScmProjectDetails({
   analyticsFlow,
   onComplete,
+  onProjectDetailsFormChange,
+  projectDetailsForm,
   selectedPlatform,
   selectedRepository,
   createdProjectSlug,
-  projectDetailsForm,
   allowMemberWithoutTeam,
 }: UseScmProjectDetailsOptions): ScmProjectDetailsForm {
   const organization = useOrganization();
@@ -139,41 +148,48 @@ export function useScmProjectDetails({
     !organization.access.includes('project:admin');
   const defaultName = slugify(selectedPlatform?.key ?? '');
 
-  // State tracks user edits. When the host restores a persisted
-  // projectDetailsForm (e.g. back-navigation in onboarding) it seeds the inputs.
-  const [projectName, setProjectName] = useState(projectDetailsForm?.projectName ?? null);
-  const [teamSlug, setTeamSlug] = useState(projectDetailsForm?.teamSlug ?? null);
-  const [alertRuleConfig, setAlertRuleConfig] = useState(
-    projectDetailsForm?.alertRuleConfig ?? DEFAULT_ISSUE_ALERT_OPTIONS_VALUES
+  // Fields absent from the host-owned form fall back to derived defaults, so
+  // a host clearing the form (e.g. on a platform change) re-derives them.
+  const projectNameResolved = projectDetailsForm?.projectName ?? defaultName;
+  const teamSlugResolved = projectDetailsForm?.teamSlug ?? firstAdminTeam?.slug ?? '';
+  const alertRuleConfig =
+    projectDetailsForm?.alertRuleConfig ?? DEFAULT_ISSUE_ALERT_OPTIONS_VALUES;
+
+  // Baseline for the unchanged-return (reuse) check below: the form as it was
+  // when this step mounted, i.e. a restored session's saved values. Live edits
+  // flow through the controlled form, so the prop can't be its own baseline.
+  const savedFormRef = useRef(projectDetailsForm);
+
+  const onProjectNameChange = useCallback(
+    (value: string) => {
+      onProjectDetailsFormChange({...projectDetailsForm, projectName: slugify(value)});
+    },
+    [onProjectDetailsFormChange, projectDetailsForm]
   );
 
-  const projectNameResolved = projectName ?? defaultName;
-  const teamSlugResolved = teamSlug ?? firstAdminTeam?.slug ?? '';
-
-  const onProjectNameChange = useCallback((value: string) => {
-    setProjectName(slugify(value));
-  }, []);
-
   const onProjectNameBlur = useCallback(() => {
-    if (projectName !== null) {
+    if (projectDetailsForm?.projectName !== undefined) {
       trackAnalytics(NAME_EDITED_EVENT[analyticsFlow], {
         organization,
-        custom: projectName !== defaultName,
+        custom: projectDetailsForm.projectName !== defaultName,
       });
     }
-  }, [projectName, defaultName, organization, analyticsFlow]);
+  }, [projectDetailsForm?.projectName, defaultName, organization, analyticsFlow]);
 
   const onTeamChange = useCallback(
     ({value}: {value: string}) => {
-      setTeamSlug(value);
+      onProjectDetailsFormChange({...projectDetailsForm, teamSlug: value});
       trackAnalytics(TEAM_SELECTED_EVENT[analyticsFlow], {organization, team: value});
     },
-    [organization, analyticsFlow]
+    [onProjectDetailsFormChange, projectDetailsForm, organization, analyticsFlow]
   );
 
   const onAlertChange = useCallback(
     <K extends keyof AlertRuleOptions>(key: K, value: AlertRuleOptions[K]) => {
-      setAlertRuleConfig(prev => ({...prev, [key]: value}));
+      onProjectDetailsFormChange({
+        ...projectDetailsForm,
+        alertRuleConfig: {...alertRuleConfig, [key]: value},
+      });
       if (key === 'alertSetting') {
         const optionMap: Record<number, string> = {
           [RuleAction.DEFAULT_ALERT]: 'high_priority',
@@ -186,7 +202,13 @@ export function useScmProjectDetails({
         });
       }
     },
-    [organization, analyticsFlow]
+    [
+      onProjectDetailsFormChange,
+      projectDetailsForm,
+      alertRuleConfig,
+      organization,
+      analyticsFlow,
+    ]
   );
 
   // Block submission until teams and the projects store have loaded so the
@@ -207,12 +229,13 @@ export function useScmProjectDetails({
   // snapshot because the Project model tracks it; alert fields are not on the
   // Project record so we compare those against the context snapshot.
   const samePlatform = existingProject?.platform === selectedPlatform?.key;
-  const savedAlert = projectDetailsForm?.alertRuleConfig;
+  const savedForm = savedFormRef.current;
+  const savedAlert = savedForm?.alertRuleConfig;
   const nothingChanged =
     samePlatform &&
-    !!projectDetailsForm &&
-    projectNameResolved === projectDetailsForm.projectName &&
-    teamSlugResolved === projectDetailsForm.teamSlug &&
+    !!savedForm &&
+    projectNameResolved === savedForm.projectName &&
+    teamSlugResolved === savedForm.teamSlug &&
     alertRuleConfig.alertSetting === savedAlert?.alertSetting &&
     alertRuleConfig.interval === savedAlert?.interval &&
     alertRuleConfig.metric === savedAlert?.metric &&

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -3,7 +3,13 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 import {TeamFixture} from 'sentry-fixture/team';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderHookWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {ProjectDetailsFormState} from 'sentry/components/onboarding/onboardingContext';
@@ -12,6 +18,7 @@ import {TeamStore} from 'sentry/stores/teamStore';
 import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import * as analytics from 'sentry/utils/analytics';
+import {useScmProjectDetails} from 'sentry/views/onboarding/components/useScmProjectDetails';
 import {MetricValues, RuleAction} from 'sentry/views/projectInstall/issueAlertOptions';
 
 import {ScmProjectDetails} from './scmProjectDetails';
@@ -110,6 +117,32 @@ describe('ScmProjectDetails', () => {
     expect(await screen.findByText('High priority issues')).toBeInTheDocument();
     expect(screen.getByText('Custom')).toBeInTheDocument();
     expect(screen.getByText("I'll create my own alerts later")).toBeInTheDocument();
+  });
+
+  it('re-derives the fields when the host clears the form', () => {
+    const hookProps: Parameters<typeof useScmProjectDetails>[0] = {
+      analyticsFlow: 'onboarding',
+      selectedPlatform: mockPlatform,
+      selectedRepository: undefined,
+      createdProjectSlug: undefined,
+      projectDetailsForm: {
+        projectName: 'restored-name',
+        teamSlug: teamWithAccess.slug,
+      },
+      onProjectDetailsFormChange: jest.fn(),
+      onComplete: jest.fn(),
+    };
+    const {result, rerender} = renderHookWithProviders(useScmProjectDetails, {
+      organization,
+      initialProps: hookProps,
+    });
+
+    expect(result.current.projectName).toBe('restored-name');
+
+    // The host clears the form (platform or repo change in the single-view
+    // flow); the name falls back to the platform default.
+    rerender({...hookProps, projectDetailsForm: undefined});
+    expect(result.current.projectName).toBe('javascript-nextjs');
   });
 
   it('create project button is disabled without platform', async () => {

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -1,3 +1,5 @@
+import {useState} from 'react';
+
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
@@ -41,20 +43,29 @@ export function ScmProjectDetails({
   selectedRepository,
   genBackButton,
 }: ScmProjectDetailsProps) {
+  // Live form for this step, seeded from the saved form in the onboarding
+  // context. The context only ever holds submitted values, which the hook's
+  // unchanged-return reuse check relies on as its baseline, so live edits stay
+  // here. This step remounts on every onboarding navigation, so each visit
+  // re-seeds and abandoned edits are discarded.
+  const [liveForm, setLiveForm] = useState(projectDetailsForm);
+
   const form = useScmProjectDetails({
     analyticsFlow: 'onboarding',
     selectedPlatform,
     selectedRepository,
     createdProjectSlug,
-    projectDetailsForm,
+    projectDetailsForm: liveForm,
+    onProjectDetailsFormChange: setLiveForm,
     onComplete: ({
       project,
       projectDetailsForm: submittedForm,
     }: ScmProjectDetailsCompletion) => {
       // Store the slug separately so onboarding.tsx can find the project via
       // useRecentCreatedProject without corrupting selectedPlatform.key (which
-      // the platform features step needs), and persist the form so navigating
-      // back from setup-docs restores it. Both land before the step advances.
+      // the platform features step needs), and persist the submitted form so
+      // navigating back from setup-docs restores it. Both land before the
+      // step advances.
       onProjectCreated(project.slug);
       onProjectDetailsFormChange(submittedForm);
       onComplete(undefined, selectedFeatures ? {product: selectedFeatures} : undefined);

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -9,7 +9,10 @@ import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {GenericFooter} from 'sentry/views/onboarding/components/genericFooter';
 import {ScmProjectDetailsCore} from 'sentry/views/onboarding/components/scmProjectDetailsCore';
-import {useScmProjectDetails} from 'sentry/views/onboarding/components/useScmProjectDetails';
+import {
+  type ScmProjectDetailsCompletion,
+  useScmProjectDetails,
+} from 'sentry/views/onboarding/components/useScmProjectDetails';
 import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 
 import {ScmStepHeader} from './components/scmStepHeader';
@@ -44,10 +47,18 @@ export function ScmProjectDetails({
     selectedRepository,
     createdProjectSlug,
     projectDetailsForm,
-    onProjectCreated,
-    onProjectDetailsFormChange,
-    onComplete: () =>
-      onComplete(undefined, selectedFeatures ? {product: selectedFeatures} : undefined),
+    onComplete: ({
+      project,
+      projectDetailsForm: submittedForm,
+    }: ScmProjectDetailsCompletion) => {
+      // Store the slug separately so onboarding.tsx can find the project via
+      // useRecentCreatedProject without corrupting selectedPlatform.key (which
+      // the platform features step needs), and persist the form so navigating
+      // back from setup-docs restores it. Both land before the step advances.
+      onProjectCreated(project.slug);
+      onProjectDetailsFormChange(submittedForm);
+      onComplete(undefined, selectedFeatures ? {product: selectedFeatures} : undefined);
+    },
   });
 
   return (


### PR DESCRIPTION
## TLDR

Makes the SCM project-details hook fully host-driven: the form state lives with the caller (`projectDetailsForm` plus `onProjectDetailsFormChange`, where absent fields derive their defaults), and completion is reported through a single `onComplete` carrying the created project and the submitted form. Prepares the hook for the single-view project-creation host, which keeps it mounted across platform changes and needs clears to actually reach the fields.

## Details

- Previously the hook seeded internal `useState` once at mount from the host's saved form, an artifact of the step component it was extracted from, which remounts on every onboarding navigation. A host that stays mounted (the single-view wizard) could clear its form without the live fields noticing.
- Controlled now: absent fields fall back to derived defaults (platform-based name, first admin team, default alert config), so a cleared form re-derives by construction. Covered by a new regression test.
- The unchanged-return reuse check compares against the form captured at mount (a restored session's saved values), since the live prop can no longer be its own baseline.
- The three completion callbacks (`onProjectCreated`, completion-time `onProjectDetailsFormChange`, `onComplete`) collapse into one `onComplete({project, projectDetailsForm})`. On a successful submit they always fired together, so no host could observe a meaningful intermediate state. The reuse path now reports the reused project and form, which match what the host already has.
- The onboarding step holds the live form in local state seeded from the context, which keeps the context to submitted values only: a step remount cannot adopt unsubmitted edits as the reuse baseline, and abandoned edits are discarded on navigation, matching the step's previous behavior and classic createProject. The completion payload still flows to the existing context setters, so observable onboarding behavior is unchanged.

## Stack

- [PR 1](https://github.com/getsentry/sentry/pull/117209): Extract project-details form into a hook and core (merged)
- [PR 2](https://github.com/getsentry/sentry/pull/117325): Keep getting-started rendered while back nav deletes (merged)
- **PR 3 (this):** Drive the project-details form from host state
- [PR 4](https://github.com/getsentry/sentry/pull/117213): Wire into single-view project creation
- [PR 5](https://github.com/getsentry/sentry/pull/117341): Commit the auto-detected platform to the host
- [PR 6](https://github.com/getsentry/sentry/pull/117342): Explain the disabled Create CTA in the SCM wizard

Refs VDY-76
