### PR TITLE
feat(search): Boost metric and AI-detected issues in recommended sort

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -884,7 +884,18 @@ register(
 register(
     "snuba.search.recommended.group-type-boost",
     type=Dict,
-    default={7001: 0.15},
+    # group type_id -> additive score boost. 7001 uptime domain check failure,
+    # 8001 metric issue, 3503-3507 AI-detected (http, db, runtime performance,
+    # security, code health).
+    default={
+        7001: 0.15,
+        8001: 0.15,
+        3503: 0.10,
+        3504: 0.10,
+        3505: 0.10,
+        3506: 0.10,
+        3507: 0.10,
+    },
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(


### PR DESCRIPTION
Extends the `snuba.search.recommended.group-type-boost` default (previously only uptime domain check failures) with:

- **Metric issues** (8001, +0.15) — these fire on thresholds a user explicitly configured, so a firing one is definitionally something they care about.
- **AI-detected issues** (3503–3507, +0.10) — http, db, runtime performance, security, and code health. These are validated by Seer before creation. Excludes the general type (3508), which is turned off.

The boost is applied inside the Snuba `recommended` aggregation, so it flows into both the `recommended` and `recommended_v2` sorts — including `recommended_v2`'s chunked Snuba fallback path, where Postgres-side signals don't apply. No code change needed; the per-type values remain tunable via options-automator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)