### PR TITLE
feat(seer): Attribute autofix referrer to MCP for MCP requests

### DIFF
--- a/src/sentry/issues/action_log/base.py
+++ b/src/sentry/issues/action_log/base.py
@@ -14,6 +14,7 @@ from sentry.issues.action_log.types import SYSTEM_ACTOR, GroupAction, GroupActio
 from sentry.issues.groupactionlogentry import GroupActionLogEntry
 from sentry.middleware import is_frontend_request
 from sentry.utils import metrics
+from sentry.utils.http import is_mcp_request
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,6 @@ logger = logging.getLogger(__name__)
 # If you're adding a new caller to an instrumented function (e.g. GroupAssignee.objects.assign),
 # wrap it with action_context_scope() so the action gets proper source attribution.
 
-MCP_USER_AGENT_PREFIX = "sentry-mcp/"
 MCP_CLIENT_FAMILY_HEADER = "HTTP_X_SENTRY_MCP_CLIENT_FAMILY"
 SEER_REFERRER_HEADER = "HTTP_X_SEER_REFERRER"
 
@@ -73,7 +73,7 @@ def resolve_action_source(request: Request) -> str:
     """
     user_agent = request.META.get("HTTP_USER_AGENT", "")
 
-    if user_agent.startswith(MCP_USER_AGENT_PREFIX):
+    if is_mcp_request(request):
         family = request.META.get(MCP_CLIENT_FAMILY_HEADER, "").strip().lower()
         if family in KNOWN_MCP_CLIENT_FAMILIES:
             return f"{ActionSource.MCP}:{family}"

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -64,6 +64,7 @@ from sentry.seer.autofix.utils import (
 )
 from sentry.seer.models import SeerPermissionError
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils.http import is_mcp_request
 
 logger = logging.getLogger(__name__)
 
@@ -74,8 +75,12 @@ def _is_unknown_run_id_error(error: SeerPermissionError) -> bool:
     return getattr(error, "message", None) == UNKNOWN_RUN_ID_FOR_GROUP
 
 
-def _parse_autofix_referrer(raw: str | None) -> AutofixReferrer:
+def _parse_autofix_referrer(raw: str | None, request: Request) -> AutofixReferrer:
     if raw is None:
+        # Fall back to the request origin: requests from the Sentry MCP server are
+        # attributed to MCP, everything else to the generic endpoint referrer.
+        if is_mcp_request(request):
+            return AutofixReferrer.MCP
         return AutofixReferrer.GROUP_AUTOFIX_ENDPOINT
     try:
         return AutofixReferrer(raw)
@@ -236,7 +241,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 handoff_result: AutofixHandoffResponse = trigger_coding_agent_handoff(
                     group=group,
                     run_id=run_id,
-                    referrer=_parse_autofix_referrer(data.get("referrer")),
+                    referrer=_parse_autofix_referrer(data.get("referrer"), request),
                     integration_id=integration_id,
                     provider=provider,
                     user_id=request.user.id if request.user else None,
@@ -258,7 +263,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 trigger_push_changes(
                     group,
                     run_id,
-                    referrer=_parse_autofix_referrer(data.get("referrer")),
+                    referrer=_parse_autofix_referrer(data.get("referrer"), request),
                     repo_name=repo_name,
                 )
             except SeerPermissionError:
@@ -273,7 +278,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
             run_id = trigger_autofix_agent(
                 group=group,
                 step=AutofixStep(step),
-                referrer=_parse_autofix_referrer(data.get("referrer")),
+                referrer=_parse_autofix_referrer(data.get("referrer"), request),
                 stopping_point=AutofixStoppingPoint(stopping_point) if stopping_point else None,
                 run_id=run_id,
                 user_context=data.get("user_context"),

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -7,11 +7,16 @@ from urllib.parse import quote, urljoin, urlparse
 from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.http import HttpRequest
+from rest_framework.request import Request
 
 from sentry import options
 
 if TYPE_CHECKING:
     from sentry.models.project import Project
+
+# User-agent prefix set by the official Sentry MCP server (source of truth:
+# getsentry/sentry-mcp). Used to attribute requests originating from the MCP.
+MCP_USER_AGENT_PREFIX = "sentry-mcp/"
 
 
 class ParsedUriMatch(NamedTuple):
@@ -210,6 +215,14 @@ def origin_from_request(request: HttpRequest) -> str | None:
     if rv in ("", "null"):
         rv = origin_from_url(request.META.get("HTTP_REFERER"))
     return rv
+
+
+def is_mcp_request(request: HttpRequest | Request) -> bool:
+    """
+    Whether the request originated from the official Sentry MCP server, identified
+    by its `sentry-mcp/` user-agent prefix.
+    """
+    return request.META.get("HTTP_USER_AGENT", "").startswith(MCP_USER_AGENT_PREFIX)
 
 
 def percent_encode(val: str) -> str:

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -56,6 +56,43 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         mock_trigger_explorer.assert_called_once()
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    def test_post_from_mcp_defaults_referrer_to_mcp(self, mock_trigger_explorer):
+        """A request from the Sentry MCP server defaults the referrer to api.mcp."""
+        group = self.create_group()
+        mock_trigger_explorer.return_value = 123
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "root_cause"},
+            format="json",
+            headers={
+                "user-agent": "sentry-mcp/0.35.0 (https://mcp.sentry.dev)",
+                "X-Sentry-MCP-Client-Family": "cursor",
+            },
+        )
+
+        assert response.status_code == 202, response.data
+        assert mock_trigger_explorer.call_args.kwargs["referrer"] == AutofixReferrer.MCP
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    def test_post_explicit_referrer_overrides_mcp_default(self, mock_trigger_explorer):
+        """An explicitly supplied referrer takes precedence over the MCP default."""
+        group = self.create_group()
+        mock_trigger_explorer.return_value = 123
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "root_cause", "referrer": AutofixReferrer.WEB.value},
+            format="json",
+            headers={"user-agent": "sentry-mcp/0.35.0 (https://mcp.sentry.dev)"},
+        )
+
+        assert response.status_code == 202, response.data
+        assert mock_trigger_explorer.call_args.kwargs["referrer"] == AutofixReferrer.WEB
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_stopping_point(self, mock_trigger_explorer):
         """Stopping point forces the step to be root_cause"""
         group = self.create_group()


### PR DESCRIPTION
When a Seer issue-fix (autofix) run is triggered through the public group autofix endpoint without an explicit `referrer`, it previously always defaulted to `api.group_ai_autofix`. This PR makes it default to `api.mcp` (`AutofixReferrer.MCP`) when the request originates from the official Sentry MCP server, so MCP-triggered runs are attributed correctly.

## Detection

MCP requests are identified by the `sentry-mcp/` user-agent prefix — the same authoritative signal `resolve_action_source` uses to gate MCP attribution. The `X-Sentry-MCP-Client-Family` header is only a refinement (it sub-buckets into `mcp:cursor` etc.) and is not required to be present, so detection stays on the user-agent.

## Changes

- Extracted the MCP user-agent detection into a reusable `is_mcp_request()` helper in `sentry.utils.http` (alongside the other request helpers), with the `MCP_USER_AGENT_PREFIX` constant.
- `sentry.issues.action_log.base.resolve_action_source` now uses the shared helper.
- `_parse_autofix_referrer` in `GroupAutofixEndpoint` takes the request and falls back to `AutofixReferrer.MCP` for MCP requests when no explicit referrer is given.

## Behavior

| Request | Explicit `referrer` | Resulting referrer |
| --- | --- | --- |
| MCP | — | `api.mcp` |
| MCP | provided | the explicit value (wins) |
| non-MCP | — | `api.group_ai_autofix` (unchanged) |

## Tests

Added endpoint tests covering the MCP default and the explicit-referrer override.



Agent transcript: https://claudescope.sentry.dev/share/Ps7Yc8hQVFqGnUv6MGje-nJ1ezKiW0WaMYeUNXZJnc4