### PR TITLE
feat(seer): Treat night-shift RCA verdicts as skips

### DIFF
--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -116,16 +116,21 @@ def _process_verdicts(
             extra={**log_extra, "unknown_group_ids": unknown_group_ids},
         )
 
+    # SKIP and ROOT_CAUSE_ONLY are both suppressed from future runs via the skip
+    # cache. ROOT_CAUSE_ONLY keeps its own action value for tracking, but is
+    # otherwise treated identically to SKIP (it does not trigger autofix).
     for v in triage_response.verdicts:
-        if v.action == TriageAction.SKIP and v.group_id in groups_by_id:
+        if (
+            v.action in (TriageAction.SKIP, TriageAction.ROOT_CAUSE_ONLY)
+            and v.group_id in groups_by_id
+        ):
             mark_skipped(v.group_id)
 
     # Convert verdicts to TriageResult objects for the shared function
     fixable_candidates = [
         TriageResult(group=groups_by_id[v.group_id], action=v.action, reason=v.reason)
         for v in triage_response.verdicts
-        if v.action in (TriageAction.AUTOFIX, TriageAction.ROOT_CAUSE_ONLY)
-        and v.group_id in groups_by_id
+        if v.action == TriageAction.AUTOFIX and v.group_id in groups_by_id
     ]
 
     sentry_sdk.metrics.distribution("night_shift.candidates_selected", len(fixable_candidates))

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -515,9 +515,7 @@ def _run_autofix_for_candidates(
     the resulting run id onto a newly created SeerNightShiftRunResult row.
     Returns the list of rows that were created.
     """
-    fixable_candidates = [
-        c for c in candidates if c.action in (TriageAction.AUTOFIX, TriageAction.ROOT_CAUSE_ONLY)
-    ]
+    fixable_candidates = [c for c in candidates if c.action == TriageAction.AUTOFIX]
     if not fixable_candidates:
         logger.info(
             "night_shift.no_fixable_candidates",
@@ -529,11 +527,7 @@ def _run_autofix_for_candidates(
 
     results: list[SeerNightShiftRunResult] = []
     for c in fixable_candidates:
-        stopping_point = (
-            AutofixStoppingPoint.ROOT_CAUSE
-            if c.action == TriageAction.ROOT_CAUSE_ONLY
-            else stopping_point_by_project_id[c.group.project_id]
-        )
+        stopping_point = stopping_point_by_project_id[c.group.project_id]
 
         user_context = (
             f"Night-shift triage already investigated this issue and concluded:\n{c.reason}"

--- a/src/sentry/tasks/seer/night_shift/skip_cache.py
+++ b/src/sentry/tasks/seer/night_shift/skip_cache.py
@@ -11,9 +11,9 @@ from sentry.utils.redis import redis_clusters
 
 logger = logging.getLogger(__name__)
 
-# Padded past 3 days so nightly-run jitter can't expire a key right at the
-# 3-day boundary; guarantees the next 3 nightly runs suppress the issue.
-SKIP_TTL_SECONDS = int(timedelta(days=3, hours=12).total_seconds())
+# Padded past 7 days so nightly-run jitter can't expire a key right at the
+# 7-day boundary; guarantees the next 7 nightly runs suppress the issue.
+SKIP_TTL_SECONDS = int(timedelta(days=7, hours=12).total_seconds())
 KEY_PREFIX = "seer:night-shift:skip:"
 
 

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -156,13 +156,11 @@ class TestDeliverNightShiftResult(TestCase):
         assert results[0].seer_run_id == "42"
         assert results[0].extras["action"] == TriageAction.AUTOFIX.value
 
-    def test_root_cause_only_verdict_uses_root_cause_stopping_point(self) -> None:
-        """ROOT_CAUSE_ONLY verdicts should use ROOT_CAUSE stopping point."""
+    def test_root_cause_only_verdict_marks_group_skipped(self) -> None:
+        """ROOT_CAUSE_ONLY verdicts are treated like SKIP: marked in the skip
+        cache and never triggering autofix, while keeping the distinct action."""
         org = self.create_organization()
         project = self.create_project(organization=org)
-        project.update_option(
-            "sentry:seer_automated_run_stopping_point", AutofixStoppingPoint.OPEN_PR.value
-        )
         group = self.create_group(project=project)
         run = self._create_night_shift_run(organization=org)
 
@@ -177,9 +175,7 @@ class TestDeliverNightShiftResult(TestCase):
         }
 
         assert run.seer_run is not None
-        with patch(
-            "sentry.tasks.seer.night_shift.cron.trigger_autofix_agent", return_value=99
-        ) as mock_trigger:
+        with patch("sentry.tasks.seer.night_shift.cron.trigger_autofix_agent") as mock_trigger:
             deliver_night_shift_result(
                 organization_id=org.id,
                 run_uuid=str(run.seer_run.uuid),
@@ -188,10 +184,17 @@ class TestDeliverNightShiftResult(TestCase):
                 error=None,
             )
 
-            mock_trigger.assert_called_once()
-            assert (
-                mock_trigger.call_args.kwargs["stopping_point"] == AutofixStoppingPoint.ROOT_CAUSE
-            )
+            mock_trigger.assert_not_called()
+
+        # Verify skip cache was set
+        redis = redis_clusters.get("default")
+        try:
+            assert redis.exists(skip_cache_key(group.id))
+        finally:
+            redis.delete(skip_cache_key(group.id))
+
+        # No results persisted for ROOT_CAUSE_ONLY verdicts
+        assert not SeerNightShiftRunResult.objects.filter(run=run).exists()
 
     def test_dry_run_skips_autofix(self) -> None:
         """Dry run mode should not trigger autofix or persist results."""

--- a/tests/sentry/tasks/seer/night_shift/test_skip_cache.py
+++ b/tests/sentry/tasks/seer/night_shift/test_skip_cache.py
@@ -34,11 +34,11 @@ def test_recently_skipped_empty_input() -> None:
     assert recently_skipped([]) == set()
 
 
-def test_ttl_padded_past_three_days() -> None:
+def test_ttl_padded_past_seven_days() -> None:
     try:
         mark_skipped(305)
         ttl = redis_clusters.get("default").ttl(key(305))
-        assert int(timedelta(days=3).total_seconds()) < ttl <= SKIP_TTL_SECONDS
+        assert int(timedelta(days=7).total_seconds()) < ttl <= SKIP_TTL_SECONDS
     finally:
         _delete(305)
 


### PR DESCRIPTION
## Summary

Night-shift triage's `ROOT_CAUSE_ONLY` (RCA) verdicts are now treated the same as `SKIP`: written to the skip cache and suppressed from future nightly runs, and no longer triggering an autofix run. The `ROOT_CAUSE_ONLY` action value is **kept distinct** so verdicts remain tracked separately (`from_fixability_score` bucketing and verdict logging are unchanged). The now-dead RCA branch in `_run_autofix_for_candidates` is removed, since delivery is its only caller and RCA can no longer reach it.

Also bumps the skip-cache TTL from **3 → 7 days** so a suppressed issue stays out of the candidate pool for a full week of nightly runs.

## Testing

- Reworked the RCA delivery test to assert it marks the group skipped and does not trigger autofix.
- Updated the skip-cache TTL test for the 7-day boundary.
- `test_delivery.py` + `test_skip_cache.py`: 19 passed; `test_night_shift.py`: 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)