### PR TITLE
ref(integrations): Always use the pipeline modal on the integration link page

### DIFF
--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -96,15 +96,6 @@ export function generateOrgSlugUrl(orgSlug: any) {
   return `${window.location.protocol}//${orgSlug}.${sentryDomain}${window.location.pathname}`;
 }
 
-/**
- * Encodes given object into url-friendly format
- */
-export function urlEncode(object: Record<string, any>): string {
-  return Object.keys(object)
-    .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(object[key])}`)
-    .join('&');
-}
-
 export function isNumericString(value: string): boolean {
   const s = value.trim();
 

--- a/static/app/views/integrationOrganizationLink/index.spec.tsx
+++ b/static/app/views/integrationOrganizationLink/index.spec.tsx
@@ -1,5 +1,7 @@
+import * as Sentry from '@sentry/react';
 import pick from 'lodash/pick';
 import {ConfigFixture} from 'sentry-fixture/config';
+import {IntegrationProviderFixture} from 'sentry-fixture/integrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {VercelProviderFixture} from 'sentry-fixture/vercelIntegration';
 
@@ -120,5 +122,51 @@ describe('IntegrationOrganizationLink', () => {
     expect(screen.getByRole('button', {name: 'Install Vercel'})).toBeEnabled();
     expect(getProviderMock).toHaveBeenCalled();
     expect(getOrgMock).toHaveBeenCalled();
+  });
+
+  it('shows an error and reports to Sentry when the provider has no pipeline', async () => {
+    setupConfigStore(org2);
+
+    const captureException = jest.spyOn(Sentry, 'captureException');
+
+    const provider = IntegrationProviderFixture({
+      key: 'generic-provider',
+      name: 'Generic Provider',
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org2.slug}/config/integrations/`,
+      match: [MockApiClient.matchQuery({provider_key: 'generic-provider'})],
+      body: {providers: [provider]},
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org2.slug}/`,
+      match: [MockApiClient.matchQuery({include_feature_flags: 1})],
+      body: org2,
+    });
+
+    render(<IntegrationOrganizationLink />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/extensions/generic-provider/link/',
+        },
+        route: '/extensions/:integrationSlug/link/',
+      },
+    });
+
+    await selectEvent.select(await screen.findByRole('textbox'), org2.name);
+
+    expect(
+      await screen.findByText(/Sentry does not support installing/)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Install Generic Provider'})
+    ).not.toBeInTheDocument();
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'No integration pipeline registered for generic-provider',
+      })
+    );
   });
 });

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import * as Sentry from '@sentry/react';
 import {skipToken, useQuery} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -13,20 +14,20 @@ import {FieldGroup} from 'sentry/components/forms/fieldGroup';
 import {IdBadge} from 'sentry/components/idBadge';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {NarrowLayout} from 'sentry/components/narrowLayout';
+import {
+  getPipelineDefinition,
+  type ProvidersByType,
+} from 'sentry/components/pipeline/registry';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {TextCopyInput} from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Integration, IntegrationProvider} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
-import {generateOrgSlugUrl, urlEncode} from 'sentry/utils';
+import {generateOrgSlugUrl} from 'sentry/utils';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
-import {
-  getIntegrationFeatureGate,
-  isScmProvider,
-  trackIntegrationAnalytics,
-} from 'sentry/utils/integrationUtil';
+import {getIntegrationFeatureGate} from 'sentry/utils/integrationUtil';
 import {singleLineRenderer} from 'sentry/utils/marked/marked';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
@@ -36,36 +37,6 @@ import {RouteError} from 'sentry/views/routeError';
 import {IntegrationLayout} from 'sentry/views/settings/organizationIntegrations/detailedView/integrationLayout';
 
 import {GitHubInstallationCallout} from './gitHubInstallationCallout';
-
-function trackExternalAnalytics({
-  eventName,
-  startSession,
-  organization,
-  provider,
-}: {
-  eventName: 'integrations.installation_start';
-  organization: Organization | null;
-  provider: IntegrationProvider | null;
-  startSession?: boolean;
-}) {
-  if (!organization || !provider) {
-    return;
-  }
-
-  trackIntegrationAnalytics(
-    eventName,
-    {
-      integration_type: 'first_party',
-      integration: provider.key,
-      is_scm: isScmProvider(provider),
-      // We actually don't know if it's installed but neither does the user in the view and multiple installs is possible
-      already_installed: false,
-      view: 'external_install',
-      organization,
-    },
-    {startSession: !!startSession}
-  );
-}
 
 /**
  * Landing page that completes an integration install initiated from a
@@ -106,9 +77,10 @@ function trackExternalAnalytics({
  *    `/extensions/vsts/configure/`). Drives the `vsts` pipeline with
  *    `vstsParams`.
  *
- *  - Anything else
- *    falls through to {@link finishLegacyInstallation}, which bounces to the
- *    legacy `/extensions/<slug>/configure/` backend endpoint.
+ * Every install routes through the API-driven pipeline modal. Providers without
+ * provider-supplied params just start the flow with no `urlParams`. A provider
+ * with no registered pipeline is treated as an invalid flow: the error is
+ * reported to Sentry and an inline error is shown instead of an install button.
  */
 export default function IntegrationOrganizationLink() {
   const location = useLocation();
@@ -297,50 +269,57 @@ export default function IntegrationOrganizationLink() {
     return {targetId};
   }, [integrationSlug, location.query]);
 
-  // Legacy install path. Redirects to `/extensions/<slug>/configure/`, which
-  // runs the Django-rendered `IntegrationExtensionConfigurationView` to drive
-  // the install server-side via the legacy pipeline. Used by every provider
-  // that hasn't been migrated to the API pipeline modal yet.
-  const finishLegacyInstallation = useCallback(() => {
-    // add the selected org to the query parameters and then redirect back to configure
-    const query = {orgSlug: selectedOrgSlug, ...location.query};
-    trackExternalAnalytics({
-      eventName: 'integrations.installation_start',
-      organization,
-      provider,
-    });
-    // need to send to control silo to finish the installation
-    window.location.assign(
-      `${organization?.links.organizationUrl || ''}/extensions/${
-        integrationSlug
-      }/configure/?${urlEncode(query)}`
-    );
-  }, [integrationSlug, location.query, organization, provider, selectedOrgSlug]);
+  // A flow is invalid when the resolved provider has no pipeline registered for
+  // it. Every first-party provider should have one, so this only happens for an
+  // unsupported provider landing on this page -- we surface it instead of
+  // rendering a dead install button.
+  const isInvalidFlow = useMemo(() => {
+    if (!provider) {
+      return false;
+    }
+    try {
+      // `provider.key` is an unconstrained string; an unsupported provider has
+      // no registered pipeline and `getPipelineDefinition` throws for it.
+      getPipelineDefinition(
+        'integration',
+        provider.key as ProvidersByType['integration']
+      );
+      return false;
+    } catch {
+      return true;
+    }
+  }, [provider]);
+
+  useEffect(() => {
+    if (provider && isInvalidFlow) {
+      Sentry.captureException(
+        new Error(`No integration pipeline registered for ${provider.key}`)
+      );
+    }
+  }, [provider, isInvalidFlow]);
 
   const handleInstallClick = useCallback(() => {
-    if (!provider || !organization) {
+    if (!provider || !organization || isInvalidFlow) {
       return;
     }
 
     // Each provider-initiated entry point contributes its own params bag.
-    // Whichever one is non-null routes through the API pipeline modal;
-    // otherwise we fall back to the legacy server-driven install flow.
+    // Whichever one is non-null is forwarded to the API pipeline modal as
+    // initial data; otherwise the flow starts with no provider-supplied params.
     const urlParams =
       gitHubAppListingParams ??
       discordAppDirectoryParams ??
       msTeamsParams ??
       jiraParams ??
       vercelParams ??
-      vstsParams;
-    if (urlParams) {
-      startFlow({provider, organization, onInstall, urlParams});
-      return;
-    }
+      vstsParams ??
+      undefined;
 
-    finishLegacyInstallation();
+    startFlow({provider, organization, onInstall, urlParams});
   }, [
     provider,
     organization,
+    isInvalidFlow,
     gitHubAppListingParams,
     discordAppDirectoryParams,
     msTeamsParams,
@@ -349,13 +328,25 @@ export default function IntegrationOrganizationLink() {
     vstsParams,
     startFlow,
     onInstall,
-    finishLegacyInstallation,
   ]);
 
   const renderAddButton = useMemo(() => {
     if (!provider || !organization) {
       return null;
     }
+
+    if (isInvalidFlow) {
+      return (
+        <Alert.Container>
+          <Alert variant="danger">
+            {tct('Sentry does not support installing [provider] from this page.', {
+              provider: <strong>{provider.name}</strong>,
+            })}
+          </Alert>
+        </Alert.Container>
+      );
+    }
+
     const {features} = provider.metadata;
 
     // Prepare the features list
@@ -386,7 +377,7 @@ export default function IntegrationOrganizationLink() {
         )}
       </IntegrationFeatures>
     );
-  }, [provider, organization, hasAccess, handleInstallClick]);
+  }, [provider, organization, hasAccess, handleInstallClick, isInvalidFlow]);
 
   const renderBottom = useMemo(() => {
     const {FeatureList} = getIntegrationFeatureGate();


### PR DESCRIPTION
The org-link page no longer falls back to the legacy server-rendered `/extensions/<slug>/configure/` install. Every provider is API-driven, so the install action always starts the pipeline modal flow.

When a provider has no registered pipeline, the page now renders an inline error and reports the invalid flow to Sentry instead of silently doing nothing.

Part of [VDY-32](https://linear.app/getsentry/issue/VDY-32/migrate-integration-setup-pipelines-to-api-driven-flows).