### PR TITLE
fix(uptime): rename 'View alert details' CTA to 'View monitor details'

### DIFF
--- a/static/app/utils/issueTypeConfig/outageConfig.tsx
+++ b/static/app/utils/issueTypeConfig/outageConfig.tsx
@@ -77,7 +77,7 @@ export const outageConfig: IssueCategoryConfigMapping = {
     detector: {
       enabled: true,
       title: t('Uptime Monitor'),
-      ctaText: t('View alert details'),
+      ctaText: t('View monitor details'),
     },
     customCopy: {
       eventUnits: t('Events'),

--- a/static/app/utils/issueTypeConfig/uptimeConfig.tsx
+++ b/static/app/utils/issueTypeConfig/uptimeConfig.tsx
@@ -24,7 +24,7 @@ export const uptimeConfig: IssueCategoryConfigMapping = {
     detector: {
       enabled: true,
       title: t('Uptime Monitor'),
-      ctaText: t('View alert details'),
+      ctaText: t('View monitor details'),
     },
     customCopy: {
       eventUnits: t('Events'),

--- a/static/app/views/issueDetails/sidebar/detectorSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/detectorSection.spec.tsx
@@ -176,7 +176,7 @@ describe('DetectorSection', () => {
     );
 
     expect(screen.getByText('Uptime Monitor')).toBeInTheDocument();
-    const link = screen.getByRole('button', {name: 'View alert details'});
+    const link = screen.getByRole('button', {name: 'View monitor details'});
     expect(link).toHaveAttribute(
       'href',
       `/organizations/${organization.slug}/issues/alerts/rules/uptime/${project.slug}/${detectorId}/details/`


### PR DESCRIPTION
Fixes button copy for uptime monitor issues — the CTA was saying "View alert details" but should consistently say "View monitor details" to match cron monitors and reflect what it actually links to.

**Changed:**
- `uptimeConfig.tsx` — uptime `_categoryDefaults` CTA
- `outageConfig.tsx` — `UPTIME_DOMAIN_FAILURE` CTA (cron monitor entry was already correct)
- `detectorSection.spec.tsx` — updated matching test assertion

Reported via user feedback.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC07525G48Q1%3A1781192940.503019%22)