### PR TITLE
feat(cmdk): route NEXT_PUBLIC_SENTRY_DSN search to Client Keys (DSN)

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
@@ -345,9 +345,10 @@ describe('GlobalCommandPaletteActions - search recall', () => {
     ['inbound', /Project Settings.*Inbound Filters/],
     ['size', /Project Settings.*Mobile Builds/],
     // The SDK env var name (and its spaced form) should surface Client Keys
-    // (DSN), just like "dsn".
+    // (DSN), just like "dsn". The Next.js public-prefixed variant should too.
     ['SENTRY_DSN', /Project Settings.*Client Keys \(DSN\)/],
     ['sentry dsn', /Project Settings.*Client Keys \(DSN\)/],
+    ['NEXT_PUBLIC_SENTRY_DSN', /Project Settings.*Client Keys \(DSN\)/],
   ])('finds expected actions for %s', async (query, ...expectedOptions) => {
     renderPalette();
 

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -693,6 +693,7 @@ export function GlobalCommandPaletteActions() {
                 t('dsn key'),
                 'SENTRY_DSN',
                 'Sentry DSN',
+                'NEXT_PUBLIC_SENTRY_DSN',
                 project.slug,
               ]}
               to={`/settings/${organization.slug}/projects/${project.slug}/keys/`}

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -184,11 +184,13 @@ export function getNavigationConfiguration({
           description: t("View and manage the project's client keys (DSN)"),
           keywords: [
             t('dsn'),
-            // The SDK environment variable name (and its spaced form) that
-            // developers search for. Not wrapped in t() — these are fixed
-            // config/product tokens, not translatable prose.
+            // SDK environment variable names (and the spaced form) that
+            // developers search for, including the Next.js public-prefixed
+            // variant. Not wrapped in t() — these are fixed config/product
+            // tokens, not translatable prose.
             'SENTRY_DSN',
             'Sentry DSN',
+            'NEXT_PUBLIC_SENTRY_DSN',
             t('auth'),
             t('token'),
             t('client key'),


### PR DESCRIPTION
## What

Make the Command+K palette surface the **Client Keys (DSN)** project settings action when a user searches for `NEXT_PUBLIC_SENTRY_DSN`.

## Why

`NEXT_PUBLIC_SENTRY_DSN` is the environment variable name Next.js apps use to hold the Sentry DSN — the `NEXT_PUBLIC_` prefix is Next.js's convention for exposing a value to client-side/browser code, which the browser SDK needs. Sentry's own Vercel integration sets exactly this variable for Next.js projects:

https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/vercel/integration.py#L166

```python
dsn_env_name = "NEXT_PUBLIC_SENTRY_DSN" if is_next_js else "SENTRY_DSN"
```

The command palette already routes `SENTRY_DSN` and `Sentry DSN` to the Client Keys (DSN) settings page (`/settings/:orgId/projects/:projectId/keys/`) via keywords. But the palette uses subsequence matching, so the longer Next.js-prefixed query `NEXT_PUBLIC_SENTRY_DSN` can't match the shorter `SENTRY_DSN` keyword — searching it surfaced nothing. Next.js is one of the most common Sentry SDK setups, so this is a real gap for developers trying to find where to grab/manage their DSN.

## What changed

Added `NEXT_PUBLIC_SENTRY_DSN` as a keyword in the two places that already list `SENTRY_DSN`:

- `static/app/views/settings/project/navigationConfiguration.tsx` — the canonical "Client Keys (DSN)" nav item (surfaces under **Project Settings** in cmd+k).
- `static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx` — the current-project "Client Keys (DSN)" shortcut.

Added a test case mirroring the existing `SENTRY_DSN` recall test.

## Testing

- `pnpm test-ci static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx` → 20 passed (incl. new `NEXT_PUBLIC_SENTRY_DSN` case)
- `pnpm run lint:js` on the changed files → clean

https://claude.ai/code/session_01VZEHfyf5DnG5og2siYoRKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZEHfyf5DnG5og2siYoRKG)_