### PR TITLE
ref(seer): Remove unused seer-code-review-gitlab feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -242,8 +242,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Seer PR code review for GitHub Enterprise Server organizations
     manager.add("organizations:seer-code-review-github-enterprise", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable Seer MR code review for GitLab organizations
-    manager.add("organizations:seer-code-review-gitlab", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Seer Agent panel for AI-powered data exploration
     manager.add("organizations:seer-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Agent Index job


### PR DESCRIPTION
## Summary

Follow-up to #117732. Now that the GitLab code review webhook flow gates on `organizations:seer-gitlab-support`, the `organizations:seer-code-review-gitlab` flag is no longer read anywhere in the codebase. This removes its registration from the feature manager.

## Changes

- Remove the `manager.add("organizations:seer-code-review-gitlab", ...)` registration (and its comment) from `src/sentry/features/temporary.py`.

## Notes

- **Stacked on #117732** — that PR removes all reads of the flag; this PR deregisters it. Merge #117732 first.
- Before this lands, any FlagPole rollout config keyed on `seer-code-review-gitlab` in `sentry-options-automator` should be cleaned up, since the flag will no longer resolve. (https://github.com/getsentry/sentry-options-automator/pull/8260)