### PR TITLE
chore: Add new feature-flag definition organizations:api-fetch-v2

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -214,6 +214,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-selective-base-snapshots", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables the playstation ingestion in relay
     manager.add("organizations:relay-playstation-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    # Enable the new apiFetch implementation that uses cell fetch.
+    manager.add("organizations:api-fetch-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     manager.add("organizations:sourcemap-issue-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable profiling
     manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -229,6 +229,10 @@ class _ClientConfig:
             yield "relocation:enabled"
         if features.has("system:multi-region"):
             yield "system:multi-region"
+        if self.last_org and features.has(
+            "organizations:api-fetch-v2", self.last_org, actor=self.user
+        ):
+            yield "organizations:api-fetch-v2"
 
     @property
     def needs_upgrade(self) -> bool:


### PR DESCRIPTION
This pattern is matching what we had with `organizations:create-org-control` where we are checking the flag against the org, but sending it as a system-feature. We need this as a system feature so we can easily pass the value into apiFetch early and via ConfigStore which acts like a global

See flag definition: https://github.com/getsentry/sentry-options-automator/pull/8208
