### PR TITLE
feat(issues): Record auto-resolve as a system action in the action log

### DIFF
--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -11,6 +11,8 @@ from sentry import analytics
 from sentry.analytics.events.issue_auto_resolved import IssueAutoResolvedEvent
 from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
 from sentry.issues import grouptype
+from sentry.issues.action_log import ActionSource, publish_action
+from sentry.issues.action_log.types import ResolveAction
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
@@ -115,6 +117,13 @@ def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwar
         remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED)
 
         if happened:
+            publish_action(
+                ResolveAction(),
+                source=ActionSource.SYSTEM,
+                group_id=group.id,
+                organization_id=project.organization_id,
+                project_id=project.id,
+            )
             activity = Activity.objects.create(
                 group=group,
                 project=project,

--- a/tests/sentry/tasks/test_auto_resolve_issues.py
+++ b/tests/sentry/tasks/test_auto_resolve_issues.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 from django.utils import timezone
 
 from sentry.analytics.events.issue_auto_resolved import IssueAutoResolvedEvent
+from sentry.issues.action_log import ActionSource
 from sentry.issues.grouptype import (
     PerformanceP95EndpointRegressionGroupType,
     PerformanceSlowDBQueryGroupType,
@@ -78,6 +79,34 @@ class ScheduleAutoResolutionTest(TestCase):
                 issue_category="error",
             ),
         )
+
+    @patch("sentry.tasks.auto_resolve_issues.kick_off_status_syncs")
+    def test_records_action_log_as_system(self, mock_kick_off_status_syncs: MagicMock) -> None:
+        project = self.create_project()
+        project.update_option("sentry:resolve_age", 1)
+
+        group = self.create_group(
+            project=project,
+            status=GroupStatus.UNRESOLVED,
+            last_seen=timezone.now() - timedelta(days=1),
+        )
+
+        with self.assertLogs("sentry.issues.action_log", level="INFO") as action_logs:
+            with self.tasks():
+                schedule_auto_resolution()
+
+        assert Group.objects.get(id=group.id).status == GroupStatus.RESOLVED
+
+        records = [
+            r
+            for r in action_logs.records
+            if r.message == "group.action_log" and getattr(r, "group_id") == str(group.id)
+        ]
+        assert records, "expected the auto-resolve to emit group.action_log records"
+        # Attributed to the system, never the unknown fallback.
+        assert {getattr(r, "source") for r in records} == {ActionSource.SYSTEM}
+        # The resolve itself is recorded, even though it bypasses update_group_status.
+        assert "resolve" in {getattr(r, "action") for r in records}
 
     @patch("sentry.tasks.auto_resolve_issues.kick_off_status_syncs")
     def test_single_event_performance(self, mock_kick_off_status_syncs: MagicMock) -> None:


### PR DESCRIPTION
## Summary

`auto_resolve_project_issues` resolves stale groups via a direct `Group.objects.filter(...).update(status=RESOLVED)` rather than `update_group_status`, so the resolve was **never recorded** in the action log (invisible — not even `source=unknown`). This publishes a system-sourced `ResolveAction` explicitly when the resolve happens.

The resolve stays a direct `.update` on purpose — it preserves the `last_seen` race guard (`happened`), and `SET_RESOLVED_BY_AGE` isn't in `ACTIVITY_TYPE_TO_GROUP_ACTION`, so routing through the primitive wouldn't publish a resolve action anyway. Since the task has no request and no deep context-reading primitive in play, we call `publish_action(..., source=SYSTEM)` directly rather than setting up an `action_context_scope`.

## Test

New `test_records_action_log_as_system`: asserts the auto-resolve emits a `group.action_log` `resolve` record attributed to `system`.

Part of ID-1631