### PR TITLE
ref(seer): Gate GitLab code review on seer-gitlab-support flag

### DIFF
--- a/src/sentry/seer/code_review/webhooks/logging.py
+++ b/src/sentry/seer/code_review/webhooks/logging.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from sentry.models.organization import Organization
     from sentry.organizations.services.organization.model import RpcOrganization
 
-_FLAG = "organizations:seer-code-review-gitlab"
+_FLAG = "organizations:seer-gitlab-support"
 
 
 def debug_log(

--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -376,7 +376,7 @@ def handle_merge_request_event(
 
     debug_log(logger, organization, "handler_started", base_log)
 
-    if not features.has("organizations:seer-code-review-gitlab", organization):
+    if not features.has("organizations:seer-gitlab-support", organization):
         return
 
     object_attributes = event.get("object_attributes", {})
@@ -829,7 +829,7 @@ def handle_merge_request_note_event(
     base_log["integration_id"] = integration.id
     debug_log(logger, organization, "note.handler_started", base_log)
 
-    if not features.has("organizations:seer-code-review-gitlab", organization):
+    if not features.has("organizations:seer-gitlab-support", organization):
         return
 
     action_value = object_attributes.get("action", "")

--- a/src/sentry/seer/code_review/webhooks/seat_tracking.py
+++ b/src/sentry/seer/code_review/webhooks/seat_tracking.py
@@ -18,7 +18,7 @@ mechanics:
   dispatches each payload once per installed organization; both can otherwise
   cause ``num_actions`` to be incremented multiple times for a single MR-open.
 
-Gated by ``organizations:seer-code-review-gitlab`` — the same cohort flag
+Gated by ``organizations:seer-gitlab-support`` — the same cohort flag
 ``handle_merge_request_event`` uses — so seeding only happens for orgs that
 are already opted in to GitLab code review. The downstream call to
 ``should_increment_contributor_seat`` additionally requires
@@ -103,7 +103,7 @@ def track_gitlab_contributor_seat_processor(
 
     debug_log(logger, organization, "processor_started", base_extra)
 
-    if not features.has("organizations:seer-code-review-gitlab", organization):
+    if not features.has("organizations:seer-gitlab-support", organization):
         return
 
     if object_attributes.get("action") != "open":

--- a/tests/sentry/seer/code_review/webhooks/test_merge_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_merge_request.py
@@ -76,7 +76,7 @@ class _MergeRequestHandlerTestBase(GitLabTestCase):
     CODE_REVIEW_FEATURES = {
         "organizations:gen-ai-features",
         "organizations:code-review-beta",
-        "organizations:seer-code-review-gitlab",
+        "organizations:seer-gitlab-support",
     }
 
     @pytest.fixture(autouse=True)
@@ -162,7 +162,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_open_uses_review_request_endpoint(self) -> None:
@@ -178,7 +178,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
 
     @with_feature({"organizations:gen-ai-features", "organizations:code-review-beta"})
     def test_skips_when_gitlab_flag_disabled(self) -> None:
-        # The GitLab MR handler is gated on organizations:seer-code-review-gitlab,
+        # The GitLab MR handler is gated on organizations:seer-gitlab-support,
         # independent of the other code-review flags.
         self._setup_code_review()
         event = _make_event("open")
@@ -192,7 +192,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_close_uses_pr_closed_endpoint(self) -> None:
@@ -210,7 +210,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_merge_uses_pr_closed_endpoint(self) -> None:
@@ -228,7 +228,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_update_uses_review_request_endpoint(self) -> None:
@@ -246,7 +246,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_update_without_oldrev_is_skipped(self) -> None:
@@ -263,7 +263,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_update_with_unrelated_changes_is_skipped(self) -> None:
@@ -281,7 +281,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_undraft_update_uses_review_request_endpoint(self) -> None:
@@ -303,7 +303,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_undraft_update_via_work_in_progress_uses_review_request_endpoint(self) -> None:
@@ -322,7 +322,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_undraft_update_trigger_is_ready_for_review(self) -> None:
@@ -340,7 +340,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_undraft_update_filtered_when_ready_trigger_disabled(self) -> None:
@@ -358,7 +358,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_skips_draft_mr(self) -> None:
@@ -374,7 +374,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_skips_work_in_progress_mr(self) -> None:
@@ -390,7 +390,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_close_still_sends_for_draft_mr(self) -> None:
@@ -406,7 +406,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_skips_unsupported_action(self) -> None:
@@ -422,7 +422,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_skips_unknown_action(self) -> None:
@@ -438,7 +438,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_skips_missing_action(self) -> None:
@@ -455,7 +455,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_skips_when_integration_is_none(self) -> None:
@@ -485,7 +485,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_skips_missing_last_commit(self) -> None:
@@ -502,7 +502,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_open_filtered_when_trigger_disabled(self) -> None:
@@ -518,7 +518,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_update_filtered_when_trigger_disabled(self) -> None:
@@ -534,7 +534,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_close_filtered_when_no_triggers_configured(self) -> None:
@@ -550,7 +550,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_close_sends_when_triggers_configured(self) -> None:
@@ -566,7 +566,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_contains_correct_pr_id(self) -> None:
@@ -585,7 +585,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_contains_gitlab_provider(self) -> None:
@@ -604,7 +604,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_owner_and_name_use_path_not_display_name(self) -> None:
@@ -625,7 +625,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_owner_and_name_handle_subgroups(self) -> None:
@@ -644,7 +644,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_is_private_true_for_private_project(self) -> None:
@@ -663,7 +663,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_is_private_true_for_internal_project(self) -> None:
@@ -682,7 +682,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_is_private_false_for_public_project(self) -> None:
@@ -701,7 +701,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_is_private_none_when_visibility_absent(self) -> None:
@@ -720,7 +720,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_trigger_on_ready_for_review_for_open(self) -> None:
@@ -739,7 +739,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_trigger_on_new_commit_for_update(self) -> None:
@@ -758,7 +758,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_contains_trigger_user_from_event(self) -> None:
@@ -777,7 +777,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_duplicate_delivery_within_window_skipped(self) -> None:
@@ -794,7 +794,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_duplicate_delivery_after_ttl_processes_again(self) -> None:
@@ -822,7 +822,7 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_distinct_commits_are_not_deduped(self) -> None:
@@ -916,7 +916,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_sentry_review_comment_schedules_seer_task(self) -> None:
@@ -935,7 +935,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_trigger_is_on_command_phrase(self) -> None:
@@ -953,7 +953,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_contains_trigger_comment_id_and_type(self) -> None:
@@ -972,7 +972,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_payload_trigger_user_is_commenter(self) -> None:
@@ -990,7 +990,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_eyes_reaction_added_to_note(self) -> None:
@@ -1011,7 +1011,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_non_review_command_is_ignored(self) -> None:
@@ -1028,7 +1028,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_issue_note_is_ignored(self) -> None:
@@ -1045,7 +1045,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_non_create_action_is_ignored(self) -> None:
@@ -1062,7 +1062,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_sentry_review_case_insensitive(self) -> None:
@@ -1079,7 +1079,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_duplicate_note_skipped(self) -> None:
@@ -1094,7 +1094,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         self.mock_seer.assert_called_once()
 
     def test_skips_when_feature_flag_disabled(self) -> None:
-        """Handler must no-op when organizations:seer-code-review-gitlab is off."""
+        """Handler must no-op when organizations:seer-gitlab-support is off."""
         self._setup_code_review()
         event = _make_note_event()
 
@@ -1107,7 +1107,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_skips_when_integration_is_none(self) -> None:
@@ -1132,7 +1132,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_reaction_failure_does_not_block_seer_task(self) -> None:
@@ -1150,7 +1150,7 @@ class MergeRequestNoteEventTest(GitLabTestCase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_duplicate_note_after_ttl_processes_again(self) -> None:
@@ -1197,7 +1197,7 @@ class MergeRequestReactionTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_eyes_reaction_added_for_open_action(self) -> None:
@@ -1215,7 +1215,7 @@ class MergeRequestReactionTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_stale_hooray_reaction_deleted_before_eyes_added(self) -> None:
@@ -1242,7 +1242,7 @@ class MergeRequestReactionTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_other_users_hooray_reaction_not_deleted(self) -> None:
@@ -1268,7 +1268,7 @@ class MergeRequestReactionTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_no_reaction_for_close_action(self) -> None:
@@ -1287,7 +1287,7 @@ class MergeRequestReactionTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_no_reaction_for_merge_action(self) -> None:
@@ -1306,7 +1306,7 @@ class MergeRequestReactionTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_reaction_failure_does_not_block_seer_task(self) -> None:
@@ -1326,7 +1326,7 @@ class MergeRequestReactionTest(_MergeRequestHandlerTestBase):
         {
             "organizations:gen-ai-features",
             "organizations:code-review-beta",
-            "organizations:seer-code-review-gitlab",
+            "organizations:seer-gitlab-support",
         }
     )
     def test_eyes_reaction_added_for_update_with_new_commit(self) -> None:

--- a/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
+++ b/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
@@ -54,7 +54,7 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
             integration=self.integration,
         )
 
-    @with_feature("organizations:seer-code-review-gitlab")
+    @with_feature("organizations:seer-gitlab-support")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
     def test_calls_track_contributor_seat_on_open(self, mock_track: Any) -> None:
         self._call()
@@ -73,19 +73,19 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
         self._call()
         mock_track.assert_not_called()
 
-    @with_feature("organizations:seer-code-review-gitlab")
+    @with_feature("organizations:seer-gitlab-support")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
     def test_no_call_on_update_action(self, mock_track: Any) -> None:
         self._call(event=_make_event(action="update"))
         mock_track.assert_not_called()
 
-    @with_feature("organizations:seer-code-review-gitlab")
+    @with_feature("organizations:seer-gitlab-support")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
     def test_no_call_on_close_action(self, mock_track: Any) -> None:
         self._call(event=_make_event(action="close"))
         mock_track.assert_not_called()
 
-    @with_feature("organizations:seer-code-review-gitlab")
+    @with_feature("organizations:seer-gitlab-support")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
     def test_no_call_without_integration(self, mock_track: Any) -> None:
         track_gitlab_contributor_seat_processor(
@@ -96,7 +96,7 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
         )
         mock_track.assert_not_called()
 
-    @with_feature("organizations:seer-code-review-gitlab")
+    @with_feature("organizations:seer-gitlab-support")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
     def test_no_call_when_author_id_missing(self, mock_track: Any) -> None:
         event = _make_event()
@@ -104,7 +104,7 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
         self._call(event=event)
         mock_track.assert_not_called()
 
-    @with_feature("organizations:seer-code-review-gitlab")
+    @with_feature("organizations:seer-gitlab-support")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
     def test_no_call_when_username_missing(self, mock_track: Any) -> None:
         event = _make_event()
@@ -112,7 +112,7 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
         self._call(event=event)
         mock_track.assert_not_called()
 
-    @with_feature("organizations:seer-code-review-gitlab")
+    @with_feature("organizations:seer-gitlab-support")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
     def test_duplicate_delivery_within_window_skipped(self, mock_track: Any) -> None:
         # GitLab redelivers webhooks on response timeout, and the endpoint
@@ -125,7 +125,7 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
 
         mock_track.assert_called_once()
 
-    @with_feature("organizations:seer-code-review-gitlab")
+    @with_feature("organizations:seer-gitlab-support")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
     def test_duplicate_delivery_after_ttl_processes_again(self, mock_track: Any) -> None:
         event = _make_event()
@@ -140,7 +140,7 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
         self._call(event=event)
         assert mock_track.call_count == 2
 
-    @with_feature("organizations:seer-code-review-gitlab")
+    @with_feature("organizations:seer-gitlab-support")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
     def test_missing_organization_does_not_poison_dedup(self, mock_track: Any) -> None:
         # If the Organization can't be resolved, no Redis key is set, so a


### PR DESCRIPTION
## Summary

The GitLab code review webhook flow was gated on `organizations:seer-code-review-gitlab`, a separate cohort flag from `organizations:seer-gitlab-support` that the rest of the GitLab support surface already uses (onboarding check, seer setup, and the frontend).

This consolidates the backend GitLab code review gating onto `seer-gitlab-support` so all GitLab gating shares a single flag.

## Changes

Repointed `features.has(...)` checks (and the shared `_FLAG` constant / docstring) from `seer-code-review-gitlab` to `seer-gitlab-support` in:

- `webhooks/merge_request.py` — MR handler gates
- `webhooks/seat_tracking.py` — contributor seat seeding gate
- `webhooks/logging.py` — `_FLAG` driving GitLab debug logging

Tests in `test_merge_request.py` and `test_seat_tracking.py` updated to match.

## Notes

- The `seer-code-review-gitlab` registration is **intentionally left** in `src/sentry/features/temporary.py` for now — it's simply no longer read. Deregistering it can follow once any rollout config keyed on it is cleaned up.
- `api_expose` differs between the flags (`False` vs `True`), but this is irrelevant here since every gate uses the Python-side `features.has(...)`.
- No behavior change for orgs that have both flags enabled.

## Test plan

- [ ] `pytest tests/sentry/seer/code_review/webhooks/`
