### PR TITLE
feat(api): Accept project slugs in organization filters

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -480,6 +480,16 @@ class OrganizationEndpoint(Endpoint):
 
             return [p for p in projects if proj_filter(p)]
 
+    def get_requested_project_ids_unchecked(self, request: HttpRequest) -> set[int]:
+        """
+        Returns the numeric project ids that were requested by the request.
+        Non-numeric values (slugs) are silently ignored.
+
+        To determine the projects to filter this endpoint by with full
+        permission checking, use ``get_projects``, instead.
+        """
+        return self.get_requested_project_ids_and_slugs_unchecked(request).ids
+
     def get_requested_project_ids_and_slugs_unchecked(
         self, request: HttpRequest
     ) -> ParsedProjectIdOrSlugParams:

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, NotRequired, TypedDict, overload
 import sentry_sdk
 from django.core.cache import cache
 from django.db.models import Q
-from django.http.request import HttpRequest
+from django.http.request import HttpRequest, QueryDict
 from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
@@ -509,6 +509,26 @@ class OrganizationEndpoint(Endpoint):
         if project_slugs:
             return ParsedProjectIdOrSlugParams(ids=set(), slugs=project_slugs)
         return self.get_requested_project_ids_and_slugs_unchecked(request)
+
+    def get_query_params_with_project_slug_precedence(self, request: HttpRequest) -> QueryDict:
+        """
+        Return query params for serializers that accept project and projectSlug.
+
+        This mirrors get_projects() precedence: non-empty legacy projectSlug
+        filters win over project filters, and blank project filters are treated
+        as absent.
+        """
+        query_params = request.GET.copy()
+        project_slug_params = [slug for slug in query_params.getlist("projectSlug") if slug]
+        if "projectSlug" in query_params:
+            query_params.setlist("projectSlug", project_slug_params)
+        if project_slug_params:
+            query_params.pop("project", None)
+        elif "project" in query_params:
+            query_params.setlist(
+                "project", [project for project in query_params.getlist("project") if project]
+            )
+        return query_params
 
     def get_environments(
         self, request: Request, organization: Organization | RpcOrganization

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -400,17 +400,12 @@ class OrganizationEndpoint(Endpoint):
         if project_slugs and project_ids:
             raise ParseError(detail="Cannot query for both ids and slugs")
 
-        query_slugs = set(filter(None, request.GET.getlist("projectSlug")))
         if project_ids:
             requested_projects = ParsedProjectIdOrSlugParams(ids=project_ids, slugs=set())
-        elif project_slugs or query_slugs:
-            # Preserve existing projectSlug behavior: explicit slug filters take
-            # precedence over the project query param.
-            requested_projects = ParsedProjectIdOrSlugParams(
-                ids=set(), slugs=set(project_slugs or query_slugs)
-            )
+        elif project_slugs:
+            requested_projects = ParsedProjectIdOrSlugParams(ids=set(), slugs=set(project_slugs))
         else:
-            requested_projects = self.get_requested_project_ids_and_slugs_unchecked(request)
+            requested_projects = self.get_requested_project_params_unchecked(request)
         ids = requested_projects.ids
         slugs = requested_projects.slugs
 
@@ -500,6 +495,20 @@ class OrganizationEndpoint(Endpoint):
         permission checking, use ``get_projects``, instead.
         """
         return parse_id_or_slug_params(request.GET.getlist("project"))
+
+    def get_requested_project_params_unchecked(
+        self, request: HttpRequest
+    ) -> ParsedProjectIdOrSlugParams:
+        """
+        Returns requested project ids and slugs from projectSlug or project query params.
+
+        To determine the projects to filter this endpoint by with full
+        permission checking, use ``get_projects``, instead.
+        """
+        project_slugs = set(filter(None, request.GET.getlist("projectSlug")))
+        if project_slugs:
+            return ParsedProjectIdOrSlugParams(ids=set(), slugs=project_slugs)
+        return self.get_requested_project_ids_and_slugs_unchecked(request)
 
     def get_environments(
         self, request: Request, organization: Organization | RpcOrganization
@@ -750,16 +759,10 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         elif request.auth is not None:
             actor_id = "apikey:%s" % request.auth.entity_id
         if actor_id is not None:
-            # Match get_projects() precedence: explicit ids, projectSlug, then project.
-            project_slug_params = set(filter(None, request.GET.getlist("projectSlug")))
             if project_ids:
                 requested_projects = ParsedProjectIdOrSlugParams(ids=project_ids, slugs=set())
-            elif project_slug_params:
-                requested_projects = ParsedProjectIdOrSlugParams(
-                    ids=set(), slugs=project_slug_params
-                )
             else:
-                requested_projects = self.get_requested_project_ids_and_slugs_unchecked(request)
+                requested_projects = self.get_requested_project_params_unchecked(request)
             key = "release_perms:1:%s" % hash_values(
                 [
                     actor_id,

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -401,7 +401,7 @@ class OrganizationEndpoint(Endpoint):
             raise ParseError(detail="Cannot query for both ids and slugs")
 
         query_slugs = set(filter(None, request.GET.getlist("projectSlug")))
-        if project_ids is not None:
+        if project_ids:
             requested_projects = ParsedProjectIdOrSlugParams(ids=project_ids, slugs=set())
         elif project_slugs or query_slugs:
             # Preserve existing projectSlug behavior: explicit slug filters take
@@ -752,7 +752,7 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         if actor_id is not None:
             # Match get_projects() precedence: explicit ids, projectSlug, then project.
             project_slug_params = set(filter(None, request.GET.getlist("projectSlug")))
-            if project_ids is not None:
+            if project_ids:
                 requested_projects = ParsedProjectIdOrSlugParams(ids=project_ids, slugs=set())
             elif project_slug_params:
                 requested_projects = ParsedProjectIdOrSlugParams(

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -510,6 +510,17 @@ class OrganizationEndpoint(Endpoint):
             return ParsedProjectIdOrSlugParams(ids=set(), slugs=project_slugs)
         return self.get_requested_project_ids_and_slugs_unchecked(request)
 
+    def get_query_params_without_empty_project_params(self, request: HttpRequest) -> QueryDict:
+        """
+        Return query params with blank project filters treated as absent.
+        """
+        query_params = request.GET.copy()
+        if "project" in query_params:
+            query_params.setlist(
+                "project", [project for project in query_params.getlist("project") if project]
+            )
+        return query_params
+
     def get_query_params_with_project_slug_precedence(self, request: HttpRequest) -> QueryDict:
         """
         Return query params for serializers that accept project and projectSlug.
@@ -518,16 +529,12 @@ class OrganizationEndpoint(Endpoint):
         filters win over project filters, and blank project filters are treated
         as absent.
         """
-        query_params = request.GET.copy()
+        query_params = self.get_query_params_without_empty_project_params(request)
         project_slug_params = [slug for slug in query_params.getlist("projectSlug") if slug]
         if "projectSlug" in query_params:
             query_params.setlist("projectSlug", project_slug_params)
         if project_slug_params:
             query_params.pop("project", None)
-        elif "project" in query_params:
-            query_params.setlist(
-                "project", [project for project in query_params.getlist("project") if project]
-            )
         return query_params
 
     def get_environments(

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -6,6 +6,7 @@ from typing import Any, Literal, NotRequired, TypedDict, overload
 
 import sentry_sdk
 from django.core.cache import cache
+from django.db.models import Q
 from django.http.request import HttpRequest
 from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.permissions import BasePermission
@@ -15,11 +16,12 @@ from rest_framework.views import APIView
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
+from sentry.api.helpers.projects import ParsedProjectIdOrSlugParams, parse_id_or_slug_params
 from sentry.api.permissions import DemoSafePermission, StaffPermissionMixin
 from sentry.api.utils import get_date_range_from_params, is_member_disabled_from_limit
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
-from sentry.constants import ALL_ACCESS_PROJECT_ID, ALL_ACCESS_PROJECTS_SLUG, ObjectStatus
+from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidParams
 from sentry.models.apikey import is_api_key_auth
 from sentry.models.apitoken import is_api_token_auth
@@ -349,8 +351,11 @@ def _validate_fetched_projects(
     """
     Validates that user has access to the specific projects they are requesting.
     """
-    missing_project_ids = ids and ids != {p.id for p in filtered_projects}
-    missing_project_slugs = slugs and slugs != {p.slug for p in filtered_projects}
+    fetched_ids = {p.id for p in filtered_projects}
+    fetched_slugs = {p.slug for p in filtered_projects}
+
+    missing_project_ids = ids and not ids.issubset(fetched_ids)
+    missing_project_slugs = slugs and not slugs.issubset(fetched_slugs)
 
     if missing_project_ids or missing_project_slugs:
         raise PermissionDenied
@@ -389,32 +394,35 @@ class OrganizationEndpoint(Endpoint):
         :return: A list of Project objects, or raises PermissionDenied. When project_ids or project_slugs
         are explicitly provided, the returned list is guaranteed non-empty (or PermissionDenied is raised).
 
-        NOTE: If both project_ids and project_slugs are passed, we will default
-        to fetching projects via project_id list.
+        NOTE: Passing both project_ids and project_slugs raises ``ParseError``.
         """
         qs = Project.objects.filter(organization_id=organization.id, status=ObjectStatus.ACTIVE)
         if project_slugs and project_ids:
             raise ParseError(detail="Cannot query for both ids and slugs")
 
-        slugs = project_slugs or set(filter(None, request.GET.getlist("projectSlug")))
-        ids = project_ids or self.get_requested_project_ids_unchecked(request)
-
-        if project_ids is None and slugs:
-            # If we're querying for project slugs specifically
-            if ALL_ACCESS_PROJECTS_SLUG in slugs:
-                # All projects I have access to
-                include_all_accessible = True
-            else:
-                qs = qs.filter(slug__in=slugs)
+        query_slugs = set(filter(None, request.GET.getlist("projectSlug")))
+        if project_ids is not None:
+            requested_projects = ParsedProjectIdOrSlugParams(ids=project_ids, slugs=set())
+        elif project_slugs or query_slugs:
+            # Preserve existing projectSlug behavior: explicit slug filters take
+            # precedence over the project query param.
+            requested_projects = ParsedProjectIdOrSlugParams(
+                ids=set(), slugs=set(project_slugs or query_slugs)
+            )
         else:
-            # If we are explicitly querying for projects via id
-            # Or we're querying for an empty set of ids
-            if ALL_ACCESS_PROJECT_ID in ids:
-                # All projects i have access to
-                include_all_accessible = True
-            elif ids:
-                qs = qs.filter(id__in=ids)
-            # No project ids === `all projects I am a member of`
+            requested_projects = self.get_requested_project_ids_and_slugs_unchecked(request)
+        ids = requested_projects.ids
+        slugs = requested_projects.slugs
+
+        if requested_projects.has_all_projects_sentinel:
+            include_all_accessible = True
+        elif ids and slugs:
+            qs = qs.filter(Q(id__in=ids) | Q(slug__in=slugs))
+        elif slugs:
+            qs = qs.filter(slug__in=slugs)
+        elif ids:
+            qs = qs.filter(id__in=ids)
+        # No project ids or slugs === `all projects I am a member of`
 
         with sentry_sdk.start_span(op="fetch_organization_projects") as span:
             projects = list(qs)
@@ -472,17 +480,16 @@ class OrganizationEndpoint(Endpoint):
 
             return [p for p in projects if proj_filter(p)]
 
-    def get_requested_project_ids_unchecked(self, request: HttpRequest) -> set[int]:
+    def get_requested_project_ids_and_slugs_unchecked(
+        self, request: HttpRequest
+    ) -> ParsedProjectIdOrSlugParams:
         """
-        Returns the project ids that were requested by the request.
+        Returns the project ids and slugs requested via the project query param.
 
         To determine the projects to filter this endpoint by with full
         permission checking, use ``get_projects``, instead.
         """
-        try:
-            return set(map(int, request.GET.getlist("project")))
-        except ValueError:
-            raise ParseError(detail="Invalid project parameter. Values must be numbers.")
+        return parse_id_or_slug_params(request.GET.getlist("project"))
 
     def get_environments(
         self, request: Request, organization: Organization | RpcOrganization
@@ -723,7 +730,7 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         they cannot access. The all-projects check respects Open Membership
         via has_global_access.
 
-        Results are cached for 60s per actor/org/release/project-ids/mode.
+        Results are cached for 60s per actor/org/release/effective-project-scope/mode.
         """
         actor_id = None
         has_perms = None
@@ -733,9 +740,16 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         elif request.auth is not None:
             actor_id = "apikey:%s" % request.auth.entity_id
         if actor_id is not None:
-            requested_project_ids = project_ids
-            if requested_project_ids is None:
-                requested_project_ids = self.get_requested_project_ids_unchecked(request)
+            # Match get_projects() precedence: explicit ids, projectSlug, then project.
+            project_slug_params = set(filter(None, request.GET.getlist("projectSlug")))
+            if project_ids is not None:
+                requested_projects = ParsedProjectIdOrSlugParams(ids=project_ids, slugs=set())
+            elif project_slug_params:
+                requested_projects = ParsedProjectIdOrSlugParams(
+                    ids=set(), slugs=project_slug_params
+                )
+            else:
+                requested_projects = self.get_requested_project_ids_and_slugs_unchecked(request)
             key = "release_perms:1:%s" % hash_values(
                 [
                     actor_id,
@@ -743,7 +757,8 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
                     release.id if release is not None else 0,
                     int(require_all_projects),
                 ]
-                + sorted(requested_project_ids)
+                + sorted(requested_projects.ids)
+                + sorted(requested_projects.slugs)
             )
             has_perms = cache.get(key)
         if has_perms is None:

--- a/src/sentry/api/endpoints/organization_stats_summary.py
+++ b/src/sentry/api/endpoints/organization_stats_summary.py
@@ -188,12 +188,12 @@ class OrganizationStatsSummaryEndpoint(OrganizationEndpoint):
         return QueryDefinition.from_query_dict(query_dict, params)
 
     def _get_projects_for_orgstats_query(self, request: Request, organization):
-        req_proj_ids = self.get_requested_project_ids_unchecked(request)
+        requested_projects = self.get_requested_project_params_unchecked(request)
 
         # the projects table always filters by project
         # the projects in the table should be those the user has access to
 
-        projects = self.get_projects(request, organization, project_ids=req_proj_ids)
+        projects = self.get_projects(request, organization, project_ids=requested_projects.ids)
         if not projects:
             raise NoProjects("No projects available")
         return [p.id for p in projects]

--- a/src/sentry/api/endpoints/organization_stats_summary.py
+++ b/src/sentry/api/endpoints/organization_stats_summary.py
@@ -21,7 +21,6 @@ from sentry.apidocs.constants import RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.exceptions import InvalidParams
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -188,18 +187,13 @@ class OrganizationStatsSummaryEndpoint(OrganizationEndpoint):
         return QueryDefinition.from_query_dict(query_dict, params)
 
     def _get_projects_for_orgstats_query(self, request: Request, organization):
-        requested_projects = self.get_requested_project_params_unchecked(request)
-
         # the projects table always filters by project
         # the projects in the table should be those the user has access to
 
-        projects = self.get_projects(request, organization, project_ids=requested_projects.ids)
+        projects = self.get_projects(request, organization)
         if not projects:
             raise NoProjects("No projects available")
         return [p.id for p in projects]
-
-    def _is_org_total_query(self, project_ids):
-        return all([not project_ids or project_ids == ALL_ACCESS_PROJECTS])
 
     def _generate_csv(self, projects):
         if not len(projects):

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -17,6 +17,7 @@ from sentry.apidocs.constants import RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.constants import ALL_ACCESS_PROJECTS, ALL_ACCESS_PROJECTS_SLUG
 from sentry.exceptions import InvalidParams
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
@@ -214,12 +215,12 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
             return [p.id for p in projects]
 
     def _is_org_total_query(self, request: Request, requested_projects):
-        return all(
-            [
-                (not requested_projects.ids and not requested_projects.slugs)
-                or requested_projects.has_all_projects_sentinel,
-                "project" not in request.GET.get("groupBy", []),
-            ]
+        no_project_filter = not requested_projects.has_values
+        all_access_filter = (
+            requested_projects.ids == ALL_ACCESS_PROJECTS and not requested_projects.slugs
+        ) or (requested_projects.slugs == {ALL_ACCESS_PROJECTS_SLUG} and not requested_projects.ids)
+        return (no_project_filter or all_access_filter) and "project" not in request.GET.getlist(
+            "groupBy"
         )
 
     @contextmanager

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -17,7 +17,6 @@ from sentry.apidocs.constants import RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.exceptions import InvalidParams
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
@@ -205,19 +204,20 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
         # look at the raw project_id filter passed in, if its empty
         # and project_id is not in groupBy filter, treat it as an
         # org wide query and don't pass project_id in to QueryDefinition
-        req_proj_ids = self.get_requested_project_ids_unchecked(request)
-        if self._is_org_total_query(request, req_proj_ids):
+        requested_projects = self.get_requested_project_params_unchecked(request)
+        if self._is_org_total_query(request, requested_projects):
             return None
         else:
-            projects = self.get_projects(request, organization, project_ids=req_proj_ids)
+            projects = self.get_projects(request, organization, project_ids=requested_projects.ids)
             if not projects:
                 raise NoProjects("No projects available")
             return [p.id for p in projects]
 
-    def _is_org_total_query(self, request: Request, project_ids):
+    def _is_org_total_query(self, request: Request, requested_projects):
         return all(
             [
-                not project_ids or project_ids == ALL_ACCESS_PROJECTS,
+                (not requested_projects.ids and not requested_projects.slugs)
+                or requested_projects.has_all_projects_sentinel,
                 "project" not in request.GET.get("groupBy", []),
             ]
         )

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -208,7 +208,7 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
         if self._is_org_total_query(request, requested_projects):
             return None
         else:
-            projects = self.get_projects(request, organization, project_ids=requested_projects.ids)
+            projects = self.get_projects(request, organization)
             if not projects:
                 raise NoProjects("No projects available")
             return [p.id for p in projects]

--- a/src/sentry/api/helpers/projects.py
+++ b/src/sentry/api/helpers/projects.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import NamedTuple, TypeAlias
 
-from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -11,6 +10,8 @@ from sentry.constants import ALL_ACCESS_PROJECT_ID, ALL_ACCESS_PROJECTS_SLUG
 from sentry.utils.slug import DEFAULT_SLUG_ERROR_MESSAGE, MIXED_SLUG_REGEX
 
 ProjectIdOrSlug: TypeAlias = int | str
+
+PROJECT_ID_OR_SLUG_SCHEMA = {"anyOf": [{"type": "integer"}, {"type": "string"}]}
 
 
 class ParsedProjectIdOrSlugParams(NamedTuple):
@@ -52,7 +53,7 @@ def parse_id_or_slug_params(
     return ParsedProjectIdOrSlugParams(ids=ids, slugs=slugs)
 
 
-@extend_schema_field(field=OpenApiTypes.STR)
+@extend_schema_field(field=PROJECT_ID_OR_SLUG_SCHEMA)
 class ProjectIdOrSlugField(serializers.Field[ProjectIdOrSlug, object, ProjectIdOrSlug, object]):
     default_error_messages = {
         "invalid": "Expected a project ID or slug.",

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -137,25 +137,13 @@ class EnvironmentParams:
 
 
 class OrganizationParams:
-    PROJECT_SLUG = OpenApiParameter(
-        name="projectSlug",
-        location="query",
-        required=False,
-        many=True,
-        type=str,
-        description="""The project slugs to filter by. This legacy parameter takes precedence over `project` if both are provided. Omit this parameter to include all accessible projects. `$all` is also accepted. For example, the following are valid parameters:
-- `/?projectSlug=$all`
-- `/?projectSlug=android&projectSlug=javascript-react`
-""",
-    )
-    PROJECT_ID_OR_SLUG = PROJECT_SLUG
     PROJECT = OpenApiParameter(
         name="project",
         location="query",
         required=False,
         many=True,
         type=str,
-        description="""The IDs or slugs of projects to filter by. Project slugs are unique within each organization. Omit this parameter to include all accessible projects. `-1` is also accepted.
+        description="""The IDs or slugs of projects to filter by. Project slugs are unique within each organization. Omit this parameter to include all accessible projects. `-1` is also accepted to include all accessible projects.
 For example, the following are valid parameters:
 - `/?project=1234&project=56789`
 - `/?project=android&project=javascript-react`

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -137,6 +137,17 @@ class EnvironmentParams:
 
 
 class OrganizationParams:
+    PROJECT_SLUG = OpenApiParameter(
+        name="projectSlug",
+        location="query",
+        required=False,
+        many=True,
+        type=str,
+        description="""The project slugs to filter by. This legacy parameter takes precedence over `project` if both are provided. Prefer `project`, which accepts project IDs or slugs. Use `$all` to include all available projects. For example, the following are valid parameters:
+- `/?projectSlug=$all`
+- `/?projectSlug=android&projectSlug=javascript-react`
+""",
+    )
     PROJECT = OpenApiParameter(
         name="project",
         location="query",

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -137,6 +137,17 @@ class EnvironmentParams:
 
 
 class OrganizationParams:
+    PROJECT_ID_OR_SLUG = OpenApiParameter(
+        name="project_id_or_slug",
+        location="query",
+        required=False,
+        many=True,
+        type=str,
+        description="""The legacy project slug filter. Prefer `project`, which accepts project IDs or slugs. Use `$all` to include all available projects. For example, the following are valid parameters:
+- `/?projectSlug=$all`
+- `/?projectSlug=android&projectSlug=javascript-react`
+""",
+    )
     PROJECT_SLUG = OpenApiParameter(
         name="projectSlug",
         location="query",

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -44,7 +44,7 @@ class GlobalParams:
     )
     PROJECT_ID_OR_SLUG = OpenApiParameter(
         name="project_id_or_slug",
-        description="The ID or slug of the project the resource belongs to.",
+        description="The ID or slug of the project the resource belongs to. Project slugs are unique within each organization.",
         required=True,
         type=str,
         location="path",
@@ -137,26 +137,28 @@ class EnvironmentParams:
 
 
 class OrganizationParams:
-    PROJECT_ID_OR_SLUG = OpenApiParameter(
-        name="project_id_or_slug",
+    PROJECT_SLUG = OpenApiParameter(
+        name="projectSlug",
         location="query",
         required=False,
         many=True,
         type=str,
-        description="""The project slugs to filter by. Use `$all` to include all available projects. For example, the following are valid parameters:
+        description="""The project slugs to filter by. This legacy parameter takes precedence over `project` if both are provided. Omit this parameter to include all accessible projects. `$all` is also accepted. For example, the following are valid parameters:
 - `/?projectSlug=$all`
 - `/?projectSlug=android&projectSlug=javascript-react`
 """,
     )
+    PROJECT_ID_OR_SLUG = PROJECT_SLUG
     PROJECT = OpenApiParameter(
         name="project",
         location="query",
         required=False,
         many=True,
-        type=int,
-        description="""The IDs of projects to filter by. `-1` means all available projects.
+        type=str,
+        description="""The IDs or slugs of projects to filter by. Project slugs are unique within each organization. Omit this parameter to include all accessible projects. `-1` is also accepted.
 For example, the following are valid parameters:
 - `/?project=1234&project=56789`
+- `/?project=android&project=javascript-react`
 - `/?project=-1`
 """,
     )

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -142,10 +142,11 @@ class OrganizationParams:
         location="query",
         required=False,
         many=True,
-        type=int,
-        description="""The IDs of projects to filter by. Omit this parameter to include all accessible projects. `-1` is also accepted to include all accessible projects.
+        type=str,
+        description="""The IDs or slugs of projects to filter by. Project slugs are unique within each organization. Omit this parameter to include all accessible projects. `-1` is also accepted to include all accessible projects.
 For example, the following are valid parameters:
 - `/?project=1234&project=56789`
+- `/?project=android&project=javascript-react`
 - `/?project=-1`
 """,
     )

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -5,6 +5,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
 
 from sentry import constants
+from sentry.api.helpers.projects import PROJECT_ID_OR_SLUG_SCHEMA
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.sessions import STATS_PERIODS
 
@@ -164,7 +165,7 @@ class OrganizationParams:
         location="query",
         required=False,
         many=True,
-        type=str,
+        type=PROJECT_ID_OR_SLUG_SCHEMA,
         description="""The IDs or slugs of projects to filter by. Project slugs are unique within each organization. Omit this parameter to include all accessible projects. `-1` is also accepted to include all accessible projects.
 For example, the following are valid parameters:
 - `/?project=1234&project=56789`

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -164,8 +164,7 @@ class OrganizationParams:
         name="project",
         location="query",
         required=False,
-        many=True,
-        type=PROJECT_ID_OR_SLUG_SCHEMA,
+        type={"type": "array", "items": PROJECT_ID_OR_SLUG_SCHEMA},
         description="""The IDs or slugs of projects to filter by. Project slugs are unique within each organization. Omit this parameter to include all accessible projects. `-1` is also accepted to include all accessible projects.
 For example, the following are valid parameters:
 - `/?project=1234&project=56789`

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -142,11 +142,10 @@ class OrganizationParams:
         location="query",
         required=False,
         many=True,
-        type=str,
-        description="""The IDs or slugs of projects to filter by. Project slugs are unique within each organization. Omit this parameter to include all accessible projects. `-1` is also accepted to include all accessible projects.
+        type=int,
+        description="""The IDs of projects to filter by. Omit this parameter to include all accessible projects. `-1` is also accepted to include all accessible projects.
 For example, the following are valid parameters:
 - `/?project=1234&project=56789`
-- `/?project=android&project=javascript-react`
 - `/?project=-1`
 """,
     )

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -526,14 +526,15 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         Fetches metric, issue, crons, and uptime alert rules for an organization
         """
         # Common setup: project resolution
-        project_ids = self.get_requested_project_ids_unchecked(request) or None
+        requested_projects = self.get_requested_project_params_unchecked(request)
+        project_ids = requested_projects.ids or None
         if project_ids == {-1}:  # All projects for org:
             project_ids = set(
                 Project.objects.filter(
                     organization=organization, status=ObjectStatus.ACTIVE
                 ).values_list("id", flat=True)
             )
-        elif project_ids is None:  # All projects for user
+        elif project_ids is None and not requested_projects.slugs:  # All projects for user
             org_team_list = Team.objects.filter(organization=organization).values_list(
                 "id", flat=True
             )

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -67,7 +67,6 @@ from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
 from sentry.middleware import is_frontend_request
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
-from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.monitors.models import (
@@ -525,32 +524,10 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         """
         Fetches metric, issue, crons, and uptime alert rules for an organization
         """
-        # Common setup: project resolution
-        requested_projects = self.get_requested_project_params_unchecked(request)
-        project_ids = requested_projects.ids or None
-        if project_ids == {-1}:  # All projects for org:
-            project_ids = set(
-                Project.objects.filter(
-                    organization=organization, status=ObjectStatus.ACTIVE
-                ).values_list("id", flat=True)
-            )
-        elif project_ids is None and not requested_projects.slugs:  # All projects for user
-            org_team_list = Team.objects.filter(organization=organization).values_list(
-                "id", flat=True
-            )
-            user_team_list = OrganizationMemberTeam.objects.filter(
-                organizationmember__user_id=request.user.id, team__in=org_team_list
-            ).values_list("team", flat=True)
-            project_ids = set(
-                Project.objects.filter(
-                    teams__in=user_team_list, status=ObjectStatus.ACTIVE
-                ).values_list("id", flat=True)
-            )
-
         # Materialize the project ids here. This helps us to not overwhelm the query planner with
         # overcomplicated subqueries. Previously, this was causing Postgres to use a suboptimal
         # index to filter on. Also enforces permission checks.
-        projects = self.get_projects(request, organization, project_ids=project_ids)
+        projects = self.get_projects(request, organization)
 
         # Common setup: team parsing
         teams = request.GET.getlist("team", [])

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -62,7 +62,6 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             OrganizationParams.PROJECT,
-            OrganizationParams.PROJECT_ID_OR_SLUG,
             NotificationParams.TRIGGER_TYPE,
         ],
         responses={

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -62,6 +62,7 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             OrganizationParams.PROJECT,
+            OrganizationParams.PROJECT_SLUG,
             NotificationParams.TRIGGER_TYPE,
         ],
         responses={
@@ -81,6 +82,7 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         For example, organization owners and managers can receive an email when a spike occurs.
 
         You can use the `project` query parameter with project IDs or slugs to filter for certain projects.
+        The legacy `projectSlug` query parameter is also supported and takes priority if both are present.
         """
         queryset = NotificationAction.objects.filter(organization_id=organization.id)
         # If a project query is specified, filter out non-project-specific actions

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -62,7 +62,7 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             OrganizationParams.PROJECT,
-            OrganizationParams.PROJECT_SLUG,
+            OrganizationParams.PROJECT_ID_OR_SLUG,
             NotificationParams.TRIGGER_TYPE,
         ],
         responses={
@@ -82,7 +82,7 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         For example, organization owners and managers can receive an email when a spike occurs.
 
         You can use the `project` query parameter with project IDs or slugs to filter for certain projects.
-        The legacy `projectSlug` query parameter is also supported and takes priority if both are present.
+        A legacy project slug query parameter is also supported and takes priority if both are present.
         """
         queryset = NotificationAction.objects.filter(organization_id=organization.id)
         # If a project query is specified, filter out non-project-specific actions

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -80,7 +80,7 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         Notification Actions notify a set of members when an action has been triggered through a notification service such as Slack or Sentry.
         For example, organization owners and managers can receive an email when a spike occurs.
 
-        You can use either the `project` or `projectSlug` query parameter to filter for certain projects. Note that if both are present, `projectSlug` takes priority.
+        You can use the `project` query parameter with project IDs or slugs to filter for certain projects.
         """
         queryset = NotificationAction.objects.filter(organization_id=organization.id)
         # If a project query is specified, filter out non-project-specific actions

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -18,6 +18,7 @@ from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
 from sentry.apidocs.examples.notification_examples import NotificationActionExamples
 from sentry.apidocs.parameters import GlobalParams, NotificationParams, OrganizationParams
 from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
+from sentry.constants import ALL_ACCESS_PROJECTS, ALL_ACCESS_PROJECTS_SLUG
 from sentry.models.organization import Organization
 from sentry.notifications.api.serializers.notification_action_request import (
     NotificationActionSerializer,
@@ -88,9 +89,12 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         # If a project query is specified, filter out non-project-specific actions
         # otherwise, include them but still ensure project permissions are enforced
         requested_projects = self.get_requested_project_params_unchecked(request)
+        all_access_filter = (
+            requested_projects.ids == ALL_ACCESS_PROJECTS and not requested_projects.slugs
+        ) or (requested_projects.slugs == {ALL_ACCESS_PROJECTS_SLUG} and not requested_projects.ids)
         project_query = (
             Q(projects__in=self.get_projects(request, organization))
-            if requested_projects.ids or requested_projects.slugs
+            if requested_projects.has_values and not all_access_filter
             else Q(projects=None) | Q(projects__in=self.get_projects(request, organization))
         )
         queryset = queryset.filter(project_query).distinct()

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -86,9 +86,10 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         queryset = NotificationAction.objects.filter(organization_id=organization.id)
         # If a project query is specified, filter out non-project-specific actions
         # otherwise, include them but still ensure project permissions are enforced
+        requested_projects = self.get_requested_project_params_unchecked(request)
         project_query = (
             Q(projects__in=self.get_projects(request, organization))
-            if self.get_requested_project_ids_unchecked(request)
+            if requested_projects.ids or requested_projects.slugs
             else Q(projects=None) | Q(projects__in=self.get_projects(request, organization))
         )
         queryset = queryset.filter(project_query).distinct()
@@ -102,7 +103,8 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
             extra={
                 "organization_id": organization.id,
                 "trigger_type_query": trigger_type_query,
-                "project_query": self.get_requested_project_ids_unchecked(request),
+                "project_query": requested_projects.ids,
+                "project_slug_query": requested_projects.slugs,
             },
         )
         return self.paginate(

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -82,7 +82,6 @@ class OrganizationReplayCountEndpoint(OrganizationEventsEndpointBase):
             GlobalParams.END,
             GlobalParams.STATS_PERIOD,
             OrganizationParams.PROJECT,
-            OrganizationParams.PROJECT_ID_OR_SLUG,
             VisibilityParams.QUERY,
             ReplayParams.DATA_SOURCE,
             ReplayParams.RETURN_IDS,

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -82,6 +82,7 @@ class OrganizationReplayCountEndpoint(OrganizationEventsEndpointBase):
             GlobalParams.END,
             GlobalParams.STATS_PERIOD,
             OrganizationParams.PROJECT,
+            OrganizationParams.PROJECT_ID_OR_SLUG,
             VisibilityParams.QUERY,
             ReplayParams.DATA_SOURCE,
             ReplayParams.RETURN_IDS,

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -17,6 +17,7 @@ from sentry.api.bases.organization import (
     OrganizationAndStaffPermission,
     OrganizationEndpoint,
     OrganizationPermission,
+    OrganizationReleasesBaseEndpoint,
 )
 from sentry.api.exceptions import (
     MemberDisabledOverLimit,
@@ -556,15 +557,8 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
     @mock.patch(
         "sentry.api.bases.organization.OrganizationEndpoint._filter_projects_by_permissions"
     )
-    @mock.patch(
-        "sentry.api.bases.organization.OrganizationEndpoint.get_requested_project_ids_unchecked"
-    )
-    def test_get_projects_no_slug_fallsback_to_ids(
-        self, mock_get_project_ids_unchecked, mock__filter_projects_by_permissions
-    ):
-        project_slugs = [""]
-        request = self.build_request(projectSlug=project_slugs)
-        mock_get_project_ids_unchecked.return_value = {self.project_1.id}
+    def test_get_projects_no_slug_fallsback_to_ids(self, mock__filter_projects_by_permissions):
+        request = self.build_request(projectSlug=[""], project=[str(self.project_1.id)])
 
         def side_effect(
             projects,
@@ -579,7 +573,6 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
             self.org,
         )
 
-        mock_get_project_ids_unchecked.assert_called_with(request)
         mock__filter_projects_by_permissions.assert_called_with(
             projects=[self.project_1],
             request=request,
@@ -656,6 +649,77 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
 
         with pytest.raises(PermissionDenied):
             self.endpoint.get_projects(request, self.org)
+
+    def test_project_param_with_slug(self) -> None:
+        self.create_team_membership(user=self.user, team=self.team_1)
+        request = self.build_request(project=[self.project_1.slug])
+
+        result = self.endpoint.get_projects(request, self.org)
+
+        assert {p.id for p in result} == {self.project_1.id}
+
+    def test_project_param_with_mixed_ids_and_slugs(self) -> None:
+        self.create_team_membership(user=self.user, team=self.team_3)
+        request = self.build_request(project=[str(self.project_1.id), self.project_2.slug])
+
+        result = self.endpoint.get_projects(request, self.org)
+
+        assert {p.id for p in result} == {self.project_1.id, self.project_2.id}
+
+    def test_project_param_with_nonexistent_slug(self) -> None:
+        self.create_team_membership(user=self.user, team=self.team_1)
+        request = self.build_request(project=["nonexistent-slug"])
+
+        with pytest.raises(PermissionDenied):
+            self.endpoint.get_projects(request, self.org)
+
+    def test_project_slug_param_takes_precedence_over_project_param(self) -> None:
+        self.create_team_membership(user=self.user, team=self.team_3)
+        request = self.build_request(
+            project=[str(self.project_1.id)], projectSlug=[self.project_2.slug]
+        )
+
+        result = self.endpoint.get_projects(request, self.org)
+
+        assert {p.id for p in result} == {self.project_2.id}
+
+    def test_empty_explicit_project_slugs_falls_back_to_project_param(self) -> None:
+        self.create_team_membership(user=self.user, team=self.team_1)
+        request = self.build_request(project=[str(self.project_1.id)])
+
+        result = self.endpoint.get_projects(request, self.org, project_slugs=set())
+
+        assert {p.id for p in result} == {self.project_1.id}
+
+    @mock.patch("sentry.api.bases.organization.cache")
+    def test_release_permission_cache_key_uses_project_slug_precedence(
+        self, mock_cache: mock.MagicMock
+    ) -> None:
+        self.create_team_membership(user=self.user, team=self.team_3)
+        mock_cache.get.return_value = None
+        endpoint = OrganizationReleasesBaseEndpoint()
+
+        endpoint.has_release_permission(
+            self.build_request(project=[self.project_1.slug], projectSlug=[self.project_2.slug]),
+            self.org,
+        )
+        first_cache_key = mock_cache.get.call_args.args[0]
+
+        endpoint.has_release_permission(
+            self.build_request(project=[self.project_2.slug], projectSlug=[self.project_1.slug]),
+            self.org,
+        )
+        second_cache_key = mock_cache.get.call_args.args[0]
+
+        assert first_cache_key != second_cache_key
+
+    def test_get_requested_project_ids_and_slugs_unchecked(self) -> None:
+        request = self.build_request(project=["1", "my-slug", "42"])
+
+        result = self.endpoint.get_requested_project_ids_and_slugs_unchecked(request)
+
+        assert result.ids == {1, 42}
+        assert result.slugs == {"my-slug"}
 
 
 class GetEnvironmentsTest(BaseOrganizationEndpointTest):

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -765,6 +765,14 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
         assert "project" not in result
         assert request.GET.getlist("project") == ["1", ""]
 
+    def test_query_params_without_empty_project_params(self) -> None:
+        request = self.build_request(project=["", "1"])
+
+        result = self.endpoint.get_query_params_without_empty_project_params(request)
+
+        assert result.getlist("project") == ["1"]
+        assert request.GET.getlist("project") == ["", "1"]
+
     def test_query_params_with_empty_project_slug_keeps_project(self) -> None:
         request = self.build_request(project=["", "1"], projectSlug=[""])
 

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -756,6 +756,23 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
         assert result.ids == {1, 42}
         assert result.slugs == {"my-slug"}
 
+    def test_query_params_with_project_slug_precedence(self) -> None:
+        request = self.build_request(project=["1", ""], projectSlug=["", "my-slug"])
+
+        result = self.endpoint.get_query_params_with_project_slug_precedence(request)
+
+        assert result.getlist("projectSlug") == ["my-slug"]
+        assert "project" not in result
+        assert request.GET.getlist("project") == ["1", ""]
+
+    def test_query_params_with_empty_project_slug_keeps_project(self) -> None:
+        request = self.build_request(project=["", "1"], projectSlug=[""])
+
+        result = self.endpoint.get_query_params_with_project_slug_precedence(request)
+
+        assert result.getlist("projectSlug") == []
+        assert result.getlist("project") == ["1"]
+
 
 class GetEnvironmentsTest(BaseOrganizationEndpointTest):
     def setUp(self) -> None:

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -713,6 +713,13 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
 
         assert first_cache_key != second_cache_key
 
+    def test_get_requested_project_ids_unchecked_ignores_slugs(self) -> None:
+        request = self.build_request(project=["1", "my-slug", "42"])
+
+        result = self.endpoint.get_requested_project_ids_unchecked(request)
+
+        assert result == {1, 42}
+
     def test_get_requested_project_ids_and_slugs_unchecked(self) -> None:
         request = self.build_request(project=["1", "my-slug", "42"])
 

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -691,6 +691,14 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
 
         assert {p.id for p in result} == {self.project_1.id}
 
+    def test_empty_explicit_project_ids_falls_back_to_project_param_slugs(self) -> None:
+        self.create_team_membership(user=self.user, team=self.team_3)
+        request = self.build_request(project=[self.project_1.slug])
+
+        result = self.endpoint.get_projects(request, self.org, project_ids=set())
+
+        assert {p.id for p in result} == {self.project_1.id}
+
     @mock.patch("sentry.api.bases.organization.cache")
     def test_release_permission_cache_key_uses_project_slug_precedence(
         self, mock_cache: mock.MagicMock
@@ -708,6 +716,26 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
         endpoint.has_release_permission(
             self.build_request(project=[self.project_2.slug], projectSlug=[self.project_1.slug]),
             self.org,
+        )
+        second_cache_key = mock_cache.get.call_args.args[0]
+
+        assert first_cache_key != second_cache_key
+
+    @mock.patch("sentry.api.bases.organization.cache")
+    def test_release_permission_cache_key_uses_project_param_slugs_when_project_ids_empty(
+        self, mock_cache: mock.MagicMock
+    ) -> None:
+        self.create_team_membership(user=self.user, team=self.team_3)
+        mock_cache.get.return_value = None
+        endpoint = OrganizationReleasesBaseEndpoint()
+
+        endpoint.has_release_permission(
+            self.build_request(project=[self.project_1.slug]), self.org, project_ids=set()
+        )
+        first_cache_key = mock_cache.get.call_args.args[0]
+
+        endpoint.has_release_permission(
+            self.build_request(project=[self.project_2.slug]), self.org, project_ids=set()
         )
         second_cache_key = mock_cache.get.call_args.args[0]
 

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -1486,6 +1486,19 @@ class OrganizationCombinedRuleIndexWorkflowEngineTest(BaseAlertRuleSerializerTes
         for rule in response.data:
             assert rule["type"] == "alert_rule"
 
+    def test_workflow_engine_filters_by_project_slug(self) -> None:
+        alert_rule1 = self.create_alert_rule(name="Project Slug Rule 1", projects=[self.project])
+        alert_rule2 = self.create_alert_rule(name="Project Slug Rule 2", projects=[self.project2])
+
+        migrate_alert_rule(alert_rule1)
+        migrate_alert_rule(alert_rule2)
+
+        response = self.get_success_response(self.organization.slug, project=[self.project.slug])
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["name"] == "Project Slug Rule 1"
+
     def test_workflow_engine_filtering_by_team(self) -> None:
         # Create second team for testing
         team2 = self.create_team(organization=self.organization, name="Team 2")

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -1499,6 +1499,20 @@ class OrganizationCombinedRuleIndexWorkflowEngineTest(BaseAlertRuleSerializerTes
         assert len(response.data) == 1
         assert response.data[0]["name"] == "Project Slug Rule 1"
 
+    def test_workflow_engine_filters_by_project_id_and_slug(self) -> None:
+        alert_rule1 = self.create_alert_rule(name="Project ID Rule", projects=[self.project])
+        alert_rule2 = self.create_alert_rule(name="Project Slug Rule", projects=[self.project2])
+
+        migrate_alert_rule(alert_rule1)
+        migrate_alert_rule(alert_rule2)
+
+        response = self.get_success_response(
+            self.organization.slug, project=[self.project.id, self.project2.slug]
+        )
+
+        assert response.status_code == 200
+        assert {rule["name"] for rule in response.data} == {"Project ID Rule", "Project Slug Rule"}
+
     def test_workflow_engine_filtering_by_team(self) -> None:
         # Create second team for testing
         team2 = self.create_team(organization=self.organization, name="Team 2")

--- a/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
+++ b/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
@@ -6,6 +6,7 @@ import responses
 from rest_framework import serializers, status
 
 from sentry.api.serializers.base import serialize
+from sentry.constants import ALL_ACCESS_PROJECTS_SLUG
 from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.notifications.models.notificationaction import (
@@ -90,6 +91,25 @@ class NotificationActionsIndexEndpointTest(APITestCase):
         assert serialize(other_notif_action) not in response.data
         for action in notif_actions:
             assert serialize(action) in response.data
+
+    def test_get_project_slug_all_includes_org_actions(self) -> None:
+        project_notif_action = self.create_notification_action(
+            organization=self.organization,
+            projects=self.projects,
+        )
+        org_notif_action = self.create_notification_action(organization=self.organization)
+        other_notif_action = self.create_notification_action(organization=self.other_organization)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            status_code=status.HTTP_200_OK,
+            qs_params={"projectSlug": ALL_ACCESS_PROJECTS_SLUG},
+        )
+
+        assert len(response.data) == 2
+        assert serialize(project_notif_action) in response.data
+        assert serialize(org_notif_action) in response.data
+        assert serialize(other_notif_action) not in response.data
 
     @patch.object(
         NotificationAction,

--- a/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
+++ b/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
@@ -133,6 +133,10 @@ class NotificationActionsIndexEndpointTest(APITestCase):
                 "query": {"project": project.id},
                 "result": {na2, na3},
             },
+            "regular project slug": {
+                "query": {"project": project.slug},
+                "result": {na2, na3},
+            },
             "regular trigger": {
                 "query": {"triggerType": "teacher"},
                 "result": {na1, na2, na4},

--- a/tests/snuba/api/endpoints/test_organization_stats_summary.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_summary.py
@@ -606,6 +606,24 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
         }
 
     @freeze_time(_now)
+    def test_project_filter_with_id_and_slug(self) -> None:
+        response = self.do_request(
+            {
+                "project": [self.project.id, self.project2.slug],
+                "statsPeriod": "1d",
+                "interval": "1d",
+                "field": ["sum(quantity)"],
+                "category": ["error", "transaction"],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert {project["id"] for project in response.data["projects"]} == {
+            self.project.id,
+            self.project2.id,
+        }
+
+    @freeze_time(_now)
     def test_reason_filter(self) -> None:
         make_request = functools.partial(
             self.client.get,

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -701,6 +701,32 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
         }
 
     @freeze_time(_now)
+    def test_project_slug_filter(self) -> None:
+        response = self.do_request(
+            {
+                "project": self.project.slug,
+                "statsPeriod": "1d",
+                "interval": "1d",
+                "field": ["sum(quantity)"],
+                "category": ["error", "transaction"],
+            },
+            org=self.org,
+            status_code=200,
+        )
+
+        assert result_sorted(response.data) == {
+            "start": isoformat_z(floor_to_utc_day(self._now) - timedelta(days=1)),
+            "end": isoformat_z(floor_to_utc_day(self._now) + timedelta(days=1)),
+            "intervals": [
+                isoformat_z(floor_to_utc_day(self._now) - timedelta(days=1)),
+                isoformat_z(floor_to_utc_day(self._now)),
+            ],
+            "groups": [
+                {"by": {}, "totals": {"sum(quantity)": 6}, "series": {"sum(quantity)": [0, 6]}}
+            ],
+        }
+
+    @freeze_time(_now)
     def test_staff_project_filter(self) -> None:
         staff_user = self.create_user(is_staff=True, is_superuser=True)
         self.login_as(user=staff_user, superuser=True)

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -727,6 +727,22 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
         }
 
     @freeze_time(_now)
+    def test_project_filter_with_id_and_slug(self) -> None:
+        response = self.do_request(
+            {
+                "project": [self.project.id, self.project2.slug],
+                "statsPeriod": "1d",
+                "interval": "1d",
+                "field": ["sum(quantity)"],
+                "category": ["error", "transaction"],
+            },
+            org=self.org,
+            status_code=200,
+        )
+
+        assert response.data["groups"][0]["totals"]["sum(quantity)"] == 7
+
+    @freeze_time(_now)
     def test_staff_project_filter(self) -> None:
         staff_user = self.create_user(is_staff=True, is_superuser=True)
         self.login_as(user=staff_user, superuser=True)

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -382,6 +382,27 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
         }
 
     @freeze_time(_now)
+    def test_user_no_proj_specific_access_with_multiple_groupbys(self) -> None:
+        response = self.do_request(
+            {
+                "project": [-1],
+                "statsPeriod": "1d",
+                "interval": "1d",
+                "field": ["sum(quantity)"],
+                "category": ["error", "transaction"],
+                "groupBy": ["category", "project"],
+            },
+            user=self.user2,
+            status_code=200,
+        )
+
+        assert result_sorted(response.data) == {
+            "start": isoformat_z(floor_to_utc_day(self._now) - timedelta(days=1)),
+            "end": isoformat_z(floor_to_utc_day(self._now) + timedelta(days=1)),
+            "groups": [],
+        }
+
+    @freeze_time(_now)
     def test_no_project_access(self) -> None:
         user = self.create_user(is_superuser=False)
         self.create_member(user=user, organization=self.organization, role="member", teams=[])


### PR DESCRIPTION
Organization project resolution now accepts project IDs, slugs, or mixed ID-and-slug values through the canonical `project` query parameter. Permission checks still run through `get_projects()`, legacy `projectSlug` filters keep existing runtime precedence, existing `projectSlug` OpenAPI fields remain available, empty project filters are treated as absent, and stats endpoints preserve permission-scoped project materialization when grouping by project.

This PR is stacked on #117445 and intentionally stops at the shared organization resolver, generic API docs, stats, and combined-alert callers. Product-specific endpoint opt-ins are split into separate draft PRs against this resolver branch.