### PR TITLE
feat(features): register organizations:am3-tier permanent feature flag

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -31,6 +31,8 @@ def register_permanent_features(manager: FeatureManager) -> None:
     permanent_organization_features = {
         # Enable advanced search features, like negation and wildcard matching.
         "organizations:advanced-search": True,
+        # Denotes organizations on the AM3 billing tier
+        "organizations:am3-tier": False,
         # Enable anomaly detection alerts
         "organizations:anomaly-detection-alerts": False,
         # Enable change alerts for an org


### PR DESCRIPTION
## Summary

Registers `organizations:am3-tier` in `src/sentry/features/permanent.py` so it is declared with the default feature manager.

The flag is referenced in `src/sentry/ingest/consumer/processors.py` (used in `collect_span_metrics` to gate span count tracking) but was missing from the permanent feature registry. In self-hosted and single-tenant deployments this causes:

> Feature organizations:am3-tier is not registered with sentry.features.default_manager

The flag is managed by getsentry/getsentry for sentry.io billing tiers (AM3), so the default here is `False` — same pattern as `organizations:spans-usage-tracking`.

## Changes

- Added `"organizations:am3-tier": False` to `permanent_organization_features` in alphabetical order

## Refs

- Fixes https://github.com/getsentry/self-hosted/issues/4377

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3ACUHS29QJ0%3A1781575403.587189%22)