### PR TITLE
ref(relay): remove `accepted_outcome_emitted`

### DIFF
--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -18,7 +18,6 @@ from sentry_protos.snuba.v1.trace_item_pb2 import (
 
 from sentry.constants import DataCategory
 from sentry.spans.consumers.process_segments.types import CompatibleSpan
-from sentry.utils import metrics
 from sentry.utils.eap import hex_to_item_id
 
 I64_MAX = 2**63 - 1
@@ -110,21 +109,15 @@ def convert_span_to_item(span: CompatibleSpan) -> TraceItem:
             sentry_sdk.capture_exception()
             attributes["sentry.dropped_links_count"] = AnyValue(int_value=len(links))
 
-    metrics.incr(
-        "spans.consumers.process_segments.outcome_emitted",
-        tags={"already_emitted": str(span.get("accepted_outcome_emitted"))},
+    outcomes = Outcomes(
+        key_id=int(span.get("key_id") or 0),
+        category_count=[
+            CategoryCount(
+                data_category=int(DataCategory.SPAN_INDEXED),
+                quantity=1,
+            ),
+        ],
     )
-    outcomes = None
-    if span.get("accepted_outcome_emitted") is False:
-        outcomes = Outcomes(
-            key_id=int(span.get("key_id") or 0),
-            category_count=[
-                CategoryCount(
-                    data_category=int(DataCategory.SPAN_INDEXED),
-                    quantity=1,
-                ),
-            ],
-        )
 
     return TraceItem(
         organization_id=span["organization_id"],

--- a/tests/sentry/spans/consumers/process_segments/test_convert.py
+++ b/tests/sentry/spans/consumers/process_segments/test_convert.py
@@ -266,9 +266,8 @@ def test_convert_renamed_attribute_meta() -> None:
     [(123, 123), ("123", 123), (None, 0)],
     ids=["int_key_id", "str_key_id", "none_key_id"],
 )
-def test_convert_outcomes_when_not_emitted(key_id, expected_key_id) -> None:
+def test_convert_outcomes(key_id, expected_key_id) -> None:
     message: SpanEvent = copy.deepcopy(SPAN_KAFKA_MESSAGE)
-    message["accepted_outcome_emitted"] = False
     message["key_id"] = key_id
 
     item = convert_span_to_item(cast(CompatibleSpan, message))
@@ -285,9 +284,8 @@ def test_convert_outcomes_when_not_emitted(key_id, expected_key_id) -> None:
     )
 
 
-def test_convert_outcomes_when_not_emitted_missing_key_id() -> None:
+def test_convert_outcomes_missing_key_id() -> None:
     message: SpanEvent = copy.deepcopy(SPAN_KAFKA_MESSAGE)
-    message["accepted_outcome_emitted"] = False
 
     item = convert_span_to_item(cast(CompatibleSpan, message))
 
@@ -301,16 +299,3 @@ def test_convert_outcomes_when_not_emitted_missing_key_id() -> None:
             ),
         ],
     )
-
-
-def test_convert_outcomes_when_already_emitted() -> None:
-    message: SpanEvent = copy.deepcopy(SPAN_KAFKA_MESSAGE)
-    message["accepted_outcome_emitted"] = True
-    item = convert_span_to_item(cast(CompatibleSpan, message))
-    assert not item.HasField("outcomes")
-
-
-def test_convert_outcomes_when_field_missing() -> None:
-    message: SpanEvent = copy.deepcopy(SPAN_KAFKA_MESSAGE)
-    item = convert_span_to_item(cast(CompatibleSpan, message))
-    assert not item.HasField("outcomes")


### PR DESCRIPTION
Changes the logic to always set the outcome (this is already the case now that the flag has been rolled out everywhere).
Part of the rollout plan specified here: [INGEST-806](https://linear.app/getsentry/issue/INGEST-806/remove-old-span-eap-outcome-code)

Ref: [INGEST-806](https://linear.app/getsentry/issue/INGEST-806/remove-old-span-eap-outcome-code)