### PR TITLE
ref(o11y): Add `set_attribute` calls in integrations base

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -403,9 +403,9 @@ class IntegrationInstallation(abc.ABC):
         )
         if integration is None:
             sentry_sdk.set_tag("integration_id", self.model.id)
-            sentry_sdk.get_isolation_scope().set_attribute("integration_id", self.model.id)
+            sentry_sdk.set_attribute("integration_id", self.model.id)
             sentry_sdk.set_tag("organization_id", self.organization_id)
-            sentry_sdk.get_isolation_scope().set_attribute("organization_id", self.organization_id)
+            sentry_sdk.set_attribute("organization_id", self.organization_id)
             raise OrganizationIntegrationNotFound("missing org_integration")
         return integration
 
@@ -504,13 +504,12 @@ class IntegrationInstallation(abc.ABC):
                 raise Identity.DoesNotExist
         identity = identity_service.get_identity(filter={"id": org_integration.default_auth_id})
         if identity is None:
-            scope = sentry_sdk.get_isolation_scope()
-            scope.set_tag("integration_provider", self.model.get_provider().name)
-            scope.set_attribute("integration_provider", self.model.get_provider().name)
-            scope.set_tag("org_integration_id", org_integration.id)
-            scope.set_attribute("org_integration_id", org_integration.id)
-            scope.set_tag("default_auth_id", org_integration.default_auth_id)
-            scope.set_attribute("default_auth_id", org_integration.default_auth_id)
+            sentry_sdk.set_tag("integration_provider", self.model.get_provider().name)
+            sentry_sdk.set_attribute("integration_provider", self.model.get_provider().name)
+            sentry_sdk.set_tag("org_integration_id", org_integration.id)
+            sentry_sdk.set_attribute("org_integration_id", org_integration.id)
+            sentry_sdk.set_tag("default_auth_id", org_integration.default_auth_id)
+            sentry_sdk.set_attribute("default_auth_id", org_integration.default_auth_id)
             raise Identity.DoesNotExist
         return identity
 

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -403,7 +403,9 @@ class IntegrationInstallation(abc.ABC):
         )
         if integration is None:
             sentry_sdk.set_tag("integration_id", self.model.id)
+            sentry_sdk.get_isolation_scope().set_attribute("integration_id", self.model.id)
             sentry_sdk.set_tag("organization_id", self.organization_id)
+            sentry_sdk.get_isolation_scope().set_attribute("organization_id", self.organization_id)
             raise OrganizationIntegrationNotFound("missing org_integration")
         return integration
 
@@ -504,8 +506,11 @@ class IntegrationInstallation(abc.ABC):
         if identity is None:
             scope = sentry_sdk.get_isolation_scope()
             scope.set_tag("integration_provider", self.model.get_provider().name)
+            scope.set_attribute("integration_provider", self.model.get_provider().name)
             scope.set_tag("org_integration_id", org_integration.id)
+            scope.set_attribute("org_integration_id", org_integration.id)
             scope.set_tag("default_auth_id", org_integration.default_auth_id)
+            scope.set_attribute("default_auth_id", org_integration.default_auth_id)
             raise Identity.DoesNotExist
         return identity
 


### PR DESCRIPTION
- Supplements existing `scope.set_tag()` / `sentry_sdk.set_tag()` calls with equivalent `set_attribute()` calls in `src/sentry/integrations/base.py`
- Switches to top-level SDK API

Once we switch to span streaming, the new attributes will get applied to spans automatically.

Related to https://github.com/getsentry/sentry-python/issues/6537