### PR TITLE
ref(profiles): begin TaskProducer rollout

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3808,6 +3808,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Rolls out the new TaskProducer to profiling tasks
+register(
+    "tasks.producer.profiles.rollout",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 register(
     "github-enterprise.disallow-domain-mismatch",
     type=Bool,

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -48,6 +48,7 @@ from sentry.models.projectsdk import (
     get_rejected_sdk_version,
 )
 from sentry.objectstore.metrics import measure_storage_operation
+from sentry.options.rollout import in_random_rollout
 from sentry.profiles.java import (
     convert_android_methods_to_jvm_frames,
     deobfuscate_signature,
@@ -63,6 +64,7 @@ from sentry.signals import first_profile_received
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import ingest_profiling_passthrough_tasks, ingest_profiling_tasks
+from sentry.taskworker.producer import get_task_producer
 from sentry.utils import json, metrics
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.eap import hex_to_item_id
@@ -85,37 +87,60 @@ CLIENT_SAMPLE_RATE = 1.0
 SERVER_SAMPLE_RATE = 1.0
 
 
-def _get_profiles_producer_from_topic(topic: Topic) -> KafkaProducer:
+def _get_profiles_producer_from_topic(
+    topic: Topic, name: str = "sentry.profiles.task"
+) -> KafkaProducer:
     return get_arroyo_producer(
-        name="sentry.profiles.task",
+        name=name,
         topic=topic,
         exclude_config_keys=["compression.type", "message.max.bytes"],
     )
 
 
+_task_producer_name = "sentry.profiles.taskproducer"
 processed_profiles_producer = SingletonProducer(
     lambda: _get_profiles_producer_from_topic(Topic.PROCESSED_PROFILES),
     max_futures=settings.SENTRY_PROCESSED_PROFILES_FUTURES_MAX_LIMIT,
+)
+processed_profiles_task_producer = get_task_producer(
+    _task_producer_name,
+    lambda: _get_profiles_producer_from_topic(Topic.PROCESSED_PROFILES, _task_producer_name),
 )
 
 profile_functions_producer = SingletonProducer(
     lambda: _get_profiles_producer_from_topic(Topic.PROFILES_CALL_TREE),
     max_futures=settings.SENTRY_PROFILE_FUNCTIONS_FUTURES_MAX_LIMIT,
 )
+profile_functions_task_producer = get_task_producer(
+    _task_producer_name,
+    lambda: _get_profiles_producer_from_topic(Topic.PROFILES_CALL_TREE, _task_producer_name),
+)
 
 profile_chunks_producer = SingletonProducer(
     lambda: _get_profiles_producer_from_topic(Topic.PROFILE_CHUNKS),
     max_futures=settings.SENTRY_PROFILE_CHUNKS_FUTURES_MAX_LIMIT,
+)
+profile_chunks_task_producer = get_task_producer(
+    _task_producer_name,
+    lambda: _get_profiles_producer_from_topic(Topic.PROFILE_CHUNKS, _task_producer_name),
 )
 
 profile_occurrences_producer = SingletonProducer(
     lambda: _get_profiles_producer_from_topic(Topic.INGEST_OCCURRENCES),
     max_futures=settings.SENTRY_PROFILE_OCCURRENCES_FUTURES_MAX_LIMIT,
 )
+profile_occurrences_task_producer = get_task_producer(
+    _task_producer_name,
+    lambda: _get_profiles_producer_from_topic(Topic.INGEST_OCCURRENCES, _task_producer_name),
+)
 
 eap_producer = SingletonProducer(
     lambda: _get_profiles_producer_from_topic(Topic.SNUBA_ITEMS),
     max_futures=settings.SENTRY_PROFILE_EAP_FUTURES_MAX_LIMIT,
+)
+eap_task_producer = get_task_producer(
+    _task_producer_name,
+    lambda: _get_profiles_producer_from_topic(Topic.SNUBA_ITEMS, _task_producer_name),
 )
 
 logger = logging.getLogger(__name__)
@@ -1364,7 +1389,10 @@ def _process_vroomrs_transaction_profile(profile: Profile, project: Project) -> 
                         topic = ArroyoTopic(
                             get_topic_definition(Topic.INGEST_OCCURRENCES)["real_topic_name"]
                         )
-                        profile_occurrences_producer.produce(topic, payload)
+                        if in_random_rollout("tasks.producer.profiles.rollout"):
+                            profile_occurrences_task_producer.produce(topic, payload)
+                        else:
+                            profile_occurrences_producer.produce(topic, payload)
             # function metrics are extracted for both sampled and unsampled profiles
             with sentry_sdk.start_span(op="processing", name="extract functions metrics"):
                 functions = prof.extract_functions_metrics(
@@ -1375,7 +1403,10 @@ def _process_vroomrs_transaction_profile(profile: Profile, project: Project) -> 
                     topic = ArroyoTopic(
                         get_topic_definition(Topic.PROFILES_CALL_TREE)["real_topic_name"]
                     )
-                    profile_functions_producer.produce(topic, payload)
+                    if in_random_rollout("tasks.producer.profiles.rollout"):
+                        profile_functions_task_producer.produce(topic, payload)
+                    else:
+                        profile_functions_producer.produce(topic, payload)
             if features.has("projects:profile-functions-metrics-eap-ingestion", project):
                 with sentry_sdk.start_span(op="processing", name="extract functions metrics (eap)"):
                     eap_functions = prof.extract_functions_metrics(
@@ -1390,7 +1421,10 @@ def _process_vroomrs_transaction_profile(profile: Profile, project: Project) -> 
                         )
                         tot = 0
                         for payload in build_profile_functions_eap_trace_items(prof, eap_functions):
-                            eap_producer.produce(topic, payload)
+                            if in_random_rollout("tasks.producer.profiles.rollout"):
+                                eap_task_producer.produce(topic, payload)
+                            else:
+                                eap_producer.produce(topic, payload)
                             tot += 1
                         metrics.incr(
                             "process_profile.eap_functions_metrics.ingested.count",
@@ -1405,7 +1439,10 @@ def _process_vroomrs_transaction_profile(profile: Profile, project: Project) -> 
                     topic = ArroyoTopic(
                         get_topic_definition(Topic.PROCESSED_PROFILES)["real_topic_name"]
                     )
-                    processed_profiles_producer.produce(topic, payload)
+                    if in_random_rollout("tasks.producer.profiles.rollout"):
+                        processed_profiles_task_producer.produce(topic, payload)
+                    else:
+                        processed_profiles_producer.produce(topic, payload)
             return True
         except Exception as e:
             sentry_sdk.capture_exception(e)
@@ -1443,7 +1480,10 @@ def _process_vroomrs_chunk_profile(profile: Profile, project: Project) -> bool:
             with sentry_sdk.start_span(op="processing", name="send chunk to kafka"):
                 payload = build_chunk_kafka_message(chunk)
                 topic = ArroyoTopic(get_topic_definition(Topic.PROFILE_CHUNKS)["real_topic_name"])
-                profile_chunks_producer.produce(topic, payload)
+                if in_random_rollout("tasks.producer.profiles.rollout"):
+                    profile_chunks_task_producer.produce(topic, payload)
+                else:
+                    profile_chunks_producer.produce(topic, payload)
             with sentry_sdk.start_span(op="processing", name="extract functions metrics"):
                 functions = chunk.extract_functions_metrics(
                     min_depth=1, filter_system_frames=True, max_unique_functions=100
@@ -1453,7 +1493,10 @@ def _process_vroomrs_chunk_profile(profile: Profile, project: Project) -> bool:
                     topic = ArroyoTopic(
                         get_topic_definition(Topic.PROFILES_CALL_TREE)["real_topic_name"]
                     )
-                    profile_functions_producer.produce(topic, payload)
+                    if in_random_rollout("tasks.producer.profiles.rollout"):
+                        profile_functions_task_producer.produce(topic, payload)
+                    else:
+                        profile_functions_producer.produce(topic, payload)
             if features.has("projects:profile-functions-metrics-eap-ingestion", project):
                 with sentry_sdk.start_span(op="processing", name="extract functions metrics (eap)"):
                     eap_functions = chunk.extract_functions_metrics(
@@ -1468,7 +1511,10 @@ def _process_vroomrs_chunk_profile(profile: Profile, project: Project) -> bool:
                         )
                         tot = 0
                         for payload in build_chunk_functions_eap_trace_items(chunk, eap_functions):
-                            eap_producer.produce(topic, payload)
+                            if in_random_rollout("tasks.producer.profiles.rollout"):
+                                eap_task_producer.produce(topic, payload)
+                            else:
+                                eap_producer.produce(topic, payload)
                             tot += 1
                         metrics.incr(
                             "process_profile.eap_functions_metrics.ingested.count",


### PR DESCRIPTION
Followup to https://github.com/getsentry/sentry/pull/117360

This PR updates the producers in profiling tasks to use `TaskProducer`.

The reason for this change is that SingletonProducer doesn't guarantee at-least-once delivery when used inside a task. TaskProducer keeps track of any producer futures generated as a part of task execution, and only marks a task as successful if all producer futures succeed.

To ensure a safe rollout, workers will instantiate an instance of the old and new producers, and cut over to the new producers based on a rollout option. This means that task futures won't be properly tracked while the rollout option is <1.0, but since our base state is to just ignore producer futures that's acceptable.