### PR TITLE
fix(sdk-crash): Add Trace ID

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import random
 from collections.abc import Mapping, Sequence
 from typing import Any
+from uuid import uuid4
 
 from sentry.issues.grouptype import GroupCategory
 from sentry.services.eventstore.models import Event, GroupEvent
@@ -121,6 +122,18 @@ class SDKCrashDetection:
                 value={
                     "original_project_id": event.project.id,
                     "original_event_id": event.event_id,
+                    "original_trace_id": event.trace_id,
+                },
+            )
+
+            # All errors need a trace ID.
+            set_path(
+                sdk_crash_event_data,
+                "contexts",
+                "trace",
+                value={
+                    "trace_id": uuid4().hex,
+                    "span_id": None,
                 },
             )
 

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -51,6 +51,7 @@ class BaseSDKCrashDetectionMixin(BaseTestCase, metaclass=abc.ABCMeta):
             assert reported_event_data["contexts"]["sdk_crash_detection"] == {
                 "original_project_id": event.project_id,
                 "original_event_id": event.event_id,
+                "original_trace_id": event.trace_id,
             }
             assert reported_event_data["user"] == {
                 "id": event.project_id,


### PR DESCRIPTION
We strip SDK crash errors in postprocess. This strips out their Trace ID; we need Trace IDs to store errors in EAP.

This PR adds a new Trace ID to these errors.