### PR TITLE
fix(issue-progress): Treat manual unresolve as a progress reset

### DIFF
--- a/src/sentry/issues/progress.py
+++ b/src/sentry/issues/progress.py
@@ -41,6 +41,11 @@ PROGRESS_STATES_DESCENDING = [
     IssueProgressState.DIAGNOSED,
 ]
 
+PROGRESS_RESET_ACTIVITY_TYPES: set[int] = {
+    ActivityType.SET_REGRESSION.value,
+    ActivityType.SET_UNRESOLVED.value,
+}
+
 
 def get_group_progress_states(
     group_ids: Sequence[int],
@@ -64,13 +69,13 @@ def get_group_progress_states(
     rows = (
         Activity.objects.filter(
             group_id__in=group_ids,
-            type__in=set(all_progress_activity_types) | {ActivityType.SET_REGRESSION.value},
+            type__in=set(all_progress_activity_types) | PROGRESS_RESET_ACTIVITY_TYPES,
         )
         .values("group_id")
         .annotate(
-            latest_regression=Max(
+            latest_reset=Max(
                 "datetime",
-                filter=Q(type=ActivityType.SET_REGRESSION.value),
+                filter=Q(type__in=PROGRESS_RESET_ACTIVITY_TYPES),
             ),
             latest_diagnosed=Max(
                 "datetime",
@@ -101,15 +106,15 @@ def get_group_progress_states(
     for row in rows:
         group_id = row["group_id"]
         groups_with_activities.add(group_id)
-        latest_regression = row["latest_regression"]
+        latest_reset = row["latest_reset"]
 
-        # Find the first matching progress progress state which occurred more recently than the latest regression
+        # Find the first matching progress state which occurred more recently than the latest reset
         for state in PROGRESS_STATES_DESCENDING:
             latest = row[annotation_key_by_state[state]]
-            if latest is not None and (latest_regression is None or latest >= latest_regression):
+            if latest is not None and (latest_reset is None or latest >= latest_reset):
                 result[group_id] = state.value
                 break
-        # If the regression was most recent
+        # If the reset was most recent
         else:
             result[group_id] = (
                 IssueProgressState.TRIAGED

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -16,6 +16,7 @@ from sentry import quotas
 from sentry.api.event_search import SearchFilter
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.exceptions import InvalidSearchQuery
+from sentry.issues.progress import PROGRESS_RESET_ACTIVITY_TYPES
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.models.group import Group, GroupStatus
@@ -37,7 +38,6 @@ from sentry.search.snuba.executors import (
 )
 from sentry.seer.autofix.constants import FixabilityScoreThresholds
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
-from sentry.types.activity import ActivityType
 from sentry.users.models.user import User
 from sentry.utils import metrics
 from sentry.utils.cursors import Cursor, CursorResult
@@ -256,15 +256,15 @@ def issue_activity_type_filter(activity_types: list[int], projects: Sequence[Pro
     group_ids = (
         Activity.objects.filter(
             project__in=projects,
-            type__in=set(activity_types) | {ActivityType.SET_REGRESSION.value},
+            type__in=set(activity_types) | PROGRESS_RESET_ACTIVITY_TYPES,
         )
         .values("group_id")
         .annotate(
             _latest_match=Max("datetime", filter=Q(type__in=activity_types)),
-            _latest_regression=Max("datetime", filter=Q(type=ActivityType.SET_REGRESSION.value)),
+            _latest_reset=Max("datetime", filter=Q(type__in=PROGRESS_RESET_ACTIVITY_TYPES)),
         )
         .filter(_latest_match__isnull=False)
-        .filter(Q(_latest_regression__isnull=True) | Q(_latest_match__gte=F("_latest_regression")))
+        .filter(Q(_latest_reset__isnull=True) | Q(_latest_match__gte=F("_latest_reset")))
         .values_list("group_id", flat=True)
     )
 
@@ -278,8 +278,8 @@ def issue_progress_filter(progress_values: list[str], projects: Sequence[Project
       identified -> triaged -> diagnosed -> fix_proposed -> fix_applied
 
     "diagnosed" and above are determined by seer/resolution activity types (see
-    ISSUE_PROGRESS_TO_ACTIVITY_TYPES). A regression (SET_REGRESSION) resets an issue
-    back, so only activities *after* the latest regression count.
+    ISSUE_PROGRESS_TO_ACTIVITY_TYPES). A regression, manual unresolve, or auto-set-ongoing
+    resets an issue back, so only activities *after* the latest reset count.
 
     "identified" and "triaged" are the two base states before any seer activity,
     distinguished solely by whether the issue is currently assigned:

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -278,8 +278,8 @@ def issue_progress_filter(progress_values: list[str], projects: Sequence[Project
       identified -> triaged -> diagnosed -> fix_proposed -> fix_applied
 
     "diagnosed" and above are determined by seer/resolution activity types (see
-    ISSUE_PROGRESS_TO_ACTIVITY_TYPES). A regression, manual unresolve, or auto-set-ongoing
-    resets an issue back, so only activities *after* the latest reset count.
+    ISSUE_PROGRESS_TO_ACTIVITY_TYPES). A regression or manual unresolve resets an issue
+    back, so only activities *after* the latest reset count.
 
     "identified" and "triaged" are the two base states before any seer activity,
     distinguished solely by whether the issue is currently assigned:

--- a/tests/sentry/issues/test_progress.py
+++ b/tests/sentry/issues/test_progress.py
@@ -131,6 +131,60 @@ class GetGroupProgressStatesTest(TestCase):
         result = get_group_progress_states([group.id])
         assert result[group.id] == IssueProgressState.DIAGNOSED
 
+    def test_unresolve_resets_progress(self) -> None:
+        group = self.create_group()
+        now = timezone.now()
+        self.create_group_activity(
+            group=group,
+            type=ActivityType.SET_RESOLVED.value,
+            datetime=now - timedelta(hours=2),
+        )
+        self.create_group_activity(
+            group=group,
+            type=ActivityType.SET_UNRESOLVED.value,
+            datetime=now - timedelta(hours=1),
+        )
+        result = get_group_progress_states([group.id])
+        assert result[group.id] == IssueProgressState.IDENTIFIED
+
+    def test_unresolve_resets_to_triaged_when_assigned(self) -> None:
+        group = self.create_group()
+        GroupAssignee.objects.assign(group, self.user)
+        now = timezone.now()
+        self.create_group_activity(
+            group=group,
+            type=ActivityType.SET_RESOLVED.value,
+            datetime=now - timedelta(hours=2),
+        )
+        self.create_group_activity(
+            group=group,
+            type=ActivityType.SET_UNRESOLVED.value,
+            datetime=now - timedelta(hours=1),
+        )
+        result = get_group_progress_states([group.id])
+        assert result[group.id] == IssueProgressState.TRIAGED
+
+    def test_activity_after_unresolve_counts(self) -> None:
+        group = self.create_group()
+        now = timezone.now()
+        self.create_group_activity(
+            group=group,
+            type=ActivityType.SET_RESOLVED.value,
+            datetime=now - timedelta(hours=3),
+        )
+        self.create_group_activity(
+            group=group,
+            type=ActivityType.SET_UNRESOLVED.value,
+            datetime=now - timedelta(hours=2),
+        )
+        self.create_group_activity(
+            group=group,
+            type=ActivityType.SEER_RCA_COMPLETED.value,
+            datetime=now - timedelta(hours=1),
+        )
+        result = get_group_progress_states([group.id])
+        assert result[group.id] == IssueProgressState.DIAGNOSED
+
     def test_bulk_multiple_groups(self) -> None:
         group1 = self.create_group()
         group2 = self.create_group()


### PR DESCRIPTION
Issue progress was resetting on issue regressions, but not when a user manually set them as unresolved. This now checks for either unresolves or regressions.