### PR TITLE
ref(span-buffer): Use bulk project lookup and cache results locally

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -141,7 +141,6 @@ from sentry.spans.segment_key import (
     segment_key_to_span_id,
 )
 from sentry.utils import metrics, redis
-from sentry.utils.local_cache import LRUCache, ThreadSafeCache
 from sentry.utils.outcomes import Outcome, track_outcome
 
 logger = logging.getLogger(__name__)
@@ -149,40 +148,6 @@ logger = logging.getLogger(__name__)
 
 def get_redis_client() -> RedisCluster[bytes] | StrictRedis[bytes]:
     return redis.redis_clusters.get_binary(settings.SENTRY_SPAN_BUFFER_CLUSTER)
-
-
-_organization_id_cache: ThreadSafeCache[int, int] | None = None
-
-
-def _get_organization_id_cache() -> ThreadSafeCache[int, int]:
-    global _organization_id_cache
-    if _organization_id_cache is None:
-        _organization_id_cache = ThreadSafeCache(LRUCache(maxlen=20_000))
-    return _organization_id_cache
-
-
-def _get_pid_to_oid_map(project_ids: Sequence[int]) -> dict[int, int]:
-    """
-    Resolve project IDs to organization IDs, keeping common projects in a
-    local in-memory cache and bulk-fetching only the missing ones.
-    """
-    cache = _get_organization_id_cache()
-
-    pid_map: dict[int, int] = {}
-    missing_pids = []
-    for project_id in project_ids:
-        organization_id = cache.get(project_id)
-        if organization_id is None:
-            missing_pids.append(project_id)
-        else:
-            pid_map[project_id] = organization_id
-
-    if missing_pids:
-        for project in Project.objects.get_many_from_cache(missing_pids):
-            cache[project.id] = project.organization_id
-            pid_map[project.id] = project.organization_id
-
-    return pid_map
 
 
 def _compute_salt(spans: Sequence[Span]) -> str:
@@ -630,17 +595,20 @@ class SpansBuffer:
                         metrics.incr("spans.buffer.segment_expired_before_flush")
 
         if dropped_by_project:
-            pid_to_oid_map = _get_pid_to_oid_map(list(dropped_by_project.keys()))
+            projects_by_id = {
+                project.id: project
+                for project in Project.objects.get_many_from_cache(list(dropped_by_project.keys()))
+            }
             for project_id, dropped in dropped_by_project.items():
-                organization_id = pid_to_oid_map.get(project_id)
-                if organization_id is None:
+                project = projects_by_id.get(project_id)
+                if project is None:
                     logger.warning(
                         "Project does not exist for segment with dropped spans",
                         extra={"project_id": project_id},
                     )
                     continue
                 track_outcome(
-                    org_id=organization_id,
+                    org_id=project.organization_id,
                     project_id=project_id,
                     key_id=None,
                     outcome=Outcome.INVALID,

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -141,6 +141,7 @@ from sentry.spans.segment_key import (
     segment_key_to_span_id,
 )
 from sentry.utils import metrics, redis
+from sentry.utils.local_cache import LRUCache, ThreadSafeCache
 from sentry.utils.outcomes import Outcome, track_outcome
 
 logger = logging.getLogger(__name__)
@@ -148,6 +149,40 @@ logger = logging.getLogger(__name__)
 
 def get_redis_client() -> RedisCluster[bytes] | StrictRedis[bytes]:
     return redis.redis_clusters.get_binary(settings.SENTRY_SPAN_BUFFER_CLUSTER)
+
+
+_organization_id_cache: ThreadSafeCache[int, int] | None = None
+
+
+def _get_organization_id_cache() -> ThreadSafeCache[int, int]:
+    global _organization_id_cache
+    if _organization_id_cache is None:
+        _organization_id_cache = ThreadSafeCache(LRUCache(maxlen=20_000))
+    return _organization_id_cache
+
+
+def _get_pid_to_oid_map(project_ids: Sequence[int]) -> dict[int, int]:
+    """
+    Resolve project IDs to organization IDs, keeping common projects in a
+    local in-memory cache and bulk-fetching only the missing ones.
+    """
+    cache = _get_organization_id_cache()
+
+    pid_map: dict[int, int] = {}
+    missing_pids = []
+    for project_id in project_ids:
+        organization_id = cache.get(project_id)
+        if organization_id is None:
+            missing_pids.append(project_id)
+        else:
+            pid_map[project_id] = organization_id
+
+    if missing_pids:
+        for project in Project.objects.get_many_from_cache(missing_pids):
+            cache[project.id] = project.organization_id
+            pid_map[project.id] = project.organization_id
+
+    return pid_map
 
 
 def _compute_salt(spans: Sequence[Span]) -> str:
@@ -595,20 +630,17 @@ class SpansBuffer:
                         metrics.incr("spans.buffer.segment_expired_before_flush")
 
         if dropped_by_project:
-            projects_by_id = {
-                project.id: project
-                for project in Project.objects.get_many_from_cache(list(dropped_by_project.keys()))
-            }
+            pid_to_oid_map = _get_pid_to_oid_map(list(dropped_by_project.keys()))
             for project_id, dropped in dropped_by_project.items():
-                project = projects_by_id.get(project_id)
-                if project is None:
+                organization_id = pid_to_oid_map.get(project_id)
+                if organization_id is None:
                     logger.warning(
                         "Project does not exist for segment with dropped spans",
                         extra={"project_id": project_id},
                     )
                     continue
                 track_outcome(
-                    org_id=project.organization_id,
+                    org_id=organization_id,
                     project_id=project_id,
                     key_id=None,
                     outcome=Outcome.INVALID,

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -100,6 +100,7 @@ from __future__ import annotations
 import itertools
 import logging
 import math
+from collections import defaultdict
 from collections.abc import Generator, Sequence
 from hashlib import blake2b
 from typing import Any, cast
@@ -553,6 +554,8 @@ class SpansBuffer:
         redis_ttl = options.get("spans.buffer.redis-ttl")
         root_timeout = options.get("spans.buffer.root-timeout")
 
+        dropped_by_project: defaultdict[int, int] = defaultdict(int)
+
         for loaded_segment in loaded_segments:
             ingest_metadata = loaded_segment.ingest_metadata
 
@@ -574,23 +577,7 @@ class SpansBuffer:
 
                 project_id_bytes, _, _ = parse_segment_key(loaded_segment.segment_key)
                 project_id_int = int(project_id_bytes)
-                try:
-                    project = Project.objects.get_from_cache(id=project_id_int)
-                except Project.DoesNotExist:
-                    logger.warning(
-                        "Project does not exist for segment with dropped spans",
-                        extra={"project_id": project_id_int},
-                    )
-                else:
-                    track_outcome(
-                        org_id=project.organization_id,
-                        project_id=project_id_int,
-                        key_id=None,
-                        outcome=Outcome.INVALID,
-                        reason="segment_too_large",
-                        category=DataCategory.SPAN_INDEXED,
-                        quantity=dropped,
-                    )
+                dropped_by_project[project_id_int] += dropped
             elif not loaded_segment.payloads:
                 # Both data and metadata are missing. This could be:
                 # 1. TTL expiration (segment sat in queue for >1 hour) - TRUE DATA LOSS
@@ -606,6 +593,29 @@ class SpansBuffer:
                     if estimated_age > redis_ttl:
                         # Segment is older than TTL - true expiration (data loss)
                         metrics.incr("spans.buffer.segment_expired_before_flush")
+
+        if dropped_by_project:
+            projects_by_id = {
+                project.id: project
+                for project in Project.objects.get_many_from_cache(list(dropped_by_project.keys()))
+            }
+            for project_id, dropped in dropped_by_project.items():
+                project = projects_by_id.get(project_id)
+                if project is None:
+                    logger.warning(
+                        "Project does not exist for segment with dropped spans",
+                        extra={"project_id": project_id},
+                    )
+                    continue
+                track_outcome(
+                    org_id=project.organization_id,
+                    project_id=project_id,
+                    key_id=None,
+                    outcome=Outcome.INVALID,
+                    reason="segment_too_large",
+                    category=DataCategory.SPAN_INDEXED,
+                    quantity=dropped,
+                )
 
         for loaded_segment in loaded_segments:
             if not loaded_segment.payloads:

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -13,7 +13,7 @@ from sentry_redis_tools.clients import RedisCluster, StrictRedis
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.constants import DataCategory
-from sentry.spans.buffer import SpansBuffer, _get_pid_to_oid_map
+from sentry.spans.buffer import SpansBuffer
 from sentry.spans.buffer_types import (
     EvalshaResult,
     FlushCandidate,
@@ -2067,7 +2067,6 @@ def test_record_segment_loss_metrics_records_dropped_spans() -> None:
     with (
         mock.patch("sentry.spans.buffer.Project") as project_model,
         mock.patch("sentry.spans.buffer.track_outcome") as track_outcome,
-        mock.patch("sentry.spans.buffer._organization_id_cache", None),
     ):
         project_model.objects.get_many_from_cache.return_value = [mock_project]
         buffer._record_segment_loss_metrics(
@@ -2090,58 +2089,6 @@ def test_record_segment_loss_metrics_records_dropped_spans() -> None:
     assert outcome_kwargs["reason"] == "segment_too_large"
     assert outcome_kwargs["category"] == DataCategory.SPAN_INDEXED
     assert outcome_kwargs["quantity"] == 2
-
-
-def test_get_pid_to_oid_map_bulk_fetches_and_caches() -> None:
-    project_a = mock.Mock(id=1, organization_id=100)
-    project_b = mock.Mock(id=2, organization_id=200)
-
-    with (
-        mock.patch("sentry.spans.buffer.Project") as project_model,
-        mock.patch("sentry.spans.buffer._organization_id_cache", None),
-    ):
-        project_model.objects.get_many_from_cache.return_value = [project_a, project_b]
-
-        assert _get_pid_to_oid_map([1, 2]) == {1: 100, 2: 200}
-        project_model.objects.get_many_from_cache.assert_called_once_with([1, 2])
-
-        # Second call is served entirely from the local cache.
-        assert _get_pid_to_oid_map([1, 2]) == {1: 100, 2: 200}
-        project_model.objects.get_many_from_cache.assert_called_once()
-
-
-def test_get_pid_to_oid_map_only_fetches_missing_projects() -> None:
-    project_a = mock.Mock(id=1, organization_id=100)
-    project_b = mock.Mock(id=2, organization_id=200)
-
-    with (
-        mock.patch("sentry.spans.buffer.Project") as project_model,
-        mock.patch("sentry.spans.buffer._organization_id_cache", None),
-    ):
-        project_model.objects.get_many_from_cache.return_value = [project_a]
-        assert _get_pid_to_oid_map([1]) == {1: 100}
-
-        project_model.objects.get_many_from_cache.return_value = [project_b]
-        assert _get_pid_to_oid_map([1, 2]) == {1: 100, 2: 200}
-        project_model.objects.get_many_from_cache.assert_called_with([2])
-
-
-def test_get_pid_to_oid_map_omits_nonexistent_projects() -> None:
-    project_a = mock.Mock(id=1, organization_id=100)
-
-    with (
-        mock.patch("sentry.spans.buffer.Project") as project_model,
-        mock.patch("sentry.spans.buffer._organization_id_cache", None),
-    ):
-        project_model.objects.get_many_from_cache.return_value = [project_a]
-
-        assert _get_pid_to_oid_map([1, 999]) == {1: 100}
-        project_model.objects.get_many_from_cache.assert_called_once_with([1, 999])
-
-        # The missing project is not cached, so it is looked up again.
-        project_model.objects.get_many_from_cache.return_value = []
-        assert _get_pid_to_oid_map([999]) == {}
-        project_model.objects.get_many_from_cache.assert_called_with([999])
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -13,7 +13,7 @@ from sentry_redis_tools.clients import RedisCluster, StrictRedis
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.constants import DataCategory
-from sentry.spans.buffer import SpansBuffer
+from sentry.spans.buffer import SpansBuffer, _get_pid_to_oid_map
 from sentry.spans.buffer_types import (
     EvalshaResult,
     FlushCandidate,
@@ -2067,6 +2067,7 @@ def test_record_segment_loss_metrics_records_dropped_spans() -> None:
     with (
         mock.patch("sentry.spans.buffer.Project") as project_model,
         mock.patch("sentry.spans.buffer.track_outcome") as track_outcome,
+        mock.patch("sentry.spans.buffer._organization_id_cache", None),
     ):
         project_model.objects.get_many_from_cache.return_value = [mock_project]
         buffer._record_segment_loss_metrics(
@@ -2089,6 +2090,58 @@ def test_record_segment_loss_metrics_records_dropped_spans() -> None:
     assert outcome_kwargs["reason"] == "segment_too_large"
     assert outcome_kwargs["category"] == DataCategory.SPAN_INDEXED
     assert outcome_kwargs["quantity"] == 2
+
+
+def test_get_pid_to_oid_map_bulk_fetches_and_caches() -> None:
+    project_a = mock.Mock(id=1, organization_id=100)
+    project_b = mock.Mock(id=2, organization_id=200)
+
+    with (
+        mock.patch("sentry.spans.buffer.Project") as project_model,
+        mock.patch("sentry.spans.buffer._organization_id_cache", None),
+    ):
+        project_model.objects.get_many_from_cache.return_value = [project_a, project_b]
+
+        assert _get_pid_to_oid_map([1, 2]) == {1: 100, 2: 200}
+        project_model.objects.get_many_from_cache.assert_called_once_with([1, 2])
+
+        # Second call is served entirely from the local cache.
+        assert _get_pid_to_oid_map([1, 2]) == {1: 100, 2: 200}
+        project_model.objects.get_many_from_cache.assert_called_once()
+
+
+def test_get_pid_to_oid_map_only_fetches_missing_projects() -> None:
+    project_a = mock.Mock(id=1, organization_id=100)
+    project_b = mock.Mock(id=2, organization_id=200)
+
+    with (
+        mock.patch("sentry.spans.buffer.Project") as project_model,
+        mock.patch("sentry.spans.buffer._organization_id_cache", None),
+    ):
+        project_model.objects.get_many_from_cache.return_value = [project_a]
+        assert _get_pid_to_oid_map([1]) == {1: 100}
+
+        project_model.objects.get_many_from_cache.return_value = [project_b]
+        assert _get_pid_to_oid_map([1, 2]) == {1: 100, 2: 200}
+        project_model.objects.get_many_from_cache.assert_called_with([2])
+
+
+def test_get_pid_to_oid_map_omits_nonexistent_projects() -> None:
+    project_a = mock.Mock(id=1, organization_id=100)
+
+    with (
+        mock.patch("sentry.spans.buffer.Project") as project_model,
+        mock.patch("sentry.spans.buffer._organization_id_cache", None),
+    ):
+        project_model.objects.get_many_from_cache.return_value = [project_a]
+
+        assert _get_pid_to_oid_map([1, 999]) == {1: 100}
+        project_model.objects.get_many_from_cache.assert_called_once_with([1, 999])
+
+        # The missing project is not cached, so it is looked up again.
+        project_model.objects.get_many_from_cache.return_value = []
+        assert _get_pid_to_oid_map([999]) == {}
+        project_model.objects.get_many_from_cache.assert_called_with([999])
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -2063,12 +2063,12 @@ def test_record_segment_loss_metrics_records_dropped_spans() -> None:
         ),
     )
 
-    mock_project = mock.Mock(organization_id=100)
+    mock_project = mock.Mock(id=1, organization_id=100)
     with (
         mock.patch("sentry.spans.buffer.Project") as project_model,
         mock.patch("sentry.spans.buffer.track_outcome") as track_outcome,
     ):
-        project_model.objects.get_from_cache.return_value = mock_project
+        project_model.objects.get_many_from_cache.return_value = [mock_project]
         buffer._record_segment_loss_metrics(
             [loaded_segment],
             now=0,


### PR DESCRIPTION
Replaced the looping project query with a single bulk project look up.