### PR TITLE
ref(nodestore): Make Bigtable read timeout configurable for workflow engine

### DIFF
--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -205,8 +205,12 @@ class IssueOccurrence:
         )
 
     @classmethod
-    def fetch(cls, id_: str, project_id: int) -> IssueOccurrence | None:
-        results = nodestore.backend.get(cls.build_storage_identifier(id_, project_id))
+    def fetch(
+        cls, id_: str, project_id: int, timeout: float | None = None
+    ) -> IssueOccurrence | None:
+        results = nodestore.backend.get(
+            cls.build_storage_identifier(id_, project_id), timeout=timeout
+        )
         if results:
             return IssueOccurrence.from_dict(results)
         return None

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2214,6 +2214,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "workflow_engine.nodestore_read_timeout",
+    default=5.0,
+    type=Float,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # === Backpressure related runtime options ===
 
 # Enables monitoring of services for backpressure management.

--- a/src/sentry/services/nodestore/base.py
+++ b/src/sentry/services/nodestore/base.py
@@ -127,11 +127,11 @@ class NodeStorage(local, Service):
         """
         return self._get_bytes(id)
 
-    def _get_bytes(self, id: str) -> bytes | None:
+    def _get_bytes(self, id: str, timeout: float | None = None) -> bytes | None:
         raise NotImplementedError
 
     @metrics.wraps("nodestore.get.duration")
-    def get(self, id: str, subkey: str | None = None) -> Any:
+    def get(self, id: str, subkey: str | None = None, timeout: float | None = None) -> Any:
         """
         >>> nodestore.get('key1')
         {"message": "hello world"}
@@ -147,7 +147,7 @@ class NodeStorage(local, Service):
                     return item_from_cache
 
             span.set_tag("subkey", str(subkey))
-            bytes_data = self._get_bytes(id)
+            bytes_data = self._get_bytes(id, timeout=timeout)
             rv = self._decode(bytes_data, subkey=subkey)
             if subkey is None:
                 # set cache item only after we know decoding did not fail

--- a/src/sentry/services/nodestore/bigtable/backend.py
+++ b/src/sentry/services/nodestore/bigtable/backend.py
@@ -65,11 +65,11 @@ class BigtableNodeStorage(NodeStorage):
         self.skip_deletes = automatic_expiry and "_SENTRY_CLEANUP" in os.environ
 
     @sentry_sdk.tracing.trace
-    def _get_bytes(self, id: str) -> bytes | None:
+    def _get_bytes(self, id: str, timeout: float | None = None) -> bytes | None:
         # Note: This metric encapsulates any decompression performed by `self.store.get()`. Other
         # instances of this metric stop measuring before decompression happens.
         with measure_storage_operation("get", "nodestore") as metric_emitter:
-            result = self.store.get(id)
+            result = self.store.get(id, timeout=timeout)
             if result:
                 metric_emitter.record_uncompressed_size(len(result))
             return result

--- a/src/sentry/services/nodestore/django/backend.py
+++ b/src/sentry/services/nodestore/django/backend.py
@@ -37,7 +37,7 @@ class DjangoNodeStorage(NodeStorage):
             logger.exception(str(e))
             return {}
 
-    def _get_bytes(self, id: str) -> bytes | None:
+    def _get_bytes(self, id: str, timeout: float | None = None) -> bytes | None:
         try:
             data = Node.objects.get(id=id).data
             return decompress(data)

--- a/src/sentry/services/nodestore/filesystem/backend.py
+++ b/src/sentry/services/nodestore/filesystem/backend.py
@@ -22,7 +22,7 @@ class FileSystemNodeStorage(NodeStorage):
         else:
             self.path = os.path.abspath(os.path.join(os.path.dirname(__file__), "./nodes"))
 
-    def _get_bytes(self, id: str) -> bytes:
+    def _get_bytes(self, id: str, timeout: float | None = None) -> bytes:
         with open(self.node_path(id), "rb") as file:
             return file.read()
 

--- a/src/sentry/utils/kvstore/bigtable.py
+++ b/src/sentry/utils/kvstore/bigtable.py
@@ -116,11 +116,11 @@ class BigtableKVStorage(KVStorage[str, bytes]):
                     )
             return table
 
-    def get(self, key: str) -> bytes | None:
+    def get(self, key: str, timeout: float | None = None) -> bytes | None:
         with sentry_sdk.start_span(op="bigtable.get"):
             # Default timeout is 60 seconds, much too long for our ingestion pipeline
             # Modify retry based on https://cloud.google.com/python/docs/reference/storage/latest/retry_timeout#configuring-retries
-            modified_retry = DEFAULT_RETRY_READ_ROWS.with_timeout(5.0)
+            modified_retry = DEFAULT_RETRY_READ_ROWS.with_timeout(timeout or 5.0)
             row = self._get_table().read_row(key, retry=modified_retry)
         if row is None:
             return None

--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -90,7 +90,10 @@ def build_workflow_event_data_from_event(
     if event.project.status != ObjectStatus.ACTIVE:
         raise ProjectNotActiveError(project_id)
 
-    occurrence = IssueOccurrence.fetch(occurrence_id, project_id) if occurrence_id else None
+    timeout = options.get("workflow_engine.nodestore_read_timeout")
+    occurrence = (
+        IssueOccurrence.fetch(occurrence_id, project_id, timeout=timeout) if occurrence_id else None
+    )
 
     group_event = GroupEvent.from_event(event, group)
     group_event.occurrence = occurrence

--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -1,6 +1,6 @@
 from google.api_core.exceptions import DeadlineExceeded, RetryError, ServiceUnavailable
 
-from sentry import nodestore
+from sentry import nodestore, options
 from sentry.constants import ObjectStatus
 from sentry.eventstream.base import GroupState
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -36,8 +36,9 @@ def fetch_event(event_id: str, project_id: int) -> Event | None:
     fetch_retry_policy = ConditionalRetryPolicy(
         _should_retry_nodestore_fetch, exponential_delay(1.00)
     )
+    timeout = options.get("workflow_engine.nodestore_read_timeout")
     with metrics.timer("workflow_engine.process_workflows.fetch_from_nodestore"):
-        data = fetch_retry_policy(lambda: nodestore.backend.get(node_id))
+        data = fetch_retry_policy(lambda: nodestore.backend.get(node_id, timeout=timeout))
     if data is None:
         return None
     evt = Event(


### PR DESCRIPTION
Adds a `timeout` kwarg to Bigtable's `get` function which is threaded down to the backends to override the general 5 sec timeout.
Modifies the workflow engine callers to pass this timeout override, which is fetched from a new `workflow_engine.nodestore_read_timeout` option.