### PR TITLE
ref: Move billing config tier selection logic to backend

### DIFF
--- a/static/gsApp/components/crons/cronsBillingBanner.tsx
+++ b/static/gsApp/components/crons/cronsBillingBanner.tsx
@@ -48,7 +48,7 @@ export function CronsBillingBanner({organization, subscription}: Props) {
   const trialDaysLeft = getTrialDaysLeft(subscription);
   const daysSinceTrial = getDaysSinceDate(subscription.lastTrialEnd ?? '');
 
-  const {data: billingConfig} = useBillingConfig({organization, subscription});
+  const {data: billingConfig} = useBillingConfig({organization});
   const {onDemandPrice, reserved} = getCronsPricingInfo(billingConfig);
 
   const {data, isPending} = useApiQuery<MonitorCountResponse>(

--- a/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.tsx
+++ b/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.tsx
@@ -34,7 +34,7 @@ const useHasRequiredFeatures = (
   organization: Organization,
   subscription: Subscription
 ) => {
-  const {data: billingConfig} = useBillingConfig({organization, subscription});
+  const {data: billingConfig} = useBillingConfig({organization});
   const subscriptionPlan = subscription.planDetails;
   const subscriptionPlanFeatures = subscriptionPlan?.features ?? [];
 

--- a/static/gsApp/components/features/pageUpsellOverlay.spec.tsx
+++ b/static/gsApp/components/features/pageUpsellOverlay.spec.tsx
@@ -19,7 +19,7 @@ describe('PageUpsellOverlay', () => {
 
   const org = OrganizationFixture({access: ['org:billing']});
   MockApiClient.addMockResponse({
-    url: `/customers/${org.slug}/billing-config/?tier=am2`,
+    url: `/customers/${org.slug}/billing-config/?tier=upsell`,
     body: BillingConfigFixture(PlanTier.AM2),
   });
 

--- a/static/gsApp/components/features/planFeature.spec.tsx
+++ b/static/gsApp/components/features/planFeature.spec.tsx
@@ -16,7 +16,7 @@ describe('PlanFeature', () => {
     SubscriptionStore.init();
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-config/`,
-      query: {tier: 'am2'},
+      query: {tier: 'upsell'},
       body: BillingConfigFixture(PlanTier.AM2),
     });
   });
@@ -125,7 +125,7 @@ describe('PlanFeature', () => {
     const mockFn = jest.fn(() => null);
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-config/`,
-      query: {tier: 'am3'},
+      query: {tier: 'upsell'},
       body: BillingConfigFixture(PlanTier.AM3),
     });
 

--- a/static/gsApp/components/features/planFeature.tsx
+++ b/static/gsApp/components/features/planFeature.tsx
@@ -37,7 +37,7 @@ type Props = {
  * particular set of features.
  */
 function PlanFeature({subscription, features, organization, children}: Props) {
-  const {data: billingConfig} = useBillingConfig({organization, subscription});
+  const {data: billingConfig} = useBillingConfig({organization});
 
   if (!billingConfig) {
     return null;

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -3,7 +3,6 @@ import {t} from 'sentry/locale';
 import {DataCategoryExact} from 'sentry/types/core';
 
 import type {BilledDataCategoryInfo} from 'getsentry/types';
-import {PlanTier} from 'getsentry/types';
 
 export const MONTHLY = 'monthly';
 export const ANNUAL = 'annual';
@@ -18,10 +17,20 @@ export const CPE_MULTIPLIER_TO_CENTS = 0.000001;
 
 export const GIGABYTE = 10 ** 9;
 
-// the first tier is the default tier
-const SUPPORTED_TIERS = [PlanTier.AM3, PlanTier.AM2, PlanTier.AM1];
-export const DEFAULT_TIER = SUPPORTED_TIERS[0];
-export const UPSELL_TIER = SUPPORTED_TIERS[1]; // TODO(am3): Update to DEFAULT_TIER when upsells are configured for AM3
+/**
+ * Pseudo-tiers accepted by the customer billing-config endpoint as its `tier`
+ * query param. The backend resolves each to a concrete plan tier so the
+ * frontend doesn't have to replicate the selection logic. See getsentry's
+ * `CustomerBillingConfigEndpoint`.
+ */
+export enum BillingConfigTier {
+  /** Tier to show in upsells: AM3 for AM3 customers, otherwise AM2. */
+  UPSELL = 'upsell',
+  /** Tier a customer should check out on. */
+  CHECKOUT = 'checkout',
+  /** The latest tier, independent of the org's current plan. */
+  DEFAULT = 'default',
+}
 
 const BASIC_TRIAL_PLANS = ['am1_t', 'am2_t', 'am3_t'];
 const ENTERPRISE_TRIAL_PLANS = ['am1_t_ent', 'am2_t_ent', 'am3_t_ent'];

--- a/static/gsApp/hooks/useBillingConfig.tsx
+++ b/static/gsApp/hooks/useBillingConfig.tsx
@@ -2,25 +2,20 @@ import type {Organization} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
-import {UPSELL_TIER} from 'getsentry/constants';
-import {PlanTier, type BillingConfig, type Subscription} from 'getsentry/types';
+import {BillingConfigTier} from 'getsentry/constants';
+import type {BillingConfig} from 'getsentry/types';
 
 interface UseBillingConfigProps {
   organization: Organization;
-  subscription: Subscription;
 }
 
-export function useBillingConfig({organization, subscription}: UseBillingConfigProps) {
-  const upsellTier =
-    subscription.planTier === PlanTier.AM3 || subscription.trialTier === PlanTier.AM3
-      ? PlanTier.AM3
-      : UPSELL_TIER;
+export function useBillingConfig({organization}: UseBillingConfigProps) {
   return useApiQuery<BillingConfig>(
     [
       getApiUrl('/customers/$organizationIdOrSlug/billing-config/', {
         path: {organizationIdOrSlug: organization.slug},
       }),
-      {query: {tier: upsellTier}},
+      {query: {tier: BillingConfigTier.UPSELL}},
     ],
     {staleTime: Infinity}
   );

--- a/static/gsApp/overrides/integrationFeatures.spec.tsx
+++ b/static/gsApp/overrides/integrationFeatures.spec.tsx
@@ -22,7 +22,7 @@ describe('hookIntegrationFeatures', () => {
   beforeEach(() => {
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-config/`,
-      query: {tier: 'am2'},
+      query: {tier: 'upsell'},
       body: BillingConfigFixture(PlanTier.AM2),
     });
   });
@@ -114,7 +114,7 @@ describe('hookIntegrationFeatures', () => {
       organization.features = ['integrations-issue-basic'];
       MockApiClient.addMockResponse({
         url: `/customers/${organization.slug}/billing-config/`,
-        query: {tier: 'am2'},
+        query: {tier: 'upsell'},
         body: BillingConfigFixture(PlanTier.AM2),
       });
     });
@@ -235,7 +235,7 @@ describe('hookIntegrationFeatures', () => {
     beforeEach(() => {
       MockApiClient.addMockResponse({
         url: `/customers/${organization.slug}/billing-config/`,
-        query: {tier: 'am2'},
+        query: {tier: 'upsell'},
         body: BillingConfigFixture(PlanTier.AM2),
       });
     });

--- a/static/gsApp/overrides/integrationFeatures.tsx
+++ b/static/gsApp/overrides/integrationFeatures.tsx
@@ -157,7 +157,7 @@ function IntegrationFeaturesBase({
   subscription,
   children,
 }: IntegrationFeaturesProps) {
-  const {data: billingConfig} = useBillingConfig({organization, subscription});
+  const {data: billingConfig} = useBillingConfig({organization});
 
   if (!billingConfig) {
     return null;

--- a/static/gsApp/overrides/memberListHeader.spec.tsx
+++ b/static/gsApp/overrides/memberListHeader.spec.tsx
@@ -34,7 +34,7 @@ describe('MemberListHeader', () => {
   beforeEach(() => {
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-config/`,
-      query: {tier: 'am2'},
+      query: {tier: 'upsell'},
       body: BillingConfigFixture(PlanTier.AM2),
     });
   });

--- a/static/gsApp/overrides/memberListHeader.tsx
+++ b/static/gsApp/overrides/memberListHeader.tsx
@@ -22,7 +22,7 @@ type Props = {
 
 function MemberListHeader({members, organization, subscription}: Props) {
   const hasDisabledMembers = members.some(isMemberDisabledFromLimit);
-  const {data: billingConfig} = useBillingConfig({organization, subscription});
+  const {data: billingConfig} = useBillingConfig({organization});
 
   const getDefaultView = () => <PanelHeader>{t('Members')}</PanelHeader>;
 

--- a/static/gsApp/overrides/scmGithubMultiOrgInstall.spec.tsx
+++ b/static/gsApp/overrides/scmGithubMultiOrgInstall.spec.tsx
@@ -63,7 +63,7 @@ describe('ScmGithubMultiOrgInstall', () => {
 
       MockApiClient.addMockResponse({
         url: `/customers/${organization.slug}/billing-config/`,
-        query: {tier: 'am2'},
+        query: {tier: 'upsell'},
         body: BillingConfigFixture(PlanTier.AM2),
       });
     }

--- a/static/gsApp/overrides/scmGithubMultiOrgInstall.tsx
+++ b/static/gsApp/overrides/scmGithubMultiOrgInstall.tsx
@@ -97,19 +97,11 @@ function UpgradeMessage({subscription}: {subscription: Subscription | null}) {
     );
   }
 
-  return (
-    <UpgradeMessageWithBilling organization={organization} subscription={subscription} />
-  );
+  return <UpgradeMessageWithBilling organization={organization} />;
 }
 
-function UpgradeMessageWithBilling({
-  organization,
-  subscription,
-}: {
-  organization: Organization;
-  subscription: Subscription;
-}) {
-  const {data: billingConfig} = useBillingConfig({organization, subscription});
+function UpgradeMessageWithBilling({organization}: {organization: Organization}) {
+  const {data: billingConfig} = useBillingConfig({organization});
   const planName = getRequiredPlanName(billingConfig);
 
   if (planName) {

--- a/static/gsApp/overrides/useScmFeatureMeta.spec.tsx
+++ b/static/gsApp/overrides/useScmFeatureMeta.spec.tsx
@@ -17,7 +17,7 @@ describe('useScmFeatureMeta', () => {
     const organization = OrganizationFixture();
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-config/`,
-      query: {tier: 'am3'},
+      query: {tier: 'default'},
       body: BillingConfigFixture(PlanTier.AM3),
     });
 
@@ -45,7 +45,7 @@ describe('useScmFeatureMeta', () => {
     const organization = OrganizationFixture();
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-config/`,
-      query: {tier: 'am3'},
+      query: {tier: 'default'},
       statusCode: 404,
       body: {detail: 'Not Found'},
     });

--- a/static/gsApp/overrides/useScmFeatureMeta.tsx
+++ b/static/gsApp/overrides/useScmFeatureMeta.tsx
@@ -11,7 +11,7 @@ import {
   type UseScmFeatureMetaResult,
 } from 'sentry/views/onboarding/components/useScmFeatureMeta';
 
-import {DEFAULT_TIER} from 'getsentry/constants';
+import {BillingConfigTier} from 'getsentry/constants';
 import type {BillingConfig, Plan} from 'getsentry/types';
 import {formatReservedWithUnits} from 'getsentry/utils/billing';
 
@@ -103,7 +103,7 @@ export function useScmFeatureMeta(): UseScmFeatureMetaResult {
       '/customers/$organizationIdOrSlug/billing-config/',
       {
         path: {organizationIdOrSlug: organization.slug},
-        query: {tier: DEFAULT_TIER},
+        query: {tier: BillingConfigTier.DEFAULT},
         staleTime: Infinity,
       }
     ),

--- a/static/gsApp/views/amCheckout/index.spec.tsx
+++ b/static/gsApp/views/amCheckout/index.spec.tsx
@@ -92,7 +92,7 @@ describe('Legacy Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am2'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -116,7 +116,7 @@ describe('Legacy Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am1'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -156,7 +156,7 @@ describe('Legacy Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am2'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -216,7 +216,7 @@ describe('Default Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am3'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -246,7 +246,7 @@ describe('Default Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am3'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -291,7 +291,7 @@ describe('Default Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am3'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -344,7 +344,7 @@ describe('Default Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am3'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -393,7 +393,7 @@ describe('Default Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am3'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -441,7 +441,7 @@ describe('Default Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am3'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -476,7 +476,7 @@ describe('Default Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am3'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -531,7 +531,7 @@ describe('Default Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am3'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -590,7 +590,7 @@ describe('Default Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am3'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -668,7 +668,7 @@ describe('Default Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am3'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -736,7 +736,7 @@ describe('Default Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am3'},
+          data: {tier: 'checkout'},
         })
       );
     });
@@ -814,7 +814,7 @@ describe('Default Tier Checkout', () => {
         `/customers/${organization.slug}/billing-config/`,
         expect.objectContaining({
           method: 'GET',
-          data: {tier: 'am3'},
+          data: {tier: 'checkout'},
         })
       );
     });

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -31,6 +31,7 @@ import {withApi} from 'sentry/utils/withApi';
 import {withSubscription} from 'getsentry/components/withSubscription';
 import {
   ANNUAL,
+  BillingConfigTier,
   MONTHLY,
   PAYG_BUSINESS_DEFAULT,
   PAYG_TEAM_DEFAULT,
@@ -453,7 +454,9 @@ function AMCheckout(props: Props) {
     try {
       const config = await api.requestPromise(endpoint, {
         method: 'GET',
-        data: {tier: checkoutTier},
+        // The endpoint resolves the concrete checkout tier server-side (it
+        // mirrors the selection in `decideCheckout`).
+        data: {tier: BillingConfigTier.CHECKOUT},
       });
 
       const planList = getPlans(config);
@@ -472,14 +475,7 @@ function AMCheckout(props: Props) {
     }
 
     setLoading(false);
-  }, [
-    api,
-    organization.slug,
-    checkoutTier,
-    getPlans,
-    getInitialData,
-    getFormDataForPreview,
-  ]);
+  }, [api, organization.slug, getPlans, getInitialData, getFormDataForPreview]);
 
   const scrollToStep = useCallback(() => {
     const hash = location?.hash;


### PR DESCRIPTION
I previously updated the backend to take a param describing the intent of the frontend so we don't need to do the tier comparison logic on the frontend. This updates the frontend to use the updated API.