### PR TITLE
fix(explore): Include AI usage token fields in visualize options

### DIFF
--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -75,6 +75,9 @@ export const SENTRY_SPAN_NUMBER_TAGS: string[] = [
   SpanFields.GEN_AI_COST_INPUT_TOKENS,
   SpanFields.GEN_AI_COST_OUTPUT_TOKENS,
   SpanFields.GEN_AI_COST_TOTAL_TOKENS,
+  SpanFields.GEN_AI_USAGE_INPUT_TOKENS,
+  SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS,
+  SpanFields.GEN_AI_USAGE_TOTAL_TOKENS,
   'gen_ai.usage.total_cost',
 ];
 

--- a/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
@@ -51,7 +51,10 @@ describe('useVisualizeFields', () => {
       'span.duration',
       'span.self_time',
       'ai.total_cost',
+      'gen_ai.usage.input_tokens',
+      'gen_ai.usage.output_tokens',
       'gen_ai.usage.total_cost',
+      'gen_ai.usage.total_tokens',
       'score.ttfb',
     ]);
   });


### PR DESCRIPTION
Explore visualize field selectors now treat the AI usage token attributes as numeric span fields, so aggregate functions like p95, avg, sum, min, and max can select them from the default field list.

This mirrors #117817 (which seeded the AI cost attributes into the span number tags) and additionally adds the three usage token attributes:

- `gen_ai.usage.input_tokens`
- `gen_ai.usage.output_tokens`
- `gen_ai.usage.total_tokens`

The UI already models these values as numeric aggregate inputs, so this seeds the known usage token attributes into the span number tags and updates the visualize fields coverage.
