### PR TITLE
fix(issues): Show auto ongoing activity duration

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -835,6 +835,7 @@ interface GroupActivityMerge extends GroupActivityBase {
 interface GroupActivityAutoSetOngoing extends GroupActivityBase {
   data: {
     afterDays?: number;
+    after_days?: number;
   };
   type: GroupActivityType.AUTO_SET_ONGOING;
 }

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -834,7 +834,6 @@ interface GroupActivityMerge extends GroupActivityBase {
 
 interface GroupActivityAutoSetOngoing extends GroupActivityBase {
   data: {
-    afterDays?: number;
     after_days?: number;
   };
   type: GroupActivityType.AUTO_SET_ONGOING;

--- a/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
@@ -682,12 +682,13 @@ export function getGroupActivityItem(
         };
       }
       case GroupActivityType.AUTO_SET_ONGOING: {
+        const afterDays = activity.data?.after_days ?? activity.data?.afterDays;
         return {
           title: t('Marked as Ongoing'),
-          message: activity.data?.afterDays
+          message: afterDays
             ? tct('automatically by [author] after [afterDays] days', {
                 author,
-                afterDays: activity.data.afterDays,
+                afterDays,
               })
             : tct('automatically by [author]', {
                 author,

--- a/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
@@ -682,7 +682,7 @@ export function getGroupActivityItem(
         };
       }
       case GroupActivityType.AUTO_SET_ONGOING: {
-        const afterDays = activity.data?.after_days ?? activity.data?.afterDays;
+        const afterDays = activity.data?.after_days;
         return {
           title: t('Marked as Ongoing'),
           message: afterDays

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -552,6 +552,30 @@ describe('ActivitySection', () => {
     }
   });
 
+  it('renders auto ongoing activity duration from backend data', async () => {
+    const ongoingGroup = GroupFixture({
+      id: '1339',
+      activity: [
+        {
+          type: GroupActivityType.AUTO_SET_ONGOING,
+          id: 'auto-ongoing-1',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {after_days: 7},
+        },
+      ],
+      project,
+    });
+
+    render(<ActivitySection group={ongoingGroup} />);
+
+    expect(await screen.findByText('Marked as Ongoing')).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        (_, element) => element?.textContent === 'automatically by Sentry after 7 days'
+      )
+    ).not.toHaveLength(0);
+  });
+
   it('renders resolved in release with integration', async () => {
     const resolvedGroup = GroupFixture({
       id: '1339',


### PR DESCRIPTION
Auto ongoing activities store the duration as `after_days`, but the issue activity feed only read `afterDays`, so it rendered "automatically by Sentry" instead of the configured duration. I think at the time we thought this might be customizable? Either way it is slightly informative.

before

<img width="354" height="66" alt="image" src="https://github.com/user-attachments/assets/d721a731-e44d-469d-bc78-e4b53e7828ef" />

after

<img width="388" height="64" alt="image" src="https://github.com/user-attachments/assets/f79d79d7-f4ae-4751-ba86-6639a209c979" />
