### PR TITLE
chore(cells) Remove more region references from UI code.

### DIFF
--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -176,8 +176,6 @@ export interface Config {
   };
   // The list of localities (formerly regions) that are available
   localities: Locality[];
-  // A list of regions that the user has membership in.
-  memberRegions: Region[];
   /**
    * This comes from django (django.contrib.messages)
    */
@@ -188,8 +186,6 @@ export interface Config {
   }>;
   needsUpgrade: boolean;
   privacyUrl: string | null;
-  // The list of regions the user has has access to.
-  regions: Region[];
   sentryConfig: {
     allowUrls: string[];
     dsn: string;

--- a/static/app/utils/cells/index.spec.tsx
+++ b/static/app/utils/cells/index.spec.tsx
@@ -28,7 +28,7 @@ describe('getLocalityUrlOptions', () => {
       value: 'https://de.sentry.io',
       label: '🇪🇺 European Union (EU)',
     });
-    expect(res[1]).toEqual({value: 'https://ja.sentry.io', label: ' ja'});
+    expect(res[1]).toEqual({value: 'https://ja.sentry.io', label: 'ja'});
 
     // Excluding the only included option = empty set.
     const none = getLocalityUrlOptions(
@@ -52,19 +52,6 @@ describe('getLocalityUrlOptions', () => {
       label: '🇺🇸 United States of America (US)',
     });
   });
-
-  it('always excludes US2', () => {
-    ConfigStore.set('localities', [
-      {name: 'us', url: 'https://us.sentry.io'},
-      {name: 'us2', url: 'https://us2.sentry.io'},
-      {name: 'de', url: 'https://de.sentry.io'},
-      {name: 'ja', url: 'https://ja.sentry.io'},
-    ]);
-
-    const res = getLocalityUrlOptions();
-    expect(res).toHaveLength(3);
-    res.forEach(item => expect(item.value).not.toContain('us2'));
-  });
 });
 
 describe('getLocalityNameOptions', () => {
@@ -77,7 +64,7 @@ describe('getLocalityNameOptions', () => {
   afterEach(() => {
     ConfigStore.loadInitialData(configstate);
   });
-  it('always excludes US2', () => {
+  it('returns options', () => {
     ConfigStore.set('localities', [
       {name: 'us', url: 'https://us.sentry.io'},
       {name: 'us2', url: 'https://us2.sentry.io'},
@@ -86,10 +73,12 @@ describe('getLocalityNameOptions', () => {
     ]);
 
     const res = getLocalityNameOptions();
-    expect(res).toHaveLength(3);
+    expect(res).toHaveLength(4);
 
     expect(res[0]).toEqual({value: 'us', label: '🇺🇸 United States of America (US)'});
-
-    res.forEach(item => expect(item.label).not.toContain('us2'));
+    expect(res[1]).toEqual({value: 'us2', label: '🇺🇸 United States of America (US2)'});
+    expect(res[2]).toEqual({value: 'de', label: '🇪🇺 European Union (EU)'});
+    // No defined label name
+    expect(res[3]).toEqual({value: 'ja', label: 'ja'});
   });
 });

--- a/static/app/utils/cells/index.tsx
+++ b/static/app/utils/cells/index.tsx
@@ -87,8 +87,7 @@ export function getLocalityUrlOptions(
     .filter(locality => {
       if (
         excludedRegionNames.includes(locality.name) ||
-        (only.length > 0 && !only.includes(locality.name)) ||
-        CUSTOMER_HIDDEN_REGIONS.has(locality.name)
+        (only.length > 0 && !only.includes(locality.name))
       ) {
         return false;
       }
@@ -98,13 +97,11 @@ export function getLocalityUrlOptions(
       const {url} = locality;
       return {
         value: url,
-        label: `${getLocalityFlagIndicator(locality)} ${getLocalityDisplayName(locality)}`,
+        label:
+          `${getLocalityFlagIndicator(locality)} ${getLocalityDisplayName(locality)}`.trim(),
       };
     });
 }
-
-// TODO(cells) Rework/remove this once Region -> Locality config changes are completed.
-const CUSTOMER_HIDDEN_REGIONS = new Set(['us2']);
 
 /**
  * Create a list of option objects with {label: displayName, value: name}
@@ -112,14 +109,13 @@ const CUSTOMER_HIDDEN_REGIONS = new Set(['us2']);
 export function getLocalityNameOptions(): Array<SelectValue<string>> {
   const localities = getLocalities();
 
-  return localities
-    .filter(locality => !CUSTOMER_HIDDEN_REGIONS.has(locality.name))
-    .map(locality => {
-      return {
-        value: locality.name,
-        label: `${getLocalityFlagIndicator(locality)} ${getLocalityDisplayName(locality)}`,
-      };
-    });
+  return localities.map(locality => {
+    return {
+      value: locality.name,
+      label:
+        `${getLocalityFlagIndicator(locality)} ${getLocalityDisplayName(locality)}`.trim(),
+    };
+  });
 }
 
 export function shouldDisplayLocalities(): boolean {

--- a/static/app/views/settings/account/accountClose.tsx
+++ b/static/app/views/settings/account/accountClose.tsx
@@ -65,7 +65,7 @@ function AccountClose() {
   const [isLoading, setIsLoading] = useState(true);
   const leaveRedirectTimeout = useRef<number | undefined>(undefined);
 
-  // Load organizations from all regions.
+  // Load all organizations the current user is an owner of.
   useEffect(() => {
     setIsLoading(true);
     fetchOrganizations(api, {owner: 1}).then((response: OwnedOrg[]) => {

--- a/static/app/views/setupWizard/types.tsx
+++ b/static/app/views/setupWizard/types.tsx
@@ -1,6 +1,6 @@
 import type {OrganizationSummary} from 'sentry/types/organization';
-import type {Region} from 'sentry/types/system';
+import type {Locality} from 'sentry/types/system';
 
-export type OrganizationSummaryWithRegion = OrganizationSummary & {
-  region: Region;
+export type OrganizationSummaryWithLocality = OrganizationSummary & {
+  region: Locality;
 };

--- a/static/app/views/setupWizard/utils/useCreateProjectFromWizard.tsx
+++ b/static/app/views/setupWizard/utils/useCreateProjectFromWizard.tsx
@@ -3,13 +3,13 @@ import {useMutation} from '@tanstack/react-query';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
 import {useApi} from 'sentry/utils/useApi';
-import type {OrganizationSummaryWithRegion} from 'sentry/views/setupWizard/types';
+import type {OrganizationSummaryWithLocality} from 'sentry/views/setupWizard/types';
 export function useCreateProjectFromWizard() {
   const api = useApi();
   return useMutation({
     mutationFn: (params: {
       name: string;
-      organization: OrganizationSummaryWithRegion;
+      organization: OrganizationSummaryWithLocality;
       platform: string;
       team: string | null;
     }): Promise<Project> => {

--- a/static/app/views/setupWizard/utils/useOrganizationDetails.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationDetails.tsx
@@ -2,12 +2,12 @@ import {skipToken, useQuery} from '@tanstack/react-query';
 
 import type {Organization} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import type {OrganizationSummaryWithRegion} from 'sentry/views/setupWizard/types';
+import type {OrganizationSummaryWithLocality} from 'sentry/views/setupWizard/types';
 
 export function useOrganizationDetails({
   organization,
 }: {
-  organization?: OrganizationSummaryWithRegion;
+  organization?: OrganizationSummaryWithLocality;
 }) {
   return useQuery({
     ...apiOptions.as<Organization>()('/organizations/$organizationIdOrSlug/', {

--- a/static/app/views/setupWizard/utils/useOrganizationProjects.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationProjects.tsx
@@ -2,13 +2,13 @@ import {skipToken, useQuery} from '@tanstack/react-query';
 
 import type {Project} from 'sentry/types/project';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import type {OrganizationSummaryWithRegion} from 'sentry/views/setupWizard/types';
+import type {OrganizationSummaryWithLocality} from 'sentry/views/setupWizard/types';
 
 export function useOrganizationProjects({
   organization,
   query,
 }: {
-  organization?: OrganizationSummaryWithRegion;
+  organization?: OrganizationSummaryWithLocality;
   query?: string;
 }) {
   return useQuery({

--- a/static/app/views/setupWizard/utils/useOrganizationTeams.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationTeams.tsx
@@ -2,12 +2,12 @@ import {skipToken, useQuery} from '@tanstack/react-query';
 
 import type {Team} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import type {OrganizationSummaryWithRegion} from 'sentry/views/setupWizard/types';
+import type {OrganizationSummaryWithLocality} from 'sentry/views/setupWizard/types';
 
 export function useOrganizationTeams({
   organization,
 }: {
-  organization?: OrganizationSummaryWithRegion;
+  organization?: OrganizationSummaryWithLocality;
 }) {
   return useQuery({
     ...apiOptions.as<Team[]>()('/organizations/$organizationIdOrSlug/teams/', {

--- a/static/app/views/setupWizard/utils/useOrganizationsWithRegion.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationsWithRegion.tsx
@@ -4,11 +4,18 @@ import {useQuery} from '@tanstack/react-query';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {OrganizationSummary} from 'sentry/types/organization';
+import type {Locality} from 'sentry/types/system';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import type {OrganizationSummaryWithRegion} from 'sentry/views/setupWizard/types';
+import {getLocalities} from 'sentry/utils/cells';
+import type {OrganizationSummaryWithLocality} from 'sentry/views/setupWizard/types';
 
 export function useOrganizationsWithRegion() {
-  const {memberRegions, links} = useLegacyStore(ConfigStore);
+  const localities = getLocalities();
+  const localitiesByUrl = localities.reduce<Record<string, Locality>>((acc, l) => {
+    acc[l.url] = l;
+    return acc;
+  }, {});
+  const {links} = useLegacyStore(ConfigStore);
 
   const query = useQuery({
     ...apiOptions.as<OrganizationSummary[]>()('/organizations/', {
@@ -18,25 +25,21 @@ export function useOrganizationsWithRegion() {
     refetchOnWindowFocus: false,
     retry: false,
     select: response => {
-      const regionByUrl = new Map(memberRegions.map(region => [region.url, region]));
-      return response.json.flatMap((org): OrganizationSummaryWithRegion[] => {
-        const region = regionByUrl.get(org.links.regionUrl);
-        if (!region) {
+      return response.json.flatMap((org): OrganizationSummaryWithLocality[] => {
+        const locality = localitiesByUrl[org.links.regionUrl];
+        if (!locality) {
           // This is not expected to happen, but log it so we can diagnose if
-          // an organization's region is missing from the member regions.
-          Sentry.captureMessage(
-            'Could not match organization region URL to a member region',
-            {
-              level: 'warning',
-              extra: {
-                organizationSlug: org.slug,
-                regionUrl: org.links.regionUrl,
-              },
-            }
-          );
+          // an organization's locality is missing from the known localities.
+          Sentry.captureMessage('Could not match organization region URL to a locality', {
+            level: 'warning',
+            extra: {
+              organizationSlug: org.slug,
+              regionUrl: org.links.regionUrl,
+            },
+          });
           return [];
         }
-        return [{...org, region} as OrganizationSummaryWithRegion];
+        return [{...org, region: locality} as OrganizationSummaryWithLocality];
       });
     },
   });

--- a/static/app/views/setupWizard/wizardProjectSelection.tsx
+++ b/static/app/views/setupWizard/wizardProjectSelection.tsx
@@ -23,7 +23,7 @@ import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/useCompactSelectOptionsCache';
 import {ProjectLoadingError} from 'sentry/views/setupWizard/projectLoadingError';
-import type {OrganizationSummaryWithRegion} from 'sentry/views/setupWizard/types';
+import type {OrganizationSummaryWithLocality} from 'sentry/views/setupWizard/types';
 import {useCreateProjectFromWizard} from 'sentry/views/setupWizard/utils/useCreateProjectFromWizard';
 import {useOrganizationDetails} from 'sentry/views/setupWizard/utils/useOrganizationDetails';
 import {useOrganizationProjects} from 'sentry/views/setupWizard/utils/useOrganizationProjects';
@@ -76,7 +76,7 @@ export function WizardProjectSelection({
   organizations,
 }: {
   hash: string;
-  organizations: OrganizationSummaryWithRegion[];
+  organizations: OrganizationSummaryWithLocality[];
 }) {
   const [search, setSearch] = useState('');
 

--- a/tests/js/fixtures/config.ts
+++ b/tests/js/fixtures/config.ts
@@ -65,7 +65,6 @@ export function ConfigFixture(params: Partial<Config> = {}): Config {
       organizationUrl: undefined,
       regionUrl: undefined,
     },
-    memberRegions: [{name: 'us', url: 'https://sentry.io'}],
     regions: [{name: 'us', url: 'https://sentry.io'}],
     ...params,
   };

--- a/tests/js/fixtures/config.ts
+++ b/tests/js/fixtures/config.ts
@@ -65,7 +65,6 @@ export function ConfigFixture(params: Partial<Config> = {}): Config {
       organizationUrl: undefined,
       regionUrl: undefined,
     },
-    regions: [{name: 'us', url: 'https://sentry.io'}],
     ...params,
   };
 }


### PR DESCRIPTION
Remove `regions` and `memberRegions` from the `Config` type which makes usage of those keys type errors. Once this has landed I'll remove the data from `__initialData`.  I've also removed the `CUSTOMER_HIDDEN_REGIONS` as we are controlling this with how we generate `__initialData` and the locality/cell split.

Refs INFRENG-332