### PR TITLE
ref(o11y): Add `scope.set_attribute` call in api base

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -383,6 +383,9 @@ class Endpoint(APIView):
 
         if request.META.get("HTTP_REFERER"):
             sentry_sdk.set_tag("http.referer", request.META.get("HTTP_REFERER"))
+            sentry_sdk.get_isolation_scope().set_attribute(
+                "http.referer", request.META.get("HTTP_REFERER", "")
+            )
 
         start_time = time.time()
 


### PR DESCRIPTION
- Supplements existing `sentry_sdk.set_tag()` call with equivalent `scope.set_attribute()` in `src/sentry/api/base.py`
- Enables attributes-based telemetry (logs, metrics, new spans) to inherit the `http.referer` value
- Skips the `set_context("cors_headers", ...)` site since it's on a pushed isolation scope only used for `capture_message`
     

Once we switch to span streaming, the new attributes will get applied to spans automatically.

Related to https://github.com/getsentry/sentry-python/issues/6537