### PR TITLE
fix(onboarding): Prevent duplicate SCM project create on repeat click

### DIFF
--- a/static/app/views/onboarding/components/useScmProjectDetails.ts
+++ b/static/app/views/onboarding/components/useScmProjectDetails.ts
@@ -1,4 +1,4 @@
-import {useCallback, useRef} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -223,13 +223,23 @@ export function useScmProjectDetails({
     team: !isOrgMemberWithNoAccess && !isLoadingTeams && teamSlugResolved.length === 0,
   };
 
+  // Tracks the create -> repo-link -> onComplete handoff as one busy span.
+  // createProjectAndRules.isPending only covers the project POST, so the
+  // repo-link request that follows it would otherwise run with the button
+  // re-enabled and let a second click create a duplicate. Reset on every exit
+  // (see the finally in submit) rather than held until unmount, so the button
+  // does not depend on the consumer unmounting on completion. The ref is the
+  // synchronous re-entry guard; the state drives the button's busy/disabled UI.
+  const isCompletingRef = useRef(false);
+  const [isCompleting, setIsCompleting] = useState(false);
+
   // Block submission until teams and the projects store have loaded so the
   // reuse check below can't be bypassed by a race.
   const canSubmit =
     !missingFields.projectName &&
     !missingFields.team &&
     !missingFields.platform &&
-    !createProjectAndRules.isPending &&
+    !isCompleting &&
     !isLoadingTeams &&
     projectsLoaded;
 
@@ -254,9 +264,11 @@ export function useScmProjectDetails({
     alertRuleConfig.threshold === savedAlert?.threshold;
 
   const submit = useCallback(async () => {
-    if (!selectedPlatform || !canSubmit) {
+    if (!selectedPlatform || !canSubmit || isCompletingRef.current) {
       return;
     }
+    isCompletingRef.current = true;
+    setIsCompleting(true);
 
     trackAnalytics(CREATE_CLICKED_EVENT[analyticsFlow], {organization});
 
@@ -266,19 +278,19 @@ export function useScmProjectDetails({
       alertRuleConfig,
     };
 
-    // User navigated back and clicked Create without changing anything; skip
-    // to completion without creating a duplicate. Any actual change abandons
-    // the previous project and creates a new one, matching legacy onboarding.
-    if (existingProject && nothingChanged) {
-      trackAnalytics(CREATE_SUCCEEDED_EVENT[analyticsFlow], {
-        organization,
-        project_slug: existingProject.slug,
-      });
-      onComplete({project: existingProject, projectDetailsForm: submittedForm});
-      return;
-    }
-
     try {
+      // User navigated back and clicked Create without changing anything; skip
+      // to completion without creating a duplicate. Any actual change abandons
+      // the previous project and creates a new one, matching legacy onboarding.
+      if (existingProject && nothingChanged) {
+        trackAnalytics(CREATE_SUCCEEDED_EVENT[analyticsFlow], {
+          organization,
+          project_slug: existingProject.slug,
+        });
+        onComplete({project: existingProject, projectDetailsForm: submittedForm});
+        return;
+      }
+
       const {project} = await createProjectAndRules.mutateAsync({
         projectName: projectNameResolved,
         platform: selectedPlatform,
@@ -309,6 +321,9 @@ export function useScmProjectDetails({
       trackAnalytics(CREATE_FAILED_EVENT[analyticsFlow], {organization});
       addErrorMessage(t('Failed to create project'));
       Sentry.captureException(error);
+    } finally {
+      isCompletingRef.current = false;
+      setIsCompleting(false);
     }
   }, [
     analyticsFlow,
@@ -337,7 +352,7 @@ export function useScmProjectDetails({
     isOrgMemberWithNoAccess,
     missingFields,
     canSubmit,
-    isBusy: createProjectAndRules.isPending,
+    isBusy: isCompleting,
     error: createProjectAndRules.error,
     submit,
   };

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -187,6 +187,66 @@ describe('ScmProjectDetails', () => {
     });
   });
 
+  it('stays busy while linking the repo so a second click cannot duplicate', async () => {
+    const created = ProjectFixture({
+      slug: 'javascript-nextjs',
+      name: 'javascript-nextjs',
+    });
+    const createRequest = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
+      method: 'POST',
+      body: created,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [teamWithAccess],
+    });
+
+    // The repo link runs after the project POST resolves, i.e. while the create
+    // mutation is no longer pending. Delaying it holds the flow in exactly the
+    // window where the button used to re-enable and accept a duplicate create.
+    const repoLinkRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${created.slug}/repo/`,
+      method: 'POST',
+      body: {
+        id: '1',
+        projectId: created.id,
+        repositoryId: mockRepository.id,
+        source: 'scm_onboarding',
+        created: true,
+      },
+      asyncDelay: 50,
+    });
+
+    const props = defaultProps({
+      selectedPlatform: mockPlatform,
+      selectedRepository: mockRepository,
+    });
+    render(<ScmProjectDetails {...props} />, {organization});
+
+    const createButton = await screen.findByRole('button', {name: 'Create project'});
+    await userEvent.click(createButton);
+
+    // Project POST resolved, repo link still in flight: the button must remain
+    // disabled, so this second click is a no-op.
+    expect(createButton).toBeDisabled();
+    await userEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(props.onComplete).toHaveBeenCalledTimes(1);
+    });
+    expect(createRequest).toHaveBeenCalledTimes(1);
+    expect(repoLinkRequest).toHaveBeenCalledTimes(1);
+  });
+
   it('links selected repository to project after creation', async () => {
     const createdProject = ProjectFixture({
       slug: 'javascript-nextjs',

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -213,6 +213,8 @@ describe('ScmProjectDetails', () => {
     // The repo link runs after the project POST resolves, i.e. while the create
     // mutation is no longer pending. Delaying it holds the flow in exactly the
     // window where the button used to re-enable and accept a duplicate create.
+    // The delay must comfortably exceed userEvent's inter-click time so a loaded
+    // CI runner can't let it elapse mid-second-click and re-enable the button.
     const repoLinkRequest = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${created.slug}/repo/`,
       method: 'POST',
@@ -223,7 +225,7 @@ describe('ScmProjectDetails', () => {
         source: 'scm_onboarding',
         created: true,
       },
-      asyncDelay: 50,
+      asyncDelay: 1000,
     });
 
     const props = defaultProps({
@@ -240,9 +242,14 @@ describe('ScmProjectDetails', () => {
     expect(createButton).toBeDisabled();
     await userEvent.click(createButton);
 
-    await waitFor(() => {
-      expect(props.onComplete).toHaveBeenCalledTimes(1);
-    });
+    // Completion only fires once the delayed repo link resolves, so give the
+    // wait headroom over the asyncDelay above.
+    await waitFor(
+      () => {
+        expect(props.onComplete).toHaveBeenCalledTimes(1);
+      },
+      {timeout: 5000}
+    );
     expect(createRequest).toHaveBeenCalledTimes(1);
     expect(repoLinkRequest).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## TLDR

The single-view SCM project creation flow could POST a duplicate project. The Create button only stayed busy for the project POST itself, so during the repo-link request that runs right after, the button re-enabled and a second click created a second project. This tracks the full create plus repo-link work with a busy flag so the button stays disabled for that whole span. Surfaced by Cursor Bugbot on #117213; the affected hook lives on master (added in #117209), so this is independent of that stack.

## Details

The Create button is gated on `useScmProjectDetails`: `disabled={!canSubmit}` and `busy={isBusy}`, and a busy or disabled button blocks clicks. `createProjectAndRules.isPending` covers the project POST, but the repo-link request that follows it (and the synchronous back-nav reuse handoff) run with `isPending` already false, so the button re-enabled in that window. A second click re-entered `submit`, and because the in-memory created slug is not set there, the reuse check did not apply and a second project was POSTed.

The fix tracks the whole `create -> repo-link -> onComplete` handoff with a completing flag, using state to drive `canSubmit`/`isBusy` and a ref as a synchronous re-entry guard. It is set when a submit begins and reset in a `finally` that runs on every exit, so the button stays disabled while the async work is in flight and then re-enables once it settles, rather than depending on the consumer unmounting on completion. Both hosts using the hook (onboarding's fixed footer and project creation's page-level footer) get the same guarantee.

A regression test drives the hook through the onboarding host with a selected repo and a delayed repo-link response: it asserts the button stays disabled while the link is in flight and that a second click in that window neither POSTs again nor double-fires completion. The test fails against the pre-fix hook and passes with the fix.
