### PR TITLE
chore(ci): Bump backend migration workflow timeout to 150s

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -365,7 +365,7 @@ jobs:
 
       - name: run tests
         run: |
-          PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations --migrations --reruns 0 --fail-slow=120s" make test-python-ci
+          PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations --migrations --reruns 0 --fail-slow=150s" make test-python-ci
 
       - name: Report failures
         if: ${{ !cancelled() && github.event_name == 'pull_request' }}


### PR DESCRIPTION
This workflow has been just barely timing out, just seconds or even sub seconds away from the 120s timeout.

For now lets just bump this and we can worry about fixing the ever increasingly slow migrations later.