### PR TITLE
feat(preprod): Surface errored snapshot images in web viewer

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -117,8 +117,10 @@ export const PairCard = memo(function PairCard({
     : undefined;
   const handleOpen = onOpenSnapshot ? () => onOpenSnapshot(snapshotKey) : undefined;
 
+  const effectiveDiffMode = status === DiffStatus.ERRORED ? 'split' : diffMode;
+
   let body: React.ReactNode;
-  if (diffMode === 'split') {
+  if (effectiveDiffMode === 'split') {
     body = (
       <SnapshotCanvasWrapper>
         <SplitPairBody
@@ -134,7 +136,7 @@ export const PairCard = memo(function PairCard({
         />
       </SnapshotCanvasWrapper>
     );
-  } else if (diffMode === 'wipe') {
+  } else if (effectiveDiffMode === 'wipe') {
     body = (
       <WipeCardBody
         baseUrl={baseUrl}

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -2,13 +2,22 @@ import {Fragment, memo, useState} from 'react';
 import {ThemeProvider} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Alert} from '@sentry/scraps/alert';
+import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {IconFile, IconInfo, IconLightning, IconLink, IconMoon} from 'sentry/icons';
+import {
+  IconFile,
+  IconInfo,
+  IconLightning,
+  IconLink,
+  IconMoon,
+  IconWarning,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
@@ -52,6 +61,18 @@ export function DarkAware({
   );
 }
 
+export function ErroredBanner() {
+  return (
+    <Container padding="0 xl md">
+      <Alert variant="danger" showIcon>
+        {t(
+          'Unknown error: failed to compare these images (base and head images still shown below).'
+        )}
+      </Alert>
+    </Container>
+  );
+}
+
 export const PairCard = memo(function PairCard({
   pair,
   imageBaseUrl,
@@ -62,6 +83,7 @@ export const PairCard = memo(function PairCard({
   overlayColor,
   diffImageBaseUrl,
   snapshotKey,
+  status = DiffStatus.CHANGED,
   onSelectSnapshot,
   onOpenSnapshot,
   onCopyLink,
@@ -80,6 +102,7 @@ export const PairCard = memo(function PairCard({
   onOpenSnapshot?: (key: string) => void;
   onSelectSnapshot?: (key: string | null) => void;
   overlayColor?: string;
+  status?: DiffStatus;
 }) {
   const [isDark, setIsDark] = useState(false);
   const image = pair.head_image;
@@ -142,7 +165,7 @@ export const PairCard = memo(function PairCard({
           displayName={image.display_name}
           fileName={image.image_file_name}
           tags={image.tags}
-          status={DiffStatus.CHANGED}
+          status={status}
           diffPercent={pair.diff}
           isDark={isDark}
           onToggleDark={() => setIsDark(v => !v)}
@@ -153,6 +176,7 @@ export const PairCard = memo(function PairCard({
           onCopyLink={onCopyLink}
           onCopyMetadata={onCopyMetadata}
         />
+        {status === DiffStatus.ERRORED && <ErroredBanner />}
         <Container padding="0 xl xl">{body}</Container>
       </SnapshotVariantFrame>
     </DarkAware>
@@ -368,6 +392,7 @@ const STATUS_VARIANT: Record<DiffStatus, ContentVariant | 'muted' | 'secondary'>
   [DiffStatus.REMOVED]: 'danger',
   [DiffStatus.RENAMED]: 'warning',
   [DiffStatus.UNCHANGED]: 'secondary',
+  [DiffStatus.ERRORED]: 'danger',
   [DiffStatus.SKIPPED]: 'muted',
 };
 
@@ -378,6 +403,14 @@ const StatusBadge = memo(function StatusBadge({
   status: DiffStatus;
   diffPercent?: number | null;
 }) {
+  if (status === DiffStatus.ERRORED) {
+    return (
+      <Tag variant="danger" icon={<IconWarning />}>
+        {t('Failed to compare')}
+      </Tag>
+    );
+  }
+
   let label: string;
   switch (status) {
     case DiffStatus.CHANGED:

--- a/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
@@ -1,0 +1,94 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {
+  SidebarItem,
+  SnapshotDiffPair,
+  SnapshotImage,
+} from 'sentry/views/preprod/types/snapshotTypes';
+
+import {SnapshotListView} from './snapshotListView';
+
+const mockZoom = {
+  containerRef: {current: null},
+  resetZoom: jest.fn(),
+  transform: {x: 0, y: 0, k: 1},
+  zoomIn: jest.fn(),
+  zoomOut: jest.fn(),
+};
+
+jest.mock('./imageDisplay/useD3Zoom', () => ({
+  useD3Zoom: () => mockZoom,
+  useSyncedD3Zoom: () => [mockZoom, mockZoom],
+}));
+
+jest.mock('sentry/utils/useCopyToClipboard', () => ({
+  useCopyToClipboard: () => ({copy: jest.fn()}),
+}));
+
+function image(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
+  return {
+    display_name: 'Login screen',
+    height: 180,
+    image_file_name: 'login.png',
+    key: 'head-login',
+    tags: null,
+    width: 320,
+    ...overrides,
+  };
+}
+
+const erroredPair: SnapshotDiffPair = {
+  base_image: image({
+    display_name: 'Login screen base',
+    image_file_name: 'login.base.png',
+    key: 'base-login',
+  }),
+  diff: null,
+  diff_image_key: null,
+  head_image: image(),
+};
+
+function renderListView(items: SidebarItem[]) {
+  return render(
+    <SnapshotListView
+      items={items}
+      imageBaseUrl="/api/0/projects/org-slug/project-slug/files/images/"
+    />
+  );
+}
+
+describe('SnapshotListView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 900,
+      height: 600,
+      top: 0,
+      left: 0,
+      bottom: 600,
+      right: 900,
+      x: 0,
+      y: 0,
+      toJSON: jest.fn(),
+    });
+    // jsdom returns empty padding strings; parseFloat('') is NaN, which would
+    // propagate into the virtualizer's height math. Force numeric padding.
+    jest
+      .spyOn(window, 'getComputedStyle')
+      .mockReturnValue({paddingLeft: '0px', paddingRight: '0px'} as CSSStyleDeclaration);
+  });
+
+  it('renders errored pairs as side-by-side cards with a failed badge', () => {
+    renderListView([
+      {
+        key: 'errored:screens',
+        name: 'Screens',
+        displayName: 'Screens',
+        pairs: [erroredPair],
+        type: 'errored',
+      },
+    ]);
+
+    expect(screen.getByText('Failed to compare')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
@@ -48,14 +48,23 @@ const erroredPair: SnapshotDiffPair = {
   head_image: image(),
 };
 
-function renderListView(items: SidebarItem[]) {
+function renderListView(items: SidebarItem[], diffMode?: 'split' | 'wipe' | 'onion') {
   return render(
     <SnapshotListView
       items={items}
       imageBaseUrl="/api/0/projects/org-slug/project-slug/files/images/"
+      diffMode={diffMode}
     />
   );
 }
+
+const erroredItem: SidebarItem = {
+  key: 'errored:screens',
+  name: 'Screens',
+  displayName: 'Screens',
+  pairs: [erroredPair],
+  type: 'errored',
+};
 
 describe('SnapshotListView', () => {
   beforeEach(() => {
@@ -79,16 +88,16 @@ describe('SnapshotListView', () => {
   });
 
   it('renders errored pairs as side-by-side cards with a failed badge', () => {
-    renderListView([
-      {
-        key: 'errored:screens',
-        name: 'Screens',
-        displayName: 'Screens',
-        pairs: [erroredPair],
-        type: 'errored',
-      },
-    ]);
+    renderListView([erroredItem]);
 
     expect(screen.getByText('Failed to compare')).toBeInTheDocument();
+  });
+
+  it('renders errored pairs side-by-side even when the diff mode is onion', () => {
+    renderListView([erroredItem], 'onion');
+
+    expect(screen.getByText('Failed to compare')).toBeInTheDocument();
+    // Onion mode renders an opacity slider; side-by-side (split) does not.
+    expect(screen.queryByRole('slider')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -18,6 +18,7 @@ import {Text} from '@sentry/scraps/text';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {DiffStatus, isPairSidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 import type {
   SidebarItem,
   SnapshotDiffPair,
@@ -61,6 +62,7 @@ type GroupCard =
       estimatedHeight: number;
       id: string;
       pair: SnapshotDiffPair;
+      status: DiffStatus;
       type: 'pair-card';
     }
   | {
@@ -108,7 +110,7 @@ function estimateCardHeight(
 }
 
 export function isItemUngrouped(item: SidebarItem): boolean {
-  if (item.type === 'changed' || item.type === 'renamed') {
+  if (isPairSidebarItem(item)) {
     return !item.pairs[0]?.head_image.group;
   }
   return !item.images[0]?.group;
@@ -118,12 +120,14 @@ function buildGroups(items: SidebarItem[], contentWidth: number): GroupRow[] {
   const groups: GroupRow[] = [];
   for (const item of items) {
     const cards: GroupCard[] = [];
-    if (item.type === 'changed') {
+    if (item.type === 'changed' || item.type === 'errored') {
+      const status = item.type === 'errored' ? DiffStatus.ERRORED : DiffStatus.CHANGED;
       for (const pair of item.pairs) {
         cards.push({
           type: 'pair-card',
           id: `c:${item.key}:${pair.head_image.image_file_name}`,
           pair,
+          status,
           estimatedHeight: Math.max(
             estimateCardHeight(pair.head_image, true, contentWidth),
             estimateCardHeight(pair.base_image, true, contentWidth)
@@ -632,7 +636,7 @@ const GroupContainer = memo(function GroupContainer({
     const snapshotKey = snapshotKeyFor(card);
     const isSelected = snapshotKey === selectedSnapshotKey;
     const copyUrl = buildSnapshotLink(snapshotKey);
-    const diffStatus = card.type === 'pair-card' ? 'changed' : card.cardType;
+    const diffStatus = card.type === 'pair-card' ? card.status : card.cardType;
     const onCopyLink = () =>
       trackAnalytics('preprod.snapshots.details.image_link_copied', {
         organization,
@@ -647,6 +651,7 @@ const GroupContainer = memo(function GroupContainer({
       <PairCard
         key={card.id}
         pair={card.pair}
+        status={card.status}
         imageBaseUrl={imageBaseUrl}
         headBranch={headBranch}
         isSelected={isSelected}

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -86,6 +86,7 @@ interface GroupRow {
 // Keep in sync with SnapshotGroupHeader: lg vertical padding + md heading height.
 const SNAPSHOT_GROUP_HEADER_HEIGHT = 44;
 const CARD_CHROME_HEIGHT = 120;
+const ERRORED_BANNER_HEIGHT = 56;
 const CARD_GAP = 0;
 const GROUP_PADDING = 0;
 const ROW_PADDING_BOTTOM = 16;
@@ -122,16 +123,18 @@ function buildGroups(items: SidebarItem[], contentWidth: number): GroupRow[] {
     const cards: GroupCard[] = [];
     if (item.type === 'changed' || item.type === 'errored') {
       const status = item.type === 'errored' ? DiffStatus.ERRORED : DiffStatus.CHANGED;
+      const bannerHeight = status === DiffStatus.ERRORED ? ERRORED_BANNER_HEIGHT : 0;
       for (const pair of item.pairs) {
         cards.push({
           type: 'pair-card',
           id: `c:${item.key}:${pair.head_image.image_file_name}`,
           pair,
           status,
-          estimatedHeight: Math.max(
-            estimateCardHeight(pair.head_image, true, contentWidth),
-            estimateCardHeight(pair.base_image, true, contentWidth)
-          ),
+          estimatedHeight:
+            Math.max(
+              estimateCardHeight(pair.head_image, true, contentWidth),
+              estimateCardHeight(pair.base_image, true, contentWidth)
+            ) + bannerHeight,
         });
       }
     } else if (item.type === 'renamed') {

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -89,6 +89,22 @@ const changedPair: SnapshotDiffPair = {
   head_image: headImage,
 };
 
+const erroredPair: SnapshotDiffPair = {
+  base_image: image({
+    display_name: 'Login screen base',
+    image_file_name: 'login.base.png',
+    key: 'base-login',
+  }),
+  diff: null,
+  diff_image_key: null,
+  head_image: image({
+    display_name: 'Login screen',
+    group: 'screens',
+    image_file_name: 'login.png',
+    key: 'head-login',
+  }),
+};
+
 const renamedPair: SnapshotDiffPair = {
   base_image: image({
     display_name: 'Button / light old',
@@ -168,6 +184,34 @@ describe('SnapshotMainContent', () => {
     await userEvent.click(nextButton);
 
     expect(onNavigateSingleView).toHaveBeenCalledWith('next');
+  });
+
+  it('renders focused errored snapshots side-by-side with a failed badge', () => {
+    renderSnapshotMainContent({
+      comparisonType: 'diff',
+      isSoloView: false,
+      selectedItem: {
+        key: 'errored-screens',
+        name: 'Screens',
+        displayName: 'Screens',
+        pairs: [erroredPair],
+        type: 'errored',
+      },
+      viewMode: 'single',
+    });
+
+    expect(screen.getByText('Screens')).toBeInTheDocument();
+    expect(screen.getByText('Login screen')).toBeInTheDocument();
+    expect(screen.getByText('Failed to compare')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Unknown error: failed to compare these images (base and head images still shown below).'
+      )
+    ).toBeInTheDocument();
+    // Side-by-side renders both base and head columns (one per diff-mode body).
+    expect(screen.getAllByText('Base').length).toBeGreaterThan(0);
+    // Errored pairs have no diff, so the diff-mode controls are not shown.
+    expect(screen.queryByRole('radio', {name: 'Split'})).not.toBeInTheDocument();
   });
 
   it('renders focused renamed snapshots as a single image with pair metadata', async () => {

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -312,7 +312,7 @@ export function SnapshotMainContent({
             imageBaseUrl={imageBaseUrl}
             diffImageBaseUrl={diffImageBaseUrl}
             overlayColor={overlayColor}
-            diffMode={diffMode}
+            diffMode={isChanged ? diffMode : 'split'}
             headLabel={headBranch ?? t('Head')}
           />
         }

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -16,12 +16,13 @@ import {
   DiffStatus,
   getImageName,
   getSnapshotImageUrl,
+  isPairSidebarItem,
 } from 'sentry/views/preprod/types/snapshotTypes';
 import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
 import {DiffImageDisplay, type DiffMode} from './imageDisplay/diffImageDisplay';
 import {SingleImageDisplay} from './imageDisplay/singleImageDisplay';
-import {CardHeader, DarkAware} from './snapshotCards';
+import {CardHeader, DarkAware, ErroredBanner} from './snapshotCards';
 import {SnapshotCardFrame, SnapshotVariantFrame} from './snapshotFrames';
 import {
   buildSnapshotLink,
@@ -117,10 +118,7 @@ export function SnapshotMainContent({
     let total = 0;
     for (const item of listItems) {
       offsets.push(total);
-      const count =
-        item.type === 'changed' || item.type === 'renamed'
-          ? item.pairs.length
-          : item.images.length;
+      const count = isPairSidebarItem(item) ? item.pairs.length : item.images.length;
       total += count;
     }
     return {cardOffsets: offsets, totalCards: total};
@@ -266,12 +264,13 @@ export function SnapshotMainContent({
 
   const groupName = isItemUngrouped(selectedItem) ? null : selectedItem.name;
 
-  if (selectedItem.type === 'changed') {
+  if (selectedItem.type === 'changed' || selectedItem.type === 'errored') {
     const currentPair = selectedItem.pairs[variantIndex];
     if (!currentPair) {
       return null;
     }
     const image = currentPair.head_image;
+    const isChanged = selectedItem.type === 'changed';
     return (
       <SingleViewLayout
         isDark={isDark}
@@ -289,7 +288,7 @@ export function SnapshotMainContent({
           displayName: image.display_name,
           fileName: image.image_file_name,
           tags: image.tags,
-          status: DiffStatus.CHANGED,
+          status: isChanged ? DiffStatus.CHANGED : DiffStatus.ERRORED,
           diffPercent: currentPair.diff,
           copyData: currentPair,
           copyUrl: buildSnapshotLink(image.image_file_name),
@@ -297,15 +296,16 @@ export function SnapshotMainContent({
           onCopyLink: () =>
             trackAnalytics('preprod.snapshots.details.image_link_copied', {
               organization,
-              diff_status: 'changed',
+              diff_status: selectedItem.type,
             }),
           onCopyMetadata: () =>
             trackAnalytics('preprod.snapshots.details.image_metadata_copied', {
               organization,
-              diff_status: 'changed',
+              diff_status: selectedItem.type,
             }),
         }}
-        diffControls={diffControls}
+        diffControls={isChanged ? diffControls : undefined}
+        banner={isChanged ? undefined : <ErroredBanner />}
         body={
           <DiffImageDisplay
             pair={currentPair}
@@ -438,6 +438,7 @@ function SingleViewLayout({
   navButtonRefs,
   headerProps,
   body,
+  banner,
   diffControls,
 }: {
   body: React.ReactNode;
@@ -453,6 +454,7 @@ function SingleViewLayout({
   soloDiffToggle: React.ReactNode;
   sortDropdown: React.ReactNode;
   toggle: React.ReactNode;
+  banner?: React.ReactNode;
   diffControls?: React.ReactNode;
 }) {
   const wheelCooldownRef = useRef(false);
@@ -521,6 +523,7 @@ function SingleViewLayout({
         onToggleDark={onToggleDark}
         showBottomBorder={false}
       />
+      {banner}
       <Flex direction="column" flex="1" minHeight="0">
         {body}
       </Flex>

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
@@ -45,6 +45,7 @@ const statusCounts: Record<DiffStatus, number> = {
   [DiffStatus.REMOVED]: 0,
   [DiffStatus.RENAMED]: 0,
   [DiffStatus.UNCHANGED]: 2,
+  [DiffStatus.ERRORED]: 0,
   [DiffStatus.SKIPPED]: 0,
 };
 

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.spec.tsx
@@ -26,17 +26,21 @@ const statusCounts: Record<DiffStatus, number> = {
   [DiffStatus.REMOVED]: 0,
   [DiffStatus.RENAMED]: 0,
   [DiffStatus.UNCHANGED]: 1,
+  [DiffStatus.ERRORED]: 0,
   [DiffStatus.SKIPPED]: 0,
 };
 
-function renderSidebar(sections: SidebarSection[]) {
+function renderSidebar(
+  sections: SidebarSection[],
+  counts: Record<DiffStatus, number> = statusCounts
+) {
   return render(
     <SnapshotSidebarContent
       sections={sections}
       searchQuery=""
       onSearchChange={noop}
       onSelectItem={noop}
-      statusCounts={statusCounts}
+      statusCounts={counts}
       activeStatuses={new Set()}
       onToggleStatus={noop}
       availableTags={new Map()}
@@ -78,5 +82,27 @@ describe('SnapshotSidebarContent', () => {
     ]);
 
     expect(await screen.findByText('components')).toBeInTheDocument();
+  });
+
+  it('renders an errored pill when there are errored images', async () => {
+    renderSidebar(
+      [
+        {
+          type: DiffStatus.ERRORED,
+          groups: [{key: 'errored:LoginScreen', displayName: 'LoginScreen', count: 2}],
+        },
+      ],
+      {
+        [DiffStatus.CHANGED]: 0,
+        [DiffStatus.ADDED]: 0,
+        [DiffStatus.REMOVED]: 0,
+        [DiffStatus.RENAMED]: 0,
+        [DiffStatus.UNCHANGED]: 0,
+        [DiffStatus.ERRORED]: 2,
+        [DiffStatus.SKIPPED]: 0,
+      }
+    );
+
+    expect(await screen.findByText('2 errored')).toBeInTheDocument();
   });
 });

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -7,7 +7,7 @@ import {InputGroup} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {IconClose, IconSearch} from 'sentry/icons';
+import {IconClose, IconSearch, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {TagChip} from 'sentry/views/preprod/snapshots/tagChip';
 import {useTagFilters} from 'sentry/views/preprod/snapshots/tagFilterContext';
@@ -26,11 +26,12 @@ export interface SidebarSection {
 
 export const DIFF_TYPE_ORDER: Record<string, number> = {
   [DiffStatus.CHANGED]: 0,
-  [DiffStatus.REMOVED]: 1,
-  [DiffStatus.ADDED]: 2,
-  [DiffStatus.RENAMED]: 3,
-  [DiffStatus.UNCHANGED]: 4,
-  [DiffStatus.SKIPPED]: 5,
+  [DiffStatus.ERRORED]: 1,
+  [DiffStatus.REMOVED]: 2,
+  [DiffStatus.ADDED]: 3,
+  [DiffStatus.RENAMED]: 4,
+  [DiffStatus.UNCHANGED]: 5,
+  [DiffStatus.SKIPPED]: 6,
 };
 
 type StatusCounts = Record<DiffStatus, number>;
@@ -41,8 +42,15 @@ const STATUS_PILLS: ReadonlyArray<{
   color: PillColor;
   label: string;
   status: DiffStatus;
+  icon?: React.ReactNode;
 }> = [
   {status: DiffStatus.CHANGED, color: 'accent', label: t('changed')},
+  {
+    status: DiffStatus.ERRORED,
+    color: 'danger',
+    label: t('errored'),
+    icon: <IconWarning size="xs" variant="danger" />,
+  },
   {status: DiffStatus.REMOVED, color: 'danger', label: t('removed')},
   {status: DiffStatus.ADDED, color: 'success', label: t('added')},
   {status: DiffStatus.RENAMED, color: 'warning', label: t('renamed')},
@@ -56,6 +64,7 @@ const STATUS_META: Record<DiffStatus, {color: PillColor; label: string}> = {
   [DiffStatus.REMOVED]: {color: 'danger', label: t('Removed')},
   [DiffStatus.RENAMED]: {color: 'warning', label: t('Renamed')},
   [DiffStatus.UNCHANGED]: {color: 'muted', label: t('Unchanged')},
+  [DiffStatus.ERRORED]: {color: 'danger', label: t('Errored')},
   [DiffStatus.SKIPPED]: {color: 'muted', label: t('Skipped')},
 };
 
@@ -185,7 +194,7 @@ export const SnapshotSidebarContent = memo(function SnapshotSidebarContent({
         </InputGroup>
         {statusCounts && (
           <Flex gap="lg" wrap="wrap">
-            {STATUS_PILLS.map(({status, color, label}) => {
+            {STATUS_PILLS.map(({status, color, label, icon}) => {
               const count = statusCounts[status];
               if (count <= 0) {
                 return null;
@@ -196,6 +205,7 @@ export const SnapshotSidebarContent = memo(function SnapshotSidebarContent({
                   color={color}
                   count={count}
                   label={label}
+                  icon={icon}
                   active={isStatusActive(status)}
                   onClick={() => onToggleStatus(status)}
                 />
@@ -326,6 +336,7 @@ function StatusPill({
   count,
   label,
   active,
+  icon,
   onClick,
 }: {
   active: boolean;
@@ -333,10 +344,11 @@ function StatusPill({
   count: number;
   label: string;
   onClick: () => void;
+  icon?: React.ReactNode;
 }) {
   return (
     <PillButton type="button" active={active} onClick={onClick}>
-      <Dot pillColor={color} active={active} />
+      {icon ?? <Dot pillColor={color} active={active} />}
       <Text size="xs" variant="muted">
         {count} {label}
       </Text>

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -31,7 +31,11 @@ import {TopBar} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {BuildError} from 'sentry/views/preprod/components/buildError';
 import {BuildProcessing} from 'sentry/views/preprod/components/buildProcessing';
-import {DiffStatus, getImageName} from 'sentry/views/preprod/types/snapshotTypes';
+import {
+  DiffStatus,
+  getImageName,
+  isPairSidebarItem,
+} from 'sentry/views/preprod/types/snapshotTypes';
 import type {
   SidebarItem,
   SnapshotDetailsApiResponse,
@@ -75,20 +79,18 @@ function groupByKey<T>(items: T[], keyOf: (item: T) => string): Map<string, T[]>
 }
 
 function itemVariantCount(item: SidebarItem): number {
-  return item.type === 'changed' || item.type === 'renamed'
-    ? item.pairs.length
-    : item.images.length;
+  return isPairSidebarItem(item) ? item.pairs.length : item.images.length;
 }
 
 function itemImages(item: SidebarItem): SnapshotImage[] {
-  if (item.type === 'changed' || item.type === 'renamed') {
+  if (isPairSidebarItem(item)) {
     return item.pairs.map(p => p.head_image);
   }
   return item.images;
 }
 
 function snapshotKeyAt(item: SidebarItem, variantIdx: number): string | null {
-  if (item.type === 'changed' || item.type === 'renamed') {
+  if (isPairSidebarItem(item)) {
     return item.pairs[variantIdx]?.head_image.image_file_name ?? null;
   }
   return item.images[variantIdx]?.image_file_name ?? null;
@@ -100,10 +102,9 @@ function findSnapshotPosition(
 ): {itemIdx: number; variantIdx: number} | null {
   for (let i = 0; i < items.length; i++) {
     const item = items[i]!;
-    const variantIdx =
-      item.type === 'changed' || item.type === 'renamed'
-        ? item.pairs.findIndex(p => p.head_image.image_file_name === snapshotKey)
-        : item.images.findIndex(img => img.image_file_name === snapshotKey);
+    const variantIdx = isPairSidebarItem(item)
+      ? item.pairs.findIndex(p => p.head_image.image_file_name === snapshotKey)
+      : item.images.findIndex(img => img.image_file_name === snapshotKey);
     if (variantIdx !== -1) {
       return {itemIdx: i, variantIdx};
     }
@@ -288,7 +289,10 @@ export default function SnapshotsPage() {
     if (comparisonType === 'diff') {
       const items: SidebarItem[] = [];
 
-      const pushDiffPairs = (pairs: SnapshotDiffPair[], type: 'changed' | 'renamed') => {
+      const pushDiffPairs = (
+        pairs: SnapshotDiffPair[],
+        type: 'changed' | 'renamed' | 'errored'
+      ) => {
         for (const [groupKey, groupedPairs] of groupByKey(pairs, p =>
           imageGroupKey(p.head_image)
         )) {
@@ -319,6 +323,7 @@ export default function SnapshotsPage() {
 
       pushDiffPairs(data.changed, 'changed');
       pushDiffPairs(data.renamed ?? [], 'renamed');
+      pushDiffPairs(data.errored ?? [], 'errored');
       pushImages(data.added, 'added');
       pushImages(data.removed, 'removed');
       pushImages(data.unchanged, 'unchanged');
@@ -490,6 +495,7 @@ export default function SnapshotsPage() {
 
     const sectionOrder = [
       DiffStatus.CHANGED,
+      DiffStatus.ERRORED,
       DiffStatus.REMOVED,
       DiffStatus.ADDED,
       DiffStatus.RENAMED,
@@ -525,6 +531,7 @@ export default function SnapshotsPage() {
       [DiffStatus.REMOVED]: 0,
       [DiffStatus.RENAMED]: 0,
       [DiffStatus.UNCHANGED]: 0,
+      [DiffStatus.ERRORED]: 0,
       [DiffStatus.SKIPPED]: 0,
     };
     for (const item of tagFilteredItems) {
@@ -938,7 +945,7 @@ function imageSearchKey(image: SnapshotImage): string {
 // Builds one lowercase search key per image/pair, joining all searchable metadata
 function buildMemberSearchKeys(item: SidebarItem): string[] {
   const groupNameLower = item.name ? item.name.toLowerCase() : '';
-  if (item.type === 'changed' || item.type === 'renamed') {
+  if (isPairSidebarItem(item)) {
     return item.pairs.map(pair => {
       const head = imageSearchKey(pair.head_image);
       const base = imageSearchKey(pair.base_image);
@@ -956,7 +963,7 @@ function narrowItemBySearch(
   memberSearchKeysForItem: string[],
   query: string
 ): SidebarItem | null {
-  if (item.type === 'changed' || item.type === 'renamed') {
+  if (isPairSidebarItem(item)) {
     const kept: SnapshotDiffPair[] = [];
     let allMatched = true;
     for (let i = 0; i < item.pairs.length; i++) {

--- a/static/app/views/preprod/snapshots/tagFiltering.ts
+++ b/static/app/views/preprod/snapshots/tagFiltering.ts
@@ -1,4 +1,5 @@
 import type {SidebarItem, SnapshotImage} from 'sentry/views/preprod/types/snapshotTypes';
+import {isPairSidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
 export function imageMatchesTagFilters(
   img: SnapshotImage,
@@ -14,7 +15,7 @@ export function narrowItemByTags(
   item: SidebarItem,
   filters: Record<string, string>
 ): SidebarItem | null {
-  if (item.type === 'changed' || item.type === 'renamed') {
+  if (isPairSidebarItem(item)) {
     const kept = item.pairs.filter(p => imageMatchesTagFilters(p.head_image, filters));
     if (kept.length === 0) {
       return null;

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -104,7 +104,7 @@ export type SidebarItem =
       images: SnapshotImage[];
     });
 
-export type SidebarPairItem = Extract<SidebarItem, {pairs: SnapshotDiffPair[]}>;
+type SidebarPairItem = Extract<SidebarItem, {pairs: SnapshotDiffPair[]}>;
 
 export function isPairSidebarItem(item: SidebarItem): item is SidebarPairItem {
   return item.type === 'changed' || item.type === 'renamed' || item.type === 'errored';

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -62,6 +62,8 @@ export interface SnapshotDetailsApiResponse {
   renamed_count?: number;
   unchanged: SnapshotImage[];
   unchanged_count: number;
+  errored?: SnapshotDiffPair[];
+  errored_count?: number;
   skipped?: SnapshotImage[];
   skipped_count?: number;
 }
@@ -72,6 +74,7 @@ export enum DiffStatus {
   REMOVED = 'removed',
   RENAMED = 'renamed',
   UNCHANGED = 'unchanged',
+  ERRORED = 'errored',
   SKIPPED = 'skipped',
 }
 
@@ -95,7 +98,14 @@ export type SidebarItem =
   | (SidebarItemBase & {type: 'solo'; images: SnapshotImage[]})
   | (SidebarItemBase & {type: 'changed'; pairs: SnapshotDiffPair[]})
   | (SidebarItemBase & {type: 'renamed'; pairs: SnapshotDiffPair[]})
+  | (SidebarItemBase & {type: 'errored'; pairs: SnapshotDiffPair[]})
   | (SidebarItemBase & {
       type: 'added' | 'removed' | 'unchanged' | 'skipped';
       images: SnapshotImage[];
     });
+
+export type SidebarPairItem = Extract<SidebarItem, {pairs: SnapshotDiffPair[]}>;
+
+export function isPairSidebarItem(item: SidebarItem): item is SidebarPairItem {
+  return item.type === 'changed' || item.type === 'renamed' || item.type === 'errored';
+}


### PR DESCRIPTION
## Summary

Snapshot comparisons can mark individual images as **errored** when they fail to compare, but the web viewer ignored that state. The detail API already returns the errored pairs, yet nothing on the frontend consumed them — so a failed image was simply invisible to users (it didn't appear in any category, count, or filter).

This surfaces `errored` as a first-class diff category in the snapshots web viewer, completing the frontend half of the errored-images work (backend landed in #117560).

## What changed

- **Sidebar**: a red **errored** pill, distinguished from the red `removed` pill by a ⚠️ icon (instead of a dot) so the two don't clash. Errored participates in filtering, counts, and section ordering like every other category.
- **Cards**: errored pairs render **side-by-side** (base + head, no diff overlay since there is no diff) via `PairCard`, with:
  - a filled red **"Failed to compare"** chip in the header, and
  - an explanatory banner: *"Unknown error: failed to compare these images (base and head images still shown below)."*
- Works in both the **list** and **single** views.
- Refactors: introduced `isPairSidebarItem` to centralize the previously-scattered `changed || renamed` pair-type checks, and collapsed the duplicated changed/errored single-view branches into one.

## Notes

- Frontend-only; no API changes (the `errored` / `errored_count` fields already ship from the backend).
- The errored single-view intentionally omits diff-mode controls (split/wipe/onion) since there is no diff to render.

## Test plan

- `pnpm test-ci static/app/views/preprod/snapshots/` — 22 pass, including new coverage for the errored pill, the side-by-side single view + banner + badge, and the list-view card.
- `pnpm run lint:js` and `pnpm run typecheck` — clean.
- Verified locally end-to-end against a real upload (a comparison with errored images renders the pill, filter, side-by-side cards, badge, and banner).
