### PR TITLE
ref(span-buffer): Exit early if the add_buffer script was previously loaded

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2847,6 +2847,13 @@ register(
     default=0.0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Skip the script_exists check in ensure_script and trust the cached SHA.
+register(
+    "spans.buffer.ensure-script.skip-exists-check",
+    type=Bool,
+    default=False,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Timeout for stale segments without a root span to be flushed.
 register(
     "spans.buffer.timeout",

--- a/src/sentry/spans/buffer_store.py
+++ b/src/sentry/spans/buffer_store.py
@@ -87,10 +87,7 @@ class SpansBufferStore:
         """
         Ensures the Lua script is loaded in Redis and returns its SHA.
         """
-        if self.add_buffer_sha:
-            return self.add_buffer_sha
-
-        if not self.client.script_exists(self.add_buffer_sha)[0]:
+        if not self.add_buffer_sha:
             self.add_buffer_sha = self.client.script_load(add_buffer_script.script)
         return self.add_buffer_sha
 

--- a/src/sentry/spans/buffer_store.py
+++ b/src/sentry/spans/buffer_store.py
@@ -87,7 +87,12 @@ class SpansBufferStore:
         """
         Ensures the Lua script is loaded in Redis and returns its SHA.
         """
-        if not self.add_buffer_sha:
+        if options.get("spans.buffer.ensure-script.skip-exists-check"):
+            if not self.add_buffer_sha:
+                self.add_buffer_sha = self.client.script_load(add_buffer_script.script)
+            return self.add_buffer_sha
+
+        if not self.add_buffer_sha or not self.client.script_exists(self.add_buffer_sha)[0]:
             self.add_buffer_sha = self.client.script_load(add_buffer_script.script)
         return self.add_buffer_sha
 

--- a/src/sentry/spans/buffer_store.py
+++ b/src/sentry/spans/buffer_store.py
@@ -87,9 +87,11 @@ class SpansBufferStore:
         """
         Ensures the Lua script is loaded in Redis and returns its SHA.
         """
-        if not self.add_buffer_sha or not self.client.script_exists(self.add_buffer_sha)[0]:
-            self.add_buffer_sha = self.client.script_load(add_buffer_script.script)
+        if self.add_buffer_sha:
+            return self.add_buffer_sha
 
+        if not self.client.script_exists(self.add_buffer_sha)[0]:
+            self.add_buffer_sha = self.client.script_load(add_buffer_script.script)
         return self.add_buffer_sha
 
     def store_payloads(

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -45,6 +45,7 @@ DEFAULT_OPTIONS = {
     "spans.buffer.flusher.max-unhealthy-seconds": 60,
     "spans.buffer.flusher.use-stuck-detector": False,
     "spans.buffer.flusher.flush-lock-ttl": 0,
+    "spans.buffer.ensure-script.skip-exists-check": True,
     "spans.buffer.flusher-cumulative-logger-enabled": False,
     "spans.buffer.flusher.log-flushed-segments": False,
     "spans.buffer.compression.level": 0,


### PR DESCRIPTION
Exit early if the add_buffer script was previously loaded. This avoids unnecessary look ups in Redis on each batch. If the script was unloaded for some reason the consumer will crash (`redis.exceptions.NoScriptError`). The existence/add checks will run again on consumer restart.

We can handle this more gracefully by catching `NoScriptError` and reloading the add_buffer script manually. However, this is such a rare edge case that its not worth inflating the diff until need requires it.