### PR TITLE
auth: auto-recover from OAuth SSO state mismatches

### DIFF
--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -18,12 +18,23 @@ from sentry.auth.provider import Provider
 from sentry.auth.view import AuthView
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.models.authidentity import AuthIdentity
+from sentry.utils import metrics
 from sentry.utils.http import absolute_uri
 
 if TYPE_CHECKING:
     from sentry.auth.helper import AuthHelper
 
-ERR_INVALID_STATE = "An error occurred while validating your request."
+# Shown only after an automatic retry has already failed, so it gives the user
+# something actionable instead of a generic validation error.
+ERR_INVALID_STATE_RETRY_FAILED = (
+    "We couldn't complete sign-in. This usually happens when sign-in was started "
+    "in another tab or your session expired. Please close other Sentry tabs and "
+    "try signing in again."
+)
+
+# Pipeline state key used to ensure we only auto-restart the flow once, so a
+# browser that genuinely cannot persist the session can't get stuck in a loop.
+STATE_RETRY_KEY = "state_mismatch_retried"
 
 
 def _get_redirect_url() -> str:
@@ -127,6 +138,37 @@ class OAuth2Callback(AuthView):
             return dict(parse_qsl(body))
         return orjson.loads(body)
 
+    def _handle_state_mismatch(self, pipeline: AuthHelper) -> HttpResponseBase:
+        # A state mismatch is almost always benign and transient rather than an
+        # attack: the user opened the login in multiple tabs (so the stored
+        # nonce was overwritten), hit the back button, or lingered on the IdP's
+        # consent screen until the session-store entry rotated. Re-initiating
+        # the login exchanges no token, so it fully preserves the CSRF
+        # protection the state parameter provides while letting these users
+        # recover instead of dead-ending on an opaque error page.
+        #
+        # We restart exactly once, guarded by pipeline state, so a browser that
+        # genuinely cannot persist the session can't get stuck in a redirect
+        # loop -- the second failure falls through to an actionable error.
+        if pipeline.fetch_state(STATE_RETRY_KEY):
+            return pipeline.error(ERR_INVALID_STATE_RETRY_FAILED)
+
+        pipeline.bind_state(STATE_RETRY_KEY, True)
+        # Rewind to the login step so the next request regenerates the nonce and
+        # bounces the user back through the IdP.
+        pipeline.state.step_index = 0
+
+        metrics.incr(
+            "sso.state_mismatch_auto_retry",
+            tags={"provider": pipeline.provider.key},
+            sample_rate=1.0,
+        )
+        logging.info(
+            "auth.sso.state_mismatch.auto_retry", extra={"provider": pipeline.provider.key}
+        )
+
+        return HttpResponseRedirect(_get_redirect_url())
+
     def dispatch(self, request: HttpRequest, pipeline: AuthHelper) -> HttpResponseBase:
         error = request.GET.get("error")
         state = request.GET.get("state")
@@ -136,7 +178,7 @@ class OAuth2Callback(AuthView):
             return pipeline.error(error)
 
         if state != pipeline.fetch_state("state"):
-            return pipeline.error(ERR_INVALID_STATE)
+            return self._handle_state_mismatch(pipeline)
 
         if code is None:
             return pipeline.error("no code was provided")

--- a/tests/sentry/web/frontend/test_auth_oauth2.py
+++ b/tests/sentry/web/frontend/test_auth_oauth2.py
@@ -198,12 +198,41 @@ class AuthOAuth2Test(AuthProviderTestCase):
         state = self.initiate_oauth_flow()
         self.initiate_callback(state, auth_data, has_2fa=True)
 
-    def test_state_mismatch(self) -> None:
-        auth_data = {"id": "oauth_external_id_1234", "email": self.user.email}
-
+    def test_state_mismatch_auto_retries(self) -> None:
+        # A single state mismatch (stale tab, expired session, back button) should
+        # transparently restart the SSO flow rather than dead-ending on an error.
         self.initiate_oauth_flow()
-        auth_resp = self.initiate_callback("bad", auth_data, expect_success=False, follow=True)
 
+        query = urlencode({"code": "1234", "state": "bad"})
+        resp = self.client.get(f"{self.sso_path}?{query}")
+
+        assert resp.status_code == 302
+        assert resp["Location"] == "http://testserver/auth/sso/"
+
+        # Following the restart re-initiates the flow and bounces back to the IdP.
+        resp = self.client.get(resp["Location"])
+        assert resp.status_code == 302
+        assert resp["Location"].startswith("http://example.com/authorize_url")
+
+    def test_state_mismatch_retry_exhausted(self) -> None:
+        # If the retry also fails, the user is shown a clear error instead of
+        # being restarted again (which would otherwise be an infinite loop).
+        auth_data = {"id": "oauth_external_id_1234", "email": self.user.email}
+        self.initiate_oauth_flow()
+
+        # First mismatch -> auto restart.
+        query = urlencode({"code": "1234", "state": "bad"})
+        resp = self.client.get(f"{self.sso_path}?{query}")
+        assert resp.status_code == 302
+        assert resp["Location"] == "http://testserver/auth/sso/"
+
+        # The restart re-initiates the flow (new nonce -> IdP).
+        resp = self.client.get(resp["Location"])
+        assert resp.status_code == 302
+        assert resp["Location"].startswith("http://example.com/authorize_url")
+
+        # A second mismatch is no longer retried: clear error, never authenticated.
+        auth_resp = self.initiate_callback("bad", auth_data, expect_success=False, follow=True)
         messages = list(auth_resp.context["messages"])
         assert len(messages) == 1
         assert str(messages[0]).startswith("Authentication error")
@@ -255,10 +284,10 @@ class AuthOAuth2Test(AuthProviderTestCase):
         auth_data = {"id": "oauth_external_id_1234", "email": self.user.email}
         urlopen.return_value = MockResponse(headers, json.dumps(auth_data))
 
+        # A state with the wrong provider key is a state mismatch, so the first
+        # attempt auto-restarts the flow rather than authenticating the user.
         query = urlencode({"code": "1234", "state": wrong_state})
-        auth_resp = self.client.get(f"{self.sso_path}?{query}", follow=True)
+        auth_resp = self.client.get(f"{self.sso_path}?{query}")
 
-        # Should fail with state mismatch error
-        messages = list(auth_resp.context["messages"])
-        assert len(messages) == 1
-        assert str(messages[0]).startswith("Authentication error")
+        assert auth_resp.status_code == 302
+        assert auth_resp["Location"] == "http://testserver/auth/sso/"


### PR DESCRIPTION
## Problem

A state mismatch in the OAuth SSO login callback (`OAuth2Callback.dispatch`) was a hard, opaque dead-end: it returned `"An error occurred while validating your request."` and dropped the user on the login page with no recovery path. Users couldn't get in and rage-clicked.

In practice these mismatches that actually reach this check are almost always **benign and transient** rather than attacks (total session loss is intercepted earlier and redirected to `/auth/login/`). The reachable causes are:

- **multi-tab / re-initiation** — the pipeline session store is single-valued per session, so a second login attempt overwrites the stored nonce; the first tab's callback then mismatches;
- **back button** replaying a stale `state`;
- **session-store rotation** while the user lingers on the IdP consent screen.

## Fix

The OAuth `state` parameter is purely a CSRF guard — its only job is to prevent us from exchanging a `code` we didn't initiate. **Re-initiating the login exchanges no token, so restarting fully preserves that protection.**

On a mismatch we now:

1. Rewind the pipeline to the login step and bounce the user back through the IdP **once** (for an already-signed-in user this round-trip is invisible, so most mismatches silently self-heal).
2. Guard the restart with a one-shot flag in pipeline state (`state_mismatch_retried`) so a browser that genuinely can't persist the session can't get stuck in a redirect loop.
3. Only if the retry *also* fails, show a clear, actionable error instead of the opaque one.

A `sso.state_mismatch_auto_retry` metric (tagged by provider) is emitted so we can measure how many sign-ins this silently recovers. Because the change lives in the shared `OAuth2Callback`, it covers Google, GitHub, and Fly SSO.

## Tests

Updated the two existing state-mismatch tests and added `test_state_mismatch_retry_exhausted` in `tests/sentry/web/frontend/test_auth_oauth2.py` to cover both the auto-restart and the retry-exhausted-error paths.

> Note: the dev environment wasn't available where this was authored, so the test suite was not run locally — `py_compile`, `ruff check`, and `ruff format --check` pass. Relying on CI for the full pytest run.

https://claude.ai/code/session_01J7qQZNpDDa4NCTkic3BbMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7qQZNpDDa4NCTkic3BbMw)_