### PR TITLE
fix(equations): Handle count_unique

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -214,7 +214,7 @@ class ResolvedFunction(ResolvedColumn):
 
     @property
     def proto_type(self) -> AttributeKey.Type.ValueType:
-        return constants.DOUBLE
+        return constants.TYPE_MAP[self.search_type]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -256,13 +256,22 @@ class ResolvedAggregate(ResolvedFunction):
     def proto_definition(self) -> AttributeAggregation:
         """The definition of this function as needed by the RPC"""
         if self.default_value is not None:
-            return AttributeAggregation(
-                aggregate=self.internal_name,
-                key=self.argument,
-                label=self.public_alias,
-                extrapolation_mode=self.extrapolation_mode,
-                default_value_double=self.default_value,
-            )
+            if self.proto_type == constants.INT:
+                return AttributeAggregation(
+                    aggregate=self.internal_name,
+                    key=self.argument,
+                    label=self.public_alias,
+                    extrapolation_mode=self.extrapolation_mode,
+                    default_value_int64=int(self.default_value),
+                )
+            else:
+                return AttributeAggregation(
+                    aggregate=self.internal_name,
+                    key=self.argument,
+                    label=self.public_alias,
+                    extrapolation_mode=self.extrapolation_mode,
+                    default_value_double=self.default_value,
+                )
         else:
             return AttributeAggregation(
                 aggregate=self.internal_name,
@@ -290,13 +299,22 @@ class ResolvedTraceMetricAggregate(ResolvedFunction):
     ) -> AttributeAggregation | AttributeConditionalAggregation:
         if self.trace_metric is None and self.trace_filter is None:
             if self.default_value is not None:
-                return AttributeAggregation(
-                    aggregate=self.internal_name,
-                    key=self.key,
-                    label=self.public_alias,
-                    extrapolation_mode=self.extrapolation_mode,
-                    default_value_double=self.default_value,
-                )
+                if self.proto_type == constants.INT:
+                    return AttributeAggregation(
+                        aggregate=self.internal_name,
+                        key=self.key,
+                        label=self.public_alias,
+                        extrapolation_mode=self.extrapolation_mode,
+                        default_value_int64=int(self.default_value),
+                    )
+                else:
+                    return AttributeAggregation(
+                        aggregate=self.internal_name,
+                        key=self.key,
+                        label=self.public_alias,
+                        extrapolation_mode=self.extrapolation_mode,
+                        default_value_double=self.default_value,
+                    )
             else:
                 return AttributeAggregation(
                     aggregate=self.internal_name,
@@ -315,14 +333,24 @@ class ResolvedTraceMetricAggregate(ResolvedFunction):
             )
 
         if self.default_value is not None:
-            return AttributeConditionalAggregation(
-                aggregate=self.internal_name,
-                key=self.key,
-                filter=trace_filter,
-                label=self.public_alias,
-                extrapolation_mode=self.extrapolation_mode,
-                default_value_double=self.default_value,
-            )
+            if self.proto_type == constants.INT:
+                return AttributeConditionalAggregation(
+                    aggregate=self.internal_name,
+                    key=self.key,
+                    filter=trace_filter,
+                    label=self.public_alias,
+                    extrapolation_mode=self.extrapolation_mode,
+                    default_value_int64=int(self.default_value),
+                )
+            else:
+                return AttributeConditionalAggregation(
+                    aggregate=self.internal_name,
+                    key=self.key,
+                    filter=trace_filter,
+                    label=self.public_alias,
+                    extrapolation_mode=self.extrapolation_mode,
+                    default_value_double=self.default_value,
+                )
         else:
             return AttributeConditionalAggregation(
                 aggregate=self.internal_name,
@@ -349,14 +377,24 @@ class ResolvedConditionalAggregate(ResolvedFunction):
     def proto_definition(self) -> AttributeConditionalAggregation:
         """The definition of this function as needed by the RPC"""
         if self.default_value is not None:
-            return AttributeConditionalAggregation(
-                aggregate=self.internal_name,
-                key=self.key,
-                filter=self.trace_filter,
-                label=self.public_alias,
-                extrapolation_mode=self.extrapolation_mode,
-                default_value_double=self.default_value,
-            )
+            if self.proto_type == constants.INT:
+                return AttributeConditionalAggregation(
+                    aggregate=self.internal_name,
+                    key=self.key,
+                    filter=self.trace_filter,
+                    label=self.public_alias,
+                    extrapolation_mode=self.extrapolation_mode,
+                    default_value_int64=int(self.default_value),
+                )
+            else:
+                return AttributeConditionalAggregation(
+                    aggregate=self.internal_name,
+                    key=self.key,
+                    filter=self.trace_filter,
+                    label=self.public_alias,
+                    extrapolation_mode=self.extrapolation_mode,
+                    default_value_double=self.default_value,
+                )
         else:
             return AttributeConditionalAggregation(
                 aggregate=self.internal_name,

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2571,6 +2571,37 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert meta["units"]["equation|tpm()"] == "1/minute"
         assert meta["fields"]["equation|tpm()"] == "rate"
 
+    def test_equation_mixed_types(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "foo",
+                        "sentry_tags": {"status": "success", "user.email": "test@test.com"},
+                        "is_segment": True,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "count_unique(user.email)",
+                    "equation|p95(span.duration) / count_unique(user.email)",
+                ],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["equation|p95(span.duration) / count_unique(user.email)"] == 1000
+
     def test_p75_if(self) -> None:
         self.store_spans(
             [


### PR DESCRIPTION
- Because default_value was always being passed as a double we would get a type error when doing a count_unique since its an integer.
- This updates the proto definition to dynamically change between the default value types depending on what the resolved function is
- Also fix a bug where all resolved functions were being treated as doubles even though this isn't true (ie. count_unique)