### PR TITLE
ref(seer): Type attribute/trace-attrs RPC responses with Pydantic models

### DIFF
--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -63,6 +63,8 @@ from sentry.seer.sentry_data_models import (
     EmptyResponse,
     GetDsnResponse,
     RepositoryDefinitionResponse,
+    TraceItemAttributesResponse,
+    TraceItemEventsResponse,
 )
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.dataset import Dataset
@@ -1766,7 +1768,7 @@ def get_trace_item_attributes(
     trace_id: str,
     item_id: str,
     item_type: str,
-) -> dict[str, Any]:
+) -> TraceItemAttributesResponse:
     """
     Fetch all attributes for a given trace item (span, metric, log, etc.).
 
@@ -1789,7 +1791,7 @@ def get_trace_item_attributes(
             "get_trace_item_attributes: Organization not found",
             extra={"org_id": org_id},
         )
-        return {"attributes": []}
+        return TraceItemAttributesResponse(attributes=[])
 
     try:
         project = Project.objects.get(id=project_id, organization=organization)
@@ -1798,7 +1800,7 @@ def get_trace_item_attributes(
             "get_trace_item_attributes: Project not found",
             extra={"org_id": org_id, "project_id": project_id},
         )
-        return {"attributes": []}
+        return TraceItemAttributesResponse(attributes=[])
 
     params = {
         "item_type": item_type,
@@ -1813,7 +1815,7 @@ def get_trace_item_attributes(
         params=params,
     )
 
-    return {"attributes": resp.data["attributes"]}
+    return TraceItemAttributesResponse(attributes=resp.data["attributes"])
 
 
 def _make_get_trace_request(
@@ -1950,7 +1952,7 @@ def get_log_attributes_for_trace(
     project_slugs: list[str] | None = None,
     sampling_mode: SAMPLING_MODES = "NORMAL",
     limit: int | None = 50,
-) -> dict[str, Any] | None:
+) -> TraceItemEventsResponse | None:
     """
     Get all attributes for all logs in a trace. You can optionally filter by message substring and/or project slugs.
 
@@ -1998,7 +2000,7 @@ def get_log_attributes_for_trace(
     )
 
     if not message_substring:
-        return {"data": items}
+        return TraceItemEventsResponse(data=items)
 
     # Filter on message substring.
     filtered_items: list[dict[str, Any]] = []
@@ -2012,7 +2014,7 @@ def get_log_attributes_for_trace(
         ):
             filtered_items.append(item)
 
-    return {"data": filtered_items}
+    return TraceItemEventsResponse(data=filtered_items)
 
 
 def get_metric_attributes_for_trace(
@@ -2026,7 +2028,7 @@ def get_metric_attributes_for_trace(
     project_slugs: list[str] | None = None,
     sampling_mode: SAMPLING_MODES = "NORMAL",
     limit: int | None = 50,
-) -> dict[str, Any] | None:
+) -> TraceItemEventsResponse | None:
     """
     Get all attributes for all metrics in a trace. You can optionally filter by metric name and/or project slugs.
     The metric name is a case-insensitive exact match.
@@ -2075,7 +2077,7 @@ def get_metric_attributes_for_trace(
     )
 
     if not metric_name:
-        return {"data": items}
+        return TraceItemEventsResponse(data=items)
 
     # Filter on metric name (exact case-insensitive match).
     filtered_items: list[dict[str, Any]] = []
@@ -2087,7 +2089,7 @@ def get_metric_attributes_for_trace(
         if metric_name.lower() == item_metric_name.lower():
             filtered_items.append(item)
 
-    return {"data": filtered_items}
+    return TraceItemEventsResponse(data=filtered_items)
 
 
 def get_baseline_tag_distribution(

--- a/src/sentry/seer/assisted_query/traces_tools.py
+++ b/src/sentry/seer/assisted_query/traces_tools.py
@@ -5,7 +5,11 @@ from sentry.api.client import ApiClient
 from sentry.constants import ALL_ACCESS_PROJECT_ID
 from sentry.models.apikey import ApiKey
 from sentry.models.organization import Organization
-from sentry.seer.sentry_data_models import AttributeNamesResponse, BuiltInField
+from sentry.seer.sentry_data_models import (
+    AttributeNamesResponse,
+    AttributeValuesResponse,
+    BuiltInField,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +180,7 @@ def get_attribute_values_with_substring(
     end: str | None = None,
     limit: int = 100,
     item_type: str = "spans",
-) -> dict:
+) -> AttributeValuesResponse:
     """
     Get attribute values for specific fields, optionally filtered by substring. Only string attributes are supported.
 
@@ -199,7 +203,7 @@ def get_attribute_values_with_substring(
         }
     """
     if not fields_with_substrings:
-        return {}
+        return AttributeValuesResponse(__root__={})
 
     organization = Organization.objects.get(id=org_id)
 
@@ -238,4 +242,6 @@ def get_attribute_values_with_substring(
         values.setdefault(field, set()).update(field_values_list[:limit])
 
     # Convert sets to sorted lists for JSON serialization
-    return {field: sorted(field_values)[:limit] for field, field_values in values.items()}
+    return AttributeValuesResponse(
+        __root__={field: sorted(field_values)[:limit] for field, field_values in values.items()}
+    )

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -363,3 +363,38 @@ class IssueFilterKeysResponse(BaseModel):
     tags: list[dict[str, Any]]
     feature_flags: list[dict[str, Any]]
     built_in_fields: list[IssueFilterBuiltInField]
+
+
+class AttributeValuesResponse(BaseModel):
+    """Bare `{field: [value, ...]}` map returned by `get_attribute_values_with_substring`."""
+
+    __root__: dict[str, list[str]]
+
+    def dict(self, **kwargs: Any) -> Any:
+        # Pre-typed code returned `{field: sorted_list, ...}` directly — unwrap so
+        # the dispatcher and downstream consumers see the bare map.
+        return dict(self.__root__)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, dict):
+            return self.dict() == other
+        return super().__eq__(other)
+
+    def __hash__(self) -> int:
+        return id(self)
+
+
+class TraceItemAttributesResponse(BaseModel):
+    """`get_trace_item_attributes` returns `{"attributes": [...]}` for a single trace item.
+
+    Items in `attributes` are the raw attribute dicts from the trace-items API —
+    passed through verbatim to preserve the upstream wire shape."""
+
+    attributes: list[dict[str, Any]]
+
+
+class TraceItemEventsResponse(BaseModel):
+    """`get_log_attributes_for_trace` and `get_metric_attributes_for_trace` return
+    `{"data": [{"id", "timestamp", "attributes"}, ...]}` — the EAP GetTrace output."""
+
+    data: list[dict[str, Any]]

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -3516,11 +3516,11 @@ class TestLogsTraceQuery(APITransactionTestCase, SnubaTestCase, OurLogTestCase):
             stats_period="1d",
         )
         assert result is not None
-        assert len(result["data"]) == 3
+        assert len(result.data) == 3
 
         auth_log_expected = self.logs[0]
         auth_log = None
-        for item in result["data"]:
+        for item in result.data:
             if item["id"] == self.get_id_str(auth_log_expected):
                 auth_log = item
 
@@ -3549,8 +3549,8 @@ class TestLogsTraceQuery(APITransactionTestCase, SnubaTestCase, OurLogTestCase):
             substring_case_sensitive=False,
         )
         assert result is not None
-        assert len(result["data"]) == 2
-        ids = [item["id"] for item in result["data"]]
+        assert len(result.data) == 2
+        ids = [item["id"] for item in result.data]
         assert self.get_id_str(self.logs[2]) in ids
         assert self.get_id_str(self.logs[3]) in ids
 
@@ -3562,8 +3562,8 @@ class TestLogsTraceQuery(APITransactionTestCase, SnubaTestCase, OurLogTestCase):
             substring_case_sensitive=True,
         )
         assert result is not None
-        assert len(result["data"]) == 1
-        assert result["data"][0]["id"] == self.get_id_str(self.logs[3])
+        assert len(result.data) == 1
+        assert result.data[0]["id"] == self.get_id_str(self.logs[3])
 
     def test_get_log_attributes_for_trace_limit_no_filter(self) -> None:
         result = get_log_attributes_for_trace(
@@ -3573,8 +3573,8 @@ class TestLogsTraceQuery(APITransactionTestCase, SnubaTestCase, OurLogTestCase):
             limit=1,
         )
         assert result is not None
-        assert len(result["data"]) == 1
-        assert result["data"][0]["id"] in [
+        assert len(result.data) == 1
+        assert result.data[0]["id"] in [
             self.get_id_str(self.logs[0]),
             self.get_id_str(self.logs[2]),
             self.get_id_str(self.logs[3]),
@@ -3590,8 +3590,8 @@ class TestLogsTraceQuery(APITransactionTestCase, SnubaTestCase, OurLogTestCase):
             limit=2,
         )
         assert result is not None
-        assert len(result["data"]) == 2
-        ids = [item["id"] for item in result["data"]]
+        assert len(result.data) == 2
+        ids = [item["id"] for item in result.data]
         assert self.get_id_str(self.logs[2]) in ids
         assert self.get_id_str(self.logs[3]) in ids
 
@@ -3665,12 +3665,12 @@ class TestMetricsTraceQuery(APITransactionTestCase, SnubaTestCase, TraceMetricsT
             stats_period="1d",
         )
         assert result is not None
-        assert len(result["data"]) == 3
+        assert len(result.data) == 3
 
         # Find the first http.request.duration metric
         http_metric_expected = self.metrics[0]
         http_metric = None
-        for item in result["data"]:
+        for item in result.data:
             if item["id"] == self.get_id_str(http_metric_expected):
                 http_metric = item
 
@@ -3702,7 +3702,7 @@ class TestMetricsTraceQuery(APITransactionTestCase, SnubaTestCase, TraceMetricsT
             metric_name="http.",
         )
         assert result is not None
-        assert len(result["data"]) == 0
+        assert len(result.data) == 0
 
         # Test an exact match (case-insensitive)
         result = get_metric_attributes_for_trace(
@@ -3712,8 +3712,8 @@ class TestMetricsTraceQuery(APITransactionTestCase, SnubaTestCase, TraceMetricsT
             metric_name="Cache.hit.rate",
         )
         assert result is not None
-        assert len(result["data"]) == 1
-        assert result["data"][0]["id"] == self.get_id_str(self.metrics[3])
+        assert len(result.data) == 1
+        assert result.data[0]["id"] == self.get_id_str(self.metrics[3])
 
     def test_get_metric_attributes_for_trace_limit_no_filter(self) -> None:
         result = get_metric_attributes_for_trace(
@@ -3723,8 +3723,8 @@ class TestMetricsTraceQuery(APITransactionTestCase, SnubaTestCase, TraceMetricsT
             limit=1,
         )
         assert result is not None
-        assert len(result["data"]) == 1
-        assert result["data"][0]["id"] in [
+        assert len(result.data) == 1
+        assert result.data[0]["id"] in [
             self.get_id_str(self.metrics[0]),
             self.get_id_str(self.metrics[2]),
             self.get_id_str(self.metrics[3]),
@@ -3739,8 +3739,8 @@ class TestMetricsTraceQuery(APITransactionTestCase, SnubaTestCase, TraceMetricsT
             limit=2,
         )
         assert result is not None
-        assert len(result["data"]) == 2
-        ids = [item["id"] for item in result["data"]]
+        assert len(result.data) == 2
+        ids = [item["id"] for item in result.data]
         assert self.get_id_str(self.metrics[0]) in ids
         assert self.get_id_str(self.metrics[2]) in ids
 

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -214,9 +214,9 @@ class TestSeerRpcMethods(APITestCase):
                 item_type="tracemetrics",
             )
 
-        assert len(result["attributes"]) == 2
+        assert len(result.attributes) == 2
         # Check that we have both types (order may vary)
-        types = {attr["type"] for attr in result["attributes"]}
+        types = {attr["type"] for attr in result.attributes}
         assert types == {"str", "float"}
         mock_get.assert_called_once()
 


### PR DESCRIPTION
Types the assisted-query attribute / trace-attrs cluster — `get_attribute_values_with_substring`, `get_trace_item_attributes`, `get_log_attributes_for_trace`, and `get_metric_attributes_for_trace`. Their return annotations move from `dict[str, Any]` to explicit Pydantic models so the seer-side SDK consumer sees a declared shape.

`AttributeValuesResponse` uses a `__root__` passthrough so the bare `{field: [...]}` map stays on the wire. `TraceItemAttributesResponse` (`{"attributes": [...]}`) and `TraceItemEventsResponse` (`{"data": [...]}`) name the top-level field and pass per-item dicts through verbatim — the trace-items API shape is too heterogeneous (`id`/`timestamp`/`attributes` with nested type-tagged values) to lock down here without dragging the upstream schema in.