### PR TITLE
ci: Link colocated stories when a component file changes

### DIFF
--- a/.github/workflows/scripts/stories-preview-comment.test.ts
+++ b/.github/workflows/scripts/stories-preview-comment.test.ts
@@ -53,6 +53,7 @@ interface Scenario {
   prs?: Array<{number: number; state: string; head?: {sha: string}}>;
   files?: Array<{filename: string; status: string}>;
   comments?: Array<{id: number; body: string}>;
+  dirContents?: Record<string, Array<{name: string; path: string}>>;
   url?: string;
 }
 
@@ -66,6 +67,7 @@ function run({
   prs = [{number: 42, state: 'open', head: {sha: DEPLOY_SHA}}],
   files = [],
   comments = [],
+  dirContents = {},
   url = 'https://sentry-abc.sentry.dev',
 }: Scenario) {
   const calls = {
@@ -76,7 +78,16 @@ function run({
   const core = {info: () => {}};
   const github = {
     rest: {
-      repos: {listPullRequestsAssociatedWithCommit: async () => ({data: prs})},
+      repos: {
+        listPullRequestsAssociatedWithCommit: async () => ({data: prs}),
+        getContent: async ({path}: {path: string}) => {
+          const entries = dirContents[path];
+          if (!entries) {
+            throw new Error('Not Found');
+          }
+          return {data: entries};
+        },
+      },
       pulls: {listFiles: 'listFiles'},
       issues: {
         listComments: 'listComments',
@@ -177,6 +188,56 @@ describe('syncStoriesPreviewComment', () => {
     });
     assert.equal(calls.create.length, 1);
     assert.match(calls.create[0].body!, /components\/foo\\\]\//);
+  });
+
+  it('links a colocated story when only the component changed', async () => {
+    const calls = await run({
+      files: [{filename: 'static/app/components/foo/foo.tsx', status: 'modified'}],
+      dirContents: {
+        'static/app/components/foo': [
+          {name: 'foo.tsx', path: 'static/app/components/foo/foo.tsx'},
+          {name: 'foo.stories.tsx', path: 'static/app/components/foo/foo.stories.tsx'},
+        ],
+      },
+    });
+    assert.equal(calls.create.length, 1);
+    assert.match(calls.create[0].body!, /foo\.stories\.tsx/);
+    assert.match(calls.create[0].body!, /stories\/product\/components\/foo\/foo\//);
+  });
+
+  it('links a directory-named story when index.tsx changed', async () => {
+    const calls = await run({
+      files: [
+        {
+          filename: 'static/app/components/core/disclosure/index.tsx',
+          status: 'modified',
+        },
+      ],
+      dirContents: {
+        'static/app/components/core/disclosure': [
+          {name: 'index.tsx', path: 'static/app/components/core/disclosure/index.tsx'},
+          {
+            name: 'disclosure.mdx',
+            path: 'static/app/components/core/disclosure/disclosure.mdx',
+          },
+        ],
+      },
+    });
+    assert.equal(calls.create.length, 1);
+    assert.match(calls.create[0].body!, /stories\/core\/disclosure\//);
+  });
+
+  it('ignores an unrelated story in the changed component directory', async () => {
+    const calls = await run({
+      files: [{filename: 'static/app/components/foo/foo.tsx', status: 'modified'}],
+      dirContents: {
+        'static/app/components/foo': [
+          {name: 'foo.tsx', path: 'static/app/components/foo/foo.tsx'},
+          {name: 'bar.stories.tsx', path: 'static/app/components/foo/bar.stories.tsx'},
+        ],
+      },
+    });
+    assert.deepEqual(calls, {create: [], update: [], delete: []});
   });
 
   it('neutralizes markdown-injecting paths in both the label and the URL', async () => {

--- a/.github/workflows/scripts/stories-preview-comment.ts
+++ b/.github/workflows/scripts/stories-preview-comment.ts
@@ -43,6 +43,12 @@ interface SyncArgs {
         }) => Promise<{
           data: Array<{number: number; state: string; head: {sha: string}}>;
         }>;
+        getContent: (params: {
+          owner: string;
+          repo: string;
+          path: string;
+          ref: string;
+        }) => Promise<{data: unknown}>;
       };
       pulls: {listFiles: unknown};
       issues: {
@@ -85,6 +91,30 @@ export const STORIES_COMMENT_MARKER = '<!-- STORIES_PREVIEW -->';
 // The stories loader globs both *.stories.tsx and *.mdx under static/app
 // (static/app/stories/view/useStoriesLoader.tsx).
 const STORY_FILE_RE = /^static\/app\/.*(\.stories\.tsx|\.mdx)$/;
+
+// A component source file (not a story, test, or spec) whose edit should also
+// surface its colocated story, if one exists.
+function isComponentFile(path: string): boolean {
+  return (
+    /^static\/app\/.*\.tsx$/.test(path) &&
+    !/\.stories\.tsx$/.test(path) &&
+    !/\.(spec|test)\.tsx$/.test(path)
+  );
+}
+
+function dirOf(path: string): string {
+  return path.slice(0, path.lastIndexOf('/'));
+}
+
+function baseName(path: string): string {
+  return path.slice(path.lastIndexOf('/') + 1);
+}
+
+// Strip the story extension to get the base a story is named for, e.g.
+// `button.stories.tsx` -> `button`, `disclosure.mdx` -> `disclosure`.
+function storyBaseName(name: string): string {
+  return name.replace(/(\.stories)?\.(tsx|mdx)$/, '');
+}
 
 // `deployment_status` can be forged by any actor with `deployments` scope, who
 // could supply an arbitrary `environment_url` and have us post a link to it on a
@@ -169,9 +199,7 @@ export function storyRoute(filesystemPath: string): string {
     return `${category}/${labelSlug}`;
   }
 
-  const segments = filesystemPath.split('/');
-  segments.shift(); // drop the leading `app`
-  segments.pop(); // drop the filename
+  const segments = filesystemPath.split('/').slice(1, -1); // drop `app` and filename
   const pathPrefix =
     segments.length > 0
       ? `${segments.map(segment => segment.toLowerCase()).join('/')}/`
@@ -215,6 +243,54 @@ function buildCommentBody(stories: string[], previewUrl: string): string {
     '',
     `<sub>Preview deployment: ${previewUrl}</sub>`,
   ].join('\n');
+}
+
+async function listDirectory(
+  github: SyncArgs['github'],
+  owner: string,
+  repo: string,
+  ref: string,
+  path: string
+): Promise<Array<{name: string; path: string}>> {
+  try {
+    const {data} = await github.rest.repos.getContent({owner, repo, path, ref});
+    return Array.isArray(data) ? (data as Array<{name: string; path: string}>) : [];
+  } catch {
+    // Directory missing at this ref (e.g. newly added elsewhere) — nothing to find.
+    return [];
+  }
+}
+
+// For each edited component file, find colocated story files (in the same
+// directory at the deployed commit) whose base name matches the component's own
+// base name or its directory name. This surfaces a component's story even when
+// the PR only edited the component and not the story itself.
+async function findAssociatedStories(
+  github: SyncArgs['github'],
+  owner: string,
+  repo: string,
+  ref: string,
+  componentPaths: string[]
+): Promise<string[]> {
+  const uniqueDirs = [...new Set(componentPaths.map(dirOf))];
+  const entriesByDir = new Map(
+    await Promise.all(
+      uniqueDirs.map(
+        async dir => [dir, await listDirectory(github, owner, repo, ref, dir)] as const
+      )
+    )
+  );
+
+  const matches = componentPaths.flatMap(path => {
+    const fileBase = baseName(path).replace(/\.tsx$/, '');
+    const dirBase = baseName(dirOf(path));
+    return (entriesByDir.get(dirOf(path)) ?? [])
+      .filter(entry => STORY_FILE_RE.test(entry.path))
+      .filter(entry => [fileBase, dirBase].includes(storyBaseName(entry.name)))
+      .map(entry => entry.path);
+  });
+
+  return [...new Set(matches)];
 }
 
 export async function syncStoriesPreviewComment({
@@ -265,11 +341,19 @@ export async function syncStoriesPreviewComment({
     per_page: 100,
   });
 
-  const stories = files
+  const changed = files
     .filter(file => file.status !== 'removed')
-    .filter(file => STORY_FILE_RE.test(file.filename))
-    .map(file => file.filename)
-    .sort();
+    .map(file => file.filename);
+
+  const directStories = changed.filter(file => STORY_FILE_RE.test(file));
+  const associatedStories = await findAssociatedStories(
+    github,
+    owner,
+    repo,
+    sha,
+    changed.filter(isComponentFile)
+  );
+  const stories = [...new Set([...directStories, ...associatedStories])].sort();
 
   const comments = await github.paginate<IssueComment>(github.rest.issues.listComments, {
     owner,
@@ -286,7 +370,7 @@ export async function syncStoriesPreviewComment({
       await github.rest.issues.deleteComment({owner, repo, comment_id: existing.id});
       core.info(`Deleted stale stories preview comment on #${pr.number}.`);
     } else {
-      core.info('No changed stories (*.stories.tsx / *.mdx) files, skipping.');
+      core.info('No changed or associated stories, skipping.');
     }
     return;
   }


### PR DESCRIPTION
Follow-up to #117309. That workflow only linked stories that were themselves edited (`*.stories.tsx` / `*.mdx`), so a reviewer editing a component without touching its story got no preview link.

Now, for each edited component file, the script also looks in that file's directory (at the deployed commit) for story files whose base name matches the component's own name or its directory name, and links those too. This covers both colocated conventions — `foo.tsx` → `foo.stories.tsx` and `disclosure/index.tsx` → `disclosure/disclosure.mdx` — and the result is deduped with the directly-changed stories.

Directory lookups go through the GitHub contents API at the deployed commit and fall back to nothing if the directory is missing, so there's no extra checkout. Covered by unit tests for the colocated, directory-named, and unrelated-story cases.