### PR TITLE
ref(span-buffer): Cache previous lookups to Redis in a local array

### DIFF
--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -133,21 +133,25 @@ table.insert(latency_table, {"redirect_step_latency_ms", redirect_end_time_ms - 
 local ingested_byte_count_key = string.format("span-buf:ibc:%s", set_key)
 local ingested_byte_count = tonumber(redis.call("get", ingested_byte_count_key) or 0)
 
--- Pre-processing loop runs first to collect all the child ibc keys.
+-- Pre-processing loop runs first to collect all the keys.
+local child_ic_keys = {}
 local child_ibc_keys = {}
 for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
     local span_id = ARGV[i]
     if span_id ~= parent_span_id then
         local child_set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
+        table.insert(child_ic_keys, string.format("span-buf:ic:%s", child_set_key))
         table.insert(child_ibc_keys, string.format("span-buf:ibc:%s", child_set_key))
     end
 end
 
--- Bulk request is made for child_ibc_keys. MGET returns in order. Further down we'll use the array.
--- The merge loop iterates in the same order. So we can use its index position to efficiently retrieve
--- the locally cached value.
+-- Bulk request is made for child_ic and child_ibc keys. MGET returns in order. Further down we'll use
+-- the array. The merge loop iterates in the same order. We can use its index position to efficiently
+-- retrieve the locally cached value.
+local child_ics = {}
 local child_ibcs = {}
 if #child_ibc_keys > 0 then
+    child_ics = redis.call("mget", unpack(child_ic_keys))
     child_ibcs = redis.call("mget", unpack(child_ibc_keys))
     for j = 1, #child_ibcs do
         byte_count = byte_count + tonumber(child_ibcs[j] or 0)
@@ -185,19 +189,19 @@ local child_idx = 0
 for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
     local span_id = ARGV[i]
     if span_id ~= parent_span_id then
-        child_idx = child_idx + 1
         local child_set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
+        child_idx = child_idx + 1
 
-        local child_ic_key = string.format("span-buf:ic:%s", child_set_key)
-        local child_ic = redis.call("get", child_ic_key)
+        local child_ic = child_ics[child_idx]
         if child_ic then
+            local child_ic_key = string.format("span-buf:ic:%s", child_set_key)
             redis.call("incrby", ingested_count_key, child_ic)
             redis.call("del", child_ic_key)
         end
 
-        local child_ibc_key = string.format("span-buf:ibc:%s", child_set_key)
         local child_ibc = child_ibcs[child_idx]
         if child_ibc then
+            local child_ibc_key = string.format("span-buf:ibc:%s", child_set_key)
             -- byte_count already holds the child's byte count, so we don't need to add again
             redis.call("del", child_ibc_key)
         end

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -132,16 +132,25 @@ table.insert(latency_table, {"redirect_step_latency_ms", redirect_end_time_ms - 
 
 local ingested_byte_count_key = string.format("span-buf:ibc:%s", set_key)
 local ingested_byte_count = tonumber(redis.call("get", ingested_byte_count_key) or 0)
-local child_ibc_table = {}
 
+-- Pre-processing loop runs first to collect all the child ibc keys.
+local child_ibc_keys = {}
 for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
     local span_id = ARGV[i]
     if span_id ~= parent_span_id then
         local child_set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
-        local child_ibc_key = string.format("span-buf:ibc:%s", child_set_key)
-        local child_ibc = redis.call("get", child_ibc_key)
-        byte_count = byte_count + tonumber(child_ibc or 0)
-        child_ibc_table[i] = child_ibc
+        table.insert(child_ibc_keys, string.format("span-buf:ibc:%s", child_set_key))
+    end
+end
+
+-- Bulk request is made for child_ibc_keys. MGET returns in order. Further down we'll use the array.
+-- The merge loop iterates in the same order. So we can use its index position to efficiently retrieve
+-- the locally cached value.
+local child_ibcs = {}
+if #child_ibc_keys > 0 then
+    child_ibcs = redis.call("mget", unpack(child_ibc_keys))
+    for j = 1, #child_ibcs do
+        byte_count = byte_count + tonumber(child_ibcs[j] or 0)
     end
 end
 
@@ -170,9 +179,13 @@ table.insert(metrics_table, {"detached_segment_locked", segment_locked and 1 or 
 local ingested_count_key = string.format("span-buf:ic:%s", set_key)
 local members_key = string.format("span-buf:mk:{%s}:%s", project_and_trace, set_span_id)
 
+-- NOTE: This loop is assumed to match the iteration semantics of the child_ibc cache key
+--       lookup loop. If it doesn't then this will breakerino.
+local child_idx = 0
 for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
     local span_id = ARGV[i]
     if span_id ~= parent_span_id then
+        child_idx = child_idx + 1
         local child_set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
 
         local child_ic_key = string.format("span-buf:ic:%s", child_set_key)
@@ -183,9 +196,7 @@ for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
         end
 
         local child_ibc_key = string.format("span-buf:ibc:%s", child_set_key)
-        -- The child_ibc_table variable has the same order as our loop allowing us to index into
-        -- the array.
-        local child_ibc = child_ibc_table[i]
+        local child_ibc = child_ibcs[child_idx]
         if child_ibc then
             -- byte_count already holds the child's byte count, so we don't need to add again
             redis.call("del", child_ibc_key)

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -132,14 +132,16 @@ table.insert(latency_table, {"redirect_step_latency_ms", redirect_end_time_ms - 
 
 local ingested_byte_count_key = string.format("span-buf:ibc:%s", set_key)
 local ingested_byte_count = tonumber(redis.call("get", ingested_byte_count_key) or 0)
+local child_ibc_table = {}
 
 for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
     local span_id = ARGV[i]
     if span_id ~= parent_span_id then
         local child_set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
         local child_ibc_key = string.format("span-buf:ibc:%s", child_set_key)
-        local child_ibc = tonumber(redis.call("get", child_ibc_key) or 0)
-        byte_count = byte_count + child_ibc
+        local child_ibc = redis.call("get", child_ibc_key)
+        byte_count = byte_count + tonumber(child_ibc or 0)
+        child_ibc_table[i] = child_ibc
     end
 end
 
@@ -181,7 +183,9 @@ for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
         end
 
         local child_ibc_key = string.format("span-buf:ibc:%s", child_set_key)
-        local child_ibc = redis.call("get", child_ibc_key)
+        -- The child_ibc_table variable has the same order as our loop allowing us to index into
+        -- the array.
+        local child_ibc = child_ibc_table[i]
         if child_ibc then
             -- byte_count already holds the child's byte count, so we don't need to add again
             redis.call("del", child_ibc_key)


### PR DESCRIPTION
We're fetching keys from Redis in a loop even though we have access to batch instructions. MGET is used to look up the count and byte-count values. The results are cached in an ordered, local array to prevent redundant look ups and enable efficient, index-based access patterns. Calls to string format are de-duplicated.

Note: the unpack of MGET args is strictly less than the [unpack of HSET args](https://github.com/getsentry/sentry/blob/2536883e46ed64f421280514ff41bd6657191611/src/sentry/scripts/spans/add-buffer.lua#L118-L128) which is O(2n). The MGET args are O(n).