### PR TITLE
ref(cells): Unregister cells.use-control-org-listing

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3724,14 +3724,6 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# TODO(cells): Fully rolled out and no longer read anywhere. Unregister once the
-# value is removed from sentry-options-automator.
-register(
-    "cells.use-control-org-listing",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # SCM
 


### PR DESCRIPTION
This cleans up the temporary option used to transition the org list API. The rollout is now complete.
