### PR TITLE
fix(devserver): exclude .artifacts from granian reload watcher

### DIFF
--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -21,6 +21,7 @@ def _run_server(options: dict[str, Any]):
         blocking_threads=options["threads"],
         respawn_failed_workers=True,
         reload=options["reload"],
+        reload_ignore_dirs=options.get("reload-ignore-dirs"),
         reload_ignore_worker_failure=options["reload-ignore-worker-failure"],
         process_name=options["proc-name"],
         workers_lifetime=options["max-worker-lifetime"],
@@ -67,6 +68,7 @@ class SentryHTTPServer(Service):
         options.setdefault("log-enabled", True)
         options.setdefault("proc-name", "sentry")
         options.setdefault("reload", reload)
+        options.setdefault("reload-ignore-dirs", [".artifacts"])
         options.setdefault("reload-ignore-worker-failure", reload)
         options.setdefault("workers-kill-timeout", 3 if reload else 30)
         options.setdefault("max-worker-lifetime", None)


### PR DESCRIPTION
Fixes getsentry/self-hosted#4379 
Granian's watchfiles-based reloader watches the entire repo directory by default. The TeeStream introduced in getsentry/sentry#117486 writes all honcho output to .artifacts/dev.log inside the repo root, which triggered an infinite reload cycle: server logs →-> dev.log updated -> watchfiles detects change ->  granian reloads ->  repeat.

Fix by passing reload_ignore_dirs=[".artifacts"] to Granian so watchfiles skips that directory. The option is surfaced through the existing options dict so it can be overridden via SENTRY_WEB_OPTIONS if needed.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
