### PR TITLE
fix(integrations): Run the install pipeline against the selected organization

### DIFF
--- a/static/app/components/pipeline/modal.tsx
+++ b/static/app/components/pipeline/modal.tsx
@@ -12,6 +12,7 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {ProgressRing} from 'sentry/components/progressRing';
 import {IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
 
 import type {
   CompletionDataFor,
@@ -28,6 +29,7 @@ interface PipelineModalProps<
   type: T;
   initialData?: Record<string, string>;
   onComplete?: (data: CompletionDataFor<T, P>) => void;
+  organization?: Organization;
 }
 
 function PipelineModal<
@@ -41,6 +43,7 @@ function PipelineModal<
   provider,
   initialData,
   onComplete,
+  organization,
 }: PipelineModalProps<T, P>) {
   const handleComplete = (data: CompletionDataFor<T, P>) => {
     onComplete?.(data);
@@ -50,6 +53,7 @@ function PipelineModal<
   const pipeline = usePipeline(type, provider, {
     onComplete: handleComplete,
     initialData,
+    organization,
   });
   const {stepDefinition} = pipeline;
 
@@ -145,12 +149,20 @@ interface OpenPipelineModalOptions<
   initialData?: Record<string, string>;
   onClose?: () => void;
   onComplete?: (data: CompletionDataFor<T, P>) => void;
+  organization?: Organization;
 }
 
 export function openPipelineModal<
   T extends RegisteredPipelineType,
   P extends ProvidersByType[T] = ProvidersByType[T],
->({type, provider, initialData, onComplete, onClose}: OpenPipelineModalOptions<T, P>) {
+>({
+  type,
+  provider,
+  initialData,
+  onComplete,
+  onClose,
+  organization,
+}: OpenPipelineModalOptions<T, P>) {
   openModal(
     deps => (
       <PipelineModal
@@ -159,6 +171,7 @@ export function openPipelineModal<
         provider={provider}
         initialData={initialData}
         onComplete={onComplete}
+        organization={organization}
       />
     ),
     {onClose, closeEvents: 'none'}

--- a/static/app/components/pipeline/usePipeline.spec.tsx
+++ b/static/app/components/pipeline/usePipeline.spec.tsx
@@ -2,13 +2,21 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import type {Organization} from 'sentry/types/organization';
+
 import {usePipeline} from './usePipeline';
 
 const organization = OrganizationFixture();
 const API_URL = `/organizations/${organization.slug}/pipeline/integration_pipeline/`;
 
-function TestHarness({onComplete}: {onComplete?: (data: any) => void} = {}) {
-  const pipeline = usePipeline('integration', 'dummy', {onComplete});
+function TestHarness({
+  onComplete,
+  organization: organizationOption,
+}: {onComplete?: (data: any) => void; organization?: Organization} = {}) {
+  const pipeline = usePipeline('integration', 'dummy', {
+    onComplete,
+    organization: organizationOption,
+  });
 
   return (
     <div>
@@ -52,6 +60,36 @@ describe('usePipeline', () => {
     expect(screen.getByTestId('step-index')).toHaveTextContent('0');
     expect(screen.getByTestId('total-steps')).toHaveTextContent('2');
     expect(screen.getByTestId('is-complete')).toHaveTextContent('false');
+  });
+
+  it('runs against the explicitly passed organization, not the context org', async () => {
+    const selectedOrg = OrganizationFixture({slug: 'selected-org', id: '99'});
+    const selectedUrl = `/organizations/${selectedOrg.slug}/pipeline/integration_pipeline/`;
+
+    const selectedRequest = MockApiClient.addMockResponse({
+      url: selectedUrl,
+      method: 'POST',
+      body: {
+        step: 'step_one',
+        stepIndex: 0,
+        totalSteps: 2,
+        provider: 'dummy',
+        data: {message: 'Hello!'},
+      },
+      match: [MockApiClient.matchData({action: 'initialize', provider: 'dummy'})],
+    });
+    const contextRequest = MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {},
+    });
+
+    // Context org is `organization`, but the caller selected a different org.
+    render(<TestHarness organization={selectedOrg} />, {organization});
+
+    expect(await screen.findByText('Hello!')).toBeInTheDocument();
+    expect(selectedRequest).toHaveBeenCalledTimes(1);
+    expect(contextRequest).not.toHaveBeenCalled();
   });
 
   it('advances through steps and completes the pipeline', async () => {

--- a/static/app/components/pipeline/usePipeline.tsx
+++ b/static/app/components/pipeline/usePipeline.tsx
@@ -2,6 +2,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useMutation} from '@tanstack/react-query';
 
 import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {RequestError} from 'sentry/utils/requestError/requestError';
@@ -75,6 +76,13 @@ interface UsePipelineOptions<
    * Called when the piepline has finished
    */
   onComplete?: (data: CompletionDataFor<T, P>) => void;
+  /**
+   * The organization the pipeline runs against. Defaults to the organization
+   * from context, but flows such as the integration org-link page (where the
+   * user explicitly picks an organization that may differ from context) must
+   * pass it so the pipeline initializes against the chosen organization.
+   */
+  organization?: Organization;
 }
 
 /**
@@ -128,7 +136,8 @@ export function usePipeline<
   provider: P,
   options: UsePipelineOptions<T, P> = {}
 ): ApiPipeline<CompletionDataFor<T, P>> {
-  const organization = useOrganization();
+  const contextOrganization = useOrganization();
+  const organization = options.organization ?? contextOrganization;
   const [state, setState] = useState<PipelineState<T, P>>({status: 'idle'});
   const initializedRef = useRef(false);
   const onCompleteRef = useRef(options.onComplete);

--- a/static/app/utils/integrations/useAddIntegration.spec.tsx
+++ b/static/app/utils/integrations/useAddIntegration.spec.tsx
@@ -35,6 +35,7 @@ describe('useAddIntegration', () => {
       type: 'integration',
       provider: 'github',
       initialData: undefined,
+      organization: OrganizationFixture(),
       onComplete: expect.any(Function),
     });
   });

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -69,6 +69,10 @@ export function useAddIntegration() {
       type: 'integration',
       provider: provider.key as ProvidersByType['integration'],
       initialData: urlParams,
+      // Pass the explicit organization so the pipeline runs against the org the
+      // caller resolved (e.g. the org-link page's selected org), rather than
+      // defaulting to the org from React context.
+      organization,
       onComplete: data => {
         trackIntegrationAnalytics('integrations.installation_complete', {
           integration: provider.key,


### PR DESCRIPTION
The integration org-link page lets a user choose which organization to install into, which may differ from the organization in React context — e.g. multiple orgs on the main sentry.io host where there's no customer-domain redirect. `startFlow` opens the pipeline modal without threading that selection through, so `usePipeline` derives the pipeline endpoint from `useOrganization()` and can initialize the install against the wrong organization even though the UI reflects the user's choice.

This threads an explicit `organization` through `startFlow` → `openPipelineModal` → `usePipeline`, falling back to the context organization when not provided. It restores the behavior of the legacy configure redirect, which carried the selected org slug.

Added a `usePipeline` regression test asserting that an explicitly-passed organization is used for the pipeline endpoint rather than the context org.

This is not new to #117363 — the org-link page has routed provider-initiated installs (marketplace / app-directory entry points such as GitHub, Jira, VSTS, Vercel, Discord, and MS Teams) through `startFlow` → the API pipeline modal since those providers were migrated, so this has likely been broken for a while for those flows. #117363 only widened the exposure to all link-page installs by removing the legacy configure fallback.

Part of [VDY-32](https://linear.app/getsentry/issue/VDY-32/migrate-integration-setup-pipelines-to-api-driven-flows).
