### PR TITLE
fix(seer): Normalize GitLab webhook trigger_at to ISO 8601

### DIFF
--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -42,6 +42,7 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Any
 
+import sentry_sdk
 from dateutil.parser import parse as parse_date
 from pydantic import ValidationError
 from scm import actions as scm_actions
@@ -563,10 +564,16 @@ def _normalize_trigger_at(raw: str | None) -> str:
     if raw:
         try:
             return parse_date(raw).astimezone(timezone.utc).isoformat()
-        except (ValueError, OverflowError):
-            logger.warning(
-                "gitlab.webhook.merge_request.trigger_at.unparseable", extra={"raw": raw}
-            )
+        except (ValueError, OverflowError) as e:
+            # We fall back to "now" below so the review still proceeds, but an
+            # unparseable GitLab timestamp means trigger_at is wrong for this
+            # review -- escalate it so the unhandled format surfaces in Sentry.
+            with sentry_sdk.new_scope() as scope:
+                scope.set_context(
+                    "code_review_trigger_at",
+                    {"raw": raw},
+                )
+                sentry_sdk.capture_exception(e)
     return datetime.now(timezone.utc).isoformat()
 
 

--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -573,7 +573,7 @@ def _normalize_trigger_at(raw: str | None) -> str:
                     "code_review_trigger_at",
                     {"raw": raw},
                 )
-                sentry_sdk.capture_exception(e)
+                sentry_sdk.capture_exception(e, level="warning")
     return datetime.now(timezone.utc).isoformat()
 
 

--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -42,6 +42,7 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Any
 
+from dateutil.parser import parse as parse_date
 from pydantic import ValidationError
 from scm import actions as scm_actions
 from scm.types import (
@@ -538,13 +539,42 @@ def handle_merge_request_event(
     )
 
 
+def _normalize_trigger_at(raw: str | None) -> str:
+    """Normalize a GitLab webhook timestamp to ISO 8601.
+
+    GitLab webhook timestamps are NOT consistently formatted across event types.
+    The "Merge request events" and "Comment events" payloads documented at
+    https://docs.gitlab.com/user/project/integrations/webhook_events/ serialize
+    ``object_attributes`` timestamps as ``"2026-01-16 05:56:22 UTC"`` (space
+    separator, textual ``UTC`` suffix) -- the Rails ``Time#to_s`` default --
+    while other event types (work items, jobs, pipelines) use ISO 8601
+    (``"2013-12-03T17:15:43Z"``, ``"2014-02-27T10:06:20+02:00"``). Some GitLab
+    versions/editions also emit ISO 8601 for MR events, which is why the bug only
+    reproduces on instances sending the ``"... UTC"`` form.
+
+    Pydantic v1's ``datetime`` validator accepts ISO 8601 only and rejects the
+    space+``UTC`` form with ``value_error.datetime``. Since
+    ``SeerCodeReviewConfig.trigger_at`` is such a field -- and a failed
+    ``parse_obj`` silently drops the whole review (see ``_schedule_task``) -- we
+    normalize here. ``dateutil.parser.parse`` handles BOTH forms, so this is a
+    strict superset of the prior behavior. Falls back to "now" when the value is
+    missing or unparseable.
+    """
+    if raw:
+        try:
+            return parse_date(raw).astimezone(timezone.utc).isoformat()
+        except (ValueError, OverflowError):
+            logger.warning(
+                "gitlab.webhook.merge_request.trigger_at.unparseable", extra={"raw": raw}
+            )
+    return datetime.now(timezone.utc).isoformat()
+
+
 def _get_trigger_metadata(event: Mapping[str, Any]) -> dict[str, Any]:
     user = event.get("user", {})
     object_attributes = event.get("object_attributes", {})
-    trigger_at = (
-        object_attributes.get("updated_at")
-        or object_attributes.get("created_at")
-        or datetime.now(timezone.utc).isoformat()
+    trigger_at = _normalize_trigger_at(
+        object_attributes.get("updated_at") or object_attributes.get("created_at")
     )
     return {
         "trigger_user": user.get("username"),
@@ -672,7 +702,7 @@ def _get_note_trigger_metadata(event: Mapping[str, Any]) -> dict[str, Any]:
     """Extract trigger metadata from a GitLab note (comment) event."""
     user = event.get("user", {})
     object_attributes = event.get("object_attributes", {})
-    trigger_at = object_attributes.get("created_at") or datetime.now(timezone.utc).isoformat()
+    trigger_at = _normalize_trigger_at(object_attributes.get("created_at"))
     return {
         "trigger_user": user.get("username"),
         "trigger_user_id": user.get("id"),

--- a/tests/sentry/seer/code_review/webhooks/test_merge_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_merge_request.py
@@ -835,6 +835,34 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
             "organizations:seer-gitlab-support",
         }
     )
+    def test_open_with_unparseable_timestamp_captures_and_falls_back(self) -> None:
+        # An unparseable trigger_at is not fatal -- the review proceeds with a
+        # "now" fallback -- but the unhandled format must be escalated to Sentry
+        # so we learn about it instead of silently using the wrong timestamp.
+        self._setup_code_review()
+        event = _make_event("open", created_at="not a timestamp", updated_at="not a timestamp")
+
+        with (
+            patch(
+                "sentry.seer.code_review.webhooks.merge_request.sentry_sdk.capture_exception"
+            ) as mock_capture,
+            self.tasks(),
+        ):
+            self._call_handler(event)
+
+        mock_capture.assert_called_once()
+        # Review still enqueues with a valid ISO 8601 fallback timestamp.
+        self.mock_seer.assert_called_once()
+        trigger_at = self.mock_seer.call_args[1]["payload"]["data"]["config"]["trigger_at"]
+        assert trigger_at.endswith("+00:00")
+
+    @with_feature(
+        {
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+            "organizations:seer-gitlab-support",
+        }
+    )
     def test_duplicate_delivery_within_window_skipped(self) -> None:
         self._setup_code_review()
         event = _make_event("open")

--- a/tests/sentry/seer/code_review/webhooks/test_merge_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_merge_request.py
@@ -780,6 +780,61 @@ class MergeRequestEventWebhookTest(_MergeRequestHandlerTestBase):
             "organizations:seer-gitlab-support",
         }
     )
+    def test_open_with_gitlab_space_utc_timestamp_enqueues(self) -> None:
+        # GitLab serializes merge_request object_attributes timestamps as the
+        # Rails "Time#to_s" default -- e.g. "2026-01-16 05:56:22 UTC" (space
+        # separator, textual "UTC" suffix) -- per the documented payload at
+        # https://docs.gitlab.com/user/project/integrations/webhook_events/.
+        # That form is NOT ISO 8601, so SeerCodeReviewConfig.trigger_at (a
+        # Pydantic v1 datetime) rejects it with value_error.datetime and the
+        # whole review is silently dropped in _schedule_task. The shared fixture
+        # happens to use ISO 8601, so this case is exercised explicitly here.
+        self._setup_code_review()
+        event = _make_event(
+            "open",
+            created_at="2026-01-16 05:56:22 UTC",
+            updated_at="2026-01-16 05:56:25 UTC",
+        )
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_seer.assert_called_once()
+        payload = self.mock_seer.call_args[1]["payload"]
+        # updated_at wins over created_at and is normalized to ISO 8601 (UTC).
+        assert payload["data"]["config"]["trigger_at"] == "2026-01-16T05:56:25+00:00"
+
+    @with_feature(
+        {
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+            "organizations:seer-gitlab-support",
+        }
+    )
+    def test_open_with_iso8601_timestamp_still_enqueues(self) -> None:
+        # Some GitLab versions/editions emit ISO 8601 for MR events. dateutil
+        # normalization must remain a strict superset and not regress that path.
+        self._setup_code_review()
+        event = _make_event(
+            "open",
+            created_at="2017-09-20T08:31:45.944Z",
+            updated_at="2017-09-28T12:23:42.365Z",
+        )
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_seer.assert_called_once()
+        payload = self.mock_seer.call_args[1]["payload"]
+        assert payload["data"]["config"]["trigger_at"] == "2017-09-28T12:23:42.365000+00:00"
+
+    @with_feature(
+        {
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+            "organizations:seer-gitlab-support",
+        }
+    )
     def test_duplicate_delivery_within_window_skipped(self) -> None:
         self._setup_code_review()
         event = _make_event("open")


### PR DESCRIPTION
gitlab uses inconsistent datetime formats :(

https://docs.gitlab.com/user/project/integrations/webhook_events/

<img width="411" height="484" alt="image" src="https://github.com/user-attachments/assets/403bc55a-c67b-45e8-843b-e2dbda0c1302" />


## Summary

GitLab merge-request and note webhooks were being **silently dropped** before reaching Seer because of a timestamp format mismatch.

`SeerCodeReviewConfig.trigger_at` is a Pydantic v1 `datetime` field. GitLab serializes `object_attributes` `created_at`/`updated_at` as the Rails `Time#to_s` default — e.g. `"2026-01-16 05:56:22 UTC"` (space separator, textual `UTC` suffix). That is **not** ISO 8601, so Pydantic rejects it with `value_error.datetime`. `_schedule_task` catches the `ValidationError`, logs `validation_failed`, records the webhook as `INVALID_PAYLOAD`, and returns — so the review never runs, but GitLab still gets a 200.

```
validation_errors=[{'loc': ('data', 'config', 'trigger_at'),
                    'msg': 'invalid datetime format',
                    'type': 'value_error.datetime'}]
```

## Format discrepancy evidence

GitLab's webhook timestamps are **inconsistent across event types and versions** (per the [official webhook docs](https://docs.gitlab.com/user/project/integrations/webhook_events/)):

- **Merge request events** + **Comment events** `object_attributes`: `"2026-01-16 05:56:22 UTC"` / `"2015-05-17 18:08:09 UTC"` — space + `UTC` (the failing form)
- **Work item / job / pipeline events**: ISO 8601 — `"2013-12-03T17:15:43Z"`, `"2014-02-27T10:06:20+02:00"`

Some GitLab versions/editions emit ISO 8601 for MR events too, which is why this reproduces only on instances sending the `"... UTC"` form (and why it appeared to work against GitLab.com during testing).

## Fix

Normalize `trigger_at` via `dateutil.parser.parse` (already the convention in `integrations/gitlab/webhooks.py`), which accepts **both** formats and emits ISO 8601 UTC. This is a strict superset of prior behavior — it cannot regress the ISO path. Applied to both the MR-event and `@sentry review` note-event paths.

## Tests

- `test_open_with_gitlab_space_utc_timestamp_enqueues` — the `"... UTC"` form now validates and enqueues, normalized to `2026-01-16T05:56:25+00:00`.
- `test_open_with_iso8601_timestamp_still_enqueues` — ISO 8601 path unaffected.
- Existing 68 tests still pass (the shared fixture happens to use ISO 8601, which is why this gap went unnoticed).

## Follow-up

A stacked PR escalates the silent-drop logging: the `validation_failed` path means we never process the PR, so it should `capture_exception` rather than only debug-log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)