### PR TITLE
feat(ourlogs): switch from LoadingIndicator to Placeholder for loading pinned rows

### DIFF
--- a/static/app/views/explore/logs/pinning/PinnedLogs.spec.tsx
+++ b/static/app/views/explore/logs/pinning/PinnedLogs.spec.tsx
@@ -109,7 +109,7 @@ describe('PinnedLogs', () => {
     expect(screen.getByTestId('pinned-row-log-3')).toBeInTheDocument();
   });
 
-  it('shows a loading indicator for a pinned row that is not yet available', () => {
+  it('shows a loading placeholder for a pinned row that is not yet available', () => {
     renderPinnedLogs(
       {
         initialRouterConfig: {
@@ -119,7 +119,7 @@ describe('PinnedLogs', () => {
       {isFetchingPinnedRows: true}
     );
 
-    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
     expect(screen.queryByTestId('pinned-row-missing-log')).not.toBeInTheDocument();
   });
 

--- a/static/app/views/explore/logs/pinning/PinnedLogs.tsx
+++ b/static/app/views/explore/logs/pinning/PinnedLogs.tsx
@@ -4,13 +4,14 @@ import styled from '@emotion/styled';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {Placeholder} from 'sentry/components/placeholder';
 import {GridRow} from 'sentry/components/tables/gridEditable/styles';
 import {IconChevron, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {TableBody} from 'sentry/views/explore/components/table';
 import type {LogsPinning} from 'sentry/views/explore/logs/pinning/useLogsPinning';
 import type {usePinnedLogsQuery} from 'sentry/views/explore/logs/pinning/usePinnedLogsQuery';
+import {LOGS_GRID_BODY_ROW_HEIGHT} from 'sentry/views/explore/logs/styles';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import type {LogTableRowItem} from 'sentry/views/explore/logs/utils';
 
@@ -56,9 +57,9 @@ export function PinnedLogs({allRows, logsPinning, pinnedLogsQuery, renderRow}: P
             if (isFetchingPinnedRows) {
               return (
                 <GridRow key={rowId}>
-                  <PinnedGridBodyCell>
-                    <LoadingIndicator mini />
-                  </PinnedGridBodyCell>
+                  <LoadingGridBodyCell>
+                    <Placeholder height="100%" />
+                  </LoadingGridBodyCell>
                 </GridRow>
               );
             }
@@ -108,4 +109,8 @@ const PinnedTableBody = styled(TableBody)`
 const PinnedGridBodyCell = styled('td')`
   grid-column: 1 / -1;
   padding: ${p => p.theme.space.sm};
+`;
+
+const LoadingGridBodyCell = styled(PinnedGridBodyCell)`
+  height: ${LOGS_GRID_BODY_ROW_HEIGHT}px;
 `;


### PR DESCRIPTION
Replace the mini `LoadingIndicator` shown while a pinned log row is still fetching with a `Placeholder` that fills the row.

The loading cell now uses the shared `LOGS_GRID_BODY_ROW_HEIGHT` constant so the placeholder stretches to match a real log row's height, rather than measuring from a hardcoded size on the spinner.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><img width="755" height="492" alt="image" src="https://github.com/user-attachments/assets/dce50475-78e8-4cab-8b3c-03b7a4e84f05" />
</td>
<td>
<img width="755" height="492" alt="image" src="https://github.com/user-attachments/assets/2ff23ee9-e624-40ed-9bcc-8f5f33da1776" />
</td>
</tr>
</tbody>
</table>

Closes LOGS-852.