### PR TITLE
ref(integrations): Remove the unused setupDialog from the integration type

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -383,7 +383,6 @@ export interface IntegrationProvider extends BaseIntegrationProvider {
     noun: string;
     source_url: string;
   };
-  setupDialog: {height: number; url: string; width: number};
 }
 
 interface OrganizationIntegrationProvider extends BaseIntegrationProvider {

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -51,11 +51,6 @@ describe('IntegrationDetailedView', () => {
             },
             name: 'Bitbucket',
 
-            setupDialog: {
-              height: 600,
-              url: '/organizations/sentry/integrations/bitbucket/setup/',
-              width: 600,
-            },
             slug: 'bitbucket',
           },
         ],

--- a/static/app/views/settings/organizationRepositories/components/connectProviderDropdown.stories.tsx
+++ b/static/app/views/settings/organizationRepositories/components/connectProviderDropdown.stories.tsx
@@ -11,7 +11,6 @@ function makeProvider(key: string, name: string): IntegrationProvider {
     canAdd: true,
     canDisable: false,
     features: [],
-    setupDialog: {url: '', width: 600, height: 600},
     metadata: {
       description: '',
       features: [],

--- a/static/app/views/settings/organizationRepositories/components/noIntegrationsEmptyState.stories.tsx
+++ b/static/app/views/settings/organizationRepositories/components/noIntegrationsEmptyState.stories.tsx
@@ -11,7 +11,6 @@ function makeProvider(key: string, name: string): IntegrationProvider {
     canAdd: true,
     canDisable: false,
     features: [],
-    setupDialog: {url: '', width: 600, height: 600},
     metadata: {
       description: '',
       features: [],

--- a/static/app/views/settings/organizationRepositories/components/scmRepositoryTable.stories.tsx
+++ b/static/app/views/settings/organizationRepositories/components/scmRepositoryTable.stories.tsx
@@ -23,7 +23,6 @@ const GITHUB_PROVIDER: IntegrationProvider = {
   canAdd: true,
   canDisable: false,
   features: [],
-  setupDialog: {url: '', width: 600, height: 600},
   metadata: {
     description: '',
     features: [],

--- a/tests/js/fixtures/githubIntegrationProvider.ts
+++ b/tests/js/fixtures/githubIntegrationProvider.ts
@@ -9,11 +9,6 @@ export function GitHubIntegrationProviderFixture(
     name: 'GitHub',
     canAdd: true,
     features: [],
-    setupDialog: {
-      url: '/github-integration-setup-uri/',
-      width: 100,
-      height: 100,
-    },
     canDisable: true,
     metadata: {
       description: '*markdown* formatted _description_',

--- a/tests/js/fixtures/gitlabIntegrationProvider.ts
+++ b/tests/js/fixtures/gitlabIntegrationProvider.ts
@@ -9,11 +9,6 @@ export function GitLabIntegrationProviderFixture(
     name: 'GitLab',
     canAdd: true,
     features: [],
-    setupDialog: {
-      url: '/gitlab-integration-setup-uri/',
-      width: 100,
-      height: 100,
-    },
     canDisable: true,
     metadata: {
       description: '*markdown* formatted _description_',

--- a/tests/js/fixtures/integrationListDirectory.ts
+++ b/tests/js/fixtures/integrationListDirectory.ts
@@ -29,11 +29,6 @@ export function ProviderListFixture(): {providers: IntegrationProvider[]} {
         },
         name: 'Bitbucket',
 
-        setupDialog: {
-          height: 600,
-          url: '/organizations/sentry/integrations/bitbucket/setup/',
-          width: 600,
-        },
         slug: 'bitbucket',
       },
     ],

--- a/tests/js/fixtures/integrationProvider.ts
+++ b/tests/js/fixtures/integrationProvider.ts
@@ -9,11 +9,6 @@ export function IntegrationProviderFixture(
     name: 'Generic Provider',
     canAdd: true,
     features: [],
-    setupDialog: {
-      url: '/generic-provider-setup-uri/',
-      width: 100,
-      height: 100,
-    },
     canDisable: true,
     metadata: {
       description: 'A generic integration provider for testing',

--- a/tests/js/fixtures/opsgenieIntegrationProvider.ts
+++ b/tests/js/fixtures/opsgenieIntegrationProvider.ts
@@ -23,11 +23,6 @@ export function OpsgenieIntegrationProviderFixture(
     canAdd: true,
     canDisable: false,
     features: ['alert-rule', 'incident-management'],
-    setupDialog: {
-      url: '/organizations/sentry/integrations/opsgenie/setup/',
-      width: 600,
-      height: 600,
-    },
     ...params,
   };
 }

--- a/tests/js/fixtures/vercelIntegration.ts
+++ b/tests/js/fixtures/vercelIntegration.ts
@@ -2,11 +2,6 @@ import type {IntegrationProvider} from 'sentry/types/integrations';
 
 export function VercelProviderFixture(): IntegrationProvider {
   return {
-    setupDialog: {
-      url: '/organizations/sentry/integrations/vercel/setup/',
-      width: 600,
-      height: 600,
-    },
     canAdd: true,
     canDisable: false,
     name: 'Vercel',


### PR DESCRIPTION
The integration setup popup that consumed `provider.setupDialog` (window URL and dimensions) was removed when integrations moved to the API-driven pipeline modal, and the backend no longer serializes the field. This drops the now-unused `setupDialog` from the `IntegrationProvider` type, along with the fixtures, stories, and spec that set it.

Backend removal of the field is in #117362.

Part of [VDY-32](https://linear.app/getsentry/issue/VDY-32/migrate-integration-setup-pipelines-to-api-driven-flows).