### PR TITLE
feat(utils): Add callsite-specific sample rates to rollout comparator

### DIFF
--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -86,6 +86,16 @@ class SafeRolloutComparator:
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.should_eval_experimental"
 
     @classmethod
+    def _experiment_sample_rate_option(cls) -> str:
+        """
+        This is the sample rate for evaluating the experimental branch. When set to a value less
+        than 1.0, only that percentage of requests will actually evaluate both branches. This is
+        useful for limiting latency impact on high-traffic callsites while still collecting
+        representative metrics. Default is 1.0 (100% of requests are evaluated).
+        """
+        return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.eval_experimental_sample_rate"
+
+    @classmethod
     def _callsite_experiment_blocklist_option(cls) -> str:
         """
         This is the callsite-level experimemt rollout option. If the option value contains a
@@ -93,6 +103,15 @@ class SafeRolloutComparator:
         see one callsite in particular start throwing.) Defaults to an empty list.
         """
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.eval_callsite_blocklist"
+
+    @classmethod
+    def _callsite_mismatch_log_allowlist_option(cls) -> str:
+        """
+        Controls which callsites emit structured mismatch logs. Add a callsite identifier to enable
+        logging for it, or set the option to `["*"]` to enable logging for all callsites. Defaults
+        to an empty list (no mismatch logging).
+        """
+        return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.mismatch_log_callsite_allowlist"
 
     @classmethod
     def _callsite_use_experimental_data_allowlist_option(cls) -> str:
@@ -104,25 +123,6 @@ class SafeRolloutComparator:
         """
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.use_experimental_data_callsite_allowlist"
 
-    @classmethod
-    def _experiment_sample_rate_option(cls) -> str:
-        """
-        This is the sample rate for evaluating the experimental branch. When set to a value less
-        than 1.0, only that percentage of requests will actually evaluate both branches. This is
-        useful for limiting latency impact on high-traffic callsites while still collecting
-        representative metrics. Default is 1.0 (100% of requests are evaluated).
-        """
-        return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.eval_experimental_sample_rate"
-
-    @classmethod
-    def _callsite_mismatch_log_allowlist_option(cls) -> str:
-        """
-        Controls which callsites emit structured mismatch logs. Add a callsite identifier to enable
-        logging for it, or set the option to `["*"]` to enable logging for all callsites. Defaults
-        to an empty list (no mismatch logging).
-        """
-        return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.mismatch_log_callsite_allowlist"
-
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
 
@@ -131,6 +131,12 @@ class SafeRolloutComparator:
             type=Bool,
             default=False,
             flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+        )
+        register(
+            cls._experiment_sample_rate_option(),
+            type=Float,
+            default=1.0,
+            flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
         )
         register(
             cls._callsite_experiment_blocklist_option(),
@@ -143,12 +149,6 @@ class SafeRolloutComparator:
             type=Sequence,
             default=[],
             flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-        )
-        register(
-            cls._experiment_sample_rate_option(),
-            type=Float,
-            default=1.0,
-            flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
         )
         register(
             cls._callsite_mismatch_log_allowlist_option(),

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -209,6 +209,29 @@ class SafeRolloutComparator:
         )
 
     @classmethod
+    def _is_valid_sample_rate(cls, value: Any) -> bool:
+        """
+        Checks to make sure the sample rate is valid (a number between 0 and 1) and logs a warning
+        if it's not.
+        """
+        rate_is_numeric = (
+            isinstance(value, (int, float))
+            # Bools are technically special cases of int
+            and not isinstance(value, bool)
+        )
+        if not rate_is_numeric or not (0 <= value <= 1):
+            logger.warning(
+                "saferollout.invalid_callsite_sample_rate",
+                extra={
+                    "rollout_name": cls.ROLLOUT_NAME,
+                    "value": cls._default_serialize_for_log(value),
+                },
+            )
+            return False
+
+        return True
+
+    @classmethod
     def should_check_experiment(cls, callsite: str) -> bool:
         """
         This function controls whether you evaluate your experimental branch at all. Useful for

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -13,7 +13,7 @@ from sentry.options.manager import (
 )
 from sentry.utils import metrics
 from sentry.utils.safe import trim
-from sentry.utils.types import Bool, Float, Sequence
+from sentry.utils.types import Bool, Dict, Float, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +96,20 @@ class SafeRolloutComparator:
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.eval_experimental_sample_rate"
 
     @classmethod
+    def _callsite_sample_rate_option(cls) -> str:
+        """
+        This is a dictionary specifying a per-callsite sample rate for evaluating the experimental
+        branch. For a given callsite, when set to a value less than 1.0, only that percentage of
+        requests will actually evaluate both branches. This is useful for limiting latency impact on
+        high-traffic callsites while still collecting representative metrics. Defaults to an empty
+        dictionary.
+
+        NOTE: If a callsite is listed here, its sample rate will be used instead of the experiment-
+        wide sample rate. Any callsite which isn't included will use the experiment-wide rate.
+        """
+        return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.callsite_experiment_sample_rate"
+
+    @classmethod
     def _callsite_experiment_blocklist_option(cls) -> str:
         """
         This is the callsite-level experimemt rollout option. If the option value contains a
@@ -137,6 +151,12 @@ class SafeRolloutComparator:
             type=Float,
             default=1.0,
             flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
+        )
+        register(
+            cls._callsite_sample_rate_option(),
+            type=Dict,
+            default={},
+            flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
         )
         register(
             cls._callsite_experiment_blocklist_option(),
@@ -248,7 +268,16 @@ class SafeRolloutComparator:
         if callsite in options.get(cls._callsite_experiment_blocklist_option()):
             return False
 
-        sample_rate = options.get(cls._experiment_sample_rate_option())
+        callsite_sample_rates = options.get(cls._callsite_sample_rate_option())  # Defaults to {}
+        if callsite in callsite_sample_rates and cls._is_valid_sample_rate(
+            callsite_sample_rates[callsite]
+        ):
+            sample_rate = callsite_sample_rates[callsite]
+        else:
+            # We don't need to validate this value, because options automator does it for us - it
+            # just can't validate values inside a dictionary, hence the check above
+            sample_rate = options.get(cls._experiment_sample_rate_option())  # Defaults to 1.0
+
         return random.random() < sample_rate
 
     @classmethod

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from sentry.options import all as all_options
 from sentry.testutils.helpers import override_options
+from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils.rollout import SafeRolloutComparator
 
 
@@ -12,6 +13,7 @@ class TestRolloutComparator(SafeRolloutComparator):
 
 TEST_SHOULD_RUN_EXPERIMENT_OPTION = TestRolloutComparator._should_run_experiment_option()
 TEST_EXPERIMENT_SAMPLE_RATE_OPTION = TestRolloutComparator._experiment_sample_rate_option()
+TEST_CALLSITE_SAMPLE_RATE_OPTION = TestRolloutComparator._callsite_sample_rate_option()
 TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION = (
     TestRolloutComparator._callsite_experiment_blocklist_option()
 )
@@ -23,6 +25,7 @@ TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION = (
 )
 
 
+@django_db_all
 class SafeRolloutComparatorTestCase(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -34,6 +37,7 @@ class SafeRolloutComparatorTestCase(TestCase):
 
         assert TEST_SHOULD_RUN_EXPERIMENT_OPTION in option_names
         assert TEST_EXPERIMENT_SAMPLE_RATE_OPTION in option_names
+        assert TEST_CALLSITE_SAMPLE_RATE_OPTION in option_names
         assert TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION in option_names
         assert TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION in option_names
         assert TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION in option_names
@@ -80,6 +84,40 @@ class SafeRolloutComparatorTestCase(TestCase):
 
             with patch("sentry.utils.rollout.random.random", return_value=0.49999):
                 assert TestRolloutComparator.should_check_experiment("test_just_under") is True
+
+    def test_callsite_sample_rate(self) -> None:
+        with override_options(
+            {
+                TEST_SHOULD_RUN_EXPERIMENT_OPTION: True,
+                TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 0.25,
+                TEST_CALLSITE_SAMPLE_RATE_OPTION: {
+                    "dogs_are_great": 0.5,
+                    "all_dogs_are_good": True,  # invalid value
+                    "roll_over": "good_dog",  # invalid value
+                },
+                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
+            }
+        ):
+            # Value which passes both the general and valid callsite-specific rates
+            with patch("sentry.utils.rollout.random.random", return_value=0.1):
+                assert TestRolloutComparator.should_check_experiment("dogs_are_great") is True
+                assert TestRolloutComparator.should_check_experiment("adopt_dont_shop") is True
+            # Value which passes the `dogs_are_great` rate but not the general one
+            with patch("sentry.utils.rollout.random.random", return_value=0.3):
+                assert TestRolloutComparator.should_check_experiment("dogs_are_great") is True
+                assert TestRolloutComparator.should_check_experiment("adopt_dont_shop") is False
+            # Value which fails both the general and valid callsite-specific rates
+            with patch("sentry.utils.rollout.random.random", return_value=0.75):
+                assert TestRolloutComparator.should_check_experiment("dogs_are_great") is False
+                assert TestRolloutComparator.should_check_experiment("adopt_dont_shop") is False
+            # Value which passes the general rate, applied to callsites with invalid values
+            with patch("sentry.utils.rollout.random.random", return_value=0.1):
+                assert TestRolloutComparator.should_check_experiment("all_dogs_are_good") is True
+                assert TestRolloutComparator.should_check_experiment("roll_over") is True
+            # Value which fails the general rate, applied to callsites with invalid values
+            with patch("sentry.utils.rollout.random.random", return_value=0.3):
+                assert TestRolloutComparator.should_check_experiment("all_dogs_are_good") is False
+                assert TestRolloutComparator.should_check_experiment("roll_over") is False
 
     def test_eval_experimental_respects_blocklist(self) -> None:
         with override_options(

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -12,14 +12,14 @@ class TestRolloutComparator(SafeRolloutComparator):
 
 TEST_SHOULD_RUN_EXPERIMENT_OPTION = TestRolloutComparator._should_run_experiment_option()
 TEST_EXPERIMENT_SAMPLE_RATE_OPTION = TestRolloutComparator._experiment_sample_rate_option()
-TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION = (
-    TestRolloutComparator._callsite_use_experimental_data_allowlist_option()
-)
 TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION = (
     TestRolloutComparator._callsite_experiment_blocklist_option()
 )
 TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION = (
     TestRolloutComparator._callsite_mismatch_log_allowlist_option()
+)
+TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION = (
+    TestRolloutComparator._callsite_use_experimental_data_allowlist_option()
 )
 
 
@@ -33,10 +33,10 @@ class SafeRolloutComparatorTestCase(TestCase):
         option_names = [o.name for o in all_options()]
 
         assert TEST_SHOULD_RUN_EXPERIMENT_OPTION in option_names
-        assert TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION in option_names
-        assert TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION in option_names
         assert TEST_EXPERIMENT_SAMPLE_RATE_OPTION in option_names
+        assert TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION in option_names
         assert TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION in option_names
+        assert TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION in option_names
 
     def test_return_as_expected(self) -> None:
         with override_options({TEST_SHOULD_RUN_EXPERIMENT_OPTION: False}):
@@ -45,8 +45,8 @@ class SafeRolloutComparatorTestCase(TestCase):
         with override_options(
             {
                 TEST_SHOULD_RUN_EXPERIMENT_OPTION: True,
-                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: ["test_blocked"],
                 TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 1.0,
+                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: ["test_blocked"],
             }
         ):
             assert TestRolloutComparator.should_check_experiment("test_2") is True
@@ -54,8 +54,8 @@ class SafeRolloutComparatorTestCase(TestCase):
 
         with override_options(
             {
-                TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: ["test_allowed"],
                 TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION: [],
+                TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: ["test_allowed"],
             }
         ):
             assert TestRolloutComparator.check_and_choose("ctl", "exp", "test_3") == "ctl"
@@ -65,8 +65,8 @@ class SafeRolloutComparatorTestCase(TestCase):
         with override_options(
             {
                 TEST_SHOULD_RUN_EXPERIMENT_OPTION: True,
-                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
                 TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 0.5,
+                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
             }
         ):
             with patch("sentry.utils.rollout.random.random", return_value=0.3):
@@ -85,8 +85,8 @@ class SafeRolloutComparatorTestCase(TestCase):
         with override_options(
             {
                 TEST_SHOULD_RUN_EXPERIMENT_OPTION: True,
-                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: ["test_blocked"],
                 TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 1.0,
+                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: ["test_blocked"],
             }
         ):
             # Even with 100% sample rate, blocklisted callsites should be blocked
@@ -98,8 +98,8 @@ class SafeRolloutComparatorTestCase(TestCase):
         with override_options(
             {
                 TEST_SHOULD_RUN_EXPERIMENT_OPTION: False,
-                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
                 TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 1.0,
+                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
             }
         ):
             assert TestRolloutComparator.should_check_experiment("test_disabled") is False
@@ -126,8 +126,8 @@ class SafeRolloutComparatorTestCase(TestCase):
         with override_options(
             {
                 TEST_SHOULD_RUN_EXPERIMENT_OPTION: True,
-                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
                 TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 1.0,
+                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
             }
         ):
             TestRolloutComparator.check_and_choose_with_timings(


### PR DESCRIPTION
This adds the ability to set different sample rates per callsite to the rollout comparator. Any callsites that aren't specified in the corresponding option value fall back to using the existing, experiment-wide option.

(I also used this as an opportunity to move the overall sample rate option to live next to the overall enablement option, so that all the overall options are grouped together, and all of the callsite-specific options are grouped together. Unfortunately, git is not smart and shows this as all of the options name methods getting modified, when really what happened to them is the same as what happened in `__init_subclass__` - one option moving up, and a new option below it. The same fix was made in tests.)