### PR TITLE
ref(seer-rpc): type get_project_preferences return as SeerProjectPreference

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -123,6 +123,7 @@ from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofi
 from sentry.seer.fetch_issues import by_error_type, by_function_name, by_text_query, utils
 from sentry.seer.fetch_issues.utils import NoProjectsForRepoError, get_repo_and_projects
 from sentry.seer.issue_detection import create_issue_occurrence
+from sentry.seer.models.seer_api_models import SeerProjectPreference
 from sentry.seer.seer_setup import get_supported_scm_providers
 from sentry.seer.sentry_data_models import (
     GetRepoInstallationIdErrorResponse,
@@ -883,7 +884,7 @@ def check_repository_integrations_status(
     return RepositoryIntegrationsStatusResponse(integration_ids=integration_ids)
 
 
-def get_project_preferences(*, organization_id: int, project_id: int) -> dict:
+def get_project_preferences(*, organization_id: int, project_id: int) -> SeerProjectPreference:
     """Get Seer project preferences for a single project.
 
     Raises Project.DoesNotExist if the project is not found or doesn't belong to the org.
@@ -892,7 +893,7 @@ def get_project_preferences(*, organization_id: int, project_id: int) -> dict:
     if project.organization_id != organization_id:
         raise Project.DoesNotExist
 
-    return read_preference_from_sentry_db(project).dict()
+    return read_preference_from_sentry_db(project)
 
 
 def bulk_get_project_preferences(

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -1566,24 +1566,22 @@ class TestSeerRpcMethods(APITestCase):
             project_id=project.id,
         )
 
-        assert result is not None
-        assert result["project_id"] == project.id
-        assert result["organization_id"] == self.organization.id
-        assert len(result["repositories"]) == 1
-        assert result["repositories"][0]["external_id"] == "123"
-        assert result["repositories"][0]["name"] == "sentry"
+        assert result.project_id == project.id
+        assert result.organization_id == self.organization.id
+        assert len(result.repositories) == 1
+        assert result.repositories[0].external_id == "123"
+        assert result.repositories[0].name == "sentry"
 
     def test_get_project_preferences_returns_default_when_no_preference(self) -> None:
         project = self.create_project(organization=self.organization)
         result = get_project_preferences(
             organization_id=self.organization.id, project_id=project.id
         )
-        assert result is not None
-        assert result["project_id"] == project.id
-        assert result["organization_id"] == self.organization.id
-        assert result["repositories"] == []
-        assert result["automated_run_stopping_point"] == "code_changes"
-        assert result["automation_handoff"] is None
+        assert result.project_id == project.id
+        assert result.organization_id == self.organization.id
+        assert result.repositories == []
+        assert result.automated_run_stopping_point == "code_changes"
+        assert result.automation_handoff is None
 
     def test_get_project_preferences_raises_for_nonexistent_project(self) -> None:
         with pytest.raises(Project.DoesNotExist):


### PR DESCRIPTION
`read_preference_from_sentry_db` already returns a `SeerProjectPreference` Pydantic model; the RPC method was calling `.dict()` only for the dispatcher to re-serialize. Returning the model directly lets the dispatcher's BaseModel adapter handle the conversion and gives seer + external SDK consumers a typed return shape.

Wire-no-op: `SeerProjectPreference.dict()` was already the serialized form. Test assertions migrate from subscript (`result["project_id"]`) to attribute access (`result.project_id`).

`bulk_get_project_preferences` is intentionally left for a follow-up — it returns `dict[str, dict]` and any typed wrap would change the wire shape, which needs a seer-side caller update first.