### PR TITLE
feat(ai-conversations): register gen-ai-conversations-columns flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -435,6 +435,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:trace-waterfall-time-compression", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Conversation focused views in AI Insights
     manager.add("organizations:gen-ai-conversations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable selectable/filterable columns for the AI Conversations table
+    manager.add("organizations:gen-ai-conversations-columns", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Conduit demo endpoint and UI
     manager.add("organizations:conduit-demo", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 


### PR DESCRIPTION
Registers the `organizations:gen-ai-conversations-columns` feature flag that will gate selectable/filterable columns for the AI Conversations table.

This is PR 1 of 4:
1. **This PR** — register the flag (Sentry)
2. https://github.com/getsentry/sentry-options-automator/pull/8295
3. https://github.com/getsentry/sentry/pull/118010
4. Frontend "edit columns" UI

The flag is `api_expose=True` so the frontend (PR 4) can read it.

Part of TET-2520