### PR TITLE
fix(seer): Wire project settings repo writes through new repos endpoint

### DIFF
--- a/static/app/utils/seer/useUpdateSeerRepos.ts
+++ b/static/app/utils/seer/useUpdateSeerRepos.ts
@@ -7,9 +7,9 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-export type SeerRepoEntry = {
-  repositoryId: number;
+type SeerRepoEntry = {
   branchName: string | null;
+  repositoryId: number;
   branchOverrides?: BranchOverride[];
   instructions?: string | null;
 };

--- a/static/app/utils/seer/useUpdateSeerRepos.ts
+++ b/static/app/utils/seer/useUpdateSeerRepos.ts
@@ -1,0 +1,47 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+
+import {projectSeerPreferencesApiOptions} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
+import type {BranchOverride} from 'sentry/components/events/autofix/types';
+import type {Project} from 'sentry/types/project';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+export type SeerRepoEntry = {
+  repositoryId: number;
+  branchName: string | null;
+  branchOverrides?: BranchOverride[];
+  instructions?: string | null;
+};
+
+/**
+ * Replaces the full set of Seer repos for a project via the dedicated repos
+ * endpoint, which looks up repos by internal repository ID. This avoids the
+ * whitespace-stripping bug in the legacy preferences endpoint that caused
+ * GitLab repos with spaces in their names to produce "Invalid repository"
+ * errors on save.
+ */
+export function useUpdateSeerRepos(project: Project) {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (repos: SeerRepoEntry[]) =>
+      fetchMutation({
+        method: 'PUT',
+        url: getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/seer/repos/', {
+          path: {
+            organizationIdOrSlug: organization.slug,
+            projectIdOrSlug: project.slug,
+          },
+        }),
+        data: {repos},
+      }),
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: projectSeerPreferencesApiOptions(organization.slug, project.slug)
+          .queryKey,
+      });
+    },
+  });
+}

--- a/static/app/views/settings/projectSeer/autofixRepositories.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepositories.tsx
@@ -12,11 +12,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
-import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
-import type {
-  ProjectSeerPreferences,
-  RepoSettings,
-} from 'sentry/components/events/autofix/types';
+import type {RepoSettings} from 'sentry/components/events/autofix/types';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
@@ -31,6 +27,7 @@ import {
   selectUniqueRepos,
 } from 'sentry/utils/repositories/repoQueryOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useUpdateSeerRepos} from 'sentry/utils/seer/useUpdateSeerRepos';
 
 import {AddAutofixRepoModal} from './addAutofixRepoModal';
 import {AutofixRepoItem} from './autofixRepoItem';
@@ -53,23 +50,12 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
   const {data: repositories, isFetching: isFetchingRepositories} = repositoriesQuery;
   const {data, isPending: isLoadingPreferences} = useProjectSeerPreferences(project);
   const {preference, code_mapping_repos: codeMappingRepos} = data ?? {};
-  const {mutate: updateProjectSeerPreferences} = useUpdateProjectSeerPreferences(project);
+  const {mutate: updateSeerRepos} = useUpdateSeerRepos(project);
 
   const [selectedRepoIds, setSelectedRepoIds] = useState<string[]>([]);
   const [repoSettings, setRepoSettings] = useState<Record<string, RepoSettings>>({});
   const [showSaveNotice, setShowSaveNotice] = useState(false);
 
-  const getDefaultStoppingPoint =
-    useCallback((): ProjectSeerPreferences['automated_run_stopping_point'] => {
-      if (organization.features.includes('seat-based-seer-enabled')) {
-        return organization.autoOpenPrs ? 'open_pr' : 'code_changes';
-      }
-      return 'root_cause';
-    }, [organization.features, organization.autoOpenPrs]);
-
-  const [automatedRunStoppingPoint, setAutomatedRunStoppingPoint] = useState<
-    ProjectSeerPreferences['automated_run_stopping_point']
-  >(getDefaultStoppingPoint());
 
   useEffect(() => {
     if (repositories) {
@@ -98,9 +84,6 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
         });
 
         setRepoSettings(initialSettings);
-        setAutomatedRunStoppingPoint(
-          preference.automated_run_stopping_point || getDefaultStoppingPoint()
-        );
       } else if (codeMappingRepos?.length) {
         // Set default settings using codeMappingRepos when no preferences exist
         const repoIds = codeMappingRepos.map(repo => repo.external_id);
@@ -116,65 +99,30 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
         });
 
         setRepoSettings(initialSettings);
-        setAutomatedRunStoppingPoint(getDefaultStoppingPoint());
       }
     }
-  }, [
-    preference,
-    repositories,
-    codeMappingRepos,
-    updateProjectSeerPreferences,
-    getDefaultStoppingPoint,
-  ]);
+  }, [preference, repositories, codeMappingRepos]);
 
   const updatePreferences = useCallback(
-    (
-      updatedIds?: string[],
-      updatedSettings?: Record<string, RepoSettings>,
-      newStoppingPoint?: 'root_cause' | 'solution' | 'code_changes' | 'open_pr'
-    ) => {
+    (updatedIds?: string[], updatedSettings?: Record<string, RepoSettings>) => {
       if (!repositories) {
         return;
       }
       const idsToUse = updatedIds || selectedRepoIds;
       const settingsToUse = updatedSettings || repoSettings;
-      const stoppingPointToUse = newStoppingPoint || automatedRunStoppingPoint;
       const selectedRepos = repositories.filter(repo =>
         idsToUse.includes(repo.externalId)
       );
-      const reposData = selectedRepos.map(repo => {
-        const [owner, name] = (repo.name || '/').split('/');
-        let provider = repo.provider?.id || '';
-        if (provider?.startsWith('integrations:')) {
-          provider = provider.split(':')[1]!;
-        }
-
-        return {
-          organization_id: parseInt(organization.id, 10),
-          integration_id: repo.integrationId,
-          provider,
-          owner: owner || '',
-          name: name || repo.name || '',
-          external_id: repo.externalId,
-          branch_name: settingsToUse[repo.externalId]?.branch || '',
-          instructions: settingsToUse[repo.externalId]?.instructions || '',
-          branch_overrides: settingsToUse[repo.externalId]?.branch_overrides || [],
-        };
-      });
-      updateProjectSeerPreferences({
-        repositories: reposData,
-        automated_run_stopping_point: stoppingPointToUse,
-      });
+      const reposPayload = selectedRepos.map(repo => ({
+        repositoryId: Number(repo.id),
+        branchName: settingsToUse[repo.externalId]?.branch || null,
+        instructions: settingsToUse[repo.externalId]?.instructions || null,
+        branchOverrides: settingsToUse[repo.externalId]?.branch_overrides || [],
+      }));
+      updateSeerRepos(reposPayload);
       setShowSaveNotice(true);
     },
-    [
-      organization.id,
-      repositories,
-      selectedRepoIds,
-      repoSettings,
-      automatedRunStoppingPoint,
-      updateProjectSeerPreferences,
-    ]
+    [repositories, selectedRepoIds, repoSettings, updateSeerRepos]
   );
 
   const handleSaveModalSelections = useCallback(

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -108,9 +108,10 @@ describe('ProjectSeer', () => {
   });
 
   it('can add a repository', async () => {
-    const seerPreferencesPostRequest = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
-      method: 'POST',
+    const seerReposPutRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/repos/`,
+      method: 'PUT',
+      status: 204,
     });
 
     render(<ProjectSeer />, {
@@ -164,46 +165,36 @@ describe('ProjectSeer', () => {
     expect(await screen.findByText('getsentry/seer')).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(seerPreferencesPostRequest).toHaveBeenCalledWith(
+      expect(seerReposPutRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          data: expect.objectContaining({
-            automated_run_stopping_point: 'root_cause',
-            repositories: [
+          data: {
+            repos: [
               {
-                organization_id: 3,
-                branch_name: '',
-                external_id: '101',
-                instructions: '',
-                name: 'sentry',
-                owner: 'getsentry',
-                provider: 'github',
-                integration_id: '201',
-                branch_overrides: [],
+                repositoryId: 1,
+                branchName: null,
+                instructions: null,
+                branchOverrides: [],
               },
               {
-                organization_id: 3,
-                branch_name: '',
-                external_id: '102',
-                instructions: '',
-                name: 'seer',
-                owner: 'getsentry',
-                provider: 'github',
-                integration_id: '202',
-                branch_overrides: [],
+                repositoryId: 2,
+                branchName: null,
+                instructions: null,
+                branchOverrides: [],
               },
             ],
-          }),
+          },
         })
       );
     });
-    expect(seerPreferencesPostRequest).toHaveBeenCalledTimes(1);
+    expect(seerReposPutRequest).toHaveBeenCalledTimes(1);
   });
 
   it('can update repository settings', async () => {
-    const seerPreferencesPostRequest = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
-      method: 'POST',
+    const seerReposPutRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/repos/`,
+      method: 'PUT',
+      status: 204,
     });
 
     render(<ProjectSeer />, {
@@ -229,35 +220,30 @@ describe('ProjectSeer', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Save'}));
 
     await waitFor(() => {
-      expect(seerPreferencesPostRequest).toHaveBeenCalledWith(
+      expect(seerReposPutRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          data: expect.objectContaining({
-            automated_run_stopping_point: 'root_cause',
-            repositories: [
+          data: {
+            repos: [
               {
-                organization_id: 3,
-                external_id: '101',
-                name: 'sentry',
-                owner: 'getsentry',
-                provider: 'github',
-                branch_name: 'develop',
+                repositoryId: 1,
+                branchName: 'develop',
                 instructions: 'Use Conventional Commits',
-                integration_id: '201',
-                branch_overrides: [],
+                branchOverrides: [],
               },
             ],
-          }),
+          },
         })
       );
     });
-    expect(seerPreferencesPostRequest).toHaveBeenCalledTimes(1);
+    expect(seerReposPutRequest).toHaveBeenCalledTimes(1);
   });
 
   it('can remove a repository', async () => {
-    const seerPreferencesPostRequest = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
-      method: 'POST',
+    const seerReposPutRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/repos/`,
+      method: 'PUT',
+      status: 204,
     });
 
     render(<ProjectSeer />, {
@@ -290,17 +276,14 @@ describe('ProjectSeer', () => {
     });
 
     await waitFor(() => {
-      expect(seerPreferencesPostRequest).toHaveBeenCalledWith(
+      expect(seerReposPutRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          data: expect.objectContaining({
-            automated_run_stopping_point: 'root_cause',
-            repositories: [],
-          }),
+          data: {repos: []},
         })
       );
     });
-    expect(seerPreferencesPostRequest).toHaveBeenCalledTimes(1);
+    expect(seerReposPutRequest).toHaveBeenCalledTimes(1);
   });
 
   it('can update the autofix autorun threshold setting', async () => {


### PR DESCRIPTION
## Problem

The Seer project settings page (`/settings/seer/projects/{project}/`) was still writing repository add/remove/update through the old `ProjectSeerPreferencesEndpoint` (`POST .../seer/preferences/`). That endpoint's serializer looks up repos by `(provider, owner, name, external_id)` and strips whitespace from `owner` and `name` during lookup.

GitLab stores repo names with spaces — e.g. `"My Group / My Repo"` — so after whitespace-stripping the lookup always failed and returned `{"detail": "Invalid repository"}` (HTTP 400). The UI showed "Failed to connect repositories", and customers with >8 GitLab repos got stuck: they couldn't add (8-repo limit) OR delete (this bug).

## Fix

Introduces `useUpdateSeerRepos`, a new hook that calls `PUT /projects/{org}/{project}/seer/repos/` — the endpoint that looks up repos by internal repository ID, immune to the whitespace issue. `AutofixRepositories` now uses this hook for all repo writes instead of the preferences endpoint.

This follows the same pattern as #117340, which fixed the Autofix modal submit path.

**Two-sentence scope:** This PR only changes the repo write path for `AutofixRepositories`. Stopping point, automation handoff, and other settings remain on the existing preferences/settings endpoints unchanged.

**Side cleanup:** Removes the dead `automatedRunStoppingPoint` state from `AutofixRepositories` — the field was read from preferences on mount but never changed in this component; stopping point is owned exclusively by `ProjectSeerGeneralForm` in `index.tsx`.

## Testing

Updated `index.spec.tsx` to assert on `PUT .../seer/repos/` with `{repos: [{repositoryId, branchName, instructions, branchOverrides}]}` for the add, update, and remove repository tests.

Manual validation: see replay [8640a02fc92048e7afd5e2f5d100f28d](https://sentry.sentry.io/replays/8640a02fc92048e7afd5e2f5d100f28d/) captured on the finverse org on Jun 12 showing the broken flow.

---
Fixes #117489

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0AKG192UP3%3A1781237406.446129%22)