### PR TITLE
ref: Pass matches to recreateRoute for react-router-dom migration

### DIFF
--- a/static/app/components/modals/redirectToProject.tsx
+++ b/static/app/components/modals/redirectToProject.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useEffect, useState} from 'react';
+import {useMatches} from 'react-router-dom';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
@@ -17,6 +18,7 @@ interface Props extends ModalRenderProps {
 }
 
 function RedirectToProjectModal({slug, Header, Body}: Props) {
+  const matches = useMatches();
   const routes = useRoutes();
   const params = useParams();
   const location = useLocation();
@@ -24,6 +26,7 @@ function RedirectToProjectModal({slug, Header, Body}: Props) {
   const [timer, setTimer] = useState(5);
 
   const newPath = recreateRoute('', {
+    matches,
     routes,
     location,
     params: {...params, projectId: slug},

--- a/static/app/components/modals/redirectToProject.tsx
+++ b/static/app/components/modals/redirectToProject.tsx
@@ -11,7 +11,6 @@ import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
-import {useRoutes} from 'sentry/utils/useRoutes';
 
 interface Props extends ModalRenderProps {
   slug: string;
@@ -19,7 +18,6 @@ interface Props extends ModalRenderProps {
 
 function RedirectToProjectModal({slug, Header, Body}: Props) {
   const matches = useMatches();
-  const routes = useRoutes();
   const params = useParams();
   const location = useLocation();
 
@@ -27,7 +25,6 @@ function RedirectToProjectModal({slug, Header, Body}: Props) {
 
   const newPath = recreateRoute('', {
     matches,
-    routes,
     location,
     params: {...params, projectId: slug},
   });

--- a/static/app/utils/recreateRoute.spec.tsx
+++ b/static/app/utils/recreateRoute.spec.tsx
@@ -1,14 +1,9 @@
 import type {UIMatch} from 'react-router-dom';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 
-import type {PlainRoute} from 'sentry/types/legacyReactRouter';
-import {recreateRoute} from 'sentry/utils/recreateRoute';
+import {matchesToRoutes, recreateRoute} from 'sentry/utils/recreateRoute';
 
 jest.unmock('sentry/utils/recreateRoute');
-
-function matchesToRoutes(ms: UIMatch[]): PlainRoute[] {
-  return ms.map(m => ({...(m.handle as any)}));
-}
 
 function makeMatch(
   pathname: string,

--- a/static/app/utils/recreateRoute.spec.tsx
+++ b/static/app/utils/recreateRoute.spec.tsx
@@ -1,26 +1,66 @@
+import type {UIMatch} from 'react-router-dom';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 
+import type {PlainRoute} from 'sentry/types/legacyReactRouter';
 import {recreateRoute} from 'sentry/utils/recreateRoute';
 
 jest.unmock('sentry/utils/recreateRoute');
 
-const routes = [
-  {path: '/', childRoutes: []},
-  {childRoutes: []},
-  {path: '/settings/', name: 'Settings'},
-  {name: 'Organizations', path: ':orgId/', childRoutes: []},
-  {childRoutes: []},
-  {path: 'api-keys/', name: 'API Key'},
-];
+function matchesToRoutes(ms: UIMatch[]): PlainRoute[] {
+  return ms.map(m => ({...(m.handle as any)}));
+}
 
-const projectRoutes = [
-  {path: '/', childRoutes: []},
-  {childRoutes: []},
-  {path: '/settings/', name: 'Settings', indexRoute: {}, childRoutes: []},
-  {name: 'Organizations', path: ':orgId/', childRoutes: []},
-  {name: 'Projects', path: ':projectId', childRoutes: []},
-  {name: 'Alerts', path: 'alerts/'},
+function makeMatch(
+  pathname: string,
+  matchParams: Record<string, string>,
+  handle: Record<string, unknown>
+): UIMatch {
+  return {id: pathname, pathname, params: matchParams, data: undefined, handle};
+}
+
+const matches: UIMatch[] = [
+  makeMatch('/', {}, {path: '/', childRoutes: []}),
+  makeMatch('/', {}, {childRoutes: []}),
+  makeMatch('/settings/', {}, {path: '/settings/', name: 'Settings'}),
+  makeMatch(
+    '/settings/org-slug/',
+    {orgId: 'org-slug'},
+    {name: 'Organizations', path: ':orgId/', childRoutes: []}
+  ),
+  makeMatch('/settings/org-slug/', {orgId: 'org-slug'}, {childRoutes: []}),
+  makeMatch(
+    '/settings/org-slug/api-keys/',
+    {orgId: 'org-slug'},
+    {path: 'api-keys/', name: 'API Key'}
+  ),
 ];
+const routes = matchesToRoutes(matches);
+
+const projectMatches: UIMatch[] = [
+  makeMatch('/', {}, {path: '/', childRoutes: []}),
+  makeMatch('/', {}, {childRoutes: []}),
+  makeMatch(
+    '/settings/',
+    {},
+    {path: '/settings/', name: 'Settings', indexRoute: {}, childRoutes: []}
+  ),
+  makeMatch(
+    '/settings/org-slug/',
+    {orgId: 'org-slug'},
+    {name: 'Organizations', path: ':orgId/', childRoutes: []}
+  ),
+  makeMatch(
+    '/settings/org-slug/project-slug',
+    {orgId: 'org-slug', projectId: 'project-slug'},
+    {name: 'Projects', path: ':projectId', childRoutes: []}
+  ),
+  makeMatch(
+    '/settings/org-slug/project-slug/alerts/',
+    {orgId: 'org-slug', projectId: 'project-slug'},
+    {name: 'Alerts', path: 'alerts/'}
+  ),
+];
+const projectRoutes = matchesToRoutes(projectMatches);
 
 const params = {
   orgId: 'org-slug',
@@ -34,51 +74,74 @@ const location = {
 
 describe('recreateRoute', () => {
   it('returns correct path to a route object', () => {
-    expect(recreateRoute(routes[0]!, {routes, params})).toBe('/');
-    expect(recreateRoute(routes[1]!, {routes, params})).toBe('/');
-    expect(recreateRoute(routes[2]!, {routes, params})).toBe('/settings/');
-    expect(recreateRoute(routes[3]!, {routes, params})).toBe('/settings/org-slug/');
-    expect(recreateRoute(routes[4]!, {routes, params})).toBe('/settings/org-slug/');
-    expect(recreateRoute(routes[5]!, {routes, params})).toBe(
+    expect(recreateRoute(routes[0]!, {routes, matches, params})).toBe('/');
+    expect(recreateRoute(routes[1]!, {routes, matches, params})).toBe('/');
+    expect(recreateRoute(routes[2]!, {routes, matches, params})).toBe('/settings/');
+    expect(recreateRoute(routes[3]!, {routes, matches, params})).toBe(
+      '/settings/org-slug/'
+    );
+    expect(recreateRoute(routes[4]!, {routes, matches, params})).toBe(
+      '/settings/org-slug/'
+    );
+    expect(recreateRoute(routes[5]!, {routes, matches, params})).toBe(
       '/settings/org-slug/api-keys/'
     );
 
     expect(
-      recreateRoute(projectRoutes[5]!, {routes: projectRoutes, location, params})
+      recreateRoute(projectRoutes[5]!, {
+        routes: projectRoutes,
+        matches: projectMatches,
+        location,
+        params,
+      })
     ).toBe('/settings/org-slug/project-slug/alerts/');
   });
 
   it('has correct path with route object with many roots (starts with "/")', () => {
-    const r = [
-      {path: '/', childRoutes: []},
-      {childRoutes: []},
-      {path: '/foo/', childRoutes: []},
-      {childRoutes: []},
-      {path: 'bar', childRoutes: []},
-      {path: '/settings/', name: 'Settings'},
-      {name: 'Organizations', path: ':orgId/', childRoutes: []},
-      {childRoutes: []},
-      {path: 'api-keys/', name: 'API Key'},
+    const m: UIMatch[] = [
+      makeMatch('/', {}, {path: '/', childRoutes: []}),
+      makeMatch('/', {}, {childRoutes: []}),
+      makeMatch('/foo/', {}, {path: '/foo/', childRoutes: []}),
+      makeMatch('/foo/', {}, {childRoutes: []}),
+      makeMatch('/foo/bar', {}, {path: 'bar', childRoutes: []}),
+      makeMatch('/settings/', {}, {path: '/settings/', name: 'Settings'}),
+      makeMatch(
+        '/settings/org-slug/',
+        {orgId: 'org-slug'},
+        {name: 'Organizations', path: ':orgId/', childRoutes: []}
+      ),
+      makeMatch('/settings/org-slug/', {orgId: 'org-slug'}, {childRoutes: []}),
+      makeMatch(
+        '/settings/org-slug/api-keys/',
+        {orgId: 'org-slug'},
+        {path: 'api-keys/', name: 'API Key'}
+      ),
     ];
+    const r = matchesToRoutes(m);
 
-    expect(recreateRoute(r[4]!, {routes: r, params})).toBe('/foo/bar/');
+    expect(recreateRoute(r[4]!, {routes: r, matches: m, params})).toBe('/foo/bar/');
   });
 
   it('returns correct path to a string (at the end of the routes)', () => {
-    expect(recreateRoute('test/', {routes, location, params})).toBe(
+    expect(recreateRoute('test/', {routes, matches, location, params})).toBe(
       '/settings/org-slug/api-keys/test/'
     );
   });
 
   it('returns correct path to a string after the 2nd to last route', () => {
-    expect(recreateRoute('test/', {routes, location, params, stepBack: -2})).toBe(
-      '/settings/org-slug/test/'
-    );
+    expect(
+      recreateRoute('test/', {routes, matches, location, params, stepBack: -2})
+    ).toBe('/settings/org-slug/test/');
   });
 
   it('switches to new org but keeps current route', () => {
     expect(
-      recreateRoute(routes[5]!, {routes, location, params: {orgId: 'new-org'}})
+      recreateRoute(routes[5]!, {
+        routes,
+        matches,
+        location,
+        params: {orgId: 'new-org'},
+      })
     ).toBe('/settings/new-org/api-keys/');
   });
 
@@ -88,8 +151,8 @@ describe('recreateRoute', () => {
       search: '?key1=foo&key2=bar',
     };
 
-    expect(recreateRoute(routes[5]!, {routes, params, location: withSearch})).toBe(
-      '/settings/org-slug/api-keys/?key1=foo&key2=bar'
-    );
+    expect(
+      recreateRoute(routes[5]!, {routes, matches, params, location: withSearch})
+    ).toBe('/settings/org-slug/api-keys/?key1=foo&key2=bar');
   });
 });

--- a/static/app/utils/recreateRoute.spec.tsx
+++ b/static/app/utils/recreateRoute.spec.tsx
@@ -69,22 +69,17 @@ const location = {
 
 describe('recreateRoute', () => {
   it('returns correct path to a route object', () => {
-    expect(recreateRoute(routes[0]!, {routes, matches, params})).toBe('/');
-    expect(recreateRoute(routes[1]!, {routes, matches, params})).toBe('/');
-    expect(recreateRoute(routes[2]!, {routes, matches, params})).toBe('/settings/');
-    expect(recreateRoute(routes[3]!, {routes, matches, params})).toBe(
-      '/settings/org-slug/'
-    );
-    expect(recreateRoute(routes[4]!, {routes, matches, params})).toBe(
-      '/settings/org-slug/'
-    );
-    expect(recreateRoute(routes[5]!, {routes, matches, params})).toBe(
+    expect(recreateRoute(routes[0]!, {matches, params})).toBe('/');
+    expect(recreateRoute(routes[1]!, {matches, params})).toBe('/');
+    expect(recreateRoute(routes[2]!, {matches, params})).toBe('/settings/');
+    expect(recreateRoute(routes[3]!, {matches, params})).toBe('/settings/org-slug/');
+    expect(recreateRoute(routes[4]!, {matches, params})).toBe('/settings/org-slug/');
+    expect(recreateRoute(routes[5]!, {matches, params})).toBe(
       '/settings/org-slug/api-keys/'
     );
 
     expect(
       recreateRoute(projectRoutes[5]!, {
-        routes: projectRoutes,
         matches: projectMatches,
         location,
         params,
@@ -114,25 +109,24 @@ describe('recreateRoute', () => {
     ];
     const r = matchesToRoutes(m);
 
-    expect(recreateRoute(r[4]!, {routes: r, matches: m, params})).toBe('/foo/bar/');
+    expect(recreateRoute(r[4]!, {matches: m, params})).toBe('/foo/bar/');
   });
 
   it('returns correct path to a string (at the end of the routes)', () => {
-    expect(recreateRoute('test/', {routes, matches, location, params})).toBe(
+    expect(recreateRoute('test/', {matches, location, params})).toBe(
       '/settings/org-slug/api-keys/test/'
     );
   });
 
   it('returns correct path to a string after the 2nd to last route', () => {
-    expect(
-      recreateRoute('test/', {routes, matches, location, params, stepBack: -2})
-    ).toBe('/settings/org-slug/test/');
+    expect(recreateRoute('test/', {matches, location, params, stepBack: -2})).toBe(
+      '/settings/org-slug/test/'
+    );
   });
 
   it('switches to new org but keeps current route', () => {
     expect(
       recreateRoute(routes[5]!, {
-        routes,
         matches,
         location,
         params: {orgId: 'new-org'},
@@ -146,8 +140,8 @@ describe('recreateRoute', () => {
       search: '?key1=foo&key2=bar',
     };
 
-    expect(
-      recreateRoute(routes[5]!, {routes, matches, params, location: withSearch})
-    ).toBe('/settings/org-slug/api-keys/?key1=foo&key2=bar');
+    expect(recreateRoute(routes[5]!, {matches, params, location: withSearch})).toBe(
+      '/settings/org-slug/api-keys/?key1=foo&key2=bar'
+    );
   });
 });

--- a/static/app/utils/recreateRoute.tsx
+++ b/static/app/utils/recreateRoute.tsx
@@ -16,7 +16,6 @@ type Options = {
   params: Record<string, string | undefined>;
 
   location?: Location;
-  routes?: PlainRoute[];
   /**
    * The number of routes to pop off of `routes
    * Must be < 0
@@ -26,6 +25,21 @@ type Options = {
   stepBack?: -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9;
 };
 
+function findRouteInMatches(to: PlainRoute, matches: UIMatch[]): number {
+  return matches.findIndex(m => {
+    const handle = m.handle;
+    if (!handle || typeof handle !== 'object') {
+      return false;
+    }
+    const toKeys = Object.keys(to);
+    const handleKeys = Object.keys(handle);
+    if (toKeys.length !== handleKeys.length) {
+      return false;
+    }
+    return toKeys.every(k => (to as any)[k] === (handle as any)[k]);
+  });
+}
+
 /**
  * Given a route object or a string and a list of routes + params from router, this will attempt to recreate a location string while replacing url params.
  * Can additionally specify the number of routes to move back
@@ -34,7 +48,7 @@ type Options = {
  */
 export function recreateRoute(to: string | PlainRoute, options: Options): string {
   const {matches, params, location, stepBack} = options;
-  const routes = options.routes ?? matchesToRoutes(matches);
+  const routes = matchesToRoutes(matches);
   const paths = routes.map(({path}) => {
     path = path || '';
     if (path.length > 0 && !path.endsWith('/')) {
@@ -45,11 +59,10 @@ export function recreateRoute(to: string | PlainRoute, options: Options): string
   let lastRootIndex: number;
   let routeIndex: number | undefined;
 
-  // TODO(ts): typescript things
   if (typeof to === 'string') {
     lastRootIndex = paths.findLastIndex((path: any) => path[0] === '/');
   } else {
-    routeIndex = routes.indexOf(to) + 1;
+    routeIndex = findRouteInMatches(to, matches) + 1;
     lastRootIndex = paths
       .slice(0, routeIndex)
       .findLastIndex((path: any) => path[0] === '/');

--- a/static/app/utils/recreateRoute.tsx
+++ b/static/app/utils/recreateRoute.tsx
@@ -1,9 +1,12 @@
+import type {UIMatch} from 'react-router-dom';
 import type {Location} from 'history';
 
 import type {PlainRoute} from 'sentry/types/legacyReactRouter';
 import {replaceRouterParams} from 'sentry/utils/replaceRouterParams';
 
 type Options = {
+  matches: UIMatch[];
+
   // parameters to replace any route string parameters (e.g. if route is `:orgId`,
   // params should have `{orgId: slug}`
   params: Record<string, string | undefined>;

--- a/static/app/utils/recreateRoute.tsx
+++ b/static/app/utils/recreateRoute.tsx
@@ -4,6 +4,10 @@ import type {Location} from 'history';
 import type {PlainRoute} from 'sentry/types/legacyReactRouter';
 import {replaceRouterParams} from 'sentry/utils/replaceRouterParams';
 
+export function matchesToRoutes(matches: UIMatch[]): PlainRoute[] {
+  return matches.map(m => ({...(m.handle as any)}));
+}
+
 type Options = {
   matches: UIMatch[];
 
@@ -11,9 +15,8 @@ type Options = {
   // params should have `{orgId: slug}`
   params: Record<string, string | undefined>;
 
-  routes: PlainRoute[];
-
   location?: Location;
+  routes?: PlainRoute[];
   /**
    * The number of routes to pop off of `routes
    * Must be < 0
@@ -30,7 +33,8 @@ type Options = {
  * See tests for examples
  */
 export function recreateRoute(to: string | PlainRoute, options: Options): string {
-  const {routes, params, location, stepBack} = options;
+  const {matches, params, location, stepBack} = options;
+  const routes = options.routes ?? matchesToRoutes(matches);
   const paths = routes.map(({path}) => {
     path = path || '';
     if (path.length > 0 && !path.endsWith('/')) {

--- a/static/app/utils/withDomainRedirect.spec.tsx
+++ b/static/app/utils/withDomainRedirect.spec.tsx
@@ -1,3 +1,5 @@
+import type {RouteObject} from 'react-router-dom';
+import {Outlet} from 'react-router-dom';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -7,21 +9,41 @@ import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useParams} from 'sentry/utils/useParams';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import {withDomainRedirect} from 'sentry/utils/withDomainRedirect';
 
 jest.unmock('sentry/utils/recreateRoute');
-jest.mock('sentry/utils/useRoutes');
 
-// /settings/:orgId/:projectId/(searches/:searchId/)alerts/
-const projectRoutes = [
-  {path: '/', childRoutes: []},
-  {childRoutes: []},
-  {path: '/settings/', name: 'Settings', indexRoute: {}, childRoutes: []},
-  {name: 'Organizations', path: ':orgId/', childRoutes: []},
-  {name: 'Projects', path: ':projectId/', childRoutes: []},
-  {name: 'Alerts', path: 'alerts/'},
-];
+// /settings/:orgId/:projectId/alerts/
+function projectRouteChildren(leaf: React.ReactElement): RouteObject[] {
+  return [
+    {
+      path: 'settings',
+      handle: {path: '/settings/', name: 'Settings', indexRoute: {}, childRoutes: []},
+      element: <Outlet />,
+      children: [
+        {
+          path: ':orgId',
+          handle: {name: 'Organizations', path: ':orgId/', childRoutes: []},
+          element: <Outlet />,
+          children: [
+            {
+              path: ':projectId',
+              handle: {name: 'Projects', path: ':projectId/', childRoutes: []},
+              element: <Outlet />,
+              children: [
+                {
+                  path: 'alerts/*',
+                  handle: {name: 'Alerts', path: 'alerts/'},
+                  element: leaf,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+}
 
 describe('withDomainRedirect', () => {
   function MyComponent() {
@@ -131,17 +153,17 @@ describe('withDomainRedirect', () => {
     const organization = OrganizationFixture({
       slug: 'albertos-apples',
     });
-    jest.mocked(useRoutes).mockReturnValue(projectRoutes);
 
     const WrappedComponent = withDomainRedirect(MyComponent);
-    const {router} = render(<WrappedComponent />, {
+    const {router} = render(<Outlet />, {
       organization,
       initialRouterConfig: {
         location: {
           pathname: '/settings/albertos-apples/react/alerts/',
           query: {q: '123'},
         },
-        route: '/settings/:orgId/:projectId/alerts/',
+        route: '/',
+        children: projectRouteChildren(<WrappedComponent />),
       },
     });
 
@@ -157,8 +179,6 @@ describe('withDomainRedirect', () => {
     const organization = OrganizationFixture({
       slug: 'albertos-apples',
     });
-
-    jest.mocked(useRoutes).mockReturnValue([]);
 
     const WrappedComponent = withDomainRedirect(MyComponent);
     const {router} = render(<WrappedComponent />, {
@@ -185,17 +205,17 @@ describe('withDomainRedirect', () => {
       sentryUrl: 'https://sentry.io',
       subdomain: '',
     });
-    jest.mocked(useRoutes).mockReturnValue(projectRoutes);
 
     const WrappedComponent = withDomainRedirect(MyComponent);
-    const {router} = render(<WrappedComponent />, {
+    const {router} = render(<Outlet />, {
       organization,
       initialRouterConfig: {
         location: {
           pathname: '/settings/albertos-apples/react/alerts/',
           query: {q: '123'},
         },
-        route: '/settings/:orgId/:projectId/alerts/',
+        route: '/',
+        children: projectRouteChildren(<WrappedComponent />),
       },
     });
 

--- a/static/app/utils/withDomainRedirect.tsx
+++ b/static/app/utils/withDomainRedirect.tsx
@@ -1,4 +1,4 @@
-import {generatePath} from 'react-router-dom';
+import {generatePath, useMatches} from 'react-router-dom';
 import trim from 'lodash/trim';
 import trimEnd from 'lodash/trimEnd';
 import trimStart from 'lodash/trimStart';
@@ -39,6 +39,7 @@ export function withDomainRedirect(WrappedComponent: React.ComponentType<any>) {
     const {sentryUrl} = links;
     const currentOrganization = useOrganization({allowNull: true});
     const params = useParams();
+    const matches = useMatches();
     const routes = useRoutes();
 
     if (customerDomain) {
@@ -63,7 +64,7 @@ export function withDomainRedirect(WrappedComponent: React.ComponentType<any>) {
       Object.keys(params).forEach(param => {
         newParams[param] = `:${param}`;
       });
-      const fullRoute = recreateRoute('', {routes, params: newParams});
+      const fullRoute = recreateRoute('', {matches, routes, params: newParams});
       const orglessSlugRoute = normalizeUrl(fullRoute, {forceCustomerDomain: true});
 
       if (orglessSlugRoute === fullRoute) {

--- a/static/app/utils/withDomainRedirect.tsx
+++ b/static/app/utils/withDomainRedirect.tsx
@@ -9,7 +9,6 @@ import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useParams} from 'sentry/utils/useParams';
-import {useRoutes} from 'sentry/utils/useRoutes';
 
 import {useOrganization} from './useOrganization';
 
@@ -40,7 +39,6 @@ export function withDomainRedirect(WrappedComponent: React.ComponentType<any>) {
     const currentOrganization = useOrganization({allowNull: true});
     const params = useParams();
     const matches = useMatches();
-    const routes = useRoutes();
 
     if (customerDomain) {
       // Customer domain is being used on a route that has an :orgId parameter.
@@ -64,7 +62,7 @@ export function withDomainRedirect(WrappedComponent: React.ComponentType<any>) {
       Object.keys(params).forEach(param => {
         newParams[param] = `:${param}`;
       });
-      const fullRoute = recreateRoute('', {matches, routes, params: newParams});
+      const fullRoute = recreateRoute('', {matches, params: newParams});
       const orglessSlugRoute = normalizeUrl(fullRoute, {forceCustomerDomain: true});
 
       if (orglessSlugRoute === fullRoute) {

--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -1,4 +1,5 @@
 import {useEffect, Fragment, useMemo, useRef} from 'react';
+import {useMatches} from 'react-router-dom';
 
 import {Stack} from '@sentry/scraps/layout';
 
@@ -51,6 +52,7 @@ export default function Create() {
   const location = useLocation();
   const params = useParams<RouteParams>();
   const navigate = useNavigate();
+  const matches = useMatches();
   const routes = useRoutes();
   const {project, members} = useAlertBuilderOutlet();
   const hasMetricAlerts = organization.features.includes('incidents');
@@ -202,6 +204,7 @@ export default function Create() {
               />
             ) : !hasMetricAlerts || alertType === AlertRuleType.ISSUE ? (
               <IssueRuleEditor
+                matches={matches}
                 location={location}
                 params={params}
                 router={router}

--- a/static/app/views/alerts/edit.tsx
+++ b/static/app/views/alerts/edit.tsx
@@ -1,4 +1,5 @@
 import {useMemo, useState, Fragment} from 'react';
+import {useMatches} from 'react-router-dom';
 
 import {Stack} from '@sentry/scraps/layout';
 
@@ -34,6 +35,7 @@ export default function ProjectAlertsEditor() {
   const location = useLocation();
   const params = useParams<RouteParams>();
   const navigate = useNavigate();
+  const matches = useMatches();
   const routes = useRoutes();
   const {project, members} = useAlertBuilderOutlet();
 
@@ -106,6 +108,7 @@ export default function ProjectAlertsEditor() {
           <Fragment>
             {alertType === CombinedAlertType.ISSUE && (
               <IssueEditor
+                matches={matches}
                 location={location}
                 params={params}
                 router={router}

--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -1,3 +1,4 @@
+import type {UIMatch} from 'react-router-dom';
 import moment from 'moment-timezone';
 import {EnvironmentsFixture} from 'sentry-fixture/environments';
 import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
@@ -49,35 +50,54 @@ jest.mock('sentry/utils/analytics', () => ({
   trackAnalytics: jest.fn(),
 }));
 
-const projectAlertRuleDetailsRoutes: PlainRoute[] = [
-  {
-    path: '/',
-  },
-  {
-    path: '/settings/',
-    indexRoute: {},
-  },
-  {
-    path: ':orgId/',
-  },
-  {
-    path: 'projects/:projectId/',
-  },
-  {},
-  {
-    indexRoute: {},
-  },
-  {
-    path: 'alerts/',
-    indexRoute: {},
-  },
-  {
-    path: 'rules/',
-    indexRoute: {},
-    childRoutes: [{path: 'new/'}, {path: ':ruleId/'}],
-  },
-  {path: ':ruleId/'},
+function makeMatch(
+  pathname: string,
+  matchParams: Record<string, string>,
+  handle: Record<string, unknown>
+): UIMatch {
+  return {id: pathname, pathname, params: matchParams, data: undefined, handle};
+}
+
+function matchesToRoutes(ms: UIMatch[]): PlainRoute[] {
+  return ms.map(m => ({...(m.handle as any)}));
+}
+
+const matches: UIMatch[] = [
+  makeMatch('/', {}, {path: '/'}),
+  makeMatch('/settings/', {}, {path: '/settings/', indexRoute: {}}),
+  makeMatch('/settings/org-slug/', {orgId: 'org-slug'}, {path: ':orgId/'}),
+  makeMatch(
+    '/settings/org-slug/projects/project-slug/',
+    {orgId: 'org-slug', projectId: 'project-slug'},
+    {path: 'projects/:projectId/'}
+  ),
+  makeMatch(
+    '/settings/org-slug/projects/project-slug/',
+    {orgId: 'org-slug', projectId: 'project-slug'},
+    {}
+  ),
+  makeMatch(
+    '/settings/org-slug/projects/project-slug/',
+    {orgId: 'org-slug', projectId: 'project-slug'},
+    {indexRoute: {}}
+  ),
+  makeMatch(
+    '/settings/org-slug/projects/project-slug/alerts/',
+    {orgId: 'org-slug', projectId: 'project-slug'},
+    {path: 'alerts/', indexRoute: {}}
+  ),
+  makeMatch(
+    '/settings/org-slug/projects/project-slug/alerts/rules/',
+    {orgId: 'org-slug', projectId: 'project-slug'},
+    {path: 'rules/', indexRoute: {}, childRoutes: [{path: 'new/'}, {path: ':ruleId/'}]}
+  ),
+  makeMatch(
+    '/settings/org-slug/projects/project-slug/alerts/rules/1/',
+    {orgId: 'org-slug', projectId: 'project-slug', ruleId: '1'},
+    {path: ':ruleId/'}
+  ),
 ];
+const projectAlertRuleDetailsRoutes: PlainRoute[] = matchesToRoutes(matches);
 
 const createWrapper = (props: Parameters<typeof initializeOrg>[0] = {}) => {
   const {organization, project} = initializeOrg(props);
@@ -103,6 +123,7 @@ const createWrapper = (props: Parameters<typeof initializeOrg>[0] = {}) => {
   const onChangeTitleMock = jest.fn();
   const wrapper = render(
     <IssueRuleEditor
+      matches={matches}
       route={RouteComponentPropsFixture().route}
       routeParams={RouteComponentPropsFixture().routeParams}
       params={params}

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1,5 +1,6 @@
 import type {ChangeEvent, ReactNode} from 'react';
 import {Fragment} from 'react';
+import type {UIMatch} from 'react-router-dom';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import classNames from 'classnames';
@@ -135,6 +136,7 @@ type IncompatibleRule = {
 
 type Props = {
   location: Location;
+  matches: UIMatch[];
   members: Member[] | undefined;
   navigate: ReactRouter3Navigate;
   organization: Organization;

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -584,7 +584,7 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
       addSuccessMessage(t('Deleted alert rule'));
       this.props.navigate(
         recreateRoute('', {
-          ...this.props,
+          matches: this.props.matches,
           params: {...this.props.params, orgId: organization.slug},
           stepBack: -2,
         }),

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.spec.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.spec.tsx
@@ -11,7 +11,7 @@ describe('Settings Breadcrumb Dropdown', () => {
     return render(
       <BreadcrumbDropdown
         value={undefined}
-        route={{path: '/', name: 'root'}}
+        routeName="root"
         options={[
           {value: '1', label: 'foo'},
           {value: '2', label: 'bar'},
@@ -76,7 +76,7 @@ describe('Settings Breadcrumb Dropdown', () => {
       <Fragment>
         <BreadcrumbDropdown
           value={undefined}
-          route={{path: '/', name: 'root'}}
+          routeName="root"
           options={[
             {value: '1', label: 'foo'},
             {value: '2', label: 'bar'},
@@ -87,7 +87,7 @@ describe('Settings Breadcrumb Dropdown', () => {
         />
         <BreadcrumbDropdown
           value={undefined}
-          route={{path: '/', name: 'root'}}
+          routeName="root"
           options={[
             {value: '1', label: 'baz'},
             {value: '2', label: 'buzz'},

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
@@ -14,7 +14,6 @@ import {OverlayTrigger, type TriggerProps} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
 import {Divider} from './divider';
-import type {RouteWithName} from './types';
 
 interface BreadcrumbDropdownProps extends Omit<
   SingleSelectProps<string>,
@@ -22,14 +21,14 @@ interface BreadcrumbDropdownProps extends Omit<
 > {
   name: React.ReactNode;
   onCrumbSelect: (value: string) => void;
-  route: RouteWithName;
   hasMenu?: boolean;
   isLast?: boolean;
+  routeName?: string;
 }
 
 export function BreadcrumbDropdown({
   hasMenu,
-  route,
+  routeName,
   isLast,
   name,
   onCrumbSelect,
@@ -46,7 +45,7 @@ export function BreadcrumbDropdown({
     return (
       <Button variant="link">
         <Flex gap="sm" align="center">
-          <Text bold={false}>{name || route.name} </Text>
+          <Text bold={false}>{name || routeName} </Text>
           {isLast ? null : <Divider />}
         </Flex>
       </Button>
@@ -66,7 +65,7 @@ export function BreadcrumbDropdown({
       value={value}
       trigger={triggerProps => (
         <MenuCrumb
-          crumbLabel={name || route.name}
+          crumbLabel={name || routeName}
           menuHasHover={isHovered}
           {...triggerProps}
         />

--- a/static/app/views/settings/components/settingsBreadcrumb/index.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/index.tsx
@@ -56,12 +56,7 @@ export function SettingsBreadcrumb({className, params}: Props) {
 
         if (hasMenu) {
           return (
-            <Menu
-              key={`${route.name}:${route.path}`}
-              routes={routes}
-              route={route}
-              isLast={isLast}
-            />
+            <Menu key={`${route.name}:${route.path}`} routeIndex={i} isLast={isLast} />
           );
         }
         if (isLast) {

--- a/static/app/views/settings/components/settingsBreadcrumb/index.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/index.tsx
@@ -7,8 +7,7 @@ import {Text} from '@sentry/scraps/text';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getRouteStringFromRoutes} from 'sentry/utils/getRouteStringFromRoutes';
-import {recreateRoute} from 'sentry/utils/recreateRoute';
-import {useRoutes} from 'sentry/utils/useRoutes';
+import {matchesToRoutes, recreateRoute} from 'sentry/utils/recreateRoute';
 
 import {useBreadcrumbsPathmap} from './context';
 import {Divider} from './divider';
@@ -27,8 +26,8 @@ type Props = {
 };
 
 export function SettingsBreadcrumb({className, params}: Props) {
-  const routes = useRoutes() as RouteWithName[];
   const matches = useMatches();
+  const routes = matchesToRoutes(matches) as RouteWithName[];
   const pathMap = useBreadcrumbsPathmap();
 
   const lastRouteIndex = routes.map(r => !!r.name).lastIndexOf(true);
@@ -75,7 +74,7 @@ export function SettingsBreadcrumb({className, params}: Props) {
         return (
           <Flex gap="sm" align="center" key={`${route.name}:${route.path}`}>
             <CrumbLink
-              to={recreateRoute(route, {matches, routes, params})}
+              to={recreateRoute(route, {matches, params})}
               onClick={onSettingsBreadcrumbLinkClick}
             >
               {pathTitle || route.name}

--- a/static/app/views/settings/components/settingsBreadcrumb/index.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/index.tsx
@@ -1,4 +1,4 @@
-import {Link as RouterLink} from 'react-router-dom';
+import {Link as RouterLink, useMatches} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -28,6 +28,7 @@ type Props = {
 
 export function SettingsBreadcrumb({className, params}: Props) {
   const routes = useRoutes() as RouteWithName[];
+  const matches = useMatches();
   const pathMap = useBreadcrumbsPathmap();
 
   const lastRouteIndex = routes.map(r => !!r.name).lastIndexOf(true);
@@ -74,7 +75,7 @@ export function SettingsBreadcrumb({className, params}: Props) {
         return (
           <Flex gap="sm" align="center" key={`${route.name}:${route.path}`}>
             <CrumbLink
-              to={recreateRoute(route, {routes, params})}
+              to={recreateRoute(route, {matches, routes, params})}
               onClick={onSettingsBreadcrumbLinkClick}
             >
               {pathTitle || route.name}

--- a/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
@@ -42,7 +42,6 @@ export function ProjectCrumb({routes, route, ...props}: SettingsBreadcrumbProps)
     navigate(
       recreateRoute(returnTo, {
         matches,
-        routes,
         params: {...params, projectId: projectSlug},
       })
     );

--- a/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
@@ -6,34 +6,31 @@ import {ProjectAvatar} from '@sentry/scraps/avatar';
 import {IdBadge} from 'sentry/components/idBadge';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {recreateRoute} from 'sentry/utils/recreateRoute';
+import {matchesToRoutes, recreateRoute} from 'sentry/utils/recreateRoute';
 import {replaceRouterParams} from 'sentry/utils/replaceRouterParams';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useProjects} from 'sentry/utils/useProjects';
-import type {SettingsBreadcrumbProps} from 'sentry/views/settings/components/settingsBreadcrumb/types';
+import type {
+  RouteWithName,
+  SettingsBreadcrumbProps,
+} from 'sentry/views/settings/components/settingsBreadcrumb/types';
 
 import {BreadcrumbDropdown} from './breadcrumbDropdown';
 import {findFirstRouteWithoutRouteParam} from './findFirstRouteWithoutRouteParam';
 import {CrumbLink} from '.';
 
-export function ProjectCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
+export function ProjectCrumb({routeIndex, ...props}: SettingsBreadcrumbProps) {
   const navigate = useNavigate();
   const matches = useMatches();
+  const routes = matchesToRoutes(matches);
+  const route = routes[routeIndex] as RouteWithName;
   const {projects, onSearch} = useProjects();
   const organization = useOrganization();
   const params = useParams();
   const handleSelect = (projectSlug: string) => {
-    // We have to make exceptions for routes like "Project Alerts Rule Edit" or "Client Key Details"
-    // Since these models are project specific, we need to traverse up a route when switching projects
-    //
-    // we manipulate `routes` so that it doesn't include the current project's route
-    // which, unlike the org version, does not start with a route param
-    const returnTo = findFirstRouteWithoutRouteParam(
-      routes.slice(routes.indexOf(route) + 1),
-      route
-    );
+    const returnTo = findFirstRouteWithoutRouteParam(routes.slice(routeIndex + 1), route);
 
     if (returnTo === undefined) {
       return;
@@ -52,7 +49,7 @@ export function ProjectCrumb({routes, route, ...props}: SettingsBreadcrumbProps)
   return (
     <BreadcrumbDropdown
       hasMenu={projects && projects.length > 1}
-      route={route}
+      routeName={route.name}
       name={
         <ProjectName>
           {activeProject ? (

--- a/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
@@ -1,3 +1,4 @@
+import {useMatches} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {ProjectAvatar} from '@sentry/scraps/avatar';
@@ -19,6 +20,7 @@ import {CrumbLink} from '.';
 
 export function ProjectCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
   const navigate = useNavigate();
+  const matches = useMatches();
   const {projects, onSearch} = useProjects();
   const organization = useOrganization();
   const params = useParams();
@@ -38,7 +40,11 @@ export function ProjectCrumb({routes, route, ...props}: SettingsBreadcrumbProps)
     }
 
     navigate(
-      recreateRoute(returnTo, {routes, params: {...params, projectId: projectSlug}})
+      recreateRoute(returnTo, {
+        matches,
+        routes,
+        params: {...params, projectId: projectSlug},
+      })
     );
   };
 

--- a/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
@@ -14,7 +14,7 @@ import type {SettingsBreadcrumbProps} from 'sentry/views/settings/components/set
 import {BreadcrumbDropdown} from './breadcrumbDropdown';
 import {CrumbLink} from '.';
 
-export function TeamCrumb({route, ...props}: SettingsBreadcrumbProps) {
+export function TeamCrumb({routeIndex: _routeIndex, ...props}: SettingsBreadcrumbProps) {
   const matches = useMatches();
   const navigate = useNavigate();
   const {teams, onSearch, fetching} = useTeams();
@@ -49,7 +49,6 @@ export function TeamCrumb({route, ...props}: SettingsBreadcrumbProps) {
         }
       }}
       hasMenu={hasMenu}
-      route={route}
       value={team.slug}
       search={{placeholder: t('Search Teams'), onChange: onSearch}}
       options={teams.map(teamItem => ({

--- a/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
@@ -14,7 +14,7 @@ import type {SettingsBreadcrumbProps} from 'sentry/views/settings/components/set
 import {BreadcrumbDropdown} from './breadcrumbDropdown';
 import {CrumbLink} from '.';
 
-export function TeamCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
+export function TeamCrumb({route, ...props}: SettingsBreadcrumbProps) {
   const matches = useMatches();
   const navigate = useNavigate();
   const {teams, onSearch, fetching} = useTeams();
@@ -38,7 +38,6 @@ export function TeamCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
       onCrumbSelect={teamSlug => {
         navigate(
           recreateRoute('', {
-            routes,
             matches,
             params: {...params, teamId: teamSlug},
           })

--- a/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
@@ -1,3 +1,5 @@
+import {useMatches} from 'react-router-dom';
+
 import {TeamAvatar} from '@sentry/scraps/avatar';
 
 import {IdBadge} from 'sentry/components/idBadge';
@@ -13,6 +15,7 @@ import {BreadcrumbDropdown} from './breadcrumbDropdown';
 import {CrumbLink} from '.';
 
 export function TeamCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
+  const matches = useMatches();
   const navigate = useNavigate();
   const {teams, onSearch, fetching} = useTeams();
   const params = useParams();
@@ -36,6 +39,7 @@ export function TeamCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
         navigate(
           recreateRoute('', {
             routes,
+            matches,
             params: {...params, teamId: teamSlug},
           })
         );

--- a/static/app/views/settings/components/settingsBreadcrumb/types.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/types.tsx
@@ -1,12 +1,9 @@
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-
-// TODO(ts): The `name` attribute doesn't appear on any of the react router route types
-
 export interface RouteWithName {
   name?: string;
   path?: string;
 }
 
-export type SettingsBreadcrumbProps = Pick<RouteComponentProps, 'route' | 'routes'> & {
+export type SettingsBreadcrumbProps = {
   isLast: boolean;
+  routeIndex: number;
 };

--- a/static/app/views/settings/project/projectFilters/index.tsx
+++ b/static/app/views/settings/project/projectFilters/index.tsx
@@ -8,7 +8,6 @@ import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {useParams} from 'sentry/utils/useParams';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {GroupTombstones} from 'sentry/views/settings/project/projectFilters/groupTombstones';
 import {ProjectFiltersChart} from 'sentry/views/settings/project/projectFilters/projectFiltersChart';
@@ -18,7 +17,6 @@ import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSet
 
 export default function ProjectFilters() {
   const matches = useMatches();
-  const routes = useRoutes();
   const params = useParams<{filterType: string; projectId: string}>();
   const {projectId, filterType} = params;
   const {project} = useProjectSettingsOutlet();
@@ -52,7 +50,6 @@ export default function ProjectFilters() {
                   key="data-filters"
                   to={recreateRoute('data-filters/', {
                     matches,
-                    routes,
                     params,
                     stepBack: -1,
                   })}
@@ -63,7 +60,6 @@ export default function ProjectFilters() {
                   key="discarded-groups"
                   to={recreateRoute('discarded-groups/', {
                     matches,
-                    routes,
                     params,
                     stepBack: -1,
                   })}

--- a/static/app/views/settings/project/projectFilters/index.tsx
+++ b/static/app/views/settings/project/projectFilters/index.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {useMatches} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {TabList, Tabs} from '@sentry/scraps/tabs';
@@ -16,6 +17,7 @@ import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermi
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
 export default function ProjectFilters() {
+  const matches = useMatches();
   const routes = useRoutes();
   const params = useParams<{filterType: string; projectId: string}>();
   const {projectId, filterType} = params;
@@ -48,13 +50,23 @@ export default function ProjectFilters() {
               <TabList>
                 <TabList.Item
                   key="data-filters"
-                  to={recreateRoute('data-filters/', {routes, params, stepBack: -1})}
+                  to={recreateRoute('data-filters/', {
+                    matches,
+                    routes,
+                    params,
+                    stepBack: -1,
+                  })}
                 >
                   {t('Data Filters')}
                 </TabList.Item>
                 <TabList.Item
                   key="discarded-groups"
-                  to={recreateRoute('discarded-groups/', {routes, params, stepBack: -1})}
+                  to={recreateRoute('discarded-groups/', {
+                    matches,
+                    routes,
+                    params,
+                    stepBack: -1,
+                  })}
                 >
                   {t('Discarded Issues')}
                 </TabList.Item>

--- a/static/app/views/settings/project/projectKeys/list/index.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.tsx
@@ -25,8 +25,6 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useParams} from 'sentry/utils/useParams';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
@@ -34,12 +32,10 @@ import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSet
 import {KeyRow} from './keyRow';
 
 export default function ProjectKeys() {
-  const params = useParams<{projectId: string}>();
   const location = useLocation();
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
   const api = useApi({persistInFlight: true});
-  const routes = useRoutes();
 
   const [keyListState, setKeyListState] = useState<ProjectKey[] | undefined>(undefined);
 
@@ -170,9 +166,6 @@ export default function ProjectKeys() {
               handleToggleKeyMutation.mutate({isActive, data})
             }
             onRemove={data => handleRemoveKeyMutation.mutate(data)}
-            routes={routes}
-            location={location}
-            params={params}
           />
         ))}
         <Pagination pageLinks={keyListResponse.headers.Link} />

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -15,7 +15,6 @@ import type {Project, ProjectKey} from 'sentry/types/project';
 import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import {ProjectKeyCredentials} from 'sentry/views/settings/project/projectKeys/credentials';
 import {LoaderScript} from 'sentry/views/settings/project/projectKeys/list/loaderScript';
 
@@ -32,11 +31,10 @@ export function KeyRow({data, onRemove, onToggle, hasWriteAccess, project}: Prop
   const location = useLocation();
   const matches = useMatches();
   const params = useParams<{projectId: string}>();
-  const routes = useRoutes();
   const handleEnable = () => onToggle(true, data);
   const handleDisable = () => onToggle(false, data);
 
-  const editUrl = recreateRoute(`${data.id}/`, {matches, routes, params, location});
+  const editUrl = recreateRoute(`${data.id}/`, {matches, params, location});
   const platform = project.platform || 'other';
   const isBrowserJavaScript = platform === 'javascript';
   const isJsPlatform = platform.startsWith('javascript');

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -1,3 +1,4 @@
+import {useMatches} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
@@ -10,9 +11,11 @@ import {PanelBody} from 'sentry/components/panels/panelBody';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Project, ProjectKey} from 'sentry/types/project';
 import {recreateRoute} from 'sentry/utils/recreateRoute';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useParams} from 'sentry/utils/useParams';
+import {useRoutes} from 'sentry/utils/useRoutes';
 import {ProjectKeyCredentials} from 'sentry/views/settings/project/projectKeys/credentials';
 import {LoaderScript} from 'sentry/views/settings/project/projectKeys/list/loaderScript';
 
@@ -23,22 +26,17 @@ type Props = {
   onToggle: (isActive: boolean, data: ProjectKey) => void;
   project: Project;
   projectId: string;
-} & Pick<RouteComponentProps, 'routes' | 'location' | 'params'>;
+};
 
-export function KeyRow({
-  data,
-  onRemove,
-  onToggle,
-  hasWriteAccess,
-  routes,
-  location,
-  params,
-  project,
-}: Props) {
+export function KeyRow({data, onRemove, onToggle, hasWriteAccess, project}: Props) {
+  const location = useLocation();
+  const matches = useMatches();
+  const params = useParams<{projectId: string}>();
+  const routes = useRoutes();
   const handleEnable = () => onToggle(true, data);
   const handleDisable = () => onToggle(false, data);
 
-  const editUrl = recreateRoute(`${data.id}/`, {routes, params, location});
+  const editUrl = recreateRoute(`${data.id}/`, {matches, routes, params, location});
   const platform = project.platform || 'other';
   const isBrowserJavaScript = platform === 'javascript';
   const isJsPlatform = platform.startsWith('javascript');
@@ -100,14 +98,7 @@ export function KeyRow({
             showUnreal={!isJsPlatform}
             showSecurityEndpoint={!isJsPlatform}
           />
-          {isBrowserJavaScript && (
-            <LoaderScript
-              projectKey={data}
-              routes={routes}
-              location={location}
-              params={params}
-            />
-          )}
+          {isBrowserJavaScript && <LoaderScript projectKey={data} />}
         </StyledPanelBody>
       </StyledClippedBox>
     </Panel>

--- a/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
+++ b/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
@@ -1,21 +1,29 @@
+import {useMatches} from 'react-router-dom';
+
 import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
 import {TextCopyInput} from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {ProjectKey} from 'sentry/types/project';
 import {recreateRoute} from 'sentry/utils/recreateRoute';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useParams} from 'sentry/utils/useParams';
+import {useRoutes} from 'sentry/utils/useRoutes';
 
 type Props = {
   projectKey: ProjectKey;
-} & Pick<RouteComponentProps, 'routes' | 'location' | 'params'>;
+};
 
-export function LoaderScript({projectKey, routes, params, location}: Props) {
+export function LoaderScript({projectKey}: Props) {
+  const location = useLocation();
+  const matches = useMatches();
+  const params = useParams<{projectId: string}>();
+  const routes = useRoutes();
   const loaderLink = projectKey.dsn.cdn;
 
-  const editUrl = recreateRoute(`${projectKey.id}/`, {routes, params, location});
+  const editUrl = recreateRoute(`${projectKey.id}/`, {matches, routes, params, location});
 
   return (
     <Stack padding="xl" gap="md">

--- a/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
+++ b/static/app/views/settings/project/projectKeys/list/loaderScript.tsx
@@ -10,7 +10,6 @@ import type {ProjectKey} from 'sentry/types/project';
 import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
-import {useRoutes} from 'sentry/utils/useRoutes';
 
 type Props = {
   projectKey: ProjectKey;
@@ -20,10 +19,9 @@ export function LoaderScript({projectKey}: Props) {
   const location = useLocation();
   const matches = useMatches();
   const params = useParams<{projectId: string}>();
-  const routes = useRoutes();
   const loaderLink = projectKey.dsn.cdn;
 
-  const editUrl = recreateRoute(`${projectKey.id}/`, {matches, routes, params, location});
+  const editUrl = recreateRoute(`${projectKey.id}/`, {matches, params, location});
 
   return (
     <Stack padding="xl" gap="md">

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -44,7 +44,6 @@ import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
@@ -414,7 +413,6 @@ export function ProjectGeneralSettings({project, onChangeSlug}: Props) {
 
 export default function ProjectGeneralSettingsContainer() {
   const matches = useMatches();
-  const routes = useRoutes();
   const navigate = useNavigate();
   const organization = useOrganization();
   const location = useLocation();
@@ -429,13 +427,12 @@ export default function ProjectGeneralSettingsContainer() {
             orgId: organization.slug,
             projectId: newSlug,
           },
-          routes,
           location,
         }),
         {replace: true}
       );
     },
-    [navigate, organization.slug, routes, location, matches]
+    [navigate, organization.slug, location, matches]
   );
 
   if (!project?.id) {

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -1,4 +1,5 @@
 import {useCallback} from 'react';
+import {useMatches} from 'react-router-dom';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
@@ -412,6 +413,7 @@ export function ProjectGeneralSettings({project, onChangeSlug}: Props) {
 }
 
 export default function ProjectGeneralSettingsContainer() {
+  const matches = useMatches();
   const routes = useRoutes();
   const navigate = useNavigate();
   const organization = useOrganization();
@@ -422,6 +424,7 @@ export default function ProjectGeneralSettingsContainer() {
     (newSlug: string) => {
       navigate(
         recreateRoute('', {
+          matches,
           params: {
             orgId: organization.slug,
             projectId: newSlug,
@@ -432,7 +435,7 @@ export default function ProjectGeneralSettingsContainer() {
         {replace: true}
       );
     },
-    [navigate, organization.slug, routes, location]
+    [navigate, organization.slug, routes, location, matches]
   );
 
   if (!project?.id) {

--- a/static/app/views/settings/projectPlugins/index.tsx
+++ b/static/app/views/settings/projectPlugins/index.tsx
@@ -65,7 +65,6 @@ export default function ProjectPluginsContainer() {
       <ProjectPermissionAlert project={project} />
 
       <ProjectPlugins
-        organization={organization}
         project={project}
         onChange={(pluginId, shouldEnable) =>
           togglePluginMutation.mutate({pluginId, shouldEnable})

--- a/static/app/views/settings/projectPlugins/projectPluginRow.spec.tsx
+++ b/static/app/views/settings/projectPlugins/projectPluginRow.spec.tsx
@@ -4,7 +4,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import ProjectPluginRow from 'sentry/views/settings/projectPlugins/projectPluginRow';
+import {ProjectPluginRow} from 'sentry/views/settings/projectPlugins/projectPluginRow';
 
 describe('ProjectPluginRow', () => {
   const plugin = PluginFixture();
@@ -16,14 +16,7 @@ describe('ProjectPluginRow', () => {
     const onChange = jest.fn();
 
     render(
-      <ProjectPluginRow
-        params={{}}
-        routes={[]}
-        {...params}
-        {...plugin}
-        onChange={onChange}
-        project={project}
-      />
+      <ProjectPluginRow {...params} {...plugin} onChange={onChange} project={project} />
     );
 
     await userEvent.click(screen.getByRole('checkbox'));
@@ -35,14 +28,7 @@ describe('ProjectPluginRow', () => {
     const onChange = jest.fn();
 
     render(
-      <ProjectPluginRow
-        params={{}}
-        routes={[]}
-        {...params}
-        {...plugin}
-        onChange={onChange}
-        project={project}
-      />,
+      <ProjectPluginRow {...params} {...plugin} onChange={onChange} project={project} />,
       {
         organization: OrganizationFixture({access: []}),
       }

--- a/static/app/views/settings/projectPlugins/projectPluginRow.tsx
+++ b/static/app/views/settings/projectPlugins/projectPluginRow.tsx
@@ -14,7 +14,6 @@ import type {Project} from 'sentry/types/project';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useRoutes} from 'sentry/utils/useRoutes';
 
 const grayText = css`
   color: #979ba0;
@@ -39,7 +38,6 @@ export function ProjectPluginRow({
 }: Props) {
   const matches = useMatches();
   const {projectId} = useParams<{projectId: string}>();
-  const routes = useRoutes();
   const organization = useOrganization();
 
   const handleChange = () => {
@@ -55,7 +53,6 @@ export function ProjectPluginRow({
 
   const configureUrl = recreateRoute(id, {
     matches,
-    routes,
     params: {projectId, orgId: organization.slug},
   });
   return (

--- a/static/app/views/settings/projectPlugins/projectPluginRow.tsx
+++ b/static/app/views/settings/projectPlugins/projectPluginRow.tsx
@@ -1,4 +1,4 @@
-import {PureComponent} from 'react';
+import {useMatches, useParams} from 'react-router-dom';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -10,12 +10,11 @@ import {Access} from 'sentry/components/acl/access';
 import {t} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import type {Plugin} from 'sentry/types/integrations';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 import {recreateRoute} from 'sentry/utils/recreateRoute';
-import {withOrganization} from 'sentry/utils/withOrganization';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useRoutes} from 'sentry/utils/useRoutes';
 
 const grayText = css`
   color: #979ba0;
@@ -23,83 +22,84 @@ const grayText = css`
 
 type Props = {
   onChange: (id: string, enabled: boolean) => void;
-  organization: Organization;
   project: Project;
-} & Plugin &
-  Pick<RouteComponentProps, 'params' | 'routes'>;
+} & Plugin;
 
-class ProjectPluginRow extends PureComponent<Props> {
-  handleChange = () => {
-    const {onChange, id, enabled} = this.props;
+export function ProjectPluginRow({
+  onChange,
+  id,
+  name,
+  slug,
+  version,
+  author,
+  hasConfiguration,
+  enabled,
+  canDisable,
+  project,
+}: Props) {
+  const matches = useMatches();
+  const {projectId} = useParams<{projectId: string}>();
+  const routes = useRoutes();
+  const organization = useOrganization();
+
+  const handleChange = () => {
     onChange(id, !enabled);
     const eventKey = enabled ? 'integrations.disabled' : 'integrations.enabled';
     trackIntegrationAnalytics(eventKey, {
       integration: id,
       integration_type: 'plugin',
       view: 'legacy_integrations',
-      organization: this.props.organization,
+      organization,
     });
   };
 
-  render() {
-    const {
-      id,
-      name,
-      slug,
-      version,
-      author,
-      hasConfiguration,
-      enabled,
-      canDisable,
-      project,
-    } = this.props;
-
-    const configureUrl = recreateRoute(id, this.props);
-    return (
-      <Access access={['project:write']} project={project}>
-        {({hasAccess}) => {
-          return (
-            <Flex align="center" flex="1" key={id} className={slug}>
-              <PluginInfo>
-                <StyledPluginIcon size={48} pluginId={id} />
-                <Stack justify="center">
-                  <PluginName>
-                    {`${name} `}
-                    <Version>{version ? `v${version}` : <em>{t('n/a')}</em>}</Version>
-                  </PluginName>
-                  <div>
-                    {author && (
-                      <ExternalLink css={grayText} href={author.url}>
-                        {author.name}
-                      </ExternalLink>
-                    )}
-                    {hasConfiguration && (
-                      <span>
-                        {' '}
-                        &middot;{' '}
-                        <Link css={grayText} to={configureUrl}>
-                          {hasAccess ? t('Configure plugin') : t('View plugin')}
-                        </Link>
-                      </span>
-                    )}
-                  </div>
-                </Stack>
-              </PluginInfo>
-              <Switch
-                size="lg"
-                disabled={!hasAccess || !canDisable}
-                checked={enabled}
-                onChange={this.handleChange}
-              />
-            </Flex>
-          );
-        }}
-      </Access>
-    );
-  }
+  const configureUrl = recreateRoute(id, {
+    matches,
+    routes,
+    params: {projectId, orgId: organization.slug},
+  });
+  return (
+    <Access access={['project:write']} project={project}>
+      {({hasAccess}) => {
+        return (
+          <Flex align="center" flex="1" key={id} className={slug}>
+            <PluginInfo>
+              <StyledPluginIcon size={48} pluginId={id} />
+              <Stack justify="center">
+                <PluginName>
+                  {`${name} `}
+                  <Version>{version ? `v${version}` : <em>{t('n/a')}</em>}</Version>
+                </PluginName>
+                <div>
+                  {author && (
+                    <ExternalLink css={grayText} href={author.url}>
+                      {author.name}
+                    </ExternalLink>
+                  )}
+                  {hasConfiguration && (
+                    <span>
+                      {' '}
+                      &middot;{' '}
+                      <Link css={grayText} to={configureUrl}>
+                        {hasAccess ? t('Configure plugin') : t('View plugin')}
+                      </Link>
+                    </span>
+                  )}
+                </div>
+              </Stack>
+            </PluginInfo>
+            <Switch
+              size="lg"
+              disabled={!hasAccess || !canDisable}
+              checked={enabled}
+              onChange={handleChange}
+            />
+          </Flex>
+        );
+      }}
+    </Access>
+  );
 }
-
-export default withOrganization(ProjectPluginRow);
 
 const PluginInfo = styled('div')`
   display: flex;

--- a/static/app/views/settings/projectPlugins/projectPlugins.spec.tsx
+++ b/static/app/views/settings/projectPlugins/projectPlugins.spec.tsx
@@ -13,7 +13,6 @@ describe('ProjectPlugins', () => {
 
     render(
       <ProjectPlugins
-        organization={organization}
         project={project}
         onChange={jest.fn()}
         loading={false}
@@ -36,7 +35,6 @@ describe('ProjectPlugins', () => {
 
     render(
       <ProjectPlugins
-        organization={organization}
         project={project}
         onChange={jest.fn()}
         loading={false}

--- a/static/app/views/settings/projectPlugins/projectPlugins.tsx
+++ b/static/app/views/settings/projectPlugins/projectPlugins.tsx
@@ -9,31 +9,22 @@ import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {PanelItem} from 'sentry/components/panels/panelItem';
 import {t, tct} from 'sentry/locale';
 import type {Plugin} from 'sentry/types/integrations';
-import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {useRoutes} from 'sentry/utils/useRoutes';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {RouteError} from 'sentry/views/routeError';
 
-import ProjectPluginRow from './projectPluginRow';
+import {ProjectPluginRow} from './projectPluginRow';
 
 type Props = {
   error: React.ComponentProps<typeof RouteError>['error'];
   loading: boolean;
   onChange: React.ComponentProps<typeof ProjectPluginRow>['onChange'];
-  organization: Organization;
   plugins: Plugin[];
   project: Project;
 };
 
-export function ProjectPlugins({
-  plugins,
-  loading,
-  error,
-  onChange,
-  organization,
-  project,
-}: Props) {
-  const routes = useRoutes();
+export function ProjectPlugins({plugins, loading, error, onChange, project}: Props) {
+  const organization = useOrganization();
 
   const hasError = error;
   const isLoading = !hasError && loading;
@@ -45,7 +36,6 @@ export function ProjectPlugins({
   if (isLoading) {
     return <LoadingIndicator />;
   }
-  const params = {orgId: organization.slug, projectId: project.slug};
 
   return (
     <Access access={['org:integrations']} project={project}>
@@ -75,13 +65,7 @@ export function ProjectPlugins({
               })
               .map(plugin => (
                 <PanelItem key={plugin.id}>
-                  <ProjectPluginRow
-                    params={params}
-                    routes={routes}
-                    project={project}
-                    {...plugin}
-                    onChange={onChange}
-                  />
+                  <ProjectPluginRow project={project} {...plugin} onChange={onChange} />
                 </PanelItem>
               ))}
           </PanelBody>

--- a/static/app/views/settings/projectSecurityHeaders/index.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/index.tsx
@@ -1,4 +1,5 @@
 import {useMemo} from 'react';
+import {useMatches} from 'react-router-dom';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
@@ -26,6 +27,7 @@ import {ReportUri} from 'sentry/views/settings/projectSecurityHeaders/reportUri'
 function ProjectSecurityHeaders() {
   const organization = useOrganization();
   const routes = useRoutes();
+  const matches = useMatches();
   const params = useParams();
   const {projectId} = useParams<{projectId: string}>();
 
@@ -40,18 +42,18 @@ function ProjectSecurityHeaders() {
     () => [
       {
         name: 'Content Security Policy (CSP)',
-        url: recreateRoute('csp/', {routes, params}),
+        url: recreateRoute('csp/', {matches, routes, params}),
       },
       {
         name: 'Certificate Transparency (Expect-CT)',
-        url: recreateRoute('expect-ct/', {routes, params}),
+        url: recreateRoute('expect-ct/', {matches, routes, params}),
       },
       {
         name: 'HTTP Public Key Pinning (HPKP)',
-        url: recreateRoute('hpkp/', {routes, params}),
+        url: recreateRoute('hpkp/', {matches, routes, params}),
       },
     ],
-    [routes, params]
+    [matches, routes, params]
   );
 
   if (isPending) {

--- a/static/app/views/settings/projectSecurityHeaders/index.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/index.tsx
@@ -19,14 +19,12 @@ import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {routeTitleGen} from 'sentry/utils/routeTitle';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {ReportUri} from 'sentry/views/settings/projectSecurityHeaders/reportUri';
 
 function ProjectSecurityHeaders() {
   const organization = useOrganization();
-  const routes = useRoutes();
   const matches = useMatches();
   const params = useParams();
   const {projectId} = useParams<{projectId: string}>();
@@ -42,18 +40,18 @@ function ProjectSecurityHeaders() {
     () => [
       {
         name: 'Content Security Policy (CSP)',
-        url: recreateRoute('csp/', {matches, routes, params}),
+        url: recreateRoute('csp/', {matches, params}),
       },
       {
         name: 'Certificate Transparency (Expect-CT)',
-        url: recreateRoute('expect-ct/', {matches, routes, params}),
+        url: recreateRoute('expect-ct/', {matches, params}),
       },
       {
         name: 'HTTP Public Key Pinning (HPKP)',
-        url: recreateRoute('hpkp/', {matches, routes, params}),
+        url: recreateRoute('hpkp/', {matches, params}),
       },
     ],
-    [matches, routes, params]
+    [matches, params]
   );
 
   if (isPending) {


### PR DESCRIPTION
Wire useMatches() from react-router-dom into all recreateRoute call sites. This prepares recreateRoute to use the new router's match data instead of relying solely on legacy route objects. Update tests to construct matches and derive routes from them.

Turns out this was annoying enough to review, without the subsequent changes to recreateRoute, that i decided to push it on it's own.


