### PR TITLE
feat(traces): show value counts in item search dropdown

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2387,6 +2387,27 @@ describe('SearchQueryBuilder', () => {
       ).toBeInTheDocument();
     });
 
+    it('shows value counts in the dropdown when the response includes them', async () => {
+      const mockGetTagValues = jest
+        .fn()
+        .mockResolvedValue([{value: 'tag_value_one', count: 1234}]);
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="custom_tag_name:"
+          getTagValues={mockGetTagValues}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit value for filter: custom_tag_name'})
+      );
+
+      const option = await screen.findByRole('option', {name: /tag_value_one/});
+
+      expect(within(option).getByText('1.2K')).toBeInTheDocument();
+    });
+
     it('unescapes asterisks before fetching tag value suggestions', async () => {
       const mockGetTagValues = jest.fn().mockResolvedValue([]);
       render(

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -44,7 +44,14 @@ export interface GetTagValuesParams {
   tag: Pick<Tag, 'key' | 'name'> & {kind: FieldKind | undefined};
 }
 
-export type GetTagValues = (params: GetTagValuesParams) => Promise<string[]>;
+export interface TagValueWithCount {
+  value: string;
+  count?: number;
+}
+
+export type GetTagValues = (
+  params: GetTagValuesParams
+) => Promise<Array<string | TagValueWithCount>>;
 
 export type GetTagKeys = (searchQuery: string) => Promise<Tag[]>;
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {isMac} from '@react-aria/utils';
 import {Item, Section} from '@react-stately/collections';
@@ -79,6 +79,7 @@ import {
   prettifyTagKey,
   type FieldDefinition,
 } from 'sentry/utils/fields';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 import {fzf} from 'sentry/utils/search/fzf';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
@@ -459,16 +460,24 @@ function useFilterSuggestions({
         hideCheck: true,
         selectionMode: canSelectMultipleValues ? 'multiple' : 'single',
         trailingItems: ({isFocused, disabled}: any) => {
+          const count =
+            suggestion.count === undefined ? null : (
+              <ValueCount>{formatAbbreviatedNumber(suggestion.count)}</ValueCount>
+            );
+
           if (!canSelectMultipleValues) {
-            return null;
+            return count;
           }
 
           return (
-            <ItemCheckbox
-              isFocused={isFocused}
-              disabled={disabled}
-              value={suggestion.value}
-            />
+            <Fragment>
+              {count}
+              <ItemCheckbox
+                isFocused={isFocused}
+                disabled={disabled}
+                value={suggestion.value}
+              />
+            </Fragment>
           );
         },
       };
@@ -486,9 +495,12 @@ function useFilterSuggestions({
         })) ?? [];
       groups = [{sectionText: '', suggestions}];
     } else if (shouldFetchValues) {
-      const suggestions = data?.map(value => {
+      const suggestions = data?.map(item => {
+        const value = typeof item === 'string' ? item : item.value;
+        const count = typeof item === 'string' ? undefined : item.count;
         return {
           value,
+          count,
           description:
             // When the key is device, we can help users by displaying the readable name
             key?.key === FieldKey.DEVICE ? (
@@ -1119,6 +1131,11 @@ const TrailingWrap = styled('div')`
   grid-auto-flow: column;
   align-items: center;
   gap: ${p => p.theme.space.md};
+`;
+
+const ValueCount = styled('span')`
+  font-variant-numeric: tabular-nums;
+  color: ${p => p.theme.tokens.content.secondary};
 `;
 
 const CheckWrap = styled('div')<{visible: boolean}>`

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/types.tsx
@@ -4,6 +4,7 @@ import type {SelectOptionWithKey} from '@sentry/scraps/compactSelect';
 
 export type SuggestionItem = {
   value: string;
+  count?: number;
   description?: ReactNode;
   label?: ReactNode;
 };

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -253,7 +253,9 @@ export function FilterSelector({
       );
     });
     // Filter values fetched using getTagValues
-    fetchedFilterValues?.forEach(value => addOption(value, optionMap));
+    fetchedFilterValues?.forEach(value =>
+      addOption(typeof value === 'string' ? value : value.value, optionMap)
+    );
 
     // Allow setting a custom filter value based on search input
     if (searchQuery && !optionMap.has(searchQuery)) {

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
@@ -24,15 +24,18 @@ describe('useGetTraceItemAttributeValues', () => {
     };
   }
 
-  function makeAttributeValue(value: string, key = attributeKey) {
+  function makeAttributeValue(value: string, key = attributeKey, count: number | null = null) {
     return {
       key,
       value,
-      first_seen: null,
-      last_seen: null,
-      times_seen: null,
+      name: value,
+      count,
+      firstSeen: null,
+      lastSeen: null,
     };
   }
+
+  type ValueResult = Array<{value: string; count?: number}>;
 
   function addAttributeValuesMock({
     body,
@@ -109,13 +112,30 @@ describe('useGetTraceItemAttributeValues', () => {
 
     expect(searchQueryMock).not.toHaveBeenCalled();
 
-    let searchResults: string[] = [];
+    let searchResults: ValueResult = [];
     await act(async () => {
       searchResults = await result.current({tag, searchQuery: 'search-query'});
     });
 
     expect(searchQueryMock).toHaveBeenCalled();
-    expect(searchResults).toEqual(['search-result']);
+    expect(searchResults).toEqual([{value: 'search-result'}]);
+  });
+
+  it('returns value counts when the response includes them', async () => {
+    const searchQueryMock = addAttributeValuesMock({
+      substringMatch: 'search-query',
+      body: [makeAttributeValue('search-result', attributeKey, 1234)],
+    });
+
+    const {result} = renderValuesHook();
+
+    let searchResults: ValueResult = [];
+    await act(async () => {
+      searchResults = await result.current({tag, searchQuery: 'search-query'});
+    });
+
+    expect(searchQueryMock).toHaveBeenCalled();
+    expect(searchResults).toEqual([{value: 'search-result', count: 1234}]);
   });
 
   it('getTraceItemAttributeValues returns empty array for number type', async () => {
@@ -136,7 +156,7 @@ describe('useGetTraceItemAttributeValues', () => {
 
     expect(searchQueryMock).not.toHaveBeenCalled();
 
-    let searchResults: string[] = [];
+    let searchResults: ValueResult = [];
     await act(async () => {
       searchResults = await result.current({tag, searchQuery: 'search-query'});
     });
@@ -163,7 +183,7 @@ describe('useGetTraceItemAttributeValues', () => {
 
     expect(searchQueryMock).not.toHaveBeenCalled();
 
-    let searchResults: string[] = [];
+    let searchResults: ValueResult = [];
     await act(async () => {
       searchResults = await result.current({tag, searchQuery: 'search-query'});
     });
@@ -181,8 +201,8 @@ describe('useGetTraceItemAttributeValues', () => {
 
     const {result} = renderValuesHook();
 
-    let prefixResults: string[] = [];
-    let longerResults: string[] = [];
+    let prefixResults: ValueResult = [];
+    let longerResults: ValueResult = [];
     await act(async () => {
       prefixResults = await result.current({tag, searchQuery: 'fo'});
       longerResults = await result.current({tag, searchQuery: 'foo'});
@@ -206,15 +226,15 @@ describe('useGetTraceItemAttributeValues', () => {
 
     const {result} = renderValuesHook();
 
-    let prefixResults: string[] = [];
-    let longerResults: string[] = [];
+    let prefixResults: ValueResult = [];
+    let longerResults: ValueResult = [];
     await act(async () => {
       prefixResults = await result.current({tag, searchQuery: 'fo'});
       longerResults = await result.current({tag, searchQuery: 'foo'});
     });
 
-    expect(prefixResults).toEqual(['foo']);
-    expect(longerResults).toEqual(['foo-value']);
+    expect(prefixResults).toEqual([{value: 'foo'}]);
+    expect(longerResults).toEqual([{value: 'foo-value'}]);
     expect(prefixRequest).toHaveBeenCalledTimes(1);
     expect(longerRequest).toHaveBeenCalledTimes(1);
   });
@@ -284,7 +304,7 @@ describe('useGetTraceItemAttributeValues', () => {
         ...scopedCase.hookProps,
       });
 
-      let results: string[] = [];
+      let results: ValueResult = [];
       await act(async () => {
         results = await result.current({
           tag: {
@@ -296,7 +316,7 @@ describe('useGetTraceItemAttributeValues', () => {
         });
       });
 
-      expect(results).toEqual([`${scopedCase.name}-value`]);
+      expect(results).toEqual([{value: `${scopedCase.name}-value`}]);
       expect(longerRequest).toHaveBeenCalledTimes(1);
     }
   });
@@ -340,12 +360,12 @@ describe('useGetTraceItemAttributeValues', () => {
     });
     const {result} = renderValuesHook({queryClient});
 
-    let results: string[] = [];
+    let results: ValueResult = [];
     await act(async () => {
       results = await result.current({tag, searchQuery: 'foo'});
     });
 
-    expect(results).toEqual(['foo-value']);
+    expect(results).toEqual([{value: 'foo-value'}]);
     expect(cachedBooleanPrefixRequest).toHaveBeenCalledTimes(1);
     expect(longerRequest).toHaveBeenCalledTimes(1);
   });

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
@@ -24,7 +24,11 @@ describe('useGetTraceItemAttributeValues', () => {
     };
   }
 
-  function makeAttributeValue(value: string, key = attributeKey, count: number | null = null) {
+  function makeAttributeValue(
+    value: string,
+    key = attributeKey,
+    count: number | null = null
+  ) {
     return {
       key,
       value,

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
@@ -7,7 +7,10 @@ import {
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import type {GetTagValuesParams} from 'sentry/components/searchQueryBuilder';
+import type {
+  GetTagValuesParams,
+  TagValueWithCount,
+} from 'sentry/components/searchQueryBuilder';
 import type {PageFilters} from 'sentry/types/core';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
@@ -19,11 +22,12 @@ import type {UseTraceItemAttributeBaseProps} from 'sentry/views/explore/types';
 import {findFreshEmptyPrefixSearchCacheMatch} from 'sentry/views/explore/utils/findFreshEmptyPrefixSearchCacheMatch';
 
 interface TraceItemAttributeValue {
-  first_seen: null;
+  count: number | null;
+  firstSeen: string | null;
   key: string;
-  last_seen: null;
-  times_seen: null;
-  value: string;
+  lastSeen: string | null;
+  name: string;
+  value: string | null;
 }
 
 interface UseGetTraceItemAttributeValuesProps extends UseTraceItemAttributeBaseProps {
@@ -48,7 +52,7 @@ export function useGetTraceItemAttributeValues({
   const queryClient = useQueryClient();
 
   return useCallback(
-    async ({tag, searchQuery}: GetTagValuesParams): Promise<string[]> => {
+    async ({tag, searchQuery}: GetTagValuesParams): Promise<TagValueWithCount[]> => {
       if (tag.kind === FieldKind.FUNCTION || type === 'number' || type === 'boolean') {
         // We can't really auto suggest values for aggregate functions, numbers, or booleans
         return Promise.resolve([]);
@@ -95,9 +99,11 @@ export function useGetTraceItemAttributeValues({
 
       try {
         const {json} = await queryClient.fetchQuery(optionsWithPrefixCacheShortcut);
-        return json
-          .filter((item: TraceItemAttributeValue) => defined(item.value))
-          .map((item: TraceItemAttributeValue) => item.value);
+        return json.flatMap((item: TraceItemAttributeValue) =>
+          defined(item.value)
+            ? [{value: item.value, count: item.count ?? undefined}]
+            : []
+        );
       } catch (e) {
         throw new Error(`Unable to fetch trace item attribute values: ${e}`);
       }

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
@@ -100,9 +100,7 @@ export function useGetTraceItemAttributeValues({
       try {
         const {json} = await queryClient.fetchQuery(optionsWithPrefixCacheShortcut);
         return json.flatMap((item: TraceItemAttributeValue) =>
-          defined(item.value)
-            ? [{value: item.value, count: item.count ?? undefined}]
-            : []
+          defined(item.value) ? [{value: item.value, count: item.count ?? undefined}] : []
         );
       } catch (e) {
         throw new Error(`Unable to fetch trace item attribute values: ${e}`);

--- a/static/app/views/insights/pages/transactionNameSearchBar.tsx
+++ b/static/app/views/insights/pages/transactionNameSearchBar.tsx
@@ -145,10 +145,11 @@ export function TransactionNameSearchBar(props: SearchBarProps) {
         });
 
         const parsedResults = results.reduce(
-          (searchGroup: SearchGroup, item: string) => {
+          (searchGroup: SearchGroup, item) => {
+            const value = typeof item === 'string' ? item : item.value;
             searchGroup.children.push({
-              value: item,
-              title: item,
+              value,
+              title: value,
               type: ItemType.LINK,
               desc: '',
             });


### PR DESCRIPTION
Adds the number of times each value was seen to the trace item search value dropdown (logs, spans, and other Explore search bars).

The `trace-items/attributes/{key}/values/` endpoint already returns a `count` per value, but the dropdown discarded it. The count now flows through the shared `getTagValues` callback and renders right-aligned in muted text next to each value suggestion.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="901" height="497" alt="Screenshot 2026-06-11 at 12 34 10 PM" src="https://github.com/user-attachments/assets/e2444d11-74be-4679-99c9-aa3ff05695bb" />
</td>
<td>
<img width="901" height="497" alt="Screenshot 2026-06-11 at 12 33 44 PM" src="https://github.com/user-attachments/assets/b97f4042-6b73-43a9-b7a2-8a460d23bc54" />
</td>
</tr>
</tbody>
</table>

Closes LOGS-838.
