### PR TITLE
ref(seer-rpc): convert SeerResponse / SeerResponseError to Pydantic

### DIFF
--- a/src/sentry/seer/fetch_issues/utils.py
+++ b/src/sentry/seer/fetch_issues/utils.py
@@ -2,9 +2,10 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, TypedDict
+from typing import Any
 
 import sentry_sdk
+from pydantic import BaseModel
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.event import EventSerializer
@@ -27,7 +28,7 @@ class NoProjectsForRepoError(Exception):
     """Raised when a repo exists but has no Sentry projects via code mappings."""
 
 
-class SeerResponseError(TypedDict):
+class SeerResponseError(BaseModel):
     error: str
 
 
@@ -59,7 +60,7 @@ class RepoProjects(RepoInfo):
     projects: list[Project]
 
 
-class SeerResponse(TypedDict):
+class SeerResponse(BaseModel):
     issues: list[int]
     issues_full: list[dict[str, Any]]
 
@@ -148,10 +149,7 @@ def bulk_serialize_for_seer(groups: list[Group]) -> SeerResponse:
     issue_ids = [issue["id"] for issue in issues_full]
     for issue in issues_full:
         issue["id"] = str(issue["id"])
-    return {
-        "issues": issue_ids,
-        "issues_full": issues_full,
-    }
+    return SeerResponse(issues=issue_ids, issues_full=issues_full)
 
 
 def _group_by_short_id(short_id: str, organization_id: int) -> Group | None:

--- a/tests/sentry/seer/fetch_issues/test_by_error_type.py
+++ b/tests/sentry/seer/fetch_issues/test_by_error_type.py
@@ -50,10 +50,10 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
             name="sentryA",
             exception_type="KeyError",
         )
-        assert "error" not in seer_response
-        assert seer_response["issues"][0] == group.id
+        assert isinstance(seer_response, utils.SeerResponse)
+        assert seer_response.issues[0] == group.id
 
-        full_issues = seer_response["issues_full"][0]
+        full_issues = seer_response.issues_full[0]
         assert full_issues["metadata"]["filename"] == "raven/scripts/runner.py"
         assert full_issues["metadata"]["function"] == "main"
         assert full_issues["metadata"]["in_app_frame_mix"] == "system-only"
@@ -167,10 +167,10 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
             name="sentryA",
             exception_type="KeyError",
         )
-        assert "error" not in seer_response
-        assert {group_1.id, group_2.id} == set(seer_response["issues"])
-        assert group_3.id not in seer_response["issues"]
-        assert group_3.id not in [int(issue["id"]) for issue in seer_response["issues_full"]]
+        assert isinstance(seer_response, utils.SeerResponse)
+        assert {group_1.id, group_2.id} == set(seer_response.issues)
+        assert group_3.id not in seer_response.issues
+        assert group_3.id not in [int(issue["id"]) for issue in seer_response.issues_full]
 
         # Assert latest event is returned
         issue_details = utils.get_latest_issue_event(group_1.id, self.organization.id)
@@ -220,10 +220,10 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
             name="sentryA",
             exception_type="KeyError",
         )
-        assert "error" not in seer_response
-        assert seer_response["issues"] == [group.id]
-        assert seer_response["issues_full"][0]["id"] == str(group.id)
-        assert seer_response["issues_full"][0]["title"] == "KeyError: This a bad error"
+        assert isinstance(seer_response, utils.SeerResponse)
+        assert seer_response.issues == [group.id]
+        assert seer_response.issues_full[0]["id"] == str(group.id)
+        assert seer_response.issues_full[0]["title"] == "KeyError: This a bad error"
 
         # Assert that KeyError did not match when filtered to 9 days
         seer_response = fetch_issues(
@@ -301,11 +301,11 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
             name="sentryA",
             exception_type="KeyError",
         )
-        assert "error" not in seer_response
-        assert seer_response["issues"] == [group_1.id]
-        assert len(seer_response["issues_full"]) == 1
-        assert seer_response["issues_full"][0]["id"] == str(group_1.id)
-        assert seer_response["issues_full"][0]["title"] == "KeyError: voodoo curse"
+        assert isinstance(seer_response, utils.SeerResponse)
+        assert seer_response.issues == [group_1.id]
+        assert len(seer_response.issues_full) == 1
+        assert seer_response.issues_full[0]["id"] == str(group_1.id)
+        assert seer_response.issues_full[0]["title"] == "KeyError: voodoo curse"
 
         # Assert that ValueError matched the exception type
         seer_response = fetch_issues(
@@ -316,11 +316,11 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
             name="sentryA",
             exception_type="ValueError",
         )
-        assert "error" not in seer_response
-        assert seer_response["issues"] == [group_2.id]
-        assert len(seer_response["issues_full"]) == 1
-        assert seer_response["issues_full"][0]["id"] == str(group_2.id)
-        assert seer_response["issues_full"][0]["title"] == "ValueError: This a bad error"
+        assert isinstance(seer_response, utils.SeerResponse)
+        assert seer_response.issues == [group_2.id]
+        assert len(seer_response.issues_full) == 1
+        assert seer_response.issues_full[0]["id"] == str(group_2.id)
+        assert seer_response.issues_full[0]["title"] == "ValueError: This a bad error"
 
     def test_fetch_issues_from_repo_projects_returns_groups(self) -> None:
         """Test that _fetch_issues_from_repo_projects returns a list of Group objects."""
@@ -441,9 +441,9 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
             name="sentryA",
             exception_type=search_exception_type,
         )
-        assert "error" not in seer_response
-        assert seer_response["issues"] == [expected_group.id]
-        assert len(seer_response["issues_full"]) == 1
+        assert isinstance(seer_response, utils.SeerResponse)
+        assert seer_response.issues == [expected_group.id]
+        assert len(seer_response.issues_full) == 1
 
     def _test_exception_type_variants(
         self, stored_exception_type: str, search_variants: list[str]
@@ -542,9 +542,9 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
             name="sentryA",
             exception_type="valueerror",
         )
-        assert "error" not in seer_response
-        assert seer_response["issues"] == [group1.id]
-        assert len(seer_response["issues_full"]) == 1
+        assert isinstance(seer_response, utils.SeerResponse)
+        assert seer_response.issues == [group1.id]
+        assert len(seer_response.issues_full) == 1
 
         # Test that "type error" matches only the second group
         seer_response = fetch_issues(
@@ -555,9 +555,9 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
             name="sentryA",
             exception_type="type error",
         )
-        assert "error" not in seer_response
-        assert seer_response["issues"] == [group2.id]
-        assert len(seer_response["issues_full"]) == 1
+        assert isinstance(seer_response, utils.SeerResponse)
+        assert seer_response.issues == [group2.id]
+        assert len(seer_response.issues_full) == 1
 
         # Test that "runtimeerror" matches neither
         seer_response = fetch_issues(

--- a/tests/sentry/seer/fetch_issues/test_by_function_name.py
+++ b/tests/sentry/seer/fetch_issues/test_by_function_name.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.models.group import Group
 from sentry.models.repository import Repository
+from sentry.seer.fetch_issues import utils
 from sentry.seer.fetch_issues.by_function_name import (
     NUM_DAYS_AGO,
     STACKFRAME_COUNT,
@@ -406,14 +407,12 @@ class TestFetchIssues(IntegrationTestCase, CreateEventTestCase):
         )
 
         # Basic structure checks
-        assert "error" not in seer_response
-        assert "issues" in seer_response
-        assert "issues_full" in seer_response
-        assert len(seer_response["issues"]) > 0
-        assert len(seer_response["issues_full"]) > 0
+        assert isinstance(seer_response, utils.SeerResponse)
+        assert len(seer_response.issues) > 0
+        assert len(seer_response.issues_full) > 0
 
         # Check the first issue's metadata and message
-        first_issue = seer_response["issues_full"][0]
+        first_issue = seer_response.issues_full[0]
         assert "metadata" in first_issue
         assert "message" in first_issue
         # Message should be present (don't check exact content since it's auto-generated)

--- a/tests/sentry/seer/fetch_issues/test_by_text_query.py
+++ b/tests/sentry/seer/fetch_issues/test_by_text_query.py
@@ -1,6 +1,7 @@
 from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.models.group import Group
 from sentry.models.repository import Repository
+from sentry.seer.fetch_issues import utils
 from sentry.seer.fetch_issues.by_text_query import _fetch_issues_from_repo_projects, fetch_issues
 from sentry.seer.fetch_issues.utils import get_repo_and_projects
 from sentry.testutils.cases import IntegrationTestCase, TestCase
@@ -98,9 +99,9 @@ class TestFetchIssuesByTextQuery(IntegrationTestCase, CreateEventTestCase):
             name="sentry",
             query="hello",
         )
-        assert "error" not in seer_response
-        assert len(seer_response["issues"]) > 0, "Should find issue with 'hello' substring"
-        assert group.id in seer_response["issues"]
+        assert isinstance(seer_response, utils.SeerResponse)
+        assert len(seer_response.issues) > 0, "Should find issue with 'hello' substring"
+        assert group.id in seer_response.issues
 
         # Test 2: Should find with substring from filename in message
         assert self.gh_repo.external_id is not None
@@ -112,12 +113,12 @@ class TestFetchIssuesByTextQuery(IntegrationTestCase, CreateEventTestCase):
             name="sentry",
             query="auth",
         )
-        assert "error" not in seer_response
-        assert len(seer_response["issues"]) > 0, "Should find issue with 'auth' substring"
-        assert group.id in seer_response["issues"]
+        assert isinstance(seer_response, utils.SeerResponse)
+        assert len(seer_response.issues) > 0, "Should find issue with 'auth' substring"
+        assert group.id in seer_response.issues
 
         # Check metadata and message fields are present in end-to-end call
-        first_issue = seer_response["issues_full"][0]
+        first_issue = seer_response.issues_full[0]
         assert "metadata" in first_issue
         assert "message" in first_issue
 
@@ -176,9 +177,9 @@ class TestFetchIssuesByTextQuery(IntegrationTestCase, CreateEventTestCase):
             query="database conn",
         )
 
-        assert "error" not in seer_response
-        assert len(seer_response["issues"]) > 0
-        assert group.id in seer_response["issues"]
+        assert isinstance(seer_response, utils.SeerResponse)
+        assert len(seer_response.issues) > 0
+        assert group.id in seer_response.issues
 
     def test_fetch_issues_limit_parameter(self) -> None:
         """Test that the limit parameter is respected."""
@@ -203,8 +204,8 @@ class TestFetchIssuesByTextQuery(IntegrationTestCase, CreateEventTestCase):
             limit=limit,
         )
 
-        assert "error" not in seer_response
-        assert len(seer_response["issues"]) <= limit
+        assert isinstance(seer_response, utils.SeerResponse)
+        assert len(seer_response.issues) <= limit
 
     def test_fetch_issues_from_repo_projects_returns_groups(self) -> None:
         """Test that _fetch_issues_from_repo_projects returns a list of Group objects."""

--- a/tests/sentry/seer/fetch_issues/test_utils.py
+++ b/tests/sentry/seer/fetch_issues/test_utils.py
@@ -190,12 +190,12 @@ class TestBulkSerializeForSeer(TestCase):
         non_null_groups = [group for group in groups if group is not None]
         result = bulk_serialize_for_seer(non_null_groups)
 
-        assert len(result["issues"]) == 2
-        assert len(result["issues_full"]) == 2
-        assert all(isinstance(item, dict) for item in result["issues_full"])
+        assert len(result.issues) == 2
+        assert len(result.issues_full) == 2
+        assert all(isinstance(item, dict) for item in result.issues_full)
 
         # Check that each dict has the expected IssueDetails fields with correct values
-        for item, group in zip(result["issues_full"], non_null_groups):
+        for item, group in zip(result.issues_full, non_null_groups):
             assert item["id"] == str(group.id)  # IDs are converted to strings
             assert item["title"] == group.title
             assert item["culprit"] == group.culprit
@@ -211,13 +211,13 @@ class TestBulkSerializeForSeer(TestCase):
         non_null_groups = [group for group in groups if group is not None]
         result = bulk_serialize_for_seer(non_null_groups)
 
-        assert len(result["issues"]) == 2
-        assert len(result["issues_full"]) == 2
-        assert all(item is not None for item in result["issues_full"])
+        assert len(result.issues) == 2
+        assert len(result.issues_full) == 2
+        assert all(item is not None for item in result.issues_full)
 
         # Check that the non-None items have the correct values
         assert event.group is not None
-        for group_serialized in result["issues_full"]:
+        for group_serialized in result.issues_full:
             assert group_serialized["id"] == str(event.group.id)  # IDs are converted to strings
             assert group_serialized["title"] == event.group.title
             assert group_serialized["culprit"] == event.group.culprit


### PR DESCRIPTION
The two response shapes used by the bug-prediction `fetch_issues` family (`get_issues_by_function_name`, `get_issues_by_raw_query`, `get_issues_related_to_exception_type`) were `TypedDict`. Convert both to `pydantic.BaseModel` so the registered RPC methods return Pydantic models end-to-end.

Single-touch: the change in `fetch_issues/utils.py` propagates to all three callsites via the `@handle_fetch_issues_exceptions` decorator and the shared `bulk_serialize_for_seer` helper — no caller modifications needed. The dispatcher's existing `BaseModel.dict()` adapter handles serialization, so the wire JSON is byte-identical to the prior TypedDict output.