### PR TITLE
fix(ourlogs): nudge truncation constant up a power of 2

### DIFF
--- a/static/app/views/explore/logs/useLogsQueryTruncate.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQueryTruncate.spec.tsx
@@ -18,11 +18,11 @@ describe('useLogsQueryTruncate', () => {
   it('rounds the formula result up to the next power of two', () => {
     mockUseWindowSize.mockReturnValue({innerWidth: 6400, innerHeight: 1080});
     const {result} = renderHookWithProviders(() => useLogsQueryTruncate());
-    expect(result.current).toBe(512);
+    expect(result.current).toBe(1024);
   });
 
   it('returns the exact value when the formula result is already a power of two', () => {
-    mockUseWindowSize.mockReturnValue({innerWidth: 4096, innerHeight: 1080});
+    mockUseWindowSize.mockReturnValue({innerWidth: 3072, innerHeight: 1080});
     const {result} = renderHookWithProviders(() => useLogsQueryTruncate());
     expect(result.current).toBe(256);
   });
@@ -30,30 +30,30 @@ describe('useLogsQueryTruncate', () => {
   it('does not shrink the truncation length when the viewport shrinks', () => {
     mockUseWindowSize.mockReturnValue({innerWidth: 6400, innerHeight: 1080});
     const {result, rerender} = renderHookWithProviders(() => useLogsQueryTruncate());
-    expect(result.current).toBe(512);
+    expect(result.current).toBe(1024);
 
     mockUseWindowSize.mockReturnValue({innerWidth: 3200, innerHeight: 1080});
     rerender();
-    expect(result.current).toBe(512);
+    expect(result.current).toBe(1024);
   });
 
   it('does not recompute when the viewport grows within the same power of two', () => {
     mockUseWindowSize.mockReturnValue({innerWidth: 3200, innerHeight: 1080});
     const {result, rerender} = renderHookWithProviders(() => useLogsQueryTruncate());
-    expect(result.current).toBe(256);
+    expect(result.current).toBe(512);
 
-    mockUseWindowSize.mockReturnValue({innerWidth: 4096, innerHeight: 1080});
+    mockUseWindowSize.mockReturnValue({innerWidth: 6000, innerHeight: 1080});
     rerender();
-    expect(result.current).toBe(256);
+    expect(result.current).toBe(512);
   });
 
   it('grows the truncation length when the viewport grows past the next power of two', () => {
-    mockUseWindowSize.mockReturnValue({innerWidth: 4096, innerHeight: 1080});
+    mockUseWindowSize.mockReturnValue({innerWidth: 3200, innerHeight: 1080});
     const {result, rerender} = renderHookWithProviders(() => useLogsQueryTruncate());
-    expect(result.current).toBe(256);
+    expect(result.current).toBe(512);
 
     mockUseWindowSize.mockReturnValue({innerWidth: 8192, innerHeight: 1080});
     rerender();
-    expect(result.current).toBe(512);
+    expect(result.current).toBe(1024);
   });
 });

--- a/static/app/views/explore/logs/useLogsQueryTruncate.tsx
+++ b/static/app/views/explore/logs/useLogsQueryTruncate.tsx
@@ -4,7 +4,7 @@ import {useWindowSize} from 'sentry/utils/window/useWindowSize';
 
 export function useLogsQueryTruncate(): number {
   const {innerWidth} = useWindowSize();
-  const target = Math.max(128, Math.floor(innerWidth / 16));
+  const target = Math.max(128, Math.floor(innerWidth / 12));
 
   // Round up to the next power of two so small viewport changes don't shift the
   // truncation length and trigger a re-query.


### PR DESCRIPTION
I noticed the `...` truncation happening on my wide monitor view for logs whose messages have a long first line. This bumps up their target string lengths by a power of two so that shouldn't happen anymore. The actual font width is closer to 12 than 16 anyway.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="1654" height="944" alt="image" src="https://github.com/user-attachments/assets/859fc918-e953-4c42-a4f5-219fc394f113" />
</td>
<td>
<img width="1654" height="944" alt="image" src="https://github.com/user-attachments/assets/c6acbcb6-effe-41e5-b6e7-616ad8b441c0" />
</td>
</tr>
</tbody>
</table>

Closes LOGS-884.