### PR TITLE
ref(preprod): Log exception type on chunk failure

### DIFF
--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -681,14 +681,19 @@ def process_snapshot_comparison_chunk(
                 org_id, project_id, head_artifact_id, base_artifact_id, chunk_index
             )
             _put_json(session, result_key, ChunkResult(chunk_index=chunk_index, images=images))
-    except Exception:
+    except Exception as e:
         # Record the chunk as terminally failed so the comparison can still
         # complete: finalize degrades a done chunk with no result blob to errored.
         # Processing-deadline timeouts raise BaseException and propagate past this
         # handler, so the broker can still retry them.
         logger.exception(
             "compare_snapshots: chunk failed",
-            extra={"comparison_id": comparison_id, "chunk_index": chunk_index},
+            extra={
+                "comparison_id": comparison_id,
+                "chunk_index": chunk_index,
+                "error_type": type(e).__name__,
+                "error": str(e),
+            },
         )
 
     _mark_chunk_done(comparison_id, chunk_index)

--- a/tests/sentry/preprod/snapshots/test_compare_snapshots.py
+++ b/tests/sentry/preprod/snapshots/test_compare_snapshots.py
@@ -408,10 +408,11 @@ class ProcessChunkTest(TestCase):
             )
 
         [record] = [r for r in logs.records if r.getMessage() == "compare_snapshots: chunk failed"]
-        assert record.error_type == "ValueError"
-        assert record.error == "odiff exploded"
-        assert record.comparison_id == comparison.id
-        assert record.chunk_index == 0
+        extra = record.__dict__
+        assert extra["error_type"] == "ValueError"
+        assert extra["error"] == "odiff exploded"
+        assert extra["comparison_id"] == comparison.id
+        assert extra["chunk_index"] == 0
 
 
 @cell_silo_test

--- a/tests/sentry/preprod/snapshots/test_compare_snapshots.py
+++ b/tests/sentry/preprod/snapshots/test_compare_snapshots.py
@@ -377,6 +377,42 @@ class ProcessChunkTest(TestCase):
         assert f"{prefix}/chunks/0.json" not in stored
         assert finalize.call_count == 1
 
+    def test_chunk_failure_logs_exception_details(self):
+        from sentry.preprod.snapshots.tasks import process_snapshot_comparison_chunk
+
+        comparison, head_artifact, base_artifact = self._comparison(1)
+        plan = self._single_chunk_plan(head_artifact, base_artifact)
+        prefix = f"{self.organization.id}/{self.project.id}/{head_artifact.id}/{base_artifact.id}"
+        stored = {f"{prefix}/plan.json": orjson.dumps(plan.dict())}
+        session = _mock_session_with_manifests(stored)
+        session.put.side_effect = lambda contents, key, content_type: stored.__setitem__(
+            key, contents
+        )
+
+        with (
+            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch(
+                "sentry.preprod.snapshots.tasks._process_chunk",
+                side_effect=ValueError("odiff exploded"),
+            ),
+            patch("sentry.preprod.snapshots.tasks.finalize_snapshot_comparison.apply_async"),
+            self.assertLogs("sentry.preprod.snapshots.tasks", level="INFO") as logs,
+        ):
+            process_snapshot_comparison_chunk(
+                comparison_id=comparison.id,
+                chunk_index=0,
+                org_id=self.organization.id,
+                project_id=self.project.id,
+                head_artifact_id=head_artifact.id,
+                base_artifact_id=base_artifact.id,
+            )
+
+        [record] = [r for r in logs.records if r.getMessage() == "compare_snapshots: chunk failed"]
+        assert record.error_type == "ValueError"
+        assert record.error == "odiff exploded"
+        assert record.comparison_id == comparison.id
+        assert record.chunk_index == 0
+
 
 @cell_silo_test
 class FinalizeSnapshotComparisonTest(TestCase):


### PR DESCRIPTION
## Summary

When a snapshot comparison chunk fails, `process_snapshot_comparison_chunk` logs `compare_snapshots: chunk failed` — but the log `extra` only carried `comparison_id` and `chunk_index`. So in the logs explore view you can see *that* a chunk failed but not *why*; the real exception type and message live two hops away in a separately-captured issue (a different transaction/trace), which is exactly what made a recent incident hard to diagnose.

## Change

Add `error_type` (e.g. `"KeyError"`) and `error` (the exception message) to the log `extra`, so the cause is visible directly on the `chunk failed` log line.

```python
except Exception as e:
    logger.exception(
        "compare_snapshots: chunk failed",
        extra={
            "comparison_id": comparison_id,
            "chunk_index": chunk_index,
            "error_type": type(e).__name__,
            "error": str(e),
        },
    )
```

No behavior change — purely diagnostic enrichment.

## Test

`ProcessChunkTest::test_chunk_failure_logs_exception_details` forces a chunk failure under `assertLogs` and asserts the emitted record carries `error_type`/`error` (plus the existing `comparison_id`/`chunk_index`).

## Context

Follow-up to the diagnosability gap surfaced while debugging the reserved-`LogRecord`-key chunk crash (#117550). Independent of that fix.
