### PR TITLE
fix(onboarding): Commit the auto-detected platform to the host

### DIFF
--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -167,11 +167,12 @@ export function ScmPlatformFeaturesCore({
 
   const currentPlatformName = getPlatformName(currentPlatformKey);
 
-  // Fire scm_platform_selected once per repo when detection auto-resolves a
-  // platform and the user hasn't explicitly chosen one. Otherwise a user who
-  // accepts the recommendation and clicks Continue never emits the event,
-  // leaving the funnel without a platform-selected step. The ref is re-armed
-  // on repo change above so a switch to a new repo fires the event again.
+  // Adopt the first detected platform once per repo when the user hasn't
+  // explicitly chosen one: commit it to the host so flows without a Continue
+  // boundary (single-view project creation) get a platform without an explicit
+  // pick, and fire scm_platform_selected so a user who just accepts the
+  // recommendation still emits a platform-selected funnel step. The ref is
+  // re-armed on repo change above so a switch to a new repo adopts again.
   useEffect(() => {
     if (
       autoDetectionTrackedRef.current ||
@@ -181,12 +182,19 @@ export function ScmPlatformFeaturesCore({
       return;
     }
     autoDetectionTrackedRef.current = true;
+    setPlatform(detectedPlatformKey);
     trackAnalytics(PLATFORM_SELECTED_EVENT[analyticsFlow], {
       organization,
       platform: detectedPlatformKey,
       source: 'detected',
     });
-  }, [detectedPlatformKey, selectedPlatform?.key, organization, analyticsFlow]);
+  }, [
+    detectedPlatformKey,
+    selectedPlatform?.key,
+    organization,
+    analyticsFlow,
+    setPlatform,
+  ]);
 
   // Wizard-driven platforms render an informational variant since the wizard CLI
   // owns product configuration and toggles aren't actionable.

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -120,7 +120,7 @@ describe('ScmPlatformFeatures', () => {
     expect(within(radioGroup).getByText('Django')).toBeInTheDocument();
   });
 
-  it('auto-selects first detected platform', async () => {
+  it('auto-selects and commits first detected platform', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/repos/42/platforms/`,
       body: {
@@ -135,14 +135,15 @@ describe('ScmPlatformFeatures', () => {
       },
     });
 
-    render(
-      <ScmPlatformFeatures {...defaultProps({selectedRepository: mockRepository})} />,
-      {organization}
-    );
+    const props = defaultProps({selectedRepository: mockRepository});
+    render(<ScmPlatformFeatures {...props} />, {organization});
 
     expect(
       await screen.findByRole('heading', {level: 3, name: 'Available with Next.js'})
     ).toBeInTheDocument();
+    expect(props.onPlatformChange).toHaveBeenCalledWith(
+      expect.objectContaining({key: 'javascript-nextjs'})
+    );
   });
 
   describe('feature card variants', () => {


### PR DESCRIPTION
## TLDR

Commits the auto-detected platform to the host in the platform-features core instead of only deriving it for display. In the single-view project-creation flow there is no Continue boundary to commit it later, so accepting the detected platform left the wizard without a platform: the project name never defaulted and the Create CTA stayed disabled.

## Details

- The core rendered `selectedPlatform?.key ?? detectedPlatformKey` but only called `onPlatformChange` on explicit picks. The onboarding step compensates with a fallback commit in its Continue handler; the single-view flow has no equivalent, so detection-only sessions never populated `selectedPlatform`.
- The commit now happens in the same once-per-repo effect that fires the `scm_platform_selected` analytics, with the same guards: skipped when the user already picked, re-armed on repo change. It does not call `onClearProjectDetailsForm`, so a restored form is not cleared.
- The onboarding step's fallback commit becomes a no-op and stays as belt and braces.

## Stack

- [PR 1](https://github.com/getsentry/sentry/pull/117209): Extract project-details form into a hook and core (merged)
- [PR 2](https://github.com/getsentry/sentry/pull/117325): Keep getting-started rendered while back nav deletes (merged)
- [PR 3](https://github.com/getsentry/sentry/pull/117333): Drive the project-details form from host state
- [PR 4](https://github.com/getsentry/sentry/pull/117213): Wire into single-view project creation
- **PR 5 (this):** Commit the auto-detected platform to the host
- [PR 6](https://github.com/getsentry/sentry/pull/117342): Explain the disabled Create CTA in the SCM wizard

Refs VDY-76
