### PR TITLE
ref: Replace am2/3 checks with capability checks

### DIFF
--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -352,7 +352,6 @@ describe('CustomerOverview', () => {
     const mm2_subscription = SubscriptionFixture({
       organization,
       plan: 'mm2_f',
-      planTier: PlanTier.MM2,
     });
 
     render(

--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -30,12 +30,7 @@ import {
   type ReservedBudgetMetricHistory,
   type Subscription,
 } from 'getsentry/types';
-import {
-  displayBudgetName,
-  hasPerformance,
-  isAm3Plan,
-  isTrialPlan,
-} from 'getsentry/utils/billing';
+import {displayBudgetName, hasPerformance, isTrialPlan} from 'getsentry/utils/billing';
 import {
   getCategoryInfoFromPlural,
   getPlanCategoryName,
@@ -705,7 +700,9 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
                     label={`${selectedPlan ? displayBudgetName(selectedPlan, {title: true}) : 'Pay-as-you-go'} Max Spend Setting`}
                     name="onDemandInvoicedManual"
                     choices={
-                      isAm3Plan(this.state.data.plan)
+                      // per-category max spend is only available on plans
+                      // with on-demand budget modes
+                      selectedPlan && !selectedPlan.hasOnDemandModes
                         ? [
                             ['SHARED', 'Shared'],
                             ['DISABLE', 'Disable'],

--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -22,7 +22,11 @@ import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 import {withApi} from 'sentry/utils/withApi';
 
 import {prettyDate} from 'admin/utils';
-import {CPE_MULTIPLIER_TO_CENTS, RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
+import {
+  CPE_MULTIPLIER_TO_CENTS,
+  MONTHLY,
+  RESERVED_BUDGET_QUOTA,
+} from 'getsentry/constants';
 import {
   ReservedBudgetCategoryType,
   type BillingConfig,
@@ -193,8 +197,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
             // Legacy errors-only enterprise plans (e1, mm2) can no longer be
             // provisioned.
             hasPerformance(plan) &&
-            !plan.id.endsWith('_ac') &&
-            !plan.id.endsWith('_auf') &&
+            plan.contractInterval === MONTHLY &&
             !isTrialPlan(plan.id) &&
             !plan.isTestPlan
           ) {

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -613,11 +613,6 @@ function setUpMocks(
     body: BillingConfigFixture(PlanTier.ALL),
     match: [MockApiClient.matchQuery({tier: 'all'})],
   });
-  // TODO(isabella): remove this once all billing config api calls are updated to use tier=all
-  MockApiClient.addMockResponse({
-    url: `/customers/${organization.slug}/billing-config/?tier=mm2`,
-    body: BillingConfigFixture(PlanTier.MM2),
-  });
   MockApiClient.addMockResponse({
     url: `/customers/${organization.slug}/billing-config/?tier=am1`,
     body: BillingConfigFixture(PlanTier.AM1),

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -73,9 +73,9 @@ import {toggleSpendAllocationModal} from 'admin/components/toggleSpendAllocation
 import {TrialSubscriptionAction} from 'admin/components/trialSubscriptionAction';
 import {RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
 import type {BilledDataCategoryInfo, BillingConfig, Subscription} from 'getsentry/types';
-import {PlanTier} from 'getsentry/types';
 import {
   hasActiveVCFeature,
+  hasPerformance,
   isBizPlanFamily,
   isUnlimitedReserved,
 } from 'getsentry/utils/billing';
@@ -861,12 +861,9 @@ export function CustomerDetails() {
             name: 'Migrate From Legacy Seer',
             help: 'Migrate a user off Legacy Seer to allow them to use the seat-based Seer plan, effective immediately or at the next billing period. Applies a prorated credit for eligible annual plans. Optionally adds a 14-day Seer seat trial.',
             disabled:
-              ![PlanTier.AM1, PlanTier.AM2, PlanTier.AM3].includes(
-                subscription.planTier as PlanTier
-              ) || !subscription.addOns?.legacySeer?.enabled,
-            disabledReason: [PlanTier.AM1, PlanTier.AM2, PlanTier.AM3].includes(
-              subscription.planTier as PlanTier
-            )
+              !hasPerformance(subscription.planDetails) ||
+              !subscription.addOns?.legacySeer?.enabled,
+            disabledReason: hasPerformance(subscription.planDetails)
               ? 'Only available for organizations with active legacy Seer that have not yet been migrated.'
               : 'Only available for AM1, AM2, and AM3 plans.',
             confirmModalOpts: {

--- a/static/gsApp/components/features/planFeature.spec.tsx
+++ b/static/gsApp/components/features/planFeature.spec.tsx
@@ -24,7 +24,7 @@ describe('PlanFeature', () => {
   it('provides the plan required for a feature', async () => {
     const mockFn = jest.fn(() => null);
 
-    const sub = SubscriptionFixture({organization, planTier: PlanTier.MM2});
+    const sub = SubscriptionFixture({organization});
     SubscriptionStore.set(organization.slug, sub);
 
     render(
@@ -44,7 +44,7 @@ describe('PlanFeature', () => {
   it('provides the business plan', async () => {
     const mockFn = jest.fn(() => null);
 
-    const sub = SubscriptionFixture({organization, planTier: PlanTier.MM2});
+    const sub = SubscriptionFixture({organization});
     SubscriptionStore.set(organization.slug, sub);
 
     render(
@@ -64,7 +64,7 @@ describe('PlanFeature', () => {
   it('provides no plan if the feature is not on a plan', async () => {
     const mockFn = jest.fn(() => null);
 
-    const sub = SubscriptionFixture({organization, planTier: PlanTier.MM2});
+    const sub = SubscriptionFixture({organization});
     SubscriptionStore.set(organization.slug, sub);
 
     render(
@@ -84,7 +84,6 @@ describe('PlanFeature', () => {
     const sub = SubscriptionFixture({
       organization,
       contractInterval: 'annual',
-      planTier: PlanTier.MM2,
     });
     SubscriptionStore.set(organization.slug, sub);
 

--- a/static/gsApp/components/powerFeatureHovercard.tsx
+++ b/static/gsApp/components/powerFeatureHovercard.tsx
@@ -13,7 +13,6 @@ import {openUpsellModal} from 'getsentry/actionCreators/modal';
 import PlanFeature from 'getsentry/components/features/planFeature';
 import {withSubscription} from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
-import {PlanTier} from 'getsentry/types';
 import {displayPlanName} from 'getsentry/utils/billing';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
@@ -87,12 +86,8 @@ function PowerFeatureHovercard({
       organization={organization}
       subscription={subscription}
     >
-      {({plan, tierChange}) => {
-        let planName = displayPlanName(plan);
-
-        if (tierChange === PlanTier.AM1) {
-          planName = `Performance ${planName}`;
-        }
+      {({plan}) => {
+        const planName = displayPlanName(plan);
 
         return (
           <LearnMoreTextBody data-test-id="power-hovercard">

--- a/static/gsApp/components/productSelectionAvailability.spec.tsx
+++ b/static/gsApp/components/productSelectionAvailability.spec.tsx
@@ -25,17 +25,14 @@ import {PlanTier} from 'getsentry/types';
 jest.mock('getsentry/components/upgradeNowModal/usePreviewData');
 
 function renderMockRequests({
-  planTier,
   organization,
   canSelfServe,
 }: {
   organization: Organization;
-  planTier: PlanTier;
   canSelfServe?: boolean;
 }) {
   const subscription = SubscriptionFixture({
     organization,
-    planTier,
     canSelfServe,
   });
 
@@ -44,14 +41,13 @@ function renderMockRequests({
   MockApiClient.addMockResponse({
     url: '/customers/org-slug/',
     body: {
-      planTier,
       canSelfServe,
     },
   });
 
   MockApiClient.addMockResponse({
     url: `/customers/${organization.slug}/billing-config/`,
-    body: BillingConfigFixture(planTier),
+    body: BillingConfigFixture(PlanTier.AM2),
   });
 }
 
@@ -73,7 +69,7 @@ describe('ProductSelectionAvailability', () => {
         },
       };
 
-      renderMockRequests({planTier: PlanTier.AM2, organization});
+      renderMockRequests({organization});
 
       render(
         <ProductSelectionAvailability
@@ -122,7 +118,7 @@ describe('ProductSelectionAvailability', () => {
     it('without performance and session replay', async () => {
       const organization = OrganizationFixture();
 
-      renderMockRequests({planTier: PlanTier.MM2, organization, canSelfServe: true});
+      renderMockRequests({organization, canSelfServe: true});
 
       render(
         <ProductSelectionAvailability
@@ -175,7 +171,7 @@ describe('ProductSelectionAvailability', () => {
         },
       };
 
-      renderMockRequests({planTier: PlanTier.AM1, organization});
+      renderMockRequests({organization});
 
       render(
         <ProductSelectionAvailability
@@ -226,7 +222,7 @@ describe('ProductSelectionAvailability', () => {
         },
       };
 
-      renderMockRequests({planTier: PlanTier.AM2, organization});
+      renderMockRequests({organization});
 
       render(
         <ProductSelectionAvailability
@@ -277,7 +273,7 @@ describe('ProductSelectionAvailability', () => {
         access: ['org:billing'],
       });
 
-      renderMockRequests({planTier: PlanTier.MM2, organization});
+      renderMockRequests({organization});
 
       render(
         <ProductSelectionAvailability
@@ -363,7 +359,7 @@ describe('ProductSelectionAvailability', () => {
       });
 
       // can self-serve
-      renderMockRequests({planTier: PlanTier.AM1, organization, canSelfServe: true});
+      renderMockRequests({organization, canSelfServe: true});
 
       const {rerender} = render(
         <ProductSelectionAvailability
@@ -408,7 +404,7 @@ describe('ProductSelectionAvailability', () => {
       ).toBeInTheDocument();
 
       // can't self-serve
-      renderMockRequests({planTier: PlanTier.AM1, organization, canSelfServe: false});
+      renderMockRequests({organization, canSelfServe: false});
       rerender(
         <ProductSelectionAvailability
           organization={organization}
@@ -437,7 +433,7 @@ describe('ProductSelectionAvailability', () => {
         },
       };
 
-      renderMockRequests({planTier: PlanTier.AM2, organization});
+      renderMockRequests({organization});
 
       render(
         <ProductSelectionAvailability
@@ -485,7 +481,7 @@ describe('ProductSelectionAvailability', () => {
         },
       };
 
-      renderMockRequests({planTier: PlanTier.AM2, organization});
+      renderMockRequests({organization});
 
       render(
         <ProductSelectionAvailability
@@ -532,7 +528,7 @@ describe('ProductSelectionAvailability', () => {
         features: ['performance-view', 'profiling-view'],
       });
 
-      renderMockRequests({planTier: PlanTier.AM2, organization});
+      renderMockRequests({organization});
 
       const {router} = render(
         <ProductSelectionAvailability
@@ -578,7 +574,7 @@ describe('ProductSelectionAvailability', () => {
         },
       };
 
-      renderMockRequests({planTier: PlanTier.AM2, organization});
+      renderMockRequests({organization});
 
       const {router} = render(
         <ProductSelectionAvailability

--- a/static/gsApp/components/productTrial/productTrialPaths.tsx
+++ b/static/gsApp/components/productTrial/productTrialPaths.tsx
@@ -1,7 +1,6 @@
 import {DataCategory} from 'sentry/types/core';
 
 import type {Subscription} from 'getsentry/types';
-import {PlanTier} from 'getsentry/types';
 
 type Product = {
   categories: DataCategory[];
@@ -108,7 +107,7 @@ export function getProductForPath(
 ): Product | null {
   path = normalizePath(path);
 
-  if (subscription.planTier === PlanTier.AM3) {
+  if (subscription.planDetails.categories.includes(DataCategory.SPANS)) {
     if (Object.hasOwn(PATHS_FOR_PRODUCT_TRIALS_AM3_OVERRIDES, path)) {
       return PATHS_FOR_PRODUCT_TRIALS_AM3_OVERRIDES[path]!;
     }

--- a/static/gsApp/components/productTrial/productTrialPaths.tsx
+++ b/static/gsApp/components/productTrial/productTrialPaths.tsx
@@ -107,7 +107,7 @@ export function getProductForPath(
 ): Product | null {
   path = normalizePath(path);
 
-  if (subscription.planDetails.categories.includes(DataCategory.SPANS)) {
+  if (subscription.planDetails?.categories.includes(DataCategory.SPANS)) {
     if (Object.hasOwn(PATHS_FOR_PRODUCT_TRIALS_AM3_OVERRIDES, path)) {
       return PATHS_FOR_PRODUCT_TRIALS_AM3_OVERRIDES[path]!;
     }

--- a/static/gsApp/components/productUnavailableCTA.spec.tsx
+++ b/static/gsApp/components/productUnavailableCTA.spec.tsx
@@ -19,22 +19,24 @@ import {ProductUnavailableCTA} from 'getsentry/components/productUnavailableCTA'
 import type {Reservations} from 'getsentry/components/upgradeNowModal/types';
 import {usePreviewData} from 'getsentry/components/upgradeNowModal/usePreviewData';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 
 jest.mock('getsentry/components/upgradeNowModal/usePreviewData');
 
 function renderMockRequests({
-  planTier,
+  isAncientPlan,
   organization,
   canSelfServe,
 }: {
   organization: Organization;
-  planTier: PlanTier;
+  // Legacy plans without performance/tracing take the "request an update" path;
+  // modern plans take the replay-onboarding path.
   canSelfServe?: boolean;
+  isAncientPlan?: boolean;
 }) {
   const subscription = SubscriptionFixture({
     organization,
-    planTier,
+    // m1 is a legacy plan with no performance/tracing categories; am1_f has them.
+    plan: isAncientPlan ? 'm1' : 'am1_f',
     canSelfServe,
   });
 
@@ -42,12 +44,8 @@ function renderMockRequests({
 
   MockApiClient.addMockResponse({
     url: `/customers/${organization.slug}/`,
-    body: {
-      planTier,
-    },
+    body: {},
   });
-
-  const isAncientPlan = [PlanTier.MM1, PlanTier.MM2].includes(planTier);
 
   if (isAncientPlan) {
     const requestUpdatePlan = MockApiClient.addMockResponse({
@@ -74,7 +72,6 @@ describe('ProductUnavailableCTA', () => {
       });
 
       renderMockRequests({
-        planTier: PlanTier.AM2,
         organization,
       });
 
@@ -87,7 +84,7 @@ describe('ProductUnavailableCTA', () => {
       const {organization} = initializeOrg();
 
       const mockRequests = renderMockRequests({
-        planTier: PlanTier.MM1,
+        isAncientPlan: true,
         organization,
       });
 
@@ -119,7 +116,6 @@ describe('ProductUnavailableCTA', () => {
       });
 
       const mockRequests = renderMockRequests({
-        planTier: PlanTier.AM1,
         organization,
       });
 
@@ -154,7 +150,6 @@ describe('ProductUnavailableCTA', () => {
       });
 
       renderMockRequests({
-        planTier: PlanTier.AM2,
         organization,
       });
 
@@ -171,7 +166,7 @@ describe('ProductUnavailableCTA', () => {
       });
 
       renderMockRequests({
-        planTier: PlanTier.MM1,
+        isAncientPlan: true,
         organization,
       });
 
@@ -196,7 +191,6 @@ describe('ProductUnavailableCTA', () => {
 
       // can self-serve
       renderMockRequests({
-        planTier: PlanTier.AM1,
         organization,
         canSelfServe: true,
       });
@@ -245,7 +239,6 @@ describe('ProductUnavailableCTA', () => {
 
       // can not self-serve
       renderMockRequests({
-        planTier: PlanTier.AM1,
         organization,
         canSelfServe: false,
       });

--- a/static/gsApp/components/productUnavailableCTA.tsx
+++ b/static/gsApp/components/productUnavailableCTA.tsx
@@ -15,7 +15,7 @@ import {
 import {withSubscription} from 'getsentry/components/withSubscription';
 import {useAM2UpsellModal} from 'getsentry/hooks/useAM2UpsellModal';
 import type {Subscription} from 'getsentry/types';
-import {PlanTier} from 'getsentry/types';
+import {hasPerformance} from 'getsentry/utils/billing';
 import type {ProductUnavailableUpsellAlert} from 'getsentry/utils/trackGetsentryAnalytics';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
@@ -246,11 +246,10 @@ function ProductUnavailableCTAContainer({
     return null;
   }
 
-  // MM1 & MM2 plans have no direct update path into AM2, prices could be wildly different
-  // Members can email owners requesting a plan upgrade and owners can manage subscription
-  const isAncientPlan = [PlanTier.MM1, PlanTier.MM2].includes(
-    subscription.planTier as PlanTier
-  );
+  // Legacy MM1 & MM2 plans predate performance/tracing and have no direct update
+  // path into AM2, prices could be wildly different. Members can email owners
+  // requesting a plan upgrade and owners can manage subscription
+  const isAncientPlan = !hasPerformance(subscription.planDetails);
 
   const hasBillingAccess = organization.access?.includes('org:billing');
   const canSelfServe = subscription.canSelfServe;

--- a/static/gsApp/components/profiling/alerts.tsx
+++ b/static/gsApp/components/profiling/alerts.tsx
@@ -23,13 +23,7 @@ import {withSubscription} from 'getsentry/components/withSubscription';
 import {useSubscription} from 'getsentry/hooks/useSubscription';
 import type {BilledDataCategoryInfo, ProductTrial, Subscription} from 'getsentry/types';
 import {PlanTier} from 'getsentry/types';
-import {
-  displayBudgetName,
-  getProductTrial,
-  isAm2Plan,
-  isAm3Plan,
-  UsageAction,
-} from 'getsentry/utils/billing';
+import {displayBudgetName, getProductTrial, UsageAction} from 'getsentry/utils/billing';
 import {getCategoryInfoFromPlural} from 'getsentry/utils/dataCategory';
 import {BudgetUsage, checkBudgetUsageFor} from 'getsentry/utils/profiling';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
@@ -281,8 +275,8 @@ export function ContinuousProfilingBillingRequirementBanner({
     return null;
   }
 
-  // only check quota for AM2/AM3 plans
-  if (!isAm2Plan(subscription.plan) && !isAm3Plan(subscription.plan)) {
+  // only check quota for plans with continuous profiling
+  if (!subscription.planDetails?.categories?.includes(DataCategory.PROFILE_DURATION)) {
     return null;
   }
 

--- a/static/gsApp/components/replayOnboardingCTA.tsx
+++ b/static/gsApp/components/replayOnboardingCTA.tsx
@@ -24,7 +24,7 @@ import {sendReplayOnboardRequest} from 'getsentry/actionCreators/upsell';
 import {usePreviewData} from 'getsentry/components/upgradeNowModal/usePreviewData';
 import {withSubscription} from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
-import {PlanTier} from 'getsentry/types';
+import {hasPerformance} from 'getsentry/utils/billing';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 type ReplayOnboardingCTAUpsellProps = {
@@ -196,8 +196,9 @@ function ReplayOnboardingCTAUpsell({
     );
   }
 
-  if ([PlanTier.MM1, PlanTier.MM2].includes(subscription.planTier as PlanTier)) {
-    // MM1 & MM2 plans have no direct update path into AM2, prices could be wildly different
+  if (!hasPerformance(subscription.planDetails)) {
+    // Legacy MM1 & MM2 plans predate performance/tracing and have no direct update
+    // path into AM2, prices could be wildly different.
     // Members get an email, owners get to Manage Subscription
     return (
       <Fragment>

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -943,15 +943,6 @@ export enum PlanTier {
    */
   AM1 = 'am1',
   /**
-   * Monthly metered plans with variable data options.
-   */
-  MM2 = 'mm2',
-  /**
-   * First generation of monthly metered plans.
-   * Features and data volumes are tightly coupled.
-   */
-  MM1 = 'mm1',
-  /**
    * No specified tier
    */
   ALL = 'all',

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -345,14 +345,6 @@ export const isBusinessTrial = (subscription: Subscription) => {
   );
 };
 
-export function isAm2Plan(planId?: string) {
-  return typeof planId === 'string' && planId.startsWith('am2');
-}
-
-export function isAm3Plan(planId?: string) {
-  return typeof planId === 'string' && planId.startsWith('am3');
-}
-
 export function hasJustStartedPlanTrial(subscription: Subscription) {
   return subscription.isTrial && subscription.isTrialStarted;
 }

--- a/static/gsApp/views/amCheckout/components/planFeatures.tsx
+++ b/static/gsApp/views/amCheckout/components/planFeatures.tsx
@@ -14,12 +14,12 @@ import {
   IconWarning,
 } from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import type {DataCategory} from 'sentry/types/core';
+import {DataCategory} from 'sentry/types/core';
 import {oxfordizeArray} from 'sentry/utils/oxfordizeArray';
 
 import {UNLIMITED_RESERVED} from 'getsentry/constants';
 import {PlanTier, type Plan} from 'getsentry/types';
-import {formatReservedWithUnits, isAm3Plan} from 'getsentry/utils/billing';
+import {formatReservedWithUnits} from 'getsentry/utils/billing';
 import {
   getPlanCategoryName,
   getSingularCategoryName,
@@ -533,7 +533,7 @@ export function PlanFeatures({
           <MonitoringAndDataFeatures planOptions={planOptions} activePlan={activePlan} />
           <ExpansionPackFeatures activePlan={activePlan} />
         </Grid>
-        {!isAm3Plan(activePlan.id) && (
+        {!activePlan.categories.includes(DataCategory.SPANS) && (
           <Flex gap="sm">
             <Container paddingTop="xs">
               <IconLightning size="sm" variant="accent" />

--- a/static/gsApp/views/amCheckout/components/volumeSliders.tsx
+++ b/static/gsApp/views/amCheckout/components/volumeSliders.tsx
@@ -64,12 +64,8 @@ export function VolumeSliders({
   checkoutTier,
   activePlan,
   organization,
-  subscription,
   onReservedChange,
-}: Pick<
-  StepProps,
-  'activePlan' | 'checkoutTier' | 'organization' | 'onUpdate' | 'subscription'
-> & {
+}: Pick<StepProps, 'activePlan' | 'checkoutTier' | 'organization' | 'onUpdate'> & {
   currentSliderValues: Partial<Record<DataCategory, number>>;
   onReservedChange: (value: number, category: DataCategory) => void;
 }) {
@@ -123,16 +119,6 @@ export function VolumeSliders({
             checkoutTier === PlanTier.AM2 &&
             organization?.features?.includes('profiling-billing') &&
             category === DataCategory.TRANSACTIONS;
-
-          // TODO: Remove after profiling launch
-          const showTransactionsDisclaimer =
-            !showPerformanceUnits &&
-            category === DataCategory.TRANSACTIONS &&
-            checkoutTier === PlanTier.AM2 &&
-            subscription.planTier === PlanTier.AM1 &&
-            subscription.planDetails.name === activePlan.name &&
-            subscription.billingInterval === activePlan.billingInterval &&
-            (subscription.categories.transactions?.reserved ?? 0) > 5_000_000;
 
           const isIncluded = eventBucket.price === 0;
 
@@ -219,13 +205,6 @@ export function VolumeSliders({
                     </div>
                   </MinMax>
                 </div>
-                {showTransactionsDisclaimer && (
-                  <span>
-                    {t(
-                      'We updated your event quota to make sure you get the best cost per transaction. Feel free to adjust as needed.'
-                    )}
-                  </span>
-                )}
               </CategoryContainer>
             </DataVolumeItem>
           );

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
@@ -138,7 +138,6 @@ export function ReserveAdditionalVolume({
             activePlan={activePlan}
             organization={organization}
             onUpdate={onUpdate}
-            subscription={subscription}
             onReservedChange={(newReserved, category) => {
               setReserved(prev => ({...prev, [category]: newReserved}));
               debouncedReservedChange(newReserved, category);

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -7,7 +7,7 @@ import moment from 'moment-timezone';
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organization';
 import {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
-import type {DataCategory} from 'sentry/types/core';
+import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
@@ -32,7 +32,6 @@ import {
   getSlot,
   hasPartnerMigrationFeature,
   hasSomeBillingDetails,
-  isAm3Plan,
   isBizPlanFamily,
   isTeamPlanFamily,
   isTrialPlan,
@@ -721,7 +720,7 @@ export function getContentForPlan(plan: Plan): PlanContent {
         discover: t('Advanced analytics with Discover'),
         enhanced_priority_alerts: t('Enhanced issue priority and alerting'),
         dashboard: t('Unlimited custom dashboards'),
-        ...(isAm3Plan(plan.id) && {
+        ...(plan.categories.includes(DataCategory.SPANS) && {
           application_insights: t('Application Insights'),
         }),
         advanced_filtering: t('Advanced server-side filtering'),

--- a/static/gsApp/views/spendLimits/spendLimitSettings.tsx
+++ b/static/gsApp/views/spendLimits/spendLimitSettings.tsx
@@ -193,7 +193,7 @@ export function SharedSpendLimitPriceTable({
         // pre-AM3 specific behavior; only plans that bill transactions alongside
         // continuous profiling show transactions as performance units
         const showPerformanceUnits =
-          activePlan.categories.includes(DataCategory.PROFILE_DURATION) &&
+          activePlan.categories.includes(DataCategory.TRANSACTIONS) &&
           organization?.features?.includes('profiling-billing') &&
           category === DataCategory.TRANSACTIONS;
 
@@ -437,7 +437,7 @@ function InnerSpendLimitSettings({
             const isLastInList =
               index === baseCategories.length - 1 && includedAddOns.length === 0;
             const showPerformanceUnits =
-              activePlan.categories.includes(DataCategory.PROFILE_DURATION) &&
+              activePlan.categories.includes(DataCategory.TRANSACTIONS) &&
               organization?.features?.includes('profiling-billing') &&
               category === DataCategory.TRANSACTIONS;
 

--- a/static/gsApp/views/spendLimits/spendLimitSettings.tsx
+++ b/static/gsApp/views/spendLimits/spendLimitSettings.tsx
@@ -29,7 +29,6 @@ import {
   displayBudgetName,
   formatReservedWithUnits,
   getReservedBudgetCategoryForAddOn,
-  isAm2Plan,
 } from 'getsentry/utils/billing';
 import {
   getCategoryInfoFromPlural,
@@ -191,9 +190,10 @@ export function SharedSpendLimitPriceTable({
         <Text bold>{t('Price')}</Text>
       </Flex>
       {baseCategories.map(category => {
-        // pre-AM3 specific behavior
+        // pre-AM3 specific behavior; only plans that bill transactions alongside
+        // continuous profiling show transactions as performance units
         const showPerformanceUnits =
-          isAm2Plan(activePlan.id) &&
+          activePlan.categories.includes(DataCategory.PROFILE_DURATION) &&
           organization?.features?.includes('profiling-billing') &&
           category === DataCategory.TRANSACTIONS;
 
@@ -437,7 +437,7 @@ function InnerSpendLimitSettings({
             const isLastInList =
               index === baseCategories.length - 1 && includedAddOns.length === 0;
             const showPerformanceUnits =
-              isAm2Plan(activePlan.id) &&
+              activePlan.categories.includes(DataCategory.PROFILE_DURATION) &&
               organization?.features?.includes('profiling-billing') &&
               category === DataCategory.TRANSACTIONS;
 

--- a/static/gsApp/views/spendLimits/spendLimitSettings.tsx
+++ b/static/gsApp/views/spendLimits/spendLimitSettings.tsx
@@ -194,6 +194,7 @@ export function SharedSpendLimitPriceTable({
         // continuous profiling show transactions as performance units
         const showPerformanceUnits =
           activePlan.categories.includes(DataCategory.TRANSACTIONS) &&
+          activePlan.categories.includes(DataCategory.PROFILE_DURATION) &&
           organization?.features?.includes('profiling-billing') &&
           category === DataCategory.TRANSACTIONS;
 
@@ -438,6 +439,7 @@ function InnerSpendLimitSettings({
               index === baseCategories.length - 1 && includedAddOns.length === 0;
             const showPerformanceUnits =
               activePlan.categories.includes(DataCategory.TRANSACTIONS) &&
+              activePlan.categories.includes(DataCategory.PROFILE_DURATION) &&
               organization?.features?.includes('profiling-billing') &&
               category === DataCategory.TRANSACTIONS;
 

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/charts.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/charts.tsx
@@ -9,7 +9,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {CHART_OPTIONS_DATA_TRANSFORM} from 'sentry/views/organizationStats/usageChart';
 
 import {PlanTier} from 'getsentry/types';
-import {addBillingStatTotals, checkIsAddOn, isAm2Plan} from 'getsentry/utils/billing';
+import {addBillingStatTotals, checkIsAddOn} from 'getsentry/utils/billing';
 import {
   getCategoryInfoFromPlural,
   getChunkCategoryFromDuration,
@@ -73,7 +73,9 @@ export function UsageCharts({
     ? {
         ...addBillingStatTotals(totals, [
           eventTotals[getChunkCategoryFromDuration(category)] ?? EMPTY_STAT_TOTAL,
-          !isAm2Plan(subscription.plan) &&
+          // on span-based plans, transaction profiles also count toward
+          // profile duration; on earlier plans they are billed with transactions
+          subscription.planDetails.categories.includes(DataCategory.SPANS) &&
           selectedProduct === DataCategory.PROFILE_DURATION
             ? (eventTotals[DataCategory.PROFILES] ?? EMPTY_STAT_TOTAL)
             : EMPTY_STAT_TOTAL,

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/charts.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/charts.tsx
@@ -8,7 +8,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {CHART_OPTIONS_DATA_TRANSFORM} from 'sentry/views/organizationStats/usageChart';
 
-import {PlanTier} from 'getsentry/types';
 import {addBillingStatTotals, checkIsAddOn} from 'getsentry/utils/billing';
 import {
   getCategoryInfoFromPlural,
@@ -86,7 +85,7 @@ export function UsageCharts({
 
   const showEventBreakdown =
     organization.features.includes('profiling-billing') &&
-    subscription.planTier === PlanTier.AM2 &&
+    subscription.planDetails.categories.includes(DataCategory.PROFILE_DURATION) &&
     category === DataCategory.TRANSACTIONS;
 
   const renderFooter = () => {

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -5074,7 +5074,7 @@ export const AM2_PLANS = {
     },
     dashboardLimit: -1,
     metricDetectorLimit: -1,
-    hasOnDemandModes: false,
+    hasOnDemandModes: true,
   },
   am2_business_ent: {
     ...commonFields,
@@ -5183,6 +5183,6 @@ export const AM2_PLANS = {
     },
     dashboardLimit: -1,
     metricDetectorLimit: -1,
-    hasOnDemandModes: false,
+    hasOnDemandModes: true,
   },
 } as const satisfies Record<string, Plan>;

--- a/tests/js/getsentry-test/fixtures/billingConfig.ts
+++ b/tests/js/getsentry-test/fixtures/billingConfig.ts
@@ -20,30 +20,6 @@ export function BillingConfigFixture(tier: PlanTier): BillingConfig {
       featureList: FeatureListFixture(),
     };
   }
-  if (tier === PlanTier.MM1) {
-    return {
-      id: PlanTier.MM1,
-      freePlan: 'f1',
-      defaultPlan: 'm1',
-      defaultReserved: {errors: 1000000},
-      annualDiscount: 0.1,
-      planList: Object.values(MM1_PLANS),
-      featureList: FeatureListFixture(),
-    };
-  }
-
-  if (tier === PlanTier.MM2) {
-    return {
-      id: PlanTier.MM2,
-      freePlan: 'mm2_f',
-      defaultPlan: 'mm2_a_100k',
-      defaultReserved: {errors: 100000},
-      annualDiscount: 0.1,
-      planList: Object.values(MM2_PLANS),
-      featureList: FeatureListFixture(),
-    };
-  }
-
   if (tier === PlanTier.AM2) {
     return {
       id: PlanTier.AM2,

--- a/tests/js/getsentry-test/fixtures/planDetailsLookup.ts
+++ b/tests/js/getsentry-test/fixtures/planDetailsLookup.ts
@@ -38,7 +38,7 @@ export function PlanDetailsLookupFixture<PlanId extends PlanIds>(
         ? AM1_PLANS[planId as keyof typeof AM1_PLANS]
         : planId.startsWith(PlanTier.AM2)
           ? AM2_PLANS[planId as keyof typeof AM2_PLANS]
-          : planId.startsWith(PlanTier.MM2)
+          : planId.startsWith('mm2')
             ? MM2_PLANS[planId as keyof typeof MM2_PLANS]
             : MM1_PLANS[planId as keyof typeof MM1_PLANS];
 


### PR DESCRIPTION
Replace calls to hardcode planId checks with checks on the underlying capability of those plans