### PR TITLE
chore(pr-metrics): drop SENTRY_APP attribution on webhooks

### DIFF
--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -135,8 +135,6 @@ def handle_attribution(
     if pr is None:
         return
 
-    if action == "opened":
-        _write_author_attribution(pr, github_user)
     if features.has("organizations:mcp-issue-view-attribution", organization):
         _write_mcp_attribution(pr)
     if action == "opened" and pull_request is not None and has_seer_access(organization):
@@ -602,20 +600,6 @@ def _detect_app_signal(github_user_id: int) -> PullRequestAttributionSignalType 
     return None
 
 
-def _write_author_attribution(pr: PullRequest, github_user: dict[str, Any]) -> None:
-    user_id = github_user.get("id")
-    if user_id is None:
-        return
-    signal_type = _detect_app_signal(user_id)
-    if signal_type is None:
-        return
-    record_attribution_signal(
-        pull_request=pr,
-        signal_type=signal_type,
-        source=PullRequestAttributionSource.WEBHOOK_DATA,
-    )
-
-
 def _detect_delegated_agent(pr: PullRequest, webhook_pull_request: Mapping[str, Any]) -> None:
     """
     Filter PRs that could have been delegated by Autofix to external coding agents,
@@ -627,6 +611,15 @@ def _detect_delegated_agent(pr: PullRequest, webhook_pull_request: Mapping[str, 
     # Our candidates are PRs from delegated agents
     # That explicitly address a Sentry issue
     if provider_hint is not None and resolved_group_ids(pr):
+        # I suspect that for Claude in particular the bot that creates the Pr is actually Sentry
+        # This is just to test that theory
+        github_login = (webhook_pull_request or {}).get("user", {}).get("id")
+        if _detect_app_signal(github_login):
+            sentry_sdk.metrics.count(
+                "pr_metrics.delegated_agent.pr_created_by_sentry_bot",
+                1,
+                attributes={"provider_hint": provider_hint},
+            )
         # TODO: Fire-and-forget request to Seer when the match endpoint exists.
         # We will send: provider_hint, github_login, head_ref
         sentry_sdk.metrics.count(

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -74,45 +74,6 @@ class HandleWebhookForPrMetricsTest(TestCase):
             repo=self.repo,
         )
 
-    # --- App ID attribution ---
-
-    def test_seer_app_user_emits_sentry_app_attribution(self) -> None:
-        self._call(user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
-
-        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
-        assert attr.signal_type == PullRequestAttributionSignalType.SENTRY_APP
-        assert attr.source == PullRequestAttributionSource.WEBHOOK_DATA
-        assert attr.is_valid is True
-        assert attr.signal_details is None
-
-    def test_sentry_app_user_emits_sentry_app_attribution(self) -> None:
-        self._call(user_id=settings.SENTRY_GITHUB_APP_USER_ID)
-
-        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
-        assert attr.signal_type == PullRequestAttributionSignalType.SENTRY_APP
-        assert attr.source == PullRequestAttributionSource.WEBHOOK_DATA
-        assert attr.is_valid is True
-        assert attr.signal_details is None
-
-    def test_unknown_user_no_attribution_created(self) -> None:
-        self._call(user_id=99999)
-
-        assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
-
-    def test_app_attribution_only_written_on_opened(self) -> None:
-        # reopened and edited should not create a second app attribution row
-        self._call(action="reopened", user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
-        self._call(
-            action="edited",
-            user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID,
-            changes={"body": {"from": "old body"}},
-        )
-
-        assert not PullRequestAttribution.objects.filter(
-            pull_request=self.pr,
-            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
-        ).exists()
-
     # --- Action gate ---
 
     def test_irrelevant_actions_skipped(self) -> None:
@@ -128,23 +89,6 @@ class HandleWebhookForPrMetricsTest(TestCase):
             self._call(action=action, user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
 
         assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
-
-    # --- Idempotency and redelivery ---
-
-    def test_idempotent_on_repeated_webhooks(self) -> None:
-        self._call(user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
-        self._call(user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
-
-        assert PullRequestAttribution.objects.filter(pull_request=self.pr).count() == 1
-
-    def test_redelivery_revives_invalidated_signal(self) -> None:
-        self._call(user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
-        PullRequestAttribution.objects.filter(pull_request=self.pr).update(is_valid=False)
-
-        self._call(user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
-
-        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
-        assert attr.is_valid is True
 
     # --- MCP attribution ---
 
@@ -192,29 +136,6 @@ class HandleWebhookForPrMetricsTest(TestCase):
             self._call(user_id=999)
 
         assert not PullRequestAttribution.objects.filter(
-            pull_request=self.pr,
-            signal_type=PullRequestAttributionSignalType.MCP,
-        ).exists()
-
-    def test_mcp_and_app_attribution_coexist(self) -> None:
-        group = self.create_group(project=self.project)
-        GroupLink.objects.create(
-            group_id=group.id,
-            project_id=group.project_id,
-            linked_type=GroupLink.LinkedType.pull_request,
-            relationship=GroupLink.Relationship.resolves,
-            linked_id=self.pr.id,
-        )
-        cache.set(cache_key_for_issue_view(group.id, "mcp"), "cursor", ISSUE_VIEW_CACHE_KEY_TTL)
-
-        with self.feature("organizations:mcp-issue-view-attribution"):
-            self._call(user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
-
-        assert PullRequestAttribution.objects.filter(
-            pull_request=self.pr,
-            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
-        ).exists()
-        assert PullRequestAttribution.objects.filter(
             pull_request=self.pr,
             signal_type=PullRequestAttributionSignalType.MCP,
         ).exists()


### PR DESCRIPTION
I'm doing this because I think we'll have conflicts on the delegated agents path AND
because the pr_created webhooks we get from Seer are reliable and have more info.

So dropping this path to avoid attributing to sentry but really should be delegated agent.
Added a metric to test the theory.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
