### PR TITLE
ref(seer): Use /seer/projects/ instead of /autofix/automation-settings/ in Autofix Add-Project modal

### DIFF
--- a/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
+++ b/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment} from 'react';
 import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
 import {z} from 'zod';
 
@@ -15,7 +15,6 @@ import {Heading, Text} from '@sentry/scraps/text';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {bulkAutofixAutomationSettingsInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useBulkAutofixAutomationSettings';
 import {IconArrow} from 'sentry/icons/iconArrow';
 import {IconBranch} from 'sentry/icons/iconBranch';
 import {IconDelete} from 'sentry/icons/iconDelete';
@@ -31,6 +30,7 @@ import {
   orgDefaultAgentQueryOptions,
   seerAgentIntegrationsSelectQueryOptions,
 } from 'sentry/utils/seer/preferredAgent';
+import {getInfiniteSeerProjectsSettingsQueryOptions} from 'sentry/utils/seer/seerProjectSettings';
 import {
   PROJECT_STOPPING_POINT_OPTIONS,
   useOrgDefaultStoppingPoint,
@@ -61,7 +61,9 @@ export function ProjectAddRepoModal({
   const repositoriesById = useRepositoriesById();
 
   const unconfiguredProjects = useUnconfiguredProjects();
-  const projectOptions = useCompactSelectProjectOptions({projects: unconfiguredProjects});
+  const projectOptions = useCompactSelectProjectOptions({
+    projects: unconfiguredProjects.data ?? [],
+  });
   const repositoryOptions = useCompactSelectRepositoryOptions();
   const {data: agentOptions = []} = useQuery(
     seerAgentIntegrationsSelectQueryOptions({organization})
@@ -379,28 +381,25 @@ export function ProjectAddRepoModal({
 function useUnconfiguredProjects() {
   const organization = useOrganization();
   const {projects} = useProjects();
-
-  const autofixSettingsQueryOptions = bulkAutofixAutomationSettingsInfiniteOptions({
-    organization,
-  });
   const result = useInfiniteQuery({
-    ...autofixSettingsQueryOptions,
-    select: ({pages}) =>
-      Array.from(
+    ...getInfiniteSeerProjectsSettingsQueryOptions({
+      organization,
+      query: {
+        per_page: 100,
+      },
+    }),
+    select: ({pages}) => {
+      const configuredProjects = Array.from(
         new Set(
           pages
             .flatMap(page => page.json)
             .filter(setting => setting.reposCount > 0)
             .map(setting => String(setting.projectId))
         )
-      ),
+      );
+      return projects.filter(p => !configuredProjects.includes(String(p.id)));
+    },
   });
   useFetchAllPages({result});
-  const {data: projectsWithRepos, isPending, hasNextPage} = result;
-
-  return useMemo(() => {
-    return isPending || hasNextPage
-      ? projects
-      : projects.filter(p => !projectsWithRepos?.includes(String(p.id)));
-  }, [projects, projectsWithRepos, isPending, hasNextPage]);
+  return result;
 }

--- a/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
+++ b/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
@@ -60,9 +60,10 @@ export function ProjectAddRepoModal({
   const projectsById = useProjectsById();
   const repositoriesById = useRepositoriesById();
 
-  const unconfiguredProjects = useUnconfiguredProjects();
+  const {projects} = useProjects();
+  const unconfiguredProjects = useUnconfiguredProjects({projects});
   const projectOptions = useCompactSelectProjectOptions({
-    projects: unconfiguredProjects.data ?? [],
+    projects: unconfiguredProjects.data ?? projects,
   });
   const repositoryOptions = useCompactSelectRepositoryOptions();
   const {data: agentOptions = []} = useQuery(
@@ -378,9 +379,8 @@ export function ProjectAddRepoModal({
   );
 }
 
-function useUnconfiguredProjects() {
+function useUnconfiguredProjects({projects}: {projects: Project[]}) {
   const organization = useOrganization();
-  const {projects} = useProjects();
   const result = useInfiniteQuery({
     ...getInfiniteSeerProjectsSettingsQueryOptions({
       organization,

--- a/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
+++ b/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
@@ -1,5 +1,5 @@
-import {Fragment} from 'react';
-import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
+import {Fragment, useCallback} from 'react';
+import {useInfiniteQuery, useQuery, type InfiniteData} from '@tanstack/react-query';
 import {z} from 'zod';
 
 import {ProjectAvatar} from '@sentry/scraps/avatar';
@@ -20,7 +20,7 @@ import {IconBranch} from 'sentry/icons/iconBranch';
 import {IconDelete} from 'sentry/icons/iconDelete';
 import {t, tct} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
-import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
+import {useFetchAllPages, type ApiResponse} from 'sentry/utils/api/apiFetch';
 import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
 import {useCompactSelectProjectOptions} from 'sentry/utils/project/useCompactSelectProjectOptions';
 import {useProjectsById} from 'sentry/utils/project/useProjectsById';
@@ -35,7 +35,10 @@ import {
   PROJECT_STOPPING_POINT_OPTIONS,
   useOrgDefaultStoppingPoint,
 } from 'sentry/utils/seer/stoppingPoint';
-import type {AutofixAgentSelectOption} from 'sentry/utils/seer/types';
+import type {
+  AutofixAgentSelectOption,
+  SeerProjectSettingResponse,
+} from 'sentry/utils/seer/types';
 import {
   AutofixSettingsPartialSaveError,
   useMutateAutofixProject,
@@ -388,17 +391,20 @@ function useUnconfiguredProjects({projects}: {projects: Project[]}) {
         per_page: 100,
       },
     }),
-    select: ({pages}) => {
-      const configuredProjects = Array.from(
-        new Set(
-          pages
-            .flatMap(page => page.json)
-            .filter(setting => setting.reposCount > 0)
-            .map(setting => String(setting.projectId))
-        )
-      );
-      return projects.filter(p => !configuredProjects.includes(String(p.id)));
-    },
+    select: useCallback(
+      ({pages}: InfiniteData<ApiResponse<SeerProjectSettingResponse[]>>) => {
+        const configuredProjects = Array.from(
+          new Set(
+            pages
+              .flatMap(page => page.json)
+              .filter(setting => setting.reposCount > 0)
+              .map(setting => String(setting.projectId))
+          )
+        );
+        return projects.filter(p => !configuredProjects.includes(String(p.id)));
+      },
+      [projects]
+    ),
   });
   useFetchAllPages({result});
   return result;


### PR DESCRIPTION
This removes one more callsite to the older/deprecated autofix endpoint.

The list output is the exact same as before. We're getting incremental loading and re-rendering as we go which is also the same as before.