### PR TITLE
fix(selective-testing): add `src/sentry/snuba/events.py` to full-suite trigger

### DIFF
--- a/.github/workflows/scripts/compute-sentry-selected-tests.py
+++ b/.github/workflows/scripts/compute-sentry-selected-tests.py
@@ -56,6 +56,9 @@ FULL_SUITE_TRIGGERS: list[str | re.Pattern[str]] = [
     re.compile(r"(^|/)conftest\.py$"),
     "src/sentry/runner/initializer.py",
     "src/sentry/constants.py",
+    # column-alias enum evaluated at import time; used indirectly by every
+    # Snuba query builder so coverage never records per-test contexts for it
+    "src/sentry/snuba/events.py",
     # option defaults registered at startup via initialize_app()
     re.compile(r"^src/sentry/options/"),
     # feature flags registered via manager.add() at import time


### PR DESCRIPTION
#117833 added `PLATFORM_SECONDARY` to `Columns`, changing how `platform:` queries resolve. `tests/snuba/api/endpoints/test_organization_group_index_stats.py::GroupListTest::test_platform_tag_collision_badge_resolved_correctly` broke after merge. Zero tests were selected for `src/sentry/snuba/events.py`.

There's no refactor that fixes this at the coverage layer — Python enum class bodies execute once at import and are never re-executed per-test, so coverage structurally cannot record per-test contexts for this file. `FULL_SUITE_TRIGGERS` is the appropriate mechanism.

---

`src/sentry/snuba/events.py` defines the `Columns` enum — column alias mappings used by every Snuba query builder. All members are instantiated at module import time during Django startup, before per-test coverage contexts activate. The coverage DB records only the empty-string startup context for the file, which the coverage query filters out, yielding zero matches. The static import scan also finds nothing since no test file directly imports from `sentry.snuba.events` — consumers access it through `snuba.py`'s pre-built lookup dicts (`SENTRY_SNUBA_MAP` etc.), which are also module-level.
