### PR TITLE
feat(seer): Detect GitLab bots in contributor seat tracking

### DIFF
--- a/src/sentry/models/organizationcontributors.py
+++ b/src/sentry/models/organizationcontributors.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from django.db import models
 
 from sentry.backup.scopes import RelocationScope
@@ -8,6 +10,18 @@ from sentry.db.models.base import DefaultFieldsModel
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 
 ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD = 2
+
+# GitLab auto-generates bot and service-account usernames with these reserved
+# prefixes. Unlike GitHub bots (whose login ends in "[bot]"), GitLab bots carry
+# no "[bot]" suffix and the merge_request webhook payload exposes no bot flag, so
+# we detect them from the username persisted in ``alias``:
+#   - project access token bots: ``project_{project_id}_bot_{random}``
+#   - group access token bots:   ``group_{group_id}_bot_{random}``
+#   - service accounts:          ``service_account_{random}`` /
+#                                ``service_account_group_{group_id}_{random}``
+# GitHub usernames cannot contain underscores, so these patterns never collide
+# with a real GitHub login.
+GITLAB_BOT_USERNAME_RE = re.compile(r"^(project_\d+_bot_|group_\d+_bot_|service_account_)")
 
 
 @cell_silo_model
@@ -48,9 +62,19 @@ class OrganizationContributors(DefaultFieldsModel):
     @property
     def is_bot(self) -> bool:
         """
-        Check if the contributor is a bot (has a [bot] suffix) or is Copilot (special case without [bot] suffix)
+        Check if the contributor is a bot.
+
+        - GitHub bots have a ``[bot]`` suffix (e.g. ``dependabot[bot]``); Copilot
+          is a special case without the suffix.
+        - GitLab bots and service accounts have no suffix or webhook bot flag, so
+          we match GitLab's reserved username prefixes (see
+          ``GITLAB_BOT_USERNAME_RE``).
         """
-        return self.alias is not None and (self.alias.endswith("[bot]") or self.alias == "Copilot")
+        return self.alias is not None and (
+            self.alias.endswith("[bot]")
+            or self.alias == "Copilot"
+            or GITLAB_BOT_USERNAME_RE.match(self.alias) is not None
+        )
 
 
 @cell_silo_model

--- a/src/sentry/models/organizationcontributors.py
+++ b/src/sentry/models/organizationcontributors.py
@@ -21,6 +21,15 @@ ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD = 2
 #                                ``service_account_group_{group_id}_{random}``
 # GitHub usernames cannot contain underscores, so these patterns never collide
 # with a real GitHub login.
+#
+# Known gap (intentional): GitLab < 16.0 named access-token bots with a numeric
+# counter and no random suffix -- ``project_{id}_bot`` / ``project_{id}_bot2`` /
+# ``group_{id}_bot2`` -- which lack the trailing ``_`` this pattern requires and
+# so are NOT matched. We only support the >= 16.0 ``_bot_{random}`` format:
+# service accounts (the other prefix) did not exist until 16.1, and the legacy
+# window (self-managed instances on 13.0-15.11 that are also on Seer GitLab
+# code review) is narrow enough that we accept miscounting those bots as human
+# rather than loosen the boundary. See SCM-121 for the broader alias caveats.
 GITLAB_BOT_USERNAME_RE = re.compile(r"^(project_\d+_bot_|group_\d+_bot_|service_account_)")
 
 

--- a/tests/sentry/models/test_organizationcontributors.py
+++ b/tests/sentry/models/test_organizationcontributors.py
@@ -28,6 +28,15 @@ NON_BOT_ALIASES = [
     "group_lead",
     "service_accountant",
     "my_project_42_bot_thing",
+    # Known gap (intentional): pre-16.0 GitLab named access-token bots with a
+    # numeric counter and no random suffix, so they lack the trailing "_bot_"
+    # the pattern requires. We deliberately do not match these -- see the note
+    # on GITLAB_BOT_USERNAME_RE -- so they are asserted as non-bots to pin that
+    # current behavior. If legacy support is ever added, move these to
+    # BOT_ALIASES.
+    "project_123_bot",
+    "project_123_bot2",
+    "group_109_bot2",
     # A null alias must never be treated as a bot.
     None,
 ]

--- a/tests/sentry/models/test_organizationcontributors.py
+++ b/tests/sentry/models/test_organizationcontributors.py
@@ -1,0 +1,43 @@
+import pytest
+
+from sentry.models.organizationcontributors import OrganizationContributors
+
+# ``is_bot`` only reads ``self.alias``, so an unsaved in-memory instance is
+# enough — no organization, integration, or database row required.
+BOT_ALIASES = [
+    # GitHub-style bots (existing behavior).
+    "dependabot[bot]",
+    "renovate[bot]",
+    "Copilot",
+    # GitLab project / group access token bots.
+    "project_278964_bot_a1b2c3d4",
+    "group_123_bot_4ffca233d8298ea1",
+    # GitLab service accounts (instance- and group-scoped).
+    "service_account_6018816a18e515214e0c34c2b33523fc",
+    "service_account_group_345_6018816a18e515214e0c34c2b33523fc",
+]
+
+NON_BOT_ALIASES = [
+    # Regular humans on either provider.
+    "agarcia",
+    "root",
+    "octocat",
+    # Names that merely resemble the GitLab bot prefixes but do not match the
+    # reserved pattern (no numeric id, or no trailing "_bot_").
+    "project_manager",
+    "group_lead",
+    "service_accountant",
+    "my_project_42_bot_thing",
+    # A null alias must never be treated as a bot.
+    None,
+]
+
+
+@pytest.mark.parametrize("alias", BOT_ALIASES)
+def test_is_bot_true(alias: str) -> None:
+    assert OrganizationContributors(alias=alias).is_bot is True
+
+
+@pytest.mark.parametrize("alias", NON_BOT_ALIASES)
+def test_is_bot_false(alias: str | None) -> None:
+    assert OrganizationContributors(alias=alias).is_bot is False


### PR DESCRIPTION
## Summary

Seer code-review seat billing tracks merge-request authors via `OrganizationContributors`, and bot authors are filtered out by the `is_bot` property. That property only recognized **GitHub's** convention (`alias` ending in `[bot]`, plus the `Copilot` special case), so **GitLab bots and service accounts were counted as human contributors** — consuming seats and able to trigger code reviews on bot-authored MRs.

GitLab's `merge_request` webhook payload exposes **no bot flag** (the `user` object is only `{id, name, username, avatar_url, email}`), so we detect bots from the username already persisted in `alias`, mirroring how GitHub detection already works.

## What changed

- `OrganizationContributors.is_bot` now also matches GitLab's reserved bot/service-account username prefixes via `GITLAB_BOT_USERNAME_RE`:
  - project access token bots — `project_{id}_bot_…`
  - group access token bots — `group_{id}_bot_…`
  - service accounts — `service_account_…` / `service_account_group_{id}_…`
- New unit tests for `is_bot` covering GitHub bots, GitLab token/service-account bots, and human lookalikes (e.g. `project_manager`, `my_project_42_bot_thing`) that must **not** match.

## Why this is safe / additive

GitHub usernames cannot contain underscores, while every GitLab bot pattern is underscore-laden — so teaching the shared `is_bot` property the GitLab patterns cannot misclassify a real GitHub login. GitHub behavior is unchanged, and no migration is needed because the GitLab username is already stored in `alias` by the seat-tracking processor.

## Evidence: GitLab bot username patterns (authoritative sources)

Each branch of `GITLAB_BOT_USERNAME_RE` maps to a GitLab-documented, auto-generated username format:

| Regex branch | GitLab-documented username | Verbatim doc example | Source |
|---|---|---|---|
| `project_\d+_bot_` | `project_{project_id}_bot_{random_string}` | `project_123_bot_4ffca233d8298ea1` | [Project access tokens](https://docs.gitlab.com/user/project/settings/project_access_tokens/) |
| `group_\d+_bot_` | `group_{group_id}_bot_{random_string}` | `group_123_bot_4ffca233d8298ea1` | [Group access tokens](https://docs.gitlab.com/user/group/settings/group_access_tokens/) |
| `service_account_` | instance: `service_account_{random}`; group: `service_account_group_{group_id}_{random}` | `service_account_6018816a18e515214e0c34c2b33523fc`, `service_account_group_345_6018816a18e515214e0c34c2b33523fc` | [Service accounts](https://docs.gitlab.com/user/profile/service_accounts/), [Group service accounts API](https://docs.gitlab.com/api/group_service_accounts/) |

Supporting facts:
- **No bot flag on the webhook.** GitLab's `merge_request` event `user` object is `{ id, name, username, avatar_url, email }` — no `is_bot`. The `is_bot` boolean exists only on `GET /users/:id`, which we deliberately avoid to keep the webhook path synchronous and cheap. Source: [Webhook events → Merge request events](https://docs.gitlab.com/user/project/integrations/webhook_events/).
- **GitHub logins can't collide.** GitHub usernames allow only alphanumeric characters and hyphens — underscores are not permitted. Source: [GitHub username considerations](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-iam/iam-configuration-reference/username-considerations-for-external-authentication).
- **Caveat:** service-account usernames are editable at creation, so `service_account_` is the *default* GitLab generates, not a guarantee — a custom-renamed service account won't be caught by prefix matching. Accepted, since the webhook exposes no other bot signal.

## Data flow: how `alias` is populated and consumed

The regex matches against `alias`, and `alias` holds the GitLab **username** (not display name or email) end-to-end:

1. **Webhook → username.** Both GitLab seat-tracking processors read the username from `event["user"]["username"]`:
   - seat processor — [seat_tracking.py#L120](https://github.com/getsentry/sentry/blob/b8263e63659c8a47b2f23f69992f06ed30fe6398/src/sentry/seer/code_review/webhooks/seat_tracking.py#L120)
   - action processor — [seat_tracking.py#L186](https://github.com/getsentry/sentry/blob/b8263e63659c8a47b2f23f69992f06ed30fe6398/src/sentry/seer/code_review/webhooks/seat_tracking.py#L186)
2. **username → `alias`.** That value is persisted as `alias` on the contributor row via `get_or_create(defaults={"alias": user_username})`:
   - [contributor_seats.py#L106](https://github.com/getsentry/sentry/blob/b8263e63659c8a47b2f23f69992f06ed30fe6398/src/sentry/seer/code_review/contributor_seats.py#L106) (`track_contributor_seat`)
   - [contributor_seats.py#L149](https://github.com/getsentry/sentry/blob/b8263e63659c8a47b2f23f69992f06ed30fe6398/src/sentry/seer/code_review/contributor_seats.py#L149) (`record_contributor_action`)
3. **`alias` → `is_bot`.** The regex runs against `alias`:
   - [organizationcontributors.py#L24](https://github.com/getsentry/sentry/blob/b8263e63659c8a47b2f23f69992f06ed30fe6398/src/sentry/models/organizationcontributors.py#L24) (`GITLAB_BOT_USERNAME_RE`)
   - [organizationcontributors.py#L76](https://github.com/getsentry/sentry/blob/b8263e63659c8a47b2f23f69992f06ed30fe6398/src/sentry/models/organizationcontributors.py#L76) (`is_bot` match)
4. **`is_bot` → seat decision.** `is_bot` short-circuits seat allocation:
   - [contributor_seats.py#L78](https://github.com/getsentry/sentry/blob/b8263e63659c8a47b2f23f69992f06ed30fe6398/src/sentry/seer/code_review/contributor_seats.py#L78) (`should_increment_contributor_seat`)

## Test plan

- `pytest tests/sentry/models/test_organizationcontributors.py tests/sentry/seer/code_review/test_contributor_seats.py` → 35 passed
- `ruff` clean; pre-commit hooks pass

## Notes

- Strategy is username-pattern matching (no extra API call). GitLab's authoritative `bot` flag only exists on `GET /users/:id`, which we deliberately avoid to keep the webhook path synchronous and cheap.
- Out of scope: the seat-tracking seeding gaps tracked in SCM-99 (processor only fires on the `open` action and short-circuits when `last_commit`/author email is missing) are orthogonal to bot detection.
- Related: SCM-121 — `alias` is sourced from the event *actor* (`event["user"]`), not the MR author (`object_attributes.author_id`). Usually identical on `open`, but when they diverge the actor-derived alias now feeds this `is_bot` check, so a mismatch can misclassify. Tracked separately.

closes https://linear.app/getsentry/issue/CW-1473/gitlab-contributors-need-to-check-event-user-for-is-bot-flag
