### PR TITLE
feat(seer): Add CPU connection pools and rollout options for severity and fixability

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -115,6 +115,7 @@ from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.net.http import connection_from_url
+from sentry.options.rollout import in_random_rollout
 from sentry.plugins.base import plugins
 from sentry.quotas.base import index_data_category
 from sentry.receivers.features import record_event_processed
@@ -2002,6 +2003,12 @@ severity_connection_pool = connection_from_url(
     timeout=settings.SEER_SEVERITY_TIMEOUT,  # Defaults to 300 milliseconds
 )
 
+severity_connection_pool_cpu = connection_from_url(
+    settings.SEER_SUMMARIZATION_URL,
+    retries=settings.SEER_SEVERITY_RETRIES,
+    timeout=settings.SEER_SEVERITY_TIMEOUT,
+)
+
 
 class SeverityScoreRequest(TypedDict):
     message: str
@@ -2250,9 +2257,17 @@ def _get_severity_score(event: Event) -> tuple[float, str]:
                     "issues.severity.seer-timeout",
                     settings.SEER_SEVERITY_TIMEOUT,
                 )
+                pool = (
+                    severity_connection_pool_cpu
+                    if in_random_rollout("seer.severity.cpu-rollout")
+                    else severity_connection_pool
+                )
                 viewer_context = SeerViewerContext(organization_id=event.project.organization_id)
                 response = make_severity_score_request(
-                    payload, timeout=timeout, viewer_context=viewer_context
+                    payload,
+                    connection_pool=pool,
+                    timeout=timeout,
+                    viewer_context=viewer_context,
                 )
                 severity = orjson.loads(response.data).get("severity")
                 reason = "ml"

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from taskbroker_client.retry import Retry
 from urllib3 import BaseHTTPResponse
+from urllib3.connectionpool import HTTPConnectionPool
 
 from sentry import features, quotas
 from sentry.api.serializers import EventSerializer, serialize
@@ -18,6 +19,7 @@ from sentry.constants import DataCategory
 from sentry.locks import locks
 from sentry.models.group import Group
 from sentry.net.http import connection_from_url
+from sentry.options.rollout import in_random_rollout
 from sentry.seer.autofix.autofix import get_trace_tree_for_event
 from sentry.seer.autofix.autofix_agent import (
     AutofixStep,
@@ -257,6 +259,11 @@ fixability_connection_pool_gpu = connection_from_url(
     timeout=settings.SEER_FIXABILITY_TIMEOUT,
 )
 
+fixability_connection_pool_cpu = connection_from_url(
+    settings.SEER_SUMMARIZATION_URL,
+    timeout=settings.SEER_FIXABILITY_TIMEOUT,
+)
+
 
 class FixabilityScoreRequest(TypedDict):
     group_id: int
@@ -268,11 +275,12 @@ class FixabilityScoreRequest(TypedDict):
 
 def make_fixability_score_request(
     body: FixabilityScoreRequest,
+    connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
     viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
-        fixability_connection_pool_gpu,
+        connection_pool or fixability_connection_pool_gpu,
         "/v1/automation/summarize/fixability",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
         timeout=timeout,
@@ -292,9 +300,17 @@ def _generate_fixability_score(
     )
     if summary is not None:
         body["summary"] = summary
+    pool = (
+        fixability_connection_pool_cpu
+        if in_random_rollout("seer.fixability.cpu-rollout")
+        else fixability_connection_pool_gpu
+    )
     viewer_context = SeerViewerContext(organization_id=group.organization.id)
     response = make_fixability_score_request(
-        body, timeout=settings.SEER_FIXABILITY_TIMEOUT, viewer_context=viewer_context
+        body,
+        connection_pool=pool,
+        timeout=settings.SEER_FIXABILITY_TIMEOUT,
+        viewer_context=viewer_context,
     )
     if response.status >= 400:
         raise Exception(f"Seer API error: {response.status}")


### PR DESCRIPTION
+ Add CPU-targeted connection pools using SEER_SUMMARIZATION_URL alongside the existing GPU pools for both severity scoring and fixability scoring. 
+ Use in_random_rollout() with the previously registered seer.severity.cpu-rollout and seer.fixability.cpu-rollout options to probabilistically route requests to CPU pods. Both options default to 0.0, so no traffic moves until explicitly configured.
+ Waiting till all regions have the models loaded in summarizations pods. Blocked till inc-2229 is resolved. 