### PR TITLE
fix(tracemetrics): Use portal to prevent clipping of dropdown menus

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricToolbar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricToolbar.tsx
@@ -88,7 +88,11 @@ export function MetricToolbar({
         {isFunction ? (
           <Fragment>
             <Flex flex="2" minWidth="0">
-              <MetricSelector traceMetric={traceMetric} onChange={setTraceMetric} />
+              <MetricSelector
+                traceMetric={traceMetric}
+                onChange={setTraceMetric}
+                usePortal
+              />
             </Flex>
             <Flex flex="1" minWidth="0">
               <AggregateDropdown traceMetric={traceMetric} singleSelect />
@@ -102,7 +106,11 @@ export function MetricToolbar({
           />
         ) : null}
         <Flex flex="1 1 100%" minWidth="0">
-          <Filter traceMetric={traceMetric} skipTraceMetricFilter={isEquation} />
+          <Filter
+            traceMetric={traceMetric}
+            skipTraceMetricFilter={isEquation}
+            portalTarget={document.body}
+          />
         </Flex>
       </Flex>
 

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -39,6 +39,7 @@ const EMPTY_ALIASES: TagCollection = {};
 interface FilterProps {
   traceMetric: TraceMetric;
   environments?: string[];
+  portalTarget?: HTMLElement;
   projectIds?: number[];
   skipTraceMetricFilter?: boolean;
 }
@@ -66,6 +67,7 @@ export function Filter({
   skipTraceMetricFilter,
   projectIds,
   environments,
+  portalTarget,
 }: FilterProps) {
   const query = useQueryParamsQuery();
   const setQuery = useSetQueryParamsQuery();
@@ -178,6 +180,7 @@ export function Filter({
         projects: projectIds,
         environments,
         disabled: isSearchBarDisabled,
+        portalTarget,
 
         // Disable the recent searches when not using a trace metric filter or when the metric name
         // is not set because the recent searches for metrics need to be namespaced on the trace metric filter.
@@ -195,6 +198,7 @@ export function Filter({
       projectIds,
       environments,
       isSearchBarDisabled,
+      portalTarget,
     ]);
 
   const searchQueryBuilderProviderProps = useTraceItemSearchQueryBuilderProps(


### PR DESCRIPTION
Use portals to prevent clipping of the metric selector dropdowns and filter bar dropdowns.

Before:
<img width="613" height="560" alt="Screenshot 2026-06-17 at 11 30 45 AM" src="https://github.com/user-attachments/assets/a1202a9d-cd7d-421a-b616-0735cd6d1d25" />
<img width="796" height="556" alt="Screenshot 2026-06-17 at 11 28 13 AM" src="https://github.com/user-attachments/assets/db723b52-1c70-42b7-9446-c0b504d5b125" />

After:
<img width="1352" height="557" alt="Screenshot 2026-06-17 at 11 31 01 AM" src="https://github.com/user-attachments/assets/525babe0-190a-4f5f-8dc8-db29a82b164d" />
<img width="953" height="613" alt="Screenshot 2026-06-17 at 11 27 29 AM" src="https://github.com/user-attachments/assets/72aa72b1-35c3-418c-b4e7-d64bf5d03b44" />
