### PR TITLE
fix(issues): Correct external issue activity title

### DIFF
--- a/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
@@ -567,10 +567,8 @@ export function getGroupActivityItem(
       }
       case GroupActivityType.CREATE_ISSUE: {
         const {data} = activity;
-        let title = t('Created Issue');
-        if (data.new === false) {
-          title = t('Linked Issue');
-        }
+        const isLinkedIssue = data.new === false;
+        const title = isLinkedIssue ? t('Linked Issue') : t('Created Issue');
 
         return {
           title,

--- a/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
@@ -568,7 +568,7 @@ export function getGroupActivityItem(
       case GroupActivityType.CREATE_ISSUE: {
         const {data} = activity;
         let title = t('Created Issue');
-        if (data.new === true) {
+        if (data.new === false) {
           title = t('Linked Issue');
         }
 

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -279,9 +279,36 @@ describe('ActivitySection', () => {
     expect(screen.queryByTestId('letter_avatar-avatar')).not.toBeInTheDocument();
   });
 
-  it('renders create issue activity details in two-column layout', async () => {
+  it('renders provider-specific icon for create issue in two-column layout', async () => {
     const createIssueGroup = GroupFixture({
       id: '1345',
+      activity: [
+        {
+          type: GroupActivityType.CREATE_ISSUE,
+          id: 'create-issue-1',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            provider: 'GitHub',
+            location: 'https://github.com/org/repo/issues/1',
+            title: 'Test Issue',
+          },
+          user,
+        },
+      ],
+      project,
+    });
+
+    render(<ActivitySection group={createIssueGroup} />, {
+      organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+    });
+
+    expect(await screen.findByText('Test Issue')).toBeInTheDocument();
+    expect(screen.queryByTestId('icon-add')).not.toBeInTheDocument();
+  });
+
+  it('renders create issue title based on whether the external issue is new', async () => {
+    const createIssueGroup = GroupFixture({
+      id: '1346',
       activity: [
         {
           type: GroupActivityType.CREATE_ISSUE,
@@ -311,15 +338,12 @@ describe('ActivitySection', () => {
       project,
     });
 
-    render(<ActivitySection group={createIssueGroup} />, {
-      organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
-    });
+    render(<ActivitySection group={createIssueGroup} />);
 
     expect(await screen.findByText('Created Issue')).toBeInTheDocument();
     expect(screen.getByText('Created external issue')).toBeInTheDocument();
     expect(screen.getByText('Linked Issue')).toBeInTheDocument();
     expect(screen.getByText('Linked external issue')).toBeInTheDocument();
-    expect(screen.queryByTestId('icon-add')).not.toBeInTheDocument();
   });
 
   it('renders note and allows for edit', async () => {

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -306,6 +306,46 @@ describe('ActivitySection', () => {
     expect(screen.queryByTestId('icon-add')).not.toBeInTheDocument();
   });
 
+  it('renders create issue title based on whether the external issue is new', async () => {
+    const createIssueGroup = GroupFixture({
+      id: '1346',
+      activity: [
+        {
+          type: GroupActivityType.CREATE_ISSUE,
+          id: 'create-issue-1',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            provider: 'GitHub',
+            location: 'https://github.com/org/repo/issues/1',
+            title: 'Created external issue',
+            new: true,
+          },
+          user,
+        },
+        {
+          type: GroupActivityType.CREATE_ISSUE,
+          id: 'link-issue-1',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            provider: 'GitHub',
+            location: 'https://github.com/org/repo/issues/2',
+            title: 'Linked external issue',
+            new: false,
+          },
+          user,
+        },
+      ],
+      project,
+    });
+
+    render(<ActivitySection group={createIssueGroup} />);
+
+    expect(await screen.findByText('Created Issue')).toBeInTheDocument();
+    expect(screen.getByText('Created external issue')).toBeInTheDocument();
+    expect(screen.getByText('Linked Issue')).toBeInTheDocument();
+    expect(screen.getByText('Linked external issue')).toBeInTheDocument();
+  });
+
   it('renders note and allows for edit', async () => {
     jest.spyOn(indicators, 'addSuccessMessage');
 

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -279,36 +279,9 @@ describe('ActivitySection', () => {
     expect(screen.queryByTestId('letter_avatar-avatar')).not.toBeInTheDocument();
   });
 
-  it('renders provider-specific icon for create issue in two-column layout', async () => {
+  it('renders create issue activity details in two-column layout', async () => {
     const createIssueGroup = GroupFixture({
       id: '1345',
-      activity: [
-        {
-          type: GroupActivityType.CREATE_ISSUE,
-          id: 'create-issue-1',
-          dateCreated: '2020-01-01T00:00:00',
-          data: {
-            provider: 'GitHub',
-            location: 'https://github.com/org/repo/issues/1',
-            title: 'Test Issue',
-          },
-          user,
-        },
-      ],
-      project,
-    });
-
-    render(<ActivitySection group={createIssueGroup} />, {
-      organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
-    });
-
-    expect(await screen.findByText('Test Issue')).toBeInTheDocument();
-    expect(screen.queryByTestId('icon-add')).not.toBeInTheDocument();
-  });
-
-  it('renders create issue title based on whether the external issue is new', async () => {
-    const createIssueGroup = GroupFixture({
-      id: '1346',
       activity: [
         {
           type: GroupActivityType.CREATE_ISSUE,
@@ -338,12 +311,15 @@ describe('ActivitySection', () => {
       project,
     });
 
-    render(<ActivitySection group={createIssueGroup} />);
+    render(<ActivitySection group={createIssueGroup} />, {
+      organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+    });
 
     expect(await screen.findByText('Created Issue')).toBeInTheDocument();
     expect(screen.getByText('Created external issue')).toBeInTheDocument();
     expect(screen.getByText('Linked Issue')).toBeInTheDocument();
     expect(screen.getByText('Linked external issue')).toBeInTheDocument();
+    expect(screen.queryByTestId('icon-add')).not.toBeInTheDocument();
   });
 
   it('renders note and allows for edit', async () => {


### PR DESCRIPTION
`new: true` means Sentry created a new external issue. just an error we've had for a long time.

before

<img width="323" height="113" alt="image" src="https://github.com/user-attachments/assets/c51efb0b-6a06-44f0-952a-a884a3c8660c" />


after

<img width="311" height="100" alt="image" src="https://github.com/user-attachments/assets/3c375792-c2c4-4924-b79c-1bc8b464a8cc" />
