### PR TITLE
feat(issue-progress): add progress activity hovercard

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -5,9 +5,8 @@ import type {LocationDescriptor} from 'history';
 
 import {Checkbox} from '@sentry/scraps/checkbox';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
-import {Stack} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
-import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
@@ -58,6 +57,7 @@ import {
   useOptionalIssueSelectionActions,
   useOptionalIssueSelectionSummary,
 } from 'sentry/views/issueList/issueSelectionContext';
+import {ProgressActivityTooltip} from 'sentry/views/issueList/progressActivityTooltip';
 import {
   createIssueLink,
   DISCOVER_EXCLUSION_FIELDS,
@@ -729,10 +729,14 @@ export function StreamGroup({
           {withColumns.includes('progress') && (
             <ProgressWrapper breakpoint={COLUMN_BREAKPOINTS.PROGRESS}>
               {progressState ? (
-                <Stack direction="row" align="center" gap="sm">
-                  {getProgressIcon(progressState)}
-                  <Text>{formatProgressState(progressState)}</Text>
-                </Stack>
+                <Container position="relative">
+                  <ProgressActivityTooltip group={group}>
+                    <Stack direction="row" align="center" gap="sm">
+                      {getProgressIcon(progressState)}
+                      {formatProgressState(progressState)}
+                    </Stack>
+                  </ProgressActivityTooltip>
+                </Container>
               ) : (
                 <Placeholder height="18px" width="80px" />
               )}

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -738,7 +738,7 @@ export function StreamGroup({
                   </ProgressActivityTooltip>
                 </Container>
               ) : (
-                <Placeholder height="18px" width="80px" />
+                <Placeholder height="18px" />
               )}
             </ProgressWrapper>
           )}

--- a/static/app/views/issueDetails/activitySection/activityColorConfig.tsx
+++ b/static/app/views/issueDetails/activitySection/activityColorConfig.tsx
@@ -1,0 +1,49 @@
+import type {Theme} from '@emotion/react';
+
+import {GroupActivityType} from 'sentry/types/group';
+
+export function getActivityColorConfig(theme: Theme, type: GroupActivityType) {
+  const defaultConfig = {
+    title: theme.tokens.content.primary,
+    icon: theme.tokens.content.secondary,
+    iconBorder: theme.tokens.content.secondary,
+  };
+
+  switch (type) {
+    case GroupActivityType.SET_RESOLVED:
+    case GroupActivityType.SET_RESOLVED_BY_AGE:
+    case GroupActivityType.SET_RESOLVED_IN_RELEASE:
+    case GroupActivityType.SET_RESOLVED_IN_COMMIT:
+    case GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST:
+    case GroupActivityType.MARK_REVIEWED:
+    case GroupActivityType.SEER_RCA_COMPLETED:
+    case GroupActivityType.SEER_SOLUTION_COMPLETED:
+    case GroupActivityType.SEER_CODING_COMPLETED:
+    case GroupActivityType.SEER_PR_CREATED:
+      return {
+        ...defaultConfig,
+        icon: theme.tokens.graphics.success.vibrant,
+        iconBorder: theme.tokens.border.success.vibrant,
+      };
+    case GroupActivityType.SET_UNRESOLVED:
+    case GroupActivityType.SET_REGRESSION:
+      return {
+        ...defaultConfig,
+        icon: theme.tokens.graphics.danger.vibrant,
+        iconBorder: theme.tokens.border.danger.vibrant,
+      };
+    case GroupActivityType.SET_ESCALATING:
+    case GroupActivityType.SET_PRIORITY:
+      return {
+        ...defaultConfig,
+        icon: theme.tokens.graphics.warning.vibrant,
+        iconBorder: theme.tokens.border.warning.vibrant,
+      };
+    case GroupActivityType.SET_IGNORED:
+      return {
+        ...defaultConfig,
+      };
+    default:
+      return defaultConfig;
+  }
+}

--- a/static/app/views/issueDetails/activitySection/activityMarker.tsx
+++ b/static/app/views/issueDetails/activitySection/activityMarker.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+
+import {SentryAppAvatar, UserAvatar} from '@sentry/scraps/avatar';
+
+import type {GroupActivity} from 'sentry/types/group';
+
+export function ActivityMarker({item, color}: {color: string; item: GroupActivity}) {
+  if (item.sentry_app) {
+    return (
+      <AvatarMarker color={color}>
+        <SentryAppAvatar
+          data-test-id="sentry-app-activity-marker"
+          sentryApp={item.sentry_app}
+          size={22}
+        />
+      </AvatarMarker>
+    );
+  }
+  if (item.user) {
+    return (
+      <AvatarMarker color={color}>
+        <UserAvatar data-test-id="user-activity-marker" user={item.user} size={22} />
+      </AvatarMarker>
+    );
+  }
+  return <SentryMarker color={color} data-test-id="sentry-activity-marker" />;
+}
+
+const AvatarMarker = styled('span')<{color: string}>`
+  display: block;
+  position: relative;
+  border-radius: 100%;
+  line-height: 0;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 100%;
+    box-shadow: inset 0 0 0 2px ${p => p.color};
+    pointer-events: none;
+  }
+`;
+
+const SentryMarker = styled('span')<{color: string}>`
+  width: 12px;
+  height: 12px;
+  border-radius: 100%;
+  background: ${p => p.theme.tokens.background.primary};
+  display: grid;
+  place-items: center;
+
+  &::after {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 100%;
+    background: ${p => p.color};
+  }
+`;

--- a/static/app/views/issueDetails/activitySection/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityIcons.tsx
@@ -29,6 +29,7 @@ import {
   IconUnsubscribed,
   IconUser,
 } from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import type {
   GroupActivity,
   GroupActivityCreateIssue,
@@ -37,14 +38,14 @@ import type {
 import {GroupActivityType} from 'sentry/types/group';
 
 interface IconWithDefaultProps {
-  Component: React.ComponentType<any> | null;
+  Component: React.ComponentType<SVGIconProps> | null;
   defaultProps: {locked?: boolean; type?: string};
   componentFunction?: (props: {
     data: GroupActivity['data'];
     sentry_app: GroupActivity['sentry_app'];
     user: GroupActivity['user'];
-  }) => React.ComponentType<any>;
-  propsFunction?: (props: any) => any;
+  }) => React.ComponentType<SVGIconProps>;
+  propsFunction?: (data: GroupActivity['data']) => Record<string, unknown>;
 }
 
 export const groupActivityTypeIconMapping: Record<

--- a/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
@@ -26,14 +26,31 @@ import {formatDuration} from 'sentry/utils/duration/formatDuration';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {isSemverRelease} from 'sentry/utils/versions/isSemverRelease';
 
+function getAuthorName(item: GroupActivity) {
+  if (item.sentry_app) {
+    return item.sentry_app.name;
+  }
+  if (item.user) {
+    return item.user.name;
+  }
+  if (
+    item.type === GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST &&
+    item.data.pullRequest?.author?.name &&
+    !item.data.pullRequest.author.email?.endsWith('@localhost')
+  ) {
+    return item.data.pullRequest.author.name;
+  }
+  return 'Sentry';
+}
+
 export function getGroupActivityItem(
   activity: GroupActivity,
   organization: Organization,
   project: Project,
   issueCategory: IssueCategory,
-  author: React.ReactNode,
   teams: Team[]
 ) {
+  const author = <strong>{getAuthorName(activity)}</strong>;
   const issuesLink = `/organizations/${organization.slug}/issues/`;
   const isFeedback = issueCategory === IssueCategoryEnum.FEEDBACK;
 

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -1,8 +1,7 @@
 import {Fragment, useCallback, useState} from 'react';
-import {useTheme, type Theme} from '@emotion/react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {SentryAppAvatar, UserAvatar} from '@sentry/scraps/avatar';
 import {LinkButton} from '@sentry/scraps/button';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -28,6 +27,8 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTeamsById} from 'sentry/utils/useTeamsById';
 import {useUser} from 'sentry/utils/useUser';
+import {getActivityColorConfig} from 'sentry/views/issueDetails/activitySection/activityColorConfig';
+import {ActivityMarker} from 'sentry/views/issueDetails/activitySection/activityMarker';
 import {CommentActionsDropdown} from 'sentry/views/issueDetails/activitySection/commentActionsDropdown';
 import {groupActivityTypeIconMapping} from 'sentry/views/issueDetails/activitySection/groupActivityIcons';
 import {getGroupActivityItem} from 'sentry/views/issueDetails/activitySection/groupActivityItem';
@@ -36,91 +37,6 @@ import {SidebarFoldSection} from 'sentry/views/issueDetails/foldSection';
 import {SidebarSectionTitle} from 'sentry/views/issueDetails/sidebar/sidebar';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
-
-function getAuthorName(item: GroupActivity) {
-  if (item.sentry_app) {
-    return item.sentry_app.name;
-  }
-  if (item.user) {
-    return item.user.name;
-  }
-  if (
-    item.type === GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST &&
-    item.data.pullRequest?.author?.name &&
-    !item.data.pullRequest.author.email?.endsWith('@localhost')
-  ) {
-    return item.data.pullRequest.author.name;
-  }
-  return 'Sentry';
-}
-
-function getActivityMarker(item: GroupActivity, color: string) {
-  if (item.sentry_app) {
-    return (
-      <AvatarMarker color={color}>
-        <SentryAppAvatar
-          data-test-id="sentry-app-activity-marker"
-          sentryApp={item.sentry_app}
-          size={22}
-        />
-      </AvatarMarker>
-    );
-  }
-  if (item.user) {
-    return (
-      <AvatarMarker color={color}>
-        <UserAvatar data-test-id="user-activity-marker" user={item.user} size={22} />
-      </AvatarMarker>
-    );
-  }
-  return <SentryMarker color={color} data-test-id="sentry-activity-marker" />;
-}
-
-function getActivityColorConfig(theme: Theme, type: GroupActivityType) {
-  const defaultConfig = {
-    title: theme.tokens.content.primary,
-    icon: theme.tokens.content.secondary,
-    iconBorder: theme.tokens.content.secondary,
-  };
-
-  switch (type) {
-    case GroupActivityType.SET_RESOLVED:
-    case GroupActivityType.SET_RESOLVED_BY_AGE:
-    case GroupActivityType.SET_RESOLVED_IN_RELEASE:
-    case GroupActivityType.SET_RESOLVED_IN_COMMIT:
-    case GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST:
-    case GroupActivityType.MARK_REVIEWED:
-    case GroupActivityType.SEER_RCA_COMPLETED:
-    case GroupActivityType.SEER_SOLUTION_COMPLETED:
-    case GroupActivityType.SEER_CODING_COMPLETED:
-    case GroupActivityType.SEER_PR_CREATED:
-      return {
-        ...defaultConfig,
-        icon: theme.tokens.graphics.success.vibrant,
-        iconBorder: theme.tokens.border.success.vibrant,
-      };
-    case GroupActivityType.SET_UNRESOLVED:
-    case GroupActivityType.SET_REGRESSION:
-      return {
-        ...defaultConfig,
-        icon: theme.tokens.graphics.danger.vibrant,
-        iconBorder: theme.tokens.border.danger.vibrant,
-      };
-    case GroupActivityType.SET_ESCALATING:
-    case GroupActivityType.SET_PRIORITY:
-      return {
-        ...defaultConfig,
-        icon: theme.tokens.graphics.warning.vibrant,
-        iconBorder: theme.tokens.border.warning.vibrant,
-      };
-    case GroupActivityType.SET_IGNORED:
-      return {
-        ...defaultConfig,
-      };
-    default:
-      return defaultConfig;
-  }
-}
 
 function TimelineItem({
   item,
@@ -145,14 +61,12 @@ function TimelineItem({
   const theme = useTheme();
   const [editing, setEditing] = useState(false);
   const useTwoColumnLayout = organization.features.includes('issue-activity-feed-v2');
-  const authorName = getAuthorName(item);
   const colorConfig = getActivityColorConfig(theme, item.type);
   const {title, message} = getGroupActivityItem(
     item,
     organization,
     group.project,
     group.issueCategory,
-    <strong>{authorName}</strong>,
     teams
   );
 
@@ -186,7 +100,11 @@ function TimelineItem({
         </Flex>
       }
       timestamp={<Timestamp date={item.dateCreated} unitStyle={timestampUnitStyle} />}
-      marker={useTwoColumnLayout ? getActivityMarker(item, colorConfig.icon) : undefined}
+      marker={
+        useTwoColumnLayout ? (
+          <ActivityMarker item={item} color={colorConfig.icon} />
+        ) : undefined
+      }
       colorConfig={useTwoColumnLayout ? colorConfig : undefined}
       icon={
         Icon && (
@@ -534,37 +452,4 @@ const MoreActivityIcon = styled('div')`
 const ActivityInputFrame = styled('div')`
   color: ${p => p.theme.tokens.content.primary};
   min-width: 0;
-`;
-
-const AvatarMarker = styled('span')<{color: string}>`
-  display: block;
-  position: relative;
-  border-radius: 100%;
-  line-height: 0;
-
-  &::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: 100%;
-    box-shadow: inset 0 0 0 2px ${p => p.color};
-    pointer-events: none;
-  }
-`;
-
-const SentryMarker = styled('span')<{color: string}>`
-  width: 12px;
-  height: 12px;
-  border-radius: 100%;
-  background: ${p => p.theme.tokens.background.primary};
-  display: grid;
-  place-items: center;
-
-  &::after {
-    content: '';
-    width: 6px;
-    height: 6px;
-    border-radius: 100%;
-    background: ${p => p.color};
-  }
 `;

--- a/static/app/views/issueList/progressActivityTooltip.spec.tsx
+++ b/static/app/views/issueList/progressActivityTooltip.spec.tsx
@@ -1,0 +1,69 @@
+import {GroupFixture} from 'sentry-fixture/group';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {GroupActivity} from 'sentry/types/group';
+import {GroupActivityType} from 'sentry/types/group';
+import {ProgressActivityTooltip} from 'sentry/views/issueList/progressActivityTooltip';
+
+describe('ProgressActivityTooltip', () => {
+  const group = GroupFixture({id: '1337'});
+  const activity: GroupActivity = {
+    id: 'activity-1',
+    type: GroupActivityType.SET_UNRESOLVED,
+    data: {},
+    dateCreated: '2024-01-01T00:00:00.000Z',
+    user: null,
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/1337/activities/',
+      body: {activity: [activity]},
+    });
+  });
+
+  it('shows progress activity in a hovercard', async () => {
+    render(
+      <ProgressActivityTooltip group={group}>
+        <button>Progress</button>
+      </ProgressActivityTooltip>
+    );
+
+    expect(screen.getByRole('button', {name: 'Progress'})).toHaveStyle({
+      textDecoration: 'underline',
+    });
+
+    await userEvent.hover(screen.getByRole('button', {name: 'Progress'}));
+
+    expect(await screen.findByText('Unresolved')).toBeInTheDocument();
+  });
+
+  it('filters out non-progress activity', async () => {
+    const noteActivity: GroupActivity = {
+      id: 'activity-2',
+      type: GroupActivityType.NOTE,
+      data: {text: 'Hidden note activity'},
+      dateCreated: '2024-01-02T00:00:00.000Z',
+      user: null,
+    };
+
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/1337/activities/',
+      body: {activity: [noteActivity, activity]},
+    });
+
+    render(
+      <ProgressActivityTooltip group={group}>
+        <button>Progress</button>
+      </ProgressActivityTooltip>
+    );
+
+    await userEvent.hover(screen.getByRole('button', {name: 'Progress'}));
+
+    expect(await screen.findByText('Unresolved')).toBeInTheDocument();
+    expect(screen.queryByText('Hidden note activity')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueList/progressActivityTooltip.spec.tsx
+++ b/static/app/views/issueList/progressActivityTooltip.spec.tsx
@@ -41,10 +41,10 @@ describe('ProgressActivityTooltip', () => {
   });
 
   it('filters out non-progress activity', async () => {
-    const noteActivity: GroupActivity = {
+    const mergeActivity: GroupActivity = {
       id: 'activity-2',
-      type: GroupActivityType.NOTE,
-      data: {text: 'Hidden note activity'},
+      type: GroupActivityType.MERGE,
+      data: {issues: [{id: '99'}]},
       dateCreated: '2024-01-02T00:00:00.000Z',
       user: null,
     };
@@ -52,7 +52,7 @@ describe('ProgressActivityTooltip', () => {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1337/activities/',
-      body: {activity: [noteActivity, activity]},
+      body: {activity: [mergeActivity, activity]},
     });
 
     render(
@@ -64,14 +64,14 @@ describe('ProgressActivityTooltip', () => {
     await userEvent.hover(screen.getByRole('button', {name: 'Progress'}));
 
     expect(await screen.findByText('Unresolved')).toBeInTheDocument();
-    expect(screen.queryByText('Hidden note activity')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Merge/)).not.toBeInTheDocument();
   });
 
   it('falls back to recent activities when none match progress types', async () => {
-    const noteActivity: GroupActivity = {
+    const mergeActivity: GroupActivity = {
       id: 'activity-3',
-      type: GroupActivityType.NOTE,
-      data: {text: 'A comment'},
+      type: GroupActivityType.MERGE,
+      data: {issues: [{id: '99'}]},
       dateCreated: '2024-01-03T00:00:00.000Z',
       user: null,
     };
@@ -79,7 +79,7 @@ describe('ProgressActivityTooltip', () => {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1337/activities/',
-      body: {activity: [noteActivity]},
+      body: {activity: [mergeActivity]},
     });
 
     render(
@@ -90,6 +90,6 @@ describe('ProgressActivityTooltip', () => {
 
     await userEvent.hover(screen.getByRole('button', {name: 'Progress'}));
 
-    expect(await screen.findByText('A comment')).toBeInTheDocument();
+    expect(await screen.findByText(/Merge/)).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueList/progressActivityTooltip.spec.tsx
+++ b/static/app/views/issueList/progressActivityTooltip.spec.tsx
@@ -66,4 +66,30 @@ describe('ProgressActivityTooltip', () => {
     expect(await screen.findByText('Unresolved')).toBeInTheDocument();
     expect(screen.queryByText('Hidden note activity')).not.toBeInTheDocument();
   });
+
+  it('falls back to recent activities when none match progress types', async () => {
+    const noteActivity: GroupActivity = {
+      id: 'activity-3',
+      type: GroupActivityType.NOTE,
+      data: {text: 'A comment'},
+      dateCreated: '2024-01-03T00:00:00.000Z',
+      user: null,
+    };
+
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/1337/activities/',
+      body: {activity: [noteActivity]},
+    });
+
+    render(
+      <ProgressActivityTooltip group={group}>
+        <button>Progress</button>
+      </ProgressActivityTooltip>
+    );
+
+    await userEvent.hover(screen.getByRole('button', {name: 'Progress'}));
+
+    expect(await screen.findByText('A comment')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/issueList/progressActivityTooltip.tsx
+++ b/static/app/views/issueList/progressActivityTooltip.tsx
@@ -5,6 +5,7 @@ import {useQuery} from '@tanstack/react-query';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
+import {NoteBody} from 'sentry/components/activity/note/body';
 import {Hovercard} from 'sentry/components/hovercard';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Timeline} from 'sentry/components/timeline';
@@ -98,7 +99,9 @@ function ProgressActivityItem({group, item}: {group: Group; item: GroupActivity}
         )
       }
     >
-      {message ? (
+      {typeof message === 'string' ? (
+        <NoteBody text={message} />
+      ) : message ? (
         <Text as="div" size="sm">
           {message}
         </Text>

--- a/static/app/views/issueList/progressActivityTooltip.tsx
+++ b/static/app/views/issueList/progressActivityTooltip.tsx
@@ -20,6 +20,8 @@ import {ActivityMarker} from 'sentry/views/issueDetails/activitySection/activity
 import {groupActivityTypeIconMapping} from 'sentry/views/issueDetails/activitySection/groupActivityIcons';
 import {getGroupActivityItem} from 'sentry/views/issueDetails/activitySection/groupActivityItem';
 
+// Only include activity items that describe issue progress changes. Other
+// activity types can be useful in the full activity feed, but are noise here.
 const PROGRESS_ACTIVITY_TYPES = new Set<GroupActivityType>([
   GroupActivityType.FIRST_SEEN,
   GroupActivityType.SEER_RCA_COMPLETED,

--- a/static/app/views/issueList/progressActivityTooltip.tsx
+++ b/static/app/views/issueList/progressActivityTooltip.tsx
@@ -43,6 +43,7 @@ const MAX_ITEMS = 3;
 function getProgressActivities(activities: GroupActivity[]): GroupActivity[] {
   // `activities` is ordered newest-first. Collect the most recent matching
   // items, then reverse so the newest activity is rendered at the bottom.
+  // Falls back to the most recent items if no progress-specific ones exist.
   const result: GroupActivity[] = [];
   for (const activity of activities) {
     if (PROGRESS_ACTIVITY_TYPES.has(activity.type)) {
@@ -52,7 +53,10 @@ function getProgressActivities(activities: GroupActivity[]): GroupActivity[] {
       }
     }
   }
-  return result.toReversed();
+  if (result.length > 0) {
+    return result.toReversed();
+  }
+  return activities.slice(0, MAX_ITEMS).toReversed();
 }
 
 function ProgressActivityItem({group, item}: {group: Group; item: GroupActivity}) {

--- a/static/app/views/issueList/progressActivityTooltip.tsx
+++ b/static/app/views/issueList/progressActivityTooltip.tsx
@@ -1,0 +1,207 @@
+import {ClassNames, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import {useQuery} from '@tanstack/react-query';
+
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {Hovercard} from 'sentry/components/hovercard';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {Timeline} from 'sentry/components/timeline';
+import {TimeSince} from 'sentry/components/timeSince';
+import {t} from 'sentry/locale';
+import type {Group, GroupActivity} from 'sentry/types/group';
+import {GroupActivityType} from 'sentry/types/group';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useTeamsById} from 'sentry/utils/useTeamsById';
+import {getActivityColorConfig} from 'sentry/views/issueDetails/activitySection/activityColorConfig';
+import {ActivityMarker} from 'sentry/views/issueDetails/activitySection/activityMarker';
+import {groupActivityTypeIconMapping} from 'sentry/views/issueDetails/activitySection/groupActivityIcons';
+import {getGroupActivityItem} from 'sentry/views/issueDetails/activitySection/groupActivityItem';
+
+const PROGRESS_ACTIVITY_TYPES = new Set<GroupActivityType>([
+  GroupActivityType.FIRST_SEEN,
+  GroupActivityType.SEER_RCA_COMPLETED,
+  GroupActivityType.SEER_PR_CREATED,
+  GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST,
+  GroupActivityType.REFERENCED_IN_COMMIT,
+  GroupActivityType.SET_RESOLVED_IN_COMMIT,
+  GroupActivityType.SET_RESOLVED_IN_RELEASE,
+  GroupActivityType.SET_RESOLVED_BY_AGE,
+  GroupActivityType.SET_RESOLVED,
+  GroupActivityType.SET_UNRESOLVED,
+  GroupActivityType.SET_REGRESSION,
+  GroupActivityType.ASSIGNED,
+  GroupActivityType.UNASSIGNED,
+]);
+
+const MAX_ITEMS = 3;
+
+function getProgressActivities(activities: GroupActivity[]): GroupActivity[] {
+  // `activities` is ordered newest-first. Collect the most recent matching
+  // items, then reverse so the newest activity is rendered at the bottom.
+  const result: GroupActivity[] = [];
+  for (const activity of activities) {
+    if (PROGRESS_ACTIVITY_TYPES.has(activity.type)) {
+      result.push(activity);
+      if (result.length >= MAX_ITEMS) {
+        break;
+      }
+    }
+  }
+  return result.toReversed();
+}
+
+function ProgressActivityItem({group, item}: {group: Group; item: GroupActivity}) {
+  const organization = useOrganization();
+  const theme = useTheme();
+  const {teams} = useTeamsById();
+
+  const colorConfig = getActivityColorConfig(theme, item.type);
+  const {title, message} = getGroupActivityItem(
+    item,
+    organization,
+    group.project,
+    group.issueCategory,
+    teams
+  );
+
+  const iconMapping = groupActivityTypeIconMapping[item.type];
+  const Icon = iconMapping?.componentFunction
+    ? iconMapping.componentFunction({
+        data: item.data,
+        user: item.user,
+        sentry_app: item.sentry_app,
+      })
+    : (iconMapping?.Component ?? null);
+
+  return (
+    <Timeline.Item
+      title={title}
+      timestamp={<Timestamp date={item.dateCreated} unitStyle="extraShort" />}
+      marker={<ActivityMarker item={item} color={colorConfig.icon} />}
+      colorConfig={colorConfig}
+      icon={
+        Icon && (
+          <Icon
+            {...iconMapping.defaultProps}
+            {...iconMapping.propsFunction?.(item.data)}
+            size="xs"
+          />
+        )
+      }
+    >
+      {message ? (
+        <Text as="div" size="sm">
+          {message}
+        </Text>
+      ) : null}
+    </Timeline.Item>
+  );
+}
+
+function ProgressActivityBody({group}: {group: Group}) {
+  const organization = useOrganization();
+
+  const {data, isPending, isError} = useQuery(
+    apiOptions.as<{activity: GroupActivity[]}>()(
+      '/organizations/$organizationIdOrSlug/issues/$issueId/activities/',
+      {
+        path: {organizationIdOrSlug: organization.slug, issueId: group.id},
+        staleTime: 30_000,
+      }
+    )
+  );
+
+  if (isPending) {
+    return (
+      <TimelineContainer>
+        <Flex align="center" justify="center" minHeight="40px">
+          <LoadingIndicator size={24} />
+        </Flex>
+      </TimelineContainer>
+    );
+  }
+
+  if (isError) {
+    return (
+      <TimelineContainer>
+        <Flex align="center" justify="center" minHeight="40px">
+          <Text variant="muted">{t('Failed to load activity.')}</Text>
+        </Flex>
+      </TimelineContainer>
+    );
+  }
+
+  const items = getProgressActivities(data?.activity ?? []);
+
+  if (items.length === 0) {
+    return (
+      <TimelineContainer>
+        <Flex align="center" justify="center" minHeight="40px">
+          <Text variant="muted">{t('No activity.')}</Text>
+        </Flex>
+      </TimelineContainer>
+    );
+  }
+
+  return (
+    <TimelineContainer>
+      <Timeline.Container>
+        {items.map(item => (
+          <ProgressActivityItem key={item.id} group={group} item={item} />
+        ))}
+      </Timeline.Container>
+    </TimelineContainer>
+  );
+}
+
+interface ProgressActivityTooltipProps {
+  children: React.ReactNode;
+  group: Group;
+}
+
+export function ProgressActivityTooltip({children, group}: ProgressActivityTooltipProps) {
+  return (
+    <ClassNames>
+      {({css}) => (
+        <ProgressHovercard
+          body={
+            <HovercardBodyBoundary onClick={event => event.stopPropagation()}>
+              <ProgressActivityBody group={group} />
+            </HovercardBodyBoundary>
+          }
+          bodyClassName={css`
+            padding: 0;
+            min-height: 0;
+          `}
+          containerDisplayMode="inline-flex"
+          showUnderline
+        >
+          {children}
+        </ProgressHovercard>
+      )}
+    </ClassNames>
+  );
+}
+
+const Timestamp = styled(TimeSince)`
+  font-size: ${p => p.theme.font.size.sm};
+  white-space: nowrap;
+`;
+
+const TimelineContainer = styled('div')`
+  width: 300px;
+`;
+
+const ProgressHovercard = styled(Hovercard)`
+  width: auto;
+`;
+
+const HovercardBodyBoundary = styled('div')`
+  padding: ${p => p.theme.space.md};
+  max-height: 320px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+`;

--- a/static/app/views/issueList/progressActivityTooltip.tsx
+++ b/static/app/views/issueList/progressActivityTooltip.tsx
@@ -24,6 +24,7 @@ import {getGroupActivityItem} from 'sentry/views/issueDetails/activitySection/gr
 // Only include activity items that describe issue progress changes. Other
 // activity types can be useful in the full activity feed, but are noise here.
 const PROGRESS_ACTIVITY_TYPES = new Set<GroupActivityType>([
+  GroupActivityType.NOTE,
   GroupActivityType.FIRST_SEEN,
   GroupActivityType.SEER_RCA_COMPLETED,
   GroupActivityType.SEER_PR_CREATED,
@@ -75,8 +76,10 @@ function ProgressActivityItem({group, item}: {group: Group; item: GroupActivity}
   );
 
   const iconMapping = groupActivityTypeIconMapping[item.type];
-  const Icon = iconMapping?.componentFunction
-    ? iconMapping.componentFunction({
+  const componentFunction =
+    item.type === GroupActivityType.NOTE ? undefined : iconMapping?.componentFunction;
+  const Icon = componentFunction
+    ? componentFunction({
         data: item.data,
         user: item.user,
         sentry_app: item.sentry_app,


### PR DESCRIPTION
Closes ISWF-2874

[See designs here](https://www.figma.com/design/EuGqrtnFNC3WkWJhJjeQLP/Specs--Issue-Stream-v2?node-id=17-54080&t=J08bG3Swac3B4PsJ-0)

This adds a progress tooltip which fetches the group activity and displays the last few relevant entries.

The tooltip code is pretty simple, but most of the diff in this PR is related to breaking up the issue details activity component so that the individual parts can be imported into the issue list and used there. I didn't want to use the existing TimelineItem component because it includes logic related to comments which is not necessary in the tooltip. We may also want to add further customization later so this decouples from the details view a bit.

<img width="343" height="242" alt="CleanShot 2026-06-16 at 13 47 00" src="https://github.com/user-attachments/assets/9c5c1a9e-de75-4534-af09-9511c86e98ee" />
