### PR TITLE
fix(seer): add GitLab support to autofix integration setup check

### DIFF
--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -13,7 +13,6 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.helpers.deprecation import deprecated
 from sentry.constants import CELL_API_DEPRECATION_DATE, DataCategory, ObjectStatus
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.types import IntegrationProviderSlug
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.group import Group
 from sentry.models.organization import Organization
@@ -24,8 +23,8 @@ from sentry.seer.autofix.utils import (
     get_autofix_repos_from_project_code_mappings,
     has_project_connected_repos,
 )
-from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS
 from sentry.seer.models import SeerApiError
+from sentry.seer.seer_setup import get_supported_scm_providers
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_autofix_default_connection_pool,
@@ -37,17 +36,15 @@ def get_autofix_integration_setup_problems(
     organization: Organization, project: Project
 ) -> str | None:
     """
-    Runs through the checks to see if we can use the GitHub integration for Autofix.
+    Runs through the checks to see if we can use the SCM integration for Autofix.
+    Supports GitHub, GitHub Enterprise, and GitLab (when the seer-gitlab-support flag is enabled).
 
     If there are no issues, returns None.
     If there is an issue, returns the reason.
     """
     organization_integrations = integration_service.get_organization_integrations(
         organization_id=organization.id,
-        providers=[
-            IntegrationProviderSlug.GITHUB.value,
-            IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
-        ],
+        providers=get_supported_scm_providers(organization),
     )
 
     # Iterate through all organization integrations to find one with an active integration
@@ -74,9 +71,8 @@ def get_repos_and_access(project: Project, group_id: int) -> list[dict]:
     repos_and_access: list[dict] = []
     path = "/v1/automation/codebase/repo/check-access"
     for repo in repos:
-        # We only support github and github enterprise for now.
         provider = repo.get("provider")
-        if provider not in SEER_SUPPORTED_SCM_PROVIDERS:
+        if provider not in get_supported_scm_providers(project.organization):
             continue
 
         body = orjson.dumps(


### PR DESCRIPTION
## What

Extends `get_autofix_integration_setup_problems` and `get_repos_and_access` in `group_autofix_setup_check.py` to respect the `organizations:seer-gitlab-support` feature flag, bringing them in line with the rest of the Seer stack.

**Changes:**
- `get_autofix_integration_setup_problems`: replaced hardcoded `[GITHUB, GITHUB_ENTERPRISE]` provider list with `get_supported_scm_providers(organization)`, which already handles the GitLab feature flag
- `get_repos_and_access`: replaced direct use of `SEER_SUPPORTED_SCM_PROVIDERS` constant with `get_supported_scm_providers(project.organization)`
- Removed now-unused `IntegrationProviderSlug` and `SEER_SUPPORTED_SCM_PROVIDERS` imports

## Why

These two functions were the only remaining spots in this file that hardcoded GitHub/GitHub Enterprise, causing GitLab orgs to always get `integration_missing` and their repos to be silently skipped, even when the feature flag is on.

## Verified

- Diff inspection confirms no other references to removed imports remain in the file
- Pattern matches the existing approach used by `organization_seer_onboarding_check.py`, `get_autofix_repos_from_project_code_mappings`, and `project_seer_repos`


Closes https://linear.app/getsentry/issue/SCM-126/fix-gitlab-autofix-setup-check-gating

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC013P75SQUB%3A1781490292.465929%22)