### PR TITLE
feat(integrations): add MCP hint to the new integration type modal

### DIFF
--- a/static/app/components/modals/createNewIntegrationModal.tsx
+++ b/static/app/components/modals/createNewIntegrationModal.tsx
@@ -3,9 +3,10 @@ import {Fragment, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
-import {ExternalLink} from '@sentry/scraps/link';
+import {ExternalLink, Link} from '@sentry/scraps/link';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {RadioGroup} from 'sentry/components/forms/controls/radioGroup';
@@ -88,6 +89,16 @@ function CreateNewIntegrationModal({Body, Header, Footer, closeModal}: ModalRend
         </Flex>
       </Header>
       <Body>
+        <Alert.Container>
+          <Alert variant="info">
+            {tct(
+              'Looking for MCP? Connect Sentry to AI-powered tools and your terminal from the [link:MCP & CLI] page.',
+              {
+                link: <Link to={`/settings/${organization.slug}/mcp-cli/`} />,
+              }
+            )}
+          </Alert>
+        </Alert.Container>
         <StyledRadioGroup
           choices={choices}
           label={t('Avatar Type')}


### PR DESCRIPTION
Add a hint for users looking for the mcp
<img width="580" height="419" alt="Screenshot 2026-06-17 at 2 06 06 PM" src="https://github.com/user-attachments/assets/efbcb81e-ccf1-476a-a306-3b5618030031" />
