### PR TITLE
fix(avatars): Avoid orphaning avatar file handle on resized requests

### DIFF
--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -875,14 +875,14 @@ class AvatarPhotoView(View):
             return HttpResponseNotFound()
 
         size_s = request.GET.get("s")
-        photo_file = photo.getfile()
         if size_s:
             try:
                 size = int(size_s)
             except ValueError:
                 return HttpResponseBadRequest()
-            else:
-                photo_file = avatar.get_cached_photo(size)
+            photo_file = avatar.get_cached_photo(size)
+        else:
+            photo_file = photo.getfile()
 
         res = HttpResponse(photo_file, content_type="image/png")
         res["Cache-Control"] = FOREVER_CACHE

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -878,9 +878,9 @@ class AvatarPhotoView(View):
         if size_s:
             try:
                 size = int(size_s)
+                photo_file = avatar.get_cached_photo(size)
             except ValueError:
                 return HttpResponseBadRequest()
-            photo_file = avatar.get_cached_photo(size)
         else:
             photo_file = photo.getfile()
 

--- a/tests/sentry/web/frontend/test_organization_avatar.py
+++ b/tests/sentry/web/frontend/test_organization_avatar.py
@@ -1,11 +1,20 @@
+import gc
+import warnings
 from io import BytesIO
 
 from django.urls import reverse
+from PIL import Image
 
 from sentry.models.avatars.organization_avatar import OrganizationAvatar
 from sentry.models.files.file import File
 from sentry.testutils.cases import TestCase
 from sentry.web.constants import FOREVER_CACHE
+
+
+def _png_bytes() -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (128, 128)).save(buf, "PNG")
+    return buf.getvalue()
 
 
 class OrganizationAvatarTest(TestCase):
@@ -55,3 +64,39 @@ class OrganizationAvatarTest(TestCase):
         assert response["Access-Control-Allow-Origin"] == "http://localhost"
         assert response.get("Vary") is None
         assert response.get("Set-Cookie") is None
+
+    def _assert_no_leaked_file_handle(self, url: str) -> None:
+        """Fetch ``url`` and assert the avatar file handle is closed before GC.
+
+        An orphaned file handle is only reclaimed by the garbage collector, which
+        emits ``ResourceWarning: unclosed file`` from the stdlib finalizer. We force
+        a collection and fail if any such warning surfaces.
+        """
+        gc.collect()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            response = self.client.get(url)
+            assert response.status_code == 200
+            response.getvalue()
+            del response
+            gc.collect()
+
+        unclosed = [
+            str(w.message)
+            for w in caught
+            if issubclass(w.category, ResourceWarning) and "unclosed file" in str(w.message)
+        ]
+        assert not unclosed, f"avatar request leaked a file handle: {unclosed}"
+
+    def test_does_not_leak_file_handle(self) -> None:
+        org = self.create_organization()
+        photo = File.objects.create(name="test.png", type="avatar.file")
+        photo.putfile(BytesIO(_png_bytes()))
+        avatar = OrganizationAvatar.objects.create(organization=org, file_id=photo.id)
+        url = reverse(
+            "sentry-organization-avatar-url",
+            kwargs={"avatar_id": avatar.ident, "organization_slug": org.slug},
+        )
+
+        self._assert_no_leaked_file_handle(url)
+        self._assert_no_leaked_file_handle(url + "?s=80")


### PR DESCRIPTION
- \`AvatarPhotoView.get\` called \`photo.getfile()\` unconditionally; that call is eager and downloads the avatar into a \`SpooledTemporaryFile\` immediately. On the resized path, \`photo_file\` was then reassigned to \`get_cached_photo()\`'s bytes, orphaning the original file handle — never closed, leaking until GC and emitting \`ResourceWarning: Unclosed file\` on every sized avatar request (cache hit or miss).
- Follow-up to https://github.com/getsentry/sentry/commit/72019ee6341716c9cfc13f824fa96d86f34864b3 which didn't fix the issue