### PR TITLE
ref(seer): Scope Seer short id lookups; mark org-wide callers explicit

### DIFF
--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -1335,8 +1335,6 @@ def get_issue_details(
     if issue_id.isdigit():
         group = Group.objects.get(project_id__in=project_ids, id=int(issue_id))
     else:
-        # Scope the short id lookup to the same projects as the numeric branch so both
-        # paths enforce the same project boundary.
         group = Group.objects.by_qualified_short_id(
             organization_id, issue_id, project_ids=project_ids
         )
@@ -1452,8 +1450,6 @@ def get_event_details(
         if issue_id.isdigit():
             group = Group.objects.get(project_id__in=project_ids, id=int(issue_id))
         else:
-            # Scope the short id lookup to the same projects as the numeric branch so both
-            # paths enforce the same project boundary.
             group = Group.objects.by_qualified_short_id(
                 organization_id, issue_id, project_ids=project_ids
             )

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -1320,22 +1320,26 @@ def get_issue_details(
     start_dt, end_dt = get_date_range_from_params({"start": start, "end": end}, optional=True)
 
     organization = Organization.objects.get(id=organization_id)
+
+    project_ids = list(
+        Project.objects.filter(
+            organization=organization,
+            status=ObjectStatus.ACTIVE,
+            **({"slug": project_slug} if project_slug else {}),
+        ).values_list("id", flat=True)
+    )
+    if not project_ids:
+        return None
+
     group: Group
     if issue_id.isdigit():
-        project_ids = list(
-            Project.objects.filter(
-                organization=organization,
-                status=ObjectStatus.ACTIVE,
-                **({"slug": project_slug} if project_slug else {}),
-            ).values_list("id", flat=True)
-        )
-        if not project_ids:
-            return None
-
         group = Group.objects.get(project_id__in=project_ids, id=int(issue_id))
     else:
-        # Note short IDs are already scoped to a project so no need for project filtering.
-        group = Group.objects.by_qualified_short_id(organization_id, issue_id)
+        # Scope the short id lookup to the same projects as the numeric branch so both
+        # paths enforce the same project boundary.
+        group = Group.objects.by_qualified_short_id(
+            organization_id, issue_id, project_ids=project_ids
+        )
 
     # Get the issue metadata.
     serialized_group = dict(serialize(group, user=None, serializer=GroupSerializer()))
@@ -1448,7 +1452,11 @@ def get_event_details(
         if issue_id.isdigit():
             group = Group.objects.get(project_id__in=project_ids, id=int(issue_id))
         else:
-            group = Group.objects.by_qualified_short_id(organization_id, issue_id)
+            # Scope the short id lookup to the same projects as the numeric branch so both
+            # paths enforce the same project boundary.
+            group = Group.objects.by_qualified_short_id(
+                organization_id, issue_id, project_ids=project_ids
+            )
         assert group is not None
         event = _get_recommended_event(group, organization, start_dt, end_dt)
 
@@ -1550,7 +1558,11 @@ def get_issue_and_event_details_v2(
         if issue_id.isdigit():
             group = Group.objects.get(project_id__in=project_ids, id=int(issue_id))
         else:
-            group = Group.objects.by_qualified_short_id(organization_id, issue_id)
+            # Scope the short id lookup to the same projects as the numeric branch so both
+            # paths enforce the same project boundary.
+            group = Group.objects.by_qualified_short_id(
+                organization_id, issue_id, project_ids=project_ids
+            )
         assert group is not None
         event = _get_recommended_event(group, organization, start_dt, end_dt)
 

--- a/src/sentry/seer/fetch_issues/utils.py
+++ b/src/sentry/seer/fetch_issues/utils.py
@@ -155,8 +155,11 @@ def bulk_serialize_for_seer(groups: list[Group]) -> SeerResponse:
 
 
 def _group_by_short_id(short_id: str, organization_id: int) -> Group | None:
+    # Intentionally org-scoped only (project_ids=None): reached via the Seer RPC
+    # (get_latest_issue_event), which operates organization-wide on behalf of the system.
+    # There is no narrower authorized-project set available at this layer to enforce.
     try:
-        return Group.objects.by_qualified_short_id(organization_id, short_id)
+        return Group.objects.by_qualified_short_id(organization_id, short_id, project_ids=None)
     except Group.DoesNotExist:
         return None
 

--- a/src/sentry/utils/groupreference.py
+++ b/src/sentry/utils/groupreference.py
@@ -62,8 +62,12 @@ def find_referenced_groups(text: str | None, org_id: int) -> set[Group]:
         for smatch in _short_id_re.finditer(fmatch.group(1)):
             short_id = smatch.group(1)
             try:
+                # Intentionally org-scoped only (project_ids=None): this runs while processing
+                # commit/PR text (see Commit/PullRequest.find_referenced_groups), which
+                # legitimately links to any issue in the organization. There is no narrower
+                # authorized-project set to enforce here.
                 group = Group.objects.by_qualified_short_id(
-                    organization_id=org_id, short_id=short_id
+                    organization_id=org_id, short_id=short_id, project_ids=None
                 )
             except Group.DoesNotExist:
                 continue

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -1689,6 +1689,22 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, SearchIssueTest
         assert result["project_id"] == group.project_id
         assert result["project_slug"] == group.project.slug
 
+    def test_by_qualified_short_id_scoped_to_project_slug(self):
+        """A short ID is only resolvable within the project_slug-scoped projects."""
+        event = self._make_error_event()
+        group = event.group
+        assert isinstance(group, Group)
+
+        other_project = self.create_project(organization=self.organization, name="other project")
+
+        # Restricting to a different project must not resolve this project's short ID.
+        with pytest.raises(Group.DoesNotExist):
+            get_issue_details(
+                organization_id=self.organization.id,
+                issue_id=group.qualified_short_id,
+                project_slug=other_project.slug,
+            )
+
     # --- timeseries ---
 
     @patch("sentry.seer.agent.tools._get_issue_event_timeseries")


### PR DESCRIPTION
The Seer agent tools (`get_issue_details`, `get_event_details`, `get_issue_and_event_details_v2`) resolved qualified short ids **organization-wide**, while the sibling numeric-id branch right next to each one already filtered by `project_id__in=project_ids`. This passes `project_ids` into the short-id branch so both paths enforce the same project boundary (`get_issue_details` hoists `project_ids` out of the numeric branch so it's shared). New test covers a short id being unresolvable under a different `project_slug` scope.

The two genuinely org-wide **system** callers now pass `project_ids=None` *explicitly*, each with a comment on why:
- commit/PR linking — `utils/groupreference.py` (a commit legitimately links to any issue in its org)
- the Seer `get_latest_issue_event` RPC — `seer/fetch_issues/utils.py` (operates org-wide on behalf of the system)

Behavior for those two is unchanged; the explicit `None` documents the org-wide scope and is forward-compatible with the final PR that makes `project_ids` required keyword-only. Builds on the merged #117047.