### PR TITLE
feat(pr-metrics): Call Seer delegated-agent match RPC from webhook

### DIFF
--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -21,7 +21,6 @@ from dataclasses import asdict
 from datetime import datetime, timedelta
 from typing import Any
 
-import sentry_sdk
 from django.conf import settings
 from django.core.cache import cache
 from django.db import IntegrityError, router, transaction
@@ -83,6 +82,11 @@ from sentry.pr_metrics.utils import (
     is_activity_tracking_enabled,
     resolved_group_ids,
 )
+from sentry.seer.autofix.utils import (
+    MatchDelegatedAgentPrRequest,
+    make_match_coding_agent_pr_request,
+)
+from sentry.seer.models import SeerRepoDefinition
 from sentry.seer.seer_setup import has_seer_access
 from sentry.utils import metrics
 
@@ -980,16 +984,72 @@ def _detect_delegated_agent(pr: PullRequest, webhook_pull_request: Mapping[str, 
     Then Seer calls the RPC "record_pr_attribution" to write the attribution row async.
     """
     provider_hint = _is_delegated_agent_candidate(webhook_pull_request)
-    # Our candidates are PRs from delegated agents
-    # That explicitly address a Sentry issue
-    if provider_hint is not None and resolved_group_ids(pr):
-        # TODO: Fire-and-forget request to Seer when the match endpoint exists.
-        # We will send: provider_hint, github_login, head_ref
-        sentry_sdk.metrics.count(
-            "pr_metrics.delegated_agent.seer_match.not_implemented",
-            1,
-            attributes={"provider_hint": provider_hint},
+    group_ids = resolved_group_ids(pr)
+    if provider_hint is None or not group_ids:
+        return
+
+    try:
+        repository = Repository.objects.get(id=pr.repository_id, organization_id=pr.organization_id)
+    except Repository.DoesNotExist:
+        logger.warning(
+            "pr_metrics.delegated_agent.repository_not_found",
+            extra={"pull_request_id": pr.id, "repository_id": pr.repository_id},
         )
+        return
+
+    repo_name_sections = repository.name.split("/")
+    if len(repo_name_sections) < 2:
+        logger.warning(
+            "pr_metrics.delegated_agent.invalid_repo_name",
+            extra={"pull_request_id": pr.id, "repo_name": repository.name},
+        )
+        return
+
+    pr_url = webhook_pull_request.get("html_url") or ""
+    head_branch = (webhook_pull_request.get("head") or {}).get("ref") or ""
+
+    request_body = MatchDelegatedAgentPrRequest(
+        organization_id=pr.organization_id,
+        pull_request_id=pr.id,
+        pr_url=pr_url,
+        repo=SeerRepoDefinition(
+            provider=repository.provider or "",
+            owner=repo_name_sections[0],
+            name="/".join(repo_name_sections[1:]),
+            external_id=repository.external_id or "",
+        ),
+        head_branch=head_branch,
+        provider=provider_hint,
+        group_ids=group_ids,
+    )
+
+    log_extra = {
+        "pull_request_id": pr.id,
+        "organization_id": pr.organization_id,
+        "provider_hint": provider_hint,
+    }
+    try:
+        response = make_match_coding_agent_pr_request(request_body, timeout=5)
+    except Exception:
+        logger.warning("pr_metrics.delegated_agent.seer_match.error", extra=log_extra)
+        metrics.incr(
+            "pr_metrics.delegated_agent.seer_match.error",
+            tags={"reason": "exception"},
+        )
+        return
+
+    if response.status >= 400:
+        logger.warning(
+            "pr_metrics.delegated_agent.seer_match.error",
+            extra={**log_extra, "status_code": response.status},
+        )
+        metrics.incr(
+            "pr_metrics.delegated_agent.seer_match.error",
+            tags={"reason": "bad_status"},
+        )
+        return
+
+    metrics.incr("pr_metrics.delegated_agent.seer_match.sent")
 
 
 def _write_mcp_attribution(pr: PullRequest) -> None:

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -171,7 +171,7 @@ def handle_attribution(
     if features.has("organizations:mcp-issue-view-attribution", organization):
         _write_mcp_attribution(pr)
     if action == "opened" and pull_request is not None and has_seer_access(organization):
-        _detect_delegated_agent(pr, pull_request)
+        _detect_delegated_agent(pr, pull_request, repo)
 
 
 def _claim_terminal_event(pr: PullRequest, verdict: PullRequestVerdict) -> bool:
@@ -977,7 +977,9 @@ def _write_author_attribution(pr: PullRequest, github_user: dict[str, Any]) -> N
     )
 
 
-def _detect_delegated_agent(pr: PullRequest, webhook_pull_request: Mapping[str, Any]) -> None:
+def _detect_delegated_agent(
+    pr: PullRequest, webhook_pull_request: Mapping[str, Any], repository: Repository
+) -> None:
     """
     Filter PRs that could have been delegated by Autofix to external coding agents,
     and fire the matching request to Seer if it's a candidate.
@@ -989,20 +991,22 @@ def _detect_delegated_agent(pr: PullRequest, webhook_pull_request: Mapping[str, 
     if provider_hint is None or not group_ids:
         return
 
-    try:
-        repository = Repository.objects.get(id=pr.repository_id, organization_id=pr.organization_id)
-    except Repository.DoesNotExist:
-        logger.warning(
-            "pr_metrics.delegated_agent.repository_not_found",
-            extra={"pull_request_id": pr.id, "repository_id": pr.repository_id},
-        )
-        return
-
     repo_name_sections = repository.name.split("/")
     if len(repo_name_sections) < 2:
         logger.warning(
             "pr_metrics.delegated_agent.invalid_repo_name",
             extra={"pull_request_id": pr.id, "repo_name": repository.name},
+        )
+        return
+
+    if not repository.provider or not repository.external_id:
+        logger.warning(
+            "pr_metrics.delegated_agent.missing_repo_metadata",
+            extra={
+                "pull_request_id": pr.id,
+                "has_provider": bool(repository.provider),
+                "has_external_id": bool(repository.external_id),
+            },
         )
         return
 
@@ -1014,10 +1018,10 @@ def _detect_delegated_agent(pr: PullRequest, webhook_pull_request: Mapping[str, 
         pull_request_id=pr.id,
         pr_url=pr_url,
         repo=SeerRepoDefinition(
-            provider=repository.provider or "",
+            provider=repository.provider,
             owner=repo_name_sections[0],
             name="/".join(repo_name_sections[1:]),
-            external_id=repository.external_id or "",
+            external_id=repository.external_id,
         ),
         head_branch=head_branch,
         provider=provider_hint,

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -21,6 +21,7 @@ from dataclasses import asdict
 from datetime import datetime, timedelta
 from typing import Any
 
+import sentry_sdk
 from django.conf import settings
 from django.core.cache import cache
 from django.db import IntegrityError, router, transaction
@@ -1023,6 +1024,14 @@ def _detect_delegated_agent(pr: PullRequest, webhook_pull_request: Mapping[str, 
         group_ids=group_ids,
     )
 
+    _send_seer_delegated_agent_match(request_body, provider_hint, pr)
+
+
+def _send_seer_delegated_agent_match(
+    request_body: MatchDelegatedAgentPrRequest,
+    provider_hint: str,
+    pr: PullRequest,
+) -> None:
     log_extra = {
         "pull_request_id": pr.id,
         "organization_id": pr.organization_id,
@@ -1032,9 +1041,10 @@ def _detect_delegated_agent(pr: PullRequest, webhook_pull_request: Mapping[str, 
         response = make_match_coding_agent_pr_request(request_body, timeout=5)
     except Exception:
         logger.warning("pr_metrics.delegated_agent.seer_match.error", extra=log_extra)
-        metrics.incr(
+        sentry_sdk.metrics.count(
             "pr_metrics.delegated_agent.seer_match.error",
-            tags={"reason": "exception"},
+            1,
+            attributes={"reason": "exception"},
         )
         return
 
@@ -1043,13 +1053,18 @@ def _detect_delegated_agent(pr: PullRequest, webhook_pull_request: Mapping[str, 
             "pr_metrics.delegated_agent.seer_match.error",
             extra={**log_extra, "status_code": response.status},
         )
-        metrics.incr(
+        sentry_sdk.metrics.count(
             "pr_metrics.delegated_agent.seer_match.error",
-            tags={"reason": "bad_status"},
+            1,
+            attributes={"reason": "bad_status"},
         )
         return
 
-    metrics.incr("pr_metrics.delegated_agent.seer_match.sent")
+    sentry_sdk.metrics.count(
+        "pr_metrics.delegated_agent.seer_match.sent",
+        1,
+        attributes={"provider": provider_hint},
+    )
 
 
 def _write_mcp_attribution(pr: PullRequest) -> None:

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -250,7 +250,7 @@ def make_match_coding_agent_pr_request(
     return make_signed_seer_api_request(
         connection_pool or autofix_connection_pool,
         "/v1/pr-metrics/delegated-agent-match",
-        body=orjson.dumps(body.dict()),
+        body=orjson.dumps(body.dict(exclude_none=True)),
         timeout=timeout,
         viewer_context=viewer_context,
     )

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -231,6 +231,31 @@ def make_update_coding_agent_state_request(
     )
 
 
+class MatchDelegatedAgentPrRequest(BaseModel):
+    organization_id: int
+    pull_request_id: int
+    pr_url: str
+    repo: SeerRepoDefinition
+    head_branch: str
+    provider: str
+    group_ids: list[int]
+
+
+def make_match_coding_agent_pr_request(
+    body: MatchDelegatedAgentPrRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+    timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or autofix_connection_pool,
+        "/v1/pr-metrics/delegated-agent-match",
+        body=orjson.dumps(body.dict()),
+        timeout=timeout,
+        viewer_context=viewer_context,
+    )
+
+
 def make_store_coding_agent_states_request(
     body: StoreCodingAgentStatesRequest,
     connection_pool: HTTPConnectionPool | None = None,

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -1823,12 +1823,17 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
 
 
+MATCH_RPC = "sentry.pr_metrics.webhooks.make_match_coding_agent_pr_request"
+
+
 @with_feature(["organizations:pr-metrics-attribution", "organizations:gen-ai-features"])
 @cell_silo_test
 class HandleDelegatedAgentDetectionTest(TestCase):
     def setUp(self) -> None:
         self.project = self.create_project(organization=self.organization)
-        self.repo = self.create_repo(self.project, provider="integrations:github", external_id="99")
+        self.repo = self.create_repo(
+            self.project, name="org/repo", provider="integrations:github", external_id="99"
+        )
         self.pr = self.create_pull_request(
             repository_id=self.repo.id,
             organization_id=self.organization.id,
@@ -1852,11 +1857,13 @@ class HandleDelegatedAgentDetectionTest(TestCase):
         head_ref: str = "feature/x",
         head_sha: str = "headsha123",
         number: int = 42,
+        html_url: str = "https://github.com/org/repo/pull/42",
     ) -> None:
         payload: dict[str, Any] = {
             "number": number,
             "user": {"id": user_id, "login": login},
             "head": {"ref": head_ref, "sha": head_sha},
+            "html_url": html_url,
         }
         handle_attribution(
             github_event=GithubWebhookType.PULL_REQUEST,
@@ -1865,95 +1872,135 @@ class HandleDelegatedAgentDetectionTest(TestCase):
             repo=self.repo,
         )
 
-    def _mock_count(self) -> Any:
-        return patch("sentry_sdk.metrics.count")
+    def _mock_seer(self, status: int = 202) -> Any:
+        mock_response = MagicMock()
+        mock_response.status = status
+        return patch(MATCH_RPC, return_value=mock_response)
 
-    # --- Candidate detection fires the signal ---
+    # --- Candidate detection calls Seer ---
 
-    def test_claude_branch_prefix_detects_candidate(self) -> None:
-        with self._mock_count() as mock_count:
+    def test_claude_branch_prefix_sends_to_seer(self) -> None:
+        with self._mock_seer() as mock_rpc:
             self._call(head_ref="claude/fix-the-bug")
 
-        mock_count.assert_called_once_with(
-            "pr_metrics.delegated_agent.seer_match.not_implemented",
-            1,
-            attributes={"provider_hint": "claude_code"},
-        )
+        mock_rpc.assert_called_once()
+        body = mock_rpc.call_args.args[0]
+        assert body.provider == "claude_code"
+        assert body.head_branch == "claude/fix-the-bug"
+        assert body.organization_id == self.organization.id
+        assert body.pull_request_id == self.pr.id
+        assert body.group_ids == [self.group.id]
+        assert body.repo.provider == "integrations:github"
+        assert body.repo.external_id == "99"
 
-    def test_copilot_branch_prefix_detects_candidate(self) -> None:
-        with self._mock_count() as mock_count:
+    def test_copilot_branch_prefix_sends_to_seer(self) -> None:
+        with self._mock_seer() as mock_rpc:
             self._call(head_ref="copilot/fix-the-bug")
 
-        assert mock_count.call_count == 1
-        assert mock_count.call_args.kwargs["attributes"]["provider_hint"] == "github_copilot"
+        mock_rpc.assert_called_once()
+        assert mock_rpc.call_args.args[0].provider == "github_copilot"
 
-    def test_copilot_author_login_detects_candidate(self) -> None:
-        # Copilot opens PRs from a non-prefixed branch but as a distinct bot user.
-        with self._mock_count() as mock_count:
+    def test_copilot_author_login_sends_to_seer(self) -> None:
+        with self._mock_seer() as mock_rpc:
             self._call(login="copilot-swe-agent[bot]", head_ref="some-branch")
 
-        assert mock_count.call_count == 1
-        assert mock_count.call_args.kwargs["attributes"]["provider_hint"] == "github_copilot"
+        mock_rpc.assert_called_once()
+        assert mock_rpc.call_args.args[0].provider == "github_copilot"
 
     def test_branch_prefix_takes_precedence_over_author(self) -> None:
-        with self._mock_count() as mock_count:
+        with self._mock_seer() as mock_rpc:
             self._call(login="copilot-swe-agent[bot]", head_ref="claude/fix")
 
-        assert mock_count.call_count == 1
-        assert mock_count.call_args.kwargs["attributes"]["provider_hint"] == "claude_code"
+        mock_rpc.assert_called_once()
+        assert mock_rpc.call_args.args[0].provider == "claude_code"
 
-    # --- Non-candidates do not fire ---
+    def test_sent_metric_incremented_on_success(self) -> None:
+        with self._mock_seer(status=202), patch(f"{MODULE}.metrics.incr") as mock_incr:
+            self._call(head_ref="claude/fix")
 
-    def test_non_candidate_branch_and_author_does_not_detect(self) -> None:
-        with self._mock_count() as mock_count:
+        assert any(
+            call.args == ("pr_metrics.delegated_agent.seer_match.sent",)
+            for call in mock_incr.call_args_list
+        )
+
+    # --- Error handling ---
+
+    def test_seer_non_2xx_logs_warning_and_error_metric(self) -> None:
+        with self._mock_seer(status=500), patch(f"{MODULE}.metrics.incr") as mock_incr:
+            self._call(head_ref="claude/fix")
+
+        assert any(
+            call.kwargs.get("tags", {}).get("reason") == "bad_status"
+            for call in mock_incr.call_args_list
+        )
+
+    def test_seer_exception_logs_warning_and_error_metric(self) -> None:
+        with (
+            patch(MATCH_RPC, side_effect=Exception("network error")),
+            patch(f"{MODULE}.metrics.incr") as mock_incr,
+        ):
+            self._call(head_ref="claude/fix")
+
+        assert any(
+            call.kwargs.get("tags", {}).get("reason") == "exception"
+            for call in mock_incr.call_args_list
+        )
+
+    def test_seer_exception_does_not_propagate(self) -> None:
+        with patch(MATCH_RPC, side_effect=Exception("network error")):
+            self._call(head_ref="claude/fix")  # must not raise
+
+    # --- Non-candidates do not call Seer ---
+
+    def test_non_candidate_branch_and_author_does_not_call_seer(self) -> None:
+        with self._mock_seer() as mock_rpc:
             self._call(login="a-human", head_ref="feature/x")
 
-        mock_count.assert_not_called()
+        mock_rpc.assert_not_called()
 
-    def test_non_opened_action_does_not_detect(self) -> None:
+    def test_non_opened_action_does_not_call_seer(self) -> None:
         for action in ("synchronize", "closed", "reopened", "edited", "labeled"):
-            with self._mock_count() as mock_count:
+            with self._mock_seer() as mock_rpc:
                 self._call(action=action, head_ref="claude/fix")
-                mock_count.assert_not_called()
+                mock_rpc.assert_not_called()
 
     # --- Gating ---
 
-    def test_attribution_flag_off_does_not_detect(self) -> None:
-        with self._mock_count() as mock_count:
+    def test_attribution_flag_off_does_not_call_seer(self) -> None:
+        with self._mock_seer() as mock_rpc:
             with self.feature({"organizations:pr-metrics-attribution": False}):
                 self._call(head_ref="claude/fix")
 
-        mock_count.assert_not_called()
+        mock_rpc.assert_not_called()
 
-    def test_no_seer_access_via_flag_does_not_detect(self) -> None:
-        with self._mock_count() as mock_count:
+    def test_no_seer_access_via_flag_does_not_call_seer(self) -> None:
+        with self._mock_seer() as mock_rpc:
             with self.feature({"organizations:gen-ai-features": False}):
                 self._call(head_ref="claude/fix")
 
-        mock_count.assert_not_called()
+        mock_rpc.assert_not_called()
 
-    def test_no_seer_access_via_hidden_ai_features_does_not_detect(self) -> None:
+    def test_no_seer_access_via_hidden_ai_features_does_not_call_seer(self) -> None:
         self.organization.update_option("sentry:hide_ai_features", True)
 
-        with self._mock_count() as mock_count:
+        with self._mock_seer() as mock_rpc:
             self._call(head_ref="claude/fix")
 
-        mock_count.assert_not_called()
+        mock_rpc.assert_not_called()
 
-    def test_missing_pr_does_not_detect(self) -> None:
-        # Candidate gate passes, but no PullRequest row exists for this number.
-        with self._mock_count() as mock_count:
+    def test_missing_pr_does_not_call_seer(self) -> None:
+        with self._mock_seer() as mock_rpc:
             self._call(head_ref="claude/fix", number=9999)
 
-        mock_count.assert_not_called()
+        mock_rpc.assert_not_called()
 
-    def test_no_linked_groups_does_not_detect(self) -> None:
+    def test_no_linked_groups_does_not_call_seer(self) -> None:
         GroupLink.objects.filter(
             linked_type=GroupLink.LinkedType.pull_request,
             linked_id=self.pr.id,
         ).delete()
 
-        with self._mock_count() as mock_count:
+        with self._mock_seer() as mock_rpc:
             self._call(head_ref="claude/fix")
 
-        mock_count.assert_not_called()
+        mock_rpc.assert_not_called()

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -1915,34 +1915,35 @@ class HandleDelegatedAgentDetectionTest(TestCase):
         assert mock_rpc.call_args.args[0].provider == "claude_code"
 
     def test_sent_metric_incremented_on_success(self) -> None:
-        with self._mock_seer(status=202), patch(f"{MODULE}.metrics.incr") as mock_incr:
+        with self._mock_seer(status=202), patch(f"{MODULE}.sentry_sdk.metrics.count") as mock_incr:
             self._call(head_ref="claude/fix")
 
         assert any(
-            call.args == ("pr_metrics.delegated_agent.seer_match.sent",)
+            call.args[0] == "pr_metrics.delegated_agent.seer_match.sent"
+            and call.kwargs.get("attributes", {}).get("provider") == "claude_code"
             for call in mock_incr.call_args_list
         )
 
     # --- Error handling ---
 
     def test_seer_non_2xx_logs_warning_and_error_metric(self) -> None:
-        with self._mock_seer(status=500), patch(f"{MODULE}.metrics.incr") as mock_incr:
+        with self._mock_seer(status=500), patch(f"{MODULE}.sentry_sdk.metrics.count") as mock_incr:
             self._call(head_ref="claude/fix")
 
         assert any(
-            call.kwargs.get("tags", {}).get("reason") == "bad_status"
+            call.kwargs.get("attributes", {}).get("reason") == "bad_status"
             for call in mock_incr.call_args_list
         )
 
     def test_seer_exception_logs_warning_and_error_metric(self) -> None:
         with (
             patch(MATCH_RPC, side_effect=Exception("network error")),
-            patch(f"{MODULE}.metrics.incr") as mock_incr,
+            patch(f"{MODULE}.sentry_sdk.metrics.count") as mock_incr,
         ):
             self._call(head_ref="claude/fix")
 
         assert any(
-            call.kwargs.get("tags", {}).get("reason") == "exception"
+            call.kwargs.get("attributes", {}).get("reason") == "exception"
             for call in mock_incr.call_args_list
         )
 

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -2005,3 +2005,21 @@ class HandleDelegatedAgentDetectionTest(TestCase):
             self._call(head_ref="claude/fix")
 
         mock_rpc.assert_not_called()
+
+    def test_repo_missing_provider_does_not_call_seer(self) -> None:
+        self.repo.provider = None
+        self.repo.save()
+
+        with self._mock_seer() as mock_rpc:
+            self._call(head_ref="claude/fix")
+
+        mock_rpc.assert_not_called()
+
+    def test_repo_missing_external_id_does_not_call_seer(self) -> None:
+        self.repo.external_id = None
+        self.repo.save()
+
+        with self._mock_seer() as mock_rpc:
+            self._call(head_ref="claude/fix")
+
+        mock_rpc.assert_not_called()


### PR DESCRIPTION
Wires the real Seer call into `_detect_delegated_agent`, replacing the no-op stub landed in CW-1486.

When a freshly-opened GitHub PR passes the delegated-agent candidate gate (branch prefix or bot author login) and resolves at least one Sentry issue, Sentry now POSTs to Seer's `POST /v1/pr-metrics/delegated-agent-match`. Seer confirms the match against recorded coding-agent launches and, on a positive match, calls back via the existing `record_pr_attribution` RPC to write a `SEER_DELEGATED_<provider>` attribution row. The call is fire-and-forget — Sentry does not read a verdict from the response.

Errors (network exceptions, non-2xx responses) are swallowed with a warning log and a `pr_metrics.delegated_agent.seer_match.error` metric, so a Seer outage cannot break the webhook path.

**New additions:**
- `MatchRepoDefinition` / `MatchDelegatedAgentPrRequest` pydantic models in `seer/autofix/utils.py`, alongside the existing coding-agent state helpers
- `make_match_coding_agent_pr_request()` signing and sending the POST via the existing Seer autofix connection pool
- `_detect_delegated_agent` in `webhooks.py` now builds the full request body and calls Seer instead of emitting a metric stub

Blocked on Seer PR getsentry/seer#6992 (the match endpoint) merging first.

Refs CW-1488