### PR TITLE
feat(seer): Run night shift every 12 hours

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1180,8 +1180,8 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
     },
     "seer-night-shift": {
         "task": "seer:sentry.tasks.seer.night_shift.schedule_night_shift",
-        # Run daily at 10:00 AM UTC (2/3 AM Pacific)
-        "schedule": crontab("0", "10", "*", "*", "*"),
+        # Run every 12 hours, at 10:00 and 22:00 UTC
+        "schedule": crontab("0", "10,22", "*", "*", "*"),
     },
     "refresh-artifact-bundles-in-use": {
         "task": "attachments:sentry.debug_files.tasks.refresh_artifact_bundles_in_use",


### PR DESCRIPTION
Change the night shift scheduler cron from a single daily run at 10:00 UTC to two runs per day, at 10:00 and 22:00 UTC — so triage runs every 12 hours.

The 10:00 UTC anchor (≈2/3 AM Pacific) is preserved; a second run is added 12 hours later at 22:00 UTC.


Agent transcript: https://claudescope.sentry.dev/share/d2oxU97KyhumJzyqoVQyiT1cUduHKyWLMcPCP_m2u0o