### PR TITLE
feat(issues): Notify when issue ranking falls back to a simpler sort

### DIFF
--- a/static/app/stores/IssueListCacheStore.tsx
+++ b/static/app/stores/IssueListCacheStore.tsx
@@ -15,6 +15,8 @@ interface IssueListCache {
   pageLinks: string;
   queryCount: number;
   queryMaxCount: number;
+  // The requested sort the backend couldn't fully honor; null when applied normally.
+  sortFallback: string | null;
 }
 
 interface IssueListCacheState {

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -983,4 +983,38 @@ describe('IssueList', () => {
       expect(screen.queryByText('Suggested Queries')).not.toBeInTheDocument();
     });
   });
+
+  describe('sort fallback notice', () => {
+    const routerConfig = {
+      location: {pathname: '/organizations/org-slug/issues/', query: {}},
+    };
+
+    it('shows a notice when the response signals a sort fallback', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues/',
+        body: [group],
+        headers: {
+          Link: DEFAULT_LINKS_HEADER,
+          'X-Sentry-Sort-Fallback': 'recommended_v2',
+        },
+      });
+
+      render(<IssueListOverview initialQuery="is:unresolved" />, {
+        organization,
+        initialRouterConfig: routerConfig,
+      });
+
+      expect(await screen.findByText(/simplified ranking/)).toBeInTheDocument();
+    });
+
+    it('shows no notice when the sort was applied normally', async () => {
+      render(<IssueListOverview initialQuery="is:unresolved" />, {
+        organization,
+        initialRouterConfig: routerConfig,
+      });
+
+      expect(await screen.findByRole('row', {name: 'is:unresolved'})).toBeInTheDocument();
+      expect(screen.queryByText(/simplified ranking/)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -300,6 +300,7 @@ function IssueListOverviewInner({
     setQueryCount(cache.queryCount);
     setQueryMaxCount(cache.queryMaxCount);
     setPageLinks(cache.pageLinks);
+    setSortFallback(cache.sortFallback);
 
     GroupStore.add(cache.groups);
 
@@ -463,13 +464,14 @@ function IssueListOverviewInner({
       const newQueryMaxCount =
         maxHits !== undefined && maxHits ? parseInt(maxHits, 10) || 0 : 0;
       const newPageLinks = resp.getResponseHeader('Link');
+      const newSortFallback = resp.getResponseHeader('X-Sentry-Sort-Fallback');
 
       setError(null);
       setIssuesLoading(false);
       setIssuesSuccessfullyLoaded(true);
       setQueryCount(newQueryCount);
       setQueryMaxCount(newQueryMaxCount);
-      setSortFallback(resp.getResponseHeader('X-Sentry-Sort-Fallback'));
+      setSortFallback(newSortFallback);
       setPageLinks(newPageLinks === null ? '' : newPageLinks);
 
       // AI query analytics
@@ -492,6 +494,7 @@ function IssueListOverviewInner({
         queryCount: newQueryCount,
         queryMaxCount: newQueryMaxCount,
         pageLinks: newPageLinks ?? '',
+        sortFallback: newSortFallback,
       });
     } catch (err) {
       trackAnalytics('issue_search.failed', {
@@ -504,6 +507,7 @@ function IssueListOverviewInner({
       setError(parseApiError(err as RequestError));
       setIssuesLoading(false);
       setIssuesSuccessfullyLoaded(false);
+      setSortFallback(null);
 
       // AI query analytics
       const aiQueryRunId = getRunIdForAnalytics();

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -10,6 +10,7 @@ import omit from 'lodash/omit';
 import pickBy from 'lodash/pickBy';
 import * as qs from 'query-string';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Grid, Stack} from '@sentry/scraps/layout';
 import type {CursorHandler} from '@sentry/scraps/pagination';
 
@@ -154,6 +155,9 @@ function IssueListOverviewInner({
   const [pageLinks, setPageLinks] = useState('');
   const [queryCount, setQueryCount] = useState(0);
   const [queryMaxCount, setQueryMaxCount] = useState(0);
+  // The requested sort the backend couldn't fully honor (too many issues to rank);
+  // results fell back to a simplified ranking. Null when the sort was applied normally.
+  const [sortFallback, setSortFallback] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [issuesLoading, setIssuesLoading] = useState(true);
   const [issuesSuccessfullyLoaded, setIssuesSuccessfullyLoaded] = useState(false);
@@ -465,6 +469,7 @@ function IssueListOverviewInner({
       setIssuesSuccessfullyLoaded(true);
       setQueryCount(newQueryCount);
       setQueryMaxCount(newQueryMaxCount);
+      setSortFallback(resp.getResponseHeader('X-Sentry-Sort-Fallback'));
       setPageLinks(newPageLinks === null ? '' : newPageLinks);
 
       // AI query analytics
@@ -968,6 +973,13 @@ function IssueListOverviewInner({
               onSortChange={onSortChange}
               onSearch={onSearch}
             />
+            {sortFallback && !issuesLoading && (
+              <Alert variant="info">
+                {t(
+                  'This search matched too many issues to fully sort. Showing a simplified ranking — narrow your search to sort them all.'
+                )}
+              </Alert>
+            )}
             <IssueListTable
               selection={selection}
               query={query}


### PR DESCRIPTION
Follow-up to the backend change (#117821). When a Postgres-data sort (`recommended_v2`, `progress`) matches too many issues to rank fully, the backend silently re-ranks results with a simplified fallback. Today the user has no idea their chosen sort wasn't honored.

This reads the `X-Sentry-Sort-Fallback` response header in the issue stream (the same way the stream already consumes `X-Hits` / `X-Max-Hits`) and renders an info notice above the issue table:

> This search matched too many issues to fully sort. Showing a simplified ranking — narrow your search to sort them all.

The notice only shows while results are loaded and the header is present, and clears automatically on the next search that ranks normally (absent header → no notice), so it's safe to ship before/after the backend independently.

Depends at runtime on the backend header from #117821 (land that first).

## Note on local checks
The JS toolchain in my dev environment is currently broken at the config-load level — ESLint, `tsgo`, and the Jest runner all fail to parse their own config files (TypeScript `verbatimModuleSyntax` / version mismatch), unrelated to this change. The pre-commit `eslint`/`format` hooks did run and auto-fixed imports/formatting. Relying on CI to execute the test suite.