### PR TITLE
fix(dynamic-sampling): Rename project_id in logs to avoid built-in column collision

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -116,7 +116,7 @@ def compare_rebalanced_projects_with_cache(
             "dynamic_sampling.per_org.project_balancing_comparison",
             extra={
                 "org_id": config.organization.id,
-                "project_id": project_id,
+                "dynamic_sampling_project_id": project_id,
                 "generic_metrics_sample_rate": generic_metrics_sample_rate,
                 "eap_sample_rate": eap_sample_rate,
                 "relative_deviation": get_relative_deviation(
@@ -149,27 +149,27 @@ def _emit_project_balancing_debug_metrics(
     eap_volume_without_extrapolation: float | None,
 ) -> None:
     tags = {"org_id": str(org_id), "dynamic_sampling_project_id": str(project_id)}
-    metrics.gauge(
+    metrics.distribution(
         f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_sample_rate",
         eap_sample_rate,
         sample_rate=1.0,
         tags=tags,
     )
     if generic_metrics_sample_rate is not None:
-        metrics.gauge(
+        metrics.distribution(
             f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.generic_metrics_sample_rate",
             generic_metrics_sample_rate,
             sample_rate=1.0,
             tags=tags,
         )
-    metrics.gauge(
+    metrics.distribution(
         f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_volume",
         eap_volume,
         sample_rate=1.0,
         tags=tags,
     )
     if eap_volume_without_extrapolation is not None:
-        metrics.gauge(
+        metrics.distribution(
             f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_volume_without_extrapolation",
             eap_volume_without_extrapolation,
             sample_rate=1.0,
@@ -294,7 +294,7 @@ def compare_rebalanced_transactions_with_cache(
             "dynamic_sampling.per_org.transaction_balancing_implicit_comparison",
             extra={
                 "org_id": config.organization.id,
-                "project_id": project_id,
+                "dynamic_sampling_project_id": project_id,
                 "generic_metrics_implicit_rate": generic_metrics_implicit_rate,
                 "eap_implicit_rate": eap_implicit_rate,
                 "relative_deviation": get_relative_deviation(
@@ -315,7 +315,7 @@ def compare_rebalanced_transactions_with_cache(
                 "dynamic_sampling.per_org.transaction_balancing_comparison",
                 extra={
                     "org_id": config.organization.id,
-                    "project_id": project_id,
+                    "dynamic_sampling_project_id": project_id,
                     "transaction": transaction,
                     "generic_metrics_sample_rate": generic_metrics_rate,
                     "eap_sample_rate": item.new_sample_rate,

--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -102,7 +102,7 @@ class ProjectBalancingCalculationsTest(TestCase):
         assert [call.kwargs["extra"] for call in logger_info.call_args_list] == [
             {
                 "org_id": org.id,
-                "project_id": project_with_volume.id,
+                "dynamic_sampling_project_id": project_with_volume.id,
                 "generic_metrics_sample_rate": 0.2,
                 "eap_sample_rate": 0.25,
                 "relative_deviation": pytest.approx(0.2),
@@ -112,7 +112,7 @@ class ProjectBalancingCalculationsTest(TestCase):
             },
             {
                 "org_id": org.id,
-                "project_id": project_without_volume.id,
+                "dynamic_sampling_project_id": project_without_volume.id,
                 "generic_metrics_sample_rate": 0.96,
                 "eap_sample_rate": 1.0,
                 "relative_deviation": pytest.approx(0.04),
@@ -288,7 +288,7 @@ class TransactionBalancingCalculationsTest(TestCase):
         assert extras == [
             {
                 "org_id": org.id,
-                "project_id": project.id,
+                "dynamic_sampling_project_id": project.id,
                 "generic_metrics_implicit_rate": 0.45,
                 "eap_implicit_rate": 0.5,
                 "relative_deviation": pytest.approx(0.1),
@@ -296,7 +296,7 @@ class TransactionBalancingCalculationsTest(TestCase):
             },
             {
                 "org_id": org.id,
-                "project_id": project.id,
+                "dynamic_sampling_project_id": project.id,
                 "transaction": "checkout",
                 "generic_metrics_sample_rate": 0.2,
                 "eap_sample_rate": 0.25,
@@ -305,7 +305,7 @@ class TransactionBalancingCalculationsTest(TestCase):
             },
             {
                 "org_id": org.id,
-                "project_id": project.id,
+                "dynamic_sampling_project_id": project.id,
                 "transaction": "cart",
                 "generic_metrics_sample_rate": 1.0,
                 "eap_sample_rate": 0.96,


### PR DESCRIPTION
In Sentry Explore Logs, querying `project_id` resolves to the built-in `sentry.project_id` column (the DSN project, always 1) instead of the custom attribute set in the log `extra` dict. This made it impossible to filter or group by the actual dynamic sampling project ID in the project and transaction balancing comparison logs.

Rename `project_id` to `dynamic_sampling_project_id` in all three `logger.info` calls, consistent with what was already done for the metrics tags in 8c290f59690. Also switch the debug metrics from `gauge` to `distribution` for better aggregation support.