### PR TITLE
feat(issues): Move issue tracker actions into external links header

### DIFF
--- a/static/app/components/dropdownMenu/index.spec.tsx
+++ b/static/app/components/dropdownMenu/index.spec.tsx
@@ -274,9 +274,18 @@ describe('DropdownMenu', () => {
   });
 
   it('closes after clicking external link', async () => {
+    const onAction = jest.fn();
+
     render(
       <DropdownMenu
-        items={[{key: 'item1', label: 'Item One', externalHref: 'https://example.com'}]}
+        items={[
+          {
+            key: 'item1',
+            label: 'Item One',
+            externalHref: 'https://example.com',
+            onAction,
+          },
+        ]}
         triggerLabel="Menu"
       />
     );
@@ -286,6 +295,7 @@ describe('DropdownMenu', () => {
     await waitFor(() => {
       expect(screen.queryByRole('menuitemradio')).not.toBeInTheDocument();
     });
+    expect(onAction).toHaveBeenCalledTimes(1);
   });
 
   it('navigates to link on enter', async () => {

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -275,19 +275,25 @@ function DropdownMenu({
         items={activeItems}
       >
         {(item: MenuItemProps) => {
+          const {onAction: _onAction, ...itemProps} = item;
+
           if (item.children && item.children.length > 0 && !item.isSubmenu) {
             return (
               <Section key={item.key} title={item.label} items={item.children}>
-                {sectionItem => (
-                  <Item size={size} {...sectionItem} key={sectionItem.key}>
-                    {sectionItem.label}
-                  </Item>
-                )}
+                {sectionItem => {
+                  const {onAction: _sectionOnAction, ...sectionItemProps} = sectionItem;
+
+                  return (
+                    <Item size={size} {...sectionItemProps} key={sectionItem.key}>
+                      {sectionItem.label}
+                    </Item>
+                  );
+                }}
               </Section>
             );
           }
           return (
-            <Item size={size} {...item} key={item.key}>
+            <Item size={size} {...itemProps} key={item.key}>
               {item.label}
             </Item>
           );

--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -139,6 +139,7 @@ export function DropdownMenuItem({
       if (resolvedCloseOnSelect) {
         requestAnimationFrame(() => rootOverlayState?.close());
       }
+      onAction?.();
       return;
     }
     if (isSubmenu) {

--- a/static/app/components/group/externalIssuesList/hooks/types.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/types.tsx
@@ -46,7 +46,7 @@ export interface ExternalIssueAction {
  * Integrations, apps, or plugins that can create external issues.
  * Each integration can have one or more configurations.
  */
-interface ExternalIssueIntegration extends BaseIssueAction {
+export interface ExternalIssueIntegration extends BaseIssueAction {
   actions: ExternalIssueAction[];
 }
 

--- a/static/app/components/group/externalIssuesList/index.spec.tsx
+++ b/static/app/components/group/externalIssuesList/index.spec.tsx
@@ -48,7 +48,6 @@ describe('ExternalIssueList', () => {
     render(<ExternalIssueList group={group} project={project} event={event} />, {
       organization,
     });
-    expect(screen.getByTestId('issue-tracking-loading')).toBeInTheDocument();
     expect(await screen.findByText(setupCTA)).toBeInTheDocument();
   });
 

--- a/static/app/components/group/externalIssuesList/index.tsx
+++ b/static/app/components/group/externalIssuesList/index.tsx
@@ -2,56 +2,20 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {AlertLink} from '@sentry/scraps/alert';
-import {Button, LinkButton, type ButtonProps} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {DropdownButton} from 'sentry/components/dropdownButton';
-import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
-import type {ExternalIssueAction} from 'sentry/components/group/externalIssuesList/hooks/types';
+import type {GroupIntegrationIssueResult} from 'sentry/components/group/externalIssuesList/hooks/types';
 import {useGroupExternalIssues} from 'sentry/components/group/externalIssuesList/hooks/useGroupExternalIssues';
+import {InlineIssueTrackerActions} from 'sentry/components/group/externalIssuesList/issueTrackerActions';
+import {LinkedIssueRows} from 'sentry/components/group/externalIssuesList/linkedIssueRows';
 import {Placeholder} from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
-
-function getActionLabelAndTextValue({
-  action,
-  integrationDisplayName,
-}: {
-  action: ExternalIssueAction;
-  integrationDisplayName: string;
-}): {label: string | React.JSX.Element; textValue: string} {
-  // If there's no subtext or subtext matches name, just show name
-  if (!action.nameSubText || action.nameSubText === action.name) {
-    return {
-      label: action.name,
-      textValue: action.name,
-    };
-  }
-
-  // If action name matches integration name, just show subtext
-  if (action.name === integrationDisplayName) {
-    return {
-      label: action.nameSubText,
-      textValue: `${action.name} ${action.nameSubText}`,
-    };
-  }
-
-  // Otherwise show both name and subtext
-  return {
-    label: (
-      <div>
-        <strong>{action.name}</strong>
-        <div>{action.nameSubText}</div>
-      </div>
-    ),
-    textValue: `${action.name} ${action.nameSubText}`,
-  };
-}
 
 interface ExternalIssueListProps {
   event: Event;
@@ -60,12 +24,30 @@ interface ExternalIssueListProps {
 }
 
 export function ExternalIssueList({group, event, project}: ExternalIssueListProps) {
-  const organization = useOrganization();
-  const {isLoading, integrations, linkedIssues} = useGroupExternalIssues({
+  const externalIssueData = useGroupExternalIssues({
     group,
     event,
     project,
   });
+
+  return (
+    <ExternalIssueListContent
+      integrations={externalIssueData.integrations}
+      isLoading={externalIssueData.isLoading}
+      linkedIssues={externalIssueData.linkedIssues}
+    />
+  );
+}
+
+export function ExternalIssueListContent({
+  integrations,
+  isLoading,
+  linkedIssues,
+}: GroupIntegrationIssueResult) {
+  const organization = useOrganization();
+  const hasLinkedPullRequestsFeature = organization.features.includes(
+    'issue-details-linked-pull-requests'
+  );
 
   if (isLoading) {
     return <Placeholder height="25px" testId="issue-tracking-loading" />;
@@ -83,128 +65,59 @@ export function ExternalIssueList({group, event, project}: ExternalIssueListProp
     );
   }
 
+  const showIssueTrackerActions =
+    !hasLinkedPullRequestsFeature && integrations.length > 0;
+
   return (
     <Fragment>
-      {linkedIssues.length > 0 && (
-        <IssueActionWrapper>
-          {linkedIssues.map(linkedIssue => (
-            <ErrorBoundary key={linkedIssue.key} mini>
-              <Tooltip
-                overlayStyle={{maxWidth: '400px'}}
-                position="bottom"
-                title={
-                  <LinkedIssueTooltipWrapper>
-                    <LinkedIssueName>{linkedIssue.title}</LinkedIssueName>
-                    <HorizontalSeparator />
-                    <UnlinkButton
-                      variant="link"
-                      size="zero"
-                      onClick={linkedIssue.onUnlink}
-                    >
-                      {t('Unlink issue')}
-                    </UnlinkButton>
-                  </LinkedIssueTooltipWrapper>
-                }
-                isHoverable
-              >
-                <LinkedIssue
-                  href={linkedIssue.url}
-                  external
-                  size="zero"
-                  icon={linkedIssue.displayIcon}
-                >
-                  <IssueActionName>{linkedIssue.displayName}</IssueActionName>
-                </LinkedIssue>
-              </Tooltip>
-            </ErrorBoundary>
-          ))}
-        </IssueActionWrapper>
-      )}
-      {integrations.length > 0 && (
-        <IssueActionWrapper>
-          {integrations.map(integration => {
-            const sharedButtonProps: ButtonProps = {
-              size: 'zero',
-              icon: integration.displayIcon,
-              variant: 'transparent',
-              children: <IssueActionName>{integration.displayName}</IssueActionName>,
-            };
-
-            if (integration.actions.length === 1) {
-              const action = integration.actions[0]!;
-              return (
-                <ErrorBoundary key={integration.key} mini>
-                  {action.href ? (
-                    // Exclusively used for group.pluginActions
-                    <IssueActionLinkButton
-                      size="zero"
-                      icon={integration.displayIcon}
-                      disabled={integration.disabled}
-                      tooltipProps={{
-                        title: integration.disabled
-                          ? integration.disabledText
-                          : undefined,
-                      }}
-                      onClick={() => {
-                        action.onClick();
-                        trackAnalytics('feedback.details-integration-issue-clicked', {
-                          organization,
-                          integration_key: integration.key,
-                        });
-                      }}
-                      href={action.href}
-                      external
-                    >
-                      <IssueActionName>{integration.displayName}</IssueActionName>
-                    </IssueActionLinkButton>
-                  ) : (
-                    <IssueActionButton
-                      {...sharedButtonProps}
-                      disabled={integration.disabled}
-                      tooltipProps={{
-                        title: integration.disabled
-                          ? integration.disabledText
-                          : undefined,
-                      }}
-                      onClick={() => {
-                        action.onClick();
-                        trackAnalytics('feedback.details-integration-issue-clicked', {
-                          organization,
-                          integration_key: integration.key,
-                        });
-                      }}
-                    />
-                  )}
-                </ErrorBoundary>
-              );
-            }
-
-            return (
-              <ErrorBoundary key={integration.key} mini>
-                <DropdownMenu
-                  trigger={triggerProps => (
-                    <IssueActionDropdownMenu
-                      {...sharedButtonProps}
-                      {...triggerProps}
-                      showChevron={false}
-                    />
-                  )}
-                  items={integration.actions.map(action => ({
-                    key: action.id,
-                    ...getActionLabelAndTextValue({
-                      action,
-                      integrationDisplayName: integration.displayName,
-                    }),
-                    onAction: action.onClick,
-                    disabled: integration.disabled,
-                  }))}
-                />
-              </ErrorBoundary>
-            );
-          })}
-        </IssueActionWrapper>
+      {linkedIssues.length > 0 &&
+        (hasLinkedPullRequestsFeature ? (
+          <LinkedIssueRows linkedIssues={linkedIssues} />
+        ) : (
+          <LinkedIssuesList linkedIssues={linkedIssues} />
+        ))}
+      {showIssueTrackerActions && (
+        <InlineIssueTrackerActions integrations={integrations} />
       )}
     </Fragment>
+  );
+}
+
+function LinkedIssuesList({
+  linkedIssues,
+}: {
+  linkedIssues: GroupIntegrationIssueResult['linkedIssues'];
+}) {
+  return (
+    <IssueActionWrapper>
+      {linkedIssues.map(linkedIssue => (
+        <ErrorBoundary key={linkedIssue.key} mini>
+          <Tooltip
+            overlayStyle={{maxWidth: '400px'}}
+            position="bottom"
+            title={
+              <LinkedIssueTooltipWrapper>
+                <LinkedIssueName>{linkedIssue.title}</LinkedIssueName>
+                <HorizontalSeparator />
+                <UnlinkButton variant="link" size="zero" onClick={linkedIssue.onUnlink}>
+                  {t('Unlink issue')}
+                </UnlinkButton>
+              </LinkedIssueTooltipWrapper>
+            }
+            isHoverable
+          >
+            <LinkedIssue
+              href={linkedIssue.url}
+              external
+              size="zero"
+              icon={linkedIssue.displayIcon}
+            >
+              <IssueActionName>{linkedIssue.displayName}</IssueActionName>
+            </LinkedIssue>
+          </Tooltip>
+        </ErrorBoundary>
+      ))}
+    </IssueActionWrapper>
   );
 }
 
@@ -222,37 +135,6 @@ const LinkedIssue = styled(LinkButton)`
   border: none;
   border-radius: ${p => p.theme.radius.md};
   font-weight: normal;
-`;
-
-const IssueActionButton = styled(Button)`
-  display: flex;
-  align-items: center;
-  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
-  border: 1px dashed ${p => p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.md};
-  font-weight: normal;
-`;
-
-const IssueActionLinkButton = styled(LinkButton)`
-  display: flex;
-  align-items: center;
-  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
-  border: 1px dashed ${p => p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.md};
-  font-weight: normal;
-`;
-
-const IssueActionDropdownMenu = styled(DropdownButton)`
-  display: flex;
-  align-items: center;
-  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
-  border: 1px dashed ${p => p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.md};
-  font-weight: normal;
-
-  &[aria-expanded='true'] {
-    border: 1px solid ${p => p.theme.tokens.border.primary};
-  }
 `;
 
 const IssueActionName = styled('div')`

--- a/static/app/components/group/externalIssuesList/index.tsx
+++ b/static/app/components/group/externalIssuesList/index.tsx
@@ -48,9 +48,10 @@ export function ExternalIssueListContent({
   const hasLinkedPullRequestsFeature = organization.features.includes(
     'issue-details-linked-pull-requests'
   );
+  const loadingPlaceholderHeight = hasLinkedPullRequestsFeature ? '34px' : '25px';
 
   if (isLoading) {
-    return <Placeholder height="25px" testId="issue-tracking-loading" />;
+    return <Placeholder height={loadingPlaceholderHeight} />;
   }
 
   const hasLinkedIssuesOrIntegrations = integrations.length || linkedIssues.length;

--- a/static/app/components/group/externalIssuesList/issueTrackerActions.tsx
+++ b/static/app/components/group/externalIssuesList/issueTrackerActions.tsx
@@ -15,6 +15,8 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
+const ISSUE_TRACKER_MENU_MAX_HEIGHT = 300;
+
 interface InlineIssueTrackerActionsProps {
   integrations: ExternalIssueIntegration[];
 }
@@ -136,6 +138,7 @@ export function InlineIssueTrackerActions({
         return (
           <ErrorBoundary key={integration.key} mini>
             <DropdownMenu
+              maxMenuHeight={ISSUE_TRACKER_MENU_MAX_HEIGHT}
               trigger={triggerProps => (
                 <IssueActionDropdownMenu
                   {...sharedButtonProps}
@@ -266,6 +269,7 @@ export function IssueTrackerActionDropdown({
 
   return (
     <DropdownMenu
+      maxMenuHeight={ISSUE_TRACKER_MENU_MAX_HEIGHT}
       trigger={(triggerProps, isOpen) => (
         <DropdownButton
           {...triggerProps}

--- a/static/app/components/group/externalIssuesList/issueTrackerActions.tsx
+++ b/static/app/components/group/externalIssuesList/issueTrackerActions.tsx
@@ -13,6 +13,7 @@ import type {
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import type {Theme} from 'sentry/utils/theme';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 const ISSUE_TRACKER_MENU_MAX_HEIGHT = 300;
@@ -23,6 +24,7 @@ interface InlineIssueTrackerActionsProps {
 
 interface IssueTrackerActionDropdownProps {
   integrations: ExternalIssueIntegration[];
+  fullWidth?: boolean;
   isLoading?: boolean;
 }
 
@@ -198,6 +200,7 @@ export function InlineIssueTrackerActions({
 }
 
 export function IssueTrackerActionDropdown({
+  fullWidth,
   integrations,
   isLoading,
 }: IssueTrackerActionDropdownProps) {
@@ -262,8 +265,10 @@ export function IssueTrackerActionDropdown({
     const {action, isDisabled, onAction, tooltipTitle} = issueTrackerActions[0]!;
 
     if (action.href) {
+      const LinkButtonComponent = fullWidth ? FullWidthLinkButton : LinkButton;
+
       return (
-        <LinkButton
+        <LinkButtonComponent
           disabled={isDisabled}
           external
           href={action.href}
@@ -274,12 +279,14 @@ export function IssueTrackerActionDropdown({
           variant="transparent"
         >
           {issueTrackerActionLabel}
-        </LinkButton>
+        </LinkButtonComponent>
       );
     }
 
+    const ButtonComponent = fullWidth ? FullWidthButton : Button;
+
     return (
-      <Button
+      <ButtonComponent
         disabled={isDisabled}
         icon={<HeaderIssueTrackerIcon />}
         onClick={onAction}
@@ -288,25 +295,31 @@ export function IssueTrackerActionDropdown({
         variant="transparent"
       >
         {issueTrackerActionLabel}
-      </Button>
+      </ButtonComponent>
     );
   }
 
   return (
     <DropdownMenu
       maxMenuHeight={ISSUE_TRACKER_MENU_MAX_HEIGHT}
-      trigger={(triggerProps, isOpen) => (
-        <DropdownButton
-          {...triggerProps}
-          isOpen={isOpen}
-          icon={<HeaderIssueTrackerIcon />}
-          showChevron={false}
-          size="zero"
-          variant="transparent"
-        >
-          {issueTrackerActionLabel}
-        </DropdownButton>
-      )}
+      trigger={(triggerProps, isOpen) => {
+        const DropdownButtonComponent = fullWidth
+          ? FullWidthDropdownButton
+          : DropdownButton;
+
+        return (
+          <DropdownButtonComponent
+            {...triggerProps}
+            isOpen={isOpen}
+            icon={<HeaderIssueTrackerIcon />}
+            showChevron={false}
+            size="zero"
+            variant="transparent"
+          >
+            {issueTrackerActionLabel}
+          </DropdownButtonComponent>
+        );
+      }}
       items={issueTrackerActionGroups.map<MenuItemProps>(({integration, actions}) => ({
         key: integration.key,
         children: actions.map(
@@ -370,6 +383,26 @@ const IssueActionDropdownMenu = styled(DropdownButton)`
 
 const HeaderIssueTrackerIcon = styled(IconAdd)`
   transform: translateY(0);
+`;
+
+const fullWidthButtonStyles = (p: {theme: Theme}) => `
+  width: 100%;
+  min-height: 34px;
+  border: 1px dashed ${p.theme.tokens.border.primary};
+  border-radius: ${p.theme.radius.md};
+  font-size: ${p.theme.font.size.md};
+`;
+
+const FullWidthButton = styled(Button)`
+  ${fullWidthButtonStyles}
+`;
+
+const FullWidthLinkButton = styled(LinkButton)`
+  ${fullWidthButtonStyles}
+`;
+
+const FullWidthDropdownButton = styled(DropdownButton)`
+  ${fullWidthButtonStyles}
 `;
 
 const IssueTrackerIcon = styled('span')`

--- a/static/app/components/group/externalIssuesList/issueTrackerActions.tsx
+++ b/static/app/components/group/externalIssuesList/issueTrackerActions.tsx
@@ -101,7 +101,9 @@ export function InlineIssueTrackerActions({
       {integrations.map(integration => {
         const sharedButtonProps: ButtonProps = {
           size: 'zero',
-          icon: integration.displayIcon,
+          icon: integration.displayIcon ? (
+            <IssueTrackerIcon>{integration.displayIcon}</IssueTrackerIcon>
+          ) : undefined,
           variant: 'transparent',
           children: <IssueActionName>{integration.displayName}</IssueActionName>,
         };
@@ -126,7 +128,11 @@ export function InlineIssueTrackerActions({
                 // Exclusively used for group.pluginActions
                 <IssueActionLinkButton
                   size="zero"
-                  icon={integration.displayIcon}
+                  icon={
+                    integration.displayIcon ? (
+                      <IssueTrackerIcon>{integration.displayIcon}</IssueTrackerIcon>
+                    ) : undefined
+                  }
                   disabled={isDisabled}
                   tooltipProps={{title: tooltipTitle}}
                   onClick={onAction}
@@ -310,7 +316,9 @@ export function IssueTrackerActionDropdown({
             textValue,
             details: isDisabled ? tooltipTitle : details,
             leadingItems: (
-              <IssueTrackerMenuIcon>{integration.displayIcon}</IssueTrackerMenuIcon>
+              <IssueTrackerIcon style={{transform: 'translateY(3px)'}}>
+                {integration.displayIcon}
+              </IssueTrackerIcon>
             ),
             externalHref: action.href,
             disabled: isDisabled,
@@ -364,10 +372,13 @@ const HeaderIssueTrackerIcon = styled(IconAdd)`
   transform: translateY(0);
 `;
 
-const IssueTrackerMenuIcon = styled('span')`
+const IssueTrackerIcon = styled('span')`
   display: inline-flex;
   align-items: center;
-  transform: translateY(3px);
+  justify-content: center;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
 `;
 
 const IssueActionName = styled('div')`

--- a/static/app/components/group/externalIssuesList/issueTrackerActions.tsx
+++ b/static/app/components/group/externalIssuesList/issueTrackerActions.tsx
@@ -1,0 +1,363 @@
+import styled from '@emotion/styled';
+
+import {Button, LinkButton, type ButtonProps} from '@sentry/scraps/button';
+import {Text} from '@sentry/scraps/text';
+
+import {DropdownButton} from 'sentry/components/dropdownButton';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {ErrorBoundary} from 'sentry/components/errorBoundary';
+import type {
+  ExternalIssueAction,
+  ExternalIssueIntegration,
+} from 'sentry/components/group/externalIssuesList/hooks/types';
+import {IconAdd} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+interface InlineIssueTrackerActionsProps {
+  integrations: ExternalIssueIntegration[];
+}
+
+interface IssueTrackerActionDropdownProps {
+  integrations: ExternalIssueIntegration[];
+  isLoading?: boolean;
+}
+
+interface IssueTrackerActionMenuLabel {
+  label: string;
+  textValue: string;
+  details?: React.ReactNode;
+}
+
+function getIssueTrackerActionMenuLabel({
+  action,
+  integrationDisplayName,
+}: {
+  action: ExternalIssueAction;
+  integrationDisplayName: string;
+}): IssueTrackerActionMenuLabel {
+  // If there's no subtext or subtext matches name, just show name
+  if (!action.nameSubText || action.nameSubText === action.name) {
+    return {
+      label: action.name,
+      textValue: action.name,
+    };
+  }
+
+  // If action name matches integration name, just show subtext
+  if (action.name === integrationDisplayName) {
+    return {
+      label: action.nameSubText,
+      textValue: `${action.name} ${action.nameSubText}`,
+    };
+  }
+
+  // Otherwise show both name and subtext
+  return {
+    label: action.name,
+    details: (
+      <Text as="span" variant="muted">
+        {action.nameSubText}
+      </Text>
+    ),
+    textValue: `${action.name} ${action.nameSubText}`,
+  };
+}
+
+function getIssueTrackerActionAvailability(
+  integration: ExternalIssueIntegration,
+  action: ExternalIssueAction
+) {
+  const isDisabled = Boolean(integration.disabled || action.disabled);
+  const tooltipTitle = isDisabled
+    ? (integration.disabledText ?? action.disabledText)
+    : undefined;
+
+  return {isDisabled, tooltipTitle};
+}
+
+export function InlineIssueTrackerActions({
+  integrations,
+}: InlineIssueTrackerActionsProps) {
+  const organization = useOrganization();
+
+  return (
+    <IssueActionWrapper>
+      {integrations.map(integration => {
+        const sharedButtonProps: ButtonProps = {
+          size: 'zero',
+          icon: integration.displayIcon,
+          variant: 'transparent',
+          children: <IssueActionName>{integration.displayName}</IssueActionName>,
+        };
+
+        if (integration.actions.length === 1) {
+          const action = integration.actions[0]!;
+          const {isDisabled, tooltipTitle} = getIssueTrackerActionAvailability(
+            integration,
+            action
+          );
+          const onAction = () => {
+            action.onClick();
+            trackAnalytics('feedback.details-integration-issue-clicked', {
+              organization,
+              integration_key: integration.key,
+            });
+          };
+
+          return (
+            <ErrorBoundary key={integration.key} mini>
+              {action.href ? (
+                // Exclusively used for group.pluginActions
+                <IssueActionLinkButton
+                  size="zero"
+                  icon={integration.displayIcon}
+                  disabled={isDisabled}
+                  tooltipProps={{title: tooltipTitle}}
+                  onClick={onAction}
+                  href={action.href}
+                  external
+                >
+                  <IssueActionName>{integration.displayName}</IssueActionName>
+                </IssueActionLinkButton>
+              ) : (
+                <IssueActionButton
+                  {...sharedButtonProps}
+                  disabled={isDisabled}
+                  tooltipProps={{title: tooltipTitle}}
+                  onClick={onAction}
+                />
+              )}
+            </ErrorBoundary>
+          );
+        }
+
+        return (
+          <ErrorBoundary key={integration.key} mini>
+            <DropdownMenu
+              trigger={triggerProps => (
+                <IssueActionDropdownMenu
+                  {...sharedButtonProps}
+                  {...triggerProps}
+                  showChevron={false}
+                />
+              )}
+              items={integration.actions.map(action => {
+                const {isDisabled, tooltipTitle} = getIssueTrackerActionAvailability(
+                  integration,
+                  action
+                );
+                const {details, label, textValue} = getIssueTrackerActionMenuLabel({
+                  action,
+                  integrationDisplayName: integration.displayName,
+                });
+
+                return {
+                  key: action.id,
+                  label,
+                  textValue,
+                  details: isDisabled ? tooltipTitle : details,
+                  onAction: () => {
+                    action.onClick();
+                    trackAnalytics('feedback.details-integration-issue-clicked', {
+                      organization,
+                      integration_key: integration.key,
+                    });
+                  },
+                  disabled: isDisabled,
+                };
+              })}
+            />
+          </ErrorBoundary>
+        );
+      })}
+    </IssueActionWrapper>
+  );
+}
+
+export function IssueTrackerActionDropdown({
+  integrations,
+  isLoading,
+}: IssueTrackerActionDropdownProps) {
+  const organization = useOrganization();
+
+  if (isLoading || integrations.length === 0) {
+    return null;
+  }
+
+  const issueTrackerActions = integrations.flatMap(integration =>
+    integration.actions.map(action => {
+      const {details, label, textValue} =
+        integration.actions.length === 1
+          ? {
+              label: integration.displayName,
+              textValue: integration.displayName,
+            }
+          : getIssueTrackerActionMenuLabel({
+              action,
+              integrationDisplayName: integration.displayName,
+            });
+      const {isDisabled, tooltipTitle} = getIssueTrackerActionAvailability(
+        integration,
+        action
+      );
+      const onAction = () => {
+        action.onClick();
+        trackAnalytics('feedback.details-integration-issue-clicked', {
+          organization,
+          integration_key: integration.key,
+        });
+      };
+
+      return {
+        action,
+        details:
+          integration.actions.length === 1 && action.nameSubText ? (
+            <Text as="span" variant="muted">
+              {action.nameSubText}
+            </Text>
+          ) : (
+            details
+          ),
+        integration,
+        isDisabled,
+        label,
+        onAction,
+        textValue,
+        tooltipTitle,
+      };
+    })
+  );
+
+  if (issueTrackerActions.length === 1) {
+    const {action, isDisabled, onAction, tooltipTitle} = issueTrackerActions[0]!;
+
+    if (action.href) {
+      return (
+        <LinkButton
+          disabled={isDisabled}
+          external
+          href={action.href}
+          icon={<HeaderIssueTrackerIcon />}
+          onClick={onAction}
+          size="zero"
+          tooltipProps={{title: tooltipTitle}}
+          variant="transparent"
+        >
+          {t('Issue Tracker')}
+        </LinkButton>
+      );
+    }
+
+    return (
+      <Button
+        disabled={isDisabled}
+        icon={<HeaderIssueTrackerIcon />}
+        onClick={onAction}
+        size="zero"
+        tooltipProps={{title: tooltipTitle}}
+        variant="transparent"
+      >
+        {t('Issue Tracker')}
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu
+      trigger={(triggerProps, isOpen) => (
+        <DropdownButton
+          {...triggerProps}
+          isOpen={isOpen}
+          icon={<HeaderIssueTrackerIcon />}
+          showChevron={false}
+          size="zero"
+          variant="transparent"
+        >
+          {t('Issue Tracker')}
+        </DropdownButton>
+      )}
+      items={issueTrackerActions.map(
+        ({
+          action,
+          details,
+          integration,
+          isDisabled,
+          label,
+          onAction,
+          textValue,
+          tooltipTitle,
+        }) => ({
+          key: `${integration.key}-${action.id}`,
+          label,
+          textValue,
+          details: isDisabled ? tooltipTitle : details,
+          leadingItems: (
+            <IssueTrackerMenuIcon>{integration.displayIcon}</IssueTrackerMenuIcon>
+          ),
+          externalHref: action.href,
+          disabled: isDisabled,
+          onAction,
+        })
+      )}
+    />
+  );
+}
+
+const IssueActionWrapper = styled('span')`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${p => p.theme.space.md};
+  line-height: 1.2;
+`;
+
+const IssueActionButton = styled(Button)`
+  display: flex;
+  align-items: center;
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
+  border: 1px dashed ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  font-weight: normal;
+`;
+
+const IssueActionLinkButton = styled(LinkButton)`
+  display: flex;
+  align-items: center;
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
+  border: 1px dashed ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  font-weight: normal;
+`;
+
+const IssueActionDropdownMenu = styled(DropdownButton)`
+  display: flex;
+  align-items: center;
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
+  border: 1px dashed ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  font-weight: normal;
+
+  &[aria-expanded='true'] {
+    border: 1px solid ${p => p.theme.tokens.border.primary};
+  }
+`;
+
+const HeaderIssueTrackerIcon = styled(IconAdd)`
+  transform: translateY(0);
+`;
+
+const IssueTrackerMenuIcon = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  transform: translateY(3px);
+`;
+
+const IssueActionName = styled('div')`
+  display: block;
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+`;

--- a/static/app/components/group/externalIssuesList/issueTrackerActions.tsx
+++ b/static/app/components/group/externalIssuesList/issueTrackerActions.tsx
@@ -4,7 +4,7 @@ import {Button, LinkButton, type ButtonProps} from '@sentry/scraps/button';
 import {Text} from '@sentry/scraps/text';
 
 import {DropdownButton} from 'sentry/components/dropdownButton';
-import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import type {
   ExternalIssueAction,
@@ -27,7 +27,7 @@ interface IssueTrackerActionDropdownProps {
 }
 
 interface IssueTrackerActionMenuLabel {
-  label: string;
+  label: React.ReactNode;
   textValue: string;
   details?: React.ReactNode;
 }
@@ -42,7 +42,11 @@ function getIssueTrackerActionMenuLabel({
   // If there's no subtext or subtext matches name, just show name
   if (!action.nameSubText || action.nameSubText === action.name) {
     return {
-      label: action.name,
+      label: (
+        <Text as="span" bold>
+          {action.name}
+        </Text>
+      ),
       textValue: action.name,
     };
   }
@@ -50,14 +54,22 @@ function getIssueTrackerActionMenuLabel({
   // If action name matches integration name, just show subtext
   if (action.name === integrationDisplayName) {
     return {
-      label: action.nameSubText,
+      label: (
+        <Text as="span" bold>
+          {action.nameSubText}
+        </Text>
+      ),
       textValue: `${action.name} ${action.nameSubText}`,
     };
   }
 
   // Otherwise show both name and subtext
   return {
-    label: action.name,
+    label: (
+      <Text as="span" bold>
+        {action.name}
+      </Text>
+    ),
     details: (
       <Text as="span" variant="muted">
         {action.nameSubText}
@@ -190,12 +202,17 @@ export function IssueTrackerActionDropdown({
     return null;
   }
 
-  const issueTrackerActions = integrations.flatMap(integration =>
-    integration.actions.map(action => {
+  const issueTrackerActionGroups = integrations.map(integration => ({
+    integration,
+    actions: integration.actions.map(action => {
       const {details, label, textValue} =
         integration.actions.length === 1
           ? {
-              label: integration.displayName,
+              label: (
+                <Text as="span" bold>
+                  {integration.displayName}
+                </Text>
+              ),
               textValue: integration.displayName,
             }
           : getIssueTrackerActionMenuLabel({
@@ -231,8 +248,9 @@ export function IssueTrackerActionDropdown({
         textValue,
         tooltipTitle,
       };
-    })
-  );
+    }),
+  }));
+  const issueTrackerActions = issueTrackerActionGroups.flatMap(group => group.actions);
 
   if (issueTrackerActions.length === 1) {
     const {action, isDisabled, onAction, tooltipTitle} = issueTrackerActions[0]!;
@@ -283,29 +301,23 @@ export function IssueTrackerActionDropdown({
           {issueTrackerActionLabel}
         </DropdownButton>
       )}
-      items={issueTrackerActions.map(
-        ({
-          action,
-          details,
-          integration,
-          isDisabled,
-          label,
-          onAction,
-          textValue,
-          tooltipTitle,
-        }) => ({
-          key: `${integration.key}-${action.id}`,
-          label,
-          textValue,
-          details: isDisabled ? tooltipTitle : details,
-          leadingItems: (
-            <IssueTrackerMenuIcon>{integration.displayIcon}</IssueTrackerMenuIcon>
-          ),
-          externalHref: action.href,
-          disabled: isDisabled,
-          onAction,
-        })
-      )}
+      items={issueTrackerActionGroups.map<MenuItemProps>(({integration, actions}) => ({
+        key: integration.key,
+        children: actions.map(
+          ({action, details, isDisabled, label, onAction, textValue, tooltipTitle}) => ({
+            key: `${integration.key}-${action.id}`,
+            label,
+            textValue,
+            details: isDisabled ? tooltipTitle : details,
+            leadingItems: (
+              <IssueTrackerMenuIcon>{integration.displayIcon}</IssueTrackerMenuIcon>
+            ),
+            externalHref: action.href,
+            disabled: isDisabled,
+            onAction,
+          })
+        ),
+      }))}
     />
   );
 }

--- a/static/app/components/group/externalIssuesList/issueTrackerActions.tsx
+++ b/static/app/components/group/externalIssuesList/issueTrackerActions.tsx
@@ -184,6 +184,7 @@ export function IssueTrackerActionDropdown({
   isLoading,
 }: IssueTrackerActionDropdownProps) {
   const organization = useOrganization();
+  const issueTrackerActionLabel = t('Link issue');
 
   if (isLoading || integrations.length === 0) {
     return null;
@@ -248,7 +249,7 @@ export function IssueTrackerActionDropdown({
           tooltipProps={{title: tooltipTitle}}
           variant="transparent"
         >
-          {t('Issue Tracker')}
+          {issueTrackerActionLabel}
         </LinkButton>
       );
     }
@@ -262,7 +263,7 @@ export function IssueTrackerActionDropdown({
         tooltipProps={{title: tooltipTitle}}
         variant="transparent"
       >
-        {t('Issue Tracker')}
+        {issueTrackerActionLabel}
       </Button>
     );
   }
@@ -279,7 +280,7 @@ export function IssueTrackerActionDropdown({
           size="zero"
           variant="transparent"
         >
-          {t('Issue Tracker')}
+          {issueTrackerActionLabel}
         </DropdownButton>
       )}
       items={issueTrackerActions.map(

--- a/static/app/components/group/externalIssuesList/linkedIssueRows.tsx
+++ b/static/app/components/group/externalIssuesList/linkedIssueRows.tsx
@@ -68,16 +68,13 @@ function LinkedIssueRow({linkedIssue}: LinkedIssueRowProps) {
           padding={hasSubtitle ? 'sm' : 'xs sm'}
           width="100%"
         >
-          <Flex
-            as="span"
+          <LinkedIssueRowIcon
             aria-hidden
-            align={hasSubtitle ? 'start' : 'center'}
-            display="inline-flex"
-            paddingTop={hasSubtitle ? '2xs' : undefined}
+            hasSubtitle={hasSubtitle}
             style={hasSubtitle ? undefined : {transform: 'translateY(-1px)'}}
           >
             {linkedIssue.displayIcon}
-          </Flex>
+          </LinkedIssueRowIcon>
           <Flex as="span" direction="column" gap={hasSubtitle ? '2xs' : '0'} minWidth={0}>
             <LinkedIssueRowTitle title={title}>{title}</LinkedIssueRowTitle>
             {subtitle && (
@@ -98,7 +95,7 @@ function LinkedIssueRow({linkedIssue}: LinkedIssueRowProps) {
         <Tooltip title={t('Unlink issue')} skipWrapper>
           <Button
             aria-label={t('Unlink %s', title)}
-            icon={<IconClose />}
+            icon={<IconClose variant="muted" />}
             onClick={linkedIssue.onUnlink}
             size="zero"
             variant="transparent"
@@ -125,6 +122,22 @@ const LinkedIssueRowLink = styled(ExternalLink)`
   min-width: 0;
   width: 100%;
   color: ${p => p.theme.tokens.content.primary};
+
+  &:hover {
+    color: ${p => p.theme.tokens.content.primary};
+  }
+`;
+
+const LinkedIssueRowIcon = styled('span', {
+  shouldForwardProp: prop => prop !== 'hasSubtitle',
+})<{hasSubtitle: boolean}>`
+  display: inline-flex;
+  align-items: ${p => (p.hasSubtitle ? 'flex-start' : 'center')};
+  justify-content: center;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  padding-top: ${p => (p.hasSubtitle ? p.theme.space['2xs'] : 0)};
 `;
 
 const LinkedIssueRowTitle = styled('span')`

--- a/static/app/components/group/externalIssuesList/linkedIssueRows.tsx
+++ b/static/app/components/group/externalIssuesList/linkedIssueRows.tsx
@@ -1,13 +1,14 @@
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import type {GroupIntegrationIssueResult} from 'sentry/components/group/externalIssuesList/hooks/types';
-import {IconDelete} from 'sentry/icons';
+import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
 interface LinkedIssueRowsProps {
@@ -55,6 +56,7 @@ function LinkedIssueRow({linkedIssue}: LinkedIssueRowProps) {
 
   return (
     <LinkedIssueRowGrid>
+      <InteractionStateLayer />
       <LinkedIssueRowLink
         aria-label={subtitle ? t('%s, %s', title, subtitle) : title}
         href={linkedIssue.url}
@@ -91,11 +93,12 @@ function LinkedIssueRow({linkedIssue}: LinkedIssueRowProps) {
         align="center"
         padding={hasSubtitle ? 'sm' : 'xs sm'}
         paddingLeft="0"
+        paddingRight="xs"
       >
         <Tooltip title={t('Unlink issue')} skipWrapper>
           <Button
             aria-label={t('Unlink %s', title)}
-            icon={<IconDelete />}
+            icon={<IconClose />}
             onClick={linkedIssue.onUnlink}
             size="zero"
             variant="transparent"
@@ -107,26 +110,21 @@ function LinkedIssueRow({linkedIssue}: LinkedIssueRowProps) {
 }
 
 const LinkedIssueRowGrid = styled('div')`
+  position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr) max-content;
   align-items: stretch;
+  overflow: hidden;
   color: ${p => p.theme.tokens.content.primary};
-
-  &:hover {
-    background: ${p => p.theme.tokens.background.secondary};
-  }
 `;
 
 const LinkedIssueRowLink = styled(ExternalLink)`
+  position: relative;
   display: flex;
   align-items: center;
   min-width: 0;
   width: 100%;
   color: ${p => p.theme.tokens.content.primary};
-
-  &:hover {
-    color: ${p => p.theme.tokens.content.primary};
-  }
 `;
 
 const LinkedIssueRowTitle = styled('span')`
@@ -134,8 +132,6 @@ const LinkedIssueRowTitle = styled('span')`
   overflow: hidden;
   width: 100%;
   font-weight: ${p => p.theme.font.weight.sans.medium};
-  font-variant-ligatures: no-common-ligatures;
-  font-feature-settings: 'liga' 0;
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/static/app/components/group/externalIssuesList/linkedIssueRows.tsx
+++ b/static/app/components/group/externalIssuesList/linkedIssueRows.tsx
@@ -1,0 +1,142 @@
+import styled from '@emotion/styled';
+
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import type {GroupIntegrationIssueResult} from 'sentry/components/group/externalIssuesList/hooks/types';
+import {IconDelete} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+interface LinkedIssueRowsProps {
+  linkedIssues: GroupIntegrationIssueResult['linkedIssues'];
+}
+
+interface LinkedIssueRowProps {
+  linkedIssue: GroupIntegrationIssueResult['linkedIssues'][number];
+}
+
+export function LinkedIssueRows({linkedIssues}: LinkedIssueRowsProps) {
+  return (
+    <Flex
+      as="ul"
+      aria-label={t('Linked issues')}
+      direction="column"
+      border="primary"
+      radius="md"
+      overflow="hidden"
+      margin="0"
+      padding="0"
+    >
+      {linkedIssues.map((linkedIssue, index) => (
+        <Container
+          as="li"
+          key={linkedIssue.key}
+          borderTop={index === 0 ? undefined : 'primary'}
+          style={{listStyle: 'none'}}
+        >
+          <LinkedIssueRow linkedIssue={linkedIssue} />
+        </Container>
+      ))}
+    </Flex>
+  );
+}
+
+function LinkedIssueRow({linkedIssue}: LinkedIssueRowProps) {
+  const title = linkedIssue.title || linkedIssue.displayName;
+  const subtitle =
+    linkedIssue.displayName &&
+    !title.toLocaleLowerCase().includes(linkedIssue.displayName.toLocaleLowerCase())
+      ? linkedIssue.displayName
+      : null;
+  const hasSubtitle = Boolean(subtitle);
+
+  return (
+    <LinkedIssueRowGrid>
+      <LinkedIssueRowLink
+        aria-label={subtitle ? t('%s, %s', title, subtitle) : title}
+        href={linkedIssue.url}
+      >
+        <Grid
+          align={hasSubtitle ? 'start' : 'center'}
+          columns="max-content minmax(0, 1fr)"
+          gap="sm"
+          padding={hasSubtitle ? 'sm' : 'xs sm'}
+          width="100%"
+        >
+          <Flex
+            as="span"
+            aria-hidden
+            align={hasSubtitle ? 'start' : 'center'}
+            display="inline-flex"
+            paddingTop={hasSubtitle ? '2xs' : undefined}
+            style={hasSubtitle ? undefined : {transform: 'translateY(-1px)'}}
+          >
+            {linkedIssue.displayIcon}
+          </Flex>
+          <Flex as="span" direction="column" gap={hasSubtitle ? '2xs' : '0'} minWidth={0}>
+            <LinkedIssueRowTitle title={title}>{title}</LinkedIssueRowTitle>
+            {subtitle && (
+              <Text as="span" ellipsis size="sm" title={subtitle} variant="muted">
+                {subtitle}
+              </Text>
+            )}
+          </Flex>
+        </Grid>
+      </LinkedIssueRowLink>
+      <Flex
+        as="span"
+        align="center"
+        padding={hasSubtitle ? 'sm' : 'xs sm'}
+        paddingLeft="0"
+      >
+        <Tooltip title={t('Unlink issue')} skipWrapper>
+          <Button
+            aria-label={t('Unlink %s', title)}
+            icon={<IconDelete />}
+            onClick={linkedIssue.onUnlink}
+            size="zero"
+            variant="transparent"
+          />
+        </Tooltip>
+      </Flex>
+    </LinkedIssueRowGrid>
+  );
+}
+
+const LinkedIssueRowGrid = styled('div')`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: stretch;
+  color: ${p => p.theme.tokens.content.primary};
+
+  &:hover {
+    background: ${p => p.theme.tokens.background.secondary};
+  }
+`;
+
+const LinkedIssueRowLink = styled(ExternalLink)`
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  width: 100%;
+  color: ${p => p.theme.tokens.content.primary};
+
+  &:hover {
+    color: ${p => p.theme.tokens.content.primary};
+  }
+`;
+
+const LinkedIssueRowTitle = styled('span')`
+  display: block;
+  overflow: hidden;
+  width: 100%;
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+  font-variant-ligatures: no-common-ligatures;
+  font-feature-settings: 'liga' 0;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -129,11 +129,11 @@ function LinkedPullRequestRow({pullRequest}: {pullRequest: LinkedPullRequest}) {
   );
 }
 
-export function LinkedPullRequests({group, showEmptyState}: LinkedPullRequestsProps) {
+export function useLinkedPullRequests({group}: {group: Group}) {
   const organization = useOrganization();
   const hasFeature = organization.features.includes(LINKED_PULL_REQUESTS_FEATURE);
 
-  const {data, isError} = useQuery(
+  return useQuery(
     apiOptions.as<LinkedPullRequestsResponse>()(
       '/organizations/$organizationIdOrSlug/issues/$issueId/pull-requests/',
       {
@@ -144,6 +144,12 @@ export function LinkedPullRequests({group, showEmptyState}: LinkedPullRequestsPr
       }
     )
   );
+}
+
+export function LinkedPullRequests({group, showEmptyState}: LinkedPullRequestsProps) {
+  const organization = useOrganization();
+  const hasFeature = organization.features.includes(LINKED_PULL_REQUESTS_FEATURE);
+  const {data, isError} = useLinkedPullRequests({group});
 
   if (!hasFeature || isError) {
     return null;

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -209,8 +209,6 @@ const PullRequestTitle = styled('span')`
   overflow: hidden;
   width: 100%;
   font-weight: ${p => p.theme.font.weight.sans.medium};
-  font-variant-ligatures: no-common-ligatures;
-  font-feature-settings: 'liga' 0;
   text-overflow: ellipsis;
   white-space: nowrap;
 `;

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -151,7 +151,9 @@ export function LinkedPullRequests({group, showEmptyState}: LinkedPullRequestsPr
 
   if (data?.pullRequests.length === 0) {
     return showEmptyState ? (
-      <EmptyLinksText variant="muted">{t('No external links yet')}</EmptyLinksText>
+      <EmptyLinksText variant="muted">
+        {t('No linked issues or pull requests')}
+      </EmptyLinksText>
     ) : null;
   }
 

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -32,6 +32,11 @@ type LinkedPullRequestsResponse = {
   pullRequests: LinkedPullRequest[];
 };
 
+interface LinkedPullRequestsProps {
+  group: Group;
+  showEmptyState?: boolean;
+}
+
 type StatusIconConfig = {
   Icon: React.ComponentType<SVGIconProps>;
   variant: SVGIconProps['variant'];
@@ -124,7 +129,7 @@ function LinkedPullRequestRow({pullRequest}: {pullRequest: LinkedPullRequest}) {
   );
 }
 
-export function LinkedPullRequests({group}: {group: Group}) {
+export function LinkedPullRequests({group, showEmptyState}: LinkedPullRequestsProps) {
   const organization = useOrganization();
   const hasFeature = organization.features.includes(LINKED_PULL_REQUESTS_FEATURE);
 
@@ -140,7 +145,17 @@ export function LinkedPullRequests({group}: {group: Group}) {
     )
   );
 
-  if (!hasFeature || isError || !data?.pullRequests.length) {
+  if (!hasFeature || isError) {
+    return null;
+  }
+
+  if (data?.pullRequests.length === 0) {
+    return showEmptyState ? (
+      <EmptyLinksText variant="muted">{t('No external links yet')}</EmptyLinksText>
+    ) : null;
+  }
+
+  if (!data?.pullRequests.length) {
     return null;
   }
 
@@ -177,6 +192,10 @@ const PullRequestRow = styled(ExternalLink)`
     color: ${p => p.theme.tokens.content.primary};
     background: ${p => p.theme.tokens.background.secondary};
   }
+`;
+
+const EmptyLinksText = styled(Text)`
+  margin: 0;
 `;
 
 const RepositoryIcon = styled(IconRepository)`

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
@@ -8,18 +8,40 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {SentryAppComponentFixture} from 'sentry-fixture/sentryAppComponent';
 import {SentryAppInstallationFixture} from 'sentry-fixture/sentryAppInstallation';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import {SentryAppComponentsStore} from 'sentry/stores/sentryAppComponentsStore';
 import {SentryAppInstallationStore} from 'sentry/stores/sentryAppInstallationsStore';
+import type {GroupIntegration} from 'sentry/types/integrations';
 
 import {ExternalIssueSidebarList} from './externalIssueSidebarList';
 
 describe('ExternalIssueSidebarList', () => {
   const organization = OrganizationFixture();
+  const organizationWithLinkedPullRequestsFeature = OrganizationFixture({
+    features: ['issue-details-linked-pull-requests'],
+  });
   const event = EventFixture();
   const group = GroupFixture();
   const project = ProjectFixture();
+
+  function mockLinkedPullRequestsFeatureRequests(integrations: GroupIntegration[]) {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
+      body: {pullRequests: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,
+      body: integrations,
+    });
+  }
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -177,6 +199,105 @@ describe('ExternalIssueSidebarList', () => {
     ).toBeInTheDocument();
     expect(
       await screen.findByRole('menuitemradio', {name: /GitHub codecov/})
+    ).toBeInTheDocument();
+  });
+
+  it('should render issue tracker actions in the section header', async () => {
+    mockLinkedPullRequestsFeatureRequests([
+      GitHubIntegrationFixture({
+        status: 'active',
+        externalIssues: [],
+        name: 'GitHub sentry',
+      }),
+      JiraIntegrationFixture({
+        id: '2',
+        status: 'active',
+        externalIssues: [],
+        name: 'Jira Integration',
+        domainName: 'example.com',
+      }),
+    ]);
+
+    render(<ExternalIssueSidebarList event={event} group={group} project={project} />, {
+      organization: organizationWithLinkedPullRequestsFeature,
+    });
+
+    expect(await screen.findByText('External Links')).toBeInTheDocument();
+    expect(screen.queryByText('Issue Tracking')).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', {name: 'Issue Tracker'})
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'GitHub'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Jira'})).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Issue Tracker'}));
+
+    expect(
+      await screen.findByRole('menuitemradio', {name: 'GitHub'})
+    ).toBeInTheDocument();
+    expect(await screen.findByRole('menuitemradio', {name: 'Jira'})).toBeInTheDocument();
+  });
+
+  it('should open the integration modal directly when there is one issue tracker action', async () => {
+    mockLinkedPullRequestsFeatureRequests([
+      GitHubIntegrationFixture({
+        id: '1',
+        status: 'active',
+        externalIssues: [],
+        name: 'GitHub sentry',
+      }),
+    ]);
+    const configMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/integrations/1/`,
+      match: [MockApiClient.matchQuery({action: 'create'})],
+      body: {createIssueConfig: [], linkIssueConfig: []},
+    });
+
+    render(<ExternalIssueSidebarList event={event} group={group} project={project} />, {
+      organization: organizationWithLinkedPullRequestsFeature,
+    });
+    renderGlobalModal({organization: organizationWithLinkedPullRequestsFeature});
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Issue Tracker'}));
+
+    expect(screen.queryByRole('menuitemradio', {name: 'GitHub'})).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(configMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should render linked issues as full-width rows', async () => {
+    const issueKey = 'DE#1275';
+    const issueTitle = 'Linear: DE#1275';
+    mockLinkedPullRequestsFeatureRequests([
+      GitHubIntegrationFixture({
+        status: 'active',
+        externalIssues: [
+          {
+            id: '321',
+            key: issueKey,
+            url: 'https://linear.app/example/issue/DE-1275',
+            title: issueTitle,
+            description: 'something else, sorry',
+            displayName: '',
+          },
+        ],
+      }),
+    ]);
+
+    render(<ExternalIssueSidebarList event={event} group={group} project={project} />, {
+      organization: organizationWithLinkedPullRequestsFeature,
+    });
+
+    const linkedIssues = await screen.findByRole('list', {name: 'Linked issues'});
+    expect(within(linkedIssues).getByRole('link', {name: issueTitle})).toHaveAttribute(
+      'href',
+      'https://linear.app/example/issue/DE-1275'
+    );
+    expect(within(linkedIssues).queryByText(issueKey)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: issueKey})).not.toBeInTheDocument();
+    expect(
+      within(linkedIssues).getByRole('button', {name: `Unlink ${issueTitle}`})
     ).toBeInTheDocument();
   });
 

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
@@ -224,13 +224,11 @@ describe('ExternalIssueSidebarList', () => {
 
     expect(await screen.findByText('External Links')).toBeInTheDocument();
     expect(screen.queryByText('Issue Tracking')).not.toBeInTheDocument();
-    expect(
-      await screen.findByRole('button', {name: 'Issue Tracker'})
-    ).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'Link issue'})).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'GitHub'})).not.toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Jira'})).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Issue Tracker'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Link issue'}));
 
     expect(
       await screen.findByRole('menuitemradio', {name: 'GitHub'})
@@ -258,7 +256,7 @@ describe('ExternalIssueSidebarList', () => {
     });
     renderGlobalModal({organization: organizationWithLinkedPullRequestsFeature});
 
-    await userEvent.click(await screen.findByRole('button', {name: 'Issue Tracker'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Link issue'}));
 
     expect(screen.queryByRole('menuitemradio', {name: 'GitHub'})).not.toBeInTheDocument();
     await waitFor(() => {
@@ -317,7 +315,7 @@ describe('ExternalIssueSidebarList', () => {
     expect(
       await screen.findByText('No linked issues or pull requests')
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Issue Tracker'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Link issue'})).toBeInTheDocument();
   });
 
   it('should render empty state when no integrations', async () => {

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
@@ -301,6 +301,23 @@ describe('ExternalIssueSidebarList', () => {
     ).toBeInTheDocument();
   });
 
+  it('should render an external links empty state', async () => {
+    mockLinkedPullRequestsFeatureRequests([
+      GitHubIntegrationFixture({
+        status: 'active',
+        externalIssues: [],
+        name: 'GitHub sentry',
+      }),
+    ]);
+
+    render(<ExternalIssueSidebarList event={event} group={group} project={project} />, {
+      organization: organizationWithLinkedPullRequestsFeature,
+    });
+
+    expect(await screen.findByText('No external links yet')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Issue Tracker'})).toBeInTheDocument();
+  });
+
   it('should render empty state when no integrations', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
@@ -314,7 +314,9 @@ describe('ExternalIssueSidebarList', () => {
       organization: organizationWithLinkedPullRequestsFeature,
     });
 
-    expect(await screen.findByText('No external links yet')).toBeInTheDocument();
+    expect(
+      await screen.findByText('No linked issues or pull requests')
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Issue Tracker'})).toBeInTheDocument();
   });
 

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
@@ -203,6 +203,19 @@ describe('ExternalIssueSidebarList', () => {
   });
 
   it('should render issue tracker actions in the section header', async () => {
+    const asanaComponent = SentryAppComponentFixture({
+      sentryApp: {
+        ...SentryAppComponentFixture().sentryApp,
+        slug: 'asana',
+        name: 'Asana',
+      },
+    });
+    SentryAppComponentsStore.loadComponents([asanaComponent]);
+    SentryAppInstallationStore.load([
+      SentryAppInstallationFixture({
+        app: asanaComponent.sentryApp,
+      }),
+    ]);
     mockLinkedPullRequestsFeatureRequests([
       GitHubIntegrationFixture({
         status: 'active',
@@ -230,10 +243,16 @@ describe('ExternalIssueSidebarList', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'Link issue'}));
 
+    const menu = await screen.findByRole('menu');
+    expect(within(menu).getAllByRole('separator')).toHaveLength(2);
+    expect(await screen.findByRole('menuitemradio', {name: 'Asana'})).toBeInTheDocument();
     expect(
       await screen.findByRole('menuitemradio', {name: 'GitHub'})
     ).toBeInTheDocument();
     expect(await screen.findByRole('menuitemradio', {name: 'Jira'})).toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitemradio', {name: 'Create Issue'})
+    ).not.toBeInTheDocument();
   });
 
   it('should open the integration modal directly when there is one issue tracker action', async () => {

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
@@ -331,10 +331,10 @@ describe('ExternalIssueSidebarList', () => {
       organization: organizationWithLinkedPullRequestsFeature,
     });
 
+    expect(await screen.findByRole('button', {name: 'Link issue'})).toBeInTheDocument();
     expect(
-      await screen.findByText('No linked issues or pull requests')
-    ).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Link issue'})).toBeInTheDocument();
+      screen.queryByText('No linked issues or pull requests')
+    ).not.toBeInTheDocument();
   });
 
   it('should render empty state when no integrations', async () => {

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
@@ -339,6 +339,10 @@ describe('ExternalIssueSidebarList', () => {
 
   it('should render empty state when no integrations', async () => {
     MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
+      body: {pullRequests: []},
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,
       body: [],
     });
@@ -347,11 +351,16 @@ describe('ExternalIssueSidebarList', () => {
       body: [],
     });
 
-    render(<ExternalIssueSidebarList event={event} group={group} project={project} />);
+    render(<ExternalIssueSidebarList event={event} group={group} project={project} />, {
+      organization: organizationWithLinkedPullRequestsFeature,
+    });
 
     expect(
       await screen.findByText('Track this issue in Jira, GitHub, etc.')
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText('No linked issues or pull requests')
+    ).not.toBeInTheDocument();
   });
 
   it('should render dropdown items with subtext correctly', async () => {

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
@@ -55,7 +55,9 @@ export function ExternalIssueSidebarList({event, group, project}: Props) {
           <LinkedPullRequests
             group={group}
             showEmptyState={
-              hasLinkedPullRequestsFeature && externalIssueData.linkedIssues.length === 0
+              hasLinkedPullRequestsFeature &&
+              !externalIssueData.isLoading &&
+              externalIssueData.linkedIssues.length === 0
             }
           />
         </ErrorBoundary>

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
@@ -57,6 +57,7 @@ export function ExternalIssueSidebarList({event, group, project}: Props) {
             showEmptyState={
               hasLinkedPullRequestsFeature &&
               !externalIssueData.isLoading &&
+              externalIssueData.integrations.length > 0 &&
               externalIssueData.linkedIssues.length === 0
             }
           />

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
@@ -2,12 +2,15 @@ import {Flex} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
-import {ExternalIssueList} from 'sentry/components/group/externalIssuesList';
+import {ExternalIssueListContent} from 'sentry/components/group/externalIssuesList';
+import {useGroupExternalIssues} from 'sentry/components/group/externalIssuesList/hooks/useGroupExternalIssues';
+import {IssueTrackerActionDropdown} from 'sentry/components/group/externalIssuesList/issueTrackerActions';
 import {LinkedPullRequests} from 'sentry/components/group/externalIssuesList/linkedPullRequests';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {SectionKey} from 'sentry/views/issueDetails/context';
 import {SidebarFoldSection} from 'sentry/views/issueDetails/foldSection';
 
@@ -18,18 +21,36 @@ interface Props {
 }
 
 export function ExternalIssueSidebarList({event, group, project}: Props) {
+  const organization = useOrganization();
+  const hasLinkedPullRequestsFeature = organization.features.includes(
+    'issue-details-linked-pull-requests'
+  );
+  const externalIssueData = useGroupExternalIssues({group, event, project});
+
   return (
     <SidebarFoldSection
       dataTestId="linked-issues"
       title={
         <Heading as="h3" size="md">
-          {t('Issue Tracking')}
+          {hasLinkedPullRequestsFeature ? t('External Links') : t('Issue Tracking')}
         </Heading>
+      }
+      actions={
+        hasLinkedPullRequestsFeature ? (
+          <IssueTrackerActionDropdown
+            integrations={externalIssueData.integrations}
+            isLoading={externalIssueData.isLoading}
+          />
+        ) : undefined
       }
       sectionKey={SectionKey.EXTERNAL_ISSUES}
     >
       <Flex direction="column" gap="md">
-        <ExternalIssueList group={group} event={event} project={project} />
+        <ExternalIssueListContent
+          integrations={externalIssueData.integrations}
+          isLoading={externalIssueData.isLoading}
+          linkedIssues={externalIssueData.linkedIssues}
+        />
         <ErrorBoundary customComponent={null}>
           <LinkedPullRequests group={group} />
         </ErrorBoundary>

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
@@ -5,7 +5,10 @@ import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {ExternalIssueListContent} from 'sentry/components/group/externalIssuesList';
 import {useGroupExternalIssues} from 'sentry/components/group/externalIssuesList/hooks/useGroupExternalIssues';
 import {IssueTrackerActionDropdown} from 'sentry/components/group/externalIssuesList/issueTrackerActions';
-import {LinkedPullRequests} from 'sentry/components/group/externalIssuesList/linkedPullRequests';
+import {
+  LinkedPullRequests,
+  useLinkedPullRequests,
+} from 'sentry/components/group/externalIssuesList/linkedPullRequests';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
@@ -26,6 +29,15 @@ export function ExternalIssueSidebarList({event, group, project}: Props) {
     'issue-details-linked-pull-requests'
   );
   const externalIssueData = useGroupExternalIssues({group, event, project});
+  const {data: linkedPullRequestsData, isPending: isLinkedPullRequestsLoading} =
+    useLinkedPullRequests({group});
+  const showEmptyIssueTrackerAction =
+    hasLinkedPullRequestsFeature &&
+    !externalIssueData.isLoading &&
+    !isLinkedPullRequestsLoading &&
+    externalIssueData.integrations.length > 0 &&
+    externalIssueData.linkedIssues.length === 0 &&
+    linkedPullRequestsData?.pullRequests.length === 0;
 
   return (
     <SidebarFoldSection
@@ -36,7 +48,7 @@ export function ExternalIssueSidebarList({event, group, project}: Props) {
         </Heading>
       }
       actions={
-        hasLinkedPullRequestsFeature ? (
+        hasLinkedPullRequestsFeature && !showEmptyIssueTrackerAction ? (
           <IssueTrackerActionDropdown
             integrations={externalIssueData.integrations}
             isLoading={externalIssueData.isLoading}
@@ -56,12 +68,20 @@ export function ExternalIssueSidebarList({event, group, project}: Props) {
             group={group}
             showEmptyState={
               hasLinkedPullRequestsFeature &&
+              !showEmptyIssueTrackerAction &&
               !externalIssueData.isLoading &&
               externalIssueData.integrations.length > 0 &&
               externalIssueData.linkedIssues.length === 0
             }
           />
         </ErrorBoundary>
+        {showEmptyIssueTrackerAction && (
+          <IssueTrackerActionDropdown
+            fullWidth
+            integrations={externalIssueData.integrations}
+            isLoading={externalIssueData.isLoading}
+          />
+        )}
       </Flex>
     </SidebarFoldSection>
   );

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
@@ -52,7 +52,12 @@ export function ExternalIssueSidebarList({event, group, project}: Props) {
           linkedIssues={externalIssueData.linkedIssues}
         />
         <ErrorBoundary customComponent={null}>
-          <LinkedPullRequests group={group} />
+          <LinkedPullRequests
+            group={group}
+            showEmptyState={
+              hasLinkedPullRequestsFeature && externalIssueData.linkedIssues.length === 0
+            }
+          />
         </ErrorBoundary>
       </Flex>
     </SidebarFoldSection>


### PR DESCRIPTION
adds a dropdown to link issues and makes linked issues appear as full lines. Behind the flag used for the pull requests that appear below linked issues.

external integrations appear as a single line, seen here with the new pull requests

<img width="334" height="217" alt="image" src="https://github.com/user-attachments/assets/a9e1ea57-9e95-4e81-9816-34ca218420d4" />

internal integrations have more information

<img width="334" height="140" alt="image" src="https://github.com/user-attachments/assets/b9880e58-349c-429a-a9e6-526b060a3029" />

the dropdown

<img width="252" height="328" alt="image" src="https://github.com/user-attachments/assets/9654d002-be24-4fed-bbf3-f703217feb67" />

new empty state

<img width="338" height="107" alt="image" src="https://github.com/user-attachments/assets/2e413bbc-28f6-45db-9469-3adf0b7ddad3" />


the current behavior (most orgs don't have this many integrations)

<img width="377" height="251" alt="image" src="https://github.com/user-attachments/assets/eb5b711c-43ae-46ad-9e1b-416c83da7dec" />

fixes https://linear.app/getsentry/issue/ID-1614

NOTE: i changed it to + link issue after getting all the screenshots