### PR TITLE
test(code-review): prove GitLab vs GitHub contributor-seeding gaps

### DIFF
--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -370,6 +370,45 @@ class WebhookTest(GitLabTestCase):
         ]
         assert error_metrics == []
 
+    @patch(
+        "sentry.integrations.gitlab.webhooks.track_gitlab_contributor_seat_processor"
+    )
+    def test_seat_processor_not_called_when_last_commit_missing(
+        self, mock_seat_processor: MagicMock
+    ) -> None:
+        """MergeEventWebhook.__call__ short-circuits before processors when last_commit is absent.
+
+        The method tries to access ``event["object_attributes"]["last_commit"]`` and
+        returns early (204) when it is missing.  ``_handle`` — which iterates over
+        ``WEBHOOK_EVENT_PROCESSORS`` — is never reached, so
+        ``track_gitlab_contributor_seat_processor`` does not run and the
+        ``OrganizationContributors`` row is never seeded.
+
+        Consequence: any subsequent ``@sentry review`` comment on this MR will be
+        denied with ``ORG_CONTRIBUTOR_NOT_FOUND`` because ``NoteEventWebhook`` has
+        no fallback seeding.  Tracked as SCM-99.
+        """
+        self.create_gitlab_repo("getsentry/sentry")
+        payload = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+        del payload["object_attributes"]["last_commit"]
+
+        response = self.client.post(
+            self.url,
+            data=orjson.dumps(payload),
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Merge Request Hook",
+        )
+
+        assert response.status_code == 204
+        # The short-circuit happens in __call__ before _handle runs processors.
+        mock_seat_processor.assert_not_called()
+        # Confirm no contributor row was seeded as a direct consequence.
+        from sentry.models.organizationcontributors import OrganizationContributors
+        assert not OrganizationContributors.objects.filter(
+            organization_id=self.organization.id
+        ).exists()
+
     def test_merge_event_invokes_code_review_handler(self) -> None:
         # The code-review handler is wired into the endpoint via the processor
         # tuple. Confirm both that it is registered and that an inbound

--- a/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
+++ b/tests/sentry/seer/code_review/webhooks/test_issue_comment.py
@@ -158,3 +158,136 @@ class IssueCommentEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             self.mock_seer.assert_called_once()
             call_args = self.mock_seer.call_args
             assert call_args[1]["path"] == "/v1/code_review/review-request"
+
+
+# ---------------------------------------------------------------------------
+# Contributor-seeding gap: IssueCommentEventWebhook has no fallback seeding
+# (mirrors GitLab NoteEventWebhook)
+# ---------------------------------------------------------------------------
+
+
+class IssueCommentContributorGapTest(GitHubWebhookCodeReviewTestCase):
+    """Prove that GitHub's IssueCommentEventWebhook has the same contributor-seeding
+    gap as GitLab's NoteEventWebhook.
+
+    PullRequestEventWebhook._handle seeds OrganizationContributors via
+    track_contributor_seat guarded by `if created:` on the PullRequest DB row.
+    IssueCommentEventWebhook has no equivalent seeding, so if the PR-open webhook
+    was never processed (or the PR predates contributor seeding), preflight returns
+    ORG_CONTRIBUTOR_NOT_FOUND and the @sentry review command is silently denied.
+
+    Unlike _send_webhook_event (used by most IssueCommentEventWebhookTest tests),
+    the helper here deliberately omits the OrganizationContributors.get_or_create
+    call to exercise the production failure path.
+    """
+
+    @pytest.fixture(autouse=True)
+    def mock_github_api_calls(self) -> Generator[None]:
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_pull_request.return_value = {"head": {"sha": "abc123"}}
+        with (
+            patch(
+                "sentry.integrations.github.client.GitHubApiClient.create_comment_reaction"
+            ) as mock_reaction,
+            patch(
+                "sentry.integrations.github.client.GitHubApiClient.get_pull_request",
+                mock_client_instance.get_pull_request,
+            ),
+            patch(
+                "sentry.integrations.github.client.GitHubApiClient.get_issue_reactions",
+                return_value=[],
+            ),
+        ):
+            self.mock_reaction = mock_reaction
+            yield
+
+    @pytest.fixture(autouse=True)
+    def mock_seer_request(self) -> Generator[None]:
+        with patch("sentry.seer.code_review.webhooks.task.make_seer_request") as mock_seer:
+            self.mock_seer = mock_seer
+            yield
+
+    def _send_without_contributor(self, event_data: bytes) -> None:
+        """Set up integration + repo + settings, but skip contributor seeding."""
+        from sentry.models.organizationcontributors import OrganizationContributors
+        from sentry.seer.code_review.utils import get_pr_author_id
+
+        event_dict = orjson.loads(event_data)
+        repo_id = str(event_dict["repository"]["id"])
+        integration = self.create_github_integration()
+        repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            external_id=repo_id,
+            integration_id=integration.id,
+        )
+        trigger_values = [t.value for t in self._triggers]
+        self.create_repository_settings(
+            repository=repo,
+            enabled_code_review=True,
+            code_review_triggers=trigger_values,
+        )
+        # Explicitly assert no contributor row was pre-seeded.
+        pr_author_id = get_pr_author_id(event_dict)
+        assert pr_author_id is not None
+        assert not OrganizationContributors.objects.filter(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+            external_identifier=pr_author_id,
+        ).exists(), "contributor row should not exist before the test"
+
+        self.send_github_webhook_event(GithubWebhookType.ISSUE_COMMENT, event_data)
+
+    def test_review_command_denied_when_contributor_row_missing(self) -> None:
+        """@sentry review is denied when the PR author has no contributor row.
+
+        IssueCommentEventWebhook runs preflight which checks OrganizationContributors.
+        Unlike PullRequestEventWebhook (which seeds the row on PR creation), the
+        comment handler has no seeding logic.  If the PR-open event was missed — or
+        the PR predates contributor seeding — every @sentry review command on that PR
+        will be denied with ORG_CONTRIBUTOR_NOT_FOUND.
+
+        The contrast with GitHub's PR-open path is tested in
+        PullRequestEventWebhookTest.test_pr_open_seeds_contributor_row_permanently.
+        """
+        event_bytes = orjson.dumps(
+            orjson.loads(
+                self._build_issue_comment_event(
+                    f"Please {SENTRY_REVIEW_COMMAND} this PR",
+                    github_org="sentry-ecosystem",
+                )
+            )
+        )
+        with self.code_review_setup(), self.tasks():
+            self._send_without_contributor(event_bytes)
+
+        self.mock_seer.assert_not_called()
+
+    def test_review_command_succeeds_when_contributor_row_exists(self) -> None:
+        """Seeding the contributor row is the only missing piece.
+
+        Identical to test_review_command_denied_when_contributor_row_missing except
+        we pre-seed the row (simulating what PullRequestEventWebhook._handle would
+        have done on PR open), proving that is sufficient for the command to succeed.
+        """
+        from sentry.models.organizationcontributors import OrganizationContributors
+        from sentry.seer.code_review.utils import get_pr_author_id
+
+        event_data = orjson.dumps(
+            orjson.loads(
+                self._build_issue_comment_event(
+                    f"Please {SENTRY_REVIEW_COMMAND} this PR",
+                    github_org="sentry-ecosystem",
+                )
+            )
+        )
+        with self.code_review_setup(), self.tasks():
+            # _send_webhook_event auto-seeds the contributor row, which is
+            # exactly what we want here — simulate the happy path where
+            # PullRequestEventWebhook fired first and seeded the row.
+            response = self._send_issue_comment_event(event_data)
+            assert response.status_code == 204
+
+        self.mock_seer.assert_called_once()
+
+

--- a/tests/sentry/seer/code_review/webhooks/test_merge_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_merge_request.py
@@ -1481,3 +1481,132 @@ class MergeRequestReactionTest(_MergeRequestHandlerTestBase):
 
         assert self.mock_scm.create_pull_request_reaction.call_count == 1
         assert self.mock_seer.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Contributor-seeding gap: NoteEventWebhook has no fallback seeding
+# ---------------------------------------------------------------------------
+
+
+class MergeRequestNoteContributorGapTest(GitLabTestCase):
+    """Prove that NoteEventWebhook has no fallback OrganizationContributors seeding.
+
+    MergeEventWebhook seeds the contributor row via
+    track_gitlab_contributor_seat_processor (first in WEBHOOK_EVENT_PROCESSORS)
+    before handle_merge_request_event runs preflight.  NoteEventWebhook only
+    registers handle_merge_request_note_event — no seeding processor — so if the
+    contributor row was never created the review command is silently denied with
+    ORG_CONTRIBUTOR_NOT_FOUND.
+
+    This class intentionally omits the OrganizationContributors.get_or_create call
+    that _setup_code_review normally inserts, to exercise the production failure path.
+    """
+
+    @pytest.fixture(autouse=True)
+    def mock_seer_request(self) -> Generator[None]:
+        with patch("sentry.seer.code_review.webhooks.task.make_seer_request") as mock_seer:
+            self.mock_seer = mock_seer
+            yield
+
+    @pytest.fixture(autouse=True)
+    def mock_scm(self) -> Generator[None]:
+        mock_scm_instance = MagicMock(spec=CreatePullRequestCommentReactionProtocol)
+        with patch(
+            "sentry.seer.code_review.webhooks.merge_request.make_scm",
+            return_value=mock_scm_instance,
+        ):
+            yield
+
+    def _setup_repo_without_contributor(self) -> None:
+        """Set up repo + settings, but deliberately omit the contributor row."""
+        repo = self.create_gitlab_repo(name="Cool Group / Sentry")
+        repo.config["path"] = "cool-group/sentry"
+        repo.save()
+        self.create_repository_settings(
+            repository=repo,
+            enabled_code_review=True,
+            code_review_triggers=[
+                CodeReviewTrigger.ON_NEW_COMMIT.value,
+                CodeReviewTrigger.ON_READY_FOR_REVIEW.value,
+            ],
+        )
+        self.repo = repo
+
+    @with_feature(
+        {
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+            "organizations:seer-code-review-gitlab",
+        }
+    )
+    def test_note_review_denied_when_contributor_row_missing(self) -> None:
+        """@sentry review on an MR whose contributor row was never seeded is denied.
+
+        The MERGE_REQUEST_NOTE_EVENT fixture has merge_request.author_id=51, matching
+        the external_identifier normally inserted by _setup_code_review.  When that
+        row is absent, _check_billing returns ORG_CONTRIBUTOR_NOT_FOUND and no Seer
+        task is enqueued — exactly what happens in production if the MR-open webhook
+        was missed or fired before track_gitlab_contributor_seat_processor was deployed.
+        """
+        self._setup_repo_without_contributor()
+
+        # Confirm the row really is absent before the test runs.
+        assert not OrganizationContributors.objects.filter(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            external_identifier="51",
+        ).exists()
+
+        event = _make_note_event()
+        with self.tasks():
+            handle_merge_request_note_event(
+                event=event,
+                organization=RpcOrganization(
+                    id=self.organization.id,
+                    slug=self.organization.slug,
+                    name=self.organization.name,
+                ),
+                repo=self.repo,
+                integration=self.integration,
+            )
+
+        self.mock_seer.assert_not_called()
+
+    @with_feature(
+        {
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+            "organizations:seer-code-review-gitlab",
+        }
+    )
+    def test_note_review_succeeds_once_contributor_row_exists(self) -> None:
+        """Seeding the contributor row unblocks the @sentry review command.
+
+        This is the counterpart to test_note_review_denied_when_contributor_row_missing:
+        identical setup except we manually seed the row, proving it is the only missing
+        piece.  In production the row is created by track_gitlab_contributor_seat_processor
+        when the MR-open webhook fires.
+        """
+        self._setup_repo_without_contributor()
+
+        OrganizationContributors.objects.get_or_create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            external_identifier="51",
+            defaults={"alias": "root"},
+        )
+
+        event = _make_note_event()
+        with self.tasks():
+            handle_merge_request_note_event(
+                event=event,
+                organization=RpcOrganization(
+                    id=self.organization.id,
+                    slug=self.organization.slug,
+                    name=self.organization.name,
+                ),
+                repo=self.repo,
+                integration=self.integration,
+            )
+
+        self.mock_seer.assert_called_once()

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -442,3 +442,142 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
 
             # Task should NOT be scheduled due to validation failure
             self.mock_seer.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Contributor seeding: GitHub uses permanent DB dedup; GitLab uses Redis TTL
+# ---------------------------------------------------------------------------
+
+
+class PullRequestContributorSeedingTest(GitHubWebhookCodeReviewTestCase):
+    """Prove that PullRequestEventWebhook._handle seeds OrganizationContributors
+    via track_contributor_seat when PullRequest.objects.update_or_create returns
+    created=True — a permanent, DB-backed dedup — unlike GitLab's
+    track_gitlab_contributor_seat_processor which uses a 20-second Redis TTL.
+
+    Key behavioural difference:
+    - GitHub: row seeded inside _handle via ``if created:``. Re-delivery of the same
+      PR-open event sets created=False (the DB row already exists) so track_contributor_seat
+      is NOT called again. The dedup lasts forever.
+    - GitLab: row seeded by track_gitlab_contributor_seat_processor (runs as the first
+      WEBHOOK_EVENT_PROCESSORS entry). Dedup is a Redis key with a 20 s TTL; after TTL
+      expiry, a redelivered open event calls track_contributor_seat again (idempotent via
+      get_or_create, but the dedup window is finite).
+    """
+
+    @pytest.fixture(autouse=True)
+    def mock_github_api_calls(self) -> Generator[None]:
+        with (
+            patch("sentry.integrations.github.client.GitHubApiClient.get_pull_request"),
+            patch("sentry.integrations.github.client.GitHubApiClient.create_issue_reaction"),
+            patch(
+                "sentry.integrations.github.client.GitHubApiClient.get_issue_reactions",
+                return_value=[],
+            ),
+            patch("sentry.integrations.github.client.GitHubApiClient.delete_issue_reaction"),
+        ):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def mock_seer_request(self) -> Generator[None]:
+        with patch("sentry.seer.code_review.webhooks.task.make_seer_request"):
+            yield
+
+    def _send_pr_event_without_contributor(self, event: dict) -> None:
+        """Send a PR webhook without pre-seeding the contributor row.
+
+        _send_webhook_event (the normal test helper) always calls
+        OrganizationContributors.get_or_create before sending the webhook, masking
+        the production seeding behaviour.  This helper replicates only the
+        integration/repo/settings setup and sends the raw webhook so we can observe
+        what PullRequestEventWebhook._handle does on its own.
+        """
+        from sentry.models.organizationcontributors import OrganizationContributors
+        from sentry.seer.code_review.utils import get_pr_author_id
+
+        event_bytes = orjson.dumps(event)
+        event_dict = event
+        repo_id = str(event_dict["repository"]["id"])
+        integration = self.create_github_integration()
+        repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            external_id=repo_id,
+            integration_id=integration.id,
+        )
+        trigger_values = [t.value for t in self._triggers]
+        self.create_repository_settings(
+            repository=repo,
+            enabled_code_review=True,
+            code_review_triggers=trigger_values,
+        )
+        # Assert the row genuinely does not exist before the webhook fires.
+        pr_author_id = get_pr_author_id(event_dict)
+        assert pr_author_id is not None
+        assert not OrganizationContributors.objects.filter(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+            external_identifier=pr_author_id,
+        ).exists(), "expected no contributor row before the PR-open webhook"
+
+        self._integration = integration
+        self._pr_author_id = pr_author_id
+        self.send_github_webhook_event(GithubWebhookType.PULL_REQUEST, event_bytes)
+
+    def test_pr_open_seeds_contributor_row_permanently(self) -> None:
+        """A PR-open webhook creates the OrganizationContributors row via track_contributor_seat.
+
+        The row is seeded inside PullRequestEventWebhook._handle — specifically the
+        ``if created:`` branch of PullRequest.objects.update_or_create — and persists
+        in the database until explicitly deleted.  This permanent DB-backed dedup is
+        stronger than GitLab's 20-second Redis TTL: re-delivering the same PR-open event
+        does not create a duplicate row and does not call track_contributor_seat again.
+        """
+        event = orjson.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
+        event["action"] = "opened"
+
+        with self.code_review_setup(), self.tasks():
+            self._send_pr_event_without_contributor(event)
+
+        # The row must exist after the webhook is processed.
+        assert OrganizationContributors.objects.filter(
+            organization_id=self.organization.id,
+            integration_id=self._integration.id,
+            external_identifier=self._pr_author_id,
+        ).exists(), "PullRequestEventWebhook._handle should seed OrganizationContributors on PR open"
+
+    def test_pr_open_redelivery_does_not_duplicate_contributor_row(self) -> None:
+        """Re-delivering a PR-open event does not create a second contributor row.
+
+        PullRequest.objects.update_or_create returns created=False for the second
+        delivery, so the ``if created:`` guard skips track_contributor_seat.  This
+        contrasts with GitLab's Redis TTL: after 20 s the same open event would call
+        track_contributor_seat again (harmlessly idempotent via get_or_create, but
+        the dedup mechanism is ephemeral rather than permanent).
+        """
+        event = orjson.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
+        event["action"] = "opened"
+
+        with self.code_review_setup(), self.tasks():
+            # First delivery — seeds the PullRequest row and the contributor row.
+            self._send_pr_event_without_contributor(event)
+            assert OrganizationContributors.objects.filter(
+                organization_id=self.organization.id,
+                integration_id=self._integration.id,
+                external_identifier=self._pr_author_id,
+            ).count() == 1
+
+            # Second delivery of the exact same event.
+            self.send_github_webhook_event(
+                GithubWebhookType.PULL_REQUEST, orjson.dumps(event)
+            )
+
+        # Still exactly one row — the DB dedup prevents a second seeding.
+        assert (
+            OrganizationContributors.objects.filter(
+                organization_id=self.organization.id,
+                integration_id=self._integration.id,
+                external_identifier=self._pr_author_id,
+            ).count()
+            == 1
+        ), "re-delivering the PR-open event must not create a duplicate contributor row"


### PR DESCRIPTION
## What

Seven new tests across four files that prove the contributor-seeding behaviour differs between GitLab and GitHub — and document the gaps.

## Why

During a review of the GitLab code-review path, two residual gaps were identified:

1. `NoteEventWebhook` (`@sentry review`) has no fallback contributor seeding — if the MR-open event was missed, preflight returns `ORG_CONTRIBUTOR_NOT_FOUND`.
2. `MergeEventWebhook.__call__` short-circuits before processors run when `last_commit` is absent, so `track_gitlab_contributor_seat_processor` never fires.
3. GitHub's `IssueCommentEventWebhook` has the same command-path gap as GitLab's note handler.

The existing tests masked these gaps by always pre-seeding `OrganizationContributors` in `_setup_code_review`. These tests deliberately omit that seeding to exercise the real failure path.

## Tests added

**`test_merge_request.py` — `MergeRequestNoteContributorGapTest`**
- `test_note_review_denied_when_contributor_row_missing` — `@sentry review` denied when no contributor row exists; no Seer task enqueued.
- `test_note_review_succeeds_once_contributor_row_exists` — identical setup plus manual seeding proves the row is the only missing piece.

**`tests/sentry/integrations/gitlab/test_webhook.py` — `WebhookTest`**
- `test_seat_processor_not_called_when_last_commit_missing` — `MergeEventWebhook.__call__` returns before `_handle` when `last_commit` is absent; `track_gitlab_contributor_seat_processor` is never invoked and no contributor row is created.

**`test_issue_comment.py` — `IssueCommentContributorGapTest`**
- `test_review_command_denied_when_contributor_row_missing` — GitHub `@sentry review` denied when the PR author has no contributor row (same gap as GitLab note handler).
- `test_review_command_succeeds_when_contributor_row_exists` — counterpart proving the row is sufficient.

**`test_pull_request.py` — `PullRequestContributorSeedingTest`**
- `test_pr_open_seeds_contributor_row_permanently` — PR-open webhook creates the contributor row via `track_contributor_seat` inside `if created:`.
- `test_pr_open_redelivery_does_not_duplicate_contributor_row` — re-delivering the same event returns `created=False`; no second row is created. Contrasts with GitLab's 20 s Redis TTL dedup.

## Verification

Tests only — no production code changed.

Related: #117710 (stale docstring fix)

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC013P75SQUB%3A1781534668.098929%22)
