### PR TITLE
feat(issues): Show span.name in low-value span issue details

### DIFF
--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.spec.tsx
@@ -6,6 +6,7 @@ import type {LowValueSpanEvidenceData} from './types';
 const evidenceData: LowValueSpanEvidenceData = {
   op: 'function',
   description: 'compute_checksum',
+  spanName: null,
   count: 1234,
   extrapolatedCount: 60_000,
   avgDurationMs: 0.4,
@@ -106,17 +107,56 @@ describe('LowValueSpanIssues ProblemSection', () => {
     );
   });
 
-  it('does not link to explore when both op and description are null', () => {
+  it('does not link to explore when op, description, and span name are all null', () => {
     render(
       <ProblemSection
         evidenceData={{
           ...evidenceData,
           op: null,
           description: null,
+          spanName: null,
         }}
       />
     );
 
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('prefers span name over op in the affected-span label', () => {
+    render(
+      <ProblemSection
+        evidenceData={{
+          ...evidenceData,
+          spanName: 'ProcessChecksum',
+        }}
+      />
+    );
+
+    expect(screen.getByText('ProcessChecksum - compute_checksum')).toBeInTheDocument();
+    expect(screen.queryByText('function - compute_checksum')).not.toBeInTheDocument();
+  });
+
+  it('uses span name when op is null', () => {
+    render(
+      <ProblemSection
+        evidenceData={{
+          ...evidenceData,
+          op: null,
+          spanName: 'ProcessChecksum',
+        }}
+      />
+    );
+
+    const exploreLink = screen.getByRole('link', {
+      name: 'ProcessChecksum - compute_checksum',
+    });
+    expect(exploreLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('span.name%3AProcessChecksum')
+    );
+    expect(exploreLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('%21has%3Aspan.op')
+    );
   });
 });

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/problemSection.tsx
@@ -26,15 +26,16 @@ interface ProblemSectionProps {
 const LOW_VALUE_SPAN_EXPLORE_REFERRER = 'low-value-span-configuration-issue';
 
 function getAffectedSpanQuery(evidenceData: LowValueSpanEvidenceData): string | null {
-  const {op, description} = evidenceData;
+  const {op, description, spanName} = evidenceData;
 
-  if (op === null && description === null) {
+  if (op === null && description === null && spanName === null) {
     return null;
   }
 
   return MutableSearch.fromQueryObject({
     'span.op': op ?? EMPTY_OPTION_VALUE,
     'span.description': description ?? EMPTY_OPTION_VALUE,
+    'span.name': spanName ?? EMPTY_OPTION_VALUE,
   }).formatString();
 }
 

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/troubleshootingSection.spec.tsx
@@ -6,6 +6,7 @@ import type {LowValueSpanEvidenceData} from './types';
 const baseEvidenceData: LowValueSpanEvidenceData = {
   op: 'function',
   description: 'compute_checksum',
+  spanName: null,
   count: 1234,
   extrapolatedCount: 60_000,
   avgDurationMs: 0.4,
@@ -190,5 +191,75 @@ describe('LowValueSpanIssues TroubleshootingSection', () => {
 
     expect(screen.getByText(/span.get\("op"\) == "function"/)).toBeInTheDocument();
     expect(screen.getByText(/span.get\("description"\) is None/)).toBeInTheDocument();
+  });
+
+  it('uses span name as the JS matcher `name:` when set', () => {
+    render(
+      <TroubleshootingSection
+        evidenceData={{
+          ...baseEvidenceData,
+          spanName: 'ProcessChecksum',
+        }}
+        projectPlatform="javascript-nextjs"
+      />
+    );
+
+    expect(screen.getByText(/op: "function"/)).toBeInTheDocument();
+    expect(screen.getByText(/name: "ProcessChecksum"/)).toBeInTheDocument();
+    expect(screen.queryByText(/name: "compute_checksum"/)).not.toBeInTheDocument();
+  });
+
+  it('emits a name-only JS matcher when op is null and span name is set', () => {
+    render(
+      <TroubleshootingSection
+        evidenceData={{
+          ...baseEvidenceData,
+          op: null,
+          spanName: 'ProcessChecksum',
+        }}
+        projectPlatform="javascript-nextjs"
+      />
+    );
+
+    expect(screen.getByText(/name: "ProcessChecksum"/)).toBeInTheDocument();
+    expect(screen.queryByText(/op:/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/will also drop other spans with this op/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('adds a span name clause to the Python snippet when set', () => {
+    render(
+      <TroubleshootingSection
+        evidenceData={{
+          ...baseEvidenceData,
+          spanName: 'ProcessChecksum',
+        }}
+        projectPlatform="python-django"
+      />
+    );
+
+    expect(screen.getByText(/span.get\("op"\) == "function"/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/span.get\("name"\) == "ProcessChecksum"/)
+    ).toBeInTheDocument();
+  });
+
+  it('uses span name in the manual instrumentation search copy when set', () => {
+    render(
+      <TroubleshootingSection
+        evidenceData={{
+          ...baseEvidenceData,
+          spanName: 'ProcessChecksum',
+          spanOrigin: 'manual',
+        }}
+        projectPlatform={null}
+      />
+    );
+
+    expect(
+      screen.getAllByText('ProcessChecksum - compute_checksum').length
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText('function - compute_checksum')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/types.ts
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/types.ts
@@ -7,6 +7,7 @@ export interface LowValueSpanEvidenceData {
   estimatedCostUsd: number | null;
   extrapolatedCount: number | null;
   op: string | null;
+  spanName: string | null;
   spanOrigin: string | null;
 }
 
@@ -19,6 +20,7 @@ type LowValueSpanEvidencePayload = Partial<{
   estimatedCostUsd: unknown;
   extrapolatedCount: unknown;
   op: unknown;
+  spanName: unknown;
   spanOrigin: unknown;
   valueScore: unknown;
 }>;
@@ -39,6 +41,7 @@ export function getLowValueSpanEvidenceData(
   return {
     op: getStringValue(data?.op),
     description: getStringValue(data?.description),
+    spanName: getStringValue(data?.spanName),
     count: getNumberValue(data?.count),
     extrapolatedCount: getNumberValue(data?.extrapolatedCount),
     avgDurationMs: getNumberValue(data?.avgDurationMs),

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
@@ -23,13 +23,14 @@ const JAVASCRIPT_PROJECT_PLATFORMS = new Set<PlatformKey>([
 ]);
 
 export function getSpanLabel(evidenceData: LowValueSpanEvidenceData): string {
-  const {op, description} = evidenceData;
+  const {op, description, spanName} = evidenceData;
+  const primary = spanName ?? op;
 
-  if (op && description) {
-    return `${op} - ${description}`;
+  if (primary && description) {
+    return `${primary} - ${description}`;
   }
-  if (op) {
-    return op;
+  if (primary) {
+    return primary;
   }
   if (description) {
     return description;
@@ -101,18 +102,21 @@ export function getCustomInstrumentationDocsUrl(): string {
 export function getJavaScriptSpanFilterSnippet(
   evidenceData: LowValueSpanEvidenceData
 ): string {
+  const {op, description, spanName} = evidenceData;
+  const matcherName = spanName ?? description;
   const matcherLines: string[] = [];
-  if (evidenceData.description === null && evidenceData.op !== null) {
-    matcherLines.push(`      // NOTE: This span has no description, so it can only be`);
+
+  if (matcherName === null && op !== null) {
+    matcherLines.push(`      // NOTE: This span has no description or name, so it can`);
     matcherLines.push(
-      `      // targeted by op. This will also drop other spans with this op.`
+      `      // only be targeted by op. This will also drop other spans with this op.`
     );
   }
-  if (evidenceData.op !== null) {
-    matcherLines.push(`      op: ${JSON.stringify(evidenceData.op)},`);
+  if (op !== null) {
+    matcherLines.push(`      op: ${JSON.stringify(op)},`);
   }
-  if (evidenceData.description !== null) {
-    matcherLines.push(`      name: ${JSON.stringify(evidenceData.description)},`);
+  if (matcherName !== null) {
+    matcherLines.push(`      name: ${JSON.stringify(matcherName)},`);
   }
 
   return `Sentry.init({
@@ -127,18 +131,22 @@ ${matcherLines.join('\n')}
 export function getPythonSpanFilterSnippet(
   evidenceData: LowValueSpanEvidenceData
 ): string {
+  const {op, description, spanName} = evidenceData;
   const conditions: string[] = [];
-  if (evidenceData.op === null) {
+  if (op === null) {
     conditions.push(`            span.get("op") is None`);
   } else {
-    conditions.push(`            span.get("op") == ${JSON.stringify(evidenceData.op)}`);
+    conditions.push(`            span.get("op") == ${JSON.stringify(op)}`);
   }
-  if (evidenceData.description === null) {
+  if (description === null) {
     conditions.push(`            and span.get("description") is None`);
   } else {
     conditions.push(
-      `            and span.get("description") == ${JSON.stringify(evidenceData.description)}`
+      `            and span.get("description") == ${JSON.stringify(description)}`
     );
+  }
+  if (spanName !== null) {
+    conditions.push(`            and span.get("name") == ${JSON.stringify(spanName)}`);
   }
 
   return `import sentry_sdk


### PR DESCRIPTION
The low-value span detector now groups by `span.name` in addition to op, description, and origin, and surfaces `span.name` in the occurrence's evidence. This adapts the configuration issue UI so OTel-style spans (op missing) and op+name spans render and filter correctly.

`getSpanLabel` prefers `spanName` over `op` when both are set, so a group with a name renders `<name> - <description>` and falls back to the existing `<op> - <description>` shape otherwise. The affected-span Explore link now includes `span.name`, the JS `ignoreSpans` matcher's `name:` key resolves to `spanName ?? description`, and the Python `before_send_transaction` snippet appends a `span.get("name")` clause when the group's name is set.

Closes TET-2484
Refs https://github.com/getsentry/getsentry/pull/20745