### PR TITLE
feat(cursor): Make agent display name editable and drop email from default

### DIFF
--- a/src/sentry/integrations/cursor/integration.py
+++ b/src/sentry/integrations/cursor/integration.py
@@ -46,6 +46,25 @@ class CursorIntegrationMetadata(BaseModel):
     domain_name: Literal["cursor.sh"] = "cursor.sh"
     api_key_name: str | None = None
     user_email: str | None = None
+    display_name: str | None = None
+
+
+INTEGRATION_NAME_MAX_LENGTH = 200
+
+
+def build_default_integration_name(api_key_name: str | None, api_key: str) -> str:
+    """Auto-generate the display name from the API key's name (or a key hint)."""
+    if api_key_name:
+        return f"Cursor Cloud Agent - {api_key_name}"
+    key_hint = api_key[:8] if len(api_key) >= 8 else api_key
+    return f"Cursor Cloud Agent ({key_hint}...)"
+
+
+def resolve_integration_name(metadata: CursorIntegrationMetadata) -> str:
+    """Use the custom display name if set, otherwise the auto-generated default."""
+    if metadata.display_name:
+        return metadata.display_name
+    return build_default_integration_name(metadata.api_key_name, metadata.api_key)
 
 
 metadata = IntegrationMetadata(
@@ -121,11 +140,7 @@ class CursorAgentIntegrationProvider(CodingAgentIntegrationProvider):
                 "Unable to validate Cursor API key. Please try again or contact support if the issue persists."
             )
 
-        if user_email and api_key_name:
-            integration_name = f"Cursor Cloud Agent - {user_email}/{api_key_name}"
-        else:
-            key_hint = api_key[:8] if len(api_key) >= 8 else api_key
-            integration_name = f"Cursor Cloud Agent ({key_hint}...)"
+        integration_name = build_default_integration_name(api_key_name, api_key)
 
         int_metadata = CursorIntegrationMetadata(
             domain_name="cursor.sh",
@@ -159,7 +174,20 @@ class CursorAgentIntegrationProvider(CodingAgentIntegrationProvider):
 
 class CursorAgentIntegration(CodingAgentIntegration):
     def get_organization_config(self) -> list[dict[str, Any]]:
+        metadata = CursorIntegrationMetadata.parse_obj(self.model.metadata or {})
+        default_name = build_default_integration_name(metadata.api_key_name, metadata.api_key)
         return [
+            {
+                "name": "display_name",
+                "type": "string",
+                "label": _("Display Name"),
+                "help": _(
+                    "Customize the name shown when launching Cursor Cloud Agents. "
+                    "Leave blank to use the default."
+                ),
+                "required": False,
+                "placeholder": default_name,
+            },
             {
                 "name": "api_key",
                 "type": "secret",
@@ -168,10 +196,24 @@ class CursorAgentIntegration(CodingAgentIntegration):
                 "required": True,
                 "placeholder": "***********************",
                 "formatMessageValue": False,
-            }
+            },
         ]
 
+    def get_config_data(self) -> Mapping[str, Any]:
+        data = dict(super().get_config_data())
+        metadata = CursorIntegrationMetadata.parse_obj(self.model.metadata or {})
+        data["display_name"] = metadata.display_name or ""
+        return data
+
     def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
+        # Editing only the display name should not require or re-verify the API key.
+        if "api_key" not in data:
+            metadata = CursorIntegrationMetadata.parse_obj(self.model.metadata or {})
+            self._update_display_name(metadata, data)
+            self._persist_metadata(metadata, name=resolve_integration_name(metadata))
+            super().update_organization_config({})
+            return
+
         api_key = data.get("api_key")
         if not api_key:
             raise IntegrationConfigurationError("API key is required")
@@ -198,14 +240,21 @@ class CursorAgentIntegration(CodingAgentIntegration):
                 "Unable to validate Cursor API key. Please try again or contact support if the issue persists."
             )
 
-        if metadata.user_email and metadata.api_key_name:
-            integration_name = f"Cursor Cloud Agent - {metadata.user_email}/{metadata.api_key_name}"
-        else:
-            key_hint = api_key[:8] if len(api_key) >= 8 else api_key
-            integration_name = f"Cursor Cloud Agent ({key_hint}...)"
-
-        self._persist_metadata(metadata, name=integration_name)
+        self._update_display_name(metadata, data)
+        self._persist_metadata(metadata, name=resolve_integration_name(metadata))
         super().update_organization_config({})
+
+    def _update_display_name(
+        self, metadata: CursorIntegrationMetadata, data: MutableMapping[str, Any]
+    ) -> None:
+        if "display_name" not in data:
+            return
+        display_name = (data.get("display_name") or "").strip()
+        if len(display_name) > INTEGRATION_NAME_MAX_LENGTH:
+            raise IntegrationConfigurationError(
+                f"Display name must be {INTEGRATION_NAME_MAX_LENGTH} characters or fewer."
+            )
+        metadata.display_name = display_name or None
 
     def get_client(self):
         return CursorAgentClient(

--- a/tests/sentry/integrations/cursor/test_integration.py
+++ b/tests/sentry/integrations/cursor/test_integration.py
@@ -64,9 +64,7 @@ def test_build_integration_with_user_api_key(provider):
         integration_data = provider.build_integration(state={"config": {"api_key": "cursor-api"}})
 
     mock_verify.assert_called_once()
-    assert (
-        integration_data["name"] == "Cursor Cloud Agent - developer@example.com/Production API Key"
-    )
+    assert integration_data["name"] == "Cursor Cloud Agent - Production API Key"
     assert integration_data["metadata"]["api_key_name"] == "Production API Key"
     assert integration_data["metadata"]["user_email"] == "developer@example.com"
 
@@ -319,7 +317,139 @@ class CursorIntegrationTest(IntegrationTestCase):
         installation = integration.get_installation(organization_id=self.organization.id)
 
         with pytest.raises(IntegrationConfigurationError, match="API key is required"):
-            installation.update_organization_config({})
+            installation.update_organization_config({"api_key": ""})
+
+    @patch("sentry.integrations.cursor.client.CursorAgentClient.verify_api_key")
+    def test_update_organization_config_sets_custom_display_name(self, mock_verify):
+        mock_verify.return_value = CursorApiKeyMetadata(
+            apiKeyName="Production Key",
+            createdAt="2024-01-15T10:30:00Z",
+            userEmail="dev@example.com",
+        )
+
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor",
+            name="Cursor Cloud Agent - Production Key",
+            external_id="cursor",
+            metadata={
+                "api_key": "old_key",
+                "webhook_secret": "secret123",
+                "domain_name": "cursor.sh",
+                "api_key_name": "Production Key",
+                "user_email": "dev@example.com",
+            },
+        )
+
+        installation = integration.get_installation(organization_id=self.organization.id)
+
+        installation.update_organization_config({"display_name": "My Team's Cursor Agent"})
+
+        mock_verify.assert_not_called()
+
+        integration.refresh_from_db()
+        assert integration.name == "My Team's Cursor Agent"
+        assert integration.metadata["display_name"] == "My Team's Cursor Agent"
+        assert integration.metadata["api_key"] == "old_key"
+
+    @patch("sentry.integrations.cursor.client.CursorAgentClient.verify_api_key")
+    def test_update_organization_config_preserves_custom_name_on_key_rotation(self, mock_verify):
+        mock_verify.return_value = CursorApiKeyMetadata(
+            apiKeyName="Rotated Key",
+            createdAt="2024-01-15T10:30:00Z",
+            userEmail="dev@example.com",
+        )
+
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor",
+            name="My Custom Name",
+            external_id="cursor",
+            metadata={
+                "api_key": "old_key",
+                "webhook_secret": "secret123",
+                "domain_name": "cursor.sh",
+                "api_key_name": "Old Key",
+                "user_email": "dev@example.com",
+                "display_name": "My Custom Name",
+            },
+        )
+
+        installation = integration.get_installation(organization_id=self.organization.id)
+
+        installation.update_organization_config({"api_key": "new_key"})
+
+        integration.refresh_from_db()
+        assert integration.name == "My Custom Name"
+        assert integration.metadata["api_key"] == "new_key"
+        assert integration.metadata["api_key_name"] == "Rotated Key"
+
+    @patch("sentry.integrations.cursor.client.CursorAgentClient.verify_api_key")
+    def test_update_organization_config_clearing_display_name_reverts_to_default(self, mock_verify):
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor",
+            name="My Custom Name",
+            external_id="cursor",
+            metadata={
+                "api_key": "some_key",
+                "webhook_secret": "secret123",
+                "domain_name": "cursor.sh",
+                "api_key_name": "Production Key",
+                "user_email": "dev@example.com",
+                "display_name": "My Custom Name",
+            },
+        )
+
+        installation = integration.get_installation(organization_id=self.organization.id)
+
+        installation.update_organization_config({"display_name": "   "})
+
+        mock_verify.assert_not_called()
+
+        integration.refresh_from_db()
+        assert integration.name == "Cursor Cloud Agent - Production Key"
+        assert integration.metadata["display_name"] is None
+
+    def test_get_config_data_returns_display_name(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor",
+            name="My Custom Name",
+            external_id="cursor",
+            metadata={
+                "api_key": "some_key",
+                "webhook_secret": "secret123",
+                "domain_name": "cursor.sh",
+                "display_name": "My Custom Name",
+            },
+        )
+
+        installation = integration.get_installation(organization_id=self.organization.id)
+
+        assert installation.get_config_data()["display_name"] == "My Custom Name"
+
+    def test_get_organization_config_includes_display_name_field(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor",
+            name="Cursor Cloud Agent - Production Key",
+            external_id="cursor",
+            metadata={
+                "api_key": "some_key",
+                "webhook_secret": "secret123",
+                "domain_name": "cursor.sh",
+                "api_key_name": "Production Key",
+            },
+        )
+
+        installation = integration.get_installation(organization_id=self.organization.id)
+
+        config = installation.get_organization_config()
+        fields = {field["name"]: field for field in config}
+        assert "display_name" in fields
+        assert fields["display_name"]["type"] == "string"
+        assert fields["display_name"]["placeholder"] == "Cursor Cloud Agent - Production Key"
 
     @patch("sentry.integrations.cursor.client.CursorAgentClient.verify_api_key")
     def test_update_organization_config_raises_on_invalid_key(self, mock_get_metadata):


### PR DESCRIPTION
The Cursor integration's stored display name was auto-generated as `Cursor Cloud Agent - {email}/{api_key_name}`, so the API key owner's email showed up directly in the coding-agent dropdown when launching agents from an issue. This drops the email from the default, leaving `Cursor Cloud Agent - {api_key_name}` (the email is still kept in metadata and shown in the configurations list, which is a more appropriate place for it).

It also adds an editable **Display Name** field to the integration settings form. Leaving it blank uses the auto-generated default and keeps it in sync with the API key name; setting a custom value stores it in metadata and preserves it across API key rotations. The settings form renders automatically from `get_organization_config()`, so no frontend changes are needed.

Existing integrations keep their current (email-bearing) name until the API key is re-saved or a custom name is set — there's no backfill in this PR.


Agent transcript: https://claudescope.sentry.dev/share/xlvzrXTtALmGrxF_vF14RbRl5aIG3nj3MyOOBHR1j4c