### PR TITLE
feat(preprod): Use one relevant-filtered link per snapshot row

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
@@ -46,14 +46,24 @@ def format_snapshot_pr_comment(
     total_errored = 0
 
     for artifact in artifacts:
-        name_cell = _name_cell(artifact, snapshot_metrics_map, base_artifact_map)
         metrics = snapshot_metrics_map.get(artifact.id)
+        comparison = comparisons_map.get(metrics.id) if metrics else None
+        include_selected_types = comparison is not None and comparison.state not in (
+            PreprodSnapshotComparison.State.PENDING,
+            PreprodSnapshotComparison.State.PROCESSING,
+            PreprodSnapshotComparison.State.FAILED,
+        )
+        name_cell = _name_cell(
+            artifact,
+            snapshot_metrics_map,
+            base_artifact_map,
+            comparison=comparison if include_selected_types else None,
+        )
 
         if not metrics:
             table_rows.append(f"| {name_cell} | - | - | - | - | - | - | {PROCESSING_STATUS} |")
             continue
 
-        comparison = comparisons_map.get(metrics.id)
         has_base = artifact.id in base_artifact_map
 
         if not comparison and not has_base:
@@ -75,10 +85,6 @@ def format_snapshot_pr_comment(
         elif comparison.state == PreprodSnapshotComparison.State.FAILED:
             table_rows.append(f"| {name_cell} | - | - | - | - | - | - | ❌ Comparison failed |")
         else:
-            name_cell = _name_cell(
-                artifact, snapshot_metrics_map, base_artifact_map, comparison=comparison
-            )
-
             has_changes = changes_map.get(artifact.id, False)
             is_approved = approvals_map is not None and artifact.id in approvals_map
             if has_changes and is_approved:

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
@@ -75,13 +75,8 @@ def format_snapshot_pr_comment(
         elif comparison.state == PreprodSnapshotComparison.State.FAILED:
             table_rows.append(f"| {name_cell} | - | - | - | - | - | - | ❌ Comparison failed |")
         else:
-            base_artifact = base_artifact_map.get(artifact.id)
-            artifact_url = (
-                get_preprod_artifact_comparison_url(
-                    artifact, base_artifact, comparison_type="snapshots"
-                )
-                if base_artifact
-                else get_preprod_artifact_url(artifact, view_type="snapshots")
+            name_cell = _name_cell(
+                artifact, snapshot_metrics_map, base_artifact_map, comparison=comparison
             )
 
             has_changes = changes_map.get(artifact.id, False)
@@ -95,12 +90,12 @@ def format_snapshot_pr_comment(
 
             table_rows.append(
                 f"| {name_cell}"
-                f" | {_section_cell(comparison.images_added, 'added', artifact_url)}"
-                f" | {_section_cell(comparison.images_removed, 'removed', artifact_url)}"
-                f" | {_section_cell(comparison.images_changed, 'changed', artifact_url)}"
-                f" | {_section_cell(comparison.images_renamed, 'renamed', artifact_url)}"
-                f" | {_section_cell(comparison.images_unchanged, 'unchanged', artifact_url)}"
-                f" | {_section_cell(comparison.images_skipped, 'skipped', artifact_url)}"
+                f" | {comparison.images_added}"
+                f" | {comparison.images_removed}"
+                f" | {comparison.images_changed}"
+                f" | {comparison.images_renamed}"
+                f" | {comparison.images_unchanged}"
+                f" | {comparison.images_skipped}"
                 f" | {status} |"
             )
             total_errored += comparison.images_errored
@@ -118,6 +113,7 @@ def _name_cell(
     artifact: PreprodArtifact,
     snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
     base_artifact_map: dict[int, PreprodArtifact],
+    comparison: PreprodSnapshotComparison | None = None,
 ) -> str:
     app_display, app_id = _app_display_info(artifact)
     metrics = snapshot_metrics_map.get(artifact.id)
@@ -129,6 +125,9 @@ def _name_cell(
         )
     else:
         artifact_url = get_preprod_artifact_url(artifact, view_type="snapshots")
+
+    if comparison is not None:
+        artifact_url += _selected_types_query(comparison)
 
     return _format_name_cell(app_display, app_id, artifact_url)
 
@@ -147,10 +146,17 @@ def _format_name_cell(app_display: str, app_id: str, url: str) -> str:
     return f"[{app_display}]({url})"
 
 
-def _section_cell(count: int, section: str, artifact_url: str) -> str:
-    if count > 0:
-        return f"[{count}]({artifact_url}?selectedTypes={section})"
-    return str(count)
+def _selected_types_query(comparison: PreprodSnapshotComparison) -> str:
+    counts = (
+        ("added", comparison.images_added),
+        ("removed", comparison.images_removed),
+        ("changed", comparison.images_changed),
+        ("renamed", comparison.images_renamed),
+    )
+    selected = [name for name, count in counts if count > 0]
+    if not selected:
+        return ""
+    return f"?selectedTypes={','.join(selected)}"
 
 
 def _format_settings_link(project: Project) -> str:

--- a/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
@@ -7,14 +7,13 @@ from sentry.integrations.source_code_management.status_check import StatusCheckS
 from sentry.models.project import Project
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
-from sentry.preprod.url_utils import get_preprod_artifact_comparison_url, get_preprod_artifact_url
+from sentry.preprod.url_utils import get_preprod_artifact_url
 from sentry.preprod.vcs.pr_comments.snapshot_templates import (
     COMPARISON_TABLE_HEADER,
     PROCESSING_STATUS,
     _app_display_info,
     _format_name_cell,
     _name_cell,
-    _section_cell,
     format_errored_note,
 )
 
@@ -302,13 +301,8 @@ def _format_snapshot_summary(
         ):
             table_rows.append(f"| {name} | - | - | - | - | - | - | {PROCESSING_STATUS} |")
         else:
-            base_artifact = base_artifact_map.get(artifact.id)
-            artifact_url = (
-                get_preprod_artifact_comparison_url(
-                    artifact, base_artifact, comparison_type="snapshots"
-                )
-                if base_artifact
-                else get_preprod_artifact_url(artifact, view_type="snapshots")
+            name = _name_cell(
+                artifact, snapshot_metrics_map, base_artifact_map, comparison=comparison
             )
 
             has_changes = changes_map.get(artifact.id, False)
@@ -322,12 +316,12 @@ def _format_snapshot_summary(
 
             table_rows.append(
                 f"| {name}"
-                f" | {_section_cell(comparison.images_added, 'added', artifact_url)}"
-                f" | {_section_cell(comparison.images_removed, 'removed', artifact_url)}"
-                f" | {_section_cell(comparison.images_changed, 'changed', artifact_url)}"
-                f" | {_section_cell(comparison.images_renamed, 'renamed', artifact_url)}"
-                f" | {_section_cell(comparison.images_unchanged, 'unchanged', artifact_url)}"
-                f" | {_section_cell(comparison.images_skipped, 'skipped', artifact_url)}"
+                f" | {comparison.images_added}"
+                f" | {comparison.images_removed}"
+                f" | {comparison.images_changed}"
+                f" | {comparison.images_renamed}"
+                f" | {comparison.images_unchanged}"
+                f" | {comparison.images_skipped}"
                 f" | {status} |"
             )
 

--- a/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
@@ -283,14 +283,23 @@ def _format_snapshot_summary(
     table_rows = []
 
     for artifact in artifacts:
-        name = _name_cell(artifact, snapshot_metrics_map, base_artifact_map)
-
         metrics = snapshot_metrics_map.get(artifact.id)
+        comparison = comparisons_map.get(metrics.id) if metrics else None
+        include_selected_types = comparison is not None and comparison.state not in (
+            PreprodSnapshotComparison.State.PENDING,
+            PreprodSnapshotComparison.State.PROCESSING,
+        )
+        name = _name_cell(
+            artifact,
+            snapshot_metrics_map,
+            base_artifact_map,
+            comparison=comparison if include_selected_types else None,
+        )
+
         if not metrics:
             table_rows.append(f"| {name} | - | - | - | - | - | - | {PROCESSING_STATUS} |")
             continue
 
-        comparison = comparisons_map.get(metrics.id)
         if not comparison:
             table_rows.append(f"| {name} | - | - | - | - | - | - | {PROCESSING_STATUS} |")
             continue
@@ -301,10 +310,6 @@ def _format_snapshot_summary(
         ):
             table_rows.append(f"| {name} | - | - | - | - | - | - | {PROCESSING_STATUS} |")
         else:
-            name = _name_cell(
-                artifact, snapshot_metrics_map, base_artifact_map, comparison=comparison
-            )
-
             has_changes = changes_map.get(artifact.id, False)
             is_approved = approvals_map is not None and artifact.id in approvals_map
             if has_changes and is_approved:

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.vcs.pr_comments.snapshot_templates import (
+    _selected_types_query,
     format_missing_base_snapshot_pr_comment,
     format_snapshot_pr_comment,
     format_solo_snapshot_pr_comment,
@@ -12,6 +15,32 @@ from sentry.preprod.vcs.pr_comments.snapshot_templates import (
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import cell_silo_test
+
+
+def _comparison(
+    *, changed: int = 0, added: int = 0, removed: int = 0, renamed: int = 0
+) -> PreprodSnapshotComparison:
+    return SimpleNamespace(
+        images_changed=changed,
+        images_added=added,
+        images_removed=removed,
+        images_renamed=renamed,
+    )  # type: ignore[return-value]
+
+
+def test_selected_types_query_all_categories() -> None:
+    assert (
+        _selected_types_query(_comparison(changed=1, added=2, removed=3, renamed=4))
+        == "?selectedTypes=added,removed,changed,renamed"
+    )
+
+
+def test_selected_types_query_subset_preserves_order() -> None:
+    assert _selected_types_query(_comparison(changed=1, added=1)) == "?selectedTypes=added,changed"
+
+
+def test_selected_types_query_none_changed_is_empty() -> None:
+    assert _selected_types_query(_comparison()) == ""
 
 
 class SnapshotPrCommentTestBase(TestCase):
@@ -251,10 +280,9 @@ class FormatSnapshotPrCommentSuccessTest(SnapshotPrCommentTestBase):
         assert "Unchanged" in result
         assert "My App" in result
         assert "`com.example.app`" in result
-        # Zero counts are plain text, non-zero unchanged is linked
         assert "| 0 | 0 | 0 | 0 |" in result
         assert "| 0 | ✅ Unchanged |" in result
-        assert "?selectedTypes=unchanged" in result
+        assert "?selectedTypes=" not in result
 
     def test_changes_show_needs_approval(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()
@@ -280,10 +308,7 @@ class FormatSnapshotPrCommentSuccessTest(SnapshotPrCommentTestBase):
         )
 
         assert "Needs approval" in result
-        assert "?selectedTypes=added" in result
-        assert "?selectedTypes=removed" in result
-        assert "?selectedTypes=changed" in result
-        assert "?selectedTypes=renamed" in result
+        assert "?selectedTypes=added,removed,changed,renamed" in result
 
     def test_approved_shows_approved_status(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -725,9 +725,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             "| Name | Added | Removed | Changed | Renamed | Unchanged | Skipped | Status |\n"
             "| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app`"
-            f" | 0 | 0 | 0 | 0"
-            f" | [{15}]({artifact_url}?selectedTypes=unchanged)"
-            f" | 0"
+            f" | 0 | 0 | 0 | 0 | 15 | 0"
             f" | ✅ Unchanged |"
             f"\n\n{configure_link}"
         )
@@ -771,13 +769,8 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         expected = (
             "| Name | Added | Removed | Changed | Renamed | Unchanged | Skipped | Status |\n"
             "| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |\n"
-            f"| [My App]({artifact_url})<br>`com.example.app`"
-            f" | [{1}]({artifact_url}?selectedTypes=added)"
-            f" | [{2}]({artifact_url}?selectedTypes=removed)"
-            f" | [{3}]({artifact_url}?selectedTypes=changed)"
-            f" | [{1}]({artifact_url}?selectedTypes=renamed)"
-            f" | [{4}]({artifact_url}?selectedTypes=unchanged)"
-            f" | 0"
+            f"| [My App]({artifact_url}?selectedTypes=added,removed,changed,renamed)<br>`com.example.app`"
+            f" | 1 | 2 | 3 | 1 | 4 | 0"
             f" | ⏳ Needs approval |"
             f"\n\n{configure_link}"
         )
@@ -1143,13 +1136,8 @@ class SnapshotApprovalFormattingTest(SnapshotStatusCheckTestBase):
         expected = (
             "| Name | Added | Removed | Changed | Renamed | Unchanged | Skipped | Status |\n"
             "| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |\n"
-            f"| [My App]({artifact_url})<br>`com.example.app`"
-            f" | [{1}]({artifact_url}?selectedTypes=added)"
-            f" | [{2}]({artifact_url}?selectedTypes=removed)"
-            f" | [{3}]({artifact_url}?selectedTypes=changed)"
-            f" | [{1}]({artifact_url}?selectedTypes=renamed)"
-            f" | [{4}]({artifact_url}?selectedTypes=unchanged)"
-            f" | 0"
+            f"| [My App]({artifact_url}?selectedTypes=added,removed,changed,renamed)<br>`com.example.app`"
+            f" | 1 | 2 | 3 | 1 | 4 | 0"
             f" | ✅ Approved |"
             f"\n\n{configure_link}"
         )


### PR DESCRIPTION
The snapshot status check and PR comment previously put a separate link on every count column (Added/Removed/Changed/Renamed/Unchanged/Skipped), so a single row could carry up to six links and reviewers couldn't tell which one to click. Each row now exposes a single link in the Name column that opens the snapshot diff view filtered to only the categories that actually changed, with the count columns rendered as plain numbers.

The link's `?selectedTypes=` filter is built from the non-zero relevant categories (`added`, `removed`, `changed`, `renamed`) — `unchanged`, `skipped`, and `errored` are never included. When nothing relevant changed, the link opens unfiltered so a reviewer is never shown an empty filtered view.

The change is confined to the shared markdown templates in `src/sentry/preprod/vcs/`; the `selectedTypes` URL param and its comma-separated parsing already exist on the frontend, so no UI change is needed.