### PR TITLE
fix(cursor): Validate pr_url and extract branch_name from statusChange webhook

### DIFF
--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -220,6 +220,13 @@ class CursorWebhookEndpoint(Endpoint):
             )
             return
 
+        if pr_url and not self._validate_pr_url(pr_url, repo_full_name):
+            logger.warning(
+                "cursor_webhook.invalid_pr_url",
+                extra={"agent_id": agent_id, "pr_url": pr_url},
+            )
+            pr_url = None
+
         result = CodingAgentResult(
             repo_full_name=repo_full_name,
             repo_provider=repo_provider,
@@ -249,6 +256,10 @@ class CursorWebhookEndpoint(Endpoint):
                     "cursor_webhook.pr_attribution_failed",
                     extra={"agent_id": agent_id, "pr_url": pr_url},
                 )
+
+    def _validate_pr_url(self, pr_url: str, repo_full_name: str) -> bool:
+        """Validates that the URL points to the expected repo."""
+        return pr_url.startswith(f"https://github.com/{repo_full_name}/pull/")
 
     def _update_coding_agent_status(
         self,

--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -159,6 +159,7 @@ class CursorWebhookEndpoint(Endpoint):
         source = payload.get("source", {})
         target = payload.get("target", {})
         pr_url = target.get("prUrl")
+        branch_name = target.get("branchName")
         agent_url = target.get("url")
         summary = payload.get("summary")
 
@@ -232,6 +233,7 @@ class CursorWebhookEndpoint(Endpoint):
             repo_provider=repo_provider,
             description=summary or f"Agent {status.lower()}",
             pr_url=pr_url if status == CodingAgentStatus.COMPLETED else None,
+            branch_name=branch_name,
         )
 
         known_to_seer = self._update_coding_agent_status(

--- a/tests/sentry/integrations/cursor/test_webhook.py
+++ b/tests/sentry/integrations/cursor/test_webhook.py
@@ -59,6 +59,7 @@ class TestCursorWebhook(APITestCase):
         repo: str = "github.com/testorg/testrepo",
         ref: str | None = "main",
         pr_url: str | None = "https://github.com/testorg/testrepo/pull/1",
+        branch_name: str | None = "cursor/fix-bug-1234",
         agent_url: str | None = "https://cursor.sh/agents/1",
         summary: str | None = "All done",
     ) -> dict[str, Any]:
@@ -67,7 +68,7 @@ class TestCursorWebhook(APITestCase):
             "id": id,
             "status": status,
             "source": {"repository": repo, "ref": ref},
-            "target": {"prUrl": pr_url, "url": agent_url},
+            "target": {"prUrl": pr_url, "branchName": branch_name, "url": agent_url},
             "summary": summary,
         }
 
@@ -91,6 +92,18 @@ class TestCursorWebhook(APITestCase):
         assert result.repo_full_name == "testorg/testrepo"
         assert result.repo_provider == "github"
         assert result.pr_url == "https://github.com/testorg/testrepo/pull/1"
+        assert result.branch_name == "cursor/fix-bug-1234"
+
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_branch_name_absent_is_none(self, mock_update_state):
+        payload = self._build_status_payload(status="FINISHED", branch_name=None)
+        body = orjson.dumps(payload)
+        headers = self._signed_headers(body)
+
+        response = self._post_with_headers(body, headers)
+
+        assert response.status_code == 204
+        assert mock_update_state.call_args[1]["result"].branch_name is None
 
     @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
     def test_finished_records_pr_attribution(self, mock_update_state):

--- a/tests/sentry/integrations/cursor/test_webhook.py
+++ b/tests/sentry/integrations/cursor/test_webhook.py
@@ -283,6 +283,31 @@ class TestCursorWebhook(APITestCase):
         assert mock_update_state.call_count == 1
 
     @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_invalid_pr_url_is_dropped(self, mock_update_state):
+        # Non-https scheme must be rejected — the pr_url is nulled out so no attribution fires.
+        mock_update_state.return_value = True
+        self.create_repo(self.project, name="testorg/testrepo", provider="integrations:github")
+
+        for bad_url in [
+            "not-a-url-at-all",
+            "http://github.com/testorg/testrepo/pull/1",
+            "https://github.com/otherorg/otherrepo/pull/1",
+            "https://github.com/testorg/testrepo/tree/main",
+        ]:
+            mock_update_state.reset_mock()
+            body = orjson.dumps(self._build_status_payload(status="FINISHED", pr_url=bad_url))
+            headers = self._signed_headers(body)
+
+            with self.feature("organizations:pr-metrics-attribution"):
+                response = self._post_with_headers(body, headers)
+
+            assert response.status_code == 204, bad_url
+            # The Seer state update still happens, but with no pr_url.
+            assert mock_update_state.call_count == 1, bad_url
+            assert mock_update_state.call_args[1]["result"].pr_url is None, bad_url
+            assert not PullRequestAttribution.objects.exists(), bad_url
+
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
     def test_signature_without_prefix(self, mock_update_state):
         payload = self._build_status_payload(status="FINISHED")
         body = orjson.dumps(payload)


### PR DESCRIPTION
As part of the pr-metrics attribution work, improve how we handle the Cursor `statusChange` webhook payload.

**`pr_url` validation** — add a `_validate_pr_url` check that ensures the reported PR URL points to the same repo already validated from `source.repository`. URLs that don't match are dropped before reaching `CodingAgentResult` or attribution, while the Seer state update still proceeds.

**`branch_name` extraction** — the [Cursor webhook docs](https://cursor.com/docs/cloud-agent/api/webhooks) include `target.branchName` in the payload. `CodingAgentResult` already had a `branch_name` field; this wires up the extraction so it's populated.