### PR TITLE
chore(weekly-report): add cache hit metric

### DIFF
--- a/src/sentry/tasks/summaries/weekly_report_cache.py
+++ b/src/sentry/tasks/summaries/weekly_report_cache.py
@@ -52,8 +52,9 @@ def read_project_metrics(
     for i, project_id in enumerate(project_ids):
         raw = results[i]
         if raw is None:
-            metrics.incr("weekly_report.cache.miss")
+            metrics.incr("weekly_report.cache_read", tags={"result": "miss"})
         else:
+            metrics.incr("weekly_report.cache_read", tags={"result": "hit"})
             result_map[project_id] = json.loads(raw)
 
     return result_map


### PR DESCRIPTION
Adds cache hit metric to weekly report cache

More details on caching found in this [merged PR](https://github.com/getsentry/sentry/pull/116739)