### PR TITLE
feat(autofix): Restore result description and fix button overflow in coding agent card

### DIFF
--- a/static/app/components/events/autofix/v3/codingAgentsCard.tsx
+++ b/static/app/components/events/autofix/v3/codingAgentsCard.tsx
@@ -3,6 +3,7 @@ import {useMemo} from 'react';
 import {Tag} from '@sentry/scraps/badge';
 import {LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 
 import {
@@ -78,7 +79,12 @@ export function CodingAgentsCard({section}: CodingAgentsCardProps) {
               </Flex>
               <Tag variant={statusVariant}>{codingAgent.status}</Tag>
             </Flex>
-            <Flex direction="row" gap="md">
+            {codingAgent.results?.map((result, index) =>
+              result.description ? (
+                <Markdown key={index} raw={result.description} />
+              ) : null
+            )}
+            <Flex direction="row" gap="md" wrap="wrap">
               {codingAgent.agent_url ? (
                 <LinkButton href={codingAgent.agent_url} external icon={<IconOpen />}>
                   {t('Open in %s', agentName)}


### PR DESCRIPTION
## Summary
- Restores rendering of `result.description` in the V3 coding agents card, which was dropped when V1 was replaced. Uses the `<Markdown>` component consistent with other V3 artifact cards (solution, root cause).
- Fixes button overflow by adding `wrap="wrap"` to the button row, preventing the "View Pull Request" button from expanding outside the card boundary.

Old Card (no description)
<img width="686" height="169" alt="Screenshot 2026-06-16 at 9 31 40 AM" src="https://github.com/user-attachments/assets/081749af-9f46-4069-b8d7-10e58f21fbba" />

Proposed Card (with description
<img width="655" height="505" alt="Screenshot 2026-06-15 at 4 59 50 PM" src="https://github.com/user-attachments/assets/b8bbdb0e-2dfc-4b4c-8c6d-916550920232" />

Old Buttons Overflowing
<img width="433" height="175" alt="Screenshot 2026-06-08 at 3 07 55 PM" src="https://github.com/user-attachments/assets/2989cabd-4b8b-431e-a854-6eb9ef534059" />

New Buttons Wrap
<img width="432" height="141" alt="Screenshot 2026-06-15 at 5 02 50 PM" src="https://github.com/user-attachments/assets/f5dbb39a-83ae-4587-92c9-34b731427013" />

## Test plan
- [x] Open an issue with a completed coding agent run and verify the result description text renders in the card
- [x] Verify buttons wrap correctly when the card is narrow enough that both buttons don't fit in one row