### PR TITLE
fix(explore): Include AI cost fields in visualize options

### DIFF
--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -69,7 +69,14 @@ export const SENTRY_SPAN_STRING_TAGS: string[] = [
   SpanFields.GEN_AI_RESPONSE_MODEL,
 ];
 
-export const SENTRY_SPAN_NUMBER_TAGS: string[] = [...SENTRY_SEARCHABLE_SPAN_NUMBER_TAGS];
+export const SENTRY_SPAN_NUMBER_TAGS: string[] = [
+  ...SENTRY_SEARCHABLE_SPAN_NUMBER_TAGS,
+  SpanFields.AI_TOTAL_COST,
+  SpanFields.GEN_AI_COST_INPUT_TOKENS,
+  SpanFields.GEN_AI_COST_OUTPUT_TOKENS,
+  SpanFields.GEN_AI_COST_TOTAL_TOKENS,
+  'gen_ai.usage.total_cost',
+];
 
 export const SENTRY_SPAN_BOOLEAN_TAGS: string[] = [
   SpanFields.IS_TRANSACTION,

--- a/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
@@ -45,8 +45,13 @@ describe('useVisualizeFields', () => {
     });
 
     expect(result.current.map(field => field.value)).toEqual([
+      'gen_ai.cost.input_tokens',
+      'gen_ai.cost.output_tokens',
+      'gen_ai.cost.total_tokens',
       'span.duration',
       'span.self_time',
+      'ai.total_cost',
+      'gen_ai.usage.total_cost',
       'score.ttfb',
     ]);
   });


### PR DESCRIPTION
Explore visualize field selectors now treat AI cost attributes as numeric span fields, so aggregate functions like p95, avg, sum, min, and max can select them from the default field list.

The UI already models these currency values as numeric aggregate inputs, so this seeds the known cost attributes into the span number tags and updates the visualize fields coverage.

Refs EXP-1005