### PR TITLE
ref(o11y): Add scope.set_attribute calls in Jira issue details

### DIFF
--- a/src/sentry/integrations/jira/views/sentry_issue_details.py
+++ b/src/sentry/integrations/jira/views/sentry_issue_details.py
@@ -135,6 +135,7 @@ class JiraSentryIssueDetailsView(JiraSentryUIBaseView):
             integration = get_integration_from_request(request, "jira")
         except AtlassianConnectValidationError as e:
             scope.set_tag("failure", "AtlassianConnectValidationError")
+            scope.set_attribute("failure", "AtlassianConnectValidationError")
             logger.info(
                 "issue_hook.validation_error",
                 extra={
@@ -145,6 +146,7 @@ class JiraSentryIssueDetailsView(JiraSentryUIBaseView):
             return self.get_response({"error_message": UNABLE_TO_VERIFY_INSTALLATION})
         except ExpiredSignatureError:
             scope.set_tag("failure", "ExpiredSignatureError")
+            scope.set_attribute("failure", "ExpiredSignatureError")
             return self.get_response({"refresh_required": True})
 
         try:
@@ -173,12 +175,15 @@ class JiraSentryIssueDetailsView(JiraSentryUIBaseView):
             ExternalIssue.MultipleObjectsReturned,
         ) as e:
             scope.set_tag("failure", e.__class__.__name__)
+            scope.set_attribute("failure", e.__class__.__name__)
             set_badge(integration, issue_key, 0)
             return self.get_response({"issue_not_linked": True})
 
         scope.set_tag("organization.slug", organization.slug)
+        scope.set_attribute("organization.slug", organization.slug)
         response = self.handle_groups(groups)
         scope.set_tag("status_code", response.status_code)
+        scope.set_attribute("status_code", response.status_code)
 
         set_badge(integration, issue_key, len(groups))
         return response
@@ -221,6 +226,7 @@ class JiraSentryIssueDetailsControlView(JiraSentryUIBaseView):
             integration = get_integration_from_request(request, "jira")
         except AtlassianConnectValidationError as e:
             scope.set_tag("failure", "AtlassianConnectValidationError")
+            scope.set_attribute("failure", "AtlassianConnectValidationError")
             logger.info(
                 "issue_hook.validation_error",
                 extra={
@@ -231,6 +237,7 @@ class JiraSentryIssueDetailsControlView(JiraSentryUIBaseView):
             return self.get_response({"error_message": UNABLE_TO_VERIFY_INSTALLATION})
         except ExpiredSignatureError:
             scope.set_tag("failure", "ExpiredSignatureError")
+            scope.set_attribute("failure", "ExpiredSignatureError")
             return self.get_response({"refresh_required": True})
 
         has_groups = False
@@ -256,6 +263,7 @@ class JiraSentryIssueDetailsControlView(JiraSentryUIBaseView):
 
         response = self.handle_groups(groups)
         scope.set_tag("status_code", response.status_code)
+        scope.set_attribute("status_code", response.status_code)
 
         set_badge(integration, issue_key, len(groups))
         return response


### PR DESCRIPTION
- Supplements existing `scope.set_tag()` calls with equivalent `scope.set_attribute()` calls in `src/sentry/integrations/jira/views/sentry_issue_details.py`
- Covers both `JiraSentryIssueDetailsView` and `JiraSentryIssueDetailsControlView`
- Tags: failure, organization.slug, status_code

Once we switch to span streaming, the new attributes will get applied to spans automatically.

Related to https://github.com/getsentry/sentry-python/issues/6537