### PR TITLE
fix(ourlogs): disable charts automerge outside of auto-refresh

### DIFF
--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -37,6 +37,7 @@ import {
   useChartVisualizationPlottables,
 } from 'sentry/views/explore/components/chart/chartVisualization';
 import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
+import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {useLogsPageDataQueryResult} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {ConfidenceFooter} from 'sentry/views/explore/logs/confidenceFooter';
@@ -126,6 +127,7 @@ function Graph({
   visualize,
 }: GraphProps) {
   const isShortViewport = useIsShortViewport();
+  const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const {isEmpty: tableIsEmpty, isPending: tableIsPending} = useLogsPageDataQueryResult();
 
   const aggregate = visualize.yAxis;
@@ -252,7 +254,9 @@ function Graph({
       Title={Title}
       Actions={Actions}
       Visualization={
-        visualize.visible && <ChartVisualization chartInfo={chartInfo} notMerge={false} />
+        visualize.visible && (
+          <ChartVisualization chartInfo={chartInfo} notMerge={!autorefreshEnabled} />
+        )
       }
       Footer={
         visualize.visible && (


### PR DESCRIPTION
I'd enabled `notMerge={false}` in #113434 to fix bugs around auto-refresh and graph tooltips. That has since caused a few downstream issues with merge behavior. This is one of them: the graphs merge weirdly when you navigate back in-app with cached queries.

This makes merge mode conditional on auto-refresh. While streaming we still merge; otherwise the chart fully replaces on a time-range change.

<img width="480" height="270" alt="giphy (1)" src="https://github.com/user-attachments/assets/81567cb4-03ed-4d75-9f26-2cb23ca20e59" />

Closes LOGS-836.