### PR TITLE
feat(issue-details): Add issue preview drawer with header content

### DIFF
--- a/static/app/views/issueDetails/header/groupStatusSubtitle.tsx
+++ b/static/app/views/issueDetails/header/groupStatusSubtitle.tsx
@@ -1,0 +1,80 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {ErrorBoundary} from 'sentry/components/errorBoundary';
+import {getBadgeProperties} from 'sentry/components/group/inboxBadges/statusBadge';
+import {UnhandledTag} from 'sentry/components/group/inboxBadges/unhandledTag';
+import {tct} from 'sentry/locale';
+import type {Group} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
+import {getTitle} from 'sentry/utils/events';
+import {Divider} from 'sentry/views/issueDetails/divider';
+import {AttachmentsBadge} from 'sentry/views/issueDetails/header/attachmentsBadge';
+import {ReplayBadge} from 'sentry/views/issueDetails/header/replayBadge';
+import {SeerBadge} from 'sentry/views/issueDetails/header/seerBadge';
+import {UserFeedbackBadge} from 'sentry/views/issueDetails/header/userFeedbackBadge';
+
+interface GroupStatusSubtitleProps {
+  group: Group;
+  project: Project;
+}
+
+export function GroupStatusSubtitle({group, project}: GroupStatusSubtitleProps) {
+  const {subtitle} = getTitle(group);
+  const statusProps = getBadgeProperties(group.status, group.substatus);
+
+  return (
+    <Flex gap="md" align="center">
+      {group.isUnhandled && (
+        <Fragment>
+          <UnhandledTag />
+          <Divider />
+        </Fragment>
+      )}
+      {statusProps?.status && (
+        <Tooltip
+          isHoverable
+          title={tct('[tooltip] [link:Learn more]', {
+            tooltip: statusProps.tooltip,
+            link: (
+              <ExternalLink href="https://docs.sentry.io/product/issues/states-triage/" />
+            ),
+          })}
+        >
+          <Subtext>{statusProps.status}</Subtext>
+        </Tooltip>
+      )}
+      {subtitle && (
+        <Fragment>
+          <Divider />
+          <Tooltip
+            title={subtitle}
+            skipWrapper
+            isHoverable
+            showOnlyOnOverflow
+            delay={1000}
+          >
+            <Subtext>{subtitle}</Subtext>
+          </Tooltip>
+        </Fragment>
+      )}
+      <ErrorBoundary customComponent={null}>
+        <AttachmentsBadge group={group} />
+        <UserFeedbackBadge group={group} project={project} />
+        <ReplayBadge group={group} project={project} />
+        <SeerBadge group={group} />
+      </ErrorBoundary>
+    </Flex>
+  );
+}
+
+const Subtext = styled('span')`
+  color: ${p => p.theme.tokens.content.secondary};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;

--- a/static/app/views/issueDetails/header/header.tsx
+++ b/static/app/views/issueDetails/header/header.tsx
@@ -5,20 +5,17 @@ import color from 'color';
 
 import {FeatureBadge, Tag} from '@sentry/scraps/badge';
 import {Flex, Grid} from '@sentry/scraps/layout';
-import {ExternalLink, Link} from '@sentry/scraps/link';
+import {Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {Count} from 'sentry/components/count';
-import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {EventMessage} from 'sentry/components/events/eventMessage';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {useFeedbackSDKIntegration} from 'sentry/components/feedbackButton/useFeedbackSDKIntegration';
-import {getBadgeProperties} from 'sentry/components/group/inboxBadges/statusBadge';
-import {UnhandledTag} from 'sentry/components/group/inboxBadges/unhandledTag';
 import {TourElement} from 'sentry/components/tours/components';
 import {MAX_PICKABLE_DAYS} from 'sentry/constants';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {getOverride} from 'sentry/overrideRegistry';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
@@ -29,14 +26,10 @@ import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {GroupActions} from 'sentry/views/issueDetails/actions/index';
-import {Divider} from 'sentry/views/issueDetails/divider';
 import {GroupPriority} from 'sentry/views/issueDetails/groupPriority';
 import {GroupHeaderAssigneeSelector} from 'sentry/views/issueDetails/header/assigneeSelector';
-import {AttachmentsBadge} from 'sentry/views/issueDetails/header/attachmentsBadge';
+import {GroupStatusSubtitle} from 'sentry/views/issueDetails/header/groupStatusSubtitle';
 import {IssueIdBreadcrumb} from 'sentry/views/issueDetails/header/issueIdBreadcrumb';
-import {ReplayBadge} from 'sentry/views/issueDetails/header/replayBadge';
-import {SeerBadge} from 'sentry/views/issueDetails/header/seerBadge';
-import {UserFeedbackBadge} from 'sentry/views/issueDetails/header/userFeedbackBadge';
 import {
   IssueDetailsTour,
   IssueDetailsTourContext,
@@ -67,7 +60,7 @@ export function GroupHeader({event, group, project}: GroupHeaderProps) {
     getOverride('react-hook:use-get-max-retention-days') ?? (() => MAX_PICKABLE_DAYS);
   const maxRetentionDays = useGetMaxRetentionDays();
   const userCountPeriod = maxRetentionDays ? `(${maxRetentionDays}d)` : '(30d)';
-  const {title: primaryTitle, subtitle} = getTitle(group);
+  const {title: primaryTitle} = getTitle(group);
   const secondaryTitle = getMessage(group);
   const isComplete = group.status === 'resolved' || group.status === 'ignored';
   const groupReprocessingStatus = getGroupReprocessingStatus(group);
@@ -80,7 +73,6 @@ export function GroupHeader({event, group, project}: GroupHeaderProps) {
 
   const isAIDetectedIssue = AI_DETECTED_ISSUE_TYPES.has(group.issueType);
 
-  const statusProps = getBadgeProperties(group.status, group.substatus);
   const issueTypeConfig = getConfigForIssueType(group, project);
 
   const crumbs = [
@@ -156,49 +148,7 @@ export function GroupHeader({event, group, project}: GroupHeaderProps) {
               <StatCount value={userCount} aria-label={t('User count')} />
             </Fragment>
           )}
-          <Flex gap="md" align="center">
-            {group.isUnhandled && (
-              <Fragment>
-                <UnhandledTag />
-                <Divider />
-              </Fragment>
-            )}
-            {statusProps?.status ? (
-              <Fragment>
-                <Tooltip
-                  isHoverable
-                  title={tct('[tooltip] [link:Learn more]', {
-                    tooltip: statusProps.tooltip,
-                    link: (
-                      <ExternalLink href="https://docs.sentry.io/product/issues/states-triage/" />
-                    ),
-                  })}
-                >
-                  <Subtext>{statusProps?.status}</Subtext>
-                </Tooltip>
-              </Fragment>
-            ) : null}
-            {subtitle && (
-              <Fragment>
-                <Divider />
-                <Tooltip
-                  title={subtitle}
-                  skipWrapper
-                  isHoverable
-                  showOnlyOnOverflow
-                  delay={1000}
-                >
-                  <Subtext>{subtitle}</Subtext>
-                </Tooltip>
-              </Fragment>
-            )}
-            <ErrorBoundary customComponent={null}>
-              <AttachmentsBadge group={group} />
-              <UserFeedbackBadge group={group} project={project} />
-              <ReplayBadge group={group} project={project} />
-              <SeerBadge group={group} />
-            </ErrorBoundary>
-          </Flex>
+          <GroupStatusSubtitle group={group} project={project} />
         </HeaderGrid>
       </Header>
       <TourElement<IssueDetailsTour>
@@ -336,13 +286,6 @@ const StatCount = styled(Count)`
   font-size: 20px;
   line-height: 1;
   text-align: right;
-`;
-
-const Subtext = styled('span')`
-  color: ${p => p.theme.tokens.content.secondary};
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 `;
 
 const ActionBar = styled('div')<{isComplete: boolean}>`

--- a/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.tsx
@@ -1,0 +1,97 @@
+import {Fragment} from 'react';
+
+import {LinkButton} from '@sentry/scraps/button';
+import {DrawerBody, DrawerHeader} from '@sentry/scraps/drawer';
+import {Container, Flex} from '@sentry/scraps/layout';
+import {Heading} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {ErrorBoundary} from 'sentry/components/errorBoundary';
+import {EventMessage} from 'sentry/components/events/eventMessage';
+import {LoadingError} from 'sentry/components/loadingError';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {IconOpen} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
+import {getMessage, getTitle} from 'sentry/utils/events';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
+import {GroupStatusSubtitle} from 'sentry/views/issueDetails/header/groupStatusSubtitle';
+import {IssueIdBreadcrumb} from 'sentry/views/issueDetails/header/issueIdBreadcrumb';
+import {useGroup} from 'sentry/views/issueDetails/useGroup';
+
+interface IssuePreviewDrawerProps {
+  groupId: string;
+}
+
+export function IssuePreviewDrawer({groupId}: IssuePreviewDrawerProps) {
+  const organization = useOrganization();
+  const {data: group, isPending, isError} = useGroup({groupId});
+  const {projects} = useProjects();
+  const project = projects.find(p => p.id === group?.project.id) ?? group?.project;
+
+  const issueDetailsUrl = normalizeUrl(
+    `/organizations/${organization.slug}/issues/${groupId}/`
+  );
+
+  return (
+    <Fragment>
+      <DrawerHeader>
+        <Flex justify="between" align="center" flex="1">
+          {group && project && <IssueIdBreadcrumb group={group} project={project} />}
+          <LinkButton
+            to={issueDetailsUrl}
+            size="xs"
+            icon={<IconOpen />}
+            style={{marginLeft: 'auto'}}
+          >
+            {t('Open Issue')}
+          </LinkButton>
+        </Flex>
+      </DrawerHeader>
+      <DrawerBody>
+        {isPending && <LoadingIndicator />}
+        {isError && <LoadingError />}
+        {group && project && (
+          <ErrorBoundary mini>
+            <IssuePreviewContent group={group} project={project} />
+          </ErrorBoundary>
+        )}
+      </DrawerBody>
+    </Fragment>
+  );
+}
+
+function IssuePreviewContent({
+  group,
+  project,
+}: {
+  group: NonNullable<ReturnType<typeof useGroup>['data']>;
+  project: Project;
+}) {
+  const {title: primaryTitle} = getTitle(group);
+  const secondaryTitle = getMessage(group);
+
+  return (
+    <Container paddingBottom="lg" borderBottom="muted">
+      <Flex direction="column" gap="xs">
+        <div>
+          <Tooltip
+            title={primaryTitle}
+            skipWrapper
+            isHoverable
+            showOnlyOnOverflow
+            delay={1000}
+          >
+            <Heading as="h3" size="lg" ellipsis>
+              {primaryTitle}
+            </Heading>
+          </Tooltip>
+          <EventMessage level={group.level} message={secondaryTitle} type={group.type} />
+        </div>
+        <GroupStatusSubtitle group={group} project={project} />
+      </Flex>
+    </Container>
+  );
+}

--- a/static/app/views/issueList/pages/awaitingInput.spec.tsx
+++ b/static/app/views/issueList/pages/awaitingInput.spec.tsx
@@ -72,6 +72,18 @@ describe('AwaitingInputPage', () => {
       method: 'POST',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/`,
+      body: group,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/attachments/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/replay-count/',
+      body: {},
+    });
 
     PageFiltersStore.onInitializeUrlState({
       projects: [parseInt(project.id, 10)],

--- a/static/app/views/issueList/pages/useIssuePreviewDrawer.spec.tsx
+++ b/static/app/views/issueList/pages/useIssuePreviewDrawer.spec.tsx
@@ -13,6 +13,21 @@ import {useIssuePreviewDrawer} from 'sentry/views/issueList/pages/useIssuePrevie
 const AWAITING_INPUT_PATH = '/organizations/org-slug/issues/awaiting-input/';
 
 describe('useIssuePreviewDrawer', () => {
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/42/',
+      body: GroupFixture({id: '42'}),
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/42/attachments/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/replay-count/',
+      body: {},
+    });
+  });
+
   it('sets the preview query param when opening a preview', async () => {
     const {result, router} = renderHookWithProviders(() => useIssuePreviewDrawer(), {
       initialRouterConfig: {location: {pathname: AWAITING_INPUT_PATH}},

--- a/static/app/views/issueList/pages/useIssuePreviewDrawer.tsx
+++ b/static/app/views/issueList/pages/useIssuePreviewDrawer.tsx
@@ -1,25 +1,17 @@
-import {Fragment, useCallback, useEffect, useRef} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import {parseAsString, useQueryState} from 'nuqs';
 
-import {DrawerBody, DrawerHeader, useDrawer} from '@sentry/scraps/drawer';
+import {useDrawer} from '@sentry/scraps/drawer';
 
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
+import {IssuePreviewDrawer} from 'sentry/views/issueDetails/issuePreview/issuePreviewDrawer';
 
 /**
  * Query param holding the id of the issue whose preview drawer is open.
  * Presence opens the drawer; absence closes it.
  */
 const SELECTED_ISSUE_QUERY_PARAM = 'preview';
-
-function IssuePreviewDrawer() {
-  return (
-    <Fragment>
-      <DrawerHeader />
-      <DrawerBody />
-    </Fragment>
-  );
-}
 
 /**
  * Opens a lightweight issue preview drawer.
@@ -53,7 +45,7 @@ export function useIssuePreviewDrawer({enabled = true}: {enabled?: boolean} = {}
     }
 
     lastOpenedIdRef.current = selectedIssueId;
-    openDrawer(() => <IssuePreviewDrawer />, {
+    openDrawer(() => <IssuePreviewDrawer groupId={selectedIssueId} />, {
       ariaLabel: t('Issue preview'),
       drawerKey: 'issue-preview-drawer',
       mode: 'passive',


### PR DESCRIPTION
Ref ISWF-2875

The issue preview drawer was just an empty shell, but this PR adds:

- Fetching full data with useGroup()
- Short ID
- Button to open full details
- Header info (title, message, third line details)

For the header info, I extracted some of it into a separate file so that it could be used in both places

<img width="1057" height="252" alt="CleanShot 2026-06-17 at 15 03 12" src="https://github.com/user-attachments/assets/7c090daf-8903-4c44-9204-3b30ef401b47" />
