### PR TITLE
ref(tracemetrics): Use useEffectEvent for restoring equation mode state

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
@@ -1,4 +1,11 @@
-import {type RefObject, useCallback, useEffect, useRef, useState} from 'react';
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from 'react';
 
 import {
   explodeFieldString,
@@ -194,15 +201,9 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
     });
   }, [state.displayType, state.yAxis, state.fields, dispatch]);
 
-  // Auto-restore the previous visualize mode when the dataset returns
-  // to TRACEMETRICS. Detects equation yAxis on return and restores the
-  // cached equation mode if the user was in equation mode when they left.
-  useEffect(() => {
-    if (state.dataset !== WidgetType.TRACEMETRICS || !hasEquations) {
-      setIsEquationMode(false);
-      return;
-    }
-
+  // Detect an equation yAxis and restore the cached equation mode if
+  // the user was in equation mode when they left.
+  const onChangeDatasetToTraceMetrics = useEffectEvent(() => {
     const aggregateSource = getTraceMetricAggregateSource(
       state.displayType,
       state.yAxis,
@@ -218,10 +219,17 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
       restoreEquationState();
       setIsEquationMode(true);
     }
-    // Intentionally keyed on dataset only — we want this to fire
-    // exactly when the user navigates back to TRACEMETRICS.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.dataset]);
+  });
+
+  // Auto-restore the previous visualize mode when the dataset returns
+  // to TRACEMETRICS.
+  useEffect(() => {
+    if (state.dataset !== WidgetType.TRACEMETRICS || !hasEquations) {
+      setIsEquationMode(false);
+      return;
+    }
+    onChangeDatasetToTraceMetrics();
+  }, [state.dataset, hasEquations]);
 
   const handleModeToggle = useCallback(
     (nextIsEquation: boolean) => {


### PR DESCRIPTION
This hook was intended to only trigger on `state.dataset` changes. To achieve this I ignored missing dependencies and had an early bailout for conditions that didn't match the dataset.

There's a `useEffectEvent` hook for this use case. It creates a callback so that it's non-reactive, i.e. doesn't cause re-renders when dependencies change. This means all of the dependencies used inside the extracted logic do not trigger the effect, and we can more intentionally declare the intend of the `useEffect` hook to trigger on a smaller set of dependencies, mainly the ones that actually should trigger updates.