### PR TITLE
build(flake8): Add S019 rule banning reserved LogRecord keys in logging extra=

### DIFF
--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -151,7 +151,7 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
                 ),
             )
         except Exception as e:
-            logger.warning("apigateway.invalid-breaker-config", extra={"message": str(e)})
+            logger.warning("apigateway.invalid-breaker-config", extra={"error": str(e)})
 
     if circuit_breaker is not None:
         if not circuit_breaker.should_allow_request():

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -620,7 +620,7 @@ def _process_chunk(
                 logger.info(
                     "preprod.snapshots.odiff.unchanged_with_diff_hash",
                     extra={
-                        "name": name,
+                        "image_name": name,
                         "org_id": org_id,
                         "head_artifact_id": head_artifact_id,
                         "base_artifact_id": base_artifact_id,

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -393,3 +393,23 @@ def test_S015_current_or_future_year() -> None:
         )
         == []
     )
+
+
+def test_S019() -> None:
+    src = """\
+import logging
+
+logger = logging.getLogger(__name__)
+
+logger.info("m", extra={"name": 1})
+logger.warning("m", extra={"message": "x"})
+logger.info("m", extra={"ok_key": 1})
+logger.info("m", extra=other)
+"""
+    expected = [
+        "t.py:5:24: S019 'name' is a reserved LogRecord attribute; using it as a key in "
+        "logging extra= raises KeyError at runtime",
+        "t.py:6:27: S019 'message' is a reserved LogRecord attribute; using it as a key in "
+        "logging extra= raises KeyError at runtime",
+    ]
+    assert _run(src) == expected

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -55,6 +55,43 @@ S018_msg = (
 S018_fqn = "django.core.cache.backends.memcached.PyMemcacheCache"  # noqa: S018
 S018_module = "django.core.cache.backends.memcached"
 
+S019_fmt = (
+    "S019 {!r} is a reserved LogRecord attribute; using it as a key in "
+    "logging extra= raises KeyError at runtime"
+)
+S019_logging_methods = frozenset(
+    ("debug", "info", "warning", "warn", "error", "exception", "critical", "fatal", "log")
+)
+# Keys rejected by logging.Logger.makeRecord: the attributes set in
+# LogRecord.__init__ plus the explicit "message"/"asctime" guard.
+S019_logrecord_attrs = frozenset(
+    (
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "taskName",
+        "message",
+        "asctime",
+    )
+)
+
 
 # --- S015: do not hardcode current or future UTC year as test "now" ---
 # Flag year >= current UTC year at lint time. Module/class scope + freeze_time(datetime(...)).
@@ -299,6 +336,19 @@ class SentryVisitor(ast.NodeVisitor):
             for keyword in node.keywords:
                 if keyword.arg == "SENTRY_OPTIONS":
                     self.errors.append((keyword.lineno, keyword.col_offset, S011_msg))
+
+        if isinstance(node.func, ast.Attribute) and node.func.attr in S019_logging_methods:
+            for keyword in node.keywords:
+                if keyword.arg == "extra" and isinstance(keyword.value, ast.Dict):
+                    for key in keyword.value.keys:
+                        if (
+                            isinstance(key, ast.Constant)
+                            and isinstance(key.value, str)
+                            and key.value in S019_logrecord_attrs
+                        ):
+                            self.errors.append(
+                                (key.lineno, key.col_offset, S019_fmt.format(key.value))
+                            )
 
         self.generic_visit(node)
 


### PR DESCRIPTION
## Summary

Passing a reserved `LogRecord` attribute (`name`, `message`, `args`, `module`, …) as a key in a logging `extra=` dict raises `KeyError: "Attempt to overwrite 'X' in LogRecord"` **at runtime**, when the log line actually fires. Nothing static catches it — it passes ruff, mypy, and a human skim — and it recently caused a silent production incident in preprod snapshots (the log call meant to aid debugging was the thing that crashed; see #117550).

This adds a custom **S019** flake8 rule (Sentry's `S###` family in `tools/flake8_plugin.py`) that flags this class before runtime, and fixes the only two existing violations it surfaces repo-wide.

This follows up a review question on #117550 ("can this class of problem be prevented before runtime?").

## Changes

- **S019 rule** (`tools/flake8_plugin.py`): flags `logger.<level>(..., extra={...})` calls whose `extra` dict has a literal string key colliding with a reserved `LogRecord` attribute. Auto-registered via the existing `S=` prefix plugin (no config change).
- **`test_S019`** (`tests/tools/test_flake8_plugin.py`): covers `name`/`message` hits, a non-reserved key (ok), and a dynamic `extra=var` (not flagged).
- **Fixes for the two surfaced violations:**
  - `hybridcloud/apigateway/proxy.py`: `"message"` → `"error"` in a breaker-config warning (would have crashed when invalid config was hit).
  - `preprod/snapshots/tasks.py`: `"name"` → `"image_name"` (same fix as #117550; identical change, no conflict whichever merges first).

## Known limitation

Only **literal** `extra={...}` dicts with constant string keys are checked. Dynamic dicts (`extra=some_var`, `extra={**spread}`, computed keys) can't be detected statically — but the literal case is the one that actually bites.

## Test Plan

- [x] `test_S019` passes; full `tests/tools/test_flake8_plugin.py` suite green (18 tests)
- [x] `flake8 --select=S019 src tests tools` reports clean after the two fixes (was 2 hits before)
- [x] ruff + mypy clean on changed files
