### PR TITLE
feat(pr-metrics): Capture branch_name in CodingAgentResult for delegated agents

### DIFF
--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -193,10 +193,17 @@ def poll_github_copilot_agents(
             client = GithubCopilotAgentClient(user_access_token)
             task_status = client.get_task_status(owner, repo, task_id)
 
-            # Find PR in artifacts - look for artifact with data.type == 'pull'
+            # Find PR and branch artifacts
             pr_artifact = next(
                 (a for a in (task_status.artifacts or []) if a.data and a.data.type == "pull"),
                 None,
+            )
+            branch_artifact = next(
+                (a for a in (task_status.artifacts or []) if a.type == "branch"),
+                None,
+            )
+            branch_name = (
+                branch_artifact.data.head_ref if branch_artifact and branch_artifact.data else None
             )
 
             if pr_artifact and pr_artifact.data and pr_artifact.data.global_id:
@@ -211,6 +218,7 @@ def poll_github_copilot_agents(
                         repo_provider="github",
                         repo_full_name=f"{owner}/{repo}",
                         pr_url=pr_url,
+                        branch_name=branch_name,
                     )
 
                     # The Copilot API uses `state` (not `status`) for task lifecycle.
@@ -420,15 +428,18 @@ def get_claude_code_client(clients, agent_id, org_id, integration_id: int | None
     return client
 
 
-def extract_result_from_events(events: list[ClaudeSessionEvent]) -> tuple[str | None, str | None]:
+def extract_result_from_events(
+    events: list[ClaudeSessionEvent],
+) -> tuple[str | None, str | None, str | None]:
     """Extract a GitHub PR or branch URL and its surrounding text block from session events.
 
     Returns:
-        Tuple of (url, text_block). text_block is the full text content of the agent
-        event block that contained the URL, suitable for display as a result description.
+        Tuple of (url, text_block, branch_name). branch_name is populated when the agent
+        returned a branch URL instead of a PR URL (i.e. auto_create_pr=False).
+        text_block is the full text content of the agent event block that contained the URL.
     """
     pr_pattern = re.compile(r"https://github\.com/[^/]+/[^/]+/pull/\d+")
-    branch_pattern = re.compile(r"https://github\.com/[^/]+/[^/]+/tree/[-\w./]*[-\w]")
+    branch_pattern = re.compile(r"https://github\.com/[^/]+/[^/]+/tree/([-\w./]*[-\w])")
 
     for event in reversed(events):
         if event.type != "agent.message":
@@ -438,12 +449,12 @@ def extract_result_from_events(events: list[ClaudeSessionEvent]) -> tuple[str | 
                 text = block.get("text", "")
                 pr_match = pr_pattern.search(text)
                 if pr_match:
-                    return pr_match.group(0), text
+                    return pr_match.group(0), text, None
                 branch_match = branch_pattern.search(text)
                 if branch_match:
-                    return branch_match.group(0), text
+                    return branch_match.group(0), text, branch_match.group(1)
 
-    return None, None
+    return None, None, None
 
 
 def build_result_from_events(
@@ -455,9 +466,10 @@ def build_result_from_events(
 ) -> tuple[Any | None, CodingAgentStatus]:
     result = None
     pr_url = None
+    branch_name = None
     description: str | None = None
     if new_status == CodingAgentStatus.COMPLETED:
-        pr_url, description = extract_result_from_events(events)
+        pr_url, description, branch_name = extract_result_from_events(events)
         if not pr_url:
             logger.warning(
                 "coding_agent.claude_code.no_result_url_in_response",
@@ -472,6 +484,7 @@ def build_result_from_events(
         )
         if result:
             result.description = description or ""
+            result.branch_name = branch_name
     except Exception:
         logger.exception(
             "coding_agent.claude_code.build_result_error",

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -147,6 +147,7 @@ class CodingAgentResult(BaseModel):
     repo_provider: str
     repo_full_name: str
     pr_url: str | None = None
+    branch_name: str | None = None
 
 
 class CodingAgentProviderType(StrEnum):

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -434,36 +434,42 @@ class TestExtractResultFromEvents(TestCase):
     def test_extracts_pr_url(self) -> None:
         text = "PR created: https://github.com/org/repo/pull/123"
         events = [_make_agent_event(text)]
-        url, block = extract_result_from_events(events)
+        url, block, branch_name = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/pull/123"
         assert block == text
+        assert branch_name is None
 
     def test_extracts_branch_url(self) -> None:
         text = "Pushed to https://github.com/org/repo/tree/my-branch"
         events = [_make_agent_event(text)]
-        url, block = extract_result_from_events(events)
+        url, block, branch_name = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/tree/my-branch"
         assert block == text
+        assert branch_name == "my-branch"
 
     def test_strips_trailing_period(self) -> None:
         events = [_make_agent_event("See https://github.com/org/repo/tree/my-branch.")]
-        url, _ = extract_result_from_events(events)
+        url, _, branch_name = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/tree/my-branch"
+        assert branch_name == "my-branch"
 
     def test_strips_trailing_comma(self) -> None:
         events = [_make_agent_event("https://github.com/org/repo/tree/my-branch, ready")]
-        url, _ = extract_result_from_events(events)
+        url, _, branch_name = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/tree/my-branch"
+        assert branch_name == "my-branch"
 
     def test_branch_with_slashes(self) -> None:
         events = [_make_agent_event("https://github.com/org/repo/tree/feat/sub/thing")]
-        url, _ = extract_result_from_events(events)
+        url, _, branch_name = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/tree/feat/sub/thing"
+        assert branch_name == "feat/sub/thing"
 
     def test_branch_with_dots_in_name(self) -> None:
         events = [_make_agent_event("https://github.com/org/repo/tree/v1.2.3-fix")]
-        url, _ = extract_result_from_events(events)
+        url, _, branch_name = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/tree/v1.2.3-fix"
+        assert branch_name == "v1.2.3-fix"
 
     def test_pr_preferred_over_branch(self) -> None:
         events = [
@@ -472,27 +478,31 @@ class TestExtractResultFromEvents(TestCase):
                 "and PR https://github.com/org/repo/pull/42"
             )
         ]
-        url, _ = extract_result_from_events(events)
+        url, _, branch_name = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/pull/42"
+        assert branch_name is None
 
     def test_returns_none_when_no_url(self) -> None:
         events = [_make_agent_event("All done, no link.")]
-        url, block = extract_result_from_events(events)
+        url, block, branch_name = extract_result_from_events(events)
         assert url is None
         assert block is None
+        assert branch_name is None
 
     def test_returns_none_for_empty_events(self) -> None:
-        url, block = extract_result_from_events([])
+        url, block, branch_name = extract_result_from_events([])
         assert url is None
         assert block is None
+        assert branch_name is None
 
     def test_searches_most_recent_event_first(self) -> None:
         events = [
             _make_agent_event("https://github.com/org/repo/tree/old-branch"),
             _make_agent_event("https://github.com/org/repo/tree/new-branch"),
         ]
-        url, _ = extract_result_from_events(events)
+        url, _, branch_name = extract_result_from_events(events)
         assert url == "https://github.com/org/repo/tree/new-branch"
+        assert branch_name == "new-branch"
 
     def test_skips_non_agent_events(self) -> None:
         events = [
@@ -502,9 +512,10 @@ class TestExtractResultFromEvents(TestCase):
             ),
             _make_agent_event("No URL here"),
         ]
-        url, block = extract_result_from_events(events)
+        url, block, branch_name = extract_result_from_events(events)
         assert url is None
         assert block is None
+        assert branch_name is None
 
 
 class TestPollClaudeCodeAgents(TestCase):


### PR DESCRIPTION
Adds `branch_name` to `CodingAgentResult` and wires it in for both Claude Code and GitHub Copilot during the polling phase, so the branch the agent created is shipped to Seer alongside `pr_url` in state updates.

**Why:** `branch_name` was never captured anywhere in this system — not in Sentry, not in Seer. It's a useful signal for matching delegated-agent sessions to GitHub PR webhooks (see CW-1485)

**What changed:**
- `CodingAgentResult` gains `branch_name: str | None = None`
- Claude Code: `extract_result_from_events` now captures the branch name from the regex group in tree URLs (`/tree/<branch>`), which is what the agent returns when `auto_create_pr=False`
- GitHub Copilot: polling now reads `head_ref` from branch-type artifacts in the task status response, which were already returned by the API but silently ignored

No status or state transitions are affected — this only adds data to the payload already being sent.

Refs CW-1485

---
On the seer side, `CodingAgentResult` already includes the `branch_name`.