### PR TITLE
ref(o11y): Add set_attribute calls in hybridcloud RPC service

### DIFF
--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -671,9 +671,10 @@ class _RemoteSiloCall:
 
     def _raise_from_response_status_error(self, response: requests.Response) -> NoReturn:
         rpc_method = f"{self.service_name}.{self.method_name}"
-        scope = sentry_sdk.get_isolation_scope()
-        scope.set_tag("rpc_method", rpc_method)
-        scope.set_tag("rpc_status_code", response.status_code)
+        sentry_sdk.set_tag("rpc_method", rpc_method)
+        sentry_sdk.set_attribute("rpc_method", rpc_method)
+        sentry_sdk.set_tag("rpc_status_code", response.status_code)
+        sentry_sdk.set_attribute("rpc_status_code", response.status_code)
 
         if response.status_code == 422:
             # Validation/Operation errors that should be shown to end user behave the same


### PR DESCRIPTION
Supplement existing set_tag/set_context/set_extra calls with set_attribute so that data gets added to attributes-based telemetry as well. This will make the migration to span streaming easier.

Related to https://github.com/getsentry/sentry-python/issues/6537