### PR TITLE
feat: options read hook

### DIFF
--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from enum import Enum
 from typing import TYPE_CHECKING
 from typing import Any as TAny
@@ -18,12 +18,21 @@ from sentry.utils.types import Any, Type, type_from_value
 if TYPE_CHECKING:
     from sentry.options.store import GroupingInfo, Key, OptionsStore
 
+    # A read hook receives the key and its resolved registry entry and returns
+    # either a value to serve or READ_HOOK_FALLBACK to defer to the normal
+    # store/disk/default resolution.
+    ReadHook = Callable[[str, Key], object]
+
 # Prevent ourselves from clobbering the builtin
 _type = type
 
 logger = logging.getLogger("sentry")
 
 NoneType = type(None)
+
+# Returned by a read hook when it has no value to serve for the key. A unique
+# object so it can never collide with a value a hook might legitimately return.
+READ_HOOK_FALLBACK = object()
 
 
 class UpdateChannel(Enum):
@@ -183,6 +192,19 @@ class OptionsManager:
     def __init__(self, store: OptionsStore):
         self.store = store
         self.registry: dict[str, Key] = {}
+        # Optional hook consulted at the start of get(). Open-source Sentry leaves
+        # this unset; getsentry installs one to dual-read FLAG_AUTOMATOR_MODIFIABLE
+        # options from sentry-options.
+        self._read_hook: ReadHook | None = None
+
+    def set_read_hook(self, hook: ReadHook | None) -> None:
+        """Install (or clear) a hook consulted at the start of every get().
+
+        Because the hook is consulted inside get() itself, every caller observes
+        it regardless of how they imported get — including references captured via
+        ``from sentry.options import get`` before the hook was installed.
+        """
+        self._read_hook = hook
 
     def set(self, key: str, value, coerce=True, channel: UpdateChannel = UpdateChannel.UNKNOWN):
         """
@@ -270,6 +292,10 @@ class OptionsManager:
         """
         opt = self.lookup_key(key)
 
+        # Keep parity with get(): a value served by the read hook counts as set.
+        if self._read_hook is not None and self._read_hook(key, opt) is not READ_HOOK_FALLBACK:
+            return True
+
         if not opt.has_any_flag({FLAG_NOSTORE}):
             result = self.store.get(opt, silent=True)
             if result is not None:
@@ -306,6 +332,13 @@ class OptionsManager:
             sample_rate=0.01,
         ) as tags:
             opt = self.lookup_key(key)
+
+            if self._read_hook is not None:
+                result = self._read_hook(key, opt)
+                if result is not READ_HOOK_FALLBACK:
+                    tags["source"] = "hook"
+                    record_option(key, result)
+                    return result
 
             # First check if the option should exist on disk, and if it actually
             # has a value set, let's use that one instead without even attempting
@@ -525,7 +558,9 @@ class OptionsManager:
             # update.
             return None
 
-        stored_value = self.get(key)
+        # Judge drift against the stored value, never a read-hook override:
+        # writability is governed by what is actually in the legacy store.
+        stored_value = self.store.get(opt, silent=True)
         if stored_value == value:
             # In theory options could have any type so this equality may
             # not be correct.

--- a/src/sentry/relocation/api/endpoints/index.py
+++ b/src/sentry/relocation/api/endpoints/index.py
@@ -23,7 +23,6 @@ from sentry.api.permissions import SentryIsAuthenticated
 from sentry.api.serializers import serialize
 from sentry.auth.elevated_mode import has_elevated_mode
 from sentry.models.files.file import File
-from sentry.options import get
 from sentry.relocation.api.endpoints import ERR_FEATURE_DISABLED
 from sentry.relocation.api.serializers.relocation import RelocationSerializer
 from sentry.relocation.models.relocation import Relocation, RelocationFile
@@ -75,7 +74,7 @@ def should_throttle_relocation(relocation_bucket_size: str) -> bool:
         recent_relocation_files,
         0,
     )
-    if num_recent_same_size_relocation_files < get(
+    if num_recent_same_size_relocation_files < options.get(
         f"relocation.daily-limit.{relocation_bucket_size}"
     ):
         return False

--- a/src/sentry/usage_accountant/accountant.py
+++ b/src/sentry/usage_accountant/accountant.py
@@ -12,8 +12,8 @@ import logging
 
 from usageaccountant import UsageAccumulator, UsageUnit
 
+from sentry import options
 from sentry.conf.types.kafka_definition import Topic
-from sentry.options import get
 from sentry.utils.arroyo_producer import get_arroyo_producer
 
 logger = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ def record(
     """
 
     global _accountant_backend
-    if resource_id not in get("shared_resources_accounting_enabled"):
+    if resource_id not in options.get("shared_resources_accounting_enabled"):
         return
 
     if _accountant_backend is None:

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -469,9 +469,7 @@ class OptionsManagerTest(TestCase):
             lambda key, opt: "hook-value" if key == "hooked" else READ_HOOK_FALLBACK
         )
         try:
-            assert (
-                self.manager.can_update("hooked", "stored", UpdateChannel.AUTOMATOR) is None
-            )
+            assert self.manager.can_update("hooked", "stored", UpdateChannel.AUTOMATOR) is None
         finally:
             self.manager.set_read_hook(None)
             self.manager.unregister("hooked")

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -17,6 +17,7 @@ from sentry.options.manager import (
     FLAG_PRIORITIZE_DISK,
     FLAG_REQUIRED,
     FLAG_STOREONLY,
+    READ_HOOK_FALLBACK,
     NotWritableReason,
     OptionsManager,
     UnknownOption,
@@ -433,3 +434,44 @@ class OptionsManagerTest(TestCase):
 
         ctx = mock_timer.return_value.__enter__.return_value
         ctx.__setitem__.assert_any_call("source", "default")
+
+    def test_read_hook_serves_get_and_isset(self) -> None:
+        # A value that lives only in the hook is served by get(), and isset() must
+        # agree — the option has a value, just from the new source.
+        self.manager.register("hooked", flags=FLAG_AUTOMATOR_MODIFIABLE)
+        self.manager.set_read_hook(
+            lambda key, opt: "served" if key == "hooked" else READ_HOOK_FALLBACK
+        )
+        try:
+            assert self.manager.get("hooked") == "served"
+            assert self.manager.isset("hooked") is True
+        finally:
+            self.manager.set_read_hook(None)
+            self.manager.unregister("hooked")
+
+    def test_read_hook_fallback_uses_legacy(self) -> None:
+        self.manager.set_read_hook(lambda key, opt: READ_HOOK_FALLBACK)
+        try:
+            # isset() before get(): get() would repopulate the cache and make
+            # isset() report True regardless (see its docstring).
+            assert self.manager.isset("foo") is False
+            assert self.manager.get("foo") == ""
+        finally:
+            self.manager.set_read_hook(None)
+
+    def test_read_hook_does_not_corrupt_can_update_drift(self) -> None:
+        # Writability/drift must be judged against the stored value, never a hook
+        # override. A CLI-set value re-asserted by the automator is allowed; if
+        # drift read the (different) hook value instead, it would falsely DRIFT.
+        self.manager.register("hooked", type=String, flags=FLAG_AUTOMATOR_MODIFIABLE)
+        self.manager.set("hooked", "stored", channel=UpdateChannel.CLI)
+        self.manager.set_read_hook(
+            lambda key, opt: "hook-value" if key == "hooked" else READ_HOOK_FALLBACK
+        )
+        try:
+            assert (
+                self.manager.can_update("hooked", "stored", UpdateChannel.AUTOMATOR) is None
+            )
+        finally:
+            self.manager.set_read_hook(None)
+            self.manager.unregister("hooked")


### PR DESCRIPTION
this adds an optional `OptionsManager.get` hook for use in https://github.com/getsentry/getsentry/pull/20665 - my first thought was to monkeypatch over sentry.options.get but it's not feasible to do it early enough since the method gets bound very early in our import graph

also took the opportunity to move options.get callsites to options.get (easier to grep)
