### PR TITLE
ref: Replace isEnterprise frontend check with backend field

### DIFF
--- a/static/gsApp/components/labelWithPowerIcon.tsx
+++ b/static/gsApp/components/labelWithPowerIcon.tsx
@@ -7,7 +7,6 @@ import {IconBusiness} from 'sentry/icons';
 import PowerFeatureHovercard from 'getsentry/components/powerFeatureHovercard';
 import {withSubscription} from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
-import {isEnterprise} from 'getsentry/utils/billing';
 
 const SSO = 'sso';
 const ALLOCATIONS = 'allocations-upsell';
@@ -67,7 +66,7 @@ function LabelWithPowerIcon({children, id, subscription}: Props) {
     return children as React.ReactElement;
   }
 
-  if (!subscription?.plan || isEnterprise(subscription.plan)) {
+  if (!subscription?.plan || subscription.planDetails?.isEnterprise) {
     return children as React.ReactElement;
   }
 

--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -34,7 +34,6 @@ import {
   hasPerformance,
   isBizPlanFamily,
   isDeveloperPlan,
-  isEnterprise,
   isNewPayingCustomer,
   isTeamPlanFamily,
   MILLISECONDS_IN_HOUR,
@@ -1061,23 +1060,6 @@ describe('getOnDemandCategories - AM2 logBytes support', () => {
       budgetMode: OnDemandBudgetMode.SHARED,
     });
     expect(categories).toContain('logBytes');
-  });
-});
-
-describe('isEnterprise', () => {
-  it('returns true for enterprise plans', () => {
-    expect(isEnterprise('e1')).toBe(true);
-    expect(isEnterprise('enterprise')).toBe(true);
-    expect(isEnterprise('am1_business_ent')).toBe(true);
-    expect(isEnterprise('am2_team_ent_auf')).toBe(true);
-    expect(isEnterprise('am3_business_ent_ds_auf')).toBe(true);
-  });
-
-  it('returns false for non-enterprise plans', () => {
-    expect(isEnterprise('_e1')).toBe(false);
-    expect(isEnterprise('_enterprise')).toBe(false);
-    expect(isEnterprise('am1_business')).toBe(false);
-    expect(isEnterprise('am2_team')).toBe(false);
   });
 });
 

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -25,7 +25,6 @@ import {
   FEE_INVOICE_ITEM_TYPES,
   OnDemandBudgetMode,
   PlanName,
-  PlanTier,
   ReservedBudgetCategoryType,
 } from 'getsentry/types';
 import type {
@@ -315,12 +314,6 @@ function displayNumber(n: number, fractionDigits = 0) {
   return n.toFixed(fractionDigits).toLocaleString();
 }
 
-/**
- * Utility functions for Pricing Plans
- */
-export const isEnterprise = (plan: string) =>
-  ['e1', 'enterprise'].some(p => plan.startsWith(p)) || isAmEnterprisePlan(plan);
-
 export const isTrialPlan = (plan: string) => TRIAL_PLANS.includes(plan);
 
 export const hasPerformance = (plan?: Plan) => {
@@ -352,24 +345,12 @@ export const isBusinessTrial = (subscription: Subscription) => {
   );
 };
 
-function isAmPlan(planId?: string) {
-  return typeof planId === 'string' && planId.startsWith('am');
-}
-
 export function isAm2Plan(planId?: string) {
   return typeof planId === 'string' && planId.startsWith('am2');
 }
 
 export function isAm3Plan(planId?: string) {
   return typeof planId === 'string' && planId.startsWith('am3');
-}
-
-export function isAmEnterprisePlan(planId?: string) {
-  if (typeof planId !== 'string' || !isAmPlan(planId)) {
-    return false;
-  }
-
-  return planId.includes('_ent');
 }
 
 export function hasJustStartedPlanTrial(subscription: Subscription) {
@@ -437,20 +418,7 @@ export const getOnDemandCategories = ({
 };
 
 export const displayPlanName = (plan?: Plan | null) => {
-  return isAmEnterprisePlan(plan?.id) ? 'Enterprise' : (plan?.name ?? '[unavailable]');
-};
-
-export const getAmPlanTier = (plan: string) => {
-  if (isAm3Plan(plan)) {
-    return PlanTier.AM3;
-  }
-  if (isAm2Plan(plan)) {
-    return PlanTier.AM2;
-  }
-  if (isAmPlan(plan)) {
-    return PlanTier.AM1;
-  }
-  return null;
+  return plan?.isEnterprise ? 'Enterprise' : (plan?.name ?? '[unavailable]');
 };
 
 export const isNewPayingCustomer = (

--- a/static/gsApp/views/amCheckout/components/planFeatures.tsx
+++ b/static/gsApp/views/amCheckout/components/planFeatures.tsx
@@ -17,9 +17,9 @@ import {t, tct} from 'sentry/locale';
 import type {DataCategory} from 'sentry/types/core';
 import {oxfordizeArray} from 'sentry/utils/oxfordizeArray';
 
-import {DEFAULT_TIER, UNLIMITED_RESERVED} from 'getsentry/constants';
+import {UNLIMITED_RESERVED} from 'getsentry/constants';
 import {PlanTier, type Plan} from 'getsentry/types';
-import {formatReservedWithUnits, getAmPlanTier} from 'getsentry/utils/billing';
+import {formatReservedWithUnits, isAm3Plan} from 'getsentry/utils/billing';
 import {
   getPlanCategoryName,
   getSingularCategoryName,
@@ -493,7 +493,6 @@ export function PlanFeatures({
   activePlan: Plan;
   planOptions: Plan[];
 }) {
-  const currentTier = getAmPlanTier(activePlan.id);
   const perPlanPriceDiffs: Record<
     Plan['id'],
     Partial<Record<DataCategory, number>> & {plan: Plan}
@@ -534,7 +533,7 @@ export function PlanFeatures({
           <MonitoringAndDataFeatures planOptions={planOptions} activePlan={activePlan} />
           <ExpansionPackFeatures activePlan={activePlan} />
         </Grid>
-        {currentTier !== DEFAULT_TIER && (
+        {!isAm3Plan(activePlan.id) && (
           <Flex gap="sm">
             <Container paddingTop="xs">
               <IconLightning size="sm" variant="accent" />

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -16,7 +16,7 @@ import {useApi} from 'sentry/utils/useApi';
 import type {Reservations} from 'getsentry/components/upgradeNowModal/types';
 import {MONTHLY, RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {AddOnCategory, PlanTier, ReservedBudgetCategoryType} from 'getsentry/types';
+import {AddOnCategory, ReservedBudgetCategoryType} from 'getsentry/types';
 import type {
   BillingDetails,
   CheckoutAddOns,
@@ -28,11 +28,11 @@ import type {
   Subscription,
 } from 'getsentry/types';
 import {
-  getAmPlanTier,
   getReservedBudgetCategoryForAddOn,
   getSlot,
   hasPartnerMigrationFeature,
   hasSomeBillingDetails,
+  isAm3Plan,
   isBizPlanFamily,
   isTeamPlanFamily,
   isTrialPlan,
@@ -721,7 +721,7 @@ export function getContentForPlan(plan: Plan): PlanContent {
         discover: t('Advanced analytics with Discover'),
         enhanced_priority_alerts: t('Enhanced issue priority and alerting'),
         dashboard: t('Unlimited custom dashboards'),
-        ...(getAmPlanTier(plan.id) === PlanTier.AM3 && {
+        ...(isAm3Plan(plan.id) && {
           application_insights: t('Application Insights'),
         }),
         advanced_filtering: t('Advanced server-side filtering'),

--- a/static/gsApp/views/spendAllocations/index.tsx
+++ b/static/gsApp/views/spendAllocations/index.tsx
@@ -28,7 +28,7 @@ import PlanFeature from 'getsentry/components/features/planFeature';
 import {withSubscription} from 'getsentry/components/withSubscription';
 import {AllocationTargetTypes} from 'getsentry/constants';
 import type {Subscription} from 'getsentry/types';
-import {displayPlanName, isAmEnterprisePlan} from 'getsentry/utils/billing';
+import {displayPlanName} from 'getsentry/utils/billing';
 import {
   getCategoryInfoFromPlural,
   getPlanCategoryName,
@@ -334,7 +334,7 @@ export function SpendAllocationsRoot({subscription}: Props) {
                       <strong>
                         {t(
                           'requires %s %s Plan',
-                          isAmEnterprisePlan(plan?.id) ? 'an' : 'a',
+                          plan?.isEnterprise ? 'an' : 'a',
                           displayPlanName(plan)
                         )}
                       </strong>


### PR DESCRIPTION
Removes some hardcoded plan.id checks from the frontend