### PR TITLE
chore(markdown): add breadcrumbs to 'copy to markdown'

### DIFF
--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
@@ -343,6 +343,207 @@ describe('useCopyIssueDetails', () => {
       expect(result).not.toContain('mainFunction');
     });
 
+    it('includes breadcrumbs when present in event', () => {
+      const eventWithBreadcrumbs = EventFixture({
+        ...event,
+        entries: [
+          {
+            type: EntryType.BREADCRUMBS,
+            data: {
+              values: [
+                {
+                  type: 'http',
+                  category: 'fetch',
+                  level: 'error',
+                  message: 'GET /api/users',
+                  data: {url: '/api/users', status_code: 500},
+                },
+                {
+                  type: 'navigation',
+                  category: 'ui.click',
+                  level: 'info',
+                  message: 'User clicked submit',
+                  data: null,
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithBreadcrumbs,
+        organization,
+      });
+
+      expect(result).toContain('## Breadcrumbs');
+      expect(result).toContain('- **http** `fetch` [error]');
+      expect(result).toContain('  GET /api/users');
+      expect(result).toContain('  {"url":"/api/users","status_code":500}');
+      expect(result).toContain('- **navigation** `ui.click` [info]');
+      expect(result).toContain('  User clicked submit');
+    });
+
+    it('truncates a single breadcrumb to the per-crumb character limit', () => {
+      const longMessage = 'x'.repeat(600);
+      const eventWithLongBreadcrumb = EventFixture({
+        ...event,
+        entries: [
+          {
+            type: EntryType.BREADCRUMBS,
+            data: {
+              values: [{type: 'default', level: 'info', message: longMessage}],
+            },
+          },
+        ],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithLongBreadcrumb,
+        organization,
+      });
+
+      // Kept the first 500 chars plus an ellipsis, dropped the rest.
+      expect(result).toContain(`${'x'.repeat(500)}...`);
+      expect(result).not.toContain('x'.repeat(501));
+    });
+
+    it('truncates the breadcrumbs section to the total character limit', () => {
+      // 10 crumbs near the per-crumb cap (~490 chars each) overflow the 5000
+      // total. The first crumb's content survives; the last crumb's tail (well
+      // past the 5000th char) is cut off.
+      const values = Array.from({length: 10}, (_, i) => {
+        if (i === 0) {
+          return {type: 'default', level: 'info', message: `FIRSTHEAD${'a'.repeat(481)}`};
+        }
+        if (i === 9) {
+          return {
+            type: 'default',
+            level: 'info',
+            message: `LASTHEAD${'a'.repeat(470)}LASTTAIL`,
+          };
+        }
+        return {type: 'default', level: 'info', message: 'a'.repeat(490)};
+      });
+      const eventWithManyLargeBreadcrumbs = EventFixture({
+        ...event,
+        entries: [{type: EntryType.BREADCRUMBS, data: {values}}],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithManyLargeBreadcrumbs,
+        organization,
+      });
+
+      expect(result).toContain('... (breadcrumbs truncated to first 5,000 characters)');
+      expect(result).toContain('FIRSTHEAD');
+      expect(result).not.toContain('LASTTAIL');
+    });
+
+    it('renders breadcrumbs after exceptions', () => {
+      const eventWithBoth = EventFixture({
+        ...event,
+        entries: [
+          {
+            type: EntryType.BREADCRUMBS,
+            data: {
+              values: [{type: 'default', level: 'info', message: 'crumb'}],
+            },
+          },
+          {
+            type: EntryType.EXCEPTION,
+            data: {
+              values: [{type: 'TypeError', value: 'boom'}],
+            },
+          },
+        ],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithBoth,
+        organization,
+      });
+
+      expect(result.indexOf('## Exception')).toBeLessThan(
+        result.indexOf('## Breadcrumbs')
+      );
+    });
+
+    it('limits breadcrumbs to the most recent 10', () => {
+      const values = Array.from({length: 15}, (_, i) => ({
+        type: 'default',
+        level: 'info',
+        message: `crumb ${i}`,
+      }));
+      const eventWithManyBreadcrumbs = EventFixture({
+        ...event,
+        entries: [{type: EntryType.BREADCRUMBS, data: {values}}],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithManyBreadcrumbs,
+        organization,
+      });
+
+      // The oldest 5 are dropped, the most recent 10 are kept.
+      expect(result).not.toContain('crumb 4');
+      expect(result).toContain('crumb 5');
+      expect(result).toContain('crumb 14');
+    });
+
+    it('skips breadcrumbs with filtered content', () => {
+      const eventWithFiltered = EventFixture({
+        ...event,
+        entries: [
+          {
+            type: EntryType.BREADCRUMBS,
+            data: {
+              values: [
+                {type: 'http', level: 'info', message: 'token: [Filtered]'},
+                {
+                  type: 'http',
+                  level: 'info',
+                  message: 'visible',
+                  data: {secret: '[Filtered]'},
+                },
+                {type: 'default', level: 'info', message: 'kept crumb'},
+              ],
+            },
+          },
+        ],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithFiltered,
+        organization,
+      });
+
+      expect(result).toContain('kept crumb');
+      expect(result).not.toContain('[Filtered]');
+      expect(result).not.toContain('visible');
+    });
+
+    it('does not include a breadcrumbs section when there are none', () => {
+      const eventWithEmptyBreadcrumbs = EventFixture({
+        ...event,
+        entries: [{type: EntryType.BREADCRUMBS, data: {values: []}}],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithEmptyBreadcrumbs,
+        organization,
+      });
+
+      expect(result).not.toContain('## Breadcrumbs');
+    });
+
     // 1006 is the occurrence type for N+1 DB Queries. Spans mirror the classic
     // cache-miss → DB-read shape: each offender is a cache.get with a distinct
     // key followed by an identical parameterized query.

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
@@ -120,14 +120,13 @@ function formatBreadcrumbsToMarkdown(crumbs: RawCrumb[]): string {
       MAX_SINGLE_BREADCRUMB_CHARS
     );
 
-    let entry = `- **${type}**${category}${level}`;
-    if (content) {
-      entry += content
-        .split('\n')
-        .map(line => `\n  ${line}`)
-        .join('');
-    }
-    entries.push(entry);
+    const body = content
+      ? content
+          .split('\n')
+          .map(line => `\n  ${line}`)
+          .join('')
+      : '';
+    entries.push(`- **${type}**${category}${level}${body}`);
   });
 
   if (entries.length === 0) {

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
@@ -13,6 +13,7 @@ import {
 import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
 import {NODE_ENV} from 'sentry/constants';
 import {t} from 'sentry/locale';
+import type {RawCrumb} from 'sentry/types/breadcrumbs';
 import {EntryType, type Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
@@ -80,8 +81,73 @@ function formatStacktraceToMarkdown(stacktrace: StacktraceType): string {
   return markdownText;
 }
 
+// Mirror Seer's breadcrumb handling: only the most recent crumbs are kept, any
+// crumb whose message or data contains redacted (`[Filtered]`) content is
+// skipped, and both the per-crumb and total output sizes are capped the same
+// way so a pathological breadcrumb can't bloat the clipboard.
+const MAX_BREADCRUMBS = 10;
+const MAX_SINGLE_BREADCRUMB_CHARS = 500;
+const MAX_BREADCRUMBS_CHARS = 5000;
+
+function truncate(value: string, maxChars: number, suffix = '...'): string {
+  return value.length > maxChars ? `${value.slice(0, maxChars)}${suffix}` : value;
+}
+
+function formatBreadcrumbsToMarkdown(crumbs: RawCrumb[]): string {
+  const entries: string[] = [];
+
+  crumbs.slice(-MAX_BREADCRUMBS).forEach(crumb => {
+    const message = crumb.message ?? '';
+
+    // Drop empty values, matching Seer's `{k: v for k, v in data if v}`.
+    const data = crumb.data
+      ? Object.fromEntries(Object.entries(crumb.data).filter(([, value]) => value))
+      : null;
+    const dataStr = data && Object.keys(data).length > 0 ? JSON.stringify(data) : '';
+
+    if (message.includes('[Filtered]') || dataStr.includes('[Filtered]')) {
+      return;
+    }
+
+    const type = crumb.type || 'default';
+    const category = crumb.category ? ` \`${crumb.category}\`` : '';
+    const level = crumb.level ? ` [${crumb.level}]` : '';
+
+    // Seer caps the combined message + data per breadcrumb. Indent it under the
+    // header line so multi-line content stays within the markdown list item.
+    const content = truncate(
+      [message, dataStr].filter(Boolean).join('\n'),
+      MAX_SINGLE_BREADCRUMB_CHARS
+    );
+
+    let entry = `- **${type}**${category}${level}`;
+    if (content) {
+      entry += content
+        .split('\n')
+        .map(line => `\n  ${line}`)
+        .join('');
+    }
+    entries.push(entry);
+  });
+
+  if (entries.length === 0) {
+    return '';
+  }
+
+  const section = truncate(
+    entries.join('\n'),
+    MAX_BREADCRUMBS_CHARS,
+    `\n... (breadcrumbs truncated to first ${MAX_BREADCRUMBS_CHARS.toLocaleString('en-US')} characters)`
+  );
+
+  return `\n## Breadcrumbs\n\n${section}\n`;
+}
+
 function formatEventToMarkdown(event: Event, activeThreadId: number | undefined): string {
   let markdownText = '';
+  // Collected separately so breadcrumbs always render after the exception /
+  // thread sections, regardless of the order entries appear in the event.
+  let breadcrumbsText = '';
 
   // Add tags
   if (event && Array.isArray(event.tags) && event.tags.length > 0) {
@@ -133,8 +199,12 @@ function formatEventToMarkdown(event: Event, activeThreadId: number | undefined)
         markdownText += '\n\n';
         markdownText += formatStacktraceToMarkdown(activeThread.stacktrace);
       }
+    } else if (entry.type === EntryType.BREADCRUMBS && entry.data.values) {
+      breadcrumbsText += formatBreadcrumbsToMarkdown(entry.data.values);
     }
   });
+
+  markdownText += breadcrumbsText;
 
   return markdownText;
 }


### PR DESCRIPTION
Adds breadcrumbs to 'copy to markdown'. This follows what Seer does:
- keep only the last 10 crumbs
- skip any crumb whose message/data contains [Filtered]
- the section renders after the exception/thread sections.

```
const MAX_BREADCRUMBS = 10;
const MAX_SINGLE_BREADCRUMB_CHARS = 500;
const MAX_BREADCRUMBS_CHARS = 5000;
```
^This follows what Seer Agent does to pick breadcrumbs. For `MAX_SINGLE_BREADCRUMB_CHARS` and `MAX_BREADCRUMBS_CHARS`, Seer Agent has token count in mind (using the reduced-context profile) but I think this is useful for not having a super giant json blob copied too. 

Example Breadcrumbs section:
```
## Breadcrumbs

- **http** `httplib` [info]
  {"http.method":"POST","http.response.status_code":200,"reason":"OK","thread.id":"140234567890123","thread.name":"Worker-7","url":"http://order-service.internal.example.net:8500/api/v2/checkout/validate_cart/"}
- **default** `query` [info]
  SELECT shop_customer.id, shop_customer.email, shop_customer.full_name,
         shop_customer.status, shop_customer.created_at, shop_customer.loyalty_tier,
         shop_customer.is_guest, shop_customer.preferences
  FROM shop_customer
  WHERE shop_customer.id = %s
  LIMIT 21
- **default** `query` [info]
  SELECT shop_order.id, shop_order.reference, shop_order.customer_id,
         shop_order.total_cents, shop_order.currency, shop_order.placed_at,
         shop_order.status, shop_order.fulfillment_type, shop_order.notes
  FROM shop_order
  WHERE shop_order.customer_id = %s
- **default** `query` [info]
  SELECT shop_lineitem.id, shop_lineitem.order_id, shop_lineitem.sku,
         shop_lineitem.quantity, shop_lineitem.unit_price_cents,
         shop_lineitem.discount_cents
  FROM shop_lineitem
  WHERE shop_lineitem.order_id = %s
- **http** `httplib` [info]
  {"http.method":"POST","http.response.status_code":200,"reason":"OK","thread.id":"140234567890123","thread.name":"Worker-7","url":"http://order-service.internal.example.net:8500/api/v2/payments/authorize/"}
- **http** `httplib` [info]
  {"http.method":"GET","http.response.status_code":200,"reason":"OK","thread.id":"140234567890123","thread.name":"Worker-7","url":"http://order-service.internal.example.net:8500/api/v2/inventory/reserve/"}
- **redis** `redis` [info]
  redis.pipeline.execute
  {"redis.transaction":true}
- **http** `httplib` [warning]
  {"code.lineno":312,"code.namespace":"foodflow.clients.payments.base","http.method":"POST","http.response.status_code":402,"reason":"Payment Required","thread.id":"140234567890123","thread.name":"Worker-7","url":"https://api.payments-provider.example.com/v1/charges/"}
- **log** `foodflow.clients.payments` [warning]
  payment.gateway_response
  {"request_type":"authorize_charge","error":"402 Client Error: Payment Required for url: https://api.payments-provider.example.com/v1/charges/","provider":"stripe-sandbox","merchant_id":"54321","status_string":"402","url":"https://api.payments-provider.example.com/v1/charges/"}

```
