### PR TITLE
feat(ingest): Run save_event inline for ingest events raw task

### DIFF
--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -77,7 +77,8 @@ def process_event(
     message: IngestMessage,
     project: Project,
     reprocess_only_stuck_events: bool = False,
-    inline: bool = False,
+    inline_save_event: bool = False,
+    inline_save_event_transaction: bool = False,
 ) -> None:
     """
     Perform some initial filtering and deserialize the message payload.
@@ -232,7 +233,7 @@ def process_event(
                 "event_id": event_id,
                 "project_id": project_id,
             }
-            if inline:
+            if inline_save_event_transaction:
                 save_event_transaction(**save_transaction_kwargs)
             else:
                 save_event_transaction.delay(**save_transaction_kwargs)
@@ -265,8 +266,8 @@ def process_event(
                     "project": project,
                     "has_attachments": bool(attachments),
                 }
-                if inline:
-                    preprocess_kwargs["inline"] = True
+                if inline_save_event:
+                    preprocess_kwargs["inline_save_event"] = True
                 preprocess_event(**preprocess_kwargs)
 
         # remember for an 1 hour that we saved this event (deduplication protection)

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -225,7 +225,7 @@ def process_event(
             assert cache_key is not None
             # No need for preprocess/process for transactions thus submit
             # directly transaction specific save_event task.
-            task_kwargs: dict[str, Any] = {
+            save_transaction_kwargs: dict[str, Any] = {
                 "cache_key": cache_key,
                 "data": None,
                 "start_time": start_time,
@@ -233,9 +233,9 @@ def process_event(
                 "project_id": project_id,
             }
             if inline:
-                save_event_transaction(**task_kwargs)
+                save_event_transaction(**save_transaction_kwargs)
             else:
-                save_event_transaction.delay(**task_kwargs)
+                save_event_transaction.delay(**save_transaction_kwargs)
 
             try:
                 collect_span_metrics(project, data)
@@ -257,7 +257,7 @@ def process_event(
             # save_event. Pass data explicitly to avoid fetching it again from the
             # cache.
             with sentry_sdk.start_span(op="ingest_consumer.process_event.preprocess_event"):
-                task_kwargs: dict[str, Any] = {
+                preprocess_kwargs: dict[str, Any] = {
                     "cache_key": cache_key or "",
                     "data": data,
                     "start_time": start_time,
@@ -266,8 +266,8 @@ def process_event(
                     "has_attachments": bool(attachments),
                 }
                 if inline:
-                    task_kwargs["inline"] = True
-                preprocess_event(**task_kwargs)
+                    preprocess_kwargs["inline"] = True
+                preprocess_event(**preprocess_kwargs)
 
         # remember for an 1 hour that we saved this event (deduplication protection)
         with sentry_sdk.start_span(op="cache.set"):

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -77,6 +77,7 @@ def process_event(
     message: IngestMessage,
     project: Project,
     reprocess_only_stuck_events: bool = False,
+    inline: bool = False,
 ) -> None:
     """
     Perform some initial filtering and deserialize the message payload.
@@ -224,13 +225,17 @@ def process_event(
             assert cache_key is not None
             # No need for preprocess/process for transactions thus submit
             # directly transaction specific save_event task.
-            save_event_transaction.delay(
-                cache_key=cache_key,
-                data=None,
-                start_time=start_time,
-                event_id=event_id,
-                project_id=project_id,
-            )
+            task_kwargs: dict[str, Any] = {
+                "cache_key": cache_key,
+                "data": None,
+                "start_time": start_time,
+                "event_id": event_id,
+                "project_id": project_id,
+            }
+            if inline:
+                save_event_transaction(**task_kwargs)
+            else:
+                save_event_transaction.delay(**task_kwargs)
 
             try:
                 collect_span_metrics(project, data)
@@ -252,14 +257,17 @@ def process_event(
             # save_event. Pass data explicitly to avoid fetching it again from the
             # cache.
             with sentry_sdk.start_span(op="ingest_consumer.process_event.preprocess_event"):
-                preprocess_event(
-                    cache_key=cache_key or "",
-                    data=data,
-                    start_time=start_time,
-                    event_id=event_id,
-                    project=project,
-                    has_attachments=bool(attachments),
-                )
+                task_kwargs: dict[str, Any] = {
+                    "cache_key": cache_key or "",
+                    "data": data,
+                    "start_time": start_time,
+                    "event_id": event_id,
+                    "project": project,
+                    "has_attachments": bool(attachments),
+                }
+                if inline:
+                    task_kwargs["inline"] = True
+                preprocess_event(**task_kwargs)
 
         # remember for an 1 hour that we saved this event (deduplication protection)
         with sentry_sdk.start_span(op="cache.set"):

--- a/src/sentry/ingest/consumer/simple_event.py
+++ b/src/sentry/ingest/consumer/simple_event.py
@@ -81,7 +81,7 @@ def process_simple_event_message(
 @instrumented_task(
     name="sentry.ingest.consumer.simple_event.process_event_from_kafka",
     namespace=ingest_events_passthrough_tasks,
-    processing_deadline_duration=60,
+    processing_deadline_duration=150,
     retry=Retry(times=2, delay=5, on=(Retriable,)),
     compression_type=CompressionType.ZSTD,
     silo_mode=SiloMode.CELL,
@@ -114,4 +114,5 @@ def process_event_from_kafka(message_bytes: bytes) -> None:
         message,
         project,
         reprocess_only_stuck_events=False,
+        inline=True,
     )

--- a/src/sentry/ingest/consumer/simple_event.py
+++ b/src/sentry/ingest/consumer/simple_event.py
@@ -7,6 +7,7 @@ from arroyo.types import BrokerValue, Message
 from taskbroker_client.constants import CompressionType
 from taskbroker_client.retry import Retry
 
+from sentry import options
 from sentry.ingest.types import ConsumerType
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
@@ -17,6 +18,9 @@ from sentry.utils import metrics
 from .processors import IngestMessage, Retriable, process_event
 
 logger = logging.getLogger(__name__)
+
+INLINE_SAVE_EVENT_OPTION = "store.ingest-events-raw-task.inline-save-event"
+INLINE_SAVE_EVENT_TRANSACTION_OPTION = "store.ingest-events-raw-task.inline-save-event-transaction"
 
 
 def process_simple_event_message(
@@ -114,5 +118,6 @@ def process_event_from_kafka(message_bytes: bytes) -> None:
         message,
         project,
         reprocess_only_stuck_events=False,
-        inline=True,
+        inline_save_event=options.get(INLINE_SAVE_EVENT_OPTION),
+        inline_save_event_transaction=options.get(INLINE_SAVE_EVENT_TRANSACTION_OPTION),
     )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -957,6 +957,19 @@ register("store.s4s-transaction-sample-rate", default=1.0, flags=FLAG_AUTOMATOR_
 # Killswitch to stop storing any reprocessing payloads.
 register("store.reprocessing-force-disable", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+register(
+    "store.ingest-events-raw-task.inline-save-event",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "store.ingest-events-raw-task.inline-save-event-transaction",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # Enable sending the flag to the microservice to tell it to purposefully take longer than our
 # timeout, to see the effect on the overall error event processing backlog

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -72,23 +72,7 @@ def submit_process(
     data_has_changed: bool = False,
     from_symbolicate: bool = False,
     has_attachments: bool = False,
-    data: MutableMapping[str, Any] | None = None,
-    inline: bool = False,
 ) -> None:
-    if inline:
-        do_process_event(
-            cache_key=cache_key,
-            start_time=start_time,
-            event_id=event_id,
-            from_reprocessing=from_reprocessing,
-            data=data,
-            data_has_changed=data_has_changed,
-            from_symbolicate=from_symbolicate,
-            has_attachments=has_attachments,
-            inline=inline,
-        )
-        return
-
     if from_reprocessing:
         task = process_event_from_reprocessing
     else:
@@ -149,7 +133,7 @@ def _do_preprocess_event(
     from_reprocessing: bool,
     project: Project | None,
     has_attachments: bool = False,
-    inline: bool = False,
+    inline_save_event: bool = False,
 ) -> None:
     from sentry.stacktraces.processing import find_stacktraces_in_data
     from sentry.tasks.symbolication import (
@@ -238,8 +222,6 @@ def _do_preprocess_event(
             start_time=start_time,
             data_has_changed=False,
             has_attachments=has_attachments,
-            data=data,
-            inline=inline,
         )
         return
 
@@ -253,7 +235,7 @@ def _do_preprocess_event(
         event_id=event_id,
         start_time=start_time,
         data=original_data,
-        inline=inline,
+        inline=inline_save_event,
     )
 
 
@@ -264,7 +246,7 @@ def preprocess_event(
     event_id: str | None = None,
     project: Project | None = None,
     has_attachments: bool = False,
-    inline: bool = False,
+    inline_save_event: bool = False,
     **kwargs: Any,
 ) -> None:
     return _do_preprocess_event(
@@ -275,7 +257,7 @@ def preprocess_event(
         from_reprocessing=False,
         project=project,
         has_attachments=has_attachments,
-        inline=inline,
+        inline_save_event=inline_save_event,
     )
 
 
@@ -336,7 +318,6 @@ def do_process_event(
     data_has_changed: bool = False,
     from_symbolicate: bool = False,
     has_attachments: bool = False,
-    inline: bool = False,
 ) -> None:
     from sentry.plugins.base import plugins
 
@@ -372,7 +353,6 @@ def do_process_event(
             event_id=data_event_id,
             start_time=start_time,
             data=data,
-            inline=inline,
         )
 
     if is_process_disabled(project_id, data_event_id, data.get("platform") or "null"):

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -72,7 +72,23 @@ def submit_process(
     data_has_changed: bool = False,
     from_symbolicate: bool = False,
     has_attachments: bool = False,
+    data: MutableMapping[str, Any] | None = None,
+    inline: bool = False,
 ) -> None:
+    if inline:
+        do_process_event(
+            cache_key=cache_key,
+            start_time=start_time,
+            event_id=event_id,
+            from_reprocessing=from_reprocessing,
+            data=data,
+            data_has_changed=data_has_changed,
+            from_symbolicate=from_symbolicate,
+            has_attachments=has_attachments,
+            inline=inline,
+        )
+        return
+
     if from_reprocessing:
         task = process_event_from_reprocessing
     else:
@@ -100,6 +116,7 @@ def submit_save_event(
     event_id: str | None,
     start_time: float | None,
     data: MutableMapping[str, Any] | None,
+    inline: bool = False,
 ) -> None:
     if cache_key:
         data = None
@@ -118,7 +135,10 @@ def submit_save_event(
         "project_id": project_id,
     }
 
-    task.delay(**task_kwargs)  # type: ignore[arg-type]
+    if inline:
+        task(**task_kwargs)  # type: ignore[arg-type]
+    else:
+        task.delay(**task_kwargs)  # type: ignore[arg-type]
 
 
 def _do_preprocess_event(
@@ -129,6 +149,7 @@ def _do_preprocess_event(
     from_reprocessing: bool,
     project: Project | None,
     has_attachments: bool = False,
+    inline: bool = False,
 ) -> None:
     from sentry.stacktraces.processing import find_stacktraces_in_data
     from sentry.tasks.symbolication import (
@@ -217,6 +238,8 @@ def _do_preprocess_event(
             start_time=start_time,
             data_has_changed=False,
             has_attachments=has_attachments,
+            data=data,
+            inline=inline,
         )
         return
 
@@ -230,6 +253,7 @@ def _do_preprocess_event(
         event_id=event_id,
         start_time=start_time,
         data=original_data,
+        inline=inline,
     )
 
 
@@ -240,6 +264,7 @@ def preprocess_event(
     event_id: str | None = None,
     project: Project | None = None,
     has_attachments: bool = False,
+    inline: bool = False,
     **kwargs: Any,
 ) -> None:
     return _do_preprocess_event(
@@ -250,6 +275,7 @@ def preprocess_event(
         from_reprocessing=False,
         project=project,
         has_attachments=has_attachments,
+        inline=inline,
     )
 
 
@@ -310,6 +336,7 @@ def do_process_event(
     data_has_changed: bool = False,
     from_symbolicate: bool = False,
     has_attachments: bool = False,
+    inline: bool = False,
 ) -> None:
     from sentry.plugins.base import plugins
 
@@ -345,6 +372,7 @@ def do_process_event(
             event_id=data_event_id,
             start_time=start_time,
             data=data,
+            inline=inline,
         )
 
     if is_process_disabled(project_id, data_event_id, data.get("platform") or "null"):

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -25,7 +25,11 @@ from sentry.ingest.consumer.processors import (
     process_individual_attachment,
     process_userreport,
 )
-from sentry.ingest.consumer.simple_event import process_event_from_kafka
+from sentry.ingest.consumer.simple_event import (
+    INLINE_SAVE_EVENT_OPTION,
+    INLINE_SAVE_EVENT_TRANSACTION_OPTION,
+    process_event_from_kafka,
+)
 from sentry.ingest.types import ConsumerType
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 from sentry.models.debugfile import create_files_from_dif_zip
@@ -144,12 +148,46 @@ def test_process_event_from_kafka(default_project, preprocess_event) -> None:
         "project": default_project,
         "start_time": start_time,
         "has_attachments": False,
-        "inline": True,
     }
 
 
 @django_db_all
-def test_process_event_from_kafka_transaction_saves_inline(
+def test_process_event_from_kafka_inlines_preprocess_save_event_with_option(
+    default_project, preprocess_event
+) -> None:
+    payload = get_normalized_event({"message": "hello world"}, default_project)
+    event_id = payload["event_id"]
+    project_id = default_project.id
+    start_time = time.time() - 3600
+
+    message = msgpack.packb(
+        {
+            "payload": orjson.dumps(payload).decode(),
+            "start_time": start_time,
+            "event_id": event_id,
+            "project_id": project_id,
+            "remote_addr": "127.0.0.1",
+            "type": "event",
+        }
+    )
+
+    with override_options({INLINE_SAVE_EVENT_OPTION: True}):
+        process_event_from_kafka(message)
+
+    (kwargs,) = preprocess_event
+    assert kwargs == {
+        "cache_key": f"e:{event_id}:{project_id}",
+        "data": payload,
+        "event_id": event_id,
+        "project": default_project,
+        "start_time": start_time,
+        "has_attachments": False,
+        "inline_save_event": True,
+    }
+
+
+@django_db_all
+def test_process_event_from_kafka_transaction_spawns_save_event_transaction_by_default(
     default_project,
     preprocess_event,
     save_event_transaction,
@@ -187,6 +225,59 @@ def test_process_event_from_kafka_transaction_saves_inline(
     )
 
     process_event_from_kafka(message)
+
+    assert not len(preprocess_event)
+    assert save_event_transaction.call_count == 0
+    assert save_event_transaction.delay.call_args[0] == ()
+    assert save_event_transaction.delay.call_args[1] == dict(
+        cache_key=f"e:{event_id}:{project_id}",
+        data=None,
+        start_time=start_time,
+        event_id=event_id,
+        project_id=project_id,
+    )
+
+
+@django_db_all
+def test_process_event_from_kafka_transaction_saves_inline_with_option(
+    default_project,
+    preprocess_event,
+    save_event_transaction,
+) -> None:
+    project_id = default_project.id
+    now = datetime.datetime.now()
+    event = {
+        "type": "transaction",
+        "timestamp": now.isoformat(),
+        "start_timestamp": now.isoformat(),
+        "spans": [],
+        "contexts": {
+            "trace": {
+                "parent_span_id": "8988cec7cc0779c1",
+                "type": "trace",
+                "op": "foobar",
+                "trace_id": "a7d67cf796774551a95be6543cacd459",
+                "span_id": "babaae0d4b7512d9",
+                "status": "ok",
+            }
+        },
+    }
+    payload = get_normalized_event(event, default_project)
+    event_id = payload["event_id"]
+    start_time = time.time() - 3600
+    message = msgpack.packb(
+        {
+            "payload": orjson.dumps(payload).decode(),
+            "start_time": start_time,
+            "event_id": event_id,
+            "project_id": project_id,
+            "remote_addr": "127.0.0.1",
+            "type": "event",
+        }
+    )
+
+    with override_options({INLINE_SAVE_EVENT_TRANSACTION_OPTION: True}):
+        process_event_from_kafka(message)
 
     assert not len(preprocess_event)
     assert save_event_transaction.call_args[0] == ()

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -144,7 +144,60 @@ def test_process_event_from_kafka(default_project, preprocess_event) -> None:
         "project": default_project,
         "start_time": start_time,
         "has_attachments": False,
+        "inline": True,
     }
+
+
+@django_db_all
+def test_process_event_from_kafka_transaction_saves_inline(
+    default_project,
+    preprocess_event,
+    save_event_transaction,
+) -> None:
+    project_id = default_project.id
+    now = datetime.datetime.now()
+    event = {
+        "type": "transaction",
+        "timestamp": now.isoformat(),
+        "start_timestamp": now.isoformat(),
+        "spans": [],
+        "contexts": {
+            "trace": {
+                "parent_span_id": "8988cec7cc0779c1",
+                "type": "trace",
+                "op": "foobar",
+                "trace_id": "a7d67cf796774551a95be6543cacd459",
+                "span_id": "babaae0d4b7512d9",
+                "status": "ok",
+            }
+        },
+    }
+    payload = get_normalized_event(event, default_project)
+    event_id = payload["event_id"]
+    start_time = time.time() - 3600
+    message = msgpack.packb(
+        {
+            "payload": orjson.dumps(payload).decode(),
+            "start_time": start_time,
+            "event_id": event_id,
+            "project_id": project_id,
+            "remote_addr": "127.0.0.1",
+            "type": "event",
+        }
+    )
+
+    process_event_from_kafka(message)
+
+    assert not len(preprocess_event)
+    assert save_event_transaction.call_args[0] == ()
+    assert save_event_transaction.call_args[1] == dict(
+        cache_key=f"e:{event_id}:{project_id}",
+        data=None,
+        start_time=start_time,
+        event_id=event_id,
+        project_id=project_id,
+    )
+    assert save_event_transaction.delay.call_count == 0
 
 
 @django_db_all

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -127,6 +127,60 @@ def test_move_to_save_event(
 
 
 @django_db_all
+def test_move_to_save_event_inline(
+    default_project, mock_process_event, mock_save_event, mock_symbolicate_event, register_plugin
+):
+    register_plugin(globals(), BasicPreprocessorPlugin)
+    data = {
+        "project": default_project.id,
+        "platform": "NOTMATTLANG",
+        "logentry": {"formatted": "test"},
+        "event_id": EVENT_ID,
+        "extra": {"foo": "bar"},
+    }
+
+    preprocess_event(cache_key="e:1", data=data, event_id=EVENT_ID, inline=True)
+
+    assert mock_symbolicate_event.delay.call_count == 0
+    assert mock_process_event.delay.call_count == 0
+    mock_save_event.assert_called_once_with(
+        cache_key="e:1",
+        data=None,
+        start_time=None,
+        event_id=EVENT_ID,
+        project_id=default_project.id,
+    )
+    assert mock_save_event.delay.call_count == 0
+
+
+@django_db_all
+def test_move_to_process_event_inline_saves_inline(
+    default_project, mock_process_event, mock_save_event, mock_symbolicate_event, register_plugin
+):
+    register_plugin(globals(), BasicPreprocessorPlugin)
+    data = {
+        "project": default_project.id,
+        "platform": "noop",
+        "logentry": {"formatted": "test"},
+        "event_id": EVENT_ID,
+        "extra": {"foo": "bar"},
+    }
+
+    preprocess_event(cache_key="e:1", data=data, event_id=EVENT_ID, inline=True)
+
+    assert mock_symbolicate_event.delay.call_count == 0
+    assert mock_process_event.delay.call_count == 0
+    mock_save_event.assert_called_once_with(
+        cache_key="e:1",
+        data=None,
+        start_time=None,
+        event_id=EVENT_ID,
+        project_id=default_project.id,
+    )
+    assert mock_save_event.delay.call_count == 0
+
+
+@django_db_all
 def test_process_event_mutate_and_save(
     default_project, mock_event_processing_store, mock_save_event, register_plugin
 ):

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -107,6 +107,34 @@ def test_move_to_process_event(
 
 
 @django_db_all
+def test_move_to_process_event_inline_save_event_still_submits_process_event(
+    default_project, mock_process_event, mock_save_event, mock_symbolicate_event, register_plugin
+):
+    register_plugin(globals(), BasicPreprocessorPlugin)
+    data = {
+        "project": default_project.id,
+        "platform": "noop",
+        "logentry": {"formatted": "test"},
+        "event_id": EVENT_ID,
+        "extra": {"foo": "bar"},
+    }
+
+    preprocess_event(cache_key="e:1", data=data, event_id=EVENT_ID, inline_save_event=True)
+
+    assert mock_symbolicate_event.delay.call_count == 0
+    mock_process_event.delay.assert_called_once_with(
+        cache_key="e:1",
+        start_time=None,
+        event_id=EVENT_ID,
+        data_has_changed=False,
+        from_symbolicate=False,
+        has_attachments=False,
+    )
+    assert mock_save_event.call_count == 0
+    assert mock_save_event.delay.call_count == 0
+
+
+@django_db_all
 def test_move_to_save_event(
     default_project, mock_process_event, mock_save_event, mock_symbolicate_event, register_plugin
 ):
@@ -139,34 +167,7 @@ def test_move_to_save_event_inline(
         "extra": {"foo": "bar"},
     }
 
-    preprocess_event(cache_key="e:1", data=data, event_id=EVENT_ID, inline=True)
-
-    assert mock_symbolicate_event.delay.call_count == 0
-    assert mock_process_event.delay.call_count == 0
-    mock_save_event.assert_called_once_with(
-        cache_key="e:1",
-        data=None,
-        start_time=None,
-        event_id=EVENT_ID,
-        project_id=default_project.id,
-    )
-    assert mock_save_event.delay.call_count == 0
-
-
-@django_db_all
-def test_move_to_process_event_inline_saves_inline(
-    default_project, mock_process_event, mock_save_event, mock_symbolicate_event, register_plugin
-):
-    register_plugin(globals(), BasicPreprocessorPlugin)
-    data = {
-        "project": default_project.id,
-        "platform": "noop",
-        "logentry": {"formatted": "test"},
-        "event_id": EVENT_ID,
-        "extra": {"foo": "bar"},
-    }
-
-    preprocess_event(cache_key="e:1", data=data, event_id=EVENT_ID, inline=True)
+    preprocess_event(cache_key="e:1", data=data, event_id=EVENT_ID, inline_save_event=True)
 
     assert mock_symbolicate_event.delay.call_count == 0
     assert mock_process_event.delay.call_count == 0


### PR DESCRIPTION
Refs STREAM-1113

Following up on https://github.com/getsentry/sentry/pull/117133, this PR folds the store `process_event` / `save_event` tasks into the parent `process_event_from_kafka` task when it runs in taskbroker passthrough mode. 

Since `process_event` and `save_event` each has a 65s processing deadline, I also increased the deadline for the parent task to 150s now that the parent task owns that work.

The existing async behavior for the regular kafka consumer path is unchanged.