### PR TITLE
docs(seer): Add simple stories for the two AutofixRepositories components, aka "Connected Repos" lists

### DIFF
--- a/static/app/components/seer/legacy/autofixRepositories.stories.tsx
+++ b/static/app/components/seer/legacy/autofixRepositories.stories.tsx
@@ -1,0 +1,32 @@
+import {parseAsString, useQueryState} from 'nuqs';
+
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {AutofixRepositories} from 'sentry/components/seer/legacy/autofixRepositories';
+import * as Storybook from 'sentry/stories';
+import {useProjects} from 'sentry/utils/useProjects';
+
+export default Storybook.story('AutofixRepositories (Legacy)', story => {
+  story('Default', () => {
+    const [projectSlug, setProjectSlug] = useQueryState('project', parseAsString);
+    const {projects} = useProjects();
+    const project = projects.find(p => p.slug === projectSlug);
+
+    return (
+      <Flex direction="column" gap="lg">
+        <Storybook.SelectProject
+          projectSlug={projectSlug}
+          setProjectSlug={setProjectSlug}
+        />
+        {project ? (
+          <AutofixRepositories project={project} />
+        ) : (
+          <Flex justify="center" padding="xl">
+            <Text variant="muted">Select a project to view the story</Text>
+          </Flex>
+        )}
+      </Flex>
+    );
+  });
+});

--- a/static/app/components/seer/projectDetails/autofixRepositoriesList.stories.tsx
+++ b/static/app/components/seer/projectDetails/autofixRepositoriesList.stories.tsx
@@ -1,0 +1,60 @@
+import {parseAsString, useQueryState} from 'nuqs';
+
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
+import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {AutofixRepositories} from 'sentry/components/seer/projectDetails/autofixRepositoriesList';
+import * as Storybook from 'sentry/stories';
+import type {Project} from 'sentry/types/project';
+import {useProjects} from 'sentry/utils/useProjects';
+
+const DEFAULT_PREFERENCE: ProjectSeerPreferences = {
+  repositories: [],
+  automated_run_stopping_point: 'root_cause',
+  automation_handoff: undefined,
+};
+
+export default Storybook.story('AutofixRepositoriesList', story => {
+  story('Default', () => {
+    const [projectSlug, setProjectSlug] = useQueryState('project', parseAsString);
+    const {projects} = useProjects();
+    const project = projects.find(p => p.slug === projectSlug);
+
+    return (
+      <Flex direction="column" gap="lg">
+        <Storybook.SelectProject
+          projectSlug={projectSlug}
+          setProjectSlug={setProjectSlug}
+        />
+        {project ? (
+          <Example project={project} />
+        ) : (
+          <Flex justify="center" padding="xl">
+            <Text variant="muted">Select a project to view the story</Text>
+          </Flex>
+        )}
+      </Flex>
+    );
+  });
+});
+
+function Example({project}: {project: Project}) {
+  const {data, isPending} = useProjectSeerPreferences(project);
+  const {preference, code_mapping_repos: codeMappingRepos} = data ?? {};
+
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
+
+  return (
+    <AutofixRepositories
+      canWrite
+      codeMappingRepos={codeMappingRepos}
+      preference={preference ?? DEFAULT_PREFERENCE}
+      project={project}
+    />
+  );
+}


### PR DESCRIPTION
These two components have a slight difference in their props, easy to fix though.

This PR is a quick one, just to see the differences without any changes

The UI is similar too:

| State | Legacy | Seat-based |
| --- | --- | --- |
| Empty | <img width="811" height="299" alt="Screenshot 2026-06-14 at 12 10 22 PM" src="https://github.com/user-attachments/assets/0d92e9b4-988d-49e1-b7c7-83bfd87afc91" /> | <img width="811" height="299" alt="Screenshot 2026-06-14 at 12 10 18 PM" src="https://github.com/user-attachments/assets/e57bdcd5-aed0-48c5-9053-062d300dc58a" />
| Collapsed | <img width="811" height="299" alt="Screenshot 2026-06-14 at 12 10 20 PM" src="https://github.com/user-attachments/assets/cf5b25ca-e863-4ac5-93f7-1c927a09ee2a" /> | <img width="811" height="299" alt="Screenshot 2026-06-14 at 12 10 15 PM" src="https://github.com/user-attachments/assets/6e736052-7007-4a1a-a0fc-325043e14c8d" />
| Expanded | <img width="811" height="546" alt="Screenshot 2026-06-14 at 12 10 52 PM" src="https://github.com/user-attachments/assets/95de5667-3e38-4bf8-8a29-60f15ecd1b51" /> |  <img width="811" height="466" alt="Screenshot 2026-06-14 at 12 10 41 PM" src="https://github.com/user-attachments/assets/bb950581-7fe0-4aac-a6d5-0a1af024ab1b" />
