### PR TITLE
ref: Replace hardcoded trial plans with API field

### DIFF
--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -34,7 +34,7 @@ import {
   type ReservedBudgetMetricHistory,
   type Subscription,
 } from 'getsentry/types';
-import {displayBudgetName, hasPerformance, isTrialPlan} from 'getsentry/utils/billing';
+import {displayBudgetName, hasPerformance} from 'getsentry/utils/billing';
 import {
   getCategoryInfoFromPlural,
   getPlanCategoryName,
@@ -198,7 +198,6 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
             // provisioned.
             hasPerformance(plan) &&
             plan.contractInterval === MONTHLY &&
-            !isTrialPlan(plan.id) &&
             !plan.isTestPlan
           ) {
             acc[plan.id] = plan;

--- a/static/gsApp/components/trialEndingModal.tsx
+++ b/static/gsApp/components/trialEndingModal.tsx
@@ -13,7 +13,7 @@ import type {Organization} from 'sentry/types/organization';
 import UpgradeOrTrialButton from 'getsentry/components/upgradeOrTrialButton';
 import {withSubscription} from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
-import {displayPlanName, getTrialDaysLeft, isTrialPlan} from 'getsentry/utils/billing';
+import {displayPlanName, getTrialDaysLeft} from 'getsentry/utils/billing';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 type Props = Pick<ModalRenderProps, 'closeModal'> & {
@@ -47,7 +47,7 @@ function TrialEndingModal({organization, subscription, closeModal}: Props) {
   }
 
   // not a trial coming from a paid plan (ex: am1_team)
-  const isFreePlanTrial = isTrialPlan(subscription.plan);
+  const isFreePlanTrial = subscription.onTrialPlan;
 
   const returnPlan = t(
     '%s Plan',

--- a/static/gsApp/components/upsellModal/details.tsx
+++ b/static/gsApp/components/upsellModal/details.tsx
@@ -16,7 +16,7 @@ import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 
 import type {Subscription} from 'getsentry/types';
-import {getTrialLength, hasPerformance, isTrialPlan} from 'getsentry/utils/billing';
+import {getTrialLength, hasPerformance} from 'getsentry/utils/billing';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 import {FeatureList} from './featureList';
@@ -250,7 +250,7 @@ export class Details extends Component<Props, State> {
 
   get shouldShowTeamFeatures() {
     const {subscription} = this.props;
-    return subscription.isFree || isTrialPlan(subscription.plan);
+    return subscription.isFree || subscription.onTrialPlan;
   }
 
   get highlightedFeature() {

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -34,10 +34,6 @@ export enum BillingConfigTier {
   ALL = 'all',
 }
 
-const BASIC_TRIAL_PLANS = ['am1_t', 'am2_t', 'am3_t'];
-const ENTERPRISE_TRIAL_PLANS = ['am1_t_ent', 'am2_t_ent', 'am3_t_ent'];
-export const TRIAL_PLANS = [...BASIC_TRIAL_PLANS, ...ENTERPRISE_TRIAL_PLANS];
-
 // While we no longer offer or support unlimited ondemand we still
 // need to render billing history records that have unlimited ondemand.
 export const UNLIMITED_ONDEMAND = -1;

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -383,6 +383,7 @@ export type Subscription = {
   onDemandPeriodEnd: string;
   onDemandPeriodStart: string;
   onDemandSpendUsed: number;
+  onTrialPlan: boolean;
   orgRetention: RetentionSettings | null;
   partner: Partner | null;
   paymentSource: {

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -15,7 +15,6 @@ import {
   GIGABYTE,
   MILLION,
   RESERVED_BUDGET_QUOTA,
-  TRIAL_PLANS,
   UNLIMITED,
   UNLIMITED_RESERVED,
 } from 'getsentry/constants';
@@ -314,8 +313,6 @@ function displayNumber(n: number, fractionDigits = 0) {
   return n.toFixed(fractionDigits).toLocaleString();
 }
 
-export const isTrialPlan = (plan: string) => TRIAL_PLANS.includes(plan);
-
 export const hasPerformance = (plan?: Plan) => {
   return (
     // Older plans will have Transactions
@@ -418,7 +415,7 @@ export const isNewPayingCustomer = (
   organization: Organization
 ) =>
   subscription.isFree ||
-  isTrialPlan(subscription.plan) ||
+  subscription.onTrialPlan ||
   hasPartnerMigrationFeature(organization);
 
 /**

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -54,7 +54,6 @@ import {
   hasPerformance,
   isBizPlanFamily,
   isNewPayingCustomer,
-  isTrialPlan,
 } from 'getsentry/utils/billing';
 import {getCompletedOrActivePromotion} from 'getsentry/utils/promotions';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
@@ -374,7 +373,7 @@ function AMCheckout(props: Props) {
             // When introducing a new category before backfilling, the reserved value from the billing metric
             // history is not available, so we default to 0.
             // Skip trial volumes - don't pre-fill with trial reserved amounts
-            let events = (!isTrialPlan(planDetails.id) && currentHistory?.reserved) || 0;
+            let events = (!subscription.onTrialPlan && currentHistory?.reserved) || 0;
 
             if (canCompare) {
               const price = getBucket({events, buckets: eventBuckets}).price;
@@ -414,7 +413,7 @@ function AMCheckout(props: Props) {
           .reduce<CheckoutAddOns>((acc, addOn) => {
             acc[addOn.apiName] = {
               // don't prepopulate add-ons from trial state
-              enabled: addOn.enabled && !isTrialPlan(subscription.plan),
+              enabled: addOn.enabled && !subscription.onTrialPlan,
             };
             return acc;
           }, {}),

--- a/static/gsApp/views/amCheckout/steps/buildYourPlan.tsx
+++ b/static/gsApp/views/amCheckout/steps/buildYourPlan.tsx
@@ -13,7 +13,6 @@ import {
   isBizPlanFamily,
   isDeveloperPlan,
   isNewPayingCustomer,
-  isTrialPlan,
 } from 'getsentry/utils/billing';
 import {PlanFeatures} from 'getsentry/views/amCheckout/components/planFeatures';
 import {PlanSelectCard} from 'getsentry/views/amCheckout/components/planSelectCard';
@@ -66,7 +65,7 @@ function PlanSubstep({
       plan.id === subscription.plan ||
       // If Developer is surfaced in checkout and the current plan is a trial plan, we should show the `Current` badge
       // on the Developer plan
-      (isTrialPlan(subscription.plan) && isDeveloperPlan(plan))
+      (subscription.onTrialPlan && isDeveloperPlan(plan))
     ) {
       const copy = t('Current');
       return <Tag variant="muted">{copy}</Tag>;

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
@@ -9,7 +9,7 @@ import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {DataCategory} from 'sentry/types/core';
 
-import {isDeveloperPlan, isTrialPlan} from 'getsentry/utils/billing';
+import {isDeveloperPlan} from 'getsentry/utils/billing';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 import {VolumeSliders} from 'getsentry/views/amCheckout/components/volumeSliders';
 import type {StepProps} from 'getsentry/views/amCheckout/types';
@@ -27,7 +27,7 @@ export function ReserveAdditionalVolume({
 >) {
   // if the customer has any reserved volume above platform already, auto-show the sliders
   const [showSliders, setShowSliders] = useState(
-    isDeveloperPlan(subscription.planDetails) || isTrialPlan(subscription.plan)
+    isDeveloperPlan(subscription.planDetails) || subscription.onTrialPlan
       ? false
       : Object.values(subscription.categories ?? {})
           .filter(

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -34,7 +34,6 @@ import {
   hasSomeBillingDetails,
   isBizPlanFamily,
   isTeamPlanFamily,
-  isTrialPlan,
 } from 'getsentry/utils/billing';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 import {trackMarketingEvent} from 'getsentry/utils/trackMarketingEvent';
@@ -389,7 +388,7 @@ function recordAnalytics(
       productSelectAnalyticsData[targetKey] = {
         enabled: data[key as keyof CheckoutAPIData] as boolean,
         // don't count trial addons
-        previously_enabled: !isTrialPlan(previousData.previous_plan) && previouslyEnabled,
+        previously_enabled: !subscription.onTrialPlan && previouslyEnabled,
       };
     }
   });
@@ -646,7 +645,7 @@ export function useSubmitCheckout({
 
       // seer automation alert
       const alreadyHasSeer =
-        !isTrialPlan(subscription.plan) &&
+        !subscription.onTrialPlan &&
         (subscription.addOns?.seer?.enabled || subscription.addOns?.legacySeer?.enabled);
       const justBoughtSeer =
         (_variables.data.addOnLegacySeer || _variables.data.addOnSeer) && !alreadyHasSeer;

--- a/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
@@ -5,12 +5,7 @@ import type {Organization} from 'sentry/types/organization';
 import {useSecondaryNavigation} from 'sentry/views/navigation/secondaryNavigationContext';
 
 import type {Subscription} from 'getsentry/types';
-import {
-  hasBillingAccess,
-  isDeveloperPlan,
-  isTrialPlan,
-  supportsPayg,
-} from 'getsentry/utils/billing';
+import {hasBillingAccess, isDeveloperPlan, supportsPayg} from 'getsentry/utils/billing';
 import {BillingInfoCard} from 'getsentry/views/subscriptionPage/headerCards/billingInfoCard';
 import {LinksCard} from 'getsentry/views/subscriptionPage/headerCards/linksCard';
 import {NextBillCard} from 'getsentry/views/subscriptionPage/headerCards/nextBillCard';
@@ -26,7 +21,7 @@ function getCards(organization: Organization, subscription: Subscription) {
   const hasBillingPerms = hasBillingAccess(organization);
   const cards: React.ReactNode[] = [];
   const isTrialOrFreePlan =
-    isTrialPlan(subscription.plan) || isDeveloperPlan(subscription.planDetails);
+    subscription.onTrialPlan || isDeveloperPlan(subscription.planDetails);
 
   // the organization can use PAYG
   const canUsePayg = supportsPayg(subscription);

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/breakdownInfo.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/breakdownInfo.tsx
@@ -24,7 +24,6 @@ import {
   formatReservedWithUnits,
   getSoftCapType,
   hasPaygBudgetForCategory,
-  isTrialPlan,
   supportsPayg,
 } from 'getsentry/utils/billing';
 import {calculateSeerUserSpend} from 'getsentry/utils/dataCategory';
@@ -289,7 +288,7 @@ function ReservedBudgetUsageBreakdownInfo({
       plan.onDemandCategories.includes(category) &&
       hasPaygBudgetForCategory(subscription, category)
   );
-  const onTrialOrSponsored = isTrialPlan(subscription.plan) || subscription.isSponsored;
+  const onTrialOrSponsored = subscription.onTrialPlan || subscription.isSponsored;
 
   const platformReservedField = onTrialOrSponsored
     ? tct('[planName] plan', {planName: plan.name})

--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -11,7 +11,12 @@ import type {Organization} from 'sentry/types/organization';
 import {RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
 import type {Plan, Subscription as TSubscription} from 'getsentry/types';
 import {AddOnCategory, BillingType} from 'getsentry/types';
-import {isTrialPlan} from 'getsentry/utils/billing';
+
+const TRIAL_PLANS = ['am1_t', 'am2_t', 'am3_t', 'am1_t_ent', 'am2_t_ent', 'am3_t_ent'];
+
+// Derives whether a plan id is a trial plan, so the fixture can set the
+// trial-related fields the backend resolves from the subscription.
+const isTrialPlan = (plan: string) => TRIAL_PLANS.includes(plan);
 
 type Props = Partial<TSubscription> & {organization: Organization};
 
@@ -94,6 +99,7 @@ export function SubscriptionFixture(props: Props): TSubscription {
     countryCode: null,
     cancelAtPeriodEnd: false,
     isTrial,
+    onTrialPlan: isTrial,
     paymentSource: {
       last4: '4242',
       countryCode: 'US',


### PR DESCRIPTION
We don't want to have frontend logic that makes assumption about the plan.id format. Moving the trial plan logic to be based on a new backend provided boolean instead