### PR TITLE
feat(api): Accept project slugs in product endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -8,6 +8,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
 from sentry.api.endpoints.organization_events_spans_performance import EventID, get_span_description
+from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.api.utils import handle_query_errors
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.types import QueryBuilderConfig
@@ -35,7 +36,7 @@ RESPONSE_KEYS = [
 
 class RootCauseAnalysisQuerySerializer(serializers.Serializer):
     transaction = serializers.CharField(max_length=200)
-    project = serializers.IntegerField()
+    project = ProjectField(scope="project:read", id_allowed=True)
     breakpoint = serializers.CharField()
     per_page = serializers.IntegerField(min_value=1, max_value=MAX_LIMIT, default=DEFAULT_LIMIT)
     span_score_threshold = serializers.IntegerField(
@@ -203,13 +204,16 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
     }
 
     def get(self, request, organization):
-        serializer = RootCauseAnalysisQuerySerializer(data=request.GET)
+        serializer = RootCauseAnalysisQuerySerializer(
+            data=request.GET,
+            context={"access": request.access, "organization": organization},
+        )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
         validated = serializer.validated_data
         transaction_name = validated["transaction"]
-        project_id = validated["project"]
+        project_id = validated["project"].id
         regression_breakpoint = validated["breakpoint"]
         limit = validated["per_page"]
         span_score_threshold = validated["span_score_threshold"]

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
@@ -10,6 +10,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.helpers.projects import ProjectIdOrSlug, ProjectIdOrSlugField
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models.organization import Organization
@@ -18,16 +19,14 @@ from sentry.models.release_threshold.release_threshold import ReleaseThreshold
 
 class ReleaseThresholdIndexGETData(TypedDict, total=False):
     environment: list[str]
-    project: list[int]
+    project: list[ProjectIdOrSlug]
 
 
 class ReleaseThresholdIndexGETValidator(serializers.Serializer[ReleaseThresholdIndexGETData]):
     environment = serializers.ListField(
         required=False, allow_empty=True, child=serializers.CharField()
     )
-    project = serializers.ListField(
-        required=True, allow_empty=False, child=serializers.IntegerField()
-    )
+    project = serializers.ListField(required=True, allow_empty=False, child=ProjectIdOrSlugField())
 
 
 @cell_silo_endpoint
@@ -38,8 +37,13 @@ class ReleaseThresholdIndexEndpoint(OrganizationEndpoint):
     }
 
     def get(self, request: Request, organization: Organization) -> HttpResponse:
+        query_params = request.query_params.copy()
+        if "project" in query_params:
+            query_params.setlist(
+                "project", [project for project in query_params.getlist("project") if project]
+            )
         validator = ReleaseThresholdIndexGETValidator(
-            data=request.query_params,
+            data=query_params,
         )
         if not validator.is_valid():
             return Response(validator.errors, status=400)

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -28,6 +28,11 @@ from sentry.api.endpoints.release_thresholds.utils import (
     get_errors_counts_timeseries_by_project_and_release,
     get_new_issue_counts,
 )
+from sentry.api.helpers.projects import (
+    ProjectIdOrSlug,
+    ProjectIdOrSlugField,
+    parse_id_or_slug_params,
+)
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST
 from sentry.apidocs.examples.release_threshold_examples import ReleaseThresholdExamples
@@ -54,6 +59,7 @@ class ReleaseThresholdStatusIndexData(TypedDict, total=False):
     start: datetime
     end: datetime
     environment: list[str]
+    project: list[ProjectIdOrSlug]
     projectSlug: list[str]
     release: list[str]
 
@@ -82,8 +88,14 @@ class ReleaseThresholdStatusIndexSerializer(
     projectSlug = serializers.ListField(
         required=False,
         allow_empty=True,
-        child=serializers.CharField(),
+        child=serializers.CharField(allow_blank=True),
         help_text=("A list of project slugs to filter your results by."),
+    )
+    project = serializers.ListField(
+        required=False,
+        allow_empty=True,
+        child=ProjectIdOrSlugField(),
+        help_text=("A list of project IDs or slugs to filter your results by."),
     )
     release = serializers.ListField(
         required=False,
@@ -136,20 +148,45 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
         # NOTE: start/end parameters determine window to query for releases
         # This is NOT the window to query snuba for event data - nor the individual threshold windows
         # ========================================================================
-        serializer = ReleaseThresholdStatusIndexSerializer(
-            data=request.query_params,
-        )
+        # Preserve legacy projectSlug precedence while treating blank project filters as absent.
+        query_params = request.query_params.copy()
+        project_slug_params = [slug for slug in query_params.getlist("projectSlug") if slug]
+        if "projectSlug" in query_params:
+            query_params.setlist("projectSlug", project_slug_params)
+        if project_slug_params:
+            query_params.pop("project", None)
+        elif "project" in query_params:
+            query_params.setlist(
+                "project", [project for project in query_params.getlist("project") if project]
+            )
+
+        serializer = ReleaseThresholdStatusIndexSerializer(data=query_params)
         if not serializer.is_valid():
             return Response(as_validation_errors(serializer), status=400)
 
         environments_list = serializer.validated_data.get(
             "environment"
         )  # list of environment names
-        project_slug_list = serializer.validated_data.get("projectSlug")
+        project_slug_list = [
+            slug for slug in serializer.validated_data.get("projectSlug", []) if slug
+        ] or None
+        requested_project = parse_id_or_slug_params(serializer.validated_data.get("project", []))
         releases_list = serializer.validated_data.get("release")  # list of release versions
+        project_ids: set[int] | None = None
+        project_slugs: list[str] | set[str] | None = project_slug_list
+        if project_slug_list is None:
+            if requested_project.ids and not requested_project.slugs:
+                project_ids = requested_project.ids
+            elif requested_project.slugs and not requested_project.ids:
+                project_slugs = requested_project.slugs
+
         try:
             filter_params = self.get_filter_params(
-                request, organization, date_filter_optional=True, project_slugs=project_slug_list
+                request,
+                organization,
+                date_filter_optional=True,
+                project_ids=project_ids,
+                project_slugs=project_slugs,
             )
         except NoProjects:
             raise NoProjects("No projects available")

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -1,8 +1,10 @@
 import logging
 
 from django.db import IntegrityError, router, transaction
+from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, status
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -13,6 +15,7 @@ from sentry.api.bases.organization import (
     OrganizationCodeMappingsBulkPermission,
     OrganizationEndpoint,
 )
+from sentry.api.helpers.projects import ProjectIdOrSlugField, parse_id_or_slug_params
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.constants import ObjectStatus
 from sentry.integrations.api.endpoints.organization_code_mappings import (
@@ -42,7 +45,7 @@ class MappingItemSerializer(serializers.Serializer[dict[str, object]]):
 
 
 class BulkCodeMappingsRequestSerializer(CamelSnakeSerializer[dict[str, object]]):
-    project = serializers.CharField(required=True)
+    project = ProjectIdOrSlugField(required=True)
     repository = serializers.CharField(required=True)
     provider = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     default_branch = serializers.RegexField(
@@ -165,20 +168,34 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
 
         data = serializer.validated_data
 
-        # Resolve project by slug
-        try:
-            project = Project.objects.get(
-                organization=organization,
-                slug=data["project"],
-                status=ObjectStatus.ACTIVE,
+        # Resolve project by ID or slug.
+        parsed_project = parse_id_or_slug_params([data["project"]])
+        if parsed_project.has_all_projects_sentinel:
+            return Response(
+                {"detail": "Invalid project"},
+                status=status.HTTP_400_BAD_REQUEST,
             )
-        except Project.DoesNotExist:
+
+        project_filter = Q(organization=organization, status=ObjectStatus.ACTIVE)
+        if parsed_project.ids:
+            project_filter &= Q(id__in=parsed_project.ids)
+        else:
+            project_filter &= Q(slug__in=parsed_project.slugs)
+
+        if not Project.objects.filter(project_filter).exists():
             return Response(
                 {"detail": f"Project not found or not active: {data['project']}"},
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        if not request.access.has_project_access(project):
+        try:
+            project = self.get_projects(
+                request,
+                organization,
+                project_ids=parsed_project.ids or None,
+                project_slugs=parsed_project.slugs or None,
+            )[0]
+        except PermissionDenied:
             return Response(
                 {"detail": "You do not have access to this project."},
                 status=status.HTTP_403_FORBIDDEN,

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -313,8 +313,9 @@ class ConfigValidator(serializers.Serializer):
 class MonitorValidator(CamelSnakeSerializer):
     project = ProjectField(
         scope="project:read",
+        id_allowed=True,
         required=True,
-        help_text="The project slug to associate the monitor to.",
+        help_text="The project ID or slug to associate the monitor to.",
     )
     name = serializers.CharField(
         max_length=128,

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -12,6 +12,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.helpers.projects import parse_id_or_slug_params
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers.base import serialize
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN
@@ -138,10 +139,13 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
         # team admins and regular org members don't have project:write on an org level
         if not request.access.has_scope("project:write"):
             # check if user has access to create notification actions for all requested projects
-            requested_projects = request.data.get("projects", [])
+            requested_projects = parse_id_or_slug_params(request.data.get("projects") or [])
             projects = self.get_projects(request, organization)
-            project_slugs = [project.slug for project in projects]
-            missing_access_projects = set(requested_projects).difference(set(project_slugs))
+            project_ids = {project.id for project in projects}
+            project_slugs = {project.slug for project in projects}
+            missing_access_projects = requested_projects.ids.difference(
+                project_ids
+            ) | requested_projects.slugs.difference(project_slugs)
 
             if missing_access_projects:
                 raise PermissionDenied(

--- a/src/sentry/notifications/api/serializers/notification_action_request.py
+++ b/src/sentry/notifications/api/serializers/notification_action_request.py
@@ -87,8 +87,8 @@ Required if **service_type** is `slack` or `opsgenie`.
         required=False,
     )
     projects = serializers.ListField(
-        help_text="""List of projects slugs that the Notification Action is created for.""",
-        child=ProjectField(scope="project:write"),
+        help_text="""List of project IDs or slugs that the Notification Action is created for.""",
+        child=ProjectField(scope="project:write", id_allowed=True),
         required=False,
     )
     # Optional and not needed for spike protection so not documenting

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -7,6 +7,7 @@ import orjson
 from django.conf import settings
 from django.db.models import Q
 from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -18,6 +19,7 @@ from sentry.api.bases.organization import (
     OrganizationEndpoint,
     OrganizationReleasePermission,
 )
+from sentry.api.helpers.projects import ProjectIdOrSlugField, parse_id_or_slug_params
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.preprod_examples import PreprodExamples
 from sentry.apidocs.parameters import GlobalParams
@@ -51,9 +53,9 @@ LATEST_BASE_SNAPSHOT_GET_QUERY_PARAMS: dict[str, Any] = {
         "description": "Set to '1' or 'true' to strip image metadata to display_name, image_file_name, group, description",
     },
     "project": {
-        "type": "integer",
+        "type": "string",
         "required": False,
-        "description": "Project ID to scope the lookup. Use either project or projectSlug when app_id is not unique across projects or project inference is unavailable.",
+        "description": "Project ID or slug to scope the lookup. Use either project or projectSlug when app_id is not unique across projects or project inference is unavailable.",
     },
     "projectSlug": {
         "type": "string",
@@ -92,10 +94,17 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
             ),
             OpenApiParameter(
                 name="project",
-                type=int,
+                type=str,
                 location="query",
                 required=False,
-                description="Project ID to scope the lookup.",
+                description="Project ID or slug to scope the lookup.",
+            ),
+            OpenApiParameter(
+                name="projectSlug",
+                type=str,
+                location="query",
+                required=False,
+                description="Project slug to scope the lookup.",
             ),
             OpenApiParameter(
                 name="compact_metadata",
@@ -147,10 +156,25 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
         branch = request.GET.get("branch")
         compact = request.GET.get("compact_metadata", "0") in ("1", "true")
 
-        try:
-            project_id = int(request.GET["project"]) if "project" in request.GET else None
-        except (ValueError, TypeError):
-            return Response({"detail": "Invalid project parameter"}, status=400)
+        # This is a single-project lookup: projectSlug wins, and all-project sentinels are invalid.
+        project_id = None
+        project_slug = None
+        if project_slug_param := request.GET.get("projectSlug"):
+            if parse_id_or_slug_params([project_slug_param]).has_all_projects_sentinel:
+                return Response({"detail": "Invalid project parameter"}, status=400)
+            project_slug = project_slug_param
+        elif project_param := request.GET.get("project"):
+            try:
+                project_id_or_slug = ProjectIdOrSlugField().run_validation(project_param)
+            except ValidationError:
+                return Response({"detail": "Invalid project parameter"}, status=400)
+            requested_project = parse_id_or_slug_params([project_id_or_slug])
+            if requested_project.has_all_projects_sentinel:
+                return Response({"detail": "Invalid project parameter"}, status=400)
+            if requested_project.ids:
+                project_id = next(iter(requested_project.ids))
+            elif requested_project.slugs:
+                project_slug = next(iter(requested_project.slugs))
 
         qs = (
             PreprodArtifact.objects.filter(
@@ -172,6 +196,8 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
 
         if project_id is not None:
             qs = qs.filter(project_id=project_id)
+        if project_slug is not None:
+            qs = qs.filter(project__slug=project_slug)
         if branch:
             qs = qs.filter(commit_comparison__head_ref=branch)
 

--- a/src/sentry/releases/endpoints/organization_release_details.py
+++ b/src/sentry/releases/endpoints/organization_release_details.py
@@ -1,7 +1,7 @@
 import sentry_sdk
 from django.db.models import Q
-from drf_spectacular.utils import extend_schema, extend_schema_serializer
-from rest_framework.exceptions import ParseError
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_serializer
+from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import ListField
@@ -17,6 +17,7 @@ from sentry.api.endpoints.organization_releases import (
     get_stats_period_detail,
 )
 from sentry.api.exceptions import ConflictError, InvalidRepository, ResourceDoesNotExist
+from sentry.api.helpers.projects import ProjectIdOrSlugField, parse_id_or_slug_params
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import (
     ReleaseHeadCommitSerializer,
@@ -314,7 +315,13 @@ class OrganizationReleaseDetailsEndpoint(
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
             ReleaseParams.VERSION,
-            ReleaseParams.PROJECT_ID,
+            OpenApiParameter(
+                name="project",
+                location="query",
+                required=False,
+                type=str,
+                description="The project ID or slug to filter by.",
+            ),
             ReleaseParams.HEALTH,
             ReleaseParams.ADOPTION_STAGES,
             ReleaseParams.SUMMARY_STATS_PERIOD,
@@ -362,15 +369,21 @@ class OrganizationReleaseDetailsEndpoint(
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        # Validate project access when project_id is provided
+        # Validate project access when a project identifier is provided.
         project = None
         if project_id:
             try:
-                project_id_int = int(project_id)
-            except ValueError:
+                project_id_or_slug = ProjectIdOrSlugField().run_validation(project_id)
+            except ValidationError:
+                raise ParseError(detail="Invalid project")
+            requested_project = parse_id_or_slug_params([project_id_or_slug])
+            if not requested_project.has_values or requested_project.has_all_projects_sentinel:
                 raise ParseError(detail="Invalid project")
             validated_projects = self.get_projects(
-                request, organization, project_ids={project_id_int}
+                request,
+                organization,
+                project_ids=requested_project.ids or None,
+                project_slugs=requested_project.slugs or None,
             )
             if not validated_projects:
                 raise ResourceDoesNotExist

--- a/src/sentry/replays/endpoints/organization_replay_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_index.py
@@ -59,7 +59,19 @@ class OrganizationReplayIndexEndpoint(OrganizationReplayEndpoint):
         except NoProjects:
             return Response({"data": []}, status=200)
 
-        result = ReplayValidator(data=request.GET)
+        # Preserve legacy projectSlug precedence while treating blank project filters as absent.
+        query_params = request.GET.copy()
+        project_slug_params = [slug for slug in query_params.getlist("projectSlug") if slug]
+        if "projectSlug" in query_params:
+            query_params.setlist("projectSlug", project_slug_params)
+        if project_slug_params:
+            query_params.pop("project", None)
+        elif "project" in query_params:
+            query_params.setlist(
+                "project", [project for project in query_params.getlist("project") if project]
+            )
+
+        result = ReplayValidator(data=query_params)
         if not result.is_valid():
             raise ParseError(result.errors)
 

--- a/src/sentry/replays/endpoints/organization_replay_selector_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_selector_index.py
@@ -118,7 +118,19 @@ class OrganizationReplaySelectorIndexEndpoint(OrganizationReplayEndpoint):
         except NoProjects:
             return Response({"data": []}, status=200)
 
-        result = ReplaySelectorValidator(data=request.GET)
+        # Preserve legacy projectSlug precedence while treating blank project filters as absent.
+        query_params = request.GET.copy()
+        project_slug_params = [slug for slug in query_params.getlist("projectSlug") if slug]
+        if "projectSlug" in query_params:
+            query_params.setlist("projectSlug", project_slug_params)
+        if project_slug_params:
+            query_params.pop("project", None)
+        elif "project" in query_params:
+            query_params.setlist(
+                "project", [project for project in query_params.getlist("project") if project]
+            )
+
+        result = ReplaySelectorValidator(data=query_params)
         if not result.is_valid():
             raise ParseError(result.errors)
 

--- a/src/sentry/replays/validators.py
+++ b/src/sentry/replays/validators.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from sentry.api.helpers.projects import ProjectIdOrSlugField
+
 VALID_FIELD_SET = (
     "activity",
     "browser",
@@ -66,8 +68,8 @@ UTC ISO8601 or epoch seconds. Use along with `start` instead of `statsPeriod`.
     )
     project = serializers.ListField(
         required=False,
-        help_text="The ID of the projects to filter by.",
-        child=serializers.IntegerField(),
+        help_text="The ID or slug of the projects to filter by.",
+        child=ProjectIdOrSlugField(),
     )
     projectSlug = serializers.ListField(
         required=False,
@@ -115,8 +117,8 @@ class ReplaySelectorValidator(serializers.Serializer):
     )
     project = serializers.ListField(
         required=False,
-        help_text="The ID of the projects to filter by.",
-        child=serializers.IntegerField(),
+        help_text="The ID or slug of the projects to filter by.",
+        child=ProjectIdOrSlugField(),
     )
     projectSlug = serializers.ListField(
         required=False,

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -407,6 +407,64 @@ class ReleaseThresholdStatusTest(APITestCase):
         r2_keys = [k for k, v in data.items() if k.split("-")[1] == self.release2.version]
         assert len(r2_keys) == 0
 
+    def test_get_success_project_param_slug_filter(self) -> None:
+        now = datetime.now(UTC)
+        yesterday = now - timedelta(hours=24)
+
+        project_slug_response = self.get_success_response(
+            self.organization.slug, start=yesterday, end=now, projectSlug=[self.project2.slug]
+        )
+        project_response = self.get_success_response(
+            self.organization.slug, start=yesterday, end=now, project=[self.project2.slug]
+        )
+
+        assert project_response.data == project_slug_response.data
+
+    def test_get_success_project_param_mixed_id_and_slug_filter(self) -> None:
+        now = datetime.now(UTC)
+        yesterday = now - timedelta(hours=24)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            start=yesterday,
+            end=now,
+            project=[str(self.project1.id), self.project2.slug],
+        )
+
+        assert set(response.data.keys()) == {
+            f"{self.project1.slug}-{self.release1.version}",
+            f"{self.project1.slug}-{self.release2.version}",
+            f"{self.project2.slug}-{self.release1.version}",
+        }
+
+    def test_get_success_project_slug_takes_precedence_over_project_id(self) -> None:
+        now = datetime.now(UTC)
+        yesterday = now - timedelta(hours=24)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            start=yesterday,
+            end=now,
+            projectSlug=[self.project2.slug],
+            project=[str(self.project1.id)],
+        )
+
+        assert set(response.data.keys()) == {f"{self.project2.slug}-{self.release1.version}"}
+
+    def test_get_success_empty_project_slug_falls_back_to_project_filter(self) -> None:
+        now = datetime.now(UTC)
+        yesterday = now - timedelta(hours=24)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            start=yesterday,
+            end=now,
+            projectSlug=[""],
+            project=[self.project2.slug],
+        )
+
+        assert set(response.data.keys()) == {f"{self.project2.slug}-{self.release1.version}"}
+
     @patch(
         "sentry.api.endpoints.release_thresholds.release_threshold_status_index.fetch_sessions_data"
     )

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_thresholds_index.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_thresholds_index.py
@@ -49,6 +49,21 @@ class ReleaseThresholdTest(APITestCase):
         assert created_threshold["environment"]["id"] == str(self.canary_environment.id)
         assert created_threshold["environment"]["name"] == self.canary_environment.name
 
+    def test_get_valid_project_slug(self) -> None:
+        ReleaseThreshold.objects.create(
+            threshold_type=0,
+            trigger_type=0,
+            value=100,
+            window_in_seconds=1800,
+            project=self.project,
+            environment=self.canary_environment,
+        )
+
+        response = self.get_success_response(self.organization.slug, project=self.project.slug)
+
+        assert len(response.data) == 1
+        assert response.data[0]["project"]["id"] == str(self.project.id)
+
     def test_get_invalid_environment(self) -> None:
         self.get_error_response(self.organization.slug, environment="foo bar", project="-1")
 

--- a/tests/sentry/api/endpoints/test_organization_events_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_events_root_cause_analysis.py
@@ -1,0 +1,59 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+from sentry.api.endpoints.organization_events_root_cause_analysis import (
+    RootCauseAnalysisQuerySerializer,
+)
+from sentry.testutils.cases import APITestCase
+
+
+class RootCauseAnalysisQuerySerializerTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.create_project(organization=self.organization)
+        self.access = MagicMock()
+        self.access.has_any_project_scope.return_value = True
+
+    def _data(self, project: str) -> dict[str, str]:
+        return {
+            "transaction": "GET /api/0/issues/",
+            "project": project,
+            "breakpoint": "2024-01-01T00:00:00Z",
+        }
+
+    def _context(self) -> dict[str, Any]:
+        return {"access": self.access, "organization": self.organization}
+
+    def test_accepts_project_id(self) -> None:
+        serializer = RootCauseAnalysisQuerySerializer(
+            data=self._data(str(self.project.id)), context=self._context()
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["project"] == self.project
+
+    def test_accepts_project_slug(self) -> None:
+        serializer = RootCauseAnalysisQuerySerializer(
+            data=self._data(self.project.slug), context=self._context()
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["project"] == self.project
+
+    def test_rejects_project_id_from_another_organization(self) -> None:
+        other_project = self.create_project(organization=self.create_organization())
+        serializer = RootCauseAnalysisQuerySerializer(
+            data=self._data(str(other_project.id)), context=self._context()
+        )
+
+        assert not serializer.is_valid()
+        assert str(serializer.errors["project"][0]) == "Invalid project"
+
+    def test_rejects_project_id_without_scope(self) -> None:
+        self.access.has_any_project_scope.return_value = False
+        serializer = RootCauseAnalysisQuerySerializer(
+            data=self._data(str(self.project.id)), context=self._context()
+        )
+
+        assert not serializer.is_valid()
+        assert str(serializer.errors["project"][0]) == "Insufficient access to project"

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -72,6 +72,12 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
             project=self.project1, repository=self.repo1
         ).exists()
 
+    def test_create_single_mapping_with_project_id(self) -> None:
+        response = self.make_post({"project": self.project1.id})
+
+        assert response.status_code == 200, response.content
+        assert response.data["created"] == 1
+
     def test_create_multiple_mappings(self) -> None:
         response = self.make_post(
             {
@@ -254,6 +260,16 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         response = self.make_post({"project": "nonexistent-project"})
         assert response.status_code == 404
         assert "Project not found" in response.data["detail"]
+
+    def test_all_project_id_sentinel_returns_400(self) -> None:
+        response = self.make_post({"project": "-1"})
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project"
+
+    def test_all_project_slug_sentinel_returns_400(self) -> None:
+        response = self.make_post({"project": "$all"})
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project"
 
     def test_unknown_repository_name(self) -> None:
         response = self.make_post({"repository": "nonexistent/repo"})
@@ -452,6 +468,12 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         other_org = self.create_organization(name="other-org", owner=self.user)
         other_project = self.create_project(organization=other_org, name="other-project")
         response = self.make_post({"project": other_project.slug})
+        assert response.status_code == 404
+
+    def test_project_id_from_other_org_returns_404(self) -> None:
+        other_org = self.create_organization(name="other-org", owner=self.user)
+        other_project = self.create_project(organization=other_org, name="other-project")
+        response = self.make_post({"project": other_project.id})
         assert response.status_code == 404
 
     def test_repo_from_other_org_returns_404(self) -> None:

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -494,6 +494,19 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
             ),
         )
 
+    def test_create_with_project_id(self) -> None:
+        data = {
+            "project": self.project.id,
+            "name": "My Monitor",
+            "type": "cron_job",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+        }
+
+        response = self.get_success_response(self.organization.slug, **data)
+
+        monitor = Monitor.objects.get(slug=response.data["slug"])
+        assert monitor.project_id == self.project.id
+
     def test_slug(self) -> None:
         data = {
             "project": self.project.slug,

--- a/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
+++ b/tests/sentry/notifications/api/endpoints/test_notification_actions_index.py
@@ -27,7 +27,8 @@ ActionRegistrationT = TypeVar("ActionRegistrationT", bound=ActionRegistration)
 
 class _Query(TypedDict, total=False):
     triggerType: str
-    project: int
+    project: int | str
+    projectSlug: str
 
 
 class _QueryResult(TypedDict):
@@ -136,6 +137,11 @@ class NotificationActionsIndexEndpointTest(APITestCase):
             "regular project slug": {
                 "query": {"project": project.slug},
                 "result": {na2, na3},
+            },
+            "empty project": {"query": {"project": ""}, "result": {na1, na2, na3, na4}},
+            "empty project slug": {
+                "query": {"projectSlug": ""},
+                "result": {na1, na2, na3, na4},
             },
             "regular trigger": {
                 "query": {"triggerType": "teacher"},
@@ -445,6 +451,43 @@ class NotificationActionsIndexEndpointTest(APITestCase):
         self.test_post_simple()
 
     @patch.dict(NotificationAction._registry, {})
+    def test_post_team_admin__success_with_project_ids(self) -> None:
+        user = self.create_user()
+        member = self.create_member(organization=self.organization, user=user, role="member")
+        OrganizationMemberTeam.objects.create(
+            team=self.team, organizationmember=member, role="admin"
+        )
+        self.login_as(user)
+
+        class MockActionRegistration(ActionRegistration):
+            validate_action = MagicMock()
+
+            def fire(self, data: Any) -> None:
+                raise NotImplementedError
+
+        registration = MockActionRegistration
+        _mock_register(self.base_data)(registration)
+
+        data = {
+            **self.base_data,
+            "projects": [self.projects[0].id, str(self.projects[1].id)],
+        }
+        response = self.get_success_response(
+            self.organization.slug,
+            status_code=status.HTTP_201_CREATED,
+            method="POST",
+            **data,
+        )
+
+        registration.validate_action.assert_called()
+        notif_action_projects = NotificationActionProject.objects.filter(
+            action_id=response.data["id"]
+        )
+        assert {action_project.project_id for action_project in notif_action_projects} == {
+            project.id for project in self.projects
+        }
+
+    @patch.dict(NotificationAction._registry, {})
     def test_post_team_admin__missing_access(self) -> None:
         user = self.create_user()
         member = self.create_member(organization=self.organization, user=user, role="member")
@@ -479,6 +522,47 @@ class NotificationActionsIndexEndpointTest(APITestCase):
             **data,
         )
 
+        assert (
+            "You do not have permission to create notification actions for projects"
+            in response.data["detail"]
+        )
+
+    @patch.dict(NotificationAction._registry, {})
+    def test_post_team_admin__missing_access_with_project_id(self) -> None:
+        user = self.create_user()
+        member = self.create_member(organization=self.organization, user=user, role="member")
+        OrganizationMemberTeam.objects.create(
+            team=self.team, organizationmember=member, role="admin"
+        )
+        self.login_as(user)
+
+        non_admin_project = self.create_project(
+            organization=self.organization, teams=[self.create_team()]
+        )
+
+        class MockActionRegistration(ActionRegistration):
+            validate_action = MagicMock()
+
+            def fire(self, data: Any) -> None:
+                raise NotImplementedError
+
+        registration = MockActionRegistration
+        _mock_register(self.base_data)(registration)
+
+        data = {
+            **self.base_data,
+            "projects": [self.projects[0].id, non_admin_project.id],
+        }
+
+        assert not registration.validate_action.called
+        response = self.get_error_response(
+            self.organization.slug,
+            status_code=status.HTTP_403_FORBIDDEN,
+            method="POST",
+            **data,
+        )
+
+        assert not registration.validate_action.called
         assert (
             "You do not have permission to create notification actions for projects"
             in response.data["detail"]

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -877,7 +877,8 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
             args=[self.org.slug],
         )
 
-    def _create_base_snapshot(self):
+    def _create_base_snapshot(self, project=None):
+        project = project or self.project
         images = {
             "components/button.png": {
                 "content_hash": "hash_button",
@@ -887,11 +888,11 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
             }
         }
         artifact = PreprodArtifact.objects.create(
-            project=self.project,
+            project=project,
             state=PreprodArtifact.ArtifactState.UPLOADED,
             app_id="com.example.app",
         )
-        manifest_key = f"{self.org.id}/{self.project.id}/{artifact.id}/manifest.json"
+        manifest_key = f"{self.org.id}/{project.id}/{artifact.id}/manifest.json"
         PreprodSnapshotMetrics.objects.create(
             preprod_artifact=artifact,
             image_count=len(images),
@@ -907,6 +908,11 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         return mock_session
 
     def test_query_params_document_project_slug(self):
+        assert LATEST_BASE_SNAPSHOT_GET_QUERY_PARAMS["project"] == {
+            "type": "string",
+            "required": False,
+            "description": "Project ID or slug to scope the lookup. Use either project or projectSlug when app_id is not unique across projects or project inference is unavailable.",
+        }
         assert LATEST_BASE_SNAPSHOT_GET_QUERY_PARAMS["projectSlug"] == {
             "type": "string",
             "required": False,
@@ -932,6 +938,108 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         assert response.data["image_count"] == 1
         assert response.data["images"][0]["image_file_name"] == "components/button.png"
         mock_get_session.assert_called_once_with(self.org.id, self.project.id)
+
+    @patch(
+        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_preprod_session"
+    )
+    def test_get_latest_base_snapshot_scoped_by_project_param_slug(self, mock_get_session):
+        artifact, _, manifest_json = self._create_base_snapshot()
+        mock_get_session.return_value = self._create_mock_session(manifest_json)
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {"app_id": "com.example.app", "project": self.project.slug},
+            )
+
+        assert response.status_code == 200
+        assert response.data["head_artifact_id"] == str(artifact.id)
+        assert response.data["project_slug"] == "sausage"
+        mock_get_session.assert_called_once_with(self.org.id, self.project.id)
+
+    @patch(
+        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_preprod_session"
+    )
+    def test_get_latest_base_snapshot_scoped_by_project_param_id(self, mock_get_session):
+        artifact, _, manifest_json = self._create_base_snapshot()
+        mock_get_session.return_value = self._create_mock_session(manifest_json)
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {"app_id": "com.example.app", "project": str(self.project.id)},
+            )
+
+        assert response.status_code == 200
+        assert response.data["head_artifact_id"] == str(artifact.id)
+        assert response.data["project_slug"] == "sausage"
+        mock_get_session.assert_called_once_with(self.org.id, self.project.id)
+
+    @patch(
+        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_preprod_session"
+    )
+    def test_get_latest_base_snapshot_project_slug_takes_precedence_over_project(
+        self, mock_get_session
+    ):
+        self._create_base_snapshot()
+        other_project = self.create_project(organization=self.org, slug="other-project")
+        artifact, _, manifest_json = self._create_base_snapshot(project=other_project)
+        mock_get_session.return_value = self._create_mock_session(manifest_json)
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {
+                    "app_id": "com.example.app",
+                    "project": self.project.slug,
+                    "projectSlug": other_project.slug,
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.data["head_artifact_id"] == str(artifact.id)
+        assert response.data["project_slug"] == "other-project"
+        mock_get_session.assert_called_once_with(self.org.id, other_project.id)
+
+    def test_get_latest_base_snapshot_rejects_all_project_id_sentinel(self):
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {"app_id": "com.example.app", "project": "-1"},
+            )
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project parameter"
+
+    def test_get_latest_base_snapshot_rejects_all_project_slug_sentinel(self):
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {"app_id": "com.example.app", "project": "$all"},
+            )
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project parameter"
+
+    def test_get_latest_base_snapshot_rejects_project_slug_all_sentinel(self):
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {"app_id": "com.example.app", "projectSlug": "$all"},
+            )
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project parameter"
+
+    def test_get_latest_base_snapshot_rejects_project_slug_id_sentinel(self):
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(
+                self._get_url(),
+                {"app_id": "com.example.app", "projectSlug": "-1"},
+            )
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project parameter"
 
 
 class ProjectPreprodSnapshotDeleteTest(APITestCase):

--- a/tests/sentry/releases/endpoints/test_organization_release_details.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_details.py
@@ -130,6 +130,9 @@ class ReleaseDetailsTest(APITestCase):
         response = self.client.get(url, {"project": self.project1.id})
         assert response.status_code == 200
 
+        response = self.client.get(url, {"project": self.project1.slug})
+        assert response.status_code == 200
+
     def test_project_from_another_org_is_rejected(self) -> None:
         """Supplying a project_id belonging to a different organization must not
         leak session health data (IDOR check)."""
@@ -170,6 +173,38 @@ class ReleaseDetailsTest(APITestCase):
 
         response = self.client.get(url, {"project": no_access_project.id})
         assert response.status_code in (403, 404)
+
+    def test_all_project_id_sentinel_is_rejected(self) -> None:
+        release = Release.objects.create(organization_id=self.organization.id, version="abcabcabc")
+        release.add_project(self.project1)
+
+        self.create_member(teams=[self.team1], user=self.user1, organization=self.organization)
+        self.login_as(user=self.user1)
+
+        url = reverse(
+            "sentry-api-0-organization-release-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "version": release.version},
+        )
+
+        response = self.client.get(url, {"project": "-1"})
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project"
+
+    def test_all_project_slug_sentinel_is_rejected(self) -> None:
+        release = Release.objects.create(organization_id=self.organization.id, version="abcabcabc")
+        release.add_project(self.project1)
+
+        self.create_member(teams=[self.team1], user=self.user1, organization=self.organization)
+        self.login_as(user=self.user1)
+
+        url = reverse(
+            "sentry-api-0-organization-release-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "version": release.version},
+        )
+
+        response = self.client.get(url, {"project": "$all"})
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid project"
 
     def test_correct_project_contains_current_project_meta(self) -> None:
         """

--- a/tests/sentry/replays/endpoints/test_organization_replay_index.py
+++ b/tests/sentry/replays/endpoints/test_organization_replay_index.py
@@ -12,6 +12,8 @@ from sentry.replays.testutils import (
     mock_replay_tap,
     mock_replay_viewed,
 )
+from sentry.replays.usecases.query import QueryResponse
+from sentry.replays.validators import ReplaySelectorValidator, ReplayValidator
 from sentry.testutils.cases import APITestCase, ReplaysSnubaTestCase
 from sentry.utils.cursors import Cursor
 from sentry.utils.snuba import QueryMemoryLimitExceeded
@@ -28,6 +30,29 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
     @property
     def features(self) -> dict[str, bool]:
         return {"organizations:session-replay": True}
+
+    def test_replay_validators_accept_project_slugs(self) -> None:
+        replay_validator = ReplayValidator(data={"project": ["my-project"]})
+        selector_validator = ReplaySelectorValidator(data={"project": ["my-project"]})
+
+        assert replay_validator.is_valid(), replay_validator.errors
+        assert selector_validator.is_valid(), selector_validator.errors
+
+    def test_get_replays_empty_project_uses_project_slug_filter(self) -> None:
+        project = self.create_project(teams=[self.team], slug="replay-project")
+
+        with self.feature(self.features):
+            with mock.patch(
+                "sentry.replays.endpoints.organization_replay_index.query_replays_collection_paginated",
+                return_value=QueryResponse(response=[], has_more=False, source="mock"),
+            ) as mock_query:
+                response = self.client.get(
+                    self.url,
+                    {"projectSlug": project.slug, "project": ""},
+                )
+
+        assert response.status_code == 200
+        assert mock_query.call_args.kwargs["project_ids"] == [project.id]
 
     def test_feature_flag_disabled(self) -> None:
         """Test replays can be disabled."""


### PR DESCRIPTION
This stacks on #117446 and extends its ID-or-slug project resolver into the remaining product surfaces that were still validating project IDs directly. Release thresholds, root-cause analysis, code mappings, monitors, notification actions, preprod snapshots, release details, and replay endpoints now accept project IDs or slugs where project IDs were already accepted.

The changes preserve existing permission checks and legacy `projectSlug` precedence. Single-project lookups reject all-project sentinels, and endpoints whose validators inspect query params normalize blank project filters as absent.

Validated with focused pytest coverage, targeted ruff and mypy through `prek`, `make test-api-docs`, and final `prek run -q`.