### PR TITLE
feat(pr-metrics): Restrict judge and activity capture to Seer-eligible orgs

### DIFF
--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -79,6 +79,13 @@ DELEGATED_SIGNAL_TYPES = frozenset(
     }
 )
 
+# Signal types that qualify a PR for Seer judge forwarding.
+# Weaker heuristics (MCP issue views, bare issue references) do not warrant
+# the expensive judge call — only direct agent authorship does.
+JUDGE_ELIGIBLE_SIGNAL_TYPES = DELEGATED_SIGNAL_TYPES | frozenset(
+    {PullRequestAttributionSignalType.SENTRY_APP}
+)
+
 
 def record_attribution_signal(
     *,

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Final, Literal
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
 from sentry.models.commit import Commit
 from sentry.models.organization import Organization
@@ -23,7 +23,7 @@ from sentry.models.pullrequest import (
     PullRequestVerdict,
 )
 from sentry.pr_metrics.attribution import SIGNAL_TYPE_CONFIDENCE
-from sentry.pr_metrics.utils import iso_or_none, resolved_group_ids
+from sentry.pr_metrics.utils import is_activity_tracking_enabled, iso_or_none, resolved_group_ids
 from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ def select_verdict(
     failed — and we defer to a judge for both outcomes rather than emit zeroed
     counters (merge) or guess abandoned (close).
     """
-    if not features.has("organizations:pr-metrics-activity", organization):
+    if not is_activity_tracking_enabled(organization):
         metrics.incr("pr_metrics.select_verdict.activity_disabled")
         return None
 

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -6,9 +6,23 @@ from datetime import datetime
 
 from django.db.models import Q
 
+from sentry import features
 from sentry.models.commit import Commit
 from sentry.models.grouplink import GroupLink
+from sentry.models.organization import Organization
 from sentry.models.pullrequest import PullRequest, PullRequestActivity, PullRequestActivityType
+from sentry.seer.seer_setup import has_seer_access
+
+
+def is_activity_tracking_enabled(organization: Organization) -> bool:
+    """Whether PR activity rows should be written for this organization.
+
+    Both the feature flag rollout and Seer access are required: activity data
+    feeds the judge path which is only meaningful for Seer-enabled orgs.
+    """
+    return features.has("organizations:pr-metrics-activity", organization) and has_seer_access(
+        organization
+    )
 
 
 def iso_or_none(value: datetime | None) -> str | None:

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -34,6 +34,7 @@ from sentry.models.pullrequest import (
     PullRequest,
     PullRequestActivity,
     PullRequestActivityType,
+    PullRequestAttribution,
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
     PullRequestMetrics,
@@ -59,7 +60,7 @@ from sentry.pr_metrics.activity_types import (
     UnassignedPayload,
     UnlabeledPayload,
 )
-from sentry.pr_metrics.attribution import record_attribution_signal
+from sentry.pr_metrics.attribution import JUDGE_ELIGIBLE_SIGNAL_TYPES, record_attribution_signal
 from sentry.pr_metrics.emit import (
     emit_pr_metrics_row,
     is_pr_tracked,
@@ -187,16 +188,53 @@ def _claim_for_judge(pr: PullRequest) -> bool:
 def _forward_to_judge(pr: PullRequest, organization: Organization) -> None:
     """Hand a needs-judge terminal event to Seer, guarded against redelivery.
 
+
+    * Only PRs in orgs that have seer access are forwarded to the judge.
+    * Only PRs with attribution in JUDGE_ELIGIBLE_SIGNAL_TYPES are forwarded to
+    the judge.
+
     Gated on ``pr-metrics-judge`` independently of emission: until it's enabled
     (and Seer's endpoint exists), a needs-judge PR is skipped — today's behavior.
     Claims the sentinel via the redelivery guard before enqueuing the forward, so
     a redelivered terminal event can't forward to Seer twice.
     """
-    if not features.has("organizations:pr-metrics-judge", organization):
-        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "needs_judge"})
+    if not has_seer_access(organization):
+        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "no_seer_access"})
         logger.info(
             "pr_metrics.emit.needs_judge",
-            extra={"organization_id": organization.id, "pull_request_id": pr.id},
+            extra={
+                "organization_id": organization.id,
+                "pull_request_id": pr.id,
+                "reason": "no_seer_access",
+            },
+        )
+        return
+
+    if not PullRequestAttribution.objects.filter(
+        pull_request=pr,
+        is_valid=True,
+        signal_type__in=JUDGE_ELIGIBLE_SIGNAL_TYPES,
+    ).exists():
+        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "not_agent_attribution"})
+        logger.info(
+            "pr_metrics.emit.needs_judge",
+            extra={
+                "organization_id": organization.id,
+                "pull_request_id": pr.id,
+                "reason": "not_agent_attribution",
+            },
+        )
+        return
+
+    if not features.has("organizations:pr-metrics-judge", organization):
+        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "blocked_by_flag"})
+        logger.info(
+            "pr_metrics.emit.needs_judge",
+            extra={
+                "organization_id": organization.id,
+                "pull_request_id": pr.id,
+                "reason": "blocked_by_flag",
+            },
         )
         return
 

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -70,6 +70,7 @@ from sentry.pr_metrics.tasks import forward_pr_to_seer_task
 from sentry.pr_metrics.utils import (
     DELEGATED_AGENT_AUTHOR_LOGINS,
     DELEGATED_AGENT_BRANCH_PREFIXES,
+    is_activity_tracking_enabled,
     resolved_group_ids,
 )
 from sentry.seer.seer_setup import has_seer_access
@@ -368,7 +369,7 @@ def handle_activity(
     if pr is None:
         return
 
-    if not features.has("organizations:pr-metrics-activity", organization):
+    if not is_activity_tracking_enabled(organization):
         return
 
     webhook_id: str | None = kwargs.get("github_delivery_id")
@@ -389,7 +390,7 @@ def handle_comment(
     if action not in ("created", "edited"):
         return
 
-    if not features.has("organizations:pr-metrics-activity", organization):
+    if not is_activity_tracking_enabled(organization):
         return
 
     issue = event.get("issue")
@@ -452,7 +453,7 @@ def handle_review(
     if action != "submitted":
         return
 
-    if not features.has("organizations:pr-metrics-activity", organization):
+    if not is_activity_tracking_enabled(organization):
         return
 
     pr = _get_pull_request(organization, repo, event.get("pull_request"))
@@ -491,7 +492,7 @@ def handle_review_comment(
     if action not in ("created", "edited"):
         return
 
-    if not features.has("organizations:pr-metrics-activity", organization):
+    if not is_activity_tracking_enabled(organization):
         return
 
     pr = _get_pull_request(organization, repo, event.get("pull_request"))
@@ -540,7 +541,7 @@ def handle_review_thread(
     if action not in ("resolved", "unresolved"):
         return
 
-    if not features.has("organizations:pr-metrics-activity", organization):
+    if not is_activity_tracking_enabled(organization):
         return
 
     pr = _get_pull_request(organization, repo, event.get("pull_request"))

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -216,7 +216,7 @@ def _forward_to_judge(pr: PullRequest, organization: Organization) -> None:
         is_valid=True,
         signal_type__in=JUDGE_ELIGIBLE_SIGNAL_TYPES,
     ).exists():
-        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "not_agent_attribution"})
+        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "no_eligible_attribution"})
         logger.info(
             "pr_metrics.emit.needs_judge",
             extra={
@@ -228,7 +228,7 @@ def _forward_to_judge(pr: PullRequest, organization: Organization) -> None:
         return
 
     if not features.has("organizations:pr-metrics-judge", organization):
-        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "blocked_by_flag"})
+        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "needs_judge"})
         logger.info(
             "pr_metrics.emit.needs_judge",
             extra={

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -55,7 +55,7 @@ METRICS = {
 
 
 @cell_silo_test
-@with_feature("organizations:pr-metrics-activity")
+@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
 class PrMetricsEmissionTest(TestCase):
     def setUp(self) -> None:
         self.repo = self.create_repo(

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -261,7 +261,7 @@ CLOSED_AT = datetime(2020, 6, 4, 10, 0, 0, tzinfo=timezone.utc)
 
 
 @with_feature("organizations:pr-metrics-emit")
-@with_feature("organizations:pr-metrics-activity")
+@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
 @cell_silo_test
 class HandleWebhookForPrMetricsEmissionTest(TestCase):
     def setUp(self) -> None:
@@ -373,6 +373,15 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
         # verdict can't be settled deterministically — defer rather than emit a
         # possibly-wrong merged_unchanged. No verdict is claimed either.
         with self.feature({"organizations:pr-metrics-activity": False}):
+            self._call(merged=True)
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
+
+    @patch("sentry.analytics.record")
+    def test_skips_emit_when_no_seer_access(self, mock_record: MagicMock) -> None:
+        # Without Seer access, activity rows are not written, so the commits-after-open
+        # signal is absent and select_verdict must defer — same invariant as flag-off.
+        with self.feature({"organizations:gen-ai-features": False}):
             self._call(merged=True)
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -1276,7 +1276,7 @@ class HandleReviewThreadForPrMetricsTest(TestCase):
 
 @with_feature("organizations:pr-metrics-emit")
 @with_feature("organizations:pr-metrics-activity")
-@with_feature("organizations:pr-metrics-judge")
+@with_feature(["organizations:pr-metrics-judge", "organizations:gen-ai-features"])
 @cell_silo_test
 class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
     """The needs-judge branch with pr-metrics-judge on: claim the sentinel and forward."""
@@ -1387,6 +1387,31 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
         # The tracking gate runs before the judge fork: an untracked PR is dropped
         # without claiming the sentinel or forwarding.
         PullRequestAttribution.objects.filter(pull_request=self.pull_request).delete()
+        self._call()
+        assert mock_delay.call_count == 0
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
+
+    @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
+    @patch("sentry.analytics.record")
+    def test_no_seer_access_skips_judge(
+        self, mock_record: MagicMock, mock_delay: MagicMock
+    ) -> None:
+        # Without Seer access the judge path is not eligible regardless of attribution.
+        with self.feature({"organizations:gen-ai-features": False}):
+            self._call()
+        assert mock_delay.call_count == 0
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
+
+    @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
+    @patch("sentry.analytics.record")
+    def test_ineligible_attribution_skips_judge(
+        self, mock_record: MagicMock, mock_delay: MagicMock
+    ) -> None:
+        # Only SENTRY_APP and SEER_DELEGATED_* attributions qualify for the judge.
+        # A PR tracked only via MCP or REFERENCED_ISSUE is skipped.
+        PullRequestAttribution.objects.filter(pull_request=self.pull_request).update(
+            signal_type=PullRequestAttributionSignalType.MCP
+        )
         self._call()
         assert mock_delay.call_count == 0
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -523,7 +523,7 @@ class HandleWebhookForPrMetricsCountersTest(TestCase):
         assert PullRequestMetrics.objects.count() == 0
 
 
-@with_feature("organizations:pr-metrics-activity")
+@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
 @cell_silo_test
 class HandleWebhookForPrMetricsActivityTest(TestCase):
     def setUp(self) -> None:
@@ -875,8 +875,14 @@ class HandleWebhookForPrMetricsActivityTest(TestCase):
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
+    def test_no_seer_access_skips_activity(self) -> None:
+        with self.feature({"organizations:gen-ai-features": False}):
+            self._call(action="opened")
 
-@with_feature("organizations:pr-metrics-activity")
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+
+@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
 @cell_silo_test
 class HandleCommentForPrMetricsTest(TestCase):
     def setUp(self) -> None:
@@ -1002,8 +1008,14 @@ class HandleCommentForPrMetricsTest(TestCase):
         activity = PullRequestActivity.objects.get(pull_request=self.pr)
         assert activity.payload["is_review"] is False
 
+    def test_no_seer_access_skips_comment(self) -> None:
+        with self.feature({"organizations:gen-ai-features": False}):
+            self._call()
 
-@with_feature("organizations:pr-metrics-activity")
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+
+@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
 @cell_silo_test
 class HandleReviewForPrMetricsTest(TestCase):
     def setUp(self) -> None:
@@ -1094,8 +1106,14 @@ class HandleReviewForPrMetricsTest(TestCase):
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
+    def test_no_seer_access_skips_review(self) -> None:
+        with self.feature({"organizations:gen-ai-features": False}):
+            self._call()
 
-@with_feature("organizations:pr-metrics-activity")
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+
+@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
 @cell_silo_test
 class HandleReviewCommentForPrMetricsTest(TestCase):
     def setUp(self) -> None:
@@ -1187,8 +1205,14 @@ class HandleReviewCommentForPrMetricsTest(TestCase):
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
+    def test_no_seer_access_skips_review_comment(self) -> None:
+        with self.feature({"organizations:gen-ai-features": False}):
+            self._call()
 
-@with_feature("organizations:pr-metrics-activity")
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+
+@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
 @cell_silo_test
 class HandleReviewThreadForPrMetricsTest(TestCase):
     def setUp(self) -> None:
@@ -1271,6 +1295,12 @@ class HandleReviewThreadForPrMetricsTest(TestCase):
             "github.pr_metrics.pr_not_found",
             extra={"repository_id": self.repo.id, "pr_number": 9999},
         )
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_no_seer_access_skips_thread_event(self) -> None:
+        with self.feature({"organizations:gen-ai-features": False}):
+            self._call()
+
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
 


### PR DESCRIPTION
Tighten the rollout of the PR metrics judge path and activity capture to orgs that have Seer access.

**Judge forwarding** previously forwarded any tracked PR to Seer whenever `select_verdict` couldn't settle locally. This meant PRs attributed only via MCP issue views or bare issue references could trigger the expensive judge call. The forward path is now restricted to two conditions:

- The org must have Seer access (`gen-ai-features` flag + no `hide_ai_features`)
- The PR must have at least one valid attribution of type `SENTRY_APP` or `SEER_DELEGATED_*` — direct agent authorship, not heuristics

A new `JUDGE_ELIGIBLE_SIGNAL_TYPES` constant in `attribution.py` captures this set.

**Activity capture** (all five handlers: `handle_activity`, `handle_comment`, `handle_review`, `handle_review_comment`, `handle_review_thread`) is similarly gated. Activity rows feed the judge path, so accumulating them for non-Seer orgs is wasteful. A new `is_activity_tracking_enabled()` util in `pr_metrics/utils.py` combines the `pr-metrics-activity` flag check with `has_seer_access()` and is used by all five handlers.

Refs CORE-248