### PR TITLE
ref(o11y): Bump `sentry_sdk` to 2.63.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dependencies = [
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm==0.22.0",
-  "sentry-sdk[http2]>=2.59.0",
+  "sentry-sdk[http2]>=2.63.0",
   "sentry-usage-accountant>=0.0.10",
   # remove once there are no unmarked transitive dependencies on setuptools
   "setuptools>=70.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2416,7 +2416,7 @@ requires-dist = [
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = "==0.22.0" },
-    { name = "sentry-sdk", extras = ["http2"], specifier = ">=2.59.0" },
+    { name = "sentry-sdk", extras = ["http2"], specifier = ">=2.63.0" },
     { name = "sentry-usage-accountant", specifier = ">=0.0.10" },
     { name = "setuptools", specifier = ">=70.0.0" },
     { name = "simplejson", specifier = ">=3.17.6" },
@@ -2645,14 +2645,14 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.59.0"
+version = "2.63.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_sdk-2.59.0-py2.py3-none-any.whl", hash = "sha256:abcf65ee9a9d9cdebf9ad369782408ecca9c1c792686ef06ba34f5ab233527fe" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_sdk-2.63.0-py3-none-any.whl", hash = "sha256:3a9b5ddd403f79eb73bd670f75f04485819db53d28f76ced7bc09041cb0dfd6a" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Need access to the new `sentry_sdk.traces.get_current_span()` API for dogfooding.
The function was added in https://github.com/getsentry/sentry-python/commit/610f7b7475050ebbdfb47f0888e39af32735f8f8.
