### PR TITLE
ref(seer-rpc): type repo-validation RPC method returns with Pydantic

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -125,8 +125,11 @@ from sentry.seer.fetch_issues.utils import NoProjectsForRepoError, get_repo_and_
 from sentry.seer.issue_detection import create_issue_occurrence
 from sentry.seer.seer_setup import get_supported_scm_providers
 from sentry.seer.sentry_data_models import (
+    GetRepoInstallationIdErrorResponse,
+    GetRepoInstallationIdSuccessResponse,
     GitHubEnterpriseConfigErrorResponse,
     GitHubEnterpriseConfigSuccessResponse,
+    HasRepoCodeMappingsResponse,
     OrganizationAutofixConsentResponse,
     OrganizationFeaturesResponse,
     OrganizationProject,
@@ -135,6 +138,8 @@ from sentry.seer.sentry_data_models import (
     RepositoryIntegrationsStatusResponse,
     SendSeerWebhookErrorResponse,
     SendSeerWebhookSuccessResponse,
+    ValidateRepoErrorResponse,
+    ValidateRepoSuccessResponse,
 )
 from sentry.seer.utils import filter_repo_by_provider
 from sentry.sentry_apps.metrics import SentryAppEventType
@@ -660,7 +665,7 @@ def send_seer_webhook(
 
 def has_repo_code_mappings(
     *, organization_id: int, provider: SeerSCMProvider, external_id: str, owner: str, name: str
-) -> dict[str, bool | dict[str, int]]:
+) -> HasRepoCodeMappingsResponse:
     """
     Validate that a repository exists and belongs to the given organization.
 
@@ -670,19 +675,18 @@ def has_repo_code_mappings(
         external_id: The repository's external ID in the provider's system
         owner: The repository owner (e.g., "getsentry")
         name: The repository name (e.g., "sentry")
-
-    Returns:
-        dict: {"has_code_mappings": bool, "project_slug_to_id": dict[str, int]}
     """
     try:
         repo_projects = get_repo_and_projects(organization_id, provider, external_id, owner, name)
     except (Repository.DoesNotExist, NoProjectsForRepoError):
-        return {"has_code_mappings": False, "project_slug_to_id": {}}
+        return HasRepoCodeMappingsResponse(has_code_mappings=False, project_slug_to_id={})
 
     project_slug_to_id = dict(
         sorted((project.slug, project.id) for project in repo_projects.projects)
     )
-    return {"has_code_mappings": True, "project_slug_to_id": project_slug_to_id}
+    return HasRepoCodeMappingsResponse(
+        has_code_mappings=True, project_slug_to_id=project_slug_to_id
+    )
 
 
 def validate_repo(
@@ -692,7 +696,7 @@ def validate_repo(
     external_id: str,
     owner: str,
     name: str,
-) -> dict[str, Any]:
+) -> ValidateRepoSuccessResponse | ValidateRepoErrorResponse:
     """
     Validate that a repository exists and belongs to the given organization.
 
@@ -702,25 +706,21 @@ def validate_repo(
         external_id: The repository's external ID in the provider's system
         owner: The repository owner (e.g., "getsentry")
         name: The repository name (e.g., "sentry")
-
-    Returns:
-        {"valid": True, "integration_id": <int|None>} if valid
-        {"valid": False, "reason": <str>} if invalid
     """
     repo = filter_repo_by_provider(organization_id, provider, external_id, owner, name).first()
 
     if not repo:
-        return {"valid": False, "reason": "repository_not_found"}
+        return ValidateRepoErrorResponse(reason="repository_not_found")
 
     try:
         organization = Organization.objects.get_from_cache(id=organization_id)
     except Organization.DoesNotExist:
-        return {"valid": False, "reason": "organization_not_found"}
+        return ValidateRepoErrorResponse(reason="organization_not_found")
     if repo.provider not in get_supported_scm_providers(organization):
         logger.warning("seer.scm.unsupported_provider", extra={"provider": repo.provider})
-        return {"valid": False, "reason": "unsupported_provider"}
+        return ValidateRepoErrorResponse(reason="unsupported_provider")
 
-    return {"valid": True, "integration_id": repo.integration_id}
+    return ValidateRepoSuccessResponse(integration_id=repo.integration_id)
 
 
 def get_repo_installation_id(
@@ -730,7 +730,7 @@ def get_repo_installation_id(
     external_id: str,
     owner: str,
     name: str,
-) -> dict[str, Any]:
+) -> GetRepoInstallationIdSuccessResponse | GetRepoInstallationIdErrorResponse:
     """
     Look up a repository and return the external_id of its associated integration (the installation ID).
 
@@ -740,30 +740,26 @@ def get_repo_installation_id(
         external_id: The repository's external ID in the provider's system
         owner: The repository owner (e.g., "getsentry")
         name: The repository name (e.g., "sentry")
-
-    Returns:
-        {"installation_id": <str>} if found
-        {"error": <str>} if not found or unsupported
     """
     repo = filter_repo_by_provider(organization_id, provider, external_id, owner, name).first()
 
     if not repo:
-        return {"error": "repository_not_found"}
+        return GetRepoInstallationIdErrorResponse(error="repository_not_found")
 
     try:
         organization = Organization.objects.get_from_cache(id=organization_id)
     except Organization.DoesNotExist:
-        return {"error": "organization_not_found"}
+        return GetRepoInstallationIdErrorResponse(error="organization_not_found")
     if repo.provider not in get_supported_scm_providers(organization):
         logger.warning("seer.scm.unsupported_provider", extra={"provider": repo.provider})
-        return {"error": "unsupported_provider"}
+        return GetRepoInstallationIdErrorResponse(error="unsupported_provider")
 
     if repo.integration_id is None:
-        return {"error": "no_integration"}
+        return GetRepoInstallationIdErrorResponse(error="no_integration")
 
     integration = integration_service.get_integration(integration_id=repo.integration_id)
     if integration is None:
-        return {"error": "integration_not_found"}
+        return GetRepoInstallationIdErrorResponse(error="integration_not_found")
 
     # GitHub stores the installation ID as the integration's external_id,
     # while GitHub Enterprise stores it in metadata["installation_id"].
@@ -773,15 +769,15 @@ def get_repo_installation_id(
         installation_id = integration.external_id
     else:
         logger.warning("seer.scm.unsupported_provider", extra={"provider": integration.provider})
-        return {"error": "unsupported_provider"}
+        return GetRepoInstallationIdErrorResponse(error="unsupported_provider")
 
     if not installation_id:
-        return {"error": "installation_id_not_found"}
+        return GetRepoInstallationIdErrorResponse(error="installation_id_not_found")
 
-    return {
-        "installation_id": installation_id,
-        "permissions": integration.metadata.get("permissions"),
-    }
+    return GetRepoInstallationIdSuccessResponse(
+        installation_id=installation_id,
+        permissions=integration.metadata.get("permissions"),
+    )
 
 
 def check_repository_integrations_status(

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -146,3 +146,33 @@ class SendSeerWebhookErrorResponse(BaseModel):
 
 class RepositoryIntegrationsStatusResponse(BaseModel):
     integration_ids: list[int | None]
+
+
+class HasRepoCodeMappingsResponse(BaseModel):
+    has_code_mappings: bool
+    project_slug_to_id: dict[str, int]
+
+
+class ValidateRepoSuccessResponse(BaseModel):
+    valid: Literal[True] = True
+    integration_id: int | None
+
+
+class ValidateRepoErrorResponse(BaseModel):
+    valid: Literal[False] = False
+    reason: str
+
+
+class GetRepoInstallationIdSuccessResponse(BaseModel):
+    installation_id: int | str
+    permissions: dict[str, Any] | None
+
+    class Config:
+        # GitHub returns the installation_id as a str; GitHub Enterprise stores
+        # it as an int in metadata. smart_union preserves the runtime type
+        # instead of coercing through the first matching union arm.
+        smart_union = True
+
+
+class GetRepoInstallationIdErrorResponse(BaseModel):
+    error: str

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -1067,7 +1067,7 @@ class TestSeerRpcMethods(APITestCase):
             owner="nonexistent",
             name="nonexistent",
         )
-        assert result == {"has_code_mappings": False, "project_slug_to_id": {}}
+        assert result.dict() == {"has_code_mappings": False, "project_slug_to_id": {}}
 
     def test_has_repo_code_mappings_no_mappings(self) -> None:
         """Test when repository exists but has no code mappings"""
@@ -1086,7 +1086,7 @@ class TestSeerRpcMethods(APITestCase):
             owner="test",
             name="repo",
         )
-        assert result == {"has_code_mappings": False, "project_slug_to_id": {}}
+        assert result.dict() == {"has_code_mappings": False, "project_slug_to_id": {}}
 
     def test_has_repo_code_mappings_with_mappings(self) -> None:
         """Test when repository exists and has code mappings"""
@@ -1126,7 +1126,7 @@ class TestSeerRpcMethods(APITestCase):
             owner="test",
             name="repo",
         )
-        assert result == {
+        assert result.dict() == {
             "has_code_mappings": True,
             "project_slug_to_id": {project.slug: project.id},
         }
@@ -1154,7 +1154,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"valid": True, "integration_id": integration.id}
+        assert result.dict() == {"valid": True, "integration_id": integration.id}
 
     def test_validate_repo_valid_with_integrations_prefix(self) -> None:
         """Test when provider is passed with integrations: prefix"""
@@ -1179,7 +1179,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"valid": True, "integration_id": integration.id}
+        assert result.dict() == {"valid": True, "integration_id": integration.id}
 
     def test_validate_repo_not_found(self) -> None:
         """Test when repository does not exist"""
@@ -1191,7 +1191,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"valid": False, "reason": "repository_not_found"}
+        assert result.dict() == {"valid": False, "reason": "repository_not_found"}
 
     def test_validate_repo_wrong_org_id(self) -> None:
         """Test that wrong organization_id returns not found (IDOR prevention)"""
@@ -1217,7 +1217,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"valid": False, "reason": "repository_not_found"}
+        assert result.dict() == {"valid": False, "reason": "repository_not_found"}
 
     def test_validate_repo_wrong_owner(self) -> None:
         """Test that wrong owner returns not found"""
@@ -1242,7 +1242,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"valid": False, "reason": "repository_not_found"}
+        assert result.dict() == {"valid": False, "reason": "repository_not_found"}
 
     def test_validate_repo_wrong_name(self) -> None:
         """Test that wrong name returns not found"""
@@ -1267,7 +1267,7 @@ class TestSeerRpcMethods(APITestCase):
             name="wrong-name",
         )
 
-        assert result == {"valid": False, "reason": "repository_not_found"}
+        assert result.dict() == {"valid": False, "reason": "repository_not_found"}
 
     def test_validate_repo_wrong_external_id(self) -> None:
         """Test that wrong external_id returns not found"""
@@ -1292,7 +1292,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"valid": False, "reason": "repository_not_found"}
+        assert result.dict() == {"valid": False, "reason": "repository_not_found"}
 
     def test_validate_repo_inactive(self) -> None:
         """Test that inactive repository returns not found"""
@@ -1317,7 +1317,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"valid": False, "reason": "repository_not_found"}
+        assert result.dict() == {"valid": False, "reason": "repository_not_found"}
 
     def test_validate_repo_unsupported_provider(self) -> None:
         """Test that unsupported provider returns appropriate error"""
@@ -1342,7 +1342,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"valid": False, "reason": "unsupported_provider"}
+        assert result.dict() == {"valid": False, "reason": "unsupported_provider"}
 
     def test_validate_repo_no_integration_id(self) -> None:
         """Test when repository has no integration_id set"""
@@ -1363,7 +1363,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"valid": True, "integration_id": None}
+        assert result.dict() == {"valid": True, "integration_id": None}
 
     def test_validate_repo_github_enterprise(self) -> None:
         """Test that github_enterprise provider works correctly"""
@@ -1388,7 +1388,7 @@ class TestSeerRpcMethods(APITestCase):
             name="internal-repo",
         )
 
-        assert result == {"valid": True, "integration_id": integration.id}
+        assert result.dict() == {"valid": True, "integration_id": integration.id}
 
     def test_get_repo_installation_id_github(self) -> None:
         """Test returns external_id as installation_id for GitHub repos"""
@@ -1413,7 +1413,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"installation_id": "12345", "permissions": None}
+        assert result.dict() == {"installation_id": "12345", "permissions": None}
 
     def test_get_repo_installation_id_github_with_permissions(self) -> None:
         """Test returns permissions from integration metadata"""
@@ -1442,7 +1442,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"installation_id": "12345", "permissions": permissions}
+        assert result.dict() == {"installation_id": "12345", "permissions": permissions}
 
     def test_get_repo_installation_id_github_enterprise(self) -> None:
         """Test returns metadata installation_id for GitHub Enterprise repos"""
@@ -1470,7 +1470,7 @@ class TestSeerRpcMethods(APITestCase):
             name="internal-repo",
         )
 
-        assert result == {"installation_id": "99999", "permissions": None}
+        assert result.dict() == {"installation_id": "99999", "permissions": None}
 
     def test_get_repo_installation_id_not_found(self) -> None:
         """Test returns error when repository does not exist"""
@@ -1482,7 +1482,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"error": "repository_not_found"}
+        assert result.dict() == {"error": "repository_not_found"}
 
     def test_get_repo_installation_id_unsupported_provider(self) -> None:
         """Test returns error for unsupported provider"""
@@ -1507,7 +1507,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"error": "unsupported_provider"}
+        assert result.dict() == {"error": "unsupported_provider"}
 
     def test_get_repo_installation_id_no_integration(self) -> None:
         """Test returns error when repo has no integration_id"""
@@ -1528,7 +1528,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"error": "no_integration"}
+        assert result.dict() == {"error": "no_integration"}
 
     def test_get_repo_installation_id_integration_not_found(self) -> None:
         """Test returns error when integration record doesn't exist"""
@@ -1549,7 +1549,7 @@ class TestSeerRpcMethods(APITestCase):
             name="sentry",
         )
 
-        assert result == {"error": "integration_not_found"}
+        assert result.dict() == {"error": "integration_not_found"}
 
     def test_get_project_preferences_returns_preference(self) -> None:
         project = self.create_project(organization=self.organization)


### PR DESCRIPTION
Type three Seer RPC method returns with Pydantic response models in `sentry_data_models.py`:

- `has_repo_code_mappings` → `HasRepoCodeMappingsResponse`
- `validate_repo` → `ValidateRepoSuccessResponse | ValidateRepoErrorResponse`
- `get_repo_installation_id` → `GetRepoInstallationIdSuccessResponse | GetRepoInstallationIdErrorResponse`

`GetRepoInstallationIdSuccessResponse.installation_id` is `int | str` because GitHub returns the installation ID as a string (`integration.external_id`) while GitHub Enterprise stores it as an int in metadata. `Config.smart_union = True` preserves the runtime type instead of coercing through the first matching union arm — without this, pydantic v1 would coerce `"12345"` to `12345`.

Wire-no-op: each model's `.dict()` produces byte-identical JSON to the prior bare-dict return.