### PR TITLE
fix(search): keep fuzzy suggestions populated after loading finishes (LOGS-876)

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -6754,6 +6754,55 @@ describe('SearchQueryBuilder', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('keeps async suggestions populated while a refetch is in flight', async () => {
+      const pendingRequest = makeDeferred<typeof asyncTags>();
+      const mockGetTagKeys = jest.fn().mockResolvedValue(asyncTags);
+      render(<SearchQueryBuilder {...defaultProps} getTagKeys={mockGetTagKeys} />);
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('async');
+
+      expect(
+        await screen.findByRole('option', {name: 'async_tag_one'})
+      ).toBeInTheDocument();
+
+      // The next debounced query never resolves, leaving a refetch in flight.
+      mockGetTagKeys.mockReturnValue(pendingRequest.promise);
+      await userEvent.keyboard('_tag');
+
+      // Previously-loaded suggestions remain visible rather than disappearing
+      // while the new fetch is pending.
+      await waitFor(() => {
+        expect(mockGetTagKeys).toHaveBeenCalledWith('async_tag');
+      });
+      expect(screen.getByRole('option', {name: 'async_tag_one'})).toBeInTheDocument();
+    });
+
+    it('clears async-only keys when a refetch resolves to an empty result', async () => {
+      const mockGetTagKeys = jest.fn((searchQuery: string) =>
+        Promise.resolve(searchQuery.includes('empty') ? [] : asyncTags)
+      );
+      render(<SearchQueryBuilder {...defaultProps} getTagKeys={mockGetTagKeys} />);
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('async');
+
+      expect(
+        await screen.findByRole('option', {name: 'async_tag_one'})
+      ).toBeInTheDocument();
+
+      // Switching to a query that resolves to an empty result should drop the
+      // previously shown async-only key once the active query settles.
+      await userEvent.clear(getLastInput());
+      await userEvent.keyboard('empty');
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('option', {name: 'async_tag_one'})
+        ).not.toBeInTheDocument();
+      });
+    });
+
     it('normalizes typed pretty tag keys using loaded async explicit keys', async () => {
       const mockGetTagKeys = jest
         .fn()

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -1,5 +1,5 @@
 import {useMemo, type ReactNode} from 'react';
-import {useQuery} from '@tanstack/react-query';
+import {keepPreviousData, useQuery} from '@tanstack/react-query';
 import type Fuse from 'fuse.js';
 
 import {
@@ -183,7 +183,7 @@ export function useSortedFilterKeyItems({
   const shouldFetchAsync = !!getTagKeys;
   const debouncedFilterValue = useDebouncedValue(filterValue);
   // eslint-disable-next-line @tanstack/query/exhaustive-deps
-  const {data: asyncKeys, isLoading: isQueryLoading} = useQuery({
+  const {data: asyncKeys, isFetching: isQueryFetching} = useQuery({
     queryKey: [
       'search-query-builder-tag-keys',
       filterKeyRegistryQueryKey,
@@ -193,10 +193,13 @@ export function useSortedFilterKeyItems({
       const searchQuery = ctx.queryKey[2];
       return getTagKeys!(typeof searchQuery === 'string' ? searchQuery : '');
     },
+    // Retain previously-fetched keys while a new debounced query is in flight so
+    // suggestions stay populated rather than disappearing mid-type.
+    placeholderData: keepPreviousData,
     enabled: shouldFetchAsync,
   });
 
-  const isLoading = shouldFetchAsync && isQueryLoading;
+  const isLoading = shouldFetchAsync && isQueryFetching;
 
   // Set of Tag.key values from static filterKeys, used consistently for deduplication.
   const staticKeyValues = useMemo(


### PR DESCRIPTION
In the shared `SearchQueryBuilder`, the async key query in `useSortedFilterKeyItems` did not retain previous data across refetches. Because the debounced filter value is part of the query key, every keystroke created a new cache entry and `asyncKeys` collapsed to `undefined` until the fetch resolved. That transiently emptied the merged key sets and caused previously-shown fuzzy suggestions to disappear mid-type, then reappear once loading finished.

This applies `placeholderData: keepPreviousData` to the query and drives the hook's loading flag off `isFetching` instead of `isLoading` — the same pattern the value combobox already uses to avoid flicker. Suggestions now stay populated under an inline spinner while a refetch is in flight, and only collapse to static-only keys when a query genuinely resolves to an empty result. The fix lives in the shared component, so it benefits every surface that uses it, not just the Logs Explorer.

Linear: https://linear.app/getsentry/issue/LOGS-876