### PR TITLE
ref: Remove tabs from change plan modal

### DIFF
--- a/static/gsAdmin/components/changePlanAction.spec.tsx
+++ b/static/gsAdmin/components/changePlanAction.spec.tsx
@@ -3,25 +3,17 @@ import {UserFixture} from 'sentry-fixture/user';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
-import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {
   SubscriptionFixture,
   SubscriptionWithLegacySeerFixture,
 } from 'getsentry-test/fixtures/subscription';
-import {
-  renderGlobalModal,
-  screen,
-  userEvent,
-  waitFor,
-  within,
-} from 'sentry-test/reactTestingLibrary';
+import {renderGlobalModal, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
 
 import {ConfigStore} from 'sentry/stores/configStore';
 import {DataCategory} from 'sentry/types/core';
 
 import {triggerChangePlanAction} from 'admin/components/changePlanAction';
-import {PlanFixture} from 'getsentry/__fixtures__/plan';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 import {PlanTier} from 'getsentry/types';
 
@@ -43,42 +35,6 @@ describe('ChangePlanAction', () => {
     },
   });
   const BILLING_CONFIG = BillingConfigFixture(PlanTier.ALL);
-  const testPlan = PlanFixture({
-    id: 'test_test_monthly',
-    name: 'TEST Tier Test Plan',
-    price: 5000,
-    basePrice: 5000,
-    billingInterval: 'monthly',
-    contractInterval: 'monthly',
-    reservedMinimum: 500000,
-    categories: [DataCategory.ERRORS, DataCategory.TRANSACTIONS],
-    checkoutCategories: [DataCategory.ERRORS, DataCategory.TRANSACTIONS],
-    planCategories: {
-      errors: [
-        {events: 50000, price: 1000},
-        {events: 100000, price: 2000},
-      ],
-      transactions: [
-        {events: 10000, price: 2500},
-        {events: 25000, price: 5000},
-      ],
-    },
-    userSelectable: false,
-    isTestPlan: true,
-  });
-
-  const freeTestPlan = PlanFixture({
-    id: 'free_test_monthly',
-    name: 'TEST Tier Free Test Plan',
-    price: 0,
-    basePrice: 0,
-    billingInterval: 'monthly',
-    userSelectable: false,
-    isTestPlan: true,
-  });
-
-  BILLING_CONFIG.planList.push(testPlan);
-  BILLING_CONFIG.planList.push(freeTestPlan);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -118,53 +74,28 @@ describe('ChangePlanAction', () => {
   it('loads the billing config and displays plan options', async () => {
     openAndLoadModal();
 
-    // Wait for async data to load
-    await waitFor(() => {
-      expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-    });
-
-    // Verify the tabs are rendered
-    expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-    expect(screen.getByRole('tab', {name: 'AM2'})).toBeInTheDocument();
-    expect(screen.queryByRole('tab', {name: 'MM2'})).not.toBeInTheDocument();
-
-    // Verify at least one plan option is displayed
-    expect(screen.getByTestId('change-plan-label-am3_business')).toBeInTheDocument();
-    await userEvent.click(screen.getAllByRole('radio')[0]!);
-
-    // Verify checkout categories are displayed
-    expect(screen.getAllByRole('textbox')).toHaveLength(
-      subscription.planDetails.checkoutCategories.length + 2 // +2 for audit fields
-    );
-    expect(screen.getByRole('textbox', {name: 'Spans'})).toBeInTheDocument();
-
-    // Does not display non-checkout categories or non-existent categories
+    // All tiers' plans load into a single list (no tabbed interface)
     expect(
-      screen.queryByRole('textbox', {name: 'Continuous profile hours'})
-    ).not.toBeInTheDocument();
+      await screen.findByTestId('change-plan-label-am3_business')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('change-plan-label-am2_business')).toBeInTheDocument();
+
+    // Selecting an AM3 plan shows its checkout categories (spans, not transactions)
+    await userEvent.click(screen.getByRole('radio', {name: /am3_business\b/}));
+    expect(screen.getByRole('textbox', {name: 'Spans'})).toBeInTheDocument();
     expect(screen.queryByRole('textbox', {name: 'Transactions'})).not.toBeInTheDocument();
     expect(
       screen.queryByRole('textbox', {name: 'Performance units'})
     ).not.toBeInTheDocument();
-
-    // Test basic interaction - click on AM2 tier
-    const am2Tab = screen.getByRole('tab', {name: 'AM2'});
-    await userEvent.click(am2Tab);
-
-    // Verify tab change changes plan options displayed
-    expect(screen.getByTestId('change-plan-label-am2_business')).toBeInTheDocument();
-    await userEvent.click(screen.getAllByRole('radio')[0]!);
-
-    // Verify tab change changes categories displayed
-    expect(screen.getAllByRole('textbox')).toHaveLength(
-      PlanDetailsLookupFixture('am2_business').checkoutCategories.length + 2 // +2 for audit fields
-    );
-    expect(screen.getByRole('textbox', {name: 'Performance units'})).toBeInTheDocument();
-    expect(screen.queryByRole('textbox', {name: 'Transactions'})).not.toBeInTheDocument();
     expect(
       screen.queryByRole('textbox', {name: 'Continuous profile hours'})
     ).not.toBeInTheDocument();
+
+    // Selecting an AM2 plan swaps to its categories (performance units, not spans)
+    await userEvent.click(screen.getByRole('radio', {name: /am2_business\b/}));
+    expect(screen.getByRole('textbox', {name: 'Performance units'})).toBeInTheDocument();
     expect(screen.queryByRole('textbox', {name: 'Spans'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox', {name: 'Transactions'})).not.toBeInTheDocument();
   });
 
   it('only displays current plan for NT customers', async () => {
@@ -191,12 +122,11 @@ describe('ChangePlanAction', () => {
 
     await openAndLoadModal({partnerPlanId: ntSubscription.plan});
 
-    expect(screen.queryByTestId('am3-tier')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('am2-tier')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('am1-tier')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('mm2-tier')).not.toBeInTheDocument();
+    // Partner plans aren't modifiable, so only the existing plan is shown
+    expect(
+      await screen.findByTestId('change-plan-label-am2_business')
+    ).toBeInTheDocument();
     expect(screen.getAllByRole('radio')).toHaveLength(1);
-    expect(screen.getByTestId('change-plan-label-am2_business')).toBeInTheDocument();
   });
 
   it('completes form submission flow', async () => {
@@ -210,13 +140,8 @@ describe('ChangePlanAction', () => {
 
     openAndLoadModal();
 
-    // Wait for component to load
-    await waitFor(() => {
-      expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-    });
-
-    // Select a plan
-    await userEvent.click(screen.getAllByRole('radio')[0]!);
+    // Select an AM3 plan from the flat list
+    await userEvent.click(await screen.findByRole('radio', {name: /am3_business\b/}));
 
     // Select reserved volumes
     await selectEvent.select(screen.getByRole('textbox', {name: 'Errors'}), '100,000');
@@ -258,11 +183,7 @@ describe('ChangePlanAction', () => {
 
     openAndLoadModal();
 
-    await waitFor(() => {
-      expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-    });
-
-    await userEvent.click(screen.getAllByRole('radio')[0]!);
+    await userEvent.click(await screen.findByRole('radio', {name: /am3_business\b/}));
 
     await selectEvent.select(screen.getByRole('textbox', {name: 'Errors'}), '100,000');
     await selectEvent.select(screen.getByRole('textbox', {name: 'Replays'}), '50');
@@ -302,95 +223,6 @@ describe('ChangePlanAction', () => {
     expect(requestData).toHaveProperty('addOnSeer', true);
   });
 
-  it('updates plan list when switching between tiers', async () => {
-    openAndLoadModal();
-
-    // Wait for component to load
-    await waitFor(() => {
-      expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-    });
-
-    // Verify AM3 tier plans are displayed
-    expect(screen.getByTestId('change-plan-label-am3_business')).toBeInTheDocument();
-
-    // Switch to AM2 tier
-    const am2Tab = screen.getByRole('tab', {name: 'AM2'});
-    await userEvent.click(am2Tab);
-
-    // When clicking on a different tier, it takes time for the plan list to update
-    // Rather than checking for a specific plan, let's check that we still have a plan option
-    // but it's no longer the AM3 plan
-    await waitFor(() => {
-      const radios = document.querySelectorAll('input[type="radio"]');
-      expect(radios.length).toBeGreaterThan(0);
-    });
-  });
-
-  it('shows only test plans when using TEST tier', async () => {
-    openAndLoadModal();
-
-    // First, click the TEST tier to activate it
-    await waitFor(() => {
-      expect(screen.getByRole('tab', {name: 'TEST'})).toBeInTheDocument();
-    });
-
-    const testTierTab = screen.getByRole('tab', {name: 'TEST'});
-    await userEvent.click(testTierTab);
-
-    // Verify >$0 TEST tier plans are shown after clicking the TEST tier tab
-    await waitFor(() => {
-      const testPlans = screen.queryAllByTestId(/_test_monthly/);
-      expect(testPlans).toHaveLength(1);
-
-      testPlans.forEach(planLabel => {
-        expect(within(planLabel).getByText('$50 / monthly')).toBeInTheDocument();
-        expect(within(planLabel).queryByText('$0 / monthly')).not.toBeInTheDocument();
-      });
-    });
-  });
-
-  it('completes form submission flow for the TEST tier', async () => {
-    // Mock the PUT endpoint response
-    const putMock = MockApiClient.addMockResponse({
-      url: `/customers/${mockOrg.slug}/subscription/`,
-      method: 'PUT',
-      body: {success: true},
-    });
-
-    openAndLoadModal();
-
-    // Wait for component to load
-    await waitFor(() => {
-      expect(screen.getByRole('tab', {name: 'TEST'})).toBeInTheDocument();
-    });
-
-    // Click on the TEST tier tab (if not already active)
-    const testTierTab = screen.getByRole('tab', {name: 'TEST'});
-    await userEvent.click(testTierTab);
-    expect(screen.getByRole('button', {name: 'Change Plan'})).toBeDisabled();
-    expect(screen.getByTestId('change-plan-label-test_test_monthly')).toBeInTheDocument();
-
-    // Select a plan
-    await userEvent.click(screen.getAllByRole('radio')[0]!);
-
-    // Select reserved volumes
-    await selectEvent.select(screen.getByRole('textbox', {name: 'Errors'}), '50,000');
-    await selectEvent.select(
-      screen.getByRole('textbox', {name: 'Transactions'}),
-      '25,000'
-    );
-
-    expect(screen.getByRole('button', {name: 'Change Plan'})).toBeEnabled();
-    await userEvent.click(screen.getByRole('button', {name: 'Change Plan'}));
-
-    // Verify the PUT API was called
-    expect(putMock).toHaveBeenCalled();
-    const requestData = putMock.mock.calls[0][1].data;
-    expect(requestData).toHaveProperty('plan', 'test_test_monthly');
-    expect(requestData).toHaveProperty('reservedErrors', 50000);
-    expect(requestData).toHaveProperty('reservedTransactions', 25000);
-  });
-
   describe('Legacy Seer', () => {
     beforeEach(() => {
       mockOrg.features = ['seer-billing'];
@@ -418,23 +250,13 @@ describe('ChangePlanAction', () => {
     it('shows Seer budget checkbox for AM tiers', async () => {
       openAndLoadModal();
 
-      await waitFor(() => {
-        expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-      });
-      await userEvent.click(screen.getAllByRole('radio')[0]!);
-
+      await userEvent.click(await screen.findByRole('radio', {name: /am3_business\b/}));
       expect(screen.getByText('Seer')).toBeInTheDocument();
 
-      const am2Tab = screen.getByRole('tab', {name: 'AM2'});
-      await userEvent.click(am2Tab);
-      await userEvent.click(screen.getAllByRole('radio')[0]!);
-
+      await userEvent.click(screen.getByRole('radio', {name: /am2_business\b/}));
       expect(screen.getByText('Seer')).toBeInTheDocument();
 
-      const am1Tab = screen.getByRole('tab', {name: 'AM1'});
-      await userEvent.click(am1Tab);
-      await userEvent.click(screen.getAllByRole('radio')[0]!);
-
+      await userEvent.click(screen.getByRole('radio', {name: /am1_business\b/}));
       expect(screen.getByText('Seer')).toBeInTheDocument();
     });
 
@@ -454,13 +276,8 @@ describe('ChangePlanAction', () => {
 
       await openAndLoadModal({subscription: subscriptionWithSeer});
 
-      // Wait for component to load
-      await waitFor(() => {
-        expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-      });
-
       // Select a plan to make the Available Products section visible
-      await userEvent.click(screen.getAllByRole('radio')[0]!);
+      await userEvent.click(await screen.findByRole('radio', {name: /am3_business\b/}));
 
       // Verify Seer budget checkbox is checked when subscription has Seer budget
       const seerCheckbox = screen.getByRole('checkbox', {
@@ -472,13 +289,8 @@ describe('ChangePlanAction', () => {
     it('initializes Seer budget checkbox as unchecked when subscription has no Seer budget', async () => {
       openAndLoadModal({});
 
-      // Wait for component to load
-      await waitFor(() => {
-        expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-      });
-
       // Select a plan to make the Available Products section visible
-      await userEvent.click(screen.getAllByRole('radio')[0]!);
+      await userEvent.click(await screen.findByRole('radio', {name: /am3_business\b/}));
 
       // Verify Seer budget checkbox is unchecked when subscription has no Seer budget
       const seerCheckbox = screen.getByRole('checkbox', {
@@ -497,13 +309,8 @@ describe('ChangePlanAction', () => {
 
       openAndLoadModal({});
 
-      // Wait for component to load
-      await waitFor(() => {
-        expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-      });
-
       // Select a plan
-      await userEvent.click(screen.getAllByRole('radio')[0]!);
+      await userEvent.click(await screen.findByRole('radio', {name: /am3_business\b/}));
 
       // Check the Seer budget checkbox
       const seerCheckbox = screen.getByRole('checkbox', {
@@ -557,13 +364,8 @@ describe('ChangePlanAction', () => {
 
       openAndLoadModal({});
 
-      // Wait for component to load
-      await waitFor(() => {
-        expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-      });
-
       // Select a plan
-      await userEvent.click(screen.getAllByRole('radio')[0]!);
+      await userEvent.click(await screen.findByRole('radio', {name: /am3_business\b/}));
 
       // Verify Seer budget checkbox is unchecked (default state)
       const seerCheckbox = screen.getByRole('checkbox', {

--- a/static/gsAdmin/components/changePlanAction.tsx
+++ b/static/gsAdmin/components/changePlanAction.tsx
@@ -1,9 +1,6 @@
 import {Fragment, useMemo, useState} from 'react';
 import classNames from 'classnames';
 
-import {Container} from '@sentry/scraps/layout';
-import {TabList, Tabs} from '@sentry/scraps/tabs';
-
 import {
   addErrorMessage,
   addLoadingMessage,
@@ -14,7 +11,6 @@ import {FormModel} from 'sentry/components/forms/model';
 import type {Data, OnSubmitCallback} from 'sentry/components/forms/types';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {ConfigStore} from 'sentry/stores/configStore';
 import type {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
@@ -23,11 +19,9 @@ import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 import {useApi} from 'sentry/utils/useApi';
 
 import {PlanList} from 'admin/components/planList';
-import {ANNUAL, MONTHLY} from 'getsentry/constants';
+import {ANNUAL, BillingConfigTier, MONTHLY} from 'getsentry/constants';
 import type {BillingConfig, Plan, Subscription} from 'getsentry/types';
-import {CheckoutType, PlanTier} from 'getsentry/types';
-
-const ALLOWED_TIERS = [PlanTier.AM1, PlanTier.AM2, PlanTier.AM3];
+import {CheckoutType} from 'getsentry/types';
 
 type Props = {
   onSuccess: () => void;
@@ -45,7 +39,6 @@ function ChangePlanAction({
 }: Props) {
   const [billingInterval, setBillingInterval] = useState(MONTHLY);
   const [contractInterval, setContractInterval] = useState(MONTHLY);
-  const [activeTier, setActiveTier] = useState(PlanTier.AM3);
   const [activePlan, setActivePlan] = useState<Plan | null>(null);
   const [formModel] = useState(() => new FormModel());
   const orgId = organization.slug;
@@ -60,7 +53,7 @@ function ChangePlanAction({
       getApiUrl('/customers/$organizationIdOrSlug/billing-config/', {
         path: {organizationIdOrSlug: orgId},
       }),
-      {query: {tier: 'all'}},
+      {query: {tier: BillingConfigTier.ALL}},
     ],
     {
       // TODO(isabella): pass billing config from customerDetails
@@ -68,14 +61,7 @@ function ChangePlanAction({
     }
   );
 
-  const planList = useMemo(
-    () =>
-      configs?.planList.filter(
-        plan =>
-          ALLOWED_TIERS.includes(plan.id.split('_')[0] as PlanTier) || plan.isTestPlan
-      ) ?? [],
-    [configs]
-  );
+  const planList = useMemo(() => configs?.planList ?? [], [configs]);
 
   if (isPending) {
     return <LoadingIndicator />;
@@ -86,26 +72,10 @@ function ChangePlanAction({
   }
 
   /**
-   * Check if the user has provision permission for test plans
+   * Get the selectable plans for the current billing/contract interval.
    */
-  const hasProvisionPermission = () => {
-    return ConfigStore.get('user')?.permissions?.has?.('billing.provision');
-  };
-
-  /**
-   * Get the plan list for the active tier
-   */
-  const getPlanListForTier = (): BillingConfig['planList'] => {
-    if (activeTier === PlanTier.TEST) {
-      return planList.filter(
-        plan =>
-          plan.isTestPlan &&
-          plan.price !== 0 && // filter out enterprise, trial, and free test plans
-          plan.billingInterval === billingInterval &&
-          plan.contractInterval === contractInterval
-      );
-    }
-    return planList
+  const getPlanList = (): BillingConfig['planList'] =>
+    planList
       .sort((a, b) => a.reservedMinimum - b.reservedMinimum)
       .filter(
         plan =>
@@ -113,12 +83,10 @@ function ChangePlanAction({
           (plan.userSelectable || plan.checkoutType === CheckoutType.BUNDLE) &&
           plan.billingInterval === billingInterval &&
           plan.contractInterval === contractInterval &&
-          // Plan id on partner sponsored subscriptions is not modifiable so only including
-          // the existing plan in the list
-          ((partnerPlanId === null && plan.id.split('_')[0] === activeTier) ||
-            partnerPlanId === plan.id)
+          // Plan id on partner sponsored subscriptions is not modifiable so only
+          // including the existing plan in the list
+          (partnerPlanId === null || partnerPlanId === plan.id)
       );
-  };
 
   /**
    * Find the closest volume tier in the plan for a given category and current volume
@@ -162,7 +130,7 @@ function ChangePlanAction({
    * and available tiers in the newly selected plan
    */
   const setInitialReservedVolumes = (planId: string): void => {
-    const plan = getPlanListForTier().find(p => p.id === planId) || null;
+    const plan = getPlanList().find(p => p.id === planId) || null;
     if (!plan) {
       return;
     }
@@ -219,78 +187,38 @@ function ChangePlanAction({
   };
 
   // Plan for partner sponsored subscriptions is not modifiable so skipping
-  // the navigation that will allow modifying billing cycle and plan tier
-  const PLAN_TABS = [
-    {
-      label: 'AM3',
-      tier: PlanTier.AM3,
-    },
-    {
-      label: 'AM2',
-      tier: PlanTier.AM2,
-    },
-    {
-      label: 'AM1',
-      tier: PlanTier.AM1,
-    },
-    {
-      label: 'TEST',
-      tier: PlanTier.TEST,
-    },
-  ];
-
+  // the navigation that will allow modifying the billing cycle
   const header = partnerPlanId ? null : (
-    <Fragment>
-      <Container marginBottom="xl">
-        <Tabs
-          value={activeTier}
-          onChange={tab => {
-            setActivePlan(null);
-            setActiveTier(tab);
+    <ul className="nav nav-pills">
+      <li
+        className={classNames({
+          active: contractInterval === MONTHLY && billingInterval === MONTHLY,
+        })}
+      >
+        <a
+          onClick={() => {
             setBillingInterval(MONTHLY);
             setContractInterval(MONTHLY);
           }}
         >
-          <TabList>
-            {PLAN_TABS.filter(
-              tab => tab.tier !== PlanTier.TEST || hasProvisionPermission()
-            ).map(tab => (
-              <TabList.Item key={tab.tier}>{tab.label}</TabList.Item>
-            ))}
-          </TabList>
-        </Tabs>
-      </Container>
-      <ul className="nav nav-pills">
-        <li
-          className={classNames({
-            active: contractInterval === MONTHLY && billingInterval === MONTHLY,
-          })}
+          Monthly
+        </a>
+      </li>
+      <li
+        className={classNames({
+          active: contractInterval === ANNUAL && billingInterval === ANNUAL,
+        })}
+      >
+        <a
+          onClick={() => {
+            setBillingInterval(ANNUAL);
+            setContractInterval(ANNUAL);
+          }}
         >
-          <a
-            onClick={() => {
-              setBillingInterval(MONTHLY);
-              setContractInterval(MONTHLY);
-            }}
-          >
-            Monthly
-          </a>
-        </li>
-        <li
-          className={classNames({
-            active: contractInterval === ANNUAL && billingInterval === ANNUAL,
-          })}
-        >
-          <a
-            onClick={() => {
-              setBillingInterval(ANNUAL);
-              setContractInterval(ANNUAL);
-            }}
-          >
-            Annual (Upfront)
-          </a>
-        </li>
-      </ul>
-    </Fragment>
+          Annual (Upfront)
+        </a>
+      </li>
+    </ul>
   );
 
   return (
@@ -313,7 +241,7 @@ function ChangePlanAction({
           addErrorMessage(error?.responseJSON?.detail ?? error);
         }}
         onPlanChange={handlePlanChange}
-        tierPlans={getPlanListForTier()}
+        tierPlans={getPlanList()}
       />
     </Fragment>
   );

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -19,8 +19,8 @@ export const GIGABYTE = 10 ** 9;
 
 /**
  * Pseudo-tiers accepted by the customer billing-config endpoint as its `tier`
- * query param. The backend resolves each to a concrete plan tier so the
- * frontend doesn't have to replicate the selection logic. See getsentry's
+ * query param. The backend resolves each server-side so the frontend doesn't
+ * have to replicate the selection logic. See getsentry's
  * `CustomerBillingConfigEndpoint`.
  */
 export enum BillingConfigTier {
@@ -30,6 +30,8 @@ export enum BillingConfigTier {
   CHECKOUT = 'checkout',
   /** The latest tier, independent of the org's current plan. */
   DEFAULT = 'default',
+  /** Plans across all usable tiers (staff/superuser only). */
+  ALL = 'all',
 }
 
 const BASIC_TRIAL_PLANS = ['am1_t', 'am2_t', 'am3_t'];


### PR DESCRIPTION
Updates the change plan admin modal to remove uses of PlanTier. This was used for determining a tabbed interface. I considered updating the backend to return data already grouped into tabs, but instead just changed the frontend to display a list instead of grouped lists in tabs.

<img width="665" height="964" alt="Screenshot 2026-06-16 at 1 28 15 PM" src="https://github.com/user-attachments/assets/7ac0d889-5975-4ed9-b6fd-fbcb5d62a7ef" />
