### PR TITLE
fix(billing): fix billing status overlay button spacing

### DIFF
--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -567,7 +567,7 @@ const Title = styled('h2')`
 `;
 
 const Body = styled('div')`
-  margin: ${p => p.theme.space.xl};
+  padding: ${p => p.theme.space.xl};
   font-size: ${p => p.theme.font.size.md};
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Fix some weird padding issues with a billing modal
Before:
<img width="431" height="342" alt="Screenshot 2026-06-16 at 2 49 27 PM" src="https://github.com/user-attachments/assets/7c469946-5e54-40a0-8598-53233429e58d" />
After:
<img width="391" height="314" alt="Screenshot 2026-06-16 at 2 49 44 PM" src="https://github.com/user-attachments/assets/322c2029-8ba3-4a2b-983f-a5ab4fee3f63" />
