### PR TITLE
fix(action_log): Refine usage of idempotency key

### DIFF
--- a/src/sentry/issues/action_log/__init__.py
+++ b/src/sentry/issues/action_log/__init__.py
@@ -1,7 +1,6 @@
 from sentry.issues.action_log.base import (
     ActionContext,
     ActionSource,
-    DuplicateActionError,
     action_context_scope,
     get_action_context,
     publish_action,
@@ -13,7 +12,6 @@ from sentry.issues.action_log.types import SYSTEM_ACTOR, GroupActionActor
 __all__ = [
     "ActionContext",
     "ActionSource",
-    "DuplicateActionError",
     "GroupActionActor",
     "SYSTEM_ACTOR",
     "action_context_scope",

--- a/src/sentry/issues/action_log/base.py
+++ b/src/sentry/issues/action_log/base.py
@@ -7,7 +7,6 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import StrEnum
 
-from django.db import IntegrityError, router, transaction
 from rest_framework.request import Request
 
 from sentry import options
@@ -134,10 +133,6 @@ def get_action_context() -> ActionContext | None:
     return _action_context.get()
 
 
-class DuplicateActionError(Exception):
-    """Raised when an idempotency_key conflicts with an existing entry."""
-
-
 def publish_action(
     action: GroupAction,
     *,
@@ -146,11 +141,9 @@ def publish_action(
     organization_id: int,
     project_id: int,
     actor: GroupActionActor = SYSTEM_ACTOR,
-    idempotency_key: str | None = None,
 ) -> None:
     """
-    Record an issue action. Raises DuplicateActionError if an idempotency_key
-    conflicts with an existing entry.
+    Record an issue action.
 
     Use this for shallow endpoint-level actions where the request is in scope
     (VIEW, COMMENT, TRIGGER_AUTOFIX). For mutation sites deeper in the stack,
@@ -171,7 +164,6 @@ def publish_action(
             "actor_type": actor.actor_type.name.lower(),
             "actor_id": str(actor.actor_id),
             "metadata": action.dict(),
-            "idempotency_key": idempotency_key,
         },
     )
 
@@ -179,7 +171,7 @@ def publish_action(
     if not options.get("issues.action-log.write-to-db"):
         return
 
-    kwargs = dict(
+    GroupActionLogEntry.objects.create(
         group_id=group_id,
         project_id=project_id,
         type=action.get_type().value,
@@ -187,25 +179,7 @@ def publish_action(
         actor_id=actor.actor_id,
         source=source,
         data=action.dict(),
-        idempotency_key=idempotency_key,
     )
-
-    if idempotency_key is None:
-        GroupActionLogEntry.objects.create(**kwargs)
-        return
-
-    try:
-        with transaction.atomic(using=router.db_for_write(GroupActionLogEntry)):
-            GroupActionLogEntry.objects.create(**kwargs)
-    except IntegrityError as e:
-        cause = e.__cause__
-        constraint = getattr(getattr(cause, "diag", None), "constraint_name", None)
-        if constraint == "uniq_groupactionlogentry_group_idempotency_key":
-            raise DuplicateActionError(
-                f"Action already recorded for group {group_id} "
-                f"with idempotency_key={idempotency_key!r}"
-            ) from e
-        raise
 
 
 def publish_action_from_context(

--- a/src/sentry/issues/groupactionlogentry.py
+++ b/src/sentry/issues/groupactionlogentry.py
@@ -59,7 +59,8 @@ class GroupActionLogEntry(Model):
     # for invalidation.
     date_updated = models.DateTimeField(auto_now=True)
 
-    # Partial unique index with group_id prevents duplicate events.
+    # Unique identifier for external action this corresponds to.
+    # Primarly exists to make backfilling third party actions simpler.
     idempotency_key = models.CharField(max_length=64, null=True)
 
     class Meta:

--- a/tests/sentry/issues/test_action_log.py
+++ b/tests/sentry/issues/test_action_log.py
@@ -1,8 +1,6 @@
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 import sentry.api.helpers.group_index.update
 import sentry.issues.endpoints.group_details
 import sentry.issues.endpoints.group_integration_details
@@ -14,7 +12,6 @@ import sentry.models.groupinbox
 from sentry.issues.action_log import (
     SYSTEM_ACTOR,
     ActionContext,
-    DuplicateActionError,
     GroupActionActor,
     action_context_scope,
     get_action_context,
@@ -575,24 +572,6 @@ class TestPublishActionWrite(TestCase):
         )
         assert len(entries) == 3
         assert entries[0].id < entries[1].id < entries[2].id
-
-    def test_duplicate_idempotency_key_raises(self) -> None:
-        kwargs = dict(
-            source=ActionSource.API,
-            group_id=self.group.id,
-            organization_id=self.group.project.organization_id,
-            project_id=self.group.project_id,
-            actor=GroupActionActor.user(self.user.id),
-            idempotency_key="view-123",
-        )
-
-        with self.options({"issues.action-log.write-to-db": True}):
-            publish_action(ViewAction(), **kwargs)
-
-            with pytest.raises(DuplicateActionError):
-                publish_action(ViewAction(), **kwargs)
-
-        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
 
     def test_option_disabled_skips_write(self) -> None:
         with self.options({"issues.action-log.write-to-db": False}):


### PR DESCRIPTION
Initially, the idempotency key was understood rather generally: we want to make it possible to avoid double-writes.
The exact use cases weren't clear, so we started with simple rejection.

As we've gotten more into the specifics, it's been clear that the semantics here are a concern for a variety of possible implementation questions, and it is useful to narrow and refine the use.

The goal is to help avoid duplication, with two primary cases of duplication in mind:
1. Backfill duplication (as from Activity) where importing actions from other sources should be possible to do easily without introducing duplicates. This path doesn't involve publish_action, which is fundamentally a live publish.
2. Avoiding dual recording of live events. This case is subtler, but we intend for publish_action to be transactional, so in most cases, if it is an action that Sentry is performing (or is being performed in Sentry code), we should either not perform the action (and not log it) or perform it (maybe even twice) and log it twice. RLE-style deduplication is possible, but shouldn't be important enough to bake in. Actions in non-Sentry code can be treated as having already happened, in which case the live path isn't necessary, or they're really happening again from the Sentry perspective, in which case we can either dual report them, or use higher level mechanisms to avoid the duplication (eg "you aren't closed this, we'll return").

Thus, the theory is that live publishing doesn't _need_ the idempotency key, and it makes the interface simpler and the implementation much easier to manage if it doesn't have it. We may end up reversing this, but I don't think we should make that choice until we have settled on our mechanism for atomicity.
