### PR TITLE
fix(metric-issues): Filter contributing issues by detector environment

### DIFF
--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -275,6 +275,73 @@ describe('MetricDetectorTriggeredSection', () => {
     await screen.findByRole('link', {name: 'RequestError'});
   });
 
+  it('filters contributing issues by environment when set on detector', async () => {
+    const startDate = '2023-12-31T23:58:00.000Z';
+
+    const dataSourceWithEnv = SnubaQueryDataSourceFixture({
+      queryObj: {
+        id: '1',
+        status: 1,
+        subscription: '1',
+        snubaQuery: {
+          aggregate: 'count()',
+          dataset: Dataset.ERRORS,
+          id: '',
+          query: 'is:unresolved',
+          timeWindow: 60,
+          eventTypes: [EventTypes.ERROR],
+          environment: 'production',
+        },
+      },
+    });
+
+    const contributingIssuesMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/',
+      body: [GroupFixture()],
+    });
+
+    const event = EventFixture({
+      dateCreated: openPeriodStartDate,
+      eventID: 'event-1',
+      groupID: '123',
+      occurrence: {
+        id: '1',
+        eventId: 'event-1',
+        fingerprint: ['fingerprint'],
+        issueTitle: 'Test Issue',
+        subtitle: 'Subtitle',
+        resourceId: 'resource-1',
+        evidenceData: {
+          conditions: [condition],
+          dataSources: [dataSourceWithEnv],
+          value: 150,
+        },
+        evidenceDisplay: [],
+        type: 8001,
+        detectionTime: '2024-01-01T00:00:00Z',
+      },
+    });
+
+    render(<MetricDetectorTriggeredSection {...defaultProps} event={event} />);
+
+    await waitFor(() => {
+      expect(contributingIssuesMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: 'issue.type:error event.type:error is:unresolved',
+            start: startDate,
+            end: openPeriodEndDate,
+            environment: 'production',
+          }),
+        })
+      );
+    });
+
+    expect(screen.getByRole('cell', {name: 'Environment'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'production'})).toBeInTheDocument();
+  });
+
   it('renders contributing issues section for crash free rate (releases) dataset', async () => {
     const startDate = '2023-12-31T23:58:00.000Z';
 

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -99,6 +99,7 @@ function isMetricDetectorEvidenceData(
 interface RelatedIssuesProps {
   aggregate: string;
   end: string;
+  environment: string | undefined;
   eventDateCreated: string | undefined;
   projectId: string | number;
   query: string;
@@ -235,6 +236,7 @@ function ContributingIssues({
   eventDateCreated,
   aggregate,
   end,
+  environment,
   start,
 }: RelatedIssuesProps) {
   const organization = useOrganization();
@@ -262,6 +264,7 @@ function ContributingIssues({
     query: `issue.type:error ${query}`,
     start,
     end,
+    ...(environment ? {environment} : {}),
     limit: 5,
     sort: aggregate === 'count_unique(user)' ? 'user' : 'freq',
     groupStatsPeriod: 'auto',
@@ -277,6 +280,7 @@ function ContributingIssues({
       dataset: SavedQueryDatasets.ERRORS,
       start,
       end,
+      ...(environment ? {environment} : {}),
     },
   };
 
@@ -509,6 +513,7 @@ function TriggeredConditionDetails({
             query={issueSearchQuery}
             eventDateCreated={eventDateCreated}
             aggregate={snubaQuery.aggregate}
+            environment={snubaQuery.environment}
             start={startDate}
             end={endDate}
           />

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -449,6 +449,15 @@ function TriggeredConditionDetails({
               value: datasetConfig.fromApiAggregate(snubaQuery.aggregate),
               subject: t('Aggregate'),
             },
+            ...(snubaQuery.environment
+              ? [
+                  {
+                    key: 'environment',
+                    value: snubaQuery.environment,
+                    subject: t('Environment'),
+                  },
+                ]
+              : []),
             ...(snubaQuery.query
               ? [
                   {


### PR DESCRIPTION
The metric issue details wasn't handling monitors with an environment very well. It didn't show it in the 'Triggered condition' table, and it didn't query with that environment in the contributing issues section. This PR addresses both of those issues.