### PR TITLE
fix(issues): Add aria-label to tags drawer sort hint

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -762,7 +762,7 @@ const Wrapper = styled(PanelItem)<{
   padding: ${p => p.theme.space.md} 0;
   min-height: 82px;
 
-  &:not(:has(:hover)):not(:has(input:checked)) {
+  &:not(:has(:hover)):not(:has(input:checked)):not(:focus-within) {
     ${CheckboxLabel} {
       ${p => p.theme.visuallyHidden};
     }

--- a/static/app/views/issueDetails/groupDistributions/tagsDistributionDrawer.tsx
+++ b/static/app/views/issueDetails/groupDistributions/tagsDistributionDrawer.tsx
@@ -10,6 +10,7 @@ import {
   EventStickyControls,
 } from 'sentry/components/events/eventDrawer';
 import {IconSort} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -85,8 +86,13 @@ export function TagsDistributionDrawer({
               />
               {includeFeatureFlagsTab ? (
                 <Fragment>
-                  <Tooltip title="Highlighted tags are shown first">
-                    <Button aria-label="" disabled size="xs" icon={<IconSort />} />
+                  <Tooltip title={t('Highlighted tags first')}>
+                    <Button
+                      aria-label={t('Highlighted tags first')}
+                      disabled
+                      size="xs"
+                      icon={<IconSort />}
+                    />
                   </Tooltip>
                 </Fragment>
               ) : null}


### PR DESCRIPTION
Adds a short aria-label so screen readers announce the disabled sort hint instead of an empty button. This short accessible name wraps the tooltip copy in `t()` for [i18n](https://www.w3.org/International/i18n-drafts/nav/about).


```tsx
// Before hardcoded
<Tooltip title="Highlighted tags are shown first">

// After 
<Tooltip title={t('Highlighted tags first')}>
  <Button
    aria-label={t('Highlighted tags first')}
    ...
  />
</Tooltip>
```
<img width="1053" height="220" alt="Screenshot 2026-06-12 at 3 23 24 PM" src="https://github.com/user-attachments/assets/4c44e359-face-48c6-bcbd-fbdfbb255f06" />

