### PR TITLE
fix(issues): Shorten sidebar activity timestamps

### DIFF
--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -24,6 +24,7 @@ import {ActivitySection} from 'sentry/views/issueDetails/activitySection';
 describe('ActivitySection', () => {
   const project = ProjectFixture();
   const user = UserFixture();
+  const tenMinutesAgo = () => new Date(Date.now() - 10 * 60 * 1000).toISOString();
   user.options.prefersIssueDetailsStreamlinedUI = true;
   ConfigStore.set('user', user);
 
@@ -183,7 +184,7 @@ describe('ActivitySection', () => {
           type: GroupActivityType.NOTE,
           id: 'note-1',
           data: {text: '**Bold Note** and [docs](https://docs.sentry.io/)'},
-          dateCreated: '2020-01-01T00:00:00',
+          dateCreated: tenMinutesAgo(),
           user,
         },
       ],
@@ -199,6 +200,7 @@ describe('ActivitySection', () => {
       'href',
       'https://docs.sentry.io/'
     );
+    expect(screen.getByText('10m ago')).toBeInTheDocument();
   });
 
   it('renders activity actor markers', async () => {
@@ -440,7 +442,7 @@ describe('ActivitySection', () => {
       type: GroupActivityType.NOTE,
       id: `note-${index + 1}`,
       data: {text: `Test Note ${index + 1}`},
-      dateCreated: '2020-01-01T00:00:00',
+      dateCreated: tenMinutesAgo(),
       user: UserFixture({id: '2'}),
       project,
     }));
@@ -462,6 +464,8 @@ describe('ActivitySection', () => {
     }
 
     expect(screen.queryByText('View 4 more')).not.toBeInTheDocument();
+    expect(screen.getAllByText('10 minutes ago')).toHaveLength(7);
+    expect(screen.queryByText('10m ago')).not.toBeInTheDocument();
   });
 
   it('filters comments correctly', async () => {

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -130,6 +130,7 @@ function TimelineItem({
   teams,
   size,
   inputVariant,
+  timestampUnitStyle,
 }: {
   group: Group;
   handleDelete: (item: GroupActivity) => void;
@@ -138,6 +139,7 @@ function TimelineItem({
   item: GroupActivity;
   size: 'sm' | 'md';
   teams: Team[];
+  timestampUnitStyle?: React.ComponentProps<typeof TimeSince>['unitStyle'];
 }) {
   const organization = useOrganization();
   const theme = useTheme();
@@ -183,7 +185,7 @@ function TimelineItem({
           )}
         </Flex>
       }
-      timestamp={<Timestamp date={item.dateCreated} />}
+      timestamp={<Timestamp date={item.dateCreated} unitStyle={timestampUnitStyle} />}
       marker={useTwoColumnLayout ? getActivityMarker(item, colorConfig.icon) : undefined}
       colorConfig={useTwoColumnLayout ? colorConfig : undefined}
       icon={
@@ -386,6 +388,7 @@ export function ActivitySection({
     item => !filterComments || item.type === GroupActivityType.NOTE
   );
   const inputVariant = variant === 'sidebar' ? 'compact' : 'full';
+  const timestampUnitStyle = variant === 'sidebar' ? 'extraShort' : undefined;
 
   const renderActivityItem = (item: GroupActivity) => (
     <TimelineItem
@@ -397,6 +400,7 @@ export function ActivitySection({
       key={item.id}
       size={size}
       inputVariant={inputVariant}
+      timestampUnitStyle={timestampUnitStyle}
     />
   );
 


### PR DESCRIPTION
Shortens the relative dates in the issue details sidebar activity feed so rows read like `10m ago`.

The standalone activity view keeps the full labels.

This is not behind the feature flag since it impacted the other version as well

before

<img width="331" height="234" alt="image" src="https://github.com/user-attachments/assets/fc04dbf8-8920-46e0-b4cb-c78d604de748" />


after

<img width="333" height="253" alt="image" src="https://github.com/user-attachments/assets/45a3e541-cf1f-44d0-a183-8e726514f67a" />
