### PR TITLE
Remove trial selection tier

### DIFF
--- a/static/gsAdmin/components/changePlanAction.spec.tsx
+++ b/static/gsAdmin/components/changePlanAction.spec.tsx
@@ -7,6 +7,7 @@ import {
   SubscriptionFixture,
   SubscriptionWithLegacySeerFixture,
 } from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {renderGlobalModal, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
 
@@ -15,7 +16,6 @@ import {DataCategory} from 'sentry/types/core';
 
 import {triggerChangePlanAction} from 'admin/components/changePlanAction';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 
 describe('ChangePlanAction', () => {
   const mockOrg = OrganizationFixture({slug: 'org-slug'});

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -8,6 +8,7 @@ import {
   SubscriptionFixture,
   SubscriptionWithLegacySeerFixture,
 } from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {
   render,
   screen,
@@ -20,7 +21,7 @@ import {DataCategory} from 'sentry/types/core';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
 import {CustomerOverview} from 'admin/components/customers/customerOverview';
-import {AddOnCategory, PlanTier} from 'getsentry/types';
+import {AddOnCategory} from 'getsentry/types';
 
 describe('CustomerOverview', () => {
   it('renders DetailLabels for SubscriptionSummary section', () => {

--- a/static/gsAdmin/components/provisionSubscriptionAction.spec.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.spec.tsx
@@ -6,6 +6,7 @@ import {
   InvoicedSubscriptionFixture,
   SubscriptionFixture,
 } from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {
   fireEvent,
   renderGlobalModal,
@@ -20,7 +21,7 @@ import {DataCategory} from 'sentry/types/core';
 
 import {triggerProvisionSubscription} from 'admin/components/provisionSubscriptionAction';
 import {RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
-import {OnDemandBudgetMode, PlanTier} from 'getsentry/types';
+import {OnDemandBudgetMode} from 'getsentry/types';
 
 describe('provisionSubscriptionAction', () => {
   const onSuccess = jest.fn();

--- a/static/gsAdmin/components/trialSubscriptionAction.spec.tsx
+++ b/static/gsAdmin/components/trialSubscriptionAction.spec.tsx
@@ -2,16 +2,10 @@ import moment from 'moment-timezone';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
-import {
-  renderGlobalModal,
-  screen,
-  userEvent,
-  within,
-} from 'sentry-test/reactTestingLibrary';
+import {renderGlobalModal, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {openAdminConfirmModal} from 'admin/components/adminConfirmationModal';
 import {TrialSubscriptionAction} from 'admin/components/trialSubscriptionAction';
-import {PlanTier} from 'getsentry/types';
 
 describe('TrialSubscriptionAction', () => {
   const organization = OrganizationFixture();
@@ -75,7 +69,6 @@ describe('TrialSubscriptionAction', () => {
     expect(onConfirm).toHaveBeenCalledWith({
       trialDays: 45,
       startEnterpriseTrial: true,
-      trialTier: PlanTier.AM3,
     });
   });
 
@@ -217,87 +210,6 @@ describe('TrialSubscriptionAction', () => {
     expect(daysInput).toHaveAccessibleDescription(
       `Their trial will end on ${formattedNow}`
     );
-  });
-
-  it('displays am3 trial tier option when free plan', async () => {
-    jest.mock('@sentry/scraps/alert');
-
-    openAdminConfirmModal({
-      onConfirm,
-      renderModalSpecificContent: deps => (
-        <TrialSubscriptionAction
-          subscription={SubscriptionFixture({
-            organization,
-            plan: 'am2_f',
-            isFree: true,
-            planTier: PlanTier.AM2,
-          })}
-          startEnterpriseTrial
-          {...deps}
-        />
-      ),
-    });
-
-    renderGlobalModal();
-
-    await userEvent.click(screen.getByTestId('trial-plan-tier-choices'));
-    const trialTierInputs = within(screen.getByRole('dialog')).getAllByRole('textbox');
-    await userEvent.click(trialTierInputs[1]!);
-    expect(screen.getByText('am3')).toBeInTheDocument();
-  });
-
-  it('displays am3 trial tier option when am3 plan', async () => {
-    jest.mock('@sentry/scraps/alert');
-
-    openAdminConfirmModal({
-      onConfirm,
-      renderModalSpecificContent: deps => (
-        <TrialSubscriptionAction
-          subscription={SubscriptionFixture({
-            organization,
-            plan: 'am3_team',
-            isFree: false,
-            planTier: PlanTier.AM3,
-          })}
-          startEnterpriseTrial
-          {...deps}
-        />
-      ),
-    });
-
-    renderGlobalModal();
-
-    await userEvent.click(screen.getByTestId('trial-plan-tier-choices'));
-    const trialTierInputs = within(screen.getByRole('dialog')).getAllByRole('textbox');
-    await userEvent.click(trialTierInputs[1]!);
-    expect(screen.getByText('am3')).toBeInTheDocument();
-  });
-
-  it('displays am3 trial tier option when am2 plan', async () => {
-    jest.mock('@sentry/scraps/alert');
-
-    openAdminConfirmModal({
-      onConfirm,
-      renderModalSpecificContent: deps => (
-        <TrialSubscriptionAction
-          subscription={SubscriptionFixture({
-            organization,
-            plan: 'am2_team',
-            isFree: false,
-            planTier: PlanTier.AM2,
-          })}
-          startEnterpriseTrial
-          {...deps}
-        />
-      ),
-    });
-
-    renderGlobalModal();
-
-    await userEvent.click(screen.getByTestId('trial-plan-tier-choices'));
-    const trialTierInputs = within(screen.getByRole('dialog')).getAllByRole('textbox');
-    await userEvent.click(trialTierInputs[1]!);
-    expect(screen.getByText('am3')).toBeInTheDocument();
   });
 
   it('defaults 14-day trial for self-serve', () => {

--- a/static/gsAdmin/components/trialSubscriptionAction.tsx
+++ b/static/gsAdmin/components/trialSubscriptionAction.tsx
@@ -4,14 +4,12 @@ import moment from 'moment-timezone';
 import {Alert} from '@sentry/scraps/alert';
 
 import {NumberField} from 'sentry/components/forms/fields/numberField';
-import {SelectField} from 'sentry/components/forms/fields/selectField';
 
 import type {
   AdminConfirmParams,
   AdminConfirmRenderProps,
 } from 'admin/components/adminConfirmationModal';
 import type {Subscription} from 'getsentry/types';
-import {PlanTier} from 'getsentry/types';
 
 type Props = AdminConfirmRenderProps & {
   subscription: Subscription;
@@ -20,7 +18,6 @@ type Props = AdminConfirmRenderProps & {
 
 type State = {
   trialDays: number;
-  trialTier?: PlanTier;
 };
 
 /**
@@ -32,7 +29,6 @@ export class TrialSubscriptionAction extends Component<Props, State> {
       this.props.subscription.isEnterpriseTrial || this.props.startEnterpriseTrial
         ? 28
         : 14,
-    trialTier: PlanTier.AM3,
   };
 
   componentDidMount() {
@@ -40,18 +36,17 @@ export class TrialSubscriptionAction extends Component<Props, State> {
   }
 
   handleConfirm = (_params: AdminConfirmParams) => {
-    const {trialDays, trialTier} = this.state;
+    const {trialDays} = this.state;
     const {startEnterpriseTrial, onConfirm} = this.props;
 
     // XXX(epurkhiser): In the original implementation none of the audit params
     // were passed, is that an oversight?
-
+    //
+    // The trial tier is resolved server-side (omitting `trialTier` falls back
+    // to the subscription's default enterprise-trial plan).
     const data = {
       trialDays,
-      ...(startEnterpriseTrial && {
-        startEnterpriseTrial,
-        trialTier,
-      }),
+      ...(startEnterpriseTrial && {startEnterpriseTrial}),
     };
 
     onConfirm?.(data);
@@ -74,7 +69,7 @@ export class TrialSubscriptionAction extends Component<Props, State> {
 
   render() {
     const {subscription, startEnterpriseTrial} = this.props;
-    const {trialDays, trialTier} = this.state;
+    const {trialDays} = this.state;
 
     if (!subscription) {
       return null;
@@ -84,12 +79,6 @@ export class TrialSubscriptionAction extends Component<Props, State> {
       (!startEnterpriseTrial && subscription.trialEnd) || undefined
     );
     const trialEndDate = currentTrialEnd.add(trialDays, 'days').format('MMMM Do YYYY');
-
-    const tierChoices: Array<[string | PlanTier, string | PlanTier]> = [
-      [PlanTier.AM3, PlanTier.AM3],
-      [PlanTier.AM2, PlanTier.AM2],
-      [PlanTier.AM1, PlanTier.AM1],
-    ];
 
     return (
       <Fragment>
@@ -114,22 +103,6 @@ export class TrialSubscriptionAction extends Component<Props, State> {
           value={trialDays}
           onChange={this.onDaysChange}
         />
-        <div data-test-id="trial-plan-tier-choices">
-          {startEnterpriseTrial && (
-            <SelectField
-              inline={false}
-              stacked
-              flexibleControlStateSize
-              label="Trial Plan Tier"
-              name="tier"
-              value={trialTier}
-              onChange={(val: any) => {
-                this.setState({trialTier: val});
-              }}
-              choices={tierChoices}
-            />
-          )}
-        </div>
       </Fragment>
     );
   }

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -14,6 +14,7 @@ import {PoliciesFixture} from 'getsentry-test/fixtures/policies';
 import {ProjectFixture} from 'getsentry-test/fixtures/project';
 import {SeerReservedBudgetFixture} from 'getsentry-test/fixtures/reservedBudget';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
@@ -35,7 +36,7 @@ import type {StatsGroup} from 'admin/components/customers/customerStats';
 import {populateChartData, useSeries} from 'admin/components/customers/customerStats';
 import {CustomerDetails} from 'admin/views/customerDetails';
 import type {Subscription} from 'getsentry/types';
-import {BillingType, PlanTier} from 'getsentry/types';
+import {BillingType} from 'getsentry/types';
 
 const theme = ThemeFixture();
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;

--- a/static/gsApp/components/crons/cronsBillingBanner.spec.tsx
+++ b/static/gsApp/components/crons/cronsBillingBanner.spec.tsx
@@ -4,10 +4,10 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {CronsBillingBanner} from 'getsentry/components/crons/cronsBillingBanner';
-import {PlanTier} from 'getsentry/types';
 
 describe('CronsBillingBanner', () => {
   beforeEach(() => {

--- a/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.spec.tsx
+++ b/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.spec.tsx
@@ -2,10 +2,10 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {InsightsDateRangeQueryLimitFooter} from 'getsentry/components/features/insightsDateRangeQueryLimitFooter';
-import {PlanTier} from 'getsentry/types';
 
 describe('InsightsUpsellPage', () => {
   const organization = OrganizationFixture();

--- a/static/gsApp/components/features/pageUpsellOverlay.spec.tsx
+++ b/static/gsApp/components/features/pageUpsellOverlay.spec.tsx
@@ -2,11 +2,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import PageUpsellOverlay from 'getsentry/components/features/pageUpsellOverlay';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 
 describe('PageUpsellOverlay', () => {
   let wrapper: any;

--- a/static/gsApp/components/features/planFeature.spec.tsx
+++ b/static/gsApp/components/features/planFeature.spec.tsx
@@ -3,11 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import PlanFeature from 'getsentry/components/features/planFeature';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 
 describe('PlanFeature', () => {
   const organization = OrganizationFixture();

--- a/static/gsApp/components/productSelectionAvailability.spec.tsx
+++ b/static/gsApp/components/productSelectionAvailability.spec.tsx
@@ -2,6 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {
   act,
   render,
@@ -20,7 +21,6 @@ import {ProductSelectionAvailability} from 'getsentry/components/productSelectio
 import type {Reservations} from 'getsentry/components/upgradeNowModal/types';
 import {usePreviewData} from 'getsentry/components/upgradeNowModal/usePreviewData';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 
 jest.mock('getsentry/components/upgradeNowModal/usePreviewData');
 

--- a/static/gsApp/components/upgradeNowModal/usePreviewData.spec.tsx
+++ b/static/gsApp/components/upgradeNowModal/usePreviewData.spec.tsx
@@ -3,10 +3,10 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PreviewDataFixture} from 'getsentry/__fixtures__/previewData';
-import {PlanTier} from 'getsentry/types';
 
 import type {Reservations} from './types';
 import {usePreviewData} from './usePreviewData';

--- a/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.spec.tsx
+++ b/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.spec.tsx
@@ -3,9 +3,8 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
-
-import {PlanTier} from 'getsentry/types';
 
 import {useUpgradeNowParams} from './useUpgradeNowParams';
 

--- a/static/gsApp/components/upsellModal/details.spec.tsx
+++ b/static/gsApp/components/upsellModal/details.spec.tsx
@@ -2,10 +2,10 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {Details} from 'getsentry/components/upsellModal/details';
-import {PlanTier} from 'getsentry/types';
 
 describe('Upsell Modal Details', () => {
   const organization = OrganizationFixture({access: ['org:billing']});

--- a/static/gsApp/overrides/integrationFeatures.spec.tsx
+++ b/static/gsApp/overrides/integrationFeatures.spec.tsx
@@ -5,13 +5,13 @@ import {UserFixture} from 'sentry-fixture/user';
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ConfigStore} from 'sentry/stores/configStore';
 
 import {hookIntegrationFeatures} from 'getsentry/overrides/integrationFeatures';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 
 describe('hookIntegrationFeatures', () => {
   const {FeatureList, IntegrationFeatures} = hookIntegrationFeatures();

--- a/static/gsApp/overrides/memberListHeader.spec.tsx
+++ b/static/gsApp/overrides/memberListHeader.spec.tsx
@@ -3,11 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import MemberListHeader from 'getsentry/overrides/memberListHeader';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 
 describe('MemberListHeader', () => {
   const organization = OrganizationFixture();

--- a/static/gsApp/overrides/scmGithubMultiOrgInstall.spec.tsx
+++ b/static/gsApp/overrides/scmGithubMultiOrgInstall.spec.tsx
@@ -2,11 +2,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {ScmGithubMultiOrgInstall} from 'getsentry/overrides/scmGithubMultiOrgInstall';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 
 function makeInstallations(
   overrides?: Array<Partial<Parameters<typeof makeInstallation>[0]>>

--- a/static/gsApp/overrides/useScmFeatureMeta.spec.tsx
+++ b/static/gsApp/overrides/useScmFeatureMeta.spec.tsx
@@ -1,12 +1,12 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
+import {PlanTier} from 'getsentry-test/planTier';
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
 import {useScmFeatureMeta} from 'getsentry/overrides/useScmFeatureMeta';
-import {PlanTier} from 'getsentry/types';
 
 describe('useScmFeatureMeta', () => {
   beforeEach(() => {

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -926,32 +926,6 @@ export type RecurringCredit =
   | RecurringPercentDiscount
   | RecurringEventCredit;
 
-export enum PlanTier {
-  /**
-   * Performance plans with continuous profiling
-   * and dynamic sampling for spans.
-   */
-  AM3 = 'am3',
-  /**
-   * Performance plans with continuous profiling
-   * and dynamic sampling for transactions.
-   */
-  AM2 = 'am2',
-  /**
-   * First generation of application monitoring plans.
-   * Includes performance features.
-   */
-  AM1 = 'am1',
-  /**
-   * No specified tier
-   */
-  ALL = 'all',
-  /**
-   * Test plans
-   */
-  TEST = 'test',
-}
-
 // Response from /organizations/:orgSlug/payments/:invoiceId/new/
 export type PaymentCreateResponse = {
   amount: string;

--- a/static/gsApp/views/amCheckout/components/cart.spec.tsx
+++ b/static/gsApp/views/amCheckout/components/cart.spec.tsx
@@ -6,6 +6,7 @@ import {BillingDetailsFixture} from 'getsentry-test/fixtures/billingDetails';
 import {InvoicePreviewFixture} from 'getsentry-test/fixtures/invoicePreview';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
@@ -18,12 +19,7 @@ import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import {PAYG_BUSINESS_DEFAULT} from 'getsentry/constants';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {
-  AddOnCategory,
-  OnDemandBudgetMode,
-  PlanTier,
-  type Subscription,
-} from 'getsentry/types';
+import {AddOnCategory, OnDemandBudgetMode, type Subscription} from 'getsentry/types';
 import AMCheckout from 'getsentry/views/amCheckout/';
 import {Cart} from 'getsentry/views/amCheckout/components/cart';
 import {type CheckoutFormData} from 'getsentry/views/amCheckout/types';

--- a/static/gsApp/views/amCheckout/index.spec.tsx
+++ b/static/gsApp/views/amCheckout/index.spec.tsx
@@ -5,10 +5,11 @@ import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixt
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {AddOnCategory, OnDemandBudgetMode, PlanTier} from 'getsentry/types';
+import {AddOnCategory, OnDemandBudgetMode} from 'getsentry/types';
 import AMCheckout from 'getsentry/views/amCheckout';
 import {getCheckoutAPIData} from 'getsentry/views/amCheckout/utils';
 import {hasOnDemandBudgetsFeature} from 'getsentry/views/spendLimits/utils';

--- a/static/gsApp/views/amCheckout/steps/addBillingInfo.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/addBillingInfo.spec.tsx
@@ -4,10 +4,10 @@ import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixt
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {BillingDetailsFixture} from 'getsentry-test/fixtures/billingDetails';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
 
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 import AMCheckout from 'getsentry/views/amCheckout/';
 
 describe('AddBillingInformation', () => {

--- a/static/gsApp/views/amCheckout/steps/buildYourPlan.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/buildYourPlan.spec.tsx
@@ -4,10 +4,10 @@ import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixt
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 import AMCheckout from 'getsentry/views/amCheckout/';
 
 describe('BuildYourPlan', () => {

--- a/static/gsApp/views/amCheckout/steps/chooseYourBillingCycle.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/chooseYourBillingCycle.spec.tsx
@@ -5,11 +5,11 @@ import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixt
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 import AMCheckout from 'getsentry/views/amCheckout/';
 
 describe('ChooseYourBillingCycle', () => {

--- a/static/gsApp/views/amCheckout/steps/productSelect.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/productSelect.spec.tsx
@@ -7,10 +7,11 @@ import {
   SubscriptionFixture,
   SubscriptionWithLegacySeerFixture,
 } from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {AddOnCategory, PlanTier} from 'getsentry/types';
+import {AddOnCategory} from 'getsentry/types';
 import AMCheckout from 'getsentry/views/amCheckout/';
 
 // XXX(isabella): This tests with both legacy Seer and Seer

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
@@ -4,12 +4,13 @@ import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {MONTHLY} from 'getsentry/constants';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier, type Subscription} from 'getsentry/types';
+import {type Subscription} from 'getsentry/types';
 import {ReserveAdditionalVolume} from 'getsentry/views/amCheckout/steps/reserveAdditionalVolume';
 
 type SliderInfo = {

--- a/static/gsApp/views/amCheckout/steps/setSpendLimit.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/setSpendLimit.spec.tsx
@@ -3,12 +3,12 @@ import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixt
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {Client} from 'sentry/api';
 
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 import AMCheckout from 'getsentry/views/amCheckout';
 
 describe('SetSpendLimit', () => {

--- a/static/gsApp/views/subscriptionPage/billingInformation.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/billingInformation.spec.tsx
@@ -3,6 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {BillingDetailsFixture} from 'getsentry-test/fixtures/billingDetails';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
@@ -14,7 +15,7 @@ import {
 
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 import type {Subscription as TSubscription} from 'getsentry/types';
-import {FTCConsentLocation, PlanTier} from 'getsentry/types';
+import {FTCConsentLocation} from 'getsentry/types';
 import {BillingInformation} from 'getsentry/views/subscriptionPage/billingInformation';
 
 // Stripe mocks handled by global setup.ts

--- a/static/gsApp/views/subscriptionPage/ondemandDisabled.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/ondemandDisabled.spec.tsx
@@ -1,10 +1,9 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
-
-import {PlanTier} from 'getsentry/types';
 
 import {OnDemandDisabled} from './ondemandDisabled';
 

--- a/static/gsApp/views/subscriptionPage/overview.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.spec.tsx
@@ -4,13 +4,13 @@ import {CustomerUsageFixture} from 'getsentry-test/fixtures/customerUsage';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {RecurringCreditFixture} from 'getsentry-test/fixtures/recurringCredit';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {SecondaryNavigationContextProvider} from 'sentry/views/navigation/secondaryNavigationContext';
 
 import {PendingChangesFixture} from 'getsentry/__fixtures__/pendingChanges';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 import Overview from 'getsentry/views/subscriptionPage/overview';
 
 describe('Subscription > Overview', () => {

--- a/static/gsApp/views/subscriptionPage/paymentHistory.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/paymentHistory.spec.tsx
@@ -3,10 +3,10 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {InvoiceFixture} from 'getsentry-test/fixtures/invoice';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 import PaymentHistory from 'getsentry/views/subscriptionPage/paymentHistory';
 
 describe('Subscription > PaymentHistory', () => {

--- a/static/gsApp/views/subscriptionPage/redeemPromoCode.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/redeemPromoCode.spec.tsx
@@ -1,10 +1,10 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 import RedeemPromoCode from 'getsentry/views/redeemPromoCode';
 
 describe('Redeem promo code', () => {

--- a/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
@@ -3,6 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
 
 import type {Organization} from 'sentry/types/organization';
@@ -11,7 +12,6 @@ import {SecondaryNavigationContextProvider} from 'sentry/views/navigation/second
 import {PendingChangesFixture} from 'getsentry/__fixtures__/pendingChanges';
 import {PlanFixture} from 'getsentry/__fixtures__/plan';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 import {SubscriptionHeader} from 'getsentry/views/subscriptionPage/subscriptionHeader';
 
 describe('SubscriptionHeader', () => {

--- a/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
@@ -5,6 +5,7 @@ import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {BillingHistoryFixture} from 'getsentry-test/fixtures/billingHistory';
 import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
@@ -13,7 +14,7 @@ import {DataCategory} from 'sentry/types/core';
 import {PreviewDataFixture} from 'getsentry/__fixtures__/previewData';
 import {GIGABYTE, UNLIMITED, UNLIMITED_ONDEMAND} from 'getsentry/constants';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {OnDemandBudgetMode, PlanTier} from 'getsentry/types';
+import {OnDemandBudgetMode} from 'getsentry/types';
 import UsageHistory from 'getsentry/views/subscriptionPage/usageHistory';
 
 describe('Subscription > UsageHistory', () => {

--- a/static/gsApp/views/subscriptionPage/usageLog.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageLog.spec.tsx
@@ -3,9 +3,9 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {UsageLogFixture} from 'getsentry-test/fixtures/usageLog';
+import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {PlanTier} from 'getsentry/types';
 import UsageLog from 'getsentry/views/subscriptionPage/usageLog';
 
 describe('Subscription Usage Log', () => {

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/charts.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/charts.spec.tsx
@@ -4,13 +4,13 @@ import {BillingStatFixture} from 'getsentry-test/fixtures/billingStat';
 import {CustomerUsageFixture} from 'getsentry-test/fixtures/customerUsage';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {UsageTotalFixture} from 'getsentry-test/fixtures/usageTotal';
+import {PlanTier} from 'getsentry-test/planTier';
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {DataCategory} from 'sentry/types/core';
 import {OrganizationContext} from 'sentry/utils/organizationContext';
 
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
 import {UsageCharts} from 'getsentry/views/subscriptionPage/usageOverview/components/charts';
 import type {BreakdownPanelProps} from 'getsentry/views/subscriptionPage/usageOverview/types';
 

--- a/tests/js/getsentry-test/fixtures/billingConfig.ts
+++ b/tests/js/getsentry-test/fixtures/billingConfig.ts
@@ -4,9 +4,9 @@ import {AM3_PLANS} from 'getsentry-test/fixtures/am3Plans';
 import {FeatureListFixture} from 'getsentry-test/fixtures/featureList';
 import {MM1_PLANS} from 'getsentry-test/fixtures/mm1Plans';
 import {MM2_PLANS} from 'getsentry-test/fixtures/mm2Plans';
+import {PlanTier} from 'getsentry-test/planTier';
 
 import type {BillingConfig} from 'getsentry/types';
-import {PlanTier} from 'getsentry/types';
 
 export function BillingConfigFixture(tier: PlanTier): BillingConfig {
   if (tier === PlanTier.TEST) {

--- a/tests/js/getsentry-test/fixtures/planDetailsLookup.ts
+++ b/tests/js/getsentry-test/fixtures/planDetailsLookup.ts
@@ -5,8 +5,7 @@ import {AM2_PLANS} from 'getsentry-test/fixtures/am2Plans';
 import {AM3_PLANS} from 'getsentry-test/fixtures/am3Plans';
 import {MM1_PLANS} from 'getsentry-test/fixtures/mm1Plans';
 import {MM2_PLANS} from 'getsentry-test/fixtures/mm2Plans';
-
-import {PlanTier} from 'getsentry/types';
+import {PlanTier} from 'getsentry-test/planTier';
 
 export type PlanIds =
   | keyof typeof AM1_PLANS

--- a/tests/js/getsentry-test/planTier.ts
+++ b/tests/js/getsentry-test/planTier.ts
@@ -1,0 +1,32 @@
+/**
+ * Plan tier identifiers, used only by tests/fixtures.
+ *
+ * Production code no longer branches on tier identity (it relies on
+ * backend-resolved tiers and plan capabilities), so this enum lives in the test
+ * tree to keep it out of the production bundle/exports.
+ */
+export enum PlanTier {
+  /**
+   * Performance plans with continuous profiling
+   * and dynamic sampling for spans.
+   */
+  AM3 = 'am3',
+  /**
+   * Performance plans with continuous profiling
+   * and dynamic sampling for transactions.
+   */
+  AM2 = 'am2',
+  /**
+   * First generation of application monitoring plans.
+   * Includes performance features.
+   */
+  AM1 = 'am1',
+  /**
+   * No specified tier
+   */
+  ALL = 'all',
+  /**
+   * Test plans
+   */
+  TEST = 'test',
+}


### PR DESCRIPTION
The enable enterprise trial modal had this tier dropdown. It's redundant because the backend already picks the appropriate tier for an enterprise trial (if the field is not supplied from the FE) and rejects if a wrong one was specified.