### PR TITLE
feat(issues): Add Progress sort option to the issue stream

### DIFF
--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -34,6 +34,8 @@ function getSortTooltip(key: IssueSortOptions) {
       return t('Number of users affected.');
     case IssueSortOptions.RECOMMENDED:
       return t('Issues ranked by combined recency, severity, and impact signals.');
+    case IssueSortOptions.PROGRESS:
+      return t('Issues ranked by how far along they are toward a fix.');
     case IssueSortOptions.DATE:
     default:
       return t('Last time the issue occurred.');
@@ -52,6 +54,9 @@ export function IssueListSortOptions({
   const hasRecommendedSort =
     organization.features.includes('issue-stream-recommended-sort') ||
     sort === IssueSortOptions.RECOMMENDED;
+  const hasProgressSort =
+    organization.features.includes('issue-stream-progress-sort') ||
+    sort === IssueSortOptions.PROGRESS;
   const sortKey = sort || IssueSortOptions.DATE;
   const sortKeys = [
     ...(FOR_REVIEW_QUERIES.includes(query || '') ? [IssueSortOptions.INBOX] : []),
@@ -61,6 +66,7 @@ export function IssueListSortOptions({
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
     ...(hasRecommendedSort ? [IssueSortOptions.RECOMMENDED] : []),
+    ...(hasProgressSort ? [IssueSortOptions.PROGRESS] : []),
   ];
 
   return (

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -31,6 +31,7 @@ export enum IssueSortOptions {
   USER = 'user',
   INBOX = 'inbox',
   RECOMMENDED = 'recommended',
+  PROGRESS = 'progress',
 }
 
 export const DEFAULT_ISSUE_STREAM_SORT = IssueSortOptions.DATE;
@@ -49,6 +50,8 @@ export function getSortLabel(key: string) {
       return t('Date Added');
     case IssueSortOptions.RECOMMENDED:
       return t('Recommended');
+    case IssueSortOptions.PROGRESS:
+      return t('Progress');
     case IssueSortOptions.DATE:
     default:
       return t('Last Seen');


### PR DESCRIPTION
Adds a **Progress** entry to the issue stream "Sort by" dropdown, gated behind `organizations:issue-stream-progress-sort` — the same flag that gates the backend sort. It mirrors how the **Recommended** sort is wired (flag check, or shown when it's already the active sort).

Selecting it sends `sort=progress` to the issues API, which orders issues by how far they are through the fix cycle (`fix_applied > fix_proposed > diagnosed > triaged > identified`), with `last_seen` as the secondary key.

## Dependencies

- Backend sort: getsentry/sentry#117707 (the API only honors `sort=progress` once that lands).
- Flag: getsentry/sentry-options-automator#8262 (enables the flag for internal testing).

Until the backend PR deploys, the dropdown option will be inert (the API falls back to the default sort), which is fine — it's flag-gated and FE/BE deploy separately anyway.

## Testing notes

No test added: this is a one-to-one mirror of the existing (untested) `hasRecommendedSort` gating, and there's no colocated test harness for this dropdown.

Refs getsentry/sentry#117707