### PR TITLE
chore(seer-activity): Prevent API from accepting activity triggers and unsupported actions

### DIFF
--- a/src/sentry/notifications/notification_action/activity_registry/base.py
+++ b/src/sentry/notifications/notification_action/activity_registry/base.py
@@ -1,6 +1,7 @@
 import logging
 
 from sentry.models.activity import Activity
+from sentry.notifications.notification_action.registry import activity_handler_registry
 from sentry.notifications.platform.service import NotificationService
 from sentry.notifications.platform.templates.workflow_engine import (
     ACTIVITY_TYPE_TO_SOURCE,
@@ -17,6 +18,18 @@ logger = logging.getLogger(__name__)
 NOTIFICATION_PLATFORM_COMPATIBLE_ACTIVITIES = [
     ActivityType(value) for value in ACTIVITY_TYPE_TO_SOURCE
 ]
+
+
+def get_supported_action_types() -> frozenset[Action.Type]:
+    from sentry.notifications.notification_action.activity_registry.unsupported import (
+        UnsupportedActivityHandler,
+    )
+
+    return frozenset(
+        Action.Type(key)
+        for key, handler in activity_handler_registry.registrations.items()
+        if handler is not UnsupportedActivityHandler
+    )
 
 
 def build_activity_data(

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -35,6 +35,7 @@ from sentry.workflow_engine.models import (
     Workflow,
     WorkflowDataConditionGroup,
 )
+from sentry.workflow_engine.models.data_condition import Condition
 
 InputData = dict[str, Any]
 ListInputData = list[InputData]
@@ -128,6 +129,30 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
             action_filter["actions"] = validated_actions
 
         return value
+
+    def _has_seer_activity_trigger(self, triggers: InputData | None) -> bool:
+        if triggers is None:
+            return False
+        return any(
+            c.get("type") == Condition.SEER_ACTIVITY_TRIGGER for c in triggers.get("conditions", [])
+        )
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        from sentry.notifications.notification_action.activity_registry.base import (
+            get_supported_action_types,
+        )
+
+        if not self._has_seer_activity_trigger(attrs.get("triggers")):
+            return attrs
+
+        supported_action_types = get_supported_action_types()
+        for action_filter in attrs.get("action_filters", []):
+            for action in action_filter.get("actions", []):
+                action_type = action.get("type")
+                if action_type and Action.Type(action_type) not in supported_action_types:
+                    raise serializers.ValidationError(
+                        f"Action type '{action_type}' is not supported for activity triggers"
+                    )
 
     def _update_or_create(
         self,

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -130,16 +130,16 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
 
         return value
 
-    def _has_seer_activity_trigger(self, triggers: InputData | None) -> bool:
-        if triggers is None:
-            return False
-        return any(
-            c.get("type") == Condition.SEER_ACTIVITY_TRIGGER for c in triggers.get("conditions", [])
-        )
-
-    def _existing_workflow_has_seer_activity_trigger(self) -> bool:
+    def has_seer_activity_trigger(self, triggers: InputData | None) -> bool:
         from sentry.workflow_engine.models import DataCondition
 
+        # If this mutation affects triggers, check the incoming payload for activity triggers...
+        if triggers:
+            return any(
+                c.get("type") == Condition.SEER_ACTIVITY_TRIGGER
+                for c in triggers.get("conditions", [])
+            )
+        # ...otherwise, check if the existing workflow being modified has activity triggers
         workflow: Workflow | None = self.context.get("workflow")
         if workflow is None or workflow.when_condition_group_id is None:
             return False
@@ -153,10 +153,7 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
             get_supported_action_types,
         )
 
-        has_activity_trigger = self._has_seer_activity_trigger(attrs.get("triggers"))
-        if not has_activity_trigger and "triggers" not in attrs:
-            has_activity_trigger = self._existing_workflow_has_seer_activity_trigger()
-
+        has_activity_trigger = self.has_seer_activity_trigger(triggers=attrs.get("triggers"))
         if not has_activity_trigger:
             return attrs
 

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -154,6 +154,8 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
                         f"Action type '{action_type}' is not supported for activity triggers"
                     )
 
+        return attrs
+
     def _update_or_create(
         self,
         input_data: dict[str, Any],

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -137,12 +137,27 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
             c.get("type") == Condition.SEER_ACTIVITY_TRIGGER for c in triggers.get("conditions", [])
         )
 
+    def _existing_workflow_has_seer_activity_trigger(self) -> bool:
+        from sentry.workflow_engine.models import DataCondition
+
+        workflow: Workflow | None = self.context.get("workflow")
+        if workflow is None or workflow.when_condition_group_id is None:
+            return False
+        return DataCondition.objects.filter(
+            condition_group_id=workflow.when_condition_group_id,
+            type=Condition.SEER_ACTIVITY_TRIGGER,
+        ).exists()
+
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         from sentry.notifications.notification_action.activity_registry.base import (
             get_supported_action_types,
         )
 
-        if not self._has_seer_activity_trigger(attrs.get("triggers")):
+        has_activity_trigger = self._has_seer_activity_trigger(attrs.get("triggers"))
+        if not has_activity_trigger and "triggers" not in attrs:
+            has_activity_trigger = self._existing_workflow_has_seer_activity_trigger()
+
+        if not has_activity_trigger:
             return attrs
 
         supported_action_types = get_supported_action_types()

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -1,4 +1,5 @@
 from contextlib import AbstractContextManager
+from unittest import mock
 
 import responses
 
@@ -27,7 +28,11 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 from sentry.workflow_engine.typings.notification_action import ActionTarget, ActionType
-from tests.sentry.workflow_engine.test_base import BaseWorkflowTest, ProjectAccessTestMixin
+from tests.sentry.workflow_engine.test_base import (
+    BaseWorkflowTest,
+    MockActionValidatorTranslator,
+    ProjectAccessTestMixin,
+)
 
 
 class OrganizationWorkflowDetailsBaseTest(APITestCase):
@@ -856,6 +861,58 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
         # Verify the other org's condition group was not modified
         other_dcg.refresh_from_db()
         assert other_dcg.conditions.count() == original_condition_count
+
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
+    def test_update_rejects_unsupported_action_when_existing_trigger_is_activity(
+        self, mock_action_validator: mock.MagicMock
+    ) -> None:
+        when_condition_group = self.create_data_condition_group(
+            organization=self.organization,
+            logic_type=DataConditionGroup.Type.ANY,
+        )
+        self.create_data_condition(
+            condition_group=when_condition_group,
+            type=Condition.SEER_ACTIVITY_TRIGGER,
+            comparison=["rca_started"],
+            condition_result=True,
+        )
+        workflow = self.create_workflow(
+            organization=self.organization,
+            when_condition_group=when_condition_group,
+        )
+
+        data = {
+            "name": workflow.name,
+            "actionFilters": [
+                {
+                    "logicType": "any",
+                    "conditions": [],
+                    "actions": [
+                        {
+                            "type": Action.Type.PAGERDUTY,
+                            "config": {
+                                "targetIdentifier": "test",
+                                "targetDisplay": "Test",
+                                "targetType": "specific",
+                            },
+                            "data": {},
+                            "integrationId": self.integration.id,
+                        },
+                    ],
+                }
+            ],
+        }
+
+        response = self.get_error_response(
+            self.organization.slug,
+            workflow.id,
+            raw_data=data,
+            status_code=400,
+        )
+        assert "not supported for activity triggers" in str(response.data)
 
 
 @cell_silo_test

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -1274,6 +1274,49 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
         other_dcg.refresh_from_db()
         assert other_dcg.conditions.count() == original_condition_count
 
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
+    def test_create_workflow__activity_trigger_rejects_unsupported_action(
+        self, mock_action_validator: mock.MagicMock
+    ) -> None:
+        self.valid_workflow["triggers"] = {
+            "logicType": "any",
+            "conditions": [
+                {
+                    "type": Condition.SEER_ACTIVITY_TRIGGER,
+                    "comparison": ["rca_started"],
+                    "conditionResult": True,
+                }
+            ],
+        }
+        self.valid_workflow["actionFilters"] = [
+            {
+                "logicType": "any",
+                "conditions": [],
+                "actions": [
+                    {
+                        "type": Action.Type.PAGERDUTY,
+                        "config": {
+                            "targetIdentifier": "test",
+                            "targetDisplay": "Test",
+                            "targetType": "specific",
+                        },
+                        "data": {},
+                        "integrationId": self.integration.id,
+                    },
+                ],
+            }
+        ]
+
+        response = self.get_error_response(
+            self.organization.slug,
+            raw_data=self.valid_workflow,
+            status_code=400,
+        )
+        assert "not supported for activity triggers" in str(response.data)
+
 
 @cell_silo_test
 class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -123,6 +123,119 @@ class TestWorkflowValidator(TestCase):
         assert validator.is_valid() is False
 
 
+class TestWorkflowValidatorActivityTrigger(TestCase):
+    def setUp(self) -> None:
+        self.context = {
+            "organization": self.organization,
+            "request": self.make_request(),
+        }
+
+        self.valid_data = {
+            "name": "test",
+            "enabled": True,
+            "config": {"frequency": 30},
+            "triggers": {
+                "logicType": "any",
+                "conditions": [
+                    {
+                        "type": Condition.SEER_ACTIVITY_TRIGGER,
+                        "comparison": ["rca_started"],
+                        "conditionResult": True,
+                    }
+                ],
+            },
+            "actionFilters": [],
+        }
+
+    @mock.patch(
+        "sentry.workflow_engine.registry.action_handler_registry.get",
+        return_value=MockActionHandler,
+    )
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
+    def test_supported_action_type_with_activity_trigger(
+        self, mock_action_validator: mock.MagicMock, mock_action_handler: mock.MagicMock
+    ) -> None:
+        self.valid_data["actionFilters"] = [
+            {
+                "logicType": "any",
+                "conditions": [],
+                "actions": [
+                    {
+                        "type": Action.Type.SLACK,
+                        "config": {"foo": "bar"},
+                        "data": {"baz": "bar"},
+                        "integrationId": self.integration.id,
+                    }
+                ],
+            }
+        ]
+        validator = WorkflowValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is True
+
+    @mock.patch(
+        "sentry.workflow_engine.registry.action_handler_registry.get",
+        return_value=MockActionHandler,
+    )
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
+    def test_unsupported_action_type_with_activity_trigger(
+        self, mock_action_validator: mock.MagicMock, mock_action_handler: mock.MagicMock
+    ) -> None:
+        self.valid_data["actionFilters"] = [
+            {
+                "logicType": "any",
+                "conditions": [],
+                "actions": [
+                    {
+                        "type": Action.Type.PAGERDUTY,
+                        "config": {"foo": "bar"},
+                        "data": {"baz": "bar"},
+                        "integrationId": self.integration.id,
+                    }
+                ],
+            }
+        ]
+        validator = WorkflowValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is False
+
+    @mock.patch(
+        "sentry.workflow_engine.registry.action_handler_registry.get",
+        return_value=MockActionHandler,
+    )
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
+    def test_unsupported_action_type_without_activity_trigger(
+        self, mock_action_validator: mock.MagicMock, mock_action_handler: mock.MagicMock
+    ) -> None:
+        self.valid_data["triggers"] = {
+            "logicType": "any",
+            "conditions": [],
+        }
+        self.valid_data["actionFilters"] = [
+            {
+                "logicType": "any",
+                "conditions": [],
+                "actions": [
+                    {
+                        "type": Action.Type.PAGERDUTY,
+                        "config": {"foo": "bar"},
+                        "data": {"baz": "bar"},
+                        "integrationId": self.integration.id,
+                    }
+                ],
+            }
+        ]
+        validator = WorkflowValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is True
+
+
 class TestWorkflowValidatorCreate(TestCase):
     def setUp(self) -> None:
         self.context = {

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -246,18 +246,17 @@ class TestWorkflowValidatorActivityTrigger(TestCase):
     def test_unsupported_action_type_update_without_triggers_in_payload(
         self, mock_action_validator: mock.MagicMock, mock_action_handler: mock.MagicMock
     ) -> None:
-        when_condition_group = DataConditionGroup.objects.create(
-            logic_type=DataConditionGroup.Type.ANY,
+        when_condition_group = self.create_data_condition_group(
             organization=self.organization,
+            logic_type=DataConditionGroup.Type.ANY,
         )
-        DataCondition.objects.create(
+        self.create_data_condition(
             condition_group=when_condition_group,
             type=Condition.SEER_ACTIVITY_TRIGGER,
             comparison=["rca_started"],
             condition_result=True,
         )
-        workflow = Workflow.objects.create(
-            name="existing",
+        workflow = self.create_workflow(
             organization=self.organization,
             when_condition_group=when_condition_group,
             config={"frequency": 30},
@@ -295,18 +294,17 @@ class TestWorkflowValidatorActivityTrigger(TestCase):
     def test_supported_action_type_update_without_triggers_in_payload(
         self, mock_action_validator: mock.MagicMock, mock_action_handler: mock.MagicMock
     ) -> None:
-        when_condition_group = DataConditionGroup.objects.create(
-            logic_type=DataConditionGroup.Type.ANY,
+        when_condition_group = self.create_data_condition_group(
             organization=self.organization,
+            logic_type=DataConditionGroup.Type.ANY,
         )
-        DataCondition.objects.create(
+        self.create_data_condition(
             condition_group=when_condition_group,
             type=Condition.SEER_ACTIVITY_TRIGGER,
             comparison=["rca_started"],
             condition_result=True,
         )
-        workflow = Workflow.objects.create(
-            name="existing",
+        workflow = self.create_workflow(
             organization=self.organization,
             when_condition_group=when_condition_group,
             config={"frequency": 30},

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -235,6 +235,104 @@ class TestWorkflowValidatorActivityTrigger(TestCase):
         validator = WorkflowValidator(data=self.valid_data, context=self.context)
         assert validator.is_valid() is True
 
+    @mock.patch(
+        "sentry.workflow_engine.registry.action_handler_registry.get",
+        return_value=MockActionHandler,
+    )
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
+    def test_unsupported_action_type_update_without_triggers_in_payload(
+        self, mock_action_validator: mock.MagicMock, mock_action_handler: mock.MagicMock
+    ) -> None:
+        when_condition_group = DataConditionGroup.objects.create(
+            logic_type=DataConditionGroup.Type.ANY,
+            organization=self.organization,
+        )
+        DataCondition.objects.create(
+            condition_group=when_condition_group,
+            type=Condition.SEER_ACTIVITY_TRIGGER,
+            comparison=["rca_started"],
+            condition_result=True,
+        )
+        workflow = Workflow.objects.create(
+            name="existing",
+            organization=self.organization,
+            when_condition_group=when_condition_group,
+            config={"frequency": 30},
+        )
+
+        data = {
+            "name": "updated",
+            "actionFilters": [
+                {
+                    "logicType": "any",
+                    "conditions": [],
+                    "actions": [
+                        {
+                            "type": Action.Type.PAGERDUTY,
+                            "config": {"foo": "bar"},
+                            "data": {"baz": "bar"},
+                            "integrationId": self.integration.id,
+                        }
+                    ],
+                }
+            ],
+        }
+        context = {**self.context, "workflow": workflow}
+        validator = WorkflowValidator(data=data, context=context)
+        assert validator.is_valid() is False
+
+    @mock.patch(
+        "sentry.workflow_engine.registry.action_handler_registry.get",
+        return_value=MockActionHandler,
+    )
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.action_validator_registry.get",
+        return_value=MockActionValidatorTranslator,
+    )
+    def test_supported_action_type_update_without_triggers_in_payload(
+        self, mock_action_validator: mock.MagicMock, mock_action_handler: mock.MagicMock
+    ) -> None:
+        when_condition_group = DataConditionGroup.objects.create(
+            logic_type=DataConditionGroup.Type.ANY,
+            organization=self.organization,
+        )
+        DataCondition.objects.create(
+            condition_group=when_condition_group,
+            type=Condition.SEER_ACTIVITY_TRIGGER,
+            comparison=["rca_started"],
+            condition_result=True,
+        )
+        workflow = Workflow.objects.create(
+            name="existing",
+            organization=self.organization,
+            when_condition_group=when_condition_group,
+            config={"frequency": 30},
+        )
+
+        data = {
+            "name": "updated",
+            "actionFilters": [
+                {
+                    "logicType": "any",
+                    "conditions": [],
+                    "actions": [
+                        {
+                            "type": Action.Type.SLACK,
+                            "config": {"foo": "bar"},
+                            "data": {"baz": "bar"},
+                            "integrationId": self.integration.id,
+                        }
+                    ],
+                }
+            ],
+        }
+        context = {**self.context, "workflow": workflow}
+        validator = WorkflowValidator(data=data, context=context)
+        assert validator.is_valid() is True
+
 
 class TestWorkflowValidatorCreate(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
We already have the graceful exit, but now we can prevent these from being saved.