### PR TITLE
fix(seer): Route project-details repo writes through seer/repos/

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesList.spec.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesList.spec.tsx
@@ -1,0 +1,167 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {RepositoryFixture} from 'sentry-fixture/repository';
+
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+
+import type {
+  ProjectSeerPreferences,
+  SeerRepoDefinition,
+} from 'sentry/components/events/autofix/types';
+
+import {AutofixRepositories} from 'getsentry/views/seerAutomation/components/projectDetails/autofixRepositoriesList';
+
+describe('AutofixRepositories (project details)', () => {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+
+  // SeerRepoDefinition carries external_id; the new repos endpoint is keyed by
+  // the internal repository id, so the component resolves external_id against
+  // the org repo list to build the `repositoryId` payload.
+  const repoA: SeerRepoDefinition = {
+    external_id: '101',
+    name: 'sentry',
+    owner: 'getsentry',
+    provider: 'github',
+    branch_name: '',
+    instructions: '',
+    branch_overrides: [],
+  };
+  const repoB: SeerRepoDefinition = {
+    external_id: '102',
+    name: 'seer',
+    owner: 'getsentry',
+    provider: 'github',
+    branch_name: '',
+    instructions: '',
+    branch_overrides: [],
+  };
+
+  const preference: ProjectSeerPreferences = {
+    repositories: [repoA, repoB],
+    automated_run_stopping_point: 'solution',
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      method: 'GET',
+      body: [
+        RepositoryFixture({id: '1', externalId: '101', name: 'getsentry/sentry'}),
+        RepositoryFixture({id: '2', externalId: '102', name: 'getsentry/seer'}),
+      ],
+    });
+  });
+
+  it('removes a repository through the seer/repos/ endpoint keyed by repositoryId', async () => {
+    const seerReposPutRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/repos/`,
+      method: 'PUT',
+      status: 204,
+    });
+
+    render(<AutofixRepositories canWrite preference={preference} project={project} />, {
+      organization,
+    });
+    renderGlobalModal();
+
+    // Disconnect the second repo (getsentry/seer); the first remains.
+    const disconnectButtons = await screen.findAllByRole('button', {
+      name: 'Disconnect Repository',
+    });
+    await userEvent.click(disconnectButtons[1]!);
+    await userEvent.click(await screen.findByRole('button', {name: 'Confirm'}));
+
+    await waitFor(() => {
+      expect(seerReposPutRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          method: 'PUT',
+          data: {
+            repos: [
+              {
+                repositoryId: 1,
+                branchName: null,
+                instructions: null,
+                branchOverrides: [],
+              },
+            ],
+          },
+        })
+      );
+    });
+  });
+
+  it('updating a working branch writes through the seer/repos/ endpoint', async () => {
+    const seerReposPutRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/repos/`,
+      method: 'PUT',
+      status: 204,
+    });
+
+    render(<AutofixRepositories canWrite preference={preference} project={project} />, {
+      organization,
+    });
+
+    // Expand the first repo row (the chevron button is labelled "Expand") to
+    // reveal the working-branch input.
+    const expandButtons = await screen.findAllByRole('button', {name: 'Expand'});
+    await userEvent.click(expandButtons[0]!);
+    await userEvent.type(screen.getByPlaceholderText('Default branch'), 'm');
+
+    await waitFor(() => {
+      expect(seerReposPutRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          method: 'PUT',
+          data: {
+            repos: [
+              {repositoryId: 1, branchName: 'm', instructions: null, branchOverrides: []},
+              {
+                repositoryId: 2,
+                branchName: null,
+                instructions: null,
+                branchOverrides: [],
+              },
+            ],
+          },
+        })
+      );
+    });
+  });
+
+  it('does not write through the legacy preferences endpoint', async () => {
+    const preferencesPost = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
+      method: 'POST',
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/repos/`,
+      method: 'PUT',
+      status: 204,
+    });
+
+    render(<AutofixRepositories canWrite preference={preference} project={project} />, {
+      organization,
+    });
+    renderGlobalModal();
+
+    const disconnectButtons = await screen.findAllByRole('button', {
+      name: 'Disconnect Repository',
+    });
+    await userEvent.click(disconnectButtons[0]!);
+    await userEvent.click(await screen.findByRole('button', {name: 'Confirm'}));
+
+    await waitFor(() => {
+      expect(preferencesPost).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesList.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesList.tsx
@@ -10,7 +10,6 @@ import {useModal} from '@sentry/scraps/modal';
 import {Heading} from '@sentry/scraps/text';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
 import type {
   ProjectSeerPreferences,
   SeerRepoDefinition,
@@ -27,6 +26,7 @@ import {
   organizationRepositoriesInfiniteOptions,
   selectUniqueRepos,
 } from 'sentry/utils/repositories/repoQueryOptions';
+import {useUpdateSeerRepos} from 'sentry/utils/seer/useUpdateSeerRepos';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {AddAutofixRepoModal} from 'sentry/views/settings/projectSeer/addAutofixRepoModal';
 
@@ -72,7 +72,7 @@ export function AutofixRepositories({canWrite, preference, project}: Props) {
   useFetchAllPages({result: repositoriesQuery});
   const {data: repositories, isFetching: isFetchingRepositories} = repositoriesQuery;
 
-  const {mutate: updateProjectSeerPreferences} = useUpdateProjectSeerPreferences(project);
+  const {mutate: updateSeerRepos} = useUpdateSeerRepos(project);
 
   const tableHeaders = getTableHeaders(organization);
 
@@ -82,20 +82,33 @@ export function AutofixRepositories({canWrite, preference, project}: Props) {
   );
 
   const handleSaveRepoList = (updatedRepositories: SeerRepoDefinition[]) => {
-    updateProjectSeerPreferences(
-      {
-        repositories: updatedRepositories,
-        automated_run_stopping_point: preference?.automated_run_stopping_point,
-        automation_handoff: preference?.automation_handoff,
-      },
-      {
-        onError: () => addErrorMessage(t('Failed to connect repositories')),
-        onSuccess: () =>
-          addSuccessMessage(
-            t('%s repo(s) connected to %s', updatedRepositories.length, project.slug)
-          ),
-      }
-    );
+    // The repos endpoint is keyed by internal repository id, so resolve each
+    // SeerRepoDefinition (which only carries external_id) against the org repo
+    // list. This sidesteps the legacy preferences endpoint's provider/owner/name
+    // lookup that 400s on GitLab repo names containing spaces. Settings such as
+    // stopping point and handoff are left untouched by this endpoint.
+    const reposPayload = updatedRepositories
+      .map(def => {
+        const orgRepo = repositories?.find(repo => repo.externalId === def.external_id);
+        if (!orgRepo) {
+          return null;
+        }
+        return {
+          repositoryId: Number(orgRepo.id),
+          branchName: def.branch_name || null,
+          instructions: def.instructions || null,
+          branchOverrides: def.branch_overrides || [],
+        };
+      })
+      .filter(repo => repo !== null);
+
+    updateSeerRepos(reposPayload, {
+      onError: () => addErrorMessage(t('Failed to connect repositories')),
+      onSuccess: () =>
+        addSuccessMessage(
+          t('%s repo(s) connected to %s', updatedRepositories.length, project.slug)
+        ),
+    });
   };
 
   const handleAddRepoClick = () => {


### PR DESCRIPTION
## Problem

The Seer **project-details "Connected Repositories" panel** in getsentry (`autofixRepositoriesList.tsx`, the gsApp twin of the sentry-side `AutofixRepositories` fixed in #117518) wrote repository add / remove / branch-edit through the legacy `POST .../seer/preferences/` endpoint via `useUpdateProjectSeerPreferences`.

That endpoint looks up repos by `(provider, owner, name, external_id)` and strips whitespace from `owner`/`name`. GitLab stores repo names with spaces, so after stripping the lookup failed and returned `{"detail": "Invalid repository"}` (HTTP 400) — the UI showed "Failed to connect repositories".

## Fix

Switch `handleSaveRepoList` to `useUpdateSeerRepos` (`PUT .../seer/repos/`), which is keyed by **internal repository id** and immune to the whitespace bug.

`SeerRepoDefinition` only carries `external_id`, while the repos endpoint needs `repositoryId`. The component already loads the org repo list (`organizationRepositoriesInfiniteOptions`), so each definition is resolved `external_id → repo.id` to build the payload:

```
{repositoryId, branchName, instructions, branchOverrides}
```

The `automated_run_stopping_point` / `automation_handoff` fields that were only re-sent to *preserve* them are dropped — the repos endpoint leaves settings untouched.

## Tests

Adds `autofixRepositoriesList.spec.tsx` (none existed before) covering remove, working-branch edit, and a guard that the legacy `POST .../seer/preferences/` is never called — all asserting `PUT .../seer/repos/` with the `repositoryId`-keyed payload.

## Stacking

Stacked on #117518 (which introduces `useUpdateSeerRepos`). Merge that first.

Refs #117489