### PR TITLE
ref(plugins): Break language plugin preprocessors out of plugin infrastructure

### DIFF
--- a/src/sentry/event_preprocessors.py
+++ b/src/sentry/event_preprocessors.py
@@ -11,19 +11,20 @@ from sentry.lang.java.utils import has_proguard_file
 from sentry.plugins.base.v2 import EventPreprocessor
 
 
-def get_event_preprocessor(data: Mapping[str, Any]) -> EventPreprocessor | None:
-    """Return the single preprocessor needed for this event, or None."""
+def get_event_preprocessors(data: Mapping[str, Any]) -> list[EventPreprocessor]:
+    """Return all preprocessors needed for this event."""
     from sentry.lang.dart.utils import deobfuscate_exception_type
     from sentry.lang.java.processing import deobfuscate_exception_value
     from sentry.lang.javascript.preprocessing import preprocess_event
 
+    preprocessors: list[EventPreprocessor] = []
     if has_proguard_file(data):
-        return deobfuscate_exception_value
-    elif data.get("platform") in ("javascript", "node"):
-        return preprocess_event
-    elif _is_obfuscated_dart_event(data):
-        return deobfuscate_exception_type
-    return None
+        preprocessors.append(deobfuscate_exception_value)
+    if data.get("platform") in ("javascript", "node"):
+        preprocessors.append(preprocess_event)
+    if _is_obfuscated_dart_event(data):
+        preprocessors.append(deobfuscate_exception_type)
+    return preprocessors
 
 
 def _is_obfuscated_dart_event(data: Mapping[str, Any]) -> bool:

--- a/src/sentry/event_preprocessors.py
+++ b/src/sentry/event_preprocessors.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from sentry.lang.dart.utils import (
+    get_debug_meta_image_ids,
+    has_native_frames_in_stacktraces,
+)
+from sentry.lang.java.utils import has_proguard_file
+from sentry.plugins.base.v2 import EventPreprocessor
+
+
+def get_event_preprocessor(data: Mapping[str, Any]) -> EventPreprocessor | None:
+    """Return the single preprocessor needed for this event, or None."""
+    from sentry.lang.dart.utils import deobfuscate_exception_type
+    from sentry.lang.java.processing import deobfuscate_exception_value
+    from sentry.lang.javascript.preprocessing import preprocess_event
+
+    if has_proguard_file(data):
+        return deobfuscate_exception_value
+    elif data.get("platform") in ("javascript", "node"):
+        return preprocess_event
+    elif _is_obfuscated_dart_event(data):
+        return deobfuscate_exception_type
+    return None
+
+
+def _is_obfuscated_dart_event(data: Mapping[str, Any]) -> bool:
+    sdk_name = (data.get("sdk") or {}).get("name", "")
+    if sdk_name not in ("sentry.dart", "sentry.dart.flutter"):
+        return False
+    if not get_debug_meta_image_ids(dict(data)):
+        return False
+    return has_native_frames_in_stacktraces(data)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -86,6 +86,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable default anomaly detection metric monitor for new projects
     manager.add("organizations:default-anomaly-detector", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:derive-tags-without-plugins", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:event-preprocessors-without-plugins", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the discover saved queries deprecation warnings
     manager.add("organizations:discover-saved-queries-deprecation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable migration of transaction widgets and queries to spans

--- a/src/sentry/lang/dart/plugin.py
+++ b/src/sentry/lang/dart/plugin.py
@@ -8,6 +8,8 @@ from sentry.plugins.base.v2 import EventPreprocessor, Plugin2
 from sentry.stacktraces.processing import find_stacktraces_in_data
 
 
+# Deprecated: preprocessor logic moved to sentry.event_preprocessors.
+# TODO(christinarlong): Delete after organizations:event-preprocessors-without-plugins is fully rolled out.
 class DartPlugin(Plugin2):
     """
     This plugin is responsible for Dart specific processing on events or attachments.

--- a/src/sentry/lang/dart/utils.py
+++ b/src/sentry/lang/dart/utils.py
@@ -10,6 +10,7 @@ import sentry_sdk
 
 from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.project import Project
+from sentry.stacktraces.processing import find_stacktraces_in_data
 from sentry.utils.safe import get_path
 
 # Obfuscated type values are either in the form of "xyz" or "xyz<abc>" where
@@ -109,3 +110,11 @@ def deobfuscate_exception_type(data: MutableMapping[str, Any]) -> None:
                 new_value = re.sub(INSTANCE_OF_VALUE_RE, replace_symbol, exception_value)
                 if new_value != exception_value:
                     exception["value"] = new_value
+
+
+def has_native_frames_in_stacktraces(data) -> bool:
+    for stacktrace_info in find_stacktraces_in_data(data):
+        frames = stacktrace_info.get_frames()
+        if frames and any(frame.get("platform") == "native" for frame in frames):
+            return True
+    return False

--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -8,6 +8,8 @@ from sentry.lang.java.utils import has_proguard_file
 from sentry.plugins.base.v2 import EventPreprocessor, Plugin2
 
 
+# Deprecated: preprocessor logic moved to sentry.event_preprocessors.
+# TODO(christinarlong): Delete after organizations:event-preprocessors-without-plugins is fully rolled out.
 class JavaPlugin(Plugin2):
     can_disable = False
 

--- a/src/sentry/lang/javascript/plugin.py
+++ b/src/sentry/lang/javascript/plugin.py
@@ -33,6 +33,8 @@ def generate_modules(data):
                 frame["module"] = generate_module(abs_path)
 
 
+# Deprecated: preprocessor logic moved to sentry.event_preprocessors and sentry.lang.javascript.preprocessing.
+# TODO(christinarlong): Delete after organizations:event-preprocessors-without-plugins is fully rolled out.
 class JavascriptPlugin(Plugin2):
     can_disable = False
 

--- a/src/sentry/lang/javascript/preprocessing.py
+++ b/src/sentry/lang/javascript/preprocessing.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from sentry.stacktraces.processing import find_stacktraces_in_data
+from sentry.utils.safe import get_path
+
+from .errorlocale import translate_exception
+from .errormapping import rewrite_exception
+from .utils import generate_module
+
+
+def preprocess_event(data):
+    rewrite_exception(data)
+    translate_exception(data)
+    generate_modules(data)
+    return data
+
+
+def generate_modules(data):
+    for info in find_stacktraces_in_data(data):
+        for frame in get_path(info.stacktrace, "frames", filter=True, default=()):
+            platform = frame.get("platform") or data["platform"]
+            if platform not in ("javascript", "node") or frame.get("module"):
+                continue
+            abs_path = frame.get("abs_path")
+            if abs_path and abs_path.startswith(("http:", "https:", "webpack:", "app:")):
+                frame["module"] = generate_module(abs_path)

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -47,8 +47,13 @@ class RetryProcessing(Exception):
     pass
 
 
+LANGUAGE_PLUGIN_SLUGS = frozenset({"javaplugin", "javascriptplugin", "dartplugin"})
+
+
 def should_process(data: Mapping[str, Any]) -> bool:
     """Quick check if processing is needed at all."""
+    from sentry.plugins.base import plugins
+
     if data.get("type") == "transaction":
         return False
 
@@ -56,9 +61,13 @@ def should_process(data: Mapping[str, Any]) -> bool:
     if features.has("organizations:event-preprocessors-without-plugins", project.organization):
         if get_event_preprocessor(data) is not None:
             return True
+        for plugin in plugins.all(version=2):
+            if plugin.slug in LANGUAGE_PLUGIN_SLUGS:
+                continue
+            processors = safe_execute(plugin.get_event_preprocessors, data=data)
+            if processors:
+                return True
     else:
-        from sentry.plugins.base import plugins
-
         for plugin in plugins.all(version=2):
             processors = safe_execute(plugin.get_event_preprocessors, data=data)
             if processors:
@@ -408,6 +417,10 @@ def do_process_event(
     if use_new_preprocessors:
         event_preprocessor = get_event_preprocessor(data)
         preprocessors = [event_preprocessor] if event_preprocessor is not None else []
+        for plugin in plugins.all(version=2):
+            if plugin.slug in LANGUAGE_PLUGIN_SLUGS:
+                continue
+            preprocessors.extend(safe_execute(plugin.get_event_preprocessors, data=data) or ())
     else:
         preprocessors = []
         for plugin in plugins.all(version=2):

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -13,7 +13,7 @@ from sentry_relay.processing import StoreNormalizer
 from sentry import features, options, reprocessing2
 from sentry.attachments import delete_cached_and_ratelimited_attachments, get_attachments_for_event
 from sentry.constants import DEFAULT_STORE_NORMALIZER_ARGS
-from sentry.event_preprocessors import get_event_preprocessor
+from sentry.event_preprocessors import get_event_preprocessors
 from sentry.feedback.usecases.ingest.save_event_feedback import (
     save_event_feedback as save_event_feedback_impl,
 )
@@ -58,8 +58,11 @@ def should_process(data: Mapping[str, Any]) -> bool:
         return False
 
     project = Project.objects.get_from_cache(id=data["project"])
+    project.set_cached_field_value(
+        "organization", Organization.objects.get_from_cache(id=project.organization_id)
+    )
     if features.has("organizations:event-preprocessors-without-plugins", project.organization):
-        if get_event_preprocessor(data) is not None:
+        if get_event_preprocessors(data):
             return True
         for plugin in plugins.all(version=2):
             if plugin.slug in LANGUAGE_PLUGIN_SLUGS:
@@ -415,8 +418,7 @@ def do_process_event(
         "organizations:event-preprocessors-without-plugins", project.organization
     )
     if use_new_preprocessors:
-        event_preprocessor = get_event_preprocessor(data)
-        preprocessors = [event_preprocessor] if event_preprocessor is not None else []
+        preprocessors = get_event_preprocessors(data)
         for plugin in plugins.all(version=2):
             if plugin.slug in LANGUAGE_PLUGIN_SLUGS:
                 continue

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -402,37 +402,41 @@ def do_process_event(
             data = new_data
 
     # Default event processors.
-    if features.has("organizations:event-preprocessors-without-plugins", project.organization):
+    use_new_preprocessors = features.has(
+        "organizations:event-preprocessors-without-plugins", project.organization
+    )
+    if use_new_preprocessors:
         event_preprocessor = get_event_preprocessor(data)
-        if event_preprocessor is not None:
-            with sentry_sdk.start_span(op="task.store.process_event.preprocessors"):
-                try:
-                    result = event_preprocessor(data)
-                except Exception:
-                    error_logger.exception("tasks.store.preprocessors.error")
-                    data.setdefault("_metrics", {})["flag.processing.error"] = True
-                    has_changed = True
-                else:
-                    if result:
-                        data = result
-                        has_changed = True
+        preprocessors = [event_preprocessor] if event_preprocessor is not None else []
     else:
+        preprocessors = []
         for plugin in plugins.all(version=2):
-            with sentry_sdk.start_span(op="task.store.process_event.preprocessors") as span:
-                span.set_data("plugin", plugin.slug)
-                span.set_data("from_symbolicate", from_symbolicate)
-                processors = safe_execute(plugin.get_event_preprocessors, data=data)
-                for processor in processors or ():
-                    try:
-                        result = processor(data)
-                    except Exception:
-                        error_logger.exception("tasks.store.preprocessors.error")
-                        data.setdefault("_metrics", {})["flag.processing.error"] = True
-                        has_changed = True
-                    else:
-                        if result:
-                            data = result
-                            has_changed = True
+            preprocessors.extend(safe_execute(plugin.get_event_preprocessors, data=data) or ())
+
+    preprocessor_span_op = (
+        "task.store.process_event.new_preprocessors"
+        if use_new_preprocessors
+        else "task.store.process_event.preprocessors"
+    )
+    preprocessor_log_msg = (
+        "tasks.store.new_preprocessors.error"
+        if use_new_preprocessors
+        else "tasks.store.preprocessors.error"
+    )
+
+    with sentry_sdk.start_span(op=preprocessor_span_op) as span:
+        span.set_data("from_symbolicate", from_symbolicate)
+        for processor in preprocessors:
+            try:
+                result = processor(data)
+            except Exception:
+                error_logger.exception(preprocessor_log_msg)
+                data.setdefault("_metrics", {})["flag.processing.error"] = True
+                has_changed = True
+            else:
+                if result:
+                    data = result
+                    has_changed = True
 
     assert data["project"] == project_id, "Project cannot be mutated by plugins"
 

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -10,9 +10,10 @@ import orjson
 import sentry_sdk
 from sentry_relay.processing import StoreNormalizer
 
-from sentry import options, reprocessing2
+from sentry import features, options, reprocessing2
 from sentry.attachments import delete_cached_and_ratelimited_attachments, get_attachments_for_event
 from sentry.constants import DEFAULT_STORE_NORMALIZER_ARGS
+from sentry.event_preprocessors import get_event_preprocessor
 from sentry.feedback.usecases.ingest.save_event_feedback import (
     save_event_feedback as save_event_feedback_impl,
 )
@@ -48,15 +49,20 @@ class RetryProcessing(Exception):
 
 def should_process(data: Mapping[str, Any]) -> bool:
     """Quick check if processing is needed at all."""
-    from sentry.plugins.base import plugins
-
     if data.get("type") == "transaction":
         return False
 
-    for plugin in plugins.all(version=2):
-        processors = safe_execute(plugin.get_event_preprocessors, data=data)
-        if processors:
+    project = Project.objects.get_from_cache(id=data["project"])
+    if features.has("organizations:event-preprocessors-without-plugins", project.organization):
+        if get_event_preprocessor(data) is not None:
             return True
+    else:
+        from sentry.plugins.base import plugins
+
+        for plugin in plugins.all(version=2):
+            processors = safe_execute(plugin.get_event_preprocessors, data=data)
+            if processors:
+                return True
 
     if should_process_for_stacktraces(data):
         return True
@@ -395,16 +401,13 @@ def do_process_event(
         if new_data is not None:
             data = new_data
 
-    # TODO(dcramer): ideally we would know if data changed by default
     # Default event processors.
-    for plugin in plugins.all(version=2):
-        with sentry_sdk.start_span(op="task.store.process_event.preprocessors") as span:
-            span.set_data("plugin", plugin.slug)
-            span.set_data("from_symbolicate", from_symbolicate)
-            processors = safe_execute(plugin.get_event_preprocessors, data=data)
-            for processor in processors or ():
+    if features.has("organizations:event-preprocessors-without-plugins", project.organization):
+        event_preprocessor = get_event_preprocessor(data)
+        if event_preprocessor is not None:
+            with sentry_sdk.start_span(op="task.store.process_event.preprocessors"):
                 try:
-                    result = processor(data)
+                    result = event_preprocessor(data)
                 except Exception:
                     error_logger.exception("tasks.store.preprocessors.error")
                     data.setdefault("_metrics", {})["flag.processing.error"] = True
@@ -413,6 +416,23 @@ def do_process_event(
                     if result:
                         data = result
                         has_changed = True
+    else:
+        for plugin in plugins.all(version=2):
+            with sentry_sdk.start_span(op="task.store.process_event.preprocessors") as span:
+                span.set_data("plugin", plugin.slug)
+                span.set_data("from_symbolicate", from_symbolicate)
+                processors = safe_execute(plugin.get_event_preprocessors, data=data)
+                for processor in processors or ():
+                    try:
+                        result = processor(data)
+                    except Exception:
+                        error_logger.exception("tasks.store.preprocessors.error")
+                        data.setdefault("_metrics", {})["flag.processing.error"] = True
+                        has_changed = True
+                    else:
+                        if result:
+                            data = result
+                            has_changed = True
 
     assert data["project"] == project_id, "Project cannot be mutated by plugins"
 

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -13,7 +13,9 @@ from sentry.tasks.store import (
     process_event,
     save_event,
     save_event_transaction,
+    should_process,
 )
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.pytest.fixtures import django_db_all
 
 EVENT_ID = "cc3e6c2bb6b6498097f336d1e6979f4b"
@@ -395,3 +397,85 @@ def test_store_consumer_type(
     mock_transaction_processing_store.get.assert_called_once_with("tx:3")
     mock_transaction_processing_store.delete_by_key.assert_called_once_with("tx:3")
     mock_transaction_processing_store.store.assert_not_called()
+
+
+@django_db_all
+@with_feature("organizations:event-preprocessors-without-plugins")
+def test_should_process_new_path_js(default_project):
+    data = {
+        "project": default_project.id,
+        "platform": "javascript",
+        "event_id": EVENT_ID,
+    }
+    assert should_process(data) is True
+
+
+@django_db_all
+@with_feature("organizations:event-preprocessors-without-plugins")
+def test_should_process_new_path_java_proguard(default_project):
+    data = {
+        "project": default_project.id,
+        "platform": "java",
+        "event_id": EVENT_ID,
+        "debug_meta": {"images": [{"type": "proguard", "uuid": "1234-abcd"}]},
+    }
+    assert should_process(data) is True
+
+
+@django_db_all
+@with_feature("organizations:event-preprocessors-without-plugins")
+def test_should_process_new_path_no_preprocessor(default_project):
+    data = {
+        "project": default_project.id,
+        "platform": "python",
+        "event_id": EVENT_ID,
+    }
+    assert should_process(data) is False
+
+
+@django_db_all
+@with_feature("organizations:event-preprocessors-without-plugins")
+def test_should_process_new_path_skips_plugins(default_project, register_plugin):
+    register_plugin(globals(), BasicPreprocessorPlugin)
+    data = {
+        "project": default_project.id,
+        "platform": "mattlang",
+        "event_id": EVENT_ID,
+    }
+    assert should_process(data) is False
+
+
+@django_db_all
+@with_feature("organizations:event-preprocessors-without-plugins")
+def test_process_event_new_path_js(default_project, mock_event_processing_store, mock_save_event):
+    data = {
+        "project": default_project.id,
+        "platform": "javascript",
+        "logentry": {"formatted": "test"},
+        "event_id": EVENT_ID,
+    }
+
+    mock_event_processing_store.get.return_value = data
+    mock_event_processing_store.store.return_value = "e:1"
+
+    process_event(cache_key="e:1", start_time=1)
+
+    mock_save_event.delay.assert_called_once()
+
+
+@django_db_all
+@with_feature("organizations:event-preprocessors-without-plugins")
+def test_preprocess_routes_to_save_new_path_python(
+    default_project, mock_process_event, mock_save_event, mock_symbolicate_event
+):
+    data = {
+        "project": default_project.id,
+        "platform": "python",
+        "logentry": {"formatted": "test"},
+        "event_id": EVENT_ID,
+    }
+
+    preprocess_event(cache_key="", data=data)
+
+    assert mock_process_event.delay.call_count == 0
+    assert mock_save_event.delay.call_count == 1

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -435,14 +435,14 @@ def test_should_process_new_path_no_preprocessor(default_project):
 
 @django_db_all
 @with_feature("organizations:event-preprocessors-without-plugins")
-def test_should_process_new_path_skips_plugins(default_project, register_plugin):
+def test_should_process_new_path_still_runs_non_language_plugins(default_project, register_plugin):
     register_plugin(globals(), BasicPreprocessorPlugin)
     data = {
         "project": default_project.id,
         "platform": "mattlang",
         "event_id": EVENT_ID,
     }
-    assert should_process(data) is False
+    assert should_process(data) is True
 
 
 @django_db_all

--- a/tests/sentry/test_event_preprocessors.py
+++ b/tests/sentry/test_event_preprocessors.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from sentry.event_preprocessors import get_event_preprocessor
+from sentry.event_preprocessors import get_event_preprocessors
 from sentry.lang.dart.utils import deobfuscate_exception_type
 from sentry.lang.java.processing import deobfuscate_exception_value
 from sentry.lang.javascript.preprocessing import preprocess_event
 from sentry.testutils.cases import TestCase
 
 
-class GetEventPreprocessorTest(TestCase):
+class GetEventPreprocessorsTest(TestCase):
     def test_java_proguard_event(self) -> None:
         data = {
             "platform": "java",
@@ -15,15 +15,15 @@ class GetEventPreprocessorTest(TestCase):
                 "images": [{"type": "proguard", "uuid": "1234-abcd"}],
             },
         }
-        assert get_event_preprocessor(data) is deobfuscate_exception_value
+        assert get_event_preprocessors(data) == [deobfuscate_exception_value]
 
     def test_javascript_event(self) -> None:
         data = {"platform": "javascript"}
-        assert get_event_preprocessor(data) is preprocess_event
+        assert get_event_preprocessors(data) == [preprocess_event]
 
     def test_node_event(self) -> None:
         data = {"platform": "node"}
-        assert get_event_preprocessor(data) is preprocess_event
+        assert get_event_preprocessors(data) == [preprocess_event]
 
     def test_dart_flutter_obfuscated_event(self) -> None:
         data = {
@@ -44,7 +44,7 @@ class GetEventPreprocessorTest(TestCase):
                 ]
             },
         }
-        assert get_event_preprocessor(data) is deobfuscate_exception_type
+        assert get_event_preprocessors(data) == [deobfuscate_exception_type]
 
     def test_dart_sdk_obfuscated_event(self) -> None:
         data = {
@@ -65,16 +65,16 @@ class GetEventPreprocessorTest(TestCase):
                 ]
             },
         }
-        assert get_event_preprocessor(data) is deobfuscate_exception_type
+        assert get_event_preprocessors(data) == [deobfuscate_exception_type]
 
-    def test_dart_no_debug_images_returns_none(self) -> None:
+    def test_dart_no_debug_images_returns_empty(self) -> None:
         data = {
             "platform": "dart",
             "sdk": {"name": "sentry.dart.flutter"},
         }
-        assert get_event_preprocessor(data) is None
+        assert get_event_preprocessors(data) == []
 
-    def test_dart_no_native_frames_returns_none(self) -> None:
+    def test_dart_no_native_frames_returns_empty(self) -> None:
         data = {
             "platform": "dart",
             "sdk": {"name": "sentry.dart.flutter"},
@@ -93,9 +93,9 @@ class GetEventPreprocessorTest(TestCase):
                 ]
             },
         }
-        assert get_event_preprocessor(data) is None
+        assert get_event_preprocessors(data) == []
 
-    def test_dart_wrong_sdk_returns_none(self) -> None:
+    def test_dart_wrong_sdk_returns_empty(self) -> None:
         data = {
             "platform": "dart",
             "sdk": {"name": "sentry.python"},
@@ -103,21 +103,21 @@ class GetEventPreprocessorTest(TestCase):
                 "images": [{"debug_id": "b8e43a-f242-3d73-a453-aeb6a777ef75"}],
             },
         }
-        assert get_event_preprocessor(data) is None
+        assert get_event_preprocessors(data) == []
 
-    def test_python_event_returns_none(self) -> None:
+    def test_python_event_returns_empty(self) -> None:
         data = {"platform": "python"}
-        assert get_event_preprocessor(data) is None
+        assert get_event_preprocessors(data) == []
 
-    def test_transaction_returns_none(self) -> None:
+    def test_transaction_returns_empty(self) -> None:
         data = {"platform": "python", "type": "transaction"}
-        assert get_event_preprocessor(data) is None
+        assert get_event_preprocessors(data) == []
 
-    def test_proguard_takes_priority_over_platform(self) -> None:
+    def test_mixed_proguard_and_js_returns_both(self) -> None:
         data = {
             "platform": "javascript",
             "debug_meta": {
                 "images": [{"type": "proguard", "uuid": "1234-abcd"}],
             },
         }
-        assert get_event_preprocessor(data) is deobfuscate_exception_value
+        assert get_event_preprocessors(data) == [deobfuscate_exception_value, preprocess_event]

--- a/tests/sentry/test_event_preprocessors.py
+++ b/tests/sentry/test_event_preprocessors.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from sentry.event_preprocessors import get_event_preprocessor
+from sentry.lang.dart.utils import deobfuscate_exception_type
+from sentry.lang.java.processing import deobfuscate_exception_value
+from sentry.lang.javascript.preprocessing import preprocess_event
+from sentry.testutils.cases import TestCase
+
+
+class GetEventPreprocessorTest(TestCase):
+    def test_java_proguard_event(self) -> None:
+        data = {
+            "platform": "java",
+            "debug_meta": {
+                "images": [{"type": "proguard", "uuid": "1234-abcd"}],
+            },
+        }
+        assert get_event_preprocessor(data) is deobfuscate_exception_value
+
+    def test_javascript_event(self) -> None:
+        data = {"platform": "javascript"}
+        assert get_event_preprocessor(data) is preprocess_event
+
+    def test_node_event(self) -> None:
+        data = {"platform": "node"}
+        assert get_event_preprocessor(data) is preprocess_event
+
+    def test_dart_flutter_obfuscated_event(self) -> None:
+        data = {
+            "platform": "dart",
+            "sdk": {"name": "sentry.dart.flutter"},
+            "debug_meta": {
+                "images": [{"debug_id": "b8e43a-f242-3d73-a453-aeb6a777ef75"}],
+            },
+            "exception": {
+                "values": [
+                    {
+                        "type": "xyz",
+                        "value": "Error",
+                        "stacktrace": {
+                            "frames": [{"platform": "native"}],
+                        },
+                    }
+                ]
+            },
+        }
+        assert get_event_preprocessor(data) is deobfuscate_exception_type
+
+    def test_dart_sdk_obfuscated_event(self) -> None:
+        data = {
+            "platform": "dart",
+            "sdk": {"name": "sentry.dart"},
+            "debug_meta": {
+                "images": [{"debug_id": "b8e43a-f242-3d73-a453-aeb6a777ef75"}],
+            },
+            "exception": {
+                "values": [
+                    {
+                        "type": "xyz",
+                        "value": "Error",
+                        "stacktrace": {
+                            "frames": [{"platform": "native"}],
+                        },
+                    }
+                ]
+            },
+        }
+        assert get_event_preprocessor(data) is deobfuscate_exception_type
+
+    def test_dart_no_debug_images_returns_none(self) -> None:
+        data = {
+            "platform": "dart",
+            "sdk": {"name": "sentry.dart.flutter"},
+        }
+        assert get_event_preprocessor(data) is None
+
+    def test_dart_no_native_frames_returns_none(self) -> None:
+        data = {
+            "platform": "dart",
+            "sdk": {"name": "sentry.dart.flutter"},
+            "debug_meta": {
+                "images": [{"debug_id": "b8e43a-f242-3d73-a453-aeb6a777ef75"}],
+            },
+            "exception": {
+                "values": [
+                    {
+                        "type": "xyz",
+                        "value": "Error",
+                        "stacktrace": {
+                            "frames": [{"platform": "dart"}],
+                        },
+                    }
+                ]
+            },
+        }
+        assert get_event_preprocessor(data) is None
+
+    def test_dart_wrong_sdk_returns_none(self) -> None:
+        data = {
+            "platform": "dart",
+            "sdk": {"name": "sentry.python"},
+            "debug_meta": {
+                "images": [{"debug_id": "b8e43a-f242-3d73-a453-aeb6a777ef75"}],
+            },
+        }
+        assert get_event_preprocessor(data) is None
+
+    def test_python_event_returns_none(self) -> None:
+        data = {"platform": "python"}
+        assert get_event_preprocessor(data) is None
+
+    def test_transaction_returns_none(self) -> None:
+        data = {"platform": "python", "type": "transaction"}
+        assert get_event_preprocessor(data) is None
+
+    def test_proguard_takes_priority_over_platform(self) -> None:
+        data = {
+            "platform": "javascript",
+            "debug_meta": {
+                "images": [{"type": "proguard", "uuid": "1234-abcd"}],
+            },
+        }
+        assert get_event_preprocessor(data) is deobfuscate_exception_value


### PR DESCRIPTION
As part of removing plugins we also need to remove these language 'plugins' that do some `processing` to the event data if they match their corresponding language (Java, JavaScript, Dart). The logic done by these plugins don't rely on the actual plugin infra so let's take their logic out (like the tags plugins) and call them directly.

Note!! There's some jank since the SessionStack plugin also runs through this path and we need to support it till the deprecation date.


## Old Flow
```
_do_preprocess_event
  └─ should_process(data)
       └─ for plugin in plugins.all(version=2):         # iterates ALL v2 plugins
            processors = plugin.get_event_preprocessors(data)
            if processors: return True                   # any plugin can claim the event
       └─ should_process_for_stacktraces(data)           # also iterates all v2 plugins
  └─ submit_process(...)

do_process_event
  └─ for plugin in plugins.all(version=2):               # iterates ALL v2 plugins again
       processors = plugin.get_event_preprocessors(data)
       for processor in processors:                      # nested loop: plugins × processors
         result = processor(data)
```

## New Flow
```
_do_preprocess_event
  └─ should_process(data)
       └─ get_event_preprocessor(data)                   # direct if/elif dispatch
            has_proguard_file(data)        → deobfuscate_exception_value
            platform in (javascript, node) → preprocess_event
            _is_obfuscated_dart_event()    → deobfuscate_exception_type
            else                           → None
       └─ should_process_for_stacktraces(data)           # unchanged (already a no-op)
  └─ submit_process(...)

do_process_event
  └─ get_event_preprocessor(data)                        # same direct dispatch
  └─ preprocessors = [result] or []                      # 0 or 1 preprocessor, no plugin loop
  └─ for processor in preprocessors:                     # shared execution path
       result = processor(data)
```
