### PR TITLE
ref(seer): Type the last five seer RPC methods and lock the registries

### DIFF
--- a/src/sentry/seer/agent/custom_tool_utils.py
+++ b/src/sentry/seer/agent/custom_tool_utils.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from sentry.models.organization import Organization
 from sentry.seer.agent.client_models import CustomToolDefinition
+from sentry.seer.sentry_data_models import CallCustomToolResponse
 
 ParamsT = TypeVar("ParamsT", bound=BaseModel)
 
@@ -107,7 +108,7 @@ def call_custom_tool(
     organization_id: int,
     allowed_prefixes: tuple[str, ...] = ("sentry.",),
     **kwargs: Any,
-) -> str:
+) -> CallCustomToolResponse:
     """Dynamically import and call a custom tool class.
 
     Args:
@@ -165,4 +166,4 @@ def call_custom_tool(
     if not isinstance(result, str):
         raise RuntimeError(f"Custom tool {module_path} must return str, got {type(result)}")
 
-    return result
+    return CallCustomToolResponse(__root__=result)

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -67,6 +67,8 @@ from sentry.seer.sentry_data_models import (
     EventDetailsResponse,
     ExecuteQueryErrorResponse,
     ExecuteQuerySuccessResponse,
+    ExecuteTimeseriesQueryErrorResponse,
+    ExecuteTimeseriesQuerySuccessResponse,
     GetDsnResponse,
     IssueAndEventDetailsResponse,
     IssueDetailsResponse,
@@ -262,7 +264,7 @@ def execute_timeseries_query(
     sampling_mode: SAMPLING_MODES = "NORMAL",
     partial: bool | None = None,
     case_insensitive: bool | None = None,
-) -> dict[str, Any] | None:
+) -> ExecuteTimeseriesQuerySuccessResponse | ExecuteTimeseriesQueryErrorResponse | None:
     """
     Execute a query to get chart/timeseries data by calling the events-stats endpoint.
 
@@ -333,11 +335,9 @@ def execute_timeseries_query(
         if e.status_code == 400:
             logger.exception("execute_timeseries_query: bad request", extra={"org_id": org_id})
             error_detail = e.body.get("detail") if isinstance(e.body, dict) else None
-            return {
-                "_seer_error_detail": (
-                    str(error_detail) if error_detail is not None else str(e.body)
-                )
-            }
+            return ExecuteTimeseriesQueryErrorResponse(
+                seer_error_detail=(str(error_detail) if error_detail is not None else str(e.body))
+            )
         raise
     data = resp.data
 
@@ -347,20 +347,22 @@ def execute_timeseries_query(
     if metric_name and metric_is_single:
         # Handle grouped data with single metric: wrap each group's data in the metric name
         if group_by:
-            return {
-                group_value: (
-                    {metric_name: group_data}
-                    if isinstance(group_data, dict) and "data" in group_data
-                    else group_data
-                )
-                for group_value, group_data in data.items()
-            }
+            return ExecuteTimeseriesQuerySuccessResponse(
+                __root__={
+                    group_value: (
+                        {metric_name: group_data}
+                        if isinstance(group_data, dict) and "data" in group_data
+                        else group_data
+                    )
+                    for group_value, group_data in data.items()
+                }
+            )
 
         # Handle non-grouped data with single metric: wrap data in the metric name
         if isinstance(data, dict) and "data" in data:
-            return {metric_name: data}
+            return ExecuteTimeseriesQuerySuccessResponse(__root__={metric_name: data})
 
-    return data
+    return ExecuteTimeseriesQuerySuccessResponse(__root__=data)
 
 
 def execute_trace_table_query(
@@ -1018,9 +1020,9 @@ def _get_issue_event_timeseries(
         partial=True,
     )
 
-    if data is None or data.get("_seer_error_detail"):
+    if data is None or isinstance(data, ExecuteTimeseriesQueryErrorResponse):
         return None
-    return data, selected_period, interval
+    return data.dict(), selected_period, interval
 
 
 def _get_recommended_event(

--- a/src/sentry/seer/assisted_query/issues_tools.py
+++ b/src/sentry/seer/assisted_query/issues_tools.py
@@ -11,6 +11,8 @@ from sentry.models.release import Release
 from sentry.models.team import Team, TeamStatus
 from sentry.seer.autofix.constants import FixabilityScoreThresholds
 from sentry.seer.sentry_data_models import (
+    ExecuteIssuesQuerySuccessResponse,
+    ExecuteQueryErrorResponse,
     FilterKeyValuesResponse,
     IssueFilterBuiltInField,
     IssueFilterKeysResponse,
@@ -673,7 +675,7 @@ def execute_issues_query(
     end: str | None = None,
     sort: str | None = None,
     limit: int = 25,
-) -> list[dict[str, Any]] | dict[str, Any] | None:
+) -> ExecuteIssuesQuerySuccessResponse | ExecuteQueryErrorResponse | None:
     """
     Execute an issues query by calling the issues endpoint.
 
@@ -722,11 +724,13 @@ def execute_issues_query(
             path=f"/organizations/{organization.slug}/issues/",
             params=params,
         )
-        return resp.data
+        return ExecuteIssuesQuerySuccessResponse(__root__=resp.data)
     except ApiError as e:
         if e.status_code == 400:
             error_detail = e.body.get("detail") if isinstance(e.body, dict) else None
-            return {"error": str(error_detail) if error_detail is not None else str(e.body)}
+            return ExecuteQueryErrorResponse(
+                error=str(error_detail) if error_detail is not None else str(e.body)
+            )
         raise
 
 

--- a/src/sentry/seer/endpoints/organization_seer_rpc.py
+++ b/src/sentry/seer/endpoints/organization_seer_rpc.py
@@ -1,5 +1,4 @@
 import logging
-from collections.abc import Callable
 from typing import Any
 
 import sentry_sdk
@@ -61,6 +60,7 @@ from sentry.seer.assisted_query.traces_tools import (
     get_attribute_values_with_substring,
 )
 from sentry.seer.autofix.autofix_tools import get_error_event_details, get_profile_details
+from sentry.seer.endpoints.registry import SeerRpcMethod, seer_rpc
 from sentry.seer.endpoints.seer_rpc import (
     get_attributes_and_values,
     get_attributes_for_span,
@@ -79,58 +79,75 @@ from sentry.viewer_context import get_viewer_context, observe_viewer_context_pro
 logger = logging.getLogger(__name__)
 
 
+# Every value in the registries below MUST be a function returning a
+# `pydantic.BaseModel` (or a union of `BaseModel` subclasses, optionally with
+# `None`). Two complementary guards enforce this:
+#   1. The `dict[str, SeerRpcMethod]` annotation rejects `dict` /
+#      `dict[str, Any]` / generic `Callable` returns at type-check time.
+#   2. Wrapping each value with `seer_rpc(...)` triggers the custom mypy plugin
+#      (`tools.mypy_helpers.plugin._check_seer_rpc_handler_not_any`) to walk
+#      the registered function's return type and reject any `Any`. Without
+#      this, `-> Any` would slip past the structural check because `Any` is
+#      bidirectionally compatible with everything.
+# To add a method, define a Pydantic response model in
+# `sentry.seer.sentry_data_models`, annotate the handler with it, and register
+# the handler as `"name": seer_rpc(handler)`.
+
+
 # Registry of read-only telemetry methods that are safe to expose
 # to organization members for local agent development
 # These methods support organization-level or cross-project access
 #
 # Parameter conventions:
 # - `organization_id` (int): Organization ID, auto-injected and validated. use map_org_id_param to map to `org_id` if needed.
-public_org_seer_method_registry: dict[str, Callable] = {
+public_org_seer_method_registry: dict[str, SeerRpcMethod] = {
     # Common to Seer features
-    "get_organization_project_ids": map_org_id_param(get_organization_project_ids),
-    "get_organization_slug": map_org_id_param(get_organization_slug),
-    "get_organization_features": map_org_id_param(get_organization_features),
-    "validate_repo": validate_repo,
-    "get_github_enterprise_integration_config": get_github_enterprise_integration_config,
+    "get_organization_project_ids": seer_rpc(map_org_id_param(get_organization_project_ids)),
+    "get_organization_slug": seer_rpc(map_org_id_param(get_organization_slug)),
+    "get_organization_features": seer_rpc(map_org_id_param(get_organization_features)),
+    "validate_repo": seer_rpc(validate_repo),
+    "get_github_enterprise_integration_config": seer_rpc(get_github_enterprise_integration_config),
     #
     # Bug prediction
-    "has_repo_code_mappings": has_repo_code_mappings,
-    "get_issues_by_function_name": by_function_name.fetch_issues,
-    "get_issues_related_to_exception_type": by_error_type.fetch_issues,
-    "get_issues_by_raw_query": by_text_query.fetch_issues,
-    "get_latest_issue_event": utils.get_latest_issue_event,
+    "has_repo_code_mappings": seer_rpc(has_repo_code_mappings),
+    "get_issues_by_function_name": seer_rpc(by_function_name.fetch_issues),
+    "get_issues_related_to_exception_type": seer_rpc(by_error_type.fetch_issues),
+    "get_issues_by_raw_query": seer_rpc(by_text_query.fetch_issues),
+    "get_latest_issue_event": seer_rpc(utils.get_latest_issue_event),
     #
     # Assisted query (cross-project)
-    "get_attribute_names": map_org_id_param(get_attribute_names),
-    "get_attribute_values_with_substring": map_org_id_param(get_attribute_values_with_substring),
-    "get_attributes_and_values": map_org_id_param(get_attributes_and_values),
-    "get_metric_metadata": map_org_id_param(get_metric_metadata),
-    "get_event_filter_keys": map_org_id_param(get_event_filter_keys),
-    "get_event_filter_key_values": map_org_id_param(get_event_filter_key_values),
-    "get_issue_filter_keys": map_org_id_param(get_issue_filter_keys),
-    "get_filter_key_values": map_org_id_param(get_filter_key_values),
+    "get_attribute_names": seer_rpc(map_org_id_param(get_attribute_names)),
+    "get_attribute_values_with_substring": seer_rpc(
+        map_org_id_param(get_attribute_values_with_substring)
+    ),
+    "get_attributes_and_values": seer_rpc(map_org_id_param(get_attributes_and_values)),
+    "get_metric_metadata": seer_rpc(map_org_id_param(get_metric_metadata)),
+    "get_event_filter_keys": seer_rpc(map_org_id_param(get_event_filter_keys)),
+    "get_event_filter_key_values": seer_rpc(map_org_id_param(get_event_filter_key_values)),
+    "get_issue_filter_keys": seer_rpc(map_org_id_param(get_issue_filter_keys)),
+    "get_filter_key_values": seer_rpc(map_org_id_param(get_filter_key_values)),
     #
     # Agent (cross-project)
-    "get_trace_waterfall": rpc_get_trace_waterfall,
-    "get_repository_definition": get_repository_definition,
-    "execute_table_query": map_org_id_param(execute_table_query),
-    "execute_timeseries_query": map_org_id_param(execute_timeseries_query),
-    "execute_trace_table_query": execute_trace_table_query,
-    "execute_issues_query": map_org_id_param(execute_issues_query),
-    "get_issue_and_event_details_v2": get_issue_and_event_details_v2,
-    "get_issue_details": get_issue_details,
-    "get_event_details": get_event_details,
-    "get_profile_flamegraph": rpc_get_profile_flamegraph,
-    "get_replay_metadata": get_replay_metadata,
-    "get_log_attributes_for_trace": map_org_id_param(get_log_attributes_for_trace),
-    "get_metric_attributes_for_trace": map_org_id_param(get_metric_attributes_for_trace),
-    "get_issues_stats": map_org_id_param(get_issues_stats),
-    "get_baseline_tag_distribution": get_baseline_tag_distribution,
-    "get_comparative_attribute_distributions": get_comparative_attribute_distributions,
-    "get_dsn": get_dsn,
+    "get_trace_waterfall": seer_rpc(rpc_get_trace_waterfall),
+    "get_repository_definition": seer_rpc(get_repository_definition),
+    "execute_table_query": seer_rpc(map_org_id_param(execute_table_query)),
+    "execute_timeseries_query": seer_rpc(map_org_id_param(execute_timeseries_query)),
+    "execute_trace_table_query": seer_rpc(execute_trace_table_query),
+    "execute_issues_query": seer_rpc(map_org_id_param(execute_issues_query)),
+    "get_issue_and_event_details_v2": seer_rpc(get_issue_and_event_details_v2),
+    "get_issue_details": seer_rpc(get_issue_details),
+    "get_event_details": seer_rpc(get_event_details),
+    "get_profile_flamegraph": seer_rpc(rpc_get_profile_flamegraph),
+    "get_replay_metadata": seer_rpc(get_replay_metadata),
+    "get_log_attributes_for_trace": seer_rpc(map_org_id_param(get_log_attributes_for_trace)),
+    "get_metric_attributes_for_trace": seer_rpc(map_org_id_param(get_metric_attributes_for_trace)),
+    "get_issues_stats": seer_rpc(map_org_id_param(get_issues_stats)),
+    "get_baseline_tag_distribution": seer_rpc(get_baseline_tag_distribution),
+    "get_comparative_attribute_distributions": seer_rpc(get_comparative_attribute_distributions),
+    "get_dsn": seer_rpc(get_dsn),
     #
     # Agent eval tooling
-    "export_explorer_indexes": map_org_id_param(export_agent_indexes),
+    "export_explorer_indexes": seer_rpc(map_org_id_param(export_agent_indexes)),
 }
 
 
@@ -140,19 +157,25 @@ public_org_seer_method_registry: dict[str, Callable] = {
 # Parameter conventions:
 # - `organization_id` (int): Organization ID, auto-injected and validated
 # - `project_id` (int): Project ID, must be provided in request args and validated
-public_project_seer_method_registry: dict[str, Callable] = {
+public_project_seer_method_registry: dict[str, SeerRpcMethod] = {
     # Agent - project-scoped methods
-    "get_transactions_for_project": accept_organization_id_param(rpc_get_transactions_for_project),
-    "get_trace_for_transaction": accept_organization_id_param(rpc_get_trace_for_transaction),
-    "get_profiles_for_trace": accept_organization_id_param(rpc_get_profiles_for_trace),
-    "get_issues_for_transaction": accept_organization_id_param(rpc_get_issues_for_transaction),
+    "get_transactions_for_project": seer_rpc(
+        accept_organization_id_param(rpc_get_transactions_for_project)
+    ),
+    "get_trace_for_transaction": seer_rpc(
+        accept_organization_id_param(rpc_get_trace_for_transaction)
+    ),
+    "get_profiles_for_trace": seer_rpc(accept_organization_id_param(rpc_get_profiles_for_trace)),
+    "get_issues_for_transaction": seer_rpc(
+        accept_organization_id_param(rpc_get_issues_for_transaction)
+    ),
     # Autofix - project-scoped methods
-    "get_error_event_details": accept_organization_id_param(get_error_event_details),
-    "get_profile_details": get_profile_details,
-    "get_attributes_for_span": map_org_id_param(get_attributes_for_span),
-    "get_trace_item_attributes": map_org_id_param(get_trace_item_attributes),
+    "get_error_event_details": seer_rpc(accept_organization_id_param(get_error_event_details)),
+    "get_profile_details": seer_rpc(get_profile_details),
+    "get_attributes_for_span": seer_rpc(map_org_id_param(get_attributes_for_span)),
+    "get_trace_item_attributes": seer_rpc(map_org_id_param(get_trace_item_attributes)),
     # Replays - project-scoped methods
-    "get_replay_summary_logs": accept_organization_id_param(rpc_get_replay_summary_logs),
+    "get_replay_summary_logs": seer_rpc(accept_organization_id_param(rpc_get_replay_summary_logs)),
 }
 
 

--- a/src/sentry/seer/endpoints/registry.py
+++ b/src/sentry/seer/endpoints/registry.py
@@ -1,0 +1,35 @@
+"""Type-only registration marker for seer RPC handlers.
+
+Each entry in `seer_method_registry`, `public_org_seer_method_registry`, and
+`public_project_seer_method_registry` must wrap its handler in `seer_rpc(...)`.
+The wrap is a runtime identity — no behavior change — but it gives the custom
+mypy plugin (`tools.mypy_helpers.plugin.SentryMypyPlugin`) a hook to verify
+the handler's declared return type contains no `Any`.
+
+**Why**: the seer-side codegen reads each registered method's return
+annotation, builds a JSON-schema manifest, and emits `Literal[method] →
+ReturnType` overloads on `RpcClient.call`. An `Any` return at this layer
+collapses the typed contract for that method on the consumer side — the
+seer-side `result = rpc_client.call("foo", ...)` loses its specific return
+type and degrades to `Any`. The structural
+`dict[str, Callable[..., BaseModel | None]]` annotation on the registries
+already rejects `dict` / `dict[str, Any]` / generic `Callable` returns, but
+`Any` is bidirectionally compatible with everything by design, so it slips
+past structural checks. The `seer_rpc()` marker + plugin hook close that hole.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+SeerRpcMethod = Callable[..., BaseModel | None]
+_RpcF = TypeVar("_RpcF", bound=SeerRpcMethod)
+
+
+def seer_rpc(fn: _RpcF) -> _RpcF:
+    """Marker the mypy plugin checks for `Any`-free return types; runtime
+    identity. See module docstring for the codegen-driven rationale."""
+    return fn

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -3,7 +3,6 @@ import hashlib
 import hmac
 import logging
 import uuid
-from collections.abc import Callable
 from typing import Any, TypedDict
 
 import sentry_sdk
@@ -122,6 +121,7 @@ from sentry.seer.autofix.utils import (
     read_preference_from_sentry_db,
 )
 from sentry.seer.constants import SeerSCMProvider
+from sentry.seer.endpoints.registry import SeerRpcMethod, seer_rpc
 from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
 from sentry.seer.fetch_issues import by_error_type, by_function_name, by_text_query, utils
 from sentry.seer.fetch_issues.utils import NoProjectsForRepoError, get_repo_and_projects
@@ -143,6 +143,8 @@ from sentry.seer.sentry_data_models import (
     OrganizationProjectIdsResponse,
     OrganizationSlugResponse,
     PrAttributionResponse,
+    RefreshMonitoringProviderTokenErrorResponse,
+    RefreshMonitoringProviderTokenSuccessResponse,
     RepositoryIntegrationsStatusResponse,
     SendSeerWebhookErrorResponse,
     SendSeerWebhookSuccessResponse,
@@ -931,40 +933,42 @@ def deliver_feature_result(
     handler(organization_id, run_uuid, status, result, error)
 
 
-def refresh_monitoring_provider_token(*, identity_id: int) -> dict:
+def refresh_monitoring_provider_token(
+    *, identity_id: int
+) -> RefreshMonitoringProviderTokenSuccessResponse | RefreshMonitoringProviderTokenErrorResponse:
     """Refresh the access token for a monitoring provider identity."""
     if not settings.SEER_GHE_ENCRYPT_KEY:
         logger.error("Cannot encrypt monitoring provider access token without SEER_GHE_ENCRYPT_KEY")
-        return {"error": "encryption_failed"}
+        return RefreshMonitoringProviderTokenErrorResponse(error="encryption_failed")
 
     identity = identity_service.get_identity(filter={"id": identity_id})
     if identity is None:
-        return {"error": "identity_not_found"}
+        return RefreshMonitoringProviderTokenErrorResponse(error="identity_not_found")
 
     idp = identity_service.get_provider(provider_id=identity.idp_id)
     if idp is None or idp.type not in MONITORING_PROVIDERS:
-        return {"error": "identity_not_found"}
+        return RefreshMonitoringProviderTokenErrorResponse(error="identity_not_found")
 
     try:
         provider = identity_manager.get(idp.type)
         provider.refresh_identity(identity)
     except IdentityNotValid:
-        return {"error": "identity_not_valid"}
+        return RefreshMonitoringProviderTokenErrorResponse(error="identity_not_valid")
     except (ApiError, KeyError, RequestException):
-        return {"error": "refresh_failed"}
+        return RefreshMonitoringProviderTokenErrorResponse(error="refresh_failed")
 
     access_token = identity.data.get("access_token")
     if not access_token:
-        return {"error": "identity_not_valid"}
+        return RefreshMonitoringProviderTokenErrorResponse(error="identity_not_valid")
 
     encrypted_access_token = encrypt_access_token_for_seer(access_token)
     if not encrypted_access_token:
-        return {"error": "encryption_failed"}
+        return RefreshMonitoringProviderTokenErrorResponse(error="encryption_failed")
 
-    return {
-        "encrypted_access_token": encrypted_access_token,
-        "expires": identity.data.get("expires"),
-    }
+    return RefreshMonitoringProviderTokenSuccessResponse(
+        encrypted_access_token=encrypted_access_token,
+        expires=identity.data.get("expires"),
+    )
 
 
 def record_pr_attribution(
@@ -1044,82 +1048,95 @@ def record_pr_attribution(
     return PrAttributionResponse(attribution_id=attribution.id)
 
 
-seer_method_registry: dict[str, Callable] = {  # return type must be serialized
+# Every value below MUST be a function returning a `pydantic.BaseModel` (or
+# a union of `BaseModel` subclasses, optionally with `None`). Two complementary
+# guards enforce this:
+#   1. The `dict[str, SeerRpcMethod]` annotation rejects `dict` /
+#      `dict[str, Any]` / generic `Callable` returns at type-check time.
+#   2. Wrapping each value with `seer_rpc(...)` triggers the custom mypy plugin
+#      (`tools.mypy_helpers.plugin._check_seer_rpc_handler_not_any`) to walk
+#      the registered function's return type and reject any `Any`. Without
+#      this, `-> Any` would slip past the structural check because `Any` is
+#      bidirectionally compatible with everything.
+# To add a method, define a Pydantic response model in
+# `sentry.seer.sentry_data_models`, annotate the handler with it, and register
+# the handler as `"name": seer_rpc(handler)`.
+seer_method_registry: dict[str, SeerRpcMethod] = {  # return type must be serialized
     # Common to Seer features
-    "get_github_enterprise_integration_config": get_github_enterprise_integration_config,
-    "get_organization_project_ids": get_organization_project_ids,
-    "get_organization_features": get_organization_features,
-    "check_repository_integrations_status": check_repository_integrations_status,
-    "validate_repo": validate_repo,
-    "get_repo_installation_id": get_repo_installation_id,
+    "get_github_enterprise_integration_config": seer_rpc(get_github_enterprise_integration_config),
+    "get_organization_project_ids": seer_rpc(get_organization_project_ids),
+    "get_organization_features": seer_rpc(get_organization_features),
+    "check_repository_integrations_status": seer_rpc(check_repository_integrations_status),
+    "validate_repo": seer_rpc(validate_repo),
+    "get_repo_installation_id": seer_rpc(get_repo_installation_id),
     #
     # Autofix
-    "get_organization_slug": get_organization_slug,
-    "get_organization_autofix_consent": get_organization_autofix_consent,
-    "get_error_event_details": get_error_event_details,
-    "get_profile_details": get_profile_details,
-    "send_seer_webhook": send_seer_webhook,
-    "get_attributes_for_span": get_attributes_for_span,
-    "get_project_preferences": get_project_preferences,
-    "bulk_get_project_preferences": bulk_get_project_preferences,
+    "get_organization_slug": seer_rpc(get_organization_slug),
+    "get_organization_autofix_consent": seer_rpc(get_organization_autofix_consent),
+    "get_error_event_details": seer_rpc(get_error_event_details),
+    "get_profile_details": seer_rpc(get_profile_details),
+    "send_seer_webhook": seer_rpc(send_seer_webhook),
+    "get_attributes_for_span": seer_rpc(get_attributes_for_span),
+    "get_project_preferences": seer_rpc(get_project_preferences),
+    "bulk_get_project_preferences": seer_rpc(bulk_get_project_preferences),
     #
     # Bug prediction
-    "has_repo_code_mappings": has_repo_code_mappings,
-    "get_issues_by_function_name": by_function_name.fetch_issues,
-    "get_issues_related_to_exception_type": by_error_type.fetch_issues,
-    "get_issues_by_raw_query": by_text_query.fetch_issues,
-    "get_latest_issue_event": utils.get_latest_issue_event,
+    "has_repo_code_mappings": seer_rpc(has_repo_code_mappings),
+    "get_issues_by_function_name": seer_rpc(by_function_name.fetch_issues),
+    "get_issues_related_to_exception_type": seer_rpc(by_error_type.fetch_issues),
+    "get_issues_by_raw_query": seer_rpc(by_text_query.fetch_issues),
+    "get_latest_issue_event": seer_rpc(utils.get_latest_issue_event),
     #
     # Assisted query
-    "get_attribute_names": get_attribute_names,
-    "get_attribute_values_with_substring": get_attribute_values_with_substring,
-    "get_attributes_and_values": get_attributes_and_values,
-    "get_metric_metadata": get_metric_metadata,
-    "get_issue_filter_keys": get_issue_filter_keys,
-    "get_filter_key_values": get_filter_key_values,
-    "get_issues_stats": get_issues_stats,
-    "get_event_filter_keys": get_event_filter_keys,
-    "get_event_filter_key_values": get_event_filter_key_values,
+    "get_attribute_names": seer_rpc(get_attribute_names),
+    "get_attribute_values_with_substring": seer_rpc(get_attribute_values_with_substring),
+    "get_attributes_and_values": seer_rpc(get_attributes_and_values),
+    "get_metric_metadata": seer_rpc(get_metric_metadata),
+    "get_issue_filter_keys": seer_rpc(get_issue_filter_keys),
+    "get_filter_key_values": seer_rpc(get_filter_key_values),
+    "get_issues_stats": seer_rpc(get_issues_stats),
+    "get_event_filter_keys": seer_rpc(get_event_filter_keys),
+    "get_event_filter_key_values": seer_rpc(get_event_filter_key_values),
     #
     # Agent
-    "get_transactions_for_project": rpc_get_transactions_for_project,
-    "get_trace_for_transaction": rpc_get_trace_for_transaction,
-    "get_profiles_for_trace": rpc_get_profiles_for_trace,
-    "get_issues_for_transaction": rpc_get_issues_for_transaction,
-    "get_trace_waterfall": rpc_get_trace_waterfall,
-    "get_issue_and_event_details_v2": get_issue_and_event_details_v2,
-    "get_issue_details": get_issue_details,
-    "get_event_details": get_event_details,
-    "get_profile_flamegraph": rpc_get_profile_flamegraph,
-    "execute_table_query": execute_table_query,
-    "execute_timeseries_query": execute_timeseries_query,
-    "execute_trace_table_query": execute_trace_table_query,
-    "execute_replays_query": execute_replays_query,
-    "execute_issues_query": execute_issues_query,
-    "get_trace_item_attributes": get_trace_item_attributes,
-    "get_repository_definition": get_repository_definition,
-    "call_custom_tool": call_custom_tool,
-    "call_on_completion_hook": call_on_completion_hook,
-    "deliver_feature_result": deliver_feature_result,
-    "record_pr_attribution": record_pr_attribution,
-    "get_log_attributes_for_trace": get_log_attributes_for_trace,
-    "get_metric_attributes_for_trace": get_metric_attributes_for_trace,
-    "get_baseline_tag_distribution": get_baseline_tag_distribution,
-    "get_comparative_attribute_distributions": get_comparative_attribute_distributions,
-    "get_dsn": get_dsn,
+    "get_transactions_for_project": seer_rpc(rpc_get_transactions_for_project),
+    "get_trace_for_transaction": seer_rpc(rpc_get_trace_for_transaction),
+    "get_profiles_for_trace": seer_rpc(rpc_get_profiles_for_trace),
+    "get_issues_for_transaction": seer_rpc(rpc_get_issues_for_transaction),
+    "get_trace_waterfall": seer_rpc(rpc_get_trace_waterfall),
+    "get_issue_and_event_details_v2": seer_rpc(get_issue_and_event_details_v2),
+    "get_issue_details": seer_rpc(get_issue_details),
+    "get_event_details": seer_rpc(get_event_details),
+    "get_profile_flamegraph": seer_rpc(rpc_get_profile_flamegraph),
+    "execute_table_query": seer_rpc(execute_table_query),
+    "execute_timeseries_query": seer_rpc(execute_timeseries_query),
+    "execute_trace_table_query": seer_rpc(execute_trace_table_query),
+    "execute_replays_query": seer_rpc(execute_replays_query),
+    "execute_issues_query": seer_rpc(execute_issues_query),
+    "get_trace_item_attributes": seer_rpc(get_trace_item_attributes),
+    "get_repository_definition": seer_rpc(get_repository_definition),
+    "call_custom_tool": seer_rpc(call_custom_tool),
+    "call_on_completion_hook": seer_rpc(call_on_completion_hook),
+    "deliver_feature_result": seer_rpc(deliver_feature_result),
+    "record_pr_attribution": seer_rpc(record_pr_attribution),
+    "get_log_attributes_for_trace": seer_rpc(get_log_attributes_for_trace),
+    "get_metric_attributes_for_trace": seer_rpc(get_metric_attributes_for_trace),
+    "get_baseline_tag_distribution": seer_rpc(get_baseline_tag_distribution),
+    "get_comparative_attribute_distributions": seer_rpc(get_comparative_attribute_distributions),
+    "get_dsn": seer_rpc(get_dsn),
     #
     # Replays
-    "get_replay_summary_logs": rpc_get_replay_summary_logs,
-    "get_replay_metadata": get_replay_metadata,
+    "get_replay_summary_logs": seer_rpc(rpc_get_replay_summary_logs),
+    "get_replay_metadata": seer_rpc(get_replay_metadata),
     #
     # Issue Detection
-    "create_issue_occurrence": create_issue_occurrence,
+    "create_issue_occurrence": seer_rpc(create_issue_occurrence),
     #
     # PR metrics (judge path)
-    "update_pr_metrics": update_pr_metrics,
+    "update_pr_metrics": seer_rpc(update_pr_metrics),
     #
     # Monitoring provider tokens (MCP)
-    "refresh_monitoring_provider_token": refresh_monitoring_provider_token,
+    "refresh_monitoring_provider_token": seer_rpc(refresh_monitoring_provider_token),
 }
 
 

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid as uuid_module
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 from rest_framework import status
 from rest_framework.response import Response
@@ -76,26 +76,34 @@ def resolve_seer_run(
     return ResolvedSeerRun(run.seer_run_state_id, str(run.uuid))
 
 
-def map_org_id_param(func: Callable) -> Callable:
+_RpcReturn = TypeVar("_RpcReturn")
+
+
+def map_org_id_param(func: Callable[..., _RpcReturn]) -> Callable[..., _RpcReturn]:
     """
     Helper to map organization_id parameter to org_id for backwards compatibility.
 
     Allows RPC methods to use 'organization_id' while underlying functions use 'org_id'.
+    The return type is preserved so the seer RPC registries can keep their
+    `Callable[..., BaseModel | None]` mypy guard through this wrapper.
     """
 
-    def wrapper(*, organization_id: int, **kwargs: Any) -> Any:
+    def wrapper(*, organization_id: int, **kwargs: Any) -> _RpcReturn:
         kwargs["org_id"] = organization_id
         return func(**kwargs)
 
     return wrapper
 
 
-def accept_organization_id_param(func: Callable) -> Callable:
+def accept_organization_id_param(func: Callable[..., _RpcReturn]) -> Callable[..., _RpcReturn]:
     """
     Helper to accept organization_id parameter.
+
+    The return type is preserved so the seer RPC registries can keep their
+    `Callable[..., BaseModel | None]` mypy guard through this wrapper.
     """
 
-    def wrapper(*, organization_id: int, **kwargs: Any) -> Any:
+    def wrapper(*, organization_id: int, **kwargs: Any) -> _RpcReturn:
         return func(**kwargs)
 
     return wrapper

--- a/src/sentry/seer/issue_detection.py
+++ b/src/sentry/seer/issue_detection.py
@@ -1,6 +1,7 @@
 import logging
 
 from sentry.models.project import Project
+from sentry.seer.sentry_data_models import CreateIssueOccurrenceResponse
 from sentry.tasks.llm_issue_detection.detection import (
     DetectedIssue,
     create_issue_occurrence_from_detection,
@@ -14,7 +15,7 @@ def create_issue_occurrence(
     organization_id: int,
     project_id: int,
     detected_issue: dict,
-) -> dict:
+) -> CreateIssueOccurrenceResponse:
     """
     Create an issue occurrence from Seer detection data.
 
@@ -45,4 +46,4 @@ def create_issue_occurrence(
         },
     )
 
-    return {"success": True}
+    return CreateIssueOccurrenceResponse()

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -742,3 +742,170 @@ class IssuesStatsResponse(BaseModel):
 
     def __hash__(self) -> int:
         return id(self)
+
+
+class CallCustomToolResponse(BaseModel):
+    """`call_custom_tool` returns the bare string the tool's `execute()` produced.
+    Wraps in a `__root__` passthrough so the wire stays a JSON string."""
+
+    __root__: str
+
+    def dict(self, **kwargs: Any) -> Any:
+        # Unwrap so the dispatcher serializes the bare string the pre-typed
+        # registry emitted, not `{"__root__": "..."}`.
+        return self.__root__
+
+    def __eq__(self, other: object) -> bool:
+        # Match the legacy wire shape (bare str) so callers comparing against
+        # `result == "literal"` keep working without an explicit `.dict()`.
+        if isinstance(other, str):
+            return self.__root__ == other
+        return super().__eq__(other)
+
+    def __hash__(self) -> int:
+        return id(self)
+
+
+class CreateIssueOccurrenceResponse(BaseModel):
+    """`create_issue_occurrence` returns `{"success": True}` after a successful
+    write. Pre-typed code never returned False here — failures raise — so the
+    `success` field is a `Literal[True]` to encode the contract."""
+
+    success: Literal[True] = True
+
+
+class ExecuteIssuesQuerySuccessResponse(BaseModel):
+    """`execute_issues_query` success path returns the bare list of issue dicts
+    from the issues API. `__root__`-based passthrough preserves that shape."""
+
+    __root__: list[dict[str, Any]]
+
+    def dict(self, **kwargs: Any) -> Any:
+        return list(self.__root__)
+
+    def __iter__(self) -> Any:
+        return iter(self.__root__)
+
+    def __len__(self) -> int:
+        return len(self.__root__)
+
+    def __getitem__(self, idx: int) -> Any:
+        return self.__root__[idx]
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, list):
+            return list(self.__root__) == other
+        return super().__eq__(other)
+
+    def __hash__(self) -> int:
+        return id(self)
+
+
+class ExecuteTimeseriesQuerySuccessResponse(BaseModel):
+    """`execute_timeseries_query` success shape has dynamic top-level keys —
+    either `{metric_name: {"data": [...], ...}}` for non-grouped queries or
+    `{group_value: {metric_name: ...}, ...}` for grouped ones — so the body
+    is a dict passthrough. SDK consumers get a named response type plus the
+    raw events-stats payload underneath."""
+
+    __root__: dict[str, Any]
+
+    def dict(self, **kwargs: Any) -> Any:
+        return dict(self.__root__)
+
+    # Dict-like proxy so test sites and seer callers can use `result[k]`,
+    # `result.items()`, `len(result)`, etc. without first unwrapping `__root__`.
+    def __contains__(self, key: object) -> bool:
+        return key in self.__root__
+
+    def __getitem__(self, key: str) -> Any:
+        return self.__root__[key]
+
+    def __len__(self) -> int:
+        return len(self.__root__)
+
+    def items(self) -> Any:
+        return self.__root__.items()
+
+    def keys(self) -> Any:
+        return self.__root__.keys()
+
+    def values(self) -> Any:
+        return self.__root__.values()
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.__root__.get(key, default)
+
+
+class ExecuteTimeseriesQueryErrorResponse(BaseModel):
+    """`execute_timeseries_query` error: `{"_seer_error_detail": <detail>}`. The
+    underscore-prefixed key is reserved to avoid colliding with the dynamic
+    metric/group keys in the success shape; `Field(alias=...)` keeps the wire
+    spelling since Pydantic forbids underscore-prefixed attribute names."""
+
+    seer_error_detail: str = Field(alias="_seer_error_detail")
+
+    class Config:
+        allow_population_by_field_name = True
+
+    def dict(self, **kwargs: Any) -> Any:
+        kwargs.setdefault("by_alias", True)
+        return super().dict(**kwargs)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self.dict()
+
+    def __getitem__(self, key: str) -> Any:
+        return self.dict()[key]
+
+    def __eq__(self, other: object) -> bool:
+        # Legacy callers compared against the bare wire dict
+        # `{"_seer_error_detail": "..."}`. Preserve that ergonomics.
+        if isinstance(other, dict):
+            return self.dict() == other
+        return super().__eq__(other)
+
+    def __hash__(self) -> int:
+        return id(self)
+
+
+class RefreshMonitoringProviderTokenSuccessResponse(BaseModel):
+    """`refresh_monitoring_provider_token` success: the freshly-encrypted access
+    token plus the Unix-second expiry the OAuth2 base helper stamps onto
+    `identity.data["expires"]` (`int(time()) + int(payload["expires_in"])`)."""
+
+    encrypted_access_token: str
+    expires: int | None
+
+    def __getitem__(self, key: str) -> Any:
+        return self.dict()[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in self.dict()
+
+
+class RefreshMonitoringProviderTokenErrorResponse(BaseModel):
+    """`refresh_monitoring_provider_token` error: `{"error": <code>}`. The four
+    error codes the function emits — one per refusal branch — encoded as a
+    Literal so the seer-side caller can switch on them safely."""
+
+    error: Literal[
+        "encryption_failed",
+        "identity_not_found",
+        "identity_not_valid",
+        "refresh_failed",
+    ]
+
+    def __getitem__(self, key: str) -> Any:
+        return self.dict()[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in self.dict()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, dict):
+            return self.dict() == other
+        return super().__eq__(other)
+
+    def __hash__(self) -> int:
+        return id(self)

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -41,7 +41,12 @@ from sentry.seer.agent.tools import (
     rpc_get_profile_flamegraph,
 )
 from sentry.seer.endpoints.seer_rpc import get_organization_project_ids
-from sentry.seer.sentry_data_models import EAPTrace, IssueDetailsResponse
+from sentry.seer.sentry_data_models import (
+    EAPTrace,
+    ExecuteTimeseriesQueryErrorResponse,
+    ExecuteTimeseriesQuerySuccessResponse,
+    IssueDetailsResponse,
+)
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.testutils.cases import (
     APITestCase,
@@ -565,7 +570,7 @@ class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
             group_by=["span.op"],
         )
 
-        assert result is not None
+        assert isinstance(result, ExecuteTimeseriesQuerySuccessResponse)
         # Grouped results have group values as top-level keys
         # Should have different span.op values like "db", "http.client", etc.
         assert len(result) > 0
@@ -1315,7 +1320,9 @@ class TestGetIssueAndEventDetailsV2(
     @patch("sentry.seer.agent.tools.execute_timeseries_query")
     def test_issue_event_timeseries_returns_none_on_query_error(self, mock_execute: Mock) -> None:
         """A _seer_error_detail payload from execute_timeseries_query is treated as no data."""
-        mock_execute.return_value = {"_seer_error_detail": "Invalid query: bad field"}
+        mock_execute.return_value = ExecuteTimeseriesQueryErrorResponse(
+            seer_error_detail="Invalid query: bad field"
+        )
         group = self.create_group(project=self.project)
 
         result = _get_issue_event_timeseries(group=group, organization=self.organization)
@@ -1336,14 +1343,14 @@ class TestGetIssueAndEventDetailsV2(
     def test_issue_event_timeseries_returns_data_on_success(self, mock_execute: Mock) -> None:
         """A normal timeseries payload flows through with the selected period and interval."""
         data: dict[str, Any] = {"count()": {"data": []}}
-        mock_execute.return_value = data
+        mock_execute.return_value = ExecuteTimeseriesQuerySuccessResponse(__root__=data)
         group = self.create_group(project=self.project)
 
         result = _get_issue_event_timeseries(group=group, organization=self.organization)
 
         assert result is not None
         returned_data, period, interval = result
-        assert returned_data is data
+        assert returned_data == data
         assert period
         assert interval
 

--- a/tests/sentry/seer/assisted_query/test_issues_tools.py
+++ b/tests/sentry/seer/assisted_query/test_issues_tools.py
@@ -12,6 +12,7 @@ from sentry.seer.assisted_query.issues_tools import (
     get_issues_stats,
 )
 from sentry.seer.sentry_data_models import (
+    ExecuteIssuesQuerySuccessResponse,
     FilterKeyValuesResponse,
     IssueFilterKeysResponse,
     IssuesStatsResponse,
@@ -544,7 +545,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, (list, FilterKeyValuesResponse))
+        assert isinstance(result, ExecuteIssuesQuerySuccessResponse)
         assert len(result) >= 2
 
         # Check structure of returned issues
@@ -576,7 +577,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, (list, FilterKeyValuesResponse))
+        assert isinstance(result, ExecuteIssuesQuerySuccessResponse)
         # Should have at least our error event
         assert len(result) >= 1
 
@@ -603,7 +604,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, (list, FilterKeyValuesResponse))
+        assert isinstance(result, ExecuteIssuesQuerySuccessResponse)
         assert len(result) >= 3
 
     def test_execute_issues_query_with_limit(self) -> None:
@@ -628,7 +629,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, (list, FilterKeyValuesResponse))
+        assert isinstance(result, ExecuteIssuesQuerySuccessResponse)
         # Should respect limit
         assert len(result) <= 2
 
@@ -672,7 +673,7 @@ class TestExecuteIssuesQuery(APITestCase, SnubaTestCase):
         )
 
         assert result is not None
-        assert isinstance(result, (list, FilterKeyValuesResponse))
+        assert isinstance(result, ExecuteIssuesQuerySuccessResponse)
         # Should have issues from both projects
         assert len(result) >= 2
         project_ids = {issue["project"]["id"] for issue in result}

--- a/tools/mypy_helpers/plugin.py
+++ b/tools/mypy_helpers/plugin.py
@@ -192,6 +192,63 @@ def _lazy_service_wrapper_attribute(ctx: AttributeContext, *, attr: str) -> Type
         return member
 
 
+_SEER_RPC_MARKER_FULLNAME = "sentry.seer.endpoints.registry.seer_rpc"
+
+
+def _return_type_contains_any(t: Type) -> bool:
+    """Walk a function's return type and report whether any node is a real `Any`.
+
+    Skips `TypeOfAny.special_form` (e.g. `Any` from `Optional[Any]` placeholder
+    resolution) and `TypeOfAny.from_error` (already-flagged errors) so we don't
+    double-report. Recurses through unions and into the type arguments of
+    generic Instances so leaks like `BaseModel | Any | None` or
+    `list[Any]` / `dict[str, Any]` are caught.
+    """
+    seen: set[int] = set()
+
+    def _walk(node: Type) -> bool:
+        node = get_proper_type(node)
+        if id(node) in seen:
+            return False
+        seen.add(id(node))
+        if isinstance(node, AnyType):
+            return node.type_of_any not in (TypeOfAny.special_form, TypeOfAny.from_error)
+        if isinstance(node, UnionType):
+            return any(_walk(item) for item in node.items)
+        if isinstance(node, Instance):
+            return any(_walk(arg) for arg in node.args)
+        return False
+
+    return _walk(t)
+
+
+def _check_seer_rpc_handler_not_any(ctx: FunctionContext) -> Type:
+    """Enforce that the function passed to `seer_rpc(...)` has a return type
+    free of `Any`. The wrapped function is what gets registered into one of
+    the three seer RPC registries; an `Any` return there silently breaks the
+    seer-side codegen that consumes these methods — the JSON-schema manifest
+    built from each registered function's return annotation degenerates to
+    "unknown" for the entry, so the typed `RpcClient.call` overloads on the
+    seer side lose their specific return type for that method.
+    """
+    if not ctx.arg_types or not ctx.arg_types[0]:
+        return ctx.default_return_type
+    fn_type = get_proper_type(ctx.arg_types[0][0])
+    if not isinstance(fn_type, CallableType):
+        return ctx.default_return_type
+    if _return_type_contains_any(fn_type.ret_type):
+        ctx.api.fail(
+            "Seer RPC handler return type must not contain `Any`: the seer-side "
+            "codegen derives its typed `RpcClient.call` overloads from this "
+            "annotation, and `Any` collapses the consumer's typed contract for "
+            "this method. Define a Pydantic response model in "
+            "`sentry.seer.sentry_data_models` and annotate the handler's "
+            "return type with it.",
+            ctx.context,
+        )
+    return ctx.default_return_type
+
+
 _RESPONSE_FULLNAME = "rest_framework.response.Response"
 _ASYNC_WRAPPERS = frozenset(
     {
@@ -428,6 +485,8 @@ class SentryMypyPlugin(Plugin):
     def get_function_hook(self, fullname: str) -> Callable[[FunctionContext], Type] | None:
         if fullname == _RESPONSE_FULLNAME:
             return _dispatch_response_hook
+        if fullname == _SEER_RPC_MARKER_FULLNAME:
+            return _check_seer_rpc_handler_not_any
         return None
 
     def get_function_signature_hook(


### PR DESCRIPTION
The five remaining seer RPC methods (`call_custom_tool`, `create_issue_occurrence`, `execute_issues_query`, `execute_timeseries_query`, `refresh_monitoring_provider_token`) get explicit Pydantic response models, so every entry in `seer_method_registry`, `public_org_seer_method_registry`, and `public_project_seer_method_registry` now returns a declared `BaseModel`.

With that complete, the registry-value annotation on each of the three registries tightens from `dict[str, Callable]` to `dict[str, Callable[..., BaseModel | None]]`. mypy then rejects any future attempt to register a function whose return is annotated `dict`, `dict[str, Any]`, or a bare `Callable`. A new `seer_rpc(...)` marker wraps each registry entry and triggers a hook in `SentryMypyPlugin` that walks the wrapped function's return type and rejects bare `Any` — closing the one hole the structural check leaves open, since `Any` is bidirectionally compatible with everything by design.

`map_org_id_param` / `accept_organization_id_param` had to be re-typed with a `TypeVar` so the wrapped function's return type flows through the wrapper. The previous `Callable -> Callable` signature would have erased the type and left both guards inert for everything that goes through them.