### PR TITLE
ref(cells): Remove unused find_all_multitenant_cell_names function

### DIFF
--- a/src/sentry/types/cell.py
+++ b/src/sentry/types/cell.py
@@ -497,14 +497,6 @@ def find_all_cell_names() -> Iterable[str]:
     return get_global_directory().get_cell_names()
 
 
-def find_all_multitenant_cell_names() -> list[str]:
-    """
-    Return all visible multi_tenant cells.
-    """
-    cells = get_global_directory().get_cells(RegionCategory.MULTI_TENANT)
-    return list([c.name for c in cells if c.visible])
-
-
 def find_all_multitenant_locality_names() -> list[str]:
     """
     Return all visible multi-tenant localities.

--- a/tests/sentry/types/test_cell.py
+++ b/tests/sentry/types/test_cell.py
@@ -21,7 +21,6 @@ from sentry.types.cell import (
     Locality,
     RegionCategory,
     find_all_cell_names,
-    find_all_multitenant_cell_names,
     find_cells_for_sentry_app,
     find_cells_for_user,
     get_cell_by_name,
@@ -259,32 +258,6 @@ class CellDirectoryTest(TestCase):
         with self._in_global_state(directory):
             result = find_all_cell_names()
             assert set(result) == {"us", "eu", "acme"}
-
-    @override_settings(SILO_MODE=SiloMode.CONTROL)
-    def test_find_all_multitenant_cell_names(self) -> None:
-        with override_settings(SENTRY_MONOLITH_REGION="us", SENTRY_FALLBACK_CELL="us"):
-            directory = load_from_config(self._INPUTS, self._LOCALITY_INPUTS)
-        with self._in_global_state(directory):
-            result = find_all_multitenant_cell_names()
-            assert set(result) == {"us", "eu"}
-
-    @override_settings(SILO_MODE=SiloMode.CONTROL)
-    def test_find_all_multitenant_cell_names_non_visible(self) -> None:
-        inputs: list[CellConfig] = [
-            *self._INPUTS,
-            {
-                "name": "ja",
-                "snowflake_id": 4,
-                "address": "https://ja.testserver",
-                "visible": False,
-            },
-        ]
-        locality_inputs: list[LocalityConfig] = self._LOCALITY_INPUTS
-        with override_settings(SENTRY_MONOLITH_REGION="us", SENTRY_FALLBACK_CELL="us"):
-            directory = load_from_config(inputs, locality_inputs)
-        with self._in_global_state(directory):
-            result = find_all_multitenant_cell_names()
-            assert set(result) == {"us", "eu"}
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_subdomain_is_locality(self) -> None:


### PR DESCRIPTION
This function is not used. Removing it is a step towards deprecating the Locality.category field.
