### PR TITLE
feat(seer): Allow Seer Agent POST endpoints in sandbox demo mode

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -5,6 +5,7 @@ import logging
 import sentry_sdk
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.permissions import SAFE_METHODS
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -13,6 +14,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_user
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.agent.client import SeerAgentClient
@@ -111,6 +113,16 @@ class OrganizationSeerAgentChatPermission(OrganizationPermission):
         "GET": ["org:read"],
         "POST": ["org:read"],
     }
+
+    # Allow POST requests in demo mode to showcase Seer Agent
+    DEMO_ALLOWED_METHODS = (*SAFE_METHODS, "POST")
+
+    def has_permission(self, request: Request, view: object) -> bool:
+        if is_demo_user(request.user):
+            if not is_demo_mode_enabled() or request.method not in self.DEMO_ALLOWED_METHODS:
+                return False
+            return True
+        return super().has_permission(request, view)
 
 
 @cell_silo_endpoint

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import sentry_sdk
 from rest_framework import serializers
@@ -8,13 +9,14 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import SAFE_METHODS
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
-from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_user
+from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_org, is_demo_user
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.agent.client import SeerAgentClient
@@ -117,12 +119,22 @@ class OrganizationSeerAgentChatPermission(OrganizationPermission):
     # Allow POST requests in demo mode to showcase Seer Agent
     DEMO_ALLOWED_METHODS = (*SAFE_METHODS, "POST")
 
-    def has_permission(self, request: Request, view: object) -> bool:
+    def has_permission(self, request: Request, view: APIView) -> bool:
         if is_demo_user(request.user):
             if not is_demo_mode_enabled() or request.method not in self.DEMO_ALLOWED_METHODS:
                 return False
             return True
         return super().has_permission(request, view)
+
+    def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:
+        if is_demo_user(request.user):
+            if not is_demo_mode_enabled() or request.method not in self.DEMO_ALLOWED_METHODS:
+                return False
+            org = obj.organization if hasattr(obj, "organization") else obj
+            if not is_demo_org(org):
+                return False
+            return True
+        return super().has_object_permission(request, view, obj)
 
 
 @cell_silo_endpoint

--- a/src/sentry/seer/endpoints/organization_seer_agent_update.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_update.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 import orjson
+from rest_framework.permissions import SAFE_METHODS
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -11,6 +12,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.constants import ENABLE_SEER_CODING_DEFAULT
+from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_user
 from sentry.models.organization import Organization
 from sentry.seer.agent.client_utils import (
     agent_connection_pool,
@@ -27,6 +29,16 @@ class OrganizationSeerAgentUpdatePermission(OrganizationPermission):
     scope_map = {
         "POST": ["org:read"],
     }
+
+    # Allow POST requests in demo mode to showcase Seer Agent
+    DEMO_ALLOWED_METHODS = (*SAFE_METHODS, "POST")
+
+    def has_permission(self, request: Request, view: object) -> bool:
+        if is_demo_user(request.user):
+            if not is_demo_mode_enabled() or request.method not in self.DEMO_ALLOWED_METHODS:
+                return False
+            return True
+        return super().has_permission(request, view)
 
 
 @cell_silo_endpoint

--- a/src/sentry/seer/endpoints/organization_seer_agent_update.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_update.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import orjson
 from rest_framework.permissions import SAFE_METHODS
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.constants import ENABLE_SEER_CODING_DEFAULT
-from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_user
+from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_org, is_demo_user
 from sentry.models.organization import Organization
 from sentry.seer.agent.client_utils import (
     agent_connection_pool,
@@ -33,12 +35,22 @@ class OrganizationSeerAgentUpdatePermission(OrganizationPermission):
     # Allow POST requests in demo mode to showcase Seer Agent
     DEMO_ALLOWED_METHODS = (*SAFE_METHODS, "POST")
 
-    def has_permission(self, request: Request, view: object) -> bool:
+    def has_permission(self, request: Request, view: APIView) -> bool:
         if is_demo_user(request.user):
             if not is_demo_mode_enabled() or request.method not in self.DEMO_ALLOWED_METHODS:
                 return False
             return True
         return super().has_permission(request, view)
+
+    def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:
+        if is_demo_user(request.user):
+            if not is_demo_mode_enabled() or request.method not in self.DEMO_ALLOWED_METHODS:
+                return False
+            org = obj.organization if hasattr(obj, "organization") else obj
+            if not is_demo_org(org):
+                return False
+            return True
+        return super().has_object_permission(request, view, obj)
 
 
 @cell_silo_endpoint


### PR DESCRIPTION
The sandbox demo mode blocks all non-safe HTTP methods (POST, PUT, DELETE) for demo users via `DemoSafePermission`, which prevents Seer Agent from working since it needs POST to start/continue chat sessions and send agent updates.

This overrides `has_permission` in `OrganizationSeerAgentChatPermission` and `OrganizationSeerAgentUpdatePermission` to allow POST for demo users when demo mode is enabled, following the same pattern already used by `GroupAiPermission` for autofix endpoints. Both endpoints already only require `org:read` scope for POST, which is included in the demo user's readonly scopes, so the scope layer needs no changes.

The relevant FlagPole flags (`seer-explorer`, `gen-ai-features`, etc.) and org settings (`allow_joinleave`) still need to be enabled for the sandbox org in `sentry-options-automator` separately.