### PR TITLE
fix(gitlab): prevent duplicate webhook creation via lock+double-check

### DIFF
--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.services.repository.service import repository_service
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.locks import locks
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.plugins.providers.integration_repository import RepositoryConfig
 from sentry.shared_integrations.exceptions import ApiError
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sentry.integrations.gitlab.integration import GitlabIntegration  # NOQA
@@ -60,14 +64,37 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
     def on_create_repository(self, repo: RpcRepository, organization: RpcOrganization) -> None:
         if repo.config.get("webhook_id"):
             return
-        installation = self.get_installation(repo.integration_id, repo.organization_id)
-        client = installation.get_client()
-        try:
-            hook_id = client.create_project_webhook(repo.config["project_id"])
-        except Exception as e:
-            raise installation.raise_error(e)
-        repo.config["webhook_id"] = hook_id
-        repository_service.update_repository(organization_id=organization.id, update=repo)
+
+        project_id = repo.config["project_id"]
+
+        # Use a per-project lock + fresh DB read to prevent duplicate webhook creation.
+        # Two concurrent callers (e.g. a manual "Sync now" and the autosync beat both
+        # dispatching create_repos_batch before either has written to DB) could both
+        # pass the stale in-memory guard above and race to call create_project_webhook.
+        # blocking_acquire serialises them; the loser re-reads from DB, finds webhook_id
+        # already present, and returns without touching GitLab.
+        lock = locks.get(
+            f"gitlab-webhook-create:{repo.integration_id}:{project_id}",
+            duration=300,
+            name="gitlab.on_create_repository",
+        )
+        with lock.blocking_acquire(initial_delay=1, timeout=30):
+            fresh_repo = repository_service.get_repository(
+                organization_id=organization.id, id=repo.id
+            )
+            if fresh_repo is None or fresh_repo.config.get("webhook_id"):
+                return
+
+            installation = self.get_installation(
+                fresh_repo.integration_id, fresh_repo.organization_id
+            )
+            client = installation.get_client()
+            try:
+                hook_id = client.create_project_webhook(project_id)
+            except Exception as e:
+                raise installation.raise_error(e)
+            fresh_repo.config["webhook_id"] = hook_id
+            repository_service.update_repository(organization_id=organization.id, update=fresh_repo)
 
     def on_delete_repository(self, repo):
         """Clean up the attached webhook"""

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from unittest import mock
 
 import orjson
 import pytest
@@ -6,6 +7,7 @@ import responses
 
 from fixtures.gitlab import COMMIT_DIFF_RESPONSE, COMMIT_LIST_RESPONSE, COMPARE_RESPONSE
 from sentry.integrations.gitlab.repository import GitlabRepositoryProvider
+from sentry.integrations.services.repository.service import repository_service
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import IntegrationError
@@ -14,6 +16,7 @@ from sentry.testutils.asserts import assert_commit_shape
 from sentry.testutils.cases import IntegrationRepositoryTestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.users.models.identity import Identity
+from sentry.utils.locking import UnableToAcquireLock
 
 
 class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
@@ -199,6 +202,58 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
             self.default_repository_config, self.integration.id, add_responses=False
         )
         assert response.status_code == 503
+
+    @responses.activate
+    def test_on_create_repository_skips_if_webhook_id_already_in_db(self) -> None:
+        """If the fresh DB read finds a webhook_id, no GitLab API call should be made."""
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        with assume_test_silo_mode(SiloMode.CELL):
+            repo = Repository.objects.get(pk=response.data["id"])
+            assert repo.config.get("webhook_id") == 99
+
+        # Simulate a second call with a stale repo object that has no webhook_id in memory
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            rpc_repo = repository_service.get_repository(
+                organization_id=self.organization.id, id=repo.id
+            )
+        assert rpc_repo is not None
+        # Strip webhook_id from the in-memory object to simulate stale state
+        stale_config = {k: v for k, v in rpc_repo.config.items() if k != "webhook_id"}
+        rpc_repo.config = stale_config
+
+        with (
+            mock.patch.object(
+                self.provider, "get_installation"
+            ) as mock_installation,
+        ):
+            self.provider.on_create_repository(rpc_repo, self.organization)
+            # Should not call GitLab because fresh DB read reveals webhook_id already set
+            mock_installation.assert_not_called()
+
+    @responses.activate
+    def test_on_create_repository_propagates_lock_timeout(self) -> None:
+        """UnableToAcquireLock propagates so the Celery task can retry."""
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        with assume_test_silo_mode(SiloMode.CELL):
+            repo = Repository.objects.get(pk=response.data["id"])
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            rpc_repo = repository_service.get_repository(
+                organization_id=self.organization.id, id=repo.id
+            )
+        assert rpc_repo is not None
+        stale_config = {k: v for k, v in rpc_repo.config.items() if k != "webhook_id"}
+        rpc_repo.config = stale_config
+
+        with mock.patch(
+            "sentry.integrations.gitlab.repository.locks"
+        ) as mock_locks:
+            mock_lock = mock.MagicMock()
+            mock_lock.blocking_acquire.side_effect = UnableToAcquireLock
+            mock_locks.get.return_value = mock_lock
+
+            with pytest.raises(UnableToAcquireLock):
+                self.provider.on_create_repository(rpc_repo, self.organization)
 
     @responses.activate
     def test_on_delete_repository_remove_webhook(self) -> None:


### PR DESCRIPTION
## Problem

When a manual "Sync now" and the autosync beat (`scm_repo_sync_beat`, fires every 1 min) both fire for the same org integration before `create_repos_batch` has written the new repo to DB, both tasks compute the repo as new and each dispatches a `create_repos_batch`. Both tasks then call `on_create_repository` concurrently. The in-memory guard (`repo.config.get('webhook_id')`) uses the stale object passed by the caller — neither task has saved `webhook_id` yet — so both proceed to call `create_project_webhook`, producing a duplicate webhook in GitLab.

The existing lock on `sync_repos_for_org` serialises the diff+dispatch phase correctly, but `create_repos_batch` runs async *after* the lock is released, so a subsequent beat tick firing in that window still sees the repo as new.

## Fix

In `on_create_repository`, acquire a per-`(integration_id, project_id)` distributed lock, then re-read the repository from DB inside the lock (double-checked locking). The losing concurrent caller finds `webhook_id` already present in the fresh read and returns without touching GitLab.

`blocking_acquire(initial_delay=1, timeout=30)` lets the loser wait briefly rather than fail immediately. `UnableToAcquireLock` propagates so the Celery task (`retry=Retry(times=3, delay=120)`) can recover.

## What was verified

- Existing `test_create_repository` and `test_create_repository_verify_payload` still cover the normal happy path (unchanged).
- New test `test_on_create_repository_skips_if_webhook_id_already_in_db`: stale in-memory object with no `webhook_id` but DB row has it → no GitLab API call.
- New test `test_on_create_repository_propagates_lock_timeout`: `UnableToAcquireLock` from lock propagates so Celery can retry.

## What remains unverified

Full test suite not run (sandbox limitation). The two new tests exercise the core correctness invariants.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0AKG192UP3%3A1781017853.082729%22)
