### PR TITLE
fix(autofix): Stream content with streaming variant, drop thinking_content fallback

### DIFF
--- a/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
+++ b/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
@@ -39,12 +39,8 @@ export function ArtifactLoadingDetails({
             return null;
           }
 
-          if (block.message.content && block.message.content !== 'Thinking...') {
-            return <Markdown key={index} raw={block.message.content} />;
-          }
-
-          if (block.message.thinking_content) {
-            return <Markdown key={index} raw={block.message.thinking_content} />;
+          if (block.message.content) {
+            return <Markdown key={index} raw={block.message.content} variant="streaming" />;
           }
 
           return null;


### PR DESCRIPTION
## Summary

The artifact loading card in `artifactLoadingDetails.tsx` uses `message.content` for streamed output. Applies the `streaming` variant to `<Markdown>` and removes the `thinking_content` fallback — streamed output lives in `content`, not `thinking_content`.

Also removes the stale `!== 'Thinking...'` sentinel check.

## Changes

- `artifactLoadingDetails.tsx`: simplify block rendering to use `message.content` with `variant="streaming"`, remove `thinking_content` fallback

## Not verified

- `pnpm typecheck` — not available in this environment (shallow clone); logic change is minimal and confined to one conditional

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0B448X3T3J%3A1781546981.890269%22)