### PR TITLE
fix(preprod): Stop chunk crash from reserved LogRecord key

### DIFF
--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -620,7 +620,7 @@ def _process_chunk(
                 logger.info(
                     "preprod.snapshots.odiff.unchanged_with_diff_hash",
                     extra={
-                        "name": name,
+                        "image_name": name,
                         "org_id": org_id,
                         "head_artifact_id": head_artifact_id,
                         "base_artifact_id": base_artifact_id,

--- a/tests/sentry/preprod/snapshots/test_compare_snapshots.py
+++ b/tests/sentry/preprod/snapshots/test_compare_snapshots.py
@@ -341,6 +341,56 @@ class ProcessChunkTest(TestCase):
         assert comparison.chunks_done_indices == [0]
         assert not finalize.called
 
+    def test_chunk_with_unchanged_diff_hash_writes_result(self):
+        from sentry.preprod.snapshots.image_diff.types import DiffResult
+        from sentry.preprod.snapshots.tasks import process_snapshot_comparison_chunk
+
+        comparison, head_artifact, base_artifact = self._comparison(1)
+        plan = self._single_chunk_plan(head_artifact, base_artifact)
+        prefix = f"{self.organization.id}/{self.project.id}/{head_artifact.id}/{base_artifact.id}"
+        stored = {f"{prefix}/plan.json": orjson.dumps(plan.dict())}
+        session = _mock_session_with_manifests(stored)
+        session.put.side_effect = lambda contents, key, content_type: stored.__setitem__(
+            key, contents
+        )
+
+        unchanged_diff = DiffResult(
+            diff_mask_png=b"png",
+            changed_pixels=0,
+            total_pixels=100,
+            aligned_height=10,
+            before_width=10,
+            before_height=10,
+            after_width=10,
+            after_height=10,
+        )
+
+        with (
+            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch(
+                "sentry.preprod.snapshots.tasks._fetch_batch_images",
+                return_value=({"h": b"img", "b": b"img"}, set()),
+            ),
+            patch(
+                "sentry.preprod.snapshots.tasks.compare_images_batch",
+                return_value=[unchanged_diff],
+            ),
+            self.assertLogs("sentry.preprod.snapshots.tasks", level="INFO"),
+        ):
+            process_snapshot_comparison_chunk(
+                comparison_id=comparison.id,
+                chunk_index=0,
+                org_id=self.organization.id,
+                project_id=self.project.id,
+                head_artifact_id=head_artifact.id,
+                base_artifact_id=base_artifact.id,
+            )
+
+        chunk_key = f"{prefix}/chunks/0.json"
+        assert chunk_key in stored
+        result = orjson.loads(stored[chunk_key])
+        assert result["images"]["a.png"]["status"] == "unchanged"
+
     def test_chunk_hard_failure_still_recorded_and_triggers_finalize(self):
         from sentry.preprod.snapshots.tasks import process_snapshot_comparison_chunk
 


### PR DESCRIPTION
## Summary

A snapshot comparison chunk could crash on a **logging statement** — not on any diff logic — silently corrupting the comparison.

In `_process_chunk`, the `unchanged_with_diff_hash` branch (image is visually unchanged but has a different content hash) logged with `extra={"name": ...}`. `name` is a reserved `LogRecord` attribute, so Python's logging internals raised:

```
KeyError: "Attempt to overwrite 'name' in LogRecord"
```

whenever that branch executed at INFO level. The bare `except Exception` in `process_snapshot_comparison_chunk` swallowed the error, marked the chunk **done with no result blob written**, and `finalize_snapshot_comparison` then hit a 404 reading the missing `chunks/{idx}.json` and degraded every affected image to `errored`.

Because errored images don't change comparison state, the comparison still finalized as **SUCCESS** — so the failure was invisible to users in the status check, PR comment, and web UI.

## Fix

Rename the colliding `extra` key from `"name"` to `"image_name"`. Audited the entire `src/sentry/preprod/` tree — this was the only reserved-`LogRecord`-key collision.

## Test

Added `ProcessChunkTest::test_chunk_with_unchanged_diff_hash_writes_result`, which drives the `unchanged_with_diff_hash` branch under `assertLogs(level="INFO")` (so the offending log line actually executes) and asserts the chunk result blob gets written. It fails before the fix (blob never written) and passes after.

## Observed in production

- `KeyError` chunk crash: SENTRY-5QH9
- Downstream finalize 404: SENTRY-5QF7

Both began together ~2026-06-09 19:00 UTC.

## Follow-ups (not in this PR)

- Surface errored images in all three user-facing channels (status checks, PR comments, web UI) — today a partial/total diff failure shows as a clean green SUCCESS.
- Attach the real exception info to the `compare_snapshots: chunk failed` log so the root cause isn't two hops away.
