### PR TITLE
fix(seer-explorer): Key tool-call rows by id, not function+index

### DIFF
--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -171,7 +171,7 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
 
         return (
           <ToolCallRow
-            key={toolCall.id}
+            key={toolCall.id ?? `${toolCall.function}-${idx}`}
             toolString={toolsUsed[idx] ?? ''}
             blockStatus={idx === 0 ? blockStatus : undefined}
             isLoading={isLoading}

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -171,7 +171,7 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
 
         return (
           <ToolCallRow
-            key={`${toolCall.function}-${idx}`}
+            key={toolCall.id}
             toolString={toolsUsed[idx] ?? ''}
             blockStatus={idx === 0 ? blockStatus : undefined}
             isLoading={isLoading}


### PR DESCRIPTION
The React key for tool-call rows was `${toolCall.function}-${idx}` — index-based (the classic anti-pattern) and not unique when a block makes two calls to the same tool, which produces duplicate keys and can mis-reconcile renders.

Key on `toolCall.id` instead. Tool-call ids are now non-null and stable across polls over the wire — getsentry/seer#6887 synthesizes a deterministic `seer:{block_id}:{index}` id when the provider (e.g. Gemini) omits one — so the id is safe to use as the key.

Best landed after/with getsentry/seer#6887, which guarantees the non-null stable id.