### PR TITLE
docs: added note about accuracy on sampled data / documented yAxis values

### DIFF
--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -166,7 +166,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
         on the parameters passed
 
         **Note**: For queries extending past `30d`, spanning billions of rows, or running on projects with low
-        sample rates, aggregations such as `yAxis=count_unique()` and filters on high-cardinality
+        sample rates, the aggregation `yAxis=count_unique()` and filters on high-cardinality
         fields (such as `query=user.id:bc`) will not return accurate results. Use these queries for rough
         estimation only.
         """

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -164,6 +164,11 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
 
         This endpoint can return timeseries for either 1 or many axis, and results grouped to the top events depending
         on the parameters passed
+
+        **Note**: For queries extending past `30d`, spanning billions of rows, or running on projects with low
+        sample rates, aggregations such as `yAxis=count_unique()` and filters on high-cardinality
+        fields (such as `query=user.id:bc`) will not return accurate results. Use these queries for rough
+        estimation only.
         """
         with sentry_sdk.start_span(op="discover.endpoint", name="filter_params") as span:
             span.set_data("organization", organization)

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -773,8 +773,8 @@ top events are""",
 - `eps` - Average number of events received per second.
 - `failure_rate()` - Percentage of events whose `status` indicates failure.
 - `failure_count()` - Total count of events with an error `status` over period.
-- `performance_score(field)` - Web Vitals performance score for the selected metric.
-- `opportunity_score(field)` - Web Vitals opportunity score for the selected metric.
+- `performance_score(field)` - Web Vitals performance score for the selected measurement.
+- `opportunity_score(field)` - Web Vitals opportunity score for the selected measurement.
 """,
     )
     DISABLE_AGGREGATE_EXTRAPOLATION = OpenApiParameter(

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -760,7 +760,22 @@ top events are""",
         location="query",
         required=False,
         type=str,
-        description="The aggregate field to create the timeseries for, defaults to `count()` when not included",
+        description="""The aggregate field to create the timeseries for, defaults to `count(span.duration)` when
+        not included.
+- `count()` - Total count of events over the period.
+- `avg(field)` - Average value of the field over the period.
+- `pXX(field)` - Percentile value of the field over the period. One of: `p50`, `p75`, `p90`, `p95`, `p99`, `p100`.
+- `sum(field)` - Sum of all values for the field over the period.
+- `min(field)` - Lowest value observed for the field over the period.
+- `max(field)` - Highest value observed for the field over the period.
+- `count_unique(field)` - Count of unique values observed for the field over the period. See *Note:* regarding accuracy on sampled data.
+- `epm` - Average number of events received per minute.
+- `eps` - Average number of events received per second.
+- `failure_rate()` - Percentage of events whose `status` indicates failure.
+- `failure_count()` - Total count of events with an error `status` over period.
+- `performance_score(field)` - Web Vitals performance score for the selected metric.
+- `opportunity_score(field)` - Web Vitals opportunity score for the selected metric.
+""",
     )
     DISABLE_AGGREGATE_EXTRAPOLATION = OpenApiParameter(
         name="disableAggregateExtrapolation",

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -760,7 +760,7 @@ top events are""",
         location="query",
         required=False,
         type=str,
-        description="""The aggregate field to create the timeseries for, defaults to `count(span.duration)` when
+        description="""The aggregate field to create the timeseries for, defaults to `count()` when
         not included.
 - `count()` - Total count of events over the period.
 - `avg(field)` - Average value of the field over the period.


### PR DESCRIPTION
`count_unique` queries suffer from counting issues when sampling rate is low (either configured as such, or when hitting a sampled query tier), as uniqueness does not change linearly. Queries on high cardinality values, like email, result in zero result gaps, depending on the distribution of high cardinality value (_maybe `bcoe` only uses the application at 4PM every day_).