### PR TITLE
chore(api): Add control silo URL patterns for monitoring provider API endpoints

### DIFF
--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -91,6 +91,8 @@ export const controlsiloUrlPatterns: RegExp[] = [
   new RegExp('^api/0/organizations/[^/]+/integrations/[^/]+/repo-sync/$'),
   new RegExp('^api/0/organizations/[^/]+/integrations/[^/]+/channels/$'),
   new RegExp('^api/0/organizations/[^/]+/integrations/[^/]+/channel-validate/$'),
+  new RegExp('^api/0/organizations/[^/]+/monitoring-providers/$'),
+  new RegExp('^api/0/organizations/[^/]+/monitoring-providers/[^/]+/$'),
   new RegExp('^api/0/organizations/[^/]+/pipeline/[^/]+/$'),
   new RegExp('^api/0/organizations/[^/]+/sentry-app-installations/$'),
   new RegExp('^api/0/organizations/[^/]+/sentry-apps/$'),


### PR DESCRIPTION
Precursor to https://github.com/getsentry/sentry/pull/117854.

Adding new URL patterns in the control silo for the monitoring provider API endpoints.

https://linear.app/getsentry/project/access-infrastructure-monitoring-data-5eb36250e0fa/overview