### PR TITLE
ref(o11y): Add set_attribute calls in middleware integration classifications

### DIFF
--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -125,9 +125,10 @@ class IntegrationClassification(BaseClassification):
 
         parser_class = self.integration_parsers.get(provider)
         if not parser_class:
-            scope = sentry_sdk.get_isolation_scope()
-            scope.set_tag("provider", provider)
-            scope.set_tag("path", request.path)
+            sentry_sdk.set_tag("provider", provider)
+            sentry_sdk.set_attribute("provider", provider)
+            sentry_sdk.set_tag("path", request.path)
+            sentry_sdk.set_attribute("path", request.path)
             sentry_sdk.capture_exception(
                 Exception("Unknown provider was extracted from integration extension url")
             )


### PR DESCRIPTION
Supplement existing set_tag/set_context/set_extra calls with set_attribute so that data gets added to attributes-based telemetry as well. This will make the migration to span streaming easier.

Related to https://github.com/getsentry/sentry-python/issues/6537