### PR TITLE
chore(deps): Bump sentry-conventions to 0.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ dependencies = [
   "rfc3986-validator>=0.1.1",
   # [end] jsonschema format validators
   "sentry-arroyo>=2.39.2",
-  "sentry-conventions>=0.11.0",
+  "sentry-conventions>=0.12.0",
   "sentry-forked-email-reply-parser>=0.5.12.post1",
   "sentry-kafka-schemas>=2.1.33",
   "sentry-ophio>=1.1.3",

--- a/uv.lock
+++ b/uv.lock
@@ -2407,7 +2407,7 @@ requires-dist = [
     { name = "rfc3339-validator", specifier = ">=0.1.2" },
     { name = "rfc3986-validator", specifier = ">=0.1.1" },
     { name = "sentry-arroyo", specifier = ">=2.39.2" },
-    { name = "sentry-conventions", specifier = ">=0.11.0" },
+    { name = "sentry-conventions", specifier = ">=0.12.0" },
     { name = "sentry-forked-email-reply-parser", specifier = ">=0.5.12.post1" },
     { name = "sentry-kafka-schemas", specifier = ">=2.1.33" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
@@ -2520,10 +2520,10 @@ wheels = [
 
 [[package]]
 name = "sentry-conventions"
-version = "0.11.0"
+version = "0.12.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_conventions-0.11.0-py3-none-any.whl", hash = "sha256:881581e4319620d1d798306a0a631fbc1265fab9581dc268401982999f70cc5c" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_conventions-0.12.0-py3-none-any.whl", hash = "sha256:1316f8b439b63a757f827c751bccdde69416136aa1854a65036661bd65c7f63e" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Bump sentry-conventions to 0.12.0

Updates `sentry-conventions` to [0.12.0](https://github.com/getsentry/sentry-conventions/releases/tag/0.12.0).

### Changes in 0.12.0

- Align MCP attributes with OTel semantic conventions ([sentry-conventions#420](https://github.com/getsentry/sentry-conventions/pull/420))
  - Deprecates MCP-specific attributes in favor of `gen_ai.*`/`jsonrpc.*` OTel equivalents
  - Adds new `gen_ai.prompt.name` and `jsonrpc.*` attributes

> **Note:** Lockfile not updated — `sentry-conventions==0.12.0` is not yet available on PyPI or the internal mirror. The lockfile will need to be updated once the package is published.