### PR TITLE
feat(issues): Record escalate/unresolve transitions in the action log

### DIFF
--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -80,6 +80,7 @@ class GroupActionType(IntEnum):
     CREATE_PLATFORM_EXTERNAL_ISSUE = 21
     LINK_PLATFORM_EXTERNAL_ISSUE = 22
     UNLINK_PLATFORM_EXTERNAL_ISSUE = 23
+    ESCALATING = 24
 
 
 class GroupAction(BaseModel, abc.ABC):
@@ -112,6 +113,12 @@ class UnresolveAction(GroupAction):
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.UNRESOLVE
+
+
+class EscalatingAction(GroupAction):
+    @classmethod
+    def get_type(cls) -> GroupActionType:
+        return GroupActionType.ESCALATING
 
 
 class ArchiveAction(GroupAction):

--- a/src/sentry/issues/escalating/escalating.py
+++ b/src/sentry/issues/escalating/escalating.py
@@ -27,6 +27,8 @@ from snuba_sdk import (
 )
 
 from sentry import options
+from sentry.issues.action_log import ActionSource, publish_action
+from sentry.issues.action_log.types import EscalatingAction, UnresolveAction
 from sentry.issues.escalating.escalating_group_forecast import EscalatingGroupForecast
 from sentry.issues.escalating.escalating_issues_alg import GroupCount
 from sentry.issues.grouptype import GroupCategory
@@ -564,6 +566,12 @@ def manage_issue_states(
             Activity.objects.create_group_activity(
                 group=group, type=ActivityType.SET_ESCALATING, data=data
             )
+            publish_action(
+                EscalatingAction(),
+                source=ActionSource.SYSTEM,
+                group_id=group.id,
+                project=group.project,
+            )
             auto_update_priority(group, PriorityChangeReason.ESCALATING)
 
     elif group_inbox_reason == GroupInboxReason.ONGOING:
@@ -585,6 +593,12 @@ def manage_issue_states(
 
             Activity.objects.create_group_activity(
                 group=group, type=ActivityType.SET_UNRESOLVED, data=data, send_notification=False
+            )
+            publish_action(
+                UnresolveAction(),
+                source=ActionSource.SYSTEM,
+                group_id=group.id,
+                project=group.project,
             )
 
     elif group_inbox_reason == GroupInboxReason.UNIGNORED:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1441,6 +1441,8 @@ def detect_new_escalation(job: PostProcessJob) -> None:
     If we detect that the group has escalated, set has_escalated to True in the
     job.
     """
+    from sentry.issues.action_log import ActionSource, publish_action
+    from sentry.issues.action_log.types import EscalatingAction
     from sentry.issues.escalating.issue_velocity import get_latest_threshold
     from sentry.issues.priority import PriorityChangeReason, auto_update_priority
     from sentry.models.activity import Activity
@@ -1486,6 +1488,12 @@ def detect_new_escalation(job: PostProcessJob) -> None:
                     group=group,
                     type=ActivityType.SET_ESCALATING,
                     data={"event_id": job["event"].event_id},
+                )
+                publish_action(
+                    EscalatingAction(),
+                    source=ActionSource.SYSTEM,
+                    group_id=group.id,
+                    project=job["event"].project,
                 )
                 auto_update_priority(group, PriorityChangeReason.ESCALATING)
             logger.info(

--- a/tests/sentry/issues/escalating/test_escalating.py
+++ b/tests/sentry/issues/escalating/test_escalating.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import pytest
 
+from sentry.issues.action_log import ActionSource
 from sentry.issues.escalating.escalating import (
     GroupsCountResponse,
     _query_groups_past_counts_eap,
@@ -16,12 +17,13 @@ from sentry.issues.escalating.escalating import (
     get_group_hourly_count_eap,
     get_group_hourly_count_snuba,
     is_escalating,
+    manage_issue_states,
     query_groups_past_counts,
 )
 from sentry.issues.escalating.escalating_group_forecast import EscalatingGroupForecast
 from sentry.issues.grouptype import GroupCategory, ProfileFileIOGroupType
 from sentry.models.group import Group, GroupStatus
-from sentry.models.groupinbox import GroupInbox
+from sentry.models.groupinbox import GroupInbox, GroupInboxReason
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.testutils.cases import (
     PerformanceIssueTestCase,
@@ -439,3 +441,37 @@ class TestEAPIsEscalating(TestCase, SnubaTestCase):
         # return exactly one bucket with count 2.
         assert len(snuba_results) == len(eap_results) == 1
         assert snuba_results[0]["count()"] == eap_results[0]["count()"] == 2
+
+
+class TestManageIssueStatesActionLog(TestCase):
+    def _action_records(self, logs: Any, group: Group) -> list[Any]:
+        return [
+            r
+            for r in logs.records
+            if r.message == "group.action_log" and getattr(r, "group_id") == str(group.id)
+        ]
+
+    def test_escalating_records_escalate_action(self) -> None:
+        group = self.create_group(status=GroupStatus.IGNORED)
+
+        with self.assertLogs("sentry.issues.action_log", level="INFO") as logs:
+            manage_issue_states(group, GroupInboxReason.ESCALATING)
+
+        group.refresh_from_db()
+        assert group.status == GroupStatus.UNRESOLVED
+        records = self._action_records(logs, group)
+        assert "escalating" in {getattr(r, "action") for r in records}
+        # Attributed to the system, never the unknown fallback.
+        assert {getattr(r, "source") for r in records} == {ActionSource.SYSTEM}
+
+    def test_ongoing_records_unresolve_action(self) -> None:
+        group = self.create_group(status=GroupStatus.IGNORED)
+
+        with self.assertLogs("sentry.issues.action_log", level="INFO") as logs:
+            manage_issue_states(group, GroupInboxReason.ONGOING)
+
+        group.refresh_from_db()
+        assert group.status == GroupStatus.UNRESOLVED
+        records = self._action_records(logs, group)
+        assert {getattr(r, "action") for r in records} == {"unresolve"}
+        assert {getattr(r, "source") for r in records} == {ActionSource.SYSTEM}

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -21,6 +21,8 @@ from sentry.feedback.lib.utils import FeedbackCreationSource
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.source_code_management.commit_context import CommitInfo, FileBlameInfo
 from sentry.integrations.types import DataForwarderProviderSlug
+from sentry.issues.action_log import ActionSource
+from sentry.issues.action_log.types import EscalatingAction
 from sentry.issues.auto_source_code_config.utils.platform import get_supported_platforms
 from sentry.issues.grouptype import (
     FeedbackGroup,
@@ -2564,8 +2566,11 @@ class CheckIfFlagsSentTestMixin(BasePostProcessGroupMixin):
 
 
 class DetectNewEscalationTestMixin(BasePostProcessGroupMixin):
+    @patch("sentry.issues.action_log.publish_action")
     @patch("sentry.tasks.post_process.run_post_process_job", side_effect=run_post_process_job)
-    def test_has_escalated(self, mock_run_post_process_job: MagicMock) -> None:
+    def test_has_escalated(
+        self, mock_run_post_process_job: MagicMock, mock_publish_action: MagicMock
+    ) -> None:
         event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
         group.update(
@@ -2587,6 +2592,13 @@ class DetectNewEscalationTestMixin(BasePostProcessGroupMixin):
         group.refresh_from_db()
         assert group.substatus == GroupSubStatus.ESCALATING
         assert group.priority == PriorityLevel.MEDIUM
+
+        # The escalation transition is recorded in the action log as a system action.
+        mock_publish_action.assert_called_once()
+        published = mock_publish_action.call_args
+        assert isinstance(published.args[0], EscalatingAction)
+        assert published.kwargs["source"] == ActionSource.SYSTEM
+        assert published.kwargs["group_id"] == group.id
 
     @patch("sentry.issues.escalating.issue_velocity.get_latest_threshold")
     @patch("sentry.tasks.post_process.run_post_process_job", side_effect=run_post_process_job)


### PR DESCRIPTION
## Summary

Several automated/system paths transition group status via direct `Group.objects...update(status=...)` (bypassing `update_group_status`), so the transitions were never recorded in the action log. This publishes a system-sourced action at each site, mirroring 1:1 the `Activity` it already writes:

- `manage_issue_states` ESCALATING (`SET_ESCALATING`) → `EscalatingAction`
- `manage_issue_states` ONGOING (`SET_UNRESOLVED`) → `UnresolveAction`
- `post_process` `detect_new_escalation` (`SET_ESCALATING`) → `EscalatingAction`

Adds `GroupActionType.ESCALATING` + `EscalatingAction`. It's named for the *state the system observed* (the group is escalating), not an actor "escalate" action — nobody performs it; it's a recorded fact mirroring Activity's `SET_ESCALATING`. (`ONGOING`/`UNIGNORED` both collapse to `SET_UNRESOLVED` in Activity, so both map to `UnresolveAction`; the dead UNIGNORED branch is left alone.)

All callers are system/automated, so `source=SYSTEM`. Uses `publish_action` directly (no `action_context_scope`) since the values are known and no deep context-reading primitive is in the path.

Regression transitions (`SET_REGRESSION`, in `event_manager` + `status_change_consumer`) are a separate, larger piece — tracked under its own ticket.

## Test

`TestManageIssueStatesActionLog` (escalating/unresolve) + `DetectNewEscalationTestMixin.test_has_escalated` (post_process escalation), asserting the matching action attributed to `system`.

Part of ID-1631