### PR TITLE
fix(search-query-builder): Align drop downs

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -108,7 +108,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
   const buttonRef = useRef<HTMLButtonElement>(null);
   const listBoxRef = useRef<HTMLUListElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
-  const containerRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const isInitialRender = useRef(true);
   const inputRef = useRef<HTMLInputElement>(null);
   const organization = useOrganization();
@@ -348,7 +348,6 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
     position: 'bottom-start',
     offset: 2,
     shouldCloseOnBlur: true,
-    shouldApplyMinWidth: false,
     isKeyboardDismissDisabled: true,
     preventOverflowOptions: {boundary: document.body},
     flipOptions: {
@@ -408,7 +407,15 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
   }
 
   return (
-    <Wrapper ref={containerRef} isDropdownOpen={state.isOpen}>
+    <Wrapper
+      ref={
+        mergeRefs(
+          containerRef,
+          triggerProps.ref as React.Ref<HTMLDivElement>
+        ) as React.Ref<HTMLInputElement & HTMLDivElement>
+      }
+      isDropdownOpen={state.isOpen}
+    >
       <PositionedSearchIconContainer>
         <SearchIcon size="sm" />
       </PositionedSearchIconContainer>
@@ -418,7 +425,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
           autoComplete="off"
           onClick={() => state.open()}
           placeholder={t('Ask Seer with Natural Language')}
-          ref={mergeRefs(inputRef, triggerProps.ref as React.Ref<HTMLInputElement>)}
+          ref={inputRef}
         />
       </InputWrapper>
       <ButtonsWrapper>

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -121,7 +121,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
   const buttonRef = useRef<HTMLButtonElement>(null);
   const listBoxRef = useRef<HTMLUListElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
-  const containerRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const isInitialRender = useRef(true);
   const inputRef = useRef<HTMLInputElement>(null);
   const organization = useOrganization();
@@ -384,7 +384,6 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
     position: 'bottom-start',
     offset: 2,
     shouldCloseOnBlur: true,
-    shouldApplyMinWidth: false,
     isKeyboardDismissDisabled: true,
     preventOverflowOptions: {boundary: document.body},
     flipOptions: {
@@ -458,7 +457,15 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
   const hasResults = queries.length > 0;
 
   return (
-    <Wrapper ref={containerRef} isDropdownOpen={state.isOpen}>
+    <Wrapper
+      ref={
+        mergeRefs(
+          containerRef,
+          triggerProps.ref as React.Ref<HTMLDivElement>
+        ) as React.Ref<HTMLInputElement & HTMLDivElement>
+      }
+      isDropdownOpen={state.isOpen}
+    >
       <PositionedSearchIconContainer>
         <SearchIcon size="sm" />
       </PositionedSearchIconContainer>
@@ -468,7 +475,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
           autoComplete="off"
           onClick={() => state.open()}
           placeholder={t('Ask Seer with Natural Language')}
-          ref={mergeRefs(inputRef, triggerProps.ref as React.Ref<HTMLInputElement>)}
+          ref={inputRef}
         />
       </InputWrapper>
       <ButtonsWrapper>

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchPopover.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchPopover.tsx
@@ -22,27 +22,7 @@ export function AskSeerSearchPopover(props: PopoverProps) {
 
   return (
     <StyledPositionWrapper {...overlayProps} visible={state.isOpen}>
-      <ListBoxOverlay
-        ref={element => {
-          popoverRef.current = element;
-          if (!element || !props.containerRef.current) {
-            return;
-          }
-
-          const resizeObserver = new ResizeObserver(entries => {
-            if (!props.containerRef.current) {
-              return;
-            }
-            element.style.width = `${entries[0]?.target.clientWidth}px`;
-          });
-
-          resizeObserver.observe(props.containerRef.current);
-
-          return () => {
-            resizeObserver.disconnect();
-          };
-        }}
-      >
+      <ListBoxOverlay ref={popoverRef}>
         <BackgroundColorWrapper>{children}</BackgroundColorWrapper>
       </ListBoxOverlay>
     </StyledPositionWrapper>
@@ -50,6 +30,8 @@ export function AskSeerSearchPopover(props: PopoverProps) {
 }
 
 const ListBoxOverlay = styled(Overlay)`
+  box-sizing: border-box;
+  width: 100%;
   max-height: 400px;
   min-width: 200px;
   overflow-y: auto;

--- a/static/app/components/searchQueryBuilder/dropdownAlignment.ts
+++ b/static/app/components/searchQueryBuilder/dropdownAlignment.ts
@@ -1,0 +1,12 @@
+import type {CSSProperties} from 'react';
+
+export function getBorderBoxAnchoredOverlayStyle(reference: HTMLElement): CSSProperties {
+  const style = getComputedStyle(reference);
+  const borderLeftWidth = Number.parseFloat(style.borderLeftWidth) || 0;
+  const borderRightWidth = Number.parseFloat(style.borderRightWidth) || 0;
+
+  return {
+    left: -borderLeftWidth,
+    width: `calc(100% + ${borderLeftWidth + borderRightWidth}px)`,
+  };
+}

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -22,6 +22,7 @@ import {
   useSearchQueryBuilderLayout,
   useSearchQueryBuilderState,
 } from 'sentry/components/searchQueryBuilder/context';
+import {getBorderBoxAnchoredOverlayStyle} from 'sentry/components/searchQueryBuilder/dropdownAlignment';
 import type {CustomComboboxMenuProps} from 'sentry/components/searchQueryBuilder/tokens/combobox';
 import {KeyDescription} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/keyDescription';
 import type {Section} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
@@ -353,7 +354,11 @@ export function FilterKeyListBox<T extends SelectOptionOrSectionWithKey<string>>
       <StyledPositionWrapper
         {...overlayProps}
         visible={isOpen}
-        style={{position: 'absolute', width: '100%', left: 0, top: 38, right: 0}}
+        style={{
+          position: 'absolute',
+          top: 38,
+          ...getBorderBoxAnchoredOverlayStyle(wrapperRef.current),
+        }}
       >
         <SectionedOverlay
           ref={popoverRef}


### PR DESCRIPTION
This PR slightly tweaks how we set the width of the dropdowns that are a part of the search query builder. I believe the issue is how we style inputs to appear "sunken" into the UI.

**Before:**
<img width="757" height="258" alt="Screenshot 2026-06-12 at 14 43 26" src="https://github.com/user-attachments/assets/6dc8ad96-719c-45fe-818d-eb46a24c4134" />

**After:**
<img width="788" height="242" alt="Screenshot 2026-06-12 at 14 43 33" src="https://github.com/user-attachments/assets/a7f320f2-9c26-402d-8f25-b549e8566513" />