### PR TITLE
ref(o11y): Add `scope.set_attribute` calls in organization events endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -241,6 +241,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
         metrics_enhanced = dataset in {metrics_performance, metrics_enhanced_performance}
 
         sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
+        sentry_sdk.set_attribute("performance.metrics_enhanced", metrics_enhanced)
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
 
         # Force the referrer to "api.auth-token.events" for events requests authorized through a bearer token
@@ -251,6 +252,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                 and referrer.startswith("seer.")
             ):
                 sentry_sdk.set_tag("query.from_seer", True)
+                sentry_sdk.set_attribute("query.from_seer", True)
             else:
                 referrer = Referrer.API_AUTH_TOKEN_EVENTS.value
         elif referrer is None or not referrer:
@@ -363,6 +365,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                     if has_errors and has_other_data and not using_metrics:
                         # In the case that the original request was not using the metrics dataset, we cannot be certain that other data is solely transactions.
                         sentry_sdk.set_tag("third_split_query", True)
+                        sentry_sdk.set_attribute("third_split_query", True)
                         transaction_results = _data_fn(
                             transactions.query, offset, limit, scoped_query
                         )

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -198,6 +198,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
 
             allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
             sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
+            sentry_sdk.set_attribute("performance.metrics_enhanced", metrics_enhanced)
 
         try:
             use_on_demand_metrics, on_demand_metrics_type = self.handle_on_demand(request)
@@ -451,6 +452,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
                     if has_errors and has_other_data and not using_metrics:
                         # In the case that the original request was not using the metrics dataset, we cannot be certain that other data is solely transactions.
                         sentry_sdk.set_tag("third_split_query", True)
+                        sentry_sdk.set_attribute("third_split_query", True)
                         transactions_only_query = f"({query}) AND event.type:transaction"
                         transaction_results = _get_event_stats(
                             discover,

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -184,6 +184,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
             use_rpc = dataset in RPC_DATASETS
 
             sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
+            sentry_sdk.set_attribute("performance.metrics_enhanced", metrics_enhanced)
             try:
                 snuba_params = self.get_snuba_params(
                     request,

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -607,6 +607,7 @@ def create_transaction_params(
     """Can't use the transaction params for errors since traces can be errors only"""
     query_metadata = options.get("performance.traces.query_timestamp_projects")
     sentry_sdk.set_tag("trace_view.queried_timestamp_projects", query_metadata)
+    sentry_sdk.set_attribute("trace_view.queried_timestamp_projects", str(query_metadata))
     if not query_metadata:
         return snuba_params
 
@@ -967,8 +968,13 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointBase):
             len_transactions = len(transactions)
 
             sentry_sdk.set_tag("trace_view.trace", trace_id)
+            sentry_sdk.set_attribute("trace_view.trace", trace_id)
             sentry_sdk.set_tag("trace_view.transactions", len_transactions)
+            sentry_sdk.set_attribute("trace_view.transactions", len_transactions)
             sentry_sdk.set_tag(
+                "trace_view.transactions.grouped", format_grouped_length(len_transactions)
+            )
+            sentry_sdk.set_attribute(
                 "trace_view.transactions.grouped", format_grouped_length(len_transactions)
             )
             set_span_attribute("trace_view.transactions", len_transactions)
@@ -979,7 +985,11 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointBase):
 
             len_projects = len(projects)
             sentry_sdk.set_tag("trace_view.projects", len_projects)
+            sentry_sdk.set_attribute("trace_view.projects", len_projects)
             sentry_sdk.set_tag("trace_view.projects.grouped", format_grouped_length(len_projects))
+            sentry_sdk.set_attribute(
+                "trace_view.projects.grouped", format_grouped_length(len_projects)
+            )
             set_span_attribute("trace_view.projects", len_projects)
 
     def get(self, request: Request, organization: Organization, trace_id: str) -> HttpResponse:

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -238,6 +238,10 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsEndpointBase):
                 "performance.trendsv2.top_events",
                 top_trending_transactions.get("data", None) is not None,
             )
+            sentry_sdk.set_attribute(
+                "performance.trendsv2.top_events",
+                top_trending_transactions.get("data", None) is not None,
+            )
             if len(top_trending_transactions.get("data", [])) == 0:
                 return {}
 
@@ -304,6 +308,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsEndpointBase):
                 )
 
             sentry_sdk.set_tag("performance.trendsv2.trends", len(trending_events) > 0)
+            sentry_sdk.set_attribute("performance.trendsv2.trends", len(trending_events) > 0)
 
             return trending_events, trends_requests
 
@@ -358,6 +363,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsEndpointBase):
             )
 
             sentry_sdk.set_tag("performance.trendsv2.stats_data", bool(stats_data))
+            sentry_sdk.set_attribute("performance.trendsv2.stats_data", bool(stats_data))
 
             # Handle empty response
             if not bool(stats_data):

--- a/src/sentry/api/endpoints/organization_metrics_meta.py
+++ b/src/sentry/api/endpoints/organization_metrics_meta.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import set_tag
@@ -100,6 +101,7 @@ class OrganizationMetricsCompatibilitySums(OrganizationEventsEndpointBase):
                 metrics_count = sum_metrics["data"][0].get("count")
                 if metrics_count == 0:
                     set_tag("empty_metrics", True)
+                    sentry_sdk.set_attribute("empty_metrics", True)
 
                 data["sum"].update(
                     {

--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -164,6 +164,7 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
         serialized = serializer.validated_data
 
         sentry_sdk.set_tag("query.dataSource", serialized["dataSource"])
+        sentry_sdk.set_attribute("query.dataSource", serialized["dataSource"])
 
         with handle_query_errors():
             executor = FlamegraphExecutor(


### PR DESCRIPTION
Supplement existing `set_tag`/`set_context`/`set_extra` calls with `set_attribute` so that data gets added to attributes-based telemetry as well. This will make the migration to span streaming easier.

Additionally, if applicable, use top-level SDK API instead of scope APIs.

Related to https://github.com/getsentry/sentry-python/issues/6537