### PR TITLE
fix(discover): Wrap attribute values with spaces in quotes

### DIFF
--- a/static/app/utils/discover/fields.spec.tsx
+++ b/static/app/utils/discover/fields.spec.tsx
@@ -7,6 +7,8 @@ import {
   explodeField,
   fieldAlignment,
   generateAggregateFields,
+  generateEquationFieldAsString,
+  generateFieldAsString,
   getAggregateAlias,
   isAggregateEquation,
   isAggregateField,
@@ -90,6 +92,55 @@ describe('parseFunction', () => {
       name: 'count',
       arguments: ['tags[foo,number]'],
     });
+  });
+});
+
+describe('generateFieldAsString', () => {
+  it('quotes function arguments that cannot parse raw', () => {
+    expect(
+      generateFieldAsString({
+        kind: 'function',
+        function: ['count_if', 'transaction.duration', 'equals', 'foo bar'],
+      })
+    ).toBe('count_if(transaction.duration,equals,"foo bar")');
+  });
+
+  it('preserves already quoted function arguments', () => {
+    expect(
+      generateFieldAsString({
+        kind: 'function',
+        function: ['count_if', 'transaction.duration', 'equals', '"foo bar"'],
+      })
+    ).toBe('count_if(transaction.duration,equals,"foo bar")');
+  });
+
+  it('preserves explicit tag function arguments', () => {
+    expect(
+      generateFieldAsString({
+        kind: 'function',
+        function: ['count', 'tags[foo,number]', undefined, undefined],
+      })
+    ).toBe('count(tags[foo,number])');
+  });
+
+  it('round-trips quoted function arguments through field parsing', () => {
+    expect(
+      explodeField({field: 'count_if(transaction.duration,equals,"foo bar")'})
+    ).toEqual({
+      kind: 'function',
+      function: ['count_if', 'transaction.duration', 'equals', 'foo bar'],
+    });
+  });
+});
+
+describe('generateEquationFieldAsString', () => {
+  it('uses function-safe field serialization', () => {
+    expect(
+      generateEquationFieldAsString({
+        kind: 'function',
+        function: ['count_if', 'transaction.duration', 'equals', 'foo bar'],
+      })
+    ).toBe('count_if(transaction.duration,equals,"foo bar")');
   });
 });
 

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -1193,7 +1193,7 @@ export function generateFieldAsString(value: QueryFieldValue): string {
   const slicedFunction = value.function.slice(1);
   const parameters: string[] = [];
   for (const parameter of slicedFunction) {
-    if (typeof parameter === 'string') {
+    if (parameter) {
       parameters.push(generateFunctionArgument(parameter));
     }
   }

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -1190,10 +1190,13 @@ export function generateFieldAsString(value: QueryFieldValue): string {
   }
 
   const aggregation = value.function[0];
-  const parameters = value.function
-    .slice(1)
-    .filter(Boolean)
-    .map(parameter => generateFunctionArgument(parameter!));
+  const slicedFunction = value.function.slice(1);
+  const parameters: string[] = [];
+  for (const parameter of slicedFunction) {
+    if (parameter) {
+      parameters.push(generateFunctionArgument(parameter));
+    }
+  }
   return `${aggregation}(${parameters.join(',')})`;
 }
 

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -1193,7 +1193,7 @@ export function generateFieldAsString(value: QueryFieldValue): string {
   const slicedFunction = value.function.slice(1);
   const parameters: string[] = [];
   for (const parameter of slicedFunction) {
-    if (parameter) {
+    if (typeof parameter === 'string') {
       parameters.push(generateFunctionArgument(parameter));
     }
   }

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -6,6 +6,7 @@ import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types'
 import {RELEASE_ADOPTION_STAGES} from 'sentry/constants';
 import type {Organization} from 'sentry/types/organization';
 import {assert} from 'sentry/types/utils';
+import {escapeDoubleQuotes} from 'sentry/utils';
 import {
   AGGREGATION_FIELDS,
   AggregationKey,
@@ -1134,18 +1135,42 @@ export function explodeFieldString(field: string, alias?: string): Column {
   const results = parseFunction(field);
 
   if (results) {
+    const args = results.arguments.map(normalizeFunctionArgument);
     return {
       kind: 'function',
-      function: [
-        results.name as AggregationKey,
-        results.arguments[0] ?? '',
-        ...results.arguments.slice(1),
-      ],
+      function: [results.name as AggregationKey, args[0] ?? '', ...args.slice(1)],
       alias,
     };
   }
 
   return {kind: 'field', field, alias};
+}
+
+const UNSAFE_FUNCTION_ARGUMENT = /[\s"(),]/;
+const EXPLICIT_TAG_FUNCTION_ARGUMENT = /^(?:sentry_tags|tags)\[.*\]$/;
+
+function isQuotedFunctionArgument(value: string): boolean {
+  return value.length >= 2 && value.startsWith('"') && value.endsWith('"');
+}
+
+function normalizeFunctionArgument(value: string): string {
+  if (!isQuotedFunctionArgument(value)) {
+    return value;
+  }
+
+  return value.slice(1, -1).replace(/\\"/g, '"');
+}
+
+function generateFunctionArgument(value: string): string {
+  if (
+    isQuotedFunctionArgument(value) ||
+    EXPLICIT_TAG_FUNCTION_ARGUMENT.test(value) ||
+    !UNSAFE_FUNCTION_ARGUMENT.test(value)
+  ) {
+    return value;
+  }
+
+  return `"${escapeDoubleQuotes(value)}"`;
 }
 
 export function generateFieldAsString(value: QueryFieldValue): string {
@@ -1162,8 +1187,15 @@ export function generateFieldAsString(value: QueryFieldValue): string {
   }
 
   const aggregation = value.function[0];
-  const parameters = value.function.slice(1).filter(Boolean);
+  const parameters = value.function
+    .slice(1)
+    .filter(Boolean)
+    .map(parameter => generateFunctionArgument(parameter!));
   return `${aggregation}(${parameters.join(',')})`;
+}
+
+export function generateEquationFieldAsString(value: QueryFieldValue): string {
+  return generateFieldAsString(value);
 }
 
 export function explodeField(field: Field): Column {

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -1148,9 +1148,12 @@ export function explodeFieldString(field: string, alias?: string): Column {
 
 const UNSAFE_FUNCTION_ARGUMENT = /[\s"(),]/;
 const EXPLICIT_TAG_FUNCTION_ARGUMENT = /^(?:sentry_tags|tags)\[.*\]$/;
+const MIN_SEPARATE_WORDS = 2;
 
 function isQuotedFunctionArgument(value: string): boolean {
-  return value.length >= 2 && value.startsWith('"') && value.endsWith('"');
+  return (
+    value.length >= MIN_SEPARATE_WORDS && value.startsWith('"') && value.endsWith('"')
+  );
 }
 
 function normalizeFunctionArgument(value: string): string {

--- a/static/app/views/discover/table/arithmeticInput.spec.tsx
+++ b/static/app/views/discover/table/arithmeticInput.spec.tsx
@@ -164,6 +164,34 @@ describe('ArithmeticInput', () => {
     );
   });
 
+  it('quotes unsafe function arguments in autocomplete options', async () => {
+    const optionValue = 'count_if(transaction.duration,equals,"foo bar")';
+
+    render(
+      <ArithmeticInput
+        name="refinement"
+        key="parameter:text"
+        type="text"
+        value=""
+        onUpdate={jest.fn()}
+        options={[
+          {
+            kind: 'function',
+            function: ['count_if', 'transaction.duration', 'equals', 'foo bar'],
+          },
+        ]}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('textbox'));
+
+    expect(screen.getByRole('listitem', {name: optionValue})).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText(optionValue));
+
+    expect(screen.getByRole('textbox')).toHaveValue(`${optionValue} `);
+  });
+
   it('autocompletes the current term when it is in the front', async () => {
     render(
       <ArithmeticInput

--- a/static/app/views/discover/table/arithmeticInput.tsx
+++ b/static/app/views/discover/table/arithmeticInput.tsx
@@ -7,7 +7,10 @@ import {Input} from '@sentry/scraps/input';
 
 import {t} from 'sentry/locale';
 import type {Column} from 'sentry/utils/discover/fields';
-import {generateFieldAsString, isLegalEquationColumn} from 'sentry/utils/discover/fields';
+import {
+  generateEquationFieldAsString,
+  isLegalEquationColumn,
+} from 'sentry/utils/discover/fields';
 
 const NONE_SELECTED = -1;
 
@@ -359,7 +362,7 @@ function makeFieldOptions(
     .map(option => ({
       kind: 'field' as const,
       active: false,
-      value: generateFieldAsString(option),
+      value: generateEquationFieldAsString(option),
     }))
     .filter(({value}) => {
       if (fieldValues.has(value)) {

--- a/static/app/views/discover/table/columnEditCollection.tsx
+++ b/static/app/views/discover/table/columnEditCollection.tsx
@@ -19,7 +19,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import type {Column} from 'sentry/utils/discover/fields';
 import {
   AGGREGATIONS,
-  generateFieldAsString,
+  generateEquationFieldAsString,
   hasDuplicate,
   isLegalEquationColumn,
 } from 'sentry/utils/discover/fields';
@@ -178,8 +178,8 @@ class ColumnEditCollection extends Component<Props, State> {
 
   updateEquationFields = (newColumns: Column[], index: number, updatedColumn: Column) => {
     const oldColumn = newColumns[index]!;
-    const existingColumn = generateFieldAsString(newColumns[index]!);
-    const updatedColumnString = generateFieldAsString(updatedColumn);
+    const existingColumn = generateEquationFieldAsString(newColumns[index]!);
+    const updatedColumnString = generateEquationFieldAsString(updatedColumn);
     if (!isLegalEquationColumn(updatedColumn) || hasDuplicate(newColumns, oldColumn)) {
       return;
     }

--- a/static/app/views/discover/table/columnEditModal.spec.tsx
+++ b/static/app/views/discover/table/columnEditModal.spec.tsx
@@ -674,6 +674,49 @@ describe('Discover -> ColumnEditModal', () => {
         {kind: 'equation', field: '(p95() / count_if(user,equals,300)  ) *   100'},
       ]);
     });
+    it('updates equations with quoted function arguments when function values change', async () => {
+      mountModal(
+        {
+          columns: [
+            {
+              kind: 'function',
+              function: ['count_if', 'transaction.duration', 'equals', 'foo bar'],
+            },
+            {
+              kind: 'function',
+              function: ['count', '', undefined, undefined],
+            },
+            {
+              kind: 'equation',
+              field: 'count_if(transaction.duration,equals,"foo bar") / count()',
+            },
+          ],
+          onApply,
+          customMeasurements: {},
+        },
+        initialData
+      );
+
+      const countIfValueInput = await screen.findByDisplayValue('foo bar');
+      fireEvent.change(countIfValueInput, {target: {value: 'bar baz'}});
+      fireEvent.blur(countIfValueInput);
+
+      expect(await screen.findByDisplayValue('bar baz')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+      expect(onApply).toHaveBeenCalledWith([
+        {
+          kind: 'function',
+          function: ['count_if', 'transaction.duration', 'equals', 'bar baz'],
+        },
+        {kind: 'function', function: ['count', '', undefined, undefined]},
+        {
+          kind: 'equation',
+          field: 'count_if(transaction.duration,equals,"bar baz") / count()',
+        },
+      ]);
+    });
+
     it('update equation with repeated columns when they change', async () => {
       mountModal(
         {


### PR DESCRIPTION
This PR resolves an issue where attribute values that had spaces weren't being quoted so that was breaking things.

Closes EXP-123

**Before:**
<img width="777" height="215" alt="Screenshot 2026-06-12 at 12 15 19" src="https://github.com/user-attachments/assets/df4198f8-d3b4-4218-a9e2-3f4972bddabf" />

**After:**
<img width="800" height="235" alt="Screenshot 2026-06-12 at 12 15 55" src="https://github.com/user-attachments/assets/5006a892-74d0-4a85-a17f-704e37f82904" />