### PR TITLE
feat(spans): add warning card for spans

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -67,6 +67,7 @@ import {Alerts} from './sections/alerts';
 import {SpanDescription} from './sections/description';
 import {GeneralInfo} from './sections/generalInfo';
 import {hasSpanHTTPInfo, SpanHTTPInfo} from './sections/http';
+import {HttpErrorCard} from './sections/httpErrorCard';
 import {hasSpanKeys, SpanKeys} from './sections/keys';
 import {hasSpanMeasurements, Measurements} from './sections/measurements';
 import {hasSpanTags, Tags} from './sections/tags';
@@ -239,6 +240,7 @@ function SpanNodeDetailsContent({
         {issues.length > 0 ? (
           <IssueList organization={organization} issues={issues} node={node} />
         ) : null}
+        {node.hasHttpError && issues.length === 0 ? <HttpErrorCard node={node} /> : null}
         <SpanDescription
           node={node}
           project={project}
@@ -549,6 +551,7 @@ function EAPSpanNodeDetailsContent({
         {issues.length > 0 ? (
           <IssueList organization={organization} issues={issues} node={node} />
         ) : null}
+        {node.hasHttpError && issues.length === 0 ? <HttpErrorCard node={node} /> : null}
         <EAPSpanDescription
           node={node}
           project={project}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.spec.tsx
@@ -1,0 +1,117 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {EapSpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode';
+import {SpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode';
+import {
+  makeEAPSpan,
+  makeSpan,
+} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+
+import {HttpErrorCard} from './httpErrorCard';
+
+const extra = {organization: OrganizationFixture()};
+
+describe('HttpErrorCard', () => {
+  it('does not render when hasHttpError is false', () => {
+    const node = new SpanNode(null, makeSpan({status: 'ok', data: {}}), extra);
+
+    const {container} = render(<HttpErrorCard node={node} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe('SpanNode', () => {
+    it('displays status text and status code', () => {
+      const node = new SpanNode(
+        null,
+        makeSpan({
+          status: 'internal_error',
+          data: {'http.response.status_code': 500},
+        }),
+        extra
+      );
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('Internal Error')).toBeInTheDocument();
+      expect(screen.getByText('HTTP 500')).toBeInTheDocument();
+    });
+
+    it('displays only status code when status is not set', () => {
+      const node = new SpanNode(
+        null,
+        makeSpan({data: {'http.response.status_code': 502}}),
+        extra
+      );
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('HTTP Error')).toBeInTheDocument();
+      expect(screen.getByText('HTTP 502')).toBeInTheDocument();
+    });
+
+    it('displays only status text when status code is not present', () => {
+      const node = new SpanNode(null, makeSpan({status: 'not_found', data: {}}), extra);
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('Not Found')).toBeInTheDocument();
+      expect(screen.queryByText(/HTTP \d/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('EapSpanNode', () => {
+    it('displays status text and status code', () => {
+      const node = new EapSpanNode(
+        null,
+        makeEAPSpan({
+          event_id: 'span-1',
+          additional_attributes: {
+            'span.status': 'resource_exhausted',
+            'http.response.status_code': 429,
+          },
+        }),
+        extra
+      );
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('Resource Exhausted')).toBeInTheDocument();
+      expect(screen.getByText('HTTP 429')).toBeInTheDocument();
+    });
+
+    it('displays only status code when span.status is not present', () => {
+      const node = new EapSpanNode(
+        null,
+        makeEAPSpan({
+          event_id: 'span-2',
+          additional_attributes: {'http.response.status_code': 503},
+        }),
+        extra
+      );
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('HTTP Error')).toBeInTheDocument();
+      expect(screen.getByText('HTTP 503')).toBeInTheDocument();
+    });
+
+    it('displays only status text when status code is not present', () => {
+      const node = new EapSpanNode(
+        null,
+        makeEAPSpan({
+          event_id: 'span-3',
+          additional_attributes: {'span.status': 'unavailable'},
+        }),
+        extra
+      );
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('Unavailable')).toBeInTheDocument();
+      expect(screen.queryByText(/HTTP \d/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.spec.tsx
@@ -60,6 +60,20 @@ describe('HttpErrorCard', () => {
       expect(screen.getByText('Not Found')).toBeInTheDocument();
       expect(screen.queryByText(/HTTP \d/)).not.toBeInTheDocument();
     });
+
+    it('does not show non-error status as title when only status code triggers the error', () => {
+      const node = new SpanNode(
+        null,
+        makeSpan({status: 'ok', data: {'http.response.status_code': 500}}),
+        extra
+      );
+
+      render(<HttpErrorCard node={node} />);
+
+      expect(screen.getByText('HTTP Error')).toBeInTheDocument();
+      expect(screen.getByText('HTTP 500')).toBeInTheDocument();
+      expect(screen.queryByText('Ok')).not.toBeInTheDocument();
+    });
   });
 
   describe('EapSpanNode', () => {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.tsx
@@ -7,6 +7,7 @@ import {Panel} from 'sentry/components/panels/panel';
 import {PanelItem} from 'sentry/components/panels/panelItem';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {HTTP_ERROR_STATUSES} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/constants';
 import type {EapSpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode';
 import {SpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode';
 
@@ -27,7 +28,10 @@ function getStatusInfo(node: SpanNode | EapSpanNode): {
 } {
   const status =
     node instanceof SpanNode ? node.value.status : node.attributes?.['span.status'];
-  const statusText = typeof status === 'string' ? formatStatusText(status) : null;
+  const statusText =
+    typeof status === 'string' && HTTP_ERROR_STATUSES.has(status)
+      ? formatStatusText(status)
+      : null;
   const raw = Number(node.attributes?.['http.response.status_code']);
   const statusCode = !isNaN(raw) && raw >= 400 ? raw : null;
   return {statusText, statusCode};

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.tsx
@@ -1,0 +1,86 @@
+import styled from '@emotion/styled';
+
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {Panel} from 'sentry/components/panels/panel';
+import {PanelItem} from 'sentry/components/panels/panelItem';
+import {IconWarning} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {EapSpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode';
+import {SpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode';
+
+type HttpErrorCardProps = {
+  node: SpanNode | EapSpanNode;
+};
+
+function formatStatusText(status: string): string {
+  return status
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function getStatusInfo(node: SpanNode | EapSpanNode): {
+  statusCode: number | null;
+  statusText: string | null;
+} {
+  const status =
+    node instanceof SpanNode ? node.value.status : node.attributes?.['span.status'];
+  const statusText = typeof status === 'string' ? formatStatusText(status) : null;
+  const raw = Number(node.attributes?.['http.response.status_code']);
+  const statusCode = !isNaN(raw) && raw >= 400 ? raw : null;
+  return {statusText, statusCode};
+}
+
+export function HttpErrorCard({node}: HttpErrorCardProps) {
+  if (!node.hasHttpError) {
+    return null;
+  }
+
+  const {statusText, statusCode} = getStatusInfo(node);
+
+  return (
+    <Wrapper>
+      <StyledPanel>
+        <StyledPanelItem>
+          <IconWrapper>
+            <IconWarning size="md" variant="warning" />
+          </IconWrapper>
+          <Stack gap="2xs">
+            <Flex gap="xs" align="center">
+              <Text bold>{statusText ?? t('HTTP Error')}</Text>
+              {statusCode !== null && (
+                <Text variant="muted">{t('HTTP %s', statusCode)}</Text>
+              )}
+            </Flex>
+            <Text size="sm" variant="muted">
+              {t('This span returned an error status but has no associated issue.')}
+            </Text>
+          </Stack>
+        </StyledPanelItem>
+      </StyledPanel>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled('div')`
+  margin: ${p => p.theme.space.md} 0;
+`;
+
+const StyledPanel = styled(Panel)`
+  margin-bottom: 0;
+`;
+
+const StyledPanelItem = styled(PanelItem)`
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl} ${p => p.theme.space.lg}
+    ${p => p.theme.space.md};
+`;
+
+const IconWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/httpErrorCard.tsx
@@ -48,9 +48,9 @@ export function HttpErrorCard({node}: HttpErrorCardProps) {
     <Wrapper>
       <StyledPanel>
         <StyledPanelItem>
-          <IconWrapper>
+          <Flex align="center" justify="center">
             <IconWarning size="md" variant="warning" />
-          </IconWrapper>
+          </Flex>
           <Stack gap="2xs">
             <Flex gap="xs" align="center">
               <Text bold>{statusText ?? t('HTTP Error')}</Text>
@@ -81,10 +81,4 @@ const StyledPanelItem = styled(PanelItem)`
   gap: ${p => p.theme.space.md};
   padding: ${p => p.theme.space.md} ${p => p.theme.space.xl} ${p => p.theme.space.lg}
     ${p => p.theme.space.md};
-`;
-
-const IconWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: center;
 `;


### PR DESCRIPTION
This is an additional PR to https://github.com/getsentry/sentry/pull/117380 - should be reviewed first.

This adds a card component and displays it for spans that have error codes to provide better visibility to users.

Focus on the span drawer on the right with "unauthenticated"
<img width="1149" height="594" alt="Screenshot 2026-06-10 at 6 38 54 PM" src="https://github.com/user-attachments/assets/18c81ee3-9c73-43f8-98bb-1bea859e07b0" />
