### PR TITLE
chore(dynamic-sampling): correct the project_id column to specify ds

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -148,7 +148,7 @@ def _emit_project_balancing_debug_metrics(
     eap_volume: float,
     eap_volume_without_extrapolation: float | None,
 ) -> None:
-    tags = {"org_id": str(org_id), "project_id": str(project_id)}
+    tags = {"org_id": str(org_id), "dynamic_sampling_project_id": str(project_id)}
     metrics.gauge(
         f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_sample_rate",
         eap_sample_rate,


### PR DESCRIPTION
- project_id seems to be overridden by datadog / metrics code somehow
- specify a custom project id