### PR TITLE
ref(spans): Compare span-first and existing detector results

### DIFF
--- a/src/sentry/issue_detection/detectors/span_first/run_detectors.py
+++ b/src/sentry/issue_detection/detectors/span_first/run_detectors.py
@@ -1,13 +1,76 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Any
 
+from sentry.issue_detection.detectors.span_first.base import SpanFirstDetector
+from sentry.issue_detection.detectors.span_first.slow_db_query_detector import (
+    SpanFirstSlowDBQueryDetector,
+)
+from sentry.issue_detection.detectors.span_first.span_first_utils import (
+    SpanFirstDetectorsRolloutController,
+)
+from sentry.issue_detection.performance_detection import get_detection_settings
 from sentry.issue_detection.performance_problem import PerformanceProblem
 from sentry.issue_detection.types import StandaloneSpan
+from sentry.models.project import Project
+from sentry.utils.rollout import SourceOfTruth
 
 logger = logging.getLogger(__name__)
+
+SpanFirstDetectorClass = type[SpanFirstDetector]
+
+# Add new span-first detector types here to include them in the experiment
+SPAN_FIRST_DETECTORS: list[SpanFirstDetectorClass] = [
+    SpanFirstSlowDBQueryDetector,
+]
+
+
+# Bucket detectors by the slug of the grouptype they produce
+SPAN_FIRST_DETECTORS_BY_GROUPTYPE: dict[str, list[SpanFirstDetectorClass]] = {}
+for detector_class in SPAN_FIRST_DETECTORS:
+    SPAN_FIRST_DETECTORS_BY_GROUPTYPE.setdefault(detector_class.grouptype.slug, []).append(
+        detector_class
+    )
+
+
+def run_span_first_detectors(
+    grouptypes: Sequence[str],
+    segment_span: StandaloneSpan,
+    spans: Sequence[StandaloneSpan],
+    project: Project,
+) -> dict[str, list[PerformanceProblem]]:
+    """
+    For each of grouptype slugs in `grouptypes`, run the corresponding span-first detectors, and
+    return the resulting problems bucketed by slug. Detectors that share a grouptype (e.g. N+1 and
+    MN+1, or SQL Injection and Query Injection) accumulate into the same bucket -- so callers should
+    sample/gate by grouptype, not by detector class. Detectors that fail are logged and excluded
+    from the result.
+
+    The caller is responsible for deciding which grouptypes to evaluate (typically via
+    `SpanFirstDetectorsRolloutController.should_check_experiment`). This function does no sampling
+    of its own.
+    """
+    detection_settings = get_detection_settings(project)
+    span_first_problems: dict[str, list[PerformanceProblem]] = {}
+
+    for grouptype in grouptypes:
+        detector_classes = SPAN_FIRST_DETECTORS_BY_GROUPTYPE.get(grouptype, [])
+
+        for detector_class in detector_classes:
+            try:
+                detector_settings = detection_settings[detector_class.type]
+                problems = run_detector(detector_class, detector_settings, segment_span, spans)
+            except Exception:
+                logger.exception(
+                    "span_first_detectors.detector_run_failed",
+                    extra={"detector": detector_class.__name__},
+                )
+            else:
+                span_first_problems.setdefault(grouptype, []).extend(problems)
+
+    return span_first_problems
 
 
 def run_detector(
@@ -32,3 +95,51 @@ def run_detector(
     detector.on_complete()
 
     return list(detector.stored_problems.values())
+
+
+def compare_span_first_problems_to_control_data(
+    span_first_problems_by_grouptype: dict[str, list[PerformanceProblem]],
+    all_control_problems: Sequence[PerformanceProblem],
+    get_source_of_truth: Callable[[str], SourceOfTruth],
+) -> None:
+    """
+    For each grouptype slug present in `span_first_problems_by_grouptype`, compare fingerprints
+    against the matching subset of control-pipeline problems via the rollout controller's `compare`
+    method. Emits a metric tagged with the grouptype slug, whether the results match, and which
+    result is being used (if any). Also optionally logs mismatches, depending on controller options.
+
+    `get_source_of_truth` is called per grouptype and should return whatever the caller intends to
+    do with that grouptype's problems downstream -- e.g. "both" if the caller will emit both control
+    and span-first occurrences, "control" if only control gets emitted, etc. The value is passed
+    straight through to the comparator's metric/log tag.
+
+    Grouptypes absent from the span-first problem dict (e.g. because the only detectors mapping to
+    them were disabled or threw during `run_span_first_detectors`) are skipped.
+    """
+    # Bucket control problems by grouptype slug to match the format in which we have the span-first
+    # problems
+    control_problems_by_grouptype: dict[str, list[PerformanceProblem]] = {}
+    for problem in all_control_problems:
+        control_problems_by_grouptype.setdefault(problem.type.slug, []).append(problem)
+
+    for grouptype, span_first_problems in span_first_problems_by_grouptype.items():
+        control_problems = control_problems_by_grouptype.get(grouptype) or []
+
+        # TODO: Fingerprint parity proves the detectors agree on which problems exist and how
+        # they're grouped, but doesn't validate the rest of the `PerformanceProblem` payload
+        # (`evidence_data`, `desc`, `offender_span_ids`, `parent_span_ids`, `cause_span_ids`,
+        # `evidence_display`). For most detectors these are derived from the same source data as the
+        # fingerprint, so divergence is unlikely -- but unlikely isn't impossible, and a mismatch
+        # there would mean end users see different issue details despite identical fingerprints.
+        # Once the fingerprint metric shows that the fingerprints are reliably matching, extend the
+        # comparison to cover these fields before cutover.
+        control_fingerprints = {problem.fingerprint for problem in control_problems}
+        span_first_fingerprints = {problem.fingerprint for problem in span_first_problems}
+
+        SpanFirstDetectorsRolloutController.compare(
+            callsite=grouptype,
+            control_data=control_fingerprints,
+            experimental_data=span_first_fingerprints,
+            is_experimental_data_nullish=not bool(span_first_fingerprints),
+            source_of_truth=get_source_of_truth(grouptype),
+        )

--- a/src/sentry/issue_detection/detectors/span_first/span_first_utils.py
+++ b/src/sentry/issue_detection/detectors/span_first/span_first_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from sentry_conventions.attributes import ATTRIBUTE_NAMES
@@ -7,11 +9,27 @@ from sentry.issue_detection.performance_detection import get_detection_settings
 from sentry.issue_detection.types import StandaloneSpan
 from sentry.models.project import Project
 from sentry.spans.consumers.process_segments.types import attribute_value
+from sentry.utils.rollout import SafeRolloutComparator
 
 # We truncate evidence values to prevent hitting Kafka's broken message size limit.
 # TODO: A better solution would be to audit the usage of `description`, `evidence_data` and
 # `evidence_display` and deduplicate those keys. Right now they are nearly identical.
 DEFAULT_MAX_EVIDENCE_VALUE_LENGTH = 10_000
+
+
+# Utility used to control sampling, metrics, comparison, and mismatch logging during rollout.
+#
+# Note: In all options relating to callsites, use `<detector_class>.grouptype.slug`. This means that
+# detectors that share a grouptype (N+1 / MN+1 and SQL / Query injection) run as a unit, which keeps
+# the parity comparison from spuriously flagging mismatches when one sibling is sampled and the
+# other isn't.
+class SpanFirstDetectorsRolloutController(SafeRolloutComparator):
+    ROLLOUT_NAME = "span_first_detectors"
+
+
+SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION = (
+    SpanFirstDetectorsRolloutController._should_run_experiment_option()
+)
 
 
 def get_settings_for_detector(

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -330,6 +330,7 @@ def _detect_performance_problems(
         logger.exception("span_first_detector_test.error")
         return
 
+    # This flag is set in Relay (though at the moment it's not turned on)
     if not segment_span.get("_performance_issues_spans"):
         return
 

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -291,7 +291,7 @@ def _detect_performance_problems(
         return
 
     event_data = build_shim_event_data(segment_span, spans)
-    performance_problems = detect_performance_problems(event_data, project, standalone=True)
+    all_control_problems = detect_performance_problems(event_data, project, standalone=True)
 
     if not segment_span.get("_performance_issues_spans"):
         return
@@ -303,7 +303,7 @@ def _detect_performance_problems(
     event_data["spans"] = []
     event_data["timestamp"] = event_data["datetime"]
 
-    for problem in performance_problems:
+    for problem in all_control_problems:
         problem.type = PerformanceStreamedSpansGroupTypeExperimental
         problem.fingerprint = (
             f"{problem.fingerprint}-{PerformanceStreamedSpansGroupTypeExperimental.type_id}"

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -17,6 +17,15 @@ from sentry.dynamic_sampling.rules.helpers.latest_releases import record_latest_
 from sentry.event_manager import INSIGHT_MODULE_TO_PROJECT_FLAG_NAME
 from sentry.insights import FilterSpan
 from sentry.insights import modules as insights_modules
+from sentry.issue_detection.detectors.span_first.run_detectors import (
+    SPAN_FIRST_DETECTORS_BY_GROUPTYPE,
+    compare_span_first_problems_to_control_data,
+    run_span_first_detectors,
+)
+from sentry.issue_detection.detectors.span_first.span_first_utils import (
+    SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION,
+    SpanFirstDetectorsRolloutController,
+)
 from sentry.issue_detection.performance_detection import detect_performance_problems
 from sentry.issues.grouptype import PerformanceStreamedSpansGroupTypeExperimental
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -287,11 +296,39 @@ def _create_models(
 def _detect_performance_problems(
     segment_span: CompatibleSpan, spans: list[CompatibleSpan], project: Project
 ) -> None:
-    if not options.get("spans.process-segments.detect-performance-problems.enable"):
+    if not options.get(SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION):
         return
 
-    event_data = build_shim_event_data(segment_span, spans)
-    all_control_problems = detect_performance_problems(event_data, project, standalone=True)
+    # Sample once per segment, up front: if no grouptypes are selected, neither the existing nor the
+    # span-first detectors will run.pipeline runs. Since for now the existing detection is only
+    # being run for the sake of comparison testing, gating it together with the experimental side
+    # avoids paying its cost on segments we won't compare.
+    sampled_grouptypes = [
+        grouptype_slug
+        for grouptype_slug in SPAN_FIRST_DETECTORS_BY_GROUPTYPE
+        if SpanFirstDetectorsRolloutController.should_check_experiment(grouptype_slug)
+    ]
+    if not sampled_grouptypes:
+        return
+
+    try:
+        event_data = build_shim_event_data(segment_span, spans)
+        all_control_problems = detect_performance_problems(event_data, project, standalone=True)
+
+        span_first_problems_by_grouptype = run_span_first_detectors(
+            sampled_grouptypes, segment_span, spans, project
+        )
+
+        compare_span_first_problems_to_control_data(
+            span_first_problems_by_grouptype,
+            all_control_problems,
+            get_source_of_truth=lambda _: (
+                "control" if segment_span.get("_performance_issues_spans") else "neither"
+            ),
+        )
+    except Exception:
+        logger.exception("span_first_detector_test.error")
+        return
 
     if not segment_span.get("_performance_issues_spans"):
         return

--- a/tests/sentry/issue_detection/span_first/test_run_detectors.py
+++ b/tests/sentry/issue_detection/span_first/test_run_detectors.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from sentry.issue_detection.base import DetectorType
+from sentry.issue_detection.detectors.span_first.base import SpanFirstDetector
+from sentry.issue_detection.detectors.span_first.run_detectors import (
+    compare_span_first_problems_to_control_data,
+    run_detector,
+    run_span_first_detectors,
+)
+from sentry.issue_detection.detectors.span_first.span_first_utils import (
+    SpanFirstDetectorsRolloutController,
+)
+from sentry.issue_detection.performance_problem import PerformanceProblem
+from sentry.issue_detection.types import StandaloneSpan
+from sentry.issues.grouptype import (
+    GroupType,
+    PerformanceNPlusOneGroupType,
+    PerformanceSlowDBQueryGroupType,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.issue_detection.segment_span_generators import (
+    create_child_span,
+    create_segment,
+)
+
+SLOW_DB_GROUPTYPE = PerformanceSlowDBQueryGroupType
+N_PLUS_ONE_GROUPTYPE = PerformanceNPlusOneGroupType
+SLOW_DB_SLUG = SLOW_DB_GROUPTYPE.slug
+N_PLUS_ONE_SLUG = N_PLUS_ONE_GROUPTYPE.slug
+
+
+def make_problem(fingerprint: str, grouptype: type[GroupType]) -> PerformanceProblem:
+    return PerformanceProblem(
+        fingerprint=fingerprint,
+        op="db",
+        desc="test problem",
+        type=grouptype,
+        parent_span_ids=[],
+        cause_span_ids=[],
+        offender_span_ids=[],
+        evidence_data={},
+        evidence_display=[],
+    )
+
+
+class MockSlowDBDetector(SpanFirstDetector):
+    type = DetectorType.SLOW_DB_QUERY
+    grouptype = SLOW_DB_GROUPTYPE
+
+    def visit_span(self, span: StandaloneSpan) -> None:
+        # No-op: this stub emits its problem in `on_complete`.
+        pass
+
+    def on_complete(self) -> None:
+        problem = make_problem("slow-db-fingerprint", SLOW_DB_GROUPTYPE)
+        self.stored_problems[problem.fingerprint] = problem
+
+
+class MockNPlusOneDetector(SpanFirstDetector):
+    type = DetectorType.N_PLUS_ONE_DB_QUERIES
+    grouptype = N_PLUS_ONE_GROUPTYPE
+
+    def visit_span(self, span: StandaloneSpan) -> None:
+        # No-op: this stub emits its problem in `on_complete`.
+        pass
+
+    def on_complete(self) -> None:
+        problem = make_problem("n-plus-one-fingerprint", N_PLUS_ONE_GROUPTYPE)
+        self.stored_problems[problem.fingerprint] = problem
+
+
+@pytest.mark.django_db
+class RunDetectorTest(TestCase):
+    def test_returns_problems_emitted_by_the_detector(self) -> None:
+        segment = create_segment([create_child_span(op="db", duration=1001)])
+
+        result = run_detector(MockSlowDBDetector, {"detection_enabled": True}, segment[0], segment)
+
+        assert len(result) == 1
+        assert result[0].fingerprint == "slow-db-fingerprint"
+
+    def test_returns_empty_list_when_creation_is_disallowed(self) -> None:
+        segment = create_segment([create_child_span(op="db", duration=1001)])
+
+        result = run_detector(MockSlowDBDetector, {"detection_enabled": False}, segment[0], segment)
+
+        assert len(result) == 0
+
+
+@pytest.mark.django_db
+class RunSpanFirstDetectorsTest(TestCase):
+    def test_returns_problems_bucketed_by_grouptype_slug(self) -> None:
+        # Each of our two mock detectors unconditionally creates a problem, so we don't need real
+        # data here
+        dummy_segment = create_segment([])
+
+        # Replace the registered detectors with stubs producing two different group types, so we
+        # can verify the bucketing without depending on whichever real detectors are wired up.
+        mock_registry = {
+            SLOW_DB_SLUG: [MockSlowDBDetector],
+            N_PLUS_ONE_SLUG: [MockNPlusOneDetector],
+        }
+        with patch.dict(
+            "sentry.issue_detection.detectors.span_first.run_detectors.SPAN_FIRST_DETECTORS_BY_GROUPTYPE",
+            mock_registry,
+            clear=True,
+        ):
+            span_first_problems_by_grouptype = run_span_first_detectors(
+                [SLOW_DB_SLUG, N_PLUS_ONE_SLUG],
+                dummy_segment[0],
+                dummy_segment,
+                self.project,
+            )
+
+        assert set(span_first_problems_by_grouptype.keys()) == {SLOW_DB_SLUG, N_PLUS_ONE_SLUG}
+
+        slow_db_problems = span_first_problems_by_grouptype[SLOW_DB_SLUG]
+        n_plus_one_problems = span_first_problems_by_grouptype[N_PLUS_ONE_SLUG]
+        assert [p.fingerprint for p in slow_db_problems] == ["slow-db-fingerprint"]
+        assert [p.fingerprint for p in n_plus_one_problems] == ["n-plus-one-fingerprint"]
+
+
+class CompareSpanFirstProblemsToControlDataTest(TestCase):
+    def test_compares_fingerprints_for_each_grouptype(self) -> None:
+        span_first_problems_by_grouptype = {
+            SLOW_DB_SLUG: [
+                make_problem("slow-db-fingerprint", SLOW_DB_GROUPTYPE),
+                make_problem("span-first-slow-db-fingerprint", SLOW_DB_GROUPTYPE),
+            ],
+            N_PLUS_ONE_SLUG: [
+                make_problem("n-plus-one-fingerprint", N_PLUS_ONE_GROUPTYPE),
+                make_problem("span-first-n-plus-one-fingerprint", N_PLUS_ONE_GROUPTYPE),
+            ],
+        }
+        control_problems = [
+            # One slow DB problem which matches the span-first set, one which doesn't
+            make_problem("slow-db-fingerprint", SLOW_DB_GROUPTYPE),
+            make_problem("control-slow-db-fingerprint", SLOW_DB_GROUPTYPE),
+            # One N+1 problem which matches the span-first set, one which doesn't
+            make_problem("n-plus-one-fingerprint", N_PLUS_ONE_GROUPTYPE),
+            make_problem("control-n-plus-one-fingerprint", N_PLUS_ONE_GROUPTYPE),
+        ]
+
+        with patch.object(SpanFirstDetectorsRolloutController, "compare") as mock_compare:
+            compare_span_first_problems_to_control_data(
+                span_first_problems_by_grouptype,
+                control_problems,
+                get_source_of_truth=lambda _: "neither",
+            )
+
+            mock_compare.assert_any_call(
+                callsite=SLOW_DB_SLUG,
+                control_data={"slow-db-fingerprint", "control-slow-db-fingerprint"},
+                experimental_data={"slow-db-fingerprint", "span-first-slow-db-fingerprint"},
+                is_experimental_data_nullish=False,
+                source_of_truth="neither",
+            )
+            mock_compare.assert_any_call(
+                callsite=N_PLUS_ONE_SLUG,
+                control_data={"n-plus-one-fingerprint", "control-n-plus-one-fingerprint"},
+                experimental_data={"n-plus-one-fingerprint", "span-first-n-plus-one-fingerprint"},
+                is_experimental_data_nullish=False,
+                source_of_truth="neither",
+            )

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -5,6 +5,10 @@ from unittest import mock
 
 import pytest
 
+from sentry.issue_detection.detectors.span_first.span_first_utils import (
+    SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION,
+    SpanFirstDetectorsRolloutController,
+)
 from sentry.issues.grouptype import PerformanceStreamedSpansGroupTypeExperimental
 from sentry.models.environment import Environment
 from sentry.models.release import Release
@@ -153,13 +157,18 @@ class TestSpansTask(TestCase):
             name="a" * 64,
         )
 
-    @override_options({"spans.process-segments.detect-performance-problems.enable": True})
+    @override_options({SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION: True})
     @mock.patch("sentry.issues.ingest.send_issue_occurrence_to_eventstream")
     def test_n_plus_one_issue_detection(self, mock_eventstream: mock.MagicMock) -> None:
         spans = self.generate_n_plus_one_spans()
-        with mock.patch(
-            "sentry.issues.grouptype.PerformanceStreamedSpansGroupTypeExperimental.released",
-            return_value=True,
+        with (
+            mock.patch(
+                "sentry.issues.grouptype.PerformanceStreamedSpansGroupTypeExperimental.released",
+                return_value=True,
+            ),
+            mock.patch.object(
+                SpanFirstDetectorsRolloutController, "should_check_experiment", return_value=True
+            ),
         ):
             process_segment(spans)
 
@@ -173,7 +182,7 @@ class TestSpansTask(TestCase):
         ]
         assert performance_problem.type == PerformanceStreamedSpansGroupTypeExperimental
 
-    @override_options({"spans.process-segments.detect-performance-problems.enable": True})
+    @override_options({SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION: True})
     @mock.patch("sentry.issues.ingest.send_issue_occurrence_to_eventstream")
     @pytest.mark.xfail(reason="batches without segment spans are not supported yet")
     def test_n_plus_one_issue_detection_without_segment_span(
@@ -216,10 +225,15 @@ class TestSpansTask(TestCase):
         repeating_spans = [repeating_span() for _ in range(7)]
         spans = [segment_span, child_span, cause_span] + repeating_spans
 
-        with mock.patch(
-            "sentry.issues.grouptype.PerformanceStreamedSpansGroupTypeExperimental.released"
-        ) as mock_released:
-            mock_released.return_value = True
+        with (
+            mock.patch(
+                "sentry.issues.grouptype.PerformanceStreamedSpansGroupTypeExperimental.released",
+                return_value=True,
+            ),
+            mock.patch.object(
+                SpanFirstDetectorsRolloutController, "should_check_experiment", return_value=True
+            ),
+        ):
             process_segment(spans)
 
         performance_problem = mock_eventstream.call_args[0][1]


### PR DESCRIPTION
This adds machinery to run new span-first issue detectors alongside existing issue detectors and compare the results. Enablement, sampling, and comparison are handled by the safe-rollout comparator.

In order to run the existing detectors (which are event-based) on spans from the span buffer, this relies on the [`build_shim_event_data` helper](https://github.com/getsentry/sentry/blob/a56e325a8bba23f7c3ec083f112ed0ad675ed180/src/sentry/spans/consumers/process_segments/shim.py#L63). This isn't a change - the code to call the helper and run the existing detectors is already included in `_detect_performance_problems` - but as far as I know it hasn't been enabled in production before. Fortunately, we're not planning to save the results it helps generate, just log cases (if any) where there's a deviance from the results of the new span-first detectors. IOW, enabling it won't put any of our existing occurrence or issue data in any danger of getting contaminated in case either side of our comparison is initially producing wonky data. For further peace of mind, the entire business is also now wrapped in a try-catch.

So far there's only one detector to test (PR for that [here](https://github.com/getsentry/sentry/pull/117551)) but more have been converted - have been waiting to PR them until we have this first one running as a proof of concept.

h/t to Claude for his help with this