### PR TITLE
fix(errors): Add conditional Ask Seer prop

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
@@ -41,6 +41,44 @@ describe('EventsSearchBar', () => {
     });
   });
 
+  it('hides Ask Seer for errors widgets', async () => {
+    organization = OrganizationFixture({
+      features: ['gen-ai-features', 'gen-ai-search-agent-translate'],
+    });
+
+    render(
+      <EventsSearchBar
+        onClose={jest.fn()}
+        dataset={DiscoverDatasets.ERRORS}
+        pageFilters={PageFiltersFixture()}
+        widgetQuery={{
+          aggregates: ['count_unique(browser.name)'],
+          columns: [],
+          conditions: '',
+          name: '',
+          orderby: '',
+          fieldAliases: undefined,
+          fields: undefined,
+          isHidden: undefined,
+          onDemand: undefined,
+          selectedAggregate: undefined,
+        }}
+      />,
+      {
+        organization,
+      }
+    );
+
+    await userEvent.click(
+      await screen.findByRole('combobox', {name: 'Add a search term'})
+    );
+    await screen.findByRole('listbox');
+
+    expect(
+      screen.queryByRole('option', {name: /Ask AI to build your query/})
+    ).not.toBeInTheDocument();
+  });
+
   it('does not show function tags in has: dropdown', async () => {
     render(
       <EventsSearchBar

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -842,6 +842,7 @@ export class Results extends Component<Props, State> {
           onSearch={this.handleSearch}
           customMeasurements={customMeasurements}
           dataset={eventView.dataset}
+          enableAISearch
           includeTransactions
           recentSearches={savedSearchType}
         />

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
@@ -72,6 +72,7 @@ type DataProviderProps = {
 
 type Props = {
   disabled?: boolean;
+  enableAISearch?: boolean;
   onChange?: (query: string, state: CallbackSearchState) => void;
   onSearch?: (query: string) => void;
   placeholder?: string;
@@ -144,6 +145,7 @@ export function ResultsSearchQueryBuilder(props: Props) {
     customMeasurements,
     dataset,
     includeTransactions = true,
+    enableAISearch: enableAISearchProp = false,
   } = props;
 
   const placeholderText = useMemo(() => {
@@ -161,12 +163,13 @@ export function ResultsSearchQueryBuilder(props: Props) {
       includeTransactions,
     });
 
-  // AI search is only enabled for Errors dataset if translate endpoint is enabled
+  // AI search is only enabled for Errors dataset if translate endpoint is enabled.
   const isErrorsDataset = dataset === DiscoverDatasets.ERRORS;
   const organization = useOrganization();
   const hasTranslateEndpoint = organization.features.includes(
     'gen-ai-search-agent-translate'
   );
+  const enableAISearch = hasTranslateEndpoint && enableAISearchProp;
 
   const searchBarProps = {
     placeholderText,
@@ -187,7 +190,7 @@ export function ResultsSearchQueryBuilder(props: Props) {
     return (
       <SearchQueryBuilderProvider
         initialQuery={props.query ?? ''}
-        enableAISearch={hasTranslateEndpoint}
+        enableAISearch={enableAISearch}
         aiSearchBadgeType="beta"
         disabled={disabled}
         fieldDefinitionGetter={undefined}


### PR DESCRIPTION
This PR adds in a prop to the `ResultsSearchQueryBuilder` to toggle the behavior of Ask Seer, and only enable it on the Discover -> Error page.