### PR TITLE
ref(seer): Only action AUTOFIX verdicts in night shift

### DIFF
--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -120,12 +120,16 @@ def _process_verdicts(
         if v.action == TriageAction.SKIP and v.group_id in groups_by_id:
             mark_skipped(v.group_id)
 
+    # For now we want to ignore TriageAction.ROOT_CAUSE_ONLY since
+    # we're not getting much value from these. So we only action
+    # full TriageAction.AUTOFIX actions.
+    fixable_actions = (TriageAction.AUTOFIX,)
+
     # Convert verdicts to TriageResult objects for the shared function
     fixable_candidates = [
         TriageResult(group=groups_by_id[v.group_id], action=v.action, reason=v.reason)
         for v in triage_response.verdicts
-        if v.action in (TriageAction.AUTOFIX, TriageAction.ROOT_CAUSE_ONLY)
-        and v.group_id in groups_by_id
+        if v.action in fixable_actions and v.group_id in groups_by_id
     ]
 
     sentry_sdk.metrics.distribution("night_shift.candidates_selected", len(fixable_candidates))

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -157,12 +157,7 @@ class TestDeliverNightShiftResult(TestCase):
         assert results[0].extras["action"] == TriageAction.AUTOFIX.value
 
     def test_root_cause_only_verdict_is_not_actioned(self) -> None:
-        """ROOT_CAUSE_ONLY verdicts are intentionally ignored.
-
-        We're not getting much value from root-cause-only runs, so only full
-        AUTOFIX verdicts trigger autofix. ROOT_CAUSE_ONLY verdicts should not
-        trigger autofix or persist a result.
-        """
+        """ROOT_CAUSE_ONLY verdicts are intentionally ignored."""
         org = self.create_organization()
         project = self.create_project(organization=org)
         project.update_option(

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -156,8 +156,13 @@ class TestDeliverNightShiftResult(TestCase):
         assert results[0].seer_run_id == "42"
         assert results[0].extras["action"] == TriageAction.AUTOFIX.value
 
-    def test_root_cause_only_verdict_uses_root_cause_stopping_point(self) -> None:
-        """ROOT_CAUSE_ONLY verdicts should use ROOT_CAUSE stopping point."""
+    def test_root_cause_only_verdict_is_not_actioned(self) -> None:
+        """ROOT_CAUSE_ONLY verdicts are intentionally ignored.
+
+        We're not getting much value from root-cause-only runs, so only full
+        AUTOFIX verdicts trigger autofix. ROOT_CAUSE_ONLY verdicts should not
+        trigger autofix or persist a result.
+        """
         org = self.create_organization()
         project = self.create_project(organization=org)
         project.update_option(
@@ -188,10 +193,9 @@ class TestDeliverNightShiftResult(TestCase):
                 error=None,
             )
 
-            mock_trigger.assert_called_once()
-            assert (
-                mock_trigger.call_args.kwargs["stopping_point"] == AutofixStoppingPoint.ROOT_CAUSE
-            )
+            mock_trigger.assert_not_called()
+
+        assert not SeerNightShiftRunResult.objects.filter(run=run).exists()
 
     def test_dry_run_skips_autofix(self) -> None:
         """Dry run mode should not trigger autofix or persist results."""


### PR DESCRIPTION
## Summary

Night shift currently triggers autofix for both `AUTOFIX` and `ROOT_CAUSE_ONLY`
verdicts. We're not getting much value from the root-cause-only runs, so this
change stops actioning them — only full `AUTOFIX` verdicts now trigger autofix.

## Changes

- `_process_verdicts` filters fixable candidates to `TriageAction.AUTOFIX` only.
- Updated `test_root_cause_only_verdict_*` to assert `ROOT_CAUSE_ONLY` verdicts
  are no longer actioned (no autofix triggered, no result persisted).

## Testing

`pytest tests/sentry/seer/night_shift/test_delivery.py` — 12 passed.



Agent transcript: https://claudescope.sentry.dev/share/2sm24Xu2f8pYMGsd2Wms8Y8bVuvMMO6ZtowQkZ17bYI