### PR TITLE
feat(issues): Track linked pull request clicks

### DIFF
--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -16,7 +16,9 @@ import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {PullRequest} from 'sentry/types/integrations';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 const LINKED_PULL_REQUESTS_FEATURE = 'issue-details-linked-pull-requests';
@@ -79,7 +81,14 @@ function getStatusLabel(status: LinkedPullRequestStatus) {
   }
 }
 
-function LinkedPullRequestRow({pullRequest}: {pullRequest: LinkedPullRequest}) {
+function LinkedPullRequestRow({
+  group,
+  pullRequest,
+}: {
+  group: Group;
+  pullRequest: LinkedPullRequest;
+}) {
+  const organization = useOrganization();
   const title = pullRequest.title ?? t('Pull request #%s', pullRequest.id);
   const statusLabel = getStatusLabel(pullRequest.status);
 
@@ -93,6 +102,16 @@ function LinkedPullRequestRow({pullRequest}: {pullRequest: LinkedPullRequest}) {
         pullRequest.repository.name
       )}
       href={pullRequest.externalUrl}
+      onClick={() =>
+        trackAnalytics('issue_details.external_issue_pull_request_clicked', {
+          organization,
+          pull_request_id: pullRequest.id,
+          pull_request_status: pullRequest.status,
+          repository_id: pullRequest.repository.id,
+          repository_provider: pullRequest.repository.provider.id,
+          ...getAnalyticsDataForGroup(group),
+        })
+      }
     >
       <Grid columns="max-content minmax(0, 1fr)" gap="sm" padding="sm">
         <Flex as="span" aria-hidden align="start" paddingTop="2xs">
@@ -185,7 +204,7 @@ export function LinkedPullRequests({group, showEmptyState}: LinkedPullRequestsPr
           borderTop={index === 0 ? undefined : 'primary'}
           style={{listStyle: 'none'}}
         >
-          <LinkedPullRequestRow pullRequest={pullRequest} />
+          <LinkedPullRequestRow group={group} pullRequest={pullRequest} />
         </Container>
       ))}
     </Flex>

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -36,6 +36,13 @@ interface ExternalIssueParams extends CommonGroupAnalyticsData {
   external_issue_type: IntegrationType;
 }
 
+interface ExternalIssuePullRequestParams extends CommonGroupAnalyticsData {
+  pull_request_id: string;
+  pull_request_status: string;
+  repository_id: string;
+  repository_provider: string;
+}
+
 interface SetPriorityParams extends CommonGroupAnalyticsData {
   from_priority: PriorityLevel;
   to_priority: PriorityLevel;
@@ -109,6 +116,7 @@ export type IssueEventParameters = {
   'issue_details.external_issue_created': ExternalIssueParams;
   'issue_details.external_issue_loaded': ExternalIssueParams & {success: boolean};
   'issue_details.external_issue_modal_opened': ExternalIssueParams;
+  'issue_details.external_issue_pull_request_clicked': ExternalIssuePullRequestParams;
   'issue_details.header_view_replay_clicked': GroupEventParams;
   'issue_details.issue_content_selected': {
     content: string;
@@ -402,6 +410,8 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_details.external_issue_modal_opened':
     'Issue Details: External Issue Modal Opened',
   'issue_details.external_issue_created': 'Issue Details: External Issue Created',
+  'issue_details.external_issue_pull_request_clicked':
+    'Issue Details: External Issue Pull Request Clicked',
   'device.classification.unclassified.ios.device':
     'Event from iOS device missing device.class',
   'device.classification.high.end.android.device': 'Event from high end Android device',


### PR DESCRIPTION
Adds analytics for the linked pull request rows in the issue details external issues section.

This records the issue context plus the PR id, status, repo id, and provider when someone opens one of those links.