### PR TITLE
fix(replays): stop showing setup message for status-0 network requests

### DIFF
--- a/static/app/views/explore/replays/detail/network/details/content.spec.tsx
+++ b/static/app/views/explore/replays/detail/network/details/content.spec.tsx
@@ -26,6 +26,8 @@ const [
   fetchEmptyBody,
   fetchWithHeaders,
   fetchWithRespBody,
+  fetchAborted,
+  fetchAbortedUrlSkipped,
 ] = hydrateSpans(ReplayRecordFixture(), [
   ReplayResourceFrameFixture({
     op: 'resource.img',
@@ -106,6 +108,28 @@ const [
       },
     },
   }),
+  ReplayRequestFrameFixture({
+    op: 'resource.fetch',
+    startTimestamp: new Date(),
+    endTimestamp: new Date(),
+    description: '/api/0/organizations/1/issues/1234',
+    data: {
+      method: 'GET',
+      statusCode: 0,
+    },
+  }),
+  ReplayRequestFrameFixture({
+    op: 'resource.fetch',
+    startTimestamp: new Date(),
+    endTimestamp: new Date(),
+    description: '/api/0/organizations/1/issues/1234',
+    data: {
+      method: 'GET',
+      statusCode: 0,
+      request: {_meta: {warnings: ['URL_SKIPPED']}, headers: {}},
+      response: {_meta: {warnings: ['URL_SKIPPED']}, headers: {}},
+    },
+  }),
 ]);
 
 const mockItems = {
@@ -115,6 +139,8 @@ const mockItems = {
   fetchEmptyBody: fetchEmptyBody!,
   fetchWithHeaders: fetchWithHeaders!,
   fetchWithRespBody: fetchWithRespBody!,
+  fetchAborted: fetchAborted!,
+  fetchAbortedUrlSkipped: fetchAbortedUrlSkipped!,
 };
 
 function basicSectionProps() {
@@ -394,6 +420,44 @@ describe('NetworkDetailsContent', () => {
           });
         }
       );
+
+      it('should render the `did not complete` message instead of the setup message when the request did not complete', () => {
+        render(
+          <NetworkDetailsContent
+            {...basicSectionProps()}
+            isCaptureBodySetup
+            isSetup
+            item={mockItems.fetchAborted}
+            visibleTab={visibleTab}
+          />
+        );
+
+        expect(
+          screen.getByText(
+            'No response body was captured for this request.'
+          )
+        ).toBeInTheDocument();
+        expect(queryScreenState().isShowingSetup).toBe(false);
+      });
+
+      it('should still render the setup message when the request did not complete and the URL is not allow-listed', () => {
+        render(
+          <NetworkDetailsContent
+            {...basicSectionProps()}
+            isCaptureBodySetup
+            isSetup
+            item={mockItems.fetchAbortedUrlSkipped}
+            visibleTab={visibleTab}
+          />
+        );
+
+        expect(queryScreenState().isShowingSetup).toBe(true);
+        expect(
+          screen.queryByText(
+            'No response body was captured for this request.'
+          )
+        ).not.toBeInTheDocument();
+      });
     });
   });
 
@@ -534,6 +598,44 @@ describe('NetworkDetailsContent', () => {
           });
         }
       );
+
+      it('should render the `did not complete` message instead of the setup message when the request did not complete', () => {
+        render(
+          <NetworkDetailsContent
+            {...basicSectionProps()}
+            isCaptureBodySetup
+            isSetup
+            item={mockItems.fetchAborted}
+            visibleTab={visibleTab}
+          />
+        );
+
+        expect(
+          screen.getByText(
+            'No response body was captured for this request.'
+          )
+        ).toBeInTheDocument();
+        expect(queryScreenState().isShowingSetup).toBe(false);
+      });
+
+      it('should still render the setup message when the request did not complete and the URL is not allow-listed', () => {
+        render(
+          <NetworkDetailsContent
+            {...basicSectionProps()}
+            isCaptureBodySetup
+            isSetup
+            item={mockItems.fetchAbortedUrlSkipped}
+            visibleTab={visibleTab}
+          />
+        );
+
+        expect(queryScreenState().isShowingSetup).toBe(true);
+        expect(
+          screen.queryByText(
+            'No response body was captured for this request.'
+          )
+        ).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/static/app/views/explore/replays/detail/network/details/content.spec.tsx
+++ b/static/app/views/explore/replays/detail/network/details/content.spec.tsx
@@ -433,9 +433,7 @@ describe('NetworkDetailsContent', () => {
         );
 
         expect(
-          screen.getByText(
-            'No response body was captured for this request.'
-          )
+          screen.getByText('No response body was captured for this request.')
         ).toBeInTheDocument();
         expect(queryScreenState().isShowingSetup).toBe(false);
       });
@@ -453,9 +451,7 @@ describe('NetworkDetailsContent', () => {
 
         expect(queryScreenState().isShowingSetup).toBe(true);
         expect(
-          screen.queryByText(
-            'No response body was captured for this request.'
-          )
+          screen.queryByText('No response body was captured for this request.')
         ).not.toBeInTheDocument();
       });
     });
@@ -611,9 +607,7 @@ describe('NetworkDetailsContent', () => {
         );
 
         expect(
-          screen.getByText(
-            'No response body was captured for this request.'
-          )
+          screen.getByText('No response body was captured for this request.')
         ).toBeInTheDocument();
         expect(queryScreenState().isShowingSetup).toBe(false);
       });
@@ -631,9 +625,7 @@ describe('NetworkDetailsContent', () => {
 
         expect(queryScreenState().isShowingSetup).toBe(true);
         expect(
-          screen.queryByText(
-            'No response body was captured for this request.'
-          )
+          screen.queryByText('No response body was captured for this request.')
         ).not.toBeInTheDocument();
       });
     });

--- a/static/app/views/explore/replays/detail/network/details/content.spec.tsx
+++ b/static/app/views/explore/replays/detail/network/details/content.spec.tsx
@@ -280,6 +280,40 @@ describe('NetworkDetailsContent', () => {
           });
         }
       );
+
+      it('should render the `did not complete` message instead of the setup message when the request did not complete', () => {
+        render(
+          <NetworkDetailsContent
+            {...basicSectionProps()}
+            isCaptureBodySetup
+            isSetup
+            item={mockItems.fetchAborted}
+            visibleTab={visibleTab}
+          />
+        );
+
+        expect(
+          screen.getByText('No headers were captured for this request.')
+        ).toBeInTheDocument();
+        expect(queryScreenState().isShowingSetup).toBe(false);
+      });
+
+      it('should still render the setup message when the request did not complete and the URL is not allow-listed', () => {
+        render(
+          <NetworkDetailsContent
+            {...basicSectionProps()}
+            isCaptureBodySetup
+            isSetup
+            item={mockItems.fetchAbortedUrlSkipped}
+            visibleTab={visibleTab}
+          />
+        );
+
+        expect(queryScreenState().isShowingSetup).toBe(true);
+        expect(
+          screen.queryByText('No headers were captured for this request.')
+        ).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/static/app/views/explore/replays/detail/network/details/content.tsx
+++ b/static/app/views/explore/replays/detail/network/details/content.tsx
@@ -53,6 +53,11 @@ export function NetworkDetailsContent(props: Props) {
           {[Output.SETUP, Output.URL_SKIPPED, Output.BODY_SKIPPED].includes(output) && (
             <Setup showSnippet={output} {...props} />
           )}
+          {output === Output.INCOMPLETE && (
+            <ParseError>
+              {t('No response body was captured for this request.')}
+            </ParseError>
+          )}
           {output === Output.UNSUPPORTED && <UnsupportedOp type="bodies" />}
         </OverflowFluidHeight>
       );
@@ -66,6 +71,11 @@ export function NetworkDetailsContent(props: Props) {
           )}
           {[Output.SETUP, Output.URL_SKIPPED, Output.BODY_SKIPPED].includes(output) && (
             <Setup showSnippet={output} {...props} />
+          )}
+          {output === Output.INCOMPLETE && (
+            <ParseError>
+              {t('No response body was captured for this request.')}
+            </ParseError>
           )}
           {output === Output.UNSUPPORTED && <UnsupportedOp type="bodies" />}
           {output === Output.BODY_PARSE_ERROR && (

--- a/static/app/views/explore/replays/detail/network/details/content.tsx
+++ b/static/app/views/explore/replays/detail/network/details/content.tsx
@@ -122,5 +122,6 @@ const SectionList = styled('dl')`
   margin: 0;
 `;
 const ParseError = styled('p')`
+  font-size: ${p => p.theme.font.size.sm};
   padding: ${p => p.theme.space.xl};
 `;

--- a/static/app/views/explore/replays/detail/network/details/content.tsx
+++ b/static/app/views/explore/replays/detail/network/details/content.tsx
@@ -110,9 +110,7 @@ export function NetworkDetailsContent(props: Props) {
             <Setup showSnippet={output} {...props} />
           )}
           {output === Output.INCOMPLETE && (
-            <ParseError>
-              {t('No headers were captured for this request.')}
-            </ParseError>
+            <ParseError>{t('No headers were captured for this request.')}</ParseError>
           )}
           {output === Output.UNSUPPORTED && <UnsupportedOp type="headers" />}
         </OverflowFluidHeight>

--- a/static/app/views/explore/replays/detail/network/details/content.tsx
+++ b/static/app/views/explore/replays/detail/network/details/content.tsx
@@ -122,6 +122,5 @@ const SectionList = styled('dl')`
   margin: 0;
 `;
 const ParseError = styled('p')`
-  font-size: ${p => p.theme.font.size.sm};
   padding: ${p => p.theme.space.xl};
 `;

--- a/static/app/views/explore/replays/detail/network/details/content.tsx
+++ b/static/app/views/explore/replays/detail/network/details/content.tsx
@@ -109,6 +109,11 @@ export function NetworkDetailsContent(props: Props) {
           {[Output.SETUP, Output.URL_SKIPPED, Output.DATA].includes(output) && (
             <Setup showSnippet={output} {...props} />
           )}
+          {output === Output.INCOMPLETE && (
+            <ParseError>
+              {t('No headers were captured for this request.')}
+            </ParseError>
+          )}
           {output === Output.UNSUPPORTED && <UnsupportedOp type="headers" />}
         </OverflowFluidHeight>
       );

--- a/static/app/views/explore/replays/detail/network/details/getOutputType.tsx
+++ b/static/app/views/explore/replays/detail/network/details/getOutputType.tsx
@@ -1,4 +1,4 @@
-import {isRequestFrame} from 'sentry/utils/replays/resourceFrame';
+import {getFrameStatus, isRequestFrame} from 'sentry/utils/replays/resourceFrame';
 import {Output} from 'sentry/views/explore/replays/detail/network/details/output';
 import type {SectionProps} from 'sentry/views/explore/replays/detail/network/details/sections';
 import type {TabKey} from 'sentry/views/explore/replays/detail/network/details/tabs';
@@ -55,6 +55,18 @@ export function getOutputType({
   if (respWarnings?.includes('UNPARSEABLE_BODY_TYPE')) {
     // Differs from BODY_PARSE_ERROR in that we did not attempt to parse it
     return Output.UNPARSEABLE_BODY_TYPE;
+  }
+
+  const didNotComplete = getFrameStatus(item) === 0;
+  const hasExplicitUrlSkip =
+    request?._meta?.warnings?.includes('URL_SKIPPED') ||
+    response?._meta?.warnings?.includes('URL_SKIPPED');
+  if (
+    didNotComplete &&
+    !hasExplicitUrlSkip &&
+    ['request', 'response'].includes(visibleTab)
+  ) {
+    return Output.INCOMPLETE;
   }
 
   if (isReqUrlSkipped || isRespUrlSkipped) {

--- a/static/app/views/explore/replays/detail/network/details/getOutputType.tsx
+++ b/static/app/views/explore/replays/detail/network/details/getOutputType.tsx
@@ -61,11 +61,7 @@ export function getOutputType({
   const hasExplicitUrlSkip =
     request?._meta?.warnings?.includes('URL_SKIPPED') ||
     response?._meta?.warnings?.includes('URL_SKIPPED');
-  if (
-    didNotComplete &&
-    !hasExplicitUrlSkip &&
-    ['request', 'response'].includes(visibleTab)
-  ) {
+  if (didNotComplete && !hasExplicitUrlSkip) {
     return Output.INCOMPLETE;
   }
 

--- a/static/app/views/explore/replays/detail/network/details/output.tsx
+++ b/static/app/views/explore/replays/detail/network/details/output.tsx
@@ -6,5 +6,6 @@ export enum Output {
   BODY_PARSE_ERROR = 'body_parse_error',
   BODY_PARSE_TIMEOUT = 'body_parse_timeout',
   UNPARSEABLE_BODY_TYPE = 'unparseable_body_type',
+  INCOMPLETE = 'incomplete',
   DATA = 'data',
 }


### PR DESCRIPTION
Right now the Replay Network detail panel shows the standard _"add to ..."_ setup for requests that don't complete, regardless of whether the URL was correctly allowed. But if there's a literal status code of `0` then we know the data went through, it was just aborted / cancelled / still in-flight during a page navigation.

This PR changes the logic to detect a status code of 0 and show an explicit `URL_SKIPPED` warning.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="917" height="686" alt="Screenshot 2026-06-12 at 2 46 31 PM" src="https://github.com/user-attachments/assets/d35ae8c8-0180-4e7b-a53d-2c5331b32356" />
</td>
<td>
<img width="917" height="686" alt="Screenshot 2026-06-12 at 2 46 33 PM" src="https://github.com/user-attachments/assets/c2501618-895b-4d6a-b31d-0766d63a68d9" />
</td>
</tr>
</tbody>
</table>

<details>
<summary>Example reproduction of an aborted XMLHttpRequest</summary>

I set this up in a basic Next.js app instrumented with replays.

```js
// in some client component
const xhr = new XMLHttpRequest();
xhr.open("GET",  "/api/joshrepro?joshrepro=def456-v2");
xhr.send();
setTimeout(() => xhr.abort(), 100);
```

```js
// app/api/joshrepro/route.ts
export async function GET() {
  await new Promise(resolve => setTimeout(resolve, 1000));
  return NextResponse.json({ hello: "world", joshrepro: true });
}
```

</details>


Closes GH-117379. Closes ENG-7909.