### PR TITLE
ref(aci): Improve metrics for activities

### DIFF
--- a/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
+++ b/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
@@ -34,7 +34,7 @@ def invoke_workflow_activity_handlers(
         activity_type = ActivityType(activity.type).name
     except ValueError:
         logger.exception(
-            "workflow_engine.seer_activity_handler.invalid_activity_type",
+            "workflow_engine.invoke_workflow_activity_handlers.invalid_activity_type",
             extra={"activity_type": activity.type},
         )
         return

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -17,6 +17,7 @@ from sentry.services.eventstore.models import GroupEvent
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker import namespaces
+from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 from sentry.utils.exceptions import quiet_redis_noise, quiet_retriable_timeouts
 from sentry.utils.locking import UnableToAcquireLock
@@ -77,9 +78,18 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: Dete
 
     evaluation.log_to(logger)
 
+    try:
+        activity_type = ActivityType(activity.type).name
+    except ValueError:
+        logger.exception(
+            "workflow_engine.process_workflow_activity.invalid_activity_type",
+            extra={"activity_type": activity.type},
+        )
+        activity_type = activity.type
+
     metrics.incr(
         "workflow_engine.tasks.process_workflows.activity_update.executed",
-        tags={"activity_type": activity.type, "detector_type": detector.type},
+        tags={"activity_type": activity_type, "detector_type": detector.type},
         sample_rate=1.0,
     )
 

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -85,7 +85,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: Dete
             "workflow_engine.process_workflow_activity.invalid_activity_type",
             extra={"activity_type": activity.type},
         )
-        activity_type = activity.type
+        activity_type = "invalid"
 
     metrics.incr(
         "workflow_engine.tasks.process_workflows.activity_update.executed",


### PR DESCRIPTION
# Description
Right now our metric handler sends the activity.type, making it difficult to grok. this changes it to be `activity_type` which is the string value in the enum.

(also fixes a typo where `seer_activity_handler` was set as the exception path instead of the invoke activities handler.