### PR TITLE
chore(markdown): add message to copy to markdown 

### DIFF
--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
@@ -114,6 +114,37 @@ describe('useCopyIssueDetails', () => {
       expect(result).toContain('## Plan');
     });
 
+    it('includes the message when it differs from the title', () => {
+      const result = issueAndEventToMarkdown({
+        group: GroupFixture({title: 'TypeError'}),
+        event: EventFixture({...event, message: 'Connection to database timed out'}),
+        organization,
+      });
+
+      expect(result).toContain('## Message');
+      expect(result).toContain('Connection to database timed out');
+    });
+
+    it('omits the message when it is already part of the title', () => {
+      const result = issueAndEventToMarkdown({
+        group: GroupFixture({title: 'TypeError: connection failed'}),
+        event: EventFixture({...event, message: 'connection failed'}),
+        organization,
+      });
+
+      expect(result).not.toContain('## Message');
+    });
+
+    it('omits the message when it is empty', () => {
+      const result = issueAndEventToMarkdown({
+        group: GroupFixture({title: 'TypeError'}),
+        event: EventFixture({...event, message: '   '}),
+        organization,
+      });
+
+      expect(result).not.toContain('## Message');
+    });
+
     it('includes tags when present in event', () => {
       const eventWithTags = {
         ...event,

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
@@ -272,6 +272,13 @@ export const issueAndEventToMarkdown = ({
     markdownText += `**Date:** ${new Date(event.dateCreated).toLocaleString()}\n`;
   }
 
+  // Mirror Seer: include the event message only when it adds something beyond
+  // the title, since for most errors the title already is the message.
+  const message = event?.message?.trim();
+  if (message && !group.title.includes(message)) {
+    markdownText += `\n## Message\n\n${message}\n`;
+  }
+
   if (autofixData) {
     const sections = getOrderedAutofixSections(autofixData);
     const rootCauseSection = sections.find(isRootCauseSection);


### PR DESCRIPTION
adds `##Message` section to the copy to markdown button, based off how seer includes it in the xml (`<message>\n{message}\n</message>`)

Example: 
```
##Message 

Unrecognized Slack API message. Api Message: The request to the Slack API failed.
```

