### PR TITLE
ref(seer-rpc): type get_dsn and get_repository_definition with explicit models

### DIFF
--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -58,7 +58,12 @@ from sentry.seer.agent.utils import (
 )
 from sentry.seer.autofix.autofix import get_all_tags_overview
 from sentry.seer.seer_setup import get_supported_scm_providers
-from sentry.seer.sentry_data_models import EAPTrace, EmptyResponse
+from sentry.seer.sentry_data_models import (
+    EAPTrace,
+    EmptyResponse,
+    GetDsnResponse,
+    RepositoryDefinitionResponse,
+)
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.ourlogs import OurLogs
@@ -833,7 +838,7 @@ def get_repository_definition(
     organization_id: int,
     repo_full_name: str,
     external_id: str | None = None,
-) -> dict | None:
+) -> RepositoryDefinitionResponse | None:
     """
     Look up a repository that the org has access to.
     Returns full RepoDefinition if found and accessible via code mappings, None otherwise.
@@ -900,14 +905,14 @@ def get_repository_definition(
     owner = repo_name_parts[0]
     name = "/".join(repo_name_parts[1:])
 
-    return {
-        "organization_id": organization_id,
-        "integration_id": str(repo.integration_id) if repo.integration_id is not None else None,
-        "provider": repo.provider,
-        "owner": owner,
-        "name": name,
-        "external_id": repo.external_id,
-    }
+    return RepositoryDefinitionResponse(
+        organization_id=organization_id,
+        integration_id=str(repo.integration_id) if repo.integration_id is not None else None,
+        provider=repo.provider,
+        owner=owner,
+        name=name,
+        external_id=repo.external_id,
+    )
 
 
 # Tuples of (total period, interval) (both in sentry stats period format).
@@ -2304,12 +2309,12 @@ def get_dsn(
     *,
     organization_id: int,
     project_slug: str,
-) -> dict[str, Any] | None:
+) -> GetDsnResponse | None:
     """
     Get the public DSN for a single project in an organization.
 
-    Returns a dict with project_slug, platform, and dsn_public, or None if the
-    organization/project does not exist or the project has no active client key.
+    Returns the project's public DSN, or None if the organization/project does
+    not exist or the project has no active client key.
     """
     try:
         organization = Organization.objects.get(id=organization_id)
@@ -2342,8 +2347,8 @@ def get_dsn(
     if key is None:
         return None
 
-    return {
-        "project_slug": project.slug,
-        "platform": project.platform,
-        "dsn_public": key.dsn_public,
-    }
+    return GetDsnResponse(
+        project_slug=project.slug,
+        platform=project.platform,
+        dsn_public=key.dsn_public,
+    )

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -249,7 +249,7 @@ class GetDsnResponse(BaseModel):
 class RepositoryDefinitionResponse(BaseModel):
     organization_id: int
     integration_id: str | None
-    provider: str
+    provider: str | None
     owner: str
     name: str
     external_id: str | None

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -238,3 +238,18 @@ class MetricMetadataErrorResponse(BaseModel):
     candidates: list[MetricMetadataRow]
     has_more: bool
     error: str
+
+
+class GetDsnResponse(BaseModel):
+    project_slug: str
+    platform: str | None
+    dsn_public: str
+
+
+class RepositoryDefinitionResponse(BaseModel):
+    organization_id: int
+    integration_id: str | None
+    provider: str
+    owner: str
+    name: str
+    external_id: str | None

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -2642,12 +2642,12 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
         )
 
         assert result is not None
-        assert result["organization_id"] == self.organization.id
-        assert result["integration_id"] == "123"
-        assert result["provider"] == "integrations:github"
-        assert result["owner"] == "getsentry"
-        assert result["name"] == "seer"
-        assert result["external_id"] == "12345678"
+        assert result.organization_id == self.organization.id
+        assert result.integration_id == "123"
+        assert result.provider == "integrations:github"
+        assert result.owner == "getsentry"
+        assert result.name == "seer"
+        assert result.external_id == "12345678"
 
     def test_get_repository_definition_invalid_format(self) -> None:
         """Test that invalid repo name format returns None"""
@@ -2721,7 +2721,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
         )
 
         assert result is not None
-        assert result["integration_id"] is None
+        assert result.integration_id is None
 
     def test_get_repository_definition_unsupported_provider(self) -> None:
         """Test that repositories with unsupported providers are filtered out"""
@@ -2760,7 +2760,7 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
         )
 
         assert result is not None
-        assert result["provider"] == "integrations:github_enterprise"
+        assert result.provider == "integrations:github_enterprise"
 
     def test_get_repository_definition_multiple_providers(self) -> None:
         """Test that when multiple repos with different supported providers exist, first one is returned"""
@@ -2790,12 +2790,12 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
 
         assert result is not None
         # Should return the first matching repo (in this case, GitHub)
-        assert result["provider"] in [
+        assert result.provider in [
             "integrations:github",
             "integrations:github_enterprise",
         ]
-        assert result["owner"] == "getsentry"
-        assert result["name"] == "seer"
+        assert result.owner == "getsentry"
+        assert result.name == "seer"
 
     def test_get_repository_definition_filters_unsupported_with_supported(self) -> None:
         """Test that unsupported providers are ignored even when a supported one exists"""
@@ -2825,8 +2825,8 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
 
         # Should return the GitHub repo, not GitLab
         assert result is not None
-        assert result["provider"] == "integrations:github"
-        assert result["external_id"] == "12345678"
+        assert result.provider == "integrations:github"
+        assert result.external_id == "12345678"
 
     def test_get_repository_definition_multipart_name(self) -> None:
         """Test repository with multi-part name (e.g., owner/project/repo)"""
@@ -2845,8 +2845,8 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
         )
 
         assert result is not None
-        assert result["owner"] == "getsentry"
-        assert result["name"] == "project/seer"
+        assert result.owner == "getsentry"
+        assert result.name == "project/seer"
 
     def test_get_repository_definition_by_external_id(self) -> None:
         """Test lookup by external_id when repo has been renamed."""
@@ -2868,8 +2868,8 @@ class TestGetRepositoryDefinition(APITransactionTestCase):
 
         assert result is not None
         # Should return the CURRENT name from the database
-        assert result["owner"] == "getsentry"
-        assert result["name"] == "new-name"
+        assert result.owner == "getsentry"
+        assert result.name == "new-name"
 
 
 class TestRpcGetProfileFlamegraph(APITestCase, SpanTestCase, SnubaTestCase):
@@ -4083,13 +4083,13 @@ class TestGetDsn(APITestCase):
         result = get_dsn(organization_id=self.organization.id, project_slug="wordcraft")
 
         assert result is not None
-        assert result == {
+        assert result.dict() == {
             "project_slug": "wordcraft",
             "platform": project.platform,
-            "dsn_public": result["dsn_public"],
+            "dsn_public": result.dsn_public,
         }
-        assert result["dsn_public"].startswith("http")
-        assert result["dsn_public"].endswith(f"/{project.id}")
+        assert result.dsn_public.startswith("http")
+        assert result.dsn_public.endswith(f"/{project.id}")
 
     def test_returns_none_for_unknown_slug(self) -> None:
         self.create_project(organization=self.organization, slug="wordcraft")


### PR DESCRIPTION
Two RPC methods get explicit Pydantic response models — schemas the codegen SDK consumer can read directly, not passthrough wrappers.

- `get_dsn` → `GetDsnResponse | None` with `project_slug: str`, `platform: str | None`, `dsn_public: str`. `platform` is nullable per the `Project.platform` model.
- `get_repository_definition` → `RepositoryDefinitionResponse | None` with `organization_id: int`, `integration_id: str | None`, `provider: str`, `owner: str`, `name: str`, `external_id: str | None`. `integration_id` is stringified (mirrors the existing serialization).

Wire-no-op: each model's `.dict()` matches the prior bare-dict shape byte-for-byte.