### PR TITLE
docs(seer): Update GitLab MR limitation comment

### DIFF
--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -5,20 +5,20 @@ https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#merge-request
 Known limitations
 -----------------
 
-Code review does not fire in production yet: GitLab contributors are never seeded.
-``handle_merge_request_event`` runs ``CodeReviewPreflightService``, whose
-``_check_billing`` looks up ``OrganizationContributors`` by
+GitLab contributor seeding must run before this handler. ``handle_merge_request_event``
+runs ``CodeReviewPreflightService``, whose ``_check_billing`` looks up
+``OrganizationContributors`` by
 ``(organization_id, integration_id, external_identifier=str(author_id))`` and
-returns ``ORG_CONTRIBUTOR_NOT_FOUND`` (before the beta exemption) when the row is
-missing. GitHub creates that row via ``track_contributor_seat`` in
-``PullRequestEventWebhook._handle`` on PR creation; the GitLab merge-request path
-(PR persistence inline in ``MergeEventWebhook.__call__``) does not, and nothing
-else seeds GitLab contributors. Until contributor seeding is added, every GitLab MR
-is filtered with ``ORG_CONTRIBUTOR_NOT_FOUND``. The handler tests pass only because
-they seed the row manually.
+returns ``ORG_CONTRIBUTOR_NOT_FOUND`` when the row is missing. GitLab seeds that row
+through ``track_gitlab_contributor_seat_processor``, which
+``MergeEventWebhook.WEBHOOK_EVENT_PROCESSORS`` registers before this handler. If
+that ordering changes, the first MR open from a new contributor is filtered before
+the same delivery can seed the contributor.
 
-The code-review tests seed OrganizationContributors manually; consider a test that
-omits it to lock in the intended production behavior (related to Issue 1).
+Contributor seeding still depends on ``MergeEventWebhook.__call__`` reaching its
+processors and only runs for ``object_attributes.action == "open"``. Payloads that
+short-circuit before processor dispatch, such as MRs missing ``last_commit`` or the
+author email, do not seed the MR author; later ``update`` events do not backfill it.
 
 GitLab has no dedicated "ready_for_review" action: un-drafting an MR arrives as an
 "update" whose top-level ``changes`` flips draft/work_in_progress to false, which is


### PR DESCRIPTION
Refreshes the GitLab merge-request code-review known limitations comment so it matches the current contributor seeding path.

The comment now documents that `track_gitlab_contributor_seat_processor` must run before the code-review handler, and that payloads which short-circuit before processor dispatch still do not seed contributors.