### PR TITLE
feat(seer): Return sentry_run_id from runs list and dashboard generate

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import BaseModel
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
@@ -108,6 +109,11 @@ User Query:
 """
 
 
+class DashboardGenerateResponse(BaseModel):
+    run_id: int
+    sentry_run_id: str
+
+
 class DashboardGenerateSerializer(serializers.Serializer[dict[str, Any]]):
     prompt = serializers.CharField(
         required=True,
@@ -198,7 +204,11 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
                 artifact_schema=GeneratedDashboard,
                 request=request,
             )
-            return Response({"run_id": run.seer_run_state_id, "sentry_run_id": str(run.uuid)})
+            return Response(
+                DashboardGenerateResponse(
+                    run_id=run.seer_run_state_id, sentry_run_id=str(run.uuid)
+                ).dict()
+            )
         except SeerPermissionError as e:
             raise PermissionDenied(e.message) from e
         except SeerApiError:

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -198,7 +198,7 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
                 artifact_schema=GeneratedDashboard,
                 request=request,
             )
-            return Response({"run_id": run.seer_run_state_id})
+            return Response({"run_id": run.seer_run_state_id, "sentry_run_id": str(run.uuid)})
         except SeerPermissionError as e:
             raise PermissionDenied(e.message) from e
         except SeerApiError:

--- a/src/sentry/seer/endpoints/organization_seer_agent_runs.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_runs.py
@@ -14,11 +14,16 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPerm
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.models.organization import Organization
 from sentry.seer.agent.client import SeerAgentClient
+from sentry.seer.agent.client_models import AgentRun
 from sentry.seer.agent.client_utils import has_seer_agent_access_with_detail
 from sentry.seer.models import SeerPermissionError
 from sentry.seer.models.run import SeerRun
 
 logger = logging.getLogger(__name__)
+
+
+class AgentRunWithUuid(AgentRun):
+    sentry_run_id: str | None
 
 
 class OrganizationSeerAgentRunsPermission(OrganizationPermission):
@@ -82,7 +87,9 @@ class OrganizationSeerAgentRunsEndpoint(OrganizationEndpoint):
             }
             return {
                 "data": [
-                    {**run.dict(), "sentry_run_id": uuid_by_state_id.get(run.run_id)}
+                    AgentRunWithUuid(
+                        **run.dict(), sentry_run_id=uuid_by_state_id.get(run.run_id)
+                    ).dict()
                     for run in runs
                 ]
             }

--- a/src/sentry/seer/endpoints/organization_seer_agent_runs.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_runs.py
@@ -16,6 +16,7 @@ from sentry.models.organization import Organization
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.agent.client_utils import has_seer_agent_access_with_detail
 from sentry.seer.models import SeerPermissionError
+from sentry.seer.models.run import SeerRun
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +73,19 @@ class OrganizationSeerAgentRunsEndpoint(OrganizationEndpoint):
             except SeerPermissionError as e:
                 raise PermissionDenied(e.message) from e
 
-            return {"data": [run.dict() for run in runs]}
+            uuid_by_state_id = {
+                seer_run_state_id: str(run_uuid)
+                for seer_run_state_id, run_uuid in SeerRun.objects.filter(
+                    organization=organization,
+                    seer_run_state_id__in=[run.run_id for run in runs],
+                ).values_list("seer_run_state_id", "uuid")
+            }
+            return {
+                "data": [
+                    {**run.dict(), "sentry_run_id": uuid_by_state_id.get(run.run_id)}
+                    for run in runs
+                ]
+            }
 
         return self.paginate(
             request=request,

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from typing import Any
 from unittest.mock import ANY, MagicMock, patch
 
@@ -31,15 +32,16 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
 
     @patch("sentry.dashboards.endpoints.organization_dashboard_generate.SeerAgentClient")
     def test_post_starts_run_and_returns_run_id(self, mock_client_class: MagicMock) -> None:
+        run_uuid = uuid.uuid4()
         mock_client = MagicMock()
-        mock_client.start_run.return_value = MagicMock(seer_run_state_id=789)
+        mock_client.start_run.return_value = MagicMock(seer_run_state_id=789, uuid=run_uuid)
         mock_client_class.return_value = mock_client
 
         data = {"prompt": "Show me error rates by project"}
         response = self.client.post(self.url, data, format="json")
 
         assert response.status_code == 200
-        assert response.data == {"run_id": 789}
+        assert response.data == {"run_id": 789, "sentry_run_id": str(run_uuid)}
 
         mock_client_class.assert_called_once_with(
             self.organization,
@@ -104,8 +106,9 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
     def test_post_with_current_dashboard_uses_edit_context(
         self, mock_client_class: MagicMock
     ) -> None:
+        run_uuid = uuid.uuid4()
         mock_client = MagicMock()
-        mock_client.start_run.return_value = MagicMock(seer_run_state_id=123)
+        mock_client.start_run.return_value = MagicMock(seer_run_state_id=123, uuid=run_uuid)
         mock_client_class.return_value = mock_client
 
         data = {
@@ -137,7 +140,7 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
         response = self.client.post(self.url, data, format="json")
 
         assert response.status_code == 200
-        assert response.data == {"run_id": 123}
+        assert response.data == {"run_id": 123, "sentry_run_id": str(run_uuid)}
 
         mock_client_class.assert_called_once_with(
             self.organization,

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_runs.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_runs.py
@@ -67,6 +67,28 @@ class TestOrganizationSeerAgentRunsEndpoint(APITestCase):
             query=None,
         )
 
+    def test_get_includes_sentry_run_id(self) -> None:
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=1)
+        self.mock_client.get_runs.return_value = [
+            AgentRun(
+                run_id=1,
+                title="Mirrored",
+                last_triggered_at=datetime.now(),
+                created_at=datetime.now(),
+            ),
+            AgentRun(
+                run_id=2,
+                title="Legacy (no mirror)",
+                last_triggered_at=datetime.now(),
+                created_at=datetime.now(),
+            ),
+        ]
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data[0]["sentry_run_id"] == str(run.uuid)
+        assert data[1]["sentry_run_id"] is None
+
     def test_get_cursor_pagination(self) -> None:
         # Mock seer response for offset 0, limit 3.
         self.mock_client.get_runs.return_value = [


### PR DESCRIPTION
Surfaces the run's UUID (`sentry_run_id`) on two more Seer endpoints that only returned the numeric run id, matching explorer chat, search agent, and autofix.

- `GET /seer/explorer-runs/` adds `sentry_run_id` per run via a single bulk `SeerRun` lookup (`null` for legacy runs with no mirror row).
- `POST /dashboards/generate/` returns `sentry_run_id` alongside `run_id`.

Purely additive — existing clients ignore the new field.

Not covered here:
- `project_seer_night_shift.py` — its `SeerRun` isn't mirrored at all (created outside the outbox); needs the deeper outbox-mirroring fix, tracked separately.
- `organization_seer_agent_pr_groups.py` — still returns a numeric-only run id.
- Frontend adoption (sessions-list picker preferring the UUID, dashboards `from-seer` flow) is separate.