### PR TITLE
docs(code-review): update stale GitLab contributor-seeding docstring

### DIFF
--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -2,23 +2,35 @@
 Handler for GitLab merge_request webhook events.
 https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#merge-request-events
 
-Known limitations
------------------
+Contributor seeding
+-------------------
 
-Code review does not fire in production yet: GitLab contributors are never seeded.
-``handle_merge_request_event`` runs ``CodeReviewPreflightService``, whose
-``_check_billing`` looks up ``OrganizationContributors`` by
-``(organization_id, integration_id, external_identifier=str(author_id))`` and
-returns ``ORG_CONTRIBUTOR_NOT_FOUND`` (before the beta exemption) when the row is
-missing. GitHub creates that row via ``track_contributor_seat`` in
-``PullRequestEventWebhook._handle`` on PR creation; the GitLab merge-request path
-(PR persistence inline in ``MergeEventWebhook.__call__``) does not, and nothing
-else seeds GitLab contributors. Until contributor seeding is added, every GitLab MR
-is filtered with ``ORG_CONTRIBUTOR_NOT_FOUND``. The handler tests pass only because
-they seed the row manually.
+``_check_billing`` in ``CodeReviewPreflightService`` requires an
+``OrganizationContributors`` row to exist before it will allow a review — even
+for beta orgs, which are only exempt from the quota check, not from the row
+existence check. ``MergeEventWebhook`` seeds that row via
+``track_gitlab_contributor_seat_processor``, which runs as the first entry in
+``WEBHOOK_EVENT_PROCESSORS`` (before ``handle_merge_request_event``) so the row
+exists when preflight runs. This mirrors GitHub's ``track_contributor_seat`` call
+in ``PullRequestEventWebhook._handle``.
 
-The code-review tests seed OrganizationContributors manually; consider a test that
-omits it to lock in the intended production behavior (related to Issue 1).
+Residual gaps
+-------------
+
+1. **Note-command path has no fallback seeding.** ``NoteEventWebhook`` only
+   registers ``handle_merge_request_note_event`` in its processors; there is no
+   ``track_gitlab_contributor_seat_processor`` equivalent. If a user types
+   ``@sentry review`` on an MR whose contributor row was never seeded (e.g. the
+   MR was opened before the seeding code was deployed, or the MR-open webhook
+   was missed), preflight returns ``ORG_CONTRIBUTOR_NOT_FOUND`` and the review
+   is silently denied.
+
+2. **MergeEventWebhook.__call__ can short-circuit before processors run.**
+   If the payload is missing ``last_commit`` (``KeyError``) or the author email
+   is absent (``Http404``), ``__call__`` returns before ``_handle`` is called,
+   so ``track_gitlab_contributor_seat_processor`` never runs and the MR author
+   is not seeded. Subsequent ``update`` events for the same MR do not fire the
+   processor either (it filters on ``action == "open"``). Tracked on SCM-99.
 
 GitLab has no dedicated "ready_for_review" action: un-drafting an MR arrives as an
 "update" whose top-level ``changes`` flips draft/work_in_progress to false, which is


### PR DESCRIPTION
## What

The `Known limitations` section in `merge_request.py` claimed that GitLab contributors are never seeded and every GitLab MR is filtered with `ORG_CONTRIBUTOR_NOT_FOUND`. That description was accurate before #116317, but is now stale.

## Why

`track_gitlab_contributor_seat_processor` was added in #116317 and is registered as the **first** entry in `MergeEventWebhook.WEBHOOK_EVENT_PROCESSORS`, so the `OrganizationContributors` row is seeded before `handle_merge_request_event` runs preflight. The old docstring (including the note that tests pass only because they seed the row manually) no longer describes production behaviour and actively misleads readers.

## Changes

- Replace the stale `Known limitations` block with a `Contributor seeding` section that describes how seeding actually works today.
- Add a `Residual gaps` section documenting what still isn't covered:
  1. `NoteEventWebhook` (`@sentry review`) has no fallback seeding — depends on the prior MR-open event having seeded the row.
  2. `MergeEventWebhook.__call__` can short-circuit before processors run (missing `last_commit` / author email), so the author is never seeded. Tracked on SCM-99.

## Verification

Docs-only change. No behaviour is modified.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC013P75SQUB%3A1781534668.098929%22)
