### PR TITLE
chore(pr-metrics): drop REFERENCED_ISSUE as attribution

### DIFF
--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -41,7 +41,6 @@ class PullRequestAttributionSignalType(models.TextChoices):
     SEER_DELEGATED_CLAUDE_CODE = "seer_delegated:claude_code"
     SEER_DELEGATED_UNKNOWN = "seer_delegated:unknown"
     MCP = "mcp"
-    REFERENCED_ISSUE = "referenced_issue"
     UNKNOWN = "unknown"
 
 

--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -56,7 +56,6 @@ SIGNAL_TYPE_CONFIDENCE: dict[str, int] = {
     PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE: 80,
     PullRequestAttributionSignalType.SEER_DELEGATED_UNKNOWN: 70,
     PullRequestAttributionSignalType.MCP: 50,
-    PullRequestAttributionSignalType.REFERENCED_ISSUE: 25,
     PullRequestAttributionSignalType.UNKNOWN: 0,
 }
 

--- a/tests/sentry/pr_metrics/test_attribution.py
+++ b/tests/sentry/pr_metrics/test_attribution.py
@@ -390,7 +390,6 @@ class RecomputePullRequestAttributionTest(TestCase):
         assert recompute_pull_request_attribution(self.pull_request) is None
 
     def test_picks_highest_confidence_signal(self) -> None:
-        self._add(PullRequestAttributionSignalType.REFERENCED_ISSUE)
         self._add(PullRequestAttributionSignalType.SENTRY_APP)
         self._add(PullRequestAttributionSignalType.MCP)
 
@@ -401,9 +400,9 @@ class RecomputePullRequestAttributionTest(TestCase):
 
     def test_ignores_invalid_signals(self) -> None:
         self._add(PullRequestAttributionSignalType.SENTRY_APP, is_valid=False)
-        self._add(PullRequestAttributionSignalType.REFERENCED_ISSUE)
+        self._add(PullRequestAttributionSignalType.MCP)
 
         assert (
             recompute_pull_request_attribution(self.pull_request)
-            == PullRequestAttributionSignalType.REFERENCED_ISSUE
+            == PullRequestAttributionSignalType.MCP
         )

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -275,7 +275,7 @@ class PrMetricsEmissionTest(TestCase):
     def test_is_pr_tracked_requires_a_valid_attribution(self) -> None:
         assert is_pr_tracked(self.pull_request) is False
         self._track(
-            PullRequestAttributionSignalType.REFERENCED_ISSUE,
+            PullRequestAttributionSignalType.SENTRY_APP,
             source=PullRequestAttributionSource.WEBHOOK_DATA,
             is_valid=False,
         )
@@ -320,7 +320,7 @@ class PrMetricsEmissionTest(TestCase):
     def test_active_attributions_only_includes_valid_signals(self) -> None:
         self._track(PullRequestAttributionSignalType.SENTRY_APP)
         self._track(
-            PullRequestAttributionSignalType.REFERENCED_ISSUE,
+            PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
             source=PullRequestAttributionSource.WEBHOOK_DATA,
             is_valid=False,
         )
@@ -329,7 +329,7 @@ class PrMetricsEmissionTest(TestCase):
     def test_active_attributions_ordered_by_priority_with_source_and_details(self) -> None:
         # Lower-confidence signal recorded first, but ordered second.
         self._track(
-            PullRequestAttributionSignalType.REFERENCED_ISSUE,
+            PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
             source=PullRequestAttributionSource.WEBHOOK_DATA,
             signal_details={"group_ids": [7]},
         )
@@ -337,7 +337,7 @@ class PrMetricsEmissionTest(TestCase):
         assert active_attributions(self.pull_request) == [
             SENTRY_APP_ATTRIBUTION,
             {
-                "signal_type": "referenced_issue",
+                "signal_type": "seer_delegated:claude_code",
                 "source": "webhook_data",
                 "signal_details": {"group_ids": [7]},
             },


### PR DESCRIPTION
We haven't written that attribution for a while now. These changes drop them completely as valid attributions.

REFERENCED_ISSUES are still persisted in the bigquery event through the emitted `group_ids`.

