### PR TITLE
fix(query-client): Stop retrying on 400s

### DIFF
--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -17,7 +17,7 @@ import type {ApiQueryKey, QueryKeyEndpointOptions} from 'sentry/utils/api/apiQue
 import {RequestError} from 'sentry/utils/requestError/requestError';
 
 // Overrides to the default react-query options.
-// See https://tanstack.com/query/v4/docs/guides/important-defaults
+// See https://tanstack.com/query/v5/docs/framework/react/guides/important-defaults
 export const DEFAULT_QUERY_CLIENT_CONFIG: QueryClientConfig = {
   defaultOptions: {
     queries: {

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -14,7 +14,7 @@ import {apiFetch} from 'sentry/utils/api/apiFetch';
 import {selectJson} from 'sentry/utils/api/apiOptions';
 import {normalizeQueryKey} from 'sentry/utils/api/apiQueryKey';
 import type {ApiQueryKey, QueryKeyEndpointOptions} from 'sentry/utils/api/apiQueryKey';
-import type {RequestError} from 'sentry/utils/requestError/requestError';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 
 // Overrides to the default react-query options.
 // See https://tanstack.com/query/v4/docs/guides/important-defaults
@@ -23,6 +23,14 @@ export const DEFAULT_QUERY_CLIENT_CONFIG: QueryClientConfig = {
     queries: {
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
+      retry: (failureCount, err) => {
+        // Disable retries for 400 status code
+        if (err instanceof RequestError && err.status === 400) {
+          return false;
+        }
+
+        return failureCount < 2;
+      },
     },
   },
 };

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -29,7 +29,7 @@ export const DEFAULT_QUERY_CLIENT_CONFIG: QueryClientConfig = {
           return false;
         }
 
-        return failureCount < 2;
+        return failureCount < 3;
       },
     },
   },


### PR DESCRIPTION
This PR modifies the default query config to not retry when the returned status code is 400.

Closes EXP-1013