### PR TITLE
fix(ourlogs): preserve graph type when adding a chart to dashboard

### DIFF
--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -25,7 +25,6 @@ import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/
 import {
   DashboardWidgetSource,
   DEFAULT_WIDGET_NAME,
-  DisplayType,
   WidgetType,
 } from 'sentry/views/dashboards/types';
 import {plottablesCanBeVisualized} from 'sentry/views/dashboards/widgets/plottablesCanBeVisualized';
@@ -38,6 +37,7 @@ import {
 } from 'sentry/views/explore/components/chart/chartVisualization';
 import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
 import {useLogsPageDataQueryResult} from 'sentry/views/explore/contexts/logs/logsPageData';
+import {CHART_TYPE_TO_DISPLAY_TYPE} from 'sentry/views/explore/hooks/useAddToDashboard';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {ConfidenceFooter} from 'sentry/views/explore/logs/confidenceFooter';
 import {
@@ -381,8 +381,7 @@ function ContextMenu({
             discoverQuery,
             pageFilters.selection
           );
-          // the chart currently track the chart type internally so force bar type for now
-          eventView.display = DisplayType.BAR;
+          eventView.display = CHART_TYPE_TO_DISPLAY_TYPE[visualize.chartType];
 
           handleAddQueryToDashboard({
             organization,
@@ -406,6 +405,7 @@ function ContextMenu({
     projects,
     search,
     setVisible,
+    visualize.chartType,
     visualize.yAxis,
   ]);
 

--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -37,8 +37,8 @@ import {
 } from 'sentry/views/explore/components/chart/chartVisualization';
 import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
 import {useLogsPageDataQueryResult} from 'sentry/views/explore/contexts/logs/logsPageData';
-import {CHART_TYPE_TO_DISPLAY_TYPE} from 'sentry/views/explore/hooks/useAddToDashboard';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
+import {CHART_TYPE_TO_DISPLAY_TYPE} from 'sentry/views/explore/hooks/useAddToDashboard';
 import {ConfidenceFooter} from 'sentry/views/explore/logs/confidenceFooter';
 import {
   useQueryParamsAggregateFields,

--- a/static/app/views/explore/logs/useSaveAsItems.spec.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.spec.tsx
@@ -15,10 +15,13 @@ import {OrganizationContext} from 'sentry/utils/organizationContext';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {DisplayType} from 'sentry/views/dashboards/types';
+import * as discoverUtils from 'sentry/views/discover/utils';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {useSaveAsItems} from 'sentry/views/explore/logs/useSaveAsItems';
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/useNavigate');
@@ -209,6 +212,37 @@ describe('useSaveAsItems', () => {
 
     expect(saveAsItems.some(item => item.key === 'update-query')).toBe(false);
     expect(saveAsItems.some(item => item.key === 'save-query')).toBe(true);
+  });
+
+  it('preserves the chart type when adding a dashboard widget', () => {
+    const handleAddQueryToDashboard = jest
+      .spyOn(discoverUtils, 'handleAddQueryToDashboard')
+      .mockImplementation(() => {});
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useSaveAsItems({
+          visualizes: [new VisualizeFunction('count(message)', {chartType: ChartType.LINE})],
+          groupBys: ['message.template'],
+          interval: '5m',
+          mode: Mode.AGGREGATE,
+          search: new MutableSearch('message:"test error"'),
+          sortBys: [{field: 'timestamp', kind: 'desc'}],
+        }),
+      {additionalWrapper: createWrapper()}
+    );
+
+    const saveAsDashboard = result.current.find(
+      item => item.key === 'add-to-dashboard'
+    ) as {children: Array<{onAction: () => void}>};
+
+    saveAsDashboard.children[0]!.onAction();
+
+    expect(handleAddQueryToDashboard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventView: expect.objectContaining({display: DisplayType.LINE}),
+      })
+    );
   });
 
   it('should call saveQuery with correct parameters when modal saves', async () => {

--- a/static/app/views/explore/logs/useSaveAsItems.spec.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.spec.tsx
@@ -222,7 +222,9 @@ describe('useSaveAsItems', () => {
     const {result} = renderHookWithProviders(
       () =>
         useSaveAsItems({
-          visualizes: [new VisualizeFunction('count(message)', {chartType: ChartType.LINE})],
+          visualizes: [
+            new VisualizeFunction('count(message)', {chartType: ChartType.LINE}),
+          ],
           groupBys: ['message.template'],
           interval: '5m',
           mode: Mode.AGGREGATE,

--- a/static/app/views/explore/logs/useSaveAsItems.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.tsx
@@ -26,12 +26,12 @@ import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import {
   DashboardWidgetSource,
   DEFAULT_WIDGET_NAME,
-  DisplayType,
   WidgetType,
 } from 'sentry/views/dashboards/types';
 import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
+import {CHART_TYPE_TO_DISPLAY_TYPE} from 'sentry/views/explore/hooks/useAddToDashboard';
 import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {useLogsSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
 import {useQueryParamsId} from 'sentry/views/explore/queryParams/context';
@@ -168,6 +168,7 @@ export function useSaveAsItems({
 
   const saveAsDashboard = useMemo(() => {
     const dashboardsUrls = aggregates.map((yAxis: string, index: number) => {
+      const visualize = visualizes[index];
       const func = parseFunction(yAxis);
       const label = func ? prettifyParsedFunction(func) : yAxis;
 
@@ -206,8 +207,9 @@ export function useSaveAsItems({
             discoverQuery,
             pageFilters.selection
           );
-          // the chart currently track the chart type internally so force bar type for now
-          eventView.display = DisplayType.BAR;
+          if (visualize) {
+            eventView.display = CHART_TYPE_TO_DISPLAY_TYPE[visualize.chartType];
+          }
 
           handleAddQueryToDashboard({
             organization,
@@ -237,7 +239,17 @@ export function useSaveAsItems({
       disabled: !dashboardsUrls || dashboardsUrls.length === 0,
       isSubmenu: true,
     };
-  }, [aggregates, groupBys, mode, organization, pageFilters, search, sortBys, location]);
+  }, [
+    aggregates,
+    groupBys,
+    mode,
+    organization,
+    pageFilters,
+    search,
+    sortBys,
+    location,
+    visualizes,
+  ]);
 
   return useMemo(() => {
     const saveAs = [];


### PR DESCRIPTION
Adding a logs chart to a dashboard hardcoded the widget to a bar chart, regardless of the line/area/bar type the user had selected on the graph. Now the selected `Visualize.chartType` is mapped to the dashboard `DisplayType` using the existing `CHART_TYPE_TO_DISPLAY_TYPE` mapping that the spans explore view already relies on.

Closes LOGS-842