### PR TITLE
fix(notifications): Use triggering event metadata in regression notifications

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1867,7 +1867,7 @@ def _handle_regression(
             "event_id": event.event_id,
             "version": release.version if release else "",
         }
-        if incoming_group_values:
+        if incoming_group_values and options.get("groups.regression-activity-event-metadata"):
             event_data = incoming_group_values.get("data", {})
             activity_data["event_metadata"] = event_data.get("metadata", {})
             activity_data["event_title"] = event_data.get("title", "")

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1745,7 +1745,12 @@ def _get_next_short_id(project: Project, delta: int = 1) -> int:
     return short_id
 
 
-def _handle_regression(group: Group, event: BaseEvent, release: Release | None) -> bool | None:
+def _handle_regression(
+    group: Group,
+    event: BaseEvent,
+    release: Release | None,
+    incoming_group_values: Mapping[str, Any] | None = None,
+) -> bool | None:
     if not group.is_resolved():
         return None
 
@@ -1858,10 +1863,15 @@ def _handle_regression(group: Group, event: BaseEvent, release: Release | None) 
             )
 
     if is_regression:
-        activity_data: dict[str, str | bool] = {
+        activity_data: dict[str, Any] = {
             "event_id": event.event_id,
             "version": release.version if release else "",
         }
+        if incoming_group_values:
+            event_data = incoming_group_values.get("data", {})
+            activity_data["event_metadata"] = event_data.get("metadata", {})
+            activity_data["event_title"] = event_data.get("title", "")
+            activity_data["event_type"] = event_data.get("type", "default")
         if resolved_in_activity and release:
             activity_data.update(
                 {
@@ -1959,7 +1969,7 @@ def _process_existing_aggregate(
     if group.first_seen > event.datetime:
         updated_group_values["first_seen"] = event.datetime
 
-    is_regression = _handle_regression(group, event, release)
+    is_regression = _handle_regression(group, event, release, incoming_group_values)
 
     existing_data = group.data
     existing_metadata = group.data.get("metadata", {})

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -21,6 +21,26 @@ class RegressionActivityNotification(GroupActivityNotification):
         super().__init__(activity)
         self.version = self.activity.data.get("version", "")
         self.version_parsed = parse_release(self.version, json_loads=orjson.loads)["description"]
+        self._apply_event_metadata()
+
+    def _apply_event_metadata(self) -> None:
+        """
+        The group's in-DB metadata may be stale when the notification fires because
+        _handle_regression queues the notification *before* buffer_incr flushes the
+        new event's data. The activity carries a snapshot of the triggering event's
+        metadata, so we patch the in-memory group to ensure the notification shows
+        the correct title and message.
+        """
+        event_metadata = self.activity.data.get("event_metadata")
+        if event_metadata is None:
+            return
+        group_data = {**self.group.data}
+        group_data["metadata"] = event_metadata
+        if "event_title" in self.activity.data:
+            group_data["title"] = self.activity.data["event_title"]
+        if "event_type" in self.activity.data:
+            group_data["type"] = self.activity.data["event_type"]
+        self.group.data = group_data
 
     def get_description(self) -> tuple[str, str | None, Mapping[str, Any]]:
         text_message, html_message, params = "{author} marked {an issue} as a regression", None, {}

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -34,7 +34,7 @@ class RegressionActivityNotification(GroupActivityNotification):
         event_metadata = self.activity.data.get("event_metadata")
         if event_metadata is None:
             return
-        group_data = {**self.group.data}
+        group_data = {**(self.group.data or {})}
         group_data["metadata"] = event_metadata
         if "event_title" in self.activity.data:
             group_data["title"] = self.activity.data["event_title"]

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2798,6 +2798,14 @@ register(
     flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Store the regression-triggering event's metadata in the activity data so
+# notifications show the correct title/message instead of stale group data.
+register(
+    "groups.regression-activity-event-metadata",
+    default=False,
+    flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # TODO: For now, only a small number of projects are going through a grouping config transition at
 # any given time, so we're sampling at 100% in order to be able to get good signal. Once we've fully

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -231,6 +231,82 @@ class ActivityNotificationTest(APITestCase):
         assert "as a regression in 777" in context["text_description"]
         assert "as a regression in <a href=" in context["html_description"]
 
+    def test_regression_uses_event_metadata_not_stale_group_data(
+        self, mock_post: MagicMock
+    ) -> None:
+        """
+        When a regression notification fires, the group's in-DB metadata may still
+        reflect a previous event because buffer_incr hasn't flushed. The activity
+        carries a snapshot of the triggering event's metadata; the notification
+        should use that instead of the (potentially stale) group data.
+        """
+        group = self.create_group(
+            message="missing field 'name'",
+            data={
+                "type": "error",
+                "metadata": {"type": "ValueError", "value": "missing field 'name'"},
+                "title": "ValueError: missing field 'name'",
+            },
+        )
+
+        notification = RegressionActivityNotification(
+            Activity(
+                project=self.project,
+                group=group,
+                user_id=self.user.id,
+                type=ActivityType.SET_REGRESSION,
+                data={
+                    "version": "2.0.0",
+                    "event_type": "error",
+                    "event_metadata": {
+                        "type": "ValueError",
+                        "value": "timeout connecting to database",
+                    },
+                    "event_title": "ValueError: timeout connecting to database",
+                },
+            )
+        )
+
+        assert notification.group.data["metadata"]["value"] == "timeout connecting to database"
+        assert notification.group.data["title"] == "ValueError: timeout connecting to database"
+        assert notification.group.data["type"] == "error"
+
+        subject = notification.get_subject()
+        assert "timeout connecting to database" in subject
+        assert "missing field" not in subject
+
+    def test_regression_without_event_metadata_falls_back_to_group(
+        self, mock_post: MagicMock
+    ) -> None:
+        """
+        Old regression activities created before this fix won't have event_metadata.
+        The notification should fall back to the group's data gracefully.
+        """
+        group = self.create_group(
+            message="original error",
+            data={
+                "type": "error",
+                "metadata": {"type": "RuntimeError", "value": "original error"},
+                "title": "RuntimeError: original error",
+            },
+        )
+
+        notification = RegressionActivityNotification(
+            Activity(
+                project=self.project,
+                group=group,
+                user_id=self.user.id,
+                type=ActivityType.SET_REGRESSION,
+                data={"version": "1.0.0"},
+            )
+        )
+
+        assert notification.group.data["metadata"]["value"] == "original error"
+        assert notification.group.data["title"] == "RuntimeError: original error"
+
+        subject = notification.get_subject()
+        assert "original error" in subject
+
     @patch("sentry.analytics.record")
     def test_sends_resolution_notification(
         self, record_analytics: MagicMock, mock_post: MagicMock


### PR DESCRIPTION
Regression notifications showed the group's original issue message instead
of the event that actually triggered the regression. For example, if an issue
was originally created by `ValueError: missing field 'name'`, resolved, then
regressed due to `ValueError: timeout connecting to database`, the notification
would still show "missing field 'name'".

**Root cause**: `_handle_regression` in `event_manager.py` creates the Activity
and queues the notification task *before* `buffer_incr` flushes the new
event's metadata to the group row. When the worker picks up the task and
loads the group from DB, `group.data` still reflects the old event's metadata.

**Fix**: Snapshot the triggering event's metadata (`event_metadata`, `event_title`,
`event_type`) into the regression Activity's `data` dict at creation time — the
data is already in memory, so this adds zero I/O. Then in
`RegressionActivityNotification.__init__`, patch the in-memory `group.data` with
the snapshot so that all downstream consumers (email subject, email body template,
Slack message builder) automatically show the correct event info.

Old activities without `event_metadata` gracefully fall back to the existing
behavior — no migration needed.

**Rollout**: Gated behind the `groups.regression-activity-event-metadata` option used as a killswitch 

Closes [TET-2491: Email/Slack notifications show original message instead of latest issue](https://linear.app/getsentry/issue/TET-2491/emailslack-notifications-show-original-message-instead-of-latest-issue)