### PR TITLE
feat(seer): Return sentry_run_id from explorer chat GET

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -188,7 +188,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         try:
             client = SeerAgentClient(organization, request.user)
             state = client.get_run(run_id=resolved.seer_run_state_id)
-            return Response({"session": state.dict()})
+            return Response({"session": state.dict(), "sentry_run_id": resolved.uuid})
         except SeerPermissionError as e:
             raise PermissionDenied(e.message) from e
         except SeerApiError as e:

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any
 
 import sentry_sdk
+from pydantic import BaseModel
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import SAFE_METHODS
@@ -20,6 +21,7 @@ from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_org, is_demo_us
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.agent.client import SeerAgentClient
+from sentry.seer.agent.client_models import SeerRunState
 from sentry.seer.agent.client_utils import (
     has_seer_agent_access_with_detail,
     snapshot_to_markdown,
@@ -34,6 +36,11 @@ logger = logging.getLogger(__name__)
 
 
 _CODE_MODE_VALUES = frozenset({"off", "on", "only"})
+
+
+class SeerAgentChatStateResponse(BaseModel):
+    session: SeerRunState
+    sentry_run_id: str | None
 
 
 class CodeModeField(serializers.Field):
@@ -188,7 +195,9 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         try:
             client = SeerAgentClient(organization, request.user)
             state = client.get_run(run_id=resolved.seer_run_state_id)
-            return Response({"session": state.dict(), "sentry_run_id": resolved.uuid})
+            return Response(
+                SeerAgentChatStateResponse(session=state, sentry_run_id=resolved.uuid).dict()
+            )
         except SeerPermissionError as e:
             raise PermissionDenied(e.message) from e
         except SeerApiError as e:

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -118,6 +118,7 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
             data = fetch_search_agent_state(
                 seer_run_id, organization.id, viewer_context=viewer_context
             )
+            data["sentry_run_id"] = resolved.uuid
             return Response(data)
 
         except SeerApiError as e:

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -53,6 +53,8 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data["session"]["run_id"] == 123
         assert response.data["session"]["status"] == "completed"
+        # No mirror row exists for this numeric run id, so there's no UUID to surface.
+        assert response.data["sentry_run_id"] is None
         mock_client.get_run.assert_called_once_with(run_id=123)
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
@@ -207,6 +209,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         response = self.client.get(f"{self.url}{run.uuid}/")
 
         assert response.status_code == 200
+        assert response.data["sentry_run_id"] == str(run.uuid)
         mock_client.get_run.assert_called_once_with(run_id=555)
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")

--- a/tests/sentry/seer/endpoints/test_search_agent_state.py
+++ b/tests/sentry/seer/endpoints/test_search_agent_state.py
@@ -26,6 +26,7 @@ class SearchAgentStateEndpointTest(APITestCase):
         with self.feature(self.features):
             response = self.get_success_response(self.organization.slug, "42")
         assert response.data["session"]["status"] == "completed"
+        assert response.data["sentry_run_id"] is None
         assert mock_request.call_args[0][0]["run_id"] == 42
 
     def test_uuid_returns_processing_when_outbox_not_drained(self) -> None:
@@ -43,6 +44,7 @@ class SearchAgentStateEndpointTest(APITestCase):
         with self.feature(self.features):
             response = self.get_success_response(self.organization.slug, str(run.uuid))
         assert response.data["session"]["status"] == "completed"
+        assert response.data["sentry_run_id"] == str(run.uuid)
         sent_body = mock_request.call_args[0][0]
         assert sent_body["run_id"] == 99
 


### PR DESCRIPTION
Two seer poll endpoints resolved the run UUID via `resolve_seer_run` but didn't return it, so a client holding only the numeric run id couldn't discover the UUID from polling:

- **explorer chat GET** (`organization_seer_agent_chat.py`) — now wraps the payload in a Pydantic `SeerAgentChatStateResponse` (reusing `SeerRunState`) and returns `sentry_run_id`.
- **search agent state GET** (`search_agent_state.py`) — now surfaces `sentry_run_id` on the poll payload, matching what `/search-agent/start/` already returns.

`null` for legacy runs with no mirror row. Purely additive: existing clients ignore the extra key.

Frontend adoption (polling by UUID) ships separately.

## Test plan
- [x] `pytest tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py tests/sentry/seer/endpoints/test_search_agent_state.py`
