### PR TITLE
feat(seer): Add Sentry Workflows run history page

### DIFF
--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -36,12 +36,13 @@ describe('SeerWorkflows', () => {
 
     render(<SeerWorkflows />, {organization});
 
-    expect(await screen.findByText('Night Shift')).toBeInTheDocument();
-    expect(screen.getByText('agentic')).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Seer Workflows'})).toBeInTheDocument();
+    expect(await screen.findByText('Agentic triage')).toBeInTheDocument();
+    expect(screen.getByLabelText('Succeeded')).toBeInTheDocument();
+    expect(screen.getByText('1 issue')).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Sentry Workflows'})).toBeInTheDocument();
   });
 
-  it('shows the error message inline when a run failed', async () => {
+  it('shows a short failure label inline and the full error after expanding', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/workflows/`,
       body: [
@@ -58,7 +59,35 @@ describe('SeerWorkflows', () => {
 
     render(<SeerWorkflows />, {organization});
 
-    expect(await screen.findByText('No Seer quota available')).toBeInTheDocument();
+    expect(await screen.findByText('Run failed')).toBeInTheDocument();
+    expect(screen.getByLabelText('Failed')).toBeInTheDocument();
+    expect(screen.queryByText('No Seer quota available')).not.toBeInTheDocument();
+
+    // The raw error string is now debug-only (employees see it inside the
+    // Debug disclosure). For a non-employee user, expanding the row should NOT
+    // surface the raw "No Seer quota available" string.
+    await userEvent.click(screen.getByRole('button', {name: 'Expand run'}));
+    expect(screen.queryByText(/No Seer quota available/)).not.toBeInTheDocument();
+  });
+
+  it('renders zero-issue triage runs as muted "No issues processed"', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {},
+          issues: [],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    expect(await screen.findByText('No issues processed')).toBeInTheDocument();
   });
 
   it('expands a row to show issue drill-down', async () => {
@@ -89,15 +118,18 @@ describe('SeerWorkflows', () => {
     const expandButton = await screen.findByRole('button', {name: 'Expand run'});
     await userEvent.click(expandButton);
 
-    expect(screen.getByText('autofix_triggered')).toBeInTheDocument();
-    expect(screen.getByText('seer-1')).toBeInTheDocument();
+    // User-facing view shows the friendly action label, not the raw enum.
+    expect(screen.getByText('Autofix queued')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: '100'})).toHaveAttribute(
       'href',
       `/organizations/${organization.slug}/issues/100/`
     );
+    // Seer Run ID is a debug field — only visible to employees inside the
+    // Debug disclosure. Non-employee tests should not see it.
+    expect(screen.queryByText('seer-1')).not.toBeInTheDocument();
   });
 
-  it('links to Seer Explorer when agent_run_id is present in extras', async () => {
+  it('links the Result cell to Seer Explorer when agent_run_id is present', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/workflows/`,
       body: [
@@ -107,21 +139,36 @@ describe('SeerWorkflows', () => {
           triageStrategy: 'agentic',
           errorMessage: null,
           extras: {agent_run_id: 42},
-          issues: [],
+          issues: [
+            {
+              id: '10',
+              groupId: '100',
+              action: 'autofix_triggered',
+              seerRunId: 'seer-1',
+              dateAdded: '2026-04-20T00:00:01Z',
+            },
+            {
+              id: '11',
+              groupId: '101',
+              action: 'autofix_triggered',
+              seerRunId: 'seer-2',
+              dateAdded: '2026-04-20T00:00:02Z',
+            },
+          ],
         },
       ],
     });
 
     render(<SeerWorkflows />, {organization});
 
-    const link = await screen.findByRole('button', {name: 'Explorer'});
+    const link = await screen.findByRole('link', {name: '2 issues'});
     expect(link).toHaveAttribute(
       'href',
       `/organizations/${organization.slug}/issues/autofix/?explorerRunId=42`
     );
   });
 
-  it('omits Explorer link when agent_run_id is missing', async () => {
+  it('renders the Result cell as plain text when agent_run_id is missing', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/workflows/`,
       body: [
@@ -131,15 +178,119 @@ describe('SeerWorkflows', () => {
           triageStrategy: 'agentic',
           errorMessage: null,
           extras: {},
-          issues: [],
+          issues: [
+            {
+              id: '10',
+              groupId: '100',
+              action: 'autofix_triggered',
+              seerRunId: 'seer-1',
+              dateAdded: '2026-04-20T00:00:01Z',
+            },
+          ],
         },
       ],
     });
 
     render(<SeerWorkflows />, {organization});
 
-    await screen.findByText('Night Shift');
-    expect(screen.queryByRole('button', {name: 'Explorer'})).not.toBeInTheDocument();
+    await screen.findByText('1 issue');
+    expect(screen.queryByRole('link', {name: '1 issue'})).not.toBeInTheDocument();
+  });
+
+  it('sorts by date desc by default and toggles asc on Date header click', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: 'older',
+          dateAdded: '2026-04-10T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {options: {source: 'cron'}},
+          issues: [
+            {
+              id: '1',
+              groupId: '100',
+              action: 'a',
+              seerRunId: 's1',
+              dateAdded: '2026-04-10T00:00:01Z',
+            },
+          ],
+        },
+        {
+          id: 'newer',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {options: {source: 'cron'}},
+          issues: [
+            {
+              id: '2',
+              groupId: '101',
+              action: 'a',
+              seerRunId: 's2',
+              dateAdded: '2026-04-20T00:00:01Z',
+            },
+            {
+              id: '3',
+              groupId: '102',
+              action: 'a',
+              seerRunId: 's3',
+              dateAdded: '2026-04-20T00:00:02Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    const {router} = render(<SeerWorkflows />, {organization});
+
+    // Default desc → "2 issues" (newer) appears before "1 issue" (older).
+    const resultsDesc = (await screen.findAllByText(/issues?$/)).map(
+      el => el.textContent
+    );
+    expect(resultsDesc).toEqual(['2 issues', '1 issue']);
+
+    await userEvent.click(screen.getByRole('columnheader', {name: /Date/}));
+
+    expect(router.location.query.sort).toBe('asc');
+    const resultsAsc = (await screen.findAllByText(/issues?$/)).map(el => el.textContent);
+    expect(resultsAsc).toEqual(['1 issue', '2 issues']);
+  });
+
+  it('toggles the expanded row when any part of the row is clicked', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {},
+          issues: [
+            {
+              id: '10',
+              groupId: '100',
+              action: 'autofix_triggered',
+              seerRunId: 'seer-1',
+              dateAdded: '2026-04-20T00:00:01Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    // Clicking the Strategy text (anywhere in the row that isn't a Link or the
+    // chevron button) should toggle the expanded view.
+    await userEvent.click(await screen.findByText('Agentic triage'));
+    expect(screen.getByText('Autofix queued')).toBeInTheDocument();
+
+    // Clicking again collapses.
+    await userEvent.click(screen.getByText('Agentic triage'));
+    expect(screen.queryByText('Autofix queued')).not.toBeInTheDocument();
   });
 
   it('shows empty state when no runs', async () => {
@@ -165,5 +316,128 @@ describe('SeerWorkflows', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', {name: /retry/i})).toBeInTheDocument();
     });
+  });
+
+  it('filters rows by status via URL query param', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {options: {source: 'cron'}},
+          issues: [
+            {
+              id: '10',
+              groupId: '100',
+              action: 'autofix_triggered',
+              seerRunId: 's1',
+              dateAdded: '2026-04-20T00:00:01Z',
+            },
+          ],
+        },
+        {
+          id: '2',
+          dateAdded: '2026-04-21T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: 'No Seer quota available',
+          extras: {options: {source: 'cron'}},
+          issues: [],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/issues/autofix/',
+          query: {status: 'failed'},
+        },
+      },
+    });
+
+    expect(await screen.findByText('Run failed')).toBeInTheDocument();
+    expect(screen.queryByText('1 issue')).not.toBeInTheDocument();
+  });
+
+  it('shows "No runs match your filters." when a filter hides everything', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {options: {source: 'cron'}},
+          issues: [
+            {
+              id: '10',
+              groupId: '100',
+              action: 'autofix_triggered',
+              seerRunId: 's1',
+              dateAdded: '2026-04-20T00:00:01Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/issues/autofix/',
+          query: {status: 'failed'},
+        },
+      },
+    });
+
+    expect(await screen.findByText('No runs match your filters.')).toBeInTheDocument();
+  });
+
+  it('Clear all resets all filter query params', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {options: {source: 'cron'}},
+          issues: [
+            {
+              id: '10',
+              groupId: '100',
+              action: 'autofix_triggered',
+              seerRunId: 's1',
+              dateAdded: '2026-04-20T00:00:01Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    const {router} = render(<SeerWorkflows />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/issues/autofix/',
+          query: {status: 'failed', strategy: 'agentic_triage', period: '7d'},
+        },
+      },
+    });
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Clear all'}));
+
+    expect(router.location.query.status).toBeUndefined();
+    expect(router.location.query.strategy).toBeUndefined();
+    expect(router.location.query.period).toBeUndefined();
+    // After clearing, the (previously hidden) succeeded row should re-appear.
+    expect(await screen.findByText('1 issue')).toBeInTheDocument();
   });
 });

--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -475,4 +475,100 @@ describe('SeerWorkflows', () => {
       screen.queryByRole('option', {name: 'Feedback summary'})
     ).not.toBeInTheDocument();
   });
+
+  it('does not linkify the result for a failed run with an agent_run_id', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: 'No Seer quota available',
+          extras: {agent_run_id: 42},
+          issues: [],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    expect(await screen.findByText('Run failed')).toBeInTheDocument();
+    // Even with an agent_run_id present, a failed result must not become a link.
+    expect(screen.queryByRole('link', {name: /Run failed/})).not.toBeInTheDocument();
+  });
+
+  it('Status filter offers only Succeeded and Failed', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {},
+          issues: [],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    await userEvent.click(await screen.findByRole('button', {name: /Status/}));
+
+    expect(screen.getByRole('option', {name: 'Succeeded'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Failed'})).toBeInTheDocument();
+    // toWorkflowRow never produces these statuses, so they aren't offered.
+    expect(screen.queryByRole('option', {name: 'Skipped'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Running'})).not.toBeInTheDocument();
+  });
+
+  it('expandLatest auto-expands the latest run visible under active filters', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        // Newest run overall, but failed — hidden by the status=succeeded filter.
+        {
+          id: 'newer-failed',
+          dateAdded: '2026-04-21T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: 'No Seer quota available',
+          extras: {},
+          issues: [],
+        },
+        // Older, succeeded run — the latest *visible* one once failures are hidden.
+        {
+          id: 'older-succeeded',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {},
+          issues: [
+            {
+              id: '10',
+              groupId: '100',
+              action: 'autofix_triggered',
+              seerRunId: 'seer-1',
+              dateAdded: '2026-04-20T00:00:01Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/issues/autofix/',
+          query: {expandLatest: 'agentic_triage', status: 'succeeded'},
+        },
+      },
+    });
+
+    // The newest run is filtered out, so the older succeeded run auto-expands
+    // (rather than nothing) — its issue drill-down shows without a click.
+    expect(await screen.findByText('Autofix queued')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -440,4 +440,39 @@ describe('SeerWorkflows', () => {
     // After clearing, the (previously hidden) succeeded row should re-appear.
     expect(await screen.findByText('1 issue')).toBeInTheDocument();
   });
+
+  it('Strategy filter lists only strategies present in the data', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {},
+          issues: [
+            {
+              id: '10',
+              groupId: '100',
+              action: 'autofix_triggered',
+              seerRunId: 'seer-1',
+              dateAdded: '2026-04-20T00:00:01Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    await userEvent.click(await screen.findByRole('button', {name: /Strategy/}));
+
+    // Only the strategy that actually has runs is offered as a filter option.
+    expect(screen.getByRole('option', {name: 'Agentic triage'})).toBeInTheDocument();
+    // Catalog-only strategies with no runs are not offered.
+    expect(
+      screen.queryByRole('option', {name: 'Feedback summary'})
+    ).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -1,58 +1,59 @@
-import {Fragment, useState} from 'react';
+import {Fragment, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Disclosure} from '@sentry/scraps/disclosure';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Heading, Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {DateTime} from 'sentry/components/dateTime';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
-import {IconChevron, IconOpen} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {TimeSince} from 'sentry/components/timeSince';
+import {
+  IconBot,
+  IconCheckmark,
+  IconChevron,
+  IconClose,
+  IconFilter,
+  IconOpen,
+  IconRefresh,
+  IconUser,
+  IconWarning,
+} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {decodeList, decodeScalar} from 'sentry/utils/queryString';
+import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-
-type SeerNightShiftRunIssue = {
-  action: string;
-  dateAdded: string;
-  groupId: string;
-  id: string;
-  seerRunId: string | null;
-};
-
-type SeerNightShiftRunExtras = {
-  agent_run_id?: number | string;
-  options?: SeerNightShiftRunOptions;
-  target_project_ids?: number[];
-  triggering_user_id?: number;
-};
-
-type SeerNightShiftRunOptions = {
-  dry_run?: boolean;
-  extra_triage_instructions?: string;
-  intelligence_level?: 'low' | 'medium' | 'high';
-  max_candidates?: number;
-  reasoning_effort?: 'low' | 'medium' | 'high';
-  source?: string;
-};
-
-type SeerNightShiftRun = {
-  dateAdded: string;
-  errorMessage: string | null;
-  extras: SeerNightShiftRunExtras;
-  id: string;
-  issues: SeerNightShiftRunIssue[];
-  triageStrategy: string;
-};
+import {
+  CATEGORY_LABELS,
+  CATEGORY_ORDER,
+  getActionLabel,
+  STRATEGY_META,
+} from 'sentry/views/seerWorkflows/strategies';
+import type {
+  RunStatus,
+  SeerNightShiftRun,
+  WorkflowKind,
+  WorkflowRow,
+} from 'sentry/views/seerWorkflows/types';
 
 function SeerWorkflows() {
   const organization = useOrganization();
-  const [expanded, setExpanded] = useState(new Set());
+  const location = useLocation();
+  const navigate = useNavigate();
+  const isSentryEmployee = useIsSentryEmployee();
+  const [expanded, setExpanded] = useState(new Set<string>());
 
   const {data, isPending, isError, refetch} = useQuery(
     apiOptions.as<SeerNightShiftRun[]>()(
@@ -64,53 +65,312 @@ function SeerWorkflows() {
     )
   );
 
-  const toggleExpanded = (runId: string) => {
+  const rows = useMemo<WorkflowRow[]>(() => {
+    const apiRows = (data ?? []).map(toWorkflowRow);
+    return isSentryEmployee
+      ? apiRows
+      : apiRows.filter(row => STRATEGY_META[row.kind]?.visibility !== 'internal');
+  }, [data, isSentryEmployee]);
+
+  const strategyFilter = decodeList(location.query.strategy) as WorkflowKind[];
+  const statusFilter = decodeList(location.query.status) as RunStatus[];
+  const sourceFilter = decodeList(location.query.source);
+  const period = decodeScalar(location.query.period);
+
+  const periodCutoffMs = useMemo(() => {
+    const days = PERIOD_TO_DAYS[period ?? ''];
+    return days === undefined ? null : Date.now() - days * 24 * 60 * 60 * 1000;
+  }, [period]);
+
+  const sourceOptions = useMemo(() => {
+    const sources = new Set<string>();
+    for (const row of rows) {
+      if (row.source) {
+        sources.add(row.source);
+      }
+    }
+    return Array.from(sources)
+      .map(value => {
+        const Icon = SOURCE_ICONS[value];
+        return {
+          value,
+          label: getSourceLabel(value),
+          leadingItems: Icon ? <Icon size="xs" /> : undefined,
+        };
+      })
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [rows]);
+
+  const filteredRows = useMemo(() => {
+    return rows.filter(row => {
+      if (strategyFilter.length && !strategyFilter.includes(row.kind)) {
+        return false;
+      }
+      if (statusFilter.length && !statusFilter.includes(row.status)) {
+        return false;
+      }
+      if (sourceFilter.length && (!row.source || !sourceFilter.includes(row.source))) {
+        return false;
+      }
+      if (periodCutoffMs !== null && Date.parse(row.dateAdded) < periodCutoffMs) {
+        return false;
+      }
+      return true;
+    });
+  }, [rows, strategyFilter, statusFilter, sourceFilter, periodCutoffMs]);
+
+  const sortDirection = decodeScalar(location.query.sort) === 'asc' ? 'asc' : 'desc';
+
+  const sortedRows = useMemo(() => {
+    const cmp = (a: WorkflowRow, b: WorkflowRow) =>
+      Date.parse(a.dateAdded) - Date.parse(b.dateAdded);
+    const next = [...filteredRows].sort(cmp);
+    return sortDirection === 'desc' ? next.reverse() : next;
+  }, [filteredRows, sortDirection]);
+
+  const hasActiveFilters =
+    strategyFilter.length > 0 ||
+    statusFilter.length > 0 ||
+    sourceFilter.length > 0 ||
+    period !== undefined;
+
+  const updateQuery = (patch: Record<string, string | string[] | undefined>) => {
+    const nextQuery: Record<string, string | string[]> = {};
+    for (const [k, v] of Object.entries(location.query)) {
+      if (typeof v === 'string' || Array.isArray(v)) {
+        nextQuery[k] = v;
+      }
+    }
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === undefined || (Array.isArray(value) && value.length === 0)) {
+        delete nextQuery[key];
+      } else {
+        nextQuery[key] = value;
+      }
+    }
+    navigate({pathname: location.pathname, query: nextQuery}, {replace: true});
+  };
+
+  const clearAllFilters = () => {
+    updateQuery({
+      strategy: undefined,
+      status: undefined,
+      source: undefined,
+      period: undefined,
+    });
+  };
+
+  const toggleSortDirection = () => {
+    updateQuery({sort: sortDirection === 'desc' ? 'asc' : undefined});
+  };
+
+  const toggleExpanded = (rowId: string) => {
     setExpanded(prev => {
       const next = new Set(prev);
-      if (next.has(runId)) {
-        next.delete(runId);
+      if (next.has(rowId)) {
+        next.delete(rowId);
       } else {
-        next.add(runId);
+        next.add(rowId);
       }
       return next;
     });
   };
 
+  const expandLatest = decodeScalar(location.query.expandLatest) as
+    | WorkflowKind
+    | undefined;
+  const autoExpandedForRef = useRef<WorkflowKind | null>(null);
+  useEffect(() => {
+    if (
+      !expandLatest ||
+      autoExpandedForRef.current === expandLatest ||
+      rows.length === 0
+    ) {
+      return;
+    }
+    const candidates = rows.filter(row => row.kind === expandLatest);
+    if (candidates.length === 0) {
+      return;
+    }
+    const latest = candidates.reduce((acc, row) =>
+      Date.parse(row.dateAdded) > Date.parse(acc.dateAdded) ? row : acc
+    );
+    setExpanded(prev => {
+      const next = new Set(prev);
+      next.add(latest.id);
+      return next;
+    });
+    autoExpandedForRef.current = expandLatest;
+  }, [expandLatest, rows]);
+
   return (
-    <SentryDocumentTitle title={t('Seer Workflows')} orgSlug={organization.slug}>
+    <SentryDocumentTitle title={t('Sentry Workflows')} orgSlug={organization.slug}>
       <Flex direction="column" gap="lg" padding="xl">
-        <Heading as="h1">{t('Seer Workflows')}</Heading>
-        <Text as="p" variant="muted">
-          {t('Historical runs of Seer workflows for this organization.')}
-        </Text>
+        <Flex direction="column" gap="2xs">
+          <Heading as="h1">{t('Sentry Workflows')}</Heading>
+          <Text as="p" variant="muted">
+            {t('Historical runs of Sentry workflows for this organization.')}
+          </Text>
+        </Flex>
 
         {isError ? (
           <LoadingError onRetry={refetch} />
         ) : isPending ? (
           <LoadingIndicator />
         ) : (
-          <Container width={{md: '100%', lg: '60%'}}>
+          <Container width={{md: '100%', lg: '70%'}}>
+            <Container
+              background="secondary"
+              border="muted"
+              radius="md"
+              padding="sm md"
+              marginBottom="md"
+            >
+              <Flex justify="between" align="center" gap="md" wrap="wrap">
+                <Flex gap="md" align="center" wrap="wrap">
+                  <Text variant="muted" aria-hidden>
+                    <IconFilter size="sm" />
+                  </Text>
+                  <CompactSelect
+                    multiple
+                    value={strategyFilter}
+                    options={STRATEGY_FILTER_SECTIONS}
+                    onChange={selected =>
+                      updateQuery({strategy: selected.map(o => String(o.value))})
+                    }
+                    trigger={triggerProps => (
+                      <OverlayTrigger.Button
+                        {...triggerProps}
+                        size="sm"
+                        prefix={t('Strategy')}
+                      />
+                    )}
+                  />
+                  <CompactSelect
+                    multiple
+                    value={statusFilter}
+                    options={STATUS_FILTER_OPTIONS}
+                    onChange={selected =>
+                      updateQuery({status: selected.map(o => String(o.value))})
+                    }
+                    trigger={triggerProps => (
+                      <OverlayTrigger.Button
+                        {...triggerProps}
+                        size="sm"
+                        prefix={t('Status')}
+                      />
+                    )}
+                  />
+                  <CompactSelect
+                    multiple
+                    value={sourceFilter}
+                    options={sourceOptions}
+                    disabled={sourceOptions.length === 0}
+                    onChange={selected =>
+                      updateQuery({source: selected.map(o => String(o.value))})
+                    }
+                    trigger={triggerProps => (
+                      <OverlayTrigger.Button
+                        {...triggerProps}
+                        size="sm"
+                        prefix={t('Source')}
+                      />
+                    )}
+                  />
+                  <CompactSelect
+                    value={period ?? ''}
+                    options={PERIOD_FILTER_OPTIONS}
+                    onChange={selected =>
+                      updateQuery({
+                        period:
+                          selected.value === '' ? undefined : String(selected.value),
+                      })
+                    }
+                    trigger={triggerProps => (
+                      <OverlayTrigger.Button
+                        {...triggerProps}
+                        size="sm"
+                        prefix={t('Date')}
+                      />
+                    )}
+                  />
+                </Flex>
+                {hasActiveFilters ? (
+                  <Button size="xs" variant="link" onClick={clearAllFilters}>
+                    {t('Clear all')}
+                  </Button>
+                ) : null}
+              </Flex>
+            </Container>
             <RunsTable>
               <SimpleTable.Header>
                 <SimpleTable.HeaderCell />
-                <SimpleTable.HeaderCell />
-                <SimpleTable.HeaderCell>{t('Date')}</SimpleTable.HeaderCell>
-                <SimpleTable.HeaderCell>{t('Workflow')}</SimpleTable.HeaderCell>
+                <SimpleTable.HeaderCell
+                  sort={sortDirection}
+                  handleSortClick={toggleSortDirection}
+                >
+                  {t('Date')}
+                </SimpleTable.HeaderCell>
                 <SimpleTable.HeaderCell>{t('Strategy')}</SimpleTable.HeaderCell>
-                <SimpleTable.HeaderCell>{t('Max candidates')}</SimpleTable.HeaderCell>
-                <SimpleTable.HeaderCell>{t('Source')}</SimpleTable.HeaderCell>
-                <SimpleTable.HeaderCell>{t('Issues')}</SimpleTable.HeaderCell>
+                <SimpleTable.HeaderCell>{t('Result')}</SimpleTable.HeaderCell>
+                <SimpleTable.HeaderCell />
               </SimpleTable.Header>
 
-              {data?.length === 0 ? (
-                <SimpleTable.Empty>{t('No workflow runs yet.')}</SimpleTable.Empty>
+              {sortedRows.length === 0 ? (
+                <SimpleTable.Empty>
+                  {rows.length === 0
+                    ? t('No workflow runs yet.')
+                    : t('No runs match your filters.')}
+                </SimpleTable.Empty>
               ) : (
-                (data ?? []).map(run => {
-                  const isExpanded = expanded.has(run.id);
-                  const explorerRunId = getExplorerRunId(run);
+                sortedRows.map(row => {
+                  const isExpanded = expanded.has(row.id);
+                  const explorerRunId = getExplorerRunId(row);
                   return (
-                    <Fragment key={run.id}>
-                      <SimpleTable.Row>
+                    <Fragment key={row.id}>
+                      <SimpleTable.Row
+                        aria-expanded={isExpanded}
+                        onClick={() => toggleExpanded(row.id)}
+                        style={{cursor: 'pointer'}}
+                      >
+                        <SimpleTable.RowCell>
+                          <StatusIcon status={row.status} />
+                        </SimpleTable.RowCell>
+                        <SimpleTable.RowCell>
+                          <Flex direction="column" gap="2xs">
+                            <Text size="sm">
+                              <DateTime date={row.dateAdded} />
+                            </Text>
+                            <Text size="xs" variant="muted">
+                              <TimeSince date={row.dateAdded} />
+                            </Text>
+                          </Flex>
+                        </SimpleTable.RowCell>
+                        <SimpleTable.RowCell>
+                          <Flex gap="sm" align="center" wrap="wrap">
+                            <SourceIcon source={row.source} />
+                            <Text size="sm">{STRATEGY_META[row.kind].label}</Text>
+                            {STRATEGY_META[row.kind]?.visibility === 'internal' ? (
+                              <Container
+                                display="inline-block"
+                                border="muted"
+                                radius="sm"
+                                padding="2xs xs"
+                              >
+                                <Text size="xs" variant="muted" uppercase>
+                                  {t('Internal')}
+                                </Text>
+                              </Container>
+                            ) : null}
+                          </Flex>
+                        </SimpleTable.RowCell>
+                        <SimpleTable.RowCell>
+                          <ResultCell
+                            row={row}
+                            explorerRunId={explorerRunId}
+                            organizationSlug={organization.slug}
+                          />
+                        </SimpleTable.RowCell>
                         <SimpleTable.RowCell>
                           <Button
                             aria-label={isExpanded ? t('Collapse run') : t('Expand run')}
@@ -119,44 +379,11 @@ function SeerWorkflows() {
                             icon={
                               <IconChevron direction={isExpanded ? 'down' : 'right'} />
                             }
-                            onClick={() => toggleExpanded(run.id)}
+                            onClick={e => {
+                              e.stopPropagation();
+                              toggleExpanded(row.id);
+                            }}
                           />
-                        </SimpleTable.RowCell>
-                        <SimpleTable.RowCell>
-                          {explorerRunId === null ? null : (
-                            <LinkButton
-                              size="xs"
-                              icon={<IconOpen />}
-                              to={{
-                                pathname: `/organizations/${organization.slug}/issues/autofix/`,
-                                query: {explorerRunId},
-                              }}
-                            >
-                              {t('Explorer')}
-                            </LinkButton>
-                          )}
-                        </SimpleTable.RowCell>
-                        <SimpleTable.RowCell>
-                          <DateTime date={run.dateAdded} />
-                        </SimpleTable.RowCell>
-                        <SimpleTable.RowCell>{t('Night Shift')}</SimpleTable.RowCell>
-                        <SimpleTable.RowCell>{run.triageStrategy}</SimpleTable.RowCell>
-                        <SimpleTable.RowCell>
-                          {run.extras.options?.max_candidates ?? '-'}
-                        </SimpleTable.RowCell>
-                        <SimpleTable.RowCell>
-                          {run.extras.options?.source ?? '-'}
-                        </SimpleTable.RowCell>
-                        <SimpleTable.RowCell>
-                          {run.errorMessage ? (
-                            <Text variant="danger" size="sm">
-                              {run.errorMessage}
-                            </Text>
-                          ) : run.extras.options?.dry_run ? (
-                            <Text variant="muted">{t('dry run')}</Text>
-                          ) : (
-                            run.issues.length
-                          )}
                         </SimpleTable.RowCell>
                       </SimpleTable.Row>
 
@@ -165,9 +392,9 @@ function SeerWorkflows() {
                           <Container
                             background="secondary"
                             padding="lg xl"
-                            style={{gridColumn: '1 / -1'}}
+                            column="1 / -1"
                           >
-                            <RunDetail run={run} organizationSlug={organization.slug} />
+                            <RunDetail row={row} organizationSlug={organization.slug} />
                           </Container>
                         </SimpleTable.Row>
                       )}
@@ -183,139 +410,595 @@ function SeerWorkflows() {
   );
 }
 
+const SOURCE_LABELS: Record<string, string> = {
+  cron: 'Automated',
+  manual: 'Manual',
+};
+
+const SOURCE_ICONS: Record<string, React.ComponentType<{size?: 'xs' | 'sm' | 'md'}>> = {
+  cron: IconBot,
+  manual: IconUser,
+};
+
+function getSourceLabel(source: string | undefined): string {
+  if (!source) {
+    return '-';
+  }
+  return SOURCE_LABELS[source] ?? source;
+}
+
+function SourceIcon({source}: {source: string | undefined}) {
+  if (!source) {
+    return null;
+  }
+  const Icon = SOURCE_ICONS[source];
+  if (!Icon) {
+    return null;
+  }
+  const label = getSourceLabel(source);
+  return (
+    <Tooltip title={label} skipWrapper>
+      <Text variant="muted" aria-label={label}>
+        <Icon size="xs" />
+      </Text>
+    </Tooltip>
+  );
+}
+
+const STRATEGY_FILTER_SECTIONS = CATEGORY_ORDER.map(category => ({
+  key: category,
+  label: CATEGORY_LABELS[category],
+  options: (Object.keys(STRATEGY_META) as WorkflowKind[])
+    .filter(kind => STRATEGY_META[kind].category === category)
+    .map(kind => ({value: kind, label: STRATEGY_META[kind].label})),
+})).filter(section => section.options.length > 0);
+
+const STATUS_FILTER_OPTIONS: Array<{label: string; value: RunStatus}> = [
+  {value: 'succeeded', label: 'Succeeded'},
+  {value: 'failed', label: 'Failed'},
+  {value: 'skipped', label: 'Skipped'},
+  {value: 'running', label: 'Running'},
+];
+
+const PERIOD_FILTER_OPTIONS: Array<{label: string; value: string}> = [
+  {value: '', label: 'All time'},
+  {value: '24h', label: 'Last 24 hours'},
+  {value: '7d', label: 'Last 7 days'},
+  {value: '14d', label: 'Last 14 days'},
+  {value: '30d', label: 'Last 30 days'},
+];
+
+const PERIOD_TO_DAYS: Record<string, number> = {
+  '24h': 1,
+  '7d': 7,
+  '14d': 14,
+  '30d': 30,
+};
+
+const STATUS_VARIANT: Record<
+  RunStatus,
+  {
+    Icon: React.ComponentType<{size?: 'xs' | 'sm' | 'md'}>;
+    label: string;
+    text: 'success' | 'danger' | 'muted' | 'warning';
+  }
+> = {
+  succeeded: {Icon: IconCheckmark, label: 'Succeeded', text: 'success'},
+  failed: {Icon: IconClose, label: 'Failed', text: 'danger'},
+  skipped: {Icon: IconWarning, label: 'Skipped', text: 'muted'},
+  running: {Icon: IconRefresh, label: 'Running', text: 'warning'},
+};
+
+function StatusIcon({status}: {status: RunStatus}) {
+  const {Icon, label, text} = STATUS_VARIANT[status];
+  return (
+    <Tooltip title={label} skipWrapper>
+      <Text variant={text} aria-label={label}>
+        <Icon size="sm" />
+      </Text>
+    </Tooltip>
+  );
+}
+
+function ResultCell({
+  row,
+  explorerRunId,
+  organizationSlug,
+}: {
+  explorerRunId: number | string | null;
+  organizationSlug: string;
+  row: WorkflowRow;
+}) {
+  const content = getResultContent(row);
+  if (explorerRunId === null) {
+    return content;
+  }
+  return (
+    <Link
+      to={{
+        pathname: `/organizations/${organizationSlug}/issues/autofix/`,
+        query: {explorerRunId},
+      }}
+      onClick={e => e.stopPropagation()}
+    >
+      <Flex gap="sm" align="center">
+        <IconOpen size="xs" variant="accent" aria-hidden />
+        {content}
+      </Flex>
+    </Link>
+  );
+}
+
+function getResultContent(row: WorkflowRow) {
+  if (row.status === 'failed') {
+    return (
+      <Text variant="danger" size="sm">
+        {t('Run failed')}
+      </Text>
+    );
+  }
+  // Caller-supplied result text wins, for strategies that don't have
+  // specialized count rendering yet (everything except triage and
+  // feedback_summary).
+  if (row.resultText) {
+    return <Text size="sm">{row.resultText}</Text>;
+  }
+  if (row.kind === 'agentic_triage') {
+    const triage = row.triage;
+    if (triage?.dryRun) {
+      return <Text variant="muted">{t('dry run')}</Text>;
+    }
+    const issueCount = triage?.issues.length ?? 0;
+    if (issueCount === 0) {
+      return (
+        <Text variant="muted" size="sm">
+          {t('No issues processed')}
+        </Text>
+      );
+    }
+    return <Text size="sm">{tn('%s issue', '%s issues', issueCount)}</Text>;
+  }
+  if (row.kind === 'feedback_summary') {
+    const feedback = row.feedback;
+    if (row.status === 'skipped') {
+      return (
+        <Text variant="muted" size="sm">
+          {feedback?.reason === 'insufficient_feedbacks'
+            ? t('Skipped — too few feedbacks')
+            : t('Skipped')}
+        </Text>
+      );
+    }
+    const themeCount = feedback?.themes.length ?? 0;
+    const feedbackCount = feedback?.numFeedbacksAnalyzed ?? 0;
+    return (
+      <Text size="sm">
+        {tn('%s theme', '%s themes', themeCount)}
+        {' · '}
+        {tn('%s feedback', '%s feedbacks', feedbackCount)}
+      </Text>
+    );
+  }
+  // Unknown kind without resultText — render an em dash so we never silently
+  // fall into a wrong-strategy template.
+  return (
+    <Text variant="muted" size="sm">
+      —
+    </Text>
+  );
+}
+
 function RunDetail({
-  run,
+  row,
   organizationSlug,
 }: {
   organizationSlug: string;
-  run: SeerNightShiftRun;
+  row: WorkflowRow;
 }) {
-  const {reasoning_effort, intelligence_level, extra_triage_instructions} =
-    run.extras.options ?? {};
-  const hasSettings =
-    reasoning_effort !== undefined ||
-    intelligence_level !== undefined ||
-    extra_triage_instructions !== undefined;
-
+  const isSentryEmployee = useIsSentryEmployee();
   return (
     <Flex direction="column" gap="lg">
-      {run.errorMessage ? (
-        <Text variant="danger" size="sm">
-          {t('Error: ')}
-          {run.errorMessage}
-        </Text>
-      ) : null}
-
-      {hasSettings ? (
-        <Grid columns="max-content 1fr" gap="sm xl" align="start">
-          {reasoning_effort === undefined ? null : (
-            <Fragment>
-              <Text bold size="xs" variant="muted">
-                {t('Reasoning effort')}
-              </Text>
-              <Text size="sm">{reasoning_effort}</Text>
-            </Fragment>
-          )}
-          {intelligence_level === undefined ? null : (
-            <Fragment>
-              <Text bold size="xs" variant="muted">
-                {t('Intelligence level')}
-              </Text>
-              <Text size="sm">{intelligence_level}</Text>
-            </Fragment>
-          )}
-          {extra_triage_instructions === undefined ? null : (
-            <Fragment>
-              <Text bold size="xs" variant="muted">
-                {t('Extra triage instructions')}
-              </Text>
-              <Text size="sm">{extra_triage_instructions}</Text>
-            </Fragment>
-          )}
-        </Grid>
-      ) : null}
-
-      <Flex direction="column" gap="sm">
-        <Text bold size="xs" variant="muted" uppercase>
-          {t('Issues (%s)', run.issues.length)}
-        </Text>
-
-        {run.issues.length === 0 ? (
-          <Text variant="muted" size="sm">
-            {t('No issues processed in this run.')}
-          </Text>
-        ) : (
-          <Grid
-            columns="max-content max-content max-content max-content max-content"
-            gap="sm xl"
-            align="center"
-          >
-            <Text bold size="xs" variant="muted">
-              {t('Group')}
-            </Text>
-            <Text bold size="xs" variant="muted">
-              {t('Action')}
-            </Text>
-            <Text bold size="xs" variant="muted">
-              {t('Seer Run ID')}
-            </Text>
-            <span />
-            <span />
-            {run.issues.flatMap(issue => [
-              <Link
-                key={`${issue.id}-group`}
-                to={`/organizations/${organizationSlug}/issues/${issue.groupId}/`}
+      <UserSection row={row} organizationSlug={organizationSlug} />
+      {isSentryEmployee ? (
+        <Disclosure>
+          <Disclosure.Title>
+            <Flex gap="sm" align="center">
+              <Text bold>{t('Debug')}</Text>
+              <Container
+                display="inline-block"
+                border="warning"
+                radius="sm"
+                padding="2xs xs"
               >
-                {issue.groupId}
-              </Link>,
-              <Text key={`${issue.id}-action`} size="sm">
-                {issue.action}
-              </Text>,
-              <Text key={`${issue.id}-seer`} size="sm" variant="muted">
-                {issue.seerRunId ?? '-'}
-              </Text>,
-              issue.seerRunId === null ? (
-                <span key={`${issue.id}-explorer`} />
-              ) : (
-                <LinkButton
-                  key={`${issue.id}-explorer`}
-                  size="xs"
-                  icon={<IconOpen />}
-                  to={{
-                    pathname: `/organizations/${organizationSlug}/issues/autofix/`,
-                    query: {explorerRunId: issue.seerRunId},
-                  }}
-                >
-                  {t('Explorer')}
-                </LinkButton>
-              ),
-              <LinkButton
-                key={`${issue.id}-autofix`}
-                size="xs"
-                icon={<IconOpen />}
-                to={{
-                  pathname: `/organizations/${organizationSlug}/issues/${issue.groupId}/`,
-                  query: {seerDrawer: true},
-                }}
-              >
-                {t('Autofix')}
-              </LinkButton>,
-            ])}
-          </Grid>
-        )}
-      </Flex>
+                <Text size="xs" variant="warning" uppercase bold>
+                  {t('Employee only')}
+                </Text>
+              </Container>
+            </Flex>
+          </Disclosure.Title>
+          <Disclosure.Content>
+            <DebugSection row={row} organizationSlug={organizationSlug} />
+          </Disclosure.Content>
+        </Disclosure>
+      ) : null}
     </Flex>
   );
 }
 
+function UserSection({
+  row,
+  organizationSlug,
+}: {
+  organizationSlug: string;
+  row: WorkflowRow;
+}) {
+  return (
+    <Flex direction="column" gap="lg">
+      {row.summary ? (
+        <Text as="p" size="md">
+          {row.summary}
+        </Text>
+      ) : null}
+      {row.kind === 'agentic_triage' ? (
+        <TriageIssuesUserPanel row={row} organizationSlug={organizationSlug} />
+      ) : row.kind === 'feedback_summary' ? (
+        <FeedbackSummaryUserPanel row={row} organizationSlug={organizationSlug} />
+      ) : null}
+    </Flex>
+  );
+}
+
+function DebugSection({
+  row,
+  organizationSlug,
+}: {
+  organizationSlug: string;
+  row: WorkflowRow;
+}) {
+  const {
+    reasoning_effort,
+    intelligence_level,
+    extra_triage_instructions,
+    max_candidates,
+  } = row.options ?? {};
+  const hasSettings =
+    reasoning_effort !== undefined ||
+    intelligence_level !== undefined ||
+    extra_triage_instructions !== undefined ||
+    max_candidates !== undefined;
+
+  return (
+    <Flex direction="column" gap="md">
+      <Grid columns="max-content 1fr" gap="sm xl" align="start">
+        <Text bold size="xs" variant="muted">
+          {t('Run ID')}
+        </Text>
+        <Text size="sm" monospace>
+          {row.runId}
+        </Text>
+        {hasSettings ? (
+          <Fragment>
+            {max_candidates === undefined ? null : (
+              <Fragment>
+                <Text bold size="xs" variant="muted">
+                  {t('Max candidates')}
+                </Text>
+                <Text size="sm">{max_candidates}</Text>
+              </Fragment>
+            )}
+            {reasoning_effort === undefined ? null : (
+              <Fragment>
+                <Text bold size="xs" variant="muted">
+                  {t('Reasoning effort')}
+                </Text>
+                <Text size="sm">{reasoning_effort}</Text>
+              </Fragment>
+            )}
+            {intelligence_level === undefined ? null : (
+              <Fragment>
+                <Text bold size="xs" variant="muted">
+                  {t('Intelligence level')}
+                </Text>
+                <Text size="sm">{intelligence_level}</Text>
+              </Fragment>
+            )}
+            {extra_triage_instructions === undefined ? null : (
+              <Fragment>
+                <Text bold size="xs" variant="muted">
+                  {t('Extra triage instructions')}
+                </Text>
+                <Text size="sm">{extra_triage_instructions}</Text>
+              </Fragment>
+            )}
+          </Fragment>
+        ) : null}
+      </Grid>
+      {row.errorMessage ? (
+        <Text variant="danger" size="sm" monospace>
+          {t('Error: ')}
+          {row.errorMessage}
+        </Text>
+      ) : null}
+      {row.kind === 'agentic_triage' ? (
+        <TriageIssuesDebugAddendum row={row} organizationSlug={organizationSlug} />
+      ) : null}
+      {row.kind === 'feedback_summary' ? (
+        <FeedbackSummaryDebugAddendum row={row} />
+      ) : null}
+    </Flex>
+  );
+}
+
+function TriageIssuesUserPanel({
+  row,
+  organizationSlug,
+}: {
+  organizationSlug: string;
+  row: WorkflowRow;
+}) {
+  const issues = row.triage?.issues ?? [];
+  return (
+    <Flex direction="column" gap="sm">
+      <Text bold size="xs" variant="muted" uppercase>
+        {t('Issues (%s)', issues.length)}
+      </Text>
+
+      {issues.length === 0 ? (
+        <Text variant="muted" size="sm">
+          {t('No issues processed in this run.')}
+        </Text>
+      ) : (
+        <Grid columns="max-content max-content max-content" gap="sm xl" align="center">
+          <Text bold size="xs" variant="muted">
+            {t('Group')}
+          </Text>
+          <Text bold size="xs" variant="muted">
+            {t('Action')}
+          </Text>
+          <span />
+          {issues.flatMap(issue => [
+            <Link
+              key={`${issue.id}-group`}
+              to={`/organizations/${organizationSlug}/issues/${issue.groupId}/`}
+            >
+              {issue.groupId}
+            </Link>,
+            <Text key={`${issue.id}-action`} size="sm">
+              {getActionLabel(issue.action)}
+            </Text>,
+            <LinkButton
+              key={`${issue.id}-autofix`}
+              size="xs"
+              icon={<IconOpen />}
+              to={{
+                pathname: `/organizations/${organizationSlug}/issues/${issue.groupId}/`,
+                query: {seerDrawer: true},
+              }}
+            >
+              {t('Autofix')}
+            </LinkButton>,
+          ])}
+        </Grid>
+      )}
+    </Flex>
+  );
+}
+
+function TriageIssuesDebugAddendum({
+  row,
+  organizationSlug,
+}: {
+  organizationSlug: string;
+  row: WorkflowRow;
+}) {
+  const issues = row.triage?.issues ?? [];
+  if (issues.length === 0) {
+    return null;
+  }
+  return (
+    <Flex direction="column" gap="sm">
+      <Text bold size="xs" variant="muted" uppercase>
+        {t('Per-issue internals')}
+      </Text>
+      <Grid
+        columns="max-content max-content max-content max-content"
+        gap="sm xl"
+        align="center"
+      >
+        <Text bold size="xs" variant="muted">
+          {t('Group')}
+        </Text>
+        <Text bold size="xs" variant="muted">
+          {t('Raw action')}
+        </Text>
+        <Text bold size="xs" variant="muted">
+          {t('Seer Run ID')}
+        </Text>
+        <span />
+        {issues.flatMap(issue => [
+          <Text key={`${issue.id}-group`} size="sm" monospace>
+            {issue.groupId}
+          </Text>,
+          <Text key={`${issue.id}-action`} size="sm" monospace>
+            {issue.action}
+          </Text>,
+          <Text key={`${issue.id}-seer`} size="sm" variant="muted" monospace>
+            {issue.seerRunId ?? '-'}
+          </Text>,
+          issue.seerRunId === null ? (
+            <span key={`${issue.id}-explorer`} />
+          ) : (
+            <LinkButton
+              key={`${issue.id}-explorer`}
+              size="xs"
+              icon={<IconOpen />}
+              to={{
+                pathname: `/organizations/${organizationSlug}/issues/autofix/`,
+                query: {explorerRunId: issue.seerRunId},
+              }}
+            >
+              {t('Explorer')}
+            </LinkButton>
+          ),
+        ])}
+      </Grid>
+    </Flex>
+  );
+}
+
+function FeedbackSummaryUserPanel({
+  row,
+  organizationSlug,
+}: {
+  organizationSlug: string;
+  row: WorkflowRow;
+}) {
+  const feedback = row.feedback;
+
+  if (row.status === 'skipped') {
+    return (
+      <Container background="primary" border="muted" radius="md" padding="md">
+        <Text variant="muted" size="sm">
+          {feedback?.reason === 'insufficient_feedbacks'
+            ? t(
+                'Skipped — fewer than 10 user feedbacks were received in the last 24 hours (saw %s).',
+                feedback.numFeedbacksAnalyzed
+              )
+            : t('Skipped.')}
+        </Text>
+      </Container>
+    );
+  }
+
+  if (row.status === 'failed' || !feedback) {
+    return null;
+  }
+
+  return (
+    <Flex direction="column" gap="md">
+      <Flex direction="column" gap="sm">
+        <Text bold size="xs" variant="muted" uppercase>
+          {t('Themes (%s)', feedback.themes.length)}
+        </Text>
+        <Grid columns={{xs: '1fr', md: 'repeat(2, 1fr)'}} gap="md">
+          {feedback.themes.map((theme, idx) => (
+            <Container
+              key={idx}
+              background="primary"
+              border="muted"
+              radius="md"
+              padding="sm md"
+            >
+              <Flex direction="column" gap="xs">
+                <Heading as="h4" size="sm">
+                  {theme.title}
+                </Heading>
+                <Text variant="muted" size="sm">
+                  {theme.description}
+                </Text>
+                {theme.feedbackGroupIds.length > 0 ? (
+                  <Flex gap="xs" align="center" wrap="wrap">
+                    <Text size="xs" variant="muted">
+                      {t('Feedback:')}
+                    </Text>
+                    {theme.feedbackGroupIds.map(groupId => (
+                      <Container
+                        key={groupId}
+                        display="inline-block"
+                        border="muted"
+                        radius="sm"
+                        padding="2xs xs"
+                      >
+                        <Link
+                          to={`/organizations/${organizationSlug}/issues/${groupId}/`}
+                        >
+                          <Text size="xs">{groupId}</Text>
+                        </Link>
+                      </Container>
+                    ))}
+                  </Flex>
+                ) : null}
+              </Flex>
+            </Container>
+          ))}
+        </Grid>
+      </Flex>
+
+      <Text size="xs" variant="muted">
+        {t('Analyzed %s feedback entries.', feedback.numFeedbacksAnalyzed)}
+      </Text>
+    </Flex>
+  );
+}
+
+function FeedbackSummaryDebugAddendum({row}: {row: WorkflowRow}) {
+  const feedback = row.feedback;
+  if (!feedback) {
+    return null;
+  }
+  return (
+    <Grid columns="max-content 1fr" gap="sm xl" align="start">
+      {feedback.agentRunId === undefined ? null : (
+        <Fragment>
+          <Text bold size="xs" variant="muted">
+            {t('Agent run ID')}
+          </Text>
+          <Text size="sm" monospace>
+            {feedback.agentRunId}
+          </Text>
+        </Fragment>
+      )}
+      {feedback.reason === undefined ? null : (
+        <Fragment>
+          <Text bold size="xs" variant="muted">
+            {t('Skip reason')}
+          </Text>
+          <Text size="sm" monospace>
+            {feedback.reason}
+          </Text>
+        </Fragment>
+      )}
+      <Text bold size="xs" variant="muted">
+        {t('Analyzed count')}
+      </Text>
+      <Text size="sm">{feedback.numFeedbacksAnalyzed}</Text>
+    </Grid>
+  );
+}
+
 const RunsTable = styled(SimpleTable)`
-  grid-template-columns: min-content min-content 1fr 1fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: min-content max-content 1fr 2fr min-content;
 `;
 
-function getExplorerRunId(run: SeerNightShiftRun): number | string | null {
-  const value = run.extras.agent_run_id;
-  if (typeof value === 'number' || typeof value === 'string') {
-    return value;
+function toWorkflowRow(run: SeerNightShiftRun): WorkflowRow {
+  const status: RunStatus = run.errorMessage ? 'failed' : 'succeeded';
+  const agentRunId = run.extras.agent_run_id;
+  return {
+    id: `${run.id}:agentic_triage`,
+    runId: run.id,
+    dateAdded: run.dateAdded,
+    kind: 'agentic_triage',
+    status,
+    source: run.extras.options?.source,
+    errorMessage: run.errorMessage,
+    options: run.extras.options,
+    triage: {
+      maxCandidates: run.extras.options?.max_candidates,
+      dryRun: run.extras.options?.dry_run,
+      issues: run.issues,
+      agentRunId:
+        typeof agentRunId === 'number' || typeof agentRunId === 'string'
+          ? agentRunId
+          : undefined,
+    },
+  };
+}
+
+function getExplorerRunId(row: WorkflowRow): number | string | null {
+  const agentRunId =
+    row.kind === 'agentic_triage' ? row.triage?.agentRunId : row.feedback?.agentRunId;
+  if (typeof agentRunId === 'number' || typeof agentRunId === 'string') {
+    return agentRunId;
   }
   return null;
 }

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -198,11 +198,13 @@ function SeerWorkflows() {
     if (
       !expandLatest ||
       autoExpandedForRef.current === expandLatest ||
-      rows.length === 0
+      filteredRows.length === 0
     ) {
       return;
     }
-    const candidates = rows.filter(row => row.kind === expandLatest);
+    // Only auto-expand a run that's actually visible under the current filters,
+    // otherwise we'd set expansion state on a row hidden by status/period/etc.
+    const candidates = filteredRows.filter(row => row.kind === expandLatest);
     if (candidates.length === 0) {
       return;
     }
@@ -215,7 +217,7 @@ function SeerWorkflows() {
       return next;
     });
     autoExpandedForRef.current = expandLatest;
-  }, [expandLatest, rows]);
+  }, [expandLatest, filteredRows]);
 
   return (
     <SentryDocumentTitle title={t('Sentry Workflows')} orgSlug={organization.slug}>
@@ -463,11 +465,11 @@ function SourceIcon({source}: {source: string | undefined}) {
   );
 }
 
+// toWorkflowRow only ever derives 'succeeded' or 'failed' from a run, so only
+// offer those as filter choices — 'skipped'/'running' would never match.
 const STATUS_FILTER_OPTIONS: Array<{label: string; value: RunStatus}> = [
   {value: 'succeeded', label: 'Succeeded'},
   {value: 'failed', label: 'Failed'},
-  {value: 'skipped', label: 'Skipped'},
-  {value: 'running', label: 'Running'},
 ];
 
 const PERIOD_FILTER_OPTIONS: Array<{label: string; value: string}> = [
@@ -520,7 +522,9 @@ function ResultCell({
   row: WorkflowRow;
 }) {
   const content = getResultContent(row);
-  if (explorerRunId === null) {
+  // A failed run shows "Run failed" — don't turn that into a Seer Explorer link
+  // even if the run happens to carry an agent_run_id.
+  if (explorerRunId === null || row.status === 'failed') {
     return content;
   }
   return (

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -101,6 +101,20 @@ function SeerWorkflows() {
       .sort((a, b) => a.label.localeCompare(b.label));
   }, [rows]);
 
+  const strategySections = useMemo(() => {
+    const present = new Set<WorkflowKind>();
+    for (const row of rows) {
+      present.add(row.kind);
+    }
+    return CATEGORY_ORDER.map(category => ({
+      key: category,
+      label: CATEGORY_LABELS[category],
+      options: Array.from(present)
+        .filter(kind => STRATEGY_META[kind]?.category === category)
+        .map(kind => ({value: kind, label: STRATEGY_META[kind].label})),
+    })).filter(section => section.options.length > 0);
+  }, [rows]);
+
   const filteredRows = useMemo(() => {
     return rows.filter(row => {
       if (strategyFilter.length && !strategyFilter.includes(row.kind)) {
@@ -234,7 +248,8 @@ function SeerWorkflows() {
                   <CompactSelect
                     multiple
                     value={strategyFilter}
-                    options={STRATEGY_FILTER_SECTIONS}
+                    options={strategySections}
+                    disabled={strategySections.length === 0}
                     onChange={selected =>
                       updateQuery({strategy: selected.map(o => String(o.value))})
                     }
@@ -444,14 +459,6 @@ function SourceIcon({source}: {source: string | undefined}) {
     </Tooltip>
   );
 }
-
-const STRATEGY_FILTER_SECTIONS = CATEGORY_ORDER.map(category => ({
-  key: category,
-  label: CATEGORY_LABELS[category],
-  options: (Object.keys(STRATEGY_META) as WorkflowKind[])
-    .filter(kind => STRATEGY_META[kind].category === category)
-    .map(kind => ({value: kind, label: STRATEGY_META[kind].label})),
-})).filter(section => section.options.length > 0);
 
 const STATUS_FILTER_OPTIONS: Array<{label: string; value: RunStatus}> = [
   {value: 'succeeded', label: 'Succeeded'},

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -548,58 +548,27 @@ function getResultContent(row: WorkflowRow) {
     );
   }
   // Caller-supplied result text wins, for strategies that don't have
-  // specialized count rendering yet (everything except triage and
-  // feedback_summary).
+  // specialized count rendering yet (everything except triage).
   if (row.resultText) {
     return <Text size="sm">{row.resultText}</Text>;
   }
-  if (row.kind === 'agentic_triage') {
-    const triage = row.triage;
-    if (triage?.dryRun) {
-      return (
-        <Text variant="muted" size="sm">
-          {t('dry run')}
-        </Text>
-      );
-    }
-    const issueCount = triage?.issues.length ?? 0;
-    if (issueCount === 0) {
-      return (
-        <Text variant="muted" size="sm">
-          {t('No issues processed')}
-        </Text>
-      );
-    }
-    return <Text size="sm">{tn('%s issue', '%s issues', issueCount)}</Text>;
-  }
-  if (row.kind === 'feedback_summary') {
-    const feedback = row.feedback;
-    if (row.status === 'skipped') {
-      return (
-        <Text variant="muted" size="sm">
-          {feedback?.reason === 'insufficient_feedbacks'
-            ? t('Skipped — too few feedbacks')
-            : t('Skipped')}
-        </Text>
-      );
-    }
-    const themeCount = feedback?.themes.length ?? 0;
-    const feedbackCount = feedback?.numFeedbacksAnalyzed ?? 0;
+  const triage = row.triage;
+  if (triage?.dryRun) {
     return (
-      <Text size="sm">
-        {tn('%s theme', '%s themes', themeCount)}
-        {' · '}
-        {tn('%s feedback', '%s feedbacks', feedbackCount)}
+      <Text variant="muted" size="sm">
+        {t('dry run')}
       </Text>
     );
   }
-  // Unknown kind without resultText — render an em dash so we never silently
-  // fall into a wrong-strategy template.
-  return (
-    <Text variant="muted" size="sm">
-      —
-    </Text>
-  );
+  const issueCount = triage?.issues.length ?? 0;
+  if (issueCount === 0) {
+    return (
+      <Text variant="muted" size="sm">
+        {t('No issues processed')}
+      </Text>
+    );
+  }
+  return <Text size="sm">{tn('%s issue', '%s issues', issueCount)}</Text>;
 }
 
 function RunDetail({
@@ -653,11 +622,7 @@ function UserSection({
           {row.summary}
         </Text>
       ) : null}
-      {row.kind === 'agentic_triage' ? (
-        <TriageIssuesUserPanel row={row} organizationSlug={organizationSlug} />
-      ) : row.kind === 'feedback_summary' ? (
-        <FeedbackSummaryUserPanel row={row} organizationSlug={organizationSlug} />
-      ) : null}
+      <TriageIssuesUserPanel row={row} organizationSlug={organizationSlug} />
     </Flex>
   );
 }
@@ -733,12 +698,7 @@ function DebugSection({
           {row.errorMessage}
         </Text>
       ) : null}
-      {row.kind === 'agentic_triage' ? (
-        <TriageIssuesDebugAddendum row={row} organizationSlug={organizationSlug} />
-      ) : null}
-      {row.kind === 'feedback_summary' ? (
-        <FeedbackSummaryDebugAddendum row={row} />
-      ) : null}
+      <TriageIssuesDebugAddendum row={row} organizationSlug={organizationSlug} />
     </Flex>
   );
 }
@@ -860,126 +820,6 @@ function TriageIssuesDebugAddendum({
   );
 }
 
-function FeedbackSummaryUserPanel({
-  row,
-  organizationSlug,
-}: {
-  organizationSlug: string;
-  row: WorkflowRow;
-}) {
-  const feedback = row.feedback;
-
-  if (row.status === 'skipped') {
-    return (
-      <Container background="primary" border="muted" radius="md" padding="md">
-        <Text variant="muted" size="sm">
-          {feedback?.reason === 'insufficient_feedbacks'
-            ? t(
-                'Skipped — fewer than 10 user feedbacks were received in the last 24 hours (saw %s).',
-                feedback.numFeedbacksAnalyzed
-              )
-            : t('Skipped.')}
-        </Text>
-      </Container>
-    );
-  }
-
-  if (row.status === 'failed' || !feedback) {
-    return null;
-  }
-
-  return (
-    <Flex direction="column" gap="md">
-      <Flex direction="column" gap="sm">
-        <Text bold size="xs" variant="muted" uppercase>
-          {t('Themes (%s)', feedback.themes.length)}
-        </Text>
-        <Grid columns={{xs: '1fr', md: 'repeat(2, 1fr)'}} gap="md">
-          {feedback.themes.map((theme, idx) => (
-            <Container
-              key={idx}
-              background="primary"
-              border="muted"
-              radius="md"
-              padding="sm md"
-            >
-              <Flex direction="column" gap="xs">
-                <Heading as="h4" size="sm">
-                  {theme.title}
-                </Heading>
-                <Text variant="muted" size="sm">
-                  {theme.description}
-                </Text>
-                {theme.feedbackGroupIds.length > 0 ? (
-                  <Flex gap="xs" align="center" wrap="wrap">
-                    <Text size="xs" variant="muted">
-                      {t('Feedback:')}
-                    </Text>
-                    {theme.feedbackGroupIds.map(groupId => (
-                      <Container
-                        key={groupId}
-                        display="inline-block"
-                        border="muted"
-                        radius="sm"
-                        padding="2xs xs"
-                      >
-                        <Link
-                          to={`/organizations/${organizationSlug}/issues/${groupId}/`}
-                        >
-                          <Text size="xs">{groupId}</Text>
-                        </Link>
-                      </Container>
-                    ))}
-                  </Flex>
-                ) : null}
-              </Flex>
-            </Container>
-          ))}
-        </Grid>
-      </Flex>
-
-      <Text size="xs" variant="muted">
-        {t('Analyzed %s feedback entries.', feedback.numFeedbacksAnalyzed)}
-      </Text>
-    </Flex>
-  );
-}
-
-function FeedbackSummaryDebugAddendum({row}: {row: WorkflowRow}) {
-  const feedback = row.feedback;
-  if (!feedback) {
-    return null;
-  }
-  return (
-    <Grid columns="max-content 1fr" gap="sm xl" align="start">
-      {feedback.agentRunId === undefined ? null : (
-        <Fragment>
-          <Text bold size="xs" variant="muted">
-            {t('Agent run ID')}
-          </Text>
-          <Text size="sm" monospace>
-            {feedback.agentRunId}
-          </Text>
-        </Fragment>
-      )}
-      {feedback.reason === undefined ? null : (
-        <Fragment>
-          <Text bold size="xs" variant="muted">
-            {t('Skip reason')}
-          </Text>
-          <Text size="sm" monospace>
-            {feedback.reason}
-          </Text>
-        </Fragment>
-      )}
-      <Text bold size="xs" variant="muted">
-        {t('Analyzed count')}
-      </Text>
-      <Text size="sm">{feedback.numFeedbacksAnalyzed}</Text>
-    </Grid>
-  );
-}
-
 const RunsTable = styled(SimpleTable)`
   grid-template-columns: min-content max-content 1fr 2fr min-content;
 `;
@@ -1009,8 +849,7 @@ function toWorkflowRow(run: SeerNightShiftRun): WorkflowRow {
 }
 
 function getExplorerRunId(row: WorkflowRow): number | string | null {
-  const agentRunId =
-    row.kind === 'agentic_triage' ? row.triage?.agentRunId : row.feedback?.agentRunId;
+  const agentRunId = row.triage?.agentRunId;
   if (typeof agentRunId === 'number' || typeof agentRunId === 'string') {
     return agentRunId;
   }

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -430,7 +430,10 @@ const SOURCE_LABELS: Record<string, string> = {
   manual: 'Manual',
 };
 
-const SOURCE_ICONS: Record<string, React.ComponentType<{size?: 'xs' | 'sm' | 'md'}>> = {
+const SOURCE_ICONS: Record<
+  string,
+  React.ComponentType<{size?: 'xs' | 'sm' | 'md'; variant?: 'muted'}>
+> = {
   cron: IconBot,
   manual: IconUser,
 };
@@ -453,9 +456,9 @@ function SourceIcon({source}: {source: string | undefined}) {
   const label = getSourceLabel(source);
   return (
     <Tooltip title={label} skipWrapper>
-      <Text variant="muted" aria-label={label}>
-        <Icon size="xs" />
-      </Text>
+      <Flex as="span" align="center" aria-label={label}>
+        <Icon size="xs" variant="muted" />
+      </Flex>
     </Tooltip>
   );
 }
@@ -553,7 +556,11 @@ function getResultContent(row: WorkflowRow) {
   if (row.kind === 'agentic_triage') {
     const triage = row.triage;
     if (triage?.dryRun) {
-      return <Text variant="muted">{t('dry run')}</Text>;
+      return (
+        <Text variant="muted" size="sm">
+          {t('dry run')}
+        </Text>
+      );
     }
     const issueCount = triage?.issues.length ?? 0;
     if (issueCount === 0) {

--- a/static/app/views/seerWorkflows/strategies.tsx
+++ b/static/app/views/seerWorkflows/strategies.tsx
@@ -1,0 +1,201 @@
+import {
+  IconBusiness,
+  IconChat,
+  IconCode,
+  IconCopy,
+  IconLab,
+  IconLightning,
+  IconMail,
+  IconMegaphone,
+  IconPlay,
+  IconReleases,
+  IconSiren,
+  IconTimer,
+} from 'sentry/icons';
+import type {
+  Frequency,
+  NotificationChannel,
+  OutputId,
+  StrategyCategory,
+  StrategyVisibility,
+  WorkflowKind,
+} from 'sentry/views/seerWorkflows/types';
+
+export type {Frequency};
+
+export type StrategyMeta = {
+  Icon: React.ComponentType<{size?: 'xs' | 'sm' | 'md'}>;
+  category: StrategyCategory;
+  frequencies: Frequency[];
+  label: string;
+  outputs: OutputId[];
+  summary: string;
+  visibility: StrategyVisibility;
+};
+
+export const STRATEGY_META: Record<WorkflowKind, StrategyMeta> = {
+  agentic_triage: {
+    label: 'Agentic triage',
+    summary:
+      'Investigates new issues nightly and recommends autofix or assignment for each.',
+    Icon: IconLab,
+    frequencies: ['daily', 'weekly'],
+    visibility: 'configurable',
+    category: 'issues',
+    outputs: ['autofix_runs', 'issue_activity'],
+  },
+  autofix_followup: {
+    label: 'Autofix follow-up',
+    summary:
+      "Reviews yesterday's autofix proposals: correctness vs. root cause, test impact, and whether an owner needs to weigh in before merging.",
+    Icon: IconCode,
+    frequencies: ['daily'],
+    visibility: 'configurable',
+    category: 'issues',
+    outputs: ['issue_activity', 'notification'],
+  },
+  feedback_summary: {
+    label: 'Feedback summary',
+    summary:
+      "Summarizes the day's user feedback into themes your engineering team can act on.",
+    Icon: IconChat,
+    frequencies: ['hourly', 'daily', 'weekly'],
+    visibility: 'configurable',
+    category: 'user_experience',
+    outputs: ['notification'],
+  },
+  replay_friction_finder: {
+    label: 'Replay friction finder',
+    summary:
+      'Surfaces Session Replay clips with elevated rage-click or dead-click density and clusters them into named UX friction themes.',
+    Icon: IconPlay,
+    frequencies: ['daily', 'weekly'],
+    visibility: 'configurable',
+    category: 'user_experience',
+    outputs: ['replay_collection'],
+  },
+  release_regression_scout: {
+    label: 'Release regression scout',
+    summary:
+      "Reviews each release's first 24 hours: new error types, crash-free deltas, and regressions linked to suspect commits.",
+    Icon: IconReleases,
+    frequencies: ['daily', 'weekly'],
+    visibility: 'configurable',
+    category: 'reliability',
+    outputs: ['release_annotation'],
+  },
+  performance_regression_scout: {
+    label: 'Performance regression scout',
+    summary:
+      "Compares this week's transaction p95s and error rates against the prior baseline. Flags degraded endpoints with span-level hypotheses and likely-culprit deploys.",
+    Icon: IconLightning,
+    frequencies: ['daily', 'weekly'],
+    visibility: 'configurable',
+    category: 'reliability',
+    outputs: ['performance_annotation'],
+  },
+  alert_tuning_advisor: {
+    label: 'Alert tuning advisor',
+    summary:
+      'Reviews alert rule fire history. Flags noisy, dead, or fatigue-inducing rules and proposes thresholds or sensitivity changes.',
+    Icon: IconSiren,
+    frequencies: ['weekly'],
+    visibility: 'configurable',
+    category: 'reliability',
+    outputs: ['alert_rule_suggestion'],
+  },
+  cron_monitor_doctor: {
+    label: 'Cron monitor doctor',
+    summary:
+      'Reviews cron monitor health. Suggests timeout, grace-period, or schedule adjustments for monitors that miss check-ins or run long.',
+    Icon: IconTimer,
+    frequencies: ['weekly'],
+    visibility: 'configurable',
+    category: 'reliability',
+    outputs: ['monitor_annotation'],
+  },
+  duplicate_issue_merger: {
+    label: 'Duplicate issue merger',
+    summary:
+      'Auto-detects semantically duplicate issues across fingerprints and proposes merges with confidence scores.',
+    Icon: IconCopy,
+    frequencies: ['daily'],
+    visibility: 'internal',
+    category: 'issues',
+    outputs: ['merge_proposal', 'issue_activity'],
+  },
+  ownership_suggester: {
+    label: 'Ownership suggester',
+    summary:
+      'Watches which engineers resolve issues touching which files. Proposes Ownership rules so future issues auto-route to the right people.',
+    Icon: IconBusiness,
+    frequencies: ['weekly'],
+    visibility: 'internal',
+    category: 'issues',
+    outputs: ['ownership_suggestion'],
+  },
+};
+
+export const FREQUENCY_LABELS: Record<Frequency, string> = {
+  hourly: 'Hourly',
+  daily: 'Daily',
+  weekly: 'Weekly',
+};
+
+export const CATEGORY_LABELS: Record<StrategyCategory, string> = {
+  issues: 'Issues',
+  reliability: 'Reliability',
+  user_experience: 'User experience',
+};
+
+export const CATEGORY_ORDER: StrategyCategory[] = [
+  'issues',
+  'reliability',
+  'user_experience',
+];
+
+type OutputMeta = {
+  Icon: React.ComponentType<{size?: 'xs' | 'sm' | 'md'}>;
+  label: string;
+};
+
+export const STRATEGY_OUTPUTS: Record<OutputId, OutputMeta> = {
+  autofix_runs: {Icon: IconCode, label: 'Autofix runs'},
+  issue_activity: {Icon: IconLab, label: 'Issue activity note'},
+  release_annotation: {Icon: IconReleases, label: 'Release insights'},
+  performance_annotation: {Icon: IconLightning, label: 'Performance markers'},
+  replay_collection: {Icon: IconPlay, label: 'Replay collection'},
+  alert_rule_suggestion: {Icon: IconSiren, label: 'Alert rule banner'},
+  monitor_annotation: {Icon: IconTimer, label: 'Monitor banner'},
+  merge_proposal: {Icon: IconCopy, label: 'Merge proposal'},
+  ownership_suggestion: {Icon: IconBusiness, label: 'Ownership suggestion'},
+  notification: {Icon: IconMegaphone, label: 'Notification'},
+};
+
+export function requiresNotification(kind: WorkflowKind): boolean {
+  return STRATEGY_META[kind].outputs.includes('notification');
+}
+
+// Maps raw triage action enum values to human-readable labels for the
+// user-facing issue list. Falls back to the raw value for unknown verbs.
+const ACTION_LABELS: Record<string, string> = {
+  autofix: 'Autofix queued',
+  autofix_triggered: 'Autofix queued',
+  root_cause_only: 'Root cause analysis',
+  skip: 'Skipped',
+};
+
+export function getActionLabel(action: string): string {
+  return ACTION_LABELS[action] ?? action;
+}
+
+type NotificationMeta = {
+  Icon: React.ComponentType<{size?: 'xs' | 'sm' | 'md'}> | null;
+  label: string;
+};
+
+export const NOTIFICATION_META: Record<NotificationChannel, NotificationMeta> = {
+  slack: {Icon: IconChat, label: 'Slack'},
+  email: {Icon: IconMail, label: 'Email'},
+  none: {Icon: null, label: 'No notifications'},
+};

--- a/static/app/views/seerWorkflows/strategies.tsx
+++ b/static/app/views/seerWorkflows/strategies.tsx
@@ -1,29 +1,13 @@
-import {
-  IconBusiness,
-  IconChat,
-  IconCode,
-  IconCopy,
-  IconLab,
-  IconLightning,
-  IconMail,
-  IconMegaphone,
-  IconPlay,
-  IconReleases,
-  IconSiren,
-  IconTimer,
-} from 'sentry/icons';
+import {IconLab} from 'sentry/icons';
 import type {
   Frequency,
-  NotificationChannel,
   OutputId,
   StrategyCategory,
   StrategyVisibility,
   WorkflowKind,
 } from 'sentry/views/seerWorkflows/types';
 
-export type {Frequency};
-
-export type StrategyMeta = {
+type StrategyMeta = {
   Icon: React.ComponentType<{size?: 'xs' | 'sm' | 'md'}>;
   category: StrategyCategory;
   frequencies: Frequency[];
@@ -44,102 +28,6 @@ export const STRATEGY_META: Record<WorkflowKind, StrategyMeta> = {
     category: 'issues',
     outputs: ['autofix_runs', 'issue_activity'],
   },
-  autofix_followup: {
-    label: 'Autofix follow-up',
-    summary:
-      "Reviews yesterday's autofix proposals: correctness vs. root cause, test impact, and whether an owner needs to weigh in before merging.",
-    Icon: IconCode,
-    frequencies: ['daily'],
-    visibility: 'configurable',
-    category: 'issues',
-    outputs: ['issue_activity', 'notification'],
-  },
-  feedback_summary: {
-    label: 'Feedback summary',
-    summary:
-      "Summarizes the day's user feedback into themes your engineering team can act on.",
-    Icon: IconChat,
-    frequencies: ['hourly', 'daily', 'weekly'],
-    visibility: 'configurable',
-    category: 'user_experience',
-    outputs: ['notification'],
-  },
-  replay_friction_finder: {
-    label: 'Replay friction finder',
-    summary:
-      'Surfaces Session Replay clips with elevated rage-click or dead-click density and clusters them into named UX friction themes.',
-    Icon: IconPlay,
-    frequencies: ['daily', 'weekly'],
-    visibility: 'configurable',
-    category: 'user_experience',
-    outputs: ['replay_collection'],
-  },
-  release_regression_scout: {
-    label: 'Release regression scout',
-    summary:
-      "Reviews each release's first 24 hours: new error types, crash-free deltas, and regressions linked to suspect commits.",
-    Icon: IconReleases,
-    frequencies: ['daily', 'weekly'],
-    visibility: 'configurable',
-    category: 'reliability',
-    outputs: ['release_annotation'],
-  },
-  performance_regression_scout: {
-    label: 'Performance regression scout',
-    summary:
-      "Compares this week's transaction p95s and error rates against the prior baseline. Flags degraded endpoints with span-level hypotheses and likely-culprit deploys.",
-    Icon: IconLightning,
-    frequencies: ['daily', 'weekly'],
-    visibility: 'configurable',
-    category: 'reliability',
-    outputs: ['performance_annotation'],
-  },
-  alert_tuning_advisor: {
-    label: 'Alert tuning advisor',
-    summary:
-      'Reviews alert rule fire history. Flags noisy, dead, or fatigue-inducing rules and proposes thresholds or sensitivity changes.',
-    Icon: IconSiren,
-    frequencies: ['weekly'],
-    visibility: 'configurable',
-    category: 'reliability',
-    outputs: ['alert_rule_suggestion'],
-  },
-  cron_monitor_doctor: {
-    label: 'Cron monitor doctor',
-    summary:
-      'Reviews cron monitor health. Suggests timeout, grace-period, or schedule adjustments for monitors that miss check-ins or run long.',
-    Icon: IconTimer,
-    frequencies: ['weekly'],
-    visibility: 'configurable',
-    category: 'reliability',
-    outputs: ['monitor_annotation'],
-  },
-  duplicate_issue_merger: {
-    label: 'Duplicate issue merger',
-    summary:
-      'Auto-detects semantically duplicate issues across fingerprints and proposes merges with confidence scores.',
-    Icon: IconCopy,
-    frequencies: ['daily'],
-    visibility: 'internal',
-    category: 'issues',
-    outputs: ['merge_proposal', 'issue_activity'],
-  },
-  ownership_suggester: {
-    label: 'Ownership suggester',
-    summary:
-      'Watches which engineers resolve issues touching which files. Proposes Ownership rules so future issues auto-route to the right people.',
-    Icon: IconBusiness,
-    frequencies: ['weekly'],
-    visibility: 'internal',
-    category: 'issues',
-    outputs: ['ownership_suggestion'],
-  },
-};
-
-export const FREQUENCY_LABELS: Record<Frequency, string> = {
-  hourly: 'Hourly',
-  daily: 'Daily',
-  weekly: 'Weekly',
 };
 
 export const CATEGORY_LABELS: Record<StrategyCategory, string> = {
@@ -154,28 +42,6 @@ export const CATEGORY_ORDER: StrategyCategory[] = [
   'user_experience',
 ];
 
-type OutputMeta = {
-  Icon: React.ComponentType<{size?: 'xs' | 'sm' | 'md'}>;
-  label: string;
-};
-
-export const STRATEGY_OUTPUTS: Record<OutputId, OutputMeta> = {
-  autofix_runs: {Icon: IconCode, label: 'Autofix runs'},
-  issue_activity: {Icon: IconLab, label: 'Issue activity note'},
-  release_annotation: {Icon: IconReleases, label: 'Release insights'},
-  performance_annotation: {Icon: IconLightning, label: 'Performance markers'},
-  replay_collection: {Icon: IconPlay, label: 'Replay collection'},
-  alert_rule_suggestion: {Icon: IconSiren, label: 'Alert rule banner'},
-  monitor_annotation: {Icon: IconTimer, label: 'Monitor banner'},
-  merge_proposal: {Icon: IconCopy, label: 'Merge proposal'},
-  ownership_suggestion: {Icon: IconBusiness, label: 'Ownership suggestion'},
-  notification: {Icon: IconMegaphone, label: 'Notification'},
-};
-
-export function requiresNotification(kind: WorkflowKind): boolean {
-  return STRATEGY_META[kind].outputs.includes('notification');
-}
-
 // Maps raw triage action enum values to human-readable labels for the
 // user-facing issue list. Falls back to the raw value for unknown verbs.
 const ACTION_LABELS: Record<string, string> = {
@@ -188,14 +54,3 @@ const ACTION_LABELS: Record<string, string> = {
 export function getActionLabel(action: string): string {
   return ACTION_LABELS[action] ?? action;
 }
-
-type NotificationMeta = {
-  Icon: React.ComponentType<{size?: 'xs' | 'sm' | 'md'}> | null;
-  label: string;
-};
-
-export const NOTIFICATION_META: Record<NotificationChannel, NotificationMeta> = {
-  slack: {Icon: IconChat, label: 'Slack'},
-  email: {Icon: IconMail, label: 'Email'},
-  none: {Icon: null, label: 'No notifications'},
-};

--- a/static/app/views/seerWorkflows/types.ts
+++ b/static/app/views/seerWorkflows/types.ts
@@ -1,4 +1,4 @@
-export type SeerNightShiftRunIssue = {
+type SeerNightShiftRunIssue = {
   action: string;
   dateAdded: string;
   groupId: string;
@@ -6,7 +6,7 @@ export type SeerNightShiftRunIssue = {
   seerRunId: string | null;
 };
 
-export type SeerNightShiftRunOptions = {
+type SeerNightShiftRunOptions = {
   dry_run?: boolean;
   extra_triage_instructions?: string;
   intelligence_level?: 'low' | 'medium' | 'high';
@@ -15,7 +15,7 @@ export type SeerNightShiftRunOptions = {
   source?: string;
 };
 
-export type SeerNightShiftRunExtras = {
+type SeerNightShiftRunExtras = {
   agent_run_id?: number | string;
   options?: SeerNightShiftRunOptions;
   target_project_ids?: number[];
@@ -31,31 +31,13 @@ export type SeerNightShiftRun = {
   triageStrategy: string;
 };
 
-export type WorkflowKind =
-  | 'agentic_triage'
-  | 'feedback_summary'
-  | 'autofix_followup'
-  | 'release_regression_scout'
-  | 'performance_regression_scout'
-  | 'replay_friction_finder'
-  | 'alert_tuning_advisor'
-  | 'cron_monitor_doctor'
-  | 'duplicate_issue_merger'
-  | 'ownership_suggester';
+export type WorkflowKind = 'agentic_triage';
 
 export type StrategyVisibility = 'configurable' | 'internal';
 export type StrategyCategory = 'issues' | 'reliability' | 'user_experience';
 export type RunStatus = 'succeeded' | 'failed' | 'skipped' | 'running';
 
-export type FeedbackTheme = {
-  description: string;
-  feedbackGroupIds: number[];
-  title: string;
-};
-
 export type Frequency = 'hourly' | 'daily' | 'weekly';
-
-export type NotificationChannel = 'slack' | 'email' | 'none';
 
 export type OutputId =
   | 'autofix_runs'
@@ -69,14 +51,6 @@ export type OutputId =
   | 'ownership_suggestion'
   | 'notification';
 
-export type ConfiguredWorkflow = {
-  frequency: Frequency;
-  id: string;
-  notification: NotificationChannel;
-  strategy: WorkflowKind;
-  lastRunAt?: string;
-};
-
 export type WorkflowRow = {
   dateAdded: string;
   id: string;
@@ -84,13 +58,6 @@ export type WorkflowRow = {
   runId: string;
   status: RunStatus;
   errorMessage?: string | null;
-  feedback?: {
-    numFeedbacksAnalyzed: number;
-    summary: string;
-    themes: FeedbackTheme[];
-    agentRunId?: number | string;
-    reason?: 'insufficient_feedbacks';
-  };
   options?: SeerNightShiftRunOptions;
   resultText?: string;
   source?: string;

--- a/static/app/views/seerWorkflows/types.ts
+++ b/static/app/views/seerWorkflows/types.ts
@@ -1,0 +1,104 @@
+export type SeerNightShiftRunIssue = {
+  action: string;
+  dateAdded: string;
+  groupId: string;
+  id: string;
+  seerRunId: string | null;
+};
+
+export type SeerNightShiftRunOptions = {
+  dry_run?: boolean;
+  extra_triage_instructions?: string;
+  intelligence_level?: 'low' | 'medium' | 'high';
+  max_candidates?: number;
+  reasoning_effort?: 'low' | 'medium' | 'high';
+  source?: string;
+};
+
+export type SeerNightShiftRunExtras = {
+  agent_run_id?: number | string;
+  options?: SeerNightShiftRunOptions;
+  target_project_ids?: number[];
+  triggering_user_id?: number;
+};
+
+export type SeerNightShiftRun = {
+  dateAdded: string;
+  errorMessage: string | null;
+  extras: SeerNightShiftRunExtras;
+  id: string;
+  issues: SeerNightShiftRunIssue[];
+  triageStrategy: string;
+};
+
+export type WorkflowKind =
+  | 'agentic_triage'
+  | 'feedback_summary'
+  | 'autofix_followup'
+  | 'release_regression_scout'
+  | 'performance_regression_scout'
+  | 'replay_friction_finder'
+  | 'alert_tuning_advisor'
+  | 'cron_monitor_doctor'
+  | 'duplicate_issue_merger'
+  | 'ownership_suggester';
+
+export type StrategyVisibility = 'configurable' | 'internal';
+export type StrategyCategory = 'issues' | 'reliability' | 'user_experience';
+export type RunStatus = 'succeeded' | 'failed' | 'skipped' | 'running';
+
+export type FeedbackTheme = {
+  description: string;
+  feedbackGroupIds: number[];
+  title: string;
+};
+
+export type Frequency = 'hourly' | 'daily' | 'weekly';
+
+export type NotificationChannel = 'slack' | 'email' | 'none';
+
+export type OutputId =
+  | 'autofix_runs'
+  | 'issue_activity'
+  | 'release_annotation'
+  | 'performance_annotation'
+  | 'replay_collection'
+  | 'alert_rule_suggestion'
+  | 'monitor_annotation'
+  | 'merge_proposal'
+  | 'ownership_suggestion'
+  | 'notification';
+
+export type ConfiguredWorkflow = {
+  frequency: Frequency;
+  id: string;
+  notification: NotificationChannel;
+  strategy: WorkflowKind;
+  lastRunAt?: string;
+};
+
+export type WorkflowRow = {
+  dateAdded: string;
+  id: string;
+  kind: WorkflowKind;
+  runId: string;
+  status: RunStatus;
+  errorMessage?: string | null;
+  feedback?: {
+    numFeedbacksAnalyzed: number;
+    summary: string;
+    themes: FeedbackTheme[];
+    agentRunId?: number | string;
+    reason?: 'insufficient_feedbacks';
+  };
+  options?: SeerNightShiftRunOptions;
+  resultText?: string;
+  source?: string;
+  summary?: string;
+  triage?: {
+    issues: SeerNightShiftRunIssue[];
+    agentRunId?: number | string;
+    dryRun?: boolean;
+    maxCandidates?: number;
+  };
+};


### PR DESCRIPTION
Replace the placeholder at `/issues/autofix/` with a run-history view of an organization's Seer workflow runs. The page fetches from the existing `/organizations/<org>/seer/workflows/` endpoint and renders runs in a sortable, filterable table with expandable per-issue drill-downs. The route and endpoint already exist on master, so this is frontend-only — no routing or backend changes.

**Standalone extraction**

First clean PR carved out of the `jc-SeerWorkflowE2E` prototype branch. It ships the run page only and intentionally leaves out the prototype scaffolding: the `?mock=1` mock-data toggle and fixtures, the onboarding modal, and the separate (mock-only) configure and overview pages. Those can follow in later PRs.

**Data-driven filters**

Runs can be filtered by strategy, status, source, and time period, sorted by date, and expanded for per-issue detail. The Strategy and Source filters are derived from the strategies/sources actually present in the returned runs — so only real options appear (today, just Agentic triage) rather than the full catalog of prototype workflow kinds. Internal-only strategies stay hidden from non-employees.