### PR TITLE
tests(action log): Verify publish transactionality

### DIFF
--- a/tests/sentry/issues/test_action_log.py
+++ b/tests/sentry/issues/test_action_log.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth.models import AnonymousUser
+from django.db import router, transaction
 
 import sentry.api.helpers.group_index.update
 import sentry.issues.endpoints.group_details
@@ -63,6 +64,10 @@ def _make_request(
 
 
 MCP_USER_AGENT = "sentry-mcp/0.18.0 (https://mcp.sentry.dev)"
+
+
+class IntentionalRollback(Exception):
+    """Raised to force a transaction rollback in tests."""
 
 
 class TestResolveActionSource(TestCase):
@@ -624,6 +629,59 @@ class TestPublishActionWrite(TestCase):
         )
         assert len(entries) == 3
         assert entries[0].id < entries[1].id < entries[2].id
+
+    def test_rolled_back_transaction_does_not_persist(self) -> None:
+        with self.options({"issues.action-log.write-to-db": True}):
+            try:
+                with transaction.atomic(using=router.db_for_write(GroupActionLogEntry)):
+                    publish_action(
+                        ViewAction(),
+                        source=ActionSource.API,
+                        group_id=self.group.id,
+                        organization_id=self.group.project.organization_id,
+                        project_id=self.group.project_id,
+                        actor=GroupActionActor.user(self.user.id),
+                    )
+                    # Verify the row is visible inside the transaction
+                    assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+                    raise IntentionalRollback()
+            except IntentionalRollback:
+                pass
+
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 0
+
+    def test_savepoint_rollback_discards_only_inner(self) -> None:
+        with self.options({"issues.action-log.write-to-db": True}):
+            with transaction.atomic(using=router.db_for_write(GroupActionLogEntry)):
+                publish_action(
+                    ViewAction(),
+                    source=ActionSource.API,
+                    group_id=self.group.id,
+                    organization_id=self.group.project.organization_id,
+                    project_id=self.group.project_id,
+                    actor=GroupActionActor.user(self.user.id),
+                )
+                try:
+                    with transaction.atomic(using=router.db_for_write(GroupActionLogEntry)):
+                        publish_action(
+                            ResolveAction(),
+                            source=ActionSource.API,
+                            group_id=self.group.id,
+                            organization_id=self.group.project.organization_id,
+                            project_id=self.group.project_id,
+                            actor=GroupActionActor.user(self.user.id),
+                        )
+                        assert (
+                            GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 2
+                        )
+                        raise IntentionalRollback()
+                except IntentionalRollback:
+                    pass
+                assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+
+        entries = list(GroupActionLogEntry.objects.filter(group_id=self.group.id))
+        assert len(entries) == 1
+        assert entries[0].type == GroupActionType.VIEW
 
     def test_option_disabled_skips_write(self) -> None:
         with self.options({"issues.action-log.write-to-db": False}):


### PR DESCRIPTION
This is an invariant we want to maintain, or be very explicit when we are not.
