### PR TITLE
feat(seer-infra-telemetry): Bypass DCR if user is already linked to an Identity with existing client id and secret

### DIFF
--- a/src/sentry/identity/datadog/provider.py
+++ b/src/sentry/identity/datadog/provider.py
@@ -19,6 +19,7 @@ from sentry.identity.oauth2 import (
 )
 from sentry.identity.pipeline import IdentityPipeline
 from sentry.integrations.utils.metrics import IntegrationPipelineViewType
+from sentry.users.models.identity import Identity
 from sentry.utils.http import absolute_uri
 
 
@@ -54,6 +55,21 @@ class DatadogOAuth2DCRView:
     def dispatch(self, request: HttpRequest, pipeline: IdentityPipeline) -> HttpResponseBase:
         if pipeline.fetch_state("dcr_client_id") and pipeline.fetch_state("dcr_client_secret"):
             return pipeline.next_step()
+
+        # Reuse DCR credentials from an existing identity if possible.
+        if pipeline.provider_model and request.user.is_authenticated:
+            try:
+                existing_identity = Identity.objects.get(
+                    idp=pipeline.provider_model, user=request.user
+                )
+                client_id = existing_identity.data.get("client_id")
+                client_secret = existing_identity.data.get("client_secret")
+                if client_id and client_secret:
+                    pipeline.bind_state("dcr_client_id", client_id)
+                    pipeline.bind_state("dcr_client_secret", client_secret)
+                    return pipeline.next_step()
+            except Identity.DoesNotExist:
+                pass
 
         with record_event(
             IntegrationPipelineViewType.DCR_REGISTRATION, pipeline.provider.key

--- a/tests/sentry/identity/datadog/test_provider.py
+++ b/tests/sentry/identity/datadog/test_provider.py
@@ -26,7 +26,7 @@ from sentry.identity.providers.dummy import DummyProvider
 from sentry.testutils.asserts import assert_failure_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.users.models.identity import Identity, IdentityProvider
+from sentry.users.models.identity import IdentityProvider
 
 REGISTER_URL = "https://mcp.datadoghq.com/api/unstable/mcp-server/register"
 AUTHORIZE_URL = "https://mcp.datadoghq.com/api/unstable/mcp-server/authorize"
@@ -41,7 +41,7 @@ class DatadogOAuth2DCRViewTest(TestCase):
         super().setUp()
         self.request = RequestFactory().get("/")
         self.request.user = self.user
-        self.identity_provider = IdentityProvider.objects.create(type="datadog")
+        self.identity_provider = self.create_identity_provider(type="datadog")
         self.pipeline = MagicMock()
         self.pipeline.config = {}
         self.pipeline.provider.key = "datadog"
@@ -126,9 +126,9 @@ class DatadogOAuth2DCRViewTest(TestCase):
 
     @responses.activate
     def test_existing_identity_and_credentials(self, mock_record: MagicMock) -> None:
-        Identity.objects.create(
-            idp=self.identity_provider,
+        self.create_identity(
             user=self.user,
+            identity_provider=self.identity_provider,
             external_id="dd-user-123",
             data={"client_id": "existing-client", "client_secret": "existing-secret"},
         )
@@ -141,10 +141,31 @@ class DatadogOAuth2DCRViewTest(TestCase):
         self.pipeline.next_step.assert_called_once()
 
     @responses.activate
-    def test_existing_identity_missing_credentials(self, mock_record: MagicMock) -> None:
-        Identity.objects.create(
-            idp=self.identity_provider,
+    def test_unauthenticated_user_skips_existing_identity(self, mock_record: MagicMock) -> None:
+        self.create_identity(
             user=self.user,
+            identity_provider=self.identity_provider,
+            external_id="dd-user-123",
+            data={"client_id": "existing-client", "client_secret": "existing-secret"},
+        )
+        self.request.user = MagicMock(is_authenticated=False)
+        responses.add(
+            responses.POST,
+            REGISTER_URL,
+            json={"client_id": "new-client", "client_secret": "new-secret"},
+        )
+
+        self.view.dispatch(self.request, self.pipeline)
+
+        assert len(responses.calls) == 1
+        self.pipeline.bind_state.assert_any_call("dcr_client_id", "new-client")
+        self.pipeline.bind_state.assert_any_call("dcr_client_secret", "new-secret")
+
+    @responses.activate
+    def test_existing_identity_missing_credentials(self, mock_record: MagicMock) -> None:
+        self.create_identity(
+            user=self.user,
+            identity_provider=self.identity_provider,
             external_id="dd-user-123",
             data={},
         )

--- a/tests/sentry/identity/datadog/test_provider.py
+++ b/tests/sentry/identity/datadog/test_provider.py
@@ -141,14 +141,13 @@ class DatadogOAuth2DCRViewTest(TestCase):
         self.pipeline.next_step.assert_called_once()
 
     @responses.activate
-    def test_unauthenticated_user_skips_existing_identity(self, mock_record: MagicMock) -> None:
+    def test_existing_identity_missing_credentials(self, mock_record: MagicMock) -> None:
         self.create_identity(
             user=self.user,
             identity_provider=self.identity_provider,
             external_id="dd-user-123",
-            data={"client_id": "existing-client", "client_secret": "existing-secret"},
+            data={},
         )
-        self.request.user = MagicMock(is_authenticated=False)
         responses.add(
             responses.POST,
             REGISTER_URL,
@@ -162,13 +161,14 @@ class DatadogOAuth2DCRViewTest(TestCase):
         self.pipeline.bind_state.assert_any_call("dcr_client_secret", "new-secret")
 
     @responses.activate
-    def test_existing_identity_missing_credentials(self, mock_record: MagicMock) -> None:
+    def test_existing_identity_unauthenticated_user(self, mock_record: MagicMock) -> None:
         self.create_identity(
             user=self.user,
             identity_provider=self.identity_provider,
             external_id="dd-user-123",
-            data={},
+            data={"client_id": "existing-client", "client_secret": "existing-secret"},
         )
+        self.request.user = MagicMock(is_authenticated=False)
         responses.add(
             responses.POST,
             REGISTER_URL,

--- a/tests/sentry/identity/datadog/test_provider.py
+++ b/tests/sentry/identity/datadog/test_provider.py
@@ -26,7 +26,7 @@ from sentry.identity.providers.dummy import DummyProvider
 from sentry.testutils.asserts import assert_failure_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.users.models.identity import IdentityProvider
+from sentry.users.models.identity import Identity, IdentityProvider
 
 REGISTER_URL = "https://mcp.datadoghq.com/api/unstable/mcp-server/register"
 AUTHORIZE_URL = "https://mcp.datadoghq.com/api/unstable/mcp-server/authorize"
@@ -40,9 +40,12 @@ class DatadogOAuth2DCRViewTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.request = RequestFactory().get("/")
+        self.request.user = self.user
+        self.identity_provider = IdentityProvider.objects.create(type="datadog")
         self.pipeline = MagicMock()
         self.pipeline.config = {}
         self.pipeline.provider.key = "datadog"
+        self.pipeline.provider_model = self.identity_provider
         self.pipeline.fetch_state.return_value = None
         self.view = DatadogOAuth2DCRView(register_url=REGISTER_URL)
 
@@ -120,6 +123,42 @@ class DatadogOAuth2DCRViewTest(TestCase):
         self.pipeline.error.assert_called_once_with("DCR response missing client credentials")
         self.pipeline.bind_state.assert_not_called()
         assert_failure_metric(mock_record, "missing_credentials")
+
+    @responses.activate
+    def test_existing_identity_and_credentials(self, mock_record: MagicMock) -> None:
+        Identity.objects.create(
+            idp=self.identity_provider,
+            user=self.user,
+            external_id="dd-user-123",
+            data={"client_id": "existing-client", "client_secret": "existing-secret"},
+        )
+
+        self.view.dispatch(self.request, self.pipeline)
+
+        assert len(responses.calls) == 0
+        self.pipeline.bind_state.assert_any_call("dcr_client_id", "existing-client")
+        self.pipeline.bind_state.assert_any_call("dcr_client_secret", "existing-secret")
+        self.pipeline.next_step.assert_called_once()
+
+    @responses.activate
+    def test_existing_identity_missing_credentials(self, mock_record: MagicMock) -> None:
+        Identity.objects.create(
+            idp=self.identity_provider,
+            user=self.user,
+            external_id="dd-user-123",
+            data={},
+        )
+        responses.add(
+            responses.POST,
+            REGISTER_URL,
+            json={"client_id": "new-client", "client_secret": "new-secret"},
+        )
+
+        self.view.dispatch(self.request, self.pipeline)
+
+        assert len(responses.calls) == 1
+        self.pipeline.bind_state.assert_any_call("dcr_client_id", "new-client")
+        self.pipeline.bind_state.assert_any_call("dcr_client_secret", "new-secret")
 
 
 @control_silo_test


### PR DESCRIPTION
Datadog's MCP OAuth requires client registration which we implement via DCR. Each DCR call creates a new client. On re-authorization, this means we'd register a throwaway client every time, even though Datadog client secrets don't expire.

This PR reuses DCR credentials (`client_id`/`client_secret`) from an existing `Identity` record when the user has already linked their Datadog account. Falls back to fresh DCR registration when no identity exists or stored credentials are missing.