### PR TITLE
ref(o11y): Add `scope.set_attribute` calls in API bases and query utils

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -548,6 +548,7 @@ class OrganizationEndpoint(Endpoint):
             if start and end:
                 total_seconds = (end - start).total_seconds()
                 sentry_sdk.set_tag("query.period", total_seconds)
+                sentry_sdk.set_attribute("query.period", total_seconds)
                 one_day = 86400
                 grouped_period = ">30d"
                 if total_seconds <= one_day:
@@ -559,6 +560,7 @@ class OrganizationEndpoint(Endpoint):
                 elif total_seconds <= one_day * 30:
                     grouped_period = "<=30d"
                 sentry_sdk.set_tag("query.period.grouped", grouped_period)
+                sentry_sdk.set_attribute("query.period.grouped", grouped_period)
         except InvalidParams as e:
             raise ParseError(detail=f"Invalid date range: {e}")
 
@@ -578,7 +580,9 @@ class OrganizationEndpoint(Endpoint):
 
         len_projects = len(projects)
         sentry_sdk.set_tag("query.num_projects", len_projects)
+        sentry_sdk.set_attribute("query.num_projects", len_projects)
         sentry_sdk.set_tag("query.num_projects.grouped", format_grouped_length(len_projects))
+        sentry_sdk.set_attribute("query.num_projects.grouped", format_grouped_length(len_projects))
         set_span_attribute("query.num_projects", len_projects)
 
         params: FilterParams = {

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -567,7 +567,8 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
             if use_rpc:
                 raise
             sentry_sdk.set_tag("user.invalid_interval", request.GET.get("interval"))
-            sentry_sdk.set_attribute("user.invalid_interval", request.GET.get("interval") or "")
+            if request.GET.get("interval"):
+                sentry_sdk.set_attribute("user.invalid_interval", request.GET.get("interval"))
             date_range = snuba_params.date_range
             stats_period = parse_stats_period(get_interval_from_range(date_range, False))
             rollup = int(stats_period.total_seconds()) if stats_period is not None else 3600

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -163,6 +163,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         if result is None:
             raise ParseError(detail=f"dataset must be one of: {', '.join(PUBLIC_DATASET_LABELS)}")
         sentry_sdk.set_tag("query.dataset", dataset_label)
+        sentry_sdk.set_attribute("query.dataset", dataset_label)
         return result
 
     def get_snuba_params(
@@ -190,6 +191,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                     raise ParseError(f"sampling mode: {sampling_mode} is not supported")
                 sampling_mode = cast(SAMPLING_MODES, sampling_mode.upper())
                 sentry_sdk.set_tag("sampling_mode", sampling_mode)
+                sentry_sdk.set_attribute("sampling_mode", sampling_mode)
 
             if quantize_date_params:
                 filter_params = self.quantize_date_params(request, filter_params)
@@ -289,16 +291,20 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         if has_errors and not has_transactions_data:
             decision = DashboardWidgetTypes.ERROR_EVENTS
             sentry_sdk.set_tag("discover.split_reason", "query_result")
+            sentry_sdk.set_attribute("discover.split_reason", "query_result")
         elif not has_errors and has_transactions_data:
             decision = DashboardWidgetTypes.TRANSACTION_LIKE
             sentry_sdk.set_tag("discover.split_reason", "query_result")
+            sentry_sdk.set_attribute("discover.split_reason", "query_result")
         else:
             # In the case that neither side has data, or both sides have data, default to errors.
             decision = DashboardWidgetTypes.ERROR_EVENTS
             source = DashboardDatasetSourcesTypes.FORCED.value
             sentry_sdk.set_tag("discover.split_reason", "default")
+            sentry_sdk.set_attribute("discover.split_reason", "default")
 
         sentry_sdk.set_tag("discover.split_decision", decision)
+        sentry_sdk.set_attribute("discover.split_decision", decision)
         if decision is not None and widget.discover_widget_split != decision:
             widget.discover_widget_split = decision
             widget.dataset_source = source
@@ -322,20 +328,25 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         if dataset_inferred_from_query is not None:
             decision = dataset_inferred_from_query
             sentry_sdk.set_tag("discover.split_reason", "inferred_from_query")
+            sentry_sdk.set_attribute("discover.split_reason", "inferred_from_query")
         elif has_errors and not has_transactions_data:
             decision = DiscoverSavedQueryTypes.ERROR_EVENTS
             sentry_sdk.set_tag("discover.split_reason", "query_result")
+            sentry_sdk.set_attribute("discover.split_reason", "query_result")
         elif not has_errors and has_transactions_data:
             decision = DiscoverSavedQueryTypes.TRANSACTION_LIKE
             sentry_sdk.set_tag("discover.split_reason", "query_result")
+            sentry_sdk.set_attribute("discover.split_reason", "query_result")
         else:
             # In the case that neither or both datasets return data,
             # default to Errors.
             decision = DiscoverSavedQueryTypes.ERROR_EVENTS
             dataset_source = DatasetSourcesTypes.FORCED.value
             sentry_sdk.set_tag("discover.split_reason", "default")
+            sentry_sdk.set_attribute("discover.split_reason", "default")
 
         sentry_sdk.set_tag("discover.split_decision", decision)
+        sentry_sdk.set_attribute("discover.split_decision", decision)
         if query.dataset != decision:
             query.dataset = decision
             query.dataset_source = dataset_source
@@ -556,6 +567,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
             if use_rpc:
                 raise
             sentry_sdk.set_tag("user.invalid_interval", request.GET.get("interval"))
+            sentry_sdk.set_attribute("user.invalid_interval", request.GET.get("interval") or "")
             date_range = snuba_params.date_range
             stats_period = parse_stats_period(get_interval_from_range(date_range, False))
             rollup = int(stats_period.total_seconds()) if stats_period is not None else 3600

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -204,7 +204,8 @@ class ProjectEndpoint(Endpoint):
 
         self.check_object_permissions(request, project)
 
-        sentry_sdk.get_isolation_scope().set_tag("project", project.id)
+        sentry_sdk.set_tag("project", project.id)
+        sentry_sdk.set_attribute("project", project.id)
 
         bind_organization_context(project.organization)
 

--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -245,6 +245,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
         conversation_ids = _extract_conversation_ids(conversation_ids_results)
 
         sentry_sdk.set_tag("ai_conversations.count", len(conversation_ids))
+        sentry_sdk.set_attribute("ai_conversations.count", len(conversation_ids))
 
         if not conversation_ids:
             return []

--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -126,11 +126,17 @@ def build_query_params_from_request(
             query = saved_search.query
 
     sentry_sdk.set_tag("search.query", query)
+    sentry_sdk.set_attribute("search.query", query)
     sentry_sdk.set_tag("search.sort", query_kwargs["sort_by"])
+    sentry_sdk.set_attribute("search.sort", query_kwargs["sort_by"])
     if projects:
         sentry_sdk.set_tag("search.projects", len(projects) if len(projects) <= 5 else ">5")
+        sentry_sdk.set_attribute("search.projects", len(projects) if len(projects) <= 5 else ">5")
     if environments:
         sentry_sdk.set_tag(
+            "search.environments", len(environments) if len(environments) <= 5 else ">5"
+        )
+        sentry_sdk.set_attribute(
             "search.environments", len(environments) if len(environments) <= 5 else ">5"
         )
     if query:

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -372,6 +372,7 @@ def handle_query_errors() -> Generator[None]:
     except InvalidColumnError as error:
         message = str(error)
         sentry_sdk.set_tag("query.error_reason", message)
+        sentry_sdk.set_attribute("query.error_reason", message)
         raise ParseError(detail=message)
     except InvalidSearchQuery as error:
         message = original_error = str(error)
@@ -379,34 +380,42 @@ def handle_query_errors() -> Generator[None]:
         if message.endswith("do not exist or are not actively selected."):
             message = "Project in query does not exist or not selected"
         sentry_sdk.set_tag("query.error_reason", message)
+        sentry_sdk.set_attribute("query.error_reason", message)
         logger.info("A query error was handled", extra={"query.error_reason": message})
         raise ParseError(detail=original_error)
     except ArithmeticError as error:
         message = str(error)
         sentry_sdk.set_tag("query.error_reason", message)
+        sentry_sdk.set_attribute("query.error_reason", message)
         raise ParseError(detail=message)
     except QueryOutsideRetentionError as error:
         sentry_sdk.set_tag("query.error_reason", "QueryOutsideRetentionError")
+        sentry_sdk.set_attribute("query.error_reason", "QueryOutsideRetentionError")
         raise ParseError(detail=str(error))
     except QueryIllegalTypeOfArgument:
         message = "Invalid query. Argument to function is wrong type."
         sentry_sdk.set_tag("query.error_reason", message)
+        sentry_sdk.set_attribute("query.error_reason", message)
         raise ParseError(detail=message)
     except IncompatibleMetricsQuery as error:
         message = str(error)
         sentry_sdk.set_tag("query.error_reason", f"Metric Error: {message}")
+        sentry_sdk.set_attribute("query.error_reason", f"Metric Error: {message}")
         raise ParseError(detail=message)
     except SnubaRPCRateLimitExceeded:
         sentry_sdk.set_tag("query.error_reason", "RateLimitExceeded")
+        sentry_sdk.set_attribute("query.error_reason", "RateLimitExceeded")
         raise Throttled(detail=RATE_LIMIT_ERROR_MESSAGE)
     except SnubaRPCTooManySimultaneous:
         sentry_sdk.set_tag("query.error_reason", "TooManySimultaneousQueries")
+        sentry_sdk.set_attribute("query.error_reason", "TooManySimultaneousQueries")
         raise Throttled(detail=RATE_LIMIT_ERROR_MESSAGE)
     except SnubaRPCError as error:
         message = "Internal error. Please try again."
         arg = error.args[0] if len(error.args) > 0 else None
         if isinstance(arg, TimeoutError):
             sentry_sdk.set_tag("query.error_reason", "Timeout")
+            sentry_sdk.set_attribute("query.error_reason", "Timeout")
             raise TimeoutException(detail=TIMEOUT_RPC_ERROR_MESSAGE)
         sentry_sdk.capture_exception(error)
         if hasattr(error, "debug"):
@@ -422,9 +431,11 @@ def handle_query_errors() -> Generator[None]:
         arg = error.args[0] if len(error.args) > 0 else None
         if isinstance(error, RateLimitExceeded):
             sentry_sdk.set_tag("query.error_reason", "RateLimitExceeded")
+            sentry_sdk.set_attribute("query.error_reason", "RateLimitExceeded")
             raise
         if isinstance(error, QueryTooManySimultaneous):
             sentry_sdk.set_tag("query.error_reason", "TooManySimultaneousQueries")
+            sentry_sdk.set_attribute("query.error_reason", "TooManySimultaneousQueries")
             raise Throttled(detail=RATE_LIMIT_ERROR_MESSAGE)
         if isinstance(
             error,
@@ -437,9 +448,11 @@ def handle_query_errors() -> Generator[None]:
             ReadTimeoutError,
         ):
             sentry_sdk.set_tag("query.error_reason", "Timeout")
+            sentry_sdk.set_attribute("query.error_reason", "Timeout")
             raise TimeoutException(detail=TIMEOUT_ERROR_MESSAGE)
         elif isinstance(error, (UnqualifiedQueryError)):
             sentry_sdk.set_tag("query.error_reason", str(error))
+            sentry_sdk.set_attribute("query.error_reason", str(error))
             raise ParseError(detail=str(error))
         elif isinstance(
             error,
@@ -468,6 +481,7 @@ def handle_query_errors() -> Generator[None]:
         is_timeout = "canceling statement due to statement timeout" in error_message
         if is_timeout:
             sentry_sdk.set_tag("query.error_reason", "Postgres statement timeout")
+            sentry_sdk.set_attribute("query.error_reason", "Postgres statement timeout")
             sentry_sdk.capture_exception(error, level="warning")
             raise Throttled(
                 detail="Query timeout. Please try with a smaller date range or fewer conditions."
@@ -486,6 +500,7 @@ def update_snuba_params_with_timestamp(
     faster than the default 7d or 14d queries"""
     # during the transition this is optional but it will become required for the trace view
     sentry_sdk.set_tag("trace_view.used_timestamp", timestamp_key in request.GET)
+    sentry_sdk.set_attribute("trace_view.used_timestamp", timestamp_key in request.GET)
     has_dates = params.start is not None and params.end is not None
     if timestamp_key in request.GET and has_dates:
         example_timestamp = parse_datetime_string(request.GET[timestamp_key])

--- a/src/sentry/utils/pagination_factory.py
+++ b/src/sentry/utils/pagination_factory.py
@@ -69,4 +69,8 @@ def get_paginator(
 def annotate_span_with_pagination_args(span: Span, per_page: int) -> None:
     span.set_data("Limit", per_page)
     sentry_sdk.set_tag("query.per_page", per_page)
+    sentry_sdk.set_attribute("query.per_page", per_page)
     sentry_sdk.set_tag("query.per_page.grouped", format_grouped_length(per_page, [1, 10, 50, 100]))
+    sentry_sdk.set_attribute(
+        "query.per_page.grouped", format_grouped_length(per_page, [1, 10, 50, 100])
+    )


### PR DESCRIPTION
Supplement existing `set_tag`/`set_context`/`set_extra` calls with `set_attribute` so that data gets added to attributes-based telemetry as well. This will make the migration to span streaming easier.

Additionally, if applicable, use top-level SDK API instead of scope APIs.

Related to https://github.com/getsentry/sentry-python/issues/6537