### PR TITLE
fix(ourlogs): reuse `useVisualizeFields` to avoid Visualize field resetting to None

### DIFF
--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -15,6 +15,7 @@ import {
   prettifyTagKey,
 } from 'sentry/utils/fields';
 import {optionFromTag} from 'sentry/views/explore/components/attributeOption';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {sortKnownAttributes} from 'sentry/views/explore/utils/sortSearchedAttributes';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -129,6 +130,23 @@ function getSupportedAttributes({
         }
         return filtered;
       }
+    }
+
+    return numberTags;
+  }
+
+  if (traceItemType === TraceItemDataset.LOGS) {
+    if (functionName === AggregationKey.COUNT) {
+      return {
+        [OurLogKnownFieldKey.MESSAGE]: {
+          name: t('logs'),
+          key: OurLogKnownFieldKey.MESSAGE,
+        },
+      };
+    }
+
+    if (functionName === AggregationKey.COUNT_UNIQUE) {
+      return {...numberTags, ...stringTags, ...booleanTags};
     }
 
     return numberTags;

--- a/static/app/views/explore/logs/logsToolbar.spec.tsx
+++ b/static/app/views/explore/logs/logsToolbar.spec.tsx
@@ -162,6 +162,52 @@ describe('LogsToolbar', () => {
       );
     });
 
+    it('keeps the selected field when it is not in the default attribute list', async () => {
+      const searchAttributesMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/trace-items/attributes/`,
+        method: 'GET',
+        body: [
+          {
+            attributeType: 'number',
+            key: 'searched_number',
+            name: 'searched_number',
+            attributeSource: {source_type: 'custom'},
+          },
+        ],
+        match: [MockApiClient.matchQuery({substringMatch: 'searched'})],
+      });
+
+      const {router} = render(<LogsToolbar />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
+
+      // The default number attributes do not include `searched_number`.
+      await userEvent.click(screen.getByRole('button', {name: 'count'}));
+      await userEvent.click(screen.getByRole('option', {name: 'avg'}));
+
+      await userEvent.click(screen.getByRole('button', {name: 'bar'}));
+      const searchInput = screen.getByRole('textbox');
+      await userEvent.type(searchInput, 'searched');
+      await waitFor(() => expect(searchAttributesMock).toHaveBeenCalled());
+
+      await userEvent.click(
+        await screen.findByRole('option', {name: 'searched_number'})
+      );
+
+      // Once the search clears, `searched_number` is no longer in the fetched
+      // attributes, but the dropdown must keep displaying the selected field
+      // rather than reverting to an empty value.
+      expect(router.location.query.aggregateField).toEqual(
+        [{groupBy: ''}, {yAxes: ['avg(searched_number)'], visible: false}].map(
+          aggregateField => JSON.stringify(aggregateField)
+        )
+      );
+      expect(
+        await screen.findByRole('button', {name: 'searched_number'})
+      ).toBeInTheDocument();
+    });
+
     it('can add/delete visualizes', async () => {
       const {router} = render(<LogsToolbar />, {
         organization,

--- a/static/app/views/explore/logs/logsToolbar.spec.tsx
+++ b/static/app/views/explore/logs/logsToolbar.spec.tsx
@@ -191,9 +191,7 @@ describe('LogsToolbar', () => {
       await userEvent.type(searchInput, 'searched');
       await waitFor(() => expect(searchAttributesMock).toHaveBeenCalled());
 
-      await userEvent.click(
-        await screen.findByRole('option', {name: 'searched_number'})
-      );
+      await userEvent.click(await screen.findByRole('option', {name: 'searched_number'}));
 
       // Once the search clears, `searched_number` is no longer in the fetched
       // attributes, but the dropdown must keep displaying the selected field

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -4,10 +4,10 @@ import styled from '@emotion/styled';
 import type {SelectKey, SelectOption} from '@sentry/scraps/compactSelect';
 
 import {t} from 'sentry/locale';
+import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils/defined';
-import {AggregationKey, FieldKind, prettifyTagKey} from 'sentry/utils/fields';
+import {AggregationKey} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
-import {optionFromTag} from 'sentry/views/explore/components/attributeOption';
 import {
   ToolbarFooter,
   ToolbarSection,
@@ -25,6 +25,7 @@ import {
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {useLogItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
+import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
 import {
   OurLogKnownFieldKey,
   type OurLogsAggregate,
@@ -125,24 +126,6 @@ function ToolbarVisualize() {
   const onSearch = setSearch;
   const onClose = useCallback(() => setSearch(undefined), []);
 
-  const sortedNumberKeys = useMemo(() => {
-    const keys = Object.keys(numberTags);
-    keys.sort();
-    return keys;
-  }, [numberTags]);
-
-  const sortedStringKeys = useMemo(() => {
-    const keys = Object.keys(stringTags);
-    keys.sort();
-    return keys;
-  }, [stringTags]);
-
-  const sortedBooleanKeys = useMemo(() => {
-    const keys = Object.keys(booleanTags);
-    keys.sort();
-    return keys;
-  }, [booleanTags]);
-
   const visualizes = useQueryParamsVisualizes();
   const setVisualizes = useSetQueryParamsVisualizes();
 
@@ -188,9 +171,9 @@ function ToolbarVisualize() {
               onDelete={onDelete}
               onReplace={newVisualize => replaceOverlay(group, newVisualize)}
               visualize={visualize}
-              sortedBooleanKeys={sortedBooleanKeys}
-              sortedNumberKeys={sortedNumberKeys}
-              sortedStringKeys={sortedStringKeys}
+              booleanTags={booleanTags}
+              numberTags={numberTags}
+              stringTags={stringTags}
               onSearch={onSearch}
               onClose={onClose}
               loading={numberTagsLoading || stringTagsLoading || booleanTagsLoading}
@@ -210,13 +193,13 @@ function ToolbarVisualize() {
 }
 
 interface VisualizeDropdownProps {
+  booleanTags: TagCollection;
   loading: boolean;
+  numberTags: TagCollection;
   onClose: () => void;
   onReplace: (visualize: Visualize) => void;
   onSearch: (search: string) => void;
-  sortedBooleanKeys: string[];
-  sortedNumberKeys: string[];
-  sortedStringKeys: string[];
+  stringTags: TagCollection;
   visualize: VisualizeFunction;
   onDelete?: () => void;
 }
@@ -228,70 +211,32 @@ function VisualizeDropdown({
   onSearch,
   onClose,
   visualize,
-  sortedBooleanKeys,
-  sortedNumberKeys,
-  sortedStringKeys,
+  booleanTags,
+  numberTags,
+  stringTags,
 }: VisualizeDropdownProps) {
+  const firstNumberKey = useMemo(
+    () => Object.keys(numberTags).sort()[0] ?? null,
+    [numberTags]
+  );
+
   const aggregateOptions: Array<SelectOption<OurLogsAggregate>> = useMemo(() => {
     return LOG_AGGREGATES.map(aggregate => {
-      const defaultArgument = getDefaultArgument(
-        aggregate.value,
-        sortedNumberKeys[0] || null
-      );
+      const defaultArgument = getDefaultArgument(aggregate.value, firstNumberKey);
       return {...aggregate, disabled: !defined(defaultArgument)};
     });
-  }, [sortedNumberKeys]);
+  }, [firstNumberKey]);
 
   const aggregateFunction = visualize.parsedFunction?.name ?? '';
   const aggregateParam = visualize.parsedFunction?.arguments?.[0] ?? '';
 
-  const fieldOptions = useMemo(() => {
-    if (aggregateFunction === AggregationKey.COUNT) {
-      return [{label: t('logs'), value: OurLogKnownFieldKey.MESSAGE}];
-    }
-    const seen = new Set<string>();
-    return aggregateFunction === AggregationKey.COUNT_UNIQUE
-      ? [
-          ...sortedNumberKeys.map(key => {
-            return optionFromTag(
-              {key, name: prettifyTagKey(key), kind: FieldKind.MEASUREMENT},
-              TraceItemDataset.LOGS
-            );
-          }),
-          ...sortedStringKeys.map(key => {
-            return optionFromTag(
-              {key, name: prettifyTagKey(key), kind: FieldKind.TAG},
-              TraceItemDataset.LOGS
-            );
-          }),
-          ...sortedBooleanKeys.map(key => {
-            return optionFromTag(
-              {key, name: prettifyTagKey(key), kind: FieldKind.BOOLEAN},
-              TraceItemDataset.LOGS
-            );
-          }),
-        ]
-          .filter(option => {
-            // Filtering by value here, so it's based off of explicit tags i.e. `key`
-            // or `tags[<key>, <boolean | number | string>]
-            if (seen.has(option.value)) {
-              return false;
-            }
-            seen.add(option.value);
-            return true;
-          })
-          .toSorted((a, b) => {
-            const aLabel = prettifyTagKey(a.value);
-            const bLabel = prettifyTagKey(b.value);
-            return aLabel.localeCompare(bLabel);
-          })
-      : sortedNumberKeys.map(key => {
-          return optionFromTag(
-            {key, name: prettifyTagKey(key), kind: FieldKind.MEASUREMENT},
-            TraceItemDataset.LOGS
-          );
-        });
-  }, [aggregateFunction, sortedBooleanKeys, sortedNumberKeys, sortedStringKeys]);
+  const fieldOptions = useVisualizeFields({
+    numberTags,
+    stringTags,
+    booleanTags,
+    parsedFunction: visualize.parsedFunction,
+    traceItemType: TraceItemDataset.LOGS,
+  });
 
   const onChangeAggregate = useCallback(
     (option: SelectOption<SelectKey>) => {
@@ -300,12 +245,12 @@ function VisualizeDropdown({
           newAggregate: option.value,
           oldAggregate: aggregateFunction,
           oldArgument: aggregateParam,
-          firstNumberKey: sortedNumberKeys[0] || null,
+          firstNumberKey,
         });
         onReplace(visualize.replace({yAxis}));
       }
     },
-    [onReplace, visualize, aggregateFunction, aggregateParam, sortedNumberKeys]
+    [onReplace, visualize, aggregateFunction, aggregateParam, firstNumberKey]
   );
 
   const onChangeArgument = useCallback(


### PR DESCRIPTION
In the logs visualize sidebar, picking a field for an aggregate would briefly show the selection and then revert to an empty/`None` value. The internals of how logs managed this was suspiciously similar to how the `useVisualizeFields` hook for spans/traces is set up.

`useVisualizeFields` has the added nice behavior of always putting the currently-selected argument as an option. Logs wasn't doing that. 

Two intentional, minor behavior changes come with the unification:

* Option sort order now matches the spans picker (known Sentry log fields first, then alphabetical)
* Thee disabled `count` "logs" option now flows through the shared option builder (no visible type badge, gains the attribute-details popover).

Closes LOGS-847