### PR TITLE
feat(dynamic-sampling): Record EAP and outcomes volume in sliding-window comparison

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -95,6 +95,20 @@ def compare_organization_sliding_window_sample_rates(
             sample_rate=1.0,
             tags=tags,
         )
+    if eap_volume is not None:
+        metrics.distribution(
+            f"{SLIDING_WINDOW_METRIC_PREFIX}.eap_volume",
+            eap_volume.total,
+            sample_rate=1.0,
+            tags=tags,
+        )
+    if outcomes_volume is not None:
+        metrics.distribution(
+            f"{SLIDING_WINDOW_METRIC_PREFIX}.outcomes_volume",
+            outcomes_volume.total,
+            sample_rate=1.0,
+            tags=tags,
+        )
 
 
 def run_project_balancing(


### PR DESCRIPTION
- Add `dynamic_sampling.per_org.sliding_window.eap_volume` and `…outcomes_volume` distribution metrics to `compare_organization_sliding_window_sample_rates`
- Records the pre-sampling volume behind each computed rate (EAP segments vs outcomes), so the volumes can be compared directly alongside the existing `eap_sample_rate` / `outcomes_sample_rate` metrics
- Same `{ds_org}` tag and emission shape as the existing metrics; each guarded on its volume being present

Contributes to TET-2514