### PR TITLE
feat(logs): always show selection checkboxes in the logs table

### DIFF
--- a/static/app/views/explore/logs/selection/useLogsSelection.spec.tsx
+++ b/static/app/views/explore/logs/selection/useLogsSelection.spec.tsx
@@ -1,0 +1,73 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {useLogsSelection} from 'sentry/views/explore/logs/selection/useLogsSelection';
+
+const enabledOrganization = OrganizationFixture({features: ['ourlogs-selection']});
+const disabledOrganization = OrganizationFixture({features: []});
+
+describe('useLogsSelection', () => {
+  it('returns undefined when the feature is disabled', () => {
+    const {result} = renderHookWithProviders(() => useLogsSelection(), {
+      organization: disabledOrganization,
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('starts with no selected rows when the feature is enabled', () => {
+    const {result} = renderHookWithProviders(() => useLogsSelection(), {
+      organization: enabledOrganization,
+    });
+
+    expect(result.current?.getSelectedRowIds()).toEqual([]);
+  });
+
+  it('adds the id to the selection when toggleSelectedRow is called for an unselected id', () => {
+    const {result} = renderHookWithProviders(() => useLogsSelection(), {
+      organization: enabledOrganization,
+    });
+
+    act(() => {
+      result.current?.toggleSelectedRow('log-1');
+    });
+
+    expect(result.current?.isRowSelected('log-1')).toBe(true);
+    expect(result.current?.getSelectedRowIds()).toEqual(['log-1']);
+  });
+
+  it('removes the id from the selection when toggleSelectedRow is called for a selected id', () => {
+    const {result} = renderHookWithProviders(() => useLogsSelection(), {
+      organization: enabledOrganization,
+    });
+
+    act(() => result.current?.toggleSelectedRow('log-1'));
+    act(() => result.current?.toggleSelectedRow('log-1'));
+
+    expect(result.current?.isRowSelected('log-1')).toBe(false);
+    expect(result.current?.getSelectedRowIds()).toEqual([]);
+  });
+
+  it('replaces the selection when setSelectedRows is called', () => {
+    const {result} = renderHookWithProviders(() => useLogsSelection(), {
+      organization: enabledOrganization,
+    });
+
+    act(() => result.current?.toggleSelectedRow('log-1'));
+    act(() => result.current?.setSelectedRows(['log-2', 'log-3']));
+
+    expect(result.current?.getSelectedRowIds()).toEqual(['log-2', 'log-3']);
+  });
+
+  it('empties the selection when clearSelectedRows is called', () => {
+    const {result} = renderHookWithProviders(() => useLogsSelection(), {
+      organization: enabledOrganization,
+    });
+
+    act(() => result.current?.setSelectedRows(['log-1', 'log-2']));
+    act(() => result.current?.clearSelectedRows());
+
+    expect(result.current?.getSelectedRowIds()).toEqual([]);
+  });
+});

--- a/static/app/views/explore/logs/selection/useLogsSelection.tsx
+++ b/static/app/views/explore/logs/selection/useLogsSelection.tsx
@@ -1,0 +1,59 @@
+import {useCallback, useMemo, useState} from 'react';
+
+import {useOurLogsSelectionEnabled} from 'sentry/views/explore/logs/selection/useOurLogsSelection';
+
+export interface LogsSelection {
+  clearSelectedRows: () => void;
+  getSelectedRowIds: () => string[];
+  isRowSelected: (id: string) => boolean;
+  setSelectedRows: (ids: string[]) => void;
+  toggleSelectedRow: (id: string) => void;
+}
+
+export function useLogsSelection(): LogsSelection | undefined {
+  const logsSelectionEnabled = useOurLogsSelectionEnabled();
+  const [selectedRowIds, setSelectedRowIds] = useState<Set<string>>(() => new Set());
+
+  const getSelectedRowIds = useCallback(
+    () => Array.from(selectedRowIds.values()),
+    [selectedRowIds]
+  );
+
+  const isRowSelected = useCallback(
+    (id: string) => selectedRowIds.has(id),
+    [selectedRowIds]
+  );
+
+  const toggleSelectedRow = useCallback((id: string) => {
+    setSelectedRowIds(previous => {
+      const next = new Set(previous);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const setSelectedRows = useCallback((ids: string[]) => {
+    setSelectedRowIds(new Set(ids));
+  }, []);
+
+  const clearSelectedRows = useCallback(() => {
+    setSelectedRowIds(new Set());
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      clearSelectedRows,
+      getSelectedRowIds,
+      isRowSelected,
+      setSelectedRows,
+      toggleSelectedRow,
+    }),
+    [clearSelectedRows, getSelectedRowIds, isRowSelected, setSelectedRows, toggleSelectedRow]
+  );
+
+  return logsSelectionEnabled ? value : undefined;
+}

--- a/static/app/views/explore/logs/selection/useOurLogsSelection.spec.tsx
+++ b/static/app/views/explore/logs/selection/useOurLogsSelection.spec.tsx
@@ -1,0 +1,48 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {useOurLogsSelectionEnabled} from 'sentry/views/explore/logs/selection/useOurLogsSelection';
+
+describe('useOurLogsSelectionEnabled', () => {
+  it('returns true when the organization has the ourlogs-selection feature', () => {
+    const {result} = renderHookWithProviders(() => useOurLogsSelectionEnabled(), {
+      organization: OrganizationFixture({features: ['ourlogs-selection']}),
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true when the location query has logsSelection set to true', () => {
+    const {result} = renderHookWithProviders(() => useOurLogsSelectionEnabled(), {
+      organization: OrganizationFixture({features: []}),
+      initialRouterConfig: {
+        location: {pathname: '/', query: {logsSelection: 'true'}},
+      },
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when neither the feature nor the query are set', () => {
+    const {result} = renderHookWithProviders(() => useOurLogsSelectionEnabled(), {
+      organization: OrganizationFixture({features: []}),
+      initialRouterConfig: {
+        location: {pathname: '/'},
+      },
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when the location query has logsSelection set to a value other than true', () => {
+    const {result} = renderHookWithProviders(() => useOurLogsSelectionEnabled(), {
+      organization: OrganizationFixture({features: []}),
+      initialRouterConfig: {
+        location: {pathname: '/', query: {logsSelection: 'false'}},
+      },
+    });
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/static/app/views/explore/logs/selection/useOurLogsSelection.tsx
+++ b/static/app/views/explore/logs/selection/useOurLogsSelection.tsx
@@ -1,0 +1,12 @@
+import {useLocation} from 'sentry/utils/useLocation';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+export function useOurLogsSelectionEnabled() {
+  const organization = useOrganization();
+  const location = useLocation();
+
+  return (
+    organization.features.includes('ourlogs-selection') ||
+    location.query.logsSelection === 'true'
+  );
+}

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -3,6 +3,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import {Checkbox} from '@sentry/scraps/checkbox';
 import {Flex, type FlexProps} from '@sentry/scraps/layout';
 
 import {HighlightComponent} from 'sentry/components/highlight';
@@ -269,6 +270,11 @@ export const DetailsBody = styled('div')`
 
 export const StyledChevronButton = styled(Button)`
   margin-right: ${p => p.theme.space.xs};
+`;
+
+export const LogSelectionCheckbox = styled(Checkbox)`
+  margin-right: ${p => p.theme.space.xs};
+  flex-shrink: 0;
 `;
 
 const DEFAULT_SIZE = '8px';

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -649,4 +649,79 @@ describe('LogsInfiniteTable', () => {
     await userEvent.click(severityHeader);
     expect(router.location.query[LOGS_SORT_BYS_KEY]).toBe('-timestamp');
   });
+
+  describe('selection checkboxes', () => {
+    const selectionRouterConfig = {
+      location: {
+        pathname: `/organizations/${organization.slug}/explore/logs/`,
+        query: {
+          [LOGS_FIELDS_KEY]: visibleColumnFields,
+          [LOGS_SORT_BYS_KEY]: '-timestamp',
+          [LOGS_QUERY_KEY]: 'severity:error',
+          logsSelection: 'true',
+        },
+      },
+    };
+
+    it('renders a selection checkbox on each row without hovering when ourlogs-selection is enabled', async () => {
+      renderWithProviders(
+        <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+        {initialRouterConfig: selectionRouterConfig}
+      );
+
+      const rows = await screen.findAllByTestId('log-table-row');
+      for (const row of rows) {
+        expect(
+          within(row).getByRole('checkbox', {name: 'Select log row'})
+        ).toBeInTheDocument();
+      }
+    });
+
+    it('does not render selection checkboxes when ourlogs-selection is disabled', async () => {
+      renderWithProviders(
+        <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />
+      );
+
+      const [firstRow] = await screen.findAllByTestId('log-table-row');
+
+      expect(
+        within(firstRow!).queryByRole('checkbox', {name: 'Select log row'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('checks the row when its selection checkbox is clicked', async () => {
+      renderWithProviders(
+        <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+        {initialRouterConfig: selectionRouterConfig}
+      );
+
+      const [firstRow] = await screen.findAllByTestId('log-table-row');
+      const checkbox = within(firstRow!).getByRole('checkbox', {name: 'Select log row'});
+      await userEvent.click(checkbox);
+
+      expect(
+        within(firstRow!).getByRole('checkbox', {name: 'Deselect log row'})
+      ).toBeChecked();
+    });
+
+    it('selects every row when the header select-all checkbox is clicked', async () => {
+      renderWithProviders(
+        <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+        {initialRouterConfig: selectionRouterConfig}
+      );
+
+      await screen.findAllByTestId('log-table-row');
+      await userEvent.click(screen.getByRole('checkbox', {name: 'Select all logs'}));
+
+      const rows = screen.getAllByTestId('log-table-row');
+      for (const row of rows) {
+        expect(
+          within(row).getByRole('checkbox', {name: 'Deselect log row'})
+        ).toBeChecked();
+      }
+      expect(
+        screen.getByRole('checkbox', {name: 'Deselect all logs'})
+      ).toBeChecked();
+    });
+  });
 });

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -50,12 +50,14 @@ import {getDisplayTotalPayloadBytes} from 'sentry/views/explore/logs/getDisplayT
 import {PinnedLogs} from 'sentry/views/explore/logs/pinning/PinnedLogs';
 import {useLogsPinning} from 'sentry/views/explore/logs/pinning/useLogsPinning';
 import {usePinnedLogsQuery} from 'sentry/views/explore/logs/pinning/usePinnedLogsQuery';
+import {useLogsSelection} from 'sentry/views/explore/logs/selection/useLogsSelection';
 import {
   FirstTableHeadCell,
   FloatingBackToTopContainer,
   FloatingBottomContainer,
   HoveringRowLoadingRendererContainer,
   LOGS_GRID_BODY_ROW_HEIGHT,
+  LogSelectionCheckbox,
   LogTable,
   LogTableBody,
   LogTableHeadCell,
@@ -450,6 +452,7 @@ export function LogsInfiniteTable({
   }, []);
 
   const logsPinning = useLogsPinning();
+  const logsSelection = useLogsSelection();
   const pinnedLogsQuery = usePinnedLogsQuery({allRows: data, logsPinning});
 
   const renderRow = useCallback(
@@ -471,9 +474,11 @@ export function LogsInfiniteTable({
           logStart={logStart}
           logEnd={logEnd}
           isPinned={logsPinning?.hasPinnedRow?.(rowId)}
+          isSelected={logsSelection?.isRowSelected?.(rowId)}
           isHoverLinked={hoveredRowId === rowId}
           setHoveredRowId={setHoveredRowId}
           togglePinnedRow={logsPinning?.togglePinnedRow}
+          toggleSelectedRow={logsSelection?.toggleSelectedRow}
         />
       );
     },
@@ -487,6 +492,7 @@ export function LogsInfiniteTable({
       logEnd,
       logStart,
       logsPinning,
+      logsSelection,
       meta,
     ]
   );
@@ -536,6 +542,7 @@ export function LogsInfiniteTable({
             stringAttributes={stringAttributes}
             booleanAttributes={booleanAttributes}
             onResizeMouseDown={onResizeMouseDown}
+            logsSelection={logsSelection}
           />
         )}
         {!isPending && logsPinning && (
@@ -614,9 +621,11 @@ export function LogsInfiniteTable({
                   showCellActions={showCellActions}
                   showExploreSimilarSpansLink={showExploreSimilarSpansLink}
                   isPinned={logsPinning?.hasPinnedRow?.(rowId)}
+                  isSelected={logsSelection?.isRowSelected?.(rowId)}
                   isHoverLinked={hoveredRowId === rowId}
                   setHoveredRowId={setHoveredRowId}
                   togglePinnedRow={logsPinning?.togglePinnedRow}
+                  toggleSelectedRow={logsSelection?.toggleSelectedRow}
                 />
               </Fragment>
             );
@@ -667,8 +676,10 @@ function LogsTableHeader({
   numberAttributes,
   stringAttributes,
   onResizeMouseDown,
+  logsSelection,
 }: Pick<LogsTableProps, 'numberAttributes' | 'stringAttributes' | 'booleanAttributes'> & {
   isFrozen: boolean;
+  logsSelection: ReturnType<typeof useLogsSelection>;
   onResizeMouseDown: (e: React.MouseEvent<HTMLDivElement>, index: number) => void;
 }) {
   const fields = useQueryParamsFields();
@@ -677,11 +688,40 @@ function LogsTableHeader({
 
   const {data, meta, isError, isPending} = useLogsPageDataQueryResult();
   const pinningEnabled = !!useLogsPinning();
+
+  const selectableRowIds = useMemo(
+    () =>
+      (data ?? [])
+        .filter(isRegularLogResponseItem)
+        .map(row => row[OurLogKnownFieldKey.ID]),
+    [data]
+  );
+  const selectedCount = logsSelection
+    ? selectableRowIds.filter(id => logsSelection.isRowSelected(id)).length
+    : 0;
+  const allSelected = selectableRowIds.length > 0 && selectedCount === selectableRowIds.length;
+  const selectAllChecked = allSelected
+    ? true
+    : selectedCount > 0
+      ? ('indeterminate' as const)
+      : false;
+
   return (
     <TableHead>
       <LogTableRow>
         <FirstTableHeadCell isFirst align="left">
-          <TableHeadCellContent isFrozen />
+          {logsSelection ? (
+            <LogSelectionCheckbox
+              checked={selectAllChecked}
+              disabled={selectableRowIds.length === 0}
+              aria-label={allSelected ? t('Deselect all logs') : t('Select all logs')}
+              onChange={() =>
+                logsSelection.setSelectedRows(allSelected ? [] : selectableRowIds)
+              }
+            />
+          ) : (
+            <TableHeadCellContent isFrozen />
+          )}
         </FirstTableHeadCell>
         {fields.map((field, index) => {
           const direction = sortBys.find(s => s.field === field)?.kind;

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -16,6 +16,7 @@ import {
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import * as analytics from 'sentry/utils/analytics';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {
   LOGS_FIELDS_KEY,
@@ -845,5 +846,93 @@ describe('logsTableRow', () => {
         /\[Replace\] \[MAC addresses\] with \[ITS_GONE\] from \[not_zzz_not_exact_match\]/
       )
     ).toBeInTheDocument();
+  });
+
+  describe('selection checkboxes', () => {
+    it('does not render a selection checkbox when toggleSelectedRow is not provided', () => {
+      render(
+        <LogRowContent
+          dataRow={rowData}
+          highlightTerms={[]}
+          meta={LogFixtureMeta(rowData)}
+          sharedHoverTimeoutRef={{current: null}}
+        />,
+        {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+      );
+
+      expect(
+        screen.queryByRole('checkbox', {name: 'Select log row'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the selection checkbox without hovering when toggleSelectedRow is provided', () => {
+      render(
+        <LogRowContent
+          dataRow={rowData}
+          highlightTerms={[]}
+          meta={LogFixtureMeta(rowData)}
+          sharedHoverTimeoutRef={{current: null}}
+          toggleSelectedRow={jest.fn()}
+        />,
+        {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+      );
+
+      expect(screen.getByRole('checkbox', {name: 'Select log row'})).toBeInTheDocument();
+    });
+
+    it('calls toggleSelectedRow with the row id when the checkbox is clicked', async () => {
+      const toggleSelectedRow = jest.fn();
+      render(
+        <LogRowContent
+          dataRow={rowData}
+          highlightTerms={[]}
+          meta={LogFixtureMeta(rowData)}
+          sharedHoverTimeoutRef={{current: null}}
+          toggleSelectedRow={toggleSelectedRow}
+        />,
+        {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+      );
+
+      await userEvent.click(screen.getByRole('checkbox', {name: 'Select log row'}));
+
+      expect(toggleSelectedRow).toHaveBeenCalledWith('1');
+    });
+
+    it('renders a checked checkbox with a deselect label when isSelected is true', () => {
+      render(
+        <LogRowContent
+          dataRow={rowData}
+          highlightTerms={[]}
+          meta={LogFixtureMeta(rowData)}
+          sharedHoverTimeoutRef={{current: null}}
+          isSelected
+          toggleSelectedRow={jest.fn()}
+        />,
+        {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+      );
+
+      expect(screen.getByRole('checkbox', {name: 'Deselect log row'})).toBeChecked();
+    });
+
+    it('does not expand the row when the checkbox is clicked', async () => {
+      const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+      render(
+        <LogRowContent
+          dataRow={rowData}
+          highlightTerms={[]}
+          meta={LogFixtureMeta(rowData)}
+          sharedHoverTimeoutRef={{current: null}}
+          toggleSelectedRow={jest.fn()}
+        />,
+        {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+      );
+
+      await userEvent.click(screen.getByRole('checkbox', {name: 'Select log row'}));
+
+      expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+        'logs.table.row_expanded',
+        expect.anything()
+      );
+    });
   });
 });

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -84,6 +84,7 @@ import {
   LogDetailTableActionsCell,
   LogDetailTableBodyCell,
   LogFirstCellContent,
+  LogSelectionCheckbox,
   LogsTableBodyFirstCell,
   LogTableBodyCell,
   LogTableRow,
@@ -131,6 +132,7 @@ type LogsRowProps = {
   isExpanded?: boolean;
   isHoverLinked?: boolean;
   isPinned?: boolean;
+  isSelected?: boolean;
   logEnd?: string;
   logStart?: string;
   onCollapse?: (logItemId: string) => void;
@@ -141,6 +143,7 @@ type LogsRowProps = {
   showCellActions?: boolean;
   showExploreSimilarSpansLink?: boolean;
   togglePinnedRow?: (logItemId: string) => void;
+  toggleSelectedRow?: (logItemId: string) => void;
 };
 
 const ALLOWED_CELL_ACTIONS: Actions[] = [
@@ -228,9 +231,11 @@ export const LogRowContent = memo(function LogRowContent({
   logStart,
   logEnd,
   isPinned,
+  isSelected,
   isHoverLinked,
   setHoveredRowId,
   togglePinnedRow,
+  toggleSelectedRow,
   showCellActions,
   showExploreSimilarSpansLink,
 }: LogsRowProps) {
@@ -443,6 +448,16 @@ export const LogRowContent = memo(function LogRowContent({
       >
         <LogsTableBodyFirstCell key="first">
           <LogFirstCellContent>
+            {toggleSelectedRow && !isPseudoRow ? (
+              <LogSelectionCheckbox
+                checked={isSelected}
+                aria-label={isSelected ? t('Deselect log row') : t('Select log row')}
+                onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                onPointerUp={(e: React.PointerEvent) => e.stopPropagation()}
+                onTouchEnd={(e: React.TouchEvent) => e.stopPropagation()}
+                onChange={() => toggleSelectedRow(rowId)}
+              />
+            ) : null}
             {isPseudoRow ? (
               <span className="log-table-row-pseudo-row-chevron-replacement" />
             ) : blockRowExpanding ? null : shouldRenderHoverElements ? (


### PR DESCRIPTION
Adds always-visible row selection checkboxes to the Logs Explorer table. Previously the only per-row affordances (the expand chevron and pin button) were revealed on hover; there were no selection checkboxes at all. Per the UX review with Martha, this renders a checkbox in each row's first cell unconditionally — not gated on hover or a hold modifier — so users discover that multi-select exists. The implementation mirrors the existing logs pinning pattern: a `useLogsSelection` hook holds ephemeral local state (selection is not persisted to the URL), and a select-all checkbox in the header column toggles every selectable row and shows an indeterminate state for partial selections.

The whole feature is gated behind the new `ourlogs-selection` flag (also togglable via `?logsSelection=true`) so it can be dark-launched and measured. The row checkbox stops pointer-event propagation so toggling selection never expands the row. Shift-click multi-select is intentionally out of scope.

Depends on the backend flag-registration PR (#118020), which must land first. Linear: https://linear.app/getsentry/issue/LOGS-881
