### PR TITLE
ref(o11y): Add `scope.set_attribute` calls in tasks

### DIFF
--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -242,7 +242,8 @@ def assemble_dif(project_id, name, checksum, chunks, debug_id=None, **kwargs):
     from sentry.models.debugfile import BadDif, create_dif_from_file
     from sentry.models.project import Project
 
-    sentry_sdk.get_isolation_scope().set_tag("project", project_id)
+    sentry_sdk.set_tag("project", project_id)
+    sentry_sdk.set_attribute("project", project_id)
 
     delete_file = False
 

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -85,6 +85,7 @@ def process_commit_context(
             project = Project.objects.get_from_cache(id=project_id)
             group = Group.objects.get_from_cache(id=group_id)
             set_tag("organization.slug", project.organization.slug)
+            sentry_sdk.set_attribute("organization.slug", project.organization.slug)
             basic_logging_details = {
                 "event": event_id,
                 "group": group_id,

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -91,6 +91,7 @@ def fetch_commits_for_compare_range(
         isinstance(repo.provider, str) and repo.provider in GITHUB_CACHEABLE_REPOSITORY_PROVIDERS
     )
     set_tag("compare_commits_cache_enabled", cache_enabled)
+    sentry_sdk.set_attribute("compare_commits_cache_enabled", cache_enabled)
     if cache_enabled:
         cache_key = get_github_compare_commits_cache_key(
             repo.organization_id, repo.id, repo.provider, start_sha, end_sha
@@ -353,6 +354,7 @@ def fetch_commits(
         except Release.DoesNotExist:
             pass
     set_tag("organization.slug", release.organization.slug)
+    sentry_sdk.set_attribute("organization.slug", release.organization.slug)
     extra = {
         "organization_id": release.organization_id,
         "user_id": user_id,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -602,6 +602,7 @@ def post_process_group(
 
         is_reprocessed = is_reprocessed_event(event.data)
         sentry_sdk.set_tag("is_reprocessed", is_reprocessed)
+        sentry_sdk.set_attribute("is_reprocessed", is_reprocessed)
 
         metric_tags = {}
         if group_id:

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -63,6 +63,7 @@ def process_incr(
 
     if model:
         sentry_sdk.set_tag("model", model._meta.model_name)
+        sentry_sdk.set_attribute("model", model._meta.model_name)
 
     buffer.backend.process(
         model=model,
@@ -78,5 +79,6 @@ def buffer_incr(model: type[Model], *args, **kwargs):
     from sentry import buffer
 
     sentry_sdk.set_tag("model", model._meta.model_name)
+    sentry_sdk.set_attribute("model", model._meta.model_name)
 
     buffer.backend.incr(model, *args, **kwargs)

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -48,6 +48,7 @@ def build_project_config(public_key=None, **kwargs):
     Do not invoke this task directly, instead use :func:`schedule_build_project_config`.
     """
     sentry_sdk.set_tag("public_key", public_key)
+    sentry_sdk.set_attribute("public_key", public_key)
 
     try:
         from sentry.models.projectkey import ProjectKey
@@ -250,11 +251,16 @@ def invalidate_project_config(
         # Cannot use bind_organization_context here because we do not have a
         # model and don't want to fetch one
         sentry_sdk.set_tag("organization_id", organization_id)
+        sentry_sdk.set_attribute("organization_id", organization_id)
     if public_key:
         sentry_sdk.set_tag("public_key", public_key)
+        sentry_sdk.set_attribute("public_key", public_key)
     sentry_sdk.set_tag("trigger", trigger)
+    sentry_sdk.set_attribute("trigger", trigger)
     sentry_sdk.set_tag("trigger_details", trigger_details)
+    sentry_sdk.set_attribute("trigger_details", trigger_details)
     sentry_sdk.set_context("kwargs", kwargs)
+    sentry_sdk.set_attribute("kwargs", str(kwargs))
 
     updated_configs = compute_configs(
         organization_id=organization_id, project_id=project_id, public_key=public_key

--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -38,7 +38,9 @@ def reprocess_group(
     acting_user_id: int | None = None,
 ) -> None:
     sentry_sdk.set_tag("project", project_id)
+    sentry_sdk.set_attribute("project", project_id)
     sentry_sdk.set_tag("group_id", group_id)
+    sentry_sdk.set_attribute("group_id", group_id)
 
     from sentry.reprocessing2 import (
         CannotReprocess,
@@ -49,6 +51,7 @@ def reprocess_group(
     )
 
     sentry_sdk.set_tag("is_start", "false")
+    sentry_sdk.set_attribute("is_start", "false")
 
     # Only executed once during reprocessing
     if start_time is None:
@@ -56,6 +59,7 @@ def reprocess_group(
         start_time = time.time()
         metrics.incr("events.reprocessing.start_group_reprocessing", sample_rate=1.0)
         sentry_sdk.set_tag("is_start", "true")
+        sentry_sdk.set_attribute("is_start", "true")
         new_group_id = start_group_reprocessing(
             project_id,
             group_id,
@@ -163,8 +167,11 @@ def handle_remaining_events(
     See doc comment in sentry.reprocessing2.
     """
     sentry_sdk.set_tag("project", project_id)
+    sentry_sdk.set_attribute("project", project_id)
     sentry_sdk.set_tag("old_group_id", old_group_id)
+    sentry_sdk.set_attribute("old_group_id", old_group_id)
     sentry_sdk.set_tag("new_group_id", new_group_id)
+    sentry_sdk.set_attribute("new_group_id", new_group_id)
 
     from sentry.models.group import Group
     from sentry.reprocessing2 import EVENT_MODELS_TO_MIGRATE, pop_batched_events_from_redis

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -55,6 +55,7 @@ def generate_summary_and_run_automation(group_id: int, **kwargs) -> None:
 
     trigger_path = kwargs.get("trigger_path", "unknown")
     sentry_sdk.set_tag("trigger_path", trigger_path)
+    sentry_sdk.set_attribute("trigger_path", trigger_path)
 
     group = _get_group_or_log(group_id, "generate_summary_and_run_automation")
     if group is None:
@@ -196,7 +197,9 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     organization = Organization.objects.get(id=organization_id)
 
     sentry_sdk.set_tag("organization_id", organization.id)
+    sentry_sdk.set_attribute("organization_id", organization.id)
     sentry_sdk.set_tag("organization_slug", organization.slug)
+    sentry_sdk.set_attribute("organization_slug", organization.slug)
 
     # Set org-level options
     organization.update_option(

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -195,7 +195,9 @@ def prepare_organization_report(
         return
     organization = Organization.objects.get(id=organization_id)
     set_tag("org.slug", organization.slug)
+    sentry_sdk.set_attribute("org.slug", organization.slug)
     set_tag("org.id", organization_id)
+    sentry_sdk.set_attribute("org.id", organization_id)
     with WeeklyReportSLO(
         operation_type=WeeklyReportOperationType.PREPARE_ORGANIZATION_REPORT, dry_run=dry_run
     ).capture() as lifecycle:
@@ -214,6 +216,7 @@ def prepare_organization_report(
         with sentry_sdk.start_span(op="weekly_reports.check_if_ctx_is_empty"):
             report_is_available = not ctx.is_empty()
         set_tag("report.available", report_is_available)
+        sentry_sdk.set_attribute("report.available", report_is_available)
 
         if not report_is_available:
             lifecycle.record_halt(WeeklyReportHaltReason.EMPTY_REPORT)


### PR DESCRIPTION
Supplement existing `set_tag`/`set_context`/`set_extra` calls with `set_attribute` so that data gets added to attributes-based telemetry as well. This will make the migration to span streaming easier.

Additionally, if applicable, use top-level SDK API instead of scope APIs.

Related to https://github.com/getsentry/sentry-python/issues/6537