### PR TITLE
feat(dashboards): Add backend support for heat map widgets

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -168,6 +168,10 @@ DATASET_CONFIG: dict[int, DatasetConfig] = {
                 DashboardWidgetDisplayTypes.BAR_CHART,
                 DashboardWidgetDisplayTypes.BIG_NUMBER,
                 DashboardWidgetDisplayTypes.CATEGORICAL_BAR_CHART,
+                # HEATMAP is additionally gated behind the
+                # ``data-browsing-heat-map-widget`` feature flag in
+                # ``validate_display_type``.
+                DashboardWidgetDisplayTypes.HEATMAP,
             }
         )
     },
@@ -399,6 +403,15 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
 
     def validate_display_type(self, display_type):
         display_type_id = DashboardWidgetDisplayTypes.get_id_for_type_name(display_type)
+
+        # Heat map widgets are only available to organizations with the feature
+        # flag. Without it, creating or updating a heat map widget is rejected.
+        if display_type_id == DashboardWidgetDisplayTypes.HEATMAP and not features.has(
+            "organizations:data-browsing-heat-map-widget", self.context["organization"]
+        ):
+            raise serializers.ValidationError(
+                f"Display type '{display_type}' is not available for this organization."
+            )
 
         widget_type_name = self.context.get("widget_type")
         if widget_type_name is not None and display_type_id is not None:

--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -187,6 +187,7 @@ class DashboardWidgetDisplayTypes(TypesClass):
     SERVER_TREE = 12
     TEXT = 13
     AGENTS_TRACES_TABLE = 14
+    HEATMAP = 15
     TYPES = [
         (LINE_CHART, "line"),
         (AREA_CHART, "area"),
@@ -200,6 +201,7 @@ class DashboardWidgetDisplayTypes(TypesClass):
         (SERVER_TREE, "server_tree"),
         (TEXT, "text"),
         (AGENTS_TRACES_TABLE, "agents_traces_table"),
+        (HEATMAP, "heatmap"),
     ]
     TYPE_NAMES = [t[1] for t in TYPES]
 

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
@@ -1485,6 +1485,54 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         )
         assert response.status_code == 200, response.data
 
+    def test_widget_type_tracemetrics_heatmap_requires_flag(self) -> None:
+        data = {
+            "title": "Test Metrics Heat Map",
+            "widgetType": "tracemetrics",
+            "displayType": "heatmap",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "metric.name:foo",
+                    "fields": ["sum(value)"],
+                    "columns": [],
+                    "aggregates": ["sum(value)"],
+                },
+            ],
+        }
+
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 400, response.data
+        assert "displayType" in response.data, response.data
+
+    def test_widget_type_tracemetrics_heatmap_with_flag(self) -> None:
+        data = {
+            "title": "Test Metrics Heat Map",
+            "widgetType": "tracemetrics",
+            "displayType": "heatmap",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "metric.name:foo",
+                    "fields": ["sum(value)"],
+                    "columns": [],
+                    "aggregates": ["sum(value)"],
+                },
+            ],
+        }
+
+        with self.feature("organizations:data-browsing-heat-map-widget"):
+            response = self.do_request(
+                "post",
+                self.url(),
+                data=data,
+            )
+        assert response.status_code == 200, response.data
+
     def test_widget_type_tracemetrics_rejects_table(self) -> None:
         data = {
             "title": "Test Metrics Query",


### PR DESCRIPTION
Adds backend support for the Heat Map dashboard widget type, split out from the larger Heat Map dashboard widget work.

- Registers `HEATMAP` as a new `DashboardWidgetDisplayTypes` value (patterned on #107370).
- Allows the `HEATMAP` display type for the trace-metrics dataset, **gated behind the `data-browsing-heat-map-widget` feature flag**. Organizations without the flag cannot create or update a heat map widget via the API — the widget serializer's display-type validation rejects it. This matches the frontend, which only offers the heat map type behind the same flag.

The frontend implementation follows in separate PRs.

Refs DAIN-1654