### PR TITLE
fix(aci) More tags for tracking metrics

### DIFF
--- a/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
+++ b/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
@@ -31,7 +31,7 @@ def invoke_workflow_activity_handlers(
     have metrics and timing support out of the box.
     """
     try:
-        activity_type = ActivityType(activity.type)
+        activity_type = ActivityType(activity.type).name
     except ValueError:
         logger.exception(
             "workflow_engine.seer_activity_handler.invalid_activity_type",

--- a/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
+++ b/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 from sentry.workflow_engine.registry import workflow_activity_registry
 from sentry.workflow_engine.types import DetectorId
@@ -29,12 +30,23 @@ def invoke_workflow_activity_handlers(
     This also means that if there's a new handler registered, it will automatically
     have metrics and timing support out of the box.
     """
+    try:
+        activity_type = ActivityType(activity.type)
+    except ValueError:
+        logger.exception(
+            "workflow_engine.seer_activity_handler.invalid_activity_type",
+            extra={"activity_type": activity.type},
+        )
+        return
+
     for handler_key, handler in workflow_activity_registry.registrations.items():
         try:
-            # metrics.timer emits the duration even when the handler raises,
-            # tagged with result=success|failure.
-            with metrics.timer(DURATION_METRIC, tags={"handler": handler_key}):
+            with metrics.timer(
+                DURATION_METRIC,
+                tags={"handler": handler_key, "activity_type": activity_type},
+            ):
                 handler(group, activity, detector_id)
+
         except Exception:
             logger.exception(
                 "workflow_engine.invoke_workflow_activity_handlers.error",
@@ -42,6 +54,6 @@ def invoke_workflow_activity_handlers(
                     "group_id": group.id,
                     "activity_id": activity.id,
                     "handler_name": handler_key,
-                    "activity_type": activity.type,
+                    "activity_type": activity_type,
                 },
             )

--- a/tests/sentry/workflow_engine/handlers/registry/test_invoke_activities.py
+++ b/tests/sentry/workflow_engine/handlers/registry/test_invoke_activities.py
@@ -60,8 +60,22 @@ class InvokeWorkflowActivityHandlersTest(TestCase):
         # One timing per handler, tagged by the registry key.
         emitted = [(call.args[0], call.args[3]) for call in mock_timing.call_args_list]
         assert emitted == [
-            (DURATION_METRIC, {"handler": "handler_a", "result": "success"}),
-            (DURATION_METRIC, {"handler": "handler_b", "result": "success"}),
+            (
+                DURATION_METRIC,
+                {
+                    "handler": "handler_a",
+                    "result": "success",
+                    "activity_type": "SEER_PR_CREATED",
+                },
+            ),
+            (
+                DURATION_METRIC,
+                {
+                    "handler": "handler_b",
+                    "result": "success",
+                    "activity_type": "SEER_PR_CREATED",
+                },
+            ),
         ]
 
     @mock.patch("sentry.utils.metrics.timing")
@@ -79,7 +93,21 @@ class InvokeWorkflowActivityHandlersTest(TestCase):
         # Failed handlers are still timed, and the loop continues to the next handler.
         emitted = [(call.args[0], call.args[3]) for call in mock_timing.call_args_list]
         assert emitted == [
-            (DURATION_METRIC, {"handler": "handler_a", "result": "failure"}),
-            (DURATION_METRIC, {"handler": "handler_b", "result": "success"}),
+            (
+                DURATION_METRIC,
+                {
+                    "handler": "handler_a",
+                    "result": "failure",
+                    "activity_type": "SEER_PR_CREATED",
+                },
+            ),
+            (
+                DURATION_METRIC,
+                {
+                    "handler": "handler_b",
+                    "result": "success",
+                    "activity_type": "SEER_PR_CREATED",
+                },
+            ),
         ]
         handler_b.assert_called_once_with(self.group, self.activity, None)


### PR DESCRIPTION
# Description
Before we could tell what handler was being called, but not the activity for each handler. This change will allow us to slice the metrics by activity, handler, or both.