### PR TITLE
ref(platform): Replace deprecated datetime.utcnow calls with a naive UTC datetime replacement

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -86,6 +86,7 @@ from sentry.types.activity import ActivityType
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.cache import cache
 from sentry.utils.cursors import Cursor, CursorResult
+from sentry.utils.dates import deprecated_utcnow
 from sentry.utils.sdk import bind_organization_context
 
 ERR_INVALID_STATS_PERIOD = "Invalid %s. Valid choices are %s"
@@ -491,9 +492,9 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
                     (
                         filter_params["start"]
                         if filter_params["start"]
-                        else datetime.utcnow() - timedelta(days=90)
+                        else deprecated_utcnow() - timedelta(days=90)
                     ),
-                    filter_params["end"] if filter_params["end"] else datetime.utcnow(),
+                    filter_params["end"] if filter_params["end"] else deprecated_utcnow(),
                 )
                 valid_versions = [
                     rv for rv in release_versions if rv not in releases_with_session_data
@@ -669,9 +670,9 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
                     (
                         filter_params["start"]
                         if filter_params["start"]
-                        else datetime.utcnow() - timedelta(days=90)
+                        else deprecated_utcnow() - timedelta(days=90)
                     ),
-                    filter_params["end"] if filter_params["end"] else datetime.utcnow(),
+                    filter_params["end"] if filter_params["end"] else deprecated_utcnow(),
                 )
                 valid_versions = [
                     rv for rv in release_versions if rv not in releases_with_session_data

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from collections.abc import Iterator, Mapping, Sequence
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import sentry_sdk
 from snuba_sdk import (
@@ -66,6 +66,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.taskworker.namespaces import telemetry_experience_tasks
 from sentry.utils import metrics
+from sentry.utils.dates import deprecated_utcnow
 from sentry.utils.snuba import raw_snql_query
 
 # This set contains all the projects for which we want to start extracting the sample rate over time. This is done
@@ -330,8 +331,8 @@ def query_project_counts_by_org(
     use_case_id = config["use_case_id"]
 
     where_conditions = [
-        Condition(Column("timestamp"), Op.GTE, datetime.utcnow() - query_interval),
-        Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+        Condition(Column("timestamp"), Op.GTE, deprecated_utcnow() - query_interval),
+        Condition(Column("timestamp"), Op.LT, deprecated_utcnow()),
         Condition(Column("metric_id"), Op.EQ, metric_id),
         Condition(Column("org_id"), Op.IN, org_ids),
         Condition(Column("project_id"), Op.IN, project_ids),

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Sequence
-from datetime import datetime
 from typing import TypedDict
 
 import sentry_sdk
@@ -53,6 +52,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.taskworker.namespaces import telemetry_experience_tasks
 from sentry.utils import metrics
+from sentry.utils.dates import deprecated_utcnow
 from sentry.utils.snuba import raw_snql_query
 
 
@@ -290,9 +290,9 @@ class FetchProjectTransactionTotals:
                 Condition(
                     Column("timestamp"),
                     Op.GTE,
-                    datetime.utcnow() - BOOST_LOW_VOLUME_TRANSACTIONS_QUERY_INTERVAL,
+                    deprecated_utcnow() - BOOST_LOW_VOLUME_TRANSACTIONS_QUERY_INTERVAL,
                 ),
-                Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+                Condition(Column("timestamp"), Op.LT, deprecated_utcnow()),
                 Condition(Column("metric_id"), Op.EQ, self.metric_id),
                 Condition(Column("org_id"), Op.IN, self.org_ids),
             ]
@@ -439,9 +439,9 @@ class FetchProjectTransactionVolumes:
                 Condition(
                     Column("timestamp"),
                     Op.GTE,
-                    datetime.utcnow() - BOOST_LOW_VOLUME_TRANSACTIONS_QUERY_INTERVAL,
+                    deprecated_utcnow() - BOOST_LOW_VOLUME_TRANSACTIONS_QUERY_INTERVAL,
                 ),
-                Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+                Condition(Column("timestamp"), Op.LT, deprecated_utcnow()),
                 Condition(Column("metric_id"), Op.EQ, self.metric_id),
                 Condition(Column("org_id"), Op.IN, self.org_ids),
             ]

--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import TypedDict
 
 import sentry_sdk
@@ -28,6 +28,7 @@ from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.naming_layer.mri import SpanMRI
 from sentry.snuba.referrer import Referrer
+from sentry.utils.dates import deprecated_utcnow
 from sentry.utils.snuba import raw_snql_query
 
 ACTIVE_ORGS_DEFAULT_TIME_INTERVAL = timedelta(hours=1)
@@ -106,9 +107,9 @@ class GetActiveOrgs:
                 Condition(
                     Column("timestamp"),
                     Op.GTE,
-                    datetime.utcnow() - self.time_interval,
+                    deprecated_utcnow() - self.time_interval,
                 ),
-                Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+                Condition(Column("timestamp"), Op.LT, deprecated_utcnow()),
                 Condition(Column("metric_id"), Op.EQ, self.metric_id),
             ]
             for tag_name, tag_value in self.tag_filters.items():
@@ -285,8 +286,8 @@ class GetActiveOrgsVolumes:
         ]
 
         where = [
-            Condition(Column("timestamp"), Op.GTE, datetime.utcnow() - self.time_interval),
-            Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+            Condition(Column("timestamp"), Op.GTE, deprecated_utcnow() - self.time_interval),
+            Condition(Column("timestamp"), Op.LT, deprecated_utcnow()),
             Condition(Column("metric_id"), Op.EQ, self.metric_id),
         ]
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -53,6 +53,7 @@ from sentry.shared_integrations.exceptions import (
 )
 from sentry.silo.base import control_silo_function
 from sentry.utils import metrics
+from sentry.utils.dates import deprecated_utcnow
 
 logger = logging.getLogger("sentry.integrations.github")
 
@@ -292,7 +293,7 @@ class GithubProxyClient(IntegrationProxyClient):
             {
                 "permissions": permissions,
                 "expires_at": expires_at,
-                "last_refresh_at": datetime.utcnow().isoformat(),
+                "last_refresh_at": deprecated_utcnow().isoformat(),
             }
         )
 
@@ -354,7 +355,7 @@ class GithubProxyClient(IntegrationProxyClient):
         at least the timedelta provided.
         """
         token_minimum_validity_time = token_minimum_validity_time or timedelta(minutes=0)
-        now = datetime.utcnow()
+        now = deprecated_utcnow()
         access_token: str | None = self.integration.metadata.get("access_token")
         expires_at: str | None = self.integration.metadata.get("expires_at")
 

--- a/src/sentry/integrations/slack/utils/auth.py
+++ b/src/sentry/integrations/slack/utils/auth.py
@@ -1,8 +1,9 @@
 import hmac
 import time
-from datetime import datetime
 from hashlib import sha256
 from typing import TYPE_CHECKING, TypedDict
+
+from sentry.utils.dates import deprecated_utcnow
 
 if TYPE_CHECKING:
     from sentry.models.organizationmember import OrganizationMember
@@ -27,7 +28,7 @@ class SigningSecretKwargs(TypedDict):
 
 def set_signing_secret(secret: str, data: bytes) -> SigningSecretKwargs:
     """Note: this is currently only used in tests."""
-    timestamp = str(int(time.mktime(datetime.utcnow().timetuple())))
+    timestamp = str(int(time.mktime(deprecated_utcnow().timetuple())))
     signature = _encode_data(secret, data, timestamp)
     return {
         "HTTP_X_SLACK_REQUEST_TIMESTAMP": timestamp,

--- a/src/sentry/issues/escalating/issue_velocity.py
+++ b/src/sentry/issues/escalating/issue_velocity.py
@@ -28,6 +28,7 @@ from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.post_process import locks
 from sentry.utils import metrics
+from sentry.utils.dates import deprecated_utcnow
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.redis import redis_clusters
 
@@ -171,7 +172,7 @@ def update_threshold(
     client = get_redis_client()
     with client.pipeline() as p:
         p.set(threshold_key, threshold, ex=ttl)
-        p.set(stale_date_key, str(datetime.utcnow()), ex=ttl)
+        p.set(stale_date_key, str(deprecated_utcnow()), ex=ttl)
         p.execute()
     metrics.incr("issues.update_new_escalation_threshold", tags={"useFallback": False})
     return threshold
@@ -189,7 +190,7 @@ def fallback_to_stale_or_zero(
     ttl = FALLBACK_TTL
     # current datetime - the amount of time a threshold is valid for + how much time to wait before trying to query Snuba for the threshold again
     stale_date = (
-        datetime.utcnow()
+        deprecated_utcnow()
         - timedelta(seconds=TIME_TO_USE_EXISTING_THRESHOLD)
         + timedelta(seconds=FALLBACK_TTL)
     )
@@ -229,7 +230,7 @@ def get_latest_threshold(project: Project) -> float:
     stale_date = None
     if cache_results[1] is not None:
         stale_date = datetime.fromisoformat(cache_results[1])
-    now = datetime.utcnow()
+    now = deprecated_utcnow()
     if (
         stale_date is None
         or threshold is None

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -4,7 +4,6 @@ import base64
 import logging
 import os
 from copy import deepcopy
-from datetime import datetime
 from typing import Any
 
 import google.auth
@@ -22,6 +21,7 @@ from sentry import features, options
 from sentry.auth.system import get_system_token
 from sentry.models.project import Project
 from sentry.utils import redis, safe
+from sentry.utils.dates import deprecated_utcnow
 from sentry.utils.http import get_origins
 
 logger = logging.getLogger(__name__)
@@ -271,7 +271,7 @@ def _last_upload_key(project_id: int) -> str:
 
 
 def record_last_upload(project: Project):
-    timestamp = int(datetime.utcnow().timestamp() * 1000)
+    timestamp = int(deprecated_utcnow().timestamp() * 1000)
     _get_cluster().setex(_last_upload_key(project.id), LAST_UPLOAD_TTL, timestamp)
 
 

--- a/src/sentry/release_health/release_monitor/metrics.py
+++ b/src/sentry/release_health/release_monitor/metrics.py
@@ -2,7 +2,7 @@ import logging
 import time
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from snuba_sdk import (
     BooleanCondition,
@@ -28,6 +28,7 @@ from sentry.sentry_metrics.utils import resolve_tag_key
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.utils import metrics
+from sentry.utils.dates import deprecated_utcnow
 from sentry.utils.snuba import raw_snql_query
 
 logger = logging.getLogger(__name__)
@@ -52,9 +53,11 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
                         groupby=[Column("org_id"), Column("project_id")],
                         where=[
                             Condition(
-                                Column("timestamp"), Op.GTE, datetime.utcnow() - timedelta(hours=6)
+                                Column("timestamp"),
+                                Op.GTE,
+                                deprecated_utcnow() - timedelta(hours=6),
                             ),
-                            Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+                            Condition(Column("timestamp"), Op.LT, deprecated_utcnow()),
                             Condition(
                                 Column("metric_id"),
                                 Op.EQ,
@@ -116,9 +119,9 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
                     groupby=[Column("org_id"), Column("project_id")],
                     where=[
                         Condition(
-                            Column("timestamp"), Op.GTE, datetime.utcnow() - timedelta(hours=6)
+                            Column("timestamp"), Op.GTE, deprecated_utcnow() - timedelta(hours=6)
                         ),
-                        Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+                        Condition(Column("timestamp"), Op.LT, deprecated_utcnow()),
                         Condition(
                             Column("metric_id"),
                             Op.EQ,
@@ -211,9 +214,9 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
                             Condition(
                                 Column("timestamp"),
                                 Op.GTE,
-                                datetime.utcnow() - timedelta(hours=6),
+                                deprecated_utcnow() - timedelta(hours=6),
                             ),
-                            Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
+                            Condition(Column("timestamp"), Op.LT, deprecated_utcnow()),
                             Condition(Column("org_id"), Op.EQ, org_id),
                             Condition(Column("project_id"), Op.IN, project_ids),
                             Condition(

--- a/src/sentry/services/eventstore/snuba/backend.py
+++ b/src/sentry/services/eventstore/snuba/backend.py
@@ -38,6 +38,7 @@ from sentry.snuba.events import Columns
 from sentry.snuba.occurrences_rpc import OccurrenceCategory, Occurrences
 from sentry.snuba.referrer import Referrer
 from sentry.utils import snuba
+from sentry.utils.dates import deprecated_utcnow
 from sentry.utils.snuba import DATASETS, _prepare_start_end, bulk_snuba_queries, raw_snql_query
 from sentry.utils.validators import normalize_event_id
 
@@ -925,7 +926,7 @@ class SnubaEventStorage(EventStorage):
         next_filter.conditions.extend(get_after_event_condition(event))
         next_filter.start = event.datetime
         if not next_filter.end:
-            next_filter.end = datetime.utcnow()
+            next_filter.end = deprecated_utcnow()
         next_filter.orderby = ASC_ORDERING
 
         dataset = self._get_dataset_for_event(event)

--- a/src/sentry/shared_integrations/client/integration_proxy_client.md
+++ b/src/sentry/shared_integrations/client/integration_proxy_client.md
@@ -59,7 +59,7 @@ def authorize_request(self, prepared_request: PreparedRequest) -> PreparedReques
         return prepared_request
 
     token_data = integration.metadata["auth_data"]
-    if token["expiration"] > datetime.utcnow():
+    if token["expiration"] > deprecated_utcnow():
         token_data = self._refresh_and_save_token_data()
 
     prepared_request.headers["Authorization"] = f"Bearer {token_data["token"]}"

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -1,7 +1,7 @@
 import logging
 import re
 import zoneinfo
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta, timezone
 from typing import Any, overload
 
 from dateutil.parser import parse
@@ -215,3 +215,16 @@ def get_timezone_choices() -> list[tuple[str, str]]:
     for item in build_results:
         results.append(item[1:])
     return results
+
+
+def deprecated_utcnow() -> datetime:
+    """
+    Returns a naive UTC timestamp. This is wrong and should be replaced with a timezone
+    aware timestamp. Calling `deprecated_utcnow()` pollutes the logs with deprecation
+    warnings. Replacing it with this function suppresses those warnings and still
+    preserves its deprecation state in an obvious way.
+
+    If you see this function being called in your code please replace it with a timezone
+    aware datetime.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -219,10 +219,13 @@ def get_timezone_choices() -> list[tuple[str, str]]:
 
 def deprecated_utcnow() -> datetime:
     """
-    Returns a naive UTC timestamp. This is wrong and should be replaced with a timezone
-    aware timestamp. Calling `deprecated_utcnow()` pollutes the logs with deprecation
-    warnings. Replacing it with this function suppresses those warnings and still
-    preserves its deprecation state in an obvious way.
+    Returns a naive UTC timestamp.
+
+    Using this function is wrong and it should be replaced with a timezone aware
+    timestamp. This function exists to replace `utcnow` which is deprecated.
+    `utcnow` logs deprecation notices which are polluting the log stream. This
+    function signals that its obviously deprecated without being annoying for people
+    trying to debug things other than timezone issue.
 
     If you see this function being called in your code please replace it with a timezone
     aware datetime.

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -13,6 +13,7 @@ from sentry.event_manager import EventManager, set_tag
 from sentry.interfaces.user import User as UserInterface
 from sentry.spans.grouping.utils import hash_values
 from sentry.utils import json
+from sentry.utils.dates import deprecated_utcnow
 from sentry.utils.platform_categories import CONSOLES
 
 logger = logging.getLogger(__name__)
@@ -182,7 +183,7 @@ def load_data(
 
     # Generate a timestamp in the present.
     if timestamp is None:
-        timestamp = datetime.utcnow() - timedelta(minutes=1)
+        timestamp = deprecated_utcnow() - timedelta(minutes=1)
         timestamp = timestamp - timedelta(microseconds=timestamp.microsecond % 1000)
     timestamp = timestamp.replace(tzinfo=timezone.utc)
     data.setdefault("timestamp", timestamp.timestamp())

--- a/src/sentry/utils/security/orgauthtoken_token.py
+++ b/src/sentry/utils/security/orgauthtoken_token.py
@@ -1,10 +1,10 @@
 import secrets
 from base64 import b64decode, b64encode
-from datetime import datetime
 from typing import Any
 
 from sentry import options
 from sentry.utils import hashlib, json
+from sentry.utils.dates import deprecated_utcnow
 
 SENTRY_ORG_AUTH_TOKEN_PREFIX = "sntrys_"
 
@@ -21,7 +21,7 @@ def generate_token(org_slug: str, region_url: str) -> str:
         raise SystemUrlPrefixMissingException
 
     payload = {
-        "iat": datetime.utcnow().timestamp(),
+        "iat": deprecated_utcnow().timestamp(),
         "url": sentry_url,
         "region_url": region_url,
         "org": org_slug,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -45,7 +45,7 @@ from sentry.snuba.query_sources import QuerySource
 from sentry.snuba.referrer import validate_referrer
 from sentry.utils import json, metrics
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
-from sentry.utils.dates import outside_retention_with_modified_start
+from sentry.utils.dates import deprecated_utcnow, outside_retention_with_modified_start
 
 logger = logging.getLogger(__name__)
 
@@ -766,7 +766,7 @@ def _prepare_start_end(
     if not start:
         start = datetime(2008, 5, 8)
     if not end:
-        end = datetime.utcnow() + timedelta(seconds=1)
+        end = deprecated_utcnow() + timedelta(seconds=1)
 
     # convert to naive UTC datetimes, as Snuba only deals in UTC
     # and this avoids offset-naive and offset-aware issues
@@ -914,7 +914,7 @@ class SnubaQueryParams:
         # This shows up in unittests: https://github.com/getsentry/sentry/pull/15939
         # We generally however require that the API user is aware of the exclusive
         # end.
-        self.end = end or datetime.utcnow() + timedelta(seconds=1)
+        self.end = end or deprecated_utcnow() + timedelta(seconds=1)
         self.groupby = groupby or []
         self.conditions = conditions or []
         self.aggregations = aggregations or []


### PR DESCRIPTION
Removes `datetime.utcnow` which is emitting a significant number of log messages and polluting the log stream. Replaces it with an identical function which does not emit the log message.