### PR TITLE
ref(span-buffer): Update path compression for existing span ids

### DIFF
--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -88,6 +88,11 @@ local start_time_ms = get_time_ms()
 local set_span_id = parent_span_id
 local redirect_depth = 0
 
+-- Intermediate nodes traversed on the way up to the root. Once the root is
+-- resolved we repoint each of these directly at it (path compression), so
+-- later walks for this trace are O(1) instead of re-traversing the chain.
+local redirect_chain = {}
+
 local main_redirect_key = string.format("span-buf:ssr:{%s}", project_and_trace)
 
 -- Navigates the tree up to the highest level parent span we can find. Such
@@ -99,6 +104,8 @@ for i = 0, 100 do -- Theoretic maximum depth of redirects is 100
         break
     end
 
+    -- set_span_id redirects further up, so it is an intermediate node to flatten.
+    table.insert(redirect_chain, set_span_id)
     set_span_id = new_set_span
 end
 
@@ -117,10 +124,19 @@ end
 
 local hset_args = {}
 
+-- The new spans are inserted to the hashset with their span-ids pointing to the best known
+-- root span-id.
 for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
-    local span_id = ARGV[i]
+    local new_span_id = ARGV[i]
+    table.insert(hset_args, new_span_id)
+    table.insert(hset_args, set_span_id)
+end
 
-    table.insert(hset_args, span_id)
+-- The old spans are updated with their span-ids pointing to the best known root span-id.
+-- Future spans targeting these span-ids will skip to the updated root rather than
+-- traversing the tree we just traversed above.
+for _, old_span_id in ipairs(redirect_chain) do
+    table.insert(hset_args, old_span_id)
     table.insert(hset_args, set_span_id)
 end
 

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -88,15 +88,15 @@ local start_time_ms = get_time_ms()
 local set_span_id = parent_span_id
 local redirect_depth = 0
 
--- Intermediate nodes traversed on the way up to the root. Once the root is
--- resolved we repoint each of these directly at it (path compression), so
--- later walks for this trace are O(1) instead of re-traversing the chain.
-local redirect_chain = {}
-
 local main_redirect_key = string.format("span-buf:ssr:{%s}", project_and_trace)
 
 -- Navigates the tree up to the highest level parent span we can find. Such
 -- span is needed to know the segment we need to merge the subsegment into.
+--
+-- The redirect_chain table contains the intermediate nodes we passed through on
+-- our way up to the root node. These nodes are NOT part of the submission set.
+-- These are nodes that had to be queried.
+local redirect_chain = {}
 for i = 0, 100 do -- Theoretic maximum depth of redirects is 100
     local new_set_span = redis.call("hget", main_redirect_key, set_span_id)
     redirect_depth = i

--- a/tests/sentry/spans/test_add_buffer_lua.py
+++ b/tests/sentry/spans/test_add_buffer_lua.py
@@ -171,9 +171,6 @@ def test_compresses_redirect_chain_on_walk(
     leaf_span_id = "c" * 16
     grandchild_span_id = "d" * 16
 
-    # Build a two-hop chain leaf -> mid -> root without flattening it. Each
-    # call's walk starts at a parent that is not yet in the redirect table, so
-    # it breaks immediately at depth 0 and never traverses the chain.
     eval_add_buffer_script(
         redis_client,
         project_and_trace=project_and_trace,
@@ -193,9 +190,6 @@ def test_compresses_redirect_chain_on_walk(
         mid_span_id.encode(): root_span_id.encode(),
     }
 
-    # A subsegment whose parent is the bottom of the chain forces a two-hop
-    # walk. Path compression repoints every traversed node straight at the root,
-    # so subsequent walks for this trace resolve in a single hop.
     result = eval_add_buffer_script(
         redis_client,
         project_and_trace=project_and_trace,

--- a/tests/sentry/spans/test_add_buffer_lua.py
+++ b/tests/sentry/spans/test_add_buffer_lua.py
@@ -161,6 +161,57 @@ def test_merges_existing_child_segment(
     }
 
 
+def test_compresses_redirect_chain_on_walk(
+    redis_client: StrictRedis[bytes] | RedisCluster[bytes],
+) -> None:
+    trace_id = "f" * 32
+    project_and_trace = f"1:{trace_id}"
+    root_span_id = "a" * 16
+    mid_span_id = "b" * 16
+    leaf_span_id = "c" * 16
+    grandchild_span_id = "d" * 16
+
+    # Build a two-hop chain leaf -> mid -> root without flattening it. Each
+    # call's walk starts at a parent that is not yet in the redirect table, so
+    # it breaks immediately at depth 0 and never traverses the chain.
+    eval_add_buffer_script(
+        redis_client,
+        project_and_trace=project_and_trace,
+        parent_span_id=mid_span_id,
+        span_ids=[leaf_span_id],
+        salt="salt-leaf",
+    )
+    eval_add_buffer_script(
+        redis_client,
+        project_and_trace=project_and_trace,
+        parent_span_id=root_span_id,
+        span_ids=[mid_span_id],
+        salt="salt-mid",
+    )
+    assert redis_client.hgetall(_redirect_key(1, trace_id)) == {
+        leaf_span_id.encode(): mid_span_id.encode(),
+        mid_span_id.encode(): root_span_id.encode(),
+    }
+
+    # A subsegment whose parent is the bottom of the chain forces a two-hop
+    # walk. Path compression repoints every traversed node straight at the root,
+    # so subsequent walks for this trace resolve in a single hop.
+    result = eval_add_buffer_script(
+        redis_client,
+        project_and_trace=project_and_trace,
+        parent_span_id=leaf_span_id,
+        span_ids=[grandchild_span_id],
+        salt="salt-grandchild",
+    )
+
+    assert _metrics_table(result)[b"redirect_depth"] == 2
+    assert redis_client.hgetall(_redirect_key(1, trace_id)) == {
+        leaf_span_id.encode(): root_span_id.encode(),
+        mid_span_id.encode(): root_span_id.encode(),
+        grandchild_span_id.encode(): root_span_id.encode(),
+    }
+
+
 def test_merges_large_child_member_key_set(
     redis_client: StrictRedis[bytes] | RedisCluster[bytes],
 ) -> None:


### PR DESCRIPTION
We need to traverse to the root-node in order to build the tree. For spans received in the current segment they will all be cached in redis with this span-id pointing to the best-known root node. Previously once inserted they were not updated again. However, this led to repeated traversals across nodes whose root was previously known. With this change we cache the root span id on the traversed nodes not in the segment set. This requires a few more operations (appended to the batch hset op) but no additional memory.

The diff is a little messed up. The old loop is untouched. A new loop is the only addition.