### PR TITLE
fix(deletions): normalize group-deletion pagination cursor for Snuba

### DIFF
--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
 from typing import Any
 
 import sentry_sdk
@@ -164,10 +165,19 @@ def fetch_events_from_eventstore(
     conditions = []
     eap_conditions: TraceItemFilter | None = build_group_id_in_filter(group_ids)
     if last_event_id and last_event_timestamp:
+        # Snuba's legacy SnQL parser (snuba_sdk.legacy.parse_datetime) only recognizes a
+        # condition value as a datetime when it has no tz offset; Event.timestamp is a
+        # tz-aware isoformat, so strip the offset to naive UTC for the legacy conditions.
+        naive_timestamp = (
+            datetime.fromisoformat(last_event_timestamp)
+            .astimezone(timezone.utc)
+            .replace(tzinfo=None)
+            .isoformat()
+        )
         conditions.extend(
             [
-                ["timestamp", "<=", last_event_timestamp],
-                [["timestamp", "<", last_event_timestamp], ["event_id", "<", last_event_id]],
+                ["timestamp", "<=", naive_timestamp],
+                [["timestamp", "<", naive_timestamp], ["event_id", "<", last_event_id]],
             ]
         )
         eap_conditions = and_trace_item_filters(

--- a/tests/sentry/deletions/tasks/test_nodestore.py
+++ b/tests/sentry/deletions/tasks/test_nodestore.py
@@ -1,8 +1,6 @@
-from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
-from snuba_sdk.legacy import parse_scalar
 
 from sentry.deletions.tasks.nodestore import (
     delete_events_for_groups_from_nodestore_and_eventstore,
@@ -100,31 +98,6 @@ class NodestoreDeletionTaskTest(TestCase):
 
         with pytest.raises(UnqualifiedQueryError):
             self.fetch_events_from_eventstore(group_ids, dataset=Dataset.Events)
-
-    def test_pagination_cursor_timestamp_is_parsed_as_datetime(self) -> None:
-        """The pagination cursor must be recognized as a datetime by Snuba's legacy SnQL
-        parser. A tz-aware isoformat with microseconds (what Event.timestamp produces) is not,
-        which previously caused Snuba to reject the timestamp condition (SNUBA-32F)."""
-        # tz-aware isoformat with microseconds, the format Event.timestamp emits.
-        tz_aware = "2023-04-01T04:02:07.644000+00:00"
-        naive_timestamp = (
-            datetime.fromisoformat(tz_aware)
-            .astimezone(timezone.utc)
-            .replace(tzinfo=None)
-            .isoformat()
-        )
-        # The raw tz-aware value falls back to a string (the bug); the normalized value parses.
-        assert not isinstance(parse_scalar(tz_aware), datetime)
-        assert isinstance(parse_scalar(naive_timestamp), datetime)
-
-        # Zero-microsecond timestamps drop the fractional component but must still parse.
-        naive_no_micros = (
-            datetime.fromisoformat("2023-04-01T04:02:07+00:00")
-            .astimezone(timezone.utc)
-            .replace(tzinfo=None)
-            .isoformat()
-        )
-        assert isinstance(parse_scalar(naive_no_micros), datetime)
 
     def test_fetch_events_with_pagination_cursor(self) -> None:
         """Fetching with a cursor (last event's id/timestamp) returns the remaining events."""

--- a/tests/sentry/deletions/tasks/test_nodestore.py
+++ b/tests/sentry/deletions/tasks/test_nodestore.py
@@ -1,6 +1,8 @@
+from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
+from snuba_sdk.legacy import parse_scalar
 
 from sentry.deletions.tasks.nodestore import (
     delete_events_for_groups_from_nodestore_and_eventstore,
@@ -23,7 +25,13 @@ class NodestoreDeletionTaskTest(TestCase):
             events.append(event)
         return events
 
-    def fetch_events_from_eventstore(self, group_ids: list[int], dataset: Dataset) -> list[Event]:
+    def fetch_events_from_eventstore(
+        self,
+        group_ids: list[int],
+        dataset: Dataset,
+        last_event_id: str | None = None,
+        last_event_timestamp: str | None = None,
+    ) -> list[Event]:
         return fetch_events_from_eventstore(
             project_id=self.project.id,
             group_ids=group_ids,
@@ -33,6 +41,8 @@ class NodestoreDeletionTaskTest(TestCase):
                 "referrer": Referrer.DELETIONS_GROUP.value,
                 "organization_id": self.project.organization_id,
             },
+            last_event_id=last_event_id,
+            last_event_timestamp=last_event_timestamp,
         )
 
     def test_simple_deletion_with_events(self) -> None:
@@ -90,3 +100,48 @@ class NodestoreDeletionTaskTest(TestCase):
 
         with pytest.raises(UnqualifiedQueryError):
             self.fetch_events_from_eventstore(group_ids, dataset=Dataset.Events)
+
+    def test_pagination_cursor_timestamp_is_parsed_as_datetime(self) -> None:
+        """The pagination cursor must be recognized as a datetime by Snuba's legacy SnQL
+        parser. A tz-aware isoformat with microseconds (what Event.timestamp produces) is not,
+        which previously caused Snuba to reject the timestamp condition (SNUBA-32F)."""
+        # tz-aware isoformat with microseconds, the format Event.timestamp emits.
+        tz_aware = "2023-04-01T04:02:07.644000+00:00"
+        naive_timestamp = (
+            datetime.fromisoformat(tz_aware)
+            .astimezone(timezone.utc)
+            .replace(tzinfo=None)
+            .isoformat()
+        )
+        # The raw tz-aware value falls back to a string (the bug); the normalized value parses.
+        assert not isinstance(parse_scalar(tz_aware), datetime)
+        assert isinstance(parse_scalar(naive_timestamp), datetime)
+
+        # Zero-microsecond timestamps drop the fractional component but must still parse.
+        naive_no_micros = (
+            datetime.fromisoformat("2023-04-01T04:02:07+00:00")
+            .astimezone(timezone.utc)
+            .replace(tzinfo=None)
+            .isoformat()
+        )
+        assert isinstance(parse_scalar(naive_no_micros), datetime)
+
+    def test_fetch_events_with_pagination_cursor(self) -> None:
+        """Fetching with a cursor (last event's id/timestamp) returns the remaining events."""
+        events = self.create_n_events_with_group(n_events=5)
+        group_ids = [event.group_id for event in events if event.group_id is not None]
+
+        all_events = self.fetch_events_from_eventstore(group_ids, dataset=Dataset.Events)
+        assert len(all_events) == 5
+
+        cursor_event = all_events[0]
+        remaining = self.fetch_events_from_eventstore(
+            group_ids,
+            dataset=Dataset.Events,
+            last_event_id=cursor_event.event_id,
+            last_event_timestamp=cursor_event.timestamp,
+        )
+        # Results are ordered by -timestamp, -event_id, so the keyset cursor excludes everything
+        # at or before the first event, returning the strictly-later remainder.
+        assert cursor_event.event_id not in {event.event_id for event in remaining}
+        assert len(remaining) == len(all_events) - 1


### PR DESCRIPTION
Group-deletion event pagination passed Event.timestamp (a tz-aware isoformat with microseconds) directly into a legacy Snuba condition. snuba_sdk.legacy.parse_datetime has no date format that accepts both a fractional-seconds component and a timezone offset, so a value like `2023-04-01T04:02:07.644000+00:00` fails to parse and falls back to a plain string literal, which Snuba's validator rejects as not a valid datetime. (A tz-aware value with zero microseconds happens to parse, so this only bites when the cursor event's timestamp has nonzero microseconds.)

Normalize the cursor to a naive-UTC isoformat for the legacy SnQL conditions only. The EAP keyset filter keeps the original tz-aware value on purpose: it computes an epoch via `fromisoformat().timestamp()`, and a naive datetime there would be interpreted as local time and produce a wrong epoch.

Fixes [SNUBA-32F](https://sentry.sentry.io/issues/3941748369/)