### PR TITLE
ref(seer): Type filter-key RPC responses with Pydantic models

### DIFF
--- a/src/sentry/seer/assisted_query/discover_tools.py
+++ b/src/sentry/seer/assisted_query/discover_tools.py
@@ -6,6 +6,12 @@ from sentry.api.client import ApiClient
 from sentry.constants import ALL_ACCESS_PROJECT_ID
 from sentry.models.apikey import ApiKey
 from sentry.models.organization import Organization
+from sentry.seer.sentry_data_models import (
+    EventFilterKeyEntry,
+    EventFilterKeysResponse,
+    EventFilterKeyValue,
+    EventFilterKeyValuesResponse,
+)
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 
@@ -165,7 +171,7 @@ def get_event_filter_keys(
     start: str | None = None,
     end: str | None = None,
     include_feature_flags: bool = False,
-) -> dict[str, dict[str, Any]] | None:
+) -> EventFilterKeysResponse | None:
     """
     Get available event filter keys for the "errors" dataset (tags, feature flags, and static fields). This mirrors the
     behavior of Discover search bar suggestions in the frontend.
@@ -197,14 +203,14 @@ def get_event_filter_keys(
         include_feature_flags=include_feature_flags,
     )
 
-    result = {}
+    result: dict[str, EventFilterKeyEntry] = {}
     for k in tag_keys | always_fields:  # deduplicate
-        result[k] = {"type": _SPECIAL_FIELD_VALUE_TYPES.get(k, "tag")}
+        result[k] = EventFilterKeyEntry(type=_SPECIAL_FIELD_VALUE_TYPES.get(k, "tag"))
 
     for k in flag_keys:
-        result[k] = {"type": "feature_flag"}
+        result[k] = EventFilterKeyEntry(type="feature_flag")
 
-    return result
+    return EventFilterKeysResponse(__root__=result)
 
 
 def get_event_filter_key_values(
@@ -216,7 +222,7 @@ def get_event_filter_key_values(
     stats_period: str | None = None,
     start: str | None = None,
     end: str | None = None,
-) -> list[dict[str, Any]] | None:
+) -> EventFilterKeyValuesResponse | None:
     """
     Get values for a specific filter key.
 
@@ -255,7 +261,9 @@ def get_event_filter_key_values(
 
     predefined_values = _get_static_values(filter_key)
     if predefined_values is not None:
-        return predefined_values
+        return EventFilterKeyValuesResponse(
+            __root__=[EventFilterKeyValue(**v) for v in predefined_values]
+        )
 
     if filter_key == "has":
         tag_keys, _ = _get_tag_and_feature_flag_keys(
@@ -267,7 +275,9 @@ def get_event_filter_key_values(
             end=end,
             include_feature_flags=False,
         )
-        return [{"value": t} for t in tag_keys]
+        return EventFilterKeyValuesResponse(
+            __root__=[EventFilterKeyValue(value=t) for t in tag_keys]
+        )
 
     api_key = ApiKey(
         organization_id=organization.id, scope_list=["org:read", "project:read", "event:read"]
@@ -306,7 +316,11 @@ def get_event_filter_key_values(
 
     data = resp.data or []
 
-    return [
-        {k: item[k] for k in item if k in ["value", "count", "lastSeen", "firstSeen"]}
-        for item in data
-    ]
+    return EventFilterKeyValuesResponse(
+        __root__=[
+            EventFilterKeyValue(
+                **{k: item[k] for k in item if k in ["value", "count", "lastSeen", "firstSeen"]}
+            )
+            for item in data
+        ]
+    )

--- a/src/sentry/seer/assisted_query/issues_tools.py
+++ b/src/sentry/seer/assisted_query/issues_tools.py
@@ -10,6 +10,12 @@ from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.release import Release
 from sentry.models.team import Team, TeamStatus
 from sentry.seer.autofix.constants import FixabilityScoreThresholds
+from sentry.seer.sentry_data_models import (
+    FilterKeyValuesResponse,
+    IssueFilterBuiltInField,
+    IssueFilterKeysResponse,
+    TagFilterKeyValue,
+)
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.types.group import PriorityLevel
@@ -418,7 +424,7 @@ def get_issue_filter_keys(
     stats_period: str | None = None,
     start: str | None = None,
     end: str | None = None,
-) -> dict[str, Any] | None:
+) -> IssueFilterKeysResponse | None:
     """
     Get available issue filter keys (tags, feature flags, and built-in fields).
 
@@ -510,11 +516,11 @@ def get_issue_filter_keys(
     tag_keys = [tag.get("key") for tag in tags if tag.get("key")]
     built_in_fields = _get_built_in_issue_fields(organization, project_ids, tag_keys)
 
-    return {
-        "tags": tags,
-        "feature_flags": feature_flags,
-        "built_in_fields": built_in_fields,
-    }
+    return IssueFilterKeysResponse(
+        tags=tags,
+        feature_flags=feature_flags,
+        built_in_fields=[IssueFilterBuiltInField(**f) for f in built_in_fields],
+    )
 
 
 def get_filter_key_values(
@@ -526,7 +532,7 @@ def get_filter_key_values(
     stats_period: str | None = None,
     start: str | None = None,
     end: str | None = None,
-) -> list[dict[str, Any]] | None:
+) -> FilterKeyValuesResponse | None:
     """
     Get values for a specific filter key.
 
@@ -568,9 +574,7 @@ def get_filter_key_values(
             org_id=org_id, project_ids=project_ids, stats_period=stats_period, start=start, end=end
         )
         if filter_keys_result:
-            tag_keys = [
-                tag.get("key") for tag in filter_keys_result.get("tags", []) if tag.get("key")
-            ]
+            tag_keys = [key for tag in filter_keys_result.tags if (key := tag.get("key"))]
 
     built_in_values = _get_built_in_field_values(attribute_key, organization, project_ids, tag_keys)
     if built_in_values is not None:
@@ -579,7 +583,7 @@ def get_filter_key_values(
             built_in_values = [
                 val for val in built_in_values if substring.lower() in val.get("value", "").lower()
             ]
-        return built_in_values
+        return FilterKeyValuesResponse(__root__=[TagFilterKeyValue(**v) for v in built_in_values])
 
     # Not a built-in field, query tags endpoint
     api_key = ApiKey(organization_id=organization.id, scope_list=API_KEY_SCOPES)
@@ -655,7 +659,7 @@ def get_filter_key_values(
 
     result = list(merged.values())
     result.sort(key=lambda x: x["count"], reverse=True)
-    return result
+    return FilterKeyValuesResponse(__root__=[TagFilterKeyValue(**v) for v in result])
 
 
 def execute_issues_query(

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -270,10 +270,13 @@ class EventFilterKeysResponse(BaseModel):
 class EventFilterKeyValue(BaseModel):
     # Subset of TagValueSerializerResponse — `get_event_filter_key_values` filters
     # the upstream dict to these four keys, so the wire shape only carries them.
-    # `lastSeen`/`firstSeen` arrive from the tags API as `datetime` objects and
-    # are stringified by DRF's JSON renderer at the dispatcher edge — typed as
-    # `Any` here so Pydantic doesn't reject the pre-render value.
-    value: str
+    # `value` matches `TagValueSerializerResponse.value` (`str | None`); the
+    # tag-values endpoint can return `value: null` and the pre-typed code passed
+    # those rows through verbatim. `lastSeen`/`firstSeen` arrive from the tags
+    # API as `datetime` objects and are stringified by DRF's JSON renderer at the
+    # dispatcher edge — typed as `Any` so Pydantic doesn't reject the pre-render
+    # value.
+    value: str | None
     count: int | None = None
     lastSeen: Any = None
     firstSeen: Any = None

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -253,3 +253,105 @@ class RepositoryDefinitionResponse(BaseModel):
     owner: str
     name: str
     external_id: str | None
+
+
+class EventFilterKeyEntry(BaseModel):
+    type: str
+
+
+class EventFilterKeysResponse(BaseModel):
+    __root__: dict[str, EventFilterKeyEntry]
+
+    def dict(self, **kwargs: Any) -> Any:
+        # Unwrap to the bare `{key: {...}}` map the seer caller expects.
+        return {k: v.dict(**kwargs) for k, v in self.__root__.items()}
+
+
+class EventFilterKeyValue(BaseModel):
+    # Subset of TagValueSerializerResponse — `get_event_filter_key_values` filters
+    # the upstream dict to these four keys, so the wire shape only carries them.
+    value: str
+    count: int | None = None
+    lastSeen: str | None = None
+    firstSeen: str | None = None
+
+
+class EventFilterKeyValuesResponse(BaseModel):
+    __root__: list[EventFilterKeyValue]
+
+    def dict(self, **kwargs: Any) -> Any:
+        # Built-in / static paths return `[{"value": x}]` — `exclude_unset` keeps the
+        # output minimal so count/lastSeen/firstSeen don't appear as None.
+        kwargs.setdefault("exclude_unset", True)
+        return [v.dict(**kwargs) for v in self.__root__]
+
+    # List-like proxy: callers iterate the response as if it were the underlying
+    # `list[dict]` it serializes to. The wire shape lives in `.dict()`.
+    def __iter__(self) -> Any:
+        return iter(self.dict())
+
+    def __len__(self) -> int:
+        return len(self.__root__)
+
+    def __getitem__(self, idx: int) -> Any:
+        return self.dict()[idx]
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, list):
+            return self.dict() == other
+        return super().__eq__(other)
+
+    def __hash__(self) -> int:
+        return id(self)
+
+
+class TagFilterKeyValue(BaseModel):
+    # Full TagValueSerializerResponse shape. Built-in static results may only carry
+    # `value`; tag/feature-flag merges fill in the rest. Field-declaration order
+    # mirrors `TagValueSerializerResponse` so the wire byte order is preserved.
+    key: str | None = None
+    name: str | None = None
+    value: str
+    count: int | None = None
+    lastSeen: str | None = None
+    firstSeen: str | None = None
+    query: str | None = None
+
+
+class FilterKeyValuesResponse(BaseModel):
+    __root__: list[TagFilterKeyValue]
+
+    def dict(self, **kwargs: Any) -> Any:
+        kwargs.setdefault("exclude_unset", True)
+        return [v.dict(**kwargs) for v in self.__root__]
+
+    def __iter__(self) -> Any:
+        return iter(self.dict())
+
+    def __len__(self) -> int:
+        return len(self.__root__)
+
+    def __getitem__(self, idx: int) -> Any:
+        return self.dict()[idx]
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, list):
+            return self.dict() == other
+        return super().__eq__(other)
+
+    def __hash__(self) -> int:
+        return id(self)
+
+
+class IssueFilterBuiltInField(BaseModel):
+    key: str
+    values: list[str]
+
+
+class IssueFilterKeysResponse(BaseModel):
+    # `tags`/`feature_flags` items are the `TagKeySerializerResponse` shape passed
+    # through verbatim from the tags API. Top-level field names are typed for SDK
+    # consumers; item shape stays opaque to preserve the upstream wire bytes.
+    tags: list[dict[str, Any]]
+    feature_flags: list[dict[str, Any]]
+    built_in_fields: list[IssueFilterBuiltInField]

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -270,10 +270,13 @@ class EventFilterKeysResponse(BaseModel):
 class EventFilterKeyValue(BaseModel):
     # Subset of TagValueSerializerResponse — `get_event_filter_key_values` filters
     # the upstream dict to these four keys, so the wire shape only carries them.
+    # `lastSeen`/`firstSeen` arrive from the tags API as `datetime` objects and
+    # are stringified by DRF's JSON renderer at the dispatcher edge — typed as
+    # `Any` here so Pydantic doesn't reject the pre-render value.
     value: str
     count: int | None = None
-    lastSeen: str | None = None
-    firstSeen: str | None = None
+    lastSeen: Any = None
+    firstSeen: Any = None
 
 
 class EventFilterKeyValuesResponse(BaseModel):
@@ -309,12 +312,14 @@ class TagFilterKeyValue(BaseModel):
     # Full TagValueSerializerResponse shape. Built-in static results may only carry
     # `value`; tag/feature-flag merges fill in the rest. Field-declaration order
     # mirrors `TagValueSerializerResponse` so the wire byte order is preserved.
+    # `lastSeen`/`firstSeen` arrive as `datetime` objects pre-render — see
+    # `EventFilterKeyValue` for the rationale on `Any`.
     key: str | None = None
     name: str | None = None
     value: str
     count: int | None = None
-    lastSeen: str | None = None
-    firstSeen: str | None = None
+    lastSeen: Any = None
+    firstSeen: Any = None
     query: str | None = None
 
 

--- a/tests/sentry/seer/assisted_query/test_discover_tools.py
+++ b/tests/sentry/seer/assisted_query/test_discover_tools.py
@@ -4,6 +4,10 @@ from sentry.seer.assisted_query.discover_tools import (
     get_event_filter_key_values,
     get_event_filter_keys,
 )
+from sentry.seer.sentry_data_models import (
+    EventFilterKeysResponse,
+    EventFilterKeyValuesResponse,
+)
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 
@@ -48,23 +52,24 @@ class TestGetEventFilterKeys(APITestCase, SnubaTestCase):
             stats_period="7d",
         )
 
-        assert result is not None
+        assert isinstance(result, EventFilterKeysResponse)
+        result_d = result.dict()
 
         # Check tags
         for k in ["fruit", "color"]:
-            assert k in result
-            assert result[k]["type"] == "tag"
+            assert k in result_d
+            assert result_d[k]["type"] == "tag"
 
         # Check feature flags
         for k in ["feature_a", "feature_b"]:
-            assert k in result
-            assert result[k]["type"] == "feature_flag"
+            assert k in result_d
+            assert result_d[k]["type"] == "feature_flag"
 
         # Check always-return fields
         for k in _ALWAYS_RETURN_EVENT_FIELDS:
-            assert k in result
+            assert k in result_d
             expected_type = _SPECIAL_FIELD_VALUE_TYPES.get(k, "tag")
-            assert result[k]["type"] == expected_type
+            assert result_d[k]["type"] == expected_type
 
     def test_get_event_filter_keys_exclude_feature_flags(self) -> None:
         """Test that get_event_filter_keys excludes feature flags when include_feature_flags is False"""
@@ -101,22 +106,23 @@ class TestGetEventFilterKeys(APITestCase, SnubaTestCase):
             stats_period="7d",
         )
 
-        assert result is not None
+        assert isinstance(result, EventFilterKeysResponse)
+        result_d = result.dict()
 
         # Check tags
         for k in ["fruit", "color"]:
-            assert k in result
-            assert result[k]["type"] == "tag"
+            assert k in result_d
+            assert result_d[k]["type"] == "tag"
 
         # Check feature flags not present
         for k in ["feature_a", "feature_b"]:
-            assert k not in result
+            assert k not in result_d
 
         # Check always-return fields
         for k in _ALWAYS_RETURN_EVENT_FIELDS:
-            assert k in result
+            assert k in result_d
             expected_type = _SPECIAL_FIELD_VALUE_TYPES.get(k, "tag")
-            assert result[k]["type"] == expected_type
+            assert result_d[k]["type"] == expected_type
 
     def test_get_event_filter_keys_multiple_projects(self) -> None:
         """Test with multiple projects"""
@@ -149,9 +155,10 @@ class TestGetEventFilterKeys(APITestCase, SnubaTestCase):
                 stats_period="7d",
             )
 
-            assert result is not None
-            assert "project1_tag" in result
-            assert "project2_tag" in result
+            assert isinstance(result, EventFilterKeysResponse)
+            result_d = result.dict()
+            assert "project1_tag" in result_d
+            assert "project2_tag" in result_d
 
 
 class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
@@ -194,23 +201,24 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             stats_period="7d",
         )
 
-        assert result is not None
-        assert len(result) > 0
+        assert isinstance(result, EventFilterKeyValuesResponse)
+        items = result.dict()
+        assert len(items) > 0
 
         # Check structure of returned values
-        for item in result:
+        for item in items:
             assert "value" in item
             assert "count" in item
             assert "lastSeen" in item
             assert "firstSeen" in item
 
         # Check that we have our environment values
-        values = {item["value"] for item in result}
+        values = {item["value"] for item in items}
         assert "production" in values
         assert "staging" in values
 
         # Check counts
-        value_counts = {item["value"]: item["count"] for item in result}
+        value_counts = {item["value"]: item["count"] for item in items}
         assert value_counts["production"] == 2
         assert value_counts["staging"] == 1
 
@@ -251,17 +259,18 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             stats_period="7d",
         )
 
-        assert result is not None
-        assert len(result) == 2
+        assert isinstance(result, EventFilterKeyValuesResponse)
+        items = result.dict()
+        assert len(items) == 2
 
-        for item in result:
+        for item in items:
             assert "value" in item
             assert "count" in item
             assert "lastSeen" in item
             assert "firstSeen" in item
             assert item["count"] == 1
 
-        values = {item["value"] for item in result}
+        values = {item["value"] for item in items}
         assert "true" in values
         assert "false" in values
 
@@ -284,10 +293,10 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             stats_period="7d",
         )
 
-        assert result is not None
-        assert isinstance(result, list)
-        assert len(result) > 0
-        values = {item["value"] for item in result}
+        assert isinstance(result, EventFilterKeyValuesResponse)
+        items = result.dict()
+        assert len(items) > 0
+        values = {item["value"] for item in items}
         assert "custom_tag" in values
         assert "custom2" in values
 
@@ -300,7 +309,8 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             stats_period="7d",
         )
 
-        assert result == []
+        assert isinstance(result, EventFilterKeyValuesResponse)
+        assert result.dict() == []
 
     def test_get_event_filter_key_values_with_substring_filter(self) -> None:
         """Test substring filtering of filter key values"""
@@ -347,12 +357,12 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             stats_period="7d",
         )
 
-        assert result is not None
-        assert isinstance(result, list)
-        assert len(result) > 0
+        assert isinstance(result, EventFilterKeyValuesResponse)
+        items = result.dict()
+        assert len(items) > 0
 
         # Should only contain values with "prod" in them
-        values = {item["value"] for item in result}
+        values = {item["value"] for item in items}
         assert "production" in values
         assert "production-eu" in values
         assert "staging" not in values
@@ -367,7 +377,8 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             stats_period="7d",
         )
         # Should return empty list, not None
-        assert result == []
+        assert isinstance(result, EventFilterKeyValuesResponse)
+        assert result.dict() == []
 
     def test_get_event_filter_key_values_multiple_projects(self) -> None:
         """Test getting filter key values across multiple projects"""
@@ -400,12 +411,12 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
                 stats_period="7d",
             )
 
-            assert result is not None
-            assert isinstance(result, list)
-            assert len(result) > 0
+            assert isinstance(result, EventFilterKeyValuesResponse)
+            items = result.dict()
+            assert len(items) > 0
 
             # Should have values from both projects
-            values = {item["value"] for item in result}
+            values = {item["value"] for item in items}
             assert "us-east" in values
             assert "us-west" in values
 
@@ -448,11 +459,11 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
             stats_period="7d",
         )
 
-        assert result_1d is not None
-        assert result_7d is not None
+        assert isinstance(result_1d, EventFilterKeyValuesResponse)
+        assert isinstance(result_7d, EventFilterKeyValuesResponse)
 
-        values_1d = {item["value"] for item in result_1d}
-        values_7d = {item["value"] for item in result_7d}
+        values_1d = {item["value"] for item in result_1d.dict()}
+        values_7d = {item["value"] for item in result_7d.dict()}
 
         # Recent value should be in both
         assert "new_value" in values_1d
@@ -461,3 +472,35 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
         # Old value should only be in 7d results
         assert "old_value" not in values_1d
         assert "old_value" in values_7d
+
+
+class TestEventFilterWireIdentity:
+    """The seer-side codegen consumes `model.dict()` as the wire shape, so a
+    drifting Pydantic serialization breaks downstream callers silently. These
+    tests pin the JSON-byte-equivalence between the pre-typed dict and the
+    typed model for every documented return path."""
+
+    def test_event_filter_keys_response_is_bare_map(self) -> None:
+        from sentry.seer.sentry_data_models import EventFilterKeyEntry
+
+        src = {
+            "fruit": {"type": "tag"},
+            "feature_a": {"type": "feature_flag"},
+            "timestamp": {"type": "datetime"},
+        }
+        m = EventFilterKeysResponse(__root__={k: EventFilterKeyEntry(**v) for k, v in src.items()})
+        assert m.dict() == src
+
+    def test_event_filter_key_values_filtered_shape(self) -> None:
+        from typing import Any
+
+        from sentry.seer.sentry_data_models import EventFilterKeyValue
+
+        # discover_tools.py filters the upstream TagValueSerializerResponse to
+        # these four keys; missing keys (e.g. built-in "has") stay missing.
+        src: list[dict[str, Any]] = [
+            {"value": "prod", "count": 5, "lastSeen": "2024-01", "firstSeen": "2023-01"},
+            {"value": "staging"},
+        ]
+        m = EventFilterKeyValuesResponse(__root__=[EventFilterKeyValue(**d) for d in src])
+        assert m.dict() == src

--- a/tests/sentry/seer/assisted_query/test_issues_tools.py
+++ b/tests/sentry/seer/assisted_query/test_issues_tools.py
@@ -11,6 +11,10 @@ from sentry.seer.assisted_query.issues_tools import (
     get_issue_filter_keys,
     get_issues_stats,
 )
+from sentry.seer.sentry_data_models import (
+    FilterKeyValuesResponse,
+    IssueFilterKeysResponse,
+)
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
@@ -71,13 +75,10 @@ class TestGetIssueFilterKeys(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             stats_period="7d",
         )
 
-        assert result is not None
-        assert "tags" in result
-        assert "feature_flags" in result
+        assert isinstance(result, IssueFilterKeysResponse)
 
         # Check tags (merged event_tags and issue_tags)
-        tags = result["tags"]
-        assert isinstance(tags, list)
+        tags = result.tags
         assert len(tags) > 0
         # Verify structure of tags
         for tag in tags:
@@ -91,8 +92,7 @@ class TestGetIssueFilterKeys(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert "color" in tag_keys
 
         # Check feature flags
-        feature_flags = result["feature_flags"]
-        assert isinstance(feature_flags, list)
+        feature_flags = result.feature_flags
         if len(feature_flags) > 0:
             for flag in feature_flags:
                 assert "key" in flag
@@ -119,12 +119,10 @@ class TestGetIssueFilterKeys(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             project_ids=[],
             stats_period="7d",
         )
-        assert result is not None
-        assert "tags" in result
-        assert "feature_flags" in result
+        assert isinstance(result, IssueFilterKeysResponse)
         # Should return empty or minimal results
-        assert isinstance(result["tags"], list)
-        assert isinstance(result["feature_flags"], list)
+        assert isinstance(result.tags, list)
+        assert isinstance(result.feature_flags, list)
 
     def test_get_issue_filter_keys_multiple_projects(self) -> None:
         """Test with multiple projects"""
@@ -155,11 +153,9 @@ class TestGetIssueFilterKeys(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             stats_period="7d",
         )
 
-        assert result is not None
-        assert "tags" in result
+        assert isinstance(result, IssueFilterKeysResponse)
 
-        tags = result["tags"]
-        tag_keys = {tag["key"] for tag in tags}
+        tag_keys = {tag["key"] for tag in result.tags}
         # Both project tags should be present
         assert "project1_tag" in tag_keys
         assert "project2_tag" in tag_keys
@@ -208,12 +204,12 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             stats_period="7d",
         )
 
-        assert result is not None
-        assert isinstance(result, list)
-        assert len(result) > 0
+        assert isinstance(result, FilterKeyValuesResponse)
+        items = result.dict()
+        assert len(items) > 0
 
         # Check structure of returned values
-        for item in result:
+        for item in items:
             assert "key" in item
             assert "name" in item
             assert "value" in item
@@ -222,12 +218,12 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             assert "firstSeen" in item
 
         # Check that we have our environment values
-        values = {item["value"] for item in result}
+        values = {item["value"] for item in items}
         assert "production" in values
         assert "staging" in values
 
         # Check counts
-        value_counts = {item["value"]: item["count"] for item in result}
+        value_counts = {item["value"]: item["count"] for item in items}
         assert value_counts["production"] == 2
         assert value_counts["staging"] == 1
 
@@ -264,11 +260,11 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             stats_period="7d",
         )
 
-        assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, FilterKeyValuesResponse)
+        items = result.dict()
         # Should have our issue_type values
-        if len(result) > 0:
-            for item in result:
+        if len(items) > 0:
+            for item in items:
                 assert "key" in item
                 assert "value" in item
                 assert "count" in item
@@ -311,11 +307,11 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             stats_period="7d",
         )
 
-        assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, FilterKeyValuesResponse)
+        items = result.dict()
         # Should have flag values
-        if len(result) > 0:
-            for item in result:
+        if len(items) > 0:
+            for item in items:
                 assert "key" in item
                 assert "value" in item
                 assert "count" in item
@@ -339,7 +335,8 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             stats_period="7d",
         )
         # Should return empty list, not None
-        assert result == []
+        assert isinstance(result, FilterKeyValuesResponse)
+        assert result.dict() == []
 
     def test_get_filter_key_values_multiple_projects(self) -> None:
         """Test getting filter key values across multiple projects"""
@@ -370,12 +367,12 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             stats_period="7d",
         )
 
-        assert result is not None
-        assert isinstance(result, list)
-        assert len(result) > 0
+        assert isinstance(result, FilterKeyValuesResponse)
+        items = result.dict()
+        assert len(items) > 0
 
         # Should have values from both projects
-        values = {item["value"] for item in result}
+        values = {item["value"] for item in items}
         assert "us-east" in values
         assert "us-west" in values
 
@@ -428,12 +425,12 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             stats_period="7d",
         )
 
-        assert result is not None
-        assert isinstance(result, list)
-        assert len(result) > 0
+        assert isinstance(result, FilterKeyValuesResponse)
+        items = result.dict()
+        assert len(items) > 0
 
         # Check that "backend" appears once but with merged count
-        value_counts = {item["value"]: item["count"] for item in result}
+        value_counts = {item["value"]: item["count"] for item in items}
 
         # "backend" should appear in both events (2x) and search_issues (1x)
         # The merge should combine these counts
@@ -444,7 +441,7 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert value_counts["backend"] >= value_counts["frontend"]
 
         # Verify results are sorted by count (descending)
-        counts = [item["count"] for item in result]
+        counts = [item["count"] for item in items]
         assert counts == sorted(counts, reverse=True), (
             "Results should be sorted by count descending"
         )
@@ -494,12 +491,12 @@ class TestGetFilterKeyValues(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             stats_period="7d",
         )
 
-        assert result is not None
-        assert isinstance(result, list)
-        assert len(result) > 0
+        assert isinstance(result, FilterKeyValuesResponse)
+        items = result.dict()
+        assert len(items) > 0
 
         # Should only contain values with "prod" in them
-        values = {item["value"] for item in result}
+        values = {item["value"] for item in items}
         assert "production" in values
         assert "production-eu" in values
         assert "staging" not in values
@@ -546,7 +543,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         assert len(result) >= 2
 
         # Check structure of returned issues
@@ -578,7 +575,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         # Should have at least our error event
         assert len(result) >= 1
 
@@ -605,7 +602,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         assert len(result) >= 3
 
     def test_execute_issues_query_with_limit(self) -> None:
@@ -630,7 +627,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         # Should respect limit
         assert len(result) <= 2
 
@@ -674,7 +671,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         # Should have issues from both projects
         assert len(result) >= 2
         project_ids = {issue["project"]["id"] for issue in result}
@@ -721,7 +718,7 @@ class TestGetIssuesStats(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         assert len(result) == 2
 
         # Verify each stat has the expected fields
@@ -801,7 +798,7 @@ class TestGetIssuesStats(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         # Should return stats for both issues
         assert len(result) >= 2
         returned_issue_ids = {stat["id"] for stat in result}
@@ -831,7 +828,7 @@ class TestGetIssuesStats(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         assert len(result) == 0
 
     def test_get_issues_stats_stats_and_lifetime_structure(self) -> None:
@@ -997,8 +994,8 @@ class TestEventContextFields(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert "built_in_fields" in result
-        built_in_fields = result["built_in_fields"]
+        assert isinstance(result, IssueFilterKeysResponse)
+        built_in_fields = [f.dict() for f in result.built_in_fields]
 
         # Get all built-in field keys
         built_in_keys = {field["key"] for field in built_in_fields}
@@ -1060,8 +1057,8 @@ class TestEventContextFields(APITestCase, SnubaTestCase):
             stats_period="7d",
         )
 
-        assert result is not None
-        built_in_fields = result["built_in_fields"]
+        assert isinstance(result, IssueFilterKeysResponse)
+        built_in_fields = [f.dict() for f in result.built_in_fields]
 
         # Find the error.handled field
         error_handled_field = next(
@@ -1085,8 +1082,8 @@ class TestEventContextFields(APITestCase, SnubaTestCase):
             stats_period="7d",
         )
 
-        assert result is not None
-        built_in_fields = result["built_in_fields"]
+        assert isinstance(result, IssueFilterKeysResponse)
+        built_in_fields = [f.dict() for f in result.built_in_fields]
 
         # Find the device.class field
         device_class_field = next((f for f in built_in_fields if f["key"] == "device.class"), None)
@@ -1213,7 +1210,7 @@ class TestGetFilterKeyValuesTextFields(APITestCase, SnubaTestCase):
 
         # Should return actual message values from events, not empty or None
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         # The API should return values (may be empty if message isn't indexed as a tag)
         # At minimum, verify we got a list back (not None which would indicate built-in handling)
 
@@ -1256,7 +1253,7 @@ class TestGetFilterKeyValuesTextFields(APITestCase, SnubaTestCase):
 
         # Should return a list (API was queried, not short-circuited)
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
 
     def test_get_filter_key_values_title_field(self) -> None:
         """Test that title field queries the API and returns actual event titles"""
@@ -1288,7 +1285,7 @@ class TestGetFilterKeyValuesTextFields(APITestCase, SnubaTestCase):
 
         # Should return a list (API was queried)
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
 
     def test_get_filter_key_values_location_field(self) -> None:
         """Test that location field queries the API"""
@@ -1329,7 +1326,7 @@ class TestGetFilterKeyValuesTextFields(APITestCase, SnubaTestCase):
 
         # Should return a list (API was queried)
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
 
     def test_text_fields_not_in_field_value_types(self) -> None:
         """Verify text fields are not in _FIELD_VALUE_TYPES so they fall through to API query"""
@@ -1372,7 +1369,7 @@ class TestGetFilterKeyValuesTextFields(APITestCase, SnubaTestCase):
 
         # Should return a list with actual release values
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         # Release is a common tag so it should have values
         if len(result) > 0:
             values = {item["value"] for item in result}
@@ -1398,7 +1395,7 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         assert len(result) > 0
 
         values = [item["value"] for item in result]
@@ -1421,7 +1418,7 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         assert len(result) > 0
 
         values = [item["value"] for item in result]
@@ -1456,7 +1453,7 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         # Should have usernames (at least the test user)
 
     def test_get_filter_key_values_subscribed_field(self) -> None:
@@ -1469,7 +1466,7 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
 
     def test_get_filter_key_values_assigned_with_substring_filter(self) -> None:
         """Test that substring filtering works on assigned field"""
@@ -1482,7 +1479,7 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         # Should only include values containing "my_"
         for item in result:
             assert "my_" in item["value"].lower()
@@ -1499,8 +1496,8 @@ class TestAssigneeAndUsernameValues(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert "built_in_fields" in result
-        built_in_fields = result["built_in_fields"]
+        assert isinstance(result, IssueFilterKeysResponse)
+        built_in_fields = [f.dict() for f in result.built_in_fields]
 
         # Find the assigned field
         assigned_field = next((f for f in built_in_fields if f["key"] == "assigned"), None)
@@ -1574,7 +1571,7 @@ class TestReleaseFieldValues(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         values = [item["value"] for item in result]
         assert release1.version in values
         assert release2.version in values
@@ -1592,7 +1589,7 @@ class TestReleaseFieldValues(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, list)
+        assert isinstance(result, (list, FilterKeyValuesResponse))
         values = [item["value"] for item in result]
         assert release1.version in values
 
@@ -1642,8 +1639,8 @@ class TestReleaseFieldValues(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert "built_in_fields" in result
-        built_in_fields = result["built_in_fields"]
+        assert isinstance(result, IssueFilterKeysResponse)
+        built_in_fields = [f.dict() for f in result.built_in_fields]
 
         # Find the release field
         release_field = next((f for f in built_in_fields if f["key"] == "release"), None)


### PR DESCRIPTION
Types the assisted-query filter-key cluster — `get_event_filter_keys`,
`get_event_filter_key_values`, `get_issue_filter_keys`, and
`get_filter_key_values` — with explicit Pydantic response models.

Wire-identical: `__root__`-based passthroughs preserve the bare map / list
shape, and `exclude_unset` keeps optional `count`/`lastSeen`/`firstSeen`/`query`
keys absent from the JSON when the source dict didn't carry them. Field
declaration order on `TagFilterKeyValue` mirrors `TagValueSerializerResponse`
so the JSON byte order matches the pre-typed return.

Part of `type-seer-rpc-coverage`. Coverage: 25/58 → 29/58 typed.