### PR TITLE
feat(apidocs): Mark deprecated endpoints in OpenAPI

### DIFF
--- a/src/sentry/api/helpers/deprecation.py
+++ b/src/sentry/api/helpers/deprecation.py
@@ -23,7 +23,6 @@ GONE_MESSAGE = {"message": "This API no longer exists."}
 DEPRECATION_HEADER = "X-Sentry-Deprecation-Date"
 SUGGESTED_API_HEADER = "X-Sentry-Replacement-Endpoint"
 OPENAPI_DEPRECATED_ATTR = "_sentry_openapi_deprecated"
-OPENAPI_DEPRECATED_URL_NAMES_ATTR = "_sentry_openapi_deprecated_url_names"
 
 
 logger = logging.getLogger(__name__)
@@ -228,8 +227,8 @@ def deprecated(
 
             return response
 
-        setattr(endpoint_method, OPENAPI_DEPRECATED_ATTR, True)
-        setattr(endpoint_method, OPENAPI_DEPRECATED_URL_NAMES_ATTR, url_names)
+        if not url_names:
+            setattr(endpoint_method, OPENAPI_DEPRECATED_ATTR, True)
         return endpoint_method
 
     return decorator

--- a/src/sentry/api/helpers/deprecation.py
+++ b/src/sentry/api/helpers/deprecation.py
@@ -22,6 +22,8 @@ from sentry.utils.settings import is_self_hosted
 GONE_MESSAGE = {"message": "This API no longer exists."}
 DEPRECATION_HEADER = "X-Sentry-Deprecation-Date"
 SUGGESTED_API_HEADER = "X-Sentry-Replacement-Endpoint"
+OPENAPI_DEPRECATED_ATTR = "_sentry_openapi_deprecated"
+OPENAPI_DEPRECATED_URL_NAMES_ATTR = "_sentry_openapi_deprecated_url_names"
 
 
 logger = logging.getLogger(__name__)
@@ -226,6 +228,8 @@ def deprecated(
 
             return response
 
+        setattr(endpoint_method, OPENAPI_DEPRECATED_ATTR, True)
+        setattr(endpoint_method, OPENAPI_DEPRECATED_URL_NAMES_ATTR, url_names)
         return endpoint_method
 
     return decorator

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -5,14 +5,12 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from typing import Any, Literal, TypedDict
 
-from django.urls import URLPattern, URLResolver
 from drf_spectacular.generators import EndpointEnumerator, SchemaGenerator
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.apidocs.api_ownership_allowlist_dont_modify import API_OWNERSHIP_ALLOWLIST_DONT_MODIFY
 from sentry.apidocs.build import OPENAPI_TAGS
-from sentry.apidocs.schema import URL_NAME_ATTR
 from sentry.apidocs.utils import SentryApiBuildError
 
 HTTP_METHOD_NAME = Literal[
@@ -90,56 +88,15 @@ def __write_ownership_data(ownership_data: dict[ApiOwner, dict]):
 
 class CustomEndpointEnumerator(EndpointEnumerator):
     _non_capturing = re.compile(r"\(\?:[a-z-]+\|[a-z-]+\)")
-    url_names_by_path_regex: dict[str, str | None]
-
-    def get_api_endpoints(self, patterns: Any = None, prefix: str = "") -> Any:
-        self.url_names_by_path_regex = {}
-        return super().get_api_endpoints(patterns, prefix)
 
     def get_path_from_regex(self, path_regex: str) -> str:
         # django 4.x changes to simplify_regex breaks these urls
         path_regex = self._non_capturing.sub("{var}", path_regex)
         return super().get_path_from_regex(path_regex)
 
-    def _get_api_endpoints(self, patterns: Any, prefix: str) -> list[tuple[str, str, str, Any]]:
-        if patterns is None:
-            patterns = self.patterns
-
-        api_endpoints = []
-
-        for pattern in patterns:
-            path_regex = prefix + str(pattern.pattern)
-            if isinstance(pattern, URLPattern):
-                path = self.get_path_from_regex(path_regex)
-                callback = pattern.callback
-                self.url_names_by_path_regex[path_regex] = pattern.name
-                if self.should_include_endpoint(path, callback):
-                    for method in self.get_allowed_methods(callback):
-                        api_endpoints.append((path, path_regex, method, callback))
-
-            elif isinstance(pattern, URLResolver):
-                nested_endpoints = self._get_api_endpoints(
-                    patterns=pattern.url_patterns,
-                    prefix=path_regex,
-                )
-                api_endpoints.extend(nested_endpoints)
-
-        return api_endpoints
-
 
 class CustomGenerator(SchemaGenerator):
     endpoint_inspector_cls = CustomEndpointEnumerator
-
-    def _get_paths_and_endpoints(self) -> list[tuple[str, str, str, Any]]:
-        view_endpoints = []
-        url_names_by_path_regex = getattr(self.inspector, "url_names_by_path_regex", {})
-        for path, path_regex, method, callback in self.endpoints:
-            view = self.create_view(callback, method)
-            setattr(view, URL_NAME_ATTR, url_names_by_path_regex.get(path_regex))
-            path = self.coerce_path(path, method, view)
-            view_endpoints.append((path, path_regex, method, view))
-
-        return view_endpoints
 
 
 # Collected during preprocessing, used in postprocessing

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -5,12 +5,14 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from typing import Any, Literal, TypedDict
 
+from django.urls import URLPattern, URLResolver
 from drf_spectacular.generators import EndpointEnumerator, SchemaGenerator
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.apidocs.api_ownership_allowlist_dont_modify import API_OWNERSHIP_ALLOWLIST_DONT_MODIFY
 from sentry.apidocs.build import OPENAPI_TAGS
+from sentry.apidocs.schema import URL_NAME_ATTR
 from sentry.apidocs.utils import SentryApiBuildError
 
 HTTP_METHOD_NAME = Literal[
@@ -88,15 +90,56 @@ def __write_ownership_data(ownership_data: dict[ApiOwner, dict]):
 
 class CustomEndpointEnumerator(EndpointEnumerator):
     _non_capturing = re.compile(r"\(\?:[a-z-]+\|[a-z-]+\)")
+    url_names_by_path_regex: dict[str, str | None]
+
+    def get_api_endpoints(self, patterns: Any = None, prefix: str = "") -> Any:
+        self.url_names_by_path_regex = {}
+        return super().get_api_endpoints(patterns, prefix)
 
     def get_path_from_regex(self, path_regex: str) -> str:
         # django 4.x changes to simplify_regex breaks these urls
         path_regex = self._non_capturing.sub("{var}", path_regex)
         return super().get_path_from_regex(path_regex)
 
+    def _get_api_endpoints(self, patterns: Any, prefix: str) -> list[tuple[str, str, str, Any]]:
+        if patterns is None:
+            patterns = self.patterns
+
+        api_endpoints = []
+
+        for pattern in patterns:
+            path_regex = prefix + str(pattern.pattern)
+            if isinstance(pattern, URLPattern):
+                path = self.get_path_from_regex(path_regex)
+                callback = pattern.callback
+                self.url_names_by_path_regex[path_regex] = pattern.name
+                if self.should_include_endpoint(path, callback):
+                    for method in self.get_allowed_methods(callback):
+                        api_endpoints.append((path, path_regex, method, callback))
+
+            elif isinstance(pattern, URLResolver):
+                nested_endpoints = self._get_api_endpoints(
+                    patterns=pattern.url_patterns,
+                    prefix=path_regex,
+                )
+                api_endpoints.extend(nested_endpoints)
+
+        return api_endpoints
+
 
 class CustomGenerator(SchemaGenerator):
     endpoint_inspector_cls = CustomEndpointEnumerator
+
+    def _get_paths_and_endpoints(self) -> list[tuple[str, str, str, Any]]:
+        view_endpoints = []
+        url_names_by_path_regex = getattr(self.inspector, "url_names_by_path_regex", {})
+        for path, path_regex, method, callback in self.endpoints:
+            view = self.create_view(callback, method)
+            setattr(view, URL_NAME_ATTR, url_names_by_path_regex.get(path_regex))
+            path = self.coerce_path(path, method, view)
+            view_endpoints.append((path, path_regex, method, view))
+
+        return view_endpoints
 
 
 # Collected during preprocessing, used in postprocessing

--- a/src/sentry/apidocs/schema.py
+++ b/src/sentry/apidocs/schema.py
@@ -1,12 +1,7 @@
 from drf_spectacular.openapi import AutoSchema
 from drf_spectacular.plumbing import get_doc
 
-from sentry.api.helpers.deprecation import (
-    OPENAPI_DEPRECATED_ATTR,
-    OPENAPI_DEPRECATED_URL_NAMES_ATTR,
-)
-
-URL_NAME_ATTR = "_sentry_url_name"
+from sentry.api.helpers.deprecation import OPENAPI_DEPRECATED_ATTR
 
 
 class SentrySchema(AutoSchema):
@@ -41,10 +36,7 @@ class SentrySchema(AutoSchema):
         func = self.view_func
         while func is not None:
             if getattr(func, OPENAPI_DEPRECATED_ATTR, False):
-                url_names = getattr(func, OPENAPI_DEPRECATED_URL_NAMES_ATTR, None)
-                if not url_names:
-                    return True
-                return getattr(self.view, URL_NAME_ATTR, None) in url_names
+                return True
             func = getattr(func, "__wrapped__", None)
 
         return False

--- a/src/sentry/apidocs/schema.py
+++ b/src/sentry/apidocs/schema.py
@@ -1,6 +1,13 @@
 from drf_spectacular.openapi import AutoSchema
 from drf_spectacular.plumbing import get_doc
 
+from sentry.api.helpers.deprecation import (
+    OPENAPI_DEPRECATED_ATTR,
+    OPENAPI_DEPRECATED_URL_NAMES_ATTR,
+)
+
+URL_NAME_ATTR = "_sentry_url_name"
+
 
 class SentrySchema(AutoSchema):
     """DRF Documentation Schema for sentry endpoints"""
@@ -26,3 +33,18 @@ class SentrySchema(AutoSchema):
         if len(docstring.splitlines()) > 1:
             return docstring
         return super().get_description()
+
+    def is_deprecated(self) -> bool:
+        if super().is_deprecated():
+            return True
+
+        func = self.view_func
+        while func is not None:
+            if getattr(func, OPENAPI_DEPRECATED_ATTR, False):
+                url_names = getattr(func, OPENAPI_DEPRECATED_URL_NAMES_ATTR, None)
+                if not url_names:
+                    return True
+                return getattr(self.view, URL_NAME_ATTR, None) in url_names
+            func = getattr(func, "__wrapped__", None)
+
+        return False

--- a/tests/sentry/apidocs/test_schema.py
+++ b/tests/sentry/apidocs/test_schema.py
@@ -1,6 +1,11 @@
+from datetime import UTC, datetime
+
+from django.urls import path
 from drf_spectacular.utils import extend_schema
 
 from sentry.api.base import Endpoint
+from sentry.api.helpers.deprecation import deprecated
+from sentry.apidocs.hooks import CustomGenerator
 from tests.sentry.apidocs import generate_schema
 
 
@@ -65,3 +70,37 @@ def test_description() -> None:
 
     assert schema["paths"]["/foo"]["put"]["operationId"] != "Autoschema Description"
     assert schema["paths"]["/foo"]["put"]["description"] == "Autoschema Description"
+
+
+def test_deprecated_decorator_marks_openapi_operation() -> None:
+    class ExampleEndpoint(Endpoint):
+        permission_classes = ()
+
+        @deprecated(datetime(2020, 1, 1, tzinfo=UTC))
+        def get(self, request, *args, **kwargs):
+            pass
+
+        def post(self, request, *args, **kwargs):
+            pass
+
+    schema = generate_schema("foo", view=ExampleEndpoint)
+    assert schema["paths"]["/foo"]["get"]["deprecated"] is True
+    assert "deprecated" not in schema["paths"]["/foo"]["post"]
+
+
+def test_deprecated_decorator_marks_openapi_operation_for_matching_url_name() -> None:
+    class ExampleEndpoint(Endpoint):
+        permission_classes = ()
+
+        @deprecated(datetime(2020, 1, 1, tzinfo=UTC), url_names=["deprecated-route"])
+        def get(self, request, *args, **kwargs):
+            pass
+
+    patterns = [
+        path("deprecated/", ExampleEndpoint.as_view(), name="deprecated-route"),
+        path("active/", ExampleEndpoint.as_view(), name="active-route"),
+    ]
+    schema = CustomGenerator(patterns=patterns).get_schema(request=None, public=True)
+
+    assert schema["paths"]["/deprecated/"]["get"]["deprecated"] is True
+    assert "deprecated" not in schema["paths"]["/active/"]["get"]

--- a/tests/sentry/apidocs/test_schema.py
+++ b/tests/sentry/apidocs/test_schema.py
@@ -1,11 +1,9 @@
 from datetime import UTC, datetime
 
-from django.urls import path
 from drf_spectacular.utils import extend_schema
 
 from sentry.api.base import Endpoint
 from sentry.api.helpers.deprecation import deprecated
-from sentry.apidocs.hooks import CustomGenerator
 from tests.sentry.apidocs import generate_schema
 
 
@@ -88,7 +86,7 @@ def test_deprecated_decorator_marks_openapi_operation() -> None:
     assert "deprecated" not in schema["paths"]["/foo"]["post"]
 
 
-def test_deprecated_decorator_marks_openapi_operation_for_matching_url_name() -> None:
+def test_deprecated_decorator_does_not_mark_url_name_specific_operation() -> None:
     class ExampleEndpoint(Endpoint):
         permission_classes = ()
 
@@ -96,11 +94,6 @@ def test_deprecated_decorator_marks_openapi_operation_for_matching_url_name() ->
         def get(self, request, *args, **kwargs):
             pass
 
-    patterns = [
-        path("deprecated/", ExampleEndpoint.as_view(), name="deprecated-route"),
-        path("active/", ExampleEndpoint.as_view(), name="active-route"),
-    ]
-    schema = CustomGenerator(patterns=patterns).get_schema(request=None, public=True)
+    schema = generate_schema("foo", view=ExampleEndpoint)
 
-    assert schema["paths"]["/deprecated/"]["get"]["deprecated"] is True
-    assert "deprecated" not in schema["paths"]["/active/"]["get"]
+    assert "deprecated" not in schema["paths"]["/foo"]["get"]


### PR DESCRIPTION
Deprecated endpoint methods now appear as deprecated OpenAPI operations when the deprecation applies to every route for the method. The existing runtime @deprecated behavior is unchanged, and route-name-specific deprecations are intentionally skipped in schema generation for now to avoid carrying URL pattern names through drf-spectacular.

Validated with targeted deprecation/schema tests, changed-file prek, and the OpenAPI docs build. Generated schema artifacts did not change after rebuild.