### PR TITLE
fix(issues): Simplify linked issue rows

### DIFF
--- a/static/app/components/group/externalIssuesList/hooks/types.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/types.tsx
@@ -4,6 +4,10 @@ interface BaseIssueAction {
   disabled?: boolean;
   disabledText?: string;
   displayIcon?: React.ReactNode;
+  /**
+   * Vertical icon offset in pixels for aligning provider icons with the row text.
+   */
+  displayIconOffset?: number;
 }
 
 /**

--- a/static/app/components/group/externalIssuesList/hooks/useIntegrationExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useIntegrationExternalIssues.tsx
@@ -13,6 +13,8 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 import type {ExternalIssueAction, GroupIntegrationIssueResult} from './types';
 
+const UNNUDGED_ICON_PROVIDER_KEYS = new Set(['github', 'github_enterprise']);
+
 interface IntegrationExternalIssueOptions {
   group: Group;
 }
@@ -87,6 +89,7 @@ export function useIntegrationExternalIssues({
           key: `integration-linked-${config.externalIssues[0]!.id}`,
           displayName: config.externalIssues[0]!.key,
           displayIcon,
+          displayIconOffset: UNNUDGED_ICON_PROVIDER_KEYS.has(providerKey) ? 0 : undefined,
           url: config.externalIssues[0]!.url,
           title: config.externalIssues[0]!.title,
           onUnlink: () => {

--- a/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
@@ -32,9 +32,6 @@ export function useSentryAppExternalIssues({
   });
   const sentryAppComponents = useSentryAppComponentsStore({componentType: 'issue-link'});
   const sentryAppInstallations = useLegacyStore(SentryAppInstallationStore);
-  const hasLinkedPullRequestsFeature = organization.features.includes(
-    'issue-details-linked-pull-requests'
-  );
 
   const result: GroupIntegrationIssueResult = {
     integrations: [],
@@ -60,16 +57,16 @@ export function useSentryAppExternalIssues({
       <SentryAppComponentIcon sentryAppComponent={component} size={14} />
     );
     if (externalIssue) {
-      const title =
-        hasLinkedPullRequestsFeature || externalIssue.displayName.includes(appDisplayName)
-          ? externalIssue.displayName
-          : `${appDisplayName}: ${externalIssue.displayName}`;
-
       result.linkedIssues.push({
         key: `sentryapp-linked-${externalIssue.id}`,
         displayName: externalIssue.displayName,
         url: externalIssue.webUrl,
-        title,
+        // Some display names look like PROJ#1234
+        // Others look like ClickUp: Title
+        // Add the integration name if it's not already included
+        title: externalIssue.displayName.includes(appDisplayName)
+          ? externalIssue.displayName
+          : `${appDisplayName}: ${externalIssue.displayName}`,
         displayIcon,
         onUnlink: () => {
           deleteExternalIssue(api, organization.slug, group.id, externalIssue.id)

--- a/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
@@ -32,6 +32,9 @@ export function useSentryAppExternalIssues({
   });
   const sentryAppComponents = useSentryAppComponentsStore({componentType: 'issue-link'});
   const sentryAppInstallations = useLegacyStore(SentryAppInstallationStore);
+  const hasLinkedPullRequestsFeature = organization.features.includes(
+    'issue-details-linked-pull-requests'
+  );
 
   const result: GroupIntegrationIssueResult = {
     integrations: [],
@@ -57,16 +60,16 @@ export function useSentryAppExternalIssues({
       <SentryAppComponentIcon sentryAppComponent={component} size={14} />
     );
     if (externalIssue) {
+      const title =
+        hasLinkedPullRequestsFeature || externalIssue.displayName.includes(appDisplayName)
+          ? externalIssue.displayName
+          : `${appDisplayName}: ${externalIssue.displayName}`;
+
       result.linkedIssues.push({
         key: `sentryapp-linked-${externalIssue.id}`,
         displayName: externalIssue.displayName,
         url: externalIssue.webUrl,
-        // Some display names look like PROJ#1234
-        // Others look like ClickUp: Title
-        // Add the integration name if it's not already included
-        title: externalIssue.displayName.includes(appDisplayName)
-          ? externalIssue.displayName
-          : `${appDisplayName}: ${externalIssue.displayName}`,
+        title,
         displayIcon,
         onUnlink: () => {
           deleteExternalIssue(api, organization.slug, group.id, externalIssue.id)

--- a/static/app/components/group/externalIssuesList/linkedIssueRows.tsx
+++ b/static/app/components/group/externalIssuesList/linkedIssueRows.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -18,6 +18,8 @@ interface LinkedIssueRowsProps {
 interface LinkedIssueRowProps {
   linkedIssue: GroupIntegrationIssueResult['linkedIssues'][number];
 }
+
+const DEFAULT_ICON_OFFSET = -1;
 
 export function LinkedIssueRows({linkedIssues}: LinkedIssueRowsProps) {
   return (
@@ -47,54 +49,44 @@ export function LinkedIssueRows({linkedIssues}: LinkedIssueRowsProps) {
 
 function LinkedIssueRow({linkedIssue}: LinkedIssueRowProps) {
   const title = linkedIssue.title || linkedIssue.displayName;
-  const subtitle =
+  const displayTitle =
     linkedIssue.displayName &&
     !title.toLocaleLowerCase().includes(linkedIssue.displayName.toLocaleLowerCase())
       ? linkedIssue.displayName
-      : null;
-  const hasSubtitle = Boolean(subtitle);
+      : title;
+  const hasHiddenTitle = displayTitle !== title;
 
   return (
     <LinkedIssueRowGrid>
       <InteractionStateLayer />
-      <LinkedIssueRowLink
-        aria-label={subtitle ? t('%s, %s', title, subtitle) : title}
-        href={linkedIssue.url}
-      >
-        <Grid
-          align={hasSubtitle ? 'start' : 'center'}
-          columns="max-content minmax(0, 1fr)"
-          gap="sm"
-          padding={hasSubtitle ? 'sm' : 'xs sm'}
-          width="100%"
+      <LinkedIssueRowLink href={linkedIssue.url}>
+        <LinkedIssueRowIcon
+          aria-hidden
+          style={{
+            transform: `translateY(${linkedIssue.displayIconOffset ?? DEFAULT_ICON_OFFSET}px)`,
+          }}
         >
-          <LinkedIssueRowIcon
-            aria-hidden
-            hasSubtitle={hasSubtitle}
-            style={hasSubtitle ? undefined : {transform: 'translateY(-1px)'}}
-          >
-            {linkedIssue.displayIcon}
-          </LinkedIssueRowIcon>
-          <Flex as="span" direction="column" gap={hasSubtitle ? '2xs' : '0'} minWidth={0}>
-            <LinkedIssueRowTitle title={title}>{title}</LinkedIssueRowTitle>
-            {subtitle && (
-              <Text as="span" ellipsis size="sm" title={subtitle} variant="muted">
-                {subtitle}
+          {linkedIssue.displayIcon}
+        </LinkedIssueRowIcon>
+        <LinkedIssueRowTitleCell>
+          <Tooltip
+            title={
+              <Text as="span" align="left" wordBreak="break-word">
+                {title}
               </Text>
-            )}
-          </Flex>
-        </Grid>
+            }
+            disabled={!hasHiddenTitle}
+            maxWidth={275}
+            skipWrapper
+          >
+            <LinkedIssueRowTitle>{displayTitle}</LinkedIssueRowTitle>
+          </Tooltip>
+        </LinkedIssueRowTitleCell>
       </LinkedIssueRowLink>
-      <Flex
-        as="span"
-        align="center"
-        padding={hasSubtitle ? 'sm' : 'xs sm'}
-        paddingLeft="0"
-        paddingRight="xs"
-      >
+      <Flex as="span" align="center" padding="xs sm" paddingLeft="0" paddingRight="xs">
         <Tooltip title={t('Unlink issue')} skipWrapper>
           <Button
-            aria-label={t('Unlink %s', title)}
+            aria-label={t('Unlink %s', displayTitle)}
             icon={<IconClose variant="muted" />}
             onClick={linkedIssue.onUnlink}
             size="zero"
@@ -117,10 +109,15 @@ const LinkedIssueRowGrid = styled('div')`
 
 const LinkedIssueRowLink = styled(ExternalLink)`
   position: relative;
-  display: flex;
+  display: grid;
   align-items: center;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: ${p => p.theme.space.sm};
   min-width: 0;
+  max-width: 100%;
   width: 100%;
+  overflow: hidden;
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
   color: ${p => p.theme.tokens.content.primary};
 
   &:hover {
@@ -128,24 +125,32 @@ const LinkedIssueRowLink = styled(ExternalLink)`
   }
 `;
 
-const LinkedIssueRowIcon = styled('span', {
-  shouldForwardProp: prop => prop !== 'hasSubtitle',
-})<{hasSubtitle: boolean}>`
+const LinkedIssueRowTitleCell = styled('span')`
+  display: block;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+`;
+
+const LinkedIssueRowIcon = styled('span')`
   display: inline-flex;
-  align-items: ${p => (p.hasSubtitle ? 'flex-start' : 'center')};
+  align-items: center;
   justify-content: center;
   flex-shrink: 0;
   width: 14px;
   height: 14px;
-  padding-top: ${p => (p.hasSubtitle ? p.theme.space['2xs'] : 0)};
 `;
 
 const LinkedIssueRowTitle = styled('span')`
   display: block;
   overflow: hidden;
+  min-width: 0;
+  max-width: 100%;
   width: 100%;
   font-weight: ${p => p.theme.font.weight.sans.medium};
-  line-height: 1.25;
+  direction: rtl;
+  text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
 `;

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
@@ -283,9 +283,9 @@ describe('ExternalIssueSidebarList', () => {
     });
   });
 
-  it('should render linked issues as full-width rows', async () => {
-    const issueKey = 'DE#1275';
-    const issueTitle = 'Linear: DE#1275';
+  it('should render linked issues as single-line full-width rows', async () => {
+    const issueKey = 'getsentry/sentry#123';
+    const issueTitle = 'Fix repository sync';
     mockLinkedPullRequestsFeatureRequests([
       GitHubIntegrationFixture({
         status: 'active',
@@ -293,7 +293,7 @@ describe('ExternalIssueSidebarList', () => {
           {
             id: '321',
             key: issueKey,
-            url: 'https://linear.app/example/issue/DE-1275',
+            url: 'https://github.com/getsentry/sentry/issues/123',
             title: issueTitle,
             description: 'something else, sorry',
             displayName: '',
@@ -307,14 +307,13 @@ describe('ExternalIssueSidebarList', () => {
     });
 
     const linkedIssues = await screen.findByRole('list', {name: 'Linked issues'});
-    expect(within(linkedIssues).getByRole('link', {name: issueTitle})).toHaveAttribute(
+    expect(within(linkedIssues).getByRole('link', {name: issueKey})).toHaveAttribute(
       'href',
-      'https://linear.app/example/issue/DE-1275'
+      'https://github.com/getsentry/sentry/issues/123'
     );
-    expect(within(linkedIssues).queryByText(issueKey)).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', {name: issueKey})).not.toBeInTheDocument();
+    expect(within(linkedIssues).queryByText(issueTitle)).not.toBeInTheDocument();
     expect(
-      within(linkedIssues).getByRole('button', {name: `Unlink ${issueTitle}`})
+      within(linkedIssues).getByRole('button', {name: `Unlink ${issueKey}`})
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
goes back to one line for all linked issues a little towards what they looked like before this feature flag

without feature flag before

<img width="339" height="206" alt="image" src="https://github.com/user-attachments/assets/463e666b-758b-4dd0-91b2-8ee1539ed2bd" />

with feature flag before

<img width="347" height="161" alt="image" src="https://github.com/user-attachments/assets/27326554-c01c-4dfe-88b5-32c679240cdf" />

after with feature flag

<img width="345" height="153" alt="image" src="https://github.com/user-attachments/assets/124f5284-d746-4f4a-ba52-cfe5f3d7caad" />
