### PR TITLE
fix(relay): Flush the organization options local cache for project recomputation

### DIFF
--- a/src/sentry/models/options/organization_option.py
+++ b/src/sentry/models/options/organization_option.py
@@ -73,6 +73,16 @@ class OrganizationOptionManager(OptionManager["OrganizationOption"]):
 
         return self._option_cache.get(cache_key, {})
 
+    def reload_task_local_cache(self, organization_id: int):
+        cache_key = self._make_key(organization_id)
+
+        result = cache.get(cache_key)
+        if result is None:
+            result = {i.key: i.value for i in self.filter(organization=organization_id)}
+            cache.set(cache_key, result)
+
+        self._option_cache[cache_key] = result
+
     def reload_cache(self, organization_id: int, update_reason: str) -> Mapping[str, Any]:
         from sentry.tasks.relay import schedule_invalidate_project_config
 

--- a/src/sentry/models/options/organization_option.py
+++ b/src/sentry/models/options/organization_option.py
@@ -80,7 +80,8 @@ class OrganizationOptionManager(OptionManager["OrganizationOption"]):
         # not populated, then subsequent accesses (via get_all_values) will re-generate the
         # value with an actual query.
         result = cache.get(cache_key)
-        self._option_cache[cache_key] = result
+        if result is None and cache_key in self._option_cache:
+            del self._option_cache[cache_key]
 
     def reload_cache(self, organization_id: int, update_reason: str) -> Mapping[str, Any]:
         from sentry.tasks.relay import schedule_invalidate_project_config

--- a/src/sentry/models/options/organization_option.py
+++ b/src/sentry/models/options/organization_option.py
@@ -76,11 +76,10 @@ class OrganizationOptionManager(OptionManager["OrganizationOption"]):
     def reload_task_local_cache(self, organization_id: int):
         cache_key = self._make_key(organization_id)
 
+        # Reload the local cache with what's in the shared cache.  If the shared cache is
+        # not populated, then subsequent accesses (via get_all_values) will re-generate the
+        # value with an actual query.
         result = cache.get(cache_key)
-        if result is None:
-            result = {i.key: i.value for i in self.filter(organization=organization_id)}
-            cache.set(cache_key, result)
-
         self._option_cache[cache_key] = result
 
     def reload_cache(self, organization_id: int, update_reason: str) -> Mapping[str, Any]:

--- a/src/sentry/models/options/organization_option.py
+++ b/src/sentry/models/options/organization_option.py
@@ -73,7 +73,7 @@ class OrganizationOptionManager(OptionManager["OrganizationOption"]):
 
         return self._option_cache.get(cache_key, {})
 
-    def reload_task_local_cache(self, organization_id: int):
+    def reload_task_local_cache(self, organization_id: int) -> None:
         cache_key = self._make_key(organization_id)
 
         # Reload the local cache with what's in the shared cache.  If the shared cache is

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -6,6 +6,7 @@ from django.db import connections, router, transaction
 
 from sentry import options
 from sentry.constants import DataCategory
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.relay import projectconfig_cache, projectconfig_debounce_cache
 from sentry.silo.base import SiloMode
@@ -61,6 +62,9 @@ def build_project_config(public_key=None, **kwargs):
             # avoid creating more tasks for it.
             projectconfig_cache.backend.set_many({public_key: {"disabled": True}})
         else:
+            # Clear the local options cache; if any of them changed, we may need to get the latest values,
+            OrganizationOption.objects.reload_task_local_cache(key.project.organization_id)
+
             config = compute_projectkey_config(key)
             projectconfig_cache.backend.set_many({public_key: config})
 
@@ -261,6 +265,10 @@ def invalidate_project_config(
     sentry_sdk.set_attribute("trigger_details", trigger_details)
     sentry_sdk.set_context("kwargs", kwargs)
     sentry_sdk.set_attribute("kwargs", str(kwargs))
+
+    if organization_id:
+        # Clear the local options cache; if any of them changed, we may need to get the latest values,
+        OrganizationOption.objects.reload_task_local_cache(organization_id)
 
     updated_configs = compute_configs(
         organization_id=organization_id, project_id=project_id, public_key=public_key

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -62,9 +62,6 @@ def build_project_config(public_key=None, **kwargs):
             # avoid creating more tasks for it.
             projectconfig_cache.backend.set_many({public_key: {"disabled": True}})
         else:
-            # Clear the local options cache; if any of them changed, we may need to get the latest values,
-            OrganizationOption.objects.reload_task_local_cache(key.project.organization_id)
-
             config = compute_projectkey_config(key)
             projectconfig_cache.backend.set_many({public_key: config})
 
@@ -207,6 +204,9 @@ def compute_projectkey_config(key):
     if key.status != ProjectKeyStatus.ACTIVE:
         return {"disabled": True}
     else:
+        # Clear the local options cache; if any of them changed, we may need to get the latest values,
+        OrganizationOption.objects.reload_task_local_cache(key.project.organization_id)
+
         return get_project_config(key.project, project_keys=[key]).to_dict()
 
 
@@ -265,10 +265,6 @@ def invalidate_project_config(
     sentry_sdk.set_attribute("trigger_details", trigger_details)
     sentry_sdk.set_context("kwargs", kwargs)
     sentry_sdk.set_attribute("kwargs", str(kwargs))
-
-    if organization_id:
-        # Clear the local options cache; if any of them changed, we may need to get the latest values,
-        OrganizationOption.objects.reload_task_local_cache(organization_id)
 
     updated_configs = compute_configs(
         organization_id=organization_id, project_id=project_id, public_key=public_key


### PR DESCRIPTION
The local OrganizationOption cache (_options_cache) is never flushed during project config updates/builds (within a task--it is correctly flushed in the monolith.)  Add a blanket reload within the invalidate and build tasks.