### PR TITLE
ref: Removed profiling beta alert banner

### DIFF
--- a/static/app/components/profiling/billing/alerts.tsx
+++ b/static/app/components/profiling/billing/alerts.tsx
@@ -1,9 +1,5 @@
 import {OverrideOrDefault} from 'sentry/components/overrideOrDefault';
 
-export const ProfilingBetaAlertBanner = OverrideOrDefault({
-  overrideName: 'component:profiling-billing-banner',
-});
-
 export const ContinuousProfilingBillingRequirementBanner = OverrideOrDefault({
   overrideName: 'component:continuous-profiling-billing-requirement-banner',
 });

--- a/static/app/types/overrides.tsx
+++ b/static/app/types/overrides.tsx
@@ -100,10 +100,6 @@ type ReplayOnboardingAlertProps = {children: React.ReactNode};
 type ReplayOnboardingCTAProps = {children: React.ReactNode; organization: Organization};
 type ProductUnavailableCTAProps = {organization: Organization};
 
-type ProfilingBetaAlertBannerProps = {
-  organization: Organization;
-};
-
 type ContinuousProfilingBillingRequirementBannerProps = {
   project: Project;
 };
@@ -213,7 +209,6 @@ type ComponentOverrides = {
   'component:partnership-agreement': React.ComponentType<PartnershipAgreementProps>;
   'component:product-selection-availability': () => React.ComponentType<ProductSelectionAvailabilityProps>;
   'component:product-unavailable-cta': () => React.ComponentType<ProductUnavailableCTAProps>;
-  'component:profiling-billing-banner': () => React.ComponentType<ProfilingBetaAlertBannerProps>;
   'component:replay-init': React.ComponentType;
   'component:replay-list-page-header': () => React.ComponentType<ReplayListPageHeaderProps> | null;
   'component:replay-onboarding-alert': () => React.ComponentType<ReplayOnboardingAlertProps>;

--- a/static/app/views/explore/profiling/content.tsx
+++ b/static/app/views/explore/profiling/content.tsx
@@ -19,7 +19,6 @@ import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPa
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {TransactionSearchQueryBuilder} from 'sentry/components/performance/transactionSearchQueryBuilder';
-import {ProfilingBetaAlertBanner} from 'sentry/components/profiling/billing/alerts';
 import {ProfileEventsTable} from 'sentry/components/profiling/profileEventsTable';
 import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -170,7 +169,6 @@ function ProfilingContentInner() {
         }
       >
         <Stack flex={1}>
-          <ProfilingBetaAlertBanner organization={organization} />
           <ProfilingContentPageHeader />
           <ExploreBodySearch>
             <Layout.Main width="full">

--- a/static/gsApp/components/profiling/alerts.tsx
+++ b/static/gsApp/components/profiling/alerts.tsx
@@ -1,32 +1,25 @@
-import {Fragment, useCallback, useEffect, useState} from 'react';
+import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
-import {Button} from '@sentry/scraps/button';
 import {Heading, Text} from '@sentry/scraps/text';
 
-import {IconClose, IconInfo, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {getDaysSinceDate} from 'sentry/utils/getDaysSinceDate';
 import {getProfileDurationCategoryForPlatform} from 'sentry/utils/profiling/platforms';
-import {useDismissAlert} from 'sentry/utils/useDismissAlert';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-import {openAM2ProfilingUpsellModal} from 'getsentry/actionCreators/modal';
 import AddEventsCTA, {type EventType} from 'getsentry/components/addEventsCTA';
 import {StartTrialButton} from 'getsentry/components/startTrialButton';
 import UpgradeOrTrialButton from 'getsentry/components/upgradeOrTrialButton';
-import {withSubscription} from 'getsentry/components/withSubscription';
 import {useSubscription} from 'getsentry/hooks/useSubscription';
 import type {BilledDataCategoryInfo, ProductTrial, Subscription} from 'getsentry/types';
-import {PlanTier} from 'getsentry/types';
 import {displayBudgetName, getProductTrial, UsageAction} from 'getsentry/utils/billing';
 import {getCategoryInfoFromPlural} from 'getsentry/utils/dataCategory';
 import {BudgetUsage, checkBudgetUsageFor} from 'getsentry/utils/profiling';
-import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 export function makeLinkToOwnersAndBillingMembers(
   organization: Organization,
@@ -41,225 +34,6 @@ export function makeLinkToManageSubscription(
 ) {
   return `/settings/${organization.slug}/billing/overview/?referrer=${referrer}`;
 }
-
-function makeAnalyticsProps(
-  organization: AlertProps['organization'],
-  subscription: AlertProps['subscription']
-) {
-  return {
-    organization,
-    surface: 'profiling' as const,
-    planTier: subscription.planTier,
-    canSelfServe: subscription.canSelfServe,
-    channel: subscription.channel,
-    has_billing_scope: organization.access?.includes('org:billing'),
-  };
-}
-
-function trackOpenModal({organization, subscription}: AlertProps) {
-  trackGetsentryAnalytics(
-    'upgrade_now.alert.open_modal',
-    makeAnalyticsProps(organization, subscription)
-  );
-}
-
-function trackPageView({organization, subscription}: AlertProps) {
-  trackGetsentryAnalytics(
-    'upgrade_now.alert.viewed',
-    makeAnalyticsProps(organization, subscription)
-  );
-}
-
-function trackDismiss({organization, subscription}: AlertProps) {
-  trackGetsentryAnalytics(
-    'upgrade_now.alert.dismiss',
-    makeAnalyticsProps(organization, subscription)
-  );
-}
-
-function trackManageSubscriptionClicked({organization, subscription}: AlertProps) {
-  trackGetsentryAnalytics(
-    'upgrade_now.alert.manage_sub',
-    makeAnalyticsProps(organization, subscription)
-  );
-}
-
-interface AlertProps {
-  organization: Organization;
-  subscription: Subscription;
-}
-
-interface GraceAlertProps {
-  action: {
-    label: string;
-    onClick?: () => void;
-  };
-  children: React.ReactNode;
-  dismiss: undefined | (() => void);
-  disableAction?: boolean;
-  type?: 'danger';
-}
-
-function GraceAlert({children, action, dismiss, type, disableAction}: GraceAlertProps) {
-  const trailingItems = (
-    <Fragment>
-      <Button size="xs" onClick={action.onClick} disabled={disableAction}>
-        {action.label}
-      </Button>
-      {dismiss ? (
-        <StyledButton variant="link" size="sm" onClick={dismiss}>
-          <IconClose variant="primary" size="sm" />
-        </StyledButton>
-      ) : null}
-    </Fragment>
-  );
-
-  return (
-    <Alert
-      icon={type ? <IconWarning /> : dismiss ? <IconInfo /> : <IconWarning />}
-      system
-      trailingItems={trailingItems}
-      variant={type ? type : dismiss ? 'info' : 'danger'}
-    >
-      {children}
-    </Alert>
-  );
-}
-
-const StyledButton = styled(Button)`
-  color: inherit;
-`;
-
-interface GenericGraceAlertProps extends AlertProps {
-  action: (props: any) => {
-    label: string;
-    onClick?: () => void;
-    to?: string | Record<PropertyKey, unknown>;
-  };
-  children: React.ReactNode;
-  dismissKey: string;
-  dismissable: boolean;
-  disableAction?: boolean;
-}
-
-function GenericGraceAlert(props: GenericGraceAlertProps) {
-  const {dismiss, isDismissed} = useDismissAlert({
-    key: props.dismissKey,
-    expirationDays: 14,
-  });
-
-  const onDismiss = useCallback(() => {
-    dismiss();
-    trackDismiss(props);
-  }, [dismiss, props]);
-
-  useEffect(() => {
-    if (!isDismissed) {
-      trackPageView(props);
-    }
-  }, [props, isDismissed]);
-
-  if (isDismissed && props.dismissable) {
-    return null;
-  }
-
-  return (
-    <GraceAlert
-      action={props.action({dismiss: onDismiss})}
-      dismiss={props.dismissable ? onDismiss : undefined}
-      disableAction={props.disableAction}
-    >
-      {props.children}
-    </GraceAlert>
-  );
-}
-
-// Beta users on AM1 - explain that free ingestion will stop
-// Users to be told that free profiling ingestion will end post-launch;
-// and they will need to upgrade to AM2 to continue using profiling.
-function ProfilingAM1BetaUserGraceAlert({organization, subscription}: AlertProps) {
-  const userCanUpgrade = organization.access?.includes('org:billing');
-
-  return (
-    <GenericGraceAlert
-      // If ingestion has not been stopped, the alert can be dismissed
-      dismissable={false}
-      dismissKey={`${organization.id}:dismiss-profiling-beta-am1-stopped-ingestion`}
-      action={({dismiss}) => {
-        if (subscription.canSelfServe) {
-          if (userCanUpgrade) {
-            return {
-              label: t('Update Plan'),
-              onClick: () => {
-                openAM2ProfilingUpsellModal({
-                  organization,
-                  subscription,
-                  onComplete: dismiss,
-                });
-                trackOpenModal({organization, subscription});
-              },
-            };
-          }
-          return {
-            label: t('See who can update'),
-            to: makeLinkToOwnersAndBillingMembers(
-              organization,
-              'profiling_onboard_am1-alert'
-            ),
-            onClick: () => trackManageSubscriptionClicked({organization, subscription}),
-          };
-        }
-        return {
-          label: t('Manage subscription'),
-          to: makeLinkToManageSubscription(organization, 'profiling_onboard_am1-alert'),
-          onClick: () => trackManageSubscriptionClicked({organization, subscription}),
-        };
-      }}
-      organization={organization}
-      subscription={subscription}
-    >
-      {t(
-        'The profiling beta has now ended, and this organization is unable to ingest new profiles. Existing data will expire per our retention policy. To continue using profiling, update to the latest version of your plan.'
-      )}
-    </GenericGraceAlert>
-  );
-}
-
-// Wrappers switch the different alerts to show for users on the AM1 plan.
-function ProfilingAM1Alerts({organization, subscription}: AlertProps) {
-  if (organization.features.includes('profiling-beta')) {
-    return (
-      <ProfilingAM1BetaUserGraceAlert
-        organization={organization}
-        subscription={subscription}
-      />
-    );
-  }
-
-  return null;
-}
-
-interface ProfilingBetaAlertBannerProps {
-  organization: Organization;
-  subscription: Subscription;
-}
-
-function ProfilingBetaAlertBannerComponent(props: ProfilingBetaAlertBannerProps) {
-  const ComponentToShow =
-    props.subscription.planTier === PlanTier.AM1 ? ProfilingAM1Alerts : null;
-
-  return ComponentToShow ? (
-    <ComponentToShow
-      organization={props.organization}
-      subscription={props.subscription}
-    />
-  ) : null;
-}
-
-export const ProfilingBetaAlertBanner = withSubscription(
-  ProfilingBetaAlertBannerComponent,
-  {noLoader: true}
-);
 
 interface ContinuousProfilingBillingRequirementBanner {
   project: Project;

--- a/static/gsApp/registerOverrides.tsx
+++ b/static/gsApp/registerOverrides.tsx
@@ -80,10 +80,7 @@ import {trackMetric} from 'getsentry/utils/trackMetric';
 import {GsBillingCommandPaletteActions} from './components/gsBillingCommandPaletteActions';
 import {PrimaryNavigationQuotaExceeded} from './components/navBillingStatus';
 import {OpenInDiscoverBtn} from './components/openInDiscoverBtn';
-import {
-  ContinuousProfilingBillingRequirementBanner,
-  ProfilingBetaAlertBanner,
-} from './components/profiling/alerts';
+import {ContinuousProfilingBillingRequirementBanner} from './components/profiling/alerts';
 import ReplayOnboardingAlert from './components/replayOnboardingAlert';
 import {ReplaySettingsAlert} from './components/replaySettingsAlert';
 import {useButtonTracking} from './overrides/useButtonTracking';
@@ -258,7 +255,6 @@ const GETSENTRY_OVERRIDES: Partial<Overrides> = {
   'component:replay-onboarding-cta': () => ReplayOnboardingCTA,
   'component:replay-settings-alert': () => ReplaySettingsAlert,
   'component:product-unavailable-cta': () => ProductUnavailableCTA,
-  'component:profiling-billing-banner': () => ProfilingBetaAlertBanner,
   'component:product-selection-availability': () => ProductSelectionAvailability,
   'component:superuser-access-category': SuperuserAccessCategory,
   'component:superuser-warning': p => <SuperuserWarning {...p} />,


### PR DESCRIPTION
This only showed for AM1 and profiling has been out of beta for a while now, rather than migrating it to billing platform it seemed best to just delete it