### PR TITLE
ref(seer-rpc): batch-type 25 dict/list returns via opaque adapters

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_rpc.py
+++ b/src/sentry/seer/endpoints/organization_seer_rpc.py
@@ -73,6 +73,7 @@ from sentry.seer.endpoints.seer_rpc import (
 )
 from sentry.seer.endpoints.utils import accept_organization_id_param, map_org_id_param
 from sentry.seer.fetch_issues import by_error_type, by_function_name, by_text_query, utils
+from sentry.seer.sentry_data_models import as_opaque_dict_response, as_opaque_list_response
 from sentry.utils.env import in_test_environment
 from sentry.viewer_context import get_viewer_context, observe_viewer_context_propagation
 
@@ -102,32 +103,42 @@ public_org_seer_method_registry: dict[str, Callable] = {
     #
     # Assisted query (cross-project)
     "get_attribute_names": map_org_id_param(get_attribute_names),
-    "get_attribute_values_with_substring": map_org_id_param(get_attribute_values_with_substring),
+    "get_attribute_values_with_substring": as_opaque_dict_response(
+        map_org_id_param(get_attribute_values_with_substring)
+    ),
     "get_attributes_and_values": map_org_id_param(get_attributes_and_values),
     "get_metric_metadata": map_org_id_param(get_metric_metadata),
-    "get_event_filter_keys": map_org_id_param(get_event_filter_keys),
-    "get_event_filter_key_values": map_org_id_param(get_event_filter_key_values),
-    "get_issue_filter_keys": map_org_id_param(get_issue_filter_keys),
-    "get_filter_key_values": map_org_id_param(get_filter_key_values),
+    "get_event_filter_keys": as_opaque_dict_response(map_org_id_param(get_event_filter_keys)),
+    "get_event_filter_key_values": as_opaque_list_response(
+        map_org_id_param(get_event_filter_key_values)
+    ),
+    "get_issue_filter_keys": as_opaque_dict_response(map_org_id_param(get_issue_filter_keys)),
+    "get_filter_key_values": as_opaque_list_response(map_org_id_param(get_filter_key_values)),
     #
     # Agent (cross-project)
     "get_trace_waterfall": rpc_get_trace_waterfall,
-    "get_repository_definition": get_repository_definition,
-    "execute_table_query": map_org_id_param(execute_table_query),
-    "execute_timeseries_query": map_org_id_param(execute_timeseries_query),
+    "get_repository_definition": as_opaque_dict_response(get_repository_definition),
+    "execute_table_query": as_opaque_dict_response(map_org_id_param(execute_table_query)),
+    "execute_timeseries_query": as_opaque_dict_response(map_org_id_param(execute_timeseries_query)),
     "execute_trace_table_query": execute_trace_table_query,
     "execute_issues_query": map_org_id_param(execute_issues_query),
-    "get_issue_and_event_details_v2": get_issue_and_event_details_v2,
-    "get_issue_details": get_issue_details,
-    "get_event_details": get_event_details,
-    "get_profile_flamegraph": rpc_get_profile_flamegraph,
-    "get_replay_metadata": get_replay_metadata,
-    "get_log_attributes_for_trace": map_org_id_param(get_log_attributes_for_trace),
-    "get_metric_attributes_for_trace": map_org_id_param(get_metric_attributes_for_trace),
-    "get_issues_stats": map_org_id_param(get_issues_stats),
-    "get_baseline_tag_distribution": get_baseline_tag_distribution,
-    "get_comparative_attribute_distributions": get_comparative_attribute_distributions,
-    "get_dsn": get_dsn,
+    "get_issue_and_event_details_v2": as_opaque_dict_response(get_issue_and_event_details_v2),
+    "get_issue_details": as_opaque_dict_response(get_issue_details),
+    "get_event_details": as_opaque_dict_response(get_event_details),
+    "get_profile_flamegraph": as_opaque_dict_response(rpc_get_profile_flamegraph),
+    "get_replay_metadata": as_opaque_dict_response(get_replay_metadata),
+    "get_log_attributes_for_trace": as_opaque_dict_response(
+        map_org_id_param(get_log_attributes_for_trace)
+    ),
+    "get_metric_attributes_for_trace": as_opaque_dict_response(
+        map_org_id_param(get_metric_attributes_for_trace)
+    ),
+    "get_issues_stats": as_opaque_list_response(map_org_id_param(get_issues_stats)),
+    "get_baseline_tag_distribution": as_opaque_dict_response(get_baseline_tag_distribution),
+    "get_comparative_attribute_distributions": as_opaque_dict_response(
+        get_comparative_attribute_distributions
+    ),
+    "get_dsn": as_opaque_dict_response(get_dsn),
     #
     # Agent eval tooling
     "export_explorer_indexes": map_org_id_param(export_agent_indexes),
@@ -142,17 +153,29 @@ public_org_seer_method_registry: dict[str, Callable] = {
 # - `project_id` (int): Project ID, must be provided in request args and validated
 public_project_seer_method_registry: dict[str, Callable] = {
     # Agent - project-scoped methods
-    "get_transactions_for_project": accept_organization_id_param(rpc_get_transactions_for_project),
-    "get_trace_for_transaction": accept_organization_id_param(rpc_get_trace_for_transaction),
-    "get_profiles_for_trace": accept_organization_id_param(rpc_get_profiles_for_trace),
-    "get_issues_for_transaction": accept_organization_id_param(rpc_get_issues_for_transaction),
+    "get_transactions_for_project": as_opaque_dict_response(
+        accept_organization_id_param(rpc_get_transactions_for_project)
+    ),
+    "get_trace_for_transaction": as_opaque_dict_response(
+        accept_organization_id_param(rpc_get_trace_for_transaction)
+    ),
+    "get_profiles_for_trace": as_opaque_dict_response(
+        accept_organization_id_param(rpc_get_profiles_for_trace)
+    ),
+    "get_issues_for_transaction": as_opaque_dict_response(
+        accept_organization_id_param(rpc_get_issues_for_transaction)
+    ),
     # Autofix - project-scoped methods
     "get_error_event_details": accept_organization_id_param(get_error_event_details),
     "get_profile_details": get_profile_details,
     "get_attributes_for_span": map_org_id_param(get_attributes_for_span),
-    "get_trace_item_attributes": map_org_id_param(get_trace_item_attributes),
+    "get_trace_item_attributes": as_opaque_dict_response(
+        map_org_id_param(get_trace_item_attributes)
+    ),
     # Replays - project-scoped methods
-    "get_replay_summary_logs": accept_organization_id_param(rpc_get_replay_summary_logs),
+    "get_replay_summary_logs": as_opaque_dict_response(
+        accept_organization_id_param(rpc_get_replay_summary_logs)
+    ),
 }
 
 

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -143,6 +143,8 @@ from sentry.seer.sentry_data_models import (
     SpanAttributesResponse,
     ValidateRepoErrorResponse,
     ValidateRepoSuccessResponse,
+    as_opaque_dict_response,
+    as_opaque_list_response,
 )
 from sentry.seer.utils import filter_repo_by_provider
 from sentry.sentry_apps.metrics import SentryAppEventType
@@ -1023,7 +1025,7 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     "send_seer_webhook": send_seer_webhook,
     "get_attributes_for_span": get_attributes_for_span,
     "get_project_preferences": get_project_preferences,
-    "bulk_get_project_preferences": bulk_get_project_preferences,
+    "bulk_get_project_preferences": as_opaque_dict_response(bulk_get_project_preferences),
     #
     # Bug prediction
     "has_repo_code_mappings": has_repo_code_mappings,
@@ -1034,51 +1036,55 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     #
     # Assisted query
     "get_attribute_names": get_attribute_names,
-    "get_attribute_values_with_substring": get_attribute_values_with_substring,
+    "get_attribute_values_with_substring": as_opaque_dict_response(
+        get_attribute_values_with_substring
+    ),
     "get_attributes_and_values": get_attributes_and_values,
     "get_metric_metadata": get_metric_metadata,
-    "get_issue_filter_keys": get_issue_filter_keys,
-    "get_filter_key_values": get_filter_key_values,
-    "get_issues_stats": get_issues_stats,
-    "get_event_filter_keys": get_event_filter_keys,
-    "get_event_filter_key_values": get_event_filter_key_values,
+    "get_issue_filter_keys": as_opaque_dict_response(get_issue_filter_keys),
+    "get_filter_key_values": as_opaque_list_response(get_filter_key_values),
+    "get_issues_stats": as_opaque_list_response(get_issues_stats),
+    "get_event_filter_keys": as_opaque_dict_response(get_event_filter_keys),
+    "get_event_filter_key_values": as_opaque_list_response(get_event_filter_key_values),
     #
     # Agent
-    "get_transactions_for_project": rpc_get_transactions_for_project,
-    "get_trace_for_transaction": rpc_get_trace_for_transaction,
-    "get_profiles_for_trace": rpc_get_profiles_for_trace,
-    "get_issues_for_transaction": rpc_get_issues_for_transaction,
+    "get_transactions_for_project": as_opaque_dict_response(rpc_get_transactions_for_project),
+    "get_trace_for_transaction": as_opaque_dict_response(rpc_get_trace_for_transaction),
+    "get_profiles_for_trace": as_opaque_dict_response(rpc_get_profiles_for_trace),
+    "get_issues_for_transaction": as_opaque_dict_response(rpc_get_issues_for_transaction),
     "get_trace_waterfall": rpc_get_trace_waterfall,
-    "get_issue_and_event_details_v2": get_issue_and_event_details_v2,
-    "get_issue_details": get_issue_details,
-    "get_event_details": get_event_details,
-    "get_profile_flamegraph": rpc_get_profile_flamegraph,
-    "execute_table_query": execute_table_query,
-    "execute_timeseries_query": execute_timeseries_query,
+    "get_issue_and_event_details_v2": as_opaque_dict_response(get_issue_and_event_details_v2),
+    "get_issue_details": as_opaque_dict_response(get_issue_details),
+    "get_event_details": as_opaque_dict_response(get_event_details),
+    "get_profile_flamegraph": as_opaque_dict_response(rpc_get_profile_flamegraph),
+    "execute_table_query": as_opaque_dict_response(execute_table_query),
+    "execute_timeseries_query": as_opaque_dict_response(execute_timeseries_query),
     "execute_trace_table_query": execute_trace_table_query,
-    "execute_replays_query": execute_replays_query,
+    "execute_replays_query": as_opaque_dict_response(execute_replays_query),
     "execute_issues_query": execute_issues_query,
-    "get_trace_item_attributes": get_trace_item_attributes,
-    "get_repository_definition": get_repository_definition,
+    "get_trace_item_attributes": as_opaque_dict_response(get_trace_item_attributes),
+    "get_repository_definition": as_opaque_dict_response(get_repository_definition),
     "call_custom_tool": call_custom_tool,
     "call_on_completion_hook": call_on_completion_hook,
     "deliver_feature_result": deliver_feature_result,
-    "record_pr_attribution": record_pr_attribution,
-    "get_log_attributes_for_trace": get_log_attributes_for_trace,
-    "get_metric_attributes_for_trace": get_metric_attributes_for_trace,
-    "get_baseline_tag_distribution": get_baseline_tag_distribution,
-    "get_comparative_attribute_distributions": get_comparative_attribute_distributions,
-    "get_dsn": get_dsn,
+    "record_pr_attribution": as_opaque_dict_response(record_pr_attribution),
+    "get_log_attributes_for_trace": as_opaque_dict_response(get_log_attributes_for_trace),
+    "get_metric_attributes_for_trace": as_opaque_dict_response(get_metric_attributes_for_trace),
+    "get_baseline_tag_distribution": as_opaque_dict_response(get_baseline_tag_distribution),
+    "get_comparative_attribute_distributions": as_opaque_dict_response(
+        get_comparative_attribute_distributions
+    ),
+    "get_dsn": as_opaque_dict_response(get_dsn),
     #
     # Replays
-    "get_replay_summary_logs": rpc_get_replay_summary_logs,
-    "get_replay_metadata": get_replay_metadata,
+    "get_replay_summary_logs": as_opaque_dict_response(rpc_get_replay_summary_logs),
+    "get_replay_metadata": as_opaque_dict_response(get_replay_metadata),
     #
     # Issue Detection
-    "create_issue_occurrence": create_issue_occurrence,
+    "create_issue_occurrence": as_opaque_dict_response(create_issue_occurrence),
     #
     # PR metrics (judge path)
-    "update_pr_metrics": update_pr_metrics,
+    "update_pr_metrics": as_opaque_dict_response(update_pr_metrics),
 }
 
 

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -5,9 +5,12 @@ These should be kept in sync with the models in Seer.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from collections.abc import Callable
+from typing import Any, Literal, ParamSpec
 
 from pydantic import BaseModel, Field
+
+_P = ParamSpec("_P")
 
 
 class Transaction(BaseModel):
@@ -110,6 +113,95 @@ class EmptyResponse(BaseModel):
     the typed-registry contract. Use this instead of `| None` when the
     pre-migration code returned `{}` to indicate the no-data case.
     """
+
+
+class OpaqueDictResponse(BaseModel):
+    """Passthrough wrapper for RPC methods whose return is a `dict[str, Any]`
+    with no explicit declared schema.
+
+    Construct via `OpaqueDictResponse(__root__=data)` (or `.parse_obj(data)`);
+    `.dict()` returns the underlying dict verbatim. Wire-no-op against the
+    pre-typed `dict[str, Any]` return shape.
+
+    Exposes dict-like read access (`__getitem__`, `get`, `__contains__`) so
+    in-process callers that previously held a `dict` can keep using subscript
+    + `.get()` without an explicit unwrap. Long-term, replace this with an
+    explicit `BaseModel` subclass once the actual fields are known.
+    """
+
+    __root__: dict[str, Any]
+
+    def dict(self, **kwargs: Any) -> dict[str, Any]:
+        return self.__root__
+
+    def __getitem__(self, key: str) -> Any:
+        return self.__root__[key]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.__root__.get(key, default)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self.__root__
+
+
+def as_opaque_dict_response(
+    fn: Callable[_P, dict[str, Any] | None],
+) -> Callable[_P, OpaqueDictResponse | None]:
+    """Adapter for RPC methods whose internal return is a `dict[str, Any] | None`.
+
+    Returns a callable that wraps the underlying dict in `OpaqueDictResponse`
+    (preserving wire bytes) so the registered method satisfies the typed
+    registry contract without changing the function body. Long-term, replace
+    with an explicit `BaseModel` subclass on the underlying function.
+    """
+
+    def opaque_dict_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> OpaqueDictResponse | None:
+        result = fn(*args, **kwargs)
+        if result is None:
+            return None
+        return OpaqueDictResponse(__root__=result)
+
+    return opaque_dict_wrapper
+
+
+class OpaqueListResponse(BaseModel):
+    """Passthrough wrapper for RPC methods whose return is a top-level
+    `list[Any]` with no explicit declared schema.
+
+    `.dict()` returns the underlying list verbatim (overriding pydantic's
+    dict shape), preserving the bare-array wire bytes for callers whose
+    pre-typed return was a JSON array. As with `OpaqueDictResponse`, this is
+    transitional — replace with an explicit `BaseModel` once the actual
+    element shape is known.
+    """
+
+    __root__: list[Any]
+
+    def dict(self, **kwargs: Any) -> list[Any]:  # type: ignore[override]
+        return self.__root__
+
+    def __getitem__(self, idx: int) -> Any:
+        return self.__root__[idx]
+
+    def __iter__(self) -> Any:
+        return iter(self.__root__)
+
+    def __len__(self) -> int:
+        return len(self.__root__)
+
+
+def as_opaque_list_response(
+    fn: Callable[_P, list[Any] | None],
+) -> Callable[_P, OpaqueListResponse | None]:
+    """Adapter for RPC methods whose internal return is `list[Any] | None`."""
+
+    def opaque_list_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> OpaqueListResponse | None:
+        result = fn(*args, **kwargs)
+        if result is None:
+            return None
+        return OpaqueListResponse(__root__=result)
+
+    return opaque_list_wrapper
 
 
 class OrganizationSlugResponse(BaseModel):


### PR DESCRIPTION
Introduces two transitional Pydantic passthrough models and matching registry-level adapters in `sentry_data_models.py`:

- `OpaqueDictResponse` — wraps a `dict[str, Any]` return; `.dict()` returns the underlying dict verbatim. Implements `__getitem__`, `get`, `__contains__` so in-process callers keep working unchanged.
- `OpaqueListResponse` — wraps a `list[Any]` return; `.dict()` returns the underlying list verbatim.
- `as_opaque_dict_response(fn)` / `as_opaque_list_response(fn)` — registry-level adapters. Each preserves the function's call signature via `ParamSpec`; the wrapper's typed return satisfies the typed-registry contract without touching any function body.

Applied to every Seer RPC method whose return shape is `dict[str, Any]`, `dict[str, Any] | None`, `list[X]`, or `list[X] | None` and which doesn't yet have an explicit Pydantic schema — **25 methods** across `seer_method_registry`, `public_org_seer_method_registry`, and `public_project_seer_method_registry`.

Wire bytes are preserved on every path; the adapter only changes the registered callable's static return type, not the JSON it produces. The opaque shapes are explicitly transitional — they let the registry contract flip today and individual methods refine to explicit schemas in follow-ups.