### PR TITLE
feat(web): add WebMCP/agent discovery endpoints, robots.txt update, a…

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -413,6 +413,7 @@ MIDDLEWARE: tuple[str, ...] = (
     "sentry.middleware.ratelimit.RatelimitMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "sentry.middleware.devtoolbar.DevToolbarAnalyticsMiddleware",
+    "sentry.middleware.agent_discovery.AgentDiscoveryMiddleware",
 )
 
 ROOT_URLCONF = "sentry.conf.urls"

--- a/src/sentry/middleware/agent_discovery.py
+++ b/src/sentry/middleware/agent_discovery.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from django.conf import settings
+from django.http import HttpRequest
+from django.http.response import HttpResponseBase
+
+from sentry.conf.types.sentry_config import SentryMode
+
+AGENT_DISCOVERY_LINK_HEADER = (
+    '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"'
+    ', </.well-known/oauth-protected-resource>; rel="oauth-protected-resource"; type="application/json"'
+    ', </.well-known/oauth-authorization-server>; rel="oauth-authorization-server"; type="application/json"'
+    ', </.well-known/mcp/server-card.json>; rel="https://modelcontextprotocol.io/rel/server-card"; type="application/json"'
+    ', </.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/skills-index"; type="application/json"'
+    ', <https://docs.sentry.io/api/>; rel="service-doc"; type="text/html"'
+)
+
+
+class AgentDiscoveryMiddleware:
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponseBase]):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponseBase:
+        response = self.get_response(request)
+
+        if settings.SENTRY_MODE != SentryMode.SAAS:
+            return response
+
+        if getattr(request, "subdomain", None):
+            return response
+
+        if request.path.startswith("/api/"):
+            return response
+
+        content_type = response.get("Content-Type", "")
+        if "text/html" not in content_type:
+            return response
+
+        existing = response.get("Link", "")
+        if existing:
+            response["Link"] = existing + ", " + AGENT_DISCOVERY_LINK_HEADER
+        else:
+            response["Link"] = AGENT_DISCOVERY_LINK_HEADER
+
+        return response

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -8,7 +8,7 @@ from rest_framework.request import Request
 from sentry.conf.types.sentry_config import SentryMode
 from sentry.utils import json
 from sentry.web.client_config import get_client_config
-from sentry.web.frontend.base import all_silo_view
+from sentry.web.frontend.base import all_silo_view, control_silo_view
 
 # Paths to pages should not be added here, otherwise crawlers will
 # not be able to access the metadata with the 'none' directive
@@ -90,7 +90,7 @@ def security_txt(request):
     return HttpResponse(SECURITY, content_type="text/plain")
 
 
-@all_silo_view
+@control_silo_view
 @cache_control(max_age=3600, public=True)
 def mcp_json(request):
     if settings.SENTRY_MODE == SentryMode.SELF_HOSTED:
@@ -151,17 +151,16 @@ def _saas_only_json_response(request, payload, content_type="application/json"):
         return response
     response = HttpResponse(json.dumps(payload), content_type=content_type)
     response["Access-Control-Allow-Origin"] = "*"
+    patch_cache_control(response, max_age=3600, public=True)
     return response
 
 
-@all_silo_view
-@cache_control(max_age=3600, public=True)
+@control_silo_view
 def api_catalog(request):
     return _saas_only_json_response(request, API_CATALOG, "application/linkset+json")
 
 
-@all_silo_view
-@cache_control(max_age=3600, public=True)
+@control_silo_view
 def oauth_authorization_server(request):
     payload = {
         **OAUTH_AUTHORIZATION_SERVER,
@@ -170,8 +169,7 @@ def oauth_authorization_server(request):
     return _saas_only_json_response(request, payload)
 
 
-@all_silo_view
-@cache_control(max_age=3600, public=True)
+@control_silo_view
 def oauth_protected_resource(request):
     payload = {
         **OAUTH_PROTECTED_RESOURCE,
@@ -180,14 +178,12 @@ def oauth_protected_resource(request):
     return _saas_only_json_response(request, payload)
 
 
-@all_silo_view
-@cache_control(max_age=3600, public=True)
+@control_silo_view
 def mcp_server_card(request):
     return _saas_only_json_response(request, MCP_SERVER_CARD)
 
 
-@all_silo_view
-@cache_control(max_age=3600, public=True)
+@control_silo_view
 def agent_skills_index(request):
     return _saas_only_json_response(request, AGENT_SKILLS_INDEX)
 

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.http import HttpResponse
+from django.utils.cache import patch_cache_control
 from django.views.decorators.cache import cache_control
 from django.views.generic.base import View as BaseView
 from rest_framework.request import Request
@@ -145,7 +146,9 @@ AGENT_SKILLS_INDEX: dict[str, list[object]] = {"skills": []}
 
 def _saas_only_json_response(request, payload, content_type="application/json"):
     if settings.SENTRY_MODE != SentryMode.SAAS or request.subdomain:
-        return HttpResponse(status=404)
+        response = HttpResponse(status=404)
+        patch_cache_control(response, no_store=True)
+        return response
     response = HttpResponse(json.dumps(payload), content_type=content_type)
     response["Access-Control-Allow-Origin"] = "*"
     return response

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -14,6 +14,7 @@ from sentry.web.frontend.base import all_silo_view
 # and the URL of these pages may still appear in search results
 ROBOTS_SENTRY_IO = """\
 User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 Disallow: /api/
 Allow: /
 
@@ -95,6 +96,103 @@ def mcp_json(request):
         return HttpResponse(status=404)
 
     return HttpResponse(json.dumps(MCP_CONFIG), content_type="application/json")
+
+
+API_CATALOG = {
+    "linkset": [
+        {
+            "anchor": "https://sentry.io/api/0/",
+            "rel": [{"href": "https://sentry.io/api/0/", "type": "application/json"}],
+        },
+        {
+            "anchor": "https://mcp.sentry.dev/mcp",
+            "rel": [
+                {
+                    "href": "https://mcp.sentry.dev/mcp",
+                    "type": "application/json",
+                }
+            ],
+        },
+    ]
+}
+
+OAUTH_AUTHORIZATION_SERVER = {
+    "issuer": "https://sentry.io",
+    "authorization_endpoint": "https://sentry.io/oauth/authorize/",
+    "token_endpoint": "https://sentry.io/oauth/token/",
+    "response_types_supported": ["code"],
+    "grant_types_supported": ["authorization_code", "refresh_token"],
+    "code_challenge_methods_supported": ["S256"],
+}
+
+OAUTH_PROTECTED_RESOURCE = {
+    "resource": "https://sentry.io",
+    "authorization_servers": ["https://sentry.io"],
+    "bearer_methods_supported": ["header"],
+    "resource_documentation": "https://docs.sentry.io/api/",
+}
+
+MCP_SERVER_CARD = {
+    "name": "Sentry",
+    "description": "Connect to Sentry, debug faster.",
+    "url": "https://mcp.sentry.dev/mcp",
+    "provider": {
+        "name": "Sentry",
+        "url": "https://sentry.io",
+    },
+    "authentication": {
+        "type": "oauth2",
+        "authorization_server": "https://sentry.io",
+    },
+}
+
+AGENT_SKILLS_INDEX = {"skills": []}
+
+
+def _saas_only_json_response(request, payload, content_type="application/json"):
+    if settings.SENTRY_MODE == SentryMode.SELF_HOSTED or request.subdomain:
+        return HttpResponse(status=404)
+    response = HttpResponse(json.dumps(payload), content_type=content_type)
+    response["Access-Control-Allow-Origin"] = "*"
+    return response
+
+
+@all_silo_view
+@cache_control(max_age=3600, public=True)
+def api_catalog(request):
+    return _saas_only_json_response(request, API_CATALOG, "application/linkset+json")
+
+
+@all_silo_view
+@cache_control(max_age=3600, public=True)
+def oauth_authorization_server(request):
+    payload = {
+        **OAUTH_AUTHORIZATION_SERVER,
+        "scopes_supported": sorted(settings.SENTRY_SCOPES),
+    }
+    return _saas_only_json_response(request, payload)
+
+
+@all_silo_view
+@cache_control(max_age=3600, public=True)
+def oauth_protected_resource(request):
+    payload = {
+        **OAUTH_PROTECTED_RESOURCE,
+        "scopes_supported": sorted(settings.SENTRY_SCOPES),
+    }
+    return _saas_only_json_response(request, payload)
+
+
+@all_silo_view
+@cache_control(max_age=3600, public=True)
+def mcp_server_card(request):
+    return _saas_only_json_response(request, MCP_SERVER_CARD)
+
+
+@all_silo_view
+@cache_control(max_age=3600, public=True)
+def agent_skills_index(request):
+    return _saas_only_json_response(request, AGENT_SKILLS_INDEX)
 
 
 @all_silo_view

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -101,18 +101,12 @@ def mcp_json(request):
 API_CATALOG = {
     "linkset": [
         {
-            "anchor": "https://sentry.io/api/0/",
-            "rel": [{"href": "https://sentry.io/api/0/", "type": "application/json"}],
-        },
-        {
-            "anchor": "https://mcp.sentry.dev/mcp",
-            "rel": [
-                {
-                    "href": "https://mcp.sentry.dev/mcp",
-                    "type": "application/json",
-                }
+            "anchor": "https://sentry.io",
+            "item": [
+                {"href": "https://sentry.io/api/0/", "type": "application/json"},
+                {"href": "https://mcp.sentry.dev/mcp", "type": "application/json"},
             ],
-        },
+        }
     ]
 }
 

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -150,7 +150,7 @@ AGENT_SKILLS_INDEX: dict[str, list[object]] = {"skills": []}
 
 
 def _saas_only_json_response(request, payload, content_type="application/json"):
-    if settings.SENTRY_MODE == SentryMode.SELF_HOSTED or request.subdomain:
+    if settings.SENTRY_MODE != SentryMode.SAAS or request.subdomain:
         return HttpResponse(status=404)
     response = HttpResponse(json.dumps(payload), content_type=content_type)
     response["Access-Control-Allow-Origin"] = "*"

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -146,7 +146,7 @@ MCP_SERVER_CARD = {
     },
 }
 
-AGENT_SKILLS_INDEX = {"skills": []}
+AGENT_SKILLS_INDEX: dict[str, list[object]] = {"skills": []}
 
 
 def _saas_only_json_response(request, payload, content_type="application/json"):

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1272,6 +1272,31 @@ urlpatterns += [
         api.mcp_json,
         name="sentry-mcp-json",
     ),
+    re_path(
+        r"^\.well-known/api-catalog$",
+        api.api_catalog,
+        name="sentry-api-catalog",
+    ),
+    re_path(
+        r"^\.well-known/oauth-authorization-server$",
+        api.oauth_authorization_server,
+        name="sentry-oauth-authorization-server",
+    ),
+    re_path(
+        r"^\.well-known/oauth-protected-resource$",
+        api.oauth_protected_resource,
+        name="sentry-oauth-protected-resource",
+    ),
+    re_path(
+        r"^\.well-known/mcp/server-card\.json$",
+        api.mcp_server_card,
+        name="sentry-mcp-server-card",
+    ),
+    re_path(
+        r"^\.well-known/agent-skills/index\.json$",
+        api.agent_skills_index,
+        name="sentry-agent-skills-index",
+    ),
     # Force a 404 of favicon.ico.
     # This url is commonly requested by browsers, and without
     # blocking this, it was treated as a 200 OK for a react page view.

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -251,4 +251,10 @@ export const controlsiloUrlPatterns: RegExp[] = [
   new RegExp('^extensions/discord/configure/$'),
   new RegExp('^extensions/discord/link-identity/[^/]+/$'),
   new RegExp('^extensions/discord/unlink-identity/[^/]+/$'),
+  new RegExp('^\\.well-known/mcp\\.json$'),
+  new RegExp('^\\.well-known/api-catalog$'),
+  new RegExp('^\\.well-known/oauth-authorization-server$'),
+  new RegExp('^\\.well-known/oauth-protected-resource$'),
+  new RegExp('^\\.well-known/mcp/server-card\\.json$'),
+  new RegExp('^\\.well-known/agent-skills/index\\.json$'),
 ];

--- a/tests/apigw/test_routing.py
+++ b/tests/apigw/test_routing.py
@@ -43,7 +43,6 @@ KNOWN_MISLEADING = {
     "",
     "robots\\.txt",
     "\\.well-known/security\\.txt",
-    "\\.well-known/mcp\\.json",
     "favicon\\.ico",
     "plugins/github/installations/webhook/",
 }

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -16,7 +16,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
-from sentry.testutils.silo import assume_test_silo_mode, cell_silo_test, create_test_cells
+from sentry.testutils.silo import assume_test_silo_mode, cell_silo_test, control_silo_test, create_test_cells
 from sentry.utils import json
 
 
@@ -672,6 +672,7 @@ class ClientConfigViewTest(TestCase):
         assert data["customerDomain"] is None
 
 
+@control_silo_test
 class McpJsonTest(TestCase):
     @cached_property
     def path(self) -> str:
@@ -704,6 +705,7 @@ class McpJsonTest(TestCase):
         assert "public" in response["Cache-Control"]
 
 
+@control_silo_test
 class ApiCatalogTest(TestCase):
     def test_saas_mode(self) -> None:
         with override_settings(SENTRY_MODE="saas"):
@@ -741,6 +743,7 @@ class ApiCatalogTest(TestCase):
         assert response.status_code == 404
 
 
+@control_silo_test
 class OauthAuthorizationServerTest(TestCase):
     def test_saas_mode(self) -> None:
         with override_settings(SENTRY_MODE="saas"):
@@ -775,6 +778,7 @@ class OauthAuthorizationServerTest(TestCase):
         assert response.status_code == 404
 
 
+@control_silo_test
 class OauthProtectedResourceTest(TestCase):
     def test_saas_mode(self) -> None:
         with override_settings(SENTRY_MODE="saas"):
@@ -807,6 +811,7 @@ class OauthProtectedResourceTest(TestCase):
         assert response.status_code == 404
 
 
+@control_silo_test
 class McpServerCardTest(TestCase):
     def test_saas_mode(self) -> None:
         with override_settings(SENTRY_MODE="saas"):
@@ -838,6 +843,7 @@ class McpServerCardTest(TestCase):
         assert response.status_code == 404
 
 
+@control_silo_test
 class AgentSkillsIndexTest(TestCase):
     def test_saas_mode(self) -> None:
         with override_settings(SENTRY_MODE="saas"):

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -51,6 +51,7 @@ Disallow: /
         assert (
             response.content
             == b"""User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 Disallow: /api/
 Allow: /
 
@@ -58,6 +59,7 @@ Sitemap: https://sentry.io/sitemap-index.xml
 """
         )
         assert response["Content-Type"] == "text/plain"
+        assert b"Content-Signal:" in response.content
 
     def test_region_domain(self) -> None:
         HTTP_HOST = "us.testserver"
@@ -700,3 +702,161 @@ class McpJsonTest(TestCase):
         assert response.status_code == 200
         assert "max-age=3600" in response["Cache-Control"]
         assert "public" in response["Cache-Control"]
+
+
+class ApiCatalogTest(TestCase):
+    def test_saas_mode(self) -> None:
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get("/.well-known/api-catalog")
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/linkset+json"
+        assert response["Access-Control-Allow-Origin"] == "*"
+        assert "max-age=3600" in response["Cache-Control"]
+        assert "public" in response["Cache-Control"]
+        data = json.loads(response.content)
+        assert "linkset" in data
+
+    def test_self_hosted_mode(self) -> None:
+        with override_settings(SENTRY_MODE="self_hosted"):
+            response = self.client.get("/.well-known/api-catalog")
+        assert response.status_code == 404
+
+    def test_subdomain_returns_404(self) -> None:
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get(
+                "/.well-known/api-catalog", HTTP_HOST="albertos-apples.testserver"
+            )
+        assert response.status_code == 404
+
+
+class OauthAuthorizationServerTest(TestCase):
+    def test_saas_mode(self) -> None:
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get("/.well-known/oauth-authorization-server")
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/json"
+        assert response["Access-Control-Allow-Origin"] == "*"
+        assert "max-age=3600" in response["Cache-Control"]
+        assert "public" in response["Cache-Control"]
+        data = json.loads(response.content)
+        assert data["issuer"] == "https://sentry.io"
+        assert data["authorization_endpoint"] == "https://sentry.io/oauth/authorize/"
+        assert data["token_endpoint"] == "https://sentry.io/oauth/token/"
+        assert isinstance(data["scopes_supported"], list)
+        assert "org:read" in data["scopes_supported"]
+
+    def test_self_hosted_mode(self) -> None:
+        with override_settings(SENTRY_MODE="self_hosted"):
+            response = self.client.get("/.well-known/oauth-authorization-server")
+        assert response.status_code == 404
+
+    def test_subdomain_returns_404(self) -> None:
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get(
+                "/.well-known/oauth-authorization-server", HTTP_HOST="albertos-apples.testserver"
+            )
+        assert response.status_code == 404
+
+
+class OauthProtectedResourceTest(TestCase):
+    def test_saas_mode(self) -> None:
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get("/.well-known/oauth-protected-resource")
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/json"
+        assert response["Access-Control-Allow-Origin"] == "*"
+        assert "max-age=3600" in response["Cache-Control"]
+        assert "public" in response["Cache-Control"]
+        data = json.loads(response.content)
+        assert data["resource"] == "https://sentry.io"
+        assert isinstance(data["scopes_supported"], list)
+        assert "org:read" in data["scopes_supported"]
+
+    def test_self_hosted_mode(self) -> None:
+        with override_settings(SENTRY_MODE="self_hosted"):
+            response = self.client.get("/.well-known/oauth-protected-resource")
+        assert response.status_code == 404
+
+    def test_subdomain_returns_404(self) -> None:
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get(
+                "/.well-known/oauth-protected-resource", HTTP_HOST="albertos-apples.testserver"
+            )
+        assert response.status_code == 404
+
+
+class McpServerCardTest(TestCase):
+    def test_saas_mode(self) -> None:
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get("/.well-known/mcp/server-card.json")
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/json"
+        assert response["Access-Control-Allow-Origin"] == "*"
+        assert "max-age=3600" in response["Cache-Control"]
+        assert "public" in response["Cache-Control"]
+        data = json.loads(response.content)
+        assert data["name"] == "Sentry"
+        assert data["url"] == "https://mcp.sentry.dev/mcp"
+
+    def test_self_hosted_mode(self) -> None:
+        with override_settings(SENTRY_MODE="self_hosted"):
+            response = self.client.get("/.well-known/mcp/server-card.json")
+        assert response.status_code == 404
+
+    def test_subdomain_returns_404(self) -> None:
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get(
+                "/.well-known/mcp/server-card.json", HTTP_HOST="albertos-apples.testserver"
+            )
+        assert response.status_code == 404
+
+
+class AgentSkillsIndexTest(TestCase):
+    def test_saas_mode(self) -> None:
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get("/.well-known/agent-skills/index.json")
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/json"
+        assert response["Access-Control-Allow-Origin"] == "*"
+        assert "max-age=3600" in response["Cache-Control"]
+        assert "public" in response["Cache-Control"]
+        data = json.loads(response.content)
+        assert data == {"skills": []}
+
+    def test_self_hosted_mode(self) -> None:
+        with override_settings(SENTRY_MODE="self_hosted"):
+            response = self.client.get("/.well-known/agent-skills/index.json")
+        assert response.status_code == 404
+
+    def test_subdomain_returns_404(self) -> None:
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get(
+                "/.well-known/agent-skills/index.json", HTTP_HOST="albertos-apples.testserver"
+            )
+        assert response.status_code == 404
+
+
+class AgentDiscoveryMiddlewareTest(TestCase):
+    def test_html_response_gets_link_header(self) -> None:
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get("/")
+
+        assert "Link" in response
+        assert "api-catalog" in response["Link"]
+
+    def test_api_response_no_link_header(self) -> None:
+        with override_settings(SENTRY_MODE="saas"):
+            response = self.client.get("/api/0/")
+
+        assert "api-catalog" not in response.get("Link", "")
+
+    def test_self_hosted_no_link_header(self) -> None:
+        with override_settings(SENTRY_MODE="self_hosted"):
+            response = self.client.get("/")
+
+        assert "api-catalog" not in response.get("Link", "")

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -16,7 +16,12 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
-from sentry.testutils.silo import assume_test_silo_mode, cell_silo_test, control_silo_test, create_test_cells
+from sentry.testutils.silo import (
+    assume_test_silo_mode,
+    cell_silo_test,
+    control_silo_test,
+    create_test_cells,
+)
 from sentry.utils import json
 
 

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -716,6 +716,11 @@ class ApiCatalogTest(TestCase):
         assert "public" in response["Cache-Control"]
         data = json.loads(response.content)
         assert "linkset" in data
+        entry = data["linkset"][0]
+        assert entry["anchor"] == "https://sentry.io"
+        hrefs = [item["href"] for item in entry["item"]]
+        assert "https://sentry.io/api/0/" in hrefs
+        assert "https://mcp.sentry.dev/mcp" in hrefs
 
     def test_non_saas_mode_returns_404(self) -> None:
         with override_settings(SENTRY_MODE="self_hosted"):

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -717,8 +717,12 @@ class ApiCatalogTest(TestCase):
         data = json.loads(response.content)
         assert "linkset" in data
 
-    def test_self_hosted_mode(self) -> None:
+    def test_non_saas_mode_returns_404(self) -> None:
         with override_settings(SENTRY_MODE="self_hosted"):
+            response = self.client.get("/.well-known/api-catalog")
+        assert response.status_code == 404
+
+        with override_settings(SENTRY_MODE="single_tenant"):
             response = self.client.get("/.well-known/api-catalog")
         assert response.status_code == 404
 
@@ -747,8 +751,12 @@ class OauthAuthorizationServerTest(TestCase):
         assert isinstance(data["scopes_supported"], list)
         assert "org:read" in data["scopes_supported"]
 
-    def test_self_hosted_mode(self) -> None:
+    def test_non_saas_mode_returns_404(self) -> None:
         with override_settings(SENTRY_MODE="self_hosted"):
+            response = self.client.get("/.well-known/oauth-authorization-server")
+        assert response.status_code == 404
+
+        with override_settings(SENTRY_MODE="single_tenant"):
             response = self.client.get("/.well-known/oauth-authorization-server")
         assert response.status_code == 404
 
@@ -775,8 +783,12 @@ class OauthProtectedResourceTest(TestCase):
         assert isinstance(data["scopes_supported"], list)
         assert "org:read" in data["scopes_supported"]
 
-    def test_self_hosted_mode(self) -> None:
+    def test_non_saas_mode_returns_404(self) -> None:
         with override_settings(SENTRY_MODE="self_hosted"):
+            response = self.client.get("/.well-known/oauth-protected-resource")
+        assert response.status_code == 404
+
+        with override_settings(SENTRY_MODE="single_tenant"):
             response = self.client.get("/.well-known/oauth-protected-resource")
         assert response.status_code == 404
 
@@ -802,8 +814,12 @@ class McpServerCardTest(TestCase):
         assert data["name"] == "Sentry"
         assert data["url"] == "https://mcp.sentry.dev/mcp"
 
-    def test_self_hosted_mode(self) -> None:
+    def test_non_saas_mode_returns_404(self) -> None:
         with override_settings(SENTRY_MODE="self_hosted"):
+            response = self.client.get("/.well-known/mcp/server-card.json")
+        assert response.status_code == 404
+
+        with override_settings(SENTRY_MODE="single_tenant"):
             response = self.client.get("/.well-known/mcp/server-card.json")
         assert response.status_code == 404
 
@@ -828,8 +844,12 @@ class AgentSkillsIndexTest(TestCase):
         data = json.loads(response.content)
         assert data == {"skills": []}
 
-    def test_self_hosted_mode(self) -> None:
+    def test_non_saas_mode_returns_404(self) -> None:
         with override_settings(SENTRY_MODE="self_hosted"):
+            response = self.client.get("/.well-known/agent-skills/index.json")
+        assert response.status_code == 404
+
+        with override_settings(SENTRY_MODE="single_tenant"):
             response = self.client.get("/.well-known/agent-skills/index.json")
         assert response.status_code == 404
 
@@ -855,8 +875,11 @@ class AgentDiscoveryMiddlewareTest(TestCase):
 
         assert "api-catalog" not in response.get("Link", "")
 
-    def test_self_hosted_no_link_header(self) -> None:
+    def test_non_saas_no_link_header(self) -> None:
         with override_settings(SENTRY_MODE="self_hosted"):
             response = self.client.get("/")
+        assert "api-catalog" not in response.get("Link", "")
 
+        with override_settings(SENTRY_MODE="single_tenant"):
+            response = self.client.get("/")
         assert "api-catalog" not in response.get("Link", "")

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -726,10 +726,12 @@ class ApiCatalogTest(TestCase):
         with override_settings(SENTRY_MODE="self_hosted"):
             response = self.client.get("/.well-known/api-catalog")
         assert response.status_code == 404
+        assert "no-store" in response.get("Cache-Control", "")
 
         with override_settings(SENTRY_MODE="single_tenant"):
             response = self.client.get("/.well-known/api-catalog")
         assert response.status_code == 404
+        assert "no-store" in response.get("Cache-Control", "")
 
     def test_subdomain_returns_404(self) -> None:
         with override_settings(SENTRY_MODE="saas"):

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -870,8 +870,23 @@ class AgentDiscoveryMiddlewareTest(TestCase):
         assert "api-catalog" in response["Link"]
 
     def test_api_response_no_link_header(self) -> None:
+        from django.http import HttpRequest, HttpResponse
+
+        from sentry.middleware.agent_discovery import AgentDiscoveryMiddleware
+
+        inner_response = HttpResponse("ok", content_type="text/html")
+
+        def get_response(request):
+            return inner_response
+
+        middleware = AgentDiscoveryMiddleware(get_response)
+        request = HttpRequest()
+        request.method = "GET"
+        request.path = "/api/0/organizations/"
+        request.subdomain = None
+
         with override_settings(SENTRY_MODE="saas"):
-            response = self.client.get("/api/0/")
+            response = middleware(request)
 
         assert "api-catalog" not in response.get("Link", "")
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Extends robots and well-known to include files used by WebMCP being installed on the marketing site. The reason it's here is due to the shared domain. 

- Add Content-Signal directive to robots.txt for sentry.io
- Add five new .well-known endpoints: api-catalog, oauth-authorization-server, oauth-protected-resource, mcp/server-card.json, agent-skills/index.json
- All new endpoints return 404 for self-hosted and customer subdomains
- scopes_supported built dynamically from settings.SENTRY_SCOPES
- New AgentDiscoveryMiddleware appends Link header to SaaS HTML responses
- Tests cover all new endpoints and middleware behavior

Files changed:

src/sentry/web/api.py — Added Content-Signal line to ROBOTS_SENTRY_IO, plus 5 new view functions (api_catalog, oauth_authorization_server, oauth_protected_resource, mcp_server_card, agent_skills_index) with a shared _saas_only_json_response helper that handles self-hosted/subdomain 404s and sets Access-Control-Allow-Origin: *. scopes_supported is built dynamically from settings.SENTRY_SCOPES.
src/sentry/web/urls.py — Registered all 5 new .well-known routes adjacent to the existing mcp.json entry.
src/sentry/middleware/agent_discovery.py (new) — AgentDiscoveryMiddleware appends the Link discovery header to SaaS, non-subdomain, HTML responses (skips /api/* paths).
src/sentry/conf/server.py — Registered AgentDiscoveryMiddleware at the end of MIDDLEWARE.
tests/sentry/web/test_api.py — Updated test_saas_mode to assert the Content-Signal line, and added test classes for all 5 new endpoints (SaaS 200, self-hosted 404, subdomain 404, cache headers, CORS) plus AgentDiscoveryMiddlewareTest.

Related PRs:

- https://github.com/getsentry/getsentry/pull/20714 Since moving to `control_silo_view` this one won't be necessary.
- https://github.com/getsentry/static-sites/pull/4315

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
