### PR TITLE
ref(o11y): Add `set_attribute` calls and switch to top level API in SCIM members

### DIFF
--- a/src/sentry/core/endpoints/scim/members.py
+++ b/src/sentry/core/endpoints/scim/members.py
@@ -579,8 +579,6 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
         """
         update_role = False
 
-        scope = sentry_sdk.get_isolation_scope()
-
         if "sentryOrgRole" in request.data and request.data["sentryOrgRole"]:
             role = request.data["sentryOrgRole"].lower()
             idp_role_restricted = True
@@ -588,8 +586,8 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
         else:
             role = organization.default_role
             idp_role_restricted = False
-        scope.set_tag("role_restricted", idp_role_restricted)
-        scope.set_attribute("role_restricted", idp_role_restricted)
+        sentry_sdk.set_tag("role_restricted", idp_role_restricted)
+        sentry_sdk.set_attribute("role_restricted", idp_role_restricted)
 
         # Allow any role as long as it doesn't have `org:admin` permissions
         allowed_roles = {role for role in roles.get_all() if not role.has_scope("org:admin")}
@@ -597,12 +595,12 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
         # Check for roles not found
         # TODO: move this to the serializer verification
         if role not in {role.id for role in allowed_roles}:
-            scope.set_tag("invalid_role_selection", True)
-            scope.set_attribute("invalid_role_selection", True)
+            sentry_sdk.set_tag("invalid_role_selection", True)
+            sentry_sdk.set_attribute("invalid_role_selection", True)
             raise SCIMApiError(detail=SCIM_400_INVALID_ORGROLE)
 
-        scope.set_tag("invalid_role_selection", False)
-        scope.set_attribute("invalid_role_selection", False)
+        sentry_sdk.set_tag("invalid_role_selection", False)
+        sentry_sdk.set_attribute("invalid_role_selection", False)
         serializer = OrganizationMemberRequestSerializer(
             data={
                 "email": request.data.get("userName"),

--- a/src/sentry/core/endpoints/scim/members.py
+++ b/src/sentry/core/endpoints/scim/members.py
@@ -589,6 +589,7 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
             role = organization.default_role
             idp_role_restricted = False
         scope.set_tag("role_restricted", idp_role_restricted)
+        scope.set_attribute("role_restricted", idp_role_restricted)
 
         # Allow any role as long as it doesn't have `org:admin` permissions
         allowed_roles = {role for role in roles.get_all() if not role.has_scope("org:admin")}
@@ -597,9 +598,11 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
         # TODO: move this to the serializer verification
         if role not in {role.id for role in allowed_roles}:
             scope.set_tag("invalid_role_selection", True)
+            scope.set_attribute("invalid_role_selection", True)
             raise SCIMApiError(detail=SCIM_400_INVALID_ORGROLE)
 
         scope.set_tag("invalid_role_selection", False)
+        scope.set_attribute("invalid_role_selection", False)
         serializer = OrganizationMemberRequestSerializer(
             data={
                 "email": request.data.get("userName"),


### PR DESCRIPTION
Supplements existing `scope.set_tag()` calls with equivalent `scope.set_attribute()` in `src/sentry/core/endpoints/scim/members.py`.

Also, switch to using top-level SDK API.

Once we switch to span streaming, the new attributes will get applied to spans automatically.

Related to https://github.com/getsentry/sentry-python/issues/6537