### PR TITLE
fix(tracemetrics): Literals in equations delete incorrect item

### DIFF
--- a/static/app/components/arithmeticBuilder/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/index.spec.tsx
@@ -264,6 +264,22 @@ describe('ArithmeticBuilder', () => {
     expect(screen.getAllByRole('row')).toHaveLength(1);
   });
 
+  it('deleting a middle literal does not shift remaining literal values', async () => {
+    const expression = 'A + 1 + 2 + 3';
+    render(
+      <ArithmeticBuilderWrapper expression={expression} references={new Set(['A'])} />
+    );
+
+    // Find the delete button for literal "1"
+    const deleteButton = screen.getByRole('button', {name: 'Remove literal 1'});
+    await userEvent.click(deleteButton);
+
+    // After deleting "1", the remaining literals should show "2" and "3"
+    expect(screen.getByDisplayValue('2')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('3')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('1')).not.toBeInTheDocument();
+  });
+
   it('throws when provided invalid references', () => {
     expect(() => {
       render(

--- a/static/app/components/arithmeticBuilder/token/literal.tsx
+++ b/static/app/components/arithmeticBuilder/token/literal.tsx
@@ -71,6 +71,12 @@ function InternalInput({item, state, token}: InternalInputProps) {
   const [inputValue, setInputValue] = useState(token.text);
   const [_selectionIndex, setSelectionIndex] = useState(0); // TODO
 
+  const [prevValue, setPrevValue] = useState(inputValue);
+  if (token.text !== prevValue) {
+    setPrevValue(token.text);
+    setInputValue(token.text);
+  }
+
   const updateSelectionIndex = useCallback(() => {
     setSelectionIndex(inputRef.current?.selectionStart ?? 0);
   }, [setSelectionIndex]);


### PR DESCRIPTION
Creating an equation with `A + 1 + 2 + 3` and deleting `1` would actually keep `1` and remove `3`.

i.e. expected: `A + 2 + 3`
actual behaviour: `A + 1 + 2`

What's happening is that the equation builder parses the tokens into keys by type and index (e.g. `lit-0`, `lit-1`, `lit-2`) and deleting `lit-0` makes the UI re-calculate these indexes. The underlying equation has correctly removed `1`, but since the "new" re-indexing creates `lit-0` and `lit-1` as keys, React re-uses the components because the keys are the same and thus `1 + 2` are kept while `3` gets dropped (because there is no longer `lit-2` after re-indexing)

The solution, working around the key behaviour, is that we need to reset the value within the token to match the new one when it changes. This is accomplished by storing the prev value and resetting state when we detect it's not correct.