### PR TITLE
feat(admin): Indicate when a customer exists in another data region

### DIFF
--- a/static/gsAdmin/components/customerGrid.tsx
+++ b/static/gsAdmin/components/customerGrid.tsx
@@ -82,6 +82,7 @@ export function CustomerGrid(props: Props) {
     <ResultGrid
       inPanel
       isCellScoped
+      probeAcrossRegions
       path="/_admin/customers/"
       method="GET"
       columns={[

--- a/static/gsAdmin/components/resultGrid.spec.tsx
+++ b/static/gsAdmin/components/resultGrid.spec.tsx
@@ -14,7 +14,7 @@ function setupCells() {
   ] as any);
 }
 
-function renderGrid(query?: string) {
+function renderGrid(query?: string, extraQuery: Record<string, string> = {}) {
   return render(
     <ResultGrid
       inPanel
@@ -30,7 +30,7 @@ function renderGrid(query?: string) {
       initialRouterConfig: {
         location: {
           pathname: '/_admin/customers/',
-          query: query ? {query} : {},
+          query: {...(query ? {query} : {}), ...extraQuery},
         },
         route: '/_admin/customers/',
       },
@@ -100,7 +100,25 @@ describe('ResultGrid region probing', () => {
     // Wait for the empty result to settle.
     expect(await screen.findByText('No results')).toBeInTheDocument();
     expect(deRequest).not.toHaveBeenCalled();
-    expect(screen.queryByRole('button', {name: /View .* in de/})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'View in de'})).not.toBeInTheDocument();
+  });
+
+  it('does not probe other regions on a paginated (non-first) empty page', async () => {
+    // The current region has results on earlier pages; this later page is empty.
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [],
+    });
+    const deRequest = MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '1', name: 'Acme'}],
+    });
+
+    renderGrid('acme', {cursor: '0:100:0'});
+
+    expect(await screen.findByText('No results')).toBeInTheDocument();
+    expect(deRequest).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', {name: 'View in de'})).not.toBeInTheDocument();
   });
 
   it('does not show a hint when another region is also empty', async () => {
@@ -119,6 +137,6 @@ describe('ResultGrid region probing', () => {
     await waitFor(() =>
       expect(screen.queryByText('Checking other regions…')).not.toBeInTheDocument()
     );
-    expect(screen.queryByRole('button', {name: /View .* in de/})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'View in de'})).not.toBeInTheDocument();
   });
 });

--- a/static/gsAdmin/components/resultGrid.spec.tsx
+++ b/static/gsAdmin/components/resultGrid.spec.tsx
@@ -1,0 +1,124 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {ConfigStore} from 'sentry/stores/configStore';
+
+import {ResultGrid} from 'admin/components/resultGrid';
+
+const US_URL = 'https://us.example.com/api/0/';
+const DE_URL = 'https://de.example.com/api/0/';
+
+function setupCells() {
+  ConfigStore.set('cells', [
+    {name: 'us', locality_url: US_URL},
+    {name: 'de', locality_url: DE_URL},
+  ] as any);
+}
+
+function renderGrid(query?: string) {
+  return render(
+    <ResultGrid
+      inPanel
+      isCellScoped
+      hasSearch
+      endpoint="/customers/"
+      path="/_admin/customers/"
+      method="GET"
+      columns={[<th key="name">Customer</th>]}
+      columnsForRow={(row: any) => [<td key="name">{row.name}</td>]}
+    />,
+    {
+      initialRouterConfig: {
+        location: {
+          pathname: '/_admin/customers/',
+          query: query ? {query} : {},
+        },
+        route: '/_admin/customers/',
+      },
+    }
+  );
+}
+
+describe('ResultGrid region probing', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    setupCells();
+  });
+
+  it('points the user to another region when the default region is empty', async () => {
+    // Default region (us) has no matches.
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [],
+    });
+    // The org actually lives in the de region.
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '1', name: 'Acme'}],
+    });
+
+    renderGrid('acme');
+
+    expect(await screen.findByRole('button', {name: 'View in de'})).toBeInTheDocument();
+  });
+
+  it('switches to the matching region when the hint is clicked', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [],
+    });
+    const deRequest = MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '1', name: 'Acme'}],
+    });
+
+    renderGrid('acme');
+
+    await userEvent.click(await screen.findByRole('button', {name: 'View in de'}));
+
+    // The grid re-fetches against the de region and renders the match.
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(deRequest).toHaveBeenCalledWith(
+        '/_admin/cells/de/customers/',
+        expect.objectContaining({host: DE_URL})
+      )
+    );
+  });
+
+  it('does not probe other regions when there is no search query', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [],
+    });
+    const deRequest = MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '1', name: 'Acme'}],
+    });
+
+    renderGrid();
+
+    // Wait for the empty result to settle.
+    expect(await screen.findByText('No results')).toBeInTheDocument();
+    expect(deRequest).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', {name: /View .* in de/})).not.toBeInTheDocument();
+  });
+
+  it('does not show a hint when another region is also empty', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [],
+    });
+
+    renderGrid('acme');
+
+    expect(await screen.findByText('No results')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText('Checking other regions…')).not.toBeInTheDocument()
+    );
+    expect(screen.queryByRole('button', {name: /View .* in de/})).not.toBeInTheDocument();
+  });
+});

--- a/static/gsAdmin/components/resultGrid.spec.tsx
+++ b/static/gsAdmin/components/resultGrid.spec.tsx
@@ -19,6 +19,7 @@ function renderGrid(query?: string, extraQuery: Record<string, string> = {}) {
     <ResultGrid
       inPanel
       isCellScoped
+      probeAcrossRegions
       hasSearch
       endpoint="/customers/"
       path="/_admin/customers/"

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -370,6 +370,16 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     // Avoid slow-fetch race conditions
     this.props.api.clear();
 
+    // api.clear() aborts any in-flight region probe, and aborted requests never
+    // run their success/error callbacks — so probeOtherRegions' finalize() would
+    // never fire and probingRegions would stay stuck. Invalidate the probe (bump
+    // the token) and clear its UI state here, the single entry point for fetches,
+    // so it's reset regardless of which caller (refresh/onCursor/onSearch) we hit.
+    this.probeToken += 1;
+    if (this.state.probingRegions || this.state.regionMatches.length > 0) {
+      this.setState({probingRegions: false, regionMatches: []});
+    }
+
     // TODO(dcramer): this should whitelist filters/sortBy/cursor/perPage
     const queryParams: Record<string, any> = {
       ...this.props.defaultParams,

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import {Alert} from '@sentry/scraps/alert';
+import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Input} from '@sentry/scraps/input';
@@ -233,13 +234,24 @@ export type State = {
   filters: Location['query'];
   loading: boolean;
   pageLinks: string | null;
+  /**
+   * Whether we are currently probing other regions after an empty result.
+   */
+  probingRegions: boolean;
   query: string;
+  /**
+   * Other regions that have at least one match for the active search.
+   */
+  regionMatches: Cell[];
   rows: any[];
   sortBy: string;
 };
 
 const extractQuery = (query: Location['query'][string], defaultVal = '') =>
   (Array.isArray(query) ? query[0] : query) ?? defaultVal;
+
+const hasSearchQuery = (query: Location['query'][string]) =>
+  extractQuery(query).trim() !== '';
 
 class ResultGridImpl extends Component<ResultGridProps, State> {
   static defaultProps: Partial<ResultGridProps> = {
@@ -287,6 +299,8 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
         : undefined,
       sortBy: extractQuery(sortBy, this.props.defaultSort),
       filters: Object.assign({}, queryParams),
+      regionMatches: [],
+      probingRegions: false,
     };
   }
 
@@ -314,6 +328,9 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     const queryParams = this.props.location?.query ?? {};
     const {cursor, query, sortBy} = queryParams;
 
+    // Invalidate any in-flight region probe from the previous search.
+    this.probeToken += 1;
+
     this.setState(
       {
         cursor: extractQuery(cursor),
@@ -323,13 +340,30 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
         pageLinks: null,
         loading: true,
         error: false,
+        regionMatches: [],
+        probingRegions: false,
       },
       this.fetchData
     );
   }
 
+  /**
+   * Monotonic token used to discard results from stale region probes (e.g.
+   * when the user switches regions or searches again before probes resolve).
+   */
+  probeToken = 0;
+
   refresh() {
     this.setState({loading: true}, this.fetchData);
+  }
+
+  // Transform endpoint to cell-scoped URL if needed
+  // Currently using region.name (e.g., "us", "de") as the cell_id.
+  // In the future when there's a cell selector, we would use the actual cell ID instead.
+  cellEndpoint(cell: Cell | undefined) {
+    return this.props.isCellScoped && cell
+      ? `/_admin/cells/${cell.name}${this.props.endpoint}`
+      : this.props.endpoint;
   }
 
   fetchData = () => {
@@ -337,34 +371,41 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     this.props.api.clear();
 
     // TODO(dcramer): this should whitelist filters/sortBy/cursor/perPage
-    const queryParams = {
+    const queryParams: Record<string, any> = {
       ...this.props.defaultParams,
       ...(this.props.useQueryString ? (this.props.location?.query ?? {}) : {}),
       sortBy: this.state.sortBy,
       cursor: this.state.cursor,
     };
 
-    // Transform endpoint to cell-scoped URL if needed
-    // Currently using region.name (e.g., "us", "de") as the cell_id.
-    // In the future when there's a cell selector, we would use the actual cell ID instead.
-    const endpoint =
-      this.props.isCellScoped && this.state.cell
-        ? `/_admin/cells/${this.state.cell.name}${this.props.endpoint}`
-        : this.props.endpoint;
+    const endpoint = this.cellEndpoint(this.state.cell);
 
     this.props.api.request(endpoint, {
       method: this.props.method,
       host: this.state.cell ? this.state.cell.locality_url : undefined,
       data: queryParams,
       success: (data, _, resp) => {
+        const rows = this.props.rowsFromData?.(data, this.state.cell) ?? data;
         this.setState({
           loading: false,
           error: false,
-          rows: this.props.rowsFromData?.(data, this.state.cell) ?? data,
+          rows,
           pageLinks: resp?.getResponseHeader('Link') ?? '',
+          regionMatches: [],
         });
         if (this.props.onLoad) {
           this.props.onLoad();
+        }
+
+        // When a region-scoped search comes up empty, check whether the org
+        // lives in another data region so we can point the user there.
+        const needsRegion = this.props.isRegional || this.props.isCellScoped;
+        const isEmpty = !Array.isArray(rows) || rows.length === 0;
+        // The query lives in the URL when useQueryString is on, otherwise in
+        // component state — fall back so probes always carry the search term.
+        const query = queryParams.query ?? this.state.query;
+        if (needsRegion && isEmpty && hasSearchQuery(query)) {
+          this.probeOtherRegions({...queryParams, query});
         }
       },
       error: res => {
@@ -377,6 +418,70 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
         }
       },
     });
+  };
+
+  /**
+   * Fire a cheap (`per_page: 1`) search against every other region to find out
+   * which ones have matches for the current query. Runs only after the active
+   * region returns no results, so there is no cost on the common path.
+   */
+  probeOtherRegions = (baseParams: Record<string, any>) => {
+    const currentCell = this.state.cell;
+    const otherCells = getCells().filter(
+      c => c.locality_url !== currentCell?.locality_url
+    );
+    if (otherCells.length === 0) {
+      return;
+    }
+
+    const token = ++this.probeToken;
+    this.setState({probingRegions: true, regionMatches: []});
+
+    // per_page: 1 — we only need to know whether the region has any match, not
+    // how many. The admin customers endpoint doesn't return an X-Hits total, so
+    // we deliberately surface presence only rather than an unreliable count.
+    const probeParams = {...baseParams, cursor: '', per_page: 1};
+    const matches: Cell[] = [];
+    let remaining = otherCells.length;
+
+    const finalize = () => {
+      remaining -= 1;
+      // Ignore results from a probe that has since been superseded.
+      if (remaining > 0 || token !== this.probeToken) {
+        return;
+      }
+      matches.sort((a, b) => a.name.localeCompare(b.name));
+      this.setState({probingRegions: false, regionMatches: matches});
+    };
+
+    otherCells.forEach(cell => {
+      this.props.api.request(this.cellEndpoint(cell), {
+        method: this.props.method,
+        host: cell.locality_url,
+        data: probeParams,
+        success: (data, _, _resp) => {
+          const rows = this.props.rowsFromData?.(data, cell) ?? data;
+          if (Array.isArray(rows) && rows.length > 0) {
+            matches.push(cell);
+          }
+          finalize();
+        },
+        error: () => finalize(),
+      });
+    });
+  };
+
+  onChangeCell = (localityUrl: string | undefined) => {
+    const cell = getCells().find(c => c.locality_url === localityUrl);
+    if (cell === undefined) {
+      return;
+    }
+    // Invalidate any in-flight probe before switching regions.
+    this.probeToken += 1;
+    this.setState(
+      {cell, loading: true, regionMatches: [], probingRegions: false},
+      this.fetchData
+    );
   };
 
   // TODO(dcramer): doesnt correctly respect filters without query strings
@@ -438,6 +543,48 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
           <EmptyMessage>No results</EmptyMessage>
         </td>
       </tr>
+    );
+  }
+
+  renderRegionHint() {
+    const needsRegion = this.props.isRegional || this.props.isCellScoped;
+    if (
+      !needsRegion ||
+      this.state.loading ||
+      this.state.error ||
+      this.state.rows.length > 0
+    ) {
+      return null;
+    }
+
+    if (this.state.probingRegions) {
+      return <RegionHintNote>Checking other regions…</RegionHintNote>;
+    }
+
+    if (this.state.regionMatches.length === 0) {
+      return null;
+    }
+
+    const currentName = this.state.cell?.name ?? 'this region';
+
+    return (
+      <RegionHintAlert variant="info" showIcon>
+        <Flex align="center" gap="md" wrap="wrap">
+          <span>
+            No results in <strong>{currentName}</strong>. Found results in another data
+            region:
+          </span>
+          {this.state.regionMatches.map(cell => (
+            <Button
+              key={cell.locality_url}
+              size="xs"
+              onClick={() => this.onChangeCell(cell.locality_url)}
+            >
+              {`View in ${cell.name}`}
+            </Button>
+          ))}
+        </Flex>
+      </RegionHintAlert>
     );
   }
 
@@ -545,22 +692,19 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
                 <OverlayTrigger.Button {...triggerProps} prefix="Region" />
               )}
               value={this.state.cell ? this.state.cell.locality_url : undefined}
-              options={cells.map(c => ({
-                label: c.name,
-                value: c.locality_url,
-              }))}
-              onChange={opt => {
-                const cellOption = cells.find(c => c.locality_url === opt.value);
-                if (cellOption === undefined) {
-                  return;
-                }
-                this.setState(
-                  {
-                    cell: cellOption,
-                  },
-                  this.fetchData
+              options={cells.map(c => {
+                const hasMatch = this.state.regionMatches.some(
+                  m => m.locality_url === c.locality_url
                 );
-              }}
+                return {
+                  label: c.name,
+                  value: c.locality_url,
+                  trailingItems: hasMatch ? (
+                    <Tag variant="success">found</Tag>
+                  ) : undefined,
+                };
+              })}
+              onChange={opt => this.onChangeCell(opt.value)}
             />
           )}
           {sortOptions && sortOptions.length > 0 && (
@@ -605,6 +749,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
             ))}
           </FilterList>
         )}
+        {this.renderRegionHint()}
         {table}
         {hasPagination && this.state.pageLinks && (
           <StyledPagination
@@ -671,6 +816,16 @@ const StyledPagination = styled(Pagination)`
 const ErrorAlert = styled(Alert)`
   margin-top: ${p => p.theme.space.xs};
   margin-bottom: ${p => p.theme.space.lg};
+`;
+
+const RegionHintAlert = styled(Alert)`
+  margin-bottom: ${p => p.theme.space.md};
+`;
+
+const RegionHintNote = styled('div')`
+  margin-bottom: ${p => p.theme.space.md};
+  color: ${p => p.theme.tokens.content.secondary};
+  font-size: ${p => p.theme.font.size.sm};
 `;
 
 type ResultGridWrapperProps = Omit<ResultGridProps, 'api' | 'location' | 'navigate'> & {

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -414,7 +414,11 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
         // The query lives in the URL when useQueryString is on, otherwise in
         // component state — fall back so probes always carry the search term.
         const query = queryParams.query ?? this.state.query;
-        if (needsRegion && isEmpty && hasSearchQuery(query)) {
+        // Only probe on the first page. A paginated empty page (cursor set) does
+        // not mean the current region has no matches — it has results on earlier
+        // pages — so probing there would falsely report "no results in <region>".
+        const isFirstPage = !extractQuery(queryParams.cursor);
+        if (needsRegion && isEmpty && isFirstPage && hasSearchQuery(query)) {
           this.probeOtherRegions({...queryParams, query});
         }
       },

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -214,6 +214,18 @@ interface ResultGridProps {
    */
   panelTitle?: string;
   /**
+   * When a region-scoped search returns no results, probe every other data
+   * region for matches and surface a hint pointing the user to them.
+   *
+   * This is opt-in because most regional/cell-scoped grids (e.g. invoice or
+   * relocation search) have no meaningful notion of "the same record in another
+   * region". Only enable it where cross-region presence is useful, such as
+   * customer search.
+   *
+   * @default false
+   */
+  probeAcrossRegions?: boolean;
+  /**
    * Translates the data object from the request into rows
    */
   rowsFromData?: (data: any, cell: Cell | undefined) => any[];
@@ -273,6 +285,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     hasPagination: true,
     isCellScoped: false,
     isRegional: false,
+    probeAcrossRegions: false,
     useQueryString: true,
   };
 
@@ -409,7 +422,6 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
 
         // When a region-scoped search comes up empty, check whether the org
         // lives in another data region so we can point the user there.
-        const needsRegion = this.props.isRegional || this.props.isCellScoped;
         const isEmpty = !Array.isArray(rows) || rows.length === 0;
         // The query lives in the URL when useQueryString is on, otherwise in
         // component state — fall back so probes always carry the search term.
@@ -418,7 +430,12 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
         // not mean the current region has no matches — it has results on earlier
         // pages — so probing there would falsely report "no results in <region>".
         const isFirstPage = !extractQuery(queryParams.cursor);
-        if (needsRegion && isEmpty && isFirstPage && hasSearchQuery(query)) {
+        if (
+          this.props.probeAcrossRegions &&
+          isEmpty &&
+          isFirstPage &&
+          hasSearchQuery(query)
+        ) {
           this.probeOtherRegions({...queryParams, query});
         }
       },
@@ -561,9 +578,8 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
   }
 
   renderRegionHint() {
-    const needsRegion = this.props.isRegional || this.props.isCellScoped;
     if (
-      !needsRegion ||
+      !this.props.probeAcrossRegions ||
       this.state.loading ||
       this.state.error ||
       this.state.rows.length > 0


### PR DESCRIPTION
The `_admin` customer search is region-scoped and defaults to the first cell (US). When a customer's organization lives in a different data region, the search came back empty with no signal that the org exists elsewhere — the user had to manually switch regions one by one and guess.

When a region-scoped search comes up empty, `ResultGrid` now probes the other cells in parallel (a cheap `per_page=1` request) and surfaces any region that has matches:

- a **"found"** tag on that region in the Region dropdown, and
- a **"View in &lt;region&gt;"** hint button above the table that switches the grid to that region.

Probing only runs **after an empty result**, so there is no extra cost on the common (found-in-current-region) path. Stale probes are discarded via a monotonic token when the user searches again or switches regions.

**Presence-only by design.** The admin customers endpoint (`CustomerIndexEndpoint`) does not pass `count_hits=True`, so it returns no `X-Hits` total. Showing a real count would require a `COUNT` query per region on every empty search, so we surface *that* a region has matches rather than an unreliable number.

Frontend-only change in `static/gsAdmin/components/resultGrid.tsx` with a colocated spec (`resultGrid.spec.tsx`, 4 tests) covering: indicator appears on empty-but-found-elsewhere, clicking the hint switches region, no probe without a search query, and no hint when other regions are also empty.