### PR TITLE
fix(issues): Keep searched release selected in resolve modal

### DIFF
--- a/static/app/components/customResolutionModal.spec.tsx
+++ b/static/app/components/customResolutionModal.spec.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import {ReleaseFixture} from 'sentry-fixture/release';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {makeCloseButton} from '@sentry/scraps/modal';
 
@@ -189,5 +189,56 @@ describe('CustomResolutionModal', () => {
       name: /sentry-android-shop.*3\.0\.0/i,
     });
     expect(matches).toHaveLength(1);
+  });
+
+  it('keeps showing a selected exact-match release after search is cleared', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/releases/${encodeURIComponent('ancient-release')}/`,
+      body: ReleaseFixture({
+        version: 'ancient-release',
+        versionInfo: {
+          buildHash: null,
+          description: 'ancient-release',
+          package: '',
+          version: {
+            raw: 'ancient-release',
+          },
+        },
+      }),
+    });
+
+    render(
+      <CustomResolutionModal
+        Header={p => <span>{p.children}</span>}
+        Body={wrapper()}
+        Footer={wrapper()}
+        projectSlug="project-slug"
+        onSelected={jest.fn()}
+        closeModal={jest.fn()}
+        CloseButton={makeCloseButton(() => null)}
+      />
+    );
+
+    const trigger = screen.getByRole('button', {name: /version/i});
+    await userEvent.click(trigger);
+    const searchInput = await screen.findByRole('textbox');
+    await userEvent.click(searchInput);
+    await userEvent.paste('ancient-release');
+
+    expect(
+      await screen.findByRole('option', {name: /ancient-release/})
+    ).toBeInTheDocument();
+    await userEvent.keyboard('{ArrowDown}');
+    await userEvent.keyboard('{Enter}');
+
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+
+    await waitFor(
+      () =>
+        expect(screen.getByRole('button', {name: /version/i})).toHaveTextContent(
+          'ancient-release'
+        ),
+      {timeout: 600}
+    );
   });
 });

--- a/static/app/components/customResolutionModal.tsx
+++ b/static/app/components/customResolutionModal.tsx
@@ -54,6 +54,19 @@ function makeReleaseOption(
   };
 }
 
+function getUniqueReleases(releases: Array<Release | null | undefined>): Release[] {
+  const seen = new Set<string>();
+
+  return releases.filter((release): release is Release => {
+    if (!release || seen.has(release.version)) {
+      return false;
+    }
+
+    seen.add(release.version);
+    return true;
+  });
+}
+
 interface CustomResolutionModalProps extends ModalRenderProps {
   onSelected: (change: {inRelease: string}) => void;
   projectSlug: string | undefined;
@@ -62,6 +75,7 @@ interface CustomResolutionModalProps extends ModalRenderProps {
 export function CustomResolutionModal(props: CustomResolutionModalProps) {
   const organization = useOrganization();
   const [version, setVersion] = useState('');
+  const [selectedRelease, setSelectedRelease] = useState<Release | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearch = useDebouncedValue(searchQuery);
   const currentUser = ConfigStore.get('user');
@@ -109,20 +123,14 @@ export function CustomResolutionModal(props: CustomResolutionModalProps) {
   });
 
   const options = useMemo((): Array<SelectOption<string>> => {
-    const baseOptions = releases.map(release =>
+    const prioritizedReleases = debouncedSearch.trim()
+      ? [exactRelease, ...releases]
+      : [selectedRelease, ...releases];
+
+    return getUniqueReleases(prioritizedReleases).map(release =>
       makeReleaseOption(release, currentUser?.email)
     );
-
-    if (exactRelease) {
-      const exactOption = makeReleaseOption(exactRelease, currentUser?.email);
-
-      const filtered = baseOptions.filter(opt => opt.value !== exactOption.value);
-      filtered.unshift(exactOption);
-      return filtered;
-    }
-
-    return baseOptions;
-  }, [currentUser?.email, exactRelease, releases]);
+  }, [currentUser?.email, debouncedSearch, exactRelease, releases, selectedRelease]);
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -157,7 +165,13 @@ export function CustomResolutionModal(props: CustomResolutionModalProps) {
           loading={isFetching}
           emptyMessage={isFetching ? t('Loading releases\u2026') : t('No releases found')}
           onChange={option => {
-            setVersion(option?.value ? String(option.value) : '');
+            const selectedVersion = option?.value ? String(option.value) : '';
+            const visibleReleases = getUniqueReleases([exactRelease, ...releases]);
+            const release =
+              visibleReleases.find(item => item.version === selectedVersion) ?? null;
+
+            setVersion(selectedVersion);
+            setSelectedRelease(release);
             setSelectionError(null);
             setSearchQuery('');
           }}


### PR DESCRIPTION
Selecting a release that only shows up through exact search made the resolve modal flip back to `Version: None`, even though the selected value was still there.

Keep the selected release around after search clears so the picker can still render its label, and add a regression test for that path.

Fixes https://github.com/getsentry/sentry/issues/117488