### PR TITLE
feat(preprod): Support zstd-compressed snapshot manifest uploads

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import logging
+from io import BytesIO
 from typing import Any, cast
 
 import jsonschema
 import orjson
 import pydantic
+import zstandard
 from django.conf import settings
 from django.db import IntegrityError, router, transaction
 from django.utils import timezone
@@ -22,6 +24,7 @@ from sentry.api.bases.organization import (
     OrganizationReleasePermission,
 )
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
+from sentry.api.endpoints.chunk import ChunkTooLarge, _read_bounded
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.preprod_examples import PreprodExamples
 from sentry.apidocs.parameters import GlobalParams
@@ -142,6 +145,26 @@ def build_snapshot_image_response(
         description=metadata.description,
         tags=metadata.tags,
     )
+
+
+MAX_SNAPSHOT_REQUEST_BODY_SIZE = 256 * 1024 * 1024
+
+
+def decode_preprod_snapshot_request_body(request: Request) -> tuple[bytes | None, str | None]:
+    encoding = request.headers.get("Content-Encoding", "").strip().lower()
+    if encoding in ("", "identity"):
+        return request.body, None
+    if encoding != "zstd":
+        return None, "Unsupported Content-Encoding"
+    try:
+        reader = zstandard.ZstdDecompressor().stream_reader(
+            BytesIO(request.body), read_across_frames=True
+        )
+        return _read_bounded(reader, MAX_SNAPSHOT_REQUEST_BODY_SIZE), None
+    except ChunkTooLarge:
+        return None, "Decompressed request body too large"
+    except zstandard.ZstdError:
+        return None, "Invalid zstd payload"
 
 
 def validate_preprod_snapshot_post_schema(
@@ -667,7 +690,11 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         ):
             return Response({"detail": "Feature not enabled"}, status=403)
 
-        data, error_message = validate_preprod_snapshot_post_schema(request.body)
+        request_body, decode_error = decode_preprod_snapshot_request_body(request)
+        if request_body is None:
+            return Response({"detail": decode_error or "Invalid request body"}, status=400)
+
+        data, error_message = validate_preprod_snapshot_post_schema(request_body)
         if error_message:
             return Response({"detail": error_message}, status=400)
 

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import orjson
+import zstandard
 from django.urls import reverse
 
 from sentry.models.commitcomparison import CommitComparison
@@ -63,6 +64,62 @@ class ProjectPreprodSnapshotTest(APITestCase):
         snapshot_metrics = PreprodSnapshotMetrics.objects.get(id=response.data["snapshotMetricsId"])
         assert snapshot_metrics.preprod_artifact == artifact
         assert snapshot_metrics.image_count == 1
+
+    def _compressible_snapshot_payload(self) -> bytes:
+        data = {
+            "app_id": "com.example.app",
+            "images": {
+                "abc123def456": {
+                    "content_hash": "abc123def456",
+                    "width": 375,
+                    "height": 812,
+                },
+            },
+        }
+        return orjson.dumps(data)
+
+    def test_snapshot_upload_zstd_encoded(self) -> None:
+        url = self._get_create_url()
+        body = zstandard.ZstdCompressor().compress(self._compressible_snapshot_payload())
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.post(
+                url,
+                data=body,
+                content_type="application/json",
+                HTTP_CONTENT_ENCODING="zstd",
+            )
+
+        assert response.status_code == 200
+        assert response.data["imageCount"] == 1
+
+    def test_snapshot_upload_invalid_zstd_payload(self) -> None:
+        url = self._get_create_url()
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.post(
+                url,
+                data=b"this is not a zstd payload",
+                content_type="application/json",
+                HTTP_CONTENT_ENCODING="zstd",
+            )
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "Invalid zstd payload"
+
+    def test_snapshot_upload_unsupported_encoding(self) -> None:
+        url = self._get_create_url()
+
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.post(
+                url,
+                data=b"anything",
+                content_type="application/json",
+                HTTP_CONTENT_ENCODING="br",
+            )
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "Unsupported Content-Encoding"
 
     def test_snapshot_upload_creates_commit_comparison(self) -> None:
         url = self._get_create_url()


### PR DESCRIPTION
## Summary

Adds support for `Content-Encoding: zstd` request bodies on the preprod snapshot upload endpoint (`ProjectPreprodSnapshotEndpoint` POST).

Snapshot manifests can be large, and clients currently have to send them uncompressed. This change decompresses a zstd-encoded request body before schema validation, letting clients shrink the payload over the wire.

## Details

- New `decode_preprod_snapshot_request_body` helper inspects `Content-Encoding`:
  - empty / `identity` → body passes through unchanged (existing behavior)
  - `zstd` → decompressed before validation
  - anything else → `400 Unsupported Content-Encoding`
- Decompression reuses the existing `_read_bounded` helper from the chunk upload endpoint, bounding output to **256 MiB** to guard against decompression bombs (peak memory stays at `limit + 1`).
- Invalid zstd payloads return `400 Invalid zstd payload`; oversized decompressed bodies return `400 Decompressed request body too large`.

## Test Plan

- `test_snapshot_upload_zstd_encoded` — happy path, zstd body decodes and creates the snapshot
- `test_snapshot_upload_invalid_zstd_payload` — malformed zstd → 400
- `test_snapshot_upload_unsupported_encoding` — unsupported encoding → 400

All three pass locally.

## Note

This imports the private `_read_bounded` / `ChunkTooLarge` from `sentry.api.endpoints.chunk`. It removes duplication, but a follow-up could extract a shared util that both endpoints import from.
