### PR TITLE
fix(intercom): Switch from user_hash to intercom_user_jwt

### DIFF
--- a/static/app/utils/intercom.tsx
+++ b/static/app/utils/intercom.tsx
@@ -80,7 +80,7 @@ async function initIntercom(orgSlug: string): Promise<void> {
       const intercomSettings: IntercomSettings = {
         app_id: intercomAppId,
         user_id: jwtData.userData.userId,
-        user_hash: jwtData.jwt,
+        intercom_user_jwt: jwtData.jwt,
         email: jwtData.userData.email,
         name: jwtData.userData.name,
         created_at: jwtData.userData.createdAt,


### PR DESCRIPTION
the backend was already setup to generate these, however we were passing them to the old property.

see docs in linear

fixes https://linear.app/getsentry/issue/VULN-1946