### PR TITLE
ref(avatars): Refactor `AvatarChooserProps` to a discriminated union on `type`

### DIFF
--- a/static/app/components/avatarChooser/index.tsx
+++ b/static/app/components/avatarChooser/index.tsx
@@ -40,30 +40,50 @@ interface SimpleAvatar {
 
 type AvatarType = Avatar['avatarType'];
 
-type AvatarChooserType =
-  | 'user'
-  | 'team'
-  | 'organization'
-  | 'sentryAppColor'
-  | 'sentryAppSimple'
-  | 'docIntegration';
+type AvatarModel = AvatarUser | Team | Organization | SentryApp | SimpleAvatar;
 
 type DefaultChoice = {
   description?: React.ReactNode;
   label?: string;
 };
 
-interface AvatarChooserProps {
+interface AvatarChooserBaseProps {
   endpoint: string;
-  model: SimpleAvatar | SentryApp;
   supportedTypes: AvatarType[];
   defaultChoice?: DefaultChoice;
   disabled?: boolean;
   help?: React.ReactNode;
-  onSave?: (model: SimpleAvatar) => void;
   title?: string;
-  type?: AvatarChooserType;
 }
+
+type AvatarChooserProps = AvatarChooserBaseProps &
+  (
+    | {
+        model: AvatarUser;
+        type: 'user';
+        onSave?: (model: AvatarUser) => void;
+      }
+    | {
+        model: Team;
+        type: 'team';
+        onSave?: (model: Team) => void;
+      }
+    | {
+        model: Organization;
+        type: 'organization';
+        onSave?: (model: Organization) => void;
+      }
+    | {
+        model: SentryApp;
+        type: 'sentryAppColor' | 'sentryAppSimple';
+        onSave?: (model: SimpleAvatar) => void;
+      }
+    | {
+        model: SimpleAvatar;
+        type: 'docIntegration';
+        onSave?: (model: SimpleAvatar) => void;
+      }
+  );
 
 // These values must be synced with the avatar endpoint in backend.
 const MIN_DIMENSION = 256;
@@ -80,7 +100,7 @@ export function AvatarChooser({
   title,
   help,
   supportedTypes,
-  type = 'user',
+  type,
   onSave,
   defaultChoice = {},
 }: AvatarChooserProps) {
@@ -126,7 +146,7 @@ export function AvatarChooser({
     throw new Error('Invalid avatar chooser type');
   };
 
-  const getAvatar = (targetModel: SimpleAvatar | SentryApp) => {
+  const getAvatar = (targetModel: AvatarModel) => {
     if ('avatar' in targetModel) {
       return targetModel.avatar;
     }
@@ -168,7 +188,7 @@ export function AvatarChooser({
       data.avatar_photo = base64Data;
     }
 
-    if (type?.startsWith('sentryApp')) {
+    if (type.startsWith('sentryApp')) {
       data.color = type === 'sentryAppColor';
       data.photoType = data.color ? 'logo' : 'icon';
     }

--- a/static/app/views/settings/organizationTeams/teamSettings/index.tsx
+++ b/static/app/views/settings/organizationTeams/teamSettings/index.tsx
@@ -168,7 +168,7 @@ export default function TeamSettings() {
         supportedTypes={['upload', 'letter_avatar']}
         endpoint={`/teams/${organization.slug}/${team.slug}/avatar/`}
         model={team}
-        onSave={resp => updateTeamSuccess(team.slug, resp as Team)}
+        onSave={resp => updateTeamSuccess(team.slug, resp)}
         disabled={isDisabled}
       />
 


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/117140/.

Refactors `AvatarChooserProps` from a single loose interface into a discriminated union on the `type` prop, so each variant pairs the correct `model` type with a correctly-typed `onSave` callback. Removes the `resp as Team` cast in team settings, since `resp` is now typed as `Team` by the union.