### PR TITLE
fix(avatars): Close avatar file in get_cached_photo

### DIFF
--- a/src/sentry/models/avatars/base.py
+++ b/src/sentry/models/avatars/base.py
@@ -84,8 +84,7 @@ class AvatarBase(Model):
         cache_key = self.get_cache_key(size)
         photo = cache.get(cache_key)
         if photo is None:
-            photo_file = file.getfile()
-            with Image.open(photo_file) as image:
+            with file.getfile() as photo_file, Image.open(photo_file) as image:
                 image = image.resize((size, size), Image.LANCZOS)
                 image_file = BytesIO()
                 image.save(image_file, "PNG")


### PR DESCRIPTION
- We see thousands of errors in our GCP logs that contain a ResourceWarning referring to this line. We can clean this up by using a context manager, which should take care of closing the file on scope exit. The PIL context manager only closes the image, not the file, so we're leaking memory in the SpooledTemporaryFile