### PR TITLE
fix(workflows): Validate delayed workflow tag filter keys

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from rest_framework.exceptions import APIException, ParseError, Throttled, ValidationError
 from rest_framework.status import HTTP_504_GATEWAY_TIMEOUT
 from sentry_sdk import Scope
+from snuba_sdk.column import InvalidColumnError
 from urllib3.exceptions import MaxRetryError, ReadTimeoutError, TimeoutError
 
 from sentry import options, quotas
@@ -368,6 +369,10 @@ def get_auth_api_token_type(auth: object) -> str | None:
 def handle_query_errors() -> Generator[None]:
     try:
         yield
+    except InvalidColumnError as error:
+        message = str(error)
+        sentry_sdk.set_tag("query.error_reason", message)
+        raise ParseError(detail=message)
     except InvalidSearchQuery as error:
         message = original_error = str(error)
         # Special case the project message since it has so many variants so tagging is messy otherwise

--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from django import forms
+from django.core.validators import RegexValidator
 
 from sentry import tagstore
 from sentry.rules import MATCH_CHOICES, EventState, MatchType, match_values
@@ -12,11 +13,15 @@ from sentry.rules.history.preview_strategy import get_dataset_columns
 from sentry.services.eventstore.models import GroupEvent
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.events import Columns
+from sentry.tagstore.base import TAG_KEY_RE
 from sentry.types.condition_activity import ConditionActivity
 
 
 class TaggedEventForm(forms.Form):
-    key = forms.CharField(widget=forms.TextInput())
+    key = forms.CharField(
+        widget=forms.TextInput(),
+        validators=[RegexValidator(TAG_KEY_RE, "Invalid tag key format.")],
+    )
     match = forms.ChoiceField(choices=list(MATCH_CHOICES.items()), widget=forms.Select())
     value = forms.CharField(widget=forms.TextInput(), required=False)
 

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -24,6 +24,7 @@ from sentry.rules.conditions.event_frequency import (
     STANDARD_INTERVALS,
 )
 from sentry.rules.match import MatchType
+from sentry.tagstore.base import TAG_KEY_RE
 from sentry.tsdb.base import SnubaCondition, TSDBKey, TSDBModel
 from sentry.utils.iterators import chunked
 from sentry.utils.registry import Registry
@@ -215,7 +216,16 @@ class BaseEventFrequencyQueryHandler(ABC):
 
         lhs: str | None = None
         if key:
-            lhs = f"tags[{condition['key']}]"
+            if not TAG_KEY_RE.fullmatch(key):
+                # Invalid tag keys should have been rejected by schema validation.
+                # Raise so callers return 0 results rather than building an
+                # invalid snuba column from persisted bad data.
+                logger.warning(
+                    "workflow_engine.invalid_tag_filter_key",
+                    extra={"key": key},
+                )
+                raise InvalidFilter
+            lhs = f"tags[{key}]"
         elif attribute:
             column = ATTR_CHOICES.get(attribute)
             if column is None:
@@ -532,19 +542,23 @@ class PercentSessionsQueryHandler(BaseEventFrequencyQueryHandler):
                 continue
 
             model = get_issue_tsdb_group_model(category)
-            # InvalidFilter should not be raised for errors
-            results = self.get_chunked_result(
-                tsdb_function=tsdb.backend.get_sums,
-                model=model,
-                group_ids=issue_ids,
-                organization_id=organization_id,
-                start=start,
-                end=end,
-                environment_id=environment_id,
-                referrer_suffix="wf_batch_alert_event_frequency_percent",
-                filters=filters,
-                group_on_time=False,
-            )
+            try:
+                results = self.get_chunked_result(
+                    tsdb_function=tsdb.backend.get_sums,
+                    model=model,
+                    group_ids=issue_ids,
+                    organization_id=organization_id,
+                    start=start,
+                    end=end,
+                    environment_id=environment_id,
+                    referrer_suffix="wf_batch_alert_event_frequency_percent",
+                    filters=filters,
+                    group_on_time=False,
+                )
+            except InvalidFilter:
+                # Filter is not supported for this issue type
+                # no events meet the query criteria
+                results = {issue_id: 0 for issue_id in issue_ids}
             for group_id, count in results.items():
                 percent: float = 100 * round(count / avg_sessions_in_interval, 4)
                 batch_percents[group_id] = percent

--- a/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
@@ -3,6 +3,7 @@ from typing import Any
 from sentry import tagstore
 from sentry.rules import MATCH_CHOICES, MatchType, match_values
 from sentry.services.eventstore.models import GroupEvent
+from sentry.tagstore.base import TAG_KEY_RE
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
@@ -17,10 +18,12 @@ class TaggedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     subgroup = DataConditionHandler.Subgroup.EVENT_ATTRIBUTES
     label_template = "The event's tags match {key} {match} {value}"
 
+    _TAG_KEY_SCHEMA = {"type": "string", "pattern": TAG_KEY_RE.pattern}
+
     comparison_json_schema = {
         "type": "object",
         "properties": {
-            "key": {"type": "string"},
+            "key": _TAG_KEY_SCHEMA,
             "match": {
                 "type": "string",
                 "enum": [*MatchType],
@@ -33,7 +36,7 @@ class TaggedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
         "oneOf": [
             {
                 "properties": {
-                    "key": {"type": "string"},
+                    "key": _TAG_KEY_SCHEMA,
                     "match": {"enum": [MatchType.IS_SET, MatchType.NOT_SET]},
                 },
                 "required": ["key", "match"],
@@ -41,7 +44,7 @@ class TaggedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
             },
             {
                 "properties": {
-                    "key": {"type": "string"},
+                    "key": _TAG_KEY_SCHEMA,
                     "match": {
                         "not": {"enum": [MatchType.IS_SET, MatchType.NOT_SET]},
                     },

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -7,6 +7,7 @@ from django.db import OperationalError
 from django.utils import timezone
 from rest_framework.exceptions import APIException, Throttled, ValidationError
 from sentry_sdk import Scope
+from snuba_sdk.column import InvalidColumnError
 
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.utils import (
@@ -179,6 +180,7 @@ class HandleQueryErrorsTest(APITestCase):
         exceptions = [
             DatasetSelectionError,
             IncompatibleMetricsQuery,
+            InvalidColumnError,
             InvalidSearchQuery,
             QueryConnectionFailed,
             QueryExecutionError,

--- a/tests/sentry/rules/conditions/test_tagged_event.py
+++ b/tests/sentry/rules/conditions/test_tagged_event.py
@@ -1,4 +1,6 @@
-from sentry.rules.conditions.tagged_event import TaggedEventCondition
+import pytest
+
+from sentry.rules.conditions.tagged_event import TaggedEventCondition, TaggedEventForm
 from sentry.rules.match import MatchType
 from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import RuleTestCase
@@ -152,3 +154,16 @@ class TaggedEventConditionTest(RuleTestCase):
 
         rule = self.get_rule(data={"match": MatchType.NOT_IN, "key": "logger", "value": "foo.bar"})
         self.assertDoesNotPass(rule, event)
+
+
+@pytest.mark.parametrize("key", ["browser", "my.custom-tag", "sentry:release"])
+def test_tagged_event_form_accepts_valid_keys(key: str) -> None:
+    form = TaggedEventForm(data={"key": key, "match": MatchType.IS_SET})
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.parametrize("key", ["flags[use-iframe-in-sidebar]", "tags[browser]", "a[b]"])
+def test_tagged_event_form_rejects_bracket_keys(key: str) -> None:
+    form = TaggedEventForm(data={"key": key, "match": MatchType.IS_SET})
+    assert not form.is_valid()
+    assert "key" in form.errors

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
@@ -65,6 +65,19 @@ def test_error_handled_is_set_not_set_skips_normalization(attribute: str, match:
     assert cond is not None
 
 
+@pytest.mark.parametrize("key", ["flags[use-iframe-in-sidebar]", "foo]"])
+def test_tag_filter_with_invalid_key_raises_invalid_filter(key: str) -> None:
+    from sentry.workflow_engine.handlers.condition.event_frequency_query_handlers import (
+        InvalidFilter,
+    )
+
+    with pytest.raises(InvalidFilter):
+        BaseEventFrequencyQueryHandler.convert_filter_to_snuba_condition(
+            {"key": key, "match": "eq", "value": "true"},
+            TSDBModel.group,
+        )
+
+
 class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
     handler = EventFrequencyQueryHandler
 
@@ -560,3 +573,24 @@ class PercentSessionsQueryTest(BaseEventFrequencyPercentTest, EventFrequencyQuer
             environment_id=self.environment2.id,
         )
         assert batch_query == {self.event3.group_id: percent}
+
+    @patch(
+        "sentry.workflow_engine.handlers.condition.event_frequency_query_handlers.MIN_SESSIONS_TO_FIRE",
+        1,
+    )
+    def test_batch_query_percent_invalid_tag_filter_returns_zero(self) -> None:
+        self._make_sessions(60, self.environment.name, received=self.end.timestamp())
+
+        batch_query = self.handler().batch_query(
+            groups=self.groups,
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+            filters=[{"key": "flags[use-iframe-in-sidebar]", "match": "eq", "value": "true"}],
+        )
+
+        assert batch_query == {
+            self.event.group_id: 0,
+            self.event2.group_id: 0,
+            self.perf_event.group_id: 0,
+        }

--- a/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
@@ -157,6 +157,15 @@ class TestTaggedEventCondition(ConditionTestCase):
         with pytest.raises(ValidationError):
             self.dc.save()
 
+    def test_json_schema_rejects_bracket_keys(self) -> None:
+        self.dc.comparison = {
+            "match": MatchType.EQUAL,
+            "key": "flags[use-iframe-in-sidebar]",
+            "value": "true",
+        }
+        with pytest.raises(ValidationError):
+            self.dc.save()
+
     def test_equals(self) -> None:
         self.dc.comparison.update(
             {"match": MatchType.EQUAL, "key": "LOGGER", "value": "sentry.example"}


### PR DESCRIPTION
Reject invalid persisted tag filter keys with TAG_KEY_RE before building Snuba columns, and return zero results instead of crashing.

Fixes SENTRY-4EBM
