### PR TITLE
feat(api): Document accepted query params on issue & release list endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -50,7 +50,13 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.examples.release_examples import ReleaseExamples
-from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
+from sentry.apidocs.parameters import (
+    CursorQueryParam,
+    GlobalParams,
+    OrganizationParams,
+    ReleaseParams,
+    VisibilityParams,
+)
 from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.exceptions import InvalidSearchQuery
@@ -361,8 +367,10 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
         operation_id="List an Organization's Releases",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
+            OrganizationParams.PROJECT,
             GlobalParams.ENVIRONMENT,
             ReleaseParams.QUERY,
+            VisibilityParams.PER_PAGE,
             CursorQueryParam,
         ],
         responses={

--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -28,7 +28,13 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.examples.event_examples import EventExamples
-from sentry.apidocs.parameters import CursorQueryParam, EventParams, GlobalParams, IssueParams
+from sentry.apidocs.parameters import (
+    CursorQueryParam,
+    EventParams,
+    GlobalParams,
+    IssueParams,
+    VisibilityParams,
+)
 from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
@@ -73,6 +79,7 @@ class GroupEventsEndpoint(GroupEndpoint):
             EventParams.FULL_PAYLOAD,
             EventParams.SAMPLE,
             EventParams.QUERY,
+            VisibilityParams.PER_PAGE,
             CursorQueryParam,
         ],
         responses={

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -77,6 +77,8 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
             GlobalParams.STATS_PERIOD,
             CursorQueryParam,
             VisibilityParams.PER_PAGE,
+            IssueParams.VIEW_SORT,
+            IssueParams.LIMIT,
             IssueParams.DEFAULT_QUERY,
             IssueParams.GROUP_INDEX_COLLAPSE,
             IssueParams.SHORT_ID_LOOKUP,

--- a/src/sentry/releases/endpoints/project_releases.py
+++ b/src/sentry/releases/endpoints/project_releases.py
@@ -27,7 +27,12 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.examples.release_examples import ReleaseExamples
-from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, ReleaseParams
+from sentry.apidocs.parameters import (
+    CursorQueryParam,
+    GlobalParams,
+    ReleaseParams,
+    VisibilityParams,
+)
 from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.activity import Activity
@@ -61,6 +66,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
             GlobalParams.PROJECT_ID_OR_SLUG,
             GlobalParams.ENVIRONMENT,
             ReleaseParams.QUERY,
+            VisibilityParams.PER_PAGE,
             CursorQueryParam,
         ],
         responses={


### PR DESCRIPTION
## Why

Several public list endpoints accept query params their handlers read, but the OpenAPI schema doesn't document them. Typed API consumers — specifically Seer's code-mode generated client (getsentry/seer#6970), which turns the public spec into a strict typed library — therefore reject these params even though the API honors them. Rather than patch the missing params into Seer's codegen, they belong in the source spec here.

## What

Docs-only `@extend_schema` additions, all using existing reusable parameter constants and all read by the existing handlers (no behavior change):

| Endpoint | Added |
|---|---|
| List a Project's Issues | `sort` (`IssueParams.VIEW_SORT`), `limit` (`IssueParams.LIMIT`) |
| List an Organization's Releases | `project` (`OrganizationParams.PROJECT`), `per_page` (`VisibilityParams.PER_PAGE`) |
| List a Project's Releases | `per_page` |
| List an Issue's Events | `per_page` |

`sort`/`limit` mirror the **List an Organization's Issues** endpoint, which already documents both and shares the same `group_index` handler. Pagination on the release/event endpoints is `per_page` (offset paginator), not `limit`.

Generated spec is regenerated by `make build-api-docs` in CI.

Refs getsentry/seer#6970