### PR TITLE
ref(o11y): Add `scope.set_attribute` calls in organization misc endpoints

### DIFF
--- a/src/sentry/api/endpoints/internal/rpc.py
+++ b/src/sentry/api/endpoints/internal/rpc.py
@@ -42,7 +42,8 @@ class InternalRpcServiceEndpoint(Endpoint):
         return False
 
     def post(self, request: Request, service_name: str, method_name: str) -> Response:
-        sentry_sdk.get_isolation_scope().set_tag("rpc_method", f"{service_name}.{method_name}")
+        sentry_sdk.set_tag("rpc_method", f"{service_name}.{method_name}")
+        sentry_sdk.set_attribute("rpc_method", f"{service_name}.{method_name}")
         if not self._is_authorized(request):
             raise PermissionDenied
 

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -94,7 +94,9 @@ class OrganizationSdkUpdatesEndpoint(OrganizationEndpoint):
 
         len_projects = len(projects)
         sentry_sdk.set_tag("query.num_projects", len_projects)
+        sentry_sdk.set_attribute("query.num_projects", len_projects)
         sentry_sdk.set_tag("query.num_projects.grouped", format_grouped_length(len_projects))
+        sentry_sdk.set_attribute("query.num_projects.grouped", format_grouped_length(len_projects))
 
         if len(projects) == 0:
             return Response([])

--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -32,20 +32,25 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
             return Response({"detail": f'Invalid tag key format for "{key}"'}, status=400)
 
         sentry_sdk.set_tag("query.tag_key", key)
+        sentry_sdk.set_attribute("query.tag_key", key)
 
         dataset = None
         if request.GET.get("dataset"):
             try:
                 dataset = Dataset(request.GET.get("dataset"))
                 sentry_sdk.set_tag("dataset", dataset.value)
+                sentry_sdk.set_attribute("dataset", dataset.value)
             except ValueError:
                 raise ParseError(detail="Invalid dataset parameter")
         elif request.GET.get("includeTransactions") == "1":
             sentry_sdk.set_tag("dataset", Dataset.Discover.value)
+            sentry_sdk.set_attribute("dataset", Dataset.Discover.value)
         elif request.GET.get("includeReplays") == "1":
             sentry_sdk.set_tag("dataset", Dataset.Replays.value)
+            sentry_sdk.set_attribute("dataset", Dataset.Replays.value)
         else:
             sentry_sdk.set_tag("dataset", Dataset.Events.value)
+            sentry_sdk.set_attribute("dataset", Dataset.Events.value)
 
         try:
             snuba_params = self.get_snuba_params(request, organization)

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -148,11 +148,17 @@ class OrganizationTagsEndpoint(OrganizationEndpoint):
 
                 # Setting the tag for now since the measurement is still experimental
                 sentry_sdk.set_tag("custom_tags.count", len(final_results))
+                sentry_sdk.set_attribute("custom_tags.count", len(final_results))
                 sentry_sdk.set_tag(
                     "custom_tags.count.grouped",
                     format_grouped_length(len(final_results), [1, 10, 50, 100]),
                 )
+                sentry_sdk.set_attribute(
+                    "custom_tags.count.grouped",
+                    format_grouped_length(len(final_results), [1, 10, 50, 100]),
+                )
                 sentry_sdk.set_tag("dataset_queried", dataset.value)
+                sentry_sdk.set_attribute("dataset_queried", dataset.value)
                 set_span_attribute("custom_tags.count", len(final_results))
 
         return Response(serialize(final_results, request.user, TagKeySerializer()))

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -582,6 +582,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
             )
 
             sentry_sdk.set_context("api_response", {"attributes": attributes})
+            sentry_sdk.set_attribute("api_response.attributes", str(attributes))
             span.set_data("attribute_count", len(attributes))
             span.set_data("attribute_type", attribute_type)
         return attributes, debug_info
@@ -654,6 +655,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                     attribute_keys[attr_key["key"]] = attr_key
         attributes = list(attribute_keys.values())
         sentry_sdk.set_context("api_response", {"attributes": attributes})
+        sentry_sdk.set_attribute("api_response.attributes", str(attributes))
         return attributes
 
 
@@ -676,6 +678,7 @@ class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttribut
             )
 
         sentry_sdk.set_tag("query.attribute_key", key)
+        sentry_sdk.set_attribute("query.attribute_key", key)
 
         serialized = serializer.validated_data
         substring_match = serialized.get("substring_match", "")

--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -377,6 +377,7 @@ class ProjectTraceItemDetailsEndpoint(ProjectEndpoint):
         trace_id = serialized.get("trace_id")
         item_type = serialized.get("item_type")
         sentry_sdk.set_tag("trace_item_details.item_type", item_type)
+        sentry_sdk.set_attribute("trace_item_details.item_type", item_type)
         referrer = serialized.get("referrer", Referrer.API_ORGANIZATION_TRACE_ITEM_DETAILS.value)
 
         trace_item_type = None

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import MutableMapping
 from typing import Any
 
+import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import set_tag, start_span
@@ -48,6 +49,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
 
         version = request.GET.get("version") or "1"
         set_tag("relay_protocol_version", version)
+        sentry_sdk.set_attribute("relay_protocol_version", version)
 
         if version == "3" and request.relay_request_data.get("global"):
             response["global"] = get_global_config()
@@ -79,8 +81,10 @@ class RelayProjectConfigsEndpoint(Endpoint):
         considering them for the full build.
         """
         set_tag("relay_endpoint_version", version)
+        sentry_sdk.set_attribute("relay_endpoint_version", version)
         no_cache = request.relay_request_data.get("noCache") or False
         set_tag("relay_no_cache", no_cache)
+        sentry_sdk.set_attribute("relay_no_cache", no_cache)
 
         post_or_schedule = True
         reason = "version"
@@ -94,7 +98,9 @@ class RelayProjectConfigsEndpoint(Endpoint):
             version = "2"  # Downgrade to 2 for reporting metrics
 
         set_tag("relay_use_post_or_schedule", post_or_schedule)
+        sentry_sdk.set_attribute("relay_use_post_or_schedule", post_or_schedule)
         set_tag("relay_use_post_or_schedule_rejected", reason)
+        sentry_sdk.set_attribute("relay_use_post_or_schedule_rejected", reason)
         if version == "2":
             metrics.incr(
                 "api.endpoints.relay.project_configs.post",

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -442,6 +442,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
                     "org_slug": self.context["organization"].slug,
                 },
             )
+            sentry_sdk.set_attribute("dashboard.org_slug", self.context["organization"].slug)
             sentry_sdk.capture_message("Created or updated widget with discover dataset.")
             raise serializers.ValidationError(
                 {
@@ -974,6 +975,13 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
                             "requested_widget_ids": widget_ids,
                         },
                     )
+                    sentry_sdk.set_attribute("dashboard.org_slug", instance.organization.slug)
+                    sentry_sdk.set_attribute("dashboard.dashboard_id", instance.id)
+                    sentry_sdk.set_attribute("dashboard.widget_id", widget_id)
+                    sentry_sdk.set_attribute(
+                        "dashboard.existing_widget_ids", str(list(existing_map.keys()))
+                    )
+                    sentry_sdk.set_attribute("dashboard.requested_widget_ids", str(widget_ids))
                     sentry_sdk.capture_message(
                         "Attempted to update widget not belonging to dashboard."
                     )

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -128,6 +128,7 @@ class DataExportQuerySerializer(serializers.Serializer[dict[str, Any]]):
             start, end = get_date_range_from_params(query_info)
         except InvalidParams as err:
             sentry_sdk.set_tag("query.error_reason", "Invalid date params")
+            sentry_sdk.set_attribute("query.error_reason", "Invalid date params")
             sentry_sdk.capture_exception(err)
             raise serializers.ValidationError("Invalid date parameters.")
 


### PR DESCRIPTION
Supplement existing `set_tag`/`set_context`/`set_extra` calls with `set_attribute` so that data gets added to attributes-based telemetry as well. This will make the migration to span streaming easier.

Additionally, if applicable, use top-level SDK API instead of scope APIs.

Related to https://github.com/getsentry/sentry-python/issues/6537