### PR TITLE
feat(admin): show authorized applications on user detail page

### DIFF
--- a/src/sentry/api/endpoints/api_authorizations.py
+++ b/src/sentry/api/endpoints/api_authorizations.py
@@ -6,9 +6,11 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.permissions import SentryIsAuthenticated
 from sentry.api.serializers import serialize
+from sentry.auth.elevated_mode import has_elevated_mode
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.models.apiapplication import ApiApplicationStatus
 from sentry.models.apiauthorization import ApiAuthorization
@@ -30,8 +32,15 @@ class ApiAuthorizationsEndpoint(Endpoint):
         if not request.user.is_authenticated:
             return Response(status=400)
 
+        user_id = request.user.id
+        if has_elevated_mode(request):
+            try:
+                user_id = int(request.GET.get("userId", user_id))
+            except (ValueError, TypeError):
+                raise ResourceDoesNotExist(detail="Invalid user ID")
+
         queryset = ApiAuthorization.objects.filter(
-            user_id=request.user.id, application__status=ApiApplicationStatus.active
+            user_id=user_id, application__status=ApiApplicationStatus.active
         ).select_related("application")
 
         return self.paginate(

--- a/static/gsAdmin/components/users/userAuthorizedApps.tsx
+++ b/static/gsAdmin/components/users/userAuthorizedApps.tsx
@@ -1,0 +1,63 @@
+import {ExternalLink} from '@sentry/scraps/link';
+
+import {EmptyMessage} from 'sentry/components/emptyMessage';
+import {Panel} from 'sentry/components/panels/panel';
+import {PanelBody} from 'sentry/components/panels/panelBody';
+import {PanelHeader} from 'sentry/components/panels/panelHeader';
+import {PanelItem} from 'sentry/components/panels/panelItem';
+import type {ApiApplication} from 'sentry/types/user';
+
+import {DetailLabel} from 'admin/components/detailLabel';
+
+type Authorization = {
+  application: ApiApplication;
+  dateCreated: string;
+  id: string;
+  organization: {name: string; slug: string} | null;
+  scopes: string[];
+};
+
+type Props = {
+  authorizations: Authorization[];
+};
+
+export function UserAuthorizedApps({authorizations}: Props) {
+  if (!authorizations.length) {
+    return (
+      <Panel>
+        <PanelHeader>Authorized Applications</PanelHeader>
+        <PanelBody>
+          <EmptyMessage>No authorized applications.</EmptyMessage>
+        </PanelBody>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel>
+      <PanelHeader>Authorized Applications</PanelHeader>
+      <PanelBody>
+        {authorizations.map(auth => (
+          <PanelItem key={auth.id} style={{flexDirection: 'column', gap: 4}}>
+            <strong>{auth.application.name}</strong>
+            {auth.application.homepageUrl && (
+              <small>
+                <ExternalLink href={auth.application.homepageUrl}>
+                  {auth.application.homepageUrl}
+                </ExternalLink>
+              </small>
+            )}
+            <DetailLabel title="Scopes">
+              <small>{auth.scopes.join(', ') || '(none)'}</small>
+            </DetailLabel>
+            {auth.organization && (
+              <DetailLabel title="Organization">
+                <small>{auth.organization.slug}</small>
+              </DetailLabel>
+            )}
+          </PanelItem>
+        ))}
+      </PanelBody>
+    </Panel>
+  );
+}

--- a/static/gsAdmin/views/userDetails.spec.tsx
+++ b/static/gsAdmin/views/userDetails.spec.tsx
@@ -45,6 +45,11 @@ describe('User Details', () => {
       body: [],
     });
 
+    MockApiClient.addMockResponse({
+      url: '/api-authorizations/',
+      body: [],
+    });
+
     ConfigStore.set('cells', [{name: 'us', locality_url: 'https://us.sentry.io'}]);
   });
 

--- a/static/gsAdmin/views/userDetails.tsx
+++ b/static/gsAdmin/views/userDetails.tsx
@@ -24,6 +24,7 @@ import {useParams} from 'sentry/utils/useParams';
 import {DetailsPage} from 'admin/components/detailsPage';
 import {MergeAccountsModal} from 'admin/components/mergeAccounts';
 import {SelectableContainer} from 'admin/components/selectableContainer';
+import {UserAuthorizedApps} from 'admin/components/users/userAuthorizedApps';
 import {UserCustomers} from 'admin/components/users/userCustomers';
 import {UserEmailLog} from 'admin/components/users/userEmailLog';
 import {UserEmails} from 'admin/components/users/userEmails';
@@ -52,6 +53,11 @@ export function UserDetails() {
     {query: {userId}},
   ];
 
+  const makeFetchAuthorizationsQueryKey = (): ApiQueryKey => [
+    getApiUrl('/api-authorizations/'),
+    {query: {userId}},
+  ];
+
   const {
     data: user,
     isPending: isUserPending,
@@ -77,10 +83,20 @@ export function UserDetails() {
     staleTime: 0,
   });
 
+  const {
+    data: authorizations,
+    isPending: isAuthorizationsPending,
+    isError: isAuthorizationsError,
+    refetch: refetchAuthorizations,
+  } = useApiQuery<any[]>(makeFetchAuthorizationsQueryKey(), {
+    staleTime: 0,
+  });
+
   const refetchData = () => {
     refetchUser();
     refetchIdentities();
     refetchTokens();
+    refetchAuthorizations();
   };
 
   const onUpdateMutation = useMutation({
@@ -143,11 +159,11 @@ export function UserDetails() {
     },
   });
 
-  if (isUserPending || isIdentitiesPending || isTokensPending) {
+  if (isUserPending || isIdentitiesPending || isTokensPending || isAuthorizationsPending) {
     return <LoadingIndicator />;
   }
 
-  if (isUserError || isIdentitiesError || isTokensError) {
+  if (isUserError || isIdentitiesError || isTokensError || isAuthorizationsError) {
     return <LoadingError onRetry={refetchData} />;
   }
 
@@ -332,6 +348,10 @@ export function UserDetails() {
         {
           noPanel: true,
           content: userEmails,
+        },
+        {
+          noPanel: true,
+          content: <UserAuthorizedApps authorizations={authorizations ?? []} />,
         },
       ]}
     />

--- a/tests/sentry/api/endpoints/test_api_authorizations.py
+++ b/tests/sentry/api/endpoints/test_api_authorizations.py
@@ -43,6 +43,27 @@ class ApiAuthorizationsListTest(ApiAuthorizationsTest):
         assert len(response.data) == 1
         assert response.data[0]["organization"]["slug"] == org.slug
 
+    def test_superuser_can_view_other_users_authorizations(self) -> None:
+        other_user = self.create_user("other@example.com")
+        app = ApiApplication.objects.create(name="other-app", owner=other_user)
+        auth = ApiAuthorization.objects.create(application=app, user=other_user)
+
+        superuser = self.create_user(is_superuser=True)
+        self.login_as(superuser, superuser=True)
+
+        response = self.get_success_response(qs_params={"userId": other_user.id})
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(auth.id)
+
+    def test_non_superuser_cannot_view_other_users_authorizations(self) -> None:
+        other_user = self.create_user("other2@example.com")
+        app = ApiApplication.objects.create(name="other-app2", owner=other_user)
+        ApiAuthorization.objects.create(application=app, user=other_user)
+
+        # Non-superuser requesting another user's authorizations falls back to own data
+        response = self.get_success_response(qs_params={"userId": other_user.id})
+        assert len(response.data) == 0
+
 
 @control_silo_test
 class ApiAuthorizationsDeleteTest(ApiAuthorizationsTest):


### PR DESCRIPTION
## Summary

Implements the user feedback asking to show authorized (OAuth) applications in the admin UI.

Adds an **Authorized Applications** panel to the gsAdmin user detail page, appearing after the Emails section — showing the same data a user sees on their own account settings page:

- Application name
- Homepage URL (linked)
- Granted scopes
- Organization scope (if limited to one org)

## Changes

### Backend — `src/sentry/api/endpoints/api_authorizations.py`

Extends `GET /api-authorizations/` to accept a `userId` query param when the requester is in elevated (superuser) mode. Mirrors the existing pattern in `/api-tokens/` (`get_appropriate_user_id`).

### Frontend

- **New** `static/gsAdmin/components/users/userAuthorizedApps.tsx` — `UserAuthorizedApps` panel component
- **Updated** `static/gsAdmin/views/userDetails.tsx` — fetches `/api-authorizations/?userId=…` and renders the new panel as a bottom section
- **Updated** `static/gsAdmin/views/userDetails.spec.tsx` — adds the required mock response for `/api-authorizations/`

## Testing

- Added backend tests for superuser `userId` lookup and regression test confirming non-superusers can't view other users' authorizations
- Existing frontend spec updated to include the new mock

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC07525G48Q1%3A1781278761.615969%22)