### PR TITLE
ref: Remove PlanTier prop from subscription

### DIFF
--- a/static/gsAdmin/components/changePlanAction.spec.tsx
+++ b/static/gsAdmin/components/changePlanAction.spec.tsx
@@ -21,7 +21,6 @@ describe('ChangePlanAction', () => {
   const mockOrg = OrganizationFixture({slug: 'org-slug'});
   const subscription = SubscriptionFixture({
     organization: mockOrg,
-    planTier: PlanTier.AM3,
     plan: 'am3_business',
     billingInterval: 'monthly',
     contractInterval: 'monthly',
@@ -264,7 +263,6 @@ describe('ChangePlanAction', () => {
       // Create subscription with Seer budget
       const subscriptionWithSeer = SubscriptionWithLegacySeerFixture({
         organization: mockOrg,
-        planTier: PlanTier.AM3,
         plan: 'am3_business',
       });
 

--- a/static/gsAdmin/components/customerStatus.tsx
+++ b/static/gsAdmin/components/customerStatus.tsx
@@ -12,10 +12,10 @@ type Props = {
 
 const getLabel = (item: Subscription) => {
   if (item.isEnterpriseTrial) {
-    return `Trialing (${item.trialTier} enterprise)`;
+    return `Trialing (${item.trialPlan} enterprise)`;
   }
   if (item.isTrial) {
-    return `Trialing (${item.trialTier})`;
+    return `Trialing (${item.trialPlan})`;
   }
   if (item.isFree) {
     return 'Free Account';

--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -8,7 +8,6 @@ import {
   SubscriptionFixture,
   SubscriptionWithLegacySeerFixture,
 } from 'getsentry-test/fixtures/subscription';
-import {PlanTier} from 'getsentry-test/planTier';
 import {
   render,
   screen,
@@ -376,7 +375,6 @@ describe('CustomerOverview', () => {
     const enterprise_subscription = InvoicedSubscriptionFixture({
       organization,
       plan: 'am3_business_ent_auf',
-      planTier: PlanTier.AM3,
     });
 
     render(
@@ -403,7 +401,6 @@ describe('CustomerOverview', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am3_f',
-      planTier: PlanTier.AM3,
     });
 
     render(
@@ -427,7 +424,6 @@ describe('CustomerOverview', () => {
     const am3Subscription = SubscriptionFixture({
       organization,
       plan: 'am3_f',
-      planTier: PlanTier.AM3,
       productTrials: [
         {
           category: DataCategory.REPLAYS,
@@ -604,7 +600,6 @@ describe('CustomerOverview', () => {
     const am3Subscription = SubscriptionFixture({
       organization,
       plan: 'am3_team',
-      planTier: PlanTier.AM3,
     });
 
     MockApiClient.addMockResponse({

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -1104,7 +1104,6 @@ describe('Customer Details', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am3_f',
-      planTier: 'am3',
     });
     subscription.reservedBudgets = [
       SeerReservedBudgetFixture({

--- a/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.spec.tsx
+++ b/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.spec.tsx
@@ -13,7 +13,6 @@ describe('InsightsUpsellPage', () => {
     organization,
     plan: 'am3_team',
     isFree: true,
-    planTier: PlanTier.AM3,
   });
 
   beforeEach(() => {

--- a/static/gsApp/components/performance/quotaExceededAlert.spec.tsx
+++ b/static/gsApp/components/performance/quotaExceededAlert.spec.tsx
@@ -30,7 +30,6 @@ describe('Renders QuotaExceededAlert correctly for spans', () => {
       onDemandBudgets: {
         enabled: true,
       } as any,
-      planTier: 'am1' as any,
       categories: {
         spans: {
           usageExceeded: spansUsageExceeded,

--- a/static/gsApp/components/profiling/profilingUpgradeModal.tsx
+++ b/static/gsApp/components/profiling/profilingUpgradeModal.tsx
@@ -60,7 +60,6 @@ function UpsellModal(props: Props) {
   useEffect(() => {
     trackGetsentryAnalytics('upgrade_now.modal.viewed', {
       organization,
-      planTier: subscription.planTier,
       canSelfServe: subscription.canSelfServe,
       channel: subscription.channel,
       has_billing_scope: organization.access?.includes('org:billing'),
@@ -219,7 +218,6 @@ function ActionButtons({
 
         trackGetsentryAnalytics('upgrade_now.modal.update_now', {
           organization,
-          planTier: subscription.planTier,
           canSelfServe: subscription.canSelfServe,
           channel: subscription.channel,
           has_billing_scope: organization.access?.includes('org:billing'),
@@ -243,7 +241,6 @@ function ActionButtons({
     trackGetsentryAnalytics('upgrade_now.modal.manage_sub', {
       organization,
       surface: 'profiling',
-      planTier: subscription.planTier,
       canSelfServe: subscription.canSelfServe,
       channel: subscription.channel,
       has_billing_scope: organization.access?.includes('org:billing'),

--- a/static/gsApp/components/replayOnboardingCTA.tsx
+++ b/static/gsApp/components/replayOnboardingCTA.tsx
@@ -49,7 +49,6 @@ function ReplayOnboardingCTAUpsell({
     trackGetsentryAnalytics('replay.list_page.viewed', {
       organization,
       surface: 'replay_onboarding_banner',
-      planTier: subscription.planTier,
       canSelfServe: subscription.canSelfServe,
       channel: subscription.channel,
       has_billing_scope: organization.access?.includes('org:billing'),
@@ -67,7 +66,6 @@ function ReplayOnboardingCTAUpsell({
         trackGetsentryAnalytics('replay.list_page.sent_email', {
           organization,
           surface: 'replay_onboarding_banner',
-          planTier: subscription.planTier,
           canSelfServe: subscription.canSelfServe,
           channel: subscription.channel,
           has_billing_scope: organization.access?.includes('org:billing'),
@@ -112,7 +110,6 @@ function ReplayOnboardingCTAUpsell({
       trackGetsentryAnalytics('replay.list_page.open_modal', {
         organization,
         surface: 'replay_onboarding_banner',
-        planTier: subscription.planTier,
         canSelfServe: subscription.canSelfServe,
         channel: subscription.channel,
         has_billing_scope: hasBillingAccess,
@@ -156,7 +153,6 @@ function ReplayOnboardingCTAUpsell({
     trackGetsentryAnalytics('replay.list_page.manage_sub', {
       organization,
       surface: 'replay_onboarding_banner',
-      planTier: subscription.planTier,
       canSelfServe: subscription.canSelfServe,
       channel: subscription.channel,
       has_billing_scope: organization.access?.includes('org:billing'),

--- a/static/gsApp/components/upgradeNowModal/actionButtons.tsx
+++ b/static/gsApp/components/upgradeNowModal/actionButtons.tsx
@@ -70,7 +70,6 @@ export function ActionButtons({
 
         trackGetsentryAnalytics('upgrade_now.modal.update_now', {
           organization,
-          planTier: subscription.planTier,
           canSelfServe: subscription.canSelfServe,
           channel: subscription.channel,
           has_billing_scope: organization.access?.includes('org:billing'),
@@ -101,7 +100,6 @@ export function ActionButtons({
         trackGetsentryAnalytics('upgrade_now.modal.sent_email', {
           organization,
           surface,
-          planTier: subscription.planTier,
           canSelfServe: subscription.canSelfServe,
           channel: subscription.channel,
           has_billing_scope: organization.access?.includes('org:billing'),
@@ -123,7 +121,6 @@ export function ActionButtons({
     trackGetsentryAnalytics('upgrade_now.modal.manage_sub', {
       organization,
       surface,
-      planTier: subscription.planTier,
       canSelfServe: subscription.canSelfServe,
       channel: subscription.channel,
       has_billing_scope: organization.access?.includes('org:billing'),

--- a/static/gsApp/components/upgradeNowModal/modalSamePrice.tsx
+++ b/static/gsApp/components/upgradeNowModal/modalSamePrice.tsx
@@ -66,7 +66,6 @@ function UpgradeNowModal({
 
         trackGetsentryAnalytics('upgrade_now.modal.update_now', {
           organization,
-          planTier: subscription.planTier,
           canSelfServe: subscription.canSelfServe,
           channel: subscription.channel,
           has_billing_scope: organization.access?.includes('org:billing'),

--- a/static/gsApp/components/upgradeNowModal/useLogUpgradeNowViewed.tsx
+++ b/static/gsApp/components/upgradeNowModal/useLogUpgradeNowViewed.tsx
@@ -24,7 +24,6 @@ export function useLogUpgradeNowViewed({
   useEffect(() => {
     trackGetsentryAnalytics('upgrade_now.modal.viewed', {
       organization,
-      planTier: subscription.planTier,
       canSelfServe: subscription.canSelfServe,
       channel: subscription.channel,
       has_billing_scope: organization.access?.includes('org:billing'),

--- a/static/gsApp/components/withSubscription.tsx
+++ b/static/gsApp/components/withSubscription.tsx
@@ -83,12 +83,11 @@ export function withSubscription<P extends InjectedSubscriptionProps>(
     private mounted = false;
 
     configureScopeWithSubscriptionData(subscription: Subscription) {
-      const {plan, planTier, totalMembers, planDetails} = subscription;
+      const {plan, totalMembers, planDetails} = subscription;
       Sentry.setTag('plan', plan);
       Sentry.setTag('plan.name', planDetails?.name);
       Sentry.setTag('plan.max_members', `${planDetails?.maxMembers}`);
       Sentry.setTag('plan.total_members', `${totalMembers}`);
-      Sentry.setTag('plan.tier', planTier);
     }
 
     onSubscriptionChange(subscription: Subscription) {

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -412,7 +412,6 @@ export type Subscription = {
   totalProjects: number | null;
   trialEnd: string | null;
   trialPlan: string | null;
-  trialTier: string | null;
   type: BillingType;
   /**
    * All quotas available on the plan are exceeded

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -397,7 +397,6 @@ export type Subscription = {
   // Subscription details
   plan: string;
   planDetails: Plan;
-  planTier: string;
   /**
    * Total events allowed for the current usage period including gifted
    */

--- a/static/gsApp/utils/pendo.tsx
+++ b/static/gsApp/utils/pendo.tsx
@@ -108,7 +108,6 @@ export function getPendoAccountFields(
       'canTrial',
       'canSelfServe',
       'plan',
-      'planTier',
     ]),
     ...pick(organization, ['isEarlyAdopter']),
   };

--- a/static/gsApp/utils/trackGetsentryAnalytics.tsx
+++ b/static/gsApp/utils/trackGetsentryAnalytics.tsx
@@ -259,7 +259,7 @@ export type AM2UpdateSurfaces =
   | 'replay_project_creation'
   | 'replay'
   | 'subscription_page';
-type UpdateProps = Pick<Subscription, 'planTier' | 'canSelfServe' | 'channel'> & {
+type UpdateProps = Pick<Subscription, 'canSelfServe' | 'channel'> & {
   has_billing_scope: boolean;
   surface: AM2UpdateSurfaces;
 };

--- a/static/gsApp/views/amCheckout/index.spec.tsx
+++ b/static/gsApp/views/amCheckout/index.spec.tsx
@@ -119,7 +119,6 @@ describe('Legacy Tier Checkout', () => {
     const am2BizSubscription = SubscriptionFixture({
       organization,
       plan: 'am2_business_bundle',
-      planTier: 'am2',
       categories: {
         errors: MetricHistoryFixture({reserved: 100_000}),
         transactions: MetricHistoryFixture({reserved: 20_000_000}),
@@ -237,7 +236,6 @@ describe('Default Tier Checkout', () => {
       organization,
       contractPeriodEnd: contractPeriodEnd.toISOString(),
       plan: 'am2_sponsored_team_auf',
-      planTier: PlanTier.AM2,
       isSponsored: true,
       partner: {
         isActive: true,
@@ -285,7 +283,6 @@ describe('Default Tier Checkout', () => {
       organization,
       contractPeriodEnd: contractPeriodEnd.toISOString(),
       plan: 'am3_f',
-      planTier: PlanTier.AM3,
       isSelfServePartner: true,
       partner: {
         isActive: true,
@@ -329,7 +326,6 @@ describe('Default Tier Checkout', () => {
       organization,
       contractPeriodEnd: contractPeriodEnd.toISOString(),
       plan: 'am3_f',
-      planTier: PlanTier.AM3,
       isSelfServePartner: true,
       partner: {
         isActive: true,
@@ -372,7 +368,6 @@ describe('Default Tier Checkout', () => {
       organization,
       contractPeriodEnd: contractPeriodEnd.toISOString(),
       plan: 'am3_f',
-      planTier: PlanTier.AM3,
       isSelfServePartner: true,
       partner: {
         isActive: true,
@@ -413,7 +408,6 @@ describe('Default Tier Checkout', () => {
       organization,
       // This plan does not have hasOnDemandModes
       plan: 'mm2_b_100k',
-      planTier: PlanTier.AM2,
     });
     SubscriptionStore.set(organization.slug, sub);
 
@@ -440,7 +434,6 @@ describe('Default Tier Checkout', () => {
     const sub = SubscriptionFixture({
       organization,
       plan: 'am3_business',
-      planTier: PlanTier.AM3,
       onDemandBudgets: {
         onDemandSpendUsed: 0,
         sharedMaxBudget: 2000,
@@ -501,7 +494,6 @@ describe('Default Tier Checkout', () => {
     const sub = SubscriptionFixture({
       organization,
       plan: 'am3_business',
-      planTier: PlanTier.AM3,
       onDemandBudgets: {
         onDemandSpendUsed: 0,
         sharedMaxBudget: 2000,
@@ -561,7 +553,6 @@ describe('Default Tier Checkout', () => {
     const sub = SubscriptionFixture({
       organization,
       plan: 'am3_business',
-      planTier: PlanTier.AM3,
       categories: {
         // Intentionally omitting 'errors' and 'attachments' categories
         replays: MetricHistoryFixture({reserved: 50}),
@@ -706,7 +697,6 @@ describe('Default Tier Checkout', () => {
     const trialSub = SubscriptionFixture({
       organization,
       plan: 'am3_t',
-      planTier: PlanTier.AM3,
       isTrial: true, // This is true for both subscription trials and plan trials
       categories: {
         // These are high trial volumes that should NOT be used in checkout

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
@@ -300,7 +300,6 @@ describe('ReserveAdditionalVolume', () => {
       const trialSub = SubscriptionFixture({
         organization,
         plan: 'am3_t',
-        planTier: PlanTier.AM3,
         isTrial: true, // This is true for both subscription trials and plan trials
         categories: {
           // These are high trial volumes that should NOT be used in checkout

--- a/static/gsApp/views/amCheckout/steps/setSpendLimit.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/setSpendLimit.spec.tsx
@@ -53,7 +53,6 @@ describe('SetSpendLimit', () => {
     const sub = SubscriptionFixture({
       organization,
       plan: 'am3_f',
-      planTier: PlanTier.AM3,
     });
     SubscriptionStore.set(organization.slug, sub);
     render(
@@ -86,7 +85,6 @@ describe('SetSpendLimit', () => {
     const sub = SubscriptionFixture({
       organization: preAm3Organization,
       plan: 'am2_team',
-      planTier: PlanTier.AM2,
     });
     SubscriptionStore.set(preAm3Organization.slug, sub);
     render(

--- a/static/gsApp/views/spendAllocations/index.spec.tsx
+++ b/static/gsApp/views/spendAllocations/index.spec.tsx
@@ -32,7 +32,6 @@ describe('SpendAllocations feature enable flow', () => {
     subscription = SubscriptionFixture({
       organization,
       plan: 'am1_f',
-      planTier: 'am1',
     });
     MockApiClient.clearMockResponses();
     dateTs = Math.max(
@@ -75,7 +74,6 @@ describe('SpendAllocations feature enable flow', () => {
   it('does not render for YY partnership', async () => {
     subscription = SubscriptionFixture({
       plan: 'am2_business',
-      planTier: 'am2',
       partner: {
         externalId: 'x123x',
         name: 'YY Org',
@@ -161,7 +159,6 @@ describe('enabled Spend Allocations page', () => {
     subscription = SubscriptionFixture({
       organization,
       plan: 'am1_f',
-      planTier: 'am1',
     });
     MockApiClient.clearMockResponses();
     dateTs = Math.max(
@@ -231,7 +228,6 @@ describe('enabled Spend Allocations page', () => {
     const am3Sub = SubscriptionFixture({
       organization,
       plan: 'am3_f',
-      planTier: 'am3',
     });
     render(<SpendAllocationsRoot subscription={am3Sub} />, {organization});
 
@@ -331,7 +327,6 @@ describe('enabled Spend Allocations page without root', () => {
     subscription = SubscriptionFixture({
       organization,
       plan: 'am1_f',
-      planTier: 'am1',
     });
     MockApiClient.clearMockResponses();
     dateTs = Math.max(
@@ -411,7 +406,6 @@ describe('POST Create spend allocation', () => {
     subscription = SubscriptionFixture({
       organization,
       plan: 'am1_f',
-      planTier: 'am1',
     });
     MockApiClient.clearMockResponses();
     dateTs = Math.max(
@@ -499,7 +493,6 @@ describe('Disable Submit button in Spend Allocation', () => {
     subscription = SubscriptionFixture({
       organization,
       plan: 'am1_f',
-      planTier: 'am1',
     });
     MockApiClient.clearMockResponses();
     dateTs = Math.max(
@@ -544,7 +537,6 @@ describe('DELETE spend allocation', () => {
     subscription = SubscriptionFixture({
       organization,
       plan: 'am1_f',
-      planTier: 'am1',
     });
     MockApiClient.clearMockResponses();
     dateTs = Math.max(
@@ -620,7 +612,6 @@ describe('PUT edit spend allocation', () => {
     subscription = SubscriptionFixture({
       organization,
       plan: 'am1_f',
-      planTier: 'am1',
     });
     MockApiClient.clearMockResponses();
     dateTs = Math.max(

--- a/static/gsApp/views/spendLimits/utils.spec.tsx
+++ b/static/gsApp/views/spendLimits/utils.spec.tsx
@@ -62,7 +62,6 @@ describe('parseOnDemandBudgetsFromSubscription', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am1_business',
-      planTier: 'am1',
       onDemandMaxSpend: 123,
       onDemandBudgets: {
         enabled: true,
@@ -84,7 +83,6 @@ describe('parseOnDemandBudgetsFromSubscription', () => {
     let subscription = SubscriptionFixture({
       organization,
       plan: 'am1_business',
-      planTier: 'am1',
       onDemandMaxSpend: 0,
       onDemandBudgets: {
         enabled: false,
@@ -104,7 +102,6 @@ describe('parseOnDemandBudgetsFromSubscription', () => {
     subscription = SubscriptionFixture({
       organization,
       plan: 'am1_business',
-      planTier: 'am1',
       onDemandMaxSpend: 0,
     });
 
@@ -118,7 +115,6 @@ describe('parseOnDemandBudgetsFromSubscription', () => {
     subscription = SubscriptionFixture({
       organization,
       plan: 'am1_business',
-      planTier: 'am1',
     });
 
     ondemandBudgets = parseOnDemandBudgetsFromSubscription(subscription);
@@ -133,7 +129,6 @@ describe('parseOnDemandBudgetsFromSubscription', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am1_business',
-      planTier: 'am1',
       onDemandMaxSpend: 100 + 200 + 300,
       onDemandBudgets: {
         enabled: true,
@@ -188,7 +183,6 @@ describe('parseOnDemandBudgetsFromSubscription', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am1_business',
-      planTier: 'am1',
       onDemandMaxSpend: 123,
     });
     subscription.categories.errors!.reserved = 200000;
@@ -245,7 +239,6 @@ describe('getTotalBudget', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am1_business',
-      planTier: 'am1',
       onDemandMaxSpend: 100 + 200 + 300,
       onDemandBudgets: {
         enabled: true,
@@ -266,7 +259,6 @@ describe('getTotalBudget', () => {
     let subscription = SubscriptionFixture({
       organization,
       plan: 'am1_business',
-      planTier: 'am1',
       onDemandMaxSpend: 0,
       onDemandBudgets: {
         enabled: false,
@@ -285,7 +277,6 @@ describe('getTotalBudget', () => {
     subscription = SubscriptionFixture({
       organization,
       plan: 'am1_business',
-      planTier: 'am1',
       onDemandMaxSpend: 0,
     });
 
@@ -298,7 +289,6 @@ describe('getTotalBudget', () => {
     subscription = SubscriptionFixture({
       organization,
       plan: 'am1_business',
-      planTier: 'am1',
     });
 
     actualTotalBudget = getTotalBudget(
@@ -312,7 +302,6 @@ describe('getTotalBudget', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am1_business',
-      planTier: 'am1',
       onDemandMaxSpend: 100 + 200 + 300,
       onDemandBudgets: {
         enabled: true,
@@ -336,7 +325,6 @@ describe('getTotalBudget', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am1_business',
-      planTier: 'am1',
       onDemandMaxSpend: 123,
     });
 

--- a/static/gsApp/views/subscriptionPage/ondemandDisabled.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/ondemandDisabled.spec.tsx
@@ -1,7 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
-import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -39,7 +38,6 @@ describe('OnDemandDisabled', () => {
       organization,
       onDemandDisabled: true,
       onDemandMaxSpend: 1000,
-      planTier: PlanTier.AM1,
     });
 
     render(<OnDemandDisabled organization={organization} subscription={subscription} />);

--- a/static/gsApp/views/subscriptionPage/ondemandDisabled.tsx
+++ b/static/gsApp/views/subscriptionPage/ondemandDisabled.tsx
@@ -23,7 +23,6 @@
  * @param props.subscription - The organization's subscription object containing:
  *   - onDemandDisabled: boolean indicating if on-demand billing is disabled
  *   - onDemandMaxSpend: number indicating maximum on-demand spend limit
- *   - planTier: string indicating the subscription plan tier
  */
 import {NavLink} from 'react-router-dom';
 

--- a/static/gsApp/views/subscriptionPage/overview.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.spec.tsx
@@ -4,7 +4,6 @@ import {CustomerUsageFixture} from 'getsentry-test/fixtures/customerUsage';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {RecurringCreditFixture} from 'getsentry-test/fixtures/recurringCredit';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
-import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {SecondaryNavigationContextProvider} from 'sentry/views/navigation/secondaryNavigationContext';
@@ -127,7 +126,6 @@ describe('Subscription > Overview', () => {
     });
     const subscription = SubscriptionFixture({
       plan: 'am1_f',
-      planTier: PlanTier.AM1,
       organization: billingOrg,
     });
     SubscriptionStore.set(billingOrg.slug, subscription);
@@ -153,7 +151,6 @@ describe('Subscription > Overview', () => {
     });
     const subscription = SubscriptionFixture({
       plan: 'am1_business',
-      planTier: PlanTier.AM1,
       organization: billingOrg,
       canSelfServe: false,
     });

--- a/static/gsApp/views/subscriptionPage/redeemPromoCode.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/redeemPromoCode.spec.tsx
@@ -1,7 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
-import {PlanTier} from 'getsentry-test/planTier';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
@@ -17,7 +16,6 @@ describe('Redeem promo code', () => {
   it('renders redeem promo code page', () => {
     const subscription = SubscriptionFixture({
       plan: 'am1_f',
-      planTier: PlanTier.AM1,
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);
@@ -36,7 +34,6 @@ describe('Redeem promo code', () => {
   it('does not render redeem promo code page for YY partnership orgs', async () => {
     const subscription = SubscriptionFixture({
       plan: 'am2_business',
-      planTier: 'am2',
       partner: {
         externalId: 'x123x',
         name: 'YY Org',
@@ -66,7 +63,6 @@ describe('Redeem promo code', () => {
   it('submits promo code successfully', async () => {
     const subscription = SubscriptionFixture({
       plan: 'am1_f',
-      planTier: PlanTier.AM1,
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);

--- a/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
@@ -386,7 +386,6 @@ describe('SubscriptionHeader', () => {
     const subscription = SubscriptionFixture({
       plan: 'am2_sponsored_team_auf',
       planDetails: PlanFixture({}),
-      planTier: 'am2',
       partner: {
         externalId: 'x123x',
         name: 'FOO Org',
@@ -419,7 +418,6 @@ describe('SubscriptionHeader', () => {
     const subscription = SubscriptionFixture({
       plan: 'am2_sponsored_team_auf',
       planDetails: PlanFixture({}),
-      planTier: 'am2',
       partner: {
         externalId: 'x123x',
         name: 'FOO Org',
@@ -452,7 +450,6 @@ describe('SubscriptionHeader', () => {
     const subscription = SubscriptionFixture({
       plan: 'am2_sponsored_team_auf',
       planDetails: PlanFixture({}),
-      planTier: 'am2',
       partner: {
         externalId: 'x123x',
         name: 'FOO Org',
@@ -492,7 +489,6 @@ describe('SubscriptionHeader', () => {
     const subscription = SubscriptionFixture({
       plan: 'am2_sponsored_team_auf',
       planDetails: PlanFixture({}),
-      planTier: 'am2',
       partner: {
         externalId: 'x123x',
         name: 'FOO Org',

--- a/static/gsApp/views/subscriptionPage/subscriptionUpsellBanner.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionUpsellBanner.spec.tsx
@@ -25,7 +25,6 @@ describe('SubscriptionUpsellBanner', () => {
     const organization = OrganizationFixture({access: ['org:billing']});
     const subscription = SubscriptionFixture({
       organization,
-      planTier: 'am2',
       plan: 'am2_f',
     });
     render(
@@ -47,7 +46,6 @@ describe('SubscriptionUpsellBanner', () => {
     const organization = OrganizationFixture();
     const subscription = SubscriptionFixture({
       organization,
-      planTier: 'am2',
       plan: 'am2_f',
     });
     render(

--- a/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
@@ -70,7 +70,6 @@ describe('Subscription > UsageHistory', () => {
     const org = OrganizationFixture();
     const subscription = SubscriptionFixture({
       plan: 'am1_f',
-      planTier: PlanTier.AM1,
       organization: org,
     });
     SubscriptionStore.set(org.slug, subscription);
@@ -88,7 +87,6 @@ describe('Subscription > UsageHistory', () => {
 
     const subscription = SubscriptionFixture({
       plan: 'am1_f',
-      planTier: PlanTier.AM1,
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);
@@ -107,7 +105,6 @@ describe('Subscription > UsageHistory', () => {
 
     const subscription = SubscriptionFixture({
       plan: 'am1_f',
-      planTier: PlanTier.AM1,
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);
@@ -139,7 +136,6 @@ describe('Subscription > UsageHistory', () => {
 
     const subscription = SubscriptionFixture({
       plan: 'am1_f',
-      planTier: PlanTier.AM1,
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);
@@ -181,7 +177,6 @@ describe('Subscription > UsageHistory', () => {
 
     const subscription = SubscriptionFixture({
       plan: 'am1_f',
-      planTier: PlanTier.AM1,
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);
@@ -224,7 +219,6 @@ describe('Subscription > UsageHistory', () => {
 
     const subscription = SubscriptionFixture({
       plan: 'am1_f',
-      planTier: PlanTier.AM1,
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);
@@ -266,7 +260,6 @@ describe('Subscription > UsageHistory', () => {
     });
     const subscription = SubscriptionFixture({
       plan: 'am1_team',
-      planTier: PlanTier.AM1,
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);
@@ -318,7 +311,6 @@ describe('Subscription > UsageHistory', () => {
     });
     const subscription = SubscriptionFixture({
       plan: 'am1_team',
-      planTier: PlanTier.AM1,
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);
@@ -352,7 +344,6 @@ describe('Subscription > UsageHistory', () => {
     });
     const subscription = SubscriptionFixture({
       plan: 'am1_team',
-      planTier: PlanTier.AM1,
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);
@@ -395,7 +386,6 @@ describe('Subscription > UsageHistory', () => {
     });
     const subscription = SubscriptionFixture({
       plan: 'am1_team',
-      planTier: PlanTier.AM1,
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);
@@ -438,7 +428,6 @@ describe('Subscription > UsageHistory', () => {
     });
     const subscription = SubscriptionFixture({
       plan: 'am1_team',
-      planTier: PlanTier.AM1,
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);
@@ -482,7 +471,6 @@ describe('Subscription > UsageHistory', () => {
     });
     const subscription = SubscriptionFixture({
       plan: 'am1_team',
-      planTier: PlanTier.AM1,
       organization,
     });
     SubscriptionStore.set(organization.slug, subscription);

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/charts.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/charts.spec.tsx
@@ -4,7 +4,6 @@ import {BillingStatFixture} from 'getsentry-test/fixtures/billingStat';
 import {CustomerUsageFixture} from 'getsentry-test/fixtures/customerUsage';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {UsageTotalFixture} from 'getsentry-test/fixtures/usageTotal';
-import {PlanTier} from 'getsentry-test/planTier';
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {DataCategory} from 'sentry/types/core';
@@ -78,7 +77,6 @@ describe('UsageCharts', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am2_team',
-      planTier: PlanTier.AM2,
     });
     organization.features.push('profiling-billing');
     subscription.categories.transactions = {

--- a/static/gsApp/views/subscriptionPage/utils.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/utils.spec.tsx
@@ -15,7 +15,6 @@ describe('calculateTotalSpend', () => {
   it('should calculate reserved usage based on total price', () => {
     const subscription = SubscriptionFixture({
       organization,
-      planTier: 'am2',
       plan: 'am2_f',
       onDemandSpendUsed: 0,
     });
@@ -38,7 +37,6 @@ describe('calculateTotalSpend', () => {
   it('should calculate on demand usage', () => {
     const subscription = SubscriptionFixture({
       organization,
-      planTier: 'am2',
       plan: 'am2_f',
     });
     subscription.planDetails.categories = [DataCategory.ERRORS];
@@ -62,7 +60,6 @@ describe('calculateTotalSpend', () => {
   it('should convert annual prepaid price to monthly', () => {
     const subscription = SubscriptionFixture({
       organization,
-      planTier: 'am2',
       plan: 'am2_f',
     });
     subscription.planDetails.categories = [DataCategory.ERRORS];
@@ -82,7 +79,6 @@ describe('calculateTotalSpend', () => {
   it('should return 0 for prepaidTotalSpent when eventsByPrice is 0', () => {
     const subscription = SubscriptionFixture({
       organization,
-      planTier: 'am2',
       plan: 'am2_f',
     });
     subscription.planDetails.categories = [DataCategory.PROFILE_DURATION_UI];

--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -89,7 +89,6 @@ export function SubscriptionFixture(props: Props): TSubscription {
     status: 'active',
     totalProjects: 0,
     trialPlan: null,
-    trialTier: null,
     onDemandPeriodStart: '2018-09-25',
     trialEnd: null,
     countryCode: null,

--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -113,7 +113,6 @@ export function SubscriptionFixture(props: Props): TSubscription {
     totalLicenses: 1,
     billingPeriodStart: '2018-09-25',
     suspensionReason: null,
-    planTier: 'am1',
     accountBalance: -10000,
     companyName: null,
     isSuspended: false,
@@ -326,13 +325,12 @@ export function SubscriptionWithLegacySeerFixture(props: Props): TSubscription {
 }
 
 export function InvoicedSubscriptionFixture(props: Props): TSubscription {
-  const planData = {plan: 'am2_business_ent_auf', planTier: 'am2', ...props};
+  const planData = {plan: 'am2_business_ent_auf', ...props};
   const planDetails = PlanDetailsLookupFixture(planData.plan as PlanIds);
   const subscription = SubscriptionFixture({
     ...props,
     planDetails,
     plan: planDetails?.id,
-    planTier: planData.planTier,
     canSelfServe: false,
     type: BillingType.INVOICED,
     channel: 'sales',


### PR DESCRIPTION
This is finally not used! Only a handful of places that sent it as an analytics tag, most also tracked the plan id itself which has more information than the tier. Removed these analytics use cases and completely deleted the type definition.