### PR TITLE
ref(exports): formalize types for DataExportPayload

### DIFF
--- a/static/app/components/exports/dataExport.spec.tsx
+++ b/static/app/components/exports/dataExport.spec.tsx
@@ -3,7 +3,10 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {DataExport} from 'sentry/components/exports/dataExport';
-import {ExportQueryType} from 'sentry/components/exports/useDataExport';
+import {
+  type DataExportPayload,
+  ExportQueryType,
+} from 'sentry/components/exports/useDataExport';
 import type {Organization} from 'sentry/types/organization';
 
 const mockUnauthorizedOrg = OrganizationFixture({
@@ -16,8 +19,8 @@ const mockAuthorizedOrg = OrganizationFixture({
 
 const mockPayload = {
   queryType: ExportQueryType.ISSUES_BY_TAG,
-  queryInfo: {project_id: '1', group_id: '1027', key: 'user'},
-};
+  queryInfo: {project: '1', group: '1027', key: 'user'},
+} satisfies DataExportPayload;
 
 const mockContext = (organization: Organization) => {
   return {organization};
@@ -116,7 +119,9 @@ describe('DataExport', () => {
     });
 
     rerender(
-      <DataExport payload={{...mockPayload, queryType: ExportQueryType.DISCOVER}} />
+      <DataExport
+        payload={{...mockPayload, queryInfo: {...mockPayload.queryInfo, key: 'browser'}}}
+      />
     );
 
     await waitFor(() => {

--- a/static/app/components/exports/useDataExport.spec.ts
+++ b/static/app/components/exports/useDataExport.spec.ts
@@ -3,7 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {ExportQueryType, useDataExport} from 'sentry/components/exports/useDataExport';
+import {
+  type DataExportPayload,
+  ExportQueryType,
+  useDataExport,
+} from 'sentry/components/exports/useDataExport';
 import {downloadFromHref} from 'sentry/utils/downloadFromHref';
 
 jest.mock('sentry/actionCreators/indicator');
@@ -15,8 +19,8 @@ const mockAuthorizedOrg = OrganizationFixture({
 
 const mockPayload = {
   queryType: ExportQueryType.ISSUES_BY_TAG,
-  queryInfo: {project_id: '1', group_id: '1027', key: 'user'},
-};
+  queryInfo: {project: '1', group: '1027', key: 'user'},
+} satisfies DataExportPayload;
 
 const requestBase = {
   url: `/organizations/${mockAuthorizedOrg.slug}/data-export/`,

--- a/static/app/components/exports/useDataExport.ts
+++ b/static/app/components/exports/useDataExport.ts
@@ -1,14 +1,17 @@
 import {useCallback} from 'react';
 
+import type {EventQuery} from 'sentry/actionCreators/events';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
 import type {ResponseMeta} from 'sentry/types/api';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import type {LocationQuery} from 'sentry/utils/discover/eventView';
 import {downloadFromHref} from 'sentry/utils/downloadFromHref';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {createLogDownloadFilename} from 'sentry/views/explore/logs/createLogDownloadFilename';
+import type {TraceItemDataset} from 'sentry/views/explore/types';
 
 // NOTE: Coordinate with other ExportQueryType (src/sentry/data_export/base.py)
 export enum ExportQueryType {
@@ -21,16 +24,50 @@ export enum ExportQueryType {
 // NOTE: Coordinate with data_export's OutputMode (src/sentry/data_export/writers.py)
 export type DataExportFormat = 'csv' | 'jsonl';
 
-export interface DataExportPayload {
-  /**
-   * TODO(LOGS-702): Formalize different possible payloads
-   */
-  queryInfo: any;
-  queryType: ExportQueryType;
+interface IssuesByTagQueryInfo {
+  group: number | string;
+  key: string;
+  project: number | string;
+}
 
+type DiscoverQueryInfo = EventQuery & LocationQuery;
+
+interface ExploreQueryInfo {
+  dataset: TraceItemDataset;
+  field: string[];
+  project: number[];
+  query: string;
+  sort: string[];
+  end?: string;
+  environment?: string[];
+  start?: string;
+  statsPeriod?: string;
+}
+
+interface DataExportPayloadBase {
   format?: DataExportFormat;
   limit?: number;
 }
+
+interface IssuesByTagExportPayload extends DataExportPayloadBase {
+  queryInfo: IssuesByTagQueryInfo;
+  queryType: ExportQueryType.ISSUES_BY_TAG;
+}
+
+interface DiscoverExportPayload extends DataExportPayloadBase {
+  queryInfo: DiscoverQueryInfo;
+  queryType: ExportQueryType.DISCOVER;
+}
+
+interface ExploreExportPayload extends DataExportPayloadBase {
+  queryInfo: ExploreQueryInfo;
+  queryType: ExportQueryType.EXPLORE | ExportQueryType.TRACE_ITEM_FULL_EXPORT;
+}
+
+export type DataExportPayload =
+  | IssuesByTagExportPayload
+  | DiscoverExportPayload
+  | ExploreExportPayload;
 
 interface UseDataExportOptions {
   inProgressCallback?: (inProgress: boolean) => void;

--- a/static/app/components/exports/useDataExport.ts
+++ b/static/app/components/exports/useDataExport.ts
@@ -32,6 +32,13 @@ interface IssuesByTagQueryInfo {
 
 type DiscoverQueryInfo = EventQuery & LocationQuery;
 
+type EventsQuerySamplingMode =
+  | 'BEST_EFFORT'
+  | 'PREFLIGHT'
+  | 'NORMAL'
+  | 'HIGHEST_ACCURACY'
+  | 'HIGHEST_ACCURACY_FLEX_TIME';
+
 interface ExploreQueryInfo {
   dataset: TraceItemDataset;
   field: string[];
@@ -40,6 +47,7 @@ interface ExploreQueryInfo {
   sort: string[];
   end?: string;
   environment?: string[];
+  sampling?: EventsQuerySamplingMode;
   start?: string;
   statsPeriod?: string;
 }

--- a/static/app/components/exports/useDataExport.ts
+++ b/static/app/components/exports/useDataExport.ts
@@ -33,8 +33,6 @@ interface IssuesByTagQueryInfo {
 type DiscoverQueryInfo = EventQuery & LocationQuery;
 
 type EventsQuerySamplingMode =
-  | 'BEST_EFFORT'
-  | 'PREFLIGHT'
   | 'NORMAL'
   | 'HIGHEST_ACCURACY'
   | 'HIGHEST_ACCURACY_FLEX_TIME';


### PR DESCRIPTION
Replaces the `queryInfo: any` placeholder on `DataExportPayload` with a proper discriminated union keyed on `queryType`. Each export query type now has a formalized query-info shape.

This also fixes up the exports tests data. They previously built their mock payload from a fictional `{project_id, group_id, key}` shape that never matched production usage. Now they use the real `{project, group, key}` issues-by-tag shape.

Closes LOGS-702.