### PR TITLE
feat(issues): Add "Awaiting Input" page to issue stream nav

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2530,6 +2530,10 @@ function buildRoutes(): RouteObject[] {
       component: make(() => import('sentry/views/issueList/pages/sentryConfiguration')),
     },
     {
+      path: 'awaiting-input/',
+      component: make(() => import('sentry/views/issueList/pages/awaitingInput')),
+    },
+    {
       path: 'views/',
       component: make(
         () => import('sentry/views/issueList/issueViews/issueViewsList/issueViewsList')

--- a/static/app/views/issueList/pages/awaitingInput.tsx
+++ b/static/app/views/issueList/pages/awaitingInput.tsx
@@ -1,0 +1,23 @@
+import {NoProjectMessage} from 'sentry/components/noProjectMessage';
+import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {IssueListContainer} from 'sentry/views/issueList';
+import IssueListOverview from 'sentry/views/issueList/overview';
+
+const TITLE = t('Awaiting Input');
+const QUERY = 'is:unresolved';
+
+export default function AwaitingInputPage() {
+  const organization = useOrganization();
+
+  return (
+    <IssueListContainer title={TITLE}>
+      <PageFiltersContainer>
+        <NoProjectMessage organization={organization}>
+          <IssueListOverview initialQuery={QUERY} title={TITLE} />
+        </NoProjectMessage>
+      </PageFiltersContainer>
+    </IssueListContainer>
+  );
+}

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -33,6 +33,17 @@ export function IssuesSecondaryNavigation() {
                 {t('Feed')}
               </SecondaryNavigation.Link>
             </SecondaryNavigation.ListItem>
+            {organization.features.includes('issue-stream-progress-ui') && (
+              <SecondaryNavigation.ListItem>
+                <SecondaryNavigation.Link
+                  to={`${baseUrl}/awaiting-input/`}
+                  end
+                  analyticsItemName="issues_awaiting_input"
+                >
+                  {t('Awaiting Input')}
+                </SecondaryNavigation.Link>
+              </SecondaryNavigation.ListItem>
+            )}
           </SecondaryNavigation.List>
         </SecondaryNavigation.Section>
         <SecondaryNavigation.Separator />


### PR DESCRIPTION
Ref ISWF-2849

Adds a new "Awaiting Input" page to the issues secondary navigation. This is a top-level nav item that sits alongside "Feed" and links to `/issues/awaiting-input/`.

The nav link is gated behind the `issue-stream-progress-ui` feature flag, so it only renders for orgs with the flag enabled. 

Eventually, this will be populated with search filters, sorts, and a new progress column, but for now this simply adds the page for me to work off of.