### PR TITLE
fix(redis): Fix handling of boolean values

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -284,6 +284,9 @@ class RedisBuffer(Buffer):
         elif isinstance(value, date):
             type_ = "d"
             value = value.strftime("%s.%f")
+        elif isinstance(value, bool):
+            type_ = "b"
+            value = int(value)
         elif isinstance(value, int):
             type_ = "i"
         elif isinstance(value, float):
@@ -317,6 +320,8 @@ class RedisBuffer(Buffer):
             return datetime.fromtimestamp(float(value)).replace(tzinfo=timezone.utc)
         elif type_ == "d":
             return date.fromtimestamp(float(value))
+        elif type_ == "b":
+            return bool(int(value))  # Stored as "0" or "1" during serialization
         elif type_ == "i":
             return int(value)
         elif type_ == "f":

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import pickle
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -242,5 +243,5 @@ class TestRedisBuffer:
     "value",
     [timezone.now(), datetime.date.today(), "a", 1, 3.14, {"a": {"i": 0}, "b": {"s": ""}}],
 )
-def test_dump_value(value: datetime.datetime) -> None:
+def test_dump_value(value: Any) -> None:
     assert RedisBuffer._load_value(json.loads(json.dumps(RedisBuffer._dump_value(value)))) == value

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -248,6 +248,7 @@ class TestRedisBuffer:
         (1, "int"),
         (3.14, "float"),
         ({"a": {"i": 0}, "b": {"s": ""}}, "dict"),
+        (False, "bool"),
     ],
     ids=lambda input: input[1],
 )

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -243,5 +243,5 @@ class TestRedisBuffer:
     "value",
     [timezone.now(), datetime.date.today(), "a", 1, 3.14, {"a": {"i": 0}, "b": {"s": ""}}],
 )
-def test_dump_value(value: Any) -> None:
+def test_dump_and_load_value(value: Any) -> None:
     assert RedisBuffer._load_value(json.loads(json.dumps(RedisBuffer._dump_value(value)))) == value

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -240,8 +240,17 @@ class TestRedisBuffer:
 
 
 @pytest.mark.parametrize(
-    "value",
-    [timezone.now(), datetime.date.today(), "a", 1, 3.14, {"a": {"i": 0}, "b": {"s": ""}}],
+    "input",
+    [
+        (timezone.now(), "datetime"),
+        (datetime.date.today(), "date"),
+        ("a", "string"),
+        (1, "int"),
+        (3.14, "float"),
+        ({"a": {"i": 0}, "b": {"s": ""}}, "dict"),
+    ],
+    ids=lambda input: input[1],
 )
-def test_dump_and_load_value(value: Any) -> None:
+def test_dump_and_load_value(input: tuple[Any, str]) -> None:
+    value = input[0]
     assert RedisBuffer._load_value(json.loads(json.dumps(RedisBuffer._dump_value(value)))) == value


### PR DESCRIPTION
When we serialize values to be able to cache them in redis, we first stringify them. In order to know how to un-stringify them on the other end, we also store each value's type alongside it.

This generally works fine, except when we're faced with a boolean. Technically, booleans are ints (they pass `isinstance(value, int)`, and `True == 1` and `False == 0` are both true statements), but they don't stringify as ints - `str(True)` is `"True"`, not `"1"`. This means that when we try to pull stored booleans from the cache, we end up trying to do `int("True")` and `int("False")`, which of course doesn't work.

This fixes that by adding bools as a separate case in our serialization, and converting them to their integer equivalents before stringifying them. That way, when we go to pull a boolean value from the cache, we know to feed it to `bool` after re-int-ifying it. (We store it as its integer equivalent, because while `bool("True")` does evaluate to `True`, `bool("False")` also evaluates to `True`. Int-ifying it first preserves its truth value.) 

It also adds a bool case to our test testing the round trip. (While I was there, I also made a few small fixes/improvements to the test - fixed the input type, made the name more accurate, and added labels to the inputs, so they don't show up in test output as `input0`, `input1`, etc., but rather with descriptive names.)

Fixes https://sentry-s4s2-monolith.sentry.io/issues/21742