### PR TITLE
ref(span-buffer): Improve performance of span buffer processor with typed msgspec deserializer

### DIFF
--- a/bin/benchmark_span_decoder
+++ b/bin/benchmark_span_decoder
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# isort: skip_file
+# flake8: noqa: S002
+
+"""
+Benchmarks the orjson vs. msgspec span decoders used by the span buffer process
+consumer (see `sentry.spans.consumers.process.factory`).
+
+Usage: python bin/benchmark_span_decoder [num_spans] [iterations]
+"""
+
+from sentry.runner import configure
+
+configure()
+
+import logging
+import sys
+import time
+
+import orjson
+import sentry_sdk
+
+from sentry.spans.consumers.process.factory import (
+    SPANS_CODEC,
+    decode_process_span_event,
+)
+
+# Disable sentry as it creates lots of noise in the output.
+sentry_sdk.init(None)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("benchmark_span_decoder")
+
+
+def make_span(i: int) -> dict:
+    """Build a single valid span event matching the ingest-spans schema."""
+    return {
+        "organization_id": 1,
+        "project_id": 12,
+        "trace_id": f"{i:032x}",
+        "span_id": f"{i:016x}",
+        "parent_span_id": f"{i + 1:016x}",
+        "start_timestamp": 1699999999.0 + i,
+        "end_timestamp": 1700000000.0 + i,
+        "received": 1700000001.0,
+        "retention_days": 90,
+        "downsampled_retention_days": 30,
+        "name": "db.query",
+        "status": "ok",
+        "is_segment": i % 2 == 0,
+        "links": [{"trace_id": f"{i:032x}", "span_id": f"{i:016x}"}],
+        "attributes": {
+            "sentry.segment.id": {"type": "string", "value": f"{i:016x}"},
+            "sentry.op": {"type": "string", "value": "db"},
+            "db.statement": {"type": "string", "value": "SELECT * FROM foo WHERE id = 1"},
+            "http.status_code": {"type": "integer", "value": 200},
+            "duration_ms": {"type": "double", "value": 12.34},
+        },
+    }
+
+
+def time_decoder(name, fn, payloads, iterations):
+    # Warm up.
+    for payload in payloads:
+        fn(payload)
+
+    start = time.perf_counter()
+    for _ in range(iterations):
+        for payload in payloads:
+            fn(payload)
+    elapsed = time.perf_counter() - start
+
+    total_ops = iterations * len(payloads)
+    per_op_us = (elapsed / total_ops) * 1_000_000
+    logger.info("%12s: %.4fs total, %.3f us/span", name, elapsed, per_op_us)
+    return elapsed
+
+
+def main(num_spans, iterations):
+    payloads = [orjson.dumps(make_span(i)) for i in range(num_spans)]
+
+    # Sanity check: both decoders agree on the fields they share, and the
+    # msgspec output validates against the schema.
+    SPANS_CODEC.validate(decode_process_span_event(payloads[0]))
+
+    avg_bytes = sum(len(p) for p in payloads) / len(payloads)
+    logger.info("spans=%d iterations=%d avg_payload=%.0f bytes\n", num_spans, iterations, avg_bytes)
+
+    orjson_elapsed = time_decoder("orjson", orjson.loads, payloads, iterations)
+    msgspec_elapsed = time_decoder("msgspec", decode_process_span_event, payloads, iterations)
+
+    speedup = orjson_elapsed / msgspec_elapsed
+    faster = "faster" if speedup >= 1 else "slower"
+    logger.info("\nmsgspec is %.2fx %s than orjson", abs(speedup), faster)
+
+
+if __name__ == "__main__":
+    num_spans = int(sys.argv[1]) if len(sys.argv) > 1 else 1000
+    iterations = int(sys.argv[2]) if len(sys.argv) > 2 else 100
+    main(num_spans, iterations)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3015,6 +3015,13 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# When enabled, the process consumer decodes span events with the typed msgspec
+# decoder instead of orjson. Used to roll out the faster decoder safely.
+register(
+    "spans.buffer.use-msgspec-decoder",
+    default=False,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Segments consumer
 register(
     "spans.process-segments.consumer.enable",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3015,11 +3015,9 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# When enabled, the process consumer decodes span events with the typed msgspec
-# decoder instead of orjson. Used to roll out the faster decoder safely.
 register(
     "spans.buffer.use-msgspec-decoder",
-    default=False,
+    default=0.0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Segments consumer

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -17,7 +17,7 @@ from arroyo.types import BrokerValue, Commit, FilteredPayload, Message, Partitio
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
 
-from sentry import killswitches, options
+from sentry import killswitches
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.options.rollout import in_random_rollout
 from sentry.spans.buffer import SpansBuffer
@@ -164,7 +164,7 @@ def process_batch(
     values: Message[ValuesBatch[tuple[int, KafkaPayload]]],
 ) -> int:
     killswitch_config = killswitches.get_killswitch_value("spans.drop-in-buffer")
-    use_msgspec_decoder = options.get("spans.buffer.use-msgspec-decoder")
+    use_msgspec_decoder = in_random_rollout("spans.buffer.use-msgspec-decoder")
     min_timestamp = None
     decode_time = 0.0
     spans = []

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -271,8 +271,6 @@ class ProcessSpanEvent(msgspec.Struct, gc=False):
     retention_days: int
     name: str | None
     status: str
-
-    # Optional fields consumed by `process_batch`.
     parent_span_id: str | None = None
     is_segment: bool | None = None
     attributes: SpanAttributes | None = None

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -261,33 +261,51 @@ class SpanAttributes(msgspec.Struct, gc=False):
 
 
 class ProcessSpanEvent(msgspec.Struct, gc=False):
+    organization_id: int
+    project_id: int
     trace_id: str
     span_id: str
-    project_id: int
+    start_timestamp: float
+    end_timestamp: float
+    received: float
+    retention_days: int
+    name: str | None
+    status: str
 
-    organization_id: int | None = None
+    # Optional fields consumed by `process_batch`.
     parent_span_id: str | None = None
     is_segment: bool | None = None
     attributes: SpanAttributes | None = None
 
 
-decoder = msgspec.json.Decoder(type=ProcessSpanEvent)
+_PROCESS_SPAN_DECODER = msgspec.json.Decoder(type=ProcessSpanEvent)
 
 
 def decode_process_span_event(buf: bytes) -> dict[str, Any]:
-    process_span_event = decoder.decode(buf)
+    process_span_event = _PROCESS_SPAN_DECODER.decode(buf)
 
-    segment_id: str | None = None
+    attributes: dict[str, Any] = {}
     if process_span_event.attributes:
         if process_span_event.attributes.segment_id:
-            segment_id = process_span_event.attributes.segment_id.value
+            attributes["sentry.segment.id"] = {
+                "value": process_span_event.attributes.segment_id.value,
+                "type": "string",
+            }
 
+    # TODO: Emulating the old behavior for now while we test the rollout. Remove this and
+    #       return ProcessSpanEvent after validation.
     return {
         "organization_id": process_span_event.organization_id,
         "project_id": process_span_event.project_id,
         "trace_id": process_span_event.trace_id,
         "span_id": process_span_event.span_id,
         "parent_span_id": process_span_event.parent_span_id,
+        "start_timestamp": process_span_event.start_timestamp,
+        "end_timestamp": process_span_event.end_timestamp,
+        "received": process_span_event.received,
+        "retention_days": process_span_event.retention_days,
+        "name": process_span_event.name,
+        "status": process_span_event.status,
         "is_segment": process_span_event.is_segment,
-        "attributes": {"sentry.segment.id": {"value": segment_id}},
+        "attributes": attributes,
     }

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -269,8 +269,8 @@ class ProcessSpanEvent(msgspec.Struct, gc=False):
     end_timestamp: float
     received: float
     retention_days: int
-    name: str | None
     status: str
+    name: str | None = None
     parent_span_id: str | None = None
     is_segment: bool | None = None
     attributes: SpanAttributes | None = None

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -2,8 +2,9 @@ import logging
 import time
 from collections.abc import Mapping
 from functools import partial
-from typing import cast
+from typing import Any, cast
 
+import msgspec
 import orjson
 import sentry_sdk
 from arroyo.backends.kafka.consumer import KafkaPayload
@@ -16,7 +17,7 @@ from arroyo.types import BrokerValue, Commit, FilteredPayload, Message, Partitio
 from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
 
-from sentry import killswitches
+from sentry import killswitches, options
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.options.rollout import in_random_rollout
 from sentry.spans.buffer import SpansBuffer
@@ -163,6 +164,7 @@ def process_batch(
     values: Message[ValuesBatch[tuple[int, KafkaPayload]]],
 ) -> int:
     killswitch_config = killswitches.get_killswitch_value("spans.drop-in-buffer")
+    use_msgspec_decoder = options.get("spans.buffer.use-msgspec-decoder")
     min_timestamp = None
     decode_time = 0.0
     spans = []
@@ -176,7 +178,10 @@ def process_batch(
                 min_timestamp = timestamp
 
             decode_start = time.monotonic()
-            val = cast(SpanEvent, orjson.loads(payload.value))
+            if use_msgspec_decoder:
+                val = cast(SpanEvent, decode_process_span_event(payload.value))
+            else:
+                val = cast(SpanEvent, orjson.loads(payload.value))
             decode_time += time.monotonic() - decode_start
 
             if killswitches.value_matches(
@@ -245,3 +250,44 @@ def validate_span_event(span_event: SpanEvent, segment_id: str | None) -> None:
     assert isinstance(span_event["trace_id"], str), "trace_id must be str"
     assert isinstance(span_event["span_id"], str), "span_id must be str"
     assert segment_id is None or isinstance(segment_id, str), "segment_id must be str or None"
+
+
+class SpanAttributeValue(msgspec.Struct, gc=False):
+    value: str | None = None
+
+
+class SpanAttributes(msgspec.Struct, gc=False):
+    segment_id: SpanAttributeValue | None = msgspec.field(name="sentry.segment.id", default=None)
+
+
+class ProcessSpanEvent(msgspec.Struct, gc=False):
+    trace_id: str
+    span_id: str
+    project_id: int
+
+    organization_id: int | None = None
+    parent_span_id: str | None = None
+    is_segment: bool | None = None
+    attributes: SpanAttributes | None = None
+
+
+decoder = msgspec.json.Decoder(type=ProcessSpanEvent)
+
+
+def decode_process_span_event(buf: bytes) -> dict[str, Any]:
+    process_span_event = decoder.decode(buf)
+
+    segment_id: str | None = None
+    if process_span_event.attributes:
+        if process_span_event.attributes.segment_id:
+            segment_id = process_span_event.attributes.segment_id.value
+
+    return {
+        "organization_id": process_span_event.organization_id,
+        "project_id": process_span_event.project_id,
+        "trace_id": process_span_event.trace_id,
+        "span_id": process_span_event.span_id,
+        "parent_span_id": process_span_event.parent_span_id,
+        "is_segment": process_span_event.is_segment,
+        "attributes": {"sentry.segment.id": {"value": segment_id}},
+    }

--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -15,7 +15,12 @@ from tests.sentry.spans.test_buffer import DEFAULT_OPTIONS
 
 
 @override_options(
-    {**DEFAULT_OPTIONS, "spans.drop-in-buffer": [], "spans.process-segments.schema-validation": 0.0}
+    {
+        **DEFAULT_OPTIONS,
+        "spans.drop-in-buffer": [],
+        "spans.process-segments.schema-validation": 0.0,
+        "spans.buffer.use-msgspec-decoder": 0.0,
+    }
 )
 @pytest.mark.parametrize("kafka_slice_id", [None, 2])
 def test_basic(kafka_slice_id: int | None) -> None:
@@ -206,7 +211,12 @@ def test_basic_msgspec_decoder() -> None:
 
 
 @override_options(
-    {**DEFAULT_OPTIONS, "spans.drop-in-buffer": [], "spans.process-segments.schema-validation": 0.0}
+    {
+        **DEFAULT_OPTIONS,
+        "spans.drop-in-buffer": [],
+        "spans.process-segments.schema-validation": 0.0,
+        "spans.buffer.use-msgspec-decoder": 0.0,
+    }
 )
 @pytest.mark.parametrize(
     "field_to_set_none",
@@ -282,7 +292,12 @@ def test_schema_validator_rejects_none_fields(field_to_set_none: str) -> None:
 
 
 @override_options(
-    {**DEFAULT_OPTIONS, "spans.drop-in-buffer": [], "spans.process-segments.schema-validation": 0.0}
+    {
+        **DEFAULT_OPTIONS,
+        "spans.drop-in-buffer": [],
+        "spans.process-segments.schema-validation": 0.0,
+        "spans.buffer.use-msgspec-decoder": 0.0,
+    }
 )
 def test_flusher_processes_limit() -> None:
     """Test that flusher respects the max_processes limit"""
@@ -330,7 +345,12 @@ def test_flusher_processes_limit() -> None:
 
 @django_db_all
 @override_options(
-    {**DEFAULT_OPTIONS, "spans.drop-in-buffer": [], "spans.process-segments.schema-validation": 0.0}
+    {
+        **DEFAULT_OPTIONS,
+        "spans.drop-in-buffer": [],
+        "spans.process-segments.schema-validation": 0.0,
+        "spans.buffer.use-msgspec-decoder": 0.0,
+    }
 )
 @pytest.mark.parametrize("kafka_slice_id", [None, 2])
 def test_produce_to_kafka_exception(kafka_slice_id: int | None) -> None:

--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -102,6 +102,110 @@ def test_basic(kafka_slice_id: int | None) -> None:
 
 
 @override_options(
+    {
+        **DEFAULT_OPTIONS,
+        "spans.drop-in-buffer": [],
+        "spans.process-segments.schema-validation": 1.0,
+        "spans.buffer.use-msgspec-decoder": 1.0,
+    }
+)
+def test_basic_msgspec_decoder() -> None:
+    # Mirrors `test_basic` but with the msgspec decoder enabled and schema
+    # validation always on, to ensure the decoded event still validates and
+    # produces the same buffered span.
+    with mock.patch("time.sleep"):
+        topic = Topic("test")
+        messages: list[tuple[int, KafkaPayload, int]] = []
+
+        fac = ProcessSpansStrategyFactory(
+            max_batch_size=1,
+            max_batch_time=10,
+            num_processes=1,
+            input_block_size=None,
+            output_block_size=None,
+            produce_to_pipe=lambda project_id, payload, dropped: messages.append(
+                (project_id, payload, dropped)
+            ),
+        )
+
+        commits = []
+
+        def add_commit(offsets, force=False):
+            commits.append(offsets)
+
+        step = fac.create_with_partitions(add_commit, {Partition(topic, 0): 0})
+
+        try:
+            step.submit(
+                Message(
+                    BrokerValue(
+                        partition=Partition(topic, 0),
+                        offset=1,
+                        payload=KafkaPayload(
+                            None,
+                            orjson.dumps(
+                                {
+                                    "organization_id": 1,
+                                    "project_id": 12,
+                                    "span_id": "a" * 16,
+                                    "trace_id": "b" * 32,
+                                    "start_timestamp": 1699999999.0,
+                                    "end_timestamp": 1700000000.0,
+                                    "received": 1700000001.0,
+                                    "retention_days": 90,
+                                    "name": "test-span",
+                                    "status": "ok",
+                                }
+                            ),
+                            [],
+                        ),
+                        timestamp=datetime.now(),
+                    )
+                )
+            )
+
+            step.poll()
+            fac._flusher.current_drift.value = 9000  # "advance" our "clock"
+
+            step.poll()
+            for _ in range(20):
+                if messages:
+                    break
+                step.poll()
+                real_sleep(0.1)
+
+            (_, msg, _) = messages[0]
+
+            result = orjson.loads(msg.value)
+            assert result.pop("flush_id") is not None
+            # The buffered payload is the original raw bytes (enriched by the
+            # buffer with the segment id), not the decoded subset, so all
+            # original fields are preserved.
+            assert result == {
+                "spans": [
+                    {
+                        "attributes": {
+                            "sentry.segment.id": {"type": "string", "value": "aaaaaaaaaaaaaaaa"},
+                        },
+                        "is_segment": True,
+                        "organization_id": 1,
+                        "project_id": 12,
+                        "span_id": "aaaaaaaaaaaaaaaa",
+                        "trace_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        "start_timestamp": 1699999999.0,
+                        "end_timestamp": 1700000000.0,
+                        "received": 1700000001.0,
+                        "retention_days": 90,
+                        "name": "test-span",
+                        "status": "ok",
+                    },
+                ],
+            }
+        finally:
+            fac._flusher.join()
+
+
+@override_options(
     {**DEFAULT_OPTIONS, "spans.drop-in-buffer": [], "spans.process-segments.schema-validation": 0.0}
 )
 @pytest.mark.parametrize(

--- a/tests/sentry/spans/consumers/process/test_factory.py
+++ b/tests/sentry/spans/consumers/process/test_factory.py
@@ -1,6 +1,9 @@
+from typing import cast
+
 import msgspec
 import orjson
 import pytest
+from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
 
 from sentry.spans.consumers.process.factory import (
     SPANS_CODEC,
@@ -57,7 +60,7 @@ def test_decode_output_passes_schema_validation() -> None:
     # The reconstructed event must satisfy the ingest-spans schema so that
     # `validate_span_event` does not crash the consumer.
     result = decode_process_span_event(orjson.dumps(_valid_span()))
-    SPANS_CODEC.validate(result)
+    SPANS_CODEC.validate(cast(SpanEvent, result))
 
 
 def test_decode_ignores_unknown_top_level_fields() -> None:
@@ -82,7 +85,7 @@ def test_decode_without_segment_id_attribute() -> None:
     # Attribute is omitted entirely rather than emitted as an invalid entry.
     assert result["attributes"] == {}
     assert attribute_value(result, "sentry.segment.id") is None
-    SPANS_CODEC.validate(result)
+    SPANS_CODEC.validate(cast(SpanEvent, result))
 
 
 def test_decode_without_attributes() -> None:
@@ -92,7 +95,7 @@ def test_decode_without_attributes() -> None:
 
     assert result["attributes"] == {}
     assert attribute_value(result, "sentry.segment.id") is None
-    SPANS_CODEC.validate(result)
+    SPANS_CODEC.validate(cast(SpanEvent, result))
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/spans/consumers/process/test_factory.py
+++ b/tests/sentry/spans/consumers/process/test_factory.py
@@ -109,7 +109,6 @@ def test_decode_without_attributes() -> None:
         "end_timestamp",
         "received",
         "retention_days",
-        "name",
         "status",
     ],
 )

--- a/tests/sentry/spans/consumers/process/test_factory.py
+++ b/tests/sentry/spans/consumers/process/test_factory.py
@@ -1,0 +1,151 @@
+import msgspec
+import orjson
+import pytest
+
+from sentry.spans.consumers.process.factory import (
+    SPANS_CODEC,
+    ProcessSpanEvent,
+    decode_process_span_event,
+)
+from sentry.spans.consumers.process_segments.types import attribute_value
+
+
+def _valid_span(**overrides: object) -> dict[str, object]:
+    span: dict[str, object] = {
+        "organization_id": 1,
+        "project_id": 12,
+        "trace_id": "b" * 32,
+        "span_id": "a" * 16,
+        "parent_span_id": "c" * 16,
+        "start_timestamp": 1699999999.0,
+        "end_timestamp": 1700000000.0,
+        "received": 1700000001.0,
+        "retention_days": 90,
+        "name": "test-span",
+        "status": "ok",
+        "is_segment": False,
+        "attributes": {
+            "sentry.segment.id": {"type": "string", "value": "a" * 16},
+            "some.other.attr": {"type": "integer", "value": 42},
+        },
+    }
+    span.update(overrides)
+    return span
+
+
+def test_decode_returns_minimum_fields() -> None:
+    result = decode_process_span_event(orjson.dumps(_valid_span()))
+
+    assert result == {
+        "organization_id": 1,
+        "project_id": 12,
+        "trace_id": "b" * 32,
+        "span_id": "a" * 16,
+        "parent_span_id": "c" * 16,
+        "start_timestamp": 1699999999.0,
+        "end_timestamp": 1700000000.0,
+        "received": 1700000001.0,
+        "retention_days": 90,
+        "name": "test-span",
+        "status": "ok",
+        "is_segment": False,
+        "attributes": {"sentry.segment.id": {"type": "string", "value": "a" * 16}},
+    }
+
+
+def test_decode_output_passes_schema_validation() -> None:
+    # The reconstructed event must satisfy the ingest-spans schema so that
+    # `validate_span_event` does not crash the consumer.
+    result = decode_process_span_event(orjson.dumps(_valid_span()))
+    SPANS_CODEC.validate(result)
+
+
+def test_decode_ignores_unknown_top_level_fields() -> None:
+    payload = _valid_span(event_id="d" * 32, links=[{"trace_id": "e" * 32}], extra="ignored")
+    result = decode_process_span_event(orjson.dumps(payload))
+
+    assert "event_id" not in result
+    assert "links" not in result
+    assert "extra" not in result
+    assert result["trace_id"] == "b" * 32
+
+
+def test_decode_extracts_segment_id() -> None:
+    result = decode_process_span_event(orjson.dumps(_valid_span()))
+    assert attribute_value(result, "sentry.segment.id") == "a" * 16
+
+
+def test_decode_without_segment_id_attribute() -> None:
+    result = decode_process_span_event(
+        orjson.dumps(_valid_span(attributes={"some.other.attr": {"type": "integer", "value": 1}}))
+    )
+    # Attribute is omitted entirely rather than emitted as an invalid entry.
+    assert result["attributes"] == {}
+    assert attribute_value(result, "sentry.segment.id") is None
+    SPANS_CODEC.validate(result)
+
+
+def test_decode_without_attributes() -> None:
+    payload = _valid_span()
+    del payload["attributes"]
+    result = decode_process_span_event(orjson.dumps(payload))
+
+    assert result["attributes"] == {}
+    assert attribute_value(result, "sentry.segment.id") is None
+    SPANS_CODEC.validate(result)
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    [
+        "organization_id",
+        "project_id",
+        "trace_id",
+        "span_id",
+        "start_timestamp",
+        "end_timestamp",
+        "received",
+        "retention_days",
+        "name",
+        "status",
+    ],
+)
+def test_decode_raises_on_missing_required_field(missing_field: str) -> None:
+    payload = _valid_span()
+    del payload[missing_field]
+
+    with pytest.raises(msgspec.ValidationError):
+        decode_process_span_event(orjson.dumps(payload))
+
+
+@pytest.mark.parametrize(
+    "field,bad_value",
+    [
+        ("trace_id", 123),
+        ("span_id", None),
+        ("start_timestamp", "not-a-number"),
+        ("status", None),
+    ],
+)
+def test_decode_raises_on_wrong_type(field: str, bad_value: object) -> None:
+    with pytest.raises(msgspec.ValidationError):
+        decode_process_span_event(orjson.dumps(_valid_span(**{field: bad_value})))
+
+
+def test_decode_coerces_integer_timestamps() -> None:
+    # JSON numbers without a fractional part decode into the float fields.
+    result = decode_process_span_event(
+        orjson.dumps(_valid_span(start_timestamp=1699999999, end_timestamp=1700000000))
+    )
+    assert result["start_timestamp"] == 1699999999.0
+    assert result["end_timestamp"] == 1700000000.0
+
+
+def test_optional_fields_default_when_absent() -> None:
+    payload = _valid_span()
+    del payload["parent_span_id"]
+    del payload["is_segment"]
+
+    event = msgspec.json.decode(orjson.dumps(payload), type=ProcessSpanEvent)
+    assert event.parent_span_id is None
+    assert event.is_segment is None


### PR DESCRIPTION
Adds minimal, typed deserialization to span buffer processor.

The schema is not as minimal as required by the function. [`if in_random_rollout("spans.process-segments.schema-validation"):`](https://github.com/getsentry/sentry/blob/8bc4e9622bc9c67044164fa27f20c7a950cc374f/src/sentry/spans/consumers/process/factory.py#L248-L249) forces a stricter schema so the schema validation step doesn't fail. This rollout option appears to be disabled but I did not verify beyond an inspection of the `options-automator` repository. I assume this is disabled for performance reasons and not correctness reasons. Comparing the msgspec struct to the output format from Relay shows there is no mismatch between what Relay can emit and what the struct will parse. Parsing the additional fields will not introduce any significant performance penalty and should not lead to excess DLQs.

The new decoder is gated by a random rollout of `spans.buffer.use-msgspec-decoder`.

### Benchmarks

34% improvement in performance with dict reconstruction. Future commits will remove dict reconstruction and validation after the change has been demonstrated to work in production.

```
python bin/benchmark_span_decoder 
13:25:52 [INFO] benchmark_span_decoder: spans=1000 iterations=100 avg_payload=714 bytes

13:25:52 [INFO] benchmark_span_decoder:       orjson: 0.1391s total, 1.391 us/span
13:25:52 [INFO] benchmark_span_decoder:      msgspec: 0.1035s total, 1.035 us/span
13:25:52 [INFO] benchmark_span_decoder: 
msgspec is 1.34x faster than orjson
```