### PR TITLE
fix(transactions): Default null measurements to an empty object

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -176,6 +176,14 @@ class SnubaProtocolEventStream(EventStream):
             # transactions processing has a configurable 'skipped contexts' to skip writing specific contexts maps
             # to the row. for now, we're ignoring that until we have a need for it
 
+        elif event_type == EventStreamEventType.Transaction:
+            # The transactions Kafka schema requires `measurements` to be an object when present.
+            # Some events carry an explicit `null`, which fails schema validation in the Snuba
+            # consumer, so default it to an empty object.
+            if event_data.get("measurements") is None and "measurements" in event_data:
+                event_data = dict(event_data)
+                event_data["measurements"] = {}
+
         self._send(
             project.id,
             "insert",

--- a/tests/sentry/eventstream/test_eventstream.py
+++ b/tests/sentry/eventstream/test_eventstream.py
@@ -421,6 +421,28 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
             contexts_after_processing = send_extra_data_data["contexts"]
             assert contexts_after_processing == {**{"geo": geo_interface}}
 
+    def test_insert_transaction_null_measurements(self) -> None:
+        es = SnubaProtocolEventStream()
+
+        event = self.__build_transaction_event()
+        event.group_id = None
+        event.groups = [self.group]
+        # Some transaction events carry an explicit `null` for measurements, which fails
+        # the transactions Kafka schema (it requires an object when present).
+        event.data["measurements"] = None
+
+        with patch.object(es, "_send") as send:
+            es.insert(
+                event,
+                True,
+                True,
+                False,
+                "acbd18db4cc2f85cedef654fccc4a4d8",
+                event.data["received"],
+            )
+            send_extra_data_data = send.call_args.kwargs["extra_data"][0]["data"]
+            assert send_extra_data_data["measurements"] == {}
+
     def test_event_forwarding_to_items(self) -> None:
         create_default_projects()
         es = self.kafka_eventstream


### PR DESCRIPTION
## Summary

Transaction events can carry an explicit `measurements: null`. The transactions Kafka schema (`sentry_kafka_schemas`) marks `measurements` as optional but requires it to be an **object** when present, so a `null` value fails validation in the Snuba transactions consumer (`codec.validate`), producing a high volume of escalating `JsonSchemaValueException: data[2].data.measurements must be object` errors.

This normalizes a present-but-`null` `measurements` to an empty object (`{}`) when serializing transaction events to the stream, fixing the data at the point it enters the topic. Genuinely absent `measurements` is left untouched (still valid, since the field is optional).

## Notes

- Fix lives in the producer (`SnubaProtocolEventStream.insert`), alongside the existing per-event-type normalization for generic events.
- This makes newly produced events conform; the existing backlog of bad messages already on the topic is logged-only (`enforce_schema: False`), not dropped, so there's no consumer data loss to backfill.

## Test

Added `test_insert_transaction_null_measurements`, which sets `measurements` to `None` on a transaction event and asserts the downstream payload has `measurements == {}`.

Fixes SNUBA-B71

https://claude.ai/code/session_01Bd1QgVu9NiDBWJqNAbWjnb



Agent transcript: https://claudescope.sentry.dev/share/rhKqpWmDZDHA4lPDoFz8yyy61Jvm5pnPjFhwDV8vzM0

Linear: [EAP-590](https://linear.app/getsentry/issue/EAP-590)
