### PR TITLE
fix(preprocessing): Handle malformed URLs and missing raw frame keys

### DIFF
--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -28,6 +28,8 @@ def deobfuscate_exception_value(data: Any) -> Any:
         and raw_frame
         and frame.get("module")
         and frame.get("function")
+        and raw_frame.get("module")
+        and raw_frame.get("function")
         and exception.get("value")
     ):
         deobfuscated_method_name = f"{frame['module']}.{frame['function']}"

--- a/src/sentry/lang/javascript/utils.py
+++ b/src/sentry/lang/javascript/utils.py
@@ -115,7 +115,10 @@ def generate_module(src: str | None) -> str:
     if not src:
         return UNKNOWN_MODULE
 
-    filename, ext = splitext(urlsplit(src).path)
+    try:
+        filename, ext = splitext(urlsplit(src).path)
+    except ValueError:
+        return UNKNOWN_MODULE
     if filename.endswith(".min"):
         filename = filename[:-4]
 


### PR DESCRIPTION
Fixes two existing errors from the preprocessing step ([logs link)](https://console.cloud.google.com/logs/query;query=jsonPayload.event%20%3D%20%22tasks.store.preprocessors.error%22%0A;summaryFields=:false:32:beginning;cursorTimestamp=2026-06-16T17:52:43.606802076Z;histogramBreakdownField=severity;duration=P1D?project=internal-sentry&rapt=AEjHL4OOB0lYq5e44LyEFUhrsPzSa7TiA7oaFopg3LFsfCo-uQBhPm2kh8Qp11EL6FfSc4QYUA6DeP23O4AvGtANkCXPyeZv1rin9PL_jSv_R8GOFtVTNEQ)
- Fix `ValueError` in JS `generate_module` when Python 3.13's stricter `urlsplit` encounters malformed bracketed hostnames (e.g. `http://[]/foo.js`). Returns `UNKNOWN_MODULE` fallback instead of crashing.
- Fix `KeyError` in Java `deobfuscate_exception_value` when `raw_frame` lacks `module` or `function` keys. Adds `.get()` guards to the existing condition block.
