### PR TITLE
feat(seer): Enable autofix code review purely on the option

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -241,10 +241,10 @@ def _default_reasoning_effort(
     return step_default
 
 
-def _code_review_enabled(organization: Organization, enable_coding: bool) -> bool:
-    # The review_code_changes tool only operates on accumulated patches, so it is
-    # only useful on coding-enabled steps.
-    return enable_coding and features.has("organizations:seer-autofix-code-review", organization)
+def _code_review_enabled(organization: Organization) -> bool:
+    # Gated purely on the option: Seer decides where the review_code_changes tool
+    # is actually useful (e.g. only once code edits have accumulated).
+    return features.has("organizations:seer-autofix-code-review", organization)
 
 
 def trigger_autofix_agent(
@@ -297,7 +297,7 @@ def trigger_autofix_agent(
         intelligence_level=resolved_intelligence_level,
         reasoning_effort=resolved_reasoning_effort,
         enable_coding=config.enable_coding,
-        code_review_enabled=_code_review_enabled(group.organization, config.enable_coding),
+        code_review_enabled=_code_review_enabled(group.organization),
     )
     if run_id is not None:
         _get_group_run_state(client, group, run_id)

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -518,9 +518,6 @@ class TestTriggerAutofixAgent(TestCase):
     def test_code_review_disabled_without_flag(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
-        # Guard against this test passing because the step stopped enabling coding.
-        assert STEP_CONFIGS[AutofixStep.CODE_CHANGES].enable_coding is True
-
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.start_run.return_value = MagicMock(seer_run_state_id=123)
@@ -561,11 +558,11 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_code_review_stays_disabled_on_non_coding_step_with_flag(
+    def test_code_review_enabled_on_non_coding_step_with_flag(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
-        # The review tool only operates on accumulated patches, so it should stay
-        # off for steps that don't enable coding, even when the flag is on.
+        # code_review_enabled is gated purely on the option, so it is set even on
+        # steps that don't enable coding. Seer decides where the tool is useful.
         assert STEP_CONFIGS[AutofixStep.ROOT_CAUSE].enable_coding is False
 
         mock_client = MagicMock()
@@ -580,7 +577,7 @@ class TestTriggerAutofixAgent(TestCase):
                 run_id=None,
             )
 
-        assert mock_client_class.call_args.kwargs["code_review_enabled"] is False
+        assert mock_client_class.call_args.kwargs["code_review_enabled"] is True
 
 
 class TestTriggerCodingAgentHandoff(TestCase):


### PR DESCRIPTION
Gate the autofix `code_review_enabled` flag purely on the `organizations:seer-autofix-code-review` option instead of also requiring the step to enable coding.

See also: https://github.com/getsentry/seer/pull/6920

Agent transcript: https://claudescope.sentry.dev/share/O3gvGiVSUk9V-Bm-_ceKxS1tTb9IiY_pnT7wFmM31AQ