### PR TITLE
feat(span buffer): Add span-first slow DB span detector

### DIFF
--- a/fixtures/events/span_first_issue_detection/slow-db/slow-db-solved-n-plus-one.json
+++ b/fixtures/events/span_first_issue_detection/slow-db/slow-db-solved-n-plus-one.json
@@ -1,0 +1,523 @@
+[
+  {
+    "span_id": "8c9cfb04076db458",
+    "parent_span_id": null,
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957970.376365,
+    "end_timestamp": 1661957972.566927,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "/books/",
+    "status": "ok",
+    "is_segment": true,
+    "attributes": {
+      "sentry.segment.name": {
+        "type": "string",
+        "value": "/books/"
+      },
+      "sentry.op": {
+        "type": "string",
+        "value": "http.server"
+      },
+      "sentry.span.source": {
+        "type": "string",
+        "value": "route"
+      }
+    }
+  },
+  {
+    "span_id": "b35fe8bfc034fe6d",
+    "parent_span_id": "8c9cfb04076db458",
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957970.378754,
+    "end_timestamp": 1661957972.566523,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "django.middleware.security.SecurityMiddleware.__call__",
+    "status": "ok",
+    "is_segment": false,
+    "attributes": {
+      "sentry.op": {
+        "type": "string",
+        "value": "django.middleware"
+      },
+      "sentry.description": {
+        "type": "string",
+        "value": "django.middleware.security.SecurityMiddleware.__call__"
+      },
+      "sentry.group": {
+        "type": "string",
+        "value": "0f43fb6f6e01ca52"
+      },
+      "sentry.exclusive_time": {
+        "type": "double",
+        "value": 0.157118
+      },
+      "django.function_name": {
+        "type": "string",
+        "value": "django.utils.deprecation.MiddlewareMixin.__call__"
+      },
+      "django.middleware_name": {
+        "type": "string",
+        "value": "django.middleware.security.SecurityMiddleware"
+      }
+    },
+    "hash": "0f43fb6f6e01ca52"
+  },
+  {
+    "span_id": "b4cc10cfb5bb0d0b",
+    "parent_span_id": "b35fe8bfc034fe6d",
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957970.378852,
+    "end_timestamp": 1661957972.566464,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "django.contrib.sessions.middleware.SessionMiddleware.__call__",
+    "status": "ok",
+    "is_segment": false,
+    "attributes": {
+      "sentry.op": {
+        "type": "string",
+        "value": "django.middleware"
+      },
+      "sentry.description": {
+        "type": "string",
+        "value": "django.contrib.sessions.middleware.SessionMiddleware.__call__"
+      },
+      "sentry.group": {
+        "type": "string",
+        "value": "3dc5dd68b38e1730"
+      },
+      "sentry.exclusive_time": {
+        "type": "double",
+        "value": 2.594948
+      },
+      "django.function_name": {
+        "type": "string",
+        "value": "django.utils.deprecation.MiddlewareMixin.__call__"
+      },
+      "django.middleware_name": {
+        "type": "string",
+        "value": "django.contrib.sessions.middleware.SessionMiddleware"
+      }
+    },
+    "hash": "3dc5dd68b38e1730"
+  },
+  {
+    "span_id": "84b7b23061a36e25",
+    "parent_span_id": "b4cc10cfb5bb0d0b",
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957970.381379,
+    "end_timestamp": 1661957972.566396,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "django.middleware.common.CommonMiddleware.__call__",
+    "status": "ok",
+    "is_segment": false,
+    "attributes": {
+      "sentry.op": {
+        "type": "string",
+        "value": "django.middleware"
+      },
+      "sentry.description": {
+        "type": "string",
+        "value": "django.middleware.common.CommonMiddleware.__call__"
+      },
+      "sentry.group": {
+        "type": "string",
+        "value": "424c6ae1641f0f0e"
+      },
+      "sentry.exclusive_time": {
+        "type": "double",
+        "value": 1.232147
+      },
+      "django.function_name": {
+        "type": "string",
+        "value": "django.utils.deprecation.MiddlewareMixin.__call__"
+      },
+      "django.middleware_name": {
+        "type": "string",
+        "value": "django.middleware.common.CommonMiddleware"
+      }
+    },
+    "hash": "424c6ae1641f0f0e"
+  },
+  {
+    "span_id": "b6af0fe580697876",
+    "parent_span_id": "84b7b23061a36e25",
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957970.382565,
+    "end_timestamp": 1661957972.56635,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "django.middleware.csrf.CsrfViewMiddleware.__call__",
+    "status": "ok",
+    "is_segment": false,
+    "attributes": {
+      "sentry.op": {
+        "type": "string",
+        "value": "django.middleware"
+      },
+      "sentry.description": {
+        "type": "string",
+        "value": "django.middleware.csrf.CsrfViewMiddleware.__call__"
+      },
+      "sentry.group": {
+        "type": "string",
+        "value": "d5da18d7274b34a1"
+      },
+      "sentry.exclusive_time": {
+        "type": "double",
+        "value": 0.113011
+      },
+      "django.function_name": {
+        "type": "string",
+        "value": "django.utils.deprecation.MiddlewareMixin.__call__"
+      },
+      "django.middleware_name": {
+        "type": "string",
+        "value": "django.middleware.csrf.CsrfViewMiddleware"
+      }
+    },
+    "hash": "d5da18d7274b34a1"
+  },
+  {
+    "span_id": "ad32d8a49d273bdc",
+    "parent_span_id": "b6af0fe580697876",
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957970.382656,
+    "end_timestamp": 1661957972.566328,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "django.contrib.auth.middleware.AuthenticationMiddleware.__call__",
+    "status": "ok",
+    "is_segment": false,
+    "attributes": {
+      "sentry.op": {
+        "type": "string",
+        "value": "django.middleware"
+      },
+      "sentry.description": {
+        "type": "string",
+        "value": "django.contrib.auth.middleware.AuthenticationMiddleware.__call__"
+      },
+      "sentry.group": {
+        "type": "string",
+        "value": "ac72fc0a4f5fe381"
+      },
+      "sentry.exclusive_time": {
+        "type": "double",
+        "value": 0.110864
+      },
+      "django.function_name": {
+        "type": "string",
+        "value": "django.utils.deprecation.MiddlewareMixin.__call__"
+      },
+      "django.middleware_name": {
+        "type": "string",
+        "value": "django.contrib.auth.middleware.AuthenticationMiddleware"
+      }
+    },
+    "hash": "ac72fc0a4f5fe381"
+  },
+  {
+    "span_id": "ac6091f22d9366a3",
+    "parent_span_id": "ad32d8a49d273bdc",
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957970.382748,
+    "end_timestamp": 1661957972.566309,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "django.contrib.messages.middleware.MessageMiddleware.__call__",
+    "status": "ok",
+    "is_segment": false,
+    "attributes": {
+      "sentry.op": {
+        "type": "string",
+        "value": "django.middleware"
+      },
+      "sentry.description": {
+        "type": "string",
+        "value": "django.contrib.messages.middleware.MessageMiddleware.__call__"
+      },
+      "sentry.group": {
+        "type": "string",
+        "value": "ac1468d8e11a0553"
+      },
+      "sentry.exclusive_time": {
+        "type": "double",
+        "value": 9.091139
+      },
+      "django.function_name": {
+        "type": "string",
+        "value": "django.utils.deprecation.MiddlewareMixin.__call__"
+      },
+      "django.middleware_name": {
+        "type": "string",
+        "value": "django.contrib.messages.middleware.MessageMiddleware"
+      }
+    },
+    "hash": "ac1468d8e11a0553"
+  },
+  {
+    "span_id": "98f79ffd92d4a060",
+    "parent_span_id": "ac6091f22d9366a3",
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957970.391788,
+    "end_timestamp": 1661957972.566258,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__",
+    "status": "ok",
+    "is_segment": false,
+    "attributes": {
+      "sentry.op": {
+        "type": "string",
+        "value": "django.middleware"
+      },
+      "sentry.description": {
+        "type": "string",
+        "value": "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__"
+      },
+      "sentry.group": {
+        "type": "string",
+        "value": "d8681423cab4275f"
+      },
+      "sentry.exclusive_time": {
+        "type": "double",
+        "value": 0.916005
+      },
+      "django.function_name": {
+        "type": "string",
+        "value": "django.utils.deprecation.MiddlewareMixin.__call__"
+      },
+      "django.middleware_name": {
+        "type": "string",
+        "value": "django.middleware.clickjacking.XFrameOptionsMiddleware"
+      }
+    },
+    "hash": "d8681423cab4275f"
+  },
+  {
+    "span_id": "b455d7ac30d3a0a0",
+    "parent_span_id": "98f79ffd92d4a060",
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957970.392019,
+    "end_timestamp": 1661957970.392034,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "django.middleware.csrf.CsrfViewMiddleware.process_view",
+    "status": "ok",
+    "is_segment": false,
+    "attributes": {
+      "sentry.op": {
+        "type": "string",
+        "value": "django.middleware"
+      },
+      "sentry.description": {
+        "type": "string",
+        "value": "django.middleware.csrf.CsrfViewMiddleware.process_view"
+      },
+      "sentry.group": {
+        "type": "string",
+        "value": "e853d2eb7fb9ebb0"
+      },
+      "sentry.exclusive_time": {
+        "type": "double",
+        "value": 0.01502
+      },
+      "django.function_name": {
+        "type": "string",
+        "value": "django.middleware.csrf.CsrfViewMiddleware.process_view"
+      },
+      "django.middleware_name": {
+        "type": "string",
+        "value": "django.middleware.csrf.CsrfViewMiddleware"
+      }
+    },
+    "hash": "e853d2eb7fb9ebb0"
+  },
+  {
+    "span_id": "975f73422c8b1592",
+    "parent_span_id": "98f79ffd92d4a060",
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957970.392127,
+    "end_timestamp": 1661957972.565666,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "index",
+    "status": "ok",
+    "is_segment": false,
+    "attributes": {
+      "sentry.op": {
+        "type": "string",
+        "value": "django.view"
+      },
+      "sentry.description": {
+        "type": "string",
+        "value": "index"
+      },
+      "sentry.group": {
+        "type": "string",
+        "value": "6a992d5529f459a4"
+      },
+      "sentry.exclusive_time": {
+        "type": "double",
+        "value": 3.560066
+      }
+    },
+    "hash": "6a992d5529f459a4"
+  },
+  {
+    "span_id": "9f31e1ee4ef94970",
+    "parent_span_id": "975f73422c8b1592",
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957970.393029,
+    "end_timestamp": 1661957972.244459,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "connect",
+    "status": "ok",
+    "is_segment": false,
+    "attributes": {
+      "sentry.op": {
+        "type": "string",
+        "value": "db"
+      },
+      "sentry.description": {
+        "type": "string",
+        "value": "connect"
+      },
+      "sentry.group": {
+        "type": "string",
+        "value": "b640a0ce465fa2a4"
+      },
+      "sentry.exclusive_time": {
+        "type": "double",
+        "value": 1520.380972
+      }
+    },
+    "hash": "b640a0ce465fa2a4"
+  },
+  {
+    "span_id": "a05754d3fde2db29",
+    "parent_span_id": "9f31e1ee4ef94970",
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957971.911963,
+    "end_timestamp": 1761957972.078148,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "SELECT VERSION()",
+    "status": "ok",
+    "is_segment": false,
+    "attributes": {
+      "sentry.op": {
+        "type": "string",
+        "value": "db"
+      },
+      "sentry.description": {
+        "type": "string",
+        "value": "SELECT VERSION(),\n@@sql_mode,\n@@default_storage_engine,\n@@sql_auto_is_null,\n@@lower_case_table_names,\nCONVERT_TZ('2001-01-01 01:00:00', 'UTC', 'UTC') IS NOT NULL"
+      },
+      "sentry.group": {
+        "type": "string",
+        "value": "3a91b85ea92a26b9"
+      },
+      "sentry.exclusive_time": {
+        "type": "double",
+        "value": 166.184903
+      }
+    },
+    "hash": "3a91b85ea92a26b9"
+  },
+  {
+    "span_id": "8ed794ef6fc2ca5d",
+    "parent_span_id": "9f31e1ee4ef94970",
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957972.07932,
+    "end_timestamp": 1661957972.244184,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+    "status": "ok",
+    "is_segment": false,
+    "attributes": {
+      "sentry.op": {
+        "type": "string",
+        "value": "db"
+      },
+      "sentry.description": {
+        "type": "string",
+        "value": "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED"
+      },
+      "sentry.group": {
+        "type": "string",
+        "value": "061710eb39a66089"
+      },
+      "sentry.exclusive_time": {
+        "type": "double",
+        "value": 164.864064
+      }
+    },
+    "hash": "061710eb39a66089"
+  },
+  {
+    "span_id": "85dc61f6b5fbfa2b",
+    "parent_span_id": "975f73422c8b1592",
+    "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+    "organization_id": 1,
+    "project_id": 1,
+    "start_timestamp": 1661957972.244967,
+    "end_timestamp": 1661957972.563516,
+    "received": 1661957972.566927,
+    "retention_days": 90,
+    "name": "SELECT books_book join books_author",
+    "status": "ok",
+    "is_segment": false,
+    "attributes": {
+      "sentry.op": {
+        "type": "string",
+        "value": "db"
+      },
+      "sentry.description": {
+        "type": "string",
+        "value": "SELECT `books_book`.`id`, `books_book`.`title`, `books_book`.`author_id`, `books_author`.`id`, `books_author`.`name` FROM `books_book` INNER JOIN `books_author` ON (`books_book`.`author_id` = `books_author`.`id`) LIMIT 10"
+      },
+      "sentry.group": {
+        "type": "string",
+        "value": "e5aa87dbfacc0120"
+      },
+      "sentry.exclusive_time": {
+        "type": "double",
+        "value": 318.548918
+      }
+    },
+    "hash": "e5aa87dbfacc0120"
+  }
+]

--- a/src/sentry/issue_detection/detectors/span_first/base.py
+++ b/src/sentry/issue_detection/detectors/span_first/base.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import builtins
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import Any, ClassVar
+
+from sentry.issue_detection.base import DetectorType
+from sentry.issue_detection.performance_problem import PerformanceProblem
+from sentry.issue_detection.types import StandaloneSpan
+from sentry.issues.grouptype import GroupType
+
+
+class SpanFirstDetector(ABC):
+    """
+    Base class for span-first performance detectors.
+
+    Subclasses are driven by `run_detector` in this package's `__init__.py`: one `visit_span` call
+    per span in the segment (root included), in input order, followed by a single `on_complete`
+    call. Whatever ends up in `self.stored_problems` after that is the detector's output.
+
+    Concrete subclasses must set the two class attributes `type` and `grouptype`, and implement
+    `visit_span`. The default `on_complete` is a no-op (override if finalization is needed). The
+    default `is_creation_allowed` returns the configured `detection_enabled` flag (override for
+    more nuanced gating).
+    """
+
+    # The detector type, used to look up settings and label metrics. Shares the type id of the
+    # legacy detector, so the two pull from the same settings entry.
+    type: ClassVar[DetectorType]
+
+    # The `GroupType` subclass this detector emits. Multiple detectors may share a grouptype
+    # (e.g. N+1 and MN+1 both emit instances of `PerformanceNPlusOneGroupType`), in which case the
+    # orchestrator buckets them together so siblings run as a unit.
+    # (Note: We have to namespace `type` here because of the `type` classvar defined above. Longterm
+    # we might investigate if we can avoid shadowing the built-in there.)
+    grouptype: ClassVar[builtins.type[GroupType]]
+
+    def __init__(
+        self,
+        settings: dict[str, Any],
+        segment_span: StandaloneSpan,
+        segment: Sequence[StandaloneSpan],
+        detector_id: int | None = None,
+    ) -> None:
+        self._settings = settings
+        self._segment_span = segment_span
+        self._detector_id = detector_id
+        self.stored_problems: dict[str, PerformanceProblem] = {}
+
+    @abstractmethod
+    def visit_span(self, span: StandaloneSpan) -> None:
+        """
+        Called once for each span in the segment, in input order (segment root first). Detectors
+        collect any problems they identify into `self.stored_problems`, keyed by fingerprint.
+        """
+
+    def on_complete(self) -> None:
+        """
+        Called once after all spans have been visited. Detectors override this hook to finalize
+        any state and emit any problems whose detection spans the whole segment (rather than a
+        single span). Default is a no-op for detectors that emit per-span.
+        """
+        pass
+
+    def is_creation_allowed(self) -> bool:
+        """
+        Returns whether this detector is allowed to emit problems. By deefault, reads
+        `detection_enabled` from settings; override for more nuanced gating.
+        """
+        return self._settings["detection_enabled"]

--- a/src/sentry/issue_detection/detectors/span_first/run_detectors.py
+++ b/src/sentry/issue_detection/detectors/span_first/run_detectors.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+from sentry.issue_detection.performance_problem import PerformanceProblem
+from sentry.issue_detection.types import StandaloneSpan
+
+logger = logging.getLogger(__name__)
+
+
+def run_detector(
+    detector_class: type[Any],
+    settings: dict[str, Any],
+    segment_span: StandaloneSpan,
+    segment: Sequence[StandaloneSpan],
+) -> list[PerformanceProblem]:
+    """
+    Span-first analogue of `sentry.issue_detection.performance_detection.run_detector_on_data`.
+
+    Instantiates the detector, walks the given spans through it, and returns the problems it
+    produced. Returns an empty list if creation gating disallows it.
+    """
+    detector = detector_class(settings, segment_span, segment)
+
+    if not detector.is_creation_allowed():
+        return []
+
+    for span in segment:
+        detector.visit_span(span)
+    detector.on_complete()
+
+    return list(detector.stored_problems.values())

--- a/src/sentry/issue_detection/detectors/span_first/slow_db_query_detector.py
+++ b/src/sentry/issue_detection/detectors/span_first/slow_db_query_detector.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Any
+
+from sentry.issue_detection.base import DetectorType
+from sentry.issue_detection.detectors.span_first.base import SpanFirstDetector
+from sentry.issue_detection.detectors.span_first.span_first_utils import (
+    get_description,
+    get_duration,
+    get_evidence_value,
+    get_grouping_hash,
+    get_op,
+    get_segment_transaction,
+    truncate,
+)
+from sentry.issue_detection.performance_problem import PerformanceProblem
+from sentry.issue_detection.types import StandaloneSpan
+from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType
+from sentry.issues.issue_occurrence import IssueEvidence
+
+logger = logging.getLogger(__name__)
+
+
+class SpanFirstSlowDBQueryDetector(SpanFirstDetector):
+    """
+    Span-first version of SlowDBQueryDetector.
+
+    Check for slow database spans.
+    """
+
+    type = DetectorType.SLOW_DB_QUERY
+    grouptype = PerformanceSlowDBQueryGroupType
+
+    def visit_span(self, span: StandaloneSpan) -> None:
+        op = get_op(span)
+        description = get_description(span)
+        span_id = span.get("span_id")
+        duration_threshold = self._settings.get("duration_threshold")
+
+        # Ensure we have the data we need
+        if not op or not description or not span_id or duration_threshold is None:
+            return
+
+        # Check op and description to ensure this is the right kind of span to be checking
+        if not self._is_span_eligible(op, description):
+            return
+
+        # This is the real check - if the span isn't slower than the threshold, nothing to report
+        if get_duration(span) < duration_threshold:
+            return
+
+        # At this point we know there's a problem to report
+
+        fingerprint = self._get_fingerprint(span)
+        transaction_name = get_segment_transaction(self._segment_span)
+
+        if fingerprint in self.stored_problems:
+            logger.info(
+                "slow_db_query_span_first.duplicate_fingerprint",
+                extra={"fingerprint": fingerprint},
+            )
+            return
+
+        evidence_value = truncate(get_evidence_value(op, description))
+        trimmed_description = truncate(description)
+        evidence_data: dict[str, Any] = {
+            "op": op,
+            "cause_span_ids": [],
+            "parent_span_ids": [],
+            "offender_span_ids": [span_id],
+            "transaction_name": transaction_name,
+            "repeating_spans": evidence_value,
+            "repeating_spans_compact": trimmed_description,
+            "num_repeating_spans": "1",
+        }
+        if self._detector_id is not None:
+            evidence_data["detector_id"] = self._detector_id
+
+        self.stored_problems[fingerprint] = PerformanceProblem(
+            type=self.grouptype,
+            fingerprint=fingerprint,
+            op=op,
+            desc=trimmed_description,
+            cause_span_ids=[],
+            parent_span_ids=[],
+            offender_span_ids=[span_id],
+            evidence_data=evidence_data,
+            evidence_display=[
+                IssueEvidence(
+                    name="Offending Spans",
+                    value=evidence_value,
+                    # Has to be marked important to be displayed in the notifications
+                    important=True,
+                )
+            ],
+        )
+
+    def _is_span_eligible(self, op: str, description: str) -> bool:
+        allowed_span_ops = self._settings.get("allowed_span_ops") or []
+        if allowed_span_ops and not any(op.startswith(prefix) for prefix in allowed_span_ops):
+            return False
+
+        if description[:6].upper() != "SELECT":
+            return False
+        if description.endswith("..."):
+            return False
+
+        return True
+
+    def _get_fingerprint(self, span: StandaloneSpan) -> str:
+        hashed_grouping_hash = hashlib.sha1(get_grouping_hash(span).encode("utf-8")).hexdigest()
+        return f"1-{self.grouptype.type_id}-{hashed_grouping_hash}"

--- a/src/sentry/issue_detection/detectors/span_first/span_first_utils.py
+++ b/src/sentry/issue_detection/detectors/span_first/span_first_utils.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+from sentry_conventions.attributes import ATTRIBUTE_NAMES
+
+from sentry.issue_detection.base import DetectorType
+from sentry.issue_detection.performance_detection import get_detection_settings
+from sentry.issue_detection.types import StandaloneSpan
+from sentry.models.project import Project
+from sentry.spans.consumers.process_segments.types import attribute_value
+
+# We truncate evidence values to prevent hitting Kafka's broken message size limit.
+# TODO: A better solution would be to audit the usage of `description`, `evidence_data` and
+# `evidence_display` and deduplicate those keys. Right now they are nearly identical.
+DEFAULT_MAX_EVIDENCE_VALUE_LENGTH = 10_000
+
+
+def get_settings_for_detector(
+    detector_type: DetectorType, project: Project | None = None
+) -> dict[str, Any]:
+    all_settings = get_detection_settings(project)
+    return all_settings[detector_type]
+
+
+def get_op(span: StandaloneSpan) -> str:
+    return (attribute_value(span, ATTRIBUTE_NAMES.SENTRY_OP) or "").strip()
+
+
+def get_description(span: StandaloneSpan) -> str:
+    return (attribute_value(span, ATTRIBUTE_NAMES.SENTRY_DESCRIPTION) or "").strip()
+
+
+def get_grouping_hash(span: StandaloneSpan) -> str:
+    # Note: This pulls the Sentry-computed hash that `SpanGroupingResults.write_to_spans` adds at
+    # the top level of each span in `_enrich_spans`, rather than the Relay-computed
+    # `attributes.sentry.group` (which Relay sets to `md5(scrubbed_description)` and which may or
+    # may not match Sentry's grouping result exactly). Doing this keeps span-first-detector-
+    # generated fingerprints equivalent to existing-detector-generated fingerprints during the
+    # parity-comparison phase, since the existing detectors read the same top-level field. We may
+    # want to revisit this once we're fully switched over.
+    return (span.get("hash") or "").strip()
+
+
+def get_segment_transaction(segment_span: StandaloneSpan) -> str:
+    return (attribute_value(segment_span, ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME) or "").strip()
+
+
+def get_duration(span: StandaloneSpan) -> float:
+    """Return span duration in ms"""
+    return (span["end_timestamp"] - span["start_timestamp"]) * 1000
+
+
+def get_evidence_value(op: str, description: str) -> str:
+    """The 'op - description' string used as evidence in issue alerts."""
+    if op and description:
+        return f"{op} - {description}"
+    return op or description or "no value"
+
+
+def truncate(value: str, max_length: int = DEFAULT_MAX_EVIDENCE_VALUE_LENGTH) -> str:
+    return value[:max_length]

--- a/src/sentry/issue_detection/types.py
+++ b/src/sentry/issue_detection/types.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import Any, NotRequired, Required, TypedDict
 
-from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
+from sentry_kafka_schemas.schema_types.ingest_spans_v1 import (
+    SpanEvent,
+    _FileColonIngestSpansFullStopV1FullStopSchemaFullStopJsonNumberSignDefinitionsAttributevalue,
+    _FileColonIngestSpansFullStopV1FullStopSchemaFullStopJsonNumberSignDefinitionsAttributevalueType,
+)
 
 # Ideally this would be fully aligned with sentry_kafka_schemas, but many mutations
 # happen in the ingestion pipeline (adding new attributes and removing required
@@ -30,6 +34,14 @@ class Span(TypedDict, total=False):
 class StandaloneSpan(SpanEvent):
     hash: NotRequired[str]
 
+
+# Alias these because... jeez
+Attribute = (
+    _FileColonIngestSpansFullStopV1FullStopSchemaFullStopJsonNumberSignDefinitionsAttributevalue
+)
+AttributeType = (
+    _FileColonIngestSpansFullStopV1FullStopSchemaFullStopJsonNumberSignDefinitionsAttributevalueType
+)
 
 #: Sentry tags used in performance issue detection.
 #:

--- a/src/sentry/issue_detection/types.py
+++ b/src/sentry/issue_detection/types.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Required, TypedDict
+from typing import Any, NotRequired, Required, TypedDict
+
+from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
 
 # Ideally this would be fully aligned with sentry_kafka_schemas, but many mutations
 # happen in the ingestion pipeline (adding new attributes and removing required
@@ -19,6 +21,14 @@ class Span(TypedDict, total=False):
     data: dict[str, Any] | None
     tags: dict[str, Any] | None
     sentry_tags: SentryTags
+
+
+# Extend `SpanEvent` both to include `hash` (added by `SpanGroupingResults.write_to_spans` in the
+# segments consumer's `_enrich_spans` helper before issue detection runs) and to rename it so it's
+# clear these are *not* spans from transaction events, but in fact the exact opposite - spans
+# from segments produced by the span buffer rather than from events.
+class StandaloneSpan(SpanEvent):
+    hash: NotRequired[str]
 
 
 #: Sentry tags used in performance issue detection.

--- a/src/sentry/testutils/issue_detection/segment_span_generators.py
+++ b/src/sentry/testutils/issue_detection/segment_span_generators.py
@@ -1,0 +1,151 @@
+"""
+Test utilities for constructing segment-shape (`StandaloneSpan`) span data, parallel to
+`event_generators.py` which produces legacy transaction-event-shape data.
+
+Use these when writing tests for the span-first detectors in
+`sentry.issue_detection.detectors.span_first.*`.
+"""
+
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from typing import Any
+
+from sentry_conventions.attributes import ATTRIBUTE_NAMES
+
+from sentry.issue_detection.types import Attribute, AttributeType, StandaloneSpan
+from sentry.testutils.factories import get_fixture_path
+from sentry.utils import json
+
+DEFAULT_PROJECT_ID = 1121
+DEFAULT_ORG_ID = 1231
+DEFAULT_TRACE_ID = "636861726c6965616e646d6169736579"
+DEFAULT_SEGMENT_SPAN_ID = "4d4149534559414e"
+DEFAULT_CHILD_SPAN_ID = "5494c42514843444"
+
+_FIXTURE_DIR = get_fixture_path("events", "span_first_issue_detection")
+_FIXTURE_PATHS: dict[str, str] = {}
+_SEGMENT_FIXTURES: dict[str, list[StandaloneSpan]] = {}
+
+
+def load_fixture(fixture_name: str) -> list[StandaloneSpan]:
+    """
+    Load the given fixture. Assumes all fixtures are formatted as an array of spans with the segment
+    span first.
+    """
+    # Populate the fixture path cache if that hasn't yet been done. (We walk the full fixture
+    # directory but only store paths rather than full fixtures because tests are sharded and we
+    # don't need every fixture in every shard. Actual fixture data is loaded as needed.)
+    if not _FIXTURE_PATHS:
+        for dirpath, _, filenames in os.walk(_FIXTURE_DIR):
+            for filename in filenames:
+                fixture_basename, extension = filename.split(".")
+
+                if extension != "json":
+                    continue
+
+                _FIXTURE_PATHS[fixture_basename] = os.path.join(dirpath, filename)
+
+    # Load the fixture itself if we haven't yet
+    if not _SEGMENT_FIXTURES.get(fixture_name):
+        with open(_FIXTURE_PATHS[fixture_name]) as f:
+            _SEGMENT_FIXTURES[fixture_name] = json.load(f)
+
+    # Create a copy to avoid the risk of tests altering the data and affecting other tests
+    return deepcopy(_SEGMENT_FIXTURES[fixture_name])
+
+
+def create_child_span(
+    op: str,
+    duration: float | int = 100,  # ms
+    description: str = "SELECT count() FROM table WHERE id = %s",
+    hash: str = "",
+    data: dict[str, Any] | None = None,
+    span_id: str = DEFAULT_CHILD_SPAN_ID,
+    parent_span_id: str | None = DEFAULT_SEGMENT_SPAN_ID,
+) -> StandaloneSpan:
+    """
+    Create a child `StandaloneSpan` with sensible test defaults.
+
+    `data` keys are placed in `attributes` alongside the `sentry.*` keys, matching the way Relay
+    flattens the legacy `data` dict into segment-shape `attributes`.
+    """
+    attributes: dict[str, Attribute | None] = {
+        ATTRIBUTE_NAMES.SENTRY_OP: _convert_to_attribute(op),
+        ATTRIBUTE_NAMES.SENTRY_DESCRIPTION: _convert_to_attribute(description),
+        ATTRIBUTE_NAMES.SENTRY_GROUP: _convert_to_attribute(hash),
+    }
+    if data:
+        for key, value in data.items():
+            attributes[key] = _convert_to_attribute(value)
+
+    return StandaloneSpan(
+        {
+            "span_id": span_id,
+            "parent_span_id": parent_span_id,
+            "trace_id": DEFAULT_TRACE_ID,
+            "organization_id": DEFAULT_ORG_ID,
+            "project_id": DEFAULT_PROJECT_ID,
+            "start_timestamp": 0.0,
+            "end_timestamp": duration / 1000.0,
+            "received": 1.0,
+            "retention_days": 90,
+            "name": description,
+            "status": "ok",
+            "is_segment": False,
+            "attributes": attributes,
+            "hash": hash,
+        }
+    )
+
+
+def create_segment(
+    child_spans: list[StandaloneSpan],
+    transaction_name: str = "default-transaction",
+    segment_span_id: str = DEFAULT_SEGMENT_SPAN_ID,
+) -> list[StandaloneSpan]:
+    """
+    Build a segment root span for the given child spans and return the full segment - a list
+    consisting of the segment root followed by the children
+    """
+    segment_span = StandaloneSpan(
+        {
+            "span_id": segment_span_id,
+            "parent_span_id": None,
+            "trace_id": DEFAULT_TRACE_ID,
+            "organization_id": DEFAULT_ORG_ID,
+            "project_id": DEFAULT_PROJECT_ID,
+            "start_timestamp": 0.0,
+            "end_timestamp": 1.0,
+            "received": 1.0,
+            "retention_days": 90,
+            "name": transaction_name,
+            "status": "ok",
+            "is_segment": True,
+            "attributes": {
+                ATTRIBUTE_NAMES.SENTRY_SEGMENT_NAME: _convert_to_attribute(transaction_name),
+                ATTRIBUTE_NAMES.SENTRY_OP: _convert_to_attribute("default"),
+            },
+        }
+    )
+    return [segment_span, *child_spans]
+
+
+def _convert_to_attribute(value: Any) -> Attribute:
+    """Wrap a raw value in an `Attribute`-type dictionary"""
+    return {"type": _infer_attribute_type(value), "value": value}
+
+
+def _infer_attribute_type(value: Any) -> AttributeType:
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "double"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    return "object"

--- a/tests/sentry/issue_detection/span_first/test_span_first_slow_db_query_detector.py
+++ b/tests/sentry/issue_detection/span_first/test_span_first_slow_db_query_detector.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from sentry.issue_detection.detectors.span_first.run_detectors import run_detector
+from sentry.issue_detection.detectors.span_first.slow_db_query_detector import (
+    SpanFirstSlowDBQueryDetector,
+)
+from sentry.issue_detection.detectors.span_first.span_first_utils import (
+    get_settings_for_detector,
+)
+from sentry.issue_detection.performance_problem import PerformanceProblem
+from sentry.issue_detection.types import StandaloneSpan
+from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType
+from sentry.issues.issue_occurrence import IssueEvidence
+from sentry.testutils.cases import TestCase
+from sentry.testutils.issue_detection.segment_span_generators import (
+    DEFAULT_CHILD_SPAN_ID,
+    create_child_span,
+    create_segment,
+    load_fixture,
+)
+
+
+@pytest.mark.django_db
+class SpanFirstSlowDBQueryDetectorTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._settings = get_settings_for_detector(SpanFirstSlowDBQueryDetector.type)
+
+    def find_problems(self, segment: Sequence[StandaloneSpan]) -> list[PerformanceProblem]:
+        segment_span = segment[0]
+        return run_detector(SpanFirstSlowDBQueryDetector, self._settings, segment_span, segment)
+
+    def test_detects_slow_spans(self) -> None:
+        assert self._settings["duration_threshold"] == 1000
+        fast_segment = create_segment([create_child_span(op="db", duration=999)])
+        slow_segment = create_segment([create_child_span(op="db", duration=1001)])
+
+        assert self.find_problems(fast_segment) == []
+        assert self.find_problems(slow_segment) == [
+            PerformanceProblem(
+                fingerprint="1-1001-da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                op="db",
+                desc="SELECT count() FROM table WHERE id = %s",
+                type=PerformanceSlowDBQueryGroupType,
+                parent_span_ids=[],
+                cause_span_ids=[],
+                offender_span_ids=[DEFAULT_CHILD_SPAN_ID],
+                evidence_data={
+                    "op": "db",
+                    "cause_span_ids": [],
+                    "parent_span_ids": [],
+                    "offender_span_ids": [DEFAULT_CHILD_SPAN_ID],
+                    "transaction_name": "default-transaction",
+                    "repeating_spans": "db - SELECT count() FROM table WHERE id = %s",
+                    "repeating_spans_compact": "SELECT count() FROM table WHERE id = %s",
+                    "num_repeating_spans": "1",
+                },
+                evidence_display=[
+                    IssueEvidence(
+                        name="Offending Spans",
+                        value="db - SELECT count() FROM table WHERE id = %s",
+                        important=True,
+                    )
+                ],
+            )
+        ]
+
+    def test_ignores_ineligible_spans(self) -> None:
+        wrong_op_segment = create_segment(
+            [create_child_span(op="dogs", duration=1001, description="SELECT some stuff")]
+        )
+        wrong_desc_segment = create_segment(
+            [create_child_span(op="db", duration=1001, description="FETCH the ball")]
+        )
+        truncated_desc_segment = create_segment(
+            [
+                create_child_span(
+                    op="db", duration=1001, description="SELECT `product`.`id` FROM `products` ..."
+                )
+            ]
+        )
+
+        assert self.find_problems(wrong_op_segment) == []
+        assert self.find_problems(wrong_desc_segment) == []
+        assert self.find_problems(truncated_desc_segment) == []
+
+    def test_respects_enablement_flag(self) -> None:
+        segment = create_segment(
+            [
+                create_child_span(
+                    op="db", duration=1005, description="SELECT `product`.`id` FROM `products`"
+                )
+            ]
+        )
+        segment_span = segment[0]
+
+        detector = SpanFirstSlowDBQueryDetector(self._settings, segment_span, segment)
+        assert detector.is_creation_allowed()
+
+        disabled_settings = {**self._settings, "detection_enabled": False}
+        detector = SpanFirstSlowDBQueryDetector(disabled_settings, segment_span, segment)
+        assert not detector.is_creation_allowed()
+
+    def test_detects_slow_span_in_solved_n_plus_one_query(self) -> None:
+        segment = load_fixture("slow-db-solved-n-plus-one")
+        expected_description = (
+            "SELECT VERSION(),\n"
+            + "@@sql_mode,\n"
+            + "@@default_storage_engine,\n"
+            + "@@sql_auto_is_null,\n"
+            + "@@lower_case_table_names,\n"
+            + "CONVERT_TZ('2001-01-01 01:00:00', 'UTC', 'UTC') IS NOT NULL"
+        )
+
+        assert self.find_problems(segment) == [
+            PerformanceProblem(
+                fingerprint="1-1001-d02c8b2fd92a2d72011671feda429fa8ce2ac00f",
+                op="db",
+                desc=expected_description,
+                type=PerformanceSlowDBQueryGroupType,
+                parent_span_ids=[],
+                cause_span_ids=[],
+                offender_span_ids=["a05754d3fde2db29"],
+                evidence_data={
+                    "op": "db",
+                    "cause_span_ids": [],
+                    "parent_span_ids": [],
+                    "offender_span_ids": ["a05754d3fde2db29"],
+                    "transaction_name": "/books/",
+                    "repeating_spans": f"db - {expected_description}",
+                    "repeating_spans_compact": expected_description,
+                    "num_repeating_spans": "1",
+                },
+                evidence_display=[
+                    IssueEvidence(
+                        name="Offending Spans",
+                        value=f"db - {expected_description}",
+                        important=True,
+                    )
+                ],
+            )
+        ]


### PR DESCRIPTION
As a first step to converting all of our performance detectors to work with the span buffer, this adds a span-first version of the slow DB span detector, along with span-first versions of some of our testing utils. Note that nothing yet runs this detector - that will come in a follow-up PR. (Update: That PR is [here](https://github.com/getsentry/sentry/pull/117631).)

h/t to Claude for the rough draft of this code