### PR TITLE
fix(seer): invalidate seer projects list after adding project via modal

### DIFF
--- a/static/app/utils/seer/useMutateAutofixProject.ts
+++ b/static/app/utils/seer/useMutateAutofixProject.ts
@@ -12,7 +12,10 @@ import {
   knownAgentIntegrationsQueryOptions,
   parseAgentOption,
 } from 'sentry/utils/seer/preferredAgent';
-import {getSeerProjectSettingsQueryOptions} from 'sentry/utils/seer/seerProjectSettings';
+import {
+  getInfiniteSeerProjectsSettingsQueryOptions,
+  getSeerProjectSettingsQueryOptions,
+} from 'sentry/utils/seer/seerProjectSettings';
 import {
   getTuningFromStoppingPoint,
   resolveStoppingPoint,
@@ -162,6 +165,15 @@ export function useMutateAutofixProject() {
           orgSlug: organization.slug,
           projectSlug: project.slug,
         }),
+      });
+      // Invalidate the org-level infinite seer projects list so the
+      // /settings/seer/projects/ table reflects the newly added project
+      // without waiting for its 60s staleTime to expire.
+      const {queryKey: infiniteProjectsQueryKey} =
+        getInfiniteSeerProjectsSettingsQueryOptions({organization, query: {}});
+      queryClient.invalidateQueries({
+        queryKey: [infiniteProjectsQueryKey[0]],
+        exact: false,
       });
     },
   });


### PR DESCRIPTION
## Problem

After adding a project to Autofix via the "Add Project" modal on `/settings/seer/projects/`, the table does not update to show the new project. It stays stale until the 60s `staleTime` expires or the page is refreshed.

## Root cause

`useMutateAutofixProject.onSettled` invalidates several caches on success:
- `projectSeerPreferencesApiOptions` (per-project legacy)
- `bulkAutofixAutomationSettingsInfiniteOptions` (legacy `/autofix/automation-settings/` endpoint)
- `getSeerProjectSettingsQueryOptions` (per-project `/projects/$org/$project/seer/settings/`)
- `makeDetailedProjectQueryKey`

But it does **not** invalidate `getInfiniteSeerProjectsSettingsQueryOptions` → `/organizations/$org/seer/projects/`, which is the exact infinite query `SeerProjectTable` fetches from.

Inline table edits (`getMutateSeerProjectSettingsOptions`) already do this correctly. The modal mutation path (`useMutateAutofixProject`) was the gap.

## Fix

Add the missing `queryClient.invalidateQueries` for the org-level seer projects infinite query in `useMutateAutofixProject.onSettled`, mirroring what `getMutateSeerProjectSettingsOptions` already does.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0AKG192UP3%3A1781646228.205609%22)