### PR TITLE
ref: Remove unused accesses of planTier

### DIFF
--- a/static/gsAdmin/components/customerStatus.tsx
+++ b/static/gsAdmin/components/customerStatus.tsx
@@ -70,7 +70,7 @@ export function CustomerStatus({customer}: Props) {
       {typeof label !== 'object' && label}
       <br />
       <InfoText variant="inherit" title={getTooltip(customer)}>
-        <small>{`${customer.planDetails?.name} Plan (${customer.planTier})`}</small>
+        <small>{`${customer.planDetails?.name} Plan (${customer.planDetails?.id})`}</small>
       </InfoText>
     </Fragment>
   );

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -619,7 +619,7 @@ describe('CustomerOverview', () => {
       />
     );
 
-    expect(screen.getByText('Team Plan (am3)')).toBeInTheDocument();
+    expect(screen.getByText('Team Plan (am3_team)')).toBeInTheDocument();
     await waitFor(() => {
       const term = screen.getByText('Sample Rate (24h):');
       const definition = term.nextElementSibling;

--- a/static/gsApp/components/features/planFeature.spec.tsx
+++ b/static/gsApp/components/features/planFeature.spec.tsx
@@ -36,7 +36,6 @@ describe('PlanFeature', () => {
     await waitFor(() => {
       expect(mockFn).toHaveBeenCalledWith({
         plan: PlanDetailsLookupFixture('am2_team'),
-        tierChange: 'am2',
       });
     });
   });
@@ -56,7 +55,6 @@ describe('PlanFeature', () => {
     await waitFor(() => {
       expect(mockFn).toHaveBeenCalledWith({
         plan: PlanDetailsLookupFixture('am2_business'),
-        tierChange: 'am2',
       });
     });
   });
@@ -74,7 +72,7 @@ describe('PlanFeature', () => {
     );
 
     await waitFor(() => {
-      expect(mockFn).toHaveBeenCalledWith({plan: null, tierChange: null});
+      expect(mockFn).toHaveBeenCalledWith({plan: null});
     });
   });
 
@@ -96,27 +94,6 @@ describe('PlanFeature', () => {
     await waitFor(() => {
       expect(mockFn).toHaveBeenCalledWith({
         plan: PlanDetailsLookupFixture('am2_business'),
-        tierChange: 'am2',
-      });
-    });
-  });
-
-  it('reports tier change as null when no tier change is required', async () => {
-    const mockFn = jest.fn(() => null);
-
-    const sub = SubscriptionFixture({organization, planTier: 'am2'});
-    SubscriptionStore.set(organization.slug, sub);
-
-    render(
-      <PlanFeature organization={organization} features={['discard-groups']}>
-        {mockFn}
-      </PlanFeature>
-    );
-
-    await waitFor(() => {
-      expect(mockFn).toHaveBeenCalledWith({
-        plan: PlanDetailsLookupFixture('am2_business'),
-        tierChange: null,
       });
     });
   });
@@ -141,7 +118,6 @@ describe('PlanFeature', () => {
     await waitFor(() => {
       expect(mockFn).toHaveBeenCalledWith({
         plan: PlanDetailsLookupFixture('am3_business'),
-        tierChange: 'am3',
       });
     });
   });
@@ -165,7 +141,6 @@ describe('PlanFeature', () => {
     await waitFor(() => {
       expect(mockFn).toHaveBeenCalledWith({
         plan: PlanDetailsLookupFixture('am2_business'),
-        tierChange: 'am2',
       });
     });
   });

--- a/static/gsApp/components/features/planFeature.tsx
+++ b/static/gsApp/components/features/planFeature.tsx
@@ -18,11 +18,6 @@ type RenderProps = {
    * user-selectable or if the users current plan is on a special tier.
    */
   plan: Plan | null;
-  /**
-   * If the feature requires changing plan tiers, this will report the required
-   * plan tier that is DIFFERENT from the users current subscription tier.
-   */
-  tierChange: string | null;
 };
 
 type Props = {
@@ -117,12 +112,7 @@ function PlanFeature({subscription, features, organization, children}: Props) {
     requiredPlan = plans.find(plan => plan.dashboardLimit === UNLIMITED_RESERVED);
   }
 
-  const tierChange =
-    requiredPlan !== undefined && subscription.planTier !== billingConfig.id
-      ? billingConfig.id
-      : null;
-
-  return <Fragment>{children({plan: requiredPlan ?? null, tierChange})}</Fragment>;
+  return <Fragment>{children({plan: requiredPlan ?? null})}</Fragment>;
 }
 
 export default withSubscription(PlanFeature, {noLoader: true});

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -256,14 +256,14 @@ function AMCheckout(props: Props) {
         );
       }
 
-      // find equivalent current plan for legacy
-      const legacyInitialPlan =
-        subscription.planTier !== config.id &&
-        planList.find(
-          ({name, contractInterval}) =>
-            name === subscription?.planDetails?.name &&
-            contractInterval === subscription?.planDetails?.contractInterval
-        );
+      // The current plan isn't directly available in this checkout's plan list
+      // (the exact-id lookup above returned nothing), so fall back to an
+      // equivalent plan matched by name + contract interval.
+      const legacyInitialPlan = planList.find(
+        ({name, contractInterval}) =>
+          name === subscription?.planDetails?.name &&
+          contractInterval === subscription?.planDetails?.contractInterval
+      );
 
       // if no legacy initial plan found, we fallback to the business plan, then the default plan (usually team)
       return (
@@ -274,7 +274,6 @@ function AMCheckout(props: Props) {
       subscription.plan,
       subscription.planDetails.name,
       subscription.planDetails?.contractInterval,
-      subscription.planTier,
       getBusinessPlan,
       shouldDefaultToBusiness,
     ]


### PR DESCRIPTION
One use was an unused prop, another was a redundant check, and the last was the admin UI which I just updated to show the whole plan id rather than the tier