### PR TITLE
fix(search): Prevent recent filter row panel spacing

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -224,7 +224,10 @@ function FilterKeyMenuContent<T extends SelectOptionOrSectionWithKey<string>>({
     <Fragment>
       {enableAISearch ? <AskSeer state={state} /> : null}
       {showRecentFilters ? (
-        <RecentFiltersPane>
+        <RecentFiltersPane
+          // PanelBody applies legacy textStyles to plain ul elements; opt this layout row out.
+          data-panel-body-text-styles="ignore"
+        >
           {recentFilters.map(filter => (
             <RecentSearchFilterOption
               key={getKeyName(filter.key)}

--- a/static/app/styles/text.tsx
+++ b/static/app/styles/text.tsx
@@ -13,7 +13,13 @@ export const textStyles = () => css`
   h6,
   p,
   /* Exclude ol/ul elements inside interactive selectors/menus */
-  ul:not([role='listbox'], [role='grid'], [role='menu']),
+  /* data-panel-body-text-styles lets layout-only lists opt out of PanelBody spacing. */
+  ul:not(
+    [role='listbox'],
+    [role='grid'],
+    [role='menu'],
+    [data-panel-body-text-styles='ignore']
+  ),
   ol:not([role='listbox'], [role='grid'], [role='menu']),
   table,
   dl,


### PR DESCRIPTION
Allow layout-only lists to opt out of `PanelBody`'s legacy content spacing so search query builder recent filter rows stay flush when rendered in panels.

**Before:**
<img width="850" height="182" alt="Screenshot 2026-06-15 at 07 41 17" src="https://github.com/user-attachments/assets/ecd111b9-6482-4709-af12-b45c4708a5d7" />

**After:**
<img width="848" height="155" alt="Screenshot 2026-06-15 at 07 44 15" src="https://github.com/user-attachments/assets/0f7e2a32-e09c-4a55-94bc-99338d277646" />
