### PR TITLE
fix(vroom): Add Trace to Vroom occurrences

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from concurrent.futures import wait
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import jsonschema
 import orjson
@@ -34,6 +34,7 @@ from sentry.services.eventstore.models import Event
 from sentry.types.actor import parse_and_validate_actor
 from sentry.utils import metrics
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
+from sentry.utils.safe import get_path, set_path
 
 logger = logging.getLogger(__name__)
 
@@ -281,6 +282,17 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                 for optional_param in optional_params:
                     if optional_param in event_payload:
                         event_data[optional_param] = event_payload.get(optional_param)
+
+                if get_path(event_data, "contexts", "trace", "trace_id") is None:
+                    set_path(
+                        event_data,
+                        "contexts",
+                        "trace",
+                        value={
+                            "trace_id": uuid4().hex,
+                            "span_id": None,
+                        },
+                    )
 
                 try:
                     jsonschema.validate(event_data, EVENT_PAYLOAD_SCHEMA)


### PR DESCRIPTION
Vroom is our profiling service, which is responsible for reporting certain types of occurrences (e.g. FrameDrop, type 2009).

Currently, `vroom` does not support traces at all. We rely on the `"trace"` context to retrieve the Trace ID, which is a required field to store these occurrences in EAP.

One option to remedy this would be to build support for contexts in `vroom`. I am reticent to take this on because I generally don't understand the full scope of how `vroom` works and don't want to break things by only building support halfway.

Instead, this PR adds trace ID during the normalization within the occurrence consumer. The path here goes:

```
sentry.profiles.task::process_profile_task
sentry.profiles.task::_process_vroomrs_profile
< To ingest-occurrences Kafka >
sentry.issues.run::process_message
sentry.issues.occurrence_consumer::_process_message
sentry.issues.occurrence_consumer::process_occurrence_message
sentry.issues.occurrence_consumer::_get_kwargs
```