### PR TITLE
ref(o11y): Add scope.set_attribute calls in organization traces

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -962,7 +962,7 @@ def process_rpc_user_queries(
 
     set_span_attribute("user_queries_count", len(queries))
     sentry_sdk.set_context("user_queries", {"raw_queries": user_queries})
-    sentry_sdk.get_isolation_scope().set_attribute("user_queries.raw_queries", user_queries)
+    sentry_sdk.set_attribute("user_queries.raw_queries", user_queries)
 
     return queries
 

--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -115,7 +115,7 @@ class OrganizationTracesSerializer(serializers.Serializer):
 
     def validate_dataset(self, value):
         sentry_sdk.set_tag("query.dataset", value)
-        sentry_sdk.get_isolation_scope().set_attribute("query.dataset", value)
+        sentry_sdk.set_attribute("query.dataset", value)
         if value == "spans":
             return Dataset.EventsAnalyticsPlatform
         raise ParseError(detail=f"Unsupported dataset: {value}")

--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -115,6 +115,7 @@ class OrganizationTracesSerializer(serializers.Serializer):
 
     def validate_dataset(self, value):
         sentry_sdk.set_tag("query.dataset", value)
+        sentry_sdk.get_isolation_scope().set_attribute("query.dataset", value)
         if value == "spans":
             return Dataset.EventsAnalyticsPlatform
         raise ParseError(detail=f"Unsupported dataset: {value}")
@@ -961,6 +962,7 @@ def process_rpc_user_queries(
 
     set_span_attribute("user_queries_count", len(queries))
     sentry_sdk.set_context("user_queries", {"raw_queries": user_queries})
+    sentry_sdk.get_isolation_scope().set_attribute("user_queries.raw_queries", user_queries)
 
     return queries
 


### PR DESCRIPTION
- Supplements existing `set_tag`/`set_context` calls with equivalent `set_attribute` calls in `src/sentry/api/endpoints/organization_traces.py`
- Skips pushed isolation scopes only used for `capture_message`

Once we switch to span streaming, the new attributes will get applied to spans automatically.

Related to https://github.com/getsentry/sentry-python/issues/6537