### PR TITLE
fix(dynamic-sampling): Rename metric tags to avoid _id suffix stripping

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -148,7 +148,7 @@ def _emit_project_balancing_debug_metrics(
     eap_volume: float,
     eap_volume_without_extrapolation: float | None,
 ) -> None:
-    tags = {"org_id": str(org_id), "ds_proj_id": str(project_id)}
+    tags = {"org": str(org_id), "ds_project": str(project_id)}
     metrics.distribution(
         f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_sample_rate",
         eap_sample_rate,


### PR DESCRIPTION
The metrics middleware (`src/sentry/metrics/middleware.py`) silently discards any metric tag whose key ends in `_id` to prevent high-cardinality explosion. Both `org_id` and `ds_proj_id` on the project balancing debug metrics matched this filter, so the metrics were arriving in Datadog with no usable tags.

Rename to `org` and `ds_project` to avoid the filter.