### PR TITLE
ref(webhooks): Remove legacy-webhook-dry-run feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -141,7 +141,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable rate limits for inviting members.
     manager.add("organizations:invite-members-rate-limits", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
     manager.add("organizations:legacy-webhook-disable-old-path", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    manager.add("organizations:legacy-webhook-dry-run", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:legacy-webhook-new-path", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:legacy-webhook-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables higher limit for alert rules

--- a/src/sentry/sentry_apps/services/legacy_webhook/service.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/service.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from typing import Any, TypedDict
 
-from sentry import features
 from sentry.eventstore.models import GroupEvent
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
@@ -110,13 +109,6 @@ def send_sentry_app_webhook(
     if sentry_app is None:
         logger.warning(
             "webhook_action_handler.sentry_app_not_found",
-            extra=logging_context,
-        )
-        return
-
-    if features.has("organizations:legacy-webhook-dry-run", organization):
-        logger.info(
-            "webhook_action_handler.sentry_app_dry_run",
             extra=logging_context,
         )
         return

--- a/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/tasks.py
@@ -7,7 +7,6 @@ from typing import Any
 from requests.exceptions import ConnectionError, ReadTimeout
 from taskbroker_client.retry import Retry
 
-from sentry import features
 from sentry.exceptions import RestrictedIPAddress
 from sentry.models.group import Group
 from sentry.sentry_apps.services.legacy_webhook.client import LegacyWebhookClient
@@ -22,7 +21,6 @@ from sentry.utils import metrics
 class LegacyWebhookOutcome(str, enum.Enum):
     SENT = "sent"
     ERROR = "error"
-    DRY_RUN = "dry_run"
     GROUP_NOT_FOUND = "group_not_found"
 
 
@@ -43,7 +41,7 @@ logger = logging.getLogger("sentry.legacy_webhook")
 )
 def send_legacy_webhook_task(url: str, payload: LegacyWebhookPayload, **kwargs: Any) -> None:
     try:
-        group = Group.objects.get(id=int(payload["id"]))
+        Group.objects.get(id=int(payload["id"]))
     except Group.DoesNotExist:
         logger.warning(
             "legacy_webhook.group_not_found",
@@ -52,15 +50,6 @@ def send_legacy_webhook_task(url: str, payload: LegacyWebhookPayload, **kwargs: 
         metrics.incr(
             "legacy_webhook.task.result",
             tags={"outcome": LegacyWebhookOutcome.GROUP_NOT_FOUND},
-            sample_rate=1.0,
-        )
-        return
-    organization = group.project.organization
-
-    if features.has("organizations:legacy-webhook-dry-run", organization):
-        metrics.incr(
-            "legacy_webhook.task.result",
-            tags={"outcome": LegacyWebhookOutcome.DRY_RUN},
             sample_rate=1.0,
         )
         return

--- a/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
+++ b/tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py
@@ -79,24 +79,6 @@ class TestWebhookActionHandlerExecute(BaseWorkflowTest):
         assert body["id"] == str(self.group.id)
 
     @responses.activate
-    def test_new_path_dry_run_does_not_send(self) -> None:
-        responses.add(responses.POST, "http://example.com/hook")
-
-        with (
-            self.tasks(),
-            self.feature(
-                {
-                    "organizations:legacy-webhook-new-path": True,
-                    "organizations:legacy-webhook-disable-old-path": True,
-                    "organizations:legacy-webhook-dry-run": True,
-                }
-            ),
-        ):
-            WebhookActionHandler.execute(self.invocation)
-
-        assert len(responses.calls) == 0
-
-    @responses.activate
     def test_disable_old_without_new_path_fires_nothing(self) -> None:
         responses.add(responses.POST, "http://example.com/hook")
 
@@ -172,37 +154,6 @@ class TestWebhookActionHandlerExecute(BaseWorkflowTest):
         assert call_kwargs["sentry_app_slug"] == "my-app"
         assert "rule_label" in call_kwargs
         mock_legacy.assert_not_called()
-
-    @with_feature(
-        {
-            "organizations:legacy-webhook-new-path": True,
-            "organizations:legacy-webhook-disable-old-path": True,
-            "organizations:legacy-webhook-dry-run": True,
-        }
-    )
-    @mock.patch("sentry.sentry_apps.services.legacy_webhook.service.send_alert_webhook_v2")
-    def test_new_path_sentry_app_dry_run_does_not_send(
-        self, mock_send_alert: mock.MagicMock
-    ) -> None:
-        action = self.create_action(
-            type=Action.Type.WEBHOOK,
-            config={"target_identifier": "my-app"},
-        )
-        invocation = ActionInvocation(
-            event_data=self.event_data,
-            action=action,
-            detector=self.detector,
-            notification_uuid=str(uuid.uuid4()),
-            workflow_id=self.workflow.id,
-        )
-        self.create_sentry_app(name="My App", organization=self.organization)
-        self.create_sentry_app_installation(
-            slug="my-app", organization=self.organization, user=self.user
-        )
-
-        WebhookActionHandler.execute(invocation)
-
-        mock_send_alert.delay.assert_not_called()
 
     @mock.patch(
         "sentry.notifications.notification_action.action_handler_registry.webhook_handler.send_sentry_app_webhook"

--- a/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
+++ b/tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py
@@ -4,7 +4,6 @@ import responses
 
 from sentry.sentry_apps.services.legacy_webhook.service import build_legacy_webhook_payload
 from sentry.sentry_apps.services.legacy_webhook.tasks import send_legacy_webhook_task
-from sentry.testutils.helpers.features import with_feature
 from sentry.utils import json
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
@@ -43,13 +42,3 @@ class TestSendLegacyWebhookTask(BaseWorkflowTest):
         body = json.loads(responses.calls[0].request.body)
         assert body["id"] == str(self.group.id)
         assert body["message"] == self.group_event.message
-
-    @responses.activate
-    @with_feature("organizations:legacy-webhook-dry-run")
-    def test_task_dry_run_does_not_send(self) -> None:
-        responses.add(responses.POST, "http://example.com/hook")
-
-        payload = build_legacy_webhook_payload(self.invocation)
-        send_legacy_webhook_task(url="http://example.com/hook", payload=payload)
-
-        assert len(responses.calls) == 0


### PR DESCRIPTION
## Summary
- Remove the `organizations:legacy-webhook-dry-run` feature flag (rolled out to 100%)
- Webhooks now send for real via the new path (no more dry-run guard)
- Clean up related test cases

## Test plan
- [ ] `pytest tests/sentry/sentry_apps/services/legacy_webhook/test_tasks.py`
- [ ] `pytest tests/sentry/notifications/notification_action/action_handler_registry/test_webhook_handler.py`