### PR TITLE
ref(span-flusher): Remove unnecessary dumping of JSON bytes

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -515,7 +515,9 @@ class SpansBuffer:
                 if is_segment:
                     has_root_span = True
 
-                output_spans.append(OutputSpan(payload=cast(dict[str, Any], span)))
+                output_spans.append(
+                    OutputSpan(payload=cast(dict[str, Any], span), payload_bytes=payload)
+                )
 
             metrics.incr(
                 "spans.buffer.flush_segments.num_segments_per_shard",

--- a/src/sentry/spans/buffer_types.py
+++ b/src/sentry/spans/buffer_types.py
@@ -225,7 +225,7 @@ class FlushedSegment(NamedTuple):
 
         spans: list[SpanPayload] = [span.payload for span in self.spans]
 
-        sizes = [len(span.payload_bytes) for span in self.spans]
+        sizes = [len(s.payload_bytes) for s in self.spans]
         if sum(sizes) <= max_segment_bytes:
             return [{"flush_id": uuid.uuid4().hex, "spans": spans}]
 

--- a/src/sentry/spans/buffer_types.py
+++ b/src/sentry/spans/buffer_types.py
@@ -12,8 +12,6 @@ import uuid
 from collections.abc import Sequence
 from typing import Any, NamedTuple
 
-import orjson
-
 from sentry import options
 from sentry.spans.segment_key import PayloadKey, SegmentKey
 from sentry.utils import metrics
@@ -122,6 +120,7 @@ class OutputSpan(NamedTuple):
     """
 
     payload: SpanPayload
+    payload_bytes: bytes
 
 
 class FlushCandidate(NamedTuple):
@@ -226,7 +225,7 @@ class FlushedSegment(NamedTuple):
 
         spans: list[SpanPayload] = [span.payload for span in self.spans]
 
-        sizes = [len(orjson.dumps(s)) for s in spans]
+        sizes = [len(span.payload_bytes) for span in self.spans]
         if sum(sizes) <= max_segment_bytes:
             return [{"flush_id": uuid.uuid4().hex, "spans": spans}]
 

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -79,15 +79,14 @@ def _payload(span_id: str) -> bytes:
 
 
 def _output_segment(span_id: bytes, segment_id: bytes, is_segment: bool) -> OutputSpan:
-    return OutputSpan(
-        payload={
-            "span_id": span_id.decode("ascii"),
-            "is_segment": is_segment,
-            "attributes": {
-                "sentry.segment.id": {"type": "string", "value": segment_id.decode("ascii")},
-            },
-        }
-    )
+    payload = {
+        "span_id": span_id.decode("ascii"),
+        "is_segment": is_segment,
+        "attributes": {
+            "sentry.segment.id": {"type": "string", "value": segment_id.decode("ascii")},
+        },
+    }
+    return OutputSpan(payload=payload, payload_bytes=orjson.dumps(payload))
 
 
 def _span(
@@ -1327,7 +1326,7 @@ def test_to_messages_under_limit(buffer: SpansBuffer) -> None:
     spans = [{"span_id": "a"}, {"span_id": "b"}]
     segment = FlushedSegment(
         queue_key=b"test",
-        spans=[OutputSpan(payload=s) for s in spans],
+        spans=[OutputSpan(payload=s, payload_bytes=orjson.dumps(s)) for s in spans],
         project_id=1,
     )
     with override_options(
@@ -1374,7 +1373,7 @@ def test_to_messages_splits_oversized(buffer: SpansBuffer) -> None:
     ]
     segment = FlushedSegment(
         queue_key=b"test",
-        spans=[OutputSpan(payload=s) for s in spans],
+        spans=[OutputSpan(payload=s, payload_bytes=orjson.dumps(s)) for s in spans],
         project_id=1,
     )
     with override_options(
@@ -1409,7 +1408,11 @@ def test_to_messages_single_large_span(buffer: SpansBuffer) -> None:
     """A single span larger than max_bytes still gets its own message."""
     segment = FlushedSegment(
         queue_key=b"test",
-        spans=[OutputSpan(payload={"span_id": "a" * 16})],
+        spans=[
+            OutputSpan(
+                payload={"span_id": "a" * 16}, payload_bytes=orjson.dumps({"span_id": "a" * 16})
+            )
+        ],
         project_id=1,
     )
     with override_options(
@@ -1430,7 +1433,7 @@ def test_to_messages_unique_flush_ids_across_calls(buffer: SpansBuffer) -> None:
     spans = [{"span_id": "a"}, {"span_id": "b"}]
     segment = FlushedSegment(
         queue_key=b"test",
-        spans=[OutputSpan(payload=s) for s in spans],
+        spans=[OutputSpan(payload=s, payload_bytes=orjson.dumps(s)) for s in spans],
         project_id=1,
     )
     with override_options(

--- a/tests/sentry/spans/test_buffer_store.py
+++ b/tests/sentry/spans/test_buffer_store.py
@@ -409,7 +409,12 @@ def test_cleanup_flushed_segments_removes_segment_data(storage: SpansBufferStore
         {
             segment_key: FlushedSegment(
                 queue_key=queue_key,
-                spans=[OutputSpan(payload={"span_id": span_id})],
+                spans=[
+                    OutputSpan(
+                        payload={"span_id": span_id},
+                        payload_bytes=orjson.dumps({"span_id": span_id}),
+                    )
+                ],
                 project_id=_TEST_PROJECT_ID,
                 payload_keys=[payload_key],
             )


### PR DESCRIPTION
Removes unnecessary dumping of JSON bytes. Raw payload is retained (rather than a length) because of expected future usage. The cost is a pointer not a copy. This should be a memory reducing change since a new byte buffer is not introduced with the duplicate JSON bytes.

Edit: I may change the ordering of the pull requests. I think I will perform the enrichment move to process-segments first and then update this dumping behavior (rather than use the wrong size).