### PR TITLE
test(trace-items): make test_tags_list_nums order-independent

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -574,62 +574,67 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             }
         )
         assert response.status_code == 200, response.data
-        assert response.data == [
-            {
-                "key": "tags[bar,number]",
-                "name": "bar",
-                "attributeType": "number",
-                "attributeSource": {"source_type": "user"},
-            },
-            {
-                "key": "tags[baz,number]",
-                "name": "baz",
-                "attributeType": "number",
-                "attributeSource": {"source_type": "user"},
-            },
-            {
-                "key": "measurements.fcp",
-                "name": "measurements.fcp",
-                "attributeType": "number",
-                "attributeSource": {"source_type": "sentry"},
-            },
-            {
-                "key": "tags[foo,number]",
-                "name": "foo",
-                "attributeType": "number",
-                "attributeSource": {"source_type": "user"},
-            },
-            {
-                "key": "http.decoded_response_content_length",
-                "name": "http.decoded_response_content_length",
-                "attributeType": "number",
-                "attributeSource": {"source_type": "sentry"},
-            },
-            {
-                "key": "http.response_content_length",
-                "name": "http.response_content_length",
-                "attributeType": "number",
-                "attributeSource": {"source_type": "sentry"},
-            },
-            {
-                "key": "http.response_transfer_size",
-                "name": "http.response_transfer_size",
-                "attributeType": "number",
-                "attributeSource": {"source_type": "sentry"},
-            },
-            {
-                "key": "measurements.lcp",
-                "name": "measurements.lcp",
-                "attributeType": "number",
-                "attributeSource": {"source_type": "sentry"},
-            },
-            {
-                "key": "span.duration",
-                "name": "span.duration",
-                "attributeType": "number",
-                "attributeSource": {"source_type": "sentry"},
-            },
-        ]
+        # Don't depend on the order of the values, just that they're all
+        # present. snuba PR getsentry/snuba#8062 changes the default sort.
+        assert sorted(response.data, key=itemgetter("key")) == sorted(
+            [
+                {
+                    "key": "tags[bar,number]",
+                    "name": "bar",
+                    "attributeType": "number",
+                    "attributeSource": {"source_type": "user"},
+                },
+                {
+                    "key": "tags[baz,number]",
+                    "name": "baz",
+                    "attributeType": "number",
+                    "attributeSource": {"source_type": "user"},
+                },
+                {
+                    "key": "measurements.fcp",
+                    "name": "measurements.fcp",
+                    "attributeType": "number",
+                    "attributeSource": {"source_type": "sentry"},
+                },
+                {
+                    "key": "tags[foo,number]",
+                    "name": "foo",
+                    "attributeType": "number",
+                    "attributeSource": {"source_type": "user"},
+                },
+                {
+                    "key": "http.decoded_response_content_length",
+                    "name": "http.decoded_response_content_length",
+                    "attributeType": "number",
+                    "attributeSource": {"source_type": "sentry"},
+                },
+                {
+                    "key": "http.response_content_length",
+                    "name": "http.response_content_length",
+                    "attributeType": "number",
+                    "attributeSource": {"source_type": "sentry"},
+                },
+                {
+                    "key": "http.response_transfer_size",
+                    "name": "http.response_transfer_size",
+                    "attributeType": "number",
+                    "attributeSource": {"source_type": "sentry"},
+                },
+                {
+                    "key": "measurements.lcp",
+                    "name": "measurements.lcp",
+                    "attributeType": "number",
+                    "attributeSource": {"source_type": "sentry"},
+                },
+                {
+                    "key": "span.duration",
+                    "name": "span.duration",
+                    "attributeType": "number",
+                    "attributeSource": {"source_type": "sentry"},
+                },
+            ],
+            key=itemgetter("key"),
+        )
 
     @override_options({"explore.trace-items.keys.max": 3})
     def test_pagination(self) -> None:


### PR DESCRIPTION
## Summary

`OrganizationTraceItemAttributesEndpointSpansTest::test_tags_list_nums` asserted the response with an exact, order-sensitive list comparison (`assert response.data == [...]`). The number-attributes endpoint does not guarantee a stable ordering of returned values, so the test should assert that all expected values are present rather than depending on their order.

This surfaced via snuba PR getsentry/snuba#8062, which changes the default sort.

## Change

Switched the assertion to the order-independent pattern already used by neighboring tests in this file — sorting both sides by `key`:

```python
assert sorted(response.data, key=itemgetter("key")) == sorted(
    [ ...expected values... ],
    key=itemgetter("key"),
)
```

`itemgetter` was already imported and this idiom matches the surrounding tests (`test_pagination`, etc.).

## Test Plan

- `ruff format --check` and `ruff check` pass on the modified file.
- Assertion now verifies all expected number attributes are present regardless of order.

https://claude.ai/code/session_01WLKmLXRfRyJpW9u8zEGsy1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLKmLXRfRyJpW9u8zEGsy1)_