### PR TITLE
chore(alerts): Bump up brownout schedule and include private endpoints

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -51,7 +51,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
         }
     )
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     def post(self, request: Request, project) -> Response:
         """
         Creates a dummy event/group and activates the actions given by request body

--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -9,7 +9,9 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers.rest_framework import DummyRuleSerializer
+from sentry.constants import ALERTS_API_DEPRECATION_DATE
 from sentry.models.rule import Rule
 from sentry.notifications.types import TEST_NOTIFICATION_ID
 from sentry.ratelimits.config import RateLimitConfig
@@ -49,6 +51,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
         }
     )
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     def post(self, request: Request, project) -> Response:
         """
         Creates a dummy event/group and activates the actions given by request body

--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -11,7 +11,7 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers.rest_framework import DummyRuleSerializer
-from sentry.constants import ALERTS_API_DEPRECATION_DATE
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY
 from sentry.models.rule import Rule
 from sentry.notifications.types import TEST_NOTIFICATION_ID
 from sentry.ratelimits.config import RateLimitConfig
@@ -51,7 +51,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
         }
     )
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     def post(self, request: Request, project) -> Response:
         """
         Creates a dummy event/group and activates the actions given by request body

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -31,7 +31,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.issue_alert_examples import IssueAlertExamples
 from sentry.apidocs.parameters import GlobalParams, IssueAlertParams
-from sentry.constants import ALERTS_API_DEPRECATION_DATE, ObjectStatus
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY, ObjectStatus
 from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.integrations.jira.actions.create_ticket import JiraCreateTicketAction
 from sentry.integrations.jira_server.actions.create_ticket import JiraServerCreateTicketAction
@@ -127,7 +127,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-workflow-details",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     def get(self, request: Request, project: Project, rule: Workflow) -> Response:
         """
@@ -184,7 +184,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-workflow-details",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     def put(self, request: Request, project: Project, rule: Rule) -> Response:
         """
@@ -369,7 +369,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-workflow-details",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     def delete(self, request: Request, project: Project, rule: Workflow) -> Response:
         """

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -127,6 +127,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-workflow-details",
+        key="api.deprecation.alerts",
     )
     def get(self, request: Request, project: Project, rule: Workflow) -> Response:
         """
@@ -183,6 +184,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-workflow-details",
+        key="api.deprecation.alerts",
     )
     def put(self, request: Request, project: Project, rule: Rule) -> Response:
         """
@@ -367,6 +369,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-workflow-details",
+        key="api.deprecation.alerts",
     )
     def delete(self, request: Request, project: Project, rule: Workflow) -> Response:
         """

--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -12,9 +12,11 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import BaseGroupSerializerResponse, GroupSerializer
 from sentry.api.serializers.rest_framework.rule import RulePreviewSerializer
+from sentry.constants import ALERTS_API_DEPRECATION_DATE
 from sentry.models.group import Group
 from sentry.models.groupinbox import InboxDetails, get_inbox_details
 from sentry.rules.history.preview import preview
@@ -30,6 +32,7 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
     permission_classes = (ProjectAlertRulePermission,)
 
     # a post endpoint because it's too hard to pass a list of objects from the frontend
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     def post(self, request: Request, project) -> Response:
         """
         Get a list of alert triggers in past 2 weeks for given rules

--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -16,7 +16,7 @@ from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import BaseGroupSerializerResponse, GroupSerializer
 from sentry.api.serializers.rest_framework.rule import RulePreviewSerializer
-from sentry.constants import ALERTS_API_DEPRECATION_DATE
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY
 from sentry.models.group import Group
 from sentry.models.groupinbox import InboxDetails, get_inbox_details
 from sentry.rules.history.preview import preview
@@ -32,7 +32,7 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
     permission_classes = (ProjectAlertRulePermission,)
 
     # a post endpoint because it's too hard to pass a list of objects from the frontend
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     def post(self, request: Request, project) -> Response:
         """
         Get a list of alert triggers in past 2 weeks for given rules

--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -32,7 +32,7 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
     permission_classes = (ProjectAlertRulePermission,)
 
     # a post endpoint because it's too hard to pass a list of objects from the frontend
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     def post(self, request: Request, project) -> Response:
         """
         Get a list of alert triggers in past 2 weeks for given rules

--- a/src/sentry/api/endpoints/project_rule_task_details.py
+++ b/src/sentry/api/endpoints/project_rule_task_details.py
@@ -6,8 +6,9 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
-from sentry.constants import ObjectStatus
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ObjectStatus
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
 from sentry.models.rule import Rule
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
@@ -24,6 +25,7 @@ class ProjectRuleTaskDetailsEndpoint(ProjectEndpoint):
     }
     permission_classes = (ProjectSettingPermission,)
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-rule-task-details")
     def get(self, request: Request, project, task_uuid) -> Response:
         """

--- a/src/sentry/api/endpoints/project_rule_task_details.py
+++ b/src/sentry/api/endpoints/project_rule_task_details.py
@@ -25,7 +25,7 @@ class ProjectRuleTaskDetailsEndpoint(ProjectEndpoint):
     }
     permission_classes = (ProjectSettingPermission,)
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-rule-task-details")
     def get(self, request: Request, project, task_uuid) -> Response:
         """

--- a/src/sentry/api/endpoints/project_rule_task_details.py
+++ b/src/sentry/api/endpoints/project_rule_task_details.py
@@ -25,8 +25,8 @@ class ProjectRuleTaskDetailsEndpoint(ProjectEndpoint):
     }
     permission_classes = (ProjectSettingPermission,)
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-rule-task-details")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     def get(self, request: Request, project, task_uuid) -> Response:
         """
         Retrieve the status of the async task

--- a/src/sentry/api/endpoints/project_rule_task_details.py
+++ b/src/sentry/api/endpoints/project_rule_task_details.py
@@ -8,7 +8,7 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
-from sentry.constants import ALERTS_API_DEPRECATION_DATE, ObjectStatus
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY, ObjectStatus
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
 from sentry.models.rule import Rule
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
@@ -25,7 +25,7 @@ class ProjectRuleTaskDetailsEndpoint(ProjectEndpoint):
     }
     permission_classes = (ProjectSettingPermission,)
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-rule-task-details")
     def get(self, request: Request, project, task_uuid) -> Response:
         """

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -849,7 +849,9 @@ class ProjectRulesEndpoint(ProjectEndpoint):
     )
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-rules")
     @deprecated(
-        ALERTS_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-workflow-index"
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-workflow-index",
+        key="api.deprecation.alerts",
     )
     def get(self, request: Request, project: Project) -> Response[list[RuleSerializerResponse]]:
         """
@@ -898,6 +900,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-workflow-index",
+        key="api.deprecation.alerts",
     )
     def post(self, request: Request, project) -> Response:
         """

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -31,7 +31,7 @@ from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RES
 from sentry.apidocs.examples.issue_alert_examples import IssueAlertExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.constants import ALERTS_API_DEPRECATION_DATE, ObjectStatus
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY, ObjectStatus
 from sentry.integrations.slack.tasks.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
 from sentry.models.project import Project
@@ -851,7 +851,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-workflow-index",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     def get(self, request: Request, project: Project) -> Response[list[RuleSerializerResponse]]:
         """
@@ -900,7 +900,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-workflow-index",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     def post(self, request: Request, project) -> Response:
         """

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -12,7 +12,12 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.deprecation import deprecated
-from sentry.constants import ALERTS_API_DEPRECATION_DATE, MIGRATED_CONDITIONS, TICKET_ACTIONS
+from sentry.constants import (
+    ALERTS_API_DEPRECATION_DATE,
+    ALERTS_API_DEPRECATION_KEY,
+    MIGRATED_CONDITIONS,
+    TICKET_ACTIONS,
+)
 from sentry.models.project import Project
 from sentry.rules import rules
 from sentry.rules.actions.integrations.create_ticket.base import TicketEventAction
@@ -27,7 +32,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     def get(self, request: Request, project: Project) -> Response:
         """
         Retrieve the list of configuration options for a given project.

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -27,7 +27,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     def get(self, request: Request, project: Project) -> Response:
         """
         Retrieve the list of configuration options for a given project.

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -11,7 +11,8 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.constants import MIGRATED_CONDITIONS, TICKET_ACTIONS
+from sentry.api.helpers.deprecation import deprecated
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, MIGRATED_CONDITIONS, TICKET_ACTIONS
 from sentry.models.project import Project
 from sentry.rules import rules
 from sentry.rules.actions.integrations.create_ticket.base import TicketEventAction
@@ -26,6 +27,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     def get(self, request: Request, project: Project) -> Response:
         """
         Retrieve the list of configuration options for a given project.

--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -110,7 +110,6 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint, Generic[T]):
 
         return (args, kwargs)
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
     def post(self, request: Request, project: Project, rule: T) -> Response:
         serializer = RuleSnoozeValidator(data=request.data)
         if not serializer.is_valid():
@@ -168,7 +167,6 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint, Generic[T]):
             status=status.HTTP_201_CREATED,
         )
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
     def delete(self, request: Request, project: Project, rule: T) -> Response:
         # find if there is a mute for all that I can remove
         shared_snooze = None

--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -247,14 +247,14 @@ class RuleSnoozeEndpoint(BaseRuleSnoozeEndpoint[Rule]):
     }
     rule_field = "rule"
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     @track_alert_endpoint_execution("POST", "sentry-api-0-rule-snooze")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     def post(self, request: Request, project: Project, rule: Rule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list, fetch_instance, and create_instance
         return super().post(request, project, rule)
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-rule-snooze")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     def delete(self, request: Request, project: Project, rule: Rule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list and fetch_instance
         return super().delete(request, project, rule)
@@ -304,14 +304,14 @@ class MetricRuleSnoozeEndpoint(BaseRuleSnoozeEndpoint[AlertRule]):
     }
     rule_field = "alert_rule"
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     @track_alert_endpoint_execution("POST", "sentry-api-0-metric-rule-snooze")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     def post(self, request: Request, project: Project, rule: AlertRule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list, fetch_instance, and create_instance
         return super().post(request, project, rule)
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-metric-rule-snooze")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     def delete(self, request: Request, project: Project, rule: AlertRule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list and fetch_instance
         return super().delete(request, project, rule)

--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -247,13 +247,13 @@ class RuleSnoozeEndpoint(BaseRuleSnoozeEndpoint[Rule]):
     }
     rule_field = "rule"
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     @track_alert_endpoint_execution("POST", "sentry-api-0-rule-snooze")
     def post(self, request: Request, project: Project, rule: Rule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list, fetch_instance, and create_instance
         return super().post(request, project, rule)
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-rule-snooze")
     def delete(self, request: Request, project: Project, rule: Rule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list and fetch_instance
@@ -304,13 +304,13 @@ class MetricRuleSnoozeEndpoint(BaseRuleSnoozeEndpoint[AlertRule]):
     }
     rule_field = "alert_rule"
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     @track_alert_endpoint_execution("POST", "sentry-api-0-metric-rule-snooze")
     def post(self, request: Request, project: Project, rule: AlertRule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list, fetch_instance, and create_instance
         return super().post(request, project, rule)
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-metric-rule-snooze")
     def delete(self, request: Request, project: Project, rule: AlertRule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list and fetch_instance

--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -249,13 +249,13 @@ class RuleSnoozeEndpoint(BaseRuleSnoozeEndpoint[Rule]):
 
     @deprecated(ALERTS_API_DEPRECATION_DATE)
     @track_alert_endpoint_execution("POST", "sentry-api-0-rule-snooze")
-    def post(self, request: Request, project: Project, rule: Rule) -> Response:
+    def post(self, request: Request, project: Project, rule: Rule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list, fetch_instance, and create_instance
         return super().post(request, project, rule)
 
     @deprecated(ALERTS_API_DEPRECATION_DATE)
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-rule-snooze")
-    def delete(self, request: Request, project: Project, rule: Rule) -> Response:
+    def delete(self, request: Request, project: Project, rule: Rule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list and fetch_instance
         return super().delete(request, project, rule)
 
@@ -306,13 +306,13 @@ class MetricRuleSnoozeEndpoint(BaseRuleSnoozeEndpoint[AlertRule]):
 
     @deprecated(ALERTS_API_DEPRECATION_DATE)
     @track_alert_endpoint_execution("POST", "sentry-api-0-metric-rule-snooze")
-    def post(self, request: Request, project: Project, rule: AlertRule) -> Response:
+    def post(self, request: Request, project: Project, rule: AlertRule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list, fetch_instance, and create_instance
         return super().post(request, project, rule)
 
     @deprecated(ALERTS_API_DEPRECATION_DATE)
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-metric-rule-snooze")
-    def delete(self, request: Request, project: Project, rule: AlertRule) -> Response:
+    def delete(self, request: Request, project: Project, rule: AlertRule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list and fetch_instance
         return super().delete(request, project, rule)
 

--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -17,9 +17,11 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import BadRequest
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.api.utils import to_valid_int_id
+from sentry.constants import ALERTS_API_DEPRECATION_DATE
 from sentry.db.models.base import Model
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.incidents.models.alert_rule import AlertRule
@@ -108,6 +110,7 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint, Generic[T]):
 
         return (args, kwargs)
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     def post(self, request: Request, project: Project, rule: T) -> Response:
         serializer = RuleSnoozeValidator(data=request.data)
         if not serializer.is_valid():
@@ -165,6 +168,7 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint, Generic[T]):
             status=status.HTTP_201_CREATED,
         )
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     def delete(self, request: Request, project: Project, rule: T) -> Response:
         # find if there is a mute for all that I can remove
         shared_snooze = None
@@ -245,11 +249,13 @@ class RuleSnoozeEndpoint(BaseRuleSnoozeEndpoint[Rule]):
     }
     rule_field = "rule"
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     @track_alert_endpoint_execution("POST", "sentry-api-0-rule-snooze")
     def post(self, request: Request, project: Project, rule: Rule) -> Response:
         # Tracking happens in fetch_rule_list, fetch_instance, and create_instance
         return super().post(request, project, rule)
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-rule-snooze")
     def delete(self, request: Request, project: Project, rule: Rule) -> Response:
         # Tracking happens in fetch_rule_list and fetch_instance
@@ -300,11 +306,13 @@ class MetricRuleSnoozeEndpoint(BaseRuleSnoozeEndpoint[AlertRule]):
     }
     rule_field = "alert_rule"
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     @track_alert_endpoint_execution("POST", "sentry-api-0-metric-rule-snooze")
     def post(self, request: Request, project: Project, rule: AlertRule) -> Response:
         # Tracking happens in fetch_rule_list, fetch_instance, and create_instance
         return super().post(request, project, rule)
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-metric-rule-snooze")
     def delete(self, request: Request, project: Project, rule: AlertRule) -> Response:
         # Tracking happens in fetch_rule_list and fetch_instance

--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -21,7 +21,7 @@ from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.api.utils import to_valid_int_id
-from sentry.constants import ALERTS_API_DEPRECATION_DATE
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY
 from sentry.db.models.base import Model
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.incidents.models.alert_rule import AlertRule
@@ -248,13 +248,13 @@ class RuleSnoozeEndpoint(BaseRuleSnoozeEndpoint[Rule]):
     rule_field = "rule"
 
     @track_alert_endpoint_execution("POST", "sentry-api-0-rule-snooze")
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     def post(self, request: Request, project: Project, rule: Rule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list, fetch_instance, and create_instance
         return super().post(request, project, rule)
 
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-rule-snooze")
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     def delete(self, request: Request, project: Project, rule: Rule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list and fetch_instance
         return super().delete(request, project, rule)
@@ -305,13 +305,13 @@ class MetricRuleSnoozeEndpoint(BaseRuleSnoozeEndpoint[AlertRule]):
     rule_field = "alert_rule"
 
     @track_alert_endpoint_execution("POST", "sentry-api-0-metric-rule-snooze")
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     def post(self, request: Request, project: Project, rule: AlertRule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list, fetch_instance, and create_instance
         return super().post(request, project, rule)
 
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-metric-rule-snooze")
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     def delete(self, request: Request, project: Project, rule: AlertRule) -> Response:  # type: ignore[override]
         # Tracking happens in fetch_rule_list and fetch_instance
         return super().delete(request, project, rule)

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -1073,3 +1073,5 @@ EXTENSION_LANGUAGE_MAP = {
 # will begin periodic brownouts.
 CELL_API_DEPRECATION_DATE = datetime(2026, 5, 15, 0, 0, 0, tzinfo=UTC)
 ALERTS_API_DEPRECATION_DATE = datetime(2026, 5, 14, 0, 0, 0, tzinfo=UTC)
+# Option key prefix for the deprecated alerts API brownout schedule and duration.
+ALERTS_API_DEPRECATION_KEY = "api.deprecation.alerts"

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -15,7 +15,7 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.deprecation import deprecated
-from sentry.constants import ALERTS_API_DEPRECATION_DATE
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY
 from sentry.incidents.logic import (
     get_available_action_integrations_for_org,
     get_opsgenie_teams,
@@ -95,7 +95,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     def get(self, request: Request, organization: Organization) -> Response:
         """
         Fetches actions that an alert rule can perform for an organization

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -14,6 +14,8 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.helpers.deprecation import deprecated
+from sentry.constants import ALERTS_API_DEPRECATION_DATE
 from sentry.incidents.logic import (
     get_available_action_integrations_for_org,
     get_opsgenie_teams,
@@ -93,6 +95,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     def get(self, request: Request, organization: Organization) -> Response:
         """
         Fetches actions that an alert rule can perform for an organization

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -95,7 +95,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     def get(self, request: Request, organization: Organization) -> Response:
         """
         Fetches actions that an alert rule can perform for an organization

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -15,7 +15,7 @@ from sentry.api.fields.actor import OwnerActorField
 from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.project import ProjectField
-from sentry.constants import ALERTS_API_DEPRECATION_DATE
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY
 from sentry.incidents.endpoints.bases import WorkflowEngineOrganizationAlertRuleEndpoint
 from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
     DetailedWorkflowEngineDetectorSerializer,
@@ -289,7 +289,7 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-details",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     @_check_project_access
     def get(
@@ -318,7 +318,7 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-details",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     @_check_project_access
     def put(
@@ -352,7 +352,7 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-details",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     @_check_project_access
     def delete(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -289,6 +289,7 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-details",
+        key="api.deprecation.alerts",
     )
     @_check_project_access
     def get(
@@ -317,6 +318,7 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-details",
+        key="api.deprecation.alerts",
     )
     @_check_project_access
     def put(
@@ -350,6 +352,7 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-details",
+        key="api.deprecation.alerts",
     )
     @_check_project_access
     def delete(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -521,12 +521,12 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = get_max_metric_alert_subscriptions(organization)
         return response
 
+    @track_alert_endpoint_execution("GET", "sentry-api-0-organization-combined-rules")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-index",
         key=ALERTS_API_DEPRECATION_KEY,
     )
-    @track_alert_endpoint_execution("GET", "sentry-api-0-organization-combined-rules")
     def get(self, request: Request, organization: Organization) -> Response:
         """
         Fetches metric, issue, crons, and uptime alert rules for an organization

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -267,6 +267,7 @@ class OrganizationOnDemandRuleStatsEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     def get(self, request: Request, organization: Organization) -> Response:
         """
         Returns the total number of on-demand alert rules for a project, along with
@@ -520,6 +521,9 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = get_max_metric_alert_subscriptions(organization)
         return response
 
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-detector-index"
+    )
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-combined-rules")
     def get(self, request: Request, organization: Organization) -> Response:
         """

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -267,7 +267,7 @@ class OrganizationOnDemandRuleStatsEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     def get(self, request: Request, organization: Organization) -> Response:
         """
         Returns the total number of on-demand alert rules for a project, along with
@@ -522,7 +522,9 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         return response
 
     @deprecated(
-        ALERTS_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-detector-index"
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-detector-index",
+        key="api.deprecation.alerts",
     )
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-combined-rules")
     def get(self, request: Request, organization: Organization) -> Response:
@@ -724,7 +726,9 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
     )
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-alert-rules")
     @deprecated(
-        ALERTS_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-detector-index"
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-detector-index",
+        key="api.deprecation.alerts",
     )
     def get(self, request: Request, organization: Organization) -> HttpResponseBase:
         """
@@ -749,7 +753,9 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
     )
     @track_alert_endpoint_execution("POST", "sentry-api-0-organization-alert-rules")
     @deprecated(
-        ALERTS_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-detector-index"
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-detector-index",
+        key="api.deprecation.alerts",
     )
     def post(self, request: Request, organization: Organization) -> HttpResponseBase:
         """

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -41,7 +41,7 @@ from sentry.api.paginator import (
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.api.utils import to_valid_int_id
-from sentry.constants import ALERTS_API_DEPRECATION_DATE, ObjectStatus
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY, ObjectStatus
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.exceptions import InvalidParams
@@ -267,7 +267,7 @@ class OrganizationOnDemandRuleStatsEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     def get(self, request: Request, organization: Organization) -> Response:
         """
         Returns the total number of on-demand alert rules for a project, along with
@@ -524,7 +524,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-index",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-combined-rules")
     def get(self, request: Request, organization: Organization) -> Response:
@@ -728,7 +728,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-index",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     def get(self, request: Request, organization: Organization) -> HttpResponseBase:
         """
@@ -755,7 +755,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-index",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     def post(self, request: Request, organization: Organization) -> HttpResponseBase:
         """

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -121,8 +121,8 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
 
         return args, kwargs
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-incident-details")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     def get(
         self,
         request: Request,

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -15,7 +15,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
 from sentry.api.utils import to_valid_int_id
-from sentry.constants import ALERTS_API_DEPRECATION_DATE
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY
 from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
 from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
     WorkflowEngineDetailedIncidentSerializer,
@@ -121,7 +121,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
 
         return args, kwargs
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-incident-details")
     def get(
         self,

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -121,7 +121,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
 
         return args, kwargs
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-incident-details")
     def get(
         self,

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -12,8 +12,10 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
 from sentry.api.utils import to_valid_int_id
+from sentry.constants import ALERTS_API_DEPRECATION_DATE
 from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
 from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
     WorkflowEngineDetailedIncidentSerializer,
@@ -119,6 +121,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
 
         return args, kwargs
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-incident-details")
     def get(
         self,

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -19,7 +19,7 @@ from sentry.api.helpers.deprecation import deprecated
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.utils import to_valid_int_id
-from sentry.constants import ALERTS_API_DEPRECATION_DATE
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.exceptions import InvalidParams
 from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
@@ -52,7 +52,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
     }
     permission_classes = (IncidentPermission,)
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-incident-index")
     def get(self, request: Request, organization: Organization) -> Response:
         """

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -52,7 +52,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
     }
     permission_classes = (IncidentPermission,)
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-incident-index")
     def get(self, request: Request, organization: Organization) -> Response:
         """

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -15,9 +15,11 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.incident import IncidentPermission
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.utils import to_valid_int_id
+from sentry.constants import ALERTS_API_DEPRECATION_DATE
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.exceptions import InvalidParams
 from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
@@ -50,6 +52,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
     }
     permission_classes = (IncidentPermission,)
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-incident-index")
     def get(self, request: Request, organization: Organization) -> Response:
         """

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -52,8 +52,8 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
     }
     permission_classes = (IncidentPermission,)
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-incident-index")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     def get(self, request: Request, organization: Organization) -> Response:
         """
         List Incidents that a User can access within an Organization

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -5,7 +5,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.helpers.deprecation import deprecated
-from sentry.constants import ALERTS_API_DEPRECATION_DATE
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY
 from sentry.incidents.endpoints.bases import WorkflowEngineProjectAlertRuleEndpoint
 from sentry.incidents.endpoints.organization_alert_rule_details import (
     fetch_alert_rule,
@@ -31,7 +31,7 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-details",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     def get(self, request: Request, project: Project, alert_rule: AlertRule | Detector) -> Response:
         """
@@ -45,7 +45,7 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-details",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     def put(self, request: Request, project: Project, alert_rule: AlertRule | Detector) -> Response:
         """
@@ -59,7 +59,7 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-details",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     def delete(
         self, request: Request, project: Project, alert_rule: AlertRule | Detector

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -31,6 +31,7 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-details",
+        key="api.deprecation.alerts",
     )
     def get(self, request: Request, project: Project, alert_rule: AlertRule | Detector) -> Response:
         """
@@ -44,6 +45,7 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-details",
+        key="api.deprecation.alerts",
     )
     def put(self, request: Request, project: Project, alert_rule: AlertRule | Detector) -> Response:
         """
@@ -57,6 +59,7 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-details",
+        key="api.deprecation.alerts",
     )
     def delete(
         self, request: Request, project: Project, alert_rule: AlertRule | Detector

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -13,7 +13,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.helpers.deprecation import deprecated
-from sentry.constants import ALERTS_API_DEPRECATION_DATE
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY
 from sentry.incidents.endpoints.organization_alert_rule_index import (
     AlertRuleFetchMixin,
     create_metric_alert,
@@ -34,7 +34,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleFetchMixin):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-index",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     def get(self, request: Request, project: Project) -> HttpResponseBase:
         """
@@ -46,7 +46,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleFetchMixin):
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="sentry-api-0-organization-detector-index",
-        key="api.deprecation.alerts",
+        key=ALERTS_API_DEPRECATION_KEY,
     )
     def post(self, request: Request, project: Project) -> HttpResponseBase:
         """

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -32,7 +32,9 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleFetchMixin):
 
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-alert-rules")
     @deprecated(
-        ALERTS_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-detector-index"
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-detector-index",
+        key="api.deprecation.alerts",
     )
     def get(self, request: Request, project: Project) -> HttpResponseBase:
         """
@@ -42,7 +44,9 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleFetchMixin):
 
     @track_alert_endpoint_execution("POST", "sentry-api-0-project-alert-rules")
     @deprecated(
-        ALERTS_API_DEPRECATION_DATE, suggested_api="sentry-api-0-organization-detector-index"
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-detector-index",
+        key="api.deprecation.alerts",
     )
     def post(self, request: Request, project: Project) -> HttpResponseBase:
         """

--- a/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
@@ -8,7 +8,7 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
-from sentry.constants import ALERTS_API_DEPRECATION_DATE
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY
 from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
     WorkflowEngineDetectorSerializer,
 )
@@ -26,7 +26,7 @@ class ProjectAlertRuleTaskDetailsEndpoint(ProjectEndpoint):
     }
     permission_classes = (ProjectSettingPermission,)
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key=ALERTS_API_DEPRECATION_KEY)
     def get(self, request: Request, project: Project, task_uuid: str) -> Response:
         """
         Retrieve the status of the async task

--- a/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
@@ -26,7 +26,7 @@ class ProjectAlertRuleTaskDetailsEndpoint(ProjectEndpoint):
     }
     permission_classes = (ProjectSettingPermission,)
 
-    @deprecated(ALERTS_API_DEPRECATION_DATE)
+    @deprecated(ALERTS_API_DEPRECATION_DATE, key="api.deprecation.alerts")
     def get(self, request: Request, project: Project, task_uuid: str) -> Response:
         """
         Retrieve the status of the async task

--- a/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
@@ -6,7 +6,9 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
+from sentry.constants import ALERTS_API_DEPRECATION_DATE
 from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
     WorkflowEngineDetectorSerializer,
 )
@@ -24,6 +26,7 @@ class ProjectAlertRuleTaskDetailsEndpoint(ProjectEndpoint):
     }
     permission_classes = (ProjectSettingPermission,)
 
+    @deprecated(ALERTS_API_DEPRECATION_DATE)
     def get(self, request: Request, project: Project, task_uuid: str) -> Response:
         """
         Retrieve the status of the async task

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1542,6 +1542,21 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Brownout schedule for the deprecated alerts API endpoints.
+# 1 minute blackout 6 times a day (every 4 hours, on the hour, UTC).
+register(
+    "api.deprecation.alerts-cron",
+    default="0 0,4,8,12,16,20 * * *",
+    type=String,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "api.deprecation.alerts-duration",
+    type=Int,
+    default=60,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Option to disable misbehaving use case IDs
 register(
     "sentry-metrics.indexer.disabled-namespaces",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1546,7 +1546,7 @@ register(
 # 1 minute blackout 6 times a day (every 4 hours, on the hour, UTC).
 register(
     "api.deprecation.alerts-cron",
-    default="0 0,4,8,12,16,20 * * *",
+    default="0 */4 * * *",
     type=String,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )


### PR DESCRIPTION
Bump up the brownouts from 1x/day (the default) to 6x/day (custom, we can revv it up as time goes on), and add private alerts endpoints to the deprecation because people and agents are using them despite them never having been documented - officially we don't have to notify people they're going away, but it's a little nicer than just ripping them out. 