### PR TITLE
fix(aci): Update docs for De-escalating issue priority

### DIFF
--- a/src/sentry/apidocs/examples/workflow_engine_examples.py
+++ b/src/sentry/apidocs/examples/workflow_engine_examples.py
@@ -53,7 +53,7 @@ class WorkflowEngineExamples:
                             {
                                 "id": "234567",
                                 "type": "issue_priority_deescalating",
-                                "comparison": True,
+                                "comparison": 25,
                                 "conditionResult": True,
                             }
                         ],
@@ -135,7 +135,7 @@ class WorkflowEngineExamples:
                             {
                                 "id": "345678",
                                 "type": "issue_priority_deescalating",
-                                "comparison": True,
+                                "comparison": 25,
                                 "conditionResult": True,
                             }
                         ],


### PR DESCRIPTION
# Description
The example for the de-escalating priority shows a comparison boolean value, but it [should be a DetectorPriorityLevel](https://github.com/getsentry/sentry/blob/master/src/sentry/workflow_engine/handlers/condition/issue_priority_deescalating_handler.py#L32-L34).