### PR TITLE
ref(vsts): Remove legacy web setup views in favor of API pipeline steps

### DIFF
--- a/fixtures/vsts.py
+++ b/fixtures/vsts.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 import responses
+from django.urls import reverse
 
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.vsts import VstsIntegrationProvider
@@ -194,49 +195,45 @@ class VstsIntegrationTestCase(IntegrationTestCase):
                 },
             )
 
-    def make_init_request(self, path=None, body=None):
-        return self.client.get(path or self.init_path, body or {})
-
-    def make_oauth_redirect_request(self, state):
-        return self.client.get(
-            "{}?{}".format(self.setup_path, urlencode({"code": "oauth-code", "state": state}))
+    def _pipeline_url(self):
+        return reverse(
+            "sentry-api-0-organization-pipeline",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "pipeline_name": "integration_pipeline",
+            },
         )
-
-    def assert_vsts_oauth_redirect(self, redirect):
-        assert redirect.scheme == "https"
-        assert redirect.netloc == "app.vssps.visualstudio.com"
-        assert redirect.path == "/oauth2/authorize"
 
     def assert_vsts_new_oauth_redirect(self, redirect):
         assert redirect.scheme == "https"
         assert redirect.netloc == "login.microsoftonline.com"
         assert redirect.path == "/common/oauth2/v2.0/authorize"
 
-    def assert_account_selection(self, response, account_id=None):
-        account_id = account_id or self.vsts_account_id
-        assert response.status_code == 200
-        assert f'<option value="{account_id}"'.encode() in response.content
-
     @assume_test_silo_mode(SiloMode.CONTROL)
-    def assert_installation(self):
-        # Initial request to the installation URL for VSTS
-        resp = self.make_init_request()
-        redirect = urlparse(resp["Location"])
+    def assert_installation(self, account_id=None):
+        # Drives the API pipeline: initialize -> oauth -> account selection.
+        account_id = account_id or self.vsts_account_id
+        pipeline_url = self._pipeline_url()
 
-        assert resp.status_code == 302
-        self.assert_vsts_new_oauth_redirect(redirect)
-
-        query = parse_qs(redirect.query)
-
-        # OAuth redirect back to Sentry (identity_pipeline_view)
-        resp = self.make_oauth_redirect_request(query["state"][0])
-        self.assert_account_selection(resp)
-
-        # User choosing which VSTS Account to use (AccountConfigView)
-        # Final step.
-        resp = self.client.post(
-            self.setup_path, {"account": self.vsts_account_id, "provider": "vsts"}
+        resp: Any = self.client.post(
+            pipeline_url, data={"action": "initialize", "provider": "vsts"}, format="json"
         )
+        assert resp.status_code == 200, resp.content
+
+        # The OAuth authorize URL carries the pipeline state signature, which is
+        # echoed back to the advance step to verify the callback.
+        oauth_url = resp.data["data"]["oauthUrl"]
+        redirect = urlparse(oauth_url)
+        self.assert_vsts_new_oauth_redirect(redirect)
+        state = parse_qs(redirect.query)["state"][0]
+
+        resp = self.client.post(
+            pipeline_url, data={"code": "oauth-code", "state": state}, format="json"
+        )
+        assert resp.status_code == 200, resp.content
+        assert resp.data["step"] == "account_selection"
+
+        resp = self.client.post(pipeline_url, data={"account": account_id}, format="json")
         return resp
 
 

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -7,9 +7,7 @@ from time import time
 from typing import Any, TypedDict
 from urllib.parse import parse_qs, quote, unquote, urlencode, urlparse
 
-from django import forms
 from django.http.request import HttpRequest
-from django.http.response import HttpResponseBase
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 from rest_framework.fields import CharField
@@ -20,7 +18,6 @@ from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
 from sentry.identity.oauth2 import OAuth2ApiStep
-from sentry.identity.pipeline import IdentityPipeline
 from sentry.identity.services.identity.model import RpcIdentity
 from sentry.identity.vsts.provider import VSTSNewIdentityProvider, get_user_info
 from sentry.integrations.base import (
@@ -55,7 +52,6 @@ from sentry.models.repository import Repository
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline.types import PipelineStepResult
 from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
-from sentry.pipeline.views.nested import NestedPipelineView
 from sentry.shared_integrations.exceptions import (
     ApiError,
     IntegrationError,
@@ -64,7 +60,6 @@ from sentry.shared_integrations.exceptions import (
 from sentry.silo.base import SiloMode
 from sentry.utils import metrics
 from sentry.utils.http import absolute_uri
-from sentry.web.helpers import render_to_response
 
 from .client import VstsApiClient, VstsSetupApiClient
 from .repository import VstsRepositoryProvider
@@ -611,20 +606,7 @@ class VstsIntegrationProvider(IntegrationProvider):
         return VstsIntegrationProvider.NEW_SCOPES
 
     def get_pipeline_views(self) -> Sequence[PipelineView[IntegrationPipeline]]:
-        identity_pipeline_config = {
-            "redirect_url": absolute_uri(self.oauth_redirect_url),
-            "oauth_scopes": self.get_scopes(),
-        }
-
-        return [
-            NestedPipelineView(
-                bind_key="identity",
-                provider_key=self.key,
-                pipeline_cls=IdentityPipeline,
-                config=identity_pipeline_config,
-            ),
-            AccountConfigView(),
-        ]
+        return []
 
     def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
         return [
@@ -650,13 +632,7 @@ class VstsIntegrationProvider(IntegrationProvider):
         )
 
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
-        # TODO: legacy views write token data to state["identity"]["data"] via
-        # NestedPipelineView. API steps write directly to state["oauth_data"].
-        # Remove the legacy path once the old views are retired.
-        if "oauth_data" in state:
-            data = state["oauth_data"]
-        else:
-            data = state["identity"]["data"]
+        data = state["oauth_data"]
         oauth_data = self.get_oauth_data(data)
         account = state["account"]
         user = get_user_info(data["access_token"])
@@ -833,58 +809,4 @@ class VstsIntegrationProvider(IntegrationProvider):
 
         bindings.add(
             "integration-repository.provider", VstsRepositoryProvider, id="integrations:vsts"
-        )
-
-
-class AccountConfigView:
-    def dispatch(self, request: HttpRequest, pipeline: IntegrationPipeline) -> HttpResponseBase:
-        with IntegrationPipelineViewEvent(
-            IntegrationPipelineViewType.ACCOUNT_CONFIG,
-            IntegrationDomain.SOURCE_CODE_MANAGEMENT,
-            VstsIntegrationProvider.key,
-        ).capture() as lifecycle:
-            account_id = request.POST.get("account")
-            if account_id is not None:
-                state_accounts: Sequence[Mapping[str, Any]] | None = pipeline.fetch_state(
-                    key="accounts"
-                )
-                account = get_account_from_id(account_id, state_accounts or [])
-                if account is not None:
-                    pipeline.bind_state("account", account)
-                    return pipeline.next_step()
-
-            state: Mapping[str, Any] | None = pipeline.fetch_state(key="identity")
-            access_token = (state or {}).get("data", {}).get("access_token")
-            user = get_user_info(access_token)
-
-            accounts = get_accounts(access_token, user["uuid"])
-            extra = {
-                "organization_id": pipeline.organization.id if pipeline.organization else None,
-                "user_id": request.user.id,
-                "accounts": accounts,
-            }
-            if not accounts or not accounts.get("value"):
-                lifecycle.record_halt(IntegrationPipelineHaltReason.NO_ACCOUNTS, extra=extra)
-                return render_to_response(
-                    template="sentry/integrations/vsts-config.html",
-                    context={"no_accounts": True},
-                    request=request,
-                )
-            accounts = accounts["value"]
-            pipeline.bind_state("accounts", accounts)
-            account_form = AccountForm(accounts)
-            return render_to_response(
-                template="sentry/integrations/vsts-config.html",
-                context={"form": account_form, "no_accounts": False},
-                request=request,
-            )
-
-
-class AccountForm(forms.Form):
-    def __init__(self, accounts: Sequence[Mapping[str, str]], *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.fields["account"] = forms.ChoiceField(
-            choices=[(acct["accountId"], acct["accountName"]) for acct in accounts],
-            label="Account",
-            help_text="Azure DevOps organization.",
         )

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -64,13 +64,11 @@ class VstsIntegrationMigrationTest(VstsIntegrationTestCase):
         state = {
             "account": {"accountName": self.vsts_account_name, "accountId": self.vsts_account_id},
             "base_url": self.vsts_base_url,
-            "identity": {
-                "data": {
-                    "access_token": self.access_token,
-                    "expires_in": "3600",
-                    "refresh_token": self.refresh_token,
-                    "token_type": "jwt-bearer",
-                }
+            "oauth_data": {
+                "access_token": self.access_token,
+                "expires_in": "3600",
+                "refresh_token": self.refresh_token,
+                "token_type": "jwt-bearer",
             },
         }
 
@@ -90,13 +88,11 @@ class VstsIntegrationMigrationTest(VstsIntegrationTestCase):
             {
                 "account": {"accountName": self.vsts_account_name, "accountId": external_id},
                 "base_url": self.vsts_base_url,
-                "identity": {
-                    "data": {
-                        "access_token": "new_access_token",
-                        "expires_in": "3600",
-                        "refresh_token": "new_refresh_token",
-                        "token_type": "bearer",
-                    }
+                "oauth_data": {
+                    "access_token": "new_access_token",
+                    "expires_in": "3600",
+                    "refresh_token": "new_refresh_token",
+                    "token_type": "bearer",
                 },
             }
         )
@@ -125,13 +121,11 @@ class VstsIntegrationMigrationTest(VstsIntegrationTestCase):
         state = {
             "account": {"accountName": self.vsts_account_name, "accountId": self.vsts_account_id},
             "base_url": self.vsts_base_url,
-            "identity": {
-                "data": {
-                    "access_token": self.access_token,
-                    "expires_in": "3600",
-                    "refresh_token": self.refresh_token,
-                    "token_type": "jwt-bearer",
-                }
+            "oauth_data": {
+                "access_token": self.access_token,
+                "expires_in": "3600",
+                "refresh_token": self.refresh_token,
+                "token_type": "jwt-bearer",
             },
             "integration_migration_version": 1,
             "subscription": {
@@ -160,13 +154,11 @@ class VstsIntegrationMigrationTest(VstsIntegrationTestCase):
             {
                 "account": {"accountName": self.vsts_account_name, "accountId": external_id},
                 "base_url": self.vsts_base_url,
-                "identity": {
-                    "data": {
-                        "access_token": "new_access_token",
-                        "expires_in": "3600",
-                        "refresh_token": "new_refresh_token",
-                        "token_type": "bearer",
-                    }
+                "oauth_data": {
+                    "access_token": "new_access_token",
+                    "expires_in": "3600",
+                    "refresh_token": "new_refresh_token",
+                    "token_type": "bearer",
                 },
                 "subscription": {
                     "id": "123",
@@ -246,16 +238,24 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
             status=403,
             json={"$id": 1, "message": "Your account is not good"},
         )
-        resp = self.make_init_request()
-        assert resp.status_code < 400, resp.content
+        pipeline_url = self._pipeline_url()
 
-        redirect = urlparse(resp["Location"])
-        query = parse_qs(redirect.query)
-
-        # OAuth redirect back to Sentry (identity_pipeline_view)
-        resp = self.make_oauth_redirect_request(query["state"][0])
+        resp: Any = self.client.post(
+            pipeline_url, data={"action": "initialize", "provider": "vsts"}, format="json"
+        )
         assert resp.status_code == 200, resp.content
-        assert b"No accounts found" in resp.content
+        state = parse_qs(urlparse(resp.data["data"]["oauthUrl"]).query)["state"][0]
+
+        # Advancing to the account selection step surfaces no accounts and
+        # records a single halt. The advance response already carries the step
+        # data, so we assert on it directly rather than re-fetching (a second
+        # GET would invoke get_step_data again and record a duplicate halt).
+        resp = self.client.post(
+            pipeline_url, data={"code": "oauth-code", "state": state}, format="json"
+        )
+        assert resp.status_code == 200, resp.content
+        assert resp.data["step"] == "account_selection"
+        assert resp.data["data"]["accounts"] == []
 
         assert_halt_metric(mock_record, "no_accounts")
 
@@ -269,13 +269,11 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         state = {
             "account": {"accountName": self.vsts_account_name, "accountId": self.vsts_account_id},
             "base_url": self.vsts_base_url,
-            "identity": {
-                "data": {
-                    "access_token": self.access_token,
-                    "expires_in": "3600",
-                    "refresh_token": self.refresh_token,
-                    "token_type": "jwt-bearer",
-                }
+            "oauth_data": {
+                "access_token": self.access_token,
+                "expires_in": "3600",
+                "refresh_token": self.refresh_token,
+                "token_type": "jwt-bearer",
             },
         }
 
@@ -307,13 +305,11 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
             {
                 "account": {"accountName": self.vsts_account_name, "accountId": external_id},
                 "base_url": self.vsts_base_url,
-                "identity": {
-                    "data": {
-                        "access_token": self.access_token,
-                        "expires_in": "3600",
-                        "refresh_token": self.refresh_token,
-                        "token_type": "jwt-bearer",
-                    }
+                "oauth_data": {
+                    "access_token": self.access_token,
+                    "expires_in": "3600",
+                    "refresh_token": self.refresh_token,
+                    "token_type": "jwt-bearer",
                 },
             }
         )
@@ -641,13 +637,11 @@ class VstsIntegrationProviderBuildIntegrationTest(VstsIntegrationTestCase):
         state = {
             "account": {"accountName": self.vsts_account_name, "accountId": self.vsts_account_id},
             "base_url": self.vsts_base_url,
-            "identity": {
-                "data": {
-                    "access_token": self.access_token,
-                    "expires_in": "3600",
-                    "refresh_token": self.refresh_token,
-                    "token_type": "jwt-bearer",
-                }
+            "oauth_data": {
+                "access_token": self.access_token,
+                "expires_in": "3600",
+                "refresh_token": self.refresh_token,
+                "token_type": "jwt-bearer",
             },
         }
 
@@ -687,13 +681,11 @@ class VstsIntegrationProviderBuildIntegrationTest(VstsIntegrationTestCase):
         state = {
             "account": {"accountName": self.vsts_account_name, "accountId": self.vsts_account_id},
             "base_url": self.vsts_base_url,
-            "identity": {
-                "data": {
-                    "access_token": self.access_token,
-                    "expires_in": "3600",
-                    "refresh_token": self.refresh_token,
-                    "token_type": "jwt-bearer",
-                }
+            "oauth_data": {
+                "access_token": self.access_token,
+                "expires_in": "3600",
+                "refresh_token": self.refresh_token,
+                "token_type": "jwt-bearer",
             },
         }
 
@@ -725,13 +717,11 @@ class VstsIntegrationProviderBuildIntegrationTest(VstsIntegrationTestCase):
         state = {
             "account": {"accountName": self.vsts_account_name, "accountId": self.vsts_account_id},
             "base_url": self.vsts_base_url,
-            "identity": {
-                "data": {
-                    "access_token": self.access_token,
-                    "expires_in": "3600",
-                    "refresh_token": self.refresh_token,
-                    "token_type": "jwt-bearer",
-                }
+            "oauth_data": {
+                "access_token": self.access_token,
+                "expires_in": "3600",
+                "refresh_token": self.refresh_token,
+                "token_type": "jwt-bearer",
             },
         }
 

--- a/tests/sentry/integrations/vsts/test_provider.py
+++ b/tests/sentry/integrations/vsts/test_provider.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 from collections.abc import Generator
 from time import time
 from typing import Any
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 from urllib.parse import parse_qs
 
 import pytest
 import responses
-from django.forms import ChoiceField
-from django.http import HttpRequest
 from django.urls import reverse
 
 from sentry.identity.vsts.provider import (
@@ -17,7 +15,7 @@ from sentry.identity.vsts.provider import (
     VSTSNewOAuth2CallbackView,
     VSTSOAuth2CallbackView,
 )
-from sentry.integrations.vsts.integration import AccountConfigView, AccountForm, get_accounts
+from sentry.integrations.vsts.integration import get_accounts
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
@@ -172,38 +170,18 @@ class TestVSTSNewOAuth2CallbackView(TestCase):
 
 
 @control_silo_test
-class TestAccountConfigView(TestCase):
+class TestGetAccounts(TestCase):
     def setUp(self) -> None:
         responses.reset()
-        account_id = "1234567-8910"
-        self.base_url = "http://sentry2.visualstudio.com/"
         self.accounts: list[dict[str, Any]] = [
             {
                 "accountId": "1234567-89",
-                "NamespaceId": "00000000-0000-0000-0000-000000000000",
                 "accountName": "sentry",
-                "OrganizationName": None,
-                "AccountType": 0,
-                "AccountOwner": "00000000-0000-0000-0000-000000000000",
-                "CreatedBy": "00000000-0000-0000-0000-000000000000",
-                "CreatedDate": "0001-01-01T00:00:00",
-                "AccountStatus": 0,
-                "StatusReason": None,
-                "LastUpdatedBy": "00000000-0000-0000-0000-000000000000",
                 "Properties": {},
             },
             {
-                "accountId": account_id,
-                "NamespaceId": "00000000-0000-0000-0000-000000000000",
+                "accountId": "1234567-8910",
                 "accountName": "sentry2",
-                "OrganizationName": None,
-                "AccountType": 0,
-                "AccountOwner": "00000000-0000-0000-0000-000000000000",
-                "CreatedBy": "00000000-0000-0000-0000-000000000000",
-                "CreatedDate": "0001-01-01T00:00:00",
-                "AccountStatus": 0,
-                "StatusReason": None,
-                "LastUpdatedBy": "00000000-0000-0000-0000-000000000000",
                 "Properties": {},
             },
         ]
@@ -213,31 +191,6 @@ class TestAccountConfigView(TestCase):
             json={"value": self.accounts, "count": len(self.accounts)},
             status=200,
         )
-        responses.add(
-            responses.GET,
-            "https://app.vssps.visualstudio.com/_apis/resourceareas/79134C72-4A58-4B42-976C-04E7115F32BF?hostId=%s&api-preview=5.0-preview.1"
-            % account_id,
-            json={"locationUrl": self.base_url},
-        )
-
-    @responses.activate
-    def test_dispatch(self) -> None:
-        view = AccountConfigView()
-        request = HttpRequest()
-        request.POST.update({"account": "1234567-8910"})
-
-        pipeline = Mock()
-        pipeline.state = {
-            "accounts": self.accounts,
-            "identity": {"data": {"access_token": "123456789"}},
-        }
-        pipeline.fetch_state = lambda key: pipeline.state[key]
-        pipeline.bind_state = lambda name, value: pipeline.state.update({name: value})
-
-        view.dispatch(request, pipeline)
-
-        assert pipeline.fetch_state(key="account") == self.accounts[1]
-        assert pipeline.next_step.call_count == 1
 
     @responses.activate
     def test_get_accounts(self) -> None:
@@ -245,44 +198,6 @@ class TestAccountConfigView(TestCase):
         assert accounts is not None
         assert accounts["value"][0]["accountName"] == "sentry"
         assert accounts["value"][1]["accountName"] == "sentry2"
-
-    @responses.activate
-    def test_account_form(self) -> None:
-        account_form = AccountForm(self.accounts)
-        field = account_form.fields["account"]
-        assert isinstance(field, ChoiceField)
-        assert field.choices == [
-            ("1234567-89", "sentry"),
-            ("1234567-8910", "sentry2"),
-        ]
-
-    @responses.activate
-    @patch("sentry.integrations.vsts.integration.get_user_info")
-    @patch("sentry.integrations.vsts.integration.render_to_response")
-    def test_no_accounts_received(
-        self, mock_render_to_response: MagicMock, mock_get_user_info: MagicMock
-    ) -> None:
-        responses.reset()
-        responses.add(
-            responses.GET,
-            "https://app.vssps.visualstudio.com/_apis/accounts",
-            json={"value": [], "count": 0},
-            status=200,
-        )
-
-        view = AccountConfigView()
-        request = Mock()
-        request.POST = {}
-        request.user = self.user
-
-        pipeline = Mock()
-        pipeline.fetch_state = lambda key: {"data": {"access_token": "1234567890"}}
-        pipeline.organization = self.organization
-
-        view.dispatch(request, pipeline)
-        assert mock_get_user_info.called is True
-        assert mock_render_to_response.called is True
-        assert mock_render_to_response.call_args[1]["context"] == {"no_accounts": True}
 
 
 @control_silo_test


### PR DESCRIPTION
VSTS installs now run through `get_pipeline_api_steps()` (`OAuth2ApiStep` + `VstsAccountSelectionApiStep`), which the frontend pipeline modal already drives. `VstsAccountSelectionApiStep` is a direct replacement for the old `AccountConfigView`, and in API mode the OAuth callback returns via the popup → pipeline endpoint rather than the web `PipelineAdvancerView`, so the server-rendered setup views are dead.

This drops the `AccountConfigView` / `AccountForm` classes and the `NestedPipelineView`-based `get_pipeline_views()` (now an empty list), and migrates the install tests and `fixtures/vsts.py` to the API pipeline flow.

`get_pipeline_views()` still returns an empty list because the base `IntegrationProvider` requires it — removing it across all providers (and the rest of the legacy web-pipeline machinery) is a follow-up.


Part of [VDY-60](https://linear.app/getsentry/issue/VDY-60/remove-legacy-azure-devops-vsts-integration-setup-views).