### PR TITLE
feat(issues): Surface Postgres sort fallback to the client

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -470,6 +470,11 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
 
         self.add_cursor_headers(request, response, cursor_result)
 
+        # The requested sort exceeded its candidate limit and results were ranked by a
+        # fallback strategy; let the client surface that the ranking was simplified.
+        if cursor_result.sort_fallback is not None:
+            response["X-Sentry-Sort-Fallback"] = cursor_result.sort_fallback
+
         # TODO(jess): add metrics that are similar to project endpoint here
         return response
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1299,6 +1299,9 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             return self.empty_result
 
         pg_overflow_fallback = False
+        # The originally-requested sort when an overflow fallback occurs, surfaced to the
+        # client so the UI can tell the user their ranking was simplified.
+        sort_fallback_from: str | None = None
         pg_strategy = self.postgres_sort_strategies.get(sort_by)
         if pg_strategy is not None:
             pg_result = self._execute_postgres_sort(
@@ -1331,6 +1334,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             # `date` shortcut below. If this sort has no Snuba-only equivalent, fall back
             # to `date`.
             pg_overflow_fallback = True
+            sort_fallback_from = sort_by
             # Keep the original sort only if it maps to a real Snuba aggregation for the
             # chunked path. Keys absent from sort_strategies, or mapped to "" (Postgres-only
             # sorts like "inbox"), have no aggregation and must fall back to `date` instead
@@ -1571,6 +1575,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             tags={"postgres_only": False},
         )
 
+        paginator_results.sort_fallback = sort_fallback_from
         return paginator_results
 
     def calculate_hits(

--- a/src/sentry/utils/cursors.py
+++ b/src/sentry/utils/cursors.py
@@ -100,6 +100,10 @@ class CursorResult(Sequence[T]):
         self.prev = prev
         self.hits = hits
         self.max_hits = max_hits
+        # Set when the requested sort couldn't be honored and results were ranked by a
+        # fallback strategy instead (e.g. a Postgres sort that exceeded its candidate
+        # limit). Holds the originally-requested sort key, else None.
+        self.sort_fallback: str | None = None
 
     def __len__(self) -> int:
         return len(self.results)

--- a/tests/snuba/search/test_postgres_sort_framework.py
+++ b/tests/snuba/search/test_postgres_sort_framework.py
@@ -377,6 +377,23 @@ class TestFallbackBehavior(PostgresSortTestBase):
         results = list(self.make_query("date"))
         assert len(results) == 3
 
+    def test_overflow_sets_sort_fallback_on_result(self):
+        # On overflow the requested sort is surfaced on the result via `sort_fallback` so
+        # the endpoint can tell the client its ranking was simplified; a non-overflowing
+        # query leaves it unset.
+        with (
+            _patch_pg_strategies({"test_sort": _ts_strategy()}),
+            mock.patch.object(
+                PostgresSnubaQueryExecutor,
+                "snuba_search",
+                return_value=([(g.id, 1) for g in self.groups], len(self.groups)),
+            ),
+        ):
+            with override_options({"snuba.search.max-pre-snuba-candidates": 0}):
+                assert self.make_query("test_sort").sort_fallback == "test_sort"
+            with override_options({"snuba.search.max-pre-snuba-candidates": 1000}):
+                assert self.make_query("test_sort").sort_fallback is None
+
 
 class TestRecommendedV2Sort(PostgresSortTestBase):
     """recommended_v2: Snuba recommended base score plus additive boosts for viewer


### PR DESCRIPTION
When a Postgres-data sort (`recommended_v2`, `progress`) exceeds its candidate limit (`snuba.search.max-pre-snuba-candidates`), `_execute_postgres_sort` returns `None` and results are silently re-ranked by the chunked Snuba path — without the Postgres-side boosts, or falling all the way back to `date` for sorts with no Snuba equivalent. The user has no idea their requested ranking wasn't honored. In production the limit is set low via options-automator, so this happens for real searches.

This propagates the originally-requested sort out of the search layer so the client can surface it:

- `CursorResult` gains a `sort_fallback: str | None` attribute (defaults to `None`).
- `executors.query()` sets it to the requested sort when the overflow fallback fires, before re-ranking.
- `OrganizationGroupIndexEndpoint` emits it as an `X-Sentry-Sort-Fallback` response header, alongside the existing cursor headers.

This mirrors how the issue stream already reads `X-Hits` / `X-Max-Hits` from the response. The header is backwards compatible — absent means no fallback — so nothing breaks before the frontend that consumes it ships.

A follow-up **frontend PR** reads the header and renders a notice in the issue stream (kept separate per the repo's frontend/backend split; this backend change lands first).