### PR TITLE
refactor(api): Centralize project id-or-slug discrimination

### DIFF
--- a/src/sentry/api/helpers/projects.py
+++ b/src/sentry/api/helpers/projects.py
@@ -13,6 +13,28 @@ from sentry.utils.slug import DEFAULT_SLUG_ERROR_MESSAGE, MIXED_SLUG_REGEX
 ProjectIdOrSlug: TypeAlias = int | str
 
 
+def coerce_id_or_slug(value: ProjectIdOrSlug) -> ProjectIdOrSlug:
+    """
+    Normalize a single project identifier into an ``int`` ID or ``str`` slug.
+
+    This is the single source of truth for deciding whether a value is an ID or
+    a slug: all-digit values and the ``-1`` all-access project sigil become
+    ints, everything else (including the ``$all`` sigil) stays a slug string.
+
+    It performs no slug-format validation and does not reject empty/``None``
+    input -- callers layer those concerns on top (``ProjectIdOrSlugField`` adds
+    strict validation; ``parse_id_or_slug_params`` skips empty values). This
+    mirrors the decimal check in ``IdOrSlugLookup`` (the ``slug__id_or_slug`` DB
+    lookup) while adding the project-specific ``-1`` sentinel, which the generic
+    DB lookup intentionally omits.
+    """
+    if isinstance(value, int):
+        return value
+    if value.isdecimal() or value == str(ALL_ACCESS_PROJECT_ID):
+        return int(value)
+    return value
+
+
 class ParsedProjectIdOrSlugParams(NamedTuple):
     ids: set[int]
     slugs: set[str]
@@ -40,15 +62,11 @@ def parse_id_or_slug_params(
     for value in values:
         if value is None or value == "":
             continue
-        if isinstance(value, int) and not isinstance(value, bool):
-            ids.add(value)
-            continue
-
-        value_str = str(value)
-        if value_str.isdecimal() or value_str == str(ALL_ACCESS_PROJECT_ID):
-            ids.add(int(value_str))
+        parsed = coerce_id_or_slug(value)
+        if isinstance(parsed, int) and not isinstance(parsed, bool):
+            ids.add(parsed)
         else:
-            slugs.add(value_str)
+            slugs.add(str(parsed))
     return ParsedProjectIdOrSlugParams(ids=ids, slugs=slugs)
 
 
@@ -62,17 +80,16 @@ class ProjectIdOrSlugField(serializers.Field[ProjectIdOrSlug, object, ProjectIdO
     def to_internal_value(self, data: object) -> ProjectIdOrSlug:
         if data is None or isinstance(data, bool):
             self.fail("invalid")
-        if isinstance(data, int):
-            return data
-        if not isinstance(data, str) or data == "":
+        if not isinstance(data, (int, str)) or data == "":
             self.fail("invalid")
-        if data.isdecimal() or data == str(ALL_ACCESS_PROJECT_ID):
-            return int(data)
-        if data == ALL_ACCESS_PROJECTS_SLUG:
-            return data
-        if MIXED_SLUG_REGEX.match(data) is None:
+        parsed = coerce_id_or_slug(data)
+        if (
+            isinstance(parsed, str)
+            and parsed != ALL_ACCESS_PROJECTS_SLUG
+            and MIXED_SLUG_REGEX.match(parsed) is None
+        ):
             self.fail("invalid_slug")
-        return data
+        return parsed
 
     def to_representation(self, value: ProjectIdOrSlug) -> ProjectIdOrSlug:
         return value


### PR DESCRIPTION
Draft / experiment **stacked on #117445** (base = `feat/project-id-or-slug-foundation`, so this diff is just the refactor). Explores the reuse opportunity raised in review: the "is this value an ID or a slug?" decision was being re-derived in several spots.

## What
Extracts a single `coerce_id_or_slug()` helper in `src/sentry/api/helpers/projects.py` as the one source of truth for the `isdecimal()` + `-1` sentinel branching. Both `ProjectIdOrSlugField.to_internal_value` and `parse_id_or_slug_params` now call it instead of each re-implementing the rule.

## Why
Before this, the same discrimination lived in three places:
- `IdOrSlugLookup.as_sql` — the generic `slug__id_or_slug` DB lookup — `str(...).isdecimal()`
- `ProjectIdOrSlugField.to_internal_value` — `data.isdecimal() or data == str(ALL_ACCESS_PROJECT_ID)`
- `parse_id_or_slug_params` — the same check again

This collapses the two new copies into one. The generic `IdOrSlugLookup` is intentionally left alone: it runs at the SQL layer across many models (Team, Org, SentryApp, DocIntegration, …) and deliberately has no notion of the project-specific `-1` / `$all` sentinels, so coupling it to project constants would be wrong. The new helper's docstring records that relationship.

## Behavior
Unchanged. The field still layers strict slug-format validation (`MIXED_SLUG_REGEX`) on top of the shared rule, and the parser still silently skips empty values without validating slug format. Validated equivalent to the pre-refactor implementation across every case in the existing tests (`tests/sentry/api/helpers/test_projects.py`, `tests/sentry/api/serializers/rest_framework/test_project.py`) plus a fuzz battery of id / slug / sentinel / edge inputs.

## Out of scope (possible follow-ups)
- `_validate_slug` in `ProjectField` still routes through the field and then rejects ints; could be expressed more directly, but left as-is to keep behavior identical.
- The two unrelated inline `str(...).isdecimal()` *organization* id-or-slug checks in `bases/organization.py` are a separate concept and not touched here.

> Verification note: `ruff` is clean; the full pytest suite + mypy could not be executed in the authoring sandbox (no `devenv`, `sentry` not importable), so equivalence was proven with a standalone harness mirroring both the old and new implementations.

https://claude.ai/code/session_014ZqyxEfBjS5hjG62L8tACF

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZqyxEfBjS5hjG62L8tACF)_