### PR TITLE
feat(issues): Record regression transitions in the action log

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -89,6 +89,8 @@ from sentry.insights import modules as insights_modules
 from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
 from sentry.issue_detection.performance_detection import detect_performance_problems
 from sentry.issue_detection.performance_problem import PerformanceProblem
+from sentry.issues.action_log import ActionSource, publish_action
+from sentry.issues.action_log.types import RegressedAction
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.killswitches import killswitch_matches_context
@@ -1843,6 +1845,12 @@ def _handle_regression(
             group,
             ActivityType.SET_REGRESSION,
             data=activity_data,
+        )
+        publish_action(
+            RegressedAction(),
+            source=ActionSource.SYSTEM,
+            group_id=group.id,
+            project=group.project,
         )
         record_group_history(group, GroupHistoryStatus.REGRESSED, actor=None, release=release)
 

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -80,6 +80,8 @@ class GroupActionType(IntEnum):
     CREATE_PLATFORM_EXTERNAL_ISSUE = 21
     LINK_PLATFORM_EXTERNAL_ISSUE = 22
     UNLINK_PLATFORM_EXTERNAL_ISSUE = 23
+    # 24 is ESCALATING (in-flight in #117852)
+    REGRESSED = 25
 
 
 class GroupAction(BaseModel, abc.ABC):
@@ -112,6 +114,12 @@ class UnresolveAction(GroupAction):
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.UNRESOLVE
+
+
+class RegressedAction(GroupAction):
+    @classmethod
+    def get_type(cls) -> GroupActionType:
+        return GroupActionType.REGRESSED
 
 
 class ArchiveAction(GroupAction):

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -41,6 +41,7 @@ from sentry.issues.action_log import publish_action_from_context
 from sentry.issues.action_log.types import (
     ArchiveAction,
     GroupAction,
+    RegressedAction,
     ResolveAction,
     UnresolveAction,
 )
@@ -252,6 +253,7 @@ ACTIVITY_TYPE_TO_GROUP_ACTION: dict[int, type[GroupAction]] = {
     ActivityType.SET_RESOLVED_IN_RELEASE.value: ResolveAction,
     ActivityType.SET_IGNORED.value: ArchiveAction,
     ActivityType.SET_UNRESOLVED.value: UnresolveAction,
+    ActivityType.SET_REGRESSION.value: RegressedAction,
 }
 
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -46,6 +46,8 @@ from sentry.incidents.grouptype import MetricIssue
 from sentry.ingest.inbound_filters import FilterStatKeys
 from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.issues.action_log import ActionSource
+from sentry.issues.action_log.types import RegressedAction
 from sentry.issues.grouptype import (
     GroupCategory,
     PerformanceNPlusOneGroupType,
@@ -622,10 +624,14 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert not group.is_resolved()
         assert send_robust.called
 
+    @mock.patch("sentry.event_manager.publish_action")
     @mock.patch("sentry.signals.issue_unresolved.send_robust")
     @mock.patch("sentry.models.groupopenperiod.get_group_type_by_type_id")
     def test_unresolves_group(
-        self, mock_get_group_type: mock.MagicMock, send_robust: mock.MagicMock
+        self,
+        mock_get_group_type: mock.MagicMock,
+        send_robust: mock.MagicMock,
+        mock_publish_action: mock.MagicMock,
     ) -> None:
         mock_get_group_type.return_value = MetricIssue
         ts = before_now(minutes=5).isoformat()
@@ -680,6 +686,16 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         open_period = open_periods[1]
         assert open_period.date_started == group.first_seen
         assert open_period.date_ended == resolved_at
+
+        # The regression is recorded in the action log as a system action.
+        regression_publishes = [
+            call
+            for call in mock_publish_action.call_args_list
+            if call.args and isinstance(call.args[0], RegressedAction)
+        ]
+        assert len(regression_publishes) == 1
+        assert regression_publishes[0].kwargs["source"] == ActionSource.SYSTEM
+        assert regression_publishes[0].kwargs["group_id"] == group.id
 
     @mock.patch("sentry.signals.issue_unresolved.send_robust")
     def test_unresolves_group_without_open_period(self, send_robust: mock.MagicMock) -> None:

--- a/tests/sentry/issues/test_status_change_consumer.py
+++ b/tests/sentry/issues/test_status_change_consumer.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from sentry.incidents.grouptype import MetricIssue
+from sentry.issues.action_log import ActionSource
 from sentry.issues.occurrence_consumer import _process_message
 from sentry.issues.status_change_consumer import bulk_get_groups_from_fingerprints
 from sentry.models.activity import Activity
@@ -240,6 +241,38 @@ class StatusChangeProcessMessageTest(IssueOccurrenceTestBase):
             PriorityLevel.MEDIUM,
             group_inbox_reason=GroupInboxReason.ONGOING,
         )
+
+    @patch("sentry.issues.status_change_consumer.kick_off_status_syncs")
+    def test_valid_payload_regressed(self, mock_kick_off_status_syncs: MagicMock) -> None:
+        message = get_test_message_status_change(
+            self.project.id,
+            fingerprint=self.fingerprint,
+            new_status=GroupStatus.UNRESOLVED,
+            new_substatus=GroupSubStatus.REGRESSED,
+        )
+        with self.assertLogs("sentry.issues.action_log", level="INFO") as action_logs:
+            result = _process_message(message)
+        assert result is not None
+
+        self._assert_statuses_set(
+            GroupStatus.UNRESOLVED,
+            GroupSubStatus.REGRESSED,
+            GroupHistoryStatus.REGRESSED,
+            ActivityType.SET_REGRESSION,
+            group_inbox_reason=GroupInboxReason.REGRESSION,
+        )
+
+        # update_group_status publishes the regression via ACTIVITY_TYPE_TO_GROUP_ACTION,
+        # within the consumer's system action context.
+        records = [
+            r
+            for r in action_logs.records
+            if r.message == "group.action_log"
+            and getattr(r, "group_id") == str(self.group.id)
+            and getattr(r, "action") == "regressed"
+        ]
+        assert len(records) == 1
+        assert getattr(records[0], "source") == ActionSource.SYSTEM
 
 
 class StatusChangeBulkGetGroupsFromFingerprintsTest(IssueOccurrenceTestBase):


### PR DESCRIPTION
## Summary

Regression transitions (RESOLVED → UNRESOLVED/REGRESSED) bypassed the action log. Two sites, two mechanisms:

- **`event_manager.handle_regression`** (error ingest) sets status via a direct `.update()` + a manual `SET_REGRESSION` Activity → publish `RegressedAction` explicitly (`source=SYSTEM`).
- **`status_change_consumer`** (issue platform) regresses via `update_group_status(activity_type=SET_REGRESSION)`. That primitive already publishes via `ACTIVITY_TYPE_TO_GROUP_ACTION`, so this adds `SET_REGRESSION → RegressedAction` to the map — exactly like `SET_RESOLVED`/`SET_UNRESOLVED` already work there. The consumer wraps its calls in `action_context_scope(source=SYSTEM)`, so it's attributed correctly. (No other production caller uses `update_group_status` with `SET_REGRESSION`, so the map change is scoped.)

Adds `GroupActionType.REGRESSED` + `RegressedAction` — a recorded state-fact (the system observed the group regressed), not an actor "regress" action, consistent with how `ESCALATING` is modeled. Uses enum value **25**; 24 is `ESCALATING` from the in-flight #117852 (duplicate IntEnum values silently alias, so they must differ).

Principle followed: add to `ACTIVITY_TYPE_TO_GROUP_ACTION` only where `update_group_status` actually performs the transition (regression does, via the consumer); the event_manager path bypasses the primitive, so it publishes explicitly.

## Test

- `EventManagerTest.test_unresolves_group` — asserts the regression publishes `RegressedAction` (source=system).
- `StatusChangeProcessMessageTest.test_valid_payload_regressed` — asserts the consumer path emits a `regressed` action attributed to `system` via the primitive.

Fixes ID-1634