### PR TITLE
feat(autofix): push changes after PR iteration

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -184,12 +184,12 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                 webhook_action_type = SeerActionType.CODING_COMPLETED
                 webhook_payload["code_changes"] = cls._format_code_changes_payload(state)
         elif current_step == AutofixStep.PR_ITERATION:
-            # PR iteration only runs against an existing PR, so there should be pr states.
-            if not state.repo_pr_states:
-                logger.error(
-                    "autofix.on_completion_hook.pr_iteration_missing_repo_pr_states",
-                    extra={"run_id": run_id, "organization_id": organization.id},
-                )
+            assert state.repo_pr_states, "PR iteration must have repo pr states"
+
+            # we only want to emit this webhook after the iteration changes are pushed
+            _, is_synced = state.has_code_changes()
+            if not is_synced and not cls._iteration_terminal_errored_repos(state):
+                return
             webhook_action_type = SeerActionType.ITERATION_COMPLETED
             iteration_index = get_latest_iteration_index(state)
             webhook_payload["pull_requests"] = cls._format_pull_requests_payload(state)
@@ -414,6 +414,14 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                     },
                 )
 
+        # PR iteration runs against an existing PR rather than the automated
+        # pipeline. Once the agent finishes iterating, push the new changes to
+        # update that PR. _push_changes is a no-op once the repos are synced, so
+        # the hook re-fire after the push doesn't loop.
+        if current_step == AutofixStep.PR_ITERATION:
+            cls._push_changes(group, run_id, state)
+            return
+
         if stopping_point is None or reached_stopping_point:
             # We've reached the stopping point
             return
@@ -496,6 +504,28 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             return introspect_iteration(organization, run_id, state, group)
 
     @classmethod
+    def _iteration_terminal_errored_repos(cls, state: SeerRunState) -> list[str]:
+        """
+        Return the errored repos when unsynced repos have terminal push failures.
+
+        Returns an empty list when there are no errored repos, or when some
+        non-errored repo is still unsynced (i.e. a push can still make progress).
+        Used to stop waiting for a synced PR after push errors without retrying.
+        """
+        diffs_by_repo = state.get_diffs_by_repo()
+        errored_repos = [
+            repo
+            for repo in diffs_by_repo
+            if (pr_state := state.repo_pr_states.get(repo)) is not None
+            and pr_state.pr_creation_status == "error"
+        ]
+        if not errored_repos:
+            return []
+        if all(state._is_repo_synced(repo) or repo in errored_repos for repo in diffs_by_repo):
+            return errored_repos
+        return []
+
+    @classmethod
     def _push_changes(cls, group: Group, run_id: int, state: SeerRunState) -> None:
         """Push code changes to create PRs."""
         # Check if there are code changes to push
@@ -513,16 +543,8 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             return
 
         # Errored repos are terminal — re-pushing would re-fire this hook in a loop.
-        diffs_by_repo = state.get_diffs_by_repo()
-        errored_repos = [
-            repo
-            for repo in diffs_by_repo
-            if (pr_state := state.repo_pr_states.get(repo)) is not None
-            and pr_state.pr_creation_status == "error"
-        ]
-        if errored_repos and all(
-            state._is_repo_synced(repo) or repo in errored_repos for repo in diffs_by_repo
-        ):
+        errored_repos = cls._iteration_terminal_errored_repos(state)
+        if errored_repos:
             logger.info(
                 "autofix.on_completion_hook.skip_no_pushable_repos",
                 extra={

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -532,6 +532,35 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
         assert "ai.autofix.pr_created.completed" not in event_names
 
     @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
+    def test_send_step_webhook_pr_iteration_skips_until_synced(self, mock_broadcast):
+        """Does not emit iteration_completed until the pushed PR is synced to the iteration."""
+        state = run_state(
+            blocks=[
+                root_cause_memory_block(),
+                solution_memory_block(),
+                code_changes_memory_block(),
+                pr_iteration_memory_block(
+                    referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT.value,
+                    commit_sha="iteration-sha",
+                ),
+            ]
+        )
+        state.repo_pr_states = {
+            "test-repo": RepoPRState(
+                repo_name="test-repo",
+                pr_id=77,
+                pr_number=7,
+                pr_url="https://example.com/pull/7",
+                pr_creation_status="completed",
+                commit_sha="stale-sha",
+            )
+        }
+
+        AutofixOnCompletionHook._send_step_webhook(self.organization, 123, state, self.group)
+
+        mock_broadcast.assert_not_called()
+
+    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
     def test_send_step_webhook_no_artifacts_no_webhook(self, mock_broadcast):
         """Does not send webhook when no artifacts or file patches exist."""
         block = MemoryBlock(

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -99,7 +99,11 @@ def code_changes_memory_block(referrer: str | None = None) -> MemoryBlock:
     )
 
 
-def pr_iteration_memory_block(referrer: str | None = None, iteration_index: int = 1) -> MemoryBlock:
+def pr_iteration_memory_block(
+    referrer: str | None = None,
+    iteration_index: int = 1,
+    commit_sha: str | None = None,
+) -> MemoryBlock:
     metadata: dict[str, str] = {
         "step": "pr_iteration",
         "iteration_index": str(iteration_index),
@@ -121,6 +125,7 @@ def pr_iteration_memory_block(referrer: str | None = None, iteration_index: int 
                 patch=FilePatch(path="test.py", type="M", added=2, removed=1),
             )
         ],
+        pr_commit_shas={"test-repo": commit_sha} if commit_sha is not None else None,
     )
 
 
@@ -465,7 +470,10 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
                 root_cause_memory_block(),
                 solution_memory_block(),
                 code_changes_memory_block(),
-                pr_iteration_memory_block(referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT.value),
+                pr_iteration_memory_block(
+                    referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT.value,
+                    commit_sha="synced-sha",
+                ),
             ]
         )
         state.repo_pr_states = {
@@ -475,6 +483,7 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
                 pr_number=7,
                 pr_url="https://example.com/pull/7",
                 pr_creation_status="completed",
+                commit_sha="synced-sha",
             )
         }
 
@@ -499,7 +508,7 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
         state = run_state(
             blocks=[
                 code_changes_memory_block(),
-                pr_iteration_memory_block(),
+                pr_iteration_memory_block(commit_sha="synced-sha"),
             ]
         )
         state.repo_pr_states = {
@@ -509,6 +518,7 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
                 pr_number=7,
                 pr_url="https://example.com/pull/7",
                 pr_creation_status="completed",
+                commit_sha="synced-sha",
             )
         }
 


### PR DESCRIPTION
we want to push changes immediately after each PR iteration automatically

i'm putting this functionality in the completion hook, so we'll run the PR iteration by manually trigger the agent by calling the endpoint in seer as a result of user input in the UI or webhooks

then after that explorer agent is done the PR iteration it will call the `on_completion_hook` which will check whether the changes have been pushed (they haven't been at this point), and trigger the `push_changes` flow, which will update the PR

the task that runs the `push_changes` logic will call the completion hook again, the hook will see that the PR and the conversation have been synced, and we'll mark the iteration as completed and record other signals / events