### PR TITLE
chore(markdown): add http request to markdown

### DIFF
--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
@@ -544,6 +544,127 @@ describe('useCopyIssueDetails', () => {
       expect(result).not.toContain('## Breadcrumbs');
     });
 
+    it('includes the request method, url, and body when present', () => {
+      const eventWithRequest = EventFixture({
+        ...event,
+        entries: [
+          {
+            type: EntryType.REQUEST,
+            data: {
+              method: 'POST',
+              url: 'https://example.com/api/checkout/',
+              data: {cart_id: 'abc123', total: 4200},
+            },
+          },
+        ],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithRequest,
+        organization,
+      });
+
+      expect(result).toContain('## Request');
+      expect(result).toContain('POST https://example.com/api/checkout/');
+      expect(result).toContain('Body:');
+      expect(result).toContain('"cart_id": "abc123"');
+    });
+
+    it('renders a string request body as-is', () => {
+      const eventWithStringBody = EventFixture({
+        ...event,
+        entries: [
+          {
+            type: EntryType.REQUEST,
+            data: {
+              method: 'GET',
+              url: 'https://example.com/api/items/',
+              data: 'raw body payload',
+            },
+          },
+        ],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithStringBody,
+        organization,
+      });
+
+      expect(result).toContain('GET https://example.com/api/items/');
+      expect(result).toContain('raw body payload');
+    });
+
+    it('renders the request after breadcrumbs', () => {
+      const eventWithBoth = EventFixture({
+        ...event,
+        entries: [
+          {
+            type: EntryType.REQUEST,
+            data: {method: 'GET', url: 'https://example.com/', data: null},
+          },
+          {
+            type: EntryType.BREADCRUMBS,
+            data: {values: [{type: 'default', level: 'info', message: 'crumb'}]},
+          },
+        ],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithBoth,
+        organization,
+      });
+
+      expect(result.indexOf('## Breadcrumbs')).toBeLessThan(result.indexOf('## Request'));
+    });
+
+    it('truncates a large request body to the character limit', () => {
+      const eventWithLargeBody = EventFixture({
+        ...event,
+        entries: [
+          {
+            type: EntryType.REQUEST,
+            data: {
+              method: 'POST',
+              url: 'https://example.com/api/upload/',
+              data: 'z'.repeat(2500),
+            },
+          },
+        ],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithLargeBody,
+        organization,
+      });
+
+      expect(result).toContain(`${'z'.repeat(2000)}...`);
+      expect(result).not.toContain('z'.repeat(2001));
+    });
+
+    it('does not include a request section when there is no request data', () => {
+      const eventWithEmptyRequest = EventFixture({
+        ...event,
+        entries: [
+          {
+            type: EntryType.REQUEST,
+            data: {method: null, url: '', data: null},
+          },
+        ],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithEmptyRequest,
+        organization,
+      });
+
+      expect(result).not.toContain('## Request');
+    });
+
     // 1006 is the occurrence type for N+1 DB Queries. Spans mirror the classic
     // cache-miss → DB-read shape: each offender is a cache.get with a distinct
     // key followed by an identical parameterized query.

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
@@ -14,7 +14,7 @@ import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
 import {NODE_ENV} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import type {RawCrumb} from 'sentry/types/breadcrumbs';
-import {EntryType, type Event} from 'sentry/types/event';
+import {EntryType, type Event, type EntryRequest} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {StacktraceType} from 'sentry/types/stacktrace';
@@ -142,11 +142,45 @@ function formatBreadcrumbsToMarkdown(crumbs: RawCrumb[]): string {
   return `\n## Breadcrumbs\n\n${section}\n`;
 }
 
+// Mirror Seer's request formatting: only the method, URL, and body are included
+// (Seer deliberately omits cookies, headers, env, and query params), and the
+// body is capped to keep an oversized payload off the clipboard. Scrubbed
+// (`[Filtered]`) values are left in place — they're already redacted by Sentry
+// and dropping the whole section would lose the method and URL.
+const MAX_REQUEST_CHARS = 2000;
+
+function formatRequestToMarkdown(data: EntryRequest['data']): string {
+  const requestLine = [data.method, data.url].filter(Boolean).join(' ');
+
+  const body = data.data;
+  const hasBody = body !== null && body !== undefined && body !== '';
+  const bodyStr = hasBody
+    ? typeof body === 'string'
+      ? body
+      : JSON.stringify(body, null, 2)
+    : '';
+
+  if (!requestLine && !bodyStr) {
+    return '';
+  }
+
+  let markdownText = '\n## Request\n\n';
+  if (requestLine) {
+    markdownText += `${requestLine}\n`;
+  }
+  if (bodyStr) {
+    markdownText += `\nBody:\n\`\`\`\n${truncate(bodyStr, MAX_REQUEST_CHARS)}\n\`\`\`\n`;
+  }
+
+  return markdownText;
+}
+
 function formatEventToMarkdown(event: Event, activeThreadId: number | undefined): string {
   let markdownText = '';
-  // Collected separately so breadcrumbs always render after the exception /
-  // thread sections, regardless of the order entries appear in the event.
+  // Collected separately so breadcrumbs and the request always render after the
+  // exception / thread sections, regardless of the order entries appear in.
   let breadcrumbsText = '';
+  let requestText = '';
 
   // Add tags
   if (event && Array.isArray(event.tags) && event.tags.length > 0) {
@@ -200,10 +234,13 @@ function formatEventToMarkdown(event: Event, activeThreadId: number | undefined)
       }
     } else if (entry.type === EntryType.BREADCRUMBS && entry.data.values) {
       breadcrumbsText += formatBreadcrumbsToMarkdown(entry.data.values);
+    } else if (entry.type === EntryType.REQUEST && entry.data) {
+      requestText += formatRequestToMarkdown(entry.data);
     }
   });
 
   markdownText += breadcrumbsText;
+  markdownText += requestText;
 
   return markdownText;
 }


### PR DESCRIPTION
adds `## Request` section to copy to markdown, as and Seer and MCP both include it.

the section includes only the method, URL, and body (copied from seer) and is capped at 2000 chars (also from seer) to keep an oversized payload off the clipboard.

Example

```
## Request

POST https://example.com/api/checkout/

Body:
{
  "cart_id": "abc123",
  "total": 4200,
  "payment_token": "[Filtered]"
}
```