### PR TITLE
ref(hybrid-cloud): Explicitly handle errors rather than 500ing

### DIFF
--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -221,7 +221,7 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
 
         return JsonResponse(
             {"error": "apigateway", "detail": "Proxied request timed out"},
-            status=504,
+            status=500,
         )
     except ConnectionError:
         metrics.incr("apigateway.proxy.connection_error", tags=metric_tags)
@@ -230,7 +230,7 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
 
         return JsonResponse(
             {"error": "apigateway", "detail": "Downstream service unavailable"},
-            status=502,
+            status=500,
         )
 
     if resp.status_code >= 502:

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -22,7 +22,6 @@ from requests.cookies import RequestsCookieJar
 from requests.exceptions import ConnectionError, Timeout
 
 from sentry import options
-from sentry.api.exceptions import RequestTimeout
 from sentry.objectstore.endpoints.organization import ChunkedEncodingDecoder, get_raw_body
 from sentry.options.rollout import in_random_rollout
 from sentry.silo.util import (
@@ -220,14 +219,19 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
         if circuit_breaker is not None:
             circuit_breaker.record_error()
 
-        # remote silo timeout. Use DRF timeout instead
-        raise RequestTimeout()
+        return JsonResponse(
+            {"error": "apigateway", "detail": "Proxied request timed out"},
+            status=504,
+        )
     except ConnectionError:
         metrics.incr("apigateway.proxy.connection_error", tags=metric_tags)
         if circuit_breaker is not None:
             circuit_breaker.record_error()
 
-        raise
+        return JsonResponse(
+            {"error": "apigateway", "detail": "Downstream service unavailable"},
+            status=502,
+        )
 
     if resp.status_code >= 502:
         metrics.incr("apigateway.proxy.request_failed", tags=metric_tags)

--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -182,14 +182,14 @@ async def proxy_cell_request(
                 circuitbreaker.incr_failures()
                 return JsonResponse(
                     {"error": "apigateway", "detail": "Proxied request timed out"},
-                    status=504,
+                    status=500,
                 )
             except httpx.RequestError:
                 metrics.incr("apigateway.proxy.request_failed", tags=metric_tags)
                 circuitbreaker.incr_failures()
                 return JsonResponse(
                     {"error": "apigateway", "detail": "Downstream service unavailable"},
-                    status=502,
+                    status=500,
                 )
     except CircuitBreakerOverflow:
         metrics.incr("apigateway.proxy.circuit_breaker.overflow", tags=metric_tags)

--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -15,7 +15,6 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse, JsonResponse, StreamingHttpResponse
 from django.http.response import HttpResponseBase
 
-from sentry.api.exceptions import RequestTimeout
 from sentry.objectstore.endpoints.organization import get_raw_body_async
 from sentry.options.rollout import in_random_rollout
 from sentry.silo.util import (
@@ -181,12 +180,17 @@ async def proxy_cell_request(
             except httpx.TimeoutException:
                 metrics.incr("apigateway.proxy.request_timeout", tags=metric_tags)
                 circuitbreaker.incr_failures()
-                # remote silo timeout. Use DRF timeout instead
-                raise RequestTimeout()
+                return JsonResponse(
+                    {"error": "apigateway", "detail": "Proxied request timed out"},
+                    status=504,
+                )
             except httpx.RequestError:
                 metrics.incr("apigateway.proxy.request_failed", tags=metric_tags)
                 circuitbreaker.incr_failures()
-                raise
+                return JsonResponse(
+                    {"error": "apigateway", "detail": "Downstream service unavailable"},
+                    status=502,
+                )
     except CircuitBreakerOverflow:
         metrics.incr("apigateway.proxy.circuit_breaker.overflow", tags=metric_tags)
         return JsonResponse(

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -9,6 +9,8 @@ from asgiref.sync import async_to_sync
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.client import RequestFactory
 from requests import PreparedRequest
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import ConnectTimeout
 
 from sentry.hybridcloud.apigateway import proxy as sync_proxy
 from sentry.hybridcloud.apigateway_async.proxy import proxy_request as _proxy_request
@@ -336,6 +338,56 @@ class ProxyTestCase(ApiGatewayTestCase):
 
         resp = proxy_request(request, self.organization.slug, url_name)
         assert not any([header in resp for header in INVALID_OUTBOUND_HEADERS])
+
+    @responses.activate
+    def test_sync_connect_timeout_returns_504(self) -> None:
+        responses.add(
+            responses.GET,
+            "http://us.internal.sentry.io/unreachable",
+            body=ConnectTimeout("connection timed out"),
+        )
+        request = RequestFactory().get("http://sentry.io/unreachable")
+        resp = sync_proxy.proxy_request(request, self.organization.slug, url_name)
+        assert resp.status_code == 504
+        assert json.loads(resp.content)["detail"] == "Proxied request timed out"
+
+    @responses.activate
+    def test_sync_connection_error_returns_502(self) -> None:
+        responses.add(
+            responses.GET,
+            "http://us.internal.sentry.io/unreachable",
+            body=RequestsConnectionError("connection refused"),
+        )
+        request = RequestFactory().get("http://sentry.io/unreachable")
+        resp = sync_proxy.proxy_request(request, self.organization.slug, url_name)
+        assert resp.status_code == 502
+        assert json.loads(resp.content)["detail"] == "Downstream service unavailable"
+
+    def test_async_timeout_returns_504(self) -> None:
+        def raise_timeout(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectTimeout("connection timed out", request=request)
+
+        self.httpx_router.add_callback(
+            "GET", "http://us.internal.sentry.io/unreachable", raise_timeout
+        )
+
+        request = RequestFactory().get("http://sentry.io/unreachable")
+        resp = proxy_request(request, self.organization.slug, url_name)
+        assert resp.status_code == 504
+        assert json.loads(resp.content)["detail"] == "Proxied request timed out"
+
+    def test_async_connection_error_returns_502(self) -> None:
+        def raise_connect_error(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused", request=request)
+
+        self.httpx_router.add_callback(
+            "GET", "http://us.internal.sentry.io/unreachable", raise_connect_error
+        )
+
+        request = RequestFactory().get("http://sentry.io/unreachable")
+        resp = proxy_request(request, self.organization.slug, url_name)
+        assert resp.status_code == 502
+        assert json.loads(resp.content)["detail"] == "Downstream service unavailable"
 
 
 api_gateway_address_cell = Cell(

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -342,7 +342,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert not any([header in resp for header in INVALID_OUTBOUND_HEADERS])
 
     @responses.activate
-    def test_sync_connect_timeout_returns_504(self) -> None:
+    def test_sync_connect_timeout_returns_500(self) -> None:
         responses.add(
             responses.GET,
             "http://us.internal.sentry.io/unreachable",
@@ -350,12 +350,12 @@ class ProxyTestCase(ApiGatewayTestCase):
         )
         request = RequestFactory().get("http://sentry.io/unreachable")
         resp = sync_proxy.proxy_request(request, self.organization.slug, url_name)
-        assert resp.status_code == 504
+        assert resp.status_code == 500
         assert isinstance(resp, JsonResponse)
         assert json.loads(resp.content)["detail"] == "Proxied request timed out"
 
     @responses.activate
-    def test_sync_connection_error_returns_502(self) -> None:
+    def test_sync_connection_error_returns_500(self) -> None:
         responses.add(
             responses.GET,
             "http://us.internal.sentry.io/unreachable",
@@ -363,11 +363,11 @@ class ProxyTestCase(ApiGatewayTestCase):
         )
         request = RequestFactory().get("http://sentry.io/unreachable")
         resp = sync_proxy.proxy_request(request, self.organization.slug, url_name)
-        assert resp.status_code == 502
+        assert resp.status_code == 500
         assert isinstance(resp, JsonResponse)
         assert json.loads(resp.content)["detail"] == "Downstream service unavailable"
 
-    def test_async_timeout_returns_504(self) -> None:
+    def test_async_timeout_returns_500(self) -> None:
         def raise_timeout(request: httpx.Request) -> NoReturn:
             raise httpx.ConnectTimeout("connection timed out", request=request)
 
@@ -377,11 +377,11 @@ class ProxyTestCase(ApiGatewayTestCase):
 
         request = RequestFactory().get("http://sentry.io/unreachable")
         resp = proxy_request(request, self.organization.slug, url_name)
-        assert resp.status_code == 504
+        assert resp.status_code == 500
         assert isinstance(resp, JsonResponse)
         assert json.loads(resp.content)["detail"] == "Proxied request timed out"
 
-    def test_async_connection_error_returns_502(self) -> None:
+    def test_async_connection_error_returns_500(self) -> None:
         def raise_connect_error(request: httpx.Request) -> NoReturn:
             raise httpx.ConnectError("connection refused", request=request)
 
@@ -391,7 +391,7 @@ class ProxyTestCase(ApiGatewayTestCase):
 
         request = RequestFactory().get("http://sentry.io/unreachable")
         resp = proxy_request(request, self.organization.slug, url_name)
-        assert resp.status_code == 502
+        assert resp.status_code == 500
         assert isinstance(resp, JsonResponse)
         assert json.loads(resp.content)["detail"] == "Downstream service unavailable"
 

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from typing import NoReturn
 from unittest.mock import Mock
 from urllib.parse import urlencode
 
@@ -7,6 +8,7 @@ import pytest
 import responses
 from asgiref.sync import async_to_sync
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.http import JsonResponse
 from django.test.client import RequestFactory
 from requests import PreparedRequest
 from requests.exceptions import ConnectionError as RequestsConnectionError
@@ -349,6 +351,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         request = RequestFactory().get("http://sentry.io/unreachable")
         resp = sync_proxy.proxy_request(request, self.organization.slug, url_name)
         assert resp.status_code == 504
+        assert isinstance(resp, JsonResponse)
         assert json.loads(resp.content)["detail"] == "Proxied request timed out"
 
     @responses.activate
@@ -361,10 +364,11 @@ class ProxyTestCase(ApiGatewayTestCase):
         request = RequestFactory().get("http://sentry.io/unreachable")
         resp = sync_proxy.proxy_request(request, self.organization.slug, url_name)
         assert resp.status_code == 502
+        assert isinstance(resp, JsonResponse)
         assert json.loads(resp.content)["detail"] == "Downstream service unavailable"
 
     def test_async_timeout_returns_504(self) -> None:
-        def raise_timeout(request: httpx.Request) -> httpx.Response:
+        def raise_timeout(request: httpx.Request) -> NoReturn:
             raise httpx.ConnectTimeout("connection timed out", request=request)
 
         self.httpx_router.add_callback(
@@ -374,10 +378,11 @@ class ProxyTestCase(ApiGatewayTestCase):
         request = RequestFactory().get("http://sentry.io/unreachable")
         resp = proxy_request(request, self.organization.slug, url_name)
         assert resp.status_code == 504
+        assert isinstance(resp, JsonResponse)
         assert json.loads(resp.content)["detail"] == "Proxied request timed out"
 
     def test_async_connection_error_returns_502(self) -> None:
-        def raise_connect_error(request: httpx.Request) -> httpx.Response:
+        def raise_connect_error(request: httpx.Request) -> NoReturn:
             raise httpx.ConnectError("connection refused", request=request)
 
         self.httpx_router.add_callback(
@@ -387,6 +392,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         request = RequestFactory().get("http://sentry.io/unreachable")
         resp = proxy_request(request, self.organization.slug, url_name)
         assert resp.status_code == 502
+        assert isinstance(resp, JsonResponse)
         assert json.loads(resp.content)["detail"] == "Downstream service unavailable"
 
 


### PR DESCRIPTION
`proxy_cell_request` is run before DRF's exception handler is boot-strapped. Raising RequestTimeout 500's. Response format matches the format found elsewhere.

Fixes: https://sentry.sentry.io/issues/7461866040/?project=1&query=is%3Aunresolved&referrer=issue-stream&sort=freq