### PR TITLE
feat(seer): Register CPU rollout options for severity and fixability

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1168,6 +1168,18 @@ register(
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "seer.severity.cpu-rollout",
+    type=Float,
+    default=0.0,
+    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "seer.fixability.cpu-rollout",
+    type=Float,
+    default=0.0,
+    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "seer.night_shift.enable",
     type=Bool,
     default=False,


### PR DESCRIPTION
+ Register seer.severity.cpu-rollout and seer.fixability.cpu-rollout as Float options to control gradual traffic migration from GPU to CPU pods.
