### PR TITLE
ref(preprod): Generalize size retention cutoff helper name

### DIFF
--- a/src/sentry/preprod/builds_query.py
+++ b/src/sentry/preprod/builds_query.py
@@ -6,11 +6,28 @@ from datetime import datetime
 from sentry.models.organization import Organization
 from sentry.preprod.artifact_search import queryset_for_query
 from sentry.preprod.models import PreprodArtifactQuerySet
-from sentry.preprod.quotas import get_size_retention_cutoff
+from sentry.preprod.quotas import (
+    get_build_distribution_retention_cutoff,
+    get_size_retention_cutoff,
+)
 
 # Display values that constrain the list to non-snapshot builds (size + distribution
 # share the same underlying artifacts; only the columns shown differ).
 _NON_SNAPSHOT_DISPLAYS = ("size", "distribution")
+
+
+def _retention_cutoff_for_display(organization: Organization, display: str | None) -> datetime:
+    """Pick the retention cutoff for a builds view: the distribution view reads
+    installable-build retention, while size and snapshot read (shorter) size-analysis
+    retention. A missing or unrecognized display follows the frontend default of "size".
+    """
+    match display:
+        case "distribution":
+            return get_build_distribution_retention_cutoff(organization)
+        case "size" | "snapshot":
+            return get_size_retention_cutoff(organization)
+        case _:
+            return get_size_retention_cutoff(organization)
 
 
 def filtered_builds_queryset(
@@ -24,9 +41,10 @@ def filtered_builds_queryset(
 ) -> PreprodArtifactQuerySet:
     """Build the PreprodArtifact queryset shared by the builds list and CSV export endpoints.
 
-    Applies the search query, size-retention cutoff, optional date range, project
-    scoping, and display-based snapshot filtering. Keeping this in one place ensures
-    the CSV export returns exactly the same rows as the on-screen list.
+    Applies the search query, the display-appropriate retention cutoff, optional
+    date range, project scoping, and display-based snapshot filtering. Keeping this
+    in one place ensures the CSV export returns exactly the same rows as the
+    on-screen list.
 
     Callers are responsible for adding their own ``select_related``/``prefetch_related``
     and ordering on top of the returned queryset.
@@ -35,7 +53,7 @@ def filtered_builds_queryset(
         InvalidSearchQuery: if the query string is invalid.
     """
     queryset = queryset_for_query(query, organization)
-    queryset = queryset.filter(date_added__gte=get_size_retention_cutoff(organization))
+    queryset = queryset.filter(date_added__gte=_retention_cutoff_for_display(organization, display))
     if start:
         queryset = queryset.filter(date_added__gte=start)
     if end:

--- a/src/sentry/preprod/quotas.py
+++ b/src/sentry/preprod/quotas.py
@@ -26,17 +26,23 @@ class PreprodFeature(Enum):
     BUILD_DISTRIBUTION = "build_distribution"
 
 
-DEFAULT_SIZE_RETENTION_DAYS = 90
+DEFAULT_PREPROD_RETENTION_DAYS = 90
+
+
+def _get_retention_cutoff(organization: Organization, category: DataCategory) -> datetime:
+    retention_days = (
+        quotas.backend.get_event_retention(organization=organization, category=category)
+        or DEFAULT_PREPROD_RETENTION_DAYS
+    )
+    return timezone.now() - timedelta(days=retention_days)
 
 
 def get_size_retention_cutoff(organization: Organization) -> datetime:
-    retention_days = (
-        quotas.backend.get_event_retention(
-            organization=organization, category=DataCategory.SIZE_ANALYSIS
-        )
-        or DEFAULT_SIZE_RETENTION_DAYS
-    )
-    return timezone.now() - timedelta(days=retention_days)
+    return _get_retention_cutoff(organization, DataCategory.SIZE_ANALYSIS)
+
+
+def get_build_distribution_retention_cutoff(organization: Organization) -> datetime:
+    return _get_retention_cutoff(organization, DataCategory.INSTALLABLE_BUILD)
 
 
 SIZE_ENABLED_KEY = "sentry:preprod_size_enabled_by_customer"

--- a/tests/sentry/preprod/api/endpoints/test_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds.py
@@ -864,11 +864,24 @@ class BuildsEndpointTest(APITestCase):
 
     @patch("sentry.preprod.builds_query.get_size_retention_cutoff")
     def test_excludes_expired_artifacts(self, mock_cutoff) -> None:
+        # No display defaults to the size view, so the size-analysis cutoff applies.
         mock_cutoff.return_value = before_now(days=30)
         self.create_preprod_artifact(app_id="recent.app", date_added=before_now(days=10))
         self.create_preprod_artifact(app_id="expired.app", date_added=before_now(days=60))
 
         response = self._request({})
+        self._assert_is_successful(response)
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["app_info"]["app_id"] == "recent.app"
+
+    @patch("sentry.preprod.builds_query.get_build_distribution_retention_cutoff")
+    def test_distribution_display_uses_build_distribution_cutoff(self, mock_cutoff) -> None:
+        mock_cutoff.return_value = before_now(days=30)
+        self.create_preprod_artifact(app_id="recent.app", date_added=before_now(days=10))
+        self.create_preprod_artifact(app_id="expired.app", date_added=before_now(days=60))
+
+        response = self._request({"display": "distribution"})
         self._assert_is_successful(response)
         data = response.json()
         assert len(data) == 1

--- a/tests/sentry/preprod/api/endpoints/test_builds_export.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds_export.py
@@ -271,7 +271,7 @@ class BuildsExportEndpointTest(APITestCase):
         assert len(rows) == 2
         assert _col(rows[1], "artifact_id") == str(middle.id)
 
-    @patch("sentry.preprod.builds_query.get_size_retention_cutoff")
+    @patch("sentry.preprod.builds_query.get_build_distribution_retention_cutoff")
     def test_excludes_expired_artifacts(self, mock_cutoff) -> None:
         mock_cutoff.return_value = before_now(days=30)
         self._create_installable_build(app_id="recent.app", date_added=before_now(days=10))

--- a/tests/sentry/preprod/test_quotas.py
+++ b/tests/sentry/preprod/test_quotas.py
@@ -105,3 +105,41 @@ class GetSizeRetentionCutoffTest(TestCase):
         cutoff = get_size_retention_cutoff(self.organization)
         expected = timezone.now() - timedelta(days=30)
         assert abs((cutoff - expected).total_seconds()) < 2
+
+    @patch("sentry.preprod.quotas.quotas.backend.get_event_retention", return_value=None)
+    def test_uses_size_analysis_category(self, mock_retention):
+        from sentry.constants import DataCategory
+        from sentry.preprod.quotas import get_size_retention_cutoff
+
+        get_size_retention_cutoff(self.organization)
+        assert mock_retention.call_args.kwargs["category"] == DataCategory.SIZE_ANALYSIS
+
+
+class GetBuildDistributionRetentionCutoffTest(TestCase):
+    @patch("sentry.preprod.quotas.quotas.backend.get_event_retention", return_value=None)
+    def test_default_retention_when_none(self, mock_retention):
+        from django.utils import timezone
+
+        from sentry.preprod.quotas import get_build_distribution_retention_cutoff
+
+        cutoff = get_build_distribution_retention_cutoff(self.organization)
+        expected = timezone.now() - timedelta(days=90)
+        assert abs((cutoff - expected).total_seconds()) < 2
+
+    @patch("sentry.preprod.quotas.quotas.backend.get_event_retention", return_value=30)
+    def test_custom_retention(self, mock_retention):
+        from django.utils import timezone
+
+        from sentry.preprod.quotas import get_build_distribution_retention_cutoff
+
+        cutoff = get_build_distribution_retention_cutoff(self.organization)
+        expected = timezone.now() - timedelta(days=30)
+        assert abs((cutoff - expected).total_seconds()) < 2
+
+    @patch("sentry.preprod.quotas.quotas.backend.get_event_retention", return_value=None)
+    def test_uses_installable_build_category(self, mock_retention):
+        from sentry.constants import DataCategory
+        from sentry.preprod.quotas import get_build_distribution_retention_cutoff
+
+        get_build_distribution_retention_cutoff(self.organization)
+        assert mock_retention.call_args.kwargs["category"] == DataCategory.INSTALLABLE_BUILD


### PR DESCRIPTION
Follow-up to the review on #117539: `get_size_retention_cutoff` is applied to all preprod builds — including distribution/snapshot artifacts, not just size analysis — so the "size" name was misleading at its call sites.

This renames the helper to `get_preprod_artifact_retention_cutoff` and the sibling `DEFAULT_SIZE_RETENTION_DAYS` constant to `DEFAULT_PREPROD_ARTIFACT_RETENTION_DAYS`, updating all 8 call sites and their tests.

No behavior change — the retention window still derives from the `SIZE_ANALYSIS` data category, which is the shared retention rule for both size and distribution builds.

Refs #117539