### PR TITLE
fix(vercel): Preserve the next param through the install pipeline

### DIFF
--- a/static/app/views/integrationOrganizationLink/index.spec.tsx
+++ b/static/app/views/integrationOrganizationLink/index.spec.tsx
@@ -5,7 +5,13 @@ import {IntegrationProviderFixture} from 'sentry-fixture/integrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {VercelProviderFixture} from 'sentry-fixture/vercelIntegration';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
 
 import {ConfigStore} from 'sentry/stores/configStore';
@@ -122,6 +128,67 @@ describe('IntegrationOrganizationLink', () => {
     expect(screen.getByRole('button', {name: 'Install Vercel'})).toBeEnabled();
     expect(getProviderMock).toHaveBeenCalled();
     expect(getOrgMock).toHaveBeenCalled();
+  });
+
+  it('forwards the next param to the integration settings page after install', async () => {
+    setupConfigStore(org2);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org2.slug}/config/integrations/`,
+      match: [MockApiClient.matchQuery({provider_key: 'vercel'})],
+      body: {providers: [VercelProviderFixture()]},
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org2.slug}/`,
+      match: [MockApiClient.matchQuery({include_feature_flags: 1})],
+      body: org2,
+    });
+
+    // Drive the API pipeline: initialize hands back the auto-advancing Vercel
+    // step, and advancing completes the install with the new integration.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org2.slug}/pipeline/integration_pipeline/`,
+      method: 'POST',
+      match: [MockApiClient.matchData({action: 'initialize', provider: 'vercel'})],
+      body: {
+        step: 'oauth_login',
+        stepIndex: 0,
+        totalSteps: 1,
+        provider: 'vercel',
+        data: {state: 'pipeline-sig'},
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org2.slug}/pipeline/integration_pipeline/`,
+      method: 'POST',
+      match: [MockApiClient.matchData({state: 'pipeline-sig'})],
+      body: {status: 'complete', data: {id: '123', provider: {key: 'vercel'}}},
+    });
+
+    render(<IntegrationOrganizationLink />, {
+      organization: org2,
+      initialRouterConfig: {
+        location: {
+          pathname: '/extensions/vercel/link/',
+          query: {code: 'oauth-code', next: 'https://vercel.com/dashboard'},
+        },
+        route: '/extensions/:integrationSlug/link/',
+      },
+    });
+    renderGlobalModal({organization: org2});
+
+    await selectEvent.select(await screen.findByRole('textbox'), org2.name);
+    await userEvent.click(screen.getByRole('button', {name: 'Install Vercel'}));
+
+    await waitFor(() => {
+      expect(testableWindowLocation.assign).toHaveBeenCalledWith(
+        expect.stringContaining('next=https%3A%2F%2Fvercel.com%2Fdashboard')
+      );
+    });
+    expect(testableWindowLocation.assign).toHaveBeenCalledWith(
+      expect.stringContaining('/settings/integrations/vercel/123/')
+    );
   });
 
   it('shows an error and reports to Sentry when the provider has no pipeline', async () => {

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 import {skipToken, useQuery} from '@tanstack/react-query';
+import * as qs from 'query-string';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
@@ -178,11 +179,17 @@ export default function IntegrationOrganizationLink() {
       const normalizedUrl = normalizeUrl(
         `/settings/${orgId}/integrations/${data.provider.key}/${data.id}/`
       );
-      window.location.assign(
-        `${organization?.links.organizationUrl || ''}${normalizedUrl}`
+      // Preserve the `next` param (e.g. Vercel's marketplace return URL) so the
+      // integration's configure page can offer a "Complete on <provider>" link
+      // back to where the install was initiated.
+      const nextParam =
+        typeof location.query.next === 'string' ? location.query.next : undefined;
+      const search = nextParam ? `?${qs.stringify({next: nextParam})}` : '';
+      testableWindowLocation.assign(
+        `${organization?.links.organizationUrl || ''}${normalizedUrl}${search}`
       );
     },
-    [organization]
+    [organization, location.query.next]
   );
 
   // GitHub App listing installs arrive here with `installationId` as a URL


### PR DESCRIPTION
Vercel marketplace installs arrive at `/extensions/vercel/configure/` with a `next` query param, which is the URL to send the user back to on Vercel once the Sentry install is finished. The legacy extension-configuration pipeline (`ExternalIntegrationPipeline._dialog_success`) forwarded `next` verbatim onto the integration settings redirect, where the project-mapper field's "Complete on Vercel" button reads it (`safeGetQsParam('next')`, validated against `https://vercel.com`) to link the user back to Vercel.

The API-pipeline refactor routed the configure URL through the org-picker link page. `next` survives that hop (the `RedirectView` has `query_string=True`), but the `onInstall` callback on the link page dropped it when redirecting to the integration settings page after the modal completed. The "Complete on Vercel" button therefore never rendered, leaving the user stranded on Sentry with no way back to Vercel.

This forwards `next` onto the settings redirect so the button reappears, restoring the pre-refactor behavior. The redirect also switches from a raw `window.location.assign` to the `testableWindowLocation.assign` already imported and used elsewhere in the file, so the flow is testable; a new test drives the install to completion and asserts `next` lands on the settings URL.