### PR TITLE
chore(cells) Remove regions & memberRegions from initialdata

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -361,49 +361,6 @@ class _ClientConfig:
         return [locality.api_serialize() for locality in localities]
 
     @property
-    def regions(self) -> list[Mapping[str, Any]]:
-        """
-        The regions available to the current user.
-
-        This will include *all* multi-tenant regions, and if the user
-        has membership on any single-tenant regions those will also be included.
-
-        :deprecated: Once the UI has been transitioned to `localities` and `cells` this can be removed.
-        """
-        # Only expose visible regions.
-        # When new regions are added they can take some work to get working correctly.
-        # Before they are working we need ways to bring parts of the region online without
-        # exposing the region to customers.
-        region_names = find_all_multitenant_locality_names()
-
-        if not region_names:
-            return [{"name": "default", "url": options.get("system.url-prefix")}]
-
-        monolith_locality = get_locality_name_for_cell(settings.SENTRY_MONOLITH_REGION)
-
-        def region_display_order(region: Locality) -> tuple[bool, bool, str]:
-            return (
-                region.name != monolith_locality,  # default locality comes first
-                region.category != RegionCategory.MULTI_TENANT,  # multi-tenant before single
-                region.name,  # then sort alphabetically
-            )
-
-        # Show all visible multi-tenant regions to unauthenticated users as they could
-        # create a new account. Else, ensure all regions the current user is in are
-        # included as there could be single tenants or hidden regions.
-        unique_regions = set(region_names) | self._member_locality_names
-        return self._serialize_localities(unique_regions, region_display_order)
-
-    @property
-    def member_regions(self) -> list[Mapping[str, Any]]:
-        """
-        The regions the user has membership in. Includes single-tenant regions.
-
-        :deprecated: Once the UI has been transitioned to use control silo org-list this can be removed.
-        """
-        return self._serialize_localities(self._member_locality_names, lambda loc: loc.name)
-
-    @property
     def localities(self) -> list[Mapping[str, Any]]:
         """
         The localities (formerly regions) that are visible to customers
@@ -527,8 +484,6 @@ class _ClientConfig:
                 "allowUrls": self.allow_list,
                 "tracePropagationTargets": settings.SENTRY_FRONTEND_TRACE_PROPAGATION_TARGETS or [],
             },
-            "memberRegions": self.member_regions,
-            "regions": self.regions,
             "relocationConfig": {"selectableRegions": options.get("relocation.selectable-regions")},
             "demoMode": is_demo_mode_enabled() and is_demo_user(self.user),
             "enableAnalytics": settings.ENABLE_ANALYTICS,

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -100,11 +100,9 @@ def test_client_config_in_silo_modes(request_factory: RequestFactory) -> None:
 
     def normalize(value: dict[str, Any]):
         # Removing the region lists as it varies based on silo mode.
-        # See Region.to_url()
+        # See Locality.to_url()
         value.pop("localities")
         value.pop("cells")
-        value.pop("regions")
-        value.pop("memberRegions")
         value["links"].pop("regionUrl")
 
     normalize(base_line)
@@ -160,7 +158,7 @@ def test_client_config_features() -> None:
 
 @no_silo_test
 @django_db_all
-def test_client_config_default_region_data() -> None:
+def test_client_config_default_locality_data() -> None:
     request, user = make_user_request_from_org()
     request.user = user
     result = get_client_config(request)
@@ -171,16 +169,6 @@ def test_client_config_default_region_data() -> None:
     assert localities[0]["url"] == options.get("system.url-prefix")
 
     assert len(result["cells"]) == 0, "No staff session"
-
-    assert len(result["regions"]) == 1
-    regions = result["regions"]
-    assert regions[0]["name"] == settings.SENTRY_MONOLITH_REGION
-    assert regions[0]["url"] == options.get("system.url-prefix")
-
-    assert len(result["memberRegions"]) == 1
-    regions = result["memberRegions"]
-    assert regions[0]["name"] == settings.SENTRY_MONOLITH_REGION
-    assert regions[0]["url"] == options.get("system.url-prefix")
 
 
 @no_silo_test
@@ -195,11 +183,6 @@ def test_client_config_empty_region_data() -> None:
         request, user = make_user_request_from_org()
         request.user = user
         result = get_client_config(request)
-
-    assert len(result["regions"]) == 1
-    regions = result["regions"]
-    assert regions[0]["name"] == settings.SENTRY_MONOLITH_REGION
-    assert regions[0]["url"] == options.get("system.url-prefix")
 
     assert len(result["cells"]) == 0, "no staff session"
     assert len(result["localities"]) == 1
@@ -220,14 +203,8 @@ def test_client_config_with_region_data() -> None:
     localities = result["localities"]
     assert {r["name"] for r in localities} == {"eu", "us"}
 
-    assert len(result["regions"]) == 2
-    regions = result["regions"]
-    assert {r["name"] for r in regions} == {"eu", "us"}
 
-    assert len(result["memberRegions"]) == 1
-
-
-hidden_regions = [
+hidden_cells = [
     cell.Cell(
         name="us",
         snowflake_id=1,
@@ -244,24 +221,19 @@ hidden_regions = [
 ]
 
 
-@control_silo_test(cells=hidden_regions, include_monolith_run=True)
+@control_silo_test(cells=hidden_cells, include_monolith_run=True)
 @django_db_all
 def test_client_config_with_hidden_region_data() -> None:
     request, user = make_user_request_from_org()
     request.user = user
     result = get_client_config(request)
 
-    assert len(result["regions"]) == 1
-    regions = result["regions"]
-    assert {r["name"] for r in regions} == {"us"}
-    assert len(result["memberRegions"]) == 1
-
     assert len(result["localities"]) == 1
     localities = result["localities"]
     assert {r["name"] for r in localities} == {"us"}
 
 
-@control_silo_test(cells=hidden_regions)
+@control_silo_test(cells=hidden_cells)
 @django_db_all
 def test_client_config_with_hidden_cell_membership() -> None:
     request, user = make_user_request_from_org()
@@ -278,51 +250,6 @@ def test_client_config_with_hidden_cell_membership() -> None:
 
     # Cell list is hidden for regular users.
     assert len(result["cells"]) == 0
-
-
-@multiregion_client_config_test
-@django_db_all
-def test_client_config_with_multiple_membership() -> None:
-    request, user = make_user_request_from_org()
-    request.user = user
-
-    # multiple us memberships and eu too
-    Factories.create_organization(slug="us-co", owner=user)
-    Factories.create_organization(slug="eu-co", owner=user)
-    mapping = OrganizationMapping.objects.get(slug="eu-co")
-    mapping.update(cell_name="eu")
-
-    result = get_client_config(request)
-
-    # Single-tenant doesn't show up unless you have membership
-    assert len(result["regions"]) == 2
-    regions = result["regions"]
-    assert {r["name"] for r in regions} == {"eu", "us"}
-
-    assert len(result["memberRegions"]) == 2
-    regions = result["memberRegions"]
-    assert {r["name"] for r in regions} == {"eu", "us"}
-
-
-@multiregion_client_config_test
-@django_db_all
-def test_client_config_with_single_tenant_membership() -> None:
-    request, user = make_user_request_from_org()
-    request.user = user
-
-    Factories.create_organization(slug="acme-co", owner=user)
-    mapping = OrganizationMapping.objects.get(slug="acme-co")
-    mapping.update(cell_name="acme")
-
-    result = get_client_config(request)
-
-    assert len(result["regions"]) == 3
-    regions = result["regions"]
-    assert {r["name"] for r in regions} == {"eu", "us", "acme"}
-
-    assert len(result["memberRegions"]) == 2
-    regions = result["memberRegions"]
-    assert {r["name"] for r in regions} == {"us", "acme"}
 
 
 @control_silo_test(cells=create_test_cells("us", "ja", "eu"))
@@ -355,7 +282,7 @@ def test_client_config_with_staff_session_fills_cells_and_cells_are_sorted() -> 
     ]
 
 
-@control_silo_test(cells=hidden_regions)
+@control_silo_test(cells=hidden_cells)
 @django_db_all
 def test_client_config_with_staff_session_includes_hidden_cells() -> None:
     request, user = make_user_request_from_org()
@@ -416,8 +343,9 @@ def test_client_config_region_display_order() -> None:
     mapping.update(cell_name="acme")
 
     result = get_client_config(request)
-    region_names = [region["name"] for region in result["regions"]]
-    assert region_names == ["us", "apac", "de", "eu", "acme"]
+    locality_names = [locality["name"] for locality in result["localities"]]
+    # single-tenants are not in the public list.
+    assert locality_names == ["us", "apac", "de", "eu"]
 
 
 @multiregion_client_config_test


### PR DESCRIPTION
We no longer use these keys in the UI code, and they can be removed in favour of `localities` and `cells` data.

Refs INFRENG-332
