### PR TITLE
feat(issue-list): add issue preview drawer for awaiting input page

### DIFF
--- a/static/app/components/groupHeaderRow.tsx
+++ b/static/app/components/groupHeaderRow.tsx
@@ -24,8 +24,7 @@ interface GroupHeaderRowProps {
   data: Group;
   eventId?: string;
   hideIcons?: boolean;
-  /** Group link clicked */
-  onClick?: () => void;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
   query?: string;
   source?: string;
 }

--- a/static/app/components/stream/group.spec.tsx
+++ b/static/app/components/stream/group.spec.tsx
@@ -159,6 +159,30 @@ describe('StreamGroup', () => {
     });
   });
 
+  it('calls onGroupClick instead of navigating when the row is clicked', async () => {
+    const onGroupClick = jest.fn();
+    const {router} = render(
+      <StreamGroup group={group1} query="is:unresolved" onGroupClick={onGroupClick} />
+    );
+
+    await userEvent.click(await screen.findByTestId('group'));
+
+    expect(onGroupClick).toHaveBeenCalledWith(group1);
+    expect(router.location.pathname).not.toBe('/organizations/org-slug/issues/1337/');
+  });
+
+  it('calls onGroupClick on a plain left-click of the title', async () => {
+    const onGroupClick = jest.fn();
+    const {router} = render(
+      <StreamGroup group={group1} query="is:unresolved" onGroupClick={onGroupClick} />
+    );
+
+    await userEvent.click(screen.getByText('RequestError'), {skipHover: true});
+
+    expect(onGroupClick).toHaveBeenCalledWith(group1);
+    expect(router.location.pathname).not.toBe('/organizations/org-slug/issues/1337/');
+  });
+
   it('displays unread indicator when issue is unread', async () => {
     const unreadGroup = GroupFixture({id: '1337', hasSeen: false});
 

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -87,6 +87,7 @@ type Props = {
   hasGuideAnchor?: boolean;
   memberList?: User[];
   onAssigneeChange?: (newAssignee: AssignableEntity | null) => void;
+  onGroupClick?: (group: Group) => void;
   onPriorityChange?: (newPriority: PriorityLevel) => void;
   progressState?: ProgressState | null;
   query?: string;
@@ -296,6 +297,7 @@ export function StreamGroup({
   showLastTriggered = false,
   onPriorityChange,
   onAssigneeChange,
+  onGroupClick,
   progressState,
 }: Props) {
   const issueSelectionSummary = useOptionalIssueSelectionSummary();
@@ -630,6 +632,11 @@ export function StreamGroup({
       return;
     }
 
+    if (onGroupClick) {
+      onGroupClick(group);
+      return;
+    }
+
     navigate(
       normalizeUrl(
         createIssueLink({
@@ -660,7 +667,22 @@ export function StreamGroup({
           />
         )}
         <GroupSummary canSelect={selectionEnabled}>
-          <GroupHeaderRow data={group} query={query} source={referrer} />
+          <GroupHeaderRow
+            data={group}
+            query={query}
+            source={referrer}
+            onClick={
+              onGroupClick
+                ? e => {
+                    // Preserve open in new tab/window behavior for modified clicks
+                    if (!isCtrlKeyPressed(e) && !e.shiftKey) {
+                      e.preventDefault();
+                      onGroupClick(group);
+                    }
+                  }
+                : undefined
+            }
+          />
           <GroupMetaRow data={group} showLifetime={false} />
         </GroupSummary>
       </Fragment>

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -33,6 +33,7 @@ type GroupListBodyProps = {
   query: string;
   refetchGroups: () => void;
   selectedProjectIds: number[];
+  onGroupClick?: (group: Group) => void;
   supergroupLookup?: SupergroupLookup;
   withColumns?: GroupListColumn[];
 };
@@ -44,6 +45,7 @@ type GroupListProps = {
   memberList: IndexedMembersByProject | undefined;
   onActionTaken: (itemIds: string[], data: IssueUpdateData) => void;
   query: string;
+  onGroupClick?: (group: Group) => void;
   supergroupLookup?: SupergroupLookup;
   withColumns?: GroupListColumn[];
 };
@@ -97,6 +99,7 @@ export function GroupListBody({
   selectedProjectIds,
   pageSize,
   onActionTaken,
+  onGroupClick,
   supergroupLookup,
   withColumns,
 }: GroupListBodyProps) {
@@ -136,6 +139,7 @@ export function GroupListBody({
       displayReprocessingLayout={displayReprocessingLayout}
       groupStatsPeriod={groupStatsPeriod}
       onActionTaken={onActionTaken}
+      onGroupClick={onGroupClick}
       supergroupLookup={supergroupLookup}
       withColumns={columns}
     />
@@ -180,6 +184,7 @@ function GroupList({
   displayReprocessingLayout,
   groupStatsPeriod,
   onActionTaken,
+  onGroupClick,
   supergroupLookup,
   withColumns = DEFAULT_COLUMNS,
 }: GroupListProps) {
@@ -225,6 +230,7 @@ function GroupList({
         useFilteredStats
         canSelect={!selectDisabled}
         onPriorityChange={priority => onActionTaken([id], {priority})}
+        onGroupClick={onGroupClick}
         withColumns={columns}
         progressState={
           showProgress ? (progressData?.results[id]?.progress ?? null) : undefined

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -9,6 +9,7 @@ import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
+import type {Group} from 'sentry/types/group';
 import {DemoTourElement, DemoTourStep} from 'sentry/utils/demoMode/demoTours';
 import type {IndexedMembersByProject} from 'sentry/utils/members/shared';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
@@ -44,6 +45,7 @@ interface IssueListTableProps {
   selection: PageFilters;
   statsLoading: boolean;
   statsPeriod: string;
+  onGroupClick?: (group: Group) => void;
   supergroupLookup?: SupergroupLookup;
   withColumns?: GroupListColumn[];
 }
@@ -70,6 +72,7 @@ export function IssueListTable({
   paginationAnalyticsEvent,
   issuesSuccessfullyLoaded,
   pageSize,
+  onGroupClick,
   supergroupLookup,
   withColumns,
 }: IssueListTableProps) {
@@ -142,6 +145,7 @@ export function IssueListTable({
                       pageSize={pageSize}
                       refetchGroups={refetchGroups}
                       onActionTaken={onActionTaken}
+                      onGroupClick={onGroupClick}
                       supergroupLookup={supergroupLookup}
                       withColumns={withColumns}
                     />

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -63,6 +63,7 @@ import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
 import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
 import {useSelectedGroupSearchView} from './issueViews/useSelectedGroupSeachView';
+import {useIssuePreviewDrawer} from './pages/useIssuePreviewDrawer';
 import {IssueListFilters} from './filters';
 import {IssueListCommandPaletteActions} from './issueListCommandPaletteActions';
 import {
@@ -82,6 +83,12 @@ const DYNAMIC_COUNTS_STATS_PERIODS = new Set(['14d', '24h', 'auto']);
 const MAX_ISSUES_COUNT = 100;
 
 interface Props {
+  /**
+   * Controls what happens when an issue row is clicked.
+   * - 'navigate' (default): navigates to the issue details page.
+   * - 'preview': opens a lightweight issue preview drawer.
+   */
+  clickBehavior?: 'navigate' | 'preview';
   headerActions?: ReactNode;
   initialQuery?: string;
   shouldFetchOnMount?: boolean;
@@ -136,12 +143,15 @@ function IssueListOverviewInner({
   title = t('Issues'),
   titleDescription,
   headerActions,
+  clickBehavior = 'navigate',
   withColumns,
 }: Props) {
   const location = useLocation();
   const organization = useOrganization();
   const navigate = useNavigate();
   const {selection} = usePageFilters();
+  const isPreviewMode = clickBehavior === 'preview';
+  const {openIssuePreview} = useIssuePreviewDrawer({enabled: isPreviewMode});
   const api = useApi();
   const urlParams = useParams<{viewId?: string}>();
   const realtimeActiveCookie = Cookies.get('realtimeActive');
@@ -986,6 +996,7 @@ function IssueListOverviewInner({
               supergroupLookup={supergroupLookup}
               error={error}
               refetchGroups={fetchData}
+              onGroupClick={isPreviewMode ? openIssuePreview : undefined}
               withColumns={withColumns}
               paginationCaption={
                 !issuesLoading && modifiedQueryCount > 0

--- a/static/app/views/issueList/pages/awaitingInput.spec.tsx
+++ b/static/app/views/issueList/pages/awaitingInput.spec.tsx
@@ -4,7 +4,7 @@ import {MemberFixture} from 'sentry-fixture/member';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TagsFixture} from 'sentry-fixture/tags';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {TagStore} from 'sentry/stores/tagStore';
@@ -99,5 +99,22 @@ describe('AwaitingInputPage', () => {
     expect(screen.getByText('Progress')).toBeInTheDocument();
     expect(screen.queryByText('Priority')).not.toBeInTheDocument();
     expect(await screen.findByText('Diagnosed')).toBeInTheDocument();
+  });
+
+  it('opens an issue preview drawer instead of navigating when an issue is clicked', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues-progress/',
+      body: {results: {1: {progress: 'diagnosed'}}},
+    });
+
+    const {router} = render(<AwaitingInputPage />);
+
+    await userEvent.click(await screen.findByText('RequestError'), {skipHover: true});
+
+    // Stays on the page and opens the drawer via the preview query param.
+    expect(router.location.query.preview).toBe('1');
+    expect(
+      await screen.findByRole('complementary', {name: 'Issue preview'})
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueList/pages/awaitingInput.tsx
+++ b/static/app/views/issueList/pages/awaitingInput.tsx
@@ -26,7 +26,12 @@ export default function AwaitingInputPage() {
     <IssueListContainer title={TITLE}>
       <PageFiltersContainer>
         <NoProjectMessage organization={organization}>
-          <IssueListOverview initialQuery={QUERY} title={TITLE} withColumns={COLUMNS} />
+          <IssueListOverview
+            initialQuery={QUERY}
+            title={TITLE}
+            withColumns={COLUMNS}
+            clickBehavior="preview"
+          />
         </NoProjectMessage>
       </PageFiltersContainer>
     </IssueListContainer>

--- a/static/app/views/issueList/pages/useIssuePreviewDrawer.spec.tsx
+++ b/static/app/views/issueList/pages/useIssuePreviewDrawer.spec.tsx
@@ -1,0 +1,52 @@
+import {GroupFixture} from 'sentry-fixture/group';
+
+import {
+  act,
+  renderHookWithProviders,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
+
+import {useIssuePreviewDrawer} from 'sentry/views/issueList/pages/useIssuePreviewDrawer';
+
+const AWAITING_INPUT_PATH = '/organizations/org-slug/issues/awaiting-input/';
+
+describe('useIssuePreviewDrawer', () => {
+  it('sets the preview query param when opening a preview', () => {
+    const {result, router} = renderHookWithProviders(() => useIssuePreviewDrawer(), {
+      initialRouterConfig: {location: {pathname: AWAITING_INPUT_PATH}},
+    });
+
+    expect(result.current.selectedIssueId).toBeUndefined();
+
+    act(() => {
+      result.current.openIssuePreview(GroupFixture({id: '42'}));
+    });
+
+    expect(router.location.query.preview).toBe('42');
+  });
+
+  it('opens the drawer when the preview param is present', async () => {
+    renderHookWithProviders(() => useIssuePreviewDrawer(), {
+      initialRouterConfig: {
+        location: {pathname: AWAITING_INPUT_PATH, query: {preview: '42'}},
+      },
+    });
+
+    expect(
+      await screen.findByRole('complementary', {name: 'Issue preview'})
+    ).toBeInTheDocument();
+  });
+
+  it('removes the preview param when the drawer is closed', async () => {
+    const {router} = renderHookWithProviders(() => useIssuePreviewDrawer(), {
+      initialRouterConfig: {
+        location: {pathname: AWAITING_INPUT_PATH, query: {preview: '42'}},
+      },
+    });
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Close Drawer'}));
+
+    expect(router.location.query.preview).toBeUndefined();
+  });
+});

--- a/static/app/views/issueList/pages/useIssuePreviewDrawer.spec.tsx
+++ b/static/app/views/issueList/pages/useIssuePreviewDrawer.spec.tsx
@@ -5,6 +5,7 @@ import {
   renderHookWithProviders,
   screen,
   userEvent,
+  waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
 import {useIssuePreviewDrawer} from 'sentry/views/issueList/pages/useIssuePreviewDrawer';
@@ -12,18 +13,20 @@ import {useIssuePreviewDrawer} from 'sentry/views/issueList/pages/useIssuePrevie
 const AWAITING_INPUT_PATH = '/organizations/org-slug/issues/awaiting-input/';
 
 describe('useIssuePreviewDrawer', () => {
-  it('sets the preview query param when opening a preview', () => {
+  it('sets the preview query param when opening a preview', async () => {
     const {result, router} = renderHookWithProviders(() => useIssuePreviewDrawer(), {
       initialRouterConfig: {location: {pathname: AWAITING_INPUT_PATH}},
     });
 
-    expect(result.current.selectedIssueId).toBeUndefined();
+    expect(result.current.selectedIssueId).toBeNull();
 
     act(() => {
       result.current.openIssuePreview(GroupFixture({id: '42'}));
     });
 
-    expect(router.location.query.preview).toBe('42');
+    await waitFor(() => {
+      expect(router.location.query.preview).toBe('42');
+    });
   });
 
   it('opens the drawer when the preview param is present', async () => {

--- a/static/app/views/issueList/pages/useIssuePreviewDrawer.tsx
+++ b/static/app/views/issueList/pages/useIssuePreviewDrawer.tsx
@@ -1,0 +1,90 @@
+import {Fragment, useCallback, useEffect, useEffectEvent, useRef} from 'react';
+
+import {DrawerBody, DrawerHeader, useDrawer} from '@sentry/scraps/drawer';
+
+import {t} from 'sentry/locale';
+import type {Group} from 'sentry/types/group';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+/**
+ * Query param holding the id of the issue whose preview drawer is open.
+ * Presence opens the drawer; absence closes it.
+ */
+export const SELECTED_ISSUE_QUERY_PARAM = 'preview';
+
+function IssuePreviewDrawer() {
+  return (
+    <Fragment>
+      <DrawerHeader />
+      <DrawerBody />
+    </Fragment>
+  );
+}
+
+/**
+ * Opens a lightweight issue preview drawer.
+ * The open/selected issue state is stored in the `preview` query param.
+ */
+export function useIssuePreviewDrawer({enabled = true}: {enabled?: boolean} = {}) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const {openDrawer} = useDrawer();
+
+  const selectedIssueId = decodeScalar(location.query[SELECTED_ISSUE_QUERY_PARAM]);
+
+  const openIssuePreview = useCallback(
+    (group: Group) => {
+      navigate(
+        {
+          pathname: location.pathname,
+          query: {
+            ...location.query,
+            [SELECTED_ISSUE_QUERY_PARAM]: group.id,
+          },
+        },
+        {replace: true, preventScrollReset: true}
+      );
+    },
+    [navigate, location.pathname, location.query]
+  );
+
+  const stripDrawerParam = useEffectEvent(() => {
+    navigate(
+      {
+        pathname: location.pathname,
+        query: {
+          ...location.query,
+          [SELECTED_ISSUE_QUERY_PARAM]: undefined,
+        },
+      },
+      {replace: true, preventScrollReset: true}
+    );
+  });
+
+  const lastOpenedIdRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!enabled || !selectedIssueId) {
+      lastOpenedIdRef.current = undefined;
+      return;
+    }
+
+    if (lastOpenedIdRef.current === selectedIssueId) {
+      return;
+    }
+
+    lastOpenedIdRef.current = selectedIssueId;
+    openDrawer(() => <IssuePreviewDrawer />, {
+      ariaLabel: t('Issue preview'),
+      drawerKey: 'issue-preview-drawer',
+      mode: 'passive',
+      shouldCloseOnLocationChange: nextLocation =>
+        !nextLocation.query[SELECTED_ISSUE_QUERY_PARAM],
+      onClose: () => stripDrawerParam(),
+    });
+  }, [enabled, selectedIssueId, openDrawer]);
+
+  return {openIssuePreview, selectedIssueId};
+}

--- a/static/app/views/issueList/pages/useIssuePreviewDrawer.tsx
+++ b/static/app/views/issueList/pages/useIssuePreviewDrawer.tsx
@@ -1,18 +1,16 @@
-import {Fragment, useCallback, useEffect, useEffectEvent, useRef} from 'react';
+import {Fragment, useCallback, useEffect, useRef} from 'react';
+import {parseAsString, useQueryState} from 'nuqs';
 
 import {DrawerBody, DrawerHeader, useDrawer} from '@sentry/scraps/drawer';
 
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
-import {decodeScalar} from 'sentry/utils/queryString';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 
 /**
  * Query param holding the id of the issue whose preview drawer is open.
  * Presence opens the drawer; absence closes it.
  */
-export const SELECTED_ISSUE_QUERY_PARAM = 'preview';
+const SELECTED_ISSUE_QUERY_PARAM = 'preview';
 
 function IssuePreviewDrawer() {
   return (
@@ -28,46 +26,25 @@ function IssuePreviewDrawer() {
  * The open/selected issue state is stored in the `preview` query param.
  */
 export function useIssuePreviewDrawer({enabled = true}: {enabled?: boolean} = {}) {
-  const location = useLocation();
-  const navigate = useNavigate();
   const {openDrawer} = useDrawer();
 
-  const selectedIssueId = decodeScalar(location.query[SELECTED_ISSUE_QUERY_PARAM]);
+  const [selectedIssueId, setSelectedIssueId] = useQueryState(
+    SELECTED_ISSUE_QUERY_PARAM,
+    parseAsString.withOptions({history: 'replace'})
+  );
 
   const openIssuePreview = useCallback(
     (group: Group) => {
-      navigate(
-        {
-          pathname: location.pathname,
-          query: {
-            ...location.query,
-            [SELECTED_ISSUE_QUERY_PARAM]: group.id,
-          },
-        },
-        {replace: true, preventScrollReset: true}
-      );
+      setSelectedIssueId(group.id);
     },
-    [navigate, location.pathname, location.query]
+    [setSelectedIssueId]
   );
 
-  const stripDrawerParam = useEffectEvent(() => {
-    navigate(
-      {
-        pathname: location.pathname,
-        query: {
-          ...location.query,
-          [SELECTED_ISSUE_QUERY_PARAM]: undefined,
-        },
-      },
-      {replace: true, preventScrollReset: true}
-    );
-  });
-
-  const lastOpenedIdRef = useRef<string | undefined>(undefined);
+  const lastOpenedIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!enabled || !selectedIssueId) {
-      lastOpenedIdRef.current = undefined;
+      lastOpenedIdRef.current = null;
       return;
     }
 
@@ -82,9 +59,9 @@ export function useIssuePreviewDrawer({enabled = true}: {enabled?: boolean} = {}
       mode: 'passive',
       shouldCloseOnLocationChange: nextLocation =>
         !nextLocation.query[SELECTED_ISSUE_QUERY_PARAM],
-      onClose: () => stripDrawerParam(),
+      onClose: () => setSelectedIssueId(null),
     });
-  }, [enabled, selectedIssueId, openDrawer]);
+  }, [enabled, selectedIssueId, openDrawer, setSelectedIssueId]);
 
   return {openIssuePreview, selectedIssueId};
 }


### PR DESCRIPTION
Ref ISWF-2875

On the awaiting input page, clicking an issue row now opens a lightweight preview drawer instead of navigating to the full issue details page. The selected issue is tracked via a `preview` query param.

This initial PR only sets up the initial logic that lets us tell the issue stream to open in a preview (just in the new awaiting input view). When the issue stream is set to `preview` behavior it will prevent default behavior and set `preview=issueId` on the URL which opens a drawer. The drawer is empty for now and will be added to in future PRs

<img width="1217" height="410" alt="CleanShot 2026-06-17 at 10 59 31" src="https://github.com/user-attachments/assets/1fa84767-d52b-4555-9866-052a7f689030" />
