### PR TITLE
feat(ui): Focus first searched item in selects

### DIFF
--- a/static/app/components/core/compactSelect/compactSelect.mdx
+++ b/static/app/components/core/compactSelect/compactSelect.mdx
@@ -235,7 +235,7 @@ const [values, setValues] = useState(['2', '4']);
 
 ## Searchable
 
-Enable `search` to allow users to filter options by typing. Essential for lists with many options. Pass `true` for default behavior, or a `SearchConfig` object to customize placeholder, filtering, the onChange callback, or `autoFocusFirstResult`. By default, searching makes the first visible enabled result active while keeping focus in the search input, so pressing Enter selects that result.
+Enable `search` to allow users to filter options by typing. Essential for lists with many options. Pass `true` for default behavior, or a `SearchConfig` object to customize placeholder, filtering, the onChange callback, or `autoFocusFirstResult`. By default, searching makes the first visible enabled result active while keeping focus in the search input, so pressing Enter selects that result. This is disabled by default when client-side filtering is disabled with `filter: false`.
 
 export function SearchDemo() {
   const [value, setValue] = useState('US');

--- a/static/app/components/core/compactSelect/compactSelect.mdx
+++ b/static/app/components/core/compactSelect/compactSelect.mdx
@@ -235,7 +235,7 @@ const [values, setValues] = useState(['2', '4']);
 
 ## Searchable
 
-Enable `search` to allow users to filter options by typing. Essential for lists with many options. Pass `true` for default behavior, or a `SearchConfig` object to customize placeholder, filtering, or the onChange callback.
+Enable `search` to allow users to filter options by typing. Essential for lists with many options. Pass `true` for default behavior, or a `SearchConfig` object to customize placeholder, filtering, the onChange callback, or `autoFocusFirstResult`. By default, searching makes the first visible enabled result active while keeping focus in the search input, so pressing Enter selects that result.
 
 export function SearchDemo() {
   const [value, setValue] = useState('US');

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -447,6 +447,54 @@ describe('CompactSelect', () => {
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
     });
 
+    it('selects the first search result on Enter without moving focus from the search input', async () => {
+      const mock = jest.fn();
+
+      render(
+        <CompactSelect
+          search={{placeholder: 'Search here…'}}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={mock}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      const searchInput = screen.getByPlaceholderText('Search here…');
+      await userEvent.type(searchInput, 'Two');
+
+      expect(searchInput).toHaveFocus();
+
+      await userEvent.keyboard('{Enter}');
+
+      expect(mock).toHaveBeenCalledWith({value: 'opt_two', label: 'Option Two'});
+    });
+
+    it('does not select the first search result when autoFocusFirstResult is false', async () => {
+      const mock = jest.fn();
+
+      render(
+        <CompactSelect
+          search={{placeholder: 'Search here…', autoFocusFirstResult: false}}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={mock}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.type(screen.getByPlaceholderText('Search here…'), 'Two');
+      await userEvent.keyboard('{Enter}');
+
+      expect(mock).not.toHaveBeenCalled();
+    });
+
     it('restores full list when search query is cleared', async () => {
       render(
         <CompactSelect

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -525,6 +525,32 @@ describe('CompactSelect', () => {
       expect(mock).not.toHaveBeenCalled();
     });
 
+    it('does not select stale results on Enter when client-side filtering is disabled', async () => {
+      const mock = jest.fn();
+
+      render(
+        <CompactSelect
+          search={{placeholder: 'Search here…', filter: false}}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={mock}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      const searchInput = screen.getByPlaceholderText('Search here…');
+      await userEvent.type(searchInput, 'Two');
+
+      expect(searchInput).not.toHaveAttribute('aria-activedescendant');
+
+      await userEvent.keyboard('{Enter}');
+
+      expect(mock).not.toHaveBeenCalled();
+    });
+
     it('restores full list when search query is cleared', async () => {
       render(
         <CompactSelect

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -503,6 +503,46 @@ describe('CompactSelect', () => {
       expect(searchInput).not.toHaveAttribute('aria-activedescendant');
     });
 
+    it('selects the current first search result when Enter follows a query update', async () => {
+      const mock = jest.fn();
+
+      render(
+        <CompactSelect
+          search={{
+            placeholder: 'Search here…',
+            filter: (option, search) => {
+              if (search === 'a') {
+                return {score: option.value === 'alpha' ? 2 : 1};
+              }
+              if (search === 'ab') {
+                return {score: option.value === 'beta' ? 2 : 1};
+              }
+              return {score: 0};
+            },
+          }}
+          options={[
+            {value: 'alpha', label: 'Alpha'},
+            {value: 'beta', label: 'Beta'},
+          ]}
+          value={undefined}
+          onChange={mock}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      const searchInput = screen.getByPlaceholderText('Search here…');
+      await userEvent.type(searchInput, 'a');
+
+      expect(searchInput).toHaveAttribute(
+        'aria-activedescendant',
+        screen.getByRole('option', {name: 'Alpha'}).id
+      );
+
+      await userEvent.keyboard('b{Enter}');
+
+      expect(mock).toHaveBeenCalledWith({value: 'beta', label: 'Beta'});
+    });
+
     it('does not select the first search result when autoFocusFirstResult is false', async () => {
       const mock = jest.fn();
 

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -467,10 +467,40 @@ describe('CompactSelect', () => {
       await userEvent.type(searchInput, 'Two');
 
       expect(searchInput).toHaveFocus();
+      const activeDescendant = searchInput.getAttribute('aria-activedescendant');
+      expect(activeDescendant).toBeTruthy();
+      expect(screen.getByRole('option', {name: 'Option Two'})).toHaveAttribute(
+        'id',
+        activeDescendant
+      );
 
       await userEvent.keyboard('{Enter}');
 
       expect(mock).toHaveBeenCalledWith({value: 'opt_two', label: 'Option Two'});
+    });
+
+    it('clears the active search result when focus moves into the list', async () => {
+      render(
+        <CompactSelect
+          search={{placeholder: 'Search here…'}}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      const searchInput = screen.getByPlaceholderText('Search here…');
+      await userEvent.type(searchInput, 'Two');
+      expect(searchInput).toHaveAttribute('aria-activedescendant');
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      expect(screen.getByRole('option', {name: 'Option Two'})).toHaveFocus();
+      expect(searchInput).not.toHaveAttribute('aria-activedescendant');
     });
 
     it('does not select the first search result when autoFocusFirstResult is false', async () => {

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useState} from 'react';
 import {expectTypeOf} from 'expect-type';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
@@ -549,6 +549,72 @@ describe('CompactSelect', () => {
       await userEvent.keyboard('{Enter}');
 
       expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('keeps the active search result mounted in virtualized lists', async () => {
+      const getBoundingClientRect = jest
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockReturnValue({
+          bottom: 100,
+          height: 100,
+          left: 0,
+          right: 200,
+          top: 0,
+          width: 200,
+          x: 0,
+          y: 0,
+          toJSON: () => {},
+        } as DOMRect);
+      const clientHeight = jest
+        .spyOn(HTMLElement.prototype, 'clientHeight', 'get')
+        .mockReturnValue(100);
+      const clientWidth = jest
+        .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+        .mockReturnValue(200);
+      const scrollHeight = jest
+        .spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
+        .mockReturnValue(8000);
+
+      try {
+        render(
+          <CompactSelect
+            search={{placeholder: 'Search here…'}}
+            virtualizeThreshold={0}
+            menuWidth={200}
+            menuHeight={100}
+            options={Array.from({length: 200}, (_, index) => ({
+              value: `opt_${index}`,
+              label: `Option ${index}`,
+            }))}
+            value={undefined}
+            onChange={jest.fn()}
+          />
+        );
+
+        await userEvent.click(screen.getByRole('button'));
+        const virtualizerWrap = document.querySelector('[data-is-virtualized="true"]');
+        const scrollContainer = virtualizerWrap?.parentElement;
+        expect(scrollContainer).toBeTruthy();
+
+        act(() => {
+          scrollContainer!.scrollTop = 4000;
+          scrollContainer!.dispatchEvent(new Event('scroll'));
+        });
+
+        const searchInput = screen.getByPlaceholderText('Search here…');
+        await userEvent.type(searchInput, 'Option 199');
+
+        await waitFor(() => {
+          const activeDescendant = searchInput.getAttribute('aria-activedescendant');
+          expect(activeDescendant).toBeTruthy();
+          expect(document.getElementById(activeDescendant!)).toBeInTheDocument();
+        });
+      } finally {
+        getBoundingClientRect.mockRestore();
+        clientHeight.mockRestore();
+        clientWidth.mockRestore();
+        scrollHeight.mockRestore();
+      }
     });
 
     it('restores full list when search query is cleared', async () => {

--- a/static/app/components/core/compactSelect/composite.spec.tsx
+++ b/static/app/components/core/compactSelect/composite.spec.tsx
@@ -291,6 +291,50 @@ describe('CompositeSelect', () => {
     expect(screen.queryByRole('Region 2')).not.toBeInTheDocument();
   });
 
+  it('selects the first search result across all regions on Enter', async () => {
+    const region1Mock = jest.fn();
+    const region2Mock = jest.fn();
+
+    render(
+      <CompositeSelect
+        search={{placeholder: 'Search placeholder…'}}
+        trigger={props => (
+          <OverlayTrigger.Button {...props}>Open menu</OverlayTrigger.Button>
+        )}
+      >
+        <CompositeSelect.Region
+          label="Region 1"
+          onChange={region1Mock}
+          value={undefined}
+          options={[
+            {value: 'choice_one', label: 'Choice One'},
+            {value: 'choice_two', label: 'Choice Two'},
+          ]}
+        />
+        <CompositeSelect.Region
+          multiple
+          label="Region 2"
+          onChange={region2Mock}
+          value={undefined}
+          options={[
+            {value: 'choice_three', label: 'Choice Three'},
+            {value: 'choice_four', label: 'Choice Four'},
+          ]}
+        />
+      </CompositeSelect>
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+    await userEvent.type(screen.getByPlaceholderText('Search placeholder…'), 'Choice');
+    await userEvent.keyboard('{Enter}');
+
+    expect(region1Mock).toHaveBeenCalledWith({
+      value: 'choice_one',
+      label: 'Choice One',
+    });
+    expect(region2Mock).not.toHaveBeenCalled();
+  });
+
   it('works with grid lists', async () => {
     function Component() {
       const [region1, setRegion1] = useState('choice_one');

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -283,6 +283,11 @@ export function Control({
   const [search, setSearch] = useState('');
   const [searchInputValue, setSearchInputValue] = useState(search);
   const searchRef = useRef<HTMLInputElement>(null);
+
+  // Keep DOM focus in the search input while still presenting the first visible,
+  // enabled result as the active option. Each List registers a controller here so the
+  // Control can coordinate that virtual search focus across composite selects that
+  // render multiple lists.
   const searchResultListControllersRef = useRef<SearchResultListController[]>([]);
   const activeSearchResultListControllerRef = useRef<SearchResultListController | null>(
     null
@@ -360,6 +365,8 @@ export function Control({
       return false;
     }
 
+    // Enter in the search input should select the same first result that is exposed
+    // via aria-activedescendant, without moving DOM focus into the options list first.
     const target = getFirstVisibleEnabledSearchResultTarget();
     if (target === null) {
       clearFocusedSearchResult();

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -267,7 +267,8 @@ export function Control({
 
   const normalizedSearch = getSearchConfig(searchConfig);
   const searchEnabled = normalizedSearch !== undefined;
-  const autoFocusFirstResult = normalizedSearch?.autoFocusFirstResult ?? true;
+  const autoFocusFirstResult =
+    normalizedSearch?.autoFocusFirstResult ?? normalizedSearch?.filter !== false;
   const searchFilter =
     typeof normalizedSearch?.filter === 'function' ? normalizedSearch.filter : undefined;
 

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -65,8 +65,13 @@ interface SearchResult {
 interface SearchResultListController {
   clearFocusedKey: () => void;
   getFirstVisibleEnabledSearchResult: () => SearchResult | null;
-  selectFocusedKey: () => boolean;
+  selectFocusedKey: (key: SelectKey) => boolean;
   setFocusedKey: (key: SelectKey) => void;
+}
+
+interface SearchResultTarget {
+  controller: SearchResultListController;
+  searchResult: SearchResult;
 }
 
 interface ControlContextValue {
@@ -292,30 +297,44 @@ export function Control({
     }
   }, []);
 
+  const getFirstVisibleEnabledSearchResultTarget = useCallback(() => {
+    for (const controller of searchResultListControllersRef.current) {
+      const searchResult = controller.getFirstVisibleEnabledSearchResult();
+      if (searchResult !== null) {
+        return {controller, searchResult};
+      }
+    }
+    return null;
+  }, []);
+
+  const focusSearchResultTarget = useCallback((target: SearchResultTarget | null) => {
+    activeSearchResultListControllerRef.current = target?.controller ?? null;
+    setActiveSearchResultId(target?.searchResult.id);
+
+    for (const controller of searchResultListControllersRef.current) {
+      if (controller === target?.controller) {
+        controller.setFocusedKey(target.searchResult.key);
+      } else {
+        controller.clearFocusedKey();
+      }
+    }
+  }, []);
+
   const focusFirstSearchResult = useCallback(() => {
     if (!searchEnabled || !autoFocusFirstResult || !searchInputValue) {
       clearFocusedSearchResult();
       return;
     }
 
-    const target = searchResultListControllersRef.current
-      .map(controller => ({
-        controller,
-        searchResult: controller.getFirstVisibleEnabledSearchResult(),
-      }))
-      .find(({searchResult}) => searchResult !== null);
-
-    activeSearchResultListControllerRef.current = target?.controller ?? null;
-    setActiveSearchResultId(target?.searchResult?.id);
-
-    for (const controller of searchResultListControllersRef.current) {
-      if (controller === target?.controller && target.searchResult !== null) {
-        controller.setFocusedKey(target.searchResult.key);
-      } else {
-        controller.clearFocusedKey();
-      }
-    }
-  }, [autoFocusFirstResult, clearFocusedSearchResult, searchEnabled, searchInputValue]);
+    focusSearchResultTarget(getFirstVisibleEnabledSearchResultTarget());
+  }, [
+    autoFocusFirstResult,
+    clearFocusedSearchResult,
+    focusSearchResultTarget,
+    getFirstVisibleEnabledSearchResultTarget,
+    searchEnabled,
+    searchInputValue,
+  ]);
 
   const registerSearchResultList = useCallback(
     (controller: SearchResultListController) => {
@@ -341,14 +360,22 @@ export function Control({
       return false;
     }
 
-    if (activeSearchResultListControllerRef.current?.selectFocusedKey()) {
-      return true;
+    const target = getFirstVisibleEnabledSearchResultTarget();
+    if (target === null) {
+      clearFocusedSearchResult();
+      return false;
     }
 
-    return searchResultListControllersRef.current.some(controller =>
-      controller.selectFocusedKey()
-    );
-  }, [autoFocusFirstResult, searchEnabled, searchInputValue]);
+    focusSearchResultTarget(target);
+    return target.controller.selectFocusedKey(target.searchResult.key);
+  }, [
+    autoFocusFirstResult,
+    clearFocusedSearchResult,
+    focusSearchResultTarget,
+    getFirstVisibleEnabledSearchResultTarget,
+    searchEnabled,
+    searchInputValue,
+  ]);
 
   const updateSearch = (newValue: string) => {
     normalizedSearch?.onChange?.(newValue);

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -57,9 +57,14 @@ function nextFrameCallback(cb: () => void) {
   }
 }
 
+interface SearchResult {
+  id: string;
+  key: SelectKey;
+}
+
 interface SearchResultListController {
   clearFocusedKey: () => void;
-  getFirstVisibleEnabledKey: () => SelectKey | null;
+  getFirstVisibleEnabledSearchResult: () => SearchResult | null;
   selectFocusedKey: () => boolean;
   setFocusedKey: (key: SelectKey) => void;
 }
@@ -74,6 +79,7 @@ interface ControlContextValue {
    * Whether the select has a search input field.
    */
   searchable: boolean;
+  clearFocusedSearchResult?: () => void;
   disabled?: boolean;
   focusFirstSearchResult?: () => void;
   /**
@@ -275,9 +281,11 @@ export function Control({
   const activeSearchResultListControllerRef = useRef<SearchResultListController | null>(
     null
   );
+  const [activeSearchResultId, setActiveSearchResultId] = useState<string>();
 
   const clearFocusedSearchResult = useCallback(() => {
     activeSearchResultListControllerRef.current = null;
+    setActiveSearchResultId(undefined);
     for (const controller of searchResultListControllersRef.current) {
       controller.clearFocusedKey();
     }
@@ -290,14 +298,18 @@ export function Control({
     }
 
     const target = searchResultListControllersRef.current
-      .map(controller => ({controller, key: controller.getFirstVisibleEnabledKey()}))
-      .find(({key}) => key !== null);
+      .map(controller => ({
+        controller,
+        searchResult: controller.getFirstVisibleEnabledSearchResult(),
+      }))
+      .find(({searchResult}) => searchResult !== null);
 
     activeSearchResultListControllerRef.current = target?.controller ?? null;
+    setActiveSearchResultId(target?.searchResult?.id);
 
     for (const controller of searchResultListControllersRef.current) {
-      if (controller === target?.controller && target.key !== null) {
-        controller.setFocusedKey(target.key);
+      if (controller === target?.controller && target.searchResult !== null) {
+        controller.setFocusedKey(target.searchResult.key);
       } else {
         controller.clearFocusedKey();
       }
@@ -316,6 +328,7 @@ export function Control({
           searchResultListControllersRef.current.filter(item => item !== controller);
         if (activeSearchResultListControllerRef.current === controller) {
           activeSearchResultListControllerRef.current = null;
+          setActiveSearchResultId(undefined);
         }
       };
     },
@@ -355,6 +368,7 @@ export function Control({
       // we should move the focus to the menu items list.
       if (e.key === 'ArrowDown') {
         e.preventDefault(); // Prevent scroll action
+        clearFocusedSearchResult();
         overlayRef.current
           ?.querySelector<HTMLLIElement>(`li[role="${grid ? 'row' : 'option'}"]`)
           ?.focus();
@@ -566,6 +580,7 @@ export function Control({
       size,
       disabled,
       searchMatcher: searchFilter,
+      clearFocusedSearchResult,
       focusFirstSearchResult,
       registerSearchResultList,
     };
@@ -577,6 +592,7 @@ export function Control({
     size,
     disabled,
     searchFilter,
+    clearFocusedSearchResult,
     focusFirstSearchResult,
     registerSearchResultList,
   ]);
@@ -659,6 +675,7 @@ export function Control({
                       ref={searchRef}
                       placeholder={normalizedSearch?.placeholder ?? 'Search…'}
                       value={searchInputValue}
+                      aria-activedescendant={activeSearchResultId}
                       onFocus={onSearchFocus}
                       onBlur={onSearchBlur}
                       onChange={e => updateSearch(e.target.value)}

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -57,6 +57,13 @@ function nextFrameCallback(cb: () => void) {
   }
 }
 
+interface SearchResultListController {
+  clearFocusedKey: () => void;
+  getFirstVisibleEnabledKey: () => SelectKey | null;
+  selectFocusedKey: () => boolean;
+  setFocusedKey: (key: SelectKey) => void;
+}
+
 interface ControlContextValue {
   overlayIsOpen: boolean;
   /**
@@ -68,11 +75,13 @@ interface ControlContextValue {
    */
   searchable: boolean;
   disabled?: boolean;
+  focusFirstSearchResult?: () => void;
   /**
    * The control's overlay state. Useful for opening/closing the menu from inside the
    * selector.
    */
   overlayState?: OverlayTriggerState;
+  registerSearchResultList?: (controller: SearchResultListController) => () => void;
   /**
    * Custom function to determine whether an option matches the search query.
    */
@@ -252,6 +261,7 @@ export function Control({
 
   const normalizedSearch = getSearchConfig(searchConfig);
   const searchEnabled = normalizedSearch !== undefined;
+  const autoFocusFirstResult = normalizedSearch?.autoFocusFirstResult ?? true;
   const searchFilter =
     typeof normalizedSearch?.filter === 'function' ? normalizedSearch.filter : undefined;
 
@@ -261,6 +271,71 @@ export function Control({
   const [search, setSearch] = useState('');
   const [searchInputValue, setSearchInputValue] = useState(search);
   const searchRef = useRef<HTMLInputElement>(null);
+  const searchResultListControllersRef = useRef<SearchResultListController[]>([]);
+  const activeSearchResultListControllerRef = useRef<SearchResultListController | null>(
+    null
+  );
+
+  const clearFocusedSearchResult = useCallback(() => {
+    activeSearchResultListControllerRef.current = null;
+    for (const controller of searchResultListControllersRef.current) {
+      controller.clearFocusedKey();
+    }
+  }, []);
+
+  const focusFirstSearchResult = useCallback(() => {
+    if (!searchEnabled || !autoFocusFirstResult || !searchInputValue) {
+      clearFocusedSearchResult();
+      return;
+    }
+
+    const target = searchResultListControllersRef.current
+      .map(controller => ({controller, key: controller.getFirstVisibleEnabledKey()}))
+      .find(({key}) => key !== null);
+
+    activeSearchResultListControllerRef.current = target?.controller ?? null;
+
+    for (const controller of searchResultListControllersRef.current) {
+      if (controller === target?.controller && target.key !== null) {
+        controller.setFocusedKey(target.key);
+      } else {
+        controller.clearFocusedKey();
+      }
+    }
+  }, [autoFocusFirstResult, clearFocusedSearchResult, searchEnabled, searchInputValue]);
+
+  const registerSearchResultList = useCallback(
+    (controller: SearchResultListController) => {
+      searchResultListControllersRef.current = [
+        ...searchResultListControllersRef.current,
+        controller,
+      ];
+
+      return () => {
+        searchResultListControllersRef.current =
+          searchResultListControllersRef.current.filter(item => item !== controller);
+        if (activeSearchResultListControllerRef.current === controller) {
+          activeSearchResultListControllerRef.current = null;
+        }
+      };
+    },
+    []
+  );
+
+  const selectFocusedSearchResult = useCallback(() => {
+    if (!searchEnabled || !autoFocusFirstResult || !searchInputValue) {
+      return false;
+    }
+
+    if (activeSearchResultListControllerRef.current?.selectFocusedKey()) {
+      return true;
+    }
+
+    return searchResultListControllersRef.current.some(controller =>
+      controller.selectFocusedKey()
+    );
+  }, [autoFocusFirstResult, searchEnabled, searchInputValue]);
+
   const updateSearch = (newValue: string) => {
     normalizedSearch?.onChange?.(newValue);
     setSearchInputValue(newValue);
@@ -271,6 +346,11 @@ export function Control({
 
   const {keyboardProps: searchKeyboardProps} = useKeyboard({
     onKeyDown: e => {
+      if (e.key === 'Enter' && selectFocusedSearchResult()) {
+        e.preventDefault();
+        return;
+      }
+
       // When the search input is focused, and the user presses Arrow Down,
       // we should move the focus to the menu items list.
       if (e.key === 'ArrowDown') {
@@ -473,6 +553,10 @@ export function Control({
     return true;
   }, [value]);
 
+  useEffect(() => {
+    focusFirstSearchResult();
+  }, [focusFirstSearchResult]);
+
   const contextValue = useMemo(() => {
     return {
       overlayState,
@@ -482,8 +566,20 @@ export function Control({
       size,
       disabled,
       searchMatcher: searchFilter,
+      focusFirstSearchResult,
+      registerSearchResultList,
     };
-  }, [overlayState, overlayIsOpen, search, searchEnabled, size, disabled, searchFilter]);
+  }, [
+    overlayState,
+    overlayIsOpen,
+    search,
+    searchEnabled,
+    size,
+    disabled,
+    searchFilter,
+    focusFirstSearchResult,
+    registerSearchResultList,
+  ]);
 
   const theme = useTheme();
 

--- a/static/app/components/core/compactSelect/gridList/index.tsx
+++ b/static/app/components/core/compactSelect/gridList/index.tsx
@@ -51,6 +51,7 @@ interface GridListProps<T extends ListItemBase>
    * Text label to be rendered as heading on top of grid list.
    */
   label?: React.ReactNode;
+  searchFocusedId?: string;
   searchFocusedKey?: SelectKey | null;
   size?: GridListOptionProps<ListItemBase>['size'];
   /**
@@ -80,6 +81,7 @@ function GridList<T extends ListItemBase>({
   sizeLimitMessage,
   keyDownHandler,
   virtualized,
+  searchFocusedId,
   searchFocusedKey,
   ...props
 }: GridListProps<T>) {
@@ -146,6 +148,7 @@ function GridList<T extends ListItemBase>({
                       key={item.key}
                       node={item}
                       listState={listState}
+                      searchFocusedId={searchFocusedId}
                       searchFocusedKey={searchFocusedKey}
                       size={size}
                     />
@@ -160,6 +163,7 @@ function GridList<T extends ListItemBase>({
                     listState={listState}
                     size={size}
                     forceFocused={item.key === searchFocusedKey}
+                    searchFocusedId={searchFocusedId}
                   />
                 );
               })}

--- a/static/app/components/core/compactSelect/gridList/index.tsx
+++ b/static/app/components/core/compactSelect/gridList/index.tsx
@@ -10,6 +10,7 @@ import {
   ListLabel,
   ListSeparator,
   ListWrap,
+  type SelectKey,
   SelectFilterContext,
   SizeLimitMessage,
   useVirtualizedItems,
@@ -50,6 +51,7 @@ interface GridListProps<T extends ListItemBase>
    * Text label to be rendered as heading on top of grid list.
    */
   label?: React.ReactNode;
+  searchFocusedKey?: SelectKey | null;
   size?: GridListOptionProps<ListItemBase>['size'];
   /**
    * Message to be displayed when some options are hidden due to `sizeLimit`.
@@ -78,6 +80,7 @@ function GridList<T extends ListItemBase>({
   sizeLimitMessage,
   keyDownHandler,
   virtualized,
+  searchFocusedKey,
   ...props
 }: GridListProps<T>) {
   const ref = useRef<HTMLUListElement>(null);
@@ -143,6 +146,7 @@ function GridList<T extends ListItemBase>({
                       key={item.key}
                       node={item}
                       listState={listState}
+                      searchFocusedKey={searchFocusedKey}
                       size={size}
                     />
                   );
@@ -155,6 +159,7 @@ function GridList<T extends ListItemBase>({
                     node={item}
                     listState={listState}
                     size={size}
+                    forceFocused={item.key === searchFocusedKey}
                   />
                 );
               })}

--- a/static/app/components/core/compactSelect/gridList/index.tsx
+++ b/static/app/components/core/compactSelect/gridList/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useContext, useId, useMemo, useRef} from 'react';
+import {Fragment, useContext, useEffect, useId, useMemo, useRef} from 'react';
 import type {AriaGridListOptions} from '@react-aria/gridlist';
 import {useGridList} from '@react-aria/gridlist';
 import {mergeProps} from '@react-aria/utils';
@@ -120,6 +120,27 @@ function GridList<T extends ListItemBase>({
     virtualized,
     size,
   });
+
+  // Keep the virtually focused row mounted. When focus stays in the search input,
+  // `searchFocusedKey` drives aria-activedescendant and the referenced row must be
+  // rendered even if the user previously scrolled it out of the virtualized range.
+  useEffect(() => {
+    const focusedKey = searchFocusedKey ?? listState.selectionManager.focusedKey;
+    if (!virtualized || focusedKey === null) {
+      return;
+    }
+
+    const focusedIndex = listItems.findIndex(item => item.key === focusedKey);
+    if (focusedIndex !== -1) {
+      virtualizer.scrollToIndex(focusedIndex);
+    }
+  }, [
+    virtualized,
+    listItems,
+    listState.selectionManager.focusedKey,
+    searchFocusedKey,
+    virtualizer,
+  ]);
 
   const mergedProps = mergeProps(gridProps, props);
 

--- a/static/app/components/core/compactSelect/gridList/option.tsx
+++ b/static/app/components/core/compactSelect/gridList/option.tsx
@@ -25,6 +25,7 @@ export interface GridListOptionProps<
   listState: ListState<T>;
   node: Node<T>;
   size: FormSize;
+  forceFocused?: boolean;
 }
 
 /**
@@ -35,6 +36,7 @@ export function GridListOption<T extends ListItemBase>({
   node,
   listState,
   size,
+  forceFocused = false,
 }: GridListOptionProps<T>) {
   const ref = useRef<HTMLLIElement>(null);
   const {
@@ -124,7 +126,7 @@ export function GridListOption<T extends ListItemBase>({
       disabled={isDisabled}
       isSelected={isSelected}
       isPressed={isPressed}
-      isFocused={isFocusWithin}
+      isFocused={forceFocused || isFocusWithin}
       priority={(priority ?? (isSelected && !multiple)) ? 'primary' : 'default'}
       innerWrapProps={gridCellProps}
       labelProps={labelPropsMemo}

--- a/static/app/components/core/compactSelect/gridList/option.tsx
+++ b/static/app/components/core/compactSelect/gridList/option.tsx
@@ -26,6 +26,7 @@ export interface GridListOptionProps<
   node: Node<T>;
   size: FormSize;
   forceFocused?: boolean;
+  searchFocusedId?: string;
 }
 
 /**
@@ -37,6 +38,7 @@ export function GridListOption<T extends ListItemBase>({
   listState,
   size,
   forceFocused = false,
+  searchFocusedId,
 }: GridListOptionProps<T>) {
   const ref = useRef<HTMLLIElement>(null);
   const {
@@ -116,9 +118,14 @@ export function GridListOption<T extends ListItemBase>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [multiple, isSelected, isDisabled, isFocused, size, leadingItems, hideCheck]);
 
+  const rowPropsWithId = {
+    ...rowPropsMerged,
+    id: forceFocused && searchFocusedId ? searchFocusedId : rowPropsMerged.id,
+  };
+
   return (
     <StyledMenuListItem
-      {...rowPropsMerged}
+      {...rowPropsWithId}
       ref={ref}
       size={size}
       label={label}

--- a/static/app/components/core/compactSelect/gridList/section.tsx
+++ b/static/app/components/core/compactSelect/gridList/section.tsx
@@ -12,6 +12,7 @@ import {
   SectionWrap,
   SelectFilterContext,
 } from '@sentry/scraps/compactSelect';
+import type {SelectKey} from '@sentry/scraps/compactSelect';
 import type {ListItemBase} from '@sentry/scraps/compactSelect/types';
 
 import {GridListOption, type GridListOptionProps} from './option';
@@ -20,6 +21,7 @@ interface GridListSectionProps<T extends ListItemBase> {
   listState: ListState<T>;
   node: Node<T>;
   size: GridListOptionProps<T>['size'];
+  searchFocusedKey?: SelectKey | null;
 }
 
 /**
@@ -29,6 +31,7 @@ interface GridListSectionProps<T extends ListItemBase> {
 export function GridListSection<T extends ListItemBase>({
   node,
   listState,
+  searchFocusedKey,
   size,
 }: GridListSectionProps<T>) {
   const titleId = useId();
@@ -70,6 +73,7 @@ export function GridListSection<T extends ListItemBase>({
               node={child}
               listState={listState}
               size={size}
+              forceFocused={child.key === searchFocusedKey}
             />
           ))}
         </SectionGroup>

--- a/static/app/components/core/compactSelect/gridList/section.tsx
+++ b/static/app/components/core/compactSelect/gridList/section.tsx
@@ -21,6 +21,7 @@ interface GridListSectionProps<T extends ListItemBase> {
   listState: ListState<T>;
   node: Node<T>;
   size: GridListOptionProps<T>['size'];
+  searchFocusedId?: string;
   searchFocusedKey?: SelectKey | null;
 }
 
@@ -31,6 +32,7 @@ interface GridListSectionProps<T extends ListItemBase> {
 export function GridListSection<T extends ListItemBase>({
   node,
   listState,
+  searchFocusedId,
   searchFocusedKey,
   size,
 }: GridListSectionProps<T>) {
@@ -74,6 +76,7 @@ export function GridListSection<T extends ListItemBase>({
               listState={listState}
               size={size}
               forceFocused={child.key === searchFocusedKey}
+              searchFocusedId={searchFocusedId}
             />
           ))}
         </SectionGroup>

--- a/static/app/components/core/compactSelect/index.tsx
+++ b/static/app/components/core/compactSelect/index.tsx
@@ -42,7 +42,6 @@ export {
   itemIsSectionWithKey,
   SectionToggle,
   getEscapedKey,
-  getSearchResultOptionId,
 } from './utils';
 
 export {useVirtualizedItems} from './useVirtualizedItems';

--- a/static/app/components/core/compactSelect/index.tsx
+++ b/static/app/components/core/compactSelect/index.tsx
@@ -42,6 +42,7 @@ export {
   itemIsSectionWithKey,
   SectionToggle,
   getEscapedKey,
+  getSearchResultOptionId,
 } from './utils';
 
 export {useVirtualizedItems} from './useVirtualizedItems';

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -326,9 +326,6 @@ export function List<Value extends SelectKey>({
   firstVisibleEnabledSearchResultRef.current = firstVisibleEnabledSearchResult;
   const hiddenOptionsRef = useRef(hiddenOptions);
   hiddenOptionsRef.current = hiddenOptions;
-  const searchFocusedKeyRef = useRef(searchFocusedKey);
-  searchFocusedKeyRef.current = searchFocusedKey;
-
   const searchResultListController = useMemo(
     () => ({
       clearFocusedKey: () => {
@@ -336,11 +333,9 @@ export function List<Value extends SelectKey>({
       },
       getFirstVisibleEnabledSearchResult: () =>
         firstVisibleEnabledSearchResultRef.current,
-      selectFocusedKey: () => {
+      selectFocusedKey: (focusedKey: SelectKey) => {
         const selectionManager = listStateRef.current.selectionManager;
-        const focusedKey = searchFocusedKeyRef.current;
         if (
-          focusedKey === null ||
           hiddenOptionsRef.current.has(focusedKey) ||
           selectionManager.isDisabled(focusedKey)
         ) {

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -32,6 +32,7 @@ import {
   getDisabledOptions,
   getEscapedKey,
   getHiddenOptions,
+  getSearchResultOptionId,
   getSelectedOptions,
   getSortedItems,
   HiddenSectionToggle,
@@ -215,6 +216,7 @@ export function List<Value extends SelectKey>({
     searchable,
     overlayIsOpen,
     searchMatcher,
+    clearFocusedSearchResult,
     focusFirstSearchResult,
     registerSearchResultList,
   } = useContext(ControlContext);
@@ -301,16 +303,27 @@ export function List<Value extends SelectKey>({
     items: sortedItems,
   });
 
+  const listId = useId();
   const firstVisibleEnabledKey = useMemo(
     () => getFirstVisibleEnabledKey(listState, hiddenOptions),
     [listState, hiddenOptions]
+  );
+  const firstVisibleEnabledSearchResult = useMemo(
+    () =>
+      firstVisibleEnabledKey === null
+        ? null
+        : {
+            id: getSearchResultOptionId(listId, firstVisibleEnabledKey),
+            key: firstVisibleEnabledKey,
+          },
+    [firstVisibleEnabledKey, listId]
   );
 
   const [searchFocusedKey, setSearchFocusedKey] = useState<SelectKey | null>(null);
   const listStateRef = useRef(listState);
   listStateRef.current = listState;
-  const firstVisibleEnabledKeyRef = useRef(firstVisibleEnabledKey);
-  firstVisibleEnabledKeyRef.current = firstVisibleEnabledKey;
+  const firstVisibleEnabledSearchResultRef = useRef(firstVisibleEnabledSearchResult);
+  firstVisibleEnabledSearchResultRef.current = firstVisibleEnabledSearchResult;
   const hiddenOptionsRef = useRef(hiddenOptions);
   hiddenOptionsRef.current = hiddenOptions;
   const searchFocusedKeyRef = useRef(searchFocusedKey);
@@ -321,7 +334,8 @@ export function List<Value extends SelectKey>({
       clearFocusedKey: () => {
         setSearchFocusedKey(null);
       },
-      getFirstVisibleEnabledKey: () => firstVisibleEnabledKeyRef.current,
+      getFirstVisibleEnabledSearchResult: () =>
+        firstVisibleEnabledSearchResultRef.current,
       selectFocusedKey: () => {
         const selectionManager = listStateRef.current.selectionManager;
         const focusedKey = searchFocusedKeyRef.current;
@@ -350,6 +364,17 @@ export function List<Value extends SelectKey>({
   useEffect(() => {
     focusFirstSearchResult?.();
   }, [firstVisibleEnabledKey, focusFirstSearchResult]);
+
+  useEffect(() => {
+    if (searchFocusedKey !== null && listState.selectionManager.isFocused) {
+      clearFocusedSearchResult?.();
+    }
+  }, [
+    clearFocusedSearchResult,
+    listState.selectionManager.focusedKey,
+    listState.selectionManager.isFocused,
+    searchFocusedKey,
+  ]);
 
   // In composite selects, focus should seamlessly move from one region (list) to
   // another when the ArrowUp/Down key is pressed
@@ -429,7 +454,10 @@ export function List<Value extends SelectKey>({
     return true;
   };
 
-  const listId = useId();
+  const searchFocusedId =
+    searchFocusedKey === null
+      ? undefined
+      : getSearchResultOptionId(listId, searchFocusedKey);
 
   const sections = useMemo(
     () =>
@@ -453,6 +481,7 @@ export function List<Value extends SelectKey>({
             id={listId}
             listState={listState}
             searchFocusedKey={searchFocusedKey}
+            searchFocusedId={searchFocusedId}
             sizeLimitMessage={sizeLimitMessage}
             keyDownHandler={keyDownHandler}
           />
@@ -466,6 +495,7 @@ export function List<Value extends SelectKey>({
           id={listId}
           listState={listState}
           searchFocusedKey={searchFocusedKey}
+          searchFocusedId={searchFocusedId}
           shouldFocusWrap={shouldFocusWrap}
           shouldFocusOnHover={shouldFocusOnHover}
           sizeLimitMessage={sizeLimitMessage}

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -41,6 +41,8 @@ import {
 
 export const SelectFilterContext = createContext(new Set<SelectKey>());
 
+// Find the first result as it appears in the rendered collection, including options
+// nested inside sections, while skipping hidden search misses and disabled options.
 function getFirstVisibleEnabledKey<T extends ListItemBase>(
   listState: ListState<T>,
   hiddenOptions: Set<SelectKey>
@@ -320,6 +322,11 @@ export function List<Value extends SelectKey>({
   );
 
   const [searchFocusedKey, setSearchFocusedKey] = useState<SelectKey | null>(null);
+
+  // Control owns the search input, but each List owns its react-stately collection and
+  // selection manager. Keep a stable registered controller with refs to the latest list
+  // state so Control can ask this list for its first result, virtually focus it, or
+  // select it on Enter without forcing a re-registration on every search update.
   const listStateRef = useRef(listState);
   listStateRef.current = listState;
   const firstVisibleEnabledSearchResultRef = useRef(firstVisibleEnabledSearchResult);
@@ -361,6 +368,8 @@ export function List<Value extends SelectKey>({
   }, [firstVisibleEnabledKey, focusFirstSearchResult]);
 
   useEffect(() => {
+    // Once the user moves real focus into the list, stop showing the search-input
+    // aria-activedescendant highlight so react-aria's focused item is the only focus.
     if (searchFocusedKey !== null && listState.selectionManager.isFocused) {
       clearFocusedSearchResult?.();
     }

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -1,9 +1,19 @@
-import {createContext, Fragment, useContext, useId, useMemo} from 'react';
+import {
+  createContext,
+  Fragment,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {useFocusManager} from '@react-aria/focus';
 import type {AriaGridListOptions} from '@react-aria/gridlist';
 import type {AriaListBoxOptions} from '@react-aria/listbox';
-import type {ListProps} from '@react-stately/list';
+import type {ListProps, ListState} from '@react-stately/list';
 import {useListState} from '@react-stately/list';
+import type {Key} from '@react-types/shared';
 
 import {defined} from 'sentry/utils/defined';
 import type {FormSize} from 'sentry/utils/theme';
@@ -29,6 +39,36 @@ import {
 } from './utils';
 
 export const SelectFilterContext = createContext(new Set<SelectKey>());
+
+function getFirstVisibleEnabledKey<T extends ListItemBase>(
+  listState: ListState<T>,
+  hiddenOptions: Set<SelectKey>
+): SelectKey | null {
+  const isVisibleAndEnabled = (key: Key) => {
+    if (typeof key !== 'string' && typeof key !== 'number') {
+      return false;
+    }
+
+    return !hiddenOptions.has(key) && !listState.selectionManager.isDisabled(key);
+  };
+
+  for (const item of listState.collection) {
+    if (item.type === 'section') {
+      for (const child of item.childNodes) {
+        if (isVisibleAndEnabled(child.key)) {
+          return child.key;
+        }
+      }
+      continue;
+    }
+
+    if (isVisibleAndEnabled(item.key)) {
+      return item.key;
+    }
+  }
+
+  return null;
+}
 
 interface BaseListProps<Value extends SelectKey>
   extends
@@ -169,8 +209,15 @@ export function List<Value extends SelectKey>({
   closeOnSelect,
   ...props
 }: SingleListProps<Value> | MultipleListProps<Value>) {
-  const {overlayState, search, searchable, overlayIsOpen, searchMatcher} =
-    useContext(ControlContext);
+  const {
+    overlayState,
+    search,
+    searchable,
+    overlayIsOpen,
+    searchMatcher,
+    focusFirstSearchResult,
+    registerSearchResultList,
+  } = useContext(ControlContext);
 
   const {hidden: hiddenOptions, scores} = useMemo(
     () => getHiddenOptions(items, search, sizeLimit, searchMatcher),
@@ -253,6 +300,56 @@ export function List<Value extends SelectKey>({
     ...listStateProps,
     items: sortedItems,
   });
+
+  const firstVisibleEnabledKey = useMemo(
+    () => getFirstVisibleEnabledKey(listState, hiddenOptions),
+    [listState, hiddenOptions]
+  );
+
+  const [searchFocusedKey, setSearchFocusedKey] = useState<SelectKey | null>(null);
+  const listStateRef = useRef(listState);
+  listStateRef.current = listState;
+  const firstVisibleEnabledKeyRef = useRef(firstVisibleEnabledKey);
+  firstVisibleEnabledKeyRef.current = firstVisibleEnabledKey;
+  const hiddenOptionsRef = useRef(hiddenOptions);
+  hiddenOptionsRef.current = hiddenOptions;
+  const searchFocusedKeyRef = useRef(searchFocusedKey);
+  searchFocusedKeyRef.current = searchFocusedKey;
+
+  const searchResultListController = useMemo(
+    () => ({
+      clearFocusedKey: () => {
+        setSearchFocusedKey(null);
+      },
+      getFirstVisibleEnabledKey: () => firstVisibleEnabledKeyRef.current,
+      selectFocusedKey: () => {
+        const selectionManager = listStateRef.current.selectionManager;
+        const focusedKey = searchFocusedKeyRef.current;
+        if (
+          focusedKey === null ||
+          hiddenOptionsRef.current.has(focusedKey) ||
+          selectionManager.isDisabled(focusedKey)
+        ) {
+          return false;
+        }
+
+        selectionManager.select(focusedKey);
+        return true;
+      },
+      setFocusedKey: (key: SelectKey) => {
+        setSearchFocusedKey(key);
+      },
+    }),
+    []
+  );
+
+  useEffect(() => {
+    return registerSearchResultList?.(searchResultListController);
+  }, [registerSearchResultList, searchResultListController]);
+
+  useEffect(() => {
+    focusFirstSearchResult?.();
+  }, [firstVisibleEnabledKey, focusFirstSearchResult]);
 
   // In composite selects, focus should seamlessly move from one region (list) to
   // another when the ArrowUp/Down key is pressed
@@ -355,6 +452,7 @@ export function List<Value extends SelectKey>({
             {...props}
             id={listId}
             listState={listState}
+            searchFocusedKey={searchFocusedKey}
             sizeLimitMessage={sizeLimitMessage}
             keyDownHandler={keyDownHandler}
           />
@@ -367,6 +465,7 @@ export function List<Value extends SelectKey>({
           hiddenOptions={hiddenOptions}
           id={listId}
           listState={listState}
+          searchFocusedKey={searchFocusedKey}
           shouldFocusWrap={shouldFocusWrap}
           shouldFocusOnHover={shouldFocusOnHover}
           sizeLimitMessage={sizeLimitMessage}

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -76,6 +76,11 @@ interface ListBoxProps<T extends ListItemBase>
    */
   scrollContainerRef?: React.Ref<HTMLDivElement>;
   /**
+   * DOM id for the search-focused result, referenced by the search input's
+   * aria-activedescendant.
+   */
+  searchFocusedId?: string;
+  /**
    * Search result key to display as focused while DOM focus remains on the search input.
    */
   searchFocusedKey?: SelectKey | null;
@@ -143,6 +148,7 @@ export function ListBox<T extends ListItemBase>({
   virtualizedListPadding = listPaddingVertical,
   scrollContainerRef,
   searchFocusedKey,
+  searchFocusedId,
   className,
   ...props
 }: ListBoxProps<T>) {
@@ -257,6 +263,7 @@ export function ListBox<T extends ListItemBase>({
                       listState={listState}
                       hiddenOptions={hiddenOptions}
                       searchFocusedKey={searchFocusedKey}
+                      searchFocusedId={searchFocusedId}
                       size={size}
                       showSectionHeaders={showSectionHeaders}
                       showDetails={showDetails}
@@ -272,6 +279,7 @@ export function ListBox<T extends ListItemBase>({
                     listState={listState}
                     size={size}
                     forceFocused={item.key === searchFocusedKey}
+                    searchFocusedId={searchFocusedId}
                     showDetails={showDetails}
                   />
                 );

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -202,18 +202,26 @@ export function ListBox<T extends ListItemBase>({
     listPadding: virtualizedListPadding,
   });
 
+  // Keep the virtually focused option mounted. When focus stays in the search input,
+  // `searchFocusedKey` drives aria-activedescendant and the referenced option must be
+  // rendered even if the user previously scrolled it out of the virtualized range.
   useEffect(() => {
-    if (!virtualized || listState.selectionManager.focusedKey === null) {
+    const focusedKey = searchFocusedKey ?? listState.selectionManager.focusedKey;
+    if (!virtualized || focusedKey === null) {
       return;
     }
 
-    const focusedIndex = listItems.findIndex(
-      item => item.key === listState.selectionManager.focusedKey
-    );
+    const focusedIndex = listItems.findIndex(item => item.key === focusedKey);
     if (focusedIndex !== -1) {
       virtualizer.scrollToIndex(focusedIndex);
     }
-  }, [virtualized, listItems, listState.selectionManager.focusedKey, virtualizer]);
+  }, [
+    virtualized,
+    listItems,
+    listState.selectionManager.focusedKey,
+    searchFocusedKey,
+    virtualizer,
+  ]);
 
   const refs = useMemo(() => {
     const overflowTracker = (scrollContainer: HTMLDivElement | null) => {

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -76,6 +76,10 @@ interface ListBoxProps<T extends ListItemBase>
    */
   scrollContainerRef?: React.Ref<HTMLDivElement>;
   /**
+   * Search result key to display as focused while DOM focus remains on the search input.
+   */
+  searchFocusedKey?: SelectKey | null;
+  /**
    * Whether the select has a search input field.
    */
   searchable?: boolean;
@@ -138,6 +142,7 @@ export function ListBox<T extends ListItemBase>({
   virtualized,
   virtualizedListPadding = listPaddingVertical,
   scrollContainerRef,
+  searchFocusedKey,
   className,
   ...props
 }: ListBoxProps<T>) {
@@ -251,6 +256,7 @@ export function ListBox<T extends ListItemBase>({
                       item={item}
                       listState={listState}
                       hiddenOptions={hiddenOptions}
+                      searchFocusedKey={searchFocusedKey}
                       size={size}
                       showSectionHeaders={showSectionHeaders}
                       showDetails={showDetails}
@@ -265,6 +271,7 @@ export function ListBox<T extends ListItemBase>({
                     item={item}
                     listState={listState}
                     size={size}
+                    forceFocused={item.key === searchFocusedKey}
                     showDetails={showDetails}
                   />
                 );

--- a/static/app/components/core/compactSelect/listBox/option.tsx
+++ b/static/app/components/core/compactSelect/listBox/option.tsx
@@ -23,6 +23,7 @@ export interface ListBoxOptionProps extends AriaOptionProps {
   'data-index'?: number;
   forceFocused?: boolean;
   ref?: React.Ref<HTMLLIElement>;
+  searchFocusedId?: string;
   showDetails?: boolean;
 }
 
@@ -37,6 +38,7 @@ export function ListBoxOption({
   showDetails = true,
   ref: refProp,
   forceFocused = false,
+  searchFocusedId,
   'data-index': dataIndex,
 }: ListBoxOptionProps) {
   const ref = useRef<HTMLLIElement>(null);
@@ -99,9 +101,14 @@ export function ListBoxOption({
     );
   }, [size, leadingItems, isDisabled, isFocused, isSelected, hideCheck, multiple]);
 
+  const optionPropsWithId = {
+    ...optionProps,
+    id: forceFocused && searchFocusedId ? searchFocusedId : optionProps.id,
+  };
+
   return (
     <StyledMenuListItem
-      {...optionProps}
+      {...optionPropsWithId}
       data-index={dataIndex}
       ref={mergeRefs(ref, refProp)}
       size={size}

--- a/static/app/components/core/compactSelect/listBox/option.tsx
+++ b/static/app/components/core/compactSelect/listBox/option.tsx
@@ -21,6 +21,7 @@ export interface ListBoxOptionProps extends AriaOptionProps {
   listState: ListState<any>;
   size: MenuListItemProps['size'];
   'data-index'?: number;
+  forceFocused?: boolean;
   ref?: React.Ref<HTMLLIElement>;
   showDetails?: boolean;
 }
@@ -35,6 +36,7 @@ export function ListBoxOption({
   size,
   showDetails = true,
   ref: refProp,
+  forceFocused = false,
   'data-index': dataIndex,
 }: ListBoxOptionProps) {
   const ref = useRef<HTMLLIElement>(null);
@@ -108,7 +110,7 @@ export function ListBoxOption({
       disabled={isDisabled}
       isPressed={isPressed}
       isSelected={isSelected}
-      isFocused={listState.selectionManager.isFocused && isFocused}
+      isFocused={forceFocused || (listState.selectionManager.isFocused && isFocused)}
       priority={(priority ?? (isSelected && !multiple)) ? 'primary' : 'default'}
       labelProps={labelPropsMemo}
       leadingItems={leadingItemsMemo}

--- a/static/app/components/core/compactSelect/listBox/section.tsx
+++ b/static/app/components/core/compactSelect/listBox/section.tsx
@@ -26,6 +26,7 @@ interface ListBoxSectionProps<T extends ListItemBase> extends AriaListBoxSection
   size: ListBoxOptionProps['size'];
   'data-index'?: number;
   ref?: React.Ref<HTMLLIElement>;
+  searchFocusedKey?: SelectKey | null;
   showDetails?: boolean;
 }
 
@@ -38,6 +39,7 @@ export function ListBoxSection<T extends ListItemBase>({
   listState,
   size,
   hiddenOptions,
+  searchFocusedKey,
   showSectionHeaders,
   showDetails = true,
   ref,
@@ -78,6 +80,7 @@ export function ListBoxSection<T extends ListItemBase>({
               item={child}
               listState={listState}
               size={size}
+              forceFocused={child.key === searchFocusedKey}
               showDetails={showDetails}
             />
           ))}

--- a/static/app/components/core/compactSelect/listBox/section.tsx
+++ b/static/app/components/core/compactSelect/listBox/section.tsx
@@ -26,6 +26,7 @@ interface ListBoxSectionProps<T extends ListItemBase> extends AriaListBoxSection
   size: ListBoxOptionProps['size'];
   'data-index'?: number;
   ref?: React.Ref<HTMLLIElement>;
+  searchFocusedId?: string;
   searchFocusedKey?: SelectKey | null;
   showDetails?: boolean;
 }
@@ -39,6 +40,7 @@ export function ListBoxSection<T extends ListItemBase>({
   listState,
   size,
   hiddenOptions,
+  searchFocusedId,
   searchFocusedKey,
   showSectionHeaders,
   showDetails = true,
@@ -81,6 +83,7 @@ export function ListBoxSection<T extends ListItemBase>({
               listState={listState}
               size={size}
               forceFocused={child.key === searchFocusedKey}
+              searchFocusedId={searchFocusedId}
               showDetails={showDetails}
             />
           ))}

--- a/static/app/components/core/compactSelect/types.tsx
+++ b/static/app/components/core/compactSelect/types.tsx
@@ -63,7 +63,7 @@ export interface SearchConfig<Value extends SelectKey> {
   /**
    * When true, searching sets the first visible enabled option as the active option
    * while keeping focus on the search input. Pressing Enter in the search input selects
-   * the active option. Defaults to true.
+   * the active option. Defaults to true unless client-side filtering is disabled.
    */
   autoFocusFirstResult?: boolean;
   /**

--- a/static/app/components/core/compactSelect/types.tsx
+++ b/static/app/components/core/compactSelect/types.tsx
@@ -61,6 +61,12 @@ export interface SearchMatchResult {
  */
 export interface SearchConfig<Value extends SelectKey> {
   /**
+   * When true, searching sets the first visible enabled option as the active option
+   * while keeping focus on the search input. Pressing Enter in the search input selects
+   * the active option. Defaults to true.
+   */
+  autoFocusFirstResult?: boolean;
+  /**
    * Controls client-side option filtering:
    * - Omitted: default fuzzy (fzf) filter, results sorted by match score
    * - Function: custom matcher (receives option + search string, returns SearchMatchResult)

--- a/static/app/components/core/compactSelect/useVirtualizedItems.tsx
+++ b/static/app/components/core/compactSelect/useVirtualizedItems.tsx
@@ -50,6 +50,9 @@ export function useVirtualizedItems<T extends ObjectLike>({
     const virtualizedItems = virtualizer.getVirtualItems();
     return {
       items: virtualizedItems,
+      scrollToIndex: (index: number) => {
+        virtualizer.scrollToIndex(index, {align: 'auto'});
+      },
       scrollElementRef,
       itemProps: (index: number) => ({
         ref: virtualizer.measureElement,
@@ -75,6 +78,7 @@ export function useVirtualizedItems<T extends ObjectLike>({
 
   return {
     items: listItems.map((_, index) => ({index, start: 0})),
+    scrollToIndex: () => {},
     scrollElementRef: undefined,
     itemProps: () => {},
     wrapperProps: {

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -43,6 +43,10 @@ export function getEscapedKey(value: SelectKey): string {
   return CSS.escape(String(value));
 }
 
+export function getSearchResultOptionId(listId: string, key: SelectKey): string {
+  return `${listId}-search-result-${encodeURIComponent(String(key))}`;
+}
+
 export function getItemsWithKeys<Value extends SelectKey>(
   options: Array<SelectOption<Value>>
 ): Array<SelectOptionWithKey<Value>>;


### PR DESCRIPTION
This PR updates the compact select so that it will highlight the first item in the list when the user searches for an item in the list, reducing some friction.

As well, a new prop is added in to control this feature, so it can be disabled if needed.