### PR TITLE
fix(workflow-engine): Require DataConditionGroup IDs to be ints

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
@@ -14,13 +14,13 @@ from sentry.workflow_engine.models.data_condition import TRIGGER_CONDITIONS, Dat
 
 
 class DataConditionGroupInput(TypedDict):
-    id: NotRequired[str]
+    id: NotRequired[int]
     logicType: str
     conditions: NotRequired[list[DataConditionInput]]
 
 
 class BaseDataConditionGroupValidator(CamelSnakeSerializer[Any]):
-    id = serializers.CharField(required=False)
+    id = serializers.IntegerField(required=False)
     logic_type = serializers.ChoiceField([(t.value, t.value) for t in DataConditionGroup.Type])
     conditions = serializers.ListField(required=False)
 

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -198,14 +198,14 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
         validator = BaseDataConditionGroupValidator(context=self.context)
 
         condition_group_id = condition_group_data.get("id")
-        if instance and condition_group_id and condition_group_id != str(instance.id):
+        if instance and condition_group_id and condition_group_id != instance.id:
             raise serializers.ValidationError(
                 f"Invalid Condition Group ID {condition_group_data.get('id')}"
             )
 
         # If an instance is provided but no id in the data, use the instance's id to ensure we update the existing condition group
         if instance and not condition_group_id:
-            condition_group_data["id"] = str(instance.id)
+            condition_group_data["id"] = instance.id
 
         actions = condition_group_data.pop("actions", None)
         condition_group = self._update_or_create(

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -110,9 +110,11 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
     def validate_action_filters(self, value: ListInputData) -> ListInputData:
         for action_filter in value:
             actions, condition_group = self._split_action_and_condition_group(action_filter)
-            BaseDataConditionGroupValidator(data=condition_group, context=self.context).is_valid(
-                raise_exception=True
+            dcg_validator = BaseDataConditionGroupValidator(
+                data=condition_group, context=self.context
             )
+            dcg_validator.is_valid(raise_exception=True)
+            action_filter.update(dcg_validator.validated_data)
 
             validated_actions = []
             for action in actions:

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -94,6 +94,33 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
         assert response.status_code == 200
         assert updated_workflow.name == "Updated Workflow"
 
+    def test_update_action_filter_with_string_encoded_id(self) -> None:
+        dcg = DataConditionGroup.objects.create(
+            organization=self.organization,
+            logic_type=DataConditionGroup.Type.ANY,
+        )
+        WorkflowDataConditionGroup.objects.create(
+            condition_group=dcg,
+            workflow=self.workflow,
+        )
+
+        data = {
+            **self.valid_workflow,
+            "actionFilters": [
+                {
+                    "id": str(dcg.id),
+                    "logicType": "all",
+                    "conditions": [],
+                    "actions": [],
+                }
+            ],
+        }
+
+        self.get_success_response(self.organization.slug, self.workflow.id, raw_data=data)
+
+        dcg.refresh_from_db()
+        assert dcg.logic_type == DataConditionGroup.Type.ALL
+
     def test_update__assigned_to_foreign_team(self) -> None:
         other_org = self.create_organization()
         other_team = self.create_team(organization=other_org)

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_data_condition_group.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_data_condition_group.py
@@ -95,6 +95,26 @@ class TestBaseDataConditionGroupValidator(TestCase):
         validator = BaseDataConditionGroupValidator(data=self.valid_data, context=self.context)
         assert validator.is_valid() is True
 
+    def test_rejects_non_integer_id(self) -> None:
+        self.valid_data["id"] = "not-a-number"
+        validator = BaseDataConditionGroupValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is False
+        assert "id" in validator.errors
+
+    def test_accepts_integer_id(self) -> None:
+        dcg = self.create_data_condition_group(organization_id=self.organization.id)
+        self.valid_data["id"] = dcg.id
+        validator = BaseDataConditionGroupValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is True
+        assert validator.validated_data["id"] == dcg.id
+
+    def test_accepts_string_encoded_integer_id(self) -> None:
+        dcg = self.create_data_condition_group(organization_id=self.organization.id)
+        self.valid_data["id"] = str(dcg.id)
+        validator = BaseDataConditionGroupValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is True
+        assert validator.validated_data["id"] == dcg.id
+
 
 class TestBaseDataConditionGroupValidatorCreate(TestBaseDataConditionGroupValidator):
     def test_create(self) -> None:


### PR DESCRIPTION
They're always required to be ints in practice, but us leaving that to the db layer to convert allows str-keyed objects to leak into our cache. That's not great behavior for our cache, but we can fix a known case of this by being strict a little earlier in our validation.

Fixes ISWF-2834.
