### PR TITLE
fix(selective-testing): always run silo and backup validate meta-tests

### DIFF
--- a/.github/workflows/scripts/compute-sentry-selected-tests.py
+++ b/.github/workflows/scripts/compute-sentry-selected-tests.py
@@ -131,6 +131,15 @@ ALWAYS_RUN_TESTS: set[str] = {
     # context is active.
     "tests/apigw/test_db.py",
     "tests/apigw/test_routing.py",
+    # Both of these tests check global codebase invariants via runtime discovery —
+    # the same reason the apigw tests above are always run. Coverage can't attribute
+    # them to individual source files because the discovery happens at startup,
+    # before per-test coverage contexts are active:
+    #   test_base.py: walks all endpoint subclasses to check for silo decorators
+    #   test_validate.py: walks the Django ORM registry (get_exportable_sentry_models)
+    #     to assign comparators — __relocation_scope__ changes on any model are invisible
+    "tests/sentry/silo/test_base.py",
+    "tests/sentry/backup/test_validate.py",
 }
 
 


### PR DESCRIPTION
Two separate incidents where selective testing missed a failure, both caused by the
same underlying pattern: tests that check global codebase invariants via runtime
discovery can't be attributed to individual source files by coverage or static
import scanning.

Incident 1 — #117474 added OrganizationEventsValidateEndpoint without a
silo decorator.
tests/sentry/silo/test_base.py::test_all_endpoints_have_silo_mode_decorator should
have caught it, but wasn't selected — the new file had no coverage history (it
didn't exist when the DB was built), and the test discovers endpoint classes by
walking the class hierarchy at runtime rather than importing them.

Incident 2 — #116226 changed Email.__relocation_scope__ to Excluded.
tests/sentry/backup/test_validate.py failed because
auto_assign_email_obfuscating_comparators() calls get_exportable_sentry_models(),
which walks the Django ORM registry. test_validate.py has no direct import of
email.py, and the registry is populated at startup before per-test coverage contexts
are active. 

Both tests belong in ALWAYS_RUN_TESTS for the same reason as the existing
test_generate_controlsilo_urls.py, test_db.py, and test_routing.py entries: their
inputs are resolved at startup, making the source-to-test dependency invisible to
both the coverage DB and the static import scan.