### PR TITLE
fix(dashboards): Allow existing tracemetrics table widgets to save

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -404,7 +404,16 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
         if widget_type_name is not None and display_type_id is not None:
             widget_type_id = DashboardWidgetTypes.get_id_for_type_name(widget_type_name)
             config = DATASET_CONFIG.get(widget_type_id)
-            if config is not None and display_type_id not in config["supported_display_types"]:
+            if (
+                config is not None
+                and display_type_id not in config["supported_display_types"]
+                # Existing tracemetrics table widgets (those sent with an ``id``)
+                # are allowed to save. The Widget Builder doesn't offer table for
+                # tracemetrics, but some widgets were created with this combo
+                # before display-type validation existed, and those dashboards
+                # must still be saveable. New widgets are still rejected.
+                and not self._is_existing_tracemetrics_table(widget_type_id, display_type_id)
+            ):
                 supported_names = sorted(
                     DashboardWidgetDisplayTypes.get_type_name(d) or str(d)
                     for d in config["supported_display_types"]
@@ -416,6 +425,13 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
                 )
 
         return display_type_id
+
+    def _is_existing_tracemetrics_table(self, widget_type_id, display_type_id):
+        return (
+            self.context.get("widget_id") is not None
+            and widget_type_id == DashboardWidgetTypes.TRACEMETRICS
+            and display_type_id == DashboardWidgetDisplayTypes.TABLE
+        )
 
     def _validate_widget_type(self, data):
         widget_type = DashboardWidgetTypes.get_id_for_type_name(data.get("widget_type"))
@@ -451,6 +467,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
         # instance across items, so stale values would otherwise leak between
         # widgets in the same request.
         self.context["widget_type"] = data.get("widget_type")
+        self.context["widget_id"] = data.get("id")
 
         if data.get("display_type"):
             additional_context["display_type"] = data.get("display_type")

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -1053,6 +1053,48 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert len(queries) == 1
         self.assert_serialized_widget_query(data["widgets"][4]["queries"][0], queries[0])
 
+    def test_save_dashboard_with_existing_tracemetrics_table_widget(self) -> None:
+        # Tracemetrics tables can't be created in the UI, but some existing
+        # widgets predate display-type validation. Saving a dashboard that
+        # contains one (without changing its display type) must still succeed.
+        widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=2,
+            title="Metrics Table",
+            display_type=DashboardWidgetDisplayTypes.TABLE,
+            widget_type=DashboardWidgetTypes.TRACEMETRICS,
+        )
+        DashboardWidgetQuery.objects.create(
+            widget=widget,
+            fields=["sum(value)"],
+            columns=[],
+            aggregates=["sum(value)"],
+            conditions="metric.name:foo",
+            order=0,
+        )
+        data: dict[str, Any] = {
+            "title": "First dashboard",
+            "widgets": [
+                {
+                    "id": str(widget.id),
+                    "title": "Metrics Table",
+                    "displayType": "table",
+                    "widgetType": "tracemetrics",
+                    "queries": [
+                        {
+                            "name": "",
+                            "fields": ["sum(value)"],
+                            "columns": [],
+                            "aggregates": ["sum(value)"],
+                            "conditions": "metric.name:foo",
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 200, response.data
+
     def test_add_widget_with_field_aliases(self) -> None:
         data: dict[str, Any] = {
             "title": "First dashboard",

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
@@ -1509,6 +1509,59 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert response.status_code == 400, response.data
         assert "displayType" in response.data, response.data
 
+    def test_widget_type_tracemetrics_allows_existing_table(self) -> None:
+        # Tracemetrics tables can't be created in the UI, but some existing
+        # widgets predate display-type validation and must still be saveable.
+        # Existing widgets are identified by the presence of an ``id``.
+        data = {
+            "id": "1",
+            "title": "Test Metrics Query",
+            "widgetType": "tracemetrics",
+            "displayType": "table",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "metric.name:foo",
+                    "fields": ["sum(value)"],
+                    "columns": [],
+                    "aggregates": ["sum(value)"],
+                },
+            ],
+        }
+
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 200, response.data
+
+    def test_existing_widget_still_rejects_other_unsupported_display_types(self) -> None:
+        # The grandfather exception only applies to tracemetrics tables. Other
+        # unsupported combinations are still rejected even for existing widgets.
+        data = {
+            "id": "1",
+            "title": "Table on preprod-app-size",
+            "displayType": "table",
+            "widgetType": "preprod-app-size",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "fields": ["count()"],
+                    "columns": [],
+                    "aggregates": ["count()"],
+                }
+            ],
+        }
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 400, response.data
+        assert "displayType" in response.data, response.data
+
     def test_text_widget_post(self) -> None:
         data = {
             "title": "Text Widget Title",


### PR DESCRIPTION
## Summary

An existing customer dashboard contained table widgets backed by the tracemetrics dataset, but saving the dashboard failed with:

> Display type 'table' is not supported for the 'tracemetrics' dataset

The tracemetrics + table combination isn't offered in the Widget Builder, but some widgets were created with it before display-type validation was added (#115951). Those dashboards must still be saveable.

## Change

`validate_display_type` now allows the **tracemetrics + table** combination through when the widget already exists (identified by an `id` in the request). The exception is intentionally narrow:

- Only `tracemetrics` + `table` is grandfathered — no other dataset/display-type combinations.
- Only existing widgets (with an `id`) — newly created tracemetrics tables are still rejected.

## Tests

- Existing tracemetrics table widget (with `id`) saves successfully (widget-details validation + end-to-end dashboard PUT).
- New tracemetrics table widget is still rejected.
- Other unsupported combinations (e.g. `table` on `preprod-app-size`) are still rejected even for existing widgets.

Fixes DAIN-1717