### PR TITLE
fix(code-review): Only increment a contributor seat after the opened PR has passed the preflight check

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -73,7 +73,7 @@ from sentry.pr_metrics.webhooks import handle_review_thread as pr_metrics_handle
 from sentry.preprod.vcs.webhooks import handle_preprod_check_run_event
 from sentry.scm.private.stream_producer import produce_event_to_scm_stream
 from sentry.seer.autofix.webhooks import handle_github_pr_webhook_for_autofix
-from sentry.seer.code_review.contributor_seats import track_contributor_seat
+from sentry.seer.code_review.contributor_seats import seed_contributor
 from sentry.seer.code_review.webhooks.handlers import (
     handle_webhook_event as code_review_handle_webhook_event,
 )
@@ -1105,13 +1105,11 @@ class PullRequestEventWebhook(GitHubWebhook):
                     },
                 )
 
-                track_contributor_seat(
+                seed_contributor(
                     organization=organization,
-                    repo=repo,
                     integration_id=integration.id,
                     user_id=user["id"],
                     user_username=user["login"],
-                    provider="github",
                 )
 
         except IntegrityError:

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -1071,6 +1071,8 @@ class PullRequestEventWebhook(GitHubWebhook):
                     )
 
         author.preload_users()
+        # Track whether this delivery is the one that first created the PR row.
+        created = False
         try:
             _, created = PullRequest.objects.update_or_create(
                 organization_id=organization.id,
@@ -1121,6 +1123,7 @@ class PullRequestEventWebhook(GitHubWebhook):
             event=event,
             organization=organization,
             repo=repo,
+            pr_was_created=created,
             **kwargs,
         )
 

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -90,6 +90,14 @@ def seed_contributor(
     user_id: str | int,
     user_username: str,
 ) -> OrganizationContributors:
+    """
+    Create the OrganizationContributors row without incrementing the number
+    of actions.
+
+    Seeding happens upstream when the PR is created; the action is incremented
+    separately only after the PR clears the code-review preflight check and
+    other checks on the webhook's properties.
+    """
     contributor, _ = OrganizationContributors.objects.get_or_create(
         organization_id=organization.id,
         integration_id=integration_id,

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -83,26 +83,47 @@ def should_increment_contributor_seat(
     )
 
 
-def track_contributor_seat(
+def seed_contributor(
     *,
     organization: Organization,
-    repo: Repository,
     integration_id: int,
     user_id: str | int,
     user_username: str,
-    provider: str,
-) -> None:
-    """
-    Track a contributor for seat billing. Creates or retrieves the contributor
-    record, checks eligibility, atomically increments the action count, and
-    queues seat assignment when the activation threshold is reached.
-    """
+) -> OrganizationContributors:
     contributor, _ = OrganizationContributors.objects.get_or_create(
         organization_id=organization.id,
         integration_id=integration_id,
         external_identifier=str(user_id),
         defaults={"alias": user_username},
     )
+    return contributor
+
+
+def increment_contributor_action(
+    *,
+    organization: Organization,
+    repo: Repository,
+    integration_id: int,
+    user_id: str | int,
+    provider: str,
+) -> None:
+    try:
+        contributor = OrganizationContributors.objects.get(
+            organization_id=organization.id,
+            integration_id=integration_id,
+            external_identifier=str(user_id),
+        )
+    except OrganizationContributors.DoesNotExist:
+        logger.warning(
+            "scm.webhook.organization_contributor.not_seeded",
+            extra={
+                "provider": provider,
+                "organization_id": organization.id,
+                "integration_id": integration_id,
+                "external_identifier": str(user_id),
+            },
+        )
+        return
 
     if not should_increment_contributor_seat(organization, repo, contributor):
         return
@@ -136,3 +157,32 @@ def track_contributor_seat(
         and locked_contributor.num_actions >= ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD
     ):
         assign_seat_to_organization_contributor.delay(locked_contributor.id)
+
+
+def track_contributor_seat(
+    *,
+    organization: Organization,
+    repo: Repository,
+    integration_id: int,
+    user_id: str | int,
+    user_username: str,
+    provider: str,
+) -> None:
+    """
+    Track a contributor for seat billing. Creates or retrieves the contributor
+    record, checks eligibility, atomically increments the action count, and
+    queues seat assignment when the activation threshold is reached.
+    """
+    seed_contributor(
+        organization=organization,
+        integration_id=integration_id,
+        user_id=user_id,
+        user_username=user_username,
+    )
+    increment_contributor_action(
+        organization=organization,
+        repo=repo,
+        integration_id=integration_id,
+        user_id=user_id,
+        provider=provider,
+    )

--- a/src/sentry/seer/code_review/webhooks/handlers.py
+++ b/src/sentry/seer/code_review/webhooks/handlers.py
@@ -48,6 +48,7 @@ def handle_webhook_event(
     organization: Organization,
     repo: Repository,
     integration: RpcIntegration | None = None,
+    pr_was_created: bool = False,
     **kwargs: Any,
 ) -> None:
     """
@@ -132,4 +133,5 @@ def handle_webhook_event(
         integration=integration,
         org_code_review_settings=preflight.settings,
         tags=tags,
+        pr_was_created=pr_was_created,
     )

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -39,6 +39,7 @@ class Log(enum.StrEnum):
     MISSING_PULL_REQUEST = "github.webhook.pull_request.missing-pull-request"
     MISSING_ACTION = "github.webhook.pull_request.missing-action"
     UNSUPPORTED_ACTION = "github.webhook.pull_request.unsupported-action"
+    MISSING_AUTHOR_ID = "github.webhook.pull_request.missing-author-id"
 
 
 class PullRequestAction(enum.StrEnum):
@@ -173,6 +174,17 @@ def handle_pull_request_event(
                 integration_id=integration.id,
                 user_id=author_id,
                 provider="github",
+            )
+        else:
+            # A missing user id means we can't identify which contributor's actions to increment.
+            # This should never happen.
+            logger.warning(
+                Log.MISSING_AUTHOR_ID.value,
+                extra={
+                    "organization_id": organization.id,
+                    "repo_id": repo.id,
+                    "integration_id": integration.id,
+                },
             )
 
     pr_number = pull_request.get("number")

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -18,6 +18,7 @@ from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.models.repositorysettings import CodeReviewSettings, CodeReviewTrigger
 
+from ..contributor_seats import increment_contributor_action
 from ..metrics import (
     CodeReviewErrorType,
     WebhookFilteredReason,
@@ -25,7 +26,11 @@ from ..metrics import (
     record_webhook_handler_error,
     record_webhook_received,
 )
-from ..utils import _get_target_commit_sha, delete_existing_reactions_and_add_reaction
+from ..utils import (
+    _get_target_commit_sha,
+    delete_existing_reactions_and_add_reaction,
+    get_pr_author_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +138,21 @@ def handle_pull_request_event(
             github_event, action_value, WebhookFilteredReason.UNSUPPORTED_ACTION
         )
         return
+
+    # Increment contributor's seat-eligible action now that the PR has cleared
+    # the code-review preflight check. The contributor is seeded upstream in the
+    # GitHub PR webhook; here we only increment so billing reflects PRs that are
+    # actually eligible for review rather than every opened PR.
+    if action == PullRequestAction.OPENED and integration is not None:
+        author_id = get_pr_author_id(event)
+        if author_id is not None:
+            increment_contributor_action(
+                organization=organization,
+                repo=repo,
+                integration_id=integration.id,
+                user_id=author_id,
+                provider="github",
+            )
 
     action_requires_trigger_permission = ACTIONS_REQUIRING_TRIGGER_CHECK.get(action)
     if action_requires_trigger_permission is not None and (

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -100,6 +100,7 @@ def handle_pull_request_event(
     tags: Mapping[str, Any],
     integration: RpcIntegration | None = None,
     org_code_review_settings: CodeReviewSettings | None = None,
+    pr_was_created: bool = False,
     **kwargs: Any,
 ) -> None:
     """
@@ -139,18 +140,6 @@ def handle_pull_request_event(
         )
         return
 
-    # Increment contributor actions now that the PR has cleared the code-review preflight check.
-    if action == PullRequestAction.OPENED and integration is not None:
-        author_id = get_pr_author_id(event)
-        if author_id is not None:
-            increment_contributor_action(
-                organization=organization,
-                repo=repo,
-                integration_id=integration.id,
-                user_id=author_id,
-                provider="github",
-            )
-
     action_requires_trigger_permission = ACTIONS_REQUIRING_TRIGGER_CHECK.get(action)
     if action_requires_trigger_permission is not None and (
         org_code_review_settings is None
@@ -171,6 +160,20 @@ def handle_pull_request_event(
     # even if the PR was converted to draft before closing
     if action != PullRequestAction.CLOSED and pull_request.get("draft") is True:
         return
+
+    # Increment contributor actions now that the PR has cleared the code-review preflight check.
+    # Gated on pr_was_created so a redelivered/concurrent "opened" webhook (PR row already exists)
+    # does not double-count.
+    if pr_was_created and action == PullRequestAction.OPENED and integration is not None:
+        author_id = get_pr_author_id(event)
+        if author_id is not None:
+            increment_contributor_action(
+                organization=organization,
+                repo=repo,
+                integration_id=integration.id,
+                user_id=author_id,
+                provider="github",
+            )
 
     pr_number = pull_request.get("number")
     if pr_number and action in ACTIONS_ELIGIBLE_FOR_EYES_REACTION:

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -139,8 +139,7 @@ def handle_pull_request_event(
         )
         return
 
-    # Increment contributor actions now that the PR has cleared
-    # the code-review preflight check.
+    # Increment contributor actions now that the PR has cleared the code-review preflight check.
     if action == PullRequestAction.OPENED and integration is not None:
         author_id = get_pr_author_id(event)
         if author_id is not None:

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -139,10 +139,8 @@ def handle_pull_request_event(
         )
         return
 
-    # Increment contributor's seat-eligible action now that the PR has cleared
-    # the code-review preflight check. The contributor is seeded upstream in the
-    # GitHub PR webhook; here we only increment so billing reflects PRs that are
-    # actually eligible for review rather than every opened PR.
+    # Increment contributor actions now that the PR has cleared
+    # the code-review preflight check.
     if action == PullRequestAction.OPENED and integration is not None:
         author_id = get_pr_author_id(event)
         if author_id is not None:

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -141,27 +141,6 @@ def handle_pull_request_event(
         )
         return
 
-    action_requires_trigger_permission = ACTIONS_REQUIRING_TRIGGER_CHECK.get(action)
-    if action_requires_trigger_permission is not None and (
-        org_code_review_settings is None
-        or action_requires_trigger_permission not in org_code_review_settings.triggers
-    ):
-        record_webhook_filtered(github_event, action_value, WebhookFilteredReason.TRIGGER_DISABLED)
-        return
-
-    # If no triggers are configured for this repo, no pr_review was ever sent for it,
-    # so there is nothing for Seer to process on close.
-    if action == PullRequestAction.CLOSED and (
-        org_code_review_settings is None or not org_code_review_settings.triggers
-    ):
-        record_webhook_filtered(github_event, action_value, WebhookFilteredReason.TRIGGER_DISABLED)
-        return
-
-    # Skip draft check for CLOSED actions to ensure Seer receives cleanup notifications
-    # even if the PR was converted to draft before closing
-    if action != PullRequestAction.CLOSED and pull_request.get("draft") is True:
-        return
-
     # Increment contributor actions now that the PR has cleared the code-review preflight check.
     # Gated on pr_was_created so a redelivered/concurrent "opened" webhook (PR row already exists)
     # does not double-count.
@@ -186,6 +165,27 @@ def handle_pull_request_event(
                     "integration_id": integration.id,
                 },
             )
+
+    action_requires_trigger_permission = ACTIONS_REQUIRING_TRIGGER_CHECK.get(action)
+    if action_requires_trigger_permission is not None and (
+        org_code_review_settings is None
+        or action_requires_trigger_permission not in org_code_review_settings.triggers
+    ):
+        record_webhook_filtered(github_event, action_value, WebhookFilteredReason.TRIGGER_DISABLED)
+        return
+
+    # If no triggers are configured for this repo, no pr_review was ever sent for it,
+    # so there is nothing for Seer to process on close.
+    if action == PullRequestAction.CLOSED and (
+        org_code_review_settings is None or not org_code_review_settings.triggers
+    ):
+        record_webhook_filtered(github_event, action_value, WebhookFilteredReason.TRIGGER_DISABLED)
+        return
+
+    # Skip draft check for CLOSED actions to ensure Seer receives cleanup notifications
+    # even if the PR was converted to draft before closing
+    if action != PullRequestAction.CLOSED and pull_request.get("draft") is True:
+        return
 
     pr_number = pull_request.get("number")
     if pr_number and action in ACTIONS_ELIGIBLE_FOR_EYES_REACTION:

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -1651,12 +1651,12 @@ class PullRequestEventWebhookTest(APITestCase):
         assert link.linked_id == pr.id
         assert link.linked_type == GroupLink.LinkedType.pull_request
 
-    @patch("sentry.integrations.github.webhook.track_contributor_seat")
-    def test_pull_request_calls_track_contributor_seat(
+    @patch("sentry.integrations.github.webhook.seed_contributor")
+    def test_pull_request_calls_seed_contributor(
         self,
-        mock_track_contributor_seat: MagicMock,
+        mock_seed_contributor: MagicMock,
     ) -> None:
-        repo = Repository.objects.create(
+        Repository.objects.create(
             organization_id=self.project.organization.id,
             external_id="35129377",
             provider="integrations:github",
@@ -1665,14 +1665,12 @@ class PullRequestEventWebhookTest(APITestCase):
 
         integration = self._create_integration_and_send_pull_request_opened_event()
 
-        mock_track_contributor_seat.assert_called_once()
-        call_kwargs = mock_track_contributor_seat.call_args[1]
+        mock_seed_contributor.assert_called_once()
+        call_kwargs = mock_seed_contributor.call_args[1]
         assert call_kwargs["integration_id"] == integration.id
         assert str(call_kwargs["user_id"]) == "6752317"
         assert call_kwargs["user_username"] == "baxterthehacker"
-        assert call_kwargs["provider"] == "github"
         assert call_kwargs["organization"] == self.project.organization
-        assert call_kwargs["repo"] == repo
 
 
 class IssuesEventWebhookTest(APITestCase):

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -98,6 +98,21 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
             assert call_kwargs["organization"].id == self.organization.id
             assert call_kwargs["repo"].external_id == str(event["repository"]["id"])
 
+    def test_pull_request_opened_redelivery_does_not_increment(self) -> None:
+        """A redelivered opened webhook (PR row already exists) must not increment again."""
+        with self.code_review_setup(), self.tasks():
+            event = orjson.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
+            with patch(
+                "sentry.seer.code_review.webhooks.pull_request.increment_contributor_action"
+            ) as mock_increment:
+                # First delivery creates the PR row -> increments once.
+                self._send_webhook_event(GithubWebhookType.PULL_REQUEST, orjson.dumps(event))
+                # Redelivery (distinct X-GitHub-Delivery, so not deduped) finds the existing
+                # PR row -> pr_was_created is False -> no second increment.
+                self.send_github_webhook_event(GithubWebhookType.PULL_REQUEST, orjson.dumps(event))
+
+            mock_increment.assert_called_once()
+
     def test_pull_request_synchronize_does_not_increment_contributor_action(self) -> None:
         """Only opened PRs increment an action; synchronize must not."""
         with self.code_review_setup(), self.tasks():

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -79,6 +79,54 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
                 GitHubReaction.EYES,
             )
 
+    def test_pull_request_opened_increments_contributor_action(self) -> None:
+        """An opened PR increments the contributor's action after clearing preflight."""
+        with self.code_review_setup(), self.tasks():
+            event = orjson.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
+            with patch(
+                "sentry.seer.code_review.webhooks.pull_request.increment_contributor_action"
+            ) as mock_increment:
+                self._send_webhook_event(
+                    GithubWebhookType.PULL_REQUEST,
+                    orjson.dumps(event),
+                )
+
+            mock_increment.assert_called_once()
+            call_kwargs = mock_increment.call_args[1]
+            assert call_kwargs["user_id"] == str(event["pull_request"]["user"]["id"])
+            assert call_kwargs["provider"] == "github"
+            assert call_kwargs["organization"].id == self.organization.id
+            assert call_kwargs["repo"].external_id == str(event["repository"]["id"])
+
+    def test_pull_request_synchronize_does_not_increment_contributor_action(self) -> None:
+        """Only opened PRs increment an action; synchronize must not."""
+        with self.code_review_setup(), self.tasks():
+            event = orjson.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
+            event["action"] = "synchronize"
+            with patch(
+                "sentry.seer.code_review.webhooks.pull_request.increment_contributor_action"
+            ) as mock_increment:
+                self._send_webhook_event(
+                    GithubWebhookType.PULL_REQUEST,
+                    orjson.dumps(event),
+                )
+
+            mock_increment.assert_not_called()
+
+    def test_pull_request_opened_does_not_increment_when_preflight_denies(self) -> None:
+        """A denied preflight short-circuits before the handler, so no action is incremented."""
+        with self.tasks():
+            event = orjson.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
+            with patch(
+                "sentry.seer.code_review.webhooks.pull_request.increment_contributor_action"
+            ) as mock_increment:
+                self._send_webhook_event(
+                    GithubWebhookType.PULL_REQUEST,
+                    orjson.dumps(event),
+                )
+
+            mock_increment.assert_not_called()
+
     def test_pull_request_skips_draft(self) -> None:
         """Test that draft PRs are skipped."""
         with self.code_review_setup(), self.tasks():


### PR DESCRIPTION
Fixes CW-1522

#### Problem

GitHub contributor seat incrementing ran too early. `track_contributor_seat` was called in `PullRequestEventWebhook._handle`'s `if created:` block (on `pull_request` **opened**) — incrementing `num_actions` and assigning seats *before* the code-review preflight check that runs downstream in the same delivery. So we incremented contributor actions on PRs that were never eligible for review.

#### Solution

Split `track_contributor_seat` into two steps:

- **`seed_contributor`** (gets the contributor row or creates it with 0 actions) stays upstream in the webhook. It must run before preflight, since `_check_billing` denies with `ORG_CONTRIBUTOR_NOT_FOUND` if the row is missing.
- **`increment_contributor_action`** (increments num actions + assigns seat) moves into `handle_pull_request_event`, gated to `OPENED` PRs, which only runs after preflight passes.

`track_contributor_seat` remains as a `seed → increment` wrapper so the GitLab processor is unchanged (out of scope for this PR). 