### PR TITLE
ref(issues): Make project_ids required on qualified short id lookups

### DIFF
--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -174,13 +174,14 @@ def get_by_short_id(
     organization_id: int,
     is_short_id_lookup: str,
     query: str,
-    project_ids: Collection[int] | None = None,
+    *,
+    project_ids: Collection[int] | None,
 ) -> Group | None:
     if is_short_id_lookup != "1":
         return None
     # A short id token anywhere in the query is treated as a direct hit,
-    # so it composes with filters. When project_ids is provided, the lookup is scoped to
-    # those projects so a short id for a project the caller cannot access does not resolve.
+    # so it composes with filters. project_ids scopes the lookup so a short id for a project
+    # the caller cannot access does not resolve; pass None only for org-wide callers.
     for token in query.split():
         if looks_like_short_id(token):
             try:

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -372,7 +372,8 @@ class GroupManager(BaseManager["Group"]):
         self,
         organization_id: int,
         short_id: str,
-        project_ids: Collection[int] | None = None,
+        *,
+        project_ids: Collection[int] | None,
     ):
         return self.by_qualified_short_id_bulk(
             organization_id, [short_id], project_ids=project_ids
@@ -382,18 +383,21 @@ class GroupManager(BaseManager["Group"]):
         self,
         organization_id: int,
         short_ids_raw: list[str],
-        project_ids: Collection[int] | None = None,
+        *,
+        project_ids: Collection[int] | None,
     ) -> Sequence[Group]:
         """
         Resolve qualified short ids (e.g. ``PROJECT-123``) to groups.
 
-        Always scoped to ``organization_id``. When ``project_ids`` is provided (including an
-        empty collection), the lookup is additionally scoped to those projects so that a short
-        id referencing a project the caller cannot access does not resolve. Callers that have
-        an authorized-project set (the projects the actor is allowed to see) should pass it to
-        enforce project-level permissions at the query layer rather than via a post-hoc check.
-        ``project_ids=None`` (the default) means "no project restriction" and must only be used
-        by callers that legitimately operate organization-wide.
+        Always scoped to ``organization_id``. ``project_ids`` is **required** (keyword-only, no
+        default) to prevent an accidental in-org IDOR: when it is a collection (including an
+        empty one), the lookup is additionally scoped to those projects so a short id
+        referencing a project the caller cannot access does not resolve. Callers with an
+        authorized-project set (the projects the actor is allowed to see) MUST pass it so
+        project-level permissions are enforced at the query layer rather than via a post-hoc
+        check. Pass ``project_ids=None`` ONLY when the caller legitimately operates
+        organization-wide (e.g. commit/PR linking, system RPCs, or reads already scoped to the
+        requested projects downstream); doing so is explicit and reviewable at the call site.
         """
         short_ids = []
         for short_id_raw in short_ids_raw:

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -139,18 +139,22 @@ class GroupTest(TestCase, SnubaTestCase):
 
         assert short_id.startswith("FOO-BAR-")
 
-        group2 = Group.objects.by_qualified_short_id(group.organization.id, short_id)
+        group2 = Group.objects.by_qualified_short_id(
+            group.organization.id, short_id, project_ids=None
+        )
 
         assert group2 == group
 
         with pytest.raises(Group.DoesNotExist):
             Group.objects.by_qualified_short_id(
-                group.organization.id, "server_name:my-server-with-dashes-0ac14dadda3b428cf"
+                group.organization.id,
+                "server_name:my-server-with-dashes-0ac14dadda3b428cf",
+                project_ids=None,
             )
 
         group.update(status=GroupStatus.PENDING_DELETION, substatus=None)
         with pytest.raises(Group.DoesNotExist):
-            Group.objects.by_qualified_short_id(group.organization.id, short_id)
+            Group.objects.by_qualified_short_id(group.organization.id, short_id, project_ids=None)
 
     def test_qualified_share_id_bulk(self) -> None:
         project = self.create_project(name="foo bar")
@@ -159,19 +163,20 @@ class GroupTest(TestCase, SnubaTestCase):
         group_short_id = group.qualified_short_id
         group_2_short_id = group_2.qualified_short_id
         assert [group] == Group.objects.by_qualified_short_id_bulk(
-            group.organization.id, [group_short_id]
+            group.organization.id, [group_short_id], project_ids=None
         )
         assert {group, group_2} == set(
             Group.objects.by_qualified_short_id_bulk(
                 group.organization.id,
                 [group_short_id, group_2_short_id],
+                project_ids=None,
             )
         )
 
         group.update(status=GroupStatus.PENDING_DELETION, substatus=None)
         with pytest.raises(Group.DoesNotExist):
             Group.objects.by_qualified_short_id_bulk(
-                group.organization.id, [group_short_id, group_2_short_id]
+                group.organization.id, [group_short_id, group_2_short_id], project_ids=None
             )
 
     def test_by_qualified_short_id_bulk_missing_id_colliding_short_id_across_projects(
@@ -194,7 +199,9 @@ class GroupTest(TestCase, SnubaTestCase):
         group_b.update(status=GroupStatus.PENDING_DELETION, substatus=None)
 
         with pytest.raises(Group.DoesNotExist):
-            Group.objects.by_qualified_short_id_bulk(org_id, [a_short_id, b_short_id])
+            Group.objects.by_qualified_short_id_bulk(
+                org_id, [a_short_id, b_short_id], project_ids=None
+            )
 
     def test_by_qualified_short_id_scoped_to_projects(self) -> None:
         project_a = self.create_project(name="proj a")
@@ -252,7 +259,9 @@ class GroupTest(TestCase, SnubaTestCase):
         short_id = group.qualified_short_id
 
         # Should resolve via case-insensitive slug fallback
-        resolved = Group.objects.by_qualified_short_id_bulk(group.organization.id, [short_id])
+        resolved = Group.objects.by_qualified_short_id_bulk(
+            group.organization.id, [short_id], project_ids=None
+        )
         assert resolved == [group]
 
     def test_first_last_release(self) -> None:


### PR DESCRIPTION
The final step of the short-id → group resolution hardening series. Makes `project_ids` a **required keyword-only** argument on `Group.objects.by_qualified_short_id` / `by_qualified_short_id_bulk` and on the `get_by_short_id` helper.

**Why:** the earlier PRs gave every caller a `project_ids` argument and threaded the right scope through. But while it had a `None` default, a *future* caller could silently omit it and fall back to organization-wide resolution — reintroducing the in-org IDOR (h1-3508011) this series fixed. Removing the default makes omission a `TypeError` + mypy error: you can't forget it, and the org-wide escape hatch must be written explicitly.

**Scope of change:** purely the signature (add `*`, drop the `= None` default) plus a docstring. No behavior change — every caller already passes `project_ids`:
- project-scoped callers pass the authorized projects (issue mutation/endpoints);
- legitimately org-wide callers pass an explicit, reviewable `project_ids=None` (commit/PR linking, the Seer RPC, and the search sites that are already project-scoped by the downstream Snuba query).

Also updates the direct manager-method tests to pass `project_ids=None`. mypy across all call sites confirms the required argument is satisfied everywhere.