### PR TITLE
feat(cells): Require explicit locality configuration

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3290,10 +3290,21 @@ if SILO_DEVSERVER:
         {
             "name": "us",
             "snowflake_id": 1,
+            # TODO(cells): Deprecate category
             "category": "MULTI_TENANT",
             "address": f"http://127.0.0.1:{region_port}",
         }
     ]
+    SENTRY_LOCALITIES = [
+        {
+            "name": "us",
+            # TODO(cells): Deprecate category
+            "category": "MULTI_TENANT",
+            "cells": ["us"],
+            "new_org_cell": "us",
+        }
+    ]
+
     SENTRY_MONOLITH_REGION = SENTRY_CELLS[0]["name"]
 
     # Cross region RPC authentication

--- a/src/sentry/types/cell.py
+++ b/src/sentry/types/cell.py
@@ -229,6 +229,16 @@ class CellDirectory:
                     f"which is not in its cells={set(loc.cells)!r}"
                 )
 
+        # SENTRY_MONOLITH_REGION is resolved as a live cell at runtime
+        # (historic monolith region lookups), so a dangling name should fail
+        # here rather than at request time.
+        if settings.SENTRY_MONOLITH_REGION not in defined_cells:
+            raise CellConfigurationError(
+                "The SENTRY_MONOLITH_REGION setting must point to a cell name "
+                f"({settings.SENTRY_MONOLITH_REGION=!r}; "
+                f"cell names = {sorted(defined_cells)!r})"
+            )
+
 
 def _parse_raw_config(cell_config: list[CellConfig]) -> Iterable[Cell]:
     for config_value in cell_config:
@@ -242,28 +252,28 @@ def _parse_raw_config(cell_config: list[CellConfig]) -> Iterable[Cell]:
         )
 
 
-def _generate_monolith_cell_if_needed(cells: Collection[Cell]) -> Iterable[Cell]:
-    """Check whether a default monolith cell must be generated.
-
-    Check the provided set of cells to see whether a cell with the configured
-    name is present. If so, return an empty iterator. Else, yield the newly generated
-    cell.
+def generate_monolith_cell_directory() -> CellDirectory:
     """
-    if not settings.SENTRY_MONOLITH_REGION:
-        raise CellConfigurationError("`SENTRY_MONOLITH_REGION` must provide a default cell name")
-    if not cells:
-        yield Cell(
-            name=settings.SENTRY_MONOLITH_REGION,
-            snowflake_id=0,
-            address=options.get("system.url-prefix"),
-            category=RegionCategory.MULTI_TENANT,
-        )
-    elif not any(r.name == settings.SENTRY_MONOLITH_REGION for r in cells):
-        raise CellConfigurationError(
-            "The SENTRY_MONOLITH_REGION setting must point to a cell name "
-            f"({settings.SENTRY_MONOLITH_REGION=!r}; "
-            f"cell names = {[r.name for r in cells]!r})"
-        )
+    Build the directory for deployments with no cell topology configured.
+
+    Monolith environments (single-tenant, self-hosted) don't define
+    SENTRY_CELLS or SENTRY_LOCALITIES; they get a single cell named after
+    SENTRY_MONOLITH_REGION with a matching 1:1 locality.
+    """
+    cell = Cell(
+        name=settings.SENTRY_MONOLITH_REGION,
+        snowflake_id=0,
+        address=options.get("system.url-prefix"),
+        category=RegionCategory.MULTI_TENANT,
+    )
+    locality = Locality(
+        name=cell.name,
+        category=cell.category,
+        cells=frozenset([cell.name]),
+        new_org_cell=cell.name,
+        visible=cell.visible,
+    )
+    return CellDirectory({cell}, {locality})
 
 
 def _parse_locality_config(
@@ -284,29 +294,11 @@ def load_from_config(
     locality_config: list[LocalityConfig],
 ) -> CellDirectory:
     try:
+        if not region_config and not locality_config:
+            return generate_monolith_cell_directory()
         cells = set(_parse_raw_config(region_config))
-        cells |= set(_generate_monolith_cell_if_needed(cells))
         localities = set(_parse_locality_config(locality_config))
-
-        if not locality_config:
-            # TODO(cells): If no locality config present — create a synthetic 1:1 locality per cell
-            # as a temporary fallback. Once SENTRY_LOCALITIES is configured, all cells
-            # must be explicitly assigned; missing cells will have no locality mapping.
-            for cell in cells:
-                localities.add(
-                    Locality(
-                        name=cell.name,
-                        category=cell.category,
-                        cells=frozenset([cell.name]),
-                        new_org_cell=cell.name,
-                        visible=cell.visible,
-                    )
-                )
-
         return CellDirectory(cells, localities)
-    except CellConfigurationError as e:
-        sentry_sdk.capture_exception(e)
-        raise
     except Exception as e:
         sentry_sdk.capture_exception(e)
         raise CellConfigurationError("Unable to parse region_config.") from e
@@ -333,9 +325,6 @@ def get_global_directory() -> CellDirectory:
 
     from django.conf import settings
 
-    # For now, assume that all cell configs can be taken in through Django
-    # settings. We may investigate other ways of delivering those configs in
-    # production.
     _global_directory = load_from_config(settings.SENTRY_CELLS, settings.SENTRY_LOCALITIES)
     return _global_directory
 

--- a/tests/sentry/types/test_cell.py
+++ b/tests/sentry/types/test_cell.py
@@ -168,7 +168,7 @@ class CellDirectoryTest(TestCase):
     def test_invalid_historic_cell_setting(self) -> None:
         with pytest.raises(CellConfigurationError):
             with override_settings(SENTRY_MONOLITH_REGION="nonexistent"):
-                load_from_config(self._INPUTS, [])
+                load_from_config(self._INPUTS, []).validate_all()
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_find_cells_for_user(self) -> None:


### PR DESCRIPTION
During cells development, when SENTRY_CELLS was configured without SENTRY_LOCALITIES, load_from_config silently generated a synthetic 1:1 locality per cell as a transitional fallback. This is no longer required, SENTRY_LOCALITIES is properly defined everywhere that also defines SENTRY_CELLS.

The exception is self-hosted/single-tenant instances that do not define either SENTRY_CELLS or SENTRY_LOCALITIES - these are synthesized from the SENTRY_MONOLITH_REGION setting, similarly to before.

It also moves the SENTRY_MONOLITH_REGION check into the `validate_all` function, which properly separates the load from validation logic, and keeps all the cell validation logic in a single place.
