### PR TITLE
chore: Bump sentry-protos 0.28.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.0.13",
-  "sentry-protos>=0.27.1",
+  "sentry-protos>=0.28.0",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm==0.22.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2412,7 +2412,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.1.33" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.0.13" },
-    { name = "sentry-protos", specifier = ">=0.27.1" },
+    { name = "sentry-protos", specifier = ">=0.28.0" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = "==0.22.0" },
@@ -2596,7 +2596,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.27.1"
+version = "0.28.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2604,7 +2604,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.27.1-py3-none-any.whl", hash = "sha256:68fd36acf542ce82962d0cc98c2a5fdfa0578799feff6506e06488dcc0a041a7" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.28.0-py3-none-any.whl", hash = "sha256:0f97ab80ba54221ce93b0a7095eba7c2862662446097034f23e3691f07b13dd3" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Picks up the refund types (`StripeRefund`, `PlatformRefund`) and the `record_charge_refunds` endpoint introduced in [sentry-protos#303](https://github.com/getsentry/sentry-protos/pull/303), released as `0.28.0` today.
- Unblocks CI on [getsentry#20611](https://github.com/getsentry/getsentry/pull/20611) (the `charge.refunded` Stripe webhook handler on the billing platform), which imports `PlatformRefund` and the new endpoint proto — currently failing on `ImportError: cannot import name 'PlatformRefund'` against the pinned `0.27.1`.

## Test plan

- [ ] CI green
- [ ] Once merged + getsentry's `sentry-version` picks it up, getsentry#20611's CI unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)