### PR TITLE
feat(seer): add validate_llm_proxy_key RPC endpoint

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -1048,6 +1048,14 @@ def record_pr_attribution(
     return PrAttributionResponse(attribution_id=attribution.id)
 
 
+class ValidateLlmProxyKeyResponse(BaseModel):
+    valid: bool
+
+
+def validate_llm_proxy_key(api_key: str) -> ValidateLlmProxyKeyResponse:
+    return ValidateLlmProxyKeyResponse(valid=True)
+
+
 # Every value below MUST be a function returning a `pydantic.BaseModel` (or
 # a union of `BaseModel` subclasses, optionally with `None`). Two complementary
 # guards enforce this:
@@ -1137,6 +1145,9 @@ seer_method_registry: dict[str, SeerRpcMethod] = {  # return type must be serial
     #
     # Monitoring provider tokens (MCP)
     "refresh_monitoring_provider_token": seer_rpc(refresh_monitoring_provider_token),
+    #
+    # LLM Proxy
+    "validate_llm_proxy_key": seer_rpc(validate_llm_proxy_key),
 }
 
 

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -91,6 +91,15 @@ class TestSeerRpc(APITestCase):
         assert "features" in response.data
         assert isinstance(response.data["features"], list)
 
+    def test_validate_llm_proxy_key(self) -> None:
+        path = self._get_path("validate_llm_proxy_key")
+        data: dict[str, Any] = {"args": {"api_key": "test-key"}}
+        response = self.client.post(
+            path, data=data, HTTP_AUTHORIZATION=self.auth_header(path, data)
+        )
+        assert response.status_code == 200
+        assert response.data["valid"] is True
+
     def test_snuba_rate_limit_returns_429(self) -> None:
         """Test that SnubaRPCRateLimitExceeded returns 429 to Seer for retry."""
         path = self._get_path("get_trace_waterfall")


### PR DESCRIPTION
## Summary

- Adds `validate_llm_proxy_key` to `seer_method_registry` in `seer_rpc.py`
- Pass-through that always returns `{"valid": true}` — validates the RPC flow before adding real key logic
- Accessible at `POST /api/0/internal/seer-rpc/validate_llm_proxy_key/`
- Authenticated via existing `SeerRpcSignatureAuthentication` (HMAC shared secret)

## Context

The llm-proxy's custom auth hook will call this endpoint to validate API keys on every LLM request (with caching). This PR proves the endpoint is reachable and the contract works. Real key validation (new table, subscription checks) comes next.

## Test plan

- [ ] Validated locally with mock getsentry returning `{"valid": true}` — full flow works
- [ ] Existing seer RPC tests still pass

Linear: AIML-2931

🤖 Generated with [Claude Code](https://claude.com/claude-code)