### PR TITLE
feat(ai-query): add poll timeout

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -147,9 +147,9 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
 
   const {
     submitQuery,
-    isPending,
+    isSessionPending,
     isPolling,
-    isError,
+    isSessionError,
     finalResponse,
     unsupportedReason,
     currentStep,
@@ -439,10 +439,10 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
     submitQuery,
   ]);
 
-  // Track errors that occur while polling/fetching results. Guarded by a ref so
+  // Track how often an error message is shown in ComboBox content. Guarded by a ref so
   // we only fire once per error occurrence (and reset once the error clears).
   useEffect(() => {
-    if (isError && !hasTrackedFetchErrorRef.current) {
+    if (isSessionError && !hasTrackedFetchErrorRef.current) {
       hasTrackedFetchErrorRef.current = true;
       trackAnalytics('ai_query.error', {
         organization,
@@ -450,10 +450,10 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
         natural_language_query: searchQuery,
         is_fetch: true,
       });
-    } else if (!isError) {
+    } else if (!isSessionError) {
       hasTrackedFetchErrorRef.current = false;
     }
-  }, [isError, organization, analyticsArea, searchQuery]);
+  }, [isSessionError, organization, analyticsArea, searchQuery]);
 
   const onMouseLeave = () => {
     state.selectionManager.setFocusedKey(null);
@@ -474,7 +474,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
     );
   }
 
-  const showLoading = isPending || isPolling;
+  const showLoading = isSessionPending || isPolling;
   const hasResults = queries.length > 0;
 
   return (
@@ -527,11 +527,9 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
                 currentStep={currentStep}
               />
             </SeerContent>
-          ) : isError ? (
+          ) : isSessionError ? (
             <SeerContent>
-              <AskSeerSearchHeader
-                title={t('An error occurred while fetching Seer queries')}
-              />
+              <AskSeerSearchHeader title={t('An error occurred while processing')} />
             </SeerContent>
           ) : hasResults ? (
             <SeerContent onMouseLeave={onMouseLeave}>

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
@@ -201,17 +201,17 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
      */
     sessionData,
     /**
-     * Whether we're waiting for a response (initial load or polling).
-     */
-    isPending: isActuallyPending,
-    /**
      * Whether polling is active.
      */
     isPolling: isPolling(sessionData, waitingForResponse),
     /**
-     * Whether the request errored.
+     * Whether we're waiting for a response (initial load or polling).
      */
-    isError: sessionData?.status === 'error',
+    isSessionPending: isActuallyPending,
+    /**
+     * Whether the agent run errored.
+     */
+    isSessionError: sessionData?.status === 'error',
     /**
      * Whether the start request failed (use fallback).
      */

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
@@ -16,6 +16,10 @@ import type {
 
 const POLL_INTERVAL = 500; // Poll every 500ms, matching Seer Explorer
 
+// Stop polling and surface an error if the agent hasn't reached a terminal
+// state within this window, to avoid polling forever.
+const SEARCH_TIMEOUT_MS = 120_000;
+
 /**
  * Generate the query key for polling the search agent state.
  */
@@ -85,18 +89,31 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
   const [runId, setRunId] = useState<number | string | null>(null);
   const [waitingForResponse, setWaitingForResponse] = useState(false);
   const [startFailed, setStartFailed] = useState(false);
+  const [timedOut, setTimedOut] = useState(false);
   const inFlightQueryRef = useRef<string | null>(null);
+  const startTimeRef = useRef<number | null>(null);
 
   const queryKey = makeAskSeerQueryKey(orgSlug, runId ?? undefined);
 
   // Poll for state
-  const {data: apiData, isPending} = useApiQuery<AskSeerPollingResponse<T>>(
+  const {
+    data: apiData,
+    isPending,
+    isFetching,
+  } = useApiQuery<AskSeerPollingResponse<T>>(
     queryKey ?? (['__disabled__', {}] as unknown as ApiQueryKey),
     {
       staleTime: 0,
       retry: false,
       enabled: !!runId && !!orgSlug,
       refetchInterval: query => {
+        // Stop polling once we've been running longer than the timeout.
+        if (
+          startTimeRef.current &&
+          Date.now() - startTimeRef.current > SEARCH_TIMEOUT_MS
+        ) {
+          return false;
+        }
         const sessionData = query.state.data?.json?.session ?? null;
         if (isPolling(sessionData, waitingForResponse)) {
           return POLL_INTERVAL;
@@ -108,6 +125,20 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
 
   const sessionData = apiData?.session ?? null;
 
+  // When a poll settles after the timeout has elapsed, stop waiting and surface
+  // an error (the refetchInterval above stops scheduling further polls).
+  useEffect(() => {
+    if (
+      !isFetching &&
+      runId &&
+      startTimeRef.current &&
+      Date.now() - startTimeRef.current > SEARCH_TIMEOUT_MS
+    ) {
+      setTimedOut(true);
+      setWaitingForResponse(false);
+    }
+  }, [isFetching, runId]);
+
   // Start a new search
   const submitQuery = useCallback(
     async (query: string) => {
@@ -116,6 +147,8 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
       }
       inFlightQueryRef.current = query;
       setWaitingForResponse(true);
+      setTimedOut(false);
+      startTimeRef.current = Date.now();
 
       try {
         const response = (await api.requestPromise(
@@ -178,9 +211,11 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
   // Reset function
   const reset = useCallback(() => {
     inFlightQueryRef.current = null;
+    startTimeRef.current = null;
     setRunId(null);
     setWaitingForResponse(false);
     setStartFailed(false);
+    setTimedOut(false);
     if (queryKey) {
       // Will be fixed soon when we get rid of setApiQueryData.
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
@@ -203,15 +238,15 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
     /**
      * Whether polling is active.
      */
-    isPolling: isPolling(sessionData, waitingForResponse),
+    isPolling: !timedOut && isPolling(sessionData, waitingForResponse),
     /**
      * Whether we're waiting for a response (initial load or polling).
      */
-    isSessionPending: isActuallyPending,
+    isSessionPending: !timedOut && isActuallyPending,
     /**
-     * Whether the agent run errored.
+     * Whether the agent run errored or polling timed out.
      */
-    isSessionError: sessionData?.status === 'error',
+    isSessionError: sessionData?.status === 'error' || timedOut,
     /**
      * Whether the start request failed (use fallback).
      */

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
@@ -99,7 +99,7 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
   const {
     data: apiData,
     isPending,
-    isFetching,
+    dataUpdatedAt,
   } = useApiQuery<AskSeerPollingResponse<T>>(
     queryKey ?? (['__disabled__', {}] as unknown as ApiQueryKey),
     {
@@ -107,10 +107,10 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
       retry: false,
       enabled: !!runId && !!orgSlug,
       refetchInterval: query => {
-        // Stop polling once we've been running longer than the timeout.
+        // Stop polling once the last fetch landed past the timeout window.
         if (
           startTimeRef.current &&
-          Date.now() - startTimeRef.current > SEARCH_TIMEOUT_MS
+          query.state.dataUpdatedAt - startTimeRef.current > SEARCH_TIMEOUT_MS
         ) {
           return false;
         }
@@ -125,19 +125,17 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
 
   const sessionData = apiData?.session ?? null;
 
-  // When a poll settles after the timeout has elapsed, stop waiting and surface
-  // an error (the refetchInterval above stops scheduling further polls).
+  // Check for timeout on each successful poll.
   useEffect(() => {
     if (
-      !isFetching &&
       runId &&
       startTimeRef.current &&
-      Date.now() - startTimeRef.current > SEARCH_TIMEOUT_MS
+      dataUpdatedAt - startTimeRef.current > SEARCH_TIMEOUT_MS
     ) {
       setTimedOut(true);
       setWaitingForResponse(false);
     }
-  }, [isFetching, runId]);
+  }, [dataUpdatedAt, runId]);
 
   // Start a new search
   const submitQuery = useCallback(


### PR DESCRIPTION
## Summary

Follow-up improvements to the Ask Seer (natural-language search) combobox UI states and polling lifecycle.

### Poll timeout

If the search agent never reaches a terminal state, the polling hook previously ran forever. It now records the start-request timestamp and, once a poll settles more than `SEARCH_TIMEOUT_MS` (120s) later, stops polling and surfaces the result as a session error — so the UI shows the error state instead of spinning indefinitely. `isPolling`/`isSessionPending` are gated on the timeout, and `isSessionError` is true when the agent errors **or** the request times out.


### Clearer UI-state naming

Renames the hook's returned flags to disambiguate the agent-run state from generic request state, and updates the consumer accordingly:

- `isPending` → `isSessionPending`
- `isError` → `isSessionError`