### PR TITLE
fix(preprod): Post snapshot PR comment when all images errored

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -203,18 +203,16 @@ def create_preprod_snapshot_pr_comment_task(
             )
 
             has_changes = any(changes_map.values())
-            # Failed comparisons are absent from changes_map (which only tracks
-            # SUCCESS state), so check comparisons_map directly to avoid
-            # suppressing failure reports.
-            has_failures = any(
-                c.state == PreprodSnapshotComparison.State.FAILED for c in comparisons_map.values()
-            )
-            has_errors = any(
-                c.state == PreprodSnapshotComparison.State.SUCCESS and c.images_errored > 0
+            # Failed comparisons and errored images are absent from changes_map
+            # (which only tracks SUCCESS state with diffs), so check
+            # comparisons_map directly to avoid suppressing these reports.
+            has_failures_or_errors = any(
+                c.state == PreprodSnapshotComparison.State.FAILED
+                or (c.state == PreprodSnapshotComparison.State.SUCCESS and c.images_errored > 0)
                 for c in comparisons_map.values()
             )
             # Suppress brand-new comments on uneventful runs to avoid PR noise.
-            if not has_changes and not has_failures and not has_errors and not existing_comment_id:
+            if not (has_changes or has_failures_or_errors or existing_comment_id):
                 logger.info(
                     "preprod.snapshot_pr_comments.create.skipped_no_diff",
                     extra={"preprod_artifact_id": artifact.id},

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -209,7 +209,12 @@ def create_preprod_snapshot_pr_comment_task(
             has_failures = any(
                 c.state == PreprodSnapshotComparison.State.FAILED for c in comparisons_map.values()
             )
-            if not has_changes and not has_failures and not existing_comment_id:
+            has_errors = any(
+                c.state == PreprodSnapshotComparison.State.SUCCESS and c.images_errored > 0
+                for c in comparisons_map.values()
+            )
+            # Suppress brand-new comments on uneventful runs to avoid PR noise.
+            if not has_changes and not has_failures and not has_errors and not existing_comment_id:
                 logger.info(
                     "preprod.snapshot_pr_comments.create.skipped_no_diff",
                     extra={"preprod_artifact_id": artifact.id},

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
@@ -214,6 +214,33 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
 
         mock_delay.assert_called_once()
 
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.post_snapshot_pr_comment_task.delay")
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
+    @patch("sentry.preprod.models.PreprodArtifact.get_base_artifacts_for_commit")
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
+    def test_posts_when_all_images_errored(
+        self, mock_get_client, mock_get_base, mock_format, mock_delay
+    ):
+        mock_get_client.return_value = Mock()
+        mock_format.return_value = "body"
+
+        artifact, metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(
+            with_commit_comparison=False, app_id="com.example.base"
+        )
+        mock_get_base.return_value = {artifact.id: base_artifact}
+        PreprodSnapshotComparison.objects.create(
+            head_snapshot_metrics=metrics,
+            base_snapshot_metrics=base_metrics,
+            state=PreprodSnapshotComparison.State.SUCCESS,
+            images_errored=3,
+        )
+
+        with self.feature(self._feature):
+            create_preprod_snapshot_pr_comment_task(artifact.id)
+
+        mock_delay.assert_called_once()
+
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     def test_skips_when_feature_flag_disabled(self, mock_get_client):
         artifact, metrics = self._create_artifact_with_metrics()


### PR DESCRIPTION
## Summary

A snapshot comparison that finishes with **every image errored** finalizes as `state=SUCCESS` with `images_errored > 0` and no detected diffs. That run passed neither suppression guard in `create_preprod_snapshot_pr_comment_task`:

- `has_changes` is false — errored images aren't added/removed/changed/renamed.
- `has_failures` is false — the comparison is `SUCCESS`, not `FAILED`.

So on a PR with no existing comment, the early return fired and the comment was **never posted** — an actionable failure was silently dropped. (Caught by @jamieQ in review of #117560.)

This adds a `has_errors` term to the guard so an all-errored run still posts.

## Why `has_errors` is scoped to `SUCCESS` state

The guard counts errored images only on `SUCCESS` comparisons, matching where `format_snapshot_pr_comment` actually renders the "⚠️ N images failed to compare" note.

Today this scoping is **defensive, not load-bearing**: `images_errored` is only ever written in `finalize`, which sets `state=SUCCESS` in the same atomic update, so `images_errored > 0` always implies `SUCCESS`.

The hypothetical it guards against: if a future change ever persisted an errored count on a non-`SUCCESS` comparison (e.g. a `FAILED` row), an unscoped `has_errors` would trigger a comment whose body renders *nothing* about those errors — a comment posted because of errors yet silent about them. Scoping to `SUCCESS` keeps the guard's definition of "errored" locked to the renderer's, so the trigger and the comment text can never disagree.

## Test

`test_posts_when_all_images_errored` — a `SUCCESS` comparison with `images_errored=3` and no changes now dispatches the post task (previously it was suppressed).
