### PR TITLE
ref(spans): Remove `relay.eap-span-outcomes.rollout-rate`

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -598,13 +598,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Rollout rate for moving accepted outcome emission for spans from Relay to the Segment Consumer.
-register(
-    "relay.eap-span-outcomes.rollout-rate",
-    type=Float,
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Killswitch for fetching projects in the endpoints.
 register(

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -17,7 +17,6 @@ RELAY_OPTIONS: list[str] = [
     "profiling.profile_metrics.unsampled_profiles.enabled",
     "relay.span-usage-metric",
     "relay.eap-outcomes.rollout-rate",
-    "relay.eap-span-outcomes.rollout-rate",
     "relay.metric-bucket-set-encodings",
     "relay.metric-bucket-distribution-encodings",
     "relay.sessions-eap.rollout-rate",

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -55,7 +55,6 @@ def call_endpoint(client, relay, private_key):
             "transactions": "base64",
         },
         "relay.eap-outcomes.rollout-rate": 1.0,
-        "relay.eap-span-outcomes.rollout-rate": 1.0,
     }
 )
 def test_global_config() -> None:


### PR DESCRIPTION
This flag was used for rolling the span outcome changes, now that they have been rolled out remove it.
Part of the rollout plan specified here: [INGEST-806](https://linear.app/getsentry/issue/INGEST-806/remove-old-span-eap-outcome-code)

Ref: [INGEST-806](https://linear.app/getsentry/issue/INGEST-806/remove-old-span-eap-outcome-code)