### PR TITLE
ref(o11y): Add scope.set_attribute call in onboarding tasks

### DIFF
--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -67,6 +67,7 @@ class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
         if created and task_id == OnboardingTask.FIRST_PROJECT:
             scope = sentry_sdk.get_current_scope()
             scope.set_extra("org", organization.id)
+            scope.set_attribute("org", organization.id)
             sentry_sdk.capture_message(
                 f"Onboarding task {task_id} was created unexpectedly. It should have been updated instead.",
                 level="warning",


### PR DESCRIPTION
- Supplements existing `scope.set_extra()` call with equivalent `scope.set_attribute()` in `src/sentry/api/endpoints/organization_onboarding_tasks.py`

Once we switch to span streaming, the new attributes will get applied to spans automatically.

Related to https://github.com/getsentry/sentry-python/issues/6537