### PR TITLE
fix(seer): Send pull_request_review_comment as code-review trigger type

### DIFF
--- a/src/sentry/seer/code_review/models.py
+++ b/src/sentry/seer/code_review/models.py
@@ -38,7 +38,7 @@ class SeerCodeReviewConfig(BaseModel):
     github_rate_limit_sensitive: bool = False
     trigger: SeerCodeReviewTrigger
     trigger_comment_id: int | None = None
-    trigger_comment_type: Literal["issue_comment"] | None = None
+    trigger_comment_type: Literal["pull_request_review_comment"] | None = None
     trigger_user: str | None = None
     trigger_user_id: int | None = None
     trigger_at: datetime | None = None  # When the trigger event occurred on GitHub

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -176,7 +176,12 @@ def _get_trigger_metadata_for_issue_comment(event_payload: Mapping[str, Any]) ->
         "trigger_user": comment_user.get("login"),
         "trigger_user_id": comment_user.get("id"),
         "trigger_comment_id": comment.get("id"),
-        "trigger_comment_type": "issue_comment",
+        # The @sentry review trigger is always a comment on a PR (non-PR issue
+        # comments are filtered out upstream), so it is treated as a review
+        # comment. On GitHub this resolves to the same issue-comment reactions
+        # endpoint; using "pull_request_review_comment" keeps the type correct
+        # for GitLab too, where it must route to the merge-request note endpoint.
+        "trigger_comment_type": "pull_request_review_comment",
         "trigger_at": trigger_at,
     }
 

--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -678,11 +678,13 @@ def _get_note_trigger_metadata(event: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "trigger_user": user.get("username"),
         "trigger_user_id": user.get("id"),
-        # Note ID is the comment identifier; "issue_comment" matches the
-        # SeerCodeReviewConfig.trigger_comment_type Literal constraint and
-        # is the value Seer uses to understand command-phrase triggering.
+        # The note id is the comment identifier. Seer keys its post-review
+        # reaction (eyes -> hooray) off trigger_comment_type: a GitLab MR note is
+        # never an issue note, so it must be "pull_request_review_comment", which
+        # Seer routes to the merge-request note award_emoji endpoint. Sending
+        # "issue_comment" here makes Seer hit /issues/... and 404.
         "trigger_comment_id": object_attributes.get("id"),
-        "trigger_comment_type": "issue_comment",
+        "trigger_comment_type": "pull_request_review_comment",
         "trigger_at": trigger_at,
     }
 

--- a/tests/sentry/seer/code_review/test_utils.py
+++ b/tests/sentry/seer/code_review/test_utils.py
@@ -41,7 +41,7 @@ class TestGetTriggerMetadata:
         assert result["trigger_comment_id"] == 12345
         assert result["trigger_user"] == "test-user"
         assert result["trigger_user_id"] == 99999
-        assert result["trigger_comment_type"] == "issue_comment"
+        assert result["trigger_comment_type"] == "pull_request_review_comment"
         assert result["trigger_at"] == "2024-01-15T10:30:00Z"
 
     def test_extracts_issue_comment_trigger_at_defaults_to_now_when_missing(self) -> None:
@@ -296,7 +296,7 @@ class TestTransformWebhookToCodegenRequest:
         assert config["trigger"] == SeerCodeReviewTrigger.ON_COMMAND_PHRASE.value
         assert config["trigger_comment_id"] == 12345
         assert config["trigger_user"] == "commenter"
-        assert config["trigger_comment_type"] == "issue_comment"
+        assert config["trigger_comment_type"] == "pull_request_review_comment"
         assert config["trigger_at"] == "2024-01-15T14:00:00Z"
         # sentry_received_trigger_at is set to current time when transform happens
         assert isinstance(config["sentry_received_trigger_at"], str)

--- a/tests/sentry/seer/code_review/webhooks/test_merge_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_merge_request.py
@@ -957,7 +957,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         }
     )
     def test_payload_contains_trigger_comment_id_and_type(self) -> None:
-        """trigger_comment_id must be the note id; trigger_comment_type must be issue_comment."""
+        """trigger_comment_id must be the note id; trigger_comment_type must be pull_request_review_comment."""
         self._setup_code_review()
         event = _make_note_event()
 
@@ -966,7 +966,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
 
         config = self.mock_seer.call_args[1]["payload"]["data"]["config"]
         assert config["trigger_comment_id"] == 1243
-        assert config["trigger_comment_type"] == "issue_comment"
+        assert config["trigger_comment_type"] == "pull_request_review_comment"
 
     @with_feature(
         {


### PR DESCRIPTION
We were sending "issue_comment" as the trigger type even though we only operate on PRs. this was fine for GH bc they treat issues and PRs the same but GL does not. change to send `pull_request_review_comment`

## Problem

When a user runs `@sentry review` on a **GitLab** merge request, Seer runs the review but the triggering comment's reaction never flips from :eyes: to :tada:. Tracing a live run shows the review completing, then:

```
⚠ Failed to remove comment reaction(s) ['eyes'] … 404 Not found
⚠ Failed to add comment reaction hooray …        404 Not found
```

## Root cause

The code-review trigger always fires on a comment attached to a PR/MR — non-PR comments are filtered upstream (GitHub: `issue.pull_request` must exist; GitLab: `noteable_type == "MergeRequest"`). But Sentry set `trigger_comment_type="issue_comment"`.

Seer dispatches reactions off that value. On GitLab, `"issue_comment"` routes to the **issue**-note award endpoint:

```
/projects/{id}/issues/{iid}/notes/{note_id}/award_emoji   → 404 (it's an MR note)
```

The review body itself posts fine because it uses a different code path; only the reaction callback (which is the only consumer of `trigger_comment_type`) is affected.

## Fix

Send `"pull_request_review_comment"` instead.

- **GitLab:** Seer routes it to `/merge_requests/{iid}/notes/{note}/award_emoji` — correct.
- **GitHub:** the provider collapses both types onto the same issue-comment reactions endpoint — no-op.

Seer already accepts `"pull_request_review_comment"` and routes it correctly, so no Seer change is required.

## Safety / compatibility

Producer-only change. Seer keeps the wider `Literal["issue_comment", "pull_request_review_comment"]`, so in-flight Celery tasks and persisted Seer run-state carrying the old value still deserialize. No migration, no coordinated deploy ordering. `trigger_comment_type` is not persisted on the Sentry side.

## Testing

- `tests/sentry/seer/code_review/test_utils.py` and `webhooks/test_merge_request.py` updated for the new value.
- `113 passed`; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)