### PR TITLE
feat(onboarding): Show all SCM project-creation steps at once

### DIFF
--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -105,9 +105,7 @@ describe('ScmCreateProject', () => {
     expect(
       await screen.findByRole('heading', {name: 'Platform & features'})
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {name: 'Project details'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Project details'})).toBeInTheDocument();
 
     // Nothing is filled in yet, so the primary action stays disabled.
     expect(screen.getByRole('button', {name: 'Create project'})).toBeDisabled();

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -53,13 +53,11 @@ describe('ScmCreateProject', () => {
   const organization = OrganizationFixture();
   const adminTeam = TeamFixture({slug: 'admin-team', access: ['team:admin']});
 
-  // Seed a persisted wizard advanced to the revealed/project-selected state, as
-  // if the user had created a project in this session.
-  function persistRevealedWizard(overrides: Partial<Record<string, unknown>> = {}) {
+  // Seed a persisted wizard for a project created in this session.
+  function persistWizardSession(overrides: Partial<Record<string, unknown>> = {}) {
     window.sessionStorage.setItem(
       WIZARD_KEY,
       JSON.stringify({
-        repoStepCompleted: true,
         selectedPlatform: pythonPlatform,
         createdProjectId: CREATED_PROJECT_ID,
         ...overrides,
@@ -100,26 +98,30 @@ describe('ScmCreateProject', () => {
     jest.clearAllMocks();
   });
 
-  it('keeps the Create CTA available (disabled) before any steps are revealed', async () => {
+  it('shows all steps with the Create CTA disabled on a fresh visit', async () => {
     render(<ScmCreateProject />, {organization});
 
+    // All sections render up front (no progressive disclosure).
     expect(
-      screen.queryByRole('heading', {name: 'Project details'})
-    ).not.toBeInTheDocument();
-    const createButton = await screen.findByRole('button', {name: 'Create project'});
-    expect(createButton).toBeDisabled();
+      await screen.findByRole('heading', {name: 'Platform & features'})
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {name: 'Project details'})
+    ).toBeInTheDocument();
+
+    // Nothing is filled in yet, so the primary action stays disabled.
+    expect(screen.getByRole('button', {name: 'Create project'})).toBeDisabled();
   });
 
-  it('resets a persisted wizard on a fresh visit (no return from getting-started)', async () => {
-    persistRevealedWizard();
+  it('drops a persisted wizard on a fresh visit (no return from getting-started)', async () => {
+    persistWizardSession({projectDetailsForm: {projectName: 'my-restored-name'}});
 
     // No referrer/project query: not a return, so the persisted state is dropped.
     render(<ScmCreateProject />, {organization});
 
     await screen.findByRole('button', {name: 'Create project'});
-    expect(
-      screen.queryByRole('heading', {name: 'Project details'})
-    ).not.toBeInTheDocument();
+    // The restored name is not applied; the field falls back to its default.
+    expect(screen.queryByDisplayValue('my-restored-name')).not.toBeInTheDocument();
   });
 
   it('restores the wizard on a valid return from getting-started', async () => {
@@ -127,7 +129,7 @@ describe('ScmCreateProject', () => {
       projectName: 'my-restored-name',
       teamSlug: adminTeam.slug,
     };
-    persistRevealedWizard({projectDetailsForm});
+    persistWizardSession({projectDetailsForm});
 
     render(<ScmCreateProject />, {
       organization,
@@ -145,7 +147,7 @@ describe('ScmCreateProject', () => {
       projectName: 'my-restored-name',
       teamSlug: adminTeam.slug,
     };
-    persistRevealedWizard({projectDetailsForm});
+    persistWizardSession({projectDetailsForm});
 
     // The back nav from getting-started can land here bare before its replace
     // navigation appends the referrer/project params (see ScmCreateProject).
@@ -157,23 +159,20 @@ describe('ScmCreateProject', () => {
     });
 
     await screen.findByRole('button', {name: 'Create project'});
-    expect(
-      screen.queryByRole('heading', {name: 'Project details'})
-    ).not.toBeInTheDocument();
+    // Not a return yet, so the persisted form is not restored.
+    expect(screen.queryByDisplayValue('my-restored-name')).not.toBeInTheDocument();
 
     router.navigate(
       `/organizations/org-slug/projects/new/?referrer=getting-started&project=${CREATED_PROJECT_ID}`,
       {replace: true}
     );
 
-    expect(
-      await screen.findByRole('heading', {name: 'Project details'})
-    ).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('project-name')).toHaveValue('my-restored-name');
+    // The late-arriving params remount the wizard and restore the form.
+    expect(await screen.findByDisplayValue('my-restored-name')).toBeInTheDocument();
   });
 
   it('navigates to the new project getting-started on creation', async () => {
-    persistRevealedWizard();
+    persistWizardSession();
 
     const createRequest = MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
@@ -212,7 +211,7 @@ describe('ScmCreateProject', () => {
     ProjectsStore.loadInitialData([
       ProjectFixture({slug: 'python', name: 'python', platform: 'python'}),
     ]);
-    persistRevealedWizard({
+    persistWizardSession({
       createdProjectSlug: 'python',
       projectDetailsForm: {
         projectName: 'python',

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useState} from 'react';
+import {useCallback, useState} from 'react';
 import {LayoutGroup, motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
@@ -44,12 +44,6 @@ interface WizardState {
   createdProjectId: string | undefined;
   createdProjectSlug: string | undefined;
   projectDetailsForm: ProjectDetailsFormState | undefined;
-  // Flips true on the first meaningful action in section 1 (repo selected
-  // or "Continue without connecting a repo" clicked). Sections 2 and 3
-  // reveal together when this is true. Decoupled from selection state so
-  // later state edits (de-selecting a repo) do not collapse the rest of
-  // the page.
-  repoStepCompleted: boolean;
   selectedFeatures: ProductSolution[] | undefined;
   selectedIntegration: Integration | undefined;
   selectedPlatform: OnboardingSelectedSDK | undefined;
@@ -57,7 +51,6 @@ interface WizardState {
 }
 
 const INITIAL_STATE: WizardState = {
-  repoStepCompleted: false,
   createdProjectId: undefined,
   createdProjectSlug: undefined,
   projectDetailsForm: undefined,
@@ -105,7 +98,6 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
   // session is only persisted once a project is created.
   const [wizardState, setState] = useState(initialState);
   const {
-    repoStepCompleted,
     createdProjectSlug,
     projectDetailsForm,
     selectedFeatures,
@@ -123,10 +115,6 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
 
   useScmPlatformDetection(selectedRepository);
 
-  const completeRepoStep = () => {
-    setState(s => ({...s, repoStepCompleted: true}));
-  };
-
   const handleIntegrationChange = useCallback(
     (integration: Integration | undefined) => {
       setState(s => ({...s, selectedIntegration: integration}));
@@ -134,16 +122,9 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
     [setState]
   );
 
-  // Selecting a repo is itself a meaningful action, so it also flips the
-  // reveal flag. The "Continue without connecting a repo" path flips the
-  // flag via completeRepoStep below.
   const handleRepositoryChange = useCallback(
     (repository: Repository | undefined) => {
-      setState(s => ({
-        ...s,
-        selectedRepository: repository,
-        repoStepCompleted: repository ? true : s.repoStepCompleted,
-      }));
+      setState(s => ({...s, selectedRepository: repository}));
     },
     [setState]
   );
@@ -228,9 +209,6 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
     onComplete: handleComplete,
   });
 
-  const showContinueWithoutRepo = !selectedRepository && !repoStepCompleted;
-  const showAllSteps = repoStepCompleted;
-
   return (
     <SentryDocumentTitle title={t('Create a new project')}>
       <Access access={canUserCreateProject ? ['project:read'] : ['project:admin']}>
@@ -281,82 +259,65 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                 onClearDerivedState={handleClearDerivedState}
                 maxWidth={CREATE_PROJECT_MAX_WIDTH}
               />
-              {showContinueWithoutRepo && (
-                <MotionFlex layout="position">
-                  <Button
-                    variant="transparent"
-                    analyticsEventKey="project_creation.scm_connect_skip_clicked"
-                    analyticsEventName="Project Creation: SCM Connect Skip Clicked"
-                    onClick={completeRepoStep}
-                  >
-                    {t('Continue without connecting a repo')}
-                  </Button>
-                </MotionFlex>
-              )}
             </MotionStack>
 
-            {showAllSteps && (
-              <Fragment>
-                <MotionStack
-                  layout="position"
-                  gap="lg"
-                  border="primary"
-                  radius="md"
-                  padding="lg"
-                >
-                  <Stack gap="md">
-                    <Heading as="h2" size="xl">
-                      {t('Platform & features')}
-                    </Heading>
-                    <Text variant="muted">
-                      {t('Choose a platform and configure what to monitor.')}
-                    </Text>
-                  </Stack>
-                  <ScmPlatformFeaturesCore
-                    analyticsFlow="project-creation"
-                    selectedRepository={selectedRepository}
-                    selectedPlatform={selectedPlatform}
-                    selectedFeatures={selectedFeatures}
-                    onPlatformChange={handlePlatformChange}
-                    onFeaturesChange={handleFeaturesChange}
-                    onClearProjectDetailsForm={handleClearProjectDetailsForm}
-                  />
-                </MotionStack>
+            <MotionStack
+              layout="position"
+              gap="lg"
+              border="primary"
+              radius="md"
+              padding="lg"
+            >
+              <Stack gap="md">
+                <Heading as="h2" size="xl">
+                  {t('Platform & features')}
+                </Heading>
+                <Text variant="muted">
+                  {t('Choose a platform and configure what to monitor.')}
+                </Text>
+              </Stack>
+              <ScmPlatformFeaturesCore
+                analyticsFlow="project-creation"
+                selectedRepository={selectedRepository}
+                selectedPlatform={selectedPlatform}
+                selectedFeatures={selectedFeatures}
+                onPlatformChange={handlePlatformChange}
+                onFeaturesChange={handleFeaturesChange}
+                onClearProjectDetailsForm={handleClearProjectDetailsForm}
+              />
+            </MotionStack>
 
-                <MotionStack
-                  layout="position"
-                  gap="lg"
-                  border="primary"
-                  radius="md"
-                  padding="lg"
-                >
-                  <Stack gap="md">
-                    <Heading as="h2" size="xl">
-                      {t('Project details')}
-                    </Heading>
-                    <Text variant="muted">
-                      {t('Name your project, assign a team, and set up issue alerts.')}
-                    </Text>
-                  </Stack>
-                  <ScmProjectDetailsCore
-                    analyticsFlow="project-creation"
-                    projectName={form.projectName}
-                    onProjectNameChange={form.onProjectNameChange}
-                    onProjectNameBlur={form.onProjectNameBlur}
-                    teamSlug={form.teamSlug}
-                    onTeamChange={form.onTeamChange}
-                    alertRuleConfig={form.alertRuleConfig}
-                    onAlertChange={form.onAlertChange}
-                    isOrgMemberWithNoAccess={form.isOrgMemberWithNoAccess}
-                  />
-                </MotionStack>
-              </Fragment>
-            )}
+            <MotionStack
+              layout="position"
+              gap="lg"
+              border="primary"
+              radius="md"
+              padding="lg"
+            >
+              <Stack gap="md">
+                <Heading as="h2" size="xl">
+                  {t('Project details')}
+                </Heading>
+                <Text variant="muted">
+                  {t('Name your project, assign a team, and set up issue alerts.')}
+                </Text>
+              </Stack>
+              <ScmProjectDetailsCore
+                analyticsFlow="project-creation"
+                projectName={form.projectName}
+                onProjectNameChange={form.onProjectNameChange}
+                onProjectNameBlur={form.onProjectNameBlur}
+                teamSlug={form.teamSlug}
+                onTeamChange={form.onTeamChange}
+                alertRuleConfig={form.alertRuleConfig}
+                onAlertChange={form.onAlertChange}
+                isOrgMemberWithNoAccess={form.isOrgMemberWithNoAccess}
+              />
+            </MotionStack>
           </LayoutGroup>
 
-          {/* Page-level CTA: always present so the primary action is available
-              regardless of which steps are currently revealed. Disabled until a
-              platform and project details are ready. */}
+          {/* Page-level CTA: disabled until a platform and project details are
+              ready. */}
           <Stack gap="md">
             <ProjectCreationErrorAlert error={form.error} />
             <Flex justify="end">
@@ -378,4 +339,3 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
 }
 
 const MotionStack = motion.create(Stack);
-const MotionFlex = motion.create(Flex);


### PR DESCRIPTION
## TLDR

The single-view SCM project creation wizard revealed the Platform & features and Project details sections only after the repo step was completed. This shows all sections up front so the whole form is visible immediately, and removes the progressive-disclosure state that drove the reveal.

## Details

Previously `repoStepCompleted` gated sections 2 and 3, flipping true when a repo was selected or the user clicked "Continue without connecting a repo". With everything visible at once that scaffolding is no longer needed, so this removes the `repoStepCompleted` wizard state and its initial value, the `showAllSteps` and `showContinueWithoutRepo` derived flags, the `completeRepoStep` handler and the "Continue without connecting a repo" button, and the now-unused `Fragment` and `MotionFlex`.

Connecting a repo stays optional. The page-level Create CTA still validates platform, name, and team, so submission behavior is unchanged.

Tests now assert all sections render on a fresh visit, and verify the persisted-session restore by field value rather than by section visibility.

## Notes

This branches from master and is independent of the open stack PRs #117341 and #117342, which also touch `scmCreateProject.tsx`. Whichever lands first, the other will need a rebase to resolve overlap in the CTA and section regions.

One cosmetic follow-up left out of scope: the first section's heading still reads "Create a new project" (duplicating the page title) above the repo-connect step, which is a little odd now that all steps show together.
