### PR TITLE
fix(issues): Tweak issue activity marker colors

### DIFF
--- a/static/app/views/issueDetails/activitySection/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityIcons.tsx
@@ -118,7 +118,7 @@ export const groupActivityTypeIconMapping: Record<
   [GroupActivityType.AUTO_SET_ONGOING]: {Component: IconPlay, defaultProps: {}},
   [GroupActivityType.SET_ESCALATING]: {
     Component: IconGraph,
-    defaultProps: {type: 'area'},
+    defaultProps: {type: 'line'},
   },
   [GroupActivityType.SET_PRIORITY]: {
     Component: IconCellSignal,
@@ -146,7 +146,6 @@ export const groupActivityTypeIconMapping: Record<
   [GroupActivityType.SEER_RCA_COMPLETED]: {
     Component: IconSeer,
     defaultProps: {},
-    propsFunction: () => ({variant: 'success'}),
   },
   [GroupActivityType.SEER_SOLUTION_STARTED]: {
     Component: IconSeer,
@@ -156,7 +155,6 @@ export const groupActivityTypeIconMapping: Record<
   [GroupActivityType.SEER_SOLUTION_COMPLETED]: {
     Component: IconSeer,
     defaultProps: {},
-    propsFunction: () => ({variant: 'success'}),
   },
   [GroupActivityType.SEER_CODING_STARTED]: {
     Component: IconSeer,
@@ -166,12 +164,10 @@ export const groupActivityTypeIconMapping: Record<
   [GroupActivityType.SEER_CODING_COMPLETED]: {
     Component: IconSeer,
     defaultProps: {},
-    propsFunction: () => ({variant: 'success'}),
   },
   [GroupActivityType.SEER_PR_CREATED]: {
     Component: IconSeer,
     defaultProps: {},
-    propsFunction: () => ({variant: 'success'}),
   },
 };
 

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -277,6 +277,72 @@ describe('ActivitySection', () => {
     expect(screen.queryByTestId('letter_avatar-avatar')).not.toBeInTheDocument();
   });
 
+  it('does not render a colored marker circle around sentry app activity markers', async () => {
+    const sentryApp = SentryAppFixture({
+      name: 'Linear',
+      slug: 'linear',
+      avatars: [
+        {
+          avatarType: 'upload',
+          avatarUrl: 'https://example.com/linear.png',
+          avatarUuid: 'linear-avatar',
+          photoType: 'icon',
+          color: true,
+        },
+      ],
+    });
+    const activityGroup = GroupFixture({
+      id: '1339',
+      activity: [
+        {
+          type: GroupActivityType.SET_RESOLVED,
+          id: 'resolved-by-sentry-app-1',
+          data: {},
+          dateCreated: '2020-01-01T00:00:00',
+          sentry_app: sentryApp,
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(<ActivitySection group={activityGroup} />, {
+      organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+    });
+
+    expect(await screen.findByText('Resolved')).toBeInTheDocument();
+    expect(screen.getByTestId('sentry-app-activity-marker')).toBeInTheDocument();
+    expect(screen.queryByTestId('colored-activity-marker')).not.toBeInTheDocument();
+  });
+
+  it('renders a marker circle around assigned user activity markers', async () => {
+    const activityGroup = GroupFixture({
+      id: '1340',
+      activity: [
+        {
+          type: GroupActivityType.ASSIGNED,
+          id: 'assigned-by-user-1',
+          data: {
+            assignee: user.id,
+            assigneeType: 'user',
+            user,
+          },
+          dateCreated: '2020-01-01T00:00:00',
+          user,
+        },
+      ],
+      project,
+    });
+
+    render(<ActivitySection group={activityGroup} />, {
+      organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+    });
+
+    expect(await screen.findByText('Assigned')).toBeInTheDocument();
+    expect(screen.getByTestId('user-activity-marker')).toBeInTheDocument();
+    expect(screen.getByTestId('colored-activity-marker')).toBeInTheDocument();
+  });
+
   it('renders provider-specific icon for create issue in two-column layout', async () => {
     const createIssueGroup = GroupFixture({
       id: '1345',

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -54,21 +54,21 @@ function getAuthorName(item: GroupActivity) {
   return 'Sentry';
 }
 
-function getActivityMarker(item: GroupActivity, color: string) {
+function ActivityMarker({item, color}: {color: string; item: GroupActivity}) {
   if (item.sentry_app) {
     return (
-      <AvatarMarker color={color}>
+      <SentryAppActivityMarker>
         <SentryAppAvatar
           data-test-id="sentry-app-activity-marker"
           sentryApp={item.sentry_app}
           size={22}
         />
-      </AvatarMarker>
+      </SentryAppActivityMarker>
     );
   }
   if (item.user) {
     return (
-      <AvatarMarker color={color}>
+      <AvatarMarker color={color} data-test-id="colored-activity-marker">
         <UserAvatar data-test-id="user-activity-marker" user={item.user} size={22} />
       </AvatarMarker>
     );
@@ -90,10 +90,6 @@ function getActivityColorConfig(theme: Theme, type: GroupActivityType) {
     case GroupActivityType.SET_RESOLVED_IN_COMMIT:
     case GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST:
     case GroupActivityType.MARK_REVIEWED:
-    case GroupActivityType.SEER_RCA_COMPLETED:
-    case GroupActivityType.SEER_SOLUTION_COMPLETED:
-    case GroupActivityType.SEER_CODING_COMPLETED:
-    case GroupActivityType.SEER_PR_CREATED:
       return {
         ...defaultConfig,
         icon: theme.tokens.graphics.success.vibrant,
@@ -107,6 +103,11 @@ function getActivityColorConfig(theme: Theme, type: GroupActivityType) {
         iconBorder: theme.tokens.border.danger.vibrant,
       };
     case GroupActivityType.SET_ESCALATING:
+      return {
+        ...defaultConfig,
+        icon: theme.tokens.content.warning,
+        iconBorder: theme.tokens.content.warning,
+      };
     case GroupActivityType.SET_PRIORITY:
       return {
         ...defaultConfig,
@@ -184,7 +185,11 @@ function TimelineItem({
         </Flex>
       }
       timestamp={<Timestamp date={item.dateCreated} />}
-      marker={useTwoColumnLayout ? getActivityMarker(item, colorConfig.icon) : undefined}
+      marker={
+        useTwoColumnLayout ? (
+          <ActivityMarker item={item} color={colorConfig.icon} />
+        ) : undefined
+      }
       colorConfig={useTwoColumnLayout ? colorConfig : undefined}
       icon={
         Icon && (
@@ -532,6 +537,14 @@ const ActivityInputFrame = styled('div')`
   min-width: 0;
 `;
 
+const SentryAppActivityMarker = styled('span')`
+  position: relative;
+  display: block;
+  width: 22px;
+  height: 22px;
+  line-height: 0;
+`;
+
 const AvatarMarker = styled('span')<{color: string}>`
   display: block;
   position: relative;
@@ -543,7 +556,7 @@ const AvatarMarker = styled('span')<{color: string}>`
     position: absolute;
     inset: 0;
     border-radius: 100%;
-    box-shadow: inset 0 0 0 2px ${p => p.color};
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, ${p => p.color} 80%, transparent);
     pointer-events: none;
   }
 `;

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -108,12 +108,6 @@ function getActivityColorConfig(theme: Theme, type: GroupActivityType) {
         icon: theme.tokens.content.warning,
         iconBorder: theme.tokens.content.warning,
       };
-    case GroupActivityType.SET_PRIORITY:
-      return {
-        ...defaultConfig,
-        icon: theme.tokens.graphics.warning.vibrant,
-        iconBorder: theme.tokens.border.warning.vibrant,
-      };
     case GroupActivityType.SET_IGNORED:
       return {
         ...defaultConfig,


### PR DESCRIPTION
- removes the colored avatar ring from app-backed activity markers like Linear
- keeps user-backed activity markers, but makes the ring thinner and slightly softer
- uses a line graph icon and darker warning color for escalated activity
- keeps priority updates and completed Seer activity neutral