### PR TITLE
fix(seer): Fix an issue where the Autofix Agent filter wasnt working properly

### DIFF
--- a/static/app/components/seer/preferredAgentDropdownMenu.tsx
+++ b/static/app/components/seer/preferredAgentDropdownMenu.tsx
@@ -1,9 +1,11 @@
+import {useQuery} from '@tanstack/react-query';
+
 import {Link} from '@sentry/scraps/link';
 
 import {DropdownMenu, type DropdownMenuProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {t} from 'sentry/locale';
-import {useSeerAgentSelectOptions} from 'sentry/utils/seer/preferredAgent';
+import {seerAgentIntegrationsSelectQueryOptions} from 'sentry/utils/seer/preferredAgent';
 import type {AutofixAgentSelectOption} from 'sentry/utils/seer/types';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -17,7 +19,9 @@ export function PreferredAgentDropdownMenu({
   size?: DropdownMenuProps['size'];
 }) {
   const organization = useOrganization();
-  const agentOptions = useSeerAgentSelectOptions();
+  const {data: agentOptions = []} = useQuery(
+    seerAgentIntegrationsSelectQueryOptions({organization})
+  );
 
   return (
     <DropdownMenu

--- a/static/app/utils/seer/preferredAgent.ts
+++ b/static/app/utils/seer/preferredAgent.ts
@@ -1,5 +1,3 @@
-import {useMemo} from 'react';
-import {useQuery} from '@tanstack/react-query';
 import {queryOptions} from '@tanstack/react-query';
 import invariant from 'invariant';
 
@@ -11,13 +9,13 @@ import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/type
 import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import type {
   AutofixAgentSelectOption,
   AgentIntegration,
   PreferredAgentProvider,
 } from 'sentry/utils/seer/types';
-import {useOrganization} from 'sentry/utils/useOrganization';
 
 export function coalesePreferredAgent(
   agent: 'seer' | CodingAgentProvider,
@@ -32,6 +30,8 @@ export function coalesePreferredAgent(
 export function isPreferredAgentProvider(
   provider: string | undefined
 ): provider is PreferredAgentProvider {
+  // These are the providers where requires_identity is false. But sometimes we
+  // need to check by type, not integration object. So it's a hard-coded list.
   return [
     'seer',
     CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
@@ -53,6 +53,27 @@ export function parseAgentOption(
   return {agent: provider, integrationId} as const;
 }
 
+function selectAgentIntegrations(
+  data: ApiResponse<{integrations: CodingAgentIntegration[]}>
+): AgentIntegration[] {
+  const mapProvider = {
+    cursor: CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
+    claude_code: CodingAgentProvider.CLAUDE_CODE_AGENT,
+    github_copilot: CodingAgentProvider.GITHUB_COPILOT_AGENT,
+  } as const;
+
+  return [
+    ...(data.json.integrations ?? [])
+      .filter(integration => integration.id)
+      .map(integration => {
+        return {
+          ...integration,
+          provider: mapProvider[integration.provider],
+        };
+      }),
+  ];
+}
+
 /**
  * Fetch the list of existing coding agent integrations.
  */
@@ -61,12 +82,6 @@ export function knownAgentIntegrationsQueryOptions({
 }: {
   organization: Organization;
 }) {
-  const mapProvider = {
-    cursor: CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
-    claude_code: CodingAgentProvider.CLAUDE_CODE_AGENT,
-    github_copilot: CodingAgentProvider.GITHUB_COPILOT_AGENT,
-  } as const;
-
   return queryOptions({
     ...apiOptions.as<{
       integrations: CodingAgentIntegration[];
@@ -74,61 +89,86 @@ export function knownAgentIntegrationsQueryOptions({
       path: {organizationIdOrSlug: organization.slug},
       staleTime: 5 * 60 * 1000,
     }),
-    select: (data): AgentIntegration[] => [
-      ...(data.json.integrations ?? [])
-        .filter(integration => integration.id)
-        .map(integration => {
-          return {
-            ...integration,
-            provider: mapProvider[integration.provider],
-          };
-        }),
+    select: selectAgentIntegrations,
+  });
+}
+
+/**
+ * Query options for a list of Agent Provider names. Formatted for use in a select component.
+ *
+ * Builds on `knownAgentIntegrationsQueryOptions` and overrides `select` to
+ * produce `{value, label}` tuples filtered to preferred-agent integration ids.
+ */
+export function seerAgentProviderSelectQueryOptions({
+  organization,
+}: {
+  organization: Organization;
+}) {
+  const labels = {
+    [CodingAgentProvider.CURSOR_BACKGROUND_AGENT]: t('Cursor Cloud Agent'),
+    [CodingAgentProvider.CLAUDE_CODE_AGENT]: t('Claude Code Agent'),
+
+    // included for completeness & typechecks, but it's filtered out.
+    [CodingAgentProvider.GITHUB_COPILOT_AGENT]: t('GitHub Copilot Agent'),
+  };
+  return queryOptions({
+    ...knownAgentIntegrationsQueryOptions({organization}),
+    select: data => [
+      {value: 'seer' as const, label: t('Seer')},
+      ...selectAgentIntegrations(data)
+        .filter(i => isPreferredAgentProvider(i.provider)) // filter out copilot, it cannot be saved.
+        .map(i => ({
+          value: i.provider,
+          label: labels[i.provider],
+        })),
     ],
   });
 }
 
 /**
- * Convert the list of known agents to a list of options for a select component.
+ * Query options for a list of Agent Integrations. Formatted for use in a select component.
  *
- * This returns a hard-coding list of agents that don't have requires_identity
- * set to true; those are the ones that we Seer can use in the background.
+ * Builds on `knownAgentIntegrationsQueryOptions` and overrides `select` to
+ * produce `{value, label}` tuples filtered to preferred-agent integration ids.
  */
-export function useSeerAgentSelectOptions() {
-  const organization = useOrganization();
-  const {data: knownAgents} = useQuery(
-    knownAgentIntegrationsQueryOptions({organization})
-  );
-
-  return useMemo(() => {
-    return [
+export function seerAgentIntegrationsSelectQueryOptions({
+  organization,
+}: {
+  organization: Organization;
+}) {
+  return queryOptions({
+    ...knownAgentIntegrationsQueryOptions({organization}),
+    select: data => [
       {value: 'seer' as const, label: t('Seer')},
-      ...(knownAgents ?? [])
-        .filter(i => isPreferredAgentProvider(i.provider))
+      ...selectAgentIntegrations(data)
+        .filter(i => isPreferredAgentProvider(i.provider)) // filter out copilot, it cannot be saved.
         .map(i => ({
-          value: `${i.provider}::${i.id}` as AutofixAgentSelectOption,
+          value: `${i.provider}::${i.id}` as const,
           label: i.name,
         })),
-    ];
-  }, [knownAgents]);
+    ],
+  });
 }
 
-export function useOrgDefaultAgentOption() {
-  const organization = useOrganization();
-  const {data: knownAgents} = useQuery(
-    knownAgentIntegrationsQueryOptions({organization})
-  );
-
-  return useMemo((): AutofixAgentSelectOption => {
-    if (organization.defaultCodingAgentIntegrationId) {
-      const match = knownAgents?.find(
-        i => i.id === String(organization.defaultCodingAgentIntegrationId)
-      );
-      if (match) {
-        return `${match.provider}::${match.id}`;
+export function orgDefaultAgentQueryOptions({
+  organization,
+}: {
+  organization: Organization;
+}) {
+  return queryOptions({
+    ...knownAgentIntegrationsQueryOptions({organization}),
+    select: (data): AutofixAgentSelectOption => {
+      if (organization.defaultCodingAgentIntegrationId) {
+        const match = selectAgentIntegrations(data).find(
+          i => i.id === String(organization.defaultCodingAgentIntegrationId)
+        );
+        if (match) {
+          return `${match.provider}::${match.id}` as const;
+        }
       }
-    }
-    return 'seer';
-  }, [organization.defaultCodingAgentIntegrationId, knownAgents]);
+      return 'seer';
+    },
+  });
 }
 
 /**

--- a/static/app/utils/seer/preferredAgent.ts
+++ b/static/app/utils/seer/preferredAgent.ts
@@ -121,15 +121,17 @@ export function seerAgentProviderNameSelectQueryOptions({
   };
   return queryOptions({
     ...knownAgentIntegrationsQueryOptions({organization}),
-    select: data => [
-      {value: 'seer' as const, label: t('Seer')},
-      ...selectAgentIntegrations(data)
-        .filter(i => isPreferredAgentProvider(i.provider)) // filter out copilot, it cannot be saved.
-        .map(i => ({
-          value: i.provider,
-          label: labels[i.provider],
-        })),
-    ],
+    select: data => {
+      const seen = new Set<CodingAgentProvider>();
+      const providerOptions: Array<{label: string; value: CodingAgentProvider}> = [];
+      for (const i of selectAgentIntegrations(data)) {
+        if (isPreferredAgentProvider(i.provider) && !seen.has(i.provider)) {
+          seen.add(i.provider);
+          providerOptions.push({value: i.provider, label: labels[i.provider]});
+        }
+      }
+      return [{value: 'seer' as const, label: t('Seer')}, ...providerOptions];
+    },
   });
 }
 

--- a/static/app/utils/seer/preferredAgent.ts
+++ b/static/app/utils/seer/preferredAgent.ts
@@ -96,10 +96,18 @@ export function knownAgentIntegrationsQueryOptions({
 /**
  * Query options for a list of Agent Provider names. Formatted for use in a select component.
  *
+ * This returns options like:
+ * ```[
+ *   {value: 'cursor_background_agent', label: 'Cursor Cloud Agent'},
+ *   {value: 'claude_code_agent', label: 'Claude Code Agent'}
+ * ]
+ * ```
+ * See Also: `seerAgentIntegrationsSelectQueryOptions()`
+ *
  * Builds on `knownAgentIntegrationsQueryOptions` and overrides `select` to
  * produce `{value, label}` tuples filtered to preferred-agent integration ids.
  */
-export function seerAgentProviderSelectQueryOptions({
+export function seerAgentProviderNameSelectQueryOptions({
   organization,
 }: {
   organization: Organization;
@@ -127,6 +135,14 @@ export function seerAgentProviderSelectQueryOptions({
 
 /**
  * Query options for a list of Agent Integrations. Formatted for use in a select component.
+ *
+ * This returns options like:
+ * ```[
+ *   {value: 'cursor_background_agent::123', label: 'Cursor Cloud Agent - <email_idenfitier>'},
+ *   {value: 'claude_code_agent::456', label: 'Claude Code Agent'}
+ * ]
+ * ```
+ * See Also: `seerAgentProviderSelectQueryOptions()`
  *
  * Builds on `knownAgentIntegrationsQueryOptions` and overrides `select` to
  * produce `{value, label}` tuples filtered to preferred-agent integration ids.

--- a/static/app/utils/seer/seerProjectSettings.stories.tsx
+++ b/static/app/utils/seer/seerProjectSettings.stories.tsx
@@ -26,7 +26,7 @@ import {ListItemSelectCheckbox} from 'sentry/utils/list/listItemSelectCheckbox';
 import {ListItemCheckboxProvider} from 'sentry/utils/list/useListItemCheckboxState';
 import {useProjectsById} from 'sentry/utils/project/useProjectsById';
 import {
-  useSeerAgentSelectOptions,
+  seerAgentIntegrationsSelectQueryOptions,
   knownAgentIntegrationsQueryOptions,
   coalesePreferredAgent,
 } from 'sentry/utils/seer/preferredAgent';
@@ -222,7 +222,9 @@ export default Storybook.story('SeerProjectSettings', story => {
         knownAgentIntegrationsQueryOptions({organization})
       );
 
-      const agentSelectOptions = useSeerAgentSelectOptions();
+      const {data: agentSelectOptions = []} = useQuery(
+        seerAgentIntegrationsSelectQueryOptions({organization})
+      );
       const stoppingPointOptions = useStoppingPointSelectOptions();
 
       const {data, isPending, isError, error} = useQuery({

--- a/static/gsApp/views/seerAutomation/components/projectAddRepoModal/projectAddRepoModal.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectAddRepoModal/projectAddRepoModal.tsx
@@ -1,5 +1,5 @@
 import {Fragment, useMemo} from 'react';
-import {useInfiniteQuery} from '@tanstack/react-query';
+import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
 import {z} from 'zod';
 
 import {ProjectAvatar} from '@sentry/scraps/avatar';
@@ -28,8 +28,8 @@ import {useProjectsById} from 'sentry/utils/project/useProjectsById';
 import {useCompactSelectRepositoryOptions} from 'sentry/utils/repositories/useCompactSelectRepositoryOptions';
 import {useRepositoriesById} from 'sentry/utils/repositories/useRepositoriesById';
 import {
-  useOrgDefaultAgentOption,
-  useSeerAgentSelectOptions,
+  orgDefaultAgentQueryOptions,
+  seerAgentIntegrationsSelectQueryOptions,
 } from 'sentry/utils/seer/preferredAgent';
 import {
   PROJECT_STOPPING_POINT_OPTIONS,
@@ -63,7 +63,9 @@ export function ProjectAddRepoModal({
   const unconfiguredProjects = useUnconfiguredProjects();
   const projectOptions = useCompactSelectProjectOptions({projects: unconfiguredProjects});
   const repositoryOptions = useCompactSelectRepositoryOptions();
-  const agentOptions = useSeerAgentSelectOptions();
+  const {data: agentOptions = []} = useQuery(
+    seerAgentIntegrationsSelectQueryOptions({organization})
+  );
   const stoppingPointOptions = PROJECT_STOPPING_POINT_OPTIONS;
 
   const repoEntrySchema = z.object({
@@ -96,7 +98,7 @@ export function ProjectAddRepoModal({
     defaultValues: {
       project: defaultProject?.id ?? '',
       repoEntries: [] as Array<{branch: string; repoId: string}>,
-      agentOption: useOrgDefaultAgentOption(),
+      agentOption: useQuery(orgDefaultAgentQueryOptions({organization})).data ?? 'seer',
       stoppingPoint: useOrgDefaultStoppingPoint(),
     },
     validators: {

--- a/static/gsApp/views/seerAutomation/components/projectAddRepoModal/projectAddRepoModal.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectAddRepoModal/projectAddRepoModal.tsx
@@ -92,14 +92,16 @@ export function ProjectAddRepoModal({
   });
 
   const saveMutation = useMutateAutofixProject();
-
+  const agentOption =
+    useQuery(orgDefaultAgentQueryOptions({organization})).data ?? 'seer';
+  const stoppingPoint = useOrgDefaultStoppingPoint();
   const form = useScrapsForm({
     ...defaultFormOptions,
     defaultValues: {
       project: defaultProject?.id ?? '',
       repoEntries: [] as Array<{branch: string; repoId: string}>,
-      agentOption: useQuery(orgDefaultAgentQueryOptions({organization})).data ?? 'seer',
-      stoppingPoint: useOrgDefaultStoppingPoint(),
+      agentOption,
+      stoppingPoint,
     },
     validators: {
       onMount: formSchema.extend({

--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
@@ -13,7 +13,7 @@ import {t, tct} from 'sentry/locale';
 import type {DetailedProject} from 'sentry/types/project';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {
-  useSeerAgentSelectOptions,
+  seerAgentIntegrationsSelectQueryOptions,
   knownAgentIntegrationsQueryOptions,
   coalesePreferredAgent,
 } from 'sentry/utils/seer/preferredAgent';
@@ -60,7 +60,9 @@ export function AutofixAgent({canWrite, project}: Props) {
     knownAgentIntegrationsQueryOptions({organization})
   );
 
-  const agentSelectOptions = useSeerAgentSelectOptions();
+  const {data: agentSelectOptions = []} = useQuery(
+    seerAgentIntegrationsSelectQueryOptions({organization})
+  );
   const stoppingPointOptions = useStoppingPointSelectOptions();
 
   const updateProject = useUpdateProject(project);

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -6,7 +6,7 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
-import {createParser, debounce, parseAsString, useQueryState} from 'nuqs';
+import {debounce, parseAsStringLiteral, parseAsString, useQueryState} from 'nuqs';
 
 import SeerConfigConnect2 from 'sentry-images/spot/seer-config-connect-2.svg';
 
@@ -36,9 +36,10 @@ import {ListItemSelectCheckbox} from 'sentry/utils/list/listItemSelectCheckbox';
 import {ListItemCheckboxProvider} from 'sentry/utils/list/useListItemCheckboxState';
 import {useProjectsById} from 'sentry/utils/project/useProjectsById';
 import {
-  useSeerAgentSelectOptions,
+  seerAgentIntegrationsSelectQueryOptions,
   knownAgentIntegrationsQueryOptions,
   coalesePreferredAgent,
+  seerAgentProviderSelectQueryOptions,
 } from 'sentry/utils/seer/preferredAgent';
 import {
   getMutateSeerProjectSettingsOptions,
@@ -49,7 +50,6 @@ import {
   coaleseStoppingPoint,
   useStoppingPointSelectOptions,
 } from 'sentry/utils/seer/stoppingPoint';
-import type {AutofixAgentSelectOption} from 'sentry/utils/seer/types';
 import {parseAsSort} from 'sentry/utils/url/parseAsSort';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -58,24 +58,6 @@ import {ProjectTableHeader} from 'getsentry/views/seerAutomation/components/proj
 import {useCanWriteSettings} from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
 
 const estimateSize = () => 41;
-
-const parseAsAgentFilter = createParser<'all' | AutofixAgentSelectOption>({
-  parse: value => {
-    if (value === 'all' || value === 'seer') {
-      return value;
-    }
-    if (
-      [
-        CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
-        CodingAgentProvider.CLAUDE_CODE_AGENT,
-      ].some(prefix => value.startsWith(`${prefix}::`))
-    ) {
-      return value as AutofixAgentSelectOption;
-    }
-    return null;
-  },
-  serialize: String,
-});
 
 export function SeerProjectTable() {
   const queryClient = useQueryClient();
@@ -86,7 +68,11 @@ export function SeerProjectTable() {
   // Query Values
   const [agentFilter, setAgentFilter] = useQueryState(
     'agent',
-    parseAsAgentFilter.withDefault('all')
+    parseAsStringLiteral([
+      'all',
+      'seer',
+      ...Object.values(CodingAgentProvider), // we will accept copilot here, but it's filtered from the dropdown options
+    ]).withDefault('all')
   );
   const [searchTerm, setSearchTerm] = useQueryState(
     'name',
@@ -99,10 +85,15 @@ export function SeerProjectTable() {
 
   // Supporting fetch calls
   const projectsById = useProjectsById();
+  const {data: knownAgentProviders = []} = useQuery(
+    seerAgentProviderSelectQueryOptions({organization})
+  );
   const {data: knownAgents} = useQuery(
     knownAgentIntegrationsQueryOptions({organization})
   );
-  const agentSelectOptions = useSeerAgentSelectOptions();
+  const {data: agentSelectOptions = []} = useQuery(
+    seerAgentIntegrationsSelectQueryOptions({organization})
+  );
   const stoppingPointOptions = useStoppingPointSelectOptions();
 
   // Main fetch call
@@ -165,13 +156,13 @@ export function SeerProjectTable() {
       <Stack>
         <Flex gap="md" wrap="wrap">
           {agentSelectOptions.length ? (
-            <CompactSelect<'all' | AutofixAgentSelectOption>
+            <CompactSelect
               trigger={triggerProps => (
                 <OverlayTrigger.Button {...triggerProps} size="md" prefix={t('Agent')}>
                   {triggerProps.children}
                 </OverlayTrigger.Button>
               )}
-              options={[{value: 'all', label: t('All')}, ...agentSelectOptions]}
+              options={[{value: 'all', label: t('All')}, ...knownAgentProviders]}
               onChange={option => setAgentFilter(option.value)}
               value={agentFilter ?? 'all'}
             />

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -39,7 +39,7 @@ import {
   seerAgentIntegrationsSelectQueryOptions,
   knownAgentIntegrationsQueryOptions,
   coalesePreferredAgent,
-  seerAgentProviderSelectQueryOptions,
+  seerAgentProviderNameSelectQueryOptions,
 } from 'sentry/utils/seer/preferredAgent';
 import {
   getMutateSeerProjectSettingsOptions,
@@ -86,7 +86,7 @@ export function SeerProjectTable() {
   // Supporting fetch calls
   const projectsById = useProjectsById();
   const {data: knownAgentProviders = []} = useQuery(
-    seerAgentProviderSelectQueryOptions({organization})
+    seerAgentProviderNameSelectQueryOptions({organization})
   );
   const {data: knownAgents} = useQuery(
     knownAgentIntegrationsQueryOptions({organization})


### PR DESCRIPTION
Before this fix the filter was incorrectly filtering projects using what is now called `seerAgentIntegrationsSelectQueryOptions`. It should instead filter by provider-name, or the new seerAgentProviderSelectQueryOptions list of options.

The difference is `cursor_background_agent:1234` vs. `cursor_background_agent`. We want to filter by provider name, not including integration_id, so that it works better as instances are created/removed

**Before**
The query param was `?agent=claude_code_agent::380236`
<img width="914" height="250" alt="SCR-20260610-nmzl" src="https://github.com/user-attachments/assets/4422b436-8ecb-46e5-8fb3-797933fd5c9e" />


**After**
The query param is `?agent=claude_code_agent`
Results are found
