### PR TITLE
ref: remove plan tier uses

### DIFF
--- a/static/gsApp/components/upgradeNowModal/actionButtons.tsx
+++ b/static/gsApp/components/upgradeNowModal/actionButtons.tsx
@@ -18,7 +18,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {sendReplayOnboardRequest} from 'getsentry/actionCreators/upsell';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 import type {Plan, PreviewData, Subscription} from 'getsentry/types';
-import {PlanTier} from 'getsentry/types';
 import type {AM2UpdateSurfaces} from 'getsentry/utils/trackGetsentryAnalytics';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
@@ -92,13 +91,10 @@ export function ActionButtons({
   };
 
   const onEmailOwner = async () => {
-    const currentPlanName =
-      subscription.planTier === PlanTier.AM2 ? 'am2-non-beta' : 'am1-non-beta';
-
     await sendReplayOnboardRequest({
       api,
       orgSlug: organization.slug,
-      currentPlan: currentPlanName,
+      currentPlan: 'am1-non-beta',
       onSuccess: () => {
         onComplete?.();
         closeModal();

--- a/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.tsx
+++ b/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.tsx
@@ -4,8 +4,8 @@ import type {Organization} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
+import {BillingConfigTier} from 'getsentry/constants';
 import type {BillingConfig, Plan, Subscription} from 'getsentry/types';
-import {PlanTier} from 'getsentry/types';
 import {hasPerformance} from 'getsentry/utils/billing';
 import {getBucket} from 'getsentry/views/amCheckout/utils';
 
@@ -41,7 +41,7 @@ export function useUpgradeNowParams({organization, subscription, enabled = true}
       }),
       {
         query: {
-          tier: PlanTier.AM2,
+          tier: BillingConfigTier.UPSELL,
         },
       },
     ],


### PR DESCRIPTION
These uses of plan tier were not necessary. upgradeNowModal is not reachable by am2 plans, and the backend now supports "upsell" so the backend can decide which plan to upsell the user to