### PR TITLE
fix(seer): add GitLab support to web vitals Seer eligibility hook

### DIFF
--- a/static/app/views/insights/browser/webVitals/utils/useHasSeerWebVitalsSuggestions.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useHasSeerWebVitalsSuggestions.tsx
@@ -28,8 +28,9 @@ export function useHasSeerWebVitalsSuggestions(selectedProject?: Project) {
   );
   const supportedProviderIds = useSeerSupportedProviderIds();
   const hasSupportedRepos = Boolean(
-    preference?.repositories?.some(repo => supportedProviderIds.includes(repo.provider)) ||
-    codeMappingRepos?.some(repo => supportedProviderIds.includes(repo.provider))
+    preference?.repositories?.some(repo =>
+      supportedProviderIds.includes(repo.provider)
+    ) || codeMappingRepos?.some(repo => supportedProviderIds.includes(repo.provider))
   );
 
   const {areAiFeaturesAllowed} = useOrganizationSeerSetup();

--- a/static/app/views/insights/browser/webVitals/utils/useHasSeerWebVitalsSuggestions.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useHasSeerWebVitalsSuggestions.tsx
@@ -1,5 +1,6 @@
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
+import {useSeerSupportedProviderIds} from 'sentry/components/events/autofix/utils';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {Project} from 'sentry/types/project';
 import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
@@ -9,7 +10,7 @@ import {useProjects} from 'sentry/utils/useProjects';
 // Checks for:
 // - Org has web vitals suggestions feature enabled
 // - Org has ai features enabled and has given consent
-// - Project has a github repository set up
+// - Project has a supported SCM repository set up (GitHub, GitHub Enterprise, or GitLab with feature flag)
 export function useHasSeerWebVitalsSuggestions(selectedProject?: Project) {
   const organization = useOrganization();
 
@@ -25,9 +26,10 @@ export function useHasSeerWebVitalsSuggestions(selectedProject?: Project) {
   const hasConfiguredRepos = Boolean(
     preference?.repositories?.length || codeMappingRepos?.length
   );
-  const hasGithubRepos = Boolean(
-    preference?.repositories?.some(repo => repo.provider.includes('github')) ||
-    codeMappingRepos?.some(repo => repo.provider.includes('github'))
+  const supportedProviderIds = useSeerSupportedProviderIds();
+  const hasSupportedRepos = Boolean(
+    preference?.repositories?.some(repo => supportedProviderIds.includes(repo.provider)) ||
+    codeMappingRepos?.some(repo => supportedProviderIds.includes(repo.provider))
   );
 
   const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
@@ -36,6 +38,6 @@ export function useHasSeerWebVitalsSuggestions(selectedProject?: Project) {
     organization.features.includes('performance-web-vitals-seer-suggestions') &&
     areAiFeaturesAllowed &&
     hasConfiguredRepos &&
-    hasGithubRepos
+    hasSupportedRepos
   );
 }


### PR DESCRIPTION
Fixes CW-1504.

## What

`useHasSeerWebVitalsSuggestions` was gating on `repo.provider.includes('github')` — a substring match that misses `'gitlab'` entirely. Also the hook comment said "Project has a github repository set up".

**Changes:**
- Import and use `useSeerSupportedProviderIds()` from `autofix/utils` (already feature-flag-aware for GitLab)
- Replace `hasGithubRepos` with `hasSupportedRepos` using an exact `includes` check against the provider ID list
- Update the stale comment

## Why

`useSeerSupportedProviderIds` is the canonical frontend equivalent of the backend's `get_supported_scm_providers` — it already handles the `seer-gitlab-support` flag. Using it here is the correct pattern. Companion BE PR: https://github.com/getsentry/sentry/pull/117746

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC013P75SQUB%3A1781490292.465929%22)