### PR TITLE
fix(ourlogs): don't specify numeric threshold for data export emails

### DIFF
--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -14,7 +14,6 @@ import type {LogsQueryInfo} from 'sentry/components/exports/dataExport';
 import {ExportQueryType, useDataExport} from 'sentry/components/exports/useDataExport';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {formatNumber} from 'sentry/utils/number/formatNumber';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {downloadLogs} from 'sentry/views/explore/logs/exports/downloadLogs';
 import {
@@ -138,12 +137,7 @@ export function LogsExportModal({
       </Header>
       <Body>
         <Stack gap="xl">
-          <Text>
-            {t(
-              'If you select more than %s rows or to export all columns of data your file will be sent to your email address.',
-              formatNumber(ROW_COUNT_VALUE_SYNC_LIMIT)
-            )}
-          </Text>
+          <Text>{t('Large data export files will be sent to your email address.')}</Text>
           <form.AppField name="columns">
             {field => (
               <field.Layout.Stack label={t('All Columns?')}>


### PR DESCRIPTION
The server is technically able to override the numeric threshold. This switches the messaging to generally refer to "larger" downloads.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="614" height="491" alt="Screenshot 2026-06-17 at 2 40 36 PM" src="https://github.com/user-attachments/assets/e1ef1f51-f853-4d95-8147-fdb961bf6393" />
</td>
<td>
<img width="614" height="470" alt="image" src="https://github.com/user-attachments/assets/17ff8923-f0fd-4b28-9377-b0f666cc1f9c" />
</td>
</tr>
</tbody>
</table>

Closes LOGS-874.