### PR TITLE
fix(errors): Platform should be resolved to platform

### DIFF
--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -126,6 +126,15 @@ class Columns(Enum):
         issue_platform_name="platform",
         alias="platform.name",
     )
+    # Secondary alias for platform
+    PLATFORM_SECONDARY = Column(
+        group_name=None,
+        event_name="platform",
+        transaction_name=None,
+        discover_name=None,
+        issue_platform_name=None,
+        alias="platform",
+    )
     ENVIRONMENT = Column(
         group_name="events.environment",
         event_name="environment",

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -198,6 +198,30 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         assert response.status_code == 200, response.content
         assert [attrs for time, attrs in response.data["data"]] == [[{"count": 1}], [{"count": 2}]]
 
+    def test_errors_platform(self) -> None:
+        """Platform on errors should resolve to the column not the tag"""
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "very bad",
+                "timestamp": (self.day_ago + timedelta(minutes=1)).isoformat(),
+                "fingerprint": ["group1"],
+                "platform": "cocoa",
+            },
+            project_id=self.project.id,
+        )
+        response = self.do_request(
+            {
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(hours=2),
+                "interval": "1h",
+                "dataset": "errors",
+                "query": "platform:cocoa",
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert [attrs for time, attrs in response.data["data"]] == [[{"count": 1}], [{"count": 0}]]
+
     def test_errors_dataset_with_environment(self) -> None:
         environment = self.create_environment(project=self.project)
         self.store_event(

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1304,7 +1304,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
                     "event_id": f"{i + 1}" * 32,
                     "timestamp": (self.day_ago + timedelta(minutes=i + 1)).isoformat(),
                     "fingerprint": ["platform-collision-group"],
-                    "tags": {"platform": "SJ1"},
+                    "platform": "cocoa",
+                    "tags": {"platform": "cocoa"},
                 },
                 project_id=self.project.id,
             )
@@ -1318,7 +1319,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
                 "start": self.day_ago,
                 "end": self.day_ago + timedelta(hours=2),
                 "interval": "1h",
-                "query": f"issue:{group.qualified_short_id} platform:SJ1",
+                "query": f"issue:{group.qualified_short_id} platform:cocoa",
                 "dataset": "errors",
                 "yAxis": "count()",
             },

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1337,7 +1337,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
                 "start": self.day_ago,
                 "end": self.day_ago + timedelta(hours=2),
                 "interval": "1h",
-                "query": f"issue:{group.qualified_short_id} tags[platform]:SJ1",
+                "query": f"issue:{group.qualified_short_id} tags[platform]:cocoa",
                 "dataset": "errors",
                 "yAxis": "count()",
             },


### PR DESCRIPTION
- currently its resolving to tags[platform] which causes issues if the sdk doesn't also send it as a tag
- Still not sure why we've decided to resolve columns differently on errors between the timeseries and table queries :shrug: