### PR TITLE
feat(seer): Add per-org night shift run-option overrides

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1136,6 +1136,17 @@ register(
     default=10,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Per-org overrides for night shift run options. Keyed by stringified
+# organization id; each value is a partial set of run-option overrides (e.g.
+# {"max_candidates": 20}) that layer on top of the global defaults but below
+# any explicit caller-provided options. See
+# sentry.tasks.seer.night_shift.tweaks.get_night_shift_org_tweaks.
+register(
+    "seer.night_shift.org_tweaks",
+    type=Dict,
+    default={},
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "seer.supergroups_backfill_lightweight.killswitch",

--- a/src/sentry/seer/endpoints/project_seer_night_shift.py
+++ b/src/sentry/seer/endpoints/project_seer_night_shift.py
@@ -16,7 +16,6 @@ from sentry.tasks.seer.night_shift.cron import (
     SeerNightShiftRunOptionsPartial,
     run_night_shift_for_org,
 )
-from sentry.tasks.seer.night_shift.tweaks import get_night_shift_tweaks
 
 logger = logging.getLogger("sentry.seer.endpoints.project_seer_night_shift")
 
@@ -34,7 +33,6 @@ class ProjectSeerNightShiftEndpoint(ProjectEndpoint):
             raise NotFound
 
         dry_run = bool(request.data.get("dryRun", False))
-        tweaks = get_night_shift_tweaks(project)
         triggering_user_id = request.user.id if request.user.is_authenticated else None
 
         logger.info(
@@ -45,20 +43,15 @@ class ProjectSeerNightShiftEndpoint(ProjectEndpoint):
                 "organization_id": project.organization_id,
                 "triggering_user_id": triggering_user_id,
                 "dry_run": dry_run,
-                "max_candidates": tweaks.max_candidates,
-                "intelligence_level": tweaks.intelligence_level,
-                "reasoning_effort": tweaks.reasoning_effort,
-                "extra_triage_instructions": tweaks.extra_triage_instructions,
             },
         )
 
+        # The project's tweaks (and any per-org overrides) are resolved by
+        # build_run_options inside run_night_shift_for_org, which scopes them to
+        # the single project_id below.
         options: SeerNightShiftRunOptionsPartial = {
             "source": "manual",
             "dry_run": dry_run,
-            "max_candidates": tweaks.max_candidates,
-            "intelligence_level": tweaks.intelligence_level,
-            "reasoning_effort": tweaks.reasoning_effort,
-            "extra_triage_instructions": tweaks.extra_triage_instructions,
         }
         run_id = run_night_shift_for_org(
             project.organization_id,

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -45,6 +45,7 @@ from sentry.tasks.seer.night_shift.tweaks import (
     NightShiftTweaks,
     ReasoningEffort,
     default_max_candidates,
+    get_night_shift_org_tweaks,
     get_night_shift_tweaks,
 )
 from sentry.taskworker.namespaces import seer_tasks
@@ -205,7 +206,14 @@ def run_night_shift_for_org(
     if organization is None:
         return None
 
-    resolved_options = build_run_options(options)
+    # Manual project runs scope to a single project, whose tweaks feed the run
+    # options; cron and org-wide manual runs have no single project.
+    single_project_id = project_ids[0] if project_ids and len(project_ids) == 1 else None
+    resolved_options = build_run_options(
+        organization_id=organization.id,
+        manual_overrides=options,
+        project_id=single_project_id,
+    )
     sentry_sdk.set_tags(
         {"organization_id": organization.id, "organization_slug": organization.slug}
     )
@@ -322,13 +330,57 @@ def _run_option_defaults(data: Mapping[str, Any]) -> SeerNightShiftRunOptions:
     )
 
 
+# Run-option fields that a NightShiftTweaks layer can override. `enabled` is
+# intentionally excluded — it gates eligibility, it is not a run option.
+_TWEAK_RUN_OPTION_FIELDS = (
+    "max_candidates",
+    "intelligence_level",
+    "reasoning_effort",
+    "extra_triage_instructions",
+)
+
+
+def _tweaks_to_partial(tweaks: NightShiftTweaks) -> dict[str, Any]:
+    """Project a NightShiftTweaks (org- or project-scoped) onto a run-options
+    partial, contributing only the fields that were *explicitly* set on it.
+
+    NightShiftTweaks fills every unset field with a default, so reading
+    attributes directly would emit all fields and clobber lower-precedence
+    layers. `exclude_unset` keeps only the fields the payload actually
+    specified, so defaults (and lower layers) show through."""
+    set_fields = tweaks.dict(exclude_unset=True)
+    return {field: set_fields[field] for field in _TWEAK_RUN_OPTION_FIELDS if field in set_fields}
+
+
 def build_run_options(
-    partial: SeerNightShiftRunOptionsPartial | None = None,
+    *,
+    organization_id: int,
+    manual_overrides: Mapping[str, Any] | None = None,
+    project_id: int | None = None,
 ) -> SeerNightShiftRunOptions:
-    """Resolve a partial options dict into a fully-populated one. Cron callers
-    pass nothing (all defaults); manual callers pass at least `source="manual"`
-    plus whichever tweaks they want to override."""
-    return _run_option_defaults(partial or {})
+    """Resolve a fully-populated set of run options, layering by precedence
+    (highest wins):
+
+        manual overrides (`manual_overrides`)
+        > project tweaks (the project's `sentry:seer_nightshift_tweaks` option,
+          applied when `project_id` is given — used by manual project runs)
+        > per-org overrides (the `seer.night_shift.org_tweaks` option, keyed by
+          `organization_id`)
+        > global defaults
+
+    Cron runs pass only `organization_id` (no project, no manual overrides);
+    manual project runs additionally pass `project_id` + at least
+    `source="manual"`. Unknown keys are ignored."""
+    layered: dict[str, Any] = {}
+    org_tweaks = get_night_shift_org_tweaks(organization_id)
+    if org_tweaks is not None:
+        layered.update(_tweaks_to_partial(org_tweaks))
+    if project_id is not None:
+        project = Project.objects.filter(id=project_id, organization_id=organization_id).first()
+        if project is not None:
+            layered.update(_tweaks_to_partial(get_night_shift_tweaks(project)))
+    layered.update(manual_overrides or {})
+    return _run_option_defaults(layered)
 
 
 def _get_eligible_orgs_from_batch(

--- a/src/sentry/tasks/seer/night_shift/tweaks.py
+++ b/src/sentry/tasks/seer/night_shift/tweaks.py
@@ -40,17 +40,41 @@ class NightShiftTweaks(pydantic.BaseModel):
         allow_population_by_field_name = True
 
 
-def get_night_shift_tweaks(project: Project) -> NightShiftTweaks:
-    raw = project.get_option("sentry:seer_nightshift_tweaks")
-    if not raw:
-        return NightShiftTweaks()
+def _parse_tweaks(raw: object, source: str) -> NightShiftTweaks | None:
+    """Parse a raw tweaks payload into NightShiftTweaks, or None if it is
+    malformed (reported to Sentry). `source` labels the option in the report."""
     if not isinstance(raw, dict):
         sentry_sdk.capture_exception(
-            TypeError(f"sentry:seer_nightshift_tweaks must be a dict, got {type(raw).__name__}")
+            TypeError(f"{source} must be a dict, got {type(raw).__name__}")
         )
-        return NightShiftTweaks()
+        return None
     try:
         return NightShiftTweaks(**raw)
     except pydantic.ValidationError:
         sentry_sdk.capture_exception()
+        return None
+
+
+def get_night_shift_tweaks(project: Project) -> NightShiftTweaks:
+    """Per-project tweaks from the `sentry:seer_nightshift_tweaks` option.
+    Falls back to all-default tweaks when unset or malformed."""
+    raw = project.get_option("sentry:seer_nightshift_tweaks")
+    if not raw:
         return NightShiftTweaks()
+    return _parse_tweaks(raw, "sentry:seer_nightshift_tweaks") or NightShiftTweaks()
+
+
+def get_night_shift_org_tweaks(organization_id: int) -> NightShiftTweaks | None:
+    """Per-org overrides from the `seer.night_shift.org_tweaks` option, a dict
+    keyed by stringified organization id. Each value is a partial
+    `NightShiftTweaks` payload (e.g. {"max_candidates": 20}); unset fields fall
+    back to the same global defaults `NightShiftTweaks` uses. Returns None when
+    nothing is configured for the org. Malformed entries are reported to Sentry
+    and treated as absent."""
+    org_tweaks = options.get("seer.night_shift.org_tweaks")
+    if not isinstance(org_tweaks, dict):
+        return None
+    raw = org_tweaks.get(str(organization_id))
+    if raw is None:
+        return None
+    return _parse_tweaks(raw, f"seer.night_shift.org_tweaks[{organization_id}]")

--- a/tests/sentry/seer/endpoints/test_project_seer_night_shift.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_night_shift.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-from sentry import options
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 
@@ -15,6 +14,9 @@ class ProjectSeerNightShiftTest(APITestCase):
 
     @with_feature("organizations:seer-night-shift")
     def test_triggers_task(self) -> None:
+        # The endpoint forwards only the manual-trigger metadata; the run
+        # options (including project tweaks) are resolved by build_run_options
+        # inside the task, scoped to project_ids.
         with patch(
             "sentry.seer.endpoints.project_seer_night_shift.run_night_shift_for_org",
             return_value=42,
@@ -28,14 +30,7 @@ class ProjectSeerNightShiftTest(APITestCase):
         assert response.data == {"run_id": 42}
         mock_task.assert_called_once_with(
             self.organization.id,
-            options={
-                "source": "manual",
-                "dry_run": False,
-                "max_candidates": options.get("seer.night_shift.issues_per_org"),
-                "intelligence_level": "high",
-                "reasoning_effort": "high",
-                "extra_triage_instructions": "",
-            },
+            options={"source": "manual", "dry_run": False},
             project_ids=[self.project.id],
             triggering_user_id=self.user.id,
             execute_in_task=True,
@@ -57,52 +52,7 @@ class ProjectSeerNightShiftTest(APITestCase):
         assert response.data == {"run_id": None}
         mock_task.assert_called_once_with(
             self.organization.id,
-            options={
-                "source": "manual",
-                "dry_run": True,
-                "max_candidates": options.get("seer.night_shift.issues_per_org"),
-                "intelligence_level": "high",
-                "reasoning_effort": "high",
-                "extra_triage_instructions": "",
-            },
-            project_ids=[self.project.id],
-            triggering_user_id=self.user.id,
-            execute_in_task=True,
-        )
-
-    @with_feature("organizations:seer-night-shift")
-    def test_forwards_tweaks_to_task(self) -> None:
-        self.project.update_option(
-            "sentry:seer_nightshift_tweaks",
-            {
-                "max_candidates": 25,
-                "intelligence_level": "low",
-                "reasoning_effort": "medium",
-                "extra_triage_instructions": "Be terse.",
-            },
-        )
-
-        with patch(
-            "sentry.seer.endpoints.project_seer_night_shift.run_night_shift_for_org",
-            return_value=99,
-        ) as mock_task:
-            response = self.get_success_response(
-                self.organization.slug,
-                self.project.slug,
-                status_code=200,
-            )
-
-        assert response.data == {"run_id": 99}
-        mock_task.assert_called_once_with(
-            self.organization.id,
-            options={
-                "source": "manual",
-                "dry_run": False,
-                "max_candidates": 25,
-                "intelligence_level": "low",
-                "reasoning_effort": "medium",
-                "extra_triage_instructions": "Be terse.",
-            },
+            options={"source": "manual", "dry_run": True},
             project_ids=[self.project.id],
             triggering_user_id=self.user.id,
             execute_in_task=True,

--- a/tests/sentry/tasks/seer/night_shift/test_tweaks.py
+++ b/tests/sentry/tasks/seer/night_shift/test_tweaks.py
@@ -1,7 +1,11 @@
 from unittest.mock import patch
 
 from sentry import options
-from sentry.tasks.seer.night_shift.tweaks import NightShiftTweaks, get_night_shift_tweaks
+from sentry.tasks.seer.night_shift.tweaks import (
+    NightShiftTweaks,
+    get_night_shift_org_tweaks,
+    get_night_shift_tweaks,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -82,3 +86,66 @@ class GetNightShiftTweaksTest(TestCase):
         mock_capture.assert_called_once()
         assert tweaks.enabled is True
         assert tweaks.max_candidates == options.get("seer.night_shift.issues_per_org")
+
+
+class GetNightShiftOrgTweaksTest(TestCase):
+    def test_unset_returns_none(self) -> None:
+        assert get_night_shift_org_tweaks(self.organization.id) is None
+
+    def test_returns_overrides_for_matching_org(self) -> None:
+        with self.options(
+            {"seer.night_shift.org_tweaks": {str(self.organization.id): {"max_candidates": 20}}}
+        ):
+            tweaks = get_night_shift_org_tweaks(self.organization.id)
+
+        assert tweaks is not None
+        assert tweaks.max_candidates == 20
+
+    def test_unset_fields_fall_back_to_global_defaults(self) -> None:
+        with self.options(
+            {
+                "seer.night_shift.org_tweaks": {str(self.organization.id): {"max_candidates": 20}},
+                "seer.night_shift.issues_per_org": 42,
+            }
+        ):
+            tweaks = get_night_shift_org_tweaks(self.organization.id)
+
+        assert tweaks is not None
+        assert tweaks.max_candidates == 20
+        assert tweaks.intelligence_level == "high"
+
+    def test_other_org_returns_none(self) -> None:
+        with self.options(
+            {"seer.night_shift.org_tweaks": {str(self.organization.id + 1): {"max_candidates": 20}}}
+        ):
+            assert get_night_shift_org_tweaks(self.organization.id) is None
+
+    def test_non_dict_override_reports_and_returns_none(self) -> None:
+        with (
+            self.options(
+                {"seer.night_shift.org_tweaks": {str(self.organization.id): "not-a-dict"}}
+            ),
+            patch(
+                "sentry.tasks.seer.night_shift.tweaks.sentry_sdk.capture_exception"
+            ) as mock_capture,
+        ):
+            assert get_night_shift_org_tweaks(self.organization.id) is None
+
+        mock_capture.assert_called_once()
+
+    def test_invalid_payload_reports_and_returns_none(self) -> None:
+        with (
+            self.options(
+                {
+                    "seer.night_shift.org_tweaks": {
+                        str(self.organization.id): {"max_candidates": "not-an-int"}
+                    }
+                }
+            ),
+            patch(
+                "sentry.tasks.seer.night_shift.tweaks.sentry_sdk.capture_exception"
+            ) as mock_capture,
+        ):
+            assert get_night_shift_org_tweaks(self.organization.id) is None
+
+        mock_capture.assert_called_once()

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -7,6 +7,7 @@ from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunR
 from sentry.seer.models.workflow import SeerWorkflowStrategy
 from sentry.tasks.seer.night_shift.cron import (
     _get_eligible_projects,
+    build_run_options,
     run_night_shift_for_org,
     schedule_night_shift,
 )
@@ -18,6 +19,64 @@ from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils.redis import redis_clusters
+
+
+@django_db_all
+class TestBuildRunOptions(TestCase):
+    """Precedence: manual_overrides > project tweaks > org overrides > defaults."""
+
+    def test_defaults_only(self) -> None:
+        with self.options({"seer.night_shift.issues_per_org": 8}):
+            resolved = build_run_options(organization_id=self.organization.id)
+
+        assert resolved["source"] == "cron"
+        assert resolved["max_candidates"] == 8
+        assert resolved["intelligence_level"] == "high"
+
+    def test_org_overrides_apply_over_defaults(self) -> None:
+        with self.options(
+            {
+                "seer.night_shift.issues_per_org": 8,
+                "seer.night_shift.org_tweaks": {str(self.organization.id): {"max_candidates": 15}},
+            }
+        ):
+            resolved = build_run_options(organization_id=self.organization.id)
+
+        assert resolved["max_candidates"] == 15
+        # Unset org fields fall through to the global default.
+        assert resolved["intelligence_level"] == "high"
+
+    def test_project_tweaks_override_org_overrides(self) -> None:
+        project = self.create_project(organization=self.organization)
+        project.update_option("sentry:seer_nightshift_tweaks", {"intelligence_level": "low"})
+
+        with self.options(
+            {"seer.night_shift.org_tweaks": {str(self.organization.id): {"max_candidates": 15}}}
+        ):
+            resolved = build_run_options(
+                organization_id=self.organization.id, project_id=project.id
+            )
+
+        # Project only set intelligence_level, so the org's max_candidates still
+        # shows through (the project layer no longer clobbers it with a default).
+        assert resolved["max_candidates"] == 15
+        assert resolved["intelligence_level"] == "low"
+
+    def test_manual_overrides_win(self) -> None:
+        project = self.create_project(organization=self.organization)
+        project.update_option("sentry:seer_nightshift_tweaks", {"max_candidates": 25})
+
+        with self.options(
+            {"seer.night_shift.org_tweaks": {str(self.organization.id): {"max_candidates": 15}}}
+        ):
+            resolved = build_run_options(
+                organization_id=self.organization.id,
+                project_id=project.id,
+                manual_overrides={"source": "manual", "max_candidates": 3},
+            )
+
+        assert resolved["source"] == "manual"
+        assert resolved["max_candidates"] == 3
 
 
 @django_db_all
@@ -343,6 +402,40 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
             "sentry.tasks.seer.night_shift.cron.fixability_score_strategy",
             return_value=[],
         ) as mock_score:
+            run_night_shift_for_org(org.id, options={"max_candidates": 7})
+
+        mock_score.assert_called_once()
+        assert mock_score.call_args.args[1] == 7
+
+    def test_org_tweaks_override_global_default(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project, max_candidates=50)
+
+        with (
+            self.options({"seer.night_shift.org_tweaks": {str(org.id): {"max_candidates": 25}}}),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy",
+                return_value=[],
+            ) as mock_score,
+        ):
+            run_night_shift_for_org(org.id)
+
+        mock_score.assert_called_once()
+        assert mock_score.call_args.args[1] == 25
+
+    def test_explicit_options_override_org_tweaks(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project, max_candidates=50)
+
+        with (
+            self.options({"seer.night_shift.org_tweaks": {str(org.id): {"max_candidates": 25}}}),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy",
+                return_value=[],
+            ) as mock_score,
+        ):
             run_night_shift_for_org(org.id, options={"max_candidates": 7})
 
         mock_score.assert_called_once()


### PR DESCRIPTION
Adds a `seer.night_shift.org_tweaks` option (a dict keyed by stringified org id) that lets us override night shift run options for individual organizations without touching the global defaults. Each value is a partial `NightShiftTweaks` payload, so any subset of `max_candidates` (a.k.a. `issues_per_org`), `intelligence_level`, `reasoning_effort`, and `extra_triage_instructions` can be set per org.

Example option value:

```yaml
seer.night_shift.org_tweaks:
  '1': # org id, quoted (looked up by str(org_id))
    max_candidates: 15
```

## Resolution model

Run-option resolution is consolidated into a single `build_run_options(organization_id, manual_overrides=None, project_id=None)` resolver, used by both cron and manual project runs. It layers by precedence (highest wins):

1. **manual overrides** — passed by the manual trigger (`source`, `dry_run`, …)
2. **project tweaks** — the project's `sentry:seer_nightshift_tweaks` option (manual project runs only)
3. **per-org overrides** — the new `seer.night_shift.org_tweaks` option
4. **global defaults**

Each tweaks layer contributes only its *explicitly-set* fields (via pydantic `exclude_unset`), so a lower layer shows through when a higher one didn't set that field — e.g. an org's `max_candidates` override isn't clobbered by a project that only set `intelligence_level`. The manual project-run endpoint now forwards just `source`/`dry_run` and lets the resolver pull project tweaks.

Agent transcript: https://claudescope.sentry.dev/share/MergrDA3VqrCXpULg-tjpHHY8yAzg0ndD3d98oifPqk