### PR TITLE
feat(logs): register ourlogs-selection feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -410,6 +410,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:ourlogs-modal-export", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable pinning logs to the top of the table in the logs UI and query parameters
     manager.add("organizations:ourlogs-pinning", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable always-visible row selection checkboxes in the logs UI
+    manager.add("organizations:ourlogs-selection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable alerting on trace metrics
     # Enable trace metrics product (known internally as tracemetrics) in UI and backend
     manager.add("organizations:tracemetrics-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)


### PR DESCRIPTION
Registers the `organizations:ourlogs-selection` feature flag (FlagPole, `api_expose=True`) that gates the new always-visible row selection checkboxes in the Logs Explorer table. The flag is exposed to the frontend so the UI can render the checkboxes only for opted-in orgs, allowing the feature to be dark-launched and measured before a wider rollout.

This is the backend half of LOGS-881 and lands first; the frontend change that reads this flag ships in a separate PR. Linear: https://linear.app/getsentry/issue/LOGS-881
