### PR TITLE
o11y(assisted-query): Track error outcomes in trackAiQueryOutcome

### DIFF
--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -110,6 +110,7 @@ function useTrackAnalytics({
   const chartError = timeseriesResult.error;
   const query_status = tableError?.message || chartError?.message ? 'error' : 'success';
   const tableErrorBox = useBox(tableError);
+  const chartErrorBox = useBox(chartError);
 
   const {isLoading: isLoadingSeerSetup} = useOrganizationSeerSetup({
     enabled: !organization.hideAiFeatures,
@@ -173,7 +174,7 @@ function useTrackAnalytics({
         referrer: 'spans',
         resultCount: aggregatesTableResult.result.data?.length ?? 0,
         runId: aiQueryRunId,
-        error: tableErrorBox.current || false,
+        error: tableErrorBox.current || chartErrorBox.current || false,
       });
     }
 
@@ -222,6 +223,7 @@ function useTrackAnalytics({
     queryType,
     query_status,
     tableErrorBox,
+    chartErrorBox,
     timeseriesResult.data,
     timeseriesResult.isPending,
     title,
@@ -307,7 +309,7 @@ function useTrackAnalytics({
         referrer: 'spans',
         resultCount: spansTableResult.result.data?.length ?? 0,
         runId: aiQueryRunId,
-        error: tableErrorBox.current || false,
+        error: tableErrorBox.current || chartErrorBox.current || false,
       });
     }
   }, [
@@ -332,6 +334,7 @@ function useTrackAnalytics({
     spansTableResult.result.isPending,
     spansTableResult.result.meta?.dataScanned,
     tableErrorBox,
+    chartErrorBox,
     timeseriesResult.data,
     timeseriesResult.isPending,
     title,
@@ -500,7 +503,7 @@ function useTrackAnalytics({
         referrer: 'traces',
         resultCount: tracesTableResult.result.data?.json?.data?.length ?? 0,
         runId: aiQueryRunId,
-        error: tableErrorBox.current || false,
+        error: tableErrorBox.current || chartErrorBox.current || false,
       });
     }
   }, [
@@ -520,6 +523,7 @@ function useTrackAnalytics({
     queryType,
     query_status,
     tableErrorBox,
+    chartErrorBox,
     timeseriesResult.data,
     timeseriesResult.isPending,
     title,

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -496,6 +496,20 @@ function IssueListOverviewInner({
         setError(parseApiError(err));
         setIssuesLoading(false);
         setIssuesSuccessfullyLoaded(false);
+
+        // AI query analytics
+        const aiQueryRunId = getRunIdForAnalytics();
+        if (aiQueryRunId !== null) {
+          trackAiQueryOutcome({
+            dataset: 'issues',
+            mode: 'samples',
+            referrer: 'issues',
+            resultCount: 0,
+            orgSlug: organization.slug,
+            runId: aiQueryRunId,
+            error: parseApiError(err),
+          });
+        }
       },
       complete: () => {
         resumePolling();


### PR DESCRIPTION
## Summary

Threads error context into `trackAiQueryOutcome` in two places where it was previously dropped, so AI-assisted queries that fail record an `error_on_load` outcome instead of being mislabeled or unrecorded.

### Issue list (`issueList/overview.tsx`)
The issue list only called `trackAiQueryOutcome` in the fetch success handler, so AI queries that errored never recorded an outcome. Added a matching call in the error handler with `resultCount: 0` and the parsed API error, mirroring the adjacent `issue_search.failed` analytics.

### Spans explore (`explore/hooks/useAnalytics.tsx`)
`trackAiQueryOutcome` in `useTrackAnalytics` only passed the table error, while `query_status` already factored in the chart (timeseries) error. A chart-only failure therefore logged `query_status: 'error'` but an `outcome` of `has_results`/`empty_results`. Boxed the existing `chartError` (same `useBox` pattern as `tableError`) and OR'd it into the error arg for the aggregate, samples, and traces calls so the outcome aligns with `query_status`.

No new chart-error sources are introduced — `chartError` is only used where it already existed; the logs and metrics analytics hooks are untouched.