### PR TITLE
feat(issueList): Add ProgressState enum and progress column icons

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -63,7 +63,11 @@ import {
   DISCOVER_EXCLUSION_FIELDS,
   isForReviewQuery,
 } from 'sentry/views/issueList/utils';
-import {formatProgressState} from 'sentry/views/issueList/utils/progress';
+import {
+  formatProgressState,
+  getProgressIcon,
+  ProgressState,
+} from 'sentry/views/issueList/utils/progress';
 
 export const DEFAULT_STREAM_GROUP_STATS_PERIOD = '24h';
 const COLUMNS: GroupListColumn[] = [
@@ -84,7 +88,7 @@ type Props = {
   memberList?: User[];
   onAssigneeChange?: (newAssignee: AssignableEntity | null) => void;
   onPriorityChange?: (newPriority: PriorityLevel) => void;
-  progressState?: string | null;
+  progressState?: ProgressState | null;
   query?: string;
   queryFilterDescription?: string;
   showLastTriggered?: boolean;
@@ -725,7 +729,10 @@ export function StreamGroup({
           {withColumns.includes('progress') && (
             <ProgressWrapper breakpoint={COLUMN_BREAKPOINTS.PROGRESS}>
               {progressState ? (
-                <Text>{formatProgressState(progressState)}</Text>
+                <Stack direction="row" align="center" gap="sm">
+                  {getProgressIcon(progressState)}
+                  <Text>{formatProgressState(progressState)}</Text>
+                </Stack>
               ) : (
                 <Placeholder height="18px" width="80px" />
               )}
@@ -981,7 +988,7 @@ const PriorityWrapper = styled('div')<{breakpoint: string}>`
 `;
 
 const ProgressWrapper = styled('div')<{breakpoint: string}>`
-  width: 90px;
+  width: 124px;
   padding-right: ${p => p.theme.space.xl};
   margin-right: ${p => p.theme.space.xl};
   align-self: center;

--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -130,7 +130,7 @@ const PriorityLabel = styled(IssueStreamHeaderLabel)`
 `;
 
 const ProgressLabel = styled(IssueStreamHeaderLabel)`
-  width: 90px;
+  width: 124px;
 `;
 
 const AssigneeLabel = styled(IssueStreamHeaderLabel)`

--- a/static/app/views/issueList/useIssueProgress.ts
+++ b/static/app/views/issueList/useIssueProgress.ts
@@ -2,9 +2,10 @@ import {skipToken, useQuery} from '@tanstack/react-query';
 
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import type {ProgressState} from 'sentry/views/issueList/utils/progress';
 
 type IssueProgressResponse = {
-  results: Record<string, {progress: string}>;
+  results: Record<string, {progress: ProgressState}>;
 };
 
 export function useIssueProgress(groupIds: string[]) {

--- a/static/app/views/issueList/utils/progress.tsx
+++ b/static/app/views/issueList/utils/progress.tsx
@@ -1,16 +1,45 @@
+import type {ReactNode} from 'react';
+
+import {IconCircle} from 'sentry/icons/iconCircle';
+import {IconInProgress} from 'sentry/icons/iconInProgress';
+import {IconInReview} from 'sentry/icons/iconInReview';
+import {IconResolved} from 'sentry/icons/iconResolved';
 import {t} from 'sentry/locale';
 
-const PROGRESS_STATE_LABELS: Record<string, string> = {
-  identified: t('Identified'),
-  triaged: t('Triaged'),
-  diagnosed: t('Diagnosed'),
-  fix_proposed: t('Fix Proposed'),
-  fix_applied: t('Fix Applied'),
+export enum ProgressState {
+  IDENTIFIED = 'identified',
+  TRIAGED = 'triaged',
+  DIAGNOSED = 'diagnosed',
+  FIX_PROPOSED = 'fix_proposed',
+  FIX_APPLIED = 'fix_applied',
+}
+
+const PROGRESS_STATE_LABELS: Record<ProgressState, string> = {
+  [ProgressState.IDENTIFIED]: t('Identified'),
+  [ProgressState.TRIAGED]: t('Triaged'),
+  [ProgressState.DIAGNOSED]: t('Diagnosed'),
+  [ProgressState.FIX_PROPOSED]: t('Fix Proposed'),
+  [ProgressState.FIX_APPLIED]: t('Fix Applied'),
 };
 
 export function formatProgressState(state: string | null | undefined): string {
   if (!state) {
     return '—';
   }
-  return PROGRESS_STATE_LABELS[state] ?? state;
+  return PROGRESS_STATE_LABELS[state as ProgressState] ?? state;
+}
+
+const PROGRESS_STATE_ICONS: Record<ProgressState, ReactNode> = {
+  [ProgressState.IDENTIFIED]: <IconCircle size="md" variant="muted" />,
+  [ProgressState.TRIAGED]: <IconCircle size="md" variant="muted" />,
+  [ProgressState.DIAGNOSED]: <IconInProgress size="md" variant="warning" />,
+  [ProgressState.FIX_PROPOSED]: <IconInReview size="md" variant="success" />,
+  [ProgressState.FIX_APPLIED]: <IconResolved size="md" variant="success" />,
+};
+
+export function getProgressIcon(state: ProgressState | null): ReactNode {
+  if (!state) {
+    return null;
+  }
+  return PROGRESS_STATE_ICONS[state] ?? null;
 }

--- a/static/app/views/issueList/utils/progress.tsx
+++ b/static/app/views/issueList/utils/progress.tsx
@@ -22,11 +22,11 @@ const PROGRESS_STATE_LABELS: Record<ProgressState, string> = {
   [ProgressState.FIX_APPLIED]: t('Fix Applied'),
 };
 
-export function formatProgressState(state: string | null | undefined): string {
+export function formatProgressState(state: ProgressState | null): string {
   if (!state) {
     return '—';
   }
-  return PROGRESS_STATE_LABELS[state as ProgressState] ?? state;
+  return PROGRESS_STATE_LABELS[state] ?? state;
 }
 
 const PROGRESS_STATE_ICONS: Record<ProgressState, ReactNode> = {


### PR DESCRIPTION
Ref ISWF-2765

Uses the new icons in the progress column. While making this change, I also introduced a `ProgressState` enum.

<img width="148" height="333" alt="CleanShot 2026-06-15 at 12 06 51" src="https://github.com/user-attachments/assets/3134b734-6553-43dd-aaa7-25deab27b1c5" />
