### PR TITLE
ref(types): drop charts/utils dependency from types/core

### DIFF
--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -4,8 +4,6 @@
  * Before a type is put here it should be required in multiple other types.
  * or used in multiple views.
  */
-import type {getInterval} from 'sentry/components/charts/utils';
-
 export type {Scope} from 'sentry/constants/scopes';
 export {DataCategory, DataCategoryExact} from 'sentry/types/dataCategory';
 export type {DataCategoryInfo} from 'sentry/types/dataCategory';
@@ -64,7 +62,7 @@ export enum Outcome {
   DROPPED = 'dropped', // this is not a real outcome coming from the server
 }
 
-export type IntervalPeriod = ReturnType<typeof getInterval>;
+export type IntervalPeriod = string;
 
 /**
  * Represents a pinned page filter sentinel value


### PR DESCRIPTION
`getInterval` returns `string` (via `GranularityLadder.getInterval(): string`), so `IntervalPeriod` is inlined to `string` and the import is dropped. 

This reduces the big type-import-cycle from 1675 to 1643 (-32).