### PR TITLE
fix(tests): Always run control silo URL tests

### DIFF
--- a/.github/workflows/scripts/compute-sentry-selected-tests.py
+++ b/.github/workflows/scripts/compute-sentry-selected-tests.py
@@ -122,6 +122,7 @@ EXCLUDED_TEST_PATTERNS: list[re.Pattern[str]] = [
 # Tests that should always be run even if not explicitly selected.
 ALWAYS_RUN_TESTS: set[str] = {
     "tests/sentry/taskworker/test_config.py",
+    "tests/sentry/management/commands/test_generate_controlsilo_urls.py",
 }
 
 


### PR DESCRIPTION
Too many edge cases with this test because URLs can come from anywhere, lets just run it all the time, only adds a couple seconds.