### PR TITLE
style(weekly-report): Update colors

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -511,21 +511,21 @@ def _pct_change(current: int, previous: int) -> str | None:
     return f"{arrow} {abs(pct)}%"
 
 
-def get_group_status_badge(group: Group) -> tuple[str, str, str]:
+def get_group_status_badge(group: Group) -> tuple[str, str, str, str]:
     """
-    Returns a tuple of (text, background_color, border_color)
-    Should be similar to GroupStatusBadge.tsx in the frontend
+    Returns a tuple of (text, background_color, border_color, text_color)
+    Muted versions of the Issues Breakdown bar colors (#FFCE00, #FF002B, #3A1873, #DAD9DE).
     """
     if group.status == GroupStatus.RESOLVED:
-        return ("Resolved", "rgba(108, 95, 199, 0.08)", "rgba(108, 95, 199, 0.5)")
+        return ("Resolved", "#EBE8F1", "#BAAECE", "#230E45")
     if group.status == GroupStatus.UNRESOLVED:
         if group.substatus == GroupSubStatus.NEW:
-            return ("New", "rgba(245, 176, 0, 0.08)", "rgba(245, 176, 0, 0.55)")
+            return ("New", "#FFFAE6", "#FFEEA6", "#997C00")
         if group.substatus == GroupSubStatus.REGRESSED:
-            return ("Regressed", "rgba(108, 95, 199, 0.08)", "rgba(108, 95, 199, 0.5)")
+            return ("Regressed", "#EBE8F1", "#BAAECE", "#230E45")
         if group.substatus == GroupSubStatus.ESCALATING:
-            return ("Escalating", "rgba(245, 84, 89, 0.09)", "rgba(245, 84, 89, 0.5)")
-    return ("Ongoing", "#DAD9DE", "#DAD9DE")
+            return ("Escalating", "#FFE6EA", "#FFA6B5", "#99001A")
+    return ("Ongoing", "#F9F9FA", "#F0F0F2", "#838285")
 
 
 def get_group_display(group: Group) -> dict[str, str]:
@@ -714,6 +714,7 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                         substatus,
                         substatus_color,
                         substatus_border_color,
+                        substatus_text_color,
                     ) = get_group_status_badge(group)
 
                     yield {
@@ -726,6 +727,7 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                         "group_substatus": substatus,
                         "group_substatus_color": substatus_color,
                         "group_substatus_border_color": substatus_border_color,
+                        "group_substatus_text_color": substatus_text_color,
                     }
 
         return heapq.nlargest(3, all_key_errors(), lambda d: d["count"])
@@ -759,6 +761,7 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                         substatus,
                         substatus_color,
                         substatus_border_color,
+                        substatus_text_color,
                     ) = get_group_status_badge(group)
                     yield {
                         "count": count,
@@ -776,6 +779,7 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                         "group_substatus": substatus,
                         "group_substatus_color": substatus_color,
                         "group_substatus_border_color": substatus_border_color,
+                        "group_substatus_text_color": substatus_text_color,
                     }
 
         return heapq.nlargest(3, all_key_performance_issues(), lambda d: d["count"])

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -459,20 +459,20 @@ class _DuplicateDeliveryCheck:
         return is_duplicate_detected
 
 
-project_breakdown_colors = ["#422C6E", "#895289", "#D6567F", "#F38150", "#F2B713"]
+project_breakdown_colors = ["#7553FF", "#7C2282", "#F0369A", "#FF9838", "#FFD00E"]
 total_color = """
 linear-gradient(
     -45deg,
-    #ccc 25%,
+    #A29FAA 25%,
     transparent 25%,
     transparent 50%,
-    #ccc 50%,
-    #ccc 75%,
+    #A29FAA 50%,
+    #A29FAA 75%,
     transparent 75%,
     transparent
 );
 """
-other_color = "#f2f0fa"
+other_color = "#DAD9DE"
 group_status_to_color = {
     GroupHistoryStatus.UNRESOLVED: "#FAD473",
     GroupHistoryStatus.RESOLVED: "#8ACBBC",
@@ -525,7 +525,35 @@ def get_group_status_badge(group: Group) -> tuple[str, str, str]:
             return ("Regressed", "rgba(108, 95, 199, 0.08)", "rgba(108, 95, 199, 0.5)")
         if group.substatus == GroupSubStatus.ESCALATING:
             return ("Escalating", "rgba(245, 84, 89, 0.09)", "rgba(245, 84, 89, 0.5)")
-    return ("Ongoing", "rgba(219, 214, 225, 1)", "rgba(219, 214, 225, 1)")
+    return ("Ongoing", "#DAD9DE", "#DAD9DE")
+
+
+def get_group_display(group: Group) -> dict[str, str]:
+    metadata = group.get_event_metadata()
+    event_type = group.get_event_type()
+    custom_title = metadata.get("title")
+
+    if event_type == "error":
+        title = (
+            custom_title
+            if custom_title and custom_title != "<unlabeled event>"
+            else metadata.get("type") or metadata.get("function") or "<unknown>"
+        )
+        message = metadata.get("value")
+    elif event_type in ("transaction", "generic"):
+        title = custom_title or group.title
+        message = metadata.get("value")
+    elif event_type == "csp":
+        title = custom_title or metadata.get("directive") or ""
+        message = metadata.get("message")
+    else:
+        title = custom_title or group.title
+        message = group.culprit
+
+    return {
+        "title": title,
+        "message": message or group.message or "",
+    }
 
 
 def get_local_dates(ctx: OrganizationReportContext, user_id: int) -> tuple[datetime, datetime]:
@@ -681,6 +709,7 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
         def all_key_errors():
             for project_ctx in user_projects:
                 for group, count in project_ctx.key_errors_by_group:
+                    display = get_group_display(group)
                     (
                         substatus,
                         substatus_color,
@@ -690,6 +719,8 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                     yield {
                         "count": count,
                         "group": group,
+                        "title": display["title"],
+                        "message": display["message"],
                         "status": "Unresolved",
                         "status_color": (group_status_to_color[GroupHistoryStatus.NEW]),
                         "group_substatus": substatus,
@@ -723,9 +754,17 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
         def all_key_performance_issues():
             for project_ctx in user_projects:
                 for group, group_history, count in project_ctx.key_performance_issues:
+                    display = get_group_display(group)
+                    (
+                        substatus,
+                        substatus_color,
+                        substatus_border_color,
+                    ) = get_group_status_badge(group)
                     yield {
                         "count": count,
                         "group": group,
+                        "title": display["title"],
+                        "message": display["message"],
                         "status": (
                             group_history.get_status_display() if group_history else "Unresolved"
                         ),
@@ -734,6 +773,9 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                             if group_history
                             else group_status_to_color[GroupHistoryStatus.NEW]
                         ),
+                        "group_substatus": substatus,
+                        "group_substatus_color": substatus_color,
+                        "group_substatus_border_color": substatus_border_color,
                     }
 
         return heapq.nlargest(3, all_key_performance_issues(), lambda d: d["count"])

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -511,21 +511,21 @@ def _pct_change(current: int, previous: int) -> str | None:
     return f"{arrow} {abs(pct)}%"
 
 
-def get_group_status_badge(group: Group) -> tuple[str, str, str, str]:
+def get_group_status_badge(group: Group) -> tuple[str, str, str]:
     """
-    Returns a tuple of (text, background_color, border_color, text_color)
-    Muted versions of the Issues Breakdown bar colors (#FFCE00, #FF002B, #3A1873, #DAD9DE).
+    Returns a tuple of (text, background_color, text_color)
+    Matches frontend Tag component: background.transparent.*.muted blended on white, content.* text.
     """
     if group.status == GroupStatus.RESOLVED:
-        return ("Resolved", "#EBE8F1", "#BAAECE", "#230E45")
+        return ("Resolved", "#E3F7E3", "#008900")
     if group.status == GroupStatus.UNRESOLVED:
         if group.substatus == GroupSubStatus.NEW:
-            return ("New", "#FFFAE6", "#FFEEA6", "#997C00")
+            return ("New", "#F9F0D2", "#A45200")
         if group.substatus == GroupSubStatus.REGRESSED:
-            return ("Regressed", "#EBE8F1", "#BAAECE", "#230E45")
+            return ("Regressed", "#EDEEFE", "#653DE9")
         if group.substatus == GroupSubStatus.ESCALATING:
-            return ("Escalating", "#FFE6EA", "#FFA6B5", "#99001A")
-    return ("Ongoing", "#F9F9FA", "#F0F0F2", "#838285")
+            return ("Escalating", "#FEE7E4", "#D50000")
+    return ("Ongoing", "#F0F0F2", "#6A6772")
 
 
 def get_group_display(group: Group) -> dict[str, str]:
@@ -713,7 +713,6 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                     (
                         substatus,
                         substatus_color,
-                        substatus_border_color,
                         substatus_text_color,
                     ) = get_group_status_badge(group)
 
@@ -726,7 +725,6 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                         "status_color": (group_status_to_color[GroupHistoryStatus.NEW]),
                         "group_substatus": substatus,
                         "group_substatus_color": substatus_color,
-                        "group_substatus_border_color": substatus_border_color,
                         "group_substatus_text_color": substatus_text_color,
                     }
 
@@ -760,7 +758,6 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                     (
                         substatus,
                         substatus_color,
-                        substatus_border_color,
                         substatus_text_color,
                     ) = get_group_status_badge(group)
                     yield {
@@ -778,7 +775,6 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                         ),
                         "group_substatus": substatus,
                         "group_substatus_color": substatus_color,
-                        "group_substatus_border_color": substatus_border_color,
                         "group_substatus_text_color": substatus_text_color,
                     }
 

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -444,7 +444,7 @@
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
       {% if a.group_substatus and a.group_substatus_color %}
-      <span style="background-color: {{a.group_substatus_color}}; border: 1px solid {{a.group_substatus_border_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.group_substatus}}</span>
+      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border: 1px solid {{a.group_substatus_border_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.group_substatus}}</span>
       {% else %}
       <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.status}}</span>
       {% endif %}
@@ -467,7 +467,7 @@
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
       {% if a.group_substatus and a.group_substatus_color %}
-      <span style="background-color: {{a.group_substatus_color}}; border: 1px solid {{a.group_substatus_border_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.group_substatus}}</span>
+      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border: 1px solid {{a.group_substatus_border_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.group_substatus}}</span>
       {% else %}
       <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.status}}</span>
       {% endif %}

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -388,9 +388,9 @@
           <h4>Issues Breakdown</h4>
         </td>
         <td class="legend-inbox">
-          <span class="swatch" style="background-color: #FFCE00;"></span>New<span class="quantity"> ({{ issue_summary.new_substatus_count }})</span>
-          <span class="swatch" style="background-color: #FF002B;"></span>Escalating<span class="quantity"> ({{ issue_summary.escalating_substatus_count }})</span>
-          <span class="swatch" style="background-color: #3A1873;"></span>Regressed<span class="quantity"> ({{ issue_summary.regression_substatus_count }})</span>
+          <span class="swatch" style="background-color: #EDCA60;"></span>New<span class="quantity"> ({{ issue_summary.new_substatus_count }})</span>
+          <span class="swatch" style="background-color: #FF978F;"></span>Escalating<span class="quantity"> ({{ issue_summary.escalating_substatus_count }})</span>
+          <span class="swatch" style="background-color: #B7B2FF;"></span>Regressed<span class="quantity"> ({{ issue_summary.regression_substatus_count }})</span>
           <span class="swatch" style="background-color: #DAD9DE;"></span>Ongoing<span class="quantity"> ({{ issue_summary.ongoing_substatus_count }})</span>
         </td>
       </tr>
@@ -398,13 +398,13 @@
         <td colspan="2">
           <table>
             <tr>
-              <td width="{% widthratio issue_summary.new_substatus_count issue_summary.total_substatus_count 100 %}%" title="New: {{ issue_summary.new_substatus_count }} events" style="background-color: #FFCE00">
+              <td width="{% widthratio issue_summary.new_substatus_count issue_summary.total_substatus_count 100 %}%" title="New: {{ issue_summary.new_substatus_count }} events" style="background-color: #EDCA60">
                 &nbsp;
               </td>
-              <td width="{% widthratio issue_summary.escalating_substatus_count issue_summary.total_substatus_count 100 %}%" title="Escalating: {{ issue_summary.escalating_substatus_count }} events" style="background-color: #FF002B">
+              <td width="{% widthratio issue_summary.escalating_substatus_count issue_summary.total_substatus_count 100 %}%" title="Escalating: {{ issue_summary.escalating_substatus_count }} events" style="background-color: #FF978F">
                 &nbsp;
               </td>
-              <td width="{% widthratio issue_summary.regression_substatus_count issue_summary.total_substatus_count 100 %}%" title="Regressed: {{ issue_summary.regression_substatus_count }} events" style="background-color: #3A1873">
+              <td width="{% widthratio issue_summary.regression_substatus_count issue_summary.total_substatus_count 100 %}%" title="Regressed: {{ issue_summary.regression_substatus_count }} events" style="background-color: #B7B2FF">
                 &nbsp;
               </td>
               <td width="{% widthratio issue_summary.ongoing_substatus_count issue_summary.total_substatus_count 100 %}%" title="Ongoing: {{ issue_summary.ongoing_substatus_count }} events" style="background-color: #DAD9DE">
@@ -444,9 +444,9 @@
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
       {% if a.group_substatus and a.group_substatus_color %}
-      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border: 1px solid {{a.group_substatus_border_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.group_substatus}}</span>
+      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center;">{{a.group_substatus}}</span>
       {% else %}
-      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.status}}</span>
+      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center;">{{a.status}}</span>
       {% endif %}
       </div>
     {% endfor %}
@@ -467,9 +467,9 @@
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
       {% if a.group_substatus and a.group_substatus_color %}
-      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border: 1px solid {{a.group_substatus_border_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.group_substatus}}</span>
+      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center;">{{a.group_substatus}}</span>
       {% else %}
-      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.status}}</span>
+      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center;">{{a.status}}</span>
       {% endif %}
     </div>
     {% endfor %}

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -3,38 +3,11 @@
 {% load sentry_helpers %}
 {% load sentry_assets %}
 
-{% block bodyclass %}weekly-report{% endblock %}
-
 {% block head %}
 
   {{ block.super }}
 
   <style type="text/css">
-    body.weekly-report,
-    body.weekly-report .main {
-      font-family: Rubik, "Helvetica Neue", helvetica, sans-serif;
-      font-weight: 400;
-    }
-
-    body.weekly-report a,
-    body.weekly-report strong,
-    body.weekly-report .btn {
-      font-weight: 400;
-    }
-
-    body.weekly-report h1,
-    body.weekly-report h2,
-    body.weekly-report h3,
-    body.weekly-report h4,
-    body.weekly-report h5,
-    body.weekly-report h6,
-    body.weekly-report .header strong {
-      font-weight: 500;
-    }
-
-    body.weekly-report .total-count {
-      font-weight: 400;
-    }
 
     .container {
       padding-top: 18px;
@@ -114,6 +87,7 @@
     .project-breakdown .total-count-title {
       margin-top: 0;
       margin-bottom: 0;
+      font-weight: 500;
     }
     .project-breakdown .total-count {
       margin-top: 5px;
@@ -166,8 +140,6 @@
   </style>
 
   <style type="text/css" inline="false">
-    @import url(https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;700&display=swap);
-
     @media only screen and (max-device-width: 480px) {
 
       .mobile-full-width > th,
@@ -227,7 +199,7 @@
     <h1 style="margin: 0;" class="total-count">
       {{ trends.total_error_count|small_count:1 }}
       {% if show_week_over_week_metric and trends.error_pct_change %}
-      <span style="font-size: 14px; font-weight: 400; margin-left: 8px; padding: 2px 8px; border-radius: 12px; vertical-align: middle; background-color: #F2F0FA; color: #3A1873;">{{ trends.error_pct_change }}</span>
+      <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 12px; vertical-align: middle; background-color: #F2F0FA; color: #3A1873;">{{ trends.error_pct_change }}</span>
       {% endif %}
     </h1>
     {% url 'sentry-organization-issue-list' organization.slug as issue_list %}
@@ -269,7 +241,7 @@
       <h1 style="margin: 0;" class="total-count">
         {{ trends.total_transaction_count|small_count:1 }}
         {% if show_week_over_week_metric and trends.transaction_pct_change %}
-        <span style="font-size: 14px; font-weight: 400; margin-left: 8px; padding: 2px 8px; border-radius: 12px; vertical-align: middle; background-color: #F2F0FA; color: #3A1873;">{{ trends.transaction_pct_change }}</span>
+        <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 12px; vertical-align: middle; background-color: #F2F0FA; color: #3A1873;">{{ trends.transaction_pct_change }}</span>
         {% endif %}
       </h1>
       {% url 'sentry-organization-performance' organization.slug as performance_landing %}
@@ -307,7 +279,7 @@
       <td class="project-breakdown-graph-cell transactions-empty">
         <div style="border: 1px solid #c4c4cc; border-radius: 4px; padding: 24px 16px; text-align: center; height: 170px;">
           <img src="{% absolute_asset_url 'sentry' 'images/email/icon-circle-lightning.png' %}" width="32px" height="32px" alt="Sentry">
-          <h1 style="font-weight: 500; font-size: 17px;">Something slow?</h1>
+          <h1 style="font-weight: bold; font-size: 17px;">Something slow?</h1>
           <p style="font-size: 11px;">Trace those 10-second page loads to poor-performing API calls.</p>
           {% url 'sentry-organization-performance' organization.slug as performance_landing %}
           {% querystring referrer="weekly_report_upsell" notification_uuid=notification_uuid as query %}

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -444,9 +444,9 @@
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
       {% if a.group_substatus and a.group_substatus_color %}
-      <span style="background-color: {{a.group_substatus_color}}; border: 1px solid {{a.group_substatus_border_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%;">{{a.group_substatus}}</span>
+      <span style="background-color: {{a.group_substatus_color}}; border: 1px solid {{a.group_substatus_border_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.group_substatus}}</span>
       {% else %}
-      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%;">{{a.status}}</span>
+      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.status}}</span>
       {% endif %}
       </div>
     {% endfor %}
@@ -467,9 +467,9 @@
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
       {% if a.group_substatus and a.group_substatus_color %}
-      <span style="background-color: {{a.group_substatus_color}}; border: 1px solid {{a.group_substatus_border_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%;">{{a.group_substatus}}</span>
+      <span style="background-color: {{a.group_substatus_color}}; border: 1px solid {{a.group_substatus_border_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.group_substatus}}</span>
       {% else %}
-      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%;">{{a.status}}</span>
+      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; width: 100px; flex-shrink: 0; box-sizing: border-box; text-align: center; white-space: nowrap;">{{a.status}}</span>
       {% endif %}
     </div>
     {% endfor %}

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -87,7 +87,6 @@
     .project-breakdown .total-count-title {
       margin-top: 0;
       margin-bottom: 0;
-      font-weight: 500;
     }
     .project-breakdown .total-count {
       margin-top: 5px;

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -3,11 +3,38 @@
 {% load sentry_helpers %}
 {% load sentry_assets %}
 
+{% block bodyclass %}weekly-report{% endblock %}
+
 {% block head %}
 
   {{ block.super }}
 
   <style type="text/css">
+    body.weekly-report,
+    body.weekly-report .main {
+      font-family: Rubik, "Helvetica Neue", helvetica, sans-serif;
+      font-weight: 400;
+    }
+
+    body.weekly-report a,
+    body.weekly-report strong,
+    body.weekly-report .btn {
+      font-weight: 400;
+    }
+
+    body.weekly-report h1,
+    body.weekly-report h2,
+    body.weekly-report h3,
+    body.weekly-report h4,
+    body.weekly-report h5,
+    body.weekly-report h6,
+    body.weekly-report .header strong {
+      font-weight: 500;
+    }
+
+    body.weekly-report .total-count {
+      font-weight: 400;
+    }
 
     .container {
       padding-top: 18px;
@@ -117,7 +144,7 @@
     .project-breakdown .summary thead th {
       font-size: 12px;
       text-transform: uppercase;
-      color: #88859a;
+      color: #2f2936;
       font-weight: 500;
     }
 
@@ -139,6 +166,8 @@
   </style>
 
   <style type="text/css" inline="false">
+    @import url(https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;700&display=swap);
+
     @media only screen and (max-device-width: 480px) {
 
       .mobile-full-width > th,
@@ -198,8 +227,7 @@
     <h1 style="margin: 0;" class="total-count">
       {{ trends.total_error_count|small_count:1 }}
       {% if show_week_over_week_metric and trends.error_pct_change %}
-      <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 12px; vertical-align: middle; background-color: #F2F0FA; color: #80708F;">{{ trends.error_pct_change }}</span>
-      <span style="font-size: 12px; font-weight: normal; color: #80708F; margin-left: 4px; vertical-align: middle;">(vs. last week)</span>
+      <span style="font-size: 14px; font-weight: 400; margin-left: 8px; padding: 2px 8px; border-radius: 12px; vertical-align: middle; background-color: #F2F0FA; color: #3A1873;">{{ trends.error_pct_change }}</span>
       {% endif %}
     </h1>
     {% url 'sentry-organization-issue-list' organization.slug as issue_list %}
@@ -218,7 +246,7 @@
                 </tr>
               {% empty %}
                 <tr>
-                  <td height="1" style="background-color: #ebe9f7;"></td>
+                  <td height="1" style="background-color: #DAD9DE;"></td>
                 </tr>
               {% endfor %}
             </table>
@@ -241,8 +269,7 @@
       <h1 style="margin: 0;" class="total-count">
         {{ trends.total_transaction_count|small_count:1 }}
         {% if show_week_over_week_metric and trends.transaction_pct_change %}
-        <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 12px; vertical-align: middle; background-color: #F2F0FA; color: #80708F;">{{ trends.transaction_pct_change }}</span>
-        <span style="font-size: 12px; font-weight: normal; color: #80708F; margin-left: 4px; vertical-align: middle;">(vs. last week)</span>
+        <span style="font-size: 14px; font-weight: 400; margin-left: 8px; padding: 2px 8px; border-radius: 12px; vertical-align: middle; background-color: #F2F0FA; color: #3A1873;">{{ trends.transaction_pct_change }}</span>
         {% endif %}
       </h1>
       {% url 'sentry-organization-performance' organization.slug as performance_landing %}
@@ -260,7 +287,7 @@
                   </tr>
                 {% empty %}
                   <tr>
-                    <td height="1" style="background-color: #ebe9f7;"></td>
+                    <td height="1" style="background-color: #DAD9DE;"></td>
                   </tr>
                 {% endfor %}
               </table>
@@ -280,7 +307,7 @@
       <td class="project-breakdown-graph-cell transactions-empty">
         <div style="border: 1px solid #c4c4cc; border-radius: 4px; padding: 24px 16px; text-align: center; height: 170px;">
           <img src="{% absolute_asset_url 'sentry' 'images/email/icon-circle-lightning.png' %}" width="32px" height="32px" alt="Sentry">
-          <h1 style="font-weight: bold; font-size: 17px;">Something slow?</h1>
+          <h1 style="font-weight: 500; font-size: 17px;">Something slow?</h1>
           <p style="font-size: 11px;">Trace those 10-second page loads to poor-performing API calls.</p>
           {% url 'sentry-organization-performance' organization.slug as performance_landing %}
           {% querystring referrer="weekly_report_upsell" notification_uuid=notification_uuid as query %}
@@ -329,22 +356,22 @@
           <h4>Errors by Issue Type</h4>
         </td>
         <td class="legend">
-          <span class="swatch" style="background-color: #DF5120;"></span>New<span class="quantity">: {% percent issue_summary.new_issue_count issue_summary.all_issue_count "0.1f" %}%</span>
-          <span class="swatch" style="background-color: #FF7738;"></span>Reopened<span class="quantity">: {% percent issue_summary.reopened_issue_count issue_summary.all_issue_count "0.1f" %}%</span>
-          <span class="swatch" style="background-color: #F9C7B9;"></span>Existing<span class="quantity">: {% percent issue_summary.existing_issue_count issue_summary.all_issue_count "0.1f" %}%</span>
+          <span class="swatch" style="background-color: #FF002B;"></span>New<span class="quantity">: {% percent issue_summary.new_issue_count issue_summary.all_issue_count "0.1f" %}%</span>
+          <span class="swatch" style="background-color: #FFCE00;"></span>Reopened<span class="quantity">: {% percent issue_summary.reopened_issue_count issue_summary.all_issue_count "0.1f" %}%</span>
+          <span class="swatch" style="background-color: #DAD9DE;"></span>Existing<span class="quantity">: {% percent issue_summary.existing_issue_count issue_summary.all_issue_count "0.1f" %}%</span>
         </td>
       </tr>
       <tr>
         <td colspan="2">
           <table>
             <tr>
-              <td width="{% widthratio issue_summary.new_issue_count issue_summary.all_issue_count 100 %}%" title="New: {{ issue_summary.new_issue_count }} events" style="background-color: #DF5120">
+              <td width="{% widthratio issue_summary.new_issue_count issue_summary.all_issue_count 100 %}%" title="New: {{ issue_summary.new_issue_count }} events" style="background-color: #FF002B">
                 &nbsp;
               </td>
-              <td width="{% widthratio issue_summary.reopened_issue_count issue_summary.all_issue_count 100 %}%" title="Reopened: {{ issue_summary.reopened_issue_count }} events" style="background-color: #FF7738">
+              <td width="{% widthratio issue_summary.reopened_issue_count issue_summary.all_issue_count 100 %}%" title="Reopened: {{ issue_summary.reopened_issue_count }} events" style="background-color: #FFCE00">
                 &nbsp;
               </td>
-              <td width="{% widthratio issue_summary.existing_issue_count issue_summary.all_issue_count 100 %}%" title="Existing: {{ issue_summary.existing_issue_count }} events" style="background-color: #F9C7B9">
+              <td width="{% widthratio issue_summary.existing_issue_count issue_summary.all_issue_count 100 %}%" title="Existing: {{ issue_summary.existing_issue_count }} events" style="background-color: #DAD9DE">
                 &nbsp;
               </td>
             </tr>
@@ -361,26 +388,26 @@
           <h4>Issues Breakdown</h4>
         </td>
         <td class="legend-inbox">
-          <span class="swatch" style="background-color: #F2B712;"></span>New<span class="quantity"> ({{ issue_summary.new_substatus_count }})</span>
-          <span class="swatch" style="background-color: #E9626E;"></span>Escalating<span class="quantity"> ({{ issue_summary.escalating_substatus_count }})</span>
-          <span class="swatch" style="background-color: #444674;"></span>Regressed<span class="quantity"> ({{ issue_summary.regression_substatus_count }})</span>
-          <span class="swatch" style="background-color: #DBD6E1;"></span>Ongoing<span class="quantity"> ({{ issue_summary.ongoing_substatus_count }})</span>
+          <span class="swatch" style="background-color: #FFCE00;"></span>New<span class="quantity"> ({{ issue_summary.new_substatus_count }})</span>
+          <span class="swatch" style="background-color: #FF002B;"></span>Escalating<span class="quantity"> ({{ issue_summary.escalating_substatus_count }})</span>
+          <span class="swatch" style="background-color: #3A1873;"></span>Regressed<span class="quantity"> ({{ issue_summary.regression_substatus_count }})</span>
+          <span class="swatch" style="background-color: #DAD9DE;"></span>Ongoing<span class="quantity"> ({{ issue_summary.ongoing_substatus_count }})</span>
         </td>
       </tr>
       <tr>
         <td colspan="2">
           <table>
             <tr>
-              <td width="{% widthratio issue_summary.new_substatus_count issue_summary.total_substatus_count 100 %}%" title="New: {{ issue_summary.new_substatus_count }} events" style="background-color: #F2B712">
+              <td width="{% widthratio issue_summary.new_substatus_count issue_summary.total_substatus_count 100 %}%" title="New: {{ issue_summary.new_substatus_count }} events" style="background-color: #FFCE00">
                 &nbsp;
               </td>
-              <td width="{% widthratio issue_summary.escalating_substatus_count issue_summary.total_substatus_count 100 %}%" title="Escalating: {{ issue_summary.escalating_substatus_count }} events" style="background-color: #E9626E">
+              <td width="{% widthratio issue_summary.escalating_substatus_count issue_summary.total_substatus_count 100 %}%" title="Escalating: {{ issue_summary.escalating_substatus_count }} events" style="background-color: #FF002B">
                 &nbsp;
               </td>
-              <td width="{% widthratio issue_summary.regression_substatus_count issue_summary.total_substatus_count 100 %}%" title="Regressed: {{ issue_summary.regression_substatus_count }} events" style="background-color: #444674">
+              <td width="{% widthratio issue_summary.regression_substatus_count issue_summary.total_substatus_count 100 %}%" title="Regressed: {{ issue_summary.regression_substatus_count }} events" style="background-color: #3A1873">
                 &nbsp;
               </td>
-              <td width="{% widthratio issue_summary.ongoing_substatus_count issue_summary.total_substatus_count 100 %}%" title="Ongoing: {{ issue_summary.ongoing_substatus_count }} events" style="background-color: #DBD6E1">
+              <td width="{% widthratio issue_summary.ongoing_substatus_count issue_summary.total_substatus_count 100 %}%" title="Ongoing: {{ issue_summary.ongoing_substatus_count }} events" style="background-color: #DAD9DE">
                 &nbsp;
               </td>
             </tr>
@@ -408,11 +435,12 @@
     {% for a in key_errors %}
     <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
       <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
-      <div style="width: 65%;">
+      <div style="width: 65%; min-width: 0;">
         {% url 'sentry-organization-issue-detail' issue_id=a.group.id organization_slug=organization.slug as issue_detail %}
         {% querystring referrer="weekly_report" notification_uuid=notification_uuid as query %}
-        <a style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; font-size: 17px; height: 24px;"
-           href="{% org_url organization issue_detail query=query %}">{{a.group.message}}</a>
+        <a title="{{a.title}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; width: auto; max-width: 100%; font-size: 17px; line-height: 1.2; margin-bottom: 2px;"
+           href="{% org_url organization issue_detail query=query %}">{{a.title}}</a>
+        <div title="{{a.message}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; width: auto; max-width: 100%; max-height: 38px; line-height: 1.2; font-size: 14px; color: #80708F; margin-bottom: 2px;">{{a.message}}</div>
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
       {% if a.group_substatus and a.group_substatus_color %}
@@ -430,14 +458,19 @@
     {% for a in key_performance_issues %}
     <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
       <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
-      <div style="width: 65%;">
+      <div style="width: 65%; min-width: 0;">
         {% url 'sentry-organization-issue-detail' issue_id=a.group.id organization_slug=organization.slug as issue_detail %}
         {% querystring referrer="weekly_report" notification_uuid=notification_uuid as query %}
-        <a style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; font-size: 17px; height: 24px;"
-           href="{% org_url organization issue_detail query=query %}">{{a.group.message}}</a>
-        <div style="font-size: 12px; color: #80708F;">{{a.group.get_type_display}}</div>
+        <a title="{{a.title}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; width: auto; max-width: 100%; font-size: 17px; line-height: 1.2; margin-bottom: 2px;"
+           href="{% org_url organization issue_detail query=query %}">{{a.title}}</a>
+        <div title="{{a.message}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; width: auto; max-width: 100%; max-height: 38px; line-height: 1.2; font-size: 14px; color: #80708F; margin-bottom: 2px;">{{a.message}}</div>
+        <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
+      {% if a.group_substatus and a.group_substatus_color %}
+      <span style="background-color: {{a.group_substatus_color}}; border: 1px solid {{a.group_substatus_border_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%;">{{a.group_substatus}}</span>
+      {% else %}
       <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; height: 100%;">{{a.status}}</span>
+      {% endif %}
     </div>
     {% endfor %}
   </div>

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -5,11 +5,19 @@ from random import Random
 from django.utils.decorators import method_decorator
 from django.utils.text import slugify
 
-from sentry.models.group import Group
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.issues.grouptype import (
+    GroupType,
+    PerformanceNPlusOneGroupType,
+    PerformanceP95EndpointRegressionGroupType,
+    PerformanceSlowDBQueryGroupType,
+)
+from sentry.models.group import Group, GroupStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.tasks.summaries.utils import ONE_DAY, OrganizationReportContext, ProjectContext
 from sentry.tasks.summaries.weekly_reports import render_template_context
+from sentry.types.group import GroupSubStatus
 from sentry.utils import loremipsum
 from sentry.utils.dates import floor_to_utc_day, to_datetime
 from sentry.web.decorators import login_required
@@ -21,6 +29,38 @@ from .mail import MailPreviewView
 def get_random(request):
     seed = request.GET.get("seed", str(time.time()))
     return Random(seed)
+
+
+def make_debug_group(
+    *,
+    group_id: int,
+    project: Project,
+    title: str,
+    message: str,
+    group_type: type[GroupType],
+    event_type: str,
+    substatus: int = GroupSubStatus.ONGOING,
+) -> Group:
+    group = Group(
+        id=group_id,
+        project=project,
+        project_id=project.id,
+        message=message,
+        status=GroupStatus.UNRESOLVED,
+        substatus=substatus,
+        type=group_type.type_id,
+        data={"type": event_type, "metadata": {"title": title, "value": message}},
+    )
+    group.get_type_display = lambda: group_type.description
+    return group
+
+
+def make_debug_issue_message(random: Random) -> str:
+    return f"{' '.join(random.sample(loremipsum.words, 18))}"
+
+
+def make_debug_issue_title(random: Random, prefix: str) -> str:
+    return f"{prefix}"
 
 
 @internal_cell_silo_view
@@ -80,8 +120,28 @@ class DebugWeeklyReportView(MailPreviewView):
             project_context.prev_week_accepted_transaction_count = int(
                 project_context.accepted_transaction_count * random.uniform(0.5, 1.5)
             )
+            substatuses = [
+                GroupSubStatus.NEW,
+                GroupSubStatus.ESCALATING,
+                GroupSubStatus.REGRESSED,
+            ]
             project_context.key_errors_by_group = [
-                (g, random.randint(0, 1000)) for g in Group.objects.all()[:3]
+                (
+                    make_debug_group(
+                        group_id=10000 + (project.id * 100) + group_index,
+                        project=project,
+                        title=make_debug_issue_title(
+                            random,
+                            random.choice(["TypeError", "ValueError", "RuntimeError"]),
+                        ),
+                        message=make_debug_issue_message(random),
+                        group_type=ErrorGroupType,
+                        event_type="error",
+                        substatus=substatuses[group_index],
+                    ),
+                    random.randint(100, 1000),
+                )
+                for group_index in range(0, 3)
             ]
 
             project_context.new_substatus_count = random.randint(5, 200)
@@ -106,9 +166,26 @@ class DebugWeeklyReportView(MailPreviewView):
                 )
                 for _ in range(0, 3)
             ]
+            performance_issue_types = [
+                PerformanceSlowDBQueryGroupType,
+                PerformanceNPlusOneGroupType,
+                PerformanceP95EndpointRegressionGroupType,
+            ]
             project_context.key_performance_issues = [
-                (g, None, random.randint(0, 1000))
-                for g in Group.objects.filter(type__gte=1000, type__lt=2000).all()[:3]
+                (
+                    make_debug_group(
+                        group_id=20000 + (project.id * 100) + group_index,
+                        project=project,
+                        title=make_debug_issue_title(random, performance_issue_type.description),
+                        message=make_debug_issue_message(random),
+                        group_type=performance_issue_type,
+                        event_type="transaction",
+                        substatus=substatuses[group_index],
+                    ),
+                    None,
+                    random.randint(100, 1000),
+                )
+                for group_index, performance_issue_type in enumerate(performance_issue_types)
             ]
 
             ctx.projects_context_map[project.id] = project_context

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -51,7 +51,6 @@ def make_debug_group(
         type=group_type.type_id,
         data={"type": event_type, "metadata": {"title": title, "value": message}},
     )
-    group.get_type_display = lambda: group_type.description
     return group
 
 

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -39,6 +39,7 @@ def make_debug_group(
     message: str,
     group_type: type[GroupType],
     event_type: str,
+    status: int = GroupStatus.UNRESOLVED,
     substatus: int = GroupSubStatus.ONGOING,
 ) -> Group:
     group = Group(
@@ -46,7 +47,7 @@ def make_debug_group(
         project=project,
         project_id=project.id,
         message=message,
-        status=GroupStatus.UNRESOLVED,
+        status=status,
         substatus=substatus,
         type=group_type.type_id,
         data={"type": event_type, "metadata": {"title": title, "value": message}},
@@ -120,9 +121,11 @@ class DebugWeeklyReportView(MailPreviewView):
                 project_context.accepted_transaction_count * random.uniform(0.5, 1.5)
             )
             substatuses = [
-                GroupSubStatus.NEW,
-                GroupSubStatus.ESCALATING,
-                GroupSubStatus.REGRESSED,
+                (GroupStatus.UNRESOLVED, GroupSubStatus.NEW),
+                (GroupStatus.UNRESOLVED, GroupSubStatus.ESCALATING),
+                (GroupStatus.UNRESOLVED, GroupSubStatus.REGRESSED),
+                (GroupStatus.RESOLVED, GroupSubStatus.NEW),
+                (GroupStatus.UNRESOLVED, GroupSubStatus.ONGOING),
             ]
             project_context.key_errors_by_group = [
                 (
@@ -136,11 +139,12 @@ class DebugWeeklyReportView(MailPreviewView):
                         message=make_debug_issue_message(random),
                         group_type=ErrorGroupType,
                         event_type="error",
-                        substatus=substatuses[group_index],
+                        status=status,
+                        substatus=substatus,
                     ),
                     random.randint(100, 1000),
                 )
-                for group_index in range(0, 3)
+                for group_index, (status, substatus) in enumerate(substatuses)
             ]
 
             project_context.new_substatus_count = random.randint(5, 200)
@@ -179,7 +183,8 @@ class DebugWeeklyReportView(MailPreviewView):
                         message=make_debug_issue_message(random),
                         group_type=performance_issue_type,
                         event_type="transaction",
-                        substatus=substatuses[group_index],
+                        status=substatuses[group_index][0],
+                        substatus=substatuses[group_index][1],
                     ),
                     None,
                     random.randint(100, 1000),

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -1167,7 +1167,7 @@ class WeeklyReportsTest(
         substatus_fields = (
             "group_substatus",
             "group_substatus_color",
-            "group_substatus_border_color",
+            "group_substatus_text_color",
         )
         assert {field: key_error[field] for field in substatus_fields} == {
             field: performance_issue[field] for field in substatus_fields

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -30,6 +30,7 @@ from sentry.tasks.summaries.organization_report_context_factory import (
 from sentry.tasks.summaries.utils import (
     ONE_DAY,
     OrganizationReportContext,
+    ProjectContext,
     _project_key_errors_eap,
     _project_key_errors_snuba,
     _project_key_performance_issues_eap,
@@ -46,6 +47,7 @@ from sentry.tasks.summaries.weekly_reports import (
     group_status_to_color,
     prepare_organization_report,
     prepare_template_context,
+    render_template_context,
     schedule_organizations,
 )
 from sentry.testutils.cases import (
@@ -1046,13 +1048,13 @@ class WeeklyReportsTest(
         assert ctx["trends"]["legend"][0] == {
             "slug": "bar",
             "url": f"http://testserver/organizations/baz/issues/?referrer=weekly_report&notification_uuid={ctx['notification_uuid']}&project={self.project.id}",
-            "color": "#422C6E",
+            "color": "#7553FF",
             "accepted_error_count": 1,
             "accepted_transaction_count": 3,
         }
 
         assert ctx["trends"]["series"][-2][1][0] == {
-            "color": "#422C6E",
+            "color": "#7553FF",
             "error_count": 1,
             "transaction_count": 3,
         }
@@ -1125,6 +1127,51 @@ class WeeklyReportsTest(
 
         unique_enum_count = len(enum_values)
         assert len(group_status_to_color) == unique_enum_count
+
+    def test_key_errors_and_performance_issues_share_substatus_badges(self) -> None:
+        user = self.create_user()
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+        error_group = self.create_group(
+            project=self.project,
+            message="error message",
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ONGOING,
+            data={
+                "type": "error",
+                "metadata": {"type": "TypeError", "value": "error message"},
+            },
+        )
+        performance_group = self.create_group(
+            project=self.project,
+            message="performance message",
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ONGOING,
+            type=PerformanceNPlusOneGroupType.type_id,
+            data={
+                "type": "transaction",
+                "metadata": {"title": "N+1 Query", "value": "performance message"},
+            },
+        )
+        ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
+        project_context = ProjectContext(self.project)
+        project_context.key_errors_by_group = [(error_group, 10)]
+        project_context.key_performance_issues = [(performance_group, None, 10)]
+        ctx.projects_context_map = {self.project.id: project_context}
+        ctx.project_ownership[user.id] = {self.project.id}
+
+        rendered_context = render_template_context(ctx, user.id)
+
+        assert rendered_context is not None
+        key_error = rendered_context["key_errors"][0]
+        performance_issue = rendered_context["key_performance_issues"][0]
+        substatus_fields = (
+            "group_substatus",
+            "group_substatus_color",
+            "group_substatus_border_color",
+        )
+        assert {field: key_error[field] for field in substatus_fields} == {
+            field: performance_issue[field] for field in substatus_fields
+        }
 
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")


### PR DESCRIPTION
Goal: update weekly report styling

**Changes**
- Followed color and font guidelines from [sentry](https://sentry.sentry.io/stories/principles/tokens/#categorical)
- Show the Issue Title and Issue Message (similar to how issues are shown on the Issue Feed) -- originally, we only showed Issue Message which was confusing because it was often truncated
- Added "Issue with the most errors" and "Most frequent performance issues" to the dev env

**To test:**
- Start dev environment
- Go to `debug/mail/weekly-reports/?seed=90`

Before:
<img width="988" height="1004" alt="image" src="https://github.com/user-attachments/assets/5e3d9d47-ef31-49ac-b497-95653ee457c9" />

After:
<img width="553" height="1138" alt="image" src="https://github.com/user-attachments/assets/0435dda0-75bc-4ef7-94a9-f2efa0dcb4d6" />




