### PR TITLE
ref(o11y): Add set_attribute calls in deliver webhooks

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -86,7 +86,6 @@ def _set_webhook_delivery_sentry_context(payload: WebhookPayload) -> None:
         "provider": payload.provider or "unknown",
     }
     sentry_sdk.set_context("webhook_delivery", context)
-    sentry_sdk.set_attribute("webhook_delivery.mailbox_name", payload.mailbox_name)
     sentry_sdk.set_attribute("webhook_delivery.provider", payload.provider or "unknown")
 
 

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -80,11 +80,14 @@ DEFAULT_PROVIDER_PRIORITY = 10
 def _set_webhook_delivery_sentry_context(payload: WebhookPayload) -> None:
     """Set Sentry context at webhook delivery entrypoint for easier debugging."""
     sentry_sdk.set_tag("mailbox_name", payload.mailbox_name)
+    sentry_sdk.set_attribute("mailbox_name", payload.mailbox_name)
     context: dict[str, str] = {
         "mailbox_name": payload.mailbox_name,
         "provider": payload.provider or "unknown",
     }
     sentry_sdk.set_context("webhook_delivery", context)
+    sentry_sdk.set_attribute("webhook_delivery.mailbox_name", payload.mailbox_name)
+    sentry_sdk.set_attribute("webhook_delivery.provider", payload.provider or "unknown")
 
 
 class DeliveryFailed(Exception):


### PR DESCRIPTION
Supplement existing set_tag/set_context/set_extra calls with set_attribute so that data gets added to attributes-based telemetry as well. This will make the migration to span streaming easier.

Related to https://github.com/getsentry/sentry-python/issues/6537