### PR TITLE
ref(cells): Fetch org listing from control silo unconditionally

### DIFF
--- a/.agents/skills/cell-architecture/SKILL.md
+++ b/.agents/skills/cell-architecture/SKILL.md
@@ -8,9 +8,8 @@ description: >-
   URL_NAME_TO_ACTION registry in test_urls.py to zero (with a recipe for each action type),
   rolling deploy safety and the two-phase pattern required by independent sentry/getsentry deploys,
   and the region -> cell rename including what not to rename (DB columns, AWS refs, uptime regions,
-  billing address). Also documents known issues with proposed fixes: org listing and creation
-  without a slug, integration TeamLinkageView routing, Jira cross-cell fan-out, and relocation
-  endpoint routing.
+  billing address). Also documents known issues with proposed fixes: integration TeamLinkageView
+  routing, Jira cross-cell fan-out, and relocation endpoint routing.
 ---
 
 > **Status**: Active migration in progress. Migration-specific sections should be removed once complete, leaving a stable architecture reference.
@@ -244,17 +243,6 @@ the context before renaming.
 ### Known Issues
 
 Specific broken areas with a description of the problem and the proposed fix. Remove each entry once resolved.
-
-#### Org Operations Without an Existing Org Slug
-
-Several org lifecycle operations have no existing org slug to route by, so Synapse can't route them to a specific cell within a locality:
-
-- **Org listing** — the frontend fans out `/organizations/` to each locality URL (`useOrganizationsWithRegion`). `OrganizationIndexEndpoint` is `@cell_silo_endpoint` and queries `Organization.objects.get_for_user_ids()`, so even if it reaches a cell it only returns orgs in that cell.
-- **Org creation** — the user picks a locality but there's no mechanism to select which cell within that locality the new org lands in.
-
-**The fix for listing**: move `OrganizationIndexEndpoint` to `@control_silo_endpoint` and query `OrganizationMemberMapping` (user -> org IDs) joined with `OrganizationMapping` — both already exist on control silo. Some response fields (e.g. avatar, auth provider, features) are not yet in `OrganizationMapping` and would need to be replicated or dropped.
-
-**Org creation**: `Locality.new_org_cell` to route new orgs to the correct cell within the selected locality.
 
 #### Integration Views and Cell Routing
 

--- a/static/app/actionCreators/organizations.spec.tsx
+++ b/static/app/actionCreators/organizations.spec.tsx
@@ -2,7 +2,6 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {fetchOrganizations} from 'sentry/actionCreators/organizations';
 import {ConfigStore} from 'sentry/stores/configStore';
-import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 
 describe('fetchOrganizations', () => {
   const api = new MockApiClient();
@@ -11,52 +10,13 @@ describe('fetchOrganizations', () => {
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
-    // Reset between tests so the control-silo flag doesn't leak into the
-    // fan-out cases (and vice versa).
-    ConfigStore.set('features', new Set());
   });
 
-  it('fetches from multiple regions', async () => {
-    ConfigStore.set('memberRegions', [
-      {name: 'us', url: 'https://us.example.org'},
-      {name: 'de', url: 'https://de.example.org'},
-    ]);
-    const usMock = MockApiClient.addMockResponse({
-      url: '/organizations/',
-      body: [usorg],
-      match: [
-        function (_url: string, options: Record<string, any>) {
-          return options.host === 'https://us.example.org';
-        },
-      ],
-    });
-    const deMock = MockApiClient.addMockResponse({
-      url: '/organizations/',
-      body: [deorg],
-      match: [
-        function (_url: string, options: Record<string, any>) {
-          return options.host === 'https://de.example.org';
-        },
-      ],
-    });
-
-    const organizations = await fetchOrganizations(api);
-
-    expect(organizations).toHaveLength(2);
-    expect(usMock).toHaveBeenCalledTimes(1);
-    expect(deMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('fetches from the control silo when organizations:use-control-org-listing is enabled', async () => {
-    ConfigStore.set('features', new Set(['organizations:use-control-org-listing']));
+  it('fetches the full cross-cell list from the control silo', async () => {
     ConfigStore.set('links', {
       ...ConfigStore.get('links'),
       sentryUrl: 'https://sentry.example.org',
     });
-    ConfigStore.set('memberRegions', [
-      {name: 'us', url: 'https://us.example.org'},
-      {name: 'de', url: 'https://de.example.org'},
-    ]);
 
     const controlMock = MockApiClient.addMockResponse({
       url: '/organizations/',
@@ -67,55 +27,10 @@ describe('fetchOrganizations', () => {
         },
       ],
     });
-    const regionMock = MockApiClient.addMockResponse({
-      url: '/organizations/',
-      body: [usorg],
-      match: [
-        function (_url: string, options: Record<string, any>) {
-          return options.host !== 'https://sentry.example.org';
-        },
-      ],
-    });
 
     const organizations = await fetchOrganizations(api);
 
-    // Single control-silo request, no per-region fan-out.
     expect(organizations).toHaveLength(2);
     expect(controlMock).toHaveBeenCalledTimes(1);
-    expect(regionMock).not.toHaveBeenCalled();
-  });
-
-  it('ignores 401 errors from a region', async () => {
-    ConfigStore.set('memberRegions', [
-      {name: 'us', url: 'https://us.example.org'},
-      {name: 'de', url: 'https://de.example.org'},
-    ]);
-    const usMock = MockApiClient.addMockResponse({
-      url: '/organizations/',
-      body: [usorg],
-      match: [
-        function (_url: string, options: Record<string, any>) {
-          return options.host === 'https://us.example.org';
-        },
-      ],
-    });
-    const deMock = MockApiClient.addMockResponse({
-      url: '/organizations/',
-      body: {detail: 'Authentication credentials required'},
-      status: 401,
-      match: [
-        function (_url: string, options: Record<string, any>) {
-          return options.host === 'https://de.example.org';
-        },
-      ],
-    });
-
-    const organizations = await fetchOrganizations(api);
-
-    expect(organizations).toHaveLength(1);
-    expect(organizations[0].slug).toEqual(usorg.slug);
-    expect(usMock).toHaveBeenCalledTimes(1);
-    expect(deMock).toHaveBeenCalledTimes(1);
-    expect(testableWindowLocation.reload).not.toHaveBeenCalled();
   });
 });

--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -214,41 +214,14 @@ export async function fetchOrganizationDetails(
 /**
  * Get all organizations for the current user.
  *
- * Will perform a fan-out across all multi-tenant regions,
- * and single-tenant regions the user has membership in.
+ * The control silo endpoint returns the full cross-cell list in one call.
  *
  * This function is challenging to type as the structure of the response
  * from /organizations can vary based on query parameters
  */
 export async function fetchOrganizations(api: Client, query?: Record<string, any>) {
-  // TODO(cells): Once this rollout completes, this becomes the only path and the
-  // cell fan-out below (plus the `memberRegions` plumbing) can be deleted.
-  if (ConfigStore.get('features').has('organizations:use-control-org-listing')) {
-    // The control silo endpoint returns the full cross-cell list in one call,
-    // so there's no fan-out to merge.
-    const controlUrl = ConfigStore.get('links').sentryUrl;
-    return api.requestPromise('/organizations/', {
-      host: controlUrl,
-      query,
-    });
-  }
-
-  const regions = ConfigStore.get('memberRegions');
-  const results = await Promise.all(
-    regions.map(region =>
-      api.requestPromise('/organizations/', {
-        host: region.url,
-        query,
-        // Authentication errors can happen as we span regions.
-        allowAuthError: true,
-      })
-    )
-  );
-  return results.reduce((acc, response) => {
-    // Don't append error results to the org list.
-    if (response[0]) {
-      acc = acc.concat(response);
-    }
-    return acc;
-  }, []);
+  return api.requestPromise('/organizations/', {
+    host: ConfigStore.get('links').sentryUrl,
+    query,
+  });
 }

--- a/static/app/views/sentryAppExternalInstallation/index.spec.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.spec.tsx
@@ -250,40 +250,6 @@ describe('SentryAppExternalInstallation', () => {
       await waitFor(() => expect(screen.getByTestId('install')).toBeEnabled());
     });
 
-    it('loads orgs from multiple regions', async () => {
-      window.__initialData = {
-        ...window.__initialData,
-        memberRegions: [
-          {name: 'us', url: 'https://us.example.org'},
-          {name: 'de', url: 'https://de.example.org'},
-        ],
-      };
-      ConfigStore.loadInitialData(window.__initialData);
-
-      const deorg = OrganizationFixture({slug: 'de-org'});
-      const getDeOrgs = MockApiClient.addMockResponse({
-        url: '/organizations/',
-        body: [deorg],
-        match: [
-          function (_url: string, options: Record<string, any>) {
-            return options.host === 'https://de.example.org';
-          },
-        ],
-      });
-
-      render(<SentryAppExternalInstallation />, {
-        initialRouterConfig: {
-          route: '/sentry-apps/:sentryAppSlug/external-install/',
-          location: {
-            pathname: `/sentry-apps/${sentryApp.slug}/external-install/`,
-          },
-        },
-      });
-      await waitFor(() => expect(getInstallationsMock).toHaveBeenCalled());
-
-      expect(getDeOrgs).toHaveBeenCalled();
-    });
-
     it('selecting org changes the url', async () => {
       const preselectedOrg = OrganizationFixture();
 


### PR DESCRIPTION
The `cells.use-control-org-listing` option has been fully rolled out, so fetchOrganizations no longer needs the feature-flag check or the per-region fan-out fallback. The control silo endpoint returns the full cross-cell list in a single request.

Also remove the resolved org listing and org creation entries from the cell-architecture skill's known issues (listing is handled by the all-silo OrganizationIndexEndpoint querying mapping tables; creation is handled by Locality.new_org_cell).

The backend option and its client_config exposure will be removed in a follow-up PR once this lands.
