### PR TITLE
ref(issues): Rename triaged progress state to assigned

### DIFF
--- a/src/sentry/issues/progress.py
+++ b/src/sentry/issues/progress.py
@@ -12,7 +12,7 @@ from sentry.types.activity import ActivityType
 
 class IssueProgressState(StrEnum):
     IDENTIFIED = "identified"
-    TRIAGED = "triaged"
+    ASSIGNED = "assigned"
     DIAGNOSED = "diagnosed"
     FIX_PROPOSED = "fix_proposed"
     FIX_APPLIED = "fix_applied"
@@ -34,7 +34,7 @@ ISSUE_PROGRESS_TO_ACTIVITY_TYPES: dict[IssueProgressState, list[int]] = {
 }
 
 # Defines the order in which progress states are considered
-# Triaged and Identified are fallbacks (depending on assignment status) so are not listed here.
+# Assigned and Identified are fallbacks (depending on assignment status) so are not listed here.
 PROGRESS_STATES_DESCENDING = [
     IssueProgressState.FIX_APPLIED,
     IssueProgressState.FIX_PROPOSED,
@@ -117,16 +117,16 @@ def get_group_progress_states(
         # If the reset was most recent
         else:
             result[group_id] = (
-                IssueProgressState.TRIAGED
+                IssueProgressState.ASSIGNED
                 if group_id in assigned_group_ids
                 else IssueProgressState.IDENTIFIED
             ).value
 
-    # If the group does not have any matching activities, it is presumed to be identified or triaged.
+    # If the group does not have any matching activities, it is presumed to be identified or assigned.
     for group_id in group_ids:
         if group_id not in groups_with_activities:
             result[group_id] = (
-                IssueProgressState.TRIAGED
+                IssueProgressState.ASSIGNED
                 if group_id in assigned_group_ids
                 else IssueProgressState.IDENTIFIED
             ).value

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -275,20 +275,20 @@ def issue_progress_filter(progress_values: list[str], projects: Sequence[Project
     """
     Filters issues by their position in the resolution lifecycle:
 
-      identified -> triaged -> diagnosed -> fix_proposed -> fix_applied
+      identified -> assigned -> diagnosed -> fix_proposed -> fix_applied
 
     "diagnosed" and above are determined by seer/resolution activity types (see
     ISSUE_PROGRESS_TO_ACTIVITY_TYPES). A regression or manual unresolve resets an issue
     back, so only activities *after* the latest reset count.
 
-    "identified" and "triaged" are the two base states before any seer activity,
+    "identified" and "assigned" are the two base states before any seer activity,
     distinguished solely by whether the issue is currently assigned:
       - identified: not assigned AND no post-regression seer activity
-      - triaged:    assigned (via GroupAssignee) AND no post-regression seer activity
+      - assigned:   assigned (via GroupAssignee) AND no post-regression seer activity
 
     Assignment is checked via GroupAssignee rather than ASSIGNED activity so that it
     survives regressions — an issue that was assigned, progressed, then regressed
-    remains triaged as long as it's still assigned.
+    remains assigned as long as it's still assigned.
     """
     from sentry.issues.progress import ISSUE_PROGRESS_TO_ACTIVITY_TYPES, IssueProgressState
 
@@ -307,7 +307,7 @@ def issue_progress_filter(progress_values: list[str], projects: Sequence[Project
         progress = IssueProgressState(value)
         if progress is IssueProgressState.IDENTIFIED:
             q |= ~assigned_q & ~has_progress_q
-        elif progress is IssueProgressState.TRIAGED:
+        elif progress is IssueProgressState.ASSIGNED:
             q |= assigned_q & ~has_progress_q
         else:
             activity_types = ISSUE_PROGRESS_TO_ACTIVITY_TYPES[progress]

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -989,10 +989,10 @@ def recommended_v2_strategy() -> PostgresSortStrategy:
 
 # Numeric rank for the "progress" sort: higher means further along the fix cycle, so it
 # sorts towards the top. Every state has a rank so issues without seer activity (the
-# identified/triaged base states) still order correctly relative to progressed issues.
+# identified/assigned base states) still order correctly relative to progressed issues.
 PROGRESS_STATE_SORT_RANK: dict[IssueProgressState, int] = {
     IssueProgressState.IDENTIFIED: 1,
-    IssueProgressState.TRIAGED: 2,
+    IssueProgressState.ASSIGNED: 2,
     IssueProgressState.DIAGNOSED: 3,
     IssueProgressState.FIX_PROPOSED: 4,
     IssueProgressState.FIX_APPLIED: 5,
@@ -1018,7 +1018,7 @@ def resolve_progress_signal(
 
 def progress_strategy() -> PostgresSortStrategy:
     """Progress sort: primary by fix-cycle rank (fix_applied > fix_proposed > diagnosed >
-    triaged > identified), secondary by last_seen. The secondary key stands in for
+    assigned > identified), secondary by last_seen. The secondary key stands in for
     ``issue.last_progressed_at`` until that field exists; for now most-recently-active issues
     rank highest within a tier."""
 

--- a/tests/sentry/issues/endpoints/test_organization_group_index_progress.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index_progress.py
@@ -20,7 +20,7 @@ class OrganizationGroupIndexProgressTest(APITestCase):
         )
         assert response.data == {"results": {str(group.id): {"progress": "identified"}}}
 
-    def test_triaged_when_assigned(self) -> None:
+    def test_assigned_when_assigned(self) -> None:
         group = self.create_group(project=self.project)
         GroupAssignee.objects.assign(group, self.user)
 
@@ -28,7 +28,7 @@ class OrganizationGroupIndexProgressTest(APITestCase):
             self.organization.slug,
             groups=[group.id],
         )
-        assert response.data == {"results": {str(group.id): {"progress": "triaged"}}}
+        assert response.data == {"results": {str(group.id): {"progress": "assigned"}}}
 
     def test_diagnosed(self) -> None:
         group = self.create_group(project=self.project)
@@ -52,7 +52,7 @@ class OrganizationGroupIndexProgressTest(APITestCase):
         assert response.data == {
             "results": {
                 str(group_a.id): {"progress": "identified"},
-                str(group_b.id): {"progress": "triaged"},
+                str(group_b.id): {"progress": "assigned"},
             }
         }
 

--- a/tests/sentry/issues/test_progress.py
+++ b/tests/sentry/issues/test_progress.py
@@ -21,7 +21,7 @@ class GetGroupProgressStatesTest(TestCase):
         group = self.create_group()
         GroupAssignee.objects.assign(group, self.user)
         result = get_group_progress_states([group.id])
-        assert result[group.id] == IssueProgressState.TRIAGED
+        assert result[group.id] == IssueProgressState.ASSIGNED
 
     def test_diagnosed_state(self) -> None:
         group = self.create_group()
@@ -93,7 +93,7 @@ class GetGroupProgressStatesTest(TestCase):
         result = get_group_progress_states([group.id])
         assert result[group.id] == IssueProgressState.IDENTIFIED
 
-    def test_regression_resets_to_triaged_when_assigned(self) -> None:
+    def test_regression_resets_to_assigned_when_assigned(self) -> None:
         group = self.create_group()
         GroupAssignee.objects.assign(group, self.user)
         now = timezone.now()
@@ -108,7 +108,7 @@ class GetGroupProgressStatesTest(TestCase):
             datetime=now - timedelta(hours=1),
         )
         result = get_group_progress_states([group.id])
-        assert result[group.id] == IssueProgressState.TRIAGED
+        assert result[group.id] == IssueProgressState.ASSIGNED
 
     def test_activity_after_regression_counts(self) -> None:
         group = self.create_group()
@@ -147,7 +147,7 @@ class GetGroupProgressStatesTest(TestCase):
         result = get_group_progress_states([group.id])
         assert result[group.id] == IssueProgressState.IDENTIFIED
 
-    def test_unresolve_resets_to_triaged_when_assigned(self) -> None:
+    def test_unresolve_resets_to_assigned_when_assigned(self) -> None:
         group = self.create_group()
         GroupAssignee.objects.assign(group, self.user)
         now = timezone.now()
@@ -162,7 +162,7 @@ class GetGroupProgressStatesTest(TestCase):
             datetime=now - timedelta(hours=1),
         )
         result = get_group_progress_states([group.id])
-        assert result[group.id] == IssueProgressState.TRIAGED
+        assert result[group.id] == IssueProgressState.ASSIGNED
 
     def test_activity_after_unresolve_counts(self) -> None:
         group = self.create_group()
@@ -197,4 +197,4 @@ class GetGroupProgressStatesTest(TestCase):
         result = get_group_progress_states([group1.id, group2.id, group3.id])
         assert result[group1.id] == IssueProgressState.DIAGNOSED
         assert result[group2.id] == IssueProgressState.FIX_APPLIED
-        assert result[group3.id] == IssueProgressState.TRIAGED
+        assert result[group3.id] == IssueProgressState.ASSIGNED

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1099,8 +1099,8 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         assert self.group1 in set(results)
         assert self.group2 not in set(results)
 
-    def test_issue_progress_triaged(self) -> None:
-        results = self.make_query(search_filter_query="issue.progress:triaged")
+    def test_issue_progress_assigned(self) -> None:
+        results = self.make_query(search_filter_query="issue.progress:assigned")
         assert self.group2 in set(results)
         assert self.group1 not in set(results)
 
@@ -1110,7 +1110,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         results = self.make_query(search_filter_query="issue.progress:diagnosed")
         assert self.group2 in set(results)
 
-        results = self.make_query(search_filter_query="issue.progress:triaged")
+        results = self.make_query(search_filter_query="issue.progress:assigned")
         assert self.group2 not in set(results)
 
     def test_issue_progress_negation(self) -> None:
@@ -1130,14 +1130,14 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         results = self.make_query(search_filter_query="issue.progress:fix_proposed")
         assert self.group1 not in set(results)
 
-    def test_issue_progress_regression_preserves_triaged(self) -> None:
+    def test_issue_progress_regression_preserves_assigned(self) -> None:
         GroupAssignee.objects.create(
             user_id=self.user.id, group=self.group1, project=self.group1.project
         )
         self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
         self.create_group_activity(group=self.group1, type=ActivityType.SET_REGRESSION.value)
 
-        results = self.make_query(search_filter_query="issue.progress:triaged")
+        results = self.make_query(search_filter_query="issue.progress:assigned")
         assert self.group1 in set(results)
 
         results = self.make_query(search_filter_query="issue.progress:fix_proposed")

--- a/tests/snuba/search/test_postgres_sort_framework.py
+++ b/tests/snuba/search/test_postgres_sort_framework.py
@@ -457,7 +457,7 @@ class TestRecommendedV2Sort(PostgresSortTestBase):
 
 class TestProgressSort(PostgresSortTestBase):
     """progress: primary sort by fix-cycle rank (fix_applied > fix_proposed > diagnosed >
-    triaged > identified), secondary by last_seen.
+    assigned > identified), secondary by last_seen.
 
     The base fixture's groups have events ~8d, ~5d, and ~3d old, so on last_seen alone they
     order [2, 1, 0] (newest first).


### PR DESCRIPTION
Renames `IssueProgressState.TRIAGED` to `ASSIGNED`. The "triaged" name was a holdover from the initial spec which included priority changes, but the it is now purely based on assignee, so "assigned" is more accurate and less confusing.

This is a backend-only rename. The enum member, its string value, all search filter references (`issue.progress:assigned`), the sort ranking map, and tests are updated. Frontend changes will follow separately.