### PR TITLE
chore(markdown): add handled to copy to markdown 

### DIFF
--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
@@ -206,6 +206,64 @@ describe('useCopyIssueDetails', () => {
       expect(result).toContain('**Type:** TypeError');
       expect(result).toContain('**Value:** Cannot read property of undefined');
       expect(result).toContain('#### Stacktrace');
+      // No mechanism on this exception, so no handled line.
+      expect(result).not.toContain('**Handled:**');
+    });
+
+    it('marks an unhandled exception', () => {
+      const eventWithUnhandled = EventFixture({
+        ...event,
+        entries: [
+          {
+            type: EntryType.EXCEPTION,
+            data: {
+              values: [
+                {
+                  type: 'TypeError',
+                  value: 'boom',
+                  mechanism: {type: 'onerror', handled: false},
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithUnhandled,
+        organization,
+      });
+
+      expect(result).toContain('**Handled:** No');
+    });
+
+    it('marks a handled exception', () => {
+      const eventWithHandled = EventFixture({
+        ...event,
+        entries: [
+          {
+            type: EntryType.EXCEPTION,
+            data: {
+              values: [
+                {
+                  type: 'ValueError',
+                  value: 'caught',
+                  mechanism: {type: 'generic', handled: true},
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      const result = issueAndEventToMarkdown({
+        group,
+        event: eventWithHandled,
+        organization,
+      });
+
+      expect(result).toContain('**Handled:** Yes');
     });
 
     it('includes thread stacktrace when activeThreadId matches', () => {

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
@@ -114,6 +114,37 @@ describe('useCopyIssueDetails', () => {
       expect(result).toContain('## Plan');
     });
 
+    it('includes the message when it differs from the title', () => {
+      const result = issueAndEventToMarkdown({
+        group: GroupFixture({title: 'TypeError'}),
+        event: EventFixture({...event, message: 'Connection to database timed out'}),
+        organization,
+      });
+
+      expect(result).toContain('## Message');
+      expect(result).toContain('Connection to database timed out');
+    });
+
+    it('omits the message when it is already part of the title', () => {
+      const result = issueAndEventToMarkdown({
+        group: GroupFixture({title: 'TypeError: connection failed'}),
+        event: EventFixture({...event, message: 'connection failed'}),
+        organization,
+      });
+
+      expect(result).not.toContain('## Message');
+    });
+
+    it('omits the message when it is empty', () => {
+      const result = issueAndEventToMarkdown({
+        group: GroupFixture({title: 'TypeError'}),
+        event: EventFixture({...event, message: '   '}),
+        organization,
+      });
+
+      expect(result).not.toContain('## Message');
+    });
+
     it('includes tags when present in event', () => {
       const eventWithTags = {
         ...event,

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
@@ -203,6 +203,12 @@ function formatEventToMarkdown(event: Event, activeThreadId: number | undefined)
           if (exception.type) {
             markdownText += `**Type:** ${exception.type}\n`;
           }
+          // Mirror Seer's `is_exception_handled`: an unhandled exception crashed
+          // the program, a handled one was caught. Only emit it when known.
+          const handled = exception.mechanism?.handled;
+          if (handled !== null && handled !== undefined) {
+            markdownText += `**Handled:** ${handled ? 'Yes' : 'No'}\n`;
+          }
           if (exception.value) {
             markdownText += `**Value:** ${exception.value}\n\n`;
           }

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
@@ -272,6 +272,13 @@ export const issueAndEventToMarkdown = ({
     markdownText += `**Date:** ${new Date(event.dateCreated).toLocaleString()}\n`;
   }
 
+  // Mirror Seer: include the event message only when it adds something beyond
+  // the title, since for most errors the title already is the message.
+  const message = event?.message?.trim();
+  if (message && !group.title.includes(message)) {
+    markdownText += `\n## Message\n\n${message}\n`;
+  }
+
   if (autofixData) {
     const sections = getOrderedAutofixSections(autofixData);
     const rootCauseSection = sections.find(isRootCauseSection);


### PR DESCRIPTION
add `**handled**` in exceptions to copy to markdown. mirrored from Seer

```
## Exceptions

### Exception 1
**Type:** KeyError
**Handled:** Yes
**Value:** 'user_id'

#### Stacktrace
...

------
### Exception 2
**Type:** ValidationError
**Handled:** No
**Value:** Missing required field: user_id

#### Stacktrace
...
```

stacked with #117882
