### PR TITLE
chore(seer-activity): Add handler for unsupported actions

### DIFF
--- a/src/sentry/notifications/notification_action/activity_registry/__init__.py
+++ b/src/sentry/notifications/notification_action/activity_registry/__init__.py
@@ -2,10 +2,12 @@ from .discord import DiscordActivityHandler
 from .email import EmailActivityHandler
 from .msteams import MSTeamsActivityHandler
 from .slack import SlackActivityHandler
+from .unsupported import UnsupportedActivityHandler
 
 __all__ = [
     "DiscordActivityHandler",
     "EmailActivityHandler",
     "MSTeamsActivityHandler",
+    "UnsupportedActivityHandler",
     "SlackActivityHandler",
 ]

--- a/src/sentry/notifications/notification_action/activity_registry/base.py
+++ b/src/sentry/notifications/notification_action/activity_registry/base.py
@@ -15,13 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 NOTIFICATION_PLATFORM_COMPATIBLE_ACTIVITIES = [
-    ActivityType.SEER_RCA_STARTED,
-    ActivityType.SEER_RCA_COMPLETED,
-    ActivityType.SEER_SOLUTION_STARTED,
-    ActivityType.SEER_SOLUTION_COMPLETED,
-    ActivityType.SEER_CODING_STARTED,
-    ActivityType.SEER_CODING_COMPLETED,
-    ActivityType.SEER_PR_CREATED,
+    ActivityType(value) for value in ACTIVITY_TYPE_TO_SOURCE
 ]
 
 

--- a/src/sentry/notifications/notification_action/activity_registry/unsupported.py
+++ b/src/sentry/notifications/notification_action/activity_registry/unsupported.py
@@ -1,0 +1,44 @@
+import logging
+
+from sentry.models.activity import Activity
+from sentry.notifications.notification_action.activity_registry.base import (
+    NOTIFICATION_PLATFORM_COMPATIBLE_ACTIVITIES,
+)
+from sentry.notifications.notification_action.registry import activity_handler_registry
+from sentry.notifications.notification_action.types import ActivityHandler
+from sentry.types.activity import ActivityType
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import ActionInvocation
+
+logger = logging.getLogger(__name__)
+
+
+@activity_handler_registry.register(Action.Type.PAGERDUTY)
+@activity_handler_registry.register(Action.Type.OPSGENIE)
+@activity_handler_registry.register(Action.Type.GITHUB)
+@activity_handler_registry.register(Action.Type.GITHUB_ENTERPRISE)
+@activity_handler_registry.register(Action.Type.JIRA)
+@activity_handler_registry.register(Action.Type.JIRA_SERVER)
+@activity_handler_registry.register(Action.Type.AZURE_DEVOPS)
+@activity_handler_registry.register(Action.Type.SENTRY_APP)
+@activity_handler_registry.register(Action.Type.PLUGIN)
+@activity_handler_registry.register(Action.Type.WEBHOOK)
+class UnsupportedActivityHandler(ActivityHandler):
+    compatible_activity_types = NOTIFICATION_PLATFORM_COMPATIBLE_ACTIVITIES
+
+    @classmethod
+    def invoke_action(cls, invocation: ActionInvocation, activity: Activity) -> None:
+        try:
+            activity_type_name = ActivityType(activity.type).name
+        except ValueError:
+            activity_type_name = str(activity.type)
+
+        logger.info(
+            "notification_action.activity.unsupported",
+            extra={
+                "action_id": invocation.action.id,
+                "action_type": invocation.action.type,
+                "activity_type": activity.type,
+                "activity_type_name": activity_type_name,
+            },
+        )

--- a/tests/sentry/notifications/notification_action/activity_registry/test_unsupported.py
+++ b/tests/sentry/notifications/notification_action/activity_registry/test_unsupported.py
@@ -24,12 +24,6 @@ UNSUPPORTED_ACTION_TYPES = [
 ]
 
 
-class TestUnsupportedActivityHandlerRegistration:
-    @pytest.mark.parametrize("action_type", UNSUPPORTED_ACTION_TYPES)
-    def test_registered(self, action_type: Action.Type) -> None:
-        assert activity_handler_registry.get(action_type) is UnsupportedActivityHandler
-
-
 class TestUnsupportedActivityHandler(BaseWorkflowTest):
     def setUp(self) -> None:
         super().setUp()
@@ -47,6 +41,10 @@ class TestUnsupportedActivityHandler(BaseWorkflowTest):
             },
         )
 
+    @pytest.mark.parametrize("action_type", UNSUPPORTED_ACTION_TYPES)
+    def test_registered(self, action_type: Action.Type) -> None:
+        assert activity_handler_registry.get(action_type) is UnsupportedActivityHandler
+
     @mock.patch("sentry.notifications.notification_action.activity_registry.unsupported.logger")
     def test_invoke_action_logs_and_returns(self, mock_logger: mock.MagicMock) -> None:
         activity = self.create_group_activity(
@@ -60,7 +58,6 @@ class TestUnsupportedActivityHandler(BaseWorkflowTest):
             detector=self.detector,
             workflow_id=self.workflow.id,
         )
-
         UnsupportedActivityHandler.invoke_action(invocation=invocation, activity=activity)
 
         mock_logger.info.assert_called_once_with(
@@ -72,23 +69,3 @@ class TestUnsupportedActivityHandler(BaseWorkflowTest):
                 "activity_type_name": "SEER_RCA_STARTED",
             },
         )
-
-    @mock.patch("sentry.notifications.notification_action.activity_registry.unsupported.logger")
-    def test_invoke_action_does_not_send_notification(self, mock_logger: mock.MagicMock) -> None:
-        activity = self.create_group_activity(
-            group=self.group,
-            type=ActivityType.SEER_SOLUTION_COMPLETED.value,
-        )
-        invocation = self.create_action_invocation(
-            event=activity,
-            group=self.group,
-            action=self.action,
-            detector=self.detector,
-            workflow_id=self.workflow.id,
-        )
-
-        with mock.patch(
-            "sentry.notifications.notification_action.activity_registry.base.NotificationService"
-        ) as mock_service:
-            UnsupportedActivityHandler.invoke_action(invocation=invocation, activity=activity)
-            mock_service.assert_not_called()

--- a/tests/sentry/notifications/notification_action/activity_registry/test_unsupported.py
+++ b/tests/sentry/notifications/notification_action/activity_registry/test_unsupported.py
@@ -1,0 +1,94 @@
+from unittest import mock
+
+import pytest
+
+from sentry.notifications.notification_action.activity_registry.unsupported import (
+    UnsupportedActivityHandler,
+)
+from sentry.notifications.notification_action.registry import activity_handler_registry
+from sentry.types.activity import ActivityType
+from sentry.workflow_engine.models import Action
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+
+UNSUPPORTED_ACTION_TYPES = [
+    Action.Type.PAGERDUTY,
+    Action.Type.OPSGENIE,
+    Action.Type.GITHUB,
+    Action.Type.GITHUB_ENTERPRISE,
+    Action.Type.JIRA,
+    Action.Type.JIRA_SERVER,
+    Action.Type.AZURE_DEVOPS,
+    Action.Type.SENTRY_APP,
+    Action.Type.PLUGIN,
+    Action.Type.WEBHOOK,
+]
+
+
+class TestUnsupportedActivityHandlerRegistration:
+    @pytest.mark.parametrize("action_type", UNSUPPORTED_ACTION_TYPES)
+    def test_registered(self, action_type: Action.Type) -> None:
+        assert activity_handler_registry.get(action_type) is UnsupportedActivityHandler
+
+
+class TestUnsupportedActivityHandler(BaseWorkflowTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+        self.workflow, self.detector, _, _ = self.create_detector_and_workflow()
+        self.integration = self.create_integration(
+            organization=self.organization, provider="pagerduty", external_id="pd_ext_id"
+        )
+        self.action = self.create_action(
+            type=Action.Type.PAGERDUTY,
+            integration_id=self.integration.id,
+            config={
+                "target_identifier": "some_service",
+                "target_type": 0,
+            },
+        )
+
+    @mock.patch("sentry.notifications.notification_action.activity_registry.unsupported.logger")
+    def test_invoke_action_logs_and_returns(self, mock_logger: mock.MagicMock) -> None:
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SEER_RCA_STARTED.value,
+        )
+        invocation = self.create_action_invocation(
+            event=activity,
+            group=self.group,
+            action=self.action,
+            detector=self.detector,
+            workflow_id=self.workflow.id,
+        )
+
+        UnsupportedActivityHandler.invoke_action(invocation=invocation, activity=activity)
+
+        mock_logger.info.assert_called_once_with(
+            "notification_action.activity.unsupported",
+            extra={
+                "action_id": self.action.id,
+                "action_type": Action.Type.PAGERDUTY,
+                "activity_type": ActivityType.SEER_RCA_STARTED.value,
+                "activity_type_name": "SEER_RCA_STARTED",
+            },
+        )
+
+    @mock.patch("sentry.notifications.notification_action.activity_registry.unsupported.logger")
+    def test_invoke_action_does_not_send_notification(self, mock_logger: mock.MagicMock) -> None:
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SEER_SOLUTION_COMPLETED.value,
+        )
+        invocation = self.create_action_invocation(
+            event=activity,
+            group=self.group,
+            action=self.action,
+            detector=self.detector,
+            workflow_id=self.workflow.id,
+        )
+
+        with mock.patch(
+            "sentry.notifications.notification_action.activity_registry.base.NotificationService"
+        ) as mock_service:
+            UnsupportedActivityHandler.invoke_action(invocation=invocation, activity=activity)
+            mock_service.assert_not_called()

--- a/tests/sentry/notifications/notification_action/activity_registry/test_unsupported.py
+++ b/tests/sentry/notifications/notification_action/activity_registry/test_unsupported.py
@@ -24,6 +24,11 @@ UNSUPPORTED_ACTION_TYPES = [
 ]
 
 
+@pytest.mark.parametrize("action_type", UNSUPPORTED_ACTION_TYPES)
+def test_unsupported_registrations(action_type: Action.Type) -> None:
+    assert activity_handler_registry.get(action_type) is UnsupportedActivityHandler
+
+
 class TestUnsupportedActivityHandler(BaseWorkflowTest):
     def setUp(self) -> None:
         super().setUp()
@@ -40,10 +45,6 @@ class TestUnsupportedActivityHandler(BaseWorkflowTest):
                 "target_type": 0,
             },
         )
-
-    @pytest.mark.parametrize("action_type", UNSUPPORTED_ACTION_TYPES)
-    def test_registered(self, action_type: Action.Type) -> None:
-        assert activity_handler_registry.get(action_type) is UnsupportedActivityHandler
 
     @mock.patch("sentry.notifications.notification_action.activity_registry.unsupported.logger")
     def test_invoke_action_logs_and_returns(self, mock_logger: mock.MagicMock) -> None:


### PR DESCRIPTION
Registers all other actions to gracefully exit, just log and noop so we can keep track, but we'll prevent these from being saved on the API and UI anyway.