### PR TITLE
ref(seer-rpc): type three Autofix-cluster RPC methods with Pydantic

### DIFF
--- a/src/sentry/seer/autofix/autofix_tools.py
+++ b/src/sentry/seer/autofix/autofix_tools.py
@@ -1,5 +1,6 @@
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.seer.agent.utils import _convert_profile_to_execution_tree, fetch_profile_data
+from sentry.seer.sentry_data_models import ProfileDetailsResponse
 from sentry.services import eventstore
 
 
@@ -10,7 +11,7 @@ def get_profile_details(
     is_continuous: bool = False,
     precise_start_ts: float | None = None,
     precise_finish_ts: float | None = None,
-):
+) -> ProfileDetailsResponse | None:
     profile = fetch_profile_data(
         profile_id=profile_id,
         organization_id=organization_id,
@@ -20,16 +21,12 @@ def get_profile_details(
         is_continuous=is_continuous,
     )
 
-    if profile:
-        execution_tree, _ = _convert_profile_to_execution_tree(profile)
-        return (
-            None
-            if not execution_tree
-            else {
-                "profile_matches_issue": True,
-                "execution_tree": execution_tree,
-            }
-        )
+    if not profile:
+        return None
+    execution_tree, _ = _convert_profile_to_execution_tree(profile)
+    if not execution_tree:
+        return None
+    return ProfileDetailsResponse(execution_tree=execution_tree)
 
 
 def get_error_event_details(project_id: int, event_id: str):

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -139,6 +139,8 @@ from sentry.seer.sentry_data_models import (
     RepositoryIntegrationsStatusResponse,
     SendSeerWebhookErrorResponse,
     SendSeerWebhookSuccessResponse,
+    SpanAttribute,
+    SpanAttributesResponse,
     ValidateRepoErrorResponse,
     ValidateRepoSuccessResponse,
 )
@@ -510,7 +512,7 @@ def get_attributes_for_span(
     project_id: int,
     trace_id: str,
     span_id: str,
-) -> dict[str, Any]:
+) -> SpanAttributesResponse:
     """
     Fetch all attributes for a given span.
     """
@@ -551,9 +553,7 @@ def get_attributes_for_span(
         include_internal=False,
     )
 
-    return {
-        "attributes": attributes,
-    }
+    return SpanAttributesResponse(attributes=[SpanAttribute(**a) for a in attributes])
 
 
 def get_github_enterprise_integration_config(

--- a/src/sentry/seer/fetch_issues/utils.py
+++ b/src/sentry/seer/fetch_issues/utils.py
@@ -164,9 +164,13 @@ def _group_by_short_id(short_id: str, organization_id: int) -> Group | None:
         return None
 
 
-def get_latest_issue_event(group_id: int | str, organization_id: int) -> dict[str, Any]:
+def get_latest_issue_event(group_id: int | str, organization_id: int) -> IssueDetails | None:
     """
-    Get an issue's latest event as a dict, matching the Seer IssueDetails model.
+    Get an issue's latest event as an IssueDetails model.
+
+    Returns None when the group / event isn't found. Previously returned `{}`
+    on the not-found path — callers checked `if not response`, which behaves
+    identically for `{}` and `None`.
     """
     if isinstance(group_id, str) and not group_id.isdigit():
         group = _group_by_short_id(group_id, organization_id)
@@ -179,7 +183,7 @@ def get_latest_issue_event(group_id: int | str, organization_id: int) -> dict[st
         logger.warning(
             "Group not found", extra={"group_id": group_id, "organization_id": organization_id}
         )
-        return {}
+        return None
 
     if group.organization.id != organization_id:
         logger.warning(
@@ -190,7 +194,7 @@ def get_latest_issue_event(group_id: int | str, organization_id: int) -> dict[st
                 "actual_organization_id": group.organization.id,
             },
         )
-        return {}
+        return None
 
     event = group.get_latest_event()
     if not event:
@@ -198,11 +202,11 @@ def get_latest_issue_event(group_id: int | str, organization_id: int) -> dict[st
             "No event found",
             extra={"group_id": group_id},
         )
-        return {}
+        return None
 
     serialized_event = serialize(event, user=None, serializer=EventSerializer())
     return IssueDetails(
         id=int(serialized_event["groupID"]),
         title=serialized_event["title"],
         events=[serialized_event],
-    ).dict()
+    )

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -176,3 +176,18 @@ class GetRepoInstallationIdSuccessResponse(BaseModel):
 
 class GetRepoInstallationIdErrorResponse(BaseModel):
     error: str
+
+
+class ProfileDetailsResponse(BaseModel):
+    profile_matches_issue: Literal[True] = True
+    execution_tree: list[ExecutionTreeNode]
+
+
+class SpanAttribute(BaseModel):
+    name: str
+    type: str
+    value: str | int | float | bool | list[str | int | float | bool] | None
+
+
+class SpanAttributesResponse(BaseModel):
+    attributes: list[SpanAttribute]

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -184,11 +184,11 @@ class TestSeerRpcMethods(APITestCase):
                 span_id="deadbeefdeadbeef",
             )
 
-        assert len(result["attributes"]) == 1
-        attribute = result["attributes"][0]
-        assert attribute["type"] == "str"
-        assert attribute["value"] == "example"
-        assert attribute["name"] in {"span.description", "tags[span.description,string]"}
+        assert len(result.attributes) == 1
+        attribute = result.attributes[0]
+        assert attribute.type == "str"
+        assert attribute.value == "example"
+        assert attribute.name in {"span.description", "tags[span.description,string]"}
         mock_rpc.assert_called_once()
 
     def test_get_trace_item_attributes_metric(self) -> None:

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -185,10 +185,10 @@ class TestSeerRpcMethods(APITestCase):
             )
 
         assert len(result.attributes) == 1
-        attribute = result.attributes[0]
-        assert attribute.type == "str"
-        assert attribute.value == "example"
-        assert attribute.name in {"span.description", "tags[span.description,string]"}
+        span_attribute = result.attributes[0]
+        assert span_attribute.type == "str"
+        assert span_attribute.value == "example"
+        assert span_attribute.name in {"span.description", "tags[span.description,string]"}
         mock_rpc.assert_called_once()
 
     def test_get_trace_item_attributes_metric(self) -> None:

--- a/tests/sentry/seer/fetch_issues/test_by_error_type.py
+++ b/tests/sentry/seer/fetch_issues/test_by_error_type.py
@@ -76,10 +76,11 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
 
         # Assert latest event is returned
         issue_details = utils.get_latest_issue_event(group.id, self.organization.id)
-        assert issue_details["id"] == group.id
-        assert issue_details["title"] == "KeyError: This a bad error"
-        assert len(issue_details["events"]) == 1
-        assert "entries" in issue_details["events"][0]
+        assert issue_details is not None
+        assert issue_details.id == group.id
+        assert issue_details.title == "KeyError: This a bad error"
+        assert len(issue_details.events) == 1
+        assert "entries" in issue_details.events[0]
 
     def test_multiple_projects(self) -> None:
         release = self.create_release(project=self.project, version="1.0.0")
@@ -173,10 +174,11 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
 
         # Assert latest event is returned
         issue_details = utils.get_latest_issue_event(group_1.id, self.organization.id)
-        assert issue_details["id"] == group_1.id
-        assert issue_details["title"] == "KeyError: This a bad error"
-        assert len(issue_details["events"]) == 1
-        assert "entries" in issue_details["events"][0]
+        assert issue_details is not None
+        assert issue_details.id == group_1.id
+        assert issue_details.title == "KeyError: This a bad error"
+        assert len(issue_details.events) == 1
+        assert "entries" in issue_details.events[0]
 
     def test_last_seen_filter(self) -> None:
         release = self.create_release(project=self.project, version="1.0.0")
@@ -237,10 +239,11 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
 
         # Assert latest event is returned
         issue_details = utils.get_latest_issue_event(group.id, self.organization.id)
-        assert issue_details["id"] == group.id
-        assert issue_details["title"] == "KeyError: This a bad error"
-        assert len(issue_details["events"]) == 1
-        assert "entries" in issue_details["events"][0]
+        assert issue_details is not None
+        assert issue_details.id == group.id
+        assert issue_details.title == "KeyError: This a bad error"
+        assert len(issue_details.events) == 1
+        assert "entries" in issue_details.events[0]
 
     def test_multiple_exception_types(self) -> None:
         release = self.create_release(project=self.project, version="1.0.0")

--- a/tests/sentry/seer/fetch_issues/test_utils.py
+++ b/tests/sentry/seer/fetch_issues/test_utils.py
@@ -247,16 +247,15 @@ class TestGetLatestIssueEvent(TestCase):
         result = get_latest_issue_event(group.id, self.organization.id)
 
         assert result is not None
-        assert isinstance(result, dict)
-        assert result["id"] == group.id
-        assert result["title"] == group.title
-        assert len(result["events"]) == 1
-        assert result["events"][0]["id"] == event.event_id
+        assert result.id == group.id
+        assert result.title == group.title
+        assert len(result.events) == 1
+        assert result.events[0]["id"] == event.event_id
 
     def test_get_latest_issue_event_not_found(self) -> None:
         nonexistent_group_id = 999999
         result = get_latest_issue_event(nonexistent_group_id, self.organization.id)
-        assert result == {}
+        assert result is None
 
     def test_get_latest_issue_event_with_short_id(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=1))
@@ -267,28 +266,27 @@ class TestGetLatestIssueEvent(TestCase):
         result = get_latest_issue_event(group.qualified_short_id, self.organization.id)
 
         assert result is not None
-        assert isinstance(result, dict)
-        assert result["id"] == group.id
-        assert result["title"] == group.title
-        assert len(result["events"]) == 1
-        assert result["events"][0]["id"] == event.event_id
+        assert result.id == group.id
+        assert result.title == group.title
+        assert len(result.events) == 1
+        assert result.events[0]["id"] == event.event_id
 
     def test_get_latest_issue_event_with_short_id_not_found(self) -> None:
         result = get_latest_issue_event("INVALID-SHORT-ID", self.organization.id)
-        assert result == {}
+        assert result is None
 
     def test_get_latest_issue_event_no_events(self) -> None:
         # Create a group but don't store any events for it
         group = self.create_group(project=self.project)
         result = get_latest_issue_event(group.id, self.organization.id)
-        assert result == {}
+        assert result is None
 
     def test_get_latest_issue_event_wrong_organization(self) -> None:
         event = self.store_event(data={}, project_id=self.project.id)
         group = event.group
         assert group is not None
         results = get_latest_issue_event(group.id, self.organization.id + 1)
-        assert results == {}
+        assert results is None
 
     def test_get_latest_issue_event_numeric_id_cross_org(self) -> None:
         """Numeric group ID from another org must not be returned."""
@@ -300,7 +298,7 @@ class TestGetLatestIssueEvent(TestCase):
         assert other_group is not None
 
         result = get_latest_issue_event(other_group.id, self.organization.id)
-        assert result == {}
+        assert result is None
 
 
 class TestHandleFetchIssuesExceptions(TestCase):


### PR DESCRIPTION
- `get_profile_details` → `ProfileDetailsResponse | None`. Wraps the existing `execution_tree` dicts in `ExecutionTreeNode` (already a Pydantic model in `sentry_data_models.py`).
- `get_attributes_for_span` → `SpanAttributesResponse`. Wraps each attribute in a new `SpanAttribute` model that mirrors the `TraceItemAttribute` TypedDict used elsewhere in the resolver.
- `get_latest_issue_event` → `IssueDetails | None`. The function was already constructing an `IssueDetails` and calling `.dict()` to flatten it — drop the flatten. The not-found path returns `None` instead of `{}`; the only known seer-side caller (`seer/code_review/tools.py`) checks `if not response` and treats both identically.

Wire shapes: byte-identical for `get_profile_details` and `get_attributes_for_span`; identical for `get_latest_issue_event`'s success path; not-found path changes `{}` → `null` (caller-equivalent).

`get_error_event_details` is intentionally left for a follow-up — its return is `EventSerializer().serialize()` output (an opaque structured event dict) and the seer caller casts to `SentryEventData`, so any wrapping needs either a key-order-preserving pass-through model or coordinated caller changes.