### PR TITLE
feat(spans): add visuals to spans that have warnings/errors

### DIFF
--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -65,7 +65,7 @@ export type AggregateSpanType = RawSpanType & {
 };
 
 /**
- * Extendeds the Raw type from json with a type for discriminating the union.
+ * Extends the Raw type from json with a type for discriminating the union.
  */
 type BaseSpanType = RawSpanType & {
   type?: undefined;

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -138,6 +138,8 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
       'thread.id',
       'tags[performance.timeOrigin,number]',
       'gen_ai.operation.type',
+      'http.response.status_code',
+      'span.status',
     ],
   });
   const tree = useTraceTree({traceSlug, trace, replay: null});

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1152,6 +1152,9 @@ const TraceStylingWrapper = styled('div')`
     &.info {
     }
     &.warning {
+      color: ${p => p.theme.tokens.content.warning};
+      --row-children-button-border-color: ${p => p.theme.tokens.content.warning};
+      --row-outline: ${p => p.theme.tokens.content.warning};
     }
     &.debug {
     }
@@ -1159,7 +1162,6 @@ const TraceStylingWrapper = styled('div')`
     &.fatal,
     &.occurrence {
       color: ${p => p.theme.tokens.content.danger};
-      --autogrouped: ${p => p.theme.tokens.content.danger};
       --row-children-button-border-color: ${p => p.theme.tokens.content.danger};
       --row-outline: ${p => p.theme.tokens.content.danger};
     }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -67,6 +67,7 @@ import {Alerts} from './sections/alerts';
 import {SpanDescription} from './sections/description';
 import {GeneralInfo} from './sections/generalInfo';
 import {hasSpanHTTPInfo, SpanHTTPInfo} from './sections/http';
+import {HttpErrorCard} from './sections/httpErrorCard';
 import {hasSpanKeys, SpanKeys} from './sections/keys';
 import {hasSpanMeasurements, Measurements} from './sections/measurements';
 import {hasSpanTags, Tags} from './sections/tags';
@@ -239,6 +240,7 @@ function SpanNodeDetailsContent({
         {issues.length > 0 ? (
           <IssueList organization={organization} issues={issues} node={node} />
         ) : null}
+        {node.hasHttpError && issues.length === 0 ? <HttpErrorCard node={node} /> : null}
         <SpanDescription
           node={node}
           project={project}
@@ -549,6 +551,7 @@ function EAPSpanNodeDetailsContent({
         {issues.length > 0 ? (
           <IssueList organization={organization} issues={issues} node={node} />
         ) : null}
+        {node.hasHttpError && issues.length === 0 ? <HttpErrorCard node={node} /> : null}
         <EAPSpanDescription
           node={node}
           project={project}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.spec.tsx
@@ -1,0 +1,131 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {EapSpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode';
+import {SpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode';
+import {
+  makeEAPSpan,
+  makeSpan,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+
+import {HttpErrorCard} from './httpErrorCard';
+
+const extra = {organization: OrganizationFixture()};
+
+describe('HttpErrorCard', () => {
+  it('does not render when hasHttpError is false', () => {
+    const node = new SpanNode(null, makeSpan({status: 'ok', data: {}}), extra);
+
+    const {container} = render(<HttpErrorCard node={node} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe('SpanNode', () => {
+    it('displays status text and status code', () => {
+      const node = new SpanNode(
+        null,
+        makeSpan({
+          status: 'internal_error',
+          data: {'http.response.status_code': 500},
+        }),
+        extra
+      );
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('Internal Error')).toBeInTheDocument();
+      expect(screen.getByText('HTTP 500')).toBeInTheDocument();
+    });
+
+    it('displays only status code when status is not set', () => {
+      const node = new SpanNode(
+        null,
+        makeSpan({data: {'http.response.status_code': 502}}),
+        extra
+      );
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('HTTP Error')).toBeInTheDocument();
+      expect(screen.getByText('HTTP 502')).toBeInTheDocument();
+    });
+
+    it('displays only status text when status code is not present', () => {
+      const node = new SpanNode(null, makeSpan({status: 'not_found', data: {}}), extra);
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('Not Found')).toBeInTheDocument();
+      expect(screen.queryByText(/HTTP \d/)).not.toBeInTheDocument();
+    });
+
+    it('does not show non-error status as title when only status code triggers the error', () => {
+      const node = new SpanNode(
+        null,
+        makeSpan({status: 'ok', data: {'http.response.status_code': 500}}),
+        extra
+      );
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('HTTP Error')).toBeInTheDocument();
+      expect(screen.getByText('HTTP 500')).toBeInTheDocument();
+      expect(screen.queryByText('Ok')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('EapSpanNode', () => {
+    it('displays status text and status code', () => {
+      const node = new EapSpanNode(
+        null,
+        makeEAPSpan({
+          event_id: 'span-1',
+          additional_attributes: {
+            'span.status': 'resource_exhausted',
+            'http.response.status_code': 429,
+          },
+        }),
+        extra
+      );
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('Resource Exhausted')).toBeInTheDocument();
+      expect(screen.getByText('HTTP 429')).toBeInTheDocument();
+    });
+
+    it('displays only status code when span.status is not present', () => {
+      const node = new EapSpanNode(
+        null,
+        makeEAPSpan({
+          event_id: 'span-2',
+          additional_attributes: {'http.response.status_code': 503},
+        }),
+        extra
+      );
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('HTTP Error')).toBeInTheDocument();
+      expect(screen.getByText('HTTP 503')).toBeInTheDocument();
+    });
+
+    it('displays only status text when status code is not present', () => {
+      const node = new EapSpanNode(
+        null,
+        makeEAPSpan({
+          event_id: 'span-3',
+          additional_attributes: {'span.status': 'unavailable'},
+        }),
+        extra
+      );
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('Unavailable')).toBeInTheDocument();
+      expect(screen.queryByText(/HTTP \d/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.tsx
@@ -1,0 +1,84 @@
+import styled from '@emotion/styled';
+
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {Panel} from 'sentry/components/panels/panel';
+import {PanelItem} from 'sentry/components/panels/panelItem';
+import {IconWarning} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {HTTP_ERROR_STATUSES} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/constants';
+import type {EapSpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode';
+import {SpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode';
+
+type HttpErrorCardProps = {
+  node: SpanNode | EapSpanNode;
+};
+
+function formatStatusText(status: string): string {
+  return status
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function getStatusInfo(node: SpanNode | EapSpanNode): {
+  statusCode: number | null;
+  statusText: string | null;
+} {
+  const status =
+    node instanceof SpanNode ? node.value.status : node.attributes?.['span.status'];
+  const statusText =
+    typeof status === 'string' && HTTP_ERROR_STATUSES.has(status)
+      ? formatStatusText(status)
+      : null;
+  const raw = Number(node.attributes?.['http.response.status_code']);
+  const statusCode = !isNaN(raw) && raw >= 400 ? raw : null;
+  return {statusText, statusCode};
+}
+
+export function HttpErrorCard({node}: HttpErrorCardProps) {
+  if (!node.hasHttpError) {
+    return null;
+  }
+
+  const {statusText, statusCode} = getStatusInfo(node);
+
+  return (
+    <Wrapper>
+      <StyledPanel>
+        <StyledPanelItem>
+          <Flex align="center" justify="center">
+            <IconWarning size="md" variant="warning" />
+          </Flex>
+          <Stack gap="2xs">
+            <Flex gap="xs" align="center">
+              <Text bold>{statusText ?? t('HTTP Error')}</Text>
+              {statusCode !== null && (
+                <Text variant="muted">{t('HTTP %s', statusCode)}</Text>
+              )}
+            </Flex>
+            <Text size="sm" variant="muted">
+              {t('This span returned an error status but has no associated issue.')}
+            </Text>
+          </Stack>
+        </StyledPanelItem>
+      </StyledPanel>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled('div')`
+  margin: ${p => p.theme.space.md} 0;
+`;
+
+const StyledPanel = styled(Panel)`
+  margin-bottom: 0;
+`;
+
+const StyledPanelItem = styled(PanelItem)`
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl} ${p => p.theme.space.lg}
+    ${p => p.theme.space.md};
+`;

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.spec.tsx
@@ -1875,4 +1875,11 @@ describe('BaseNode', () => {
       expect(node.hasOccurrences).toBe(true);
     });
   });
+
+  describe('hasHttpError', () => {
+    it('should return false by default', () => {
+      const node = new TestNode(null, createMockValue(), createMockExtra());
+      expect(node.hasHttpError).toBe(false);
+    });
+  });
 });

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
@@ -268,6 +268,10 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
     return this.errors.size > 0;
   }
 
+  get hasHttpError(): boolean {
+    return false;
+  }
+
   get hasProfiles(): boolean {
     return !!(this.profileId || this.profilerId);
   }

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/constants.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/constants.tsx
@@ -1,0 +1,11 @@
+export const HTTP_ERROR_STATUSES = new Set([
+  'internal_error',
+  'invalid_argument',
+  'not_found',
+  'permission_denied',
+  'unauthenticated',
+  'resource_exhausted',
+  'unimplemented',
+  'unavailable',
+  'deadline_exceeded',
+]);

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.spec.tsx
@@ -1058,6 +1058,15 @@ describe('EapSpanNode', () => {
       expect(node.hasHttpError).toBe(true);
     });
 
+    it('should return true when http.response.status_code is a string >= 400', () => {
+      const value = makeEAPSpan({
+        event_id: 'test',
+        additional_attributes: {'http.response.status_code': '502'},
+      });
+      const node = new EapSpanNode(null, value, createMockExtra());
+      expect(node.hasHttpError).toBe(true);
+    });
+
     it('should return false when http.response.status_code is 0 and no span.status', () => {
       const value = makeEAPSpan({
         event_id: 'test',

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.spec.tsx
@@ -1023,4 +1023,60 @@ describe('EapSpanNode', () => {
       expect(node.resolveValueFromSearchKey('transaction.duration')).toBeNull();
     });
   });
+
+  describe('hasHttpError', () => {
+    it('should return false when additional_attributes is undefined', () => {
+      const value = makeEAPSpan({event_id: 'test'});
+      const node = new EapSpanNode(null, value, createMockExtra());
+      expect(node.hasHttpError).toBe(false);
+    });
+
+    it('should return true when span.status is an error string', () => {
+      const value = makeEAPSpan({
+        event_id: 'test',
+        additional_attributes: {'span.status': 'internal_error'},
+      });
+      const node = new EapSpanNode(null, value, createMockExtra());
+      expect(node.hasHttpError).toBe(true);
+    });
+
+    it('should return false when span.status is a non-error string', () => {
+      const value = makeEAPSpan({
+        event_id: 'test',
+        additional_attributes: {'span.status': 'ok'},
+      });
+      const node = new EapSpanNode(null, value, createMockExtra());
+      expect(node.hasHttpError).toBe(false);
+    });
+
+    it('should return true when http.response.status_code >= 400', () => {
+      const value = makeEAPSpan({
+        event_id: 'test',
+        additional_attributes: {'http.response.status_code': 503},
+      });
+      const node = new EapSpanNode(null, value, createMockExtra());
+      expect(node.hasHttpError).toBe(true);
+    });
+
+    it('should return false when http.response.status_code is 0 and no span.status', () => {
+      const value = makeEAPSpan({
+        event_id: 'test',
+        additional_attributes: {'http.response.status_code': 0},
+      });
+      const node = new EapSpanNode(null, value, createMockExtra());
+      expect(node.hasHttpError).toBe(false);
+    });
+
+    it('should return true when http.response.status_code is 0 but span.status is an error', () => {
+      const value = makeEAPSpan({
+        event_id: 'test',
+        additional_attributes: {
+          'http.response.status_code': 0,
+          'span.status': 'internal_error',
+        },
+      });
+      const node = new EapSpanNode(null, value, createMockExtra());
+      expect(node.hasHttpError).toBe(true);
+    });
+  });
 });

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
@@ -13,6 +13,7 @@ import {TraceEAPSpanRow} from 'sentry/views/performance/newTraceDetails/traceRow
 import type {TraceRowProps} from 'sentry/views/performance/newTraceDetails/traceRow/traceRow';
 
 import {BaseNode, type TraceTreeNodeExtra} from './baseNode';
+import {HTTP_ERROR_STATUSES} from './constants';
 import {traceChronologicalSort} from './utils';
 
 export class EapSpanNode extends BaseNode<TraceTree.EAPSpan> {
@@ -155,6 +156,19 @@ export class EapSpanNode extends BaseNode<TraceTree.EAPSpan> {
     return this.value.is_transaction
       ? undefined
       : this.findClosestParentTransaction()?.profileId;
+  }
+
+  get hasHttpError(): boolean {
+    const statusCode = this.value.additional_attributes?.['http.response.status_code'];
+    if (typeof statusCode === 'number' && statusCode >= 400) {
+      return true;
+    }
+
+    const status = this.value.additional_attributes?.['span.status'];
+    if (typeof status === 'string' && HTTP_ERROR_STATUSES.has(status)) {
+      return true;
+    }
+    return false;
   }
 
   get profilerId(): string | undefined {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
@@ -159,8 +159,10 @@ export class EapSpanNode extends BaseNode<TraceTree.EAPSpan> {
   }
 
   get hasHttpError(): boolean {
-    const statusCode = this.value.additional_attributes?.['http.response.status_code'];
-    if (typeof statusCode === 'number' && statusCode >= 400) {
+    const statusCode = Number(
+      this.value.additional_attributes?.['http.response.status_code']
+    );
+    if (!isNaN(statusCode) && statusCode >= 400) {
       return true;
     }
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.spec.tsx
@@ -417,6 +417,12 @@ describe('SpanNode', () => {
       expect(node.hasHttpError).toBe(true);
     });
 
+    it('should return true when http.response.status_code is a string >= 400', () => {
+      const span = makeSpan({data: {'http.response.status_code': '500'}});
+      const node = new SpanNode(null, span, createMockExtra());
+      expect(node.hasHttpError).toBe(true);
+    });
+
     it('should return false when http.response.status_code < 400', () => {
       const span = makeSpan({data: {'http.response.status_code': 200}});
       const node = new SpanNode(null, span, createMockExtra());

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.spec.tsx
@@ -387,4 +387,40 @@ describe('SpanNode', () => {
       expect(node.resolveValueFromSearchKey('transaction.duration')).toBeNull();
     });
   });
+
+  describe('hasHttpError', () => {
+    it('should return false with no status and no status code', () => {
+      const span = makeSpan({});
+      const node = new SpanNode(null, span, createMockExtra());
+      expect(node.hasHttpError).toBe(false);
+    });
+
+    it('should return true for error status strings', () => {
+      for (const status of ['internal_error', 'not_found', 'permission_denied']) {
+        const span = makeSpan({status});
+        const node = new SpanNode(null, span, createMockExtra());
+        expect(node.hasHttpError).toBe(true);
+      }
+    });
+
+    it('should return false for non-error status strings', () => {
+      for (const status of ['ok', 'unknown', 'cancelled']) {
+        const span = makeSpan({status});
+        const node = new SpanNode(null, span, createMockExtra());
+        expect(node.hasHttpError).toBe(false);
+      }
+    });
+
+    it('should return true when http.response.status_code >= 400', () => {
+      const span = makeSpan({data: {'http.response.status_code': 500}});
+      const node = new SpanNode(null, span, createMockExtra());
+      expect(node.hasHttpError).toBe(true);
+    });
+
+    it('should return false when http.response.status_code < 400', () => {
+      const span = makeSpan({data: {'http.response.status_code': 200}});
+      const node = new SpanNode(null, span, createMockExtra());
+      expect(node.hasHttpError).toBe(false);
+    });
+  });
 });

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.tsx
@@ -10,6 +10,7 @@ import type {TraceRowProps} from 'sentry/views/performance/newTraceDetails/trace
 import {TraceSpanRow} from 'sentry/views/performance/newTraceDetails/traceRow/traceSpanRow';
 
 import {BaseNode, type TraceTreeNodeExtra} from './baseNode';
+import {HTTP_ERROR_STATUSES} from './constants';
 
 export class SpanNode extends BaseNode<TraceTree.Span> {
   id: string;
@@ -79,6 +80,19 @@ export class SpanNode extends BaseNode<TraceTree.Span> {
     }
 
     return this.findClosestParentTransaction()?.profilerId;
+  }
+
+  get hasHttpError(): boolean {
+    if (this.value.status && HTTP_ERROR_STATUSES.has(this.value.status)) {
+      return true;
+    }
+
+    const statusCode = this.value.data?.['http.response.status_code'];
+    if (typeof statusCode === 'number' && statusCode >= 400) {
+      return true;
+    }
+
+    return false;
   }
 
   get transactionId(): string | undefined {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode.tsx
@@ -87,8 +87,8 @@ export class SpanNode extends BaseNode<TraceTree.Span> {
       return true;
     }
 
-    const statusCode = this.value.data?.['http.response.status_code'];
-    if (typeof statusCode === 'number' && statusCode >= 400) {
+    const statusCode = Number(this.value.data?.['http.response.status_code']);
+    if (!isNaN(statusCode) && statusCode >= 400) {
       return true;
     }
 

--- a/static/app/views/performance/newTraceDetails/traceRow/traceEAPSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceEAPSpanRow.tsx
@@ -82,7 +82,7 @@ export function TraceEAPSpanRow(props: TraceRowProps<EapSpanNode>) {
           : undefined
       }
       tabIndex={props.tabIndex}
-      className={`TraceRow ${props.rowSearchClassName} ${props.node.hasErrors ? props.node.maxIssueSeverity : ''}`}
+      className={`TraceRow ${props.rowSearchClassName} ${props.node.hasErrors ? props.node.maxIssueSeverity : props.node.hasHttpError ? 'warning' : ''}`}
       onPointerDown={props.onRowClick}
       onKeyDown={props.onRowKeyDown}
       style={props.style}

--- a/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceSpanRow.tsx
@@ -32,7 +32,7 @@ export function TraceSpanRow(props: TraceRowProps<SpanNode>) {
           : undefined
       }
       tabIndex={props.tabIndex}
-      className={`TraceRow ${props.rowSearchClassName} ${props.node.hasErrors ? props.node.maxIssueSeverity : ''}`}
+      className={`TraceRow ${props.rowSearchClassName} ${props.node.hasErrors ? props.node.maxIssueSeverity : props.node.hasHttpError ? 'warning' : ''}`}
       onPointerDown={props.onRowClick}
       onKeyDown={props.onRowKeyDown}
       style={props.style}


### PR DESCRIPTION
This PR adds better warning visuals for spans that have status codes >= 400, or an error-like `sentry.status`. 

Example
<img width="1111" height="386" alt="Screenshot 2026-06-10 at 3 07 04 PM" src="https://github.com/user-attachments/assets/667ac168-5ee2-45d2-8de1-c42c206ec840" />

This highlights Spans and EAPSpan nodes that return true for the newly added `hasHttpError` method. 

A follow-up PR will add a card to the span drawer that will corroborate this with some explanation.

Closes EXP-680