### PR TITLE
chore: fix up pnpm-lock.yaml from bad merge; enable oxfmt's `--no-error-on-unmatched-pattern`

### DIFF
--- a/.github/workflows/scripts/frontend-changed-scope.sh
+++ b/.github/workflows/scripts/frontend-changed-scope.sh
@@ -20,19 +20,19 @@ set -euo pipefail
 MERGE_BASE=$(./.github/workflows/scripts/git-merge-base.sh)
 
 if [ -z "$MERGE_BASE" ]; then
-  echo "No merge base — running over all files" >&2
+  echo "No merge base: running over all files" >&2
   echo "merge_base="
   echo "scope=full"
 elif ! CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD^2); then
-  echo "Could not diff against merge base — running over all files" >&2
+  echo "Could not diff against merge base: running over all files" >&2
   echo "merge_base=$MERGE_BASE"
   echo "scope=full"
 elif printf '%s' "$CHANGED" | grep -qvE '^static/'; then
-  echo "Non-static file changed — running over all files" >&2
+  echo "Non-static file changed: running over all files" >&2
   echo "merge_base=$MERGE_BASE"
   echo "scope=full"
 else
-  echo "Merge base: $MERGE_BASE — running over impacted files only" >&2
+  echo "Merge base: $MERGE_BASE: running over impacted files only" >&2
   echo "merge_base=$MERGE_BASE"
   echo "scope=scoped"
 fi

--- a/.github/workflows/scripts/frontend-changed-scope.sh
+++ b/.github/workflows/scripts/frontend-changed-scope.sh
@@ -20,19 +20,19 @@ set -euo pipefail
 MERGE_BASE=$(./.github/workflows/scripts/git-merge-base.sh)
 
 if [ -z "$MERGE_BASE" ]; then
-  echo "No merge base: running over all files" >&2
+  echo "No merge base — running over all files" >&2
   echo "merge_base="
   echo "scope=full"
 elif ! CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD^2); then
-  echo "Could not diff against merge base: running over all files" >&2
+  echo "Could not diff against merge base — running over all files" >&2
   echo "merge_base=$MERGE_BASE"
   echo "scope=full"
 elif printf '%s' "$CHANGED" | grep -qvE '^static/'; then
-  echo "Non-static file changed: running over all files" >&2
+  echo "Non-static file changed — running over all files" >&2
   echo "merge_base=$MERGE_BASE"
   echo "scope=full"
 else
-  echo "Merge base: $MERGE_BASE: running over impacted files only" >&2
+  echo "Merge base: $MERGE_BASE — running over impacted files only" >&2
   echo "merge_base=$MERGE_BASE"
   echo "scope=scoped"
 fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,7 +118,7 @@ repos:
         # "Expected at least one target file" when its config drops every
         # input file, so skip them at the hook level instead.
         exclude: ^(api-docs|fixtures)/.*\.json$
-        entry: ./node_modules/.bin/oxfmt
+        entry: ./node_modules/.bin/oxfmt --no-error-on-unmatched-pattern
 
       - id: knip
         name: knip

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12431,11 +12431,11 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.20
+      '@types/node': 22.19.19
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 22.19.20
+      '@types/node': 22.19.19
 
   '@types/css-font-loading-module@0.0.7': {}
 
@@ -13927,7 +13927,7 @@ snapshots:
   engine.io@6.6.4:
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 22.19.20
+      '@types/node': 22.19.19
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.7.2


### PR DESCRIPTION
Fixes failures like https://github.com/getsentry/getsentry/actions/runs/27561056309/job/81472873302:

```plaintext
Run cd ../sentry && pnpm install --frozen-lockfile
Lockfile is up to date, resolution step is skipped
 ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for '@types/node@22.19.20' in pnpm-lock.yaml

This issue is probably caused by a badly resolved merge conflict.
To fix the lockfile, run 'pnpm install --no-frozen-lockfile'.
```