### PR TITLE
fix(sentry apps): Dont use alarm for control webhooks

### DIFF
--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -197,9 +197,9 @@ def _send_webhook_request(
     app_platform_event: AppPlatformEvent[T],
 ) -> Response:
     # We don't want to use the alarm in CONTROL silo as it's only used for installation webhooks which are v. low volume
-    # Also that we aren't guarenteed to be in main thread
+    # Also that we aren't guaranteed to be in main thread
     context_wrapper: contextlib.AbstractContextManager[None]
-    if SiloMode.get_current_mode() == SiloMode.CONTROL:
+    if SiloMode.get_current_mode() is SiloMode.CONTROL:
         context_wrapper = contextlib.nullcontext()
     else:
         timeout_seconds = options.get("sentry-apps.webhook.hard-timeout.sec")

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -198,6 +198,7 @@ def _send_webhook_request(
 ) -> Response:
     # We don't want to use the alarm in CONTROL silo as it's only used for installation webhooks which are v. low volume
     # Also that we aren't guarenteed to be in main thread
+    context_wrapper: contextlib.AbstractContextManager[None]
     if SiloMode.get_current_mode() == SiloMode.CONTROL:
         context_wrapper = contextlib.nullcontext()
     else:

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import Callable, Mapping
 from types import FrameType
@@ -195,11 +196,18 @@ def _send_webhook_request(
     url: str,
     app_platform_event: AppPlatformEvent[T],
 ) -> Response:
+    # We don't want to use the alarm in CONTROL silo as it's only used for installation webhooks which are v. low volume
+    # Also that we aren't guarenteed to be in main thread
+    if SiloMode.get_current_mode() == SiloMode.CONTROL:
+        context_wrapper = contextlib.nullcontext()
+    else:
+        timeout_seconds = options.get("sentry-apps.webhook.hard-timeout.sec")
+        context_wrapper = timeout_alarm(timeout_seconds, _handle_webhook_timeout)
+
     # We're using a signal based timeout here because we need to interrupt the blocking
     # socket.connect() operation. See SENTRY-5HA6 for more context. Here we're hanging at
     # the socket.connect() call and the timeout we set in safe_urlopen is not being respected.
-    timeout_seconds = options.get("sentry-apps.webhook.hard-timeout.sec")
-    with timeout_alarm(timeout_seconds, _handle_webhook_timeout):
+    with context_wrapper:
         return safe_urlopen(
             url=url,
             data=app_platform_event.body,


### PR DESCRIPTION
Since installation deletions rely on the notifier to succeed in the transaction, the requests were failing since (I believe) granian does not guarantee you will be in the main thread. We worked around this by spawning a seperate task for metric alerts but sicne this is so low volume I think just not using the alarm is fine

Fixes https://sentry.sentry.io/issues/7383283972/events/13c8fd318a2448bf892d3a7d05d0ac25/?project=1&statsPeriod=24h