### PR TITLE
feat(insights): Add analytics events for AI trace interactions

### DIFF
--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -110,12 +110,16 @@ export type TracingEventParameters = {
     has_logs_details: boolean;
     has_profile_details: boolean;
   };
+  'trace.trace_drawer_details.gen_ai_span_details_viewed': {
+    operation_type: string;
+  };
   'trace.trace_drawer_explore_search': {
     key: string;
     kind: TraceDrawerActionKind;
     source: 'drawer' | 'toolbar_menu';
     value: string | number;
   };
+  'trace.trace_layout.ai_tab_clicked': Record<string, unknown>;
   'trace.trace_layout.change': {
     layout: string;
   };
@@ -168,6 +172,11 @@ export type TracingEventParameters = {
   'trace_explorer.compare_queries': Record<string, unknown>;
   'trace_explorer.delete_query': Record<string, unknown>;
   'trace_explorer.open_in_issues': Record<string, unknown>;
+  'trace_explorer.open_saved_query': {
+    is_prebuilt: boolean;
+    query_name: string;
+    dataset?: string;
+  };
   'trace_explorer.open_trace': {
     source: 'trace explorer' | 'new explore';
   };
@@ -230,6 +239,9 @@ export const tracingEventMap: Record<TracingEventKey, string | null> = {
   'trace.trace_layout.drawer_minimize': 'Minimized Trace Drawer',
   'trace.trace_drawer_explore_search': 'Searched Trace Explorer',
   'trace.trace_drawer_details.eap_span_has_details': 'EAP Span has Details',
+  'trace.trace_drawer_details.gen_ai_span_details_viewed':
+    'Viewed Gen AI Span Details in Trace',
+  'trace.trace_layout.ai_tab_clicked': 'Clicked AI Tab in Trace',
   'trace.tracing_onboarding': 'Tracing Onboarding UI',
   'trace.tracing_onboarding_platform_docs_viewed':
     'Viewed Platform Docs for Onboarding UI',
@@ -266,6 +278,7 @@ export const tracingEventMap: Record<TracingEventKey, string | null> = {
   'trace.trace_layout.span_row_click': 'Clicked Span Row in Trace',
   'trace_explorer.add_span_condition': 'Trace Explorer: Add Another Span',
   'trace_explorer.open_in_issues': 'Trace Explorer: Open Trace in Issues',
+  'trace_explorer.open_saved_query': 'Trace Explorer: Open Saved Query',
   'trace_explorer.open_trace': 'Trace Explorer: Open Trace in Trace Viewer',
   'trace_explorer.open_trace_span': 'Trace Explorer: Open Trace Span in Trace Viewer',
   'trace_explorer.remove_span_condition': 'Trace Explorer: Remove Span',

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useEffect, useMemo} from 'react';
 import type {ReactNode} from 'react';
 import * as Sentry from '@sentry/react';
 
@@ -14,6 +14,7 @@ import {TourContextProvider} from 'sentry/components/tours/components';
 import {useAssistant} from 'sentry/components/tours/useAssistant';
 import {t} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {defined} from 'sentry/utils/defined';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {
@@ -160,6 +161,19 @@ function SpansTabHeader() {
   const title = useQueryParamsTitle();
   const organization = useOrganization();
   const {data: savedQuery} = useGetSavedQuery(id);
+
+  useEffect(() => {
+    if (defined(id) && defined(savedQuery)) {
+      trackAnalytics('trace_explorer.open_saved_query', {
+        organization,
+        query_name: savedQuery.name,
+        is_prebuilt: savedQuery.isPrebuilt ?? false,
+        dataset: savedQuery.dataset,
+      });
+    }
+    // Only fire once per saved query load, keyed by id
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, savedQuery?.id]);
 
   const hasSavedQueryTitle =
     defined(id) && defined(savedQuery) && savedQuery.name.length > 0;

--- a/static/app/views/performance/newTraceDetails/traceAnalytics.tsx
+++ b/static/app/views/performance/newTraceDetails/traceAnalytics.tsx
@@ -162,6 +162,17 @@ const trackEAPSpanHasDetails = (
     has_logs_details: hasLogsDetails,
   });
 
+const trackAITabClicked = (organization: Organization) =>
+  trackAnalytics('trace.trace_layout.ai_tab_clicked', {
+    organization,
+  });
+
+const trackGenAISpanDetailsViewed = (organization: Organization, operationType: string) =>
+  trackAnalytics('trace.trace_drawer_details.gen_ai_span_details_viewed', {
+    organization,
+    operation_type: operationType,
+  });
+
 const trackResetZoom = (organization: Organization) =>
   trackAnalytics('trace.trace_layout.reset_zoom', {
     organization,
@@ -304,6 +315,9 @@ const traceAnalytics = {
   trackMissingInstrumentationPreferenceChange,
   // Trace Drawer Details
   trackEAPSpanHasDetails,
+  trackGenAISpanDetailsViewed,
+  // AI
+  trackAITabClicked,
 };
 
 export {traceAnalytics};

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -505,6 +505,18 @@ function EAPSpanNodeDetailsContent({
     }
   }, [hasProfileDetails, hasLogDetails, organization]);
 
+  const genAiOperationType = attributesMap['gen_ai.operation.type'];
+  useEffect(() => {
+    // Skip when rendered outside the waterfall drawer (e.g. the AI tab and
+    // conversations views render the same details with node actions hidden).
+    if (hideNodeActions) {
+      return;
+    }
+    if (typeof genAiOperationType === 'string' && genAiOperationType) {
+      traceAnalytics.trackGenAISpanDetailsViewed(organization, genAiOperationType);
+    }
+  }, [genAiOperationType, organization, hideNodeActions]);
+
   const isSdkSentV2Span =
     // The presence of this attribute indicates that the EAP span was sent as a v2 span
     // from SDKs rather than an SDK-sent transaction converted to EAP spans during ingestion.

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -3,7 +3,9 @@ import * as qs from 'query-string';
 
 import {t} from 'sentry/locale';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
+import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
 import {
   getTraceMetaLogsCount,
   getTraceMetaMetricsCount,
@@ -154,6 +156,7 @@ export function useTraceLayoutTabs({
   metricsEnabled,
 }: UseTraceLayoutTabsProps): TraceLayoutTabsConfig {
   const navigate = useNavigate();
+  const organization = useOrganization();
   const sections = useTraceContextSections({
     tree,
     logs,
@@ -180,6 +183,9 @@ export function useTraceLayoutTabs({
 
   const onTabChange = useCallback(
     (slug: Tab['slug']) => {
+      if (slug === TraceLayoutTabKeys.AI_SPANS) {
+        traceAnalytics.trackAITabClicked(organization);
+      }
       navigate(
         {
           pathname: location.pathname,
@@ -192,7 +198,7 @@ export function useTraceLayoutTabs({
       );
       setCurrentTab(slug);
     },
-    [navigate, queryParams]
+    [navigate, queryParams, organization]
   );
 
   // Update the tab when the tabOptions change


### PR DESCRIPTION
Three AI-related interactions in the trace and explore views were previously untracked. This adds dedicated analytics events for each so we can measure adoption.

- `trace_explorer.open_saved_query` fires when a saved query is opened in the Traces explorer. The new Explore product already tracked saving and starring queries but never tracked opening one. The prebuilt **LLM Calls** query is identified by filtering on `query_name` (with `is_prebuilt: true`).
- `trace.trace_layout.ai_tab_clicked` fires when a user selects the AI tab in the trace view. It lives in the tab-change handler, so it fires once per click and not on initial load when AI is the default tab.
- `trace.trace_drawer_details.gen_ai_span_details_viewed` fires when a span with a `gen_ai.operation.type` attribute is opened in the waterfall drawer, with the operation type as a parameter. It is gated on `hideNodeActions` so it does not also fire when the same details panel is rendered inside the AI tab or conversations view.