### PR TITLE
o11y(ai-search): Track polling errors and refine ask-seer error UX

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -33,6 +33,7 @@ import {useSearchTokenCombobox} from 'sentry/components/searchQueryBuilder/token
 import {IconClose, IconMegaphone, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useOverlay} from 'sentry/utils/useOverlay';
@@ -139,11 +140,12 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
     ...props.askSeerMutationOptions,
     onError: (error, variables, onMutateResult, context) => {
       props.askSeerMutationOptions.onError?.(error, variables, onMutateResult, context);
-      addErrorMessage(t('Failed to process AI query: %(error)s', {error: error.message}));
+      addErrorMessage(t('Seer was unable to process your search. Please try again.'));
       trackAnalytics('ai_query.error', {
         organization,
         area: analyticsArea,
         natural_language_query: searchQuery,
+        status_code: error instanceof RequestError ? error.status : undefined,
       });
     },
   });

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -1,4 +1,4 @@
-import {useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {type AriaComboBoxProps} from '@react-aria/combobox';
 import {mergeRefs} from '@react-aria/utils';
@@ -124,6 +124,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
   const containerRef = useRef<HTMLInputElement>(null);
   const isInitialRender = useRef(true);
   const inputRef = useRef<HTMLInputElement>(null);
+  const hasTrackedFetchErrorRef = useRef(false);
   const organization = useOrganization();
 
   const [searchQuery, setSearchQuery] = useState(() =>
@@ -165,6 +166,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
         organization,
         area: analyticsArea,
         natural_language_query: searchQuery,
+        is_fetch: false,
       });
     },
   });
@@ -434,6 +436,22 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
     setAutoSubmitSeer,
     submitQuery,
   ]);
+
+  // Track errors that occur while polling/fetching results. Guarded by a ref so
+  // we only fire once per error occurrence (and reset once the error clears).
+  useEffect(() => {
+    if (isError && !hasTrackedFetchErrorRef.current) {
+      hasTrackedFetchErrorRef.current = true;
+      trackAnalytics('ai_query.error', {
+        organization,
+        area: analyticsArea,
+        natural_language_query: searchQuery,
+        is_fetch: true,
+      });
+    } else if (!isError) {
+      hasTrackedFetchErrorRef.current = false;
+    }
+  }, [isError, organization, analyticsArea, searchQuery]);
 
   const onMouseLeave = () => {
     state.selectionManager.setFocusedKey(null);

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -33,6 +33,7 @@ import {useSearchTokenCombobox} from 'sentry/components/searchQueryBuilder/token
 import {IconClose, IconMegaphone, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useOverlay} from 'sentry/utils/useOverlay';
@@ -161,12 +162,13 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
     strategy,
     options: extraOptions,
     onError: error => {
-      addErrorMessage(t('Failed to process AI query: %(error)s', {error: error.message}));
+      addErrorMessage(t('Seer was unable to process your search. Please try again.'));
       trackAnalytics('ai_query.error', {
         organization,
         area: analyticsArea,
         natural_language_query: searchQuery,
         is_fetch: false,
+        status_code: error instanceof RequestError ? error.status : undefined,
       });
     },
   });

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
+import * as Sentry from '@sentry/react';
 import {useQueryClient} from '@tanstack/react-query';
 
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {setApiQueryData, useApiQuery} from 'sentry/utils/queryClient';
@@ -133,6 +133,7 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
 
         const newRunId = response.sentry_run_id ?? response.run_id;
         if (!newRunId) {
+          Sentry.captureMessage('Search agent start response missing run ID', 'error');
           throw new Error('Search agent start response missing run ID');
         }
         setRunId(newRunId);
@@ -148,7 +149,6 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
         inFlightQueryRef.current = null;
         setWaitingForResponse(false);
         setStartFailed(true);
-        addErrorMessage((error as Error)?.message ?? 'Failed to start AI search');
         options.onError?.(error as Error);
       }
     },

--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -15,6 +15,11 @@ export type SeerAnalyticsEventsParameters = {
      * absent) when it occurred while starting the search agent.
      */
     is_fetch?: boolean;
+    /**
+     * HTTP status code of the failed start request. Only available on the
+     * start-failure path; absent for polling errors (which have no HTTP status).
+     */
+    status_code?: number;
   };
   'ai_query.feedback': {
     area: string;

--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -10,6 +10,11 @@ export type SeerAnalyticsEventsParameters = {
   'ai_query.error': {
     area: string;
     natural_language_query: string;
+    /**
+     * True when the error occurred while polling/fetching results, false (or
+     * absent) when it occurred while starting the search agent.
+     */
+    is_fetch?: boolean;
   };
   'ai_query.feedback': {
     area: string;


### PR DESCRIPTION
## Summary

Improves analytics coverage and the user-facing error message for Ask Seer (natural-language search).

### Track polling/fetch errors

The `ai_query.error` analytics event previously only fired when the search-agent **start** request failed. Errors surfaced while polling for results (`session.status === 'error'`) were shown in the UI but never tracked. This adds an effect that fires `ai_query.error` for that case, distinguished by a new `is_fetch` property:

- `is_fetch: true` — error while polling/fetching results
- `is_fetch: false` — error starting the search agent

The effect is guarded by a ref so it fires once per error occurrence and resets when the error clears.

### Refine the error message

The error toast interpolated `error.message`, which for a `RequestError` is the raw request line (HTTP method, internal endpoint path, status code) and otherwise an internal implementation string — neither meaningful nor appropriate for users. It now shows a clean, action-oriented message. Diagnostic detail is still captured in analytics and Sentry.

### Capture status code in analytics

Added an optional `status_code` to `ai_query.error`, populated from the failed request's status on the start and fallback-mutation paths, so errors can be segmented by HTTP status. Polling errors have no HTTP status, so the property is absent there.

Applied across all three `ai_query.error` call sites (`askSeerPollingComboBox`, `askSeerComboBox`).

Refs AIML-2945
