### PR TITLE
ref(seer-rpc): introduce EmptyResponse sentinel for `{}` not-found wire

### DIFF
--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -58,7 +58,7 @@ from sentry.seer.agent.utils import (
 )
 from sentry.seer.autofix.autofix import get_all_tags_overview
 from sentry.seer.seer_setup import get_supported_scm_providers
-from sentry.seer.sentry_data_models import EAPTrace
+from sentry.seer.sentry_data_models import EAPTrace, EmptyResponse
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.ourlogs import OurLogs
@@ -606,13 +606,18 @@ def rpc_get_trace_waterfall(
     organization_id: int,
     additional_attributes: list[str] | None = None,
     referrer: str | None = None,
-) -> dict[str, Any]:
+) -> EAPTrace | EmptyResponse:
+    """Surface the underlying typed `EAPTrace` directly.
+
+    The not-found path returns `EmptyResponse`, which serializes to `{}` via
+    `.dict()` — byte-identical to the prior wire shape.
+    """
     try:
         referrer_enum = Referrer(referrer) if referrer else Referrer.SEER_EXPLORER_TOOLS
     except ValueError:
         referrer_enum = Referrer.SEER_EXPLORER_TOOLS
     trace = get_trace_waterfall(trace_id, organization_id, additional_attributes, referrer_enum)
-    return trace.dict() if trace else {}
+    return trace if trace else EmptyResponse()
 
 
 def rpc_get_profile_flamegraph(

--- a/src/sentry/seer/fetch_issues/utils.py
+++ b/src/sentry/seer/fetch_issues/utils.py
@@ -14,7 +14,7 @@ from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.models.repository import Repository
 from sentry.seer.constants import SeerSCMProvider
-from sentry.seer.sentry_data_models import IssueDetails
+from sentry.seer.sentry_data_models import EmptyResponse, IssueDetails
 from sentry.seer.utils import filter_repo_by_provider
 
 logger = logging.getLogger(__name__)
@@ -162,13 +162,14 @@ def _group_by_short_id(short_id: str, organization_id: int) -> Group | None:
         return None
 
 
-def get_latest_issue_event(group_id: int | str, organization_id: int) -> IssueDetails | None:
+def get_latest_issue_event(
+    group_id: int | str, organization_id: int
+) -> IssueDetails | EmptyResponse:
     """
     Get an issue's latest event as an IssueDetails model.
 
-    Returns None when the group / event isn't found. Previously returned `{}`
-    on the not-found path — callers checked `if not response`, which behaves
-    identically for `{}` and `None`.
+    Returns `EmptyResponse` when the group / event isn't found. This serializes
+    to `{}` via `.dict()`, matching the pre-Pydantic wire shape byte-for-byte.
     """
     if isinstance(group_id, str) and not group_id.isdigit():
         group = _group_by_short_id(group_id, organization_id)
@@ -181,7 +182,7 @@ def get_latest_issue_event(group_id: int | str, organization_id: int) -> IssueDe
         logger.warning(
             "Group not found", extra={"group_id": group_id, "organization_id": organization_id}
         )
-        return None
+        return EmptyResponse()
 
     if group.organization.id != organization_id:
         logger.warning(
@@ -192,7 +193,7 @@ def get_latest_issue_event(group_id: int | str, organization_id: int) -> IssueDe
                 "actual_organization_id": group.organization.id,
             },
         )
-        return None
+        return EmptyResponse()
 
     event = group.get_latest_event()
     if not event:
@@ -200,7 +201,7 @@ def get_latest_issue_event(group_id: int | str, organization_id: int) -> IssueDe
             "No event found",
             extra={"group_id": group_id},
         )
-        return None
+        return EmptyResponse()
 
     serialized_event = serialize(event, user=None, serializer=EventSerializer())
     return IssueDetails(

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -102,6 +102,16 @@ class TransactionIssues(BaseModel):
 # `public_org_seer_method_registry`, or `public_project_seer_method_registry`.
 
 
+class EmptyResponse(BaseModel):
+    """Sentinel for RPC methods whose pre-typed not-found shape was `{}`.
+
+    `EmptyResponse().dict()` is `{}`, so a return of `SomeModel | EmptyResponse`
+    preserves the original wire bytes for the empty path while still satisfying
+    the typed-registry contract. Use this instead of `| None` when the
+    pre-migration code returned `{}` to indicate the no-data case.
+    """
+
+
 class OrganizationSlugResponse(BaseModel):
     slug: str
 

--- a/tests/sentry/seer/fetch_issues/test_by_error_type.py
+++ b/tests/sentry/seer/fetch_issues/test_by_error_type.py
@@ -2,6 +2,7 @@ from sentry.models.group import Group
 from sentry.seer.fetch_issues import utils
 from sentry.seer.fetch_issues.by_error_type import _fetch_issues_from_repo_projects, fetch_issues
 from sentry.seer.fetch_issues.utils import get_repo_and_projects
+from sentry.seer.sentry_data_models import IssueDetails
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.samples import load_data
@@ -76,7 +77,7 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
 
         # Assert latest event is returned
         issue_details = utils.get_latest_issue_event(group.id, self.organization.id)
-        assert issue_details is not None
+        assert isinstance(issue_details, IssueDetails)
         assert issue_details.id == group.id
         assert issue_details.title == "KeyError: This a bad error"
         assert len(issue_details.events) == 1
@@ -174,7 +175,7 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
 
         # Assert latest event is returned
         issue_details = utils.get_latest_issue_event(group_1.id, self.organization.id)
-        assert issue_details is not None
+        assert isinstance(issue_details, IssueDetails)
         assert issue_details.id == group_1.id
         assert issue_details.title == "KeyError: This a bad error"
         assert len(issue_details.events) == 1
@@ -239,7 +240,7 @@ class TestFetchIssuesByErrorType(APITestCase, SnubaTestCase):
 
         # Assert latest event is returned
         issue_details = utils.get_latest_issue_event(group.id, self.organization.id)
-        assert issue_details is not None
+        assert isinstance(issue_details, IssueDetails)
         assert issue_details.id == group.id
         assert issue_details.title == "KeyError: This a bad error"
         assert len(issue_details.events) == 1

--- a/tests/sentry/seer/fetch_issues/test_utils.py
+++ b/tests/sentry/seer/fetch_issues/test_utils.py
@@ -11,6 +11,7 @@ from sentry.seer.fetch_issues.utils import (
     get_repo_and_projects,
     handle_fetch_issues_exceptions,
 )
+from sentry.seer.sentry_data_models import EmptyResponse, IssueDetails
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.samples import load_data
@@ -246,7 +247,7 @@ class TestGetLatestIssueEvent(TestCase):
         assert group is not None
         result = get_latest_issue_event(group.id, self.organization.id)
 
-        assert result is not None
+        assert isinstance(result, IssueDetails)
         assert result.id == group.id
         assert result.title == group.title
         assert len(result.events) == 1
@@ -255,7 +256,7 @@ class TestGetLatestIssueEvent(TestCase):
     def test_get_latest_issue_event_not_found(self) -> None:
         nonexistent_group_id = 999999
         result = get_latest_issue_event(nonexistent_group_id, self.organization.id)
-        assert result is None
+        assert isinstance(result, EmptyResponse)
 
     def test_get_latest_issue_event_with_short_id(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=1))
@@ -265,7 +266,7 @@ class TestGetLatestIssueEvent(TestCase):
         assert group is not None
         result = get_latest_issue_event(group.qualified_short_id, self.organization.id)
 
-        assert result is not None
+        assert isinstance(result, IssueDetails)
         assert result.id == group.id
         assert result.title == group.title
         assert len(result.events) == 1
@@ -273,20 +274,20 @@ class TestGetLatestIssueEvent(TestCase):
 
     def test_get_latest_issue_event_with_short_id_not_found(self) -> None:
         result = get_latest_issue_event("INVALID-SHORT-ID", self.organization.id)
-        assert result is None
+        assert isinstance(result, EmptyResponse)
 
     def test_get_latest_issue_event_no_events(self) -> None:
         # Create a group but don't store any events for it
         group = self.create_group(project=self.project)
         result = get_latest_issue_event(group.id, self.organization.id)
-        assert result is None
+        assert isinstance(result, EmptyResponse)
 
     def test_get_latest_issue_event_wrong_organization(self) -> None:
         event = self.store_event(data={}, project_id=self.project.id)
         group = event.group
         assert group is not None
         results = get_latest_issue_event(group.id, self.organization.id + 1)
-        assert results is None
+        assert isinstance(results, EmptyResponse)
 
     def test_get_latest_issue_event_numeric_id_cross_org(self) -> None:
         """Numeric group ID from another org must not be returned."""
@@ -298,7 +299,7 @@ class TestGetLatestIssueEvent(TestCase):
         assert other_group is not None
 
         result = get_latest_issue_event(other_group.id, self.organization.id)
-        assert result is None
+        assert isinstance(result, EmptyResponse)
 
 
 class TestHandleFetchIssuesExceptions(TestCase):


### PR DESCRIPTION
Adds a Pydantic sentinel — `class EmptyResponse(BaseModel)` — whose `.dict()` produces `{}`. RPC methods whose pre-typed not-found return was `{}` can use `SomeModel | EmptyResponse` instead of `SomeModel | None`, keeping byte-identical wire bytes while still satisfying the typed-registry contract.

Applied to two functions:

- `rpc_get_trace_waterfall` → `EAPTrace | EmptyResponse`. Previously returned `dict[str, Any]` via `trace.dict() if trace else {}`. Surfaces the underlying typed `EAPTrace` directly.
- `get_latest_issue_event` → `IssueDetails | EmptyResponse`. Backfill for the earlier typing PR that had switched `{}` → `None` and unintentionally changed the wire on the not-found path. This restores the original `{}` bytes.

Wire-no-op: success paths emit the typed model's `.dict()` (same as before for both); not-found path emits `{}` for both.