### PR TITLE
feat(weekly-report): Remove dropped columns from chart

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -560,22 +560,19 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
     local_start, local_end = get_local_dates(ctx, user_id)
 
     # Render the first section of the email where we had the table showing the
-    # number of accepted/dropped errors/transactions for each project.
+    # number of accepted errors/transactions for each project.
     def trends():
-        # Given an iterator of event counts, sum up their accepted/dropped errors/transaction counts.
+        # Given an iterator of event counts, sum up their accepted errors/transaction counts.
         def sum_event_counts(project_ctxs):
             event_counts = [
                 (
                     project_ctx.accepted_error_count,
-                    project_ctx.dropped_error_count,
                     project_ctx.accepted_transaction_count,
-                    project_ctx.dropped_transaction_count,
                     project_ctx.accepted_replay_count,
-                    project_ctx.dropped_replay_count,
                 )
                 for project_ctx in project_ctxs
             ]
-            return tuple(sum(event[i] for event in event_counts) for i in range(6))
+            return tuple(sum(event[i] for event in event_counts) for i in range(3))
 
         # Highest volume projects go first
         projects_associated_with_user = sorted(
@@ -586,11 +583,8 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
         # Calculate total
         (
             total_error,
-            total_dropped_error,
             total_transaction,
-            total_dropped_transaction,
             total_replays,
-            total_dropped_replays,
         ) = sum_event_counts(projects_associated_with_user)
 
         # The number of reports to keep is the same as the number of colors
@@ -607,11 +601,8 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                     params={"referrer": "weekly_report", "notification_uuid": notification_uuid}
                 ),
                 "color": project_breakdown_colors[i],
-                "dropped_error_count": project_ctx.dropped_error_count,
                 "accepted_error_count": project_ctx.accepted_error_count,
-                "dropped_transaction_count": project_ctx.dropped_transaction_count,
                 "accepted_transaction_count": project_ctx.accepted_transaction_count,
-                "dropped_replay_count": project_ctx.dropped_replay_count,
                 "accepted_replay_count": project_ctx.accepted_replay_count,
             }
             for i, project_ctx in enumerate(projects_taken)
@@ -620,21 +611,15 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
         if len(projects_not_taken) > 0:
             (
                 others_error,
-                others_dropped_error,
                 others_transaction,
-                others_dropped_transaction,
                 others_replays,
-                others_dropped_replays,
             ) = sum_event_counts(projects_not_taken)
             legend.append(
                 {
                     "slug": f"Other ({len(projects_not_taken)})",
                     "color": other_color,
-                    "dropped_error_count": others_dropped_error,
                     "accepted_error_count": others_error,
-                    "dropped_transaction_count": others_dropped_transaction,
                     "accepted_transaction_count": others_transaction,
-                    "dropped_replay_count": others_dropped_replays,
                     "accepted_replay_count": others_replays,
                 }
             )
@@ -643,11 +628,8 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                 {
                     "slug": f"Total ({len(projects_associated_with_user)})",
                     "color": total_color,
-                    "dropped_error_count": total_dropped_error,
                     "accepted_error_count": total_error,
-                    "dropped_transaction_count": total_dropped_transaction,
                     "accepted_transaction_count": total_transaction,
-                    "dropped_replay_count": total_dropped_replays,
                     "accepted_replay_count": total_replays,
                 }
             )

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -165,9 +165,6 @@
       text-align: center;
     }
 
-    .project-breakdown .col-errors-dropped {
-      padding-right: 2rem;
-    }
   </style>
 
   <style type="text/css" inline="false">
@@ -185,10 +182,6 @@
 
       .header td {
         text-align: center !important;
-      }
-
-      .project-breakdown .col-dropped {
-        display: none;
       }
 
       #events-by-issue-type .legend {
@@ -391,9 +384,7 @@
           <th style="width: 2em; padding-right: 0.5em"></th>
           <th>Project</th>
           <th style="width: 5em;" class="numeric">Errors</th>
-          <th style="width: 5em;" class="numeric col-dropped col-errors-dropped">Dropped</th>
           <th style="width: 7em;" class="numeric">Transactions</th>
-          <th style="width: 7em;" class="numeric col-dropped">Dropped</th>
         </tr>
       </thead>
       <tbody>
@@ -406,9 +397,7 @@
               {% if project.url %}<a href="{{ project.url }}">{% endif %}{{ project.slug }}{% if project.url %}</a>{% endif %}
           </td>
           <td class="numeric">{{ project.accepted_error_count|small_count:1 }}</td>
-          <td class="numeric col-dropped col-errors-dropped">{{ project.dropped_error_count|small_count:1 }}</td>
           <td class="numeric">{{ project.accepted_transaction_count|small_count:1 }}</td>
-          <td class="numeric col-dropped">{{ project.dropped_transaction_count|small_count:1 }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -383,7 +383,7 @@
         <tr>
           <th style="width: 2em; padding-right: 0.5em"></th>
           <th>Project</th>
-          <th style="width: 5em;" class="numeric">Errors</th>
+          <th style="width: 5em; padding-right: 2em;" class="numeric">Errors</th>
           <th style="width: 7em;" class="numeric">Transactions</th>
         </tr>
       </thead>
@@ -396,7 +396,7 @@
           <td>
               {% if project.url %}<a href="{{ project.url }}">{% endif %}{{ project.slug }}{% if project.url %}</a>{% endif %}
           </td>
-          <td class="numeric">{{ project.accepted_error_count|small_count:1 }}</td>
+          <td class="numeric" style="padding-right: 2em;">{{ project.accepted_error_count|small_count:1 }}</td>
           <td class="numeric">{{ project.accepted_transaction_count|small_count:1 }}</td>
         </tr>
       {% endfor %}

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -81,15 +81,6 @@ class DebugWeeklyReportView(MailPreviewView):
             project_context.accepted_replay_count = sum(
                 project_context.replay_count_by_day.values()
             )
-            project_context.dropped_error_count = int(
-                random.weibullvariate(5, 1) * random.paretovariate(0.2)
-            )
-            project_context.dropped_transaction_count = int(
-                random.weibullvariate(5, 1) * random.paretovariate(0.2)
-            )
-            project_context.dropped_replay_count = int(
-                random.weibullvariate(5, 1) * random.paretovariate(0.2)
-            )
             project_context.prev_week_accepted_error_count = int(
                 project_context.accepted_error_count * random.uniform(0.5, 1.5)
             )

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -1047,11 +1047,8 @@ class WeeklyReportsTest(
             "slug": "bar",
             "url": f"http://testserver/organizations/baz/issues/?referrer=weekly_report&notification_uuid={ctx['notification_uuid']}&project={self.project.id}",
             "color": "#422C6E",
-            "dropped_error_count": 2,
             "accepted_error_count": 1,
             "accepted_replay_count": 0,
-            "dropped_replay_count": 0,
-            "dropped_transaction_count": 9,
             "accepted_transaction_count": 3,
         }
 
@@ -1110,11 +1107,8 @@ class WeeklyReportsTest(
             "slug": "bar",
             "url": f"http://testserver/organizations/baz/issues/?referrer=weekly_report&notification_uuid={ctx['notification_uuid']}&project={self.project.id}",
             "color": "#422C6E",
-            "dropped_error_count": 0,
             "accepted_error_count": 0,
             "accepted_replay_count": 6,
-            "dropped_replay_count": 7,
-            "dropped_transaction_count": 0,
             "accepted_transaction_count": 0,
         }
 


### PR DESCRIPTION
Resolves frontend of [ID-1628](https://linear.app/getsentry/issue/ID-1628/remove-dropped-errors-section-from-weekly-report-chart)

Goal: remove the dropped errors/transactions columns from the weekly report. This only affects the frontend. There will be another PR that gets rid of the Snuba queries related to the dropped errors/transactions. 

To test:
- Start dev environment
- Go to `debug/mail/weekly-reports/`

Example: 
<img width="1244" height="586" alt="image" src="https://github.com/user-attachments/assets/44794bfa-e192-4342-81df-0abe12da9090" />