### PR TITLE
feat(pr-metrics): Include GroupLinks from PR activity commits in resolved group IDs

### DIFF
--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -222,7 +222,7 @@ def emit_pr_metrics_row(
         pull_request=pull_request,
         close_action=close_action,
         attributions=attributions,
-        group_ids=resolved_group_ids(pull_request, include_groups_from_commits=True),
+        group_ids=resolved_group_ids(pull_request),
     )
     analytics.record(row)
     metrics.incr("pr_metrics.emit.recorded", tags={"close_action": close_action})

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Final, Literal
 
+from django.db.models import Q
+
 from sentry import analytics, features
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
 from sentry.models.commit import Commit
@@ -120,6 +122,83 @@ def active_attributions(pull_request: PullRequest) -> list[dict[str, Any]]:
         {"signal_type": a.signal_type, "source": a.source, "signal_details": a.signal_details}
         for a in ordered
     ]
+
+
+def _commit_shas_from_activity(pull_request: PullRequest) -> set[str]:
+    """SHAs reachable from SYNCHRONIZED activity, stopping at any force push.
+
+    Walks the SYNCHRONIZED chain newest→oldest. A force push is detected
+    when an event's after_sha doesn't continue from the expected point;
+    traversal stops there. Returns an empty set when there are no events.
+    """
+    payloads = list(
+        PullRequestActivity.objects.filter(
+            pull_request=pull_request,
+            event_type=PullRequestActivityType.SYNCHRONIZED,
+        )
+        .order_by("-date_added", "-id")
+        .values_list("payload", flat=True)
+    )
+
+    shas: set[str] = set()
+    seen_first = False
+    expected_after: str | None = None
+
+    for payload in payloads:  # newest → oldest
+        after_sha = payload.get("after_sha") or ""
+        before_sha = payload.get("before_sha") or ""
+        if not after_sha:
+            continue
+        if not seen_first:
+            seen_first = True
+            shas.add(after_sha)
+        elif after_sha != expected_after:
+            # Gap in chain — force push rewrote history before this point.
+            break
+        else:
+            shas.add(after_sha)
+        if not before_sha:
+            # Can't verify further without a before_sha.
+            expected_after = None
+            break
+        expected_after = before_sha
+
+    # The oldest before_sha is a commit that predates any tracked push.
+    if expected_after:
+        shas.add(expected_after)
+
+    return shas
+
+
+def _resolved_group_ids(pull_request: PullRequest) -> list[int]:
+    """Group IDs this PR resolves, from the resolving GroupLink rows.
+
+    Includes groups linked directly to the PR and groups linked to commits
+    reachable from SYNCHRONIZED activity (stopping at any force push). Both
+    lookup paths are merged into a single GroupLink query via a subquery.
+    Sorted for a deterministic row; empty when the PR resolves no issues.
+    """
+    pr_filter = Q(
+        linked_type=GroupLink.LinkedType.pull_request,
+        relationship=GroupLink.Relationship.resolves,
+        linked_id=pull_request.id,
+    )
+
+    shas = _commit_shas_from_activity(pull_request)
+    if shas:
+        commit_ids = Commit.objects.filter(
+            repository_id=pull_request.repository_id,
+            key__in=shas,
+        ).values("id")
+        combined = pr_filter | Q(
+            linked_type=GroupLink.LinkedType.commit,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id__in=commit_ids,
+        )
+    else:
+        combined = pr_filter
+
+    return sorted(GroupLink.objects.filter(combined).values_list("group_id", flat=True).distinct())
 
 
 def _merge_commit_id(pull_request: PullRequest) -> int | None:

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -130,6 +130,20 @@ def _commit_shas_from_activity(pull_request: PullRequest) -> set[str]:
     Walks the SYNCHRONIZED chain newest→oldest. A force push is detected
     when an event's after_sha doesn't continue from the expected point;
     traversal stops there. Returns an empty set when there are no events.
+
+    Known limitation — undetectable squash force-push:
+    A squash-and-force-push of the most recent commits produces a
+    ``synchronize`` event with ``before=<previous_head>`` and
+    ``after=<new_squashed_commit>``.  Because ``before`` equals the previous
+    HEAD, the chain appears unbroken and the old (now-squashed) SHAs are
+    included in the result alongside the new squashed SHA.  This cannot be
+    detected from the webhook payload alone; distinguishing a squash from a
+    regular push would require commit-graph data (e.g. verifying that
+    ``after`` is a descendant of ``before``).
+
+    By contrast, a force-push that *removes intermediate commits* (i.e. the
+    new ``before`` jumps back past the previous HEAD) creates a gap in the
+    chain that IS correctly detected and halts traversal.
     """
     payloads = list(
         PullRequestActivity.objects.filter(

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 import logging
 from typing import Any, Final, Literal
 
-from django.db.models import Q
-
 from sentry import analytics, features
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
 from sentry.models.commit import Commit
@@ -124,97 +122,6 @@ def active_attributions(pull_request: PullRequest) -> list[dict[str, Any]]:
     ]
 
 
-def _commit_shas_from_activity(pull_request: PullRequest) -> set[str]:
-    """SHAs reachable from SYNCHRONIZED activity, stopping at any force push.
-
-    Walks the SYNCHRONIZED chain newest→oldest. A force push is detected
-    when an event's after_sha doesn't continue from the expected point;
-    traversal stops there. Returns an empty set when there are no events.
-
-    Known limitation — undetectable squash force-push:
-    A squash-and-force-push of the most recent commits produces a
-    ``synchronize`` event with ``before=<previous_head>`` and
-    ``after=<new_squashed_commit>``.  Because ``before`` equals the previous
-    HEAD, the chain appears unbroken and the old (now-squashed) SHAs are
-    included in the result alongside the new squashed SHA.  This cannot be
-    detected from the webhook payload alone; distinguishing a squash from a
-    regular push would require commit-graph data (e.g. verifying that
-    ``after`` is a descendant of ``before``).
-
-    By contrast, a force-push that *removes intermediate commits* (i.e. the
-    new ``before`` jumps back past the previous HEAD) creates a gap in the
-    chain that IS correctly detected and halts traversal.
-    """
-    payloads = list(
-        PullRequestActivity.objects.filter(
-            pull_request=pull_request,
-            event_type=PullRequestActivityType.SYNCHRONIZED,
-        )
-        .order_by("-date_added", "-id")
-        .values_list("payload", flat=True)
-    )
-
-    shas: set[str] = set()
-    seen_first = False
-    expected_after: str | None = None
-
-    for payload in payloads:  # newest → oldest
-        after_sha = payload.get("after_sha") or ""
-        before_sha = payload.get("before_sha") or ""
-        if not after_sha:
-            continue
-        if not seen_first:
-            seen_first = True
-            shas.add(after_sha)
-        elif after_sha != expected_after:
-            # Gap in chain — force push rewrote history before this point.
-            break
-        else:
-            shas.add(after_sha)
-        if not before_sha:
-            # Can't verify further without a before_sha.
-            expected_after = None
-            break
-        expected_after = before_sha
-
-    # The oldest before_sha is a commit that predates any tracked push.
-    if expected_after:
-        shas.add(expected_after)
-
-    return shas
-
-
-def _resolved_group_ids(pull_request: PullRequest) -> list[int]:
-    """Group IDs this PR resolves, from the resolving GroupLink rows.
-
-    Includes groups linked directly to the PR and groups linked to commits
-    reachable from SYNCHRONIZED activity (stopping at any force push). Both
-    lookup paths are merged into a single GroupLink query via a subquery.
-    Sorted for a deterministic row; empty when the PR resolves no issues.
-    """
-    pr_filter = Q(
-        linked_type=GroupLink.LinkedType.pull_request,
-        relationship=GroupLink.Relationship.resolves,
-        linked_id=pull_request.id,
-    )
-
-    shas = _commit_shas_from_activity(pull_request)
-    if shas:
-        commit_ids = Commit.objects.filter(
-            repository_id=pull_request.repository_id,
-            key__in=shas,
-        ).values("id")
-        combined = pr_filter | Q(
-            linked_type=GroupLink.LinkedType.commit,
-            relationship=GroupLink.Relationship.resolves,
-            linked_id__in=commit_ids,
-        )
-    else:
-        combined = pr_filter
-
-    return sorted(GroupLink.objects.filter(combined).values_list("group_id", flat=True).distinct())
-
-
 def _merge_commit_id(pull_request: PullRequest) -> int | None:
     """The Sentry Commit row id for the PR's merge commit, if Sentry tracks it.
 
@@ -315,7 +222,7 @@ def emit_pr_metrics_row(
         pull_request=pull_request,
         close_action=close_action,
         attributions=attributions,
-        group_ids=resolved_group_ids(pull_request),
+        group_ids=resolved_group_ids(pull_request, include_groups_from_commits=True),
     )
     analytics.record(row)
     metrics.incr("pr_metrics.emit.recorded", tags={"close_action": close_action})

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from django.db.models import Q
+
+from sentry.models.commit import Commit
 from sentry.models.grouplink import GroupLink
-from sentry.models.pullrequest import PullRequest
+from sentry.models.pullrequest import PullRequest, PullRequestActivity, PullRequestActivityType
 
 
 def iso_or_none(value: datetime | None) -> str | None:
@@ -31,15 +34,101 @@ DELEGATED_AGENT_AUTHOR_LOGINS: dict[str, str] = {
 }
 
 
-def resolved_group_ids(pull_request: PullRequest) -> list[int]:
+def _commit_shas_from_activity(pull_request: PullRequest) -> set[str]:
+    """SHAs reachable from SYNCHRONIZED activity, stopping at any force push.
+
+    Walks the SYNCHRONIZED chain newest→oldest. A force push is detected
+    when an event's after_sha doesn't continue from the expected point;
+    traversal stops there. Returns an empty set when there are no events.
+
+    Known limitation — undetectable squash force-push:
+    A squash-and-force-push of the most recent commits produces a
+    ``synchronize`` event with ``before=<previous_head>`` and
+    ``after=<new_squashed_commit>``.  Because ``before`` equals the previous
+    HEAD, the chain appears unbroken and the old (now-squashed) SHAs are
+    included in the result alongside the new squashed SHA.  This cannot be
+    detected from the webhook payload alone; distinguishing a squash from a
+    regular push would require commit-graph data (e.g. verifying that
+    ``after`` is a descendant of ``before``).
+
+    By contrast, a force-push that *removes intermediate commits* (i.e. the
+    new ``before`` jumps back past the previous HEAD) creates a gap in the
+    chain that IS correctly detected and halts traversal.
+    """
+    payloads = list(
+        PullRequestActivity.objects.filter(
+            pull_request=pull_request,
+            event_type=PullRequestActivityType.SYNCHRONIZED,
+        )
+        .order_by("-date_added", "-id")
+        .values_list("payload", flat=True)
+    )
+
+    if not payloads:
+        return set()
+
+    first_sha = payloads[0].get("after_sha") or ""
+    first_expected = payloads[0].get("before_sha") or ""
+    if len(payloads) == 1:
+        return {first_sha} if first_sha else set()
+
+    shas: set[str] = {first_sha}
+    expected_after: str | None = first_expected
+
+    for payload in payloads[1:]:  # newest → oldest
+        after_sha = payload.get("after_sha") or ""
+        before_sha = payload.get("before_sha") or ""
+        if not after_sha:
+            break
+        elif after_sha != expected_after:
+            # Gap in chain — force push rewrote history before this point.
+            break
+        else:
+            shas.add(after_sha)
+        if not before_sha:
+            # Can't verify further without a before_sha.
+            expected_after = None
+            break
+        expected_after = before_sha
+
+    return shas
+
+
+def resolved_group_ids(
+    pull_request: PullRequest,
+    *,
+    include_groups_from_commits: bool = False,
+) -> list[int]:
     """Group IDs this PR resolves, from the resolving GroupLink rows.
+
+    When ``include_groups_from_commits`` is ``False`` (default), only groups
+    linked directly to the PR are returned.  When ``True``, groups linked to
+    commits reachable from SYNCHRONIZED activity (stopping at any force push)
+    are merged in via a single combined query.
 
     Sorted for a deterministic ordering; empty when the PR resolves no issues.
     """
-    return sorted(
-        GroupLink.objects.filter(
-            linked_type=GroupLink.LinkedType.pull_request,
-            relationship=GroupLink.Relationship.resolves,
-            linked_id=pull_request.id,
-        ).values_list("group_id", flat=True)
+    pr_filter = Q(
+        linked_type=GroupLink.LinkedType.pull_request,
+        relationship=GroupLink.Relationship.resolves,
+        linked_id=pull_request.id,
     )
+
+    if include_groups_from_commits:
+        shas = _commit_shas_from_activity(pull_request)
+        if shas:
+            commit_ids = Commit.objects.filter(
+                repository_id=pull_request.repository_id,
+                key__in=shas,
+            ).values("id")
+            combined = pr_filter | Q(
+                linked_type=GroupLink.LinkedType.commit,
+                relationship=GroupLink.Relationship.resolves,
+                linked_id__in=commit_ids,
+            )
+        else:
+            combined = pr_filter
+    else:
+        combined = pr_filter
+
+    return sorted(GroupLink.objects.filter(combined).values_list("group_id", flat=True).distinct())

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -94,17 +94,12 @@ def _commit_shas_from_activity(pull_request: PullRequest) -> set[str]:
     return shas
 
 
-def resolved_group_ids(
-    pull_request: PullRequest,
-    *,
-    include_groups_from_commits: bool = False,
-) -> list[int]:
+def resolved_group_ids(pull_request: PullRequest) -> list[int]:
     """Group IDs this PR resolves, from the resolving GroupLink rows.
 
-    When ``include_groups_from_commits`` is ``False`` (default), only groups
-    linked directly to the PR are returned.  When ``True``, groups linked to
-    commits reachable from SYNCHRONIZED activity (stopping at any force push)
-    are merged in via a single combined query.
+    Includes groups linked directly to the PR and groups linked to commits
+    reachable from SYNCHRONIZED activity (stopping at any force push). Both
+    lookup paths are merged into a single GroupLink query.
 
     Sorted for a deterministic ordering; empty when the PR resolves no issues.
     """
@@ -114,20 +109,17 @@ def resolved_group_ids(
         linked_id=pull_request.id,
     )
 
-    if include_groups_from_commits:
-        shas = _commit_shas_from_activity(pull_request)
-        if shas:
-            commit_ids = Commit.objects.filter(
-                repository_id=pull_request.repository_id,
-                key__in=shas,
-            ).values("id")
-            combined = pr_filter | Q(
-                linked_type=GroupLink.LinkedType.commit,
-                relationship=GroupLink.Relationship.resolves,
-                linked_id__in=commit_ids,
-            )
-        else:
-            combined = pr_filter
+    shas = _commit_shas_from_activity(pull_request)
+    if shas:
+        commit_ids = Commit.objects.filter(
+            repository_id=pull_request.repository_id,
+            key__in=shas,
+        ).values("id")
+        combined = pr_filter | Q(
+            linked_type=GroupLink.LinkedType.commit,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id__in=commit_ids,
+        )
     else:
         combined = pr_filter
 

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -29,7 +29,6 @@ from sentry import features
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.issues.constants import cache_key_for_issue_view
-from sentry.models.grouplink import GroupLink
 from sentry.models.organization import Organization
 from sentry.models.pullrequest import (
     PullRequest,
@@ -638,13 +637,7 @@ def _detect_delegated_agent(pr: PullRequest, webhook_pull_request: Mapping[str, 
 
 
 def _write_mcp_attribution(pr: PullRequest) -> None:
-    group_ids = list(
-        GroupLink.objects.filter(
-            linked_type=GroupLink.LinkedType.pull_request,
-            relationship=GroupLink.Relationship.resolves,
-            linked_id=pr.id,
-        ).values_list("group_id", flat=True)
-    )
+    group_ids = resolved_group_ids(pr)
     if not group_ids:
         return
 

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -626,7 +626,7 @@ def _detect_delegated_agent(pr: PullRequest, webhook_pull_request: Mapping[str, 
     provider_hint = _is_delegated_agent_candidate(webhook_pull_request)
     # Our candidates are PRs from delegated agents
     # That explicitly address a Sentry issue
-    if provider_hint is not None and resolved_group_ids(pr, include_groups_from_commits=True):
+    if provider_hint is not None and resolved_group_ids(pr):
         # TODO: Fire-and-forget request to Seer when the match endpoint exists.
         # We will send: provider_hint, github_login, head_ref
         sentry_sdk.metrics.count(

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -627,7 +627,7 @@ def _detect_delegated_agent(pr: PullRequest, webhook_pull_request: Mapping[str, 
     provider_hint = _is_delegated_agent_candidate(webhook_pull_request)
     # Our candidates are PRs from delegated agents
     # That explicitly address a Sentry issue
-    if provider_hint is not None and resolved_group_ids(pr):
+    if provider_hint is not None and resolved_group_ids(pr, include_groups_from_commits=True):
         # TODO: Fire-and-forget request to Seer when the match endpoint exists.
         # We will send: provider_hint, github_login, head_ref
         sentry_sdk.metrics.count(

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -483,15 +483,13 @@ class PrMetricsEmissionTest(TestCase):
     def test_resolved_group_ids_includes_commit_link_via_activity(self) -> None:
         group_id, _ = self._link_commit_group(key="a" * 40)
         self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
-        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == [group_id]
+        assert resolved_group_ids(self.pull_request) == [group_id]
 
     def test_resolved_group_ids_merges_pr_and_commit_links(self) -> None:
         pr_group_id = self._link_group()
         commit_group_id, _ = self._link_commit_group(key="c" * 40)
         self._sync_activity(after_sha="c" * 40, before_sha="d" * 40, webhook_id="s1")
-        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == sorted(
-            [pr_group_id, commit_group_id]
-        )
+        assert resolved_group_ids(self.pull_request) == sorted([pr_group_id, commit_group_id])
 
     def test_resolved_group_ids_deduplicates_pr_and_commit_links(self) -> None:
         # Same group linked both via PR and via a commit in the activity chain.
@@ -512,7 +510,7 @@ class PrMetricsEmissionTest(TestCase):
             linked_id=commit.id,
         )
         self._sync_activity(after_sha="e" * 40, before_sha="f" * 40, webhook_id="s1")
-        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == [group.id]
+        assert resolved_group_ids(self.pull_request) == [group.id]
 
     def test_resolved_group_ids_excludes_commit_references_links(self) -> None:
         commit = self.create_commit(repo=self.repo, key="a" * 40)
@@ -525,7 +523,7 @@ class PrMetricsEmissionTest(TestCase):
             linked_id=commit.id,
         )
         self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
-        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == []
+        assert resolved_group_ids(self.pull_request) == []
 
     def test_resolved_group_ids_excludes_commits_after_force_push(self) -> None:
         # sha "x" is behind a force-push boundary and should be excluded.
@@ -534,22 +532,19 @@ class PrMetricsEmissionTest(TestCase):
         self._sync_activity(after_sha="x" * 40, before_sha="y" * 40, webhook_id="s1")
         self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s2")
         # "x" != "b" → force push detected; only "a" survives.
-        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == []
+        assert resolved_group_ids(self.pull_request) == []
 
     def test_resolved_group_ids_ignores_untracked_commit_shas(self) -> None:
         # A SHA in the activity that has no Commit row in Sentry doesn't error.
         self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
-        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == []
+        assert resolved_group_ids(self.pull_request) == []
 
     def test_resolved_group_ids_with_commits_falls_back_to_pr_links_when_no_activity(
         self,
     ) -> None:
-        # include_groups_from_commits=True but no SYNCHRONIZED activity: the PR-linked
-        # groups are still returned (the commit path is simply a no-op).
+        # No SYNCHRONIZED activity: PR-linked groups are still returned (commit path is a no-op).
         pr_group_id = self._link_group()
-        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == [
-            pr_group_id
-        ]
+        assert resolved_group_ids(self.pull_request) == [pr_group_id]
 
     @patch("sentry.analytics.record")
     def test_emit_picks_up_commit_linked_groups_via_activity(self, mock_record: Any) -> None:

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -16,15 +16,13 @@ from sentry.models.pullrequest import (
     PullRequestVerdict,
 )
 from sentry.pr_metrics.emit import (
-    _commit_shas_from_activity,
-    _resolved_group_ids,
     active_attributions,
     build_pr_metrics_row,
     emit_pr_metrics_row,
     is_pr_tracked,
     select_verdict,
 )
-from sentry.pr_metrics.utils import resolved_group_ids
+from sentry.pr_metrics.utils import _commit_shas_from_activity, resolved_group_ids
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
@@ -425,7 +423,7 @@ class PrMetricsEmissionTest(TestCase):
 
     def test_commit_shas_from_activity_single_event(self) -> None:
         self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
-        assert _commit_shas_from_activity(self.pull_request) == {"a" * 40, "b" * 40}
+        assert _commit_shas_from_activity(self.pull_request) == {"a" * 40}
 
     def test_commit_shas_from_activity_normal_chain(self) -> None:
         # Two pushes in a normal (non-force) sequence.
@@ -435,7 +433,6 @@ class PrMetricsEmissionTest(TestCase):
         assert _commit_shas_from_activity(self.pull_request) == {
             "a" * 40,
             "b" * 40,
-            "c" * 40,
         }
 
     def test_commit_shas_from_activity_stops_at_force_push(self) -> None:
@@ -443,10 +440,10 @@ class PrMetricsEmissionTest(TestCase):
         # P2 (newer): after=a, before=b — always included.
         self._sync_activity(after_sha="x" * 40, before_sha="y" * 40, webhook_id="s1")
         self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s2")
-        # "x" != "b" → force push detected; only a, b survive.
-        assert _commit_shas_from_activity(self.pull_request) == {"a" * 40, "b" * 40}
+        # "x" != "b" → force push detected; only a survives.
+        assert _commit_shas_from_activity(self.pull_request) == {"a" * 40}
 
-    def test_commit_shas_from_activity_skips_missing_after_sha(self) -> None:
+    def test_commit_shas_from_activity_returns_empty_when_only_event_has_no_after_sha(self) -> None:
         PullRequestActivity.objects.create(
             pull_request=self.pull_request,
             webhook_id="s1",
@@ -454,6 +451,19 @@ class PrMetricsEmissionTest(TestCase):
             payload={"before_sha": "b" * 40},  # no after_sha
         )
         assert _commit_shas_from_activity(self.pull_request) == set()
+
+    def test_commit_shas_from_activity_stops_when_chain_event_has_no_after_sha(self) -> None:
+        # Three events newest→oldest: s3, s2 (no after_sha), s1.
+        # The loop breaks on s2; s1 is never reached.
+        self._sync_activity(after_sha="b" * 40, before_sha="a" * 40, webhook_id="s1")
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id="s2",
+            event_type=PullRequestActivityType.SYNCHRONIZED,
+            payload={"before_sha": "c" * 40},  # no after_sha — middle event
+        )
+        self._sync_activity(after_sha="c" * 40, before_sha="d" * 40, webhook_id="s3")
+        assert _commit_shas_from_activity(self.pull_request) == {"c" * 40}
 
     # --- _resolved_group_ids (commit-link extension) ---
 
@@ -473,13 +483,15 @@ class PrMetricsEmissionTest(TestCase):
     def test_resolved_group_ids_includes_commit_link_via_activity(self) -> None:
         group_id, _ = self._link_commit_group(key="a" * 40)
         self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
-        assert _resolved_group_ids(self.pull_request) == [group_id]
+        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == [group_id]
 
     def test_resolved_group_ids_merges_pr_and_commit_links(self) -> None:
         pr_group_id = self._link_group()
         commit_group_id, _ = self._link_commit_group(key="c" * 40)
         self._sync_activity(after_sha="c" * 40, before_sha="d" * 40, webhook_id="s1")
-        assert _resolved_group_ids(self.pull_request) == sorted([pr_group_id, commit_group_id])
+        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == sorted(
+            [pr_group_id, commit_group_id]
+        )
 
     def test_resolved_group_ids_deduplicates_pr_and_commit_links(self) -> None:
         # Same group linked both via PR and via a commit in the activity chain.
@@ -500,7 +512,7 @@ class PrMetricsEmissionTest(TestCase):
             linked_id=commit.id,
         )
         self._sync_activity(after_sha="e" * 40, before_sha="f" * 40, webhook_id="s1")
-        assert _resolved_group_ids(self.pull_request) == [group.id]
+        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == [group.id]
 
     def test_resolved_group_ids_excludes_commit_references_links(self) -> None:
         commit = self.create_commit(repo=self.repo, key="a" * 40)
@@ -513,7 +525,7 @@ class PrMetricsEmissionTest(TestCase):
             linked_id=commit.id,
         )
         self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
-        assert _resolved_group_ids(self.pull_request) == []
+        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == []
 
     def test_resolved_group_ids_excludes_commits_after_force_push(self) -> None:
         # sha "x" is behind a force-push boundary and should be excluded.
@@ -521,10 +533,30 @@ class PrMetricsEmissionTest(TestCase):
         # Older event first → lower timestamp/id.
         self._sync_activity(after_sha="x" * 40, before_sha="y" * 40, webhook_id="s1")
         self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s2")
-        # "x" != "b" → force push; only a,b survive.
-        assert _resolved_group_ids(self.pull_request) == []
+        # "x" != "b" → force push detected; only "a" survives.
+        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == []
 
     def test_resolved_group_ids_ignores_untracked_commit_shas(self) -> None:
         # A SHA in the activity that has no Commit row in Sentry doesn't error.
         self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
-        assert _resolved_group_ids(self.pull_request) == []
+        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == []
+
+    def test_resolved_group_ids_with_commits_falls_back_to_pr_links_when_no_activity(
+        self,
+    ) -> None:
+        # include_groups_from_commits=True but no SYNCHRONIZED activity: the PR-linked
+        # groups are still returned (the commit path is simply a no-op).
+        pr_group_id = self._link_group()
+        assert resolved_group_ids(self.pull_request, include_groups_from_commits=True) == [
+            pr_group_id
+        ]
+
+    @patch("sentry.analytics.record")
+    def test_emit_picks_up_commit_linked_groups_via_activity(self, mock_record: Any) -> None:
+        # The full path: a commit reachable from SYNCHRONIZED activity resolves a
+        # group → emit should include that group_id in the emitted row.
+        self._track()
+        group_id, _ = self._link_commit_group(key="a" * 40)
+        self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
+        emit_pr_metrics_row(pull_request=self.pull_request)
+        assert mock_record.call_args[0][0].group_ids == [group_id]

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -16,6 +16,8 @@ from sentry.models.pullrequest import (
     PullRequestVerdict,
 )
 from sentry.pr_metrics.emit import (
+    _commit_shas_from_activity,
+    _resolved_group_ids,
     active_attributions,
     build_pr_metrics_row,
     emit_pr_metrics_row,
@@ -407,3 +409,122 @@ class PrMetricsEmissionTest(TestCase):
         emitted = emit_pr_metrics_row(pull_request=self.pull_request)
         assert emitted is False
         assert mock_record.call_count == 0
+
+    # --- _commit_shas_from_activity ---
+
+    def _sync_activity(self, *, after_sha: str, before_sha: str, webhook_id: str) -> None:
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id=webhook_id,
+            event_type=PullRequestActivityType.SYNCHRONIZED,
+            payload={"after_sha": after_sha, "before_sha": before_sha},
+        )
+
+    def test_commit_shas_from_activity_empty_when_no_events(self) -> None:
+        assert _commit_shas_from_activity(self.pull_request) == set()
+
+    def test_commit_shas_from_activity_single_event(self) -> None:
+        self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
+        assert _commit_shas_from_activity(self.pull_request) == {"a" * 40, "b" * 40}
+
+    def test_commit_shas_from_activity_normal_chain(self) -> None:
+        # Two pushes in a normal (non-force) sequence.
+        # Older event created first so it gets a lower timestamp/id.
+        self._sync_activity(after_sha="b" * 40, before_sha="c" * 40, webhook_id="s1")
+        self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s2")
+        assert _commit_shas_from_activity(self.pull_request) == {
+            "a" * 40,
+            "b" * 40,
+            "c" * 40,
+        }
+
+    def test_commit_shas_from_activity_stops_at_force_push(self) -> None:
+        # P1 (older): after=x, before=y — disconnected from P2.after; force push.
+        # P2 (newer): after=a, before=b — always included.
+        self._sync_activity(after_sha="x" * 40, before_sha="y" * 40, webhook_id="s1")
+        self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s2")
+        # "x" != "b" → force push detected; only a, b survive.
+        assert _commit_shas_from_activity(self.pull_request) == {"a" * 40, "b" * 40}
+
+    def test_commit_shas_from_activity_skips_missing_after_sha(self) -> None:
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id="s1",
+            event_type=PullRequestActivityType.SYNCHRONIZED,
+            payload={"before_sha": "b" * 40},  # no after_sha
+        )
+        assert _commit_shas_from_activity(self.pull_request) == set()
+
+    # --- _resolved_group_ids (commit-link extension) ---
+
+    def _link_commit_group(self, *, key: str) -> tuple[int, int]:
+        """Create a commit + resolving GroupLink; return (group_id, commit_id)."""
+        commit = self.create_commit(repo=self.repo, key=key)
+        group = self.create_group(project=self.project)
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.commit,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id=commit.id,
+        )
+        return group.id, commit.id
+
+    def test_resolved_group_ids_includes_commit_link_via_activity(self) -> None:
+        group_id, _ = self._link_commit_group(key="a" * 40)
+        self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
+        assert _resolved_group_ids(self.pull_request) == [group_id]
+
+    def test_resolved_group_ids_merges_pr_and_commit_links(self) -> None:
+        pr_group_id = self._link_group()
+        commit_group_id, _ = self._link_commit_group(key="c" * 40)
+        self._sync_activity(after_sha="c" * 40, before_sha="d" * 40, webhook_id="s1")
+        assert _resolved_group_ids(self.pull_request) == sorted([pr_group_id, commit_group_id])
+
+    def test_resolved_group_ids_deduplicates_pr_and_commit_links(self) -> None:
+        # Same group linked both via PR and via a commit in the activity chain.
+        group = self.create_group(project=self.project)
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.pull_request,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id=self.pull_request.id,
+        )
+        commit = self.create_commit(repo=self.repo, key="e" * 40)
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.commit,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id=commit.id,
+        )
+        self._sync_activity(after_sha="e" * 40, before_sha="f" * 40, webhook_id="s1")
+        assert _resolved_group_ids(self.pull_request) == [group.id]
+
+    def test_resolved_group_ids_excludes_commit_references_links(self) -> None:
+        commit = self.create_commit(repo=self.repo, key="a" * 40)
+        group = self.create_group(project=self.project)
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.commit,
+            relationship=GroupLink.Relationship.references,
+            linked_id=commit.id,
+        )
+        self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
+        assert _resolved_group_ids(self.pull_request) == []
+
+    def test_resolved_group_ids_excludes_commits_after_force_push(self) -> None:
+        # sha "x" is behind a force-push boundary and should be excluded.
+        group_id, _ = self._link_commit_group(key="x" * 40)
+        # Older event first → lower timestamp/id.
+        self._sync_activity(after_sha="x" * 40, before_sha="y" * 40, webhook_id="s1")
+        self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s2")
+        # "x" != "b" → force push; only a,b survive.
+        assert _resolved_group_ids(self.pull_request) == []
+
+    def test_resolved_group_ids_ignores_untracked_commit_shas(self) -> None:
+        # A SHA in the activity that has no Commit row in Sentry doesn't error.
+        self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
+        assert _resolved_group_ids(self.pull_request) == []


### PR DESCRIPTION
Previously `resolved_group_ids` only returned groups linked directly to the PR via a `GroupLink(linked_type=pull_request)` row. Groups fixed by commits in the PR — where the link is `GroupLink(linked_type=commit)` — were invisible to the analytics row.

This adds a second lookup path through `PullRequestActivity`. A new helper `_commit_shas_from_activity` in `pr_metrics/utils.py` walks the `SYNCHRONIZED` event chain newest→oldest, collecting the branch head SHAs from each push. It stops when it detects a force push (a gap where an event's `after_sha` doesn't match the expected continuation of the chain).

The extended lookup is gated behind an `include_groups_from_commits=False` keyword argument on `resolved_group_ids`. Both lookup paths are merged into a single `GroupLink` query by embedding the `Commit` id lookup as a subquery, keeping the total at two DB round-trips. Call sites opt in explicitly:

- `emit_pr_metrics_row`: `True` — commit-linked groups count toward the emitted analytics row
- webhooks `provider_hint` gate: `True` — same intent
- judge path (`judge.py`): `False` — unchanged, judge only needs PR-direct links

Note that coverage is a sample, not exhaustive: `SYNCHRONIZED` events record only the branch head before and after each push, not every individual commit in the push. This matches the expectation described in CORE-240.

Fixes CORE-240
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>