### PR TITLE
ref(replays): Log query stats for /replay-counts/ on `spans` dataset

### DIFF
--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -10,6 +10,7 @@ from typing import Any, Literal, Protocol, overload
 from sentry.api.event_search import ParenExpression, QueryToken, SearchFilter, parse_search_query
 from sentry.models.group import Group
 from sentry.replays.query import query_replays_count
+from sentry.search.eap.sampling import sampling_tier_name
 from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
 from sentry.search.events.types import EventsResponse, SnubaParams
 from sentry.snuba import discover, errors, issue_platform, transactions
@@ -38,6 +39,7 @@ logger = logging.getLogger(__name__)
 class _SpansIdQueryResult:
     replay_ids: set[str]
     row_count: int
+    sampling_tier: int | None
 
 
 class _DatasetQueryFunc(Protocol):
@@ -133,7 +135,12 @@ def _get_replay_counts_spans(
     unique_ids_count = len(spans_result.replay_ids)
 
     if not spans_result.replay_ids:
-        _log_spans_query_results(row_count=row_count, unique_ids_count=0, found_replays_count=None)
+        _log_spans_query_results(
+            row_count=row_count,
+            unique_ids_count=0,
+            found_replays_count=None,
+            sampling_tier=spans_result.sampling_tier,
+        )
         return {}
 
     replay_results = query_replays_count(
@@ -158,6 +165,7 @@ def _get_replay_counts_spans(
         row_count=row_count,
         unique_ids_count=unique_ids_count,
         found_replays_count=found_replays_count,
+        sampling_tier=spans_result.sampling_tier,
     )
     return result
 
@@ -260,7 +268,11 @@ def _query_eap_spans_for_replay_ids(
         if (replay_id := row.get("replay.id", ""))
     }
 
-    return _SpansIdQueryResult(replay_ids=replay_ids, row_count=row_count)
+    sampling_tier: int | None = result["meta"].get("sampling_tier")
+
+    return _SpansIdQueryResult(
+        replay_ids=replay_ids, row_count=row_count, sampling_tier=sampling_tier
+    )
 
 
 def _get_counts(replay_results: Any, replay_ids_mapping: dict[str, list[int]]) -> dict[int, int]:
@@ -325,13 +337,19 @@ def extract_columns_recursive(query: Sequence[QueryToken]) -> Generator[SearchFi
 
 
 def _log_spans_query_results(
-    row_count: int, unique_ids_count: int, found_replays_count: int | None
+    row_count: int,
+    unique_ids_count: int,
+    found_replays_count: int | None,
+    sampling_tier: int | None,
 ):
     extra: dict[str, object] = {
         "ids_query.limit": SPANS_DATASET_ID_QUERY_LIMIT,
         "ids_query.row_count": row_count,
         "ids_query.unique_ids_count": unique_ids_count,
         "ids_query.limit_reached": row_count >= SPANS_DATASET_ID_QUERY_LIMIT,
+        "ids_query.sampling_tier": sampling_tier_name(sampling_tier)
+        if sampling_tier is not None
+        else None,
     }
 
     if found_replays_count is not None:

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -302,14 +302,14 @@ def _log_spans_query_results(ids_found: int, replays_found: int | None):
     }
 
     if replays_found is not None:
-        assert ids_found > 0
         extra.update(
             {
                 "replays_query.limit": MAX_REPLAY_COUNT,
                 "replays_query.num_found": replays_found,
                 "replays_query.limit_reached": replays_found >= MAX_REPLAY_COUNT,
-                "replays_query.found_ratio": replays_found / ids_found,
             }
         )
+        if ids_found > 0:
+            extra["replays_query.found_ratio"] = replays_found / ids_found
 
     logger.info("replay_counts.spans.query_stats", extra=extra)

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import logging
 import uuid
 from collections import defaultdict
 from collections.abc import Generator, Sequence
@@ -16,6 +17,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.spans_rpc import Spans
 
 MAX_REPLAY_COUNT = 51
+SPANS_DATASET_ID_QUERY_LIMIT = 51 * 10
 MAX_VALS_PROVIDED = {
     "issue.id": 25,
     "transaction": 25,
@@ -23,6 +25,9 @@ MAX_VALS_PROVIDED = {
 }
 
 FILTER_HAS_A_REPLAY = ' AND !replay.id:""'
+
+
+logger = logging.getLogger(__name__)
 
 
 class _DatasetQueryFunc(Protocol):
@@ -72,17 +77,23 @@ def get_replay_counts(
     if snuba_params.start is None or snuba_params.end is None or snuba_params.organization is None:
         raise ValueError("Must provide start and end")
 
+    is_spans_dataset = data_source == SupportedTraceItemType.SPANS.value
     if not isinstance(data_source, Dataset):
-        if data_source == SupportedTraceItemType.SPANS.value:
+        if is_spans_dataset:
             data_source = Dataset.EventsAnalyticsPlatform
         else:
             data_source = Dataset(data_source)
 
     replay_ids_mapping = _get_replay_id_mappings(query, snuba_params, data_source)
+    spans_ids_found_count = (
+        sum(len(v) for v in replay_ids_mapping.values()) if is_spans_dataset else 0
+    )
 
     # It's not guaranteed that any results will be returned by this query. If the result-set
     # is empty exit early to save us a query.
     if not replay_ids_mapping:
+        if is_spans_dataset:
+            _log_spans_query_results(0, None)
         return {}
 
     replay_results = query_replays_count(
@@ -93,10 +104,17 @@ def get_replay_counts(
         tenant_ids={"organization_id": snuba_params.organization.id},
     )
 
+    result: dict[int, list[str]] | dict[int, int] = {}
+    spans_replays_found_count = 0
     if return_ids:
-        return _get_replay_ids(replay_results, replay_ids_mapping)
+        result, spans_replays_found_count = _get_replay_ids(replay_results, replay_ids_mapping)
     else:
-        return _get_counts(replay_results, replay_ids_mapping)
+        result, spans_replays_found_count = _get_counts(replay_results, replay_ids_mapping)
+
+    if is_spans_dataset:
+        _log_spans_query_results(spans_ids_found_count, spans_replays_found_count)
+
+    return result
 
 
 def _get_replay_id_mappings(
@@ -195,7 +213,7 @@ def _query_eap_spans_for_replay_ids(
         offset=0,
         # In buffer mode we'll often set IDs for replays that are never sent to
         # Sentry - load a lot of extra IDs to compensate.
-        limit=MAX_REPLAY_COUNT * 10,
+        limit=SPANS_DATASET_ID_QUERY_LIMIT,
         referrer="api.organization-issue-replay-count",
         config=SearchResolverConfig(),
     )
@@ -209,34 +227,40 @@ def _query_eap_spans_for_replay_ids(
     return replay_id_to_identifier_map
 
 
-def _get_counts(replay_results: Any, replay_ids_mapping: dict[str, list[int]]) -> dict[int, int]:
+def _get_counts(
+    replay_results: Any, replay_ids_mapping: dict[str, list[int]]
+) -> tuple[dict[int, int], int]:
     """
     Get the number of existing replays associated with each identifier (ex identifier: issue_id)
     """
     ret: dict[int, int] = defaultdict(int)
+    count = 0
     for row in replay_results["data"]:
         identifiers = replay_ids_mapping[
             row["rid"]
         ]  # use rid because replay_id results column might have dashes
         for identifier in identifiers:
             ret[identifier] = min(ret[identifier] + 1, MAX_REPLAY_COUNT)
-    return ret
+            count += 1
+    return (ret, count)
 
 
 def _get_replay_ids(
     replay_results: Any, replay_ids_mapping: dict[str, list[int]]
-) -> dict[int, list[str]]:
+) -> tuple[dict[int, list[str]], int]:
     """
     Get replay ids associated with each identifier (identifier -> [replay_id]) (ex identifier: issue_id)
     Can think of it as the inverse of _get_replay_id_mappings, excluding the replay_ids that don't exist
     """
     ret: dict[int, list[str]] = defaultdict(list)
+    count = 0
     for row in replay_results["data"]:
         identifiers = replay_ids_mapping[row["rid"]]
         for identifier in identifiers:
+            count += 1
             if len(ret[identifier]) < MAX_REPLAY_COUNT:
                 ret[identifier].append(row["rid"])
-    return ret
+    return (ret, count)
 
 
 def _get_select_column(query: str) -> tuple[str, Sequence[Any]]:
@@ -268,3 +292,24 @@ def extract_columns_recursive(query: Sequence[QueryToken]) -> Generator[SearchFi
                 yield condition
         elif isinstance(condition, ParenExpression):
             yield from extract_columns_recursive(condition.children)
+
+
+def _log_spans_query_results(ids_found: int, replays_found: int | None):
+    extra: dict[str, object] = {
+        "ids_query.limit": SPANS_DATASET_ID_QUERY_LIMIT,
+        "ids_query.num_found": ids_found,
+        "ids_query.limit_reached": ids_found >= SPANS_DATASET_ID_QUERY_LIMIT,
+    }
+
+    if replays_found is not None:
+        assert ids_found > 0
+        extra.update(
+            {
+                "replays_query.limit": MAX_REPLAY_COUNT,
+                "replays_query.num_found": replays_found,
+                "replays_query.limit_reached": replays_found >= MAX_REPLAY_COUNT,
+                "replays_query.found_ratio": replays_found / ids_found,
+            }
+        )
+
+    logger.info("replay_counts.spans.query_stats", extra=extra)

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -17,7 +17,11 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.spans_rpc import Spans
 
 MAX_REPLAY_COUNT = 51
+
+# In buffer mode we'll often set IDs for replays that are never sent to Sentry -
+# load a lot of extra IDs to compensate.
 SPANS_DATASET_ID_QUERY_LIMIT = 51 * 10
+
 MAX_VALS_PROVIDED = {
     "issue.id": 25,
     "transaction": 25,
@@ -28,6 +32,12 @@ FILTER_HAS_A_REPLAY = ' AND !replay.id:""'
 
 
 logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class _SpansIdQueryResult:
+    replay_ids: set[str]
+    row_count: int
 
 
 class _DatasetQueryFunc(Protocol):
@@ -55,18 +65,18 @@ _DATASET_QUERY_FUNCS: dict[Dataset, _DatasetQueryFunc] = {
 @overload
 def get_replay_counts(
     snuba_params: SnubaParams, query: str, data_source: str | Dataset, *, return_ids: Literal[True]
-) -> dict[int, list[str]]: ...
+) -> dict[Any, list[str]]: ...
 
 
 @overload
 def get_replay_counts(
     snuba_params: SnubaParams, query: str, data_source: str | Dataset, *, return_ids: Literal[False]
-) -> dict[int, int]: ...
+) -> dict[Any, int]: ...
 
 
 def get_replay_counts(
     snuba_params: SnubaParams, query: str, data_source: str | Dataset, *, return_ids: bool
-) -> dict[int, list[str]] | dict[int, int]:
+) -> dict[Any, list[str]] | dict[Any, int]:
     """
     Queries snuba/clickhouse for replay count of each identifier (usually an issue or transaction).
     - Identifier is parsed from 'query' (select column), and 'snuba_params' is used to filter on time range + project_id
@@ -77,23 +87,17 @@ def get_replay_counts(
     if snuba_params.start is None or snuba_params.end is None or snuba_params.organization is None:
         raise ValueError("Must provide start and end")
 
-    is_spans_dataset = data_source == SupportedTraceItemType.SPANS.value
+    if data_source == SupportedTraceItemType.SPANS.value:
+        return _get_replay_counts_spans(snuba_params, query, return_ids=return_ids)
+
     if not isinstance(data_source, Dataset):
-        if is_spans_dataset:
-            data_source = Dataset.EventsAnalyticsPlatform
-        else:
-            data_source = Dataset(data_source)
+        data_source = Dataset(data_source)
 
     replay_ids_mapping = _get_replay_id_mappings(query, snuba_params, data_source)
-    spans_ids_found_count = (
-        sum(len(v) for v in replay_ids_mapping.values()) if is_spans_dataset else 0
-    )
 
     # It's not guaranteed that any results will be returned by this query. If the result-set
     # is empty exit early to save us a query.
     if not replay_ids_mapping:
-        if is_spans_dataset:
-            _log_spans_query_results(0, None)
         return {}
 
     replay_results = query_replays_count(
@@ -104,16 +108,57 @@ def get_replay_counts(
         tenant_ids={"organization_id": snuba_params.organization.id},
     )
 
-    result: dict[int, list[str]] | dict[int, int] = {}
-    spans_replays_found_count = 0
     if return_ids:
-        result, spans_replays_found_count = _get_replay_ids(replay_results, replay_ids_mapping)
+        return _get_replay_ids(replay_results, replay_ids_mapping)
     else:
-        result, spans_replays_found_count = _get_counts(replay_results, replay_ids_mapping)
+        return _get_counts(replay_results, replay_ids_mapping)
 
-    if is_spans_dataset:
-        _log_spans_query_results(spans_ids_found_count, spans_replays_found_count)
 
+def _get_replay_counts_spans(
+    snuba_params: SnubaParams, query: str, *, return_ids: bool
+) -> dict[str, list[str]] | dict[str, int]:
+    assert snuba_params.start is not None
+    assert snuba_params.end is not None
+    assert snuba_params.organization is not None
+
+    select_column, column_value = _get_select_column(query)
+
+    if select_column != "transaction":
+        raise ValueError("The spans data source only supports transaction queries")
+    if len(column_value) != 1:
+        raise ValueError("The spans data source only supports a single value")
+
+    spans_result = _query_eap_spans_for_replay_ids(query + FILTER_HAS_A_REPLAY, snuba_params)
+    row_count = spans_result.row_count
+    unique_ids_count = len(spans_result.replay_ids)
+
+    if not spans_result.replay_ids:
+        _log_spans_query_results(row_count=row_count, unique_ids_count=0, found_replays_count=None)
+        return {}
+
+    replay_results = query_replays_count(
+        project_ids=[p.id for p in snuba_params.projects],
+        start=snuba_params.start,
+        end=snuba_params.end,
+        replay_ids=list(spans_result.replay_ids),
+        tenant_ids={"organization_id": snuba_params.organization.id},
+    )
+
+    identifier = column_value[0]
+    found_replay_ids = [row["rid"] for row in replay_results["data"]]
+    found_replays_count = len(found_replay_ids)
+
+    result: dict[str, list[str]] | dict[str, int]
+    if return_ids:
+        result = {identifier: found_replay_ids[:MAX_REPLAY_COUNT]}
+    else:
+        result = {identifier: min(found_replays_count, MAX_REPLAY_COUNT)}
+
+    _log_spans_query_results(
+        row_count=row_count,
+        unique_ids_count=unique_ids_count,
+        found_replays_count=found_replays_count,
+    )
     return result
 
 
@@ -162,13 +207,6 @@ def _get_replay_id_mappings(
         if not snuba_params.projects:
             return {}
 
-    if data_source == Dataset.EventsAnalyticsPlatform:
-        if len(column_value) != 1:
-            raise ValueError("The spans data source only supports a single value")
-        return _query_eap_spans_for_replay_ids(
-            query + FILTER_HAS_A_REPLAY, snuba_params, column_value[0]
-        )
-
     if data_source not in _DATASET_QUERY_FUNCS:
         raise ValueError("Invalid data source")
     search_query_func = _DATASET_QUERY_FUNCS[data_source]
@@ -202,65 +240,57 @@ def _get_replay_id_mappings(
 def _query_eap_spans_for_replay_ids(
     query: str,
     snuba_params: SnubaParams,
-    identifier: Any,
-) -> dict[str, list[Any]]:
-    """Query EAP spans for unique replay IDs matching the given identifier."""
+) -> _SpansIdQueryResult:
+    """Query EAP spans for unique replay IDs matching the given query."""
     result = Spans.run_table_query(
         params=snuba_params,
         query_string=query,
         selected_columns=["replay.id"],
         orderby=None,
         offset=0,
-        # In buffer mode we'll often set IDs for replays that are never sent to
-        # Sentry - load a lot of extra IDs to compensate.
         limit=SPANS_DATASET_ID_QUERY_LIMIT,
         referrer="api.organization-issue-replay-count",
         config=SearchResolverConfig(),
     )
 
-    replay_id_to_identifier_map = defaultdict(list)
-    replay_ids = {replay_id for row in result["data"] if (replay_id := row.get("replay.id", ""))}
-    for replay_id in replay_ids:
-        replay_id = replay_id.replace("-", "")
-        replay_id_to_identifier_map[replay_id].append(identifier)
+    row_count = len(result["data"])
+    replay_ids = {
+        replay_id.replace("-", "")
+        for row in result["data"]
+        if (replay_id := row.get("replay.id", ""))
+    }
 
-    return replay_id_to_identifier_map
+    return _SpansIdQueryResult(replay_ids=replay_ids, row_count=row_count)
 
 
-def _get_counts(
-    replay_results: Any, replay_ids_mapping: dict[str, list[int]]
-) -> tuple[dict[int, int], int]:
+def _get_counts(replay_results: Any, replay_ids_mapping: dict[str, list[int]]) -> dict[int, int]:
     """
     Get the number of existing replays associated with each identifier (ex identifier: issue_id)
     """
     ret: dict[int, int] = defaultdict(int)
-    count = 0
     for row in replay_results["data"]:
         identifiers = replay_ids_mapping[
             row["rid"]
         ]  # use rid because replay_id results column might have dashes
         for identifier in identifiers:
             ret[identifier] = min(ret[identifier] + 1, MAX_REPLAY_COUNT)
-            count += 1
-    return (ret, count)
+    return ret
 
 
 def _get_replay_ids(
     replay_results: Any, replay_ids_mapping: dict[str, list[int]]
-) -> tuple[dict[int, list[str]], int]:
+) -> dict[int, list[str]]:
     """
     Get replay ids associated with each identifier (identifier -> [replay_id]) (ex identifier: issue_id)
     Can think of it as the inverse of _get_replay_id_mappings, excluding the replay_ids that don't exist
     """
     ret: dict[int, list[str]] = defaultdict(list)
-    count = 0
     for row in replay_results["data"]:
         identifiers = replay_ids_mapping[row["rid"]]
         for identifier in identifiers:
-            count += 1
             if len(ret[identifier]) < MAX_REPLAY_COUNT:
                 ret[identifier].append(row["rid"])
-    return (ret, count)
+    return ret
 
 
 def _get_select_column(query: str) -> tuple[str, Sequence[Any]]:
@@ -294,22 +324,25 @@ def extract_columns_recursive(query: Sequence[QueryToken]) -> Generator[SearchFi
             yield from extract_columns_recursive(condition.children)
 
 
-def _log_spans_query_results(ids_found: int, replays_found: int | None):
+def _log_spans_query_results(
+    row_count: int, unique_ids_count: int, found_replays_count: int | None
+):
     extra: dict[str, object] = {
         "ids_query.limit": SPANS_DATASET_ID_QUERY_LIMIT,
-        "ids_query.num_found": ids_found,
-        "ids_query.limit_reached": ids_found >= SPANS_DATASET_ID_QUERY_LIMIT,
+        "ids_query.row_count": row_count,
+        "ids_query.unique_ids_count": unique_ids_count,
+        "ids_query.limit_reached": row_count >= SPANS_DATASET_ID_QUERY_LIMIT,
     }
 
-    if replays_found is not None:
+    if found_replays_count is not None:
         extra.update(
             {
                 "replays_query.limit": MAX_REPLAY_COUNT,
-                "replays_query.num_found": replays_found,
-                "replays_query.limit_reached": replays_found >= MAX_REPLAY_COUNT,
+                "replays_query.found_replays_count": found_replays_count,
+                "replays_query.limit_reached": found_replays_count >= MAX_REPLAY_COUNT,
             }
         )
-        if ids_found > 0:
-            extra["replays_query.found_ratio"] = replays_found / ids_found
+        if unique_ids_count > 0:
+            extra["replays_query.found_replays_ratio"] = found_replays_count / unique_ids_count
 
     logger.info("replay_counts.spans.query_stats", extra=extra)

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -21,7 +21,7 @@ MAX_REPLAY_COUNT = 51
 
 # In buffer mode we'll often set IDs for replays that are never sent to Sentry -
 # load a lot of extra IDs to compensate.
-SPANS_DATASET_ID_QUERY_LIMIT = 51 * 10
+SPANS_DATASET_ID_QUERY_LIMIT = MAX_REPLAY_COUNT * 10
 
 MAX_VALS_PROVIDED = {
     "issue.id": 25,

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -35,13 +35,6 @@ FILTER_HAS_A_REPLAY = ' AND !replay.id:""'
 logger = logging.getLogger(__name__)
 
 
-@dataclasses.dataclass(frozen=True)
-class _SpansIdQueryResult:
-    replay_ids: set[str]
-    row_count: int
-    sampling_tier: int | None
-
-
 class _DatasetQueryFunc(Protocol):
     def __call__(
         self,
@@ -243,6 +236,13 @@ def _get_replay_id_mappings(
                 replay_id_to_issue_map[replay_id].append(row[select_column])
 
     return replay_id_to_issue_map
+
+
+@dataclasses.dataclass(frozen=True)
+class _SpansIdQueryResult:
+    replay_ids: set[str]
+    row_count: int
+    sampling_tier: int | None
 
 
 def _query_eap_spans_for_replay_ids(

--- a/src/sentry/search/eap/sampling.py
+++ b/src/sentry/search/eap/sampling.py
@@ -10,6 +10,12 @@ from sentry.search.eap.constants import SAMPLING_MODE_MAP
 from sentry.search.events.types import SAMPLING_MODES, EventsMeta
 
 
+def sampling_tier_name(tier: int) -> str:
+    return DownsampledStorageMeta.SelectedTier.Name(
+        DownsampledStorageMeta.SelectedTier.ValueType(tier)
+    )
+
+
 def handle_downsample_meta(meta: DownsampledStorageMeta) -> bool:
     return not meta.can_go_to_higher_accuracy_tier
 
@@ -38,4 +44,5 @@ def events_meta_from_rpc_request_meta(meta: ResponseMeta) -> EventsMeta:
         fields={},
         full_scan=full_scan,
         bytes_scanned=bytes_scanned,
+        sampling_tier=meta.downsampled_storage_meta.tier or None,
     )

--- a/src/sentry/search/eap/sampling.py
+++ b/src/sentry/search/eap/sampling.py
@@ -11,6 +11,8 @@ from sentry.search.events.types import SAMPLING_MODES, EventsMeta
 
 
 def sampling_tier_name(tier: int) -> str:
+    if tier not in DownsampledStorageMeta.SelectedTier.DESCRIPTOR.values_by_number:
+        return str(tier)
     return DownsampledStorageMeta.SelectedTier.Name(
         DownsampledStorageMeta.SelectedTier.ValueType(tier)
     )

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -75,6 +75,7 @@ class EventsMeta(TypedDict):
     debug_info: NotRequired[dict[str, Any]]
     full_scan: NotRequired[bool]
     bytes_scanned: NotRequired[int | None]
+    sampling_tier: NotRequired[int | None]
 
 
 class EventsResponse(TypedDict):


### PR DESCRIPTION
When querying the replay count for a named transaction using the `spans` dataset, we're currently querying 10x the desired number of replays (51) because under span streaming, replay IDs can be recorded without the associated replay ever being sent to Sentry. This may be more than we need, or not enough - in order to get a feel for the actual distributions in prod, log the relevant query stats.

Instead of a ton of special casing for the spans dataset (which already had a fair amount of special casing), I refactored it into its own function.

🤖: Used an LLM for local review and to assist with the refactor + type fixes.