### PR TITLE
feat(broadcasts): Add sdk_update broadcast category

### DIFF
--- a/src/sentry/models/broadcast.py
+++ b/src/sentry/models/broadcast.py
@@ -17,6 +17,7 @@ BROADCAST_CATEGORIES = [
     ("blog", "Blog Post"),
     ("event", "Event"),
     ("video", "Video"),
+    ("sdk_update", "SDK Update"),
 ]
 
 

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -265,7 +265,7 @@ export interface Broadcast {
    * Category of the broadcast.
    * Synced with https://github.com/getsentry/sentry/blob/master/src/sentry/models/broadcast.py#L14
    */
-  category?: 'announcement' | 'feature' | 'blog' | 'event' | 'video';
+  category?: 'announcement' | 'feature' | 'blog' | 'event' | 'video' | 'sdk_update';
   /**
    * The text for the CTA link at the bottom of the panel item
    */

--- a/static/app/views/navigation/primary/whatsNew.spec.tsx
+++ b/static/app/views/navigation/primary/whatsNew.spec.tsx
@@ -349,6 +349,7 @@ describe('WhatsNew', () => {
         BroadcastFixture({id: '3', title: 'Broadcast 3', category: 'blog'}),
         BroadcastFixture({id: '4', title: 'Broadcast 4', category: 'event'}),
         BroadcastFixture({id: '5', title: 'Broadcast 5', category: 'video'}),
+        BroadcastFixture({id: '6', title: 'Broadcast 6', category: 'sdk_update'}),
       ],
     });
 
@@ -361,5 +362,6 @@ describe('WhatsNew', () => {
     expect(screen.getByText('Blog Post')).toBeInTheDocument();
     expect(screen.getByText('Event')).toBeInTheDocument();
     expect(screen.getByText('Video')).toBeInTheDocument();
+    expect(screen.getByText('SDK Update')).toBeInTheDocument();
   });
 });

--- a/static/app/views/navigation/primary/whatsNew.tsx
+++ b/static/app/views/navigation/primary/whatsNew.tsx
@@ -27,6 +27,7 @@ const BROADCAST_CATEGORIES: Record<NonNullable<Broadcast['category']>, string> =
   blog: t('Blog Post'),
   event: t('Event'),
   video: t('Video'),
+  sdk_update: t('SDK Update'),
 };
 
 function BroadcastImage({src, alt}: {alt: string; src: string}) {


### PR DESCRIPTION
Add 'sdk_update' to the Broadcast model's BROADCAST_CATEGORIES choices and the frontend "What's New" panel category mapping, so changelog entries can be labeled as SDK Updates.

The new category is consumed from the sentry-changelog API via getsentry's broadcast sync task. Existing categories (blog, event, video) are preserved for backward compatibility.

