### PR TITLE
ref(search): Resolve issue: short ids org-wide with explicit project_ids=None

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -256,10 +256,6 @@ class SearchResolver:
                 Group.objects.by_qualified_short_id_bulk(
                     organization_id=self.params.organization_id,
                     short_ids_raw=list(collected),
-                    # Scope to the projects the query is restricted to so a short id for a
-                    # project outside the search scope does not resolve. Fall back to None
-                    # (no pre-filter) when there is no project scope, so an organization-wide
-                    # query still resolves; the downstream Snuba query enforces the projects.
                     project_ids=self.params.project_ids or None,
                 )
             )

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -254,7 +254,11 @@ class SearchResolver:
         try:
             groups = list(
                 Group.objects.by_qualified_short_id_bulk(
-                    organization_id=self.params.organization_id, short_ids_raw=list(collected)
+                    organization_id=self.params.organization_id,
+                    short_ids_raw=list(collected),
+                    # Scope to the projects the query is restricted to so a short id for a
+                    # project outside the search scope does not resolve.
+                    project_ids=self.params.project_ids,
                 )
             )
         except Group.DoesNotExist:

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -257,8 +257,10 @@ class SearchResolver:
                     organization_id=self.params.organization_id,
                     short_ids_raw=list(collected),
                     # Scope to the projects the query is restricted to so a short id for a
-                    # project outside the search scope does not resolve.
-                    project_ids=self.params.project_ids,
+                    # project outside the search scope does not resolve. Fall back to None
+                    # (no pre-filter) when there is no project scope, so an organization-wide
+                    # query still resolves; the downstream Snuba query enforces the projects.
+                    project_ids=self.params.project_ids or None,
                 )
             )
         except Group.DoesNotExist:

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -256,7 +256,8 @@ class SearchResolver:
                 Group.objects.by_qualified_short_id_bulk(
                     organization_id=self.params.organization_id,
                     short_ids_raw=list(collected),
-                    project_ids=self.params.project_ids or None,
+                    # org-wide: the Snuba query is already scoped to the requested projects.
+                    project_ids=None,
                 )
             )
         except Group.DoesNotExist:

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1702,7 +1702,8 @@ class DiscoverDatasetConfig(DatasetConfig):
                 groups = Group.objects.by_qualified_short_id_bulk(
                     self.builder.params.organization.id,
                     group_short_ids,
-                    project_ids=self.builder.params.project_ids or None,
+                    # org-wide: the Snuba query is already scoped to the requested projects.
+                    project_ids=None,
                 )
             except Group.DoesNotExist:
                 raise InvalidIssueSearchQuery(group_short_ids)

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1703,8 +1703,10 @@ class DiscoverDatasetConfig(DatasetConfig):
                     self.builder.params.organization.id,
                     group_short_ids,
                     # Scope to the projects the query is restricted to so a short id for a
-                    # project outside the search scope does not resolve.
-                    project_ids=self.builder.params.project_ids,
+                    # project outside the search scope does not resolve. Fall back to None
+                    # (no pre-filter) when there is no project scope, so an organization-wide
+                    # query still resolves; the downstream Snuba query enforces the projects.
+                    project_ids=self.builder.params.project_ids or None,
                 )
             except Group.DoesNotExist:
                 raise InvalidIssueSearchQuery(group_short_ids)

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1702,10 +1702,6 @@ class DiscoverDatasetConfig(DatasetConfig):
                 groups = Group.objects.by_qualified_short_id_bulk(
                     self.builder.params.organization.id,
                     group_short_ids,
-                    # Scope to the projects the query is restricted to so a short id for a
-                    # project outside the search scope does not resolve. Fall back to None
-                    # (no pre-filter) when there is no project scope, so an organization-wide
-                    # query still resolves; the downstream Snuba query enforces the projects.
                     project_ids=self.builder.params.project_ids or None,
                 )
             except Group.DoesNotExist:

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1702,6 +1702,9 @@ class DiscoverDatasetConfig(DatasetConfig):
                 groups = Group.objects.by_qualified_short_id_bulk(
                     self.builder.params.organization.id,
                     group_short_ids,
+                    # Scope to the projects the query is restricted to so a short id for a
+                    # project outside the search scope does not resolve.
+                    project_ids=self.builder.params.project_ids,
                 )
             except Group.DoesNotExist:
                 raise InvalidIssueSearchQuery(group_short_ids)

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -772,6 +772,10 @@ def format_search_filter(
                 groups = Group.objects.by_qualified_short_id_bulk(
                     params["organization_id"],
                     group_short_ids,
+                    # Scope to the projects the query is restricted to so a short id for a
+                    # project outside the search scope does not resolve. ``project_id`` may be
+                    # absent (None) for organization-wide queries.
+                    project_ids=params.get("project_id"),
                 )
             except Exception:
                 raise InvalidSearchQuery(f"Invalid value '{group_short_ids}' for 'issue:' filter")

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -772,7 +772,8 @@ def format_search_filter(
                 groups = Group.objects.by_qualified_short_id_bulk(
                     params["organization_id"],
                     group_short_ids,
-                    project_ids=params.get("project_id") or None,
+                    # org-wide: the Snuba query is already scoped to the requested projects.
+                    project_ids=None,
                 )
             except Exception:
                 raise InvalidSearchQuery(f"Invalid value '{group_short_ids}' for 'issue:' filter")

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -773,9 +773,10 @@ def format_search_filter(
                     params["organization_id"],
                     group_short_ids,
                     # Scope to the projects the query is restricted to so a short id for a
-                    # project outside the search scope does not resolve. ``project_id`` may be
-                    # absent (None) for organization-wide queries.
-                    project_ids=params.get("project_id"),
+                    # project outside the search scope does not resolve. Fall back to None
+                    # (no pre-filter) when there is no project scope, so an organization-wide
+                    # query still resolves; the downstream Snuba query enforces the projects.
+                    project_ids=params.get("project_id") or None,
                 )
             except Exception:
                 raise InvalidSearchQuery(f"Invalid value '{group_short_ids}' for 'issue:' filter")

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -772,10 +772,6 @@ def format_search_filter(
                 groups = Group.objects.by_qualified_short_id_bulk(
                     params["organization_id"],
                     group_short_ids,
-                    # Scope to the projects the query is restricted to so a short id for a
-                    # project outside the search scope does not resolve. Fall back to None
-                    # (no pre-filter) when there is no project scope, so an organization-wide
-                    # query still resolves; the downstream Snuba query enforces the projects.
                     project_ids=params.get("project_id") or None,
                 )
             except Exception:


### PR DESCRIPTION
Migrates the three `issue:PROJECT-123` short-id resolution sites (`filter.py`, `datasets/discover.py`, `eap/resolver.py`) to pass an explicit `project_ids=None` into `by_qualified_short_id_bulk`, preparing for the upcoming change that makes `project_ids` a required argument.

**Why `None` (org-wide), not the query's projects?** Project-level enforcement is unnecessary at this resolution step:
- The resolved group id is only ever applied inside a Snuba query already scoped to the requested projects (`RequestMeta.project_ids` in the EAP resolver; a `project_id` condition in discover/filter). A short id for a project outside the query simply matches zero rows.
- The access boundary is enforced upstream, where the endpoint builds `SnubaParams` via `get_projects()` (which runs `has_project_access`). And `by_qualified_short_id` is itself org-scoped, so cross-org never resolves.
- `SnubaParams.project_ids` is the query's project *scope*, not the caller's access set (internal callers can construct arbitrary project_ids), so scoping resolution to it would be both unnecessary and semantically misleading.

So these sites resolve org-wide and document that intent with `project_ids=None`. **No behavior change from master** — it just makes the org-wide choice explicit and forward-compatible with the required-`project_ids` hardening. (Earlier revisions scoped to `params.project_ids`; superseded per review — the genuinely protective scoping lives in the issue *mutation* path, not search.)