### PR TITLE
ref(alerts): Migrate handleOwnerChange from api.request to requestPromise

### DIFF
--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -128,7 +128,7 @@ export default function AlertRulesList() {
     });
   };
 
-  const handleOwnerChange = (
+  const handleOwnerChange = async (
     projectId: string,
     rule: CombinedAlerts,
     ownerValue: string
@@ -144,16 +144,15 @@ export default function AlertRulesList() {
         : `/projects/${organization.slug}/${projectId}/rules/${rule.id}/`;
     const updatedRule = {...rule, owner: ownerValue};
 
-    api.request(endpoint, {
-      method: 'PUT',
-      data: updatedRule,
-      success: () => {
-        addMessage(t('Updated alert rule'), 'success');
-      },
-      error: () => {
-        addMessage(t('Unable to save change'), 'error');
-      },
-    });
+    try {
+      await api.requestPromise(endpoint, {
+        method: 'PUT',
+        data: updatedRule,
+      });
+      addMessage(t('Updated alert rule'), 'success');
+    } catch {
+      addMessage(t('Unable to save change'), 'error');
+    }
   };
 
   const handleDeleteRule = async (projectId: string, rule: CombinedAlerts) => {


### PR DESCRIPTION
## Summary
- Converts `handleOwnerChange` in `alertRulesList.tsx` from deprecated callback-based `api.request()` to `api.requestPromise()` with async/await and try/catch
- The `success` callback becomes the try block, and the `error` callback becomes the catch block

Fixes FRONTEND-TSC-2D
