### PR TITLE
fix(dashboards): Prevent crash on time series widgets with missing aggregates

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
@@ -1,0 +1,59 @@
+import {WidgetFixture} from 'sentry-fixture/widget';
+import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
+
+import {DisplayType} from 'sentry/views/dashboards/types';
+
+import {getWidgetConfigError} from './getWidgetConfigError';
+
+describe('getWidgetConfigError', () => {
+  it.each([DisplayType.LINE, DisplayType.AREA, DisplayType.BAR, DisplayType.TOP_N])(
+    'returns an error for %s widgets with no aggregates',
+    displayType => {
+      const widget = WidgetFixture({
+        displayType,
+        queries: [WidgetQueryFixture({aggregates: []})],
+      });
+
+      expect(getWidgetConfigError(widget)).toBeDefined();
+    }
+  );
+
+  it('returns undefined for time series widgets with aggregates', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      queries: [WidgetQueryFixture({aggregates: ['count()']})],
+    });
+
+    expect(getWidgetConfigError(widget)).toBeUndefined();
+  });
+
+  it('returns undefined for table widgets with no aggregates', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      queries: [WidgetQueryFixture({aggregates: []})],
+    });
+
+    expect(getWidgetConfigError(widget)).toBeUndefined();
+  });
+
+  it('returns undefined for big number widgets with no aggregates', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.BIG_NUMBER,
+      queries: [WidgetQueryFixture({aggregates: []})],
+    });
+
+    expect(getWidgetConfigError(widget)).toBeUndefined();
+  });
+
+  it('returns undefined when at least one query has aggregates', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      queries: [
+        WidgetQueryFixture({aggregates: []}),
+        WidgetQueryFixture({aggregates: ['count()']}),
+      ],
+    });
+
+    expect(getWidgetConfigError(widget)).toBeUndefined();
+  });
+});

--- a/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
@@ -6,7 +6,7 @@ import {DisplayType} from 'sentry/views/dashboards/types';
 import {getWidgetConfigError} from './getWidgetConfigError';
 
 describe('getWidgetConfigError', () => {
-  it.each([DisplayType.LINE, DisplayType.AREA, DisplayType.BAR, DisplayType.TOP_N])(
+  it.each([DisplayType.LINE, DisplayType.AREA, DisplayType.BAR])(
     'returns an error for %s widgets with no aggregates',
     displayType => {
       const widget = WidgetFixture({

--- a/static/app/views/dashboards/utils/getWidgetConfigError.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.tsx
@@ -1,0 +1,19 @@
+import {t} from 'sentry/locale';
+import type {Widget} from 'sentry/views/dashboards/types';
+import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
+
+/**
+ * Returns a user-facing error message if the widget has a static config
+ * problem that would prevent it from displaying data. Returns undefined
+ * if the widget config is valid.
+ */
+export function getWidgetConfigError(widget: Widget): string | undefined {
+  if (
+    usesTimeSeriesData(widget.displayType) &&
+    widget.queries.every(q => q.aggregates.length === 0)
+  ) {
+    return t('The widget configuration is not valid. Please add a "Visualize" field.');
+  }
+
+  return undefined;
+}

--- a/static/app/views/dashboards/utils/transformEventsResponseToSeries.tsx
+++ b/static/app/views/dashboards/utils/transformEventsResponseToSeries.tsx
@@ -24,7 +24,11 @@ export function transformEventsResponseToSeries(
   const queryAlias = widgetQuery.name;
 
   if (isEventsStats(data)) {
-    const field = widgetQuery.aggregates[0]!;
+    // Widgets with no aggregates can exist due to API bugs (see DAIN-1712)
+    const field = widgetQuery.aggregates[0];
+    if (!field) {
+      return [];
+    }
     const prefixedName = queryAlias ? `${queryAlias} : ${field}` : field;
 
     seriesWithOrdering.push([0, transformEventsStatsToSeries(data, prefixedName, field)]);

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -195,7 +195,7 @@ export function WidgetBuilderV2({
                       dashboard={dashboard}
                       dashboardFilters={dashboardFilters}
                       setIsPreviewDraggable={setIsPreviewDraggable}
-                      isWidgetInvalid={!queryConditionsValid}
+                      isQueryConditionInvalid={!queryConditionsValid}
                       openWidgetTemplates={openWidgetTemplates}
                       setOpenWidgetTemplates={setOpenWidgetTemplates}
                       onDataFetched={handleWidgetDataFetched}
@@ -214,7 +214,7 @@ export function WidgetBuilderV2({
                           dashboard={dashboard}
                           dragPosition={translate}
                           isDraggable={isPreviewDraggable}
-                          isWidgetInvalid={!queryConditionsValid}
+                          isQueryConditionInvalid={!queryConditionsValid}
                           onDataFetched={handleWidgetDataFetched}
                           openWidgetTemplates={openWidgetTemplates}
                         />
@@ -234,7 +234,7 @@ export function WidgetBuilderV2({
 export function WidgetPreviewContainer({
   dashboardFilters,
   dashboard,
-  isWidgetInvalid,
+  isQueryConditionInvalid,
   dragPosition,
   isDraggable,
   onDataFetched,
@@ -242,9 +242,9 @@ export function WidgetPreviewContainer({
 }: {
   dashboard: DashboardDetails;
   dashboardFilters: DashboardFilters;
-  isWidgetInvalid: boolean;
   dragPosition?: WidgetDragPositioning;
   isDraggable?: boolean;
+  isQueryConditionInvalid?: boolean;
   onDataFetched?: (results: OnDataFetchedParams) => void;
   openWidgetTemplates?: boolean;
 }) {
@@ -365,7 +365,7 @@ export function WidgetPreviewContainer({
                     <WidgetPreview
                       dashboardFilters={dashboardFilters}
                       dashboard={dashboard}
-                      isWidgetInvalid={isWidgetInvalid}
+                      isQueryConditionInvalid={isQueryConditionInvalid}
                       onDataFetched={onDataFetched}
                       shouldForceDescriptionTooltip={!isSmallScreen}
                     />

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -82,7 +82,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid={false}
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -119,7 +118,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid={false}
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -153,7 +151,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid={false}
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -188,7 +185,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid={false}
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -218,7 +214,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid={false}
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -257,7 +252,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -297,7 +291,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -335,7 +328,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -379,7 +371,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -414,7 +405,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={onSave}
@@ -444,7 +434,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={onSave}
@@ -473,7 +462,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={onSave}
@@ -497,7 +485,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={onSave}
@@ -521,7 +508,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={onSave}
@@ -549,7 +535,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid={false}
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -589,7 +574,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid={false}
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -631,7 +615,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid={false}
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -668,7 +651,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid={false}
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -701,7 +683,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid={false}
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -735,7 +716,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid={false}
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}
@@ -768,7 +748,6 @@ describe('WidgetBuilderSlideout', () => {
       <WidgetBuilderSlideout
         dashboard={DashboardFixture([])}
         dashboardFilters={{release: undefined}}
-        isWidgetInvalid={false}
         onClose={jest.fn()}
         onQueryConditionChange={jest.fn()}
         onSave={jest.fn()}
@@ -818,7 +797,6 @@ describe('WidgetBuilderSlideout', () => {
       <WidgetBuilderSlideout
         dashboard={DashboardFixture([])}
         dashboardFilters={{release: undefined}}
-        isWidgetInvalid={false}
         onClose={jest.fn()}
         onQueryConditionChange={jest.fn()}
         onSave={jest.fn()}
@@ -870,7 +848,6 @@ describe('WidgetBuilderSlideout', () => {
       <WidgetBuilderSlideout
         dashboard={DashboardFixture([])}
         dashboardFilters={{release: undefined}}
-        isWidgetInvalid={false}
         onClose={jest.fn()}
         onQueryConditionChange={jest.fn()}
         onSave={jest.fn()}
@@ -905,7 +882,6 @@ describe('WidgetBuilderSlideout', () => {
         <WidgetBuilderSlideout
           dashboard={DashboardFixture([])}
           dashboardFilters={{release: undefined}}
-          isWidgetInvalid={false}
           onClose={jest.fn()}
           onQueryConditionChange={jest.fn()}
           onSave={jest.fn()}

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -79,13 +79,13 @@ import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLM
 type WidgetBuilderSlideoutProps = {
   dashboard: DashboardDetails;
   dashboardFilters: DashboardFilters;
-  isWidgetInvalid: boolean;
   onClose: () => void;
   onQueryConditionChange: (valid: boolean) => void;
   onSave: ({index, widget}: {index: number | undefined; widget: Widget}) => void;
   openWidgetTemplates: boolean;
   setIsPreviewDraggable: (draggable: boolean) => void;
   setOpenWidgetTemplates: (openWidgetTemplates: boolean) => void;
+  isQueryConditionInvalid?: boolean;
   onDataFetched?: (results: OnDataFetchedParams) => void;
   thresholdMetaState?: ThresholdMetaState;
 };
@@ -97,7 +97,7 @@ function WidgetBuilderSlideoutInner({
   dashboard,
   dashboardFilters,
   setIsPreviewDraggable,
-  isWidgetInvalid,
+  isQueryConditionInvalid,
   openWidgetTemplates,
   setOpenWidgetTemplates,
   onDataFetched,
@@ -408,7 +408,7 @@ function WidgetBuilderSlideoutInner({
                         <WidgetPreviewContainer
                           dashboard={dashboard}
                           dashboardFilters={dashboardFilters}
-                          isWidgetInvalid={isWidgetInvalid}
+                          isQueryConditionInvalid={isQueryConditionInvalid}
                           onDataFetched={onDataFetched}
                           openWidgetTemplates={openWidgetTemplates}
                         />
@@ -465,7 +465,7 @@ function WidgetBuilderSlideoutInner({
                           <WidgetPreviewContainer
                             dashboard={dashboard}
                             dashboardFilters={dashboardFilters}
-                            isWidgetInvalid={isWidgetInvalid}
+                            isQueryConditionInvalid={isQueryConditionInvalid}
                             onDataFetched={onDataFetched}
                             openWidgetTemplates={openWidgetTemplates}
                           />

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -30,7 +30,7 @@ import {FieldValueKind} from 'sentry/views/discover/table/types';
 interface WidgetPreviewProps {
   dashboard: DashboardDetails;
   dashboardFilters: DashboardFilters;
-  isWidgetInvalid?: boolean;
+  isQueryConditionInvalid?: boolean;
   onDataFetched?: (results: OnDataFetchedParams) => void;
   shouldForceDescriptionTooltip?: boolean;
 }
@@ -40,7 +40,7 @@ const MIN_TABLE_COLUMN_WIDTH_PX = 125;
 export function WidgetPreview({
   dashboard,
   dashboardFilters,
-  isWidgetInvalid,
+  isQueryConditionInvalid,
   onDataFetched,
   shouldForceDescriptionTooltip,
 }: WidgetPreviewProps) {
@@ -119,13 +119,24 @@ export function WidgetPreview({
     }
   }
 
+  if (isQueryConditionInvalid) {
+    return (
+      <Widget
+        Title={<Widget.WidgetTitle title={widget.title} />}
+        Visualization={
+          <Widget.WidgetError error={t('Widget query condition is invalid.')} />
+        }
+        noVisualizationPadding
+      />
+    );
+  }
+
   return (
     <WidgetCard
       disableFullscreen
       borderless
       // need to pass in undefined to avoid tooltip not showing up on hover
       forceDescriptionTooltip={shouldForceDescriptionTooltip ? true : undefined}
-      isWidgetInvalid={isWidgetInvalid}
       shouldResize={state.displayType !== DisplayType.TABLE}
       selection={pageFilters.selection}
       widget={

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
@@ -48,10 +48,11 @@ export function WidgetCardConfidenceFooter({
     seriesName?.match(/.* : Other$|^Other$/)
   );
 
+  // Guard against division by zero — widgets with no aggregates can exist due to API bugs (see DAIN-1712)
+  const aggregatesCount = widget.queries[0]?.aggregates.length || 1;
   const topEventsCountExcludingOther =
     timeseriesResults?.length && widget.queries[0]?.columns.length
-      ? Math.floor(timeseriesResults.length / widget.queries[0]?.aggregates.length) -
-        (hasOtherSeries ? 1 : 0)
+      ? Math.floor(timeseriesResults.length / aggregatesCount) - (hasOtherSeries ? 1 : 0)
       : undefined;
 
   const isTopN =

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
@@ -48,7 +48,8 @@ export function WidgetCardConfidenceFooter({
     seriesName?.match(/.* : Other$|^Other$/)
   );
 
-  // Guard against division by zero — widgets with no aggregates can exist due to API bugs (see DAIN-1712)
+  // All queries share the same aggregates, so queries[0] is representative.
+  // Fallback to 1 to guard against division by zero (DAIN-1712).
   const aggregatesCount = widget.queries[0]?.aggregates.length || 1;
   const topEventsCountExcludingOther =
     timeseriesResults?.length && widget.queries[0]?.columns.length

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -565,9 +565,9 @@ describe('Dashboards > WidgetCard', () => {
       queries: [
         {
           conditions: '',
-          fields: [],
+          fields: ['count()'],
           columns: [],
-          aggregates: [],
+          aggregates: ['count()'],
           name: '',
           orderby: '',
         },
@@ -601,9 +601,9 @@ describe('Dashboards > WidgetCard', () => {
       queries: [
         {
           conditions: '',
-          fields: [],
+          fields: ['count()'],
           columns: [],
-          aggregates: [],
+          aggregates: ['count()'],
           name: '',
           orderby: '',
         },

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -45,6 +45,7 @@ import {
   OnDemandExtractionState,
   WidgetType,
 } from 'sentry/views/dashboards/types';
+import {getWidgetConfigError} from 'sentry/views/dashboards/utils/getWidgetConfigError';
 import {widgetCanUseTimeSeriesVisualization} from 'sentry/views/dashboards/utils/widgetCanUseTimeSeriesVisualization';
 import {WidgetCardChartContainer} from 'sentry/views/dashboards/widgetCard/widgetCardChartContainer';
 import type {WidgetLegendSelectionState} from 'sentry/views/dashboards/widgetLegendSelectionState';
@@ -104,7 +105,6 @@ type Props = {
   isEditingWidget?: boolean;
   isMobile?: boolean;
   isPreview?: boolean;
-  isWidgetInvalid?: boolean;
   legendOptions?: LegendComponentOption;
   minTableColumnWidth?: number;
   onDataFetched?: (results: OnDataFetchedParams) => void;
@@ -156,6 +156,8 @@ function WidgetCard(props: Props) {
       ? DisplayType.AREA
       : props.widget.displayType;
 
+  const widgetQueryError = getWidgetConfigError(props.widget);
+
   // Push widget metadata into the LLM context tree for Seer Explorer.
   useLLMContext({
     title: props.widget.title,
@@ -168,6 +170,7 @@ function WidgetCard(props: Props) {
       columns: q.columns,
       orderby: q.orderby,
     })),
+    ...(widgetQueryError && {error: widgetQueryError}),
   });
 
   const onDataFetched = (newData: Data) => {
@@ -196,7 +199,6 @@ function WidgetCard(props: Props) {
     tableItemLimit,
     windowWidth,
     dashboardFilters,
-    isWidgetInvalid,
     onWidgetSplitDecision,
     shouldResize,
     onLegendSelectChanged,
@@ -354,10 +356,6 @@ function WidgetCard(props: Props) {
         data?.timeseriesResults
       )
     : [];
-
-  const widgetQueryError = isWidgetInvalid
-    ? t('Widget query condition is invalid.')
-    : undefined;
 
   const errorBoundaryHandler = () => {
     return (


### PR DESCRIPTION
Our API is a bit permissive, and allows crimes where some widgets have no `aggregates` and they crash on the frontend when we process the response. Technically, asking `/events-stats/` for no aggregate falls down to `count()` but I didn't want to actually allow this to work in the UI since it's almost definitely not intentional.

Rather than just papering over the issues, I opted to

1. Improve the error handling somewhat by adding validation to `WidgetCard` which will now check if the configuration makes sense (just one condition so far, but we can extend this later)
2. Make the _existing_ widget error handling (related to the state of the "Filter" field) a lot more explicit. Instead of passing an error deep into the `WidgetCard`, it just renders an error state (same as what it already does for some errors) so the error handling is all centralized. The Widget Builder's in-flight errors are manually treated there, and the `WidgetCard` validates the widget on render
3. Add a nicer error state for invalid widgets, that tells users how to fix it (and expose it to Seer too, so it can figure out what's wrong)
4. File a separate ticket to forbid making crime widgets

**Before:**
<img width="412" height="232" alt="Screenshot 2026-06-10 at 6 11 33 PM" src="https://github.com/user-attachments/assets/1b9576ee-3be7-432e-85ee-fdece6e2099e" />

**After:**
<img width="409" height="241" alt="Screenshot 2026-06-10 at 6 11 59 PM" src="https://github.com/user-attachments/assets/e7367ad4-9fae-4c9d-ae9b-853b497007cc" />

Closes DAIN-1713