### PR TITLE
fix(explore): Preserve agent-selected interval not in the dropdown

### DIFF
--- a/static/app/utils/useChartInterval.spec.tsx
+++ b/static/app/utils/useChartInterval.spec.tsx
@@ -109,6 +109,102 @@ describe('useChartInterval', () => {
     expect(chartInterval).toBe('3h');
   });
 
+  it('preserves a custom interval that is not too granular for the time range', () => {
+    // Default 14d period produces ladder-derived options ['1h', '3h', '6h', '1d'].
+    // A 12h interval is coarser than the minimum (1h), so it should be preserved
+    // even though it is not a standard option, and surfaced in the dropdown.
+    let chartInterval!: ReturnType<typeof useChartInterval>[0];
+    let intervalOptions!: ReturnType<typeof useChartInterval>[2];
+
+    function TestPage() {
+      [chartInterval, , intervalOptions] = useChartInterval();
+      return null;
+    }
+
+    render(<TestPage />, {
+      initialRouterConfig: {
+        location: {pathname: '/', query: {interval: '12h'}},
+      },
+    });
+
+    expect(chartInterval).toBe('12h');
+    expect(intervalOptions).toEqual([
+      {value: '1h', label: '1 hour'},
+      {value: '3h', label: '3 hours'},
+      {value: '6h', label: '6 hours'},
+      {value: '12h', label: '12 hours'},
+      {value: '1d', label: '1 day'},
+    ]);
+  });
+
+  it('preserves a 1d interval at a 7d time range', () => {
+    // A 7d period produces ladder-derived options ['30m', '1h', '3h'] and does not
+    // include '1d' by default, but a 1d interval is not too granular so it persists.
+    let chartInterval!: ReturnType<typeof useChartInterval>[0];
+    let intervalOptions!: ReturnType<typeof useChartInterval>[2];
+
+    function TestPage() {
+      [chartInterval, , intervalOptions] = useChartInterval();
+      return null;
+    }
+
+    render(<TestPage />, {
+      initialRouterConfig: {
+        location: {pathname: '/', query: {interval: '1d'}},
+      },
+    });
+
+    act(() =>
+      PageFiltersStore.updateDateTime({
+        period: '7d',
+        start: null,
+        end: null,
+        utc: true,
+      })
+    );
+
+    expect(chartInterval).toBe('1d');
+    expect(intervalOptions.map(o => o.value)).toContain('1d');
+  });
+
+  it('falls back to the default when the custom interval is too granular', () => {
+    // Default 14d period has a minimum interval of 1h. A 5m interval is too
+    // granular, so it should fall back to the default rather than being preserved.
+    let chartInterval!: ReturnType<typeof useChartInterval>[0];
+    let intervalOptions!: ReturnType<typeof useChartInterval>[2];
+
+    function TestPage() {
+      [chartInterval, , intervalOptions] = useChartInterval();
+      return null;
+    }
+
+    render(<TestPage />, {
+      initialRouterConfig: {
+        location: {pathname: '/', query: {interval: '5m'}},
+      },
+    });
+
+    expect(chartInterval).toBe('1h');
+    expect(intervalOptions.map(o => o.value)).not.toContain('5m');
+  });
+
+  it('falls back to the default for an invalid interval', () => {
+    let chartInterval!: ReturnType<typeof useChartInterval>[0];
+
+    function TestPage() {
+      [chartInterval] = useChartInterval();
+      return null;
+    }
+
+    render(<TestPage />, {
+      initialRouterConfig: {
+        location: {pathname: '/', query: {interval: 'not-an-interval'}},
+      },
+    });
+
+    expect(chartInterval).toBe('1h');
+  });
+
   it('falls back to the only option when USE_SECOND_BIGGEST is used with a single-option period', () => {
     // A 1-minute period produces only ['1m'] as the valid interval option.
     // options[length-2] is undefined, so the fallback is options[length-1] = '1m'.

--- a/static/app/utils/useChartInterval.tsx
+++ b/static/app/utils/useChartInterval.tsx
@@ -13,8 +13,9 @@ import {
   TWELVE_HOURS,
   TWO_WEEKS,
 } from 'sentry/components/charts/utils';
+import {parseStatsPeriod} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {t} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -68,41 +69,83 @@ function useChartIntervalImpl({
 ] {
   const {datetime} = pagefilters.selection;
 
-  const {intervalOptions, defaultInterval} = useMemo(() => {
-    const diffInMinutes = getDiffInMinutes(datetime);
-    const options = getIntervalOptionsForPageFilter(datetime);
+  const {baseIntervalOptions, defaultInterval, minimumIntervalInHours, timeRangeInHours} =
+    useMemo(() => {
+      const diffInMinutes = getDiffInMinutes(datetime);
+      const options = getIntervalOptionsForPageFilter(datetime);
 
-    // Compute the default from the ladder-derived options, before appending extras
-    let fallback: string;
-    switch (unspecifiedStrategy) {
-      case ChartIntervalUnspecifiedStrategy.USE_SMALLEST:
-        fallback = options[0]!.value;
-        break;
-      case ChartIntervalUnspecifiedStrategy.USE_BIGGEST:
-        fallback = options[options.length - 1]!.value;
-        break;
-      case ChartIntervalUnspecifiedStrategy.USE_SECOND_BIGGEST:
-      default:
-        fallback =
-          options[options.length - 2]?.value ?? options[options.length - 1]!.value;
-        break;
-    }
+      // Compute the default from the ladder-derived options, before appending extras
+      let fallback: string;
+      switch (unspecifiedStrategy) {
+        case ChartIntervalUnspecifiedStrategy.USE_SMALLEST:
+          fallback = options[0]!.value;
+          break;
+        case ChartIntervalUnspecifiedStrategy.USE_BIGGEST:
+          fallback = options[options.length - 1]!.value;
+          break;
+        case ChartIntervalUnspecifiedStrategy.USE_SECOND_BIGGEST:
+        default:
+          fallback =
+            options[options.length - 2]?.value ?? options[options.length - 1]!.value;
+          break;
+      }
 
-    if (diffInMinutes >= MINIMUM_DURATION_FOR_ONE_DAY_INTERVAL) {
-      options.push(ONE_DAY_OPTION);
-    }
+      if (diffInMinutes >= MINIMUM_DURATION_FOR_ONE_DAY_INTERVAL) {
+        options.push(ONE_DAY_OPTION);
+      }
 
-    return {intervalOptions: options, defaultInterval: fallback};
-  }, [datetime, unspecifiedStrategy]);
+      return {
+        baseIntervalOptions: options,
+        defaultInterval: fallback,
+        // The smallest interval allowed for the current time range. Anything more
+        // granular than this would produce too many buckets.
+        minimumIntervalInHours: parsePeriodToHours(
+          MINIMUM_INTERVAL.getInterval(diffInMinutes)
+        ),
+        // The full duration of the selected time range. An interval larger than
+        // this would produce a single (incomplete) bucket.
+        timeRangeInHours: diffInMinutes / 60,
+      };
+    }, [datetime, unspecifiedStrategy]);
 
-  const interval = useMemo(() => {
+  const [interval, intervalOptions] = useMemo((): [
+    string,
+    Array<{label: string; value: string}>,
+  ] => {
     const decodedInterval = decodeScalar(location.query.interval);
 
-    return decodedInterval &&
-      intervalOptions.some(option => option.value === decodedInterval)
-      ? decodedInterval
-      : defaultInterval;
-  }, [location.query.interval, intervalOptions, defaultInterval]);
+    if (!decodedInterval) {
+      return [defaultInterval, baseIntervalOptions];
+    }
+
+    // The interval is one of the standard options for this time range.
+    if (baseIntervalOptions.some(option => option.value === decodedInterval)) {
+      return [decodedInterval, baseIntervalOptions];
+    }
+
+    // The interval isn't a standard option (e.g. it was selected by the agent).
+    // Keep it as long as it it's valid (not to granular, not too coarse).
+    const decodedIntervalInHours = parsePeriodToHours(decodedInterval);
+    if (
+      decodedIntervalInHours >= minimumIntervalInHours &&
+      decodedIntervalInHours <= timeRangeInHours
+    ) {
+      const options = [
+        ...baseIntervalOptions,
+        {value: decodedInterval, label: getIntervalLabel(decodedInterval)},
+      ].sort((a, b) => parsePeriodToHours(a.value) - parsePeriodToHours(b.value));
+
+      return [decodedInterval, options];
+    }
+
+    return [defaultInterval, baseIntervalOptions];
+  }, [
+    location.query.interval,
+    baseIntervalOptions,
+    defaultInterval,
+    minimumIntervalInHours,
+    timeRangeInHours,
+  ]);
 
   const setInterval = useCallback(
     (newInterval: string) => {
@@ -159,6 +202,35 @@ const MAXIMUM_INTERVAL = new GranularityLadder([
 
 const ONE_DAY_OPTION = {value: '1d', label: t('1 day')};
 const MINIMUM_DURATION_FOR_ONE_DAY_INTERVAL = TWO_WEEKS;
+
+/**
+ * Builds a human readable label for an arbitrary interval shorthand (e.g. `1d`),
+ * preserving the unit chosen rather than normalizing it.
+ */
+function getIntervalLabel(interval: string): string {
+  const parsed = parseStatsPeriod(interval);
+
+  if (!parsed?.period || !parsed.periodLength) {
+    return interval;
+  }
+
+  const value = parseInt(parsed.period, 10);
+
+  switch (parsed.periodLength) {
+    case 's':
+      return tn('%s second', '%s seconds', value);
+    case 'm':
+      return tn('%s minute', '%s minutes', value);
+    case 'h':
+      return tn('%s hour', '%s hours', value);
+    case 'd':
+      return tn('%s day', '%s days', value);
+    case 'w':
+      return tn('%s week', '%s weeks', value);
+    default:
+      return interval;
+  }
+}
 
 export function getIntervalOptionsForPageFilter(datetime: PageFilters['datetime']) {
   const diffInMinutes = getDiffInMinutes(datetime);


### PR DESCRIPTION
## Summary

When the assisted-query agent picks a chart interval that isn't one of the standard dropdown options for the current time range, the Explore UI silently reset it to the default. `useChartInterval` only accepted intervals that exactly matched a ladder-derived option, so an agent-selected interval like `1d` on a 7-day range was dropped.

Now a custom interval is preserved as long as it is **not too granular** (≥ the minimum interval for the time range) and **not coarser than the time range itself** (≤ the full duration). A kept interval is merged into the dropdown options (sorted by duration) so it shows up as the selected value and is sent to the chart query. Too-granular or invalid intervals fall back to the default as before.

Because traces, logs, and metrics all consume `useChartInterval`, this applies to all three.

## Notes

- The time-range upper bound is a deliberate addition: an interval larger than the whole window produces a single incomplete bucket, so intervals coarser than the selected range still fall back. This keeps the `1d`-on-7d case working while rejecting degenerate ones.
- Added `getIntervalLabel()` to produce a readable, i18n-friendly dropdown label for arbitrary interval shorthands while preserving the agent's chosen unit.
- `useChartInterval` is also used by Dashboards (via `useDashboardChartInterval`), so this more permissive behavior applies there too. That's intentional; existing dashboard interval tests still pass.

Generated with claude

Refs BROWSE-550