### PR TITLE
fix(onboarding): Add `dataCollection.httpBodies` to setup snippet

### DIFF
--- a/static/app/gettingStartedDocs/javascript-angular/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-angular/utils.tsx
@@ -127,9 +127,9 @@ bootstrapApplication(appConfig, AppComponent)
     params,
     staticParts: [
       `dsn: "${params.dsn.public}"`,
-      `// To disable sending user data, uncomment the line below. For more info visit:
+      `// To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
       // https://docs.sentry.io/platforms/javascript/guides/angular/configuration/options/#dataCollection
-      // dataCollection: { userInfo: false }`,
+      // dataCollection: { userInfo: false, httpBodies: [] }`,
     ],
     getIntegrations,
     getDynamicParts,

--- a/static/app/gettingStartedDocs/javascript-astro/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-astro/onboarding.tsx
@@ -30,9 +30,9 @@ import * as Sentry from "@sentry/astro";
 
 Sentry.init({
   dsn: "${params.dsn.public}",
-  // To disable sending user data, uncomment the line below. For more info visit:
+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },${logsConfig}${performanceConfig}
+  // dataCollection: { userInfo: false, httpBodies: [] },${logsConfig}${performanceConfig}
 });
 `;
 }
@@ -81,9 +81,9 @@ import * as Sentry from "@sentry/astro";
 
 Sentry.init({
   dsn: "${params.dsn.public}",
-  // To disable sending user data, uncomment the line below. For more info visit:
+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },${integrationsConfig}${logsConfig}${performanceConfig}${replaySampleRates}
+  // dataCollection: { userInfo: false, httpBodies: [] },${integrationsConfig}${logsConfig}${performanceConfig}${replaySampleRates}
 });
 `;
 }

--- a/static/app/gettingStartedDocs/javascript-ember/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-ember/utils.tsx
@@ -69,9 +69,9 @@ export function getSdkSetupSnippet(params: DocsParams) {
     params,
     staticParts: [
       `dsn: "${params.dsn.public}"`,
-      `// To disable sending user data, uncomment the line below. For more info visit:
+      `// To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
       // https://docs.sentry.io/platforms/javascript/guides/ember/configuration/options/#dataCollection
-      // dataCollection: { userInfo: false }`,
+      // dataCollection: { userInfo: false, httpBodies: [] }`,
     ],
     getIntegrations,
     getDynamicParts,

--- a/static/app/gettingStartedDocs/javascript-gatsby/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-gatsby/onboarding.spec.tsx
@@ -155,7 +155,9 @@ describe('javascript-gatsby onboarding docs', () => {
 
     expect(
       screen.getByText(
-        textWithMarkupMatcher(/\/\/ dataCollection: \{ userInfo: false \}/)
+        textWithMarkupMatcher(
+          /\/\/ dataCollection: \{ userInfo: false, httpBodies: \[\] \}/
+        )
       )
     ).toBeInTheDocument();
   });

--- a/static/app/gettingStartedDocs/javascript-gatsby/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-gatsby/utils.tsx
@@ -75,9 +75,9 @@ export function getSdkSetupSnippet(params: DocsParams) {
     params,
     staticParts: [
       `dsn: "${params.dsn.public}"`,
-      `// To disable sending user data, uncomment the line below. For more info visit:
+      `// To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
       // https://docs.sentry.io/platforms/javascript/guides/gatsby/configuration/options/#dataCollection
-      // dataCollection: { userInfo: false }`,
+      // dataCollection: { userInfo: false, httpBodies: [] }`,
     ],
     getIntegrations,
     getDynamicParts,

--- a/static/app/gettingStartedDocs/javascript-react-router/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-react-router/utils.tsx
@@ -66,9 +66,9 @@ import { HydratedRouter } from "react-router/dom";
 
 Sentry.init({
   dsn: "${params.dsn.public}",
-  // To disable sending user data, uncomment the line below. For more info visit:
+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },${integrationsCode}${logsSnippet}${performanceSnippet}${replaySnippet}
+  // dataCollection: { userInfo: false, httpBodies: [] },${integrationsCode}${logsSnippet}${performanceSnippet}${replaySnippet}
 });
 
 startTransition(() => {

--- a/static/app/gettingStartedDocs/javascript-react/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-react/utils.tsx
@@ -72,9 +72,9 @@ export function getSdkSetupSnippet(params: DocsParams) {
     params,
     staticParts: [
       `dsn: "${params.dsn.public}"`,
-      `// To disable sending user data, uncomment the line below. For more info visit:
+      `// To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
       // https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/#dataCollection
-      // dataCollection: { userInfo: false }`,
+      // dataCollection: { userInfo: false, httpBodies: [] }`,
     ],
     getIntegrations,
     getDynamicParts,

--- a/static/app/gettingStartedDocs/javascript-solid/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-solid/utils.tsx
@@ -75,9 +75,9 @@ export function getSdkSetupSnippet(params: DocsParams) {
     params,
     staticParts: [
       `dsn: "${params.dsn.public}"`,
-      `// To disable sending user data, uncomment the line below. For more info visit:
+      `// To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
       // https://docs.sentry.io/platforms/javascript/guides/solid/configuration/options/#dataCollection
-      // dataCollection: { userInfo: false }`,
+      // dataCollection: { userInfo: false, httpBodies: [] }`,
     ],
     getIntegrations,
     getDynamicParts,

--- a/static/app/gettingStartedDocs/javascript-solidstart/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-solidstart/onboarding.tsx
@@ -33,9 +33,9 @@ Sentry.init({
         profileSessionSampleRate: 1.0,`
       : ''
   }
-  // To disable sending user data, uncomment the line below. For more info visit:
+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/solidstart/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },
+  // dataCollection: { userInfo: false, httpBodies: [] },
 });
 `;
 }

--- a/static/app/gettingStartedDocs/javascript-solidstart/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-solidstart/utils.tsx
@@ -69,9 +69,9 @@ export function getSdkClientSetupSnippet(params: DocsParams) {
     params,
     staticParts: [
       `dsn: "${params.dsn.public}"`,
-      `// To disable sending user data, uncomment the line below. For more info visit:
+      `// To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
       // https://docs.sentry.io/platforms/javascript/guides/solidstart/configuration/options/#dataCollection
-      // dataCollection: { userInfo: false }`,
+      // dataCollection: { userInfo: false, httpBodies: [] }`,
     ],
     getIntegrations,
     getDynamicParts,

--- a/static/app/gettingStartedDocs/javascript-svelte/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-svelte/utils.tsx
@@ -72,9 +72,9 @@ export function getSdkSetupSnippet(params: DocsParams, isVersion5: boolean) {
     params,
     staticParts: [
       `dsn: "${params.dsn.public}"`,
-      `// To disable sending user data, uncomment the line below. For more info visit:
+      `// To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
       // https://docs.sentry.io/platforms/javascript/guides/svelte/configuration/options/#dataCollection
-      // dataCollection: { userInfo: false }`,
+      // dataCollection: { userInfo: false, httpBodies: [] }`,
     ],
     getIntegrations,
     getDynamicParts,

--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
@@ -70,9 +70,9 @@ export const onboarding: OnboardingConfig = {
 Sentry.init({
   dsn: "${params.dsn.public}",
 
-  // To disable sending user data, uncomment the line below. For more info visit:
+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },${
+  // dataCollection: { userInfo: false, httpBodies: [] },${
     params.isReplaySelected
       ? `
 
@@ -205,9 +205,9 @@ export const getRouter = () => {
 Sentry.init({
   dsn: "${params.dsn.public}",
 
-  // To disable sending user data, uncomment the line below. For more info visit:
+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },${
+  // dataCollection: { userInfo: false, httpBodies: [] },${
     params.isPerformanceSelected
       ? `
 

--- a/static/app/gettingStartedDocs/javascript-vue/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-vue/utils.tsx
@@ -149,9 +149,9 @@ function getSentryInitLayout(params: Params, siblingOption: string): string {
     staticParts: [
       siblingOption === VueVersion.VUE2 ? 'Vue' : 'app',
       `dsn: "${params.dsn.public}"`,
-      `// To disable sending user data, uncomment the line below. For more info visit:
+      `// To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
       // https://docs.sentry.io/platforms/javascript/guides/vue/configuration/options/#dataCollection
-      // dataCollection: { userInfo: false }`,
+      // dataCollection: { userInfo: false, httpBodies: [] }`,
     ],
     getIntegrations,
     getDynamicParts,

--- a/static/app/gettingStartedDocs/javascript/performance.tsx
+++ b/static/app/gettingStartedDocs/javascript/performance.tsx
@@ -52,9 +52,9 @@ Sentry.init({
   tracesSampleRate: 1.0,
   // Set \`tracePropagationTargets\` to control for which URLs distributed tracing should be enabled
   tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],
-  // To disable sending user data, uncomment the line below. For more info visit:
+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
   // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },
+  // dataCollection: { userInfo: false, httpBodies: [] },
 });
 `,
         },
@@ -101,9 +101,9 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],
-  // To disable sending user data, uncomment the line below. For more info visit:
+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
   // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },
+  // dataCollection: { userInfo: false, httpBodies: [] },
 });
 `,
         },

--- a/static/app/gettingStartedDocs/javascript/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript/utils.tsx
@@ -107,9 +107,9 @@ export const getSdkSetupSnippet = (params: Params) => {
     params,
     staticParts: [
       `dsn: "${params.dsn.public}"`,
-      `// To disable sending user data, uncomment the line below. For more info visit:
+      `// To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
       // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
-      // dataCollection: { userInfo: false }`,
+      // dataCollection: { userInfo: false, httpBodies: [] }`,
     ],
     getIntegrations,
     getDynamicParts,

--- a/static/app/gettingStartedDocs/node-cloudflare-pages/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-pages/onboarding.tsx
@@ -46,9 +46,9 @@ export const onRequest = [
         : ''
     }
 
-    // To disable sending user data, uncomment the line below. For more info visit:
+    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
     // https://docs.sentry.io/platforms/javascript/guides/cloudflare-pages/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false },
+    // dataCollection: { userInfo: false, httpBodies: [] },
   })),
   // Add more middlewares here
 ];`;

--- a/static/app/gettingStartedDocs/node-cloudflare-workers/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-workers/onboarding.tsx
@@ -44,9 +44,9 @@ export default Sentry.withSentry(
         : ''
     }
 
-    // To disable sending user data, uncomment the line below. For more info visit:
+    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
     // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false },
+    // dataCollection: { userInfo: false, httpBodies: [] },
   }),
   {
     async fetch(request, env, ctx) {

--- a/static/app/gettingStartedDocs/node-hono/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-hono/onboarding.tsx
@@ -72,9 +72,9 @@ Sentry.init({
   enableLogs: true,`
       : ''
   }
-  // To disable sending user data, uncomment the line below. For more info visit:
+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },
+  // dataCollection: { userInfo: false, httpBodies: [] },
 });`;
 }
 
@@ -115,9 +115,9 @@ app.use(
     enableLogs: true,`
         : ''
     }
-    // To disable sending user data, uncomment the line below. For more info visit:
+    // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
     // https://docs.sentry.io/platforms/javascript/guides/hono/configuration/options/#dataCollection
-    // dataCollection: { userInfo: false },
+    // dataCollection: { userInfo: false, httpBodies: [] },
   }),
 );
 

--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -236,9 +236,9 @@ Sentry.init({
   profilesSampleRate: 1.0,`
   }
 
-  // To disable sending user data, uncomment the line below. For more info visit:
+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },
+  // dataCollection: { userInfo: false, httpBodies: [] },
 });${
                 params.profilingOptions?.defaultProfilingMode === 'continuous' &&
                 profilingLifecycle === 'trace'
@@ -360,9 +360,9 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   // Tracing must be enabled for MCP monitoring to work
   tracesSampleRate: 1.0,
-  // To disable sending user data, uncomment the line below. For more info visit:
+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },
+  // dataCollection: { userInfo: false, httpBodies: [] },
 });`,
             },
           ],
@@ -618,9 +618,9 @@ Sentry.init({
     profileLifecycle: 'trace',`
       : ''
   }
-  // To disable sending user data, uncomment the line below. For more info visit:
+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },
+  // dataCollection: { userInfo: false, httpBodies: [] },
   });${
     params.isProfilingSelected &&
     params.profilingOptions?.defaultProfilingMode === 'continuous'

--- a/static/app/gettingStartedDocs/react-native/utils.tsx
+++ b/static/app/gettingStartedDocs/react-native/utils.tsx
@@ -30,9 +30,9 @@ import * as Sentry from "@sentry/react-native";
 
 Sentry.init({
   dsn: "${params.dsn.public}",
-  // To disable sending user data, uncomment the line below. For more info visit:
+  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
   // https://docs.sentry.io/platforms/react-native/configuration/options/#dataCollection
-  // dataCollection: { userInfo: false },${
+  // dataCollection: { userInfo: false, httpBodies: [] },${
     params.isPerformanceSelected
       ? `
   // Set tracesSampleRate to 1.0 to capture 100% of transactions for tracing.


### PR DESCRIPTION
Updates all JS setup snippets to this one:

```
  // To disable sending user data and HTTP bodies, uncomment the line below. For more info visit:
  // https://docs.sentry.io/platforms/javascript/guides/angular/configuration/options/#dataCollection
  // dataCollection: { userInfo: false, httpBodies: [] },
```
