### PR TITLE
feat(auth): Add signup email verification utility

### DIFF
--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+
+from django.core.signing import SignatureExpired
+from django.http import HttpRequest
+from django.urls import reverse
+
+from sentry import options
+from sentry.utils.email import MessageBuilder
+from sentry.utils.http import absolute_uri
+from sentry.utils.signing import sign, unsign
+
+logger = logging.getLogger("sentry.auth.email_verification")
+
+DEFAULT_MAX_AGE_MINUTES = 120
+
+
+def _get_salt() -> str:
+    return options.get("auth.signup-verification-email-salt")
+
+
+def _format_expiry(minutes: int) -> str:
+    """Convert minutes to a human-friendly expiry string."""
+    if minutes >= 60 and minutes % 60 == 0:
+        hours = minutes // 60
+        return f"{hours} hour{'s' if hours != 1 else ''}"
+    return f"{minutes} minute{'s' if minutes != 1 else ''}"
+
+
+def send_signup_verification_email(
+    request: HttpRequest,
+    email: str,
+    max_age_minutes: int = DEFAULT_MAX_AGE_MINUTES,
+) -> None:
+    """
+    Send a verification email for signup flows.
+
+    Signs {email, session_id, expires_at} into a URL-safe blob.
+    The recipient clicks the link to prove email ownership.
+    """
+    if not request.session.session_key:
+        request.session.create()
+
+    payload = {
+        "email": email,
+        "session_id": request.session.session_key,
+        "expires_at": time.time() + (max_age_minutes * 60),
+    }
+    signed_data = sign(salt=_get_salt(), **payload)
+
+    url = absolute_uri(reverse("sentry-signup-verify-email", args=[signed_data]))
+
+    context = {
+        "confirm_email": email,
+        "url": url,
+        "is_new_user": True,
+        "expiry_text": _format_expiry(max_age_minutes),
+    }
+
+    msg = MessageBuilder(
+        subject="{}Confirm Email".format(options.get("mail.subject-prefix")),
+        template="sentry/emails/confirm_email.txt",
+        html_template="sentry/emails/confirm_email.html",
+        type="user.confirm_email",
+        context=context,
+    )
+    msg.send_async([email])
+
+    logger.info(
+        "signup_verification.sent",
+        extra={"email_hash": hashlib.sha256(email.lower().encode()).hexdigest()},
+    )
+
+
+def unsign_signup_verification(signed_data: str, request: HttpRequest) -> dict:
+    """
+    Verify and decode a signup verification link.
+
+    Returns the decoded payload dict with keys: email, session_id, expires_at.
+
+    Because expiration varies, the send side embeds expires_at in the signed payload.
+    We unsign without checking expiration so we can use the value from the payload.
+
+    Raises BadSignature, SignatureExpired, ValueError on failure.
+    """
+    payload = unsign(signed_data, salt=_get_salt(), max_age=None)
+    if time.time() > payload["expires_at"]:
+        raise SignatureExpired("Verification link expired")
+    if payload["session_id"] != request.session.session_key:
+        raise ValueError("Session mismatch")
+    return payload

--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import binascii
-import hashlib
 import logging
 import time
 from typing import Any
@@ -13,6 +12,7 @@ from django.urls import reverse
 from sentry import options
 from sentry.utils.dates import format_duration
 from sentry.utils.email import MessageBuilder
+from sentry.utils.hashlib import sha256_text
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
 
@@ -58,7 +58,7 @@ def send_signup_verification_email(
 
     logger.info(
         "signup_verification.sent",
-        extra={"email_hash": hashlib.sha256(email.lower().encode()).hexdigest()},
+        extra={"email_hash": sha256_text(email.lower()).hexdigest()},
     )
 
 

--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from django.conf import settings
 from django.core.signing import BadSignature, SignatureExpired
-from django.http import HttpRequest
 from django.urls import reverse
 
 from sentry import options
@@ -23,22 +22,18 @@ DEFAULT_MAX_AGE_MINUTES = 120
 
 
 def send_signup_verification_email(
-    request: HttpRequest,
     email: str,
     max_age_minutes: int = DEFAULT_MAX_AGE_MINUTES,
 ) -> None:
     """
     Send a verification email for signup flows.
 
-    Signs {email, session_id, expires_at} into a URL-safe blob.
-    The recipient clicks the link to prove email ownership.
+    Signs {email, expires_at} into a URL-safe blob and emails the link.
+    Pure send function — callers are responsible for session state
+    (setting request.session[PENDING_VERIFICATION_SESSION_KEY])
     """
-    if not request.session.session_key:
-        request.session.create()
-
     payload = {
         "email": email,
-        "session_id": request.session.session_key,
         "expires_at": time.time() + (max_age_minutes * 60),
     }
     signed_data = sign(salt=settings.SIGNUP_VERIFICATION_EMAIL_SALT, **payload)
@@ -67,24 +62,25 @@ def send_signup_verification_email(
     )
 
 
-def unsign_signup_verification(signed_data: str, request: HttpRequest) -> dict[str, Any]:
+def unsign_signup_verification(signed_data: str) -> dict[str, Any]:
     """
     Verify and decode a signup verification link.
 
-    Returns the decoded payload dict with keys: email, session_id, expires_at.
+    Returns the decoded payload dict with keys: email, expires_at.
 
-    Because expiration varies, the send side embeds expires_at in the signed payload.
-    We unsign without checking expiration so we can use the value from the payload.
+    Because expiration varies by signup method, the send side embeds
+    expires_at in the signed payload and we check it here rather than
+    using TimestampSigner's max_age.
 
-    Raises BadSignature, SignatureExpired, ValueError on failure.
+    Session binding is the caller's responsibility — compare
+    payload["email"] against request.session[PENDING_VERIFICATION_SESSION_KEY].
+
+    Raises BadSignature if tampered, SignatureExpired if past expires_at.
     """
     try:
         payload = unsign(signed_data, salt=settings.SIGNUP_VERIFICATION_EMAIL_SALT, max_age=None)
     except binascii.Error as e:
-        # A malformed link is just an invalid signature to us.
         raise BadSignature("Malformed verification link") from e
     if time.time() > payload["expires_at"]:
         raise SignatureExpired("Verification link expired")
-    if payload["session_id"] != request.session.session_key:
-        raise ValueError("Session mismatch")
     return payload

--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import binascii
 import hashlib
 import logging
 import time
+from typing import Any
 
-from django.core.signing import SignatureExpired
+from django.core.signing import BadSignature, SignatureExpired
 from django.http import HttpRequest
 from django.urls import reverse
 
@@ -75,7 +77,7 @@ def send_signup_verification_email(
     )
 
 
-def unsign_signup_verification(signed_data: str, request: HttpRequest) -> dict:
+def unsign_signup_verification(signed_data: str, request: HttpRequest) -> dict[str, Any]:
     """
     Verify and decode a signup verification link.
 
@@ -86,7 +88,11 @@ def unsign_signup_verification(signed_data: str, request: HttpRequest) -> dict:
 
     Raises BadSignature, SignatureExpired, ValueError on failure.
     """
-    payload = unsign(signed_data, salt=_get_salt(), max_age=None)
+    try:
+        payload = unsign(signed_data, salt=_get_salt(), max_age=None)
+    except binascii.Error as e:
+        # A malformed link is just an invalid signature to us.
+        raise BadSignature("Malformed verification link") from e
     if time.time() > payload["expires_at"]:
         raise SignatureExpired("Verification link expired")
     if payload["session_id"] != request.session.session_key:

--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -11,6 +11,7 @@ from django.http import HttpRequest
 from django.urls import reverse
 
 from sentry import options
+from sentry.utils.dates import format_duration
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
@@ -22,14 +23,6 @@ DEFAULT_MAX_AGE_MINUTES = 120
 
 def _get_salt() -> str:
     return options.get("auth.signup-verification-email-salt")
-
-
-def _format_expiry(minutes: int) -> str:
-    """Convert minutes to a human-friendly expiry string."""
-    if minutes >= 60 and minutes % 60 == 0:
-        hours = minutes // 60
-        return f"{hours} hour{'s' if hours != 1 else ''}"
-    return f"{minutes} minute{'s' if minutes != 1 else ''}"
 
 
 def send_signup_verification_email(
@@ -59,7 +52,7 @@ def send_signup_verification_email(
         "confirm_email": email,
         "url": url,
         "is_new_user": True,
-        "expiry_text": _format_expiry(max_age_minutes),
+        "expiry_text": format_duration(max_age_minutes, floor_to_largest_unit=False),
     }
 
     msg = MessageBuilder(

--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -6,6 +6,7 @@ import logging
 import time
 from typing import Any
 
+from django.conf import settings
 from django.core.signing import BadSignature, SignatureExpired
 from django.http import HttpRequest
 from django.urls import reverse
@@ -19,10 +20,6 @@ from sentry.utils.signing import sign, unsign
 logger = logging.getLogger("sentry.auth.email_verification")
 
 DEFAULT_MAX_AGE_MINUTES = 120
-
-
-def _get_salt() -> str:
-    return options.get("auth.signup-verification-email-salt")
 
 
 def send_signup_verification_email(
@@ -44,7 +41,7 @@ def send_signup_verification_email(
         "session_id": request.session.session_key,
         "expires_at": time.time() + (max_age_minutes * 60),
     }
-    signed_data = sign(salt=_get_salt(), **payload)
+    signed_data = sign(salt=settings.SIGNUP_VERIFICATION_EMAIL_SALT, **payload)
 
     url = absolute_uri(reverse("sentry-signup-verify-email", args=[signed_data]))
 
@@ -82,7 +79,7 @@ def unsign_signup_verification(signed_data: str, request: HttpRequest) -> dict[s
     Raises BadSignature, SignatureExpired, ValueError on failure.
     """
     try:
-        payload = unsign(signed_data, salt=_get_salt(), max_age=None)
+        payload = unsign(signed_data, salt=settings.SIGNUP_VERIFICATION_EMAIL_SALT, max_age=None)
     except binascii.Error as e:
         # A malformed link is just an invalid signature to us.
         raise BadSignature("Malformed verification link") from e

--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -62,7 +62,7 @@ def send_signup_verification_email(
     )
 
 
-def unsign_signup_verification(signed_data: str) -> dict[str, Any]:
+def verify_signup_link(signed_data: str) -> dict[str, Any]:
     """
     Verify and decode a signup verification link.
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -727,6 +727,11 @@ INITIAL_CUSTOM_USER_MIGRATION = "0108_fix_user"
 # Protect login/registration endpoints during development phase
 AUTH_V2_SECRET = os.environ.get("AUTH_V2_SECRET", None)
 
+# Used when signing signup email-verification links
+SIGNUP_VERIFICATION_EMAIL_SALT = os.environ.get(
+    "SIGNUP_VERIFICATION_EMAIL_SALT", "signup-verification-email-salt"
+)
+
 # Auth engines and the settings required for them to be listed
 AUTH_PROVIDERS = {
     "github": ("GITHUB_APP_ID", "GITHUB_API_SECRET"),

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -8,7 +8,6 @@ from urllib.parse import urlencode
 import orjson
 import sentry_sdk
 from django.conf import settings
-from django.template.defaultfilters import pluralize
 from django.urls import reverse
 
 from sentry import analytics, features
@@ -37,6 +36,7 @@ from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.users.services.user_option import RpcUserOption, user_option_service
+from sentry.utils.dates import format_duration
 from sentry.utils.email import MessageBuilder
 from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
     DetectorSerializerResponse,
@@ -124,27 +124,6 @@ class SentryAppActionHandler(DefaultActionHandler):
     @property
     def provider(self) -> str:
         return "sentry_app"
-
-
-def format_duration(minutes: int | float) -> str:
-    """
-    Format minutes into a duration string
-    """
-
-    if minutes >= 1440:
-        days = int(minutes // 1440)
-        return f"{days:d} day{pluralize(days)}"
-
-    if minutes >= 60:
-        hours = int(minutes // 60)
-        return f"{hours:d} hour{pluralize(hours)}"
-
-    if minutes >= 1:
-        minutes = int(minutes)
-        return f"{minutes:d} minute{pluralize(minutes)}"
-
-    seconds = int(minutes // 60)
-    return f"{seconds:d} second{pluralize(seconds)}"
 
 
 def generate_incident_trigger_email_context(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -246,6 +246,12 @@ register(
     default=False,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_REQUIRED,
 )
+register(
+    "auth.signup-verification-email-salt",
+    type=String,
+    default="signup-verification-email-salt",
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # User Settings
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -246,13 +246,6 @@ register(
     default=False,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_REQUIRED,
 )
-register(
-    "auth.signup-verification-email-salt",
-    type=String,
-    default="signup-verification-email-salt",
-    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # User Settings
 register(
     "user-settings.signed-url-confirmation-emails-salt",

--- a/src/sentry/templates/sentry/emails/confirm_email.html
+++ b/src/sentry/templates/sentry/emails/confirm_email.html
@@ -7,7 +7,7 @@
     {% if is_new_user %}
         <p>Thanks for signing up for Sentry</p>
     {% endif %}
-    <p>Please confirm your email ({{ confirm_email }}) by clicking the button below. This link will expire in 48 hours.</p>
+    <p>Please confirm your email ({{ confirm_email }}) by clicking the button below. This link will expire in {{ expiry_text|default:"48 hours" }}.</p>
     <p><a href="{{ url }}" class="btn">Confirm</a></p>
     {% if is_new_user %}
         <p>If you did not sign up, you may simply ignore this email.</p>

--- a/src/sentry/templates/sentry/emails/confirm_email.txt
+++ b/src/sentry/templates/sentry/emails/confirm_email.txt
@@ -6,7 +6,7 @@ Please confirm your email ({{ confirm_email|safe }}) by clicking the link below:
 
 {{ url|safe }}
 
-This link will expire in 48 hours.
+This link will expire in {{ expiry_text|default:"48 hours" }}.
 
 {% if is_new_user %}
 If you did not sign up, you may simply ignore this email.

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -37,7 +37,8 @@ def format_duration(minutes: int | float, floor_to_largest_unit: bool = True) ->
     and any remainder is dropped. (90 -> "1 hour", 1500 -> "1 day")
 
     floor_to_largest_unit=False: duration is rendered exactly, only promoted to hours
-    when it divides evenly, otherwise it stays in minutes. (90 -> "90 minutes", 120 -> "2 hours")
+    when it divides evenly, otherwise it stays in MINUTES (does not have seconds resolution).
+    (90 -> "90 minutes", 120 -> "2 hours", 0.5 -> "0 minutes")
     """
     if not floor_to_largest_unit:
         if minutes >= 60 and minutes % 60 == 0:
@@ -55,7 +56,7 @@ def format_duration(minutes: int | float, floor_to_largest_unit: bool = True) ->
     if minutes >= 1:
         minutes = int(minutes)
         return f"{minutes:d} minute{pluralize(minutes)}"
-    seconds = int(minutes // 60)
+    seconds = int(minutes * 60)
     return f"{seconds:d} second{pluralize(seconds)}"
 
 

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -40,24 +40,22 @@ def format_duration(minutes: int | float, floor_to_largest_unit: bool = True) ->
     when it divides evenly, otherwise it stays in MINUTES (does not have seconds resolution).
     (90 -> "90 minutes", 120 -> "2 hours", 0.5 -> "0 minutes")
     """
+
+    def unit(value: int, name: str) -> str:
+        return f"{value:d} {name}{pluralize(value)}"
+
     if not floor_to_largest_unit:
         if minutes >= 60 and minutes % 60 == 0:
-            hours = int(minutes // 60)
-            return f"{hours:d} hour{pluralize(hours)}"
-        minutes = int(minutes)
-        return f"{minutes:d} minute{pluralize(minutes)}"
+            return unit(int(minutes // 60), "hour")
+        return unit(int(minutes), "minute")
 
     if minutes >= 1440:
-        days = int(minutes // 1440)
-        return f"{days:d} day{pluralize(days)}"
+        return unit(int(minutes // 1440), "day")
     if minutes >= 60:
-        hours = int(minutes // 60)
-        return f"{hours:d} hour{pluralize(hours)}"
+        return unit(int(minutes // 60), "hour")
     if minutes >= 1:
-        minutes = int(minutes)
-        return f"{minutes:d} minute{pluralize(minutes)}"
-    seconds = int(minutes * 60)
-    return f"{seconds:d} second{pluralize(seconds)}"
+        return unit(int(minutes), "minute")
+    return unit(int(minutes * 60), "second")
 
 
 @overload

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -6,6 +6,7 @@ from typing import Any, overload
 
 from dateutil.parser import parse
 from django.http.request import HttpRequest
+from django.template.defaultfilters import pluralize
 from django.utils.timezone import is_aware, make_aware
 
 from sentry import quotas
@@ -26,6 +27,36 @@ def ensure_aware(value: datetime) -> datetime:
     if is_aware(value):
         return value
     return make_aware(value)
+
+
+def format_duration(minutes: int | float, floor_to_largest_unit: bool = True) -> str:
+    """
+    Format a number of minutes into a human-friendly, pluralized duration string.
+
+    floor_to_largest_unit=True: the value is floored to the largest whole unit that fits
+    and any remainder is dropped. (90 -> "1 hour", 1500 -> "1 day")
+
+    floor_to_largest_unit=False: duration is rendered exactly, only promoted to hours
+    when it divides evenly, otherwise it stays in minutes. (90 -> "90 minutes", 120 -> "2 hours")
+    """
+    if not floor_to_largest_unit:
+        if minutes >= 60 and minutes % 60 == 0:
+            hours = int(minutes // 60)
+            return f"{hours:d} hour{pluralize(hours)}"
+        minutes = int(minutes)
+        return f"{minutes:d} minute{pluralize(minutes)}"
+
+    if minutes >= 1440:
+        days = int(minutes // 1440)
+        return f"{days:d} day{pluralize(days)}"
+    if minutes >= 60:
+        hours = int(minutes // 60)
+        return f"{hours:d} hour{pluralize(hours)}"
+    if minutes >= 1:
+        minutes = int(minutes)
+        return f"{minutes:d} minute{pluralize(minutes)}"
+    seconds = int(minutes // 60)
+    return f"{seconds:d} second{pluralize(seconds)}"
 
 
 @overload

--- a/src/sentry/utils/signing.py
+++ b/src/sentry/utils/signing.py
@@ -24,7 +24,7 @@ def sign(*, salt: str = SALT, **kwargs: object) -> str:
     )
 
 
-def unsign(data: str | bytes, salt: str = SALT, max_age: int = 60 * 60 * 24 * 2) -> Any:
+def unsign(data: str | bytes, salt: str = SALT, max_age: int | None = 60 * 60 * 24 * 2) -> Any:
     """
     Unsign a signed base64 string. Accepts the base64 value as a string or bytes.
 

--- a/tests/sentry/auth/test_email_verification.py
+++ b/tests/sentry/auth/test_email_verification.py
@@ -1,0 +1,135 @@
+import time
+from unittest import mock
+
+import pytest
+from django.core.signing import BadSignature, SignatureExpired
+from django.test import RequestFactory
+
+from sentry.auth.email_verification import (
+    _format_expiry,
+    send_signup_verification_email,
+    unsign_signup_verification,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+from sentry.utils.signing import sign
+
+TEST_SALT = "test-salt"
+
+
+@control_silo_test
+class SendSignupVerificationEmailTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.request = self.factory.get("/")
+        session = mock.MagicMock()
+        session.session_key = "test-session-key"
+        self.request.session = session
+
+    @mock.patch(
+        "sentry.auth.email_verification.reverse",
+        return_value="/api/0/signup/verify-email/fakeblob/",
+    )
+    @mock.patch("sentry.auth.email_verification.MessageBuilder")
+    def test_sends_verification_email(self, mock_builder, mock_reverse):
+        mock_msg = mock.MagicMock()
+        mock_builder.return_value = mock_msg
+
+        send_signup_verification_email(self.request, "test@example.com", max_age_minutes=10)
+
+        context = mock_builder.call_args[1]["context"]
+        assert context["confirm_email"] == "test@example.com"
+        assert context["is_new_user"] is True
+        assert context["expiry_text"] == "10 minutes"
+        mock_msg.send_async.assert_called_once_with(["test@example.com"])
+
+    @mock.patch(
+        "sentry.auth.email_verification.reverse",
+        return_value="/api/0/signup/verify-email/fakeblob/",
+    )
+    @mock.patch("sentry.auth.email_verification.MessageBuilder")
+    def test_signed_blob_contains_payload(self, mock_builder, mock_reverse):
+        mock_builder.return_value = mock.MagicMock()
+
+        send_signup_verification_email(self.request, "user@example.com")
+
+        signed_blob = mock_reverse.call_args[1]["args"][0]
+        payload = unsign_signup_verification(signed_blob, self.request)
+        assert payload["email"] == "user@example.com"
+        assert payload["session_id"] == "test-session-key"
+        assert payload["expires_at"] > time.time()
+
+    @mock.patch(
+        "sentry.auth.email_verification.reverse",
+        return_value="/api/0/signup/verify-email/fakeblob/",
+    )
+    @mock.patch("sentry.auth.email_verification.MessageBuilder")
+    def test_creates_session_if_missing(self, mock_builder, mock_reverse):
+        mock_builder.return_value = mock.MagicMock()
+        request = self.factory.get("/")
+        session = mock.MagicMock()
+        session.session_key = None
+        request.session = session
+
+        send_signup_verification_email(request, "test@example.com")
+
+        session.create.assert_called_once()
+
+
+@control_silo_test
+class UnsignSignupVerificationTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.request = self.factory.get("/")
+        session = mock.MagicMock()
+        session.session_key = "s1"
+        self.request.session = session
+
+    @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
+    def test_valid_signature(self, mock_salt):
+        exp = time.time() + 300
+        signed = sign(salt=TEST_SALT, email="a@b.com", session_id="s1", expires_at=exp)
+        result = unsign_signup_verification(signed, self.request)
+        assert result["email"] == "a@b.com"
+        assert result["session_id"] == "s1"
+
+    @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
+    def test_expired_link(self, mock_salt):
+        exp = time.time() - 1
+        signed = sign(salt=TEST_SALT, email="a@b.com", session_id="s1", expires_at=exp)
+        with pytest.raises(SignatureExpired):
+            unsign_signup_verification(signed, self.request)
+
+    @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
+    def test_tampered_signature(self, mock_salt):
+        exp = time.time() + 300
+        signed = sign(salt=TEST_SALT, email="a@b.com", session_id="s1", expires_at=exp)
+        with pytest.raises(BadSignature):
+            unsign_signup_verification(signed + "x", self.request)
+
+    @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
+    def test_wrong_salt(self, mock_salt):
+        exp = time.time() + 300
+        signed = sign(salt="wrong-salt", email="a@b.com", session_id="s1", expires_at=exp)
+        with pytest.raises(BadSignature):
+            unsign_signup_verification(signed, self.request)
+
+    @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
+    def test_session_mismatch(self, mock_salt):
+        exp = time.time() + 300
+        signed = sign(salt=TEST_SALT, email="a@b.com", session_id="else", expires_at=exp)
+        with pytest.raises(ValueError, match="Session mismatch"):
+            unsign_signup_verification(signed, self.request)
+
+
+class FormatExpiryTest(TestCase):
+    def test_hours(self):
+        assert _format_expiry(60) == "1 hour"
+        assert _format_expiry(120) == "2 hours"
+
+    def test_minutes(self):
+        assert _format_expiry(1) == "1 minute"
+        assert _format_expiry(10) == "10 minutes"
+
+    def test_non_round_hours(self):
+        assert _format_expiry(90) == "90 minutes"

--- a/tests/sentry/auth/test_email_verification.py
+++ b/tests/sentry/auth/test_email_verification.py
@@ -20,7 +20,7 @@ SALT = settings.SIGNUP_VERIFICATION_EMAIL_SALT
 class SendSignupVerificationEmailTest(TestCase):
     @mock.patch(
         "sentry.auth.email_verification.reverse",
-        return_value="/api/0/signup/verify-email/fakeblob/",
+        return_value="/auth/signup/verify-email/fakeblob/",
     )
     @mock.patch("sentry.auth.email_verification.MessageBuilder")
     def test_sends_verification_email(
@@ -39,7 +39,7 @@ class SendSignupVerificationEmailTest(TestCase):
 
     @mock.patch(
         "sentry.auth.email_verification.reverse",
-        return_value="/api/0/signup/verify-email/fakeblob/",
+        return_value="/auth/signup/verify-email/fakeblob/",
     )
     @mock.patch("sentry.auth.email_verification.MessageBuilder")
     def test_signed_blob_contains_payload(

--- a/tests/sentry/auth/test_email_verification.py
+++ b/tests/sentry/auth/test_email_verification.py
@@ -2,6 +2,7 @@ import time
 from unittest import mock
 
 import pytest
+from django.conf import settings
 from django.core.signing import BadSignature, SignatureExpired
 from django.test import RequestFactory
 
@@ -13,7 +14,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.signing import sign
 
-TEST_SALT = "test-salt"
+SALT = settings.SIGNUP_VERIFICATION_EMAIL_SALT
 
 
 @control_silo_test
@@ -90,44 +91,38 @@ class UnsignSignupVerificationTest(TestCase):
         session.session_key = "s1"
         self.request.session = session
 
-    @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
-    def test_valid_signature(self, mock_salt: mock.MagicMock) -> None:
+    def test_valid_signature(self) -> None:
         exp = time.time() + 300
-        signed = sign(salt=TEST_SALT, email="a@b.com", session_id="s1", expires_at=exp)
+        signed = sign(salt=SALT, email="a@b.com", session_id="s1", expires_at=exp)
         result = unsign_signup_verification(signed, self.request)
         assert result["email"] == "a@b.com"
         assert result["session_id"] == "s1"
 
-    @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
-    def test_expired_link(self, mock_salt: mock.MagicMock) -> None:
+    def test_expired_link(self) -> None:
         exp = time.time() - 1
-        signed = sign(salt=TEST_SALT, email="a@b.com", session_id="s1", expires_at=exp)
+        signed = sign(salt=SALT, email="a@b.com", session_id="s1", expires_at=exp)
         with pytest.raises(SignatureExpired):
             unsign_signup_verification(signed, self.request)
 
-    @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
-    def test_tampered_signature(self, mock_salt: mock.MagicMock) -> None:
+    def test_tampered_signature(self) -> None:
         exp = time.time() + 300
-        signed = sign(salt=TEST_SALT, email="a@b.com", session_id="s1", expires_at=exp)
+        signed = sign(salt=SALT, email="a@b.com", session_id="s1", expires_at=exp)
         tampered = signed[:-1] + ("A" if signed[-1] != "A" else "B")
         with pytest.raises(BadSignature):
             unsign_signup_verification(tampered, self.request)
 
-    @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
-    def test_malformed_link_throws_bad_sig(self, mock_salt: mock.MagicMock) -> None:
+    def test_malformed_link_throws_bad_sig(self) -> None:
         with pytest.raises(BadSignature):
             unsign_signup_verification("not-valid-base64-!!!", self.request)
 
-    @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
-    def test_wrong_salt(self, mock_salt: mock.MagicMock) -> None:
+    def test_wrong_salt(self) -> None:
         exp = time.time() + 300
         signed = sign(salt="wrong-salt", email="a@b.com", session_id="s1", expires_at=exp)
         with pytest.raises(BadSignature):
             unsign_signup_verification(signed, self.request)
 
-    @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
-    def test_session_mismatch(self, mock_salt: mock.MagicMock) -> None:
+    def test_session_mismatch(self) -> None:
         exp = time.time() + 300
-        signed = sign(salt=TEST_SALT, email="a@b.com", session_id="else", expires_at=exp)
+        signed = sign(salt=SALT, email="a@b.com", session_id="else", expires_at=exp)
         with pytest.raises(ValueError, match="Session mismatch"):
             unsign_signup_verification(signed, self.request)

--- a/tests/sentry/auth/test_email_verification.py
+++ b/tests/sentry/auth/test_email_verification.py
@@ -7,7 +7,7 @@ from django.core.signing import BadSignature, SignatureExpired
 
 from sentry.auth.email_verification import (
     send_signup_verification_email,
-    unsign_signup_verification,
+    verify_signup_link,
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
@@ -50,7 +50,7 @@ class SendSignupVerificationEmailTest(TestCase):
         send_signup_verification_email("user@example.com")
 
         signed_blob = mock_reverse.call_args[1]["args"][0]
-        payload = unsign_signup_verification(signed_blob)
+        payload = verify_signup_link(signed_blob)
         assert payload["email"] == "user@example.com"
         assert payload["expires_at"] > time.time()
 
@@ -60,7 +60,7 @@ class UnsignSignupVerificationTest(TestCase):
     def test_valid_signature(self) -> None:
         exp = time.time() + 300
         signed = sign(salt=SALT, email="a@b.com", expires_at=exp)
-        result = unsign_signup_verification(signed)
+        result = verify_signup_link(signed)
         assert result["email"] == "a@b.com"
         assert result["expires_at"] == exp
 
@@ -68,21 +68,21 @@ class UnsignSignupVerificationTest(TestCase):
         exp = time.time() - 1
         signed = sign(salt=SALT, email="a@b.com", expires_at=exp)
         with pytest.raises(SignatureExpired):
-            unsign_signup_verification(signed)
+            verify_signup_link(signed)
 
     def test_tampered_signature(self) -> None:
         exp = time.time() + 300
         signed = sign(salt=SALT, email="a@b.com", expires_at=exp)
         tampered = signed[:-1] + ("A" if signed[-1] != "A" else "B")
         with pytest.raises(BadSignature):
-            unsign_signup_verification(tampered)
+            verify_signup_link(tampered)
 
     def test_malformed_link_throws_bad_sig(self) -> None:
         with pytest.raises(BadSignature):
-            unsign_signup_verification("not-valid-base64-!!!")
+            verify_signup_link("not-valid-base64-!!!")
 
     def test_wrong_salt(self) -> None:
         exp = time.time() + 300
         signed = sign(salt="wrong-salt", email="a@b.com", expires_at=exp)
         with pytest.raises(BadSignature):
-            unsign_signup_verification(signed)
+            verify_signup_link(signed)

--- a/tests/sentry/auth/test_email_verification.py
+++ b/tests/sentry/auth/test_email_verification.py
@@ -6,7 +6,6 @@ from django.core.signing import BadSignature, SignatureExpired
 from django.test import RequestFactory
 
 from sentry.auth.email_verification import (
-    _format_expiry,
     send_signup_verification_email,
     unsign_signup_verification,
 )
@@ -132,16 +131,3 @@ class UnsignSignupVerificationTest(TestCase):
         signed = sign(salt=TEST_SALT, email="a@b.com", session_id="else", expires_at=exp)
         with pytest.raises(ValueError, match="Session mismatch"):
             unsign_signup_verification(signed, self.request)
-
-
-class FormatExpiryTest(TestCase):
-    def test_hours(self) -> None:
-        assert _format_expiry(60) == "1 hour"
-        assert _format_expiry(120) == "2 hours"
-
-    def test_minutes(self) -> None:
-        assert _format_expiry(1) == "1 minute"
-        assert _format_expiry(10) == "10 minutes"
-
-    def test_non_round_hours(self) -> None:
-        assert _format_expiry(90) == "90 minutes"

--- a/tests/sentry/auth/test_email_verification.py
+++ b/tests/sentry/auth/test_email_verification.py
@@ -19,7 +19,7 @@ TEST_SALT = "test-salt"
 
 @control_silo_test
 class SendSignupVerificationEmailTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.factory = RequestFactory()
         self.request = self.factory.get("/")
         session = mock.MagicMock()
@@ -31,7 +31,9 @@ class SendSignupVerificationEmailTest(TestCase):
         return_value="/api/0/signup/verify-email/fakeblob/",
     )
     @mock.patch("sentry.auth.email_verification.MessageBuilder")
-    def test_sends_verification_email(self, mock_builder, mock_reverse):
+    def test_sends_verification_email(
+        self, mock_builder: mock.MagicMock, mock_reverse: mock.MagicMock
+    ) -> None:
         mock_msg = mock.MagicMock()
         mock_builder.return_value = mock_msg
 
@@ -48,7 +50,9 @@ class SendSignupVerificationEmailTest(TestCase):
         return_value="/api/0/signup/verify-email/fakeblob/",
     )
     @mock.patch("sentry.auth.email_verification.MessageBuilder")
-    def test_signed_blob_contains_payload(self, mock_builder, mock_reverse):
+    def test_signed_blob_contains_payload(
+        self, mock_builder: mock.MagicMock, mock_reverse: mock.MagicMock
+    ) -> None:
         mock_builder.return_value = mock.MagicMock()
 
         send_signup_verification_email(self.request, "user@example.com")
@@ -64,7 +68,9 @@ class SendSignupVerificationEmailTest(TestCase):
         return_value="/api/0/signup/verify-email/fakeblob/",
     )
     @mock.patch("sentry.auth.email_verification.MessageBuilder")
-    def test_creates_session_if_missing(self, mock_builder, mock_reverse):
+    def test_creates_session_if_missing(
+        self, mock_builder: mock.MagicMock, mock_reverse: mock.MagicMock
+    ) -> None:
         mock_builder.return_value = mock.MagicMock()
         request = self.factory.get("/")
         session = mock.MagicMock()
@@ -78,7 +84,7 @@ class SendSignupVerificationEmailTest(TestCase):
 
 @control_silo_test
 class UnsignSignupVerificationTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.factory = RequestFactory()
         self.request = self.factory.get("/")
         session = mock.MagicMock()
@@ -86,7 +92,7 @@ class UnsignSignupVerificationTest(TestCase):
         self.request.session = session
 
     @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
-    def test_valid_signature(self, mock_salt):
+    def test_valid_signature(self, mock_salt: mock.MagicMock) -> None:
         exp = time.time() + 300
         signed = sign(salt=TEST_SALT, email="a@b.com", session_id="s1", expires_at=exp)
         result = unsign_signup_verification(signed, self.request)
@@ -94,28 +100,34 @@ class UnsignSignupVerificationTest(TestCase):
         assert result["session_id"] == "s1"
 
     @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
-    def test_expired_link(self, mock_salt):
+    def test_expired_link(self, mock_salt: mock.MagicMock) -> None:
         exp = time.time() - 1
         signed = sign(salt=TEST_SALT, email="a@b.com", session_id="s1", expires_at=exp)
         with pytest.raises(SignatureExpired):
             unsign_signup_verification(signed, self.request)
 
     @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
-    def test_tampered_signature(self, mock_salt):
+    def test_tampered_signature(self, mock_salt: mock.MagicMock) -> None:
         exp = time.time() + 300
         signed = sign(salt=TEST_SALT, email="a@b.com", session_id="s1", expires_at=exp)
+        tampered = signed[:-1] + ("A" if signed[-1] != "A" else "B")
         with pytest.raises(BadSignature):
-            unsign_signup_verification(signed + "x", self.request)
+            unsign_signup_verification(tampered, self.request)
 
     @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
-    def test_wrong_salt(self, mock_salt):
+    def test_malformed_link_throws_bad_sig(self, mock_salt: mock.MagicMock) -> None:
+        with pytest.raises(BadSignature):
+            unsign_signup_verification("not-valid-base64-!!!", self.request)
+
+    @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
+    def test_wrong_salt(self, mock_salt: mock.MagicMock) -> None:
         exp = time.time() + 300
         signed = sign(salt="wrong-salt", email="a@b.com", session_id="s1", expires_at=exp)
         with pytest.raises(BadSignature):
             unsign_signup_verification(signed, self.request)
 
     @mock.patch("sentry.auth.email_verification._get_salt", return_value=TEST_SALT)
-    def test_session_mismatch(self, mock_salt):
+    def test_session_mismatch(self, mock_salt: mock.MagicMock) -> None:
         exp = time.time() + 300
         signed = sign(salt=TEST_SALT, email="a@b.com", session_id="else", expires_at=exp)
         with pytest.raises(ValueError, match="Session mismatch"):
@@ -123,13 +135,13 @@ class UnsignSignupVerificationTest(TestCase):
 
 
 class FormatExpiryTest(TestCase):
-    def test_hours(self):
+    def test_hours(self) -> None:
         assert _format_expiry(60) == "1 hour"
         assert _format_expiry(120) == "2 hours"
 
-    def test_minutes(self):
+    def test_minutes(self) -> None:
         assert _format_expiry(1) == "1 minute"
         assert _format_expiry(10) == "10 minutes"
 
-    def test_non_round_hours(self):
+    def test_non_round_hours(self) -> None:
         assert _format_expiry(90) == "90 minutes"

--- a/tests/sentry/auth/test_email_verification.py
+++ b/tests/sentry/auth/test_email_verification.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pytest
 from django.conf import settings
 from django.core.signing import BadSignature, SignatureExpired
-from django.test import RequestFactory
 
 from sentry.auth.email_verification import (
     send_signup_verification_email,
@@ -19,13 +18,6 @@ SALT = settings.SIGNUP_VERIFICATION_EMAIL_SALT
 
 @control_silo_test
 class SendSignupVerificationEmailTest(TestCase):
-    def setUp(self) -> None:
-        self.factory = RequestFactory()
-        self.request = self.factory.get("/")
-        session = mock.MagicMock()
-        session.session_key = "test-session-key"
-        self.request.session = session
-
     @mock.patch(
         "sentry.auth.email_verification.reverse",
         return_value="/api/0/signup/verify-email/fakeblob/",
@@ -37,7 +29,7 @@ class SendSignupVerificationEmailTest(TestCase):
         mock_msg = mock.MagicMock()
         mock_builder.return_value = mock_msg
 
-        send_signup_verification_email(self.request, "test@example.com", max_age_minutes=10)
+        send_signup_verification_email("test@example.com", max_age_minutes=10)
 
         context = mock_builder.call_args[1]["context"]
         assert context["confirm_email"] == "test@example.com"
@@ -55,74 +47,42 @@ class SendSignupVerificationEmailTest(TestCase):
     ) -> None:
         mock_builder.return_value = mock.MagicMock()
 
-        send_signup_verification_email(self.request, "user@example.com")
+        send_signup_verification_email("user@example.com")
 
         signed_blob = mock_reverse.call_args[1]["args"][0]
-        payload = unsign_signup_verification(signed_blob, self.request)
+        payload = unsign_signup_verification(signed_blob)
         assert payload["email"] == "user@example.com"
-        assert payload["session_id"] == "test-session-key"
         assert payload["expires_at"] > time.time()
-
-    @mock.patch(
-        "sentry.auth.email_verification.reverse",
-        return_value="/api/0/signup/verify-email/fakeblob/",
-    )
-    @mock.patch("sentry.auth.email_verification.MessageBuilder")
-    def test_creates_session_if_missing(
-        self, mock_builder: mock.MagicMock, mock_reverse: mock.MagicMock
-    ) -> None:
-        mock_builder.return_value = mock.MagicMock()
-        request = self.factory.get("/")
-        session = mock.MagicMock()
-        session.session_key = None
-        request.session = session
-
-        send_signup_verification_email(request, "test@example.com")
-
-        session.create.assert_called_once()
 
 
 @control_silo_test
 class UnsignSignupVerificationTest(TestCase):
-    def setUp(self) -> None:
-        self.factory = RequestFactory()
-        self.request = self.factory.get("/")
-        session = mock.MagicMock()
-        session.session_key = "s1"
-        self.request.session = session
-
     def test_valid_signature(self) -> None:
         exp = time.time() + 300
-        signed = sign(salt=SALT, email="a@b.com", session_id="s1", expires_at=exp)
-        result = unsign_signup_verification(signed, self.request)
+        signed = sign(salt=SALT, email="a@b.com", expires_at=exp)
+        result = unsign_signup_verification(signed)
         assert result["email"] == "a@b.com"
-        assert result["session_id"] == "s1"
+        assert result["expires_at"] == exp
 
     def test_expired_link(self) -> None:
         exp = time.time() - 1
-        signed = sign(salt=SALT, email="a@b.com", session_id="s1", expires_at=exp)
+        signed = sign(salt=SALT, email="a@b.com", expires_at=exp)
         with pytest.raises(SignatureExpired):
-            unsign_signup_verification(signed, self.request)
+            unsign_signup_verification(signed)
 
     def test_tampered_signature(self) -> None:
         exp = time.time() + 300
-        signed = sign(salt=SALT, email="a@b.com", session_id="s1", expires_at=exp)
+        signed = sign(salt=SALT, email="a@b.com", expires_at=exp)
         tampered = signed[:-1] + ("A" if signed[-1] != "A" else "B")
         with pytest.raises(BadSignature):
-            unsign_signup_verification(tampered, self.request)
+            unsign_signup_verification(tampered)
 
     def test_malformed_link_throws_bad_sig(self) -> None:
         with pytest.raises(BadSignature):
-            unsign_signup_verification("not-valid-base64-!!!", self.request)
+            unsign_signup_verification("not-valid-base64-!!!")
 
     def test_wrong_salt(self) -> None:
         exp = time.time() + 300
-        signed = sign(salt="wrong-salt", email="a@b.com", session_id="s1", expires_at=exp)
+        signed = sign(salt="wrong-salt", email="a@b.com", expires_at=exp)
         with pytest.raises(BadSignature):
-            unsign_signup_verification(signed, self.request)
-
-    def test_session_mismatch(self) -> None:
-        exp = time.time() + 300
-        signed = sign(salt=SALT, email="a@b.com", session_id="else", expires_at=exp)
-        with pytest.raises(ValueError, match="Session mismatch"):
-            unsign_signup_verification(signed, self.request)
+            unsign_signup_verification(signed)

--- a/tests/sentry/utils/test_dates.py
+++ b/tests/sentry/utils/test_dates.py
@@ -2,7 +2,12 @@ import datetime
 
 import pytest
 
-from sentry.utils.dates import date_to_utc_datetime, parse_stats_period, parse_timestamp
+from sentry.utils.dates import (
+    date_to_utc_datetime,
+    format_duration,
+    parse_stats_period,
+    parse_timestamp,
+)
 
 
 def test_parse_stats_period() -> None:
@@ -34,3 +39,35 @@ def test_parse_timestamp() -> None:
 def test_parse_timestamp_error() -> None:
     with pytest.raises(ValueError):
         parse_timestamp("2024-05-20T17:29:00gu")
+
+
+class TestFormatDuration:
+    FLOOR_DURATION_CASES = [
+        (0, "0 seconds"),
+        (0.5, "0 seconds"),
+        (1, "1 minute"),
+        (59, "59 minutes"),
+        (60, "1 hour"),
+        (90, "1 hour"),
+        (120, "2 hours"),
+        (1439, "23 hours"),
+        (1440, "1 day"),
+        (1500, "1 day"),
+        (2880, "2 days"),
+    ]
+
+    @pytest.mark.parametrize("minutes, expected", FLOOR_DURATION_CASES)
+    def test_format_duration_floor(self, minutes: int | float, expected: str) -> None:
+        assert format_duration(minutes) == expected
+
+    EXACT_DURATION_CASES = [
+        (1, "1 minute"),
+        (10, "10 minutes"),
+        (60, "1 hour"),
+        (90, "90 minutes"),
+        (120, "2 hours"),
+    ]
+
+    @pytest.mark.parametrize("minutes, expected", EXACT_DURATION_CASES)
+    def test_format_duration_exact(self, minutes: int, expected: str) -> None:
+        assert format_duration(minutes, floor_to_largest_unit=False) == expected

--- a/tests/sentry/utils/test_dates.py
+++ b/tests/sentry/utils/test_dates.py
@@ -44,7 +44,7 @@ def test_parse_timestamp_error() -> None:
 class TestFormatDuration:
     FLOOR_DURATION_CASES = [
         (0, "0 seconds"),
-        (0.5, "0 seconds"),
+        (0.5, "30 seconds"),
         (1, "1 minute"),
         (59, "59 minutes"),
         (60, "1 hour"),
@@ -61,6 +61,7 @@ class TestFormatDuration:
         assert format_duration(minutes) == expected
 
     EXACT_DURATION_CASES = [
+        (0.5, "0 minutes"),
         (1, "1 minute"),
         (10, "10 minutes"),
         (60, "1 hour"),


### PR DESCRIPTION
Add shared infrastructure for verifying email ownership during signup.

This is the foundation for requiring email verification before account creation across SSO, social auth, and email+password signup flows.

- `send_signup_verification_email`: signs `{email, session_id, expires_at}` into a tamper-proof blob and sends a confirmation email
- `unsign_signup_verification`: validates the blob, checks expiry and session match
- Reuses existing `confirm_email` templates with variable expiry text
- Salt is configurable via options for rotation without deploy
- Allow `max_age=None` in `utils/signing.py unsign()` to skip built-in expiry check (we embed `expires_at` in the payload instead)