### PR TITLE
chore(metrics): Fix automator latency metric

### DIFF
--- a/src/sentry/runner/commands/configoptions.py
+++ b/src/sentry/runner/commands/configoptions.py
@@ -17,10 +17,15 @@ def _attempt_update(
     drifted_options: set[str],
     dry_run: bool,
     hide_drift: bool,
-) -> None:
+) -> bool:
     """
     Updates the option if it is not drifted and if we are not in dry
     run mode.
+
+    Returns True only when the option's value actually changed in the DB.
+    Drift, no-op reconciliations (value already matches), and channel-only
+    takeovers return False, so callers can tell whether this run propagated a
+    real value change.
     """
 
     from sentry import options
@@ -34,7 +39,7 @@ def _attempt_update(
             presenter_delegator.drift(key, "")
         else:
             presenter_delegator.drift(key, db_value_to_print)
-        return
+        return False
 
     last_update_channel = options.get_last_update_channel(key)
     if db_value == value:
@@ -57,7 +62,7 @@ def _attempt_update(
             if not dry_run:
                 options.set(key, value, coerce=False, channel=options.UpdateChannel.AUTOMATOR)
             presenter_delegator.channel_update(key)
-        return
+        return False
 
     if not dry_run:
         options.set(key, value, coerce=False, channel=options.UpdateChannel.AUTOMATOR)
@@ -65,6 +70,7 @@ def _attempt_update(
         presenter_delegator.update(key, db_value, value)
     else:
         presenter_delegator.set(key, value)
+    return True
 
 
 def _load_options(file: str | None) -> dict[str, Any]:
@@ -117,6 +123,29 @@ def _validate_options(
             presenter_delegator.unregistered(key)
 
     return drifted_options, invalid_options
+
+
+def _record_latency(ctx: click.Context, updated: bool, status: str) -> None:
+    """
+    Emit the automator end-to-end latency (commit timestamp -> value applied to
+    the DB), but only when this run actually applied a value change.
+
+    The automator is re-run repeatedly between deploys (e.g. on configmap watch
+    re-syncs) with the same stale ``--timestamp``. Emitting on every run made the
+    metric ramp up as "time since last deploy" instead of measuring propagation.
+    Gating on ``updated`` means we emit once per deploy that changes something,
+    which is the latency we actually care about.
+    """
+    from sentry.utils import metrics
+
+    timestamp = ctx.obj["timestamp"]
+    if timestamp is not None and updated:
+        metrics.distribution(
+            key="options_automator.latency_seconds",
+            value=time.time() - timestamp,
+            tags={"status": status},
+            sample_rate=1.0,
+        )
 
 
 @click.group()
@@ -227,17 +256,19 @@ def patch(ctx: click.Context) -> None:
 
     options_to_update = _load_options(_single_file(ctx, "patch"))
     drifted_options, invalid_options = _validate_options(options_to_update, presenter_delegator)
+    updated = False
     for key, value in options_to_update.items():
         if key not in invalid_options:
             try:
-                _attempt_update(
+                if _attempt_update(
                     presenter_delegator,
                     key,
                     value,
                     drifted_options,
                     dry_run,
                     bool(ctx.obj["hide_drift"]),
-                )
+                ):
+                    updated = True
             except Exception:
                 metrics.incr(
                     "options_automator.run",
@@ -269,13 +300,7 @@ def patch(ctx: click.Context) -> None:
         tags={"status": status},
         sample_rate=1.0,
     )
-    if ctx.obj["timestamp"] is not None:
-        metrics.distribution(
-            key="options_automator.latency_seconds",
-            value=time.time() - ctx.obj["timestamp"],
-            tags={"status": status},
-            sample_rate=1.0,
-        )
+    _record_latency(ctx, updated, status)
     exit(ret_val)
 
 
@@ -304,18 +329,20 @@ def sync(ctx: click.Context) -> None:
     options_to_update = _load_options(_single_file(ctx, "sync"))
     drifted_options, invalid_options = _validate_options(options_to_update, presenter_delegator)
     drift_found = bool(drifted_options)
+    updated = False
     for opt in all_options:
         if opt.name not in invalid_options:
             if opt.name in options_to_update:
                 try:
-                    _attempt_update(
+                    if _attempt_update(
                         presenter_delegator,
                         opt.name,
                         options_to_update[opt.name],
                         drifted_options,
                         dry_run,
                         bool(ctx.obj["hide_drift"]),
-                    )
+                    ):
+                        updated = True
                 except Exception:
                     metrics.incr(
                         "options_automator.run",
@@ -342,6 +369,8 @@ def sync(ctx: click.Context) -> None:
                             )
                             presenter_delegator.flush()
                             raise
+                    # A deletion is a real change worth measuring latency for.
+                    updated = True
                     presenter_delegator.unset(opt.name)
                 elif last_updated == options.UpdateChannel.CLI:
                     presenter_delegator.drift(opt.name, options.get(opt.name))
@@ -373,13 +402,7 @@ def sync(ctx: click.Context) -> None:
         tags={"status": status},
         sample_rate=1.0,
     )
-    if ctx.obj["timestamp"] is not None:
-        metrics.distribution(
-            key="options_automator.latency_seconds",
-            value=time.time() - ctx.obj["timestamp"],
-            tags={"status": status},
-            sample_rate=1.0,
-        )
+    _record_latency(ctx, updated, status)
 
     exit(ret_val)
 

--- a/src/sentry/runner/commands/configoptions.py
+++ b/src/sentry/runner/commands/configoptions.py
@@ -20,12 +20,8 @@ def _attempt_update(
 ) -> bool:
     """
     Updates the option if it is not drifted and if we are not in dry
-    run mode.
-
-    Returns True only when the option's value actually changed in the DB.
-    Drift, no-op reconciliations (value already matches), and channel-only
-    takeovers return False, so callers can tell whether this run propagated a
-    real value change.
+    run mode. Returns True only when the stored value actually changed
+    (drift, no-op reconciliations, and channel takeovers return False).
     """
 
     from sentry import options
@@ -127,14 +123,10 @@ def _validate_options(
 
 def _record_latency(ctx: click.Context, updated: bool, status: str) -> None:
     """
-    Emit the automator end-to-end latency (commit timestamp -> value applied to
-    the DB), but only when this run actually applied a value change.
-
-    The automator is re-run repeatedly between deploys (e.g. on configmap watch
-    re-syncs) with the same stale ``--timestamp``. Emitting on every run made the
-    metric ramp up as "time since last deploy" instead of measuring propagation.
-    Gating on ``updated`` means we emit once per deploy that changes something,
-    which is the latency we actually care about.
+    Emit latency from the deployed commit (``--timestamp``) to the DB write.
+    Only when a value changed: the automator re-runs between deploys with the
+    same stale timestamp, so emitting every run made the metric ramp up as
+    "time since last deploy" instead of measuring propagation.
     """
     from sentry.utils import metrics
 
@@ -369,7 +361,7 @@ def sync(ctx: click.Context) -> None:
                             )
                             presenter_delegator.flush()
                             raise
-                    # A deletion is a real change worth measuring latency for.
+                    # A deletion counts as a change.
                     updated = True
                     presenter_delegator.unset(opt.name)
                 elif last_updated == options.UpdateChannel.CLI:

--- a/src/sentry/runner/commands/configoptions.py
+++ b/src/sentry/runner/commands/configoptions.py
@@ -66,7 +66,8 @@ def _attempt_update(
         presenter_delegator.update(key, db_value, value)
     else:
         presenter_delegator.set(key, value)
-    return True
+    # don't emit in ci
+    return not dry_run
 
 
 def _load_options(file: str | None) -> dict[str, Any]:
@@ -361,8 +362,8 @@ def sync(ctx: click.Context) -> None:
                             )
                             presenter_delegator.flush()
                             raise
-                    # A deletion counts as a change.
-                    updated = True
+                        # A deletion counts as a change.
+                        updated = True
                     presenter_delegator.unset(opt.name)
                 elif last_updated == options.UpdateChannel.CLI:
                     presenter_delegator.drift(opt.name, options.get(opt.name))


### PR DESCRIPTION
The implementation of this metric was incorrect, updating unconditionally whenever `configoptions` was run, whether or not an option value changed.
<img width="1246" height="631" alt="image" src="https://github.com/user-attachments/assets/8ff6945b-ffda-4ee5-83c8-3d5aa52e2186" />

^ This means propogation time keeps going up in this sawtooth pattern until a real change happens (because `commit_timestamp` only updates during real changes). This PR aims to fix this by augmenting `_attempt_update` with a "didChange" boolean. We use this in the new `_record_latency` helper function to determine whether or not to emit a metric.

After this is merged, our metric should be much more accurate