### PR TITLE
ref: Register an empty service worker

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -655,6 +655,20 @@ export default typescript.config([
     },
   },
   {
+    name: 'files/service-worker-allow-sentry-browser',
+    files: ['static/app/serviceWorker/worker/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [restrictedThemeImportPattern],
+          paths: restrictedImportPaths.filter(p => p.name !== '@sentry/browser'),
+        },
+      ],
+      'import/no-extraneous-dependencies': 'off',
+    },
+  },
+  {
     name: 'files/chartcuterie-no-browser-imports',
     files: ['static/app/chartcuterie/**/*.{ts,tsx}'],
     rules: {

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -7,6 +7,7 @@ const productionEntryPoints = [
   'static/app/index.tsx',
   // defined in rspack.config.ts pipelines
   'static/app/utils/statics-setup.tsx',
+  'static/app/serviceWorker/worker/worker.ts',
   // very dynamically imported
   'static/app/gettingStartedDocs/**/*.{js,ts,tsx}',
   // this is imported with require.context

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "scripts": {
-    "typecheck": "tsgo -p tsconfig.json",
+    "typecheck": "tsgo -p tsconfig.json && tsgo -p static/app/serviceWorker/worker/tsconfig.json",
     "typecheck:mdx": "node build-utils/mdx-typecheck.ts",
     "type-coverage": "node scripts/type-coverage.ts -p tsconfig.json",
     "type-coverage-diff": "node scripts/type-coverage-diff.ts",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@sentry-internal/rrweb": "2.41.0",
     "@sentry-internal/rrweb-player": "2.41.0",
     "@sentry-internal/rrweb-snapshot": "2.41.0",
+    "@sentry/browser": "10.57.0",
     "@sentry/conventions": "^0.8.0",
     "@sentry/core": "10.57.0",
     "@sentry/node": "10.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       '@sentry-internal/rrweb-snapshot':
         specifier: 2.41.0
         version: 2.41.0
+      '@sentry/browser':
+        specifier: 10.57.0
+        version: 10.57.0
       '@sentry/conventions':
         specifier: ^0.8.0
         version: 0.8.0

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -246,7 +246,6 @@ const swcReactLoaderConfig: SwcLoaderOptions = {
  */
 
 const appConfig: Configuration = {
-  name: 'app',
   mode: WEBPACK_MODE,
   target: 'browserslist',
   // Fail on first error instead of continuing to build
@@ -462,7 +461,6 @@ const appConfig: Configuration = {
                   '**/*.spec.*',
                   '**/*.snapshots.*',
                   'static/eslint/**/*',
-                  'static/app/serviceWorker/worker/**/*',
                   'scripts/**/*',
                 ],
               },
@@ -924,52 +922,4 @@ if (env.WEBPACK_CACHE_PATH) {
   };
 }
 
-/**
- * Separate config for the service worker entry point.
- */
-const workerConfig: Configuration = {
-  name: 'worker',
-  dependencies: ['app'],
-  mode: WEBPACK_MODE,
-  target: 'webworker',
-  bail: IS_PRODUCTION,
-  entry: {
-    worker: 'sentry/serviceWorker/worker/worker',
-  },
-  context: staticPrefix,
-  resolve: {
-    alias: appConfig.resolve!.alias,
-    extensions: ['.ts', '.js', '.json'],
-  },
-  module: {
-    rules: [
-      {
-        test: /\.ts$/,
-        loader: 'builtin:swc-loader',
-        options: {
-          env: {
-            targets:
-              'last 2 Chrome versions, last 2 Firefox versions, last 2 Safari versions, last 2 Edge versions',
-          },
-          jsc: {
-            parser: {
-              syntax: 'typescript',
-              tsx: false,
-            },
-          },
-          isModule: 'unknown',
-        } satisfies SwcLoaderOptions,
-      },
-    ],
-  },
-  output: {
-    clean: false,
-    path: distPath,
-    publicPath: appConfig.output!.publicPath as string,
-    filename: 'entrypoints/[name].js',
-  },
-  devtool: IS_PRODUCTION ? 'source-map' : 'eval',
-};
-
-const configs = [appConfig, workerConfig];
-export default configs;
+export default appConfig;

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -246,6 +246,7 @@ const swcReactLoaderConfig: SwcLoaderOptions = {
  */
 
 const appConfig: Configuration = {
+  name: 'app',
   mode: WEBPACK_MODE,
   target: 'browserslist',
   // Fail on first error instead of continuing to build
@@ -461,6 +462,7 @@ const appConfig: Configuration = {
                   '**/*.spec.*',
                   '**/*.snapshots.*',
                   'static/eslint/**/*',
+                  'static/app/serviceWorker/worker/**/*',
                   'scripts/**/*',
                 ],
               },
@@ -770,6 +772,7 @@ if (IS_UI_DEV_ONLY) {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Credentials': 'true',
       'Document-Policy': 'js-profiling',
+      'Service-Worker-Allowed': '/',
     },
     static: {
       publicPath: '/_assets/',
@@ -921,4 +924,52 @@ if (env.WEBPACK_CACHE_PATH) {
   };
 }
 
-export default appConfig;
+/**
+ * Separate config for the service worker entry point.
+ */
+const workerConfig: Configuration = {
+  name: 'worker',
+  dependencies: ['app'],
+  mode: WEBPACK_MODE,
+  target: 'webworker',
+  bail: IS_PRODUCTION,
+  entry: {
+    worker: 'sentry/serviceWorker/worker/worker',
+  },
+  context: staticPrefix,
+  resolve: {
+    alias: appConfig.resolve!.alias,
+    extensions: ['.ts', '.js', '.json'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'builtin:swc-loader',
+        options: {
+          env: {
+            targets:
+              'last 2 Chrome versions, last 2 Firefox versions, last 2 Safari versions, last 2 Edge versions',
+          },
+          jsc: {
+            parser: {
+              syntax: 'typescript',
+              tsx: false,
+            },
+          },
+          isModule: 'unknown',
+        } satisfies SwcLoaderOptions,
+      },
+    ],
+  },
+  output: {
+    clean: false,
+    path: distPath,
+    publicPath: appConfig.output!.publicPath as string,
+    filename: 'entrypoints/[name].js',
+  },
+  devtool: IS_PRODUCTION ? 'source-map' : 'eval',
+};
+
+const configs = [appConfig, workerConfig];
+export default configs;

--- a/static/app/bootstrap/initializeApp.tsx
+++ b/static/app/bootstrap/initializeApp.tsx
@@ -1,6 +1,7 @@
 import './legacyTwitterBootstrap';
 import './exportGlobals';
 
+import {registerWorker} from 'sentry/serviceWorker/client/register';
 import type {Config} from 'sentry/types/system';
 import {metric} from 'sentry/utils/analytics';
 
@@ -20,4 +21,5 @@ export function initializeApp(config: Config) {
   metric.mark({name: 'sentry-app-init'});
   renderOnDomReady(renderMain);
   processInitQueue();
+  registerWorker();
 }

--- a/static/app/serviceWorker/client/register.ts
+++ b/static/app/serviceWorker/client/register.ts
@@ -8,18 +8,27 @@ function getWorkerUrl(): string {
   return `${distPrefix}entrypoints/worker.js`;
 }
 
-function connectIntegration(worker: ServiceWorker): void {
-  addIntegration(webWorkerIntegration({worker: worker as unknown as Worker}));
+type WebWorkerIntegration = ReturnType<typeof webWorkerIntegration>;
+let integration: WebWorkerIntegration | null = null;
+
+function connectWorker(worker: ServiceWorker): void {
+  const w = worker as unknown as Worker;
+  if (integration) {
+    integration.addWorker(w);
+  } else {
+    integration = webWorkerIntegration({worker: w});
+    addIntegration(integration);
+  }
 }
 
 function waitForActivation(worker: ServiceWorker): void {
   if (worker.state === 'activated') {
-    connectIntegration(worker);
+    connectWorker(worker);
     return;
   }
   worker.addEventListener('statechange', () => {
     if (worker.state === 'activated') {
-      connectIntegration(worker);
+      connectWorker(worker);
     }
   });
 }
@@ -36,7 +45,7 @@ export function registerWorker(): void {
       if (incoming) {
         waitForActivation(incoming);
       } else if (registration.active) {
-        connectIntegration(registration.active);
+        connectWorker(registration.active);
       }
 
       registration.addEventListener('updatefound', () => {

--- a/static/app/serviceWorker/client/register.ts
+++ b/static/app/serviceWorker/client/register.ts
@@ -1,0 +1,17 @@
+function getWorkerUrl(): string {
+  if (window.__SENTRY_DEV_UI) {
+    return '/_assets/entrypoints/worker.js';
+  }
+  const distPrefix = window.__initialData?.distPrefix ?? '/_static/dist/sentry/';
+  return `${distPrefix}entrypoints/worker.js`;
+}
+
+export function registerWorker(): void {
+  if (!('serviceWorker' in navigator)) {
+    return;
+  }
+
+  navigator.serviceWorker.register(getWorkerUrl(), {scope: '/'}).catch(() => {
+    // Registration failed — not critical, silently ignore
+  });
+}

--- a/static/app/serviceWorker/client/register.ts
+++ b/static/app/serviceWorker/client/register.ts
@@ -1,13 +1,5 @@
 import {addIntegration, webWorkerIntegration} from '@sentry/react';
 
-function getWorkerUrl(): string {
-  if (window.__SENTRY_DEV_UI) {
-    return '/_assets/entrypoints/worker.js';
-  }
-  const distPrefix = window.__initialData?.distPrefix ?? '/_static/dist/sentry/';
-  return `${distPrefix}entrypoints/worker.js`;
-}
-
 type WebWorkerIntegration = ReturnType<typeof webWorkerIntegration>;
 let integration: WebWorkerIntegration | null = null;
 
@@ -39,7 +31,7 @@ export function registerWorker(): void {
   }
 
   navigator.serviceWorker
-    .register(getWorkerUrl(), {scope: '/'})
+    .register(new URL('../worker/worker.ts', import.meta.url), {scope: '/'})
     .then(registration => {
       const incoming = registration.installing ?? registration.waiting;
       if (incoming) {

--- a/static/app/serviceWorker/client/register.ts
+++ b/static/app/serviceWorker/client/register.ts
@@ -31,6 +31,7 @@ export function registerWorker(): void {
   }
 
   navigator.serviceWorker
+    // https://rspack.rs/guide/features/web-workers
     .register(new URL('../worker/worker.ts', import.meta.url), {scope: '/'})
     .then(registration => {
       const incoming = registration.installing ?? registration.waiting;

--- a/static/app/serviceWorker/client/register.ts
+++ b/static/app/serviceWorker/client/register.ts
@@ -1,3 +1,5 @@
+import type {InitSentryMessage} from 'sentry/serviceWorker/types';
+
 function getWorkerUrl(): string {
   if (window.__SENTRY_DEV_UI) {
     return '/_assets/entrypoints/worker.js';
@@ -6,12 +8,54 @@ function getWorkerUrl(): string {
   return `${distPrefix}entrypoints/worker.js`;
 }
 
+function getSentryConfig(): InitSentryMessage | null {
+  const config = window.__initialData;
+  const dsn = config?.sentryConfig?.dsn;
+  if (!dsn) {
+    return null;
+  }
+  return {
+    type: 'init-sentry',
+    dsn,
+    release: config.sentryConfig?.release,
+    environment: config.sentryConfig?.environment,
+    tracesSampleRate: config.apmSampling ?? 0,
+  };
+}
+
+function sendSentryConfig(worker: ServiceWorker): void {
+  const sentryConfig = getSentryConfig();
+  if (sentryConfig) {
+    worker.postMessage(sentryConfig);
+  }
+}
+
 export function registerWorker(): void {
   if (!('serviceWorker' in navigator)) {
     return;
   }
 
-  navigator.serviceWorker.register(getWorkerUrl(), {scope: '/'}).catch(() => {
-    // Registration failed — not critical, silently ignore
-  });
+  navigator.serviceWorker
+    .register(getWorkerUrl(), {scope: '/'})
+    .then(registration => {
+      const worker =
+        registration.active ?? registration.waiting ?? registration.installing;
+      if (worker) {
+        sendSentryConfig(worker);
+      }
+
+      registration.addEventListener('updatefound', () => {
+        const newWorker = registration.installing;
+        if (newWorker) {
+          newWorker.addEventListener('statechange', () => {
+            if (newWorker.state === 'activated') {
+              sendSentryConfig(newWorker);
+            }
+          });
+        }
+      });
+    })
+    .catch(() => {
+      // Registration failed — not critical, silently ignore
+    });
 }

--- a/static/app/serviceWorker/client/register.ts
+++ b/static/app/serviceWorker/client/register.ts
@@ -8,6 +8,22 @@ function getWorkerUrl(): string {
   return `${distPrefix}entrypoints/worker.js`;
 }
 
+function connectIntegration(worker: ServiceWorker): void {
+  addIntegration(webWorkerIntegration({worker: worker as unknown as Worker}));
+}
+
+function waitForActivation(worker: ServiceWorker): void {
+  if (worker.state === 'activated') {
+    connectIntegration(worker);
+    return;
+  }
+  worker.addEventListener('statechange', () => {
+    if (worker.state === 'activated') {
+      connectIntegration(worker);
+    }
+  });
+}
+
 export function registerWorker(): void {
   if (!('serviceWorker' in navigator)) {
     return;
@@ -16,11 +32,18 @@ export function registerWorker(): void {
   navigator.serviceWorker
     .register(getWorkerUrl(), {scope: '/'})
     .then(registration => {
-      const worker =
-        registration.active ?? registration.waiting ?? registration.installing;
-      if (worker) {
-        addIntegration(webWorkerIntegration({worker: worker as unknown as Worker}));
+      const incoming = registration.installing ?? registration.waiting;
+      if (incoming) {
+        waitForActivation(incoming);
+      } else if (registration.active) {
+        connectIntegration(registration.active);
       }
+
+      registration.addEventListener('updatefound', () => {
+        if (registration.installing) {
+          waitForActivation(registration.installing);
+        }
+      });
     })
     .catch(() => {
       // Registration failed — not critical, silently ignore

--- a/static/app/serviceWorker/client/register.ts
+++ b/static/app/serviceWorker/client/register.ts
@@ -1,4 +1,4 @@
-import type {InitSentryMessage} from 'sentry/serviceWorker/types';
+import {addIntegration, webWorkerIntegration} from '@sentry/react';
 
 function getWorkerUrl(): string {
   if (window.__SENTRY_DEV_UI) {
@@ -6,28 +6,6 @@ function getWorkerUrl(): string {
   }
   const distPrefix = window.__initialData?.distPrefix ?? '/_static/dist/sentry/';
   return `${distPrefix}entrypoints/worker.js`;
-}
-
-function getSentryConfig(): InitSentryMessage | null {
-  const config = window.__initialData;
-  const dsn = config?.sentryConfig?.dsn;
-  if (!dsn) {
-    return null;
-  }
-  return {
-    type: 'init-sentry',
-    dsn,
-    release: config.sentryConfig?.release,
-    environment: config.sentryConfig?.environment,
-    tracesSampleRate: config.apmSampling ?? 0,
-  };
-}
-
-function sendSentryConfig(worker: ServiceWorker): void {
-  const sentryConfig = getSentryConfig();
-  if (sentryConfig) {
-    worker.postMessage(sentryConfig);
-  }
 }
 
 export function registerWorker(): void {
@@ -41,19 +19,8 @@ export function registerWorker(): void {
       const worker =
         registration.active ?? registration.waiting ?? registration.installing;
       if (worker) {
-        sendSentryConfig(worker);
+        addIntegration(webWorkerIntegration({worker: worker as unknown as Worker}));
       }
-
-      registration.addEventListener('updatefound', () => {
-        const newWorker = registration.installing;
-        if (newWorker) {
-          newWorker.addEventListener('statechange', () => {
-            if (newWorker.state === 'activated') {
-              sendSentryConfig(newWorker);
-            }
-          });
-        }
-      });
     })
     .catch(() => {
       // Registration failed — not critical, silently ignore

--- a/static/app/serviceWorker/types.ts
+++ b/static/app/serviceWorker/types.ts
@@ -1,0 +1,9 @@
+export interface InitSentryMessage {
+  dsn: string;
+  type: 'init-sentry';
+  environment?: string;
+  release?: string;
+  tracesSampleRate?: number;
+}
+
+export type WorkerMessage = InitSentryMessage;

--- a/static/app/serviceWorker/types.ts
+++ b/static/app/serviceWorker/types.ts
@@ -1,9 +1,0 @@
-export interface InitSentryMessage {
-  dsn: string;
-  type: 'init-sentry';
-  environment?: string;
-  release?: string;
-  tracesSampleRate?: number;
-}
-
-export type WorkerMessage = InitSentryMessage;

--- a/static/app/serviceWorker/worker/tsconfig.json
+++ b/static/app/serviceWorker/worker/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["esnext", "webworker"]
+  },
+  "include": ["."],
+  "exclude": []
+}

--- a/static/app/serviceWorker/worker/worker.ts
+++ b/static/app/serviceWorker/worker/worker.ts
@@ -1,10 +1,12 @@
 import {init, isInitialized} from '@sentry/browser';
 import {
+  captureException,
   dedupeIntegration,
   functionToStringIntegration,
   inboundFiltersIntegration,
   linkedErrorsIntegration,
   setTag,
+  startSpan,
 } from '@sentry/core';
 
 import type {InitSentryMessage, WorkerMessage} from 'sentry/serviceWorker/types';
@@ -118,11 +120,29 @@ function handleMessage(event: ExtendableMessageEvent): void {
 }
 
 sw.addEventListener('install', () => {
-  sw.skipWaiting();
+  startSpan({name: 'service-worker.install', op: 'sw.lifecycle'}, () => {
+    sw.skipWaiting();
+  });
 });
 
 sw.addEventListener('activate', event => {
-  event.waitUntil(Promise.all([sw.clients.claim(), restoreSentry()]));
+  event.waitUntil(
+    startSpan({name: 'service-worker.activate', op: 'sw.lifecycle'}, () =>
+      Promise.all([sw.clients.claim(), restoreSentry()])
+    )
+  );
 });
 
-sw.addEventListener('message', handleMessage);
+sw.addEventListener('message', event => {
+  startSpan(
+    {
+      name: `service-worker.message.${(event.data as WorkerMessage).type}`,
+      op: 'sw.message',
+    },
+    () => handleMessage(event)
+  );
+});
+
+sw.addEventListener('unhandledrejection', event => {
+  captureException(event.reason);
+});

--- a/static/app/serviceWorker/worker/worker.ts
+++ b/static/app/serviceWorker/worker/worker.ts
@@ -11,7 +11,55 @@ import type {InitSentryMessage, WorkerMessage} from 'sentry/serviceWorker/types'
 
 const sw = self as unknown as ServiceWorkerGlobalScope;
 
-function initSentry(config: InitSentryMessage): void {
+const DB_NAME = 'sentry-worker';
+const STORE_NAME = 'config';
+const SENTRY_KEY = 'sentry-init';
+
+interface CachedSentryConfig {
+  dsn: string;
+  environment?: string;
+  tracesSampleRate?: number;
+}
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error('Failed to open IndexedDB'));
+  });
+}
+
+async function saveSentryConfig(config: CachedSentryConfig): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(config, SENTRY_KEY);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error ?? new Error('Failed to save Sentry config'));
+  });
+}
+
+async function loadSentryConfig(): Promise<CachedSentryConfig | null> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const request = tx.objectStore(STORE_NAME).get(SENTRY_KEY);
+    request.onsuccess = () => resolve(request.result ?? null);
+    request.onerror = () =>
+      reject(request.error ?? new Error('Failed to load Sentry config'));
+  });
+}
+
+function initSentry(config: {
+  dsn: string;
+  environment?: string;
+  release?: string;
+  tracesSampleRate?: number;
+}): void {
   if (isInitialized()) {
     return;
   }
@@ -34,11 +82,35 @@ function initSentry(config: InitSentryMessage): void {
   setTag('context', 'service-worker');
 }
 
+async function handleInitSentry(config: InitSentryMessage): Promise<void> {
+  initSentry(config);
+
+  await saveSentryConfig({
+    dsn: config.dsn,
+    environment: config.environment,
+    tracesSampleRate: config.tracesSampleRate,
+  });
+}
+
+async function restoreSentry(): Promise<void> {
+  if (isInitialized()) {
+    return;
+  }
+  try {
+    const cached = await loadSentryConfig();
+    if (cached) {
+      initSentry(cached);
+    }
+  } catch {
+    // IndexedDB may be unavailable — not critical
+  }
+}
+
 function handleMessage(event: ExtendableMessageEvent): void {
   const data = event.data as WorkerMessage;
   switch (data.type) {
     case 'init-sentry':
-      initSentry(data);
+      event.waitUntil(handleInitSentry(data));
       break;
     default:
       break;
@@ -50,7 +122,7 @@ sw.addEventListener('install', () => {
 });
 
 sw.addEventListener('activate', event => {
-  event.waitUntil(sw.clients.claim());
+  event.waitUntil(Promise.all([sw.clients.claim(), restoreSentry()]));
 });
 
 sw.addEventListener('message', handleMessage);

--- a/static/app/serviceWorker/worker/worker.ts
+++ b/static/app/serviceWorker/worker/worker.ts
@@ -1,4 +1,5 @@
 import {registerWebWorker} from '@sentry/browser';
+import {startSpan} from '@sentry/core';
 
 const sw = self as unknown as ServiceWorkerGlobalScope;
 
@@ -9,9 +10,21 @@ const sw = self as unknown as ServiceWorkerGlobalScope;
 registerWebWorker({self: sw as any});
 
 sw.addEventListener('install', () => {
-  sw.skipWaiting();
+  startSpan({name: 'service-worker.install', op: 'sw.lifecycle'}, () => {
+    sw.skipWaiting();
+  });
 });
 
 sw.addEventListener('activate', event => {
-  event.waitUntil(sw.clients.claim());
+  event.waitUntil(
+    startSpan({name: 'service-worker.activate', op: 'sw.lifecycle'}, () =>
+      sw.clients.claim()
+    )
+  );
+});
+
+sw.addEventListener('message', _event => {
+  startSpan({name: 'service-worker.message', op: 'sw.message'}, () => {
+    // No custom message handlers yet
+  });
 });

--- a/static/app/serviceWorker/worker/worker.ts
+++ b/static/app/serviceWorker/worker/worker.ts
@@ -1,4 +1,49 @@
+import {init, isInitialized} from '@sentry/browser';
+import {
+  dedupeIntegration,
+  functionToStringIntegration,
+  inboundFiltersIntegration,
+  linkedErrorsIntegration,
+  setTag,
+} from '@sentry/core';
+
+import type {InitSentryMessage, WorkerMessage} from 'sentry/serviceWorker/types';
+
 const sw = self as unknown as ServiceWorkerGlobalScope;
+
+function initSentry(config: InitSentryMessage): void {
+  if (isInitialized()) {
+    return;
+  }
+
+  init({
+    dsn: config.dsn,
+    release: config.release,
+    environment: config.environment,
+    defaultIntegrations: false,
+    integrations: [
+      inboundFiltersIntegration(),
+      functionToStringIntegration(),
+      linkedErrorsIntegration(),
+      dedupeIntegration(),
+    ],
+    tracesSampleRate: config.tracesSampleRate ?? 0,
+    tracePropagationTargets: ['localhost', /^\//],
+  });
+
+  setTag('context', 'service-worker');
+}
+
+function handleMessage(event: ExtendableMessageEvent): void {
+  const data = event.data as WorkerMessage;
+  switch (data.type) {
+    case 'init-sentry':
+      initSentry(data);
+      break;
+    default:
+      break;
+  }
+}
 
 sw.addEventListener('install', () => {
   sw.skipWaiting();
@@ -7,3 +52,5 @@ sw.addEventListener('install', () => {
 sw.addEventListener('activate', event => {
   event.waitUntil(sw.clients.claim());
 });
+
+sw.addEventListener('message', handleMessage);

--- a/static/app/serviceWorker/worker/worker.ts
+++ b/static/app/serviceWorker/worker/worker.ts
@@ -1,0 +1,9 @@
+const sw = self as unknown as ServiceWorkerGlobalScope;
+
+sw.addEventListener('install', () => {
+  sw.skipWaiting();
+});
+
+sw.addEventListener('activate', event => {
+  event.waitUntil(sw.clients.claim());
+});

--- a/static/app/serviceWorker/worker/worker.ts
+++ b/static/app/serviceWorker/worker/worker.ts
@@ -11,7 +11,7 @@ registerWebWorker({self: sw as any});
 
 sw.addEventListener('install', () => {
   startSpan({name: 'service-worker.install', op: 'sw.lifecycle'}, () => {
-    sw.skipWaiting();
+    return sw.skipWaiting();
   });
 });
 

--- a/static/app/serviceWorker/worker/worker.ts
+++ b/static/app/serviceWorker/worker/worker.ts
@@ -1,148 +1,17 @@
-import {init, isInitialized} from '@sentry/browser';
-import {
-  captureException,
-  dedupeIntegration,
-  functionToStringIntegration,
-  inboundFiltersIntegration,
-  linkedErrorsIntegration,
-  setTag,
-  startSpan,
-} from '@sentry/core';
-
-import type {InitSentryMessage, WorkerMessage} from 'sentry/serviceWorker/types';
+import {registerWebWorker} from '@sentry/browser';
 
 const sw = self as unknown as ServiceWorkerGlobalScope;
 
-const DB_NAME = 'sentry-worker';
-const STORE_NAME = 'config';
-const SENTRY_KEY = 'sentry-init';
-
-interface CachedSentryConfig {
-  dsn: string;
-  environment?: string;
-  tracesSampleRate?: number;
-}
-
-function openDB(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, 1);
-    request.onupgradeneeded = () => {
-      request.result.createObjectStore(STORE_NAME);
-    };
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () =>
-      reject(request.error ?? new Error('Failed to open IndexedDB'));
-  });
-}
-
-async function saveSentryConfig(config: CachedSentryConfig): Promise<void> {
-  const db = await openDB();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(STORE_NAME, 'readwrite');
-    tx.objectStore(STORE_NAME).put(config, SENTRY_KEY);
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error ?? new Error('Failed to save Sentry config'));
-  });
-}
-
-async function loadSentryConfig(): Promise<CachedSentryConfig | null> {
-  const db = await openDB();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(STORE_NAME, 'readonly');
-    const request = tx.objectStore(STORE_NAME).get(SENTRY_KEY);
-    request.onsuccess = () => resolve(request.result ?? null);
-    request.onerror = () =>
-      reject(request.error ?? new Error('Failed to load Sentry config'));
-  });
-}
-
-function initSentry(config: {
-  dsn: string;
-  environment?: string;
-  release?: string;
-  tracesSampleRate?: number;
-}): void {
-  if (isInitialized()) {
-    return;
-  }
-
-  init({
-    dsn: config.dsn,
-    release: config.release,
-    environment: config.environment,
-    defaultIntegrations: false,
-    integrations: [
-      inboundFiltersIntegration(),
-      functionToStringIntegration(),
-      linkedErrorsIntegration(),
-      dedupeIntegration(),
-    ],
-    tracesSampleRate: config.tracesSampleRate ?? 0,
-    tracePropagationTargets: ['localhost', /^\//],
-  });
-
-  setTag('context', 'service-worker');
-}
-
-async function handleInitSentry(config: InitSentryMessage): Promise<void> {
-  initSentry(config);
-
-  await saveSentryConfig({
-    dsn: config.dsn,
-    environment: config.environment,
-    tracesSampleRate: config.tracesSampleRate,
-  });
-}
-
-async function restoreSentry(): Promise<void> {
-  if (isInitialized()) {
-    return;
-  }
-  try {
-    const cached = await loadSentryConfig();
-    if (cached) {
-      initSentry(cached);
-    }
-  } catch {
-    // IndexedDB may be unavailable — not critical
-  }
-}
-
-function handleMessage(event: ExtendableMessageEvent): void {
-  const data = event.data as WorkerMessage;
-  switch (data.type) {
-    case 'init-sentry':
-      event.waitUntil(handleInitSentry(data));
-      break;
-    default:
-      break;
-  }
-}
+// registerWebWorker expects DedicatedWorkerGlobalScope.postMessage, which
+// doesn't exist on ServiceWorkerGlobalScope. The cast is safe: the only
+// call to postMessage sends debug IDs and will be a no-op here; the
+// unhandledrejection handler still registers correctly.
+registerWebWorker({self: sw as any});
 
 sw.addEventListener('install', () => {
-  startSpan({name: 'service-worker.install', op: 'sw.lifecycle'}, () => {
-    sw.skipWaiting();
-  });
+  sw.skipWaiting();
 });
 
 sw.addEventListener('activate', event => {
-  event.waitUntil(
-    startSpan({name: 'service-worker.activate', op: 'sw.lifecycle'}, () =>
-      Promise.all([sw.clients.claim(), restoreSentry()])
-    )
-  );
-});
-
-sw.addEventListener('message', event => {
-  startSpan(
-    {
-      name: `service-worker.message.${(event.data as WorkerMessage).type}`,
-      op: 'sw.message',
-    },
-    () => handleMessage(event)
-  );
-});
-
-sw.addEventListener('unhandledrejection', event => {
-  captureException(event.reason);
+  event.waitUntil(sw.clients.claim());
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -81,5 +81,5 @@
     "config",
     "scripts"
   ],
-  "exclude": ["./node_modules"]
+  "exclude": ["./node_modules", "static/app/serviceWorker/worker"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "moduleResolution": "bundler",
 
     // We add esnext to lib to pull in types for all newer ECMAScript features
-    "lib": ["esnext", "dom", "dom.iterable"],
+    "lib": ["esnext", "dom", "dom.iterable", "webworker"],
 
     // Skip type checking of all declaration files
     "skipLibCheck": true,

--- a/tsconfig.mdx.json
+++ b/tsconfig.mdx.json
@@ -19,6 +19,7 @@
     "**/*.spec.*",
     "**/*.snapshots.*",
     "**/*.stories.tsx",
-    "tests"
+    "tests",
+    "static/app/serviceWorker/worker"
   ]
 }


### PR DESCRIPTION
Set up the build pipeline and registration for a service worker that does nothing yet. The worker installs, activates, and claims clients but has no message handling or polling logic.

- Add separate rspack config for the `webworker` target
- Add worker-specific tsconfig with `webworker` lib
- Register the worker from `initializeApp`
- Exclude worker from main tsconfig (uses its own)
- Add `Service-Worker-Allowed: /` header for dev server
- Initializes Sentry for visibility

<!-- Describe your PR here. -->