### PR TITLE
fix(validate): Make the default behaviour better

### DIFF
--- a/src/sentry/api/endpoints/organization_events_validate.py
+++ b/src/sentry/api/endpoints/organization_events_validate.py
@@ -35,8 +35,12 @@ class Validation:
 
 
 @dataclass(kw_only=True)
-class AttributeValidation(Validation):
+class NamedValidation(Validation):
     name: str
+
+
+@dataclass(kw_only=True)
+class AttributeValidation(NamedValidation):
     # None when its an error
     attrType: str | None
 
@@ -44,7 +48,7 @@ class AttributeValidation(Validation):
 @dataclass(kw_only=True)
 class ValidationResponse:
     valid: bool
-    dataset: list[Validation] = dataclass_field(default_factory=list)
+    dataset: list[NamedValidation] = dataclass_field(default_factory=list)
     environment: list[Validation] = dataclass_field(default_factory=list)
     field: list[AttributeValidation] = dataclass_field(default_factory=list)
     orderby: list[AttributeValidation] = dataclass_field(default_factory=list)
@@ -205,12 +209,17 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
             dataset = self.get_dataset(request, organization)
         except ParseError as error:
             response.valid = False
-            response.dataset.append(Validation(valid=False, error=str(error)))
+            response.dataset.append(
+                NamedValidation(
+                    name=request.GET.get("dataset", "discover"), valid=False, error=str(error)
+                )
+            )
             return self.serialize_response(response)
 
         if dataset not in RPC_DATASETS:
             response.dataset.append(
-                Validation(
+                NamedValidation(
+                    name=request.GET.get("dataset", "discover"),
                     valid=True,
                     error="This dataset is not compatible with the validate endpoint, your request may still be valid",
                 )

--- a/tests/sentry/api/endpoints/test_organization_events_validate.py
+++ b/tests/sentry/api/endpoints/test_organization_events_validate.py
@@ -39,8 +39,26 @@ class OrganizationEventsValidateEndpointTest(APITestCase, SnubaTestCase, SpanTes
         assert not response.data["valid"]
         assert len(response.data["dataset"]) == 1
         dataset_error = response.data["dataset"][0]
+        assert dataset_error["name"] == "foobar"
         assert "dataset must be one of" in dataset_error["error"]
-        assert dataset_error["valid"] is False
+        assert not dataset_error["valid"]
+
+    def test_default_dataset_error(self) -> None:
+        """Validate matches the behaviour of /events/ where the default dataset is discover, but this is not a RPC
+        dataset so the validate endpoint will fail"""
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["valid"]
+        assert len(response.data["dataset"]) == 1
+        dataset_error = response.data["dataset"][0]
+        assert dataset_error["name"] == "discover"
+        assert "This dataset is not compatible with the validate endpoint" in dataset_error["error"]
+        assert dataset_error["valid"]
 
     def test_invalid_attributes(self) -> None:
         response = self.do_request(


### PR DESCRIPTION
- Dataset defaults to discover to match the behaviour on events/ in these cases the endpoint will exit early and not validate anything but the API response doesn't really make this very clear