### PR TITLE
ref(deletions): Split EAP deletion into async task with retries

### DIFF
--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -28,9 +28,12 @@ from sentry.snuba.referrer import Referrer
 from sentry.tasks.base import instrumented_task, track_group_async_operation
 from sentry.taskworker.namespaces import deletion_tasks
 from sentry.utils import metrics
-from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.utils.snuba import UnqualifiedQueryError, bulk_snuba_queries
-from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
+from sentry.utils.snuba_rpc import (
+    SnubaRPCRateLimitExceeded,
+    SnubaRPCTimeout,
+    SnubaRPCTooManySimultaneous,
+)
 
 EVENT_CHUNK_SIZE = 10000
 # https://github.com/getsentry/snuba/blob/54feb15b7575142d4b3af7f50d2c2c865329f2db/snuba/datasets/configuration/issues/storages/search_issues.yaml#L139
@@ -234,36 +237,46 @@ def delete_events_from_eventstore(
         eventstream_state = eventstream.backend.start_delete_groups(project_id, group_ids)
         eventstream.backend.end_delete_groups(eventstream_state)
 
-    delete_events_from_eap(organization_id, project_id, group_ids, dataset)
+    delete_events_from_eap.apply_async(
+        kwargs={
+            "organization_id": organization_id,
+            "project_id": project_id,
+            "group_ids": group_ids,
+            "dataset_str": dataset.value,
+        },
+    )
 
 
+@instrumented_task(
+    name="sentry.deletions.tasks.nodestore.delete_events_from_eap",
+    namespace=deletion_tasks,
+    processing_deadline_duration=60 * 2,
+    retry=Retry(
+        times=MAX_RETRIES,
+        on=(SnubaRPCTimeout, SnubaRPCRateLimitExceeded, SnubaRPCTooManySimultaneous),
+        delay=60,
+    ),
+    silo_mode=SiloMode.CELL,
+)
 def delete_events_from_eap(
     organization_id: int,
     project_id: int,
     group_ids: Sequence[int],
-    dataset: Dataset,
+    dataset_str: str,
 ) -> None:
     if not options.get("eventstream.eap.deletion-enabled"):
         return
 
-    retry_policy = ConditionalRetryPolicy(
-        test_function=lambda attempt, exc: attempt < 5
-        and isinstance(exc, SnubaRPCRateLimitExceeded),
-        delay_function=exponential_delay(1.0),
-    )
-
     try:
-        retry_policy(
-            lambda: delete_groups_from_eap_rpc(
-                organization_id=organization_id,
-                project_id=project_id,
-                group_ids=group_ids,
-                referrer="deletions.group.eap",
-            )
+        delete_groups_from_eap_rpc(
+            organization_id=organization_id,
+            project_id=project_id,
+            group_ids=group_ids,
+            referrer="deletions.group.eap",
         )
         metrics.incr(
             "deletions.group.eap.success",
-            tags={"dataset": dataset.value},
+            tags={"dataset": dataset_str},
             sample_rate=1.0,
         )
     except Exception:
@@ -273,14 +286,15 @@ def delete_events_from_eap(
                 "organization_id": organization_id,
                 "project_id": project_id,
                 "group_ids": group_ids[:10],
-                "dataset": dataset.value,
+                "dataset": dataset_str,
             },
         )
         metrics.incr(
             "deletions.group.eap.failure",
-            tags={"dataset": dataset.value},
+            tags={"dataset": dataset_str},
             sample_rate=1.0,
         )
+        raise
 
 
 def delete_events_from_eventstore_issue_platform(

--- a/tests/sentry/eventstream/test_eap.py
+++ b/tests/sentry/eventstream/test_eap.py
@@ -8,7 +8,11 @@ from sentry.deletions.tasks.nodestore import delete_events_from_eap
 from sentry.eventstream.eap import delete_groups_from_eap_rpc
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
-from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
+from sentry.utils.snuba_rpc import (
+    SnubaRPCRateLimitExceeded,
+    SnubaRPCTimeout,
+    SnubaRPCTooManySimultaneous,
+)
 
 
 class TestEAPDeletion(TestCase):
@@ -25,7 +29,10 @@ class TestEAPDeletion(TestCase):
         )
 
         delete_events_from_eap(
-            self.organization_id, self.project_id, self.group_ids, Dataset.Events
+            organization_id=self.organization_id,
+            project_id=self.project_id,
+            group_ids=self.group_ids,
+            dataset_str=Dataset.Events.value,
         )
         assert mock_rpc.call_count == 1
 
@@ -55,7 +62,10 @@ class TestEAPDeletion(TestCase):
         many_group_ids = [10, 20, 30, 40, 50]
 
         delete_events_from_eap(
-            self.organization_id, self.project_id, many_group_ids, Dataset.Events
+            organization_id=self.organization_id,
+            project_id=self.project_id,
+            group_ids=many_group_ids,
+            dataset_str=Dataset.Events.value,
         )
 
         request = mock_rpc.call_args[0][0]
@@ -68,7 +78,10 @@ class TestEAPDeletion(TestCase):
     def test_eap_deletion_disabled_skips_deletion(self, mock_rpc: MagicMock) -> None:
         with self.options({"eventstream.eap.deletion-enabled": False}):
             delete_events_from_eap(
-                self.organization_id, self.project_id, self.group_ids, Dataset.Events
+                organization_id=self.organization_id,
+                project_id=self.project_id,
+                group_ids=self.group_ids,
+                dataset_str=Dataset.Events.value,
             )
 
         mock_rpc.assert_not_called()
@@ -82,51 +95,40 @@ class TestEAPDeletion(TestCase):
             )
 
     @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")
-    def test_exception_does_not_propagate(self, mock_rpc: MagicMock) -> None:
-        mock_rpc.side_effect = Exception("RPC connection failed")
+    def test_rpc_errors_propagate_and_are_retried(self, mock_rpc: MagicMock) -> None:
+        retry = delete_events_from_eap._retry
 
-        # Should not raise - exception should be caught
-        try:
+        for exc in [
+            SnubaRPCTimeout("read timed out"),
+            SnubaRPCRateLimitExceeded("rate limited"),
+            SnubaRPCTooManySimultaneous("too many queries"),
+        ]:
+            mock_rpc.side_effect = exc
+
+            with pytest.raises(type(exc)):
+                delete_events_from_eap(
+                    organization_id=self.organization_id,
+                    project_id=self.project_id,
+                    group_ids=self.group_ids,
+                    dataset_str=Dataset.Events.value,
+                )
+
+            state = retry.initial_state()
+            assert retry.should_retry(state, exc) is True
+
+    @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")
+    def test_non_rpc_error_propagates_and_is_not_retried(self, mock_rpc: MagicMock) -> None:
+        exc = RuntimeError("unexpected failure")
+        mock_rpc.side_effect = exc
+
+        with pytest.raises(RuntimeError, match="unexpected failure"):
             delete_events_from_eap(
-                self.organization_id, self.project_id, self.group_ids, Dataset.Events
+                organization_id=self.organization_id,
+                project_id=self.project_id,
+                group_ids=self.group_ids,
+                dataset_str=Dataset.Events.value,
             )
-        except Exception:
-            pytest.fail("Exception should have been caught and not propagated")
 
-    @patch("sentry.deletions.tasks.nodestore.exponential_delay")
-    @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")
-    def test_rate_limit_error_is_retried(self, mock_rpc: MagicMock, mock_delay: MagicMock) -> None:
-        mock_rpc.side_effect = SnubaRPCRateLimitExceeded("rate limited")
-        mock_delay.return_value = lambda _: 0
-
-        delete_events_from_eap(
-            self.organization_id, self.project_id, self.group_ids, Dataset.Events
-        )
-
-        assert mock_rpc.call_count == 5
-
-    @patch("sentry.deletions.tasks.nodestore.exponential_delay")
-    @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")
-    def test_rate_limit_succeeds_on_retry(self, mock_rpc: MagicMock, mock_delay: MagicMock) -> None:
-        mock_rpc.side_effect = [
-            SnubaRPCRateLimitExceeded("rate limited"),
-            SnubaRPCRateLimitExceeded("rate limited"),
-            DeleteTraceItemsResponse(meta=ResponseMeta(), matching_items_count=10),
-        ]
-        mock_delay.return_value = lambda _: 0
-
-        delete_events_from_eap(
-            self.organization_id, self.project_id, self.group_ids, Dataset.Events
-        )
-
-        assert mock_rpc.call_count == 3
-
-    @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")
-    def test_non_rate_limit_error_not_retried(self, mock_rpc: MagicMock) -> None:
-        mock_rpc.side_effect = Exception("Some other error")
-
-        delete_events_from_eap(
-            self.organization_id, self.project_id, self.group_ids, Dataset.Events
-        )
-
-        assert mock_rpc.call_count == 1
+        retry = delete_events_from_eap._retry
+        state = retry.initial_state()
+        assert retry.should_retry(state, exc) is False

--- a/tests/sentry/eventstream/test_eap.py
+++ b/tests/sentry/eventstream/test_eap.py
@@ -97,6 +97,7 @@ class TestEAPDeletion(TestCase):
     @patch("sentry.eventstream.eap.snuba_rpc.delete_trace_items_rpc")
     def test_rpc_errors_propagate_and_are_retried(self, mock_rpc: MagicMock) -> None:
         retry = delete_events_from_eap._retry
+        assert retry is not None
 
         for exc in [
             SnubaRPCTimeout("read timed out"),
@@ -130,5 +131,6 @@ class TestEAPDeletion(TestCase):
             )
 
         retry = delete_events_from_eap._retry
+        assert retry is not None
         state = retry.initial_state()
         assert retry.should_retry(state, exc) is False


### PR DESCRIPTION
Converts `delete_events_from_eap` from a synchronous function into an async `@instrumented_task` with task-level `Retry` defined. This has the effect of:
- More comprehensive retries for Snuba RPC exceptions, many of which can be transient
- Reduce overall latency for the deletions process, since EAP timeouts and retry backoff could previously tie up the deletions worker thread

The new task retries on `SnubaRPCTimeout`, `SnubaRPCRateLimitExceeded`, and `SnubaRPCTooManySimultaneous` with a 60s fixed delay, up to 5 attempts. After retries are exhausted, the task is discarded - we're okay with this EAP deletion being best-effort for now since the primary deletion is still the nodestore/eventstore operation.

[Slack thread for context](https://sentry.slack.com/archives/C1B4LB39D/p1781721272770889?thread_ts=1781718537.081559&cid=C1B4LB39D)