### PR TITLE
feat(devserver): Tee console output to a local dev log file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ That is all that is required to run `pytest`.
 
 `devservices serve` starts the development server.
 
+When the devserver is running, its full console output (all honcho-managed processes — `server`, `taskworker`, kafka consumers, webpack/watchers, etc.) is teed to `.artifacts/dev.log`, ANSI-stripped and gitignored. Agents can't see the devserver terminal, so `tail`/`grep` this file to inspect what's happening (startup, reloads, request logs, tracebacks). The file is truncated on each devserver process start (in-process granian reloads keep appending); override its path with `SENTRY_DEV_LOG_FILE`. Dev-only — this teeing lives in `sentry devserver` and is not used in production.
+
 #### Linting
 
 prek is the single entrypoint for all lint, format, and type-checking tools.

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import threading
 from collections.abc import MutableSequence, Sequence
+from pathlib import Path
 from typing import NoReturn
 
 import click
@@ -461,9 +462,17 @@ def devserver(
 
         cwd = os.path.realpath(os.path.join(settings.PROJECT_ROOT, os.pardir, os.pardir))
 
-        from sentry.runner.formatting import get_honcho_printer
+        from sentry.runner.formatting import TeeStream, get_honcho_printer
 
-        honcho_printer = get_honcho_printer(prefix=prefix, pretty=pretty)
+        log_path = Path(
+            os.environ.get("SENTRY_DEV_LOG_FILE", os.path.join(cwd, ".artifacts", "dev.log"))
+        )
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_file = open(log_path, "w", encoding="utf-8")
+
+        honcho_printer = get_honcho_printer(
+            prefix=prefix, pretty=pretty, output=TeeStream(sys.stdout, log_file)
+        )
 
         manager = Manager(honcho_printer)
         for name, cmd in daemons:

--- a/src/sentry/runner/formatting.py
+++ b/src/sentry/runner/formatting.py
@@ -1,10 +1,36 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+import sys
+from typing import IO, TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     import honcho.printer
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+class TeeStream:
+    """Mirror writes to a console stream verbatim and a log file with ANSI stripped."""
+
+    def __init__(self, console: IO[str], log_file: IO[str]) -> None:
+        self._console = console
+        self._log_file = log_file
+
+    def write(self, s: str) -> int:
+        self._console.write(s)
+        self._log_file.write(_ANSI_RE.sub("", s))
+        self._log_file.flush()
+        return len(s)
+
+    def flush(self) -> None:
+        self._console.flush()
+        self._log_file.flush()
+
+    def isatty(self) -> bool:
+        # Delegate so honcho keeps coloring the console; the file copy is stripped above.
+        return self._console.isatty()
+
 
 # Sentry colors taken from our design system. Might not look good on all
 # terminal themes tbh
@@ -75,7 +101,9 @@ def colorize_traceback(pattern: re.Match[str]) -> str:
     )
 
 
-def get_honcho_printer(*, prefix: bool, pretty: bool) -> honcho.printer.Printer:
+def get_honcho_printer(
+    *, prefix: bool, pretty: bool, output: IO[str] | TeeStream | None = None
+) -> honcho.printer.Printer:
     import honcho.printer
 
     class SentryPrinter(honcho.printer.Printer):
@@ -117,4 +145,6 @@ def get_honcho_printer(*, prefix: bool, pretty: bool) -> honcho.printer.Printer:
             for line in string.splitlines():
                 self.output.write(f"{prefix}{line}\n")
 
-    return SentryPrinter(prefix=prefix)
+    return SentryPrinter(
+        prefix=prefix, output=cast("IO[str]", output) if output is not None else sys.stdout
+    )


### PR DESCRIPTION
## Summary

The devserver now mirrors all honcho-routed console output to a log file (truncated each run) so it can be inspected after the fact — for example, by AI agents reading the local dev logs.

- A new `TeeStream` in `sentry/runner/formatting.py` wraps stdout: it writes to the console verbatim and writes an **ANSI-stripped** copy to the log file, flushing each write.
- The interactive console keeps its coloring — `TeeStream.isatty()` delegates to the underlying console so honcho still colorizes terminal output; only the file copy is stripped.
- `get_honcho_printer(...)` gains an optional `output` parameter; the devserver passes it a `TeeStream`.
- The log path defaults to `<repo>/.artifacts/dev.log` and is configurable via the `SENTRY_DEV_LOG_FILE` environment variable. Both `.artifacts/` and `*.log` are already gitignored.

This mirrors an approach already in use in the seer repo.

## Notes

- This captures output that flows through honcho (all daemons: server, workers, webpack, consumers). Output emitted before honcho takes over and the bare no-daemon `server.run()` path are not tee'd, which is fine for the intended use case.