### PR TITLE
feat(project-creation): Make alert frequency collapsible via ScmCollapsibleSection

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -27,8 +27,6 @@ const productionEntryPoints = [
   'static/app/views/seerExplorer/contexts/**/*.{js,ts,tsx}',
   // TODO: Remove when wired into the connect repository modal
   'static/app/components/connectRepository/**/*.{ts,tsx}',
-  // TODO: Remove when consumed in production (#117849 wires it into alert frequency)
-  'static/app/views/onboarding/components/scmCollapsibleSection.tsx',
 ];
 
 const testingEntryPoints = [

--- a/static/app/views/onboarding/components/scmProjectDetailsCore.spec.tsx
+++ b/static/app/views/onboarding/components/scmProjectDetailsCore.spec.tsx
@@ -1,6 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import * as analytics from 'sentry/utils/analytics';
 import {DEFAULT_ISSUE_ALERT_OPTIONS_VALUES} from 'sentry/views/projectInstall/issueAlertOptions';
@@ -56,5 +56,27 @@ describe('ScmProjectDetailsCore', () => {
 
     expect(screen.getByText('Project name')).toBeInTheDocument();
     expect(screen.queryByText('Team')).not.toBeInTheDocument();
+  });
+
+  it('makes the alert-frequency section a collapsible toggle in project creation', async () => {
+    renderCore({analyticsFlow: 'project-creation'});
+
+    const toggle = screen.getByRole('button', {name: 'Alert frequency'});
+    expect(screen.getByText('Get notified when things go wrong')).toBeInTheDocument();
+
+    await userEvent.click(toggle);
+    expect(
+      screen.queryByText('Get notified when things go wrong')
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the alert-frequency section always expanded in onboarding', () => {
+    renderCore({analyticsFlow: 'onboarding'});
+
+    expect(
+      screen.queryByRole('button', {name: 'Alert frequency'})
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Alert frequency')).toBeInTheDocument();
+    expect(screen.getByText('Get notified when things go wrong')).toBeInTheDocument();
   });
 });

--- a/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
+++ b/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
@@ -13,6 +13,7 @@ import type {AlertRuleOptions} from 'sentry/views/projectInstall/issueAlertOptio
 
 import {ScmAlertFrequency} from './scmAlertFrequency';
 import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
+import {ScmCollapsibleSection} from './scmCollapsibleSection';
 
 const STEP_VIEWED_EVENT = {
   onboarding: 'onboarding.scm_project_details_step_viewed',
@@ -59,9 +60,23 @@ export function ScmProjectDetailsCore({
 }: ScmProjectDetailsCoreProps) {
   const organization = useOrganization();
 
+  // Match the feature-selection section: the alert-frequency section folds away
+  // in project creation (one of several stacked config cards) but stays always
+  // expanded in onboarding.
+  const collapsible = analyticsFlow === 'project-creation';
+
   useEffect(() => {
     trackAnalytics(STEP_VIEWED_EVENT[analyticsFlow], {organization});
   }, [organization, analyticsFlow]);
+
+  const alertFrequencyBody = (
+    <Stack gap="md" width="100%">
+      <Text variant="muted" density="comfortable">
+        {t('Get notified when things go wrong')}
+      </Text>
+      <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
+    </Stack>
+  );
 
   return (
     <Stack gap="3xl" width="100%" maxWidth={contentMaxWidth}>
@@ -116,22 +131,27 @@ export function ScmProjectDetailsCore({
         )}
       </Grid>
 
-      <Stack gap="md">
-        <Stack gap="xs">
-          <Container>
-            <Text bold size="md" density="comfortable">
-              {t('Alert frequency')}
-            </Text>
-          </Container>
-          <Container>
-            <Text variant="muted" density="comfortable">
-              {t('Get notified when things go wrong')}
-            </Text>
-          </Container>
+      {collapsible ? (
+        <ScmCollapsibleSection title={t('Alert frequency')}>
+          {alertFrequencyBody}
+        </ScmCollapsibleSection>
+      ) : (
+        <Stack gap="md">
+          <Stack gap="xs">
+            <Container>
+              <Text bold size="md" density="comfortable">
+                {t('Alert frequency')}
+              </Text>
+            </Container>
+            <Container>
+              <Text variant="muted" density="comfortable">
+                {t('Get notified when things go wrong')}
+              </Text>
+            </Container>
+          </Stack>
+          <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
         </Stack>
-
-        <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
-      </Stack>
+      )}
     </Stack>
   );
 }


### PR DESCRIPTION
## TLDR

Applies `ScmCollapsibleSection` to the alert-frequency section of `ScmProjectDetailsCore`, folding it behind a toggle in the project-creation flow. Onboarding keeps the always-expanded header. This is the first production consumer of the component.

## Details

- Gated with `collapsible = analyticsFlow === 'project-creation'`.
- The chevron and "Alert frequency" title replace the `IconSiren` header, and the "Get notified when things go wrong" subtitle moves into the collapsible body so it hides when collapsed.
- Onboarding renders the original `IconSiren` header with an always-expanded body. The body markup is shared between both branches, so onboarding stays visually unchanged.
- Removes the knip production-entry exemption that #117847 added for `ScmCollapsibleSection`. Now that the component has a production consumer, the exemption is redundant and would trip knip's config-hint check.

## Stack

- [#117731](https://github.com/getsentry/sentry/pull/117731): SCM integration selector (merged)
- [#117846](https://github.com/getsentry/sentry/pull/117846): Typography and copy polish (merged)
- [#117847](https://github.com/getsentry/sentry/pull/117847): Reusable collapsible section (base of this PR)
- **PR 4 (this) #117849:** Alert-frequency collapsible
