### PR TITLE
feat(issues): Add a new "Progress" column to the awaiting input page

### DIFF
--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -35,6 +35,7 @@ export type GroupListColumn =
   | 'event'
   | 'users'
   | 'priority'
+  | 'progress'
   | 'assignee'
   | 'lastTriggered'
   | 'firstSeen'

--- a/static/app/components/issues/groupListHeader.tsx
+++ b/static/app/components/issues/groupListHeader.tsx
@@ -50,6 +50,11 @@ export function GroupListHeader({
           {t('Priority')}
         </PriorityLabel>
       )}
+      {withColumns.includes('progress') && (
+        <ProgressLabel breakpoint={COLUMN_BREAKPOINTS.PROGRESS} align="right">
+          {t('Progress')}
+        </ProgressLabel>
+      )}
       {withColumns.includes('assignee') && (
         <AssigneeLabel breakpoint={COLUMN_BREAKPOINTS.ASSIGNEE} align="right">
           {t('Assignee')}
@@ -86,6 +91,10 @@ const EventsOrUsersLabel = styled(GroupListHeaderLabel)`
 
 const PriorityLabel = styled(GroupListHeaderLabel)`
   width: 70px;
+`;
+
+const ProgressLabel = styled(GroupListHeaderLabel)`
+  width: 90px;
 `;
 
 const AssigneeLabel = styled(GroupListHeaderLabel)`

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -7,6 +7,7 @@ import {Checkbox} from '@sentry/scraps/checkbox';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
 import {Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
@@ -62,6 +63,7 @@ import {
   DISCOVER_EXCLUSION_FIELDS,
   isForReviewQuery,
 } from 'sentry/views/issueList/utils';
+import {formatProgressState} from 'sentry/views/issueList/utils/progress';
 
 export const DEFAULT_STREAM_GROUP_STATS_PERIOD = '24h';
 const COLUMNS: GroupListColumn[] = [
@@ -82,6 +84,7 @@ type Props = {
   memberList?: User[];
   onAssigneeChange?: (newAssignee: AssignableEntity | null) => void;
   onPriorityChange?: (newPriority: PriorityLevel) => void;
+  progressState?: string | null;
   query?: string;
   queryFilterDescription?: string;
   showLastTriggered?: boolean;
@@ -250,15 +253,20 @@ export function LoadingStreamGroup({
               <Placeholder height="18px" width="40px" />
             </NarrowEventsOrUsersCountsWrapper>
           )}
-          {withColumns.includes('assignee') && (
-            <AssigneeWrapper breakpoint={COLUMN_BREAKPOINTS.ASSIGNEE}>
-              <Placeholder height="24px" />
-            </AssigneeWrapper>
+          {withColumns.includes('progress') && (
+            <ProgressWrapper breakpoint={COLUMN_BREAKPOINTS.PROGRESS}>
+              <Placeholder height="18px" />
+            </ProgressWrapper>
           )}
           {withColumns.includes('priority') && (
             <PriorityWrapper breakpoint={COLUMN_BREAKPOINTS.PRIORITY}>
               <Placeholder height="24px" />
             </PriorityWrapper>
+          )}
+          {withColumns.includes('assignee') && (
+            <AssigneeWrapper breakpoint={COLUMN_BREAKPOINTS.ASSIGNEE}>
+              <Placeholder height="24px" />
+            </AssigneeWrapper>
           )}
         </Fragment>
       )}
@@ -284,6 +292,7 @@ export function StreamGroup({
   showLastTriggered = false,
   onPriorityChange,
   onAssigneeChange,
+  progressState,
 }: Props) {
   const issueSelectionSummary = useOptionalIssueSelectionSummary();
   const issueSelectionActions = useOptionalIssueSelectionActions();
@@ -713,6 +722,15 @@ export function StreamGroup({
               ) : null}
             </PriorityWrapper>
           )}
+          {withColumns.includes('progress') && (
+            <ProgressWrapper breakpoint={COLUMN_BREAKPOINTS.PROGRESS}>
+              {progressState ? (
+                <Text>{formatProgressState(progressState)}</Text>
+              ) : (
+                <Placeholder height="18px" width="80px" />
+              )}
+            </ProgressWrapper>
+          )}
           {withColumns.includes('assignee') && (
             <AssigneeWrapper breakpoint={COLUMN_BREAKPOINTS.ASSIGNEE}>
               <AssigneeSelector
@@ -956,6 +974,19 @@ const PriorityWrapper = styled('div')<{breakpoint: string}>`
   align-self: center;
   display: flex;
   justify-content: flex-end;
+
+  @container (width < ${p => p.breakpoint}) {
+    display: none;
+  }
+`;
+
+const ProgressWrapper = styled('div')<{breakpoint: string}>`
+  width: 90px;
+  padding-right: ${p => p.theme.space.xl};
+  margin-right: ${p => p.theme.space.xl};
+  align-self: center;
+  display: flex;
+  justify-content: flex-start;
 
   @container (width < ${p => p.breakpoint}) {
     display: none;

--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
 
+import type {GroupListColumn} from 'sentry/components/issues/groupList';
 import {IssueStreamHeaderLabel} from 'sentry/components/IssueStreamHeaderLabel';
 import {ToolbarHeader} from 'sentry/components/toolbarHeader';
 import {t} from 'sentry/locale';
@@ -15,6 +16,7 @@ type Props = {
   selection: PageFilters;
   statsPeriod: string;
   isSavedSearchesOpen?: boolean;
+  withColumns?: GroupListColumn[];
 };
 
 export function Headers({
@@ -22,6 +24,7 @@ export function Headers({
   statsPeriod,
   onSelectStatsPeriod,
   isReprocessingQuery,
+  withColumns,
 }: Props) {
   return (
     <Fragment>
@@ -66,9 +69,15 @@ export function Headers({
           <EventsOrUsersLabel breakpoint={COLUMN_BREAKPOINTS.USERS} align="right">
             {t('Users')}
           </EventsOrUsersLabel>
-          <PriorityLabel breakpoint={COLUMN_BREAKPOINTS.PRIORITY} align="left">
-            {t('Priority')}
-          </PriorityLabel>
+          {withColumns?.includes('progress') ? (
+            <ProgressLabel breakpoint={COLUMN_BREAKPOINTS.PROGRESS} align="left">
+              {t('Progress')}
+            </ProgressLabel>
+          ) : (
+            <PriorityLabel breakpoint={COLUMN_BREAKPOINTS.PRIORITY} align="left">
+              {t('Priority')}
+            </PriorityLabel>
+          )}
           <AssigneeLabel breakpoint={COLUMN_BREAKPOINTS.ASSIGNEE} align="right">
             {t('Assignee')}
           </AssigneeLabel>
@@ -118,6 +127,10 @@ const EventsOrUsersLabel = styled(IssueStreamHeaderLabel)`
 
 const PriorityLabel = styled(IssueStreamHeaderLabel)`
   width: 64px;
+`;
+
+const ProgressLabel = styled(IssueStreamHeaderLabel)`
+  width: 90px;
 `;
 
 const AssigneeLabel = styled(IssueStreamHeaderLabel)`

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -10,6 +10,7 @@ import {Flex} from '@sentry/scraps/layout';
 
 import {bulkDelete, mergeGroups} from 'sentry/actionCreators/group';
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
+import type {GroupListColumn} from 'sentry/components/issues/groupList';
 import {IssueStreamHeaderLabel} from 'sentry/components/IssueStreamHeaderLabel';
 import {Sticky} from 'sentry/components/sticky';
 import {t, tct, tn} from 'sentry/locale';
@@ -51,6 +52,7 @@ type IssueListActionsProps = {
   selection: PageFilters;
   statsPeriod: string;
   onActionTaken?: (itemIds: string[], data: IssueUpdateData) => void;
+  withColumns?: GroupListColumn[];
 };
 
 const animationProps: MotionNodeAnimationOptions = {
@@ -79,6 +81,7 @@ function ActionsBarPriority({
   isSavedSearchesOpen,
   statsPeriod,
   selection,
+  withColumns,
 }: {
   allInQuerySelected: boolean;
   anySelected: boolean;
@@ -98,6 +101,7 @@ function ActionsBarPriority({
   selection: PageFilters;
   statsPeriod: string;
   toggleSelectAllVisible: () => void;
+  withColumns?: GroupListColumn[];
 }) {
   const shouldDisplayActions = anySelected && !narrowViewport;
 
@@ -145,6 +149,7 @@ function ActionsBarPriority({
               statsPeriod={statsPeriod}
               isReprocessingQuery={displayReprocessingActions}
               isSavedSearchesOpen={isSavedSearchesOpen}
+              withColumns={withColumns}
             />
           </AnimatedHeaderItemsContainer>
         )}
@@ -164,6 +169,7 @@ export function IssueListActions({
   query,
   selection,
   statsPeriod,
+  withColumns,
 }: IssueListActionsProps) {
   const api = useApi();
   const queryClient = useQueryClient();
@@ -297,6 +303,7 @@ export function IssueListActions({
         isSavedSearchesOpen={isSavedSearchesOpen}
         anySelected={anySelected}
         onSelectStatsPeriod={onSelectStatsPeriod}
+        withColumns={withColumns}
       />
       {!allResultsVisible && pageSelected && (
         <Alert system variant="info">

--- a/static/app/views/issueList/actions/utils.tsx
+++ b/static/app/views/issueList/actions/utils.tsx
@@ -179,6 +179,7 @@ export const COLUMN_BREAKPOINTS = {
   EVENTS: '700px',
   USERS: '900px',
   PRIORITY: '1100px',
+  PROGRESS: '1100px',
   ASSIGNEE: '500px',
 };
 

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -16,6 +16,7 @@ import {aggregateSupergroupStats} from 'sentry/views/issueList/supergroups/aggre
 import type {SupergroupDetail} from 'sentry/views/issueList/supergroups/types';
 import type {SupergroupLookup} from 'sentry/views/issueList/supergroups/useSuperGroups';
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
+import {useIssueProgress} from 'sentry/views/issueList/useIssueProgress';
 
 import {NoGroupsHandler} from './noGroupsHandler';
 import {SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY} from './utils';
@@ -33,6 +34,7 @@ type GroupListBodyProps = {
   refetchGroups: () => void;
   selectedProjectIds: number[];
   supergroupLookup?: SupergroupLookup;
+  withColumns?: GroupListColumn[];
 };
 
 type GroupListProps = {
@@ -43,9 +45,10 @@ type GroupListProps = {
   onActionTaken: (itemIds: string[], data: IssueUpdateData) => void;
   query: string;
   supergroupLookup?: SupergroupLookup;
+  withColumns?: GroupListColumn[];
 };
 
-const COLUMNS: GroupListColumn[] = [
+const DEFAULT_COLUMNS: GroupListColumn[] = [
   'graph',
   'firstSeen',
   'lastSeen',
@@ -63,7 +66,9 @@ type RenderItem =
 function LoadingSkeleton({
   pageSize,
   displayReprocessingLayout,
+  columns,
 }: {
+  columns: GroupListColumn[];
   displayReprocessingLayout: boolean;
   pageSize: number;
 }) {
@@ -73,7 +78,7 @@ function LoadingSkeleton({
         <LoadingStreamGroup
           key={`loading-group-${index}`}
           displayReprocessingLayout={displayReprocessingLayout}
-          withColumns={COLUMNS}
+          withColumns={columns}
         />
       ))}
     </PanelBody>
@@ -93,14 +98,17 @@ export function GroupListBody({
   pageSize,
   onActionTaken,
   supergroupLookup,
+  withColumns,
 }: GroupListBodyProps) {
   const organization = useOrganization();
+  const columns = withColumns ?? DEFAULT_COLUMNS;
 
   if (loading) {
     return (
       <LoadingSkeleton
         displayReprocessingLayout={displayReprocessingLayout}
         pageSize={pageSize}
+        columns={columns}
       />
     );
   }
@@ -129,6 +137,7 @@ export function GroupListBody({
       groupStatsPeriod={groupStatsPeriod}
       onActionTaken={onActionTaken}
       supergroupLookup={supergroupLookup}
+      withColumns={columns}
     />
   );
 }
@@ -172,6 +181,7 @@ function GroupList({
   groupStatsPeriod,
   onActionTaken,
   supergroupLookup,
+  withColumns = DEFAULT_COLUMNS,
 }: GroupListProps) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -183,6 +193,9 @@ function GroupList({
   const selectDisabled = useMedia(
     `(width < ${isSavedSearchesOpen ? theme.breakpoints.xl : theme.breakpoints.md})`
   );
+
+  const showProgress = withColumns.includes('progress');
+  const {data: progressData} = useIssueProgress(showProgress ? groupIds : []);
 
   const hasTopIssuesUI = organization.features.includes('top-issues-ui');
   const renderItems = useMemo(
@@ -213,6 +226,9 @@ function GroupList({
         canSelect={!selectDisabled}
         onPriorityChange={priority => onActionTaken([id], {priority})}
         withColumns={columns}
+        progressState={
+          showProgress ? (progressData?.results[id]?.progress ?? null) : undefined
+        }
       />
     );
   };
@@ -221,7 +237,7 @@ function GroupList({
     <PanelBody>
       {renderItems.map(item => {
         if (item.type === 'issue') {
-          return renderStreamGroup(item.id, COLUMNS);
+          return renderStreamGroup(item.id, withColumns);
         }
 
         const {supergroup, matchingIds} = item;

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import type {CursorHandler} from '@sentry/scraps/pagination';
 import {Pagination} from '@sentry/scraps/pagination';
 
+import type {GroupListColumn} from 'sentry/components/issues/groupList';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {t} from 'sentry/locale';
@@ -44,6 +45,7 @@ interface IssueListTableProps {
   statsLoading: boolean;
   statsPeriod: string;
   supergroupLookup?: SupergroupLookup;
+  withColumns?: GroupListColumn[];
 }
 
 export function IssueListTable({
@@ -69,6 +71,7 @@ export function IssueListTable({
   issuesSuccessfullyLoaded,
   pageSize,
   supergroupLookup,
+  withColumns,
 }: IssueListTableProps) {
   const location = useLocation();
 
@@ -115,6 +118,7 @@ export function IssueListTable({
                     groupIds={groupIds}
                     allResultsVisible={allResultsVisible}
                     displayReprocessingActions={displayReprocessingActions}
+                    withColumns={withColumns}
                   />
                 </HoverOverlayGroupProvider>
               )}
@@ -139,6 +143,7 @@ export function IssueListTable({
                       refetchGroups={refetchGroups}
                       onActionTaken={onActionTaken}
                       supergroupLookup={supergroupLookup}
+                      withColumns={withColumns}
                     />
                   </VisuallyCompleteWithData>
                 </PanelBody>

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -14,6 +14,7 @@ import {Grid, Stack} from '@sentry/scraps/layout';
 import type {CursorHandler} from '@sentry/scraps/pagination';
 
 import {addMessage} from 'sentry/actionCreators/indicator';
+import type {GroupListColumn} from 'sentry/components/issues/groupList';
 import {extractSelectionParameters} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {QueryCount} from 'sentry/components/queryCount';
@@ -86,6 +87,7 @@ interface Props {
   shouldFetchOnMount?: boolean;
   title?: ReactNode;
   titleDescription?: ReactNode;
+  withColumns?: GroupListColumn[];
 }
 
 interface EndpointParams extends Partial<PageFilters['datetime']> {
@@ -134,6 +136,7 @@ function IssueListOverviewInner({
   title = t('Issues'),
   titleDescription,
   headerActions,
+  withColumns,
 }: Props) {
   const location = useLocation();
   const organization = useOrganization();
@@ -982,6 +985,7 @@ function IssueListOverviewInner({
               supergroupLookup={supergroupLookup}
               error={error}
               refetchGroups={fetchData}
+              withColumns={withColumns}
               paginationCaption={
                 !issuesLoading && modifiedQueryCount > 0
                   ? tct('[start]-[end] of [total]', {

--- a/static/app/views/issueList/pages/awaitingInput.spec.tsx
+++ b/static/app/views/issueList/pages/awaitingInput.spec.tsx
@@ -1,0 +1,103 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {GroupStatsFixture} from 'sentry-fixture/groupStats';
+import {MemberFixture} from 'sentry-fixture/member';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {TagsFixture} from 'sentry-fixture/tags';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {TagStore} from 'sentry/stores/tagStore';
+
+import AwaitingInputPage from './awaitingInput';
+
+const DEFAULT_LINKS_HEADER =
+  '<http://127.0.0.1:8000/api/0/organizations/org-slug/issues/?cursor=1443575731:0:1>; rel="previous"; results="false"; cursor="1443575731:0:1", ' +
+  '<http://127.0.0.1:8000/api/0/organizations/org-slug/issues/?cursor=1443575000:0:0>; rel="next"; results="true"; cursor="1443575000:0:0"';
+
+describe('AwaitingInputPage', () => {
+  const project = ProjectFixture({
+    id: '3559',
+    slug: 'project-slug',
+    firstEvent: new Date().toISOString(),
+  });
+  const group = GroupFixture({id: '1', project});
+
+  beforeEach(() => {
+    Object.defineProperty(Element.prototype, 'clientWidth', {value: 1000});
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/',
+      body: [group],
+      headers: {Link: DEFAULT_LINKS_HEADER},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues-stats/',
+      body: [GroupStatsFixture()],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues-count/',
+      body: [{}],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/processingissues/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      body: TagsFixture(),
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [MemberFixture({projects: [project.slug]})],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/members/',
+      body: [MemberFixture()],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/sent-first-event/',
+      body: {sentFirstEvent: true},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      method: 'POST',
+      body: [],
+    });
+
+    PageFiltersStore.onInitializeUrlState({
+      projects: [parseInt(project.id, 10)],
+      environments: [],
+      datetime: {period: '14d', start: null, end: null, utc: null},
+    });
+
+    TagStore.init?.();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    MockApiClient.clearMockResponses();
+  });
+
+  it('displays progress column instead of priority', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues-progress/',
+      body: {results: {1: {progress: 'diagnosed'}}},
+    });
+
+    render(<AwaitingInputPage />);
+
+    expect(await screen.findByText('Progress')).toBeInTheDocument();
+    expect(screen.queryByText('Priority')).not.toBeInTheDocument();
+    expect(await screen.findByText('Diagnosed')).toBeInTheDocument();
+    expect(screen.getByText('RequestError')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueList/pages/awaitingInput.tsx
+++ b/static/app/views/issueList/pages/awaitingInput.tsx
@@ -1,3 +1,4 @@
+import type {GroupListColumn} from 'sentry/components/issues/groupList';
 import {NoProjectMessage} from 'sentry/components/noProjectMessage';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import {t} from 'sentry/locale';
@@ -8,6 +9,16 @@ import IssueListOverview from 'sentry/views/issueList/overview';
 const TITLE = t('Awaiting Input');
 const QUERY = 'is:unresolved';
 
+const COLUMNS: GroupListColumn[] = [
+  'graph',
+  'firstSeen',
+  'lastSeen',
+  'event',
+  'users',
+  'progress',
+  'assignee',
+];
+
 export default function AwaitingInputPage() {
   const organization = useOrganization();
 
@@ -15,7 +26,7 @@ export default function AwaitingInputPage() {
     <IssueListContainer title={TITLE}>
       <PageFiltersContainer>
         <NoProjectMessage organization={organization}>
-          <IssueListOverview initialQuery={QUERY} title={TITLE} />
+          <IssueListOverview initialQuery={QUERY} title={TITLE} withColumns={COLUMNS} />
         </NoProjectMessage>
       </PageFiltersContainer>
     </IssueListContainer>

--- a/static/app/views/issueList/useIssueProgress.ts
+++ b/static/app/views/issueList/useIssueProgress.ts
@@ -1,0 +1,23 @@
+import {skipToken, useQuery} from '@tanstack/react-query';
+
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+type IssueProgressResponse = {
+  results: Record<string, {progress: string}>;
+};
+
+export function useIssueProgress(groupIds: string[]) {
+  const organization = useOrganization();
+
+  return useQuery(
+    apiOptions.as<IssueProgressResponse>()(
+      '/organizations/$organizationIdOrSlug/issues-progress/',
+      {
+        path: groupIds.length ? {organizationIdOrSlug: organization.slug} : skipToken,
+        query: {groups: groupIds},
+        staleTime: 30_000,
+      }
+    )
+  );
+}

--- a/static/app/views/issueList/utils/progress.tsx
+++ b/static/app/views/issueList/utils/progress.tsx
@@ -1,0 +1,16 @@
+import {t} from 'sentry/locale';
+
+const PROGRESS_STATE_LABELS: Record<string, string> = {
+  identified: t('Identified'),
+  triaged: t('Triaged'),
+  diagnosed: t('Diagnosed'),
+  fix_proposed: t('Fix Proposed'),
+  fix_applied: t('Fix Applied'),
+};
+
+export function formatProgressState(state: string | null | undefined): string {
+  if (!state) {
+    return '—';
+  }
+  return PROGRESS_STATE_LABELS[state] ?? state;
+}


### PR DESCRIPTION
Ref ISWF-2765

- Adds support for a new "progress" column on StreamGroup which calls the new `/issue-progress/` endpoint
- Adds the ability to customize columns on the top-level issue stream component (which just forwards with `withColumn` prop to StreamGroup)
- Defines the customized list of columns in the new awaiting input page

Still todo: Add progress icons, add tooltip which shows latest activity

If we do end up supporting column customizability more widely, we'll probably need to rewrite StreamGroup altogether because it is quite old and fragile. But for now with this hardcoded column I don't think it's worth doing any more than this.

<img width="2326" height="746" alt="CleanShot 2026-06-11 at 15 45 01@2x" src="https://github.com/user-attachments/assets/1dde0dd8-ca2d-42f4-afe0-4b3f968d4dad" />
