### PR TITLE
fix(issues): Resolve PR activity users by external actor

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -1046,15 +1046,13 @@ class PullRequestEventWebhook(GitHubWebhook):
                 organization_id=organization.id, external_id=self.get_external_id(user["login"])
             )
         except CommitAuthor.DoesNotExist:
-            # Don't set external_id on @localhost authors -- the push webhook
-            # needs to claim it on the real-email CommitAuthor instead.
-            defaults: dict[str, str] = {"name": user["login"][:128]}
-            if not author_email.endswith("@localhost"):
-                defaults["external_id"] = self.get_external_id(user["login"])
             author, author_created = CommitAuthor.objects.get_or_create(
                 organization_id=organization.id,
                 email=author_email,
-                defaults=defaults,
+                defaults={
+                    "name": user["login"][:128],
+                    "external_id": self.get_external_id(user["login"]),
+                },
             )
             if author_created:
                 try:

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -86,6 +86,10 @@ def _find_pull_request_author_user(author: CommitAuthor, organization_id: int) -
     if users:
         return users[0]
 
+    # Commit resolution generally has a real commit author email, so find_users()
+    # can match an org member by verified email. PR webhooks can create authors
+    # from a GitHub actor with a placeholder email, so use the same ExternalActor
+    # fallback that serializes PR authors.
     # Keep this lazy; receivers are imported during process initialization.
     from sentry.api.serializers.models.release import get_author_users_by_external_actors
 

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -13,6 +13,7 @@ from sentry.issues.action_log import (
 )
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
+from sentry.models.commitauthor import CommitAuthor
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.grouphistory import (
@@ -22,6 +23,7 @@ from sentry.models.grouphistory import (
 )
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupsubscription import GroupSubscription
+from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
 from sentry.models.pullrequest import PullRequest
 from sentry.models.release import Release
@@ -33,6 +35,7 @@ from sentry.tasks.clear_expired_resolutions import clear_expired_resolutions
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 from sentry.users.services.user import RpcUser
+from sentry.users.services.user.service import user_service
 from sentry.users.services.user_option import get_option_from_list, user_option_service
 
 
@@ -73,6 +76,34 @@ def remove_resolved_link(link):
             record_group_history_from_activity_type(
                 Group.objects.get(id=link.group_id), ActivityType.SET_UNRESOLVED.value
             )
+
+
+def _find_pull_request_author_user(author: CommitAuthor, organization_id: int) -> RpcUser | None:
+    if author.organization_id != organization_id:
+        return None
+
+    users = list(author.find_users())
+    if users:
+        return users[0]
+
+    # Keep this lazy; receivers are imported during process initialization.
+    from sentry.api.serializers.models.release import get_author_users_by_external_actors
+
+    external_actor_users, _ = get_author_users_by_external_actors(
+        [author],
+        organization_id,
+    )
+    user_id = external_actor_users.get(author)
+    if user_id is None:
+        return None
+
+    user_id_int = int(user_id)
+    if not OrganizationMember.objects.filter(
+        organization_id=organization_id, user_id=user_id_int
+    ).exists():
+        return None
+
+    return user_service.get_user(user_id=user_id_int)
 
 
 def resolved_in_commit(instance: Commit, created, **kwargs):
@@ -202,10 +233,11 @@ def resolved_in_pull_request(instance: PullRequest, created, **kwargs):
         repo = Repository.objects.get(id=instance.repository_id)
     except Repository.DoesNotExist:
         repo = None
-    if instance.author:
-        user_list = list(instance.author.find_users())
-    else:
-        user_list = []
+    acting_user = (
+        _find_pull_request_author_user(instance.author, instance.organization_id)
+        if instance.author
+        else None
+    )
 
     for group in groups:
         try:
@@ -217,9 +249,7 @@ def resolved_in_pull_request(instance: PullRequest, created, **kwargs):
                     relationship=GroupLink.Relationship.resolves,
                     linked_id=instance.id,
                 )
-                acting_user: RpcUser | None = None
-                if user_list:
-                    acting_user = user_list[0]
+                if acting_user:
                     with action_context_scope(
                         source=ActionSource.SYSTEM, actor=GroupActionActor.user(acting_user.id)
                     ):

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -837,56 +837,6 @@ class PushEventWebhookTest(APITestCase):
         assert external_actors[0].external_name == "@NewDev"
 
     @responses.activate
-    def test_push_after_pr_resolves_localhost_author(self) -> None:
-        """
-        PR webhook arrives first and creates an @localhost CommitAuthor.
-        Push webhook arrives second with the real git email. The @localhost
-        record must not hold external_id or the real-email record can never
-        claim it.
-        """
-        self._setup_github_integration_and_repo()
-
-        pr_body = json.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
-        pr_body["pull_request"]["user"]["login"] = "newdev"
-        pr_body["pull_request"]["user"]["id"] = 99999
-        pr_bytes = json.dumps(pr_body).encode()
-        sig1 = GitHubIntegrationsWebhookEndpoint.compute_signature("sha1", pr_bytes, self.secret)
-        sig256 = GitHubIntegrationsWebhookEndpoint.compute_signature(
-            "sha256", pr_bytes, self.secret
-        )
-        response = self.client.post(
-            path=self.url,
-            data=pr_bytes,
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="pull_request",
-            HTTP_X_HUB_SIGNATURE=f"sha1={sig1}",
-            HTTP_X_HUB_SIGNATURE_256=f"sha256={sig256}",
-            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
-        )
-        assert response.status_code == 204
-
-        # @localhost CommitAuthor exists but without external_id.
-        localhost_author = CommitAuthor.objects.get(
-            organization_id=self.organization.id, email="newdev@localhost"
-        )
-        assert localhost_author.external_id is None
-
-        # Push webhook sets external_id on the real-email record without collision.
-        assert (
-            self._send_push_event(
-                push_event_with_author(
-                    name="New Dev", email="newdev@example.com", username="newdev"
-                )
-            ).status_code
-            == 204
-        )
-
-        real_author = CommitAuthor.objects.get(
-            organization_id=self.organization.id, email="newdev@example.com"
-        )
-        assert real_author.external_id == "github:newdev"
-
-    @responses.activate
     @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @patch("sentry.integrations.github.webhook.PushEventWebhook.__call__")
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from sentry.buffer.base import Buffer
+from sentry.integrations.types import ExternalProviders
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
@@ -13,6 +14,7 @@ from sentry.models.groupinbox import GroupInbox, GroupInboxReason, add_group_to_
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.organizationmember import OrganizationMember
+from sentry.models.pullrequest import PullRequest
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.repository import Repository
@@ -255,6 +257,126 @@ class ResolvedInCommitTest(TestCase):
         ).exists()
 
         assert GroupSubscription.objects.filter(group=group, user_id=user.id).exists()
+
+
+class ResolvedInPullRequestTest(TestCase):
+    def _create_pull_request_author(
+        self, github_username: str, organization_id: int
+    ) -> CommitAuthor:
+        author = self.create_commit_author(
+            organization_id=organization_id,
+            email=f"{github_username}@localhost",
+        )
+        author.update(name=github_username, external_id=f"github:{github_username}")
+        return author
+
+    def _create_resolving_pull_request(
+        self, group: Group, repo: Repository, author: CommitAuthor
+    ) -> PullRequest:
+        return self.create_pull_request(
+            key="1",
+            repository_id=repo.id,
+            organization_id=group.organization.id,
+            title="very cool PR to fix the thing",
+            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
+            author=author,
+        )
+
+    @receivers_raise_on_send()
+    def test_matching_external_actor_sets_activity_user(self) -> None:
+        group = self.create_group()
+        user = self.create_user(name="Foo Bar", email="foo@example.com", is_active=True)
+        self.create_member(organization=group.organization, user=user)
+        integration = self.create_integration(
+            organization=group.organization,
+            external_id="github:1",
+            provider="github",
+        )
+        self.create_external_user(
+            user=user,
+            organization=group.organization,
+            integration=integration,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="@newdev",
+        )
+        repo = self.create_repo(
+            project=group.project,
+            provider="integrations:github",
+            integration_id=integration.id,
+        )
+        author = self._create_pull_request_author("newdev", group.organization.id)
+
+        pull_request = self._create_resolving_pull_request(group, repo, author)
+
+        activity = Activity.objects.get(
+            group=group,
+            type=ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value,
+        )
+        assert activity.user_id == user.id
+        assert activity.data == {"pull_request": pull_request.id}
+        assert GroupAssignee.objects.filter(group=group, user_id=user.id).exists()
+
+    @receivers_raise_on_send()
+    def test_author_from_different_organization_does_not_set_activity_user(self) -> None:
+        group = self.create_group()
+        user = self.create_user(name="Foo Bar", email="foo@example.com", is_active=True)
+        other_organization = self.create_organization(owner=user)
+        self.create_member(organization=group.organization, user=user)
+        integration = self.create_integration(
+            organization=other_organization,
+            external_id="github:1",
+            provider="github",
+        )
+        self.create_external_user(
+            user=user,
+            organization=other_organization,
+            integration=integration,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="@newdev",
+        )
+        repo = self.create_repo(project=group.project, provider="integrations:github")
+        author = self._create_pull_request_author("newdev", other_organization.id)
+
+        self._create_resolving_pull_request(group, repo, author)
+
+        activity = Activity.objects.get(
+            group=group,
+            type=ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value,
+        )
+        assert activity.user_id is None
+        assert not GroupAssignee.objects.filter(group=group).exists()
+
+    @receivers_raise_on_send()
+    def test_external_actor_user_must_be_organization_member(self) -> None:
+        group = self.create_group()
+        user = self.create_user(name="Foo Bar", email="foo@example.com", is_active=True)
+        integration = self.create_integration(
+            organization=group.organization,
+            external_id="github:1",
+            provider="github",
+        )
+        self.create_external_user(
+            user=user,
+            organization=group.organization,
+            integration=integration,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="@newdev",
+        )
+        repo = self.create_repo(
+            project=group.project,
+            provider="integrations:github",
+            integration_id=integration.id,
+        )
+        author = self._create_pull_request_author("newdev", group.organization.id)
+
+        self._create_resolving_pull_request(group, repo, author)
+
+        activity = Activity.objects.get(
+            group=group,
+            type=ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value,
+        )
+        assert activity.user_id is None
+        assert not GroupAssignee.objects.filter(group=group).exists()
 
 
 class ProjectHasReleasesReceiverTest(TestCase):


### PR DESCRIPTION
fixes the null top-level user on `set_resolved_in_pull_request` activity rows when the PR author came from the webhook as a localhost commit author.

#117574 tried to fix this by changing how localhost commit authors claim `external_id`, but that premise was wrong. this reverts that webhook change and fixes the activity attribution where the null user is actually written.

the PR author serializer already knows how to resolve `github:<login>` through external actor mappings, so this uses that same lookup before writing the activity/assignment actor.

fixes https://linear.app/getsentry/issue/ID-1629/improve-pull-request-created-attribution