### PR TITLE
feat(pr-metrics): Emit conversation-judge analysis to BigQuery

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -60,21 +60,23 @@ class PrCloseMetricsEvent(analytics.Event):
     diagnosis_labels: list[str] | None = None
 
     # --- Conversation judge (set only on a judged close/merge row) ---
-    # One of several judges' outputs; a future judge lands its own columns
-    # alongside. Semantic outputs are promoted to columns so dashboards can
-    # group/filter directly; all are null off the judge path and BigQuery-only.
-    # Enum-like values are free strings so a Seer vocabulary change can't break it.
+    # One of several judges' outputs. Columns are prefixed ``conversation_`` so a
+    # future judge's columns sit alongside without collision, and to disambiguate
+    # the judge's comment counts from the webhook ``comments_count`` above. Semantic
+    # outputs are promoted to columns so dashboards group/filter directly; all are
+    # null off the judge path and BigQuery-only. Enum-like values are free strings
+    # so a Seer vocabulary change can't break the schema.
     #
     # positive | neutral | negative | mixed. Null when the judge was skipped (no
     # comments), so there's no separate ``analyzed`` flag.
-    sentiment: str | None = None
-    # "did bots/humans comment?"
-    bot_comment_count: int | None = None
-    human_comment_count: int | None = None
-    # comments_truncated > 0 means a chatty PR was capped before judging.
-    comments_total: int | None = None
-    comments_judged: int | None = None
-    comments_truncated: int | None = None
+    conversation_sentiment: str | None = None
+    # Comments split by author class — "did bots/humans comment?"
+    conversation_comments_bot: int | None = None
+    conversation_comments_human: int | None = None
+    # conversation_comments_truncated > 0 means a chatty PR was capped before judging.
+    conversation_comments_total: int | None = None
+    conversation_comments_judged: int | None = None
+    conversation_comments_truncated: int | None = None
     # The judge's drill-down detail (per-comment intents, reasoning, version
     # markers), JSON-encoded like ``attributions`` and stored verbatim. A future
     # judge gets its own ``*_metadata``.

--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -67,8 +67,9 @@ class PrCloseMetricsEvent(analytics.Event):
     # null off the judge path and BigQuery-only. Enum-like values are free strings
     # so a Seer vocabulary change can't break the schema.
     #
-    # positive | neutral | negative | mixed. Null when the judge was skipped (no
-    # comments), so there's no separate ``analyzed`` flag.
+    # positive | neutral | negative | mixed. Null when there was nothing to judge
+    # (no comments) or the judge couldn't run; conversation_comments_total
+    # disambiguates (0 = no comments, >0 = judge ran but produced no sentiment).
     conversation_sentiment: str | None = None
     # Comments split by author class — "did bots/humans comment?"
     conversation_comments_bot: int | None = None

--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -54,6 +54,31 @@ class PrCloseMetricsEvent(analytics.Event):
     # The Seer judge verdict (one of ``PullRequestVerdict``). Null on the no-judge
     # path and until the judge callback lands a result for a forwarded PR.
     verdict: str | None = None
+    # Close-reason labels behind the verdict (e.g. out_of_scope_or_unwanted) — the
+    # "why", a vocabulary shared across judges, not specific to any one. Repeated
+    # free-string column; null off the judge path. BigQuery-only.
+    diagnosis_labels: list[str] | None = None
+
+    # --- Conversation judge (set only on a judged close/merge row) ---
+    # One of several judges' outputs; a future judge lands its own columns
+    # alongside. Semantic outputs are promoted to columns so dashboards can
+    # group/filter directly; all are null off the judge path and BigQuery-only.
+    # Enum-like values are free strings so a Seer vocabulary change can't break it.
+    #
+    # positive | neutral | negative | mixed. Null when the judge was skipped (no
+    # comments), so there's no separate ``analyzed`` flag.
+    sentiment: str | None = None
+    # "did bots/humans comment?"
+    bot_comment_count: int | None = None
+    human_comment_count: int | None = None
+    # comments_truncated > 0 means a chatty PR was capped before judging.
+    comments_total: int | None = None
+    comments_judged: int | None = None
+    comments_truncated: int | None = None
+    # The judge's drill-down detail (per-comment intents, reasoning, version
+    # markers), JSON-encoded like ``attributions`` and stored verbatim. A future
+    # judge gets its own ``*_metadata``.
+    conversation_metadata: str | None = None
 
 
 analytics.register(PrCloseMetricsEvent)

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -8,7 +8,10 @@ production). A PR is "tracked" once it has at least one valid
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import Any, Final, Literal
+
+from pydantic import BaseModel
 
 from sentry import analytics
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
@@ -36,6 +39,30 @@ CLOSE_ACTION_MERGED: Final = "merged"
 CloseAction = Literal["closed", "merged"]
 
 
+class PrConversationAnalysis(BaseModel):
+    """The conversation judge's analysis of a closed/merged PR — one of several
+    judges, each with its own result type and columns.
+
+    Mirrors the ``conversation_analysis`` Seer sends to ``update_pr_metrics`` (keep
+    in sync with getsentry/seer:src/seer/pr_metrics/models.py). BigQuery-only: it
+    shapes the emitted ``PrCloseMetricsEvent`` and is never persisted. Enum-like
+    values stay free strings, so a Seer vocabulary change can't fail validation.
+    """
+
+    # positive | neutral | negative | mixed. Null when the judge was skipped (no
+    # comments), so there's no separate ``analyzed`` flag.
+    sentiment: str | None = None
+    bot_comment_count: int | None = None
+    human_comment_count: int | None = None
+    # comments_truncated > 0 means a chatty PR was capped before judging.
+    comments_total: int | None = None
+    comments_judged: int | None = None
+    comments_truncated: int | None = None
+    # Opaque drill-down stored verbatim: per-comment intents, reasoning, version
+    # markers, intent counts.
+    metadata: dict[str, Any] | None = None
+
+
 def select_verdict(
     pull_request: PullRequest, organization: Organization
 ) -> PullRequestVerdict | None:
@@ -51,7 +78,7 @@ def select_verdict(
       diff-similarity judge.
     - Closed with no engagement — no later commits, comments, or review comments →
       ``closed_unmerged``: an abandoned PR with nothing to analyze. A close with any
-      engagement needs the comment judge to decide why it was closed.
+      engagement needs the conversation judge to decide why it was closed.
 
     The commits-after-open signal is a ``SYNCHRONIZED`` activity row, one per push
     to the PR branch after it opened. Those rows are only written under
@@ -141,12 +168,38 @@ def _merge_commit_id(pull_request: PullRequest) -> int | None:
     )
 
 
+def _conversation_analysis_fields(
+    conversation_analysis: PrConversationAnalysis | None,
+) -> dict[str, Any]:
+    """The ``PrCloseMetricsEvent`` columns from the conversation judge, or ``{}``
+    (every column keeps its ``None`` default) when no analysis was supplied. Only
+    ``metadata`` is JSON-encoded; the semantic outputs get their own columns.
+    """
+    if conversation_analysis is None:
+        return {}
+    return {
+        "sentiment": conversation_analysis.sentiment,
+        "bot_comment_count": conversation_analysis.bot_comment_count,
+        "human_comment_count": conversation_analysis.human_comment_count,
+        "comments_total": conversation_analysis.comments_total,
+        "comments_judged": conversation_analysis.comments_judged,
+        "comments_truncated": conversation_analysis.comments_truncated,
+        "conversation_metadata": (
+            json.dumps(conversation_analysis.metadata)
+            if conversation_analysis.metadata is not None
+            else None
+        ),
+    }
+
+
 def build_pr_metrics_row(
     *,
     pull_request: PullRequest,
     close_action: CloseAction,
     attributions: list[dict[str, Any]],
     group_ids: list[int],
+    conversation_analysis: PrConversationAnalysis | None = None,
+    diagnosis_labels: Sequence[str] | None = None,
 ) -> PrCloseMetricsEvent:
     """Assemble the close/merge analytics row.
 
@@ -155,6 +208,11 @@ def build_pr_metrics_row(
     reuse this. ``attributions`` is passed in so the tracking gate and the
     emitted row read the same query. A missing metrics row (a PR Sentry never saw
     active) coalesces every counter to its default.
+
+    The judge enrichment is set on the judge path only: ``conversation_analysis``
+    is the conversation judge's result (semantic outputs become columns, its
+    ``metadata`` is JSON-encoded), and ``diagnosis_labels`` is the cross-judge
+    close-reason "why".
     """
     head_commit_sha = pull_request.head_commit_sha
     closed_at = pull_request.closed_at
@@ -192,12 +250,16 @@ def build_pr_metrics_row(
         is_assigned=metrics.is_assigned,
         attributions=json.dumps(attributions),
         verdict=metrics.verdict,
+        diagnosis_labels=list(diagnosis_labels) if diagnosis_labels is not None else None,
+        **_conversation_analysis_fields(conversation_analysis),
     )
 
 
 def emit_pr_metrics_row(
     *,
     pull_request: PullRequest,
+    conversation_analysis: PrConversationAnalysis | None = None,
+    diagnosis_labels: Sequence[str] | None = None,
 ) -> bool:
     """Emit one BigQuery row for a tracked PR's terminal event.
 
@@ -206,7 +268,8 @@ def emit_pr_metrics_row(
     attributed to. Returns whether a row was emitted, for callers/tests.
 
     Takes only the canonical ``PullRequest`` — no webhook payload — so Seer's
-    judge can call it directly via RPC callback.
+    judge can call it directly via RPC callback. ``conversation_analysis`` and
+    ``diagnosis_labels`` are set only on that judge path.
     """
     # Fetch the attribution snapshot once: it both gates emission (≥1 valid row)
     # and rides along on the emitted row, so the two can't diverge.
@@ -223,6 +286,8 @@ def emit_pr_metrics_row(
         close_action=close_action,
         attributions=attributions,
         group_ids=resolved_group_ids(pull_request),
+        conversation_analysis=conversation_analysis,
+        diagnosis_labels=diagnosis_labels,
     )
     analytics.record(row)
     metrics.incr("pr_metrics.emit.recorded", tags={"close_action": close_action})

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -58,8 +58,8 @@ class PrConversationAnalysis(BaseModel):
     and the graceful-drop behavior (it'd drop the whole analysis on any new field).
     """
 
-    # positive | neutral | negative | mixed. Null when the judge was skipped (no
-    # comments), so there's no separate ``analyzed`` flag.
+    # positive | neutral | negative | mixed. Null when there was nothing to judge
+    # (no comments) or the judge couldn't run; comments_total disambiguates.
     sentiment: str | None = None
     # Comments split by author class.
     comments_bot: int | None = None

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -43,17 +43,27 @@ class PrConversationAnalysis(BaseModel):
     """The conversation judge's analysis of a closed/merged PR — one of several
     judges, each with its own result type and columns.
 
-    Mirrors the ``conversation_analysis`` Seer sends to ``update_pr_metrics`` (keep
-    in sync with getsentry/seer:src/seer/pr_metrics/models.py). BigQuery-only: it
-    shapes the emitted ``PrCloseMetricsEvent`` and is never persisted. Enum-like
-    values stay free strings, so a Seer vocabulary change can't fail validation.
+    Mirrors the ``conversation_analysis`` Seer sends to ``update_pr_metrics`` — the
+    inbound-callback half of the contract, so it lives here beside the row it
+    shapes, separate from the outbound request mirrors in ``judge.py``; keep both in
+    sync with getsentry/seer:src/seer/pr_metrics/models.py. BigQuery-only: it shapes
+    the emitted ``PrCloseMetricsEvent`` and is never persisted. Enum-like values
+    stay free strings, so a Seer vocabulary change can't fail validation.
+
+    Extra keys are ignored (pydantic v1's default), deliberately: it keeps old
+    Sentry pods forward-compatible with fields a newer Seer adds. The flip side — a
+    near-miss payload that matches some field names populates those and silently
+    leaves the rest null — is owned by the Seer-side builder + a shared contract
+    test, not tightened here: ``extra="forbid"`` would fight both that forward-compat
+    and the graceful-drop behavior (it'd drop the whole analysis on any new field).
     """
 
     # positive | neutral | negative | mixed. Null when the judge was skipped (no
     # comments), so there's no separate ``analyzed`` flag.
     sentiment: str | None = None
-    bot_comment_count: int | None = None
-    human_comment_count: int | None = None
+    # Comments split by author class.
+    comments_bot: int | None = None
+    comments_human: int | None = None
     # comments_truncated > 0 means a chatty PR was capped before judging.
     comments_total: int | None = None
     comments_judged: int | None = None
@@ -178,12 +188,12 @@ def _conversation_analysis_fields(
     if conversation_analysis is None:
         return {}
     return {
-        "sentiment": conversation_analysis.sentiment,
-        "bot_comment_count": conversation_analysis.bot_comment_count,
-        "human_comment_count": conversation_analysis.human_comment_count,
-        "comments_total": conversation_analysis.comments_total,
-        "comments_judged": conversation_analysis.comments_judged,
-        "comments_truncated": conversation_analysis.comments_truncated,
+        "conversation_sentiment": conversation_analysis.sentiment,
+        "conversation_comments_bot": conversation_analysis.comments_bot,
+        "conversation_comments_human": conversation_analysis.comments_human,
+        "conversation_comments_total": conversation_analysis.comments_total,
+        "conversation_comments_judged": conversation_analysis.comments_judged,
+        "conversation_comments_truncated": conversation_analysis.comments_truncated,
         "conversation_metadata": (
             json.dumps(conversation_analysis.metadata)
             if conversation_analysis.metadata is not None

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -45,7 +45,7 @@ from sentry.seer.sentry_data_models import (
     UpdatePrMetricsSuccessResponse,
 )
 from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
-from sentry.utils import metrics
+from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +69,7 @@ RESULT_VERDICTS = frozenset(PullRequestVerdict.values) - {PullRequestVerdict.JUD
 # package or codegen; both sides validate with pydantic, so drift surfaces as a
 # ValidationError here or a 4xx from Seer rather than silent corruption.
 # https://github.com/getsentry/seer/blob/main/src/seer/pr_metrics/models.py
+# TODO move this to a new file "contracts.py" and PrConversationAnalysis there as well
 class PrActivityEvent(BaseModel):
     """One captured ``PullRequestActivity`` row, projected for the judge.
 
@@ -255,7 +256,15 @@ def _parse_conversation_analysis(
     if raw is None:
         return None
     try:
-        return PrConversationAnalysis.parse_obj(raw)
+        analysis = PrConversationAnalysis.parse_obj(raw)
+        # ``metadata`` is an Any-typed bag emitted verbatim as JSON later, outside
+        # this guard and after the verdict is committed. Round-trip it now so a
+        # non-serializable value is dropped here (honoring the graceful-drop
+        # contract) rather than raising mid-emit. Real RPC payloads are JSON-derived
+        # and so always serializable; this guards direct/synthetic callers.
+        if analysis.metadata is not None:
+            json.dumps(analysis.metadata)
+        return analysis
     except (ValidationError, TypeError, ValueError):
         logger.warning("pr_metrics.update.invalid_conversation_analysis", extra=dict(log_extra))
         metrics.incr("pr_metrics.update.invalid_conversation_analysis")
@@ -266,9 +275,11 @@ def _clean_diagnosis_labels(raw: Any, log_extra: Mapping[str, Any]) -> list[str]
     """Sanitize ``diagnosis_labels`` (a list of free-string labels) at the boundary.
 
     Like ``conversation_analysis`` it's BigQuery-only enrichment, so a wrong-typed
-    value (not a list of strings) is dropped gracefully — log + metric, emit without
-    it — rather than 422-ing the callback. Only the shape is checked, never the
-    label values, so the shared diagnosis vocabulary can iterate freely.
+    value (not a list of strings, e.g. a bare string or a mixed-type list) is
+    dropped gracefully — log + metric, emit without it — rather than 422-ing the
+    callback. Only the shape is checked, never the label values, so the shared
+    diagnosis vocabulary can iterate freely. An empty list is valid and returns
+    ``[]`` (the judge ran, found no labels), distinct from ``None`` (none supplied).
     """
     if raw is None:
         return None

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -17,7 +17,7 @@ from typing import Any
 from django.conf import settings
 from django.db import router, transaction
 from django.db.models import Q
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from urllib3.exceptions import HTTPError
 
 from sentry.models.pullrequest import (
@@ -33,6 +33,7 @@ from sentry.net.http import connection_from_url
 from sentry.pr_metrics.attribution import record_attribution_signal
 from sentry.pr_metrics.emit import (
     CloseAction,
+    PrConversationAnalysis,
     active_attributions,
     emit_pr_metrics_row,
 )
@@ -242,13 +243,55 @@ def _parse_attributions(
     return parsed
 
 
+def _parse_conversation_analysis(
+    raw: Mapping[str, Any] | None, log_extra: Mapping[str, Any]
+) -> PrConversationAnalysis | None:
+    """Parse ``conversation_analysis``, or ``None`` if absent or malformed.
+
+    Being BigQuery-only enrichment (unlike ``attributions``, which writes to
+    Postgres), a broken payload degrades gracefully — log + metric, emit without it
+    — rather than 422-ing and blocking the verdict from settling.
+    """
+    if raw is None:
+        return None
+    try:
+        return PrConversationAnalysis.parse_obj(raw)
+    except (ValidationError, TypeError, ValueError):
+        logger.warning("pr_metrics.update.invalid_conversation_analysis", extra=dict(log_extra))
+        metrics.incr("pr_metrics.update.invalid_conversation_analysis")
+        return None
+
+
+def _clean_diagnosis_labels(raw: Any, log_extra: Mapping[str, Any]) -> list[str] | None:
+    """Sanitize ``diagnosis_labels`` (a list of free-string labels) at the boundary.
+
+    Like ``conversation_analysis`` it's BigQuery-only enrichment, so a wrong-typed
+    value (not a list of strings) is dropped gracefully — log + metric, emit without
+    it — rather than 422-ing the callback. Only the shape is checked, never the
+    label values, so the shared diagnosis vocabulary can iterate freely.
+    """
+    if raw is None:
+        return None
+    if (
+        isinstance(raw, Sequence)
+        and not isinstance(raw, str)
+        and all(isinstance(x, str) for x in raw)
+    ):
+        return list(raw)
+    logger.warning("pr_metrics.update.invalid_diagnosis_labels", extra=dict(log_extra))
+    metrics.incr("pr_metrics.update.invalid_diagnosis_labels")
+    return None
+
+
 def update_pr_metrics(
     *,
     pull_request_id: int,
     organization_id: int,
     repository_id: int,
     verdict: str | None = None,
+    diagnosis_labels: Sequence[str] | None = None,
     attributions: Sequence[Mapping[str, Any]] | None = None,
+    conversation_analysis: Mapping[str, Any] | None = None,
 ) -> UpdatePrMetricsSuccessResponse | UpdatePrMetricsErrorResponse:
     """Persist Seer's judge result for a PR and emit the enriched metrics row.
 
@@ -261,6 +304,15 @@ def update_pr_metrics(
     ``attributions`` are new signals Seer surfaced during judging (recorded with
     a ``seer_*`` source), additive to the ones the webhook already detected — not
     an echo or filter of the attributions Sentry forwarded.
+
+    ``conversation_analysis`` is the conversation judge's result — one of several
+    judges (others, e.g. diff-similarity, arrive as their own args). Its semantic
+    outputs become emitted columns; its ``metadata`` rides along as a verbatim JSON
+    blob. ``diagnosis_labels`` is the cross-judge close-reason "why" (a shared
+    vocabulary). Both are optional (null for old Seer pods / the no-judge path →
+    rolling-deploy safe) and BigQuery-only — never persisted. A malformed value is
+    dropped, not rejected — see ``_parse_conversation_analysis`` /
+    ``_clean_diagnosis_labels``.
 
     The PR is located by its Sentry id but constrained to the reported
     ``organization_id``/``repository_id``, so a mismatched id can't reach another
@@ -290,6 +342,9 @@ def update_pr_metrics(
         logger.warning("pr_metrics.update.invalid_attribution", extra=log_extra)
         metrics.incr("pr_metrics.update.skipped", tags={"reason": "invalid_attribution"})
         return UpdatePrMetricsErrorResponse(error="invalid_attribution")
+
+    parsed_conversation_analysis = _parse_conversation_analysis(conversation_analysis, log_extra)
+    clean_diagnosis_labels = _clean_diagnosis_labels(diagnosis_labels, log_extra)
 
     # Scope the lookup to the reported org+repo: the id alone is attacker-influenced
     # (it round-trips through Seer), so trusting it unscoped would be an IDOR.
@@ -341,7 +396,11 @@ def update_pr_metrics(
                 signal_details=signal_details,
             )
 
-    emit_pr_metrics_row(pull_request=pull_request)
+    emit_pr_metrics_row(
+        pull_request=pull_request,
+        conversation_analysis=parsed_conversation_analysis,
+        diagnosis_labels=clean_diagnosis_labels,
+    )
 
     metrics.incr("pr_metrics.update.recorded", tags={"verdict": verdict})
     logger.info("pr_metrics.update.recorded", extra={**log_extra, "verdict": verdict})

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -16,6 +16,7 @@ from sentry.models.pullrequest import (
     PullRequestVerdict,
 )
 from sentry.pr_metrics.emit import (
+    PrConversationAnalysis,
     active_attributions,
     build_pr_metrics_row,
     emit_pr_metrics_row,
@@ -34,6 +35,28 @@ SENTRY_APP_ATTRIBUTION = {
     "source": "seer_data",
     "signal_details": None,
 }
+
+# A conversation judge result for the emission tests: the semantic
+# outputs promoted to columns plus the opaque metadata drill-down bundle.
+CONVERSATION_METADATA = {
+    "judge": "conversation.v1",
+    "sentiment_reasoning": "reviewer approved after the fix",
+    "comment_intents": [
+        {"comment_id": "IC_123", "author": "octocat", "author_class": "human", "intent": "praise"},
+    ],
+    "intent_counts": {"praise": 1},
+}
+CONVERSATION_ANALYSIS = PrConversationAnalysis(
+    sentiment="positive",
+    bot_comment_count=0,
+    human_comment_count=1,
+    comments_total=3,
+    comments_judged=2,
+    comments_truncated=1,
+    metadata=CONVERSATION_METADATA,
+)
+# Cross-judge close-reason labels, threaded independently of the conversation analysis.
+DIAGNOSIS_LABELS = ["trivial"]
 
 HEAD_SHA = "a" * 40
 MERGE_SHA = "b" * 40
@@ -363,6 +386,78 @@ class PrMetricsEmissionTest(TestCase):
             group_ids=[7, 9],
         )
         assert row.group_ids == [7, 9]
+
+    def test_build_row_carries_conversation_analysis(self) -> None:
+        # The conversation judge's semantic outputs land on their own columns; only the
+        # metadata bundle is JSON-encoded (same convention as attributions).
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+            conversation_analysis=CONVERSATION_ANALYSIS,
+        )
+        assert row.sentiment == "positive"
+        assert row.bot_comment_count == 0
+        assert row.human_comment_count == 1
+        assert row.comments_total == 3
+        assert row.comments_judged == 2
+        assert row.comments_truncated == 1
+        assert json.loads(row.conversation_metadata) == CONVERSATION_METADATA
+
+    def test_build_row_carries_diagnosis_labels(self) -> None:
+        # The cross-judge close-reason "why" is threaded independently of the
+        # conversation analysis, onto its own repeated column.
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="closed",
+            attributions=[],
+            group_ids=[],
+            diagnosis_labels=DIAGNOSIS_LABELS,
+        )
+        assert row.diagnosis_labels == ["trivial"]
+
+    def test_build_row_without_judge_enrichment_leaves_fields_null(self) -> None:
+        # The no-judge path / old Seer pods supply nothing — every judge column
+        # stays null rather than emitting an empty placeholder.
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.sentiment is None
+        assert row.bot_comment_count is None
+        assert row.diagnosis_labels is None
+        assert row.conversation_metadata is None
+
+    def test_build_row_conversation_metadata_null_when_absent(self) -> None:
+        # An analysis without a metadata bundle emits a null conversation_metadata (not
+        # "null"-the-string); the semantic columns still populate.
+        conversation_analysis = PrConversationAnalysis(sentiment="neutral")
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+            conversation_analysis=conversation_analysis,
+        )
+        assert row.sentiment == "neutral"
+        assert row.conversation_metadata is None
+
+    @patch("sentry.analytics.record")
+    def test_emit_threads_judge_enrichment(self, mock_record: Any) -> None:
+        self._track()
+        emit_pr_metrics_row(
+            pull_request=self.pull_request,
+            conversation_analysis=CONVERSATION_ANALYSIS,
+            diagnosis_labels=DIAGNOSIS_LABELS,
+        )
+        row = mock_record.call_args[0][0]
+        assert row.sentiment == "positive"
+        assert row.human_comment_count == 1
+        assert row.diagnosis_labels == ["trivial"]
+        assert json.loads(row.conversation_metadata) == CONVERSATION_METADATA
 
     @patch("sentry.analytics.record")
     def test_emit_carries_resolved_group_ids(self, mock_record: Any) -> None:

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -403,6 +403,7 @@ class PrMetricsEmissionTest(TestCase):
         assert row.conversation_comments_total == 3
         assert row.conversation_comments_judged == 2
         assert row.conversation_comments_truncated == 1
+        assert row.conversation_metadata is not None
         assert json.loads(row.conversation_metadata) == CONVERSATION_METADATA
 
     def test_build_row_carries_diagnosis_labels(self) -> None:

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -48,8 +48,8 @@ CONVERSATION_METADATA = {
 }
 CONVERSATION_ANALYSIS = PrConversationAnalysis(
     sentiment="positive",
-    bot_comment_count=0,
-    human_comment_count=1,
+    comments_bot=0,
+    comments_human=1,
     comments_total=3,
     comments_judged=2,
     comments_truncated=1,
@@ -388,8 +388,8 @@ class PrMetricsEmissionTest(TestCase):
         assert row.group_ids == [7, 9]
 
     def test_build_row_carries_conversation_analysis(self) -> None:
-        # The conversation judge's semantic outputs land on their own columns; only the
-        # metadata bundle is JSON-encoded (same convention as attributions).
+        # The conversation judge's semantic outputs land on their own prefixed
+        # columns; only the metadata bundle is JSON-encoded (as attributions is).
         row = build_pr_metrics_row(
             pull_request=self.pull_request,
             close_action="merged",
@@ -397,17 +397,17 @@ class PrMetricsEmissionTest(TestCase):
             group_ids=[],
             conversation_analysis=CONVERSATION_ANALYSIS,
         )
-        assert row.sentiment == "positive"
-        assert row.bot_comment_count == 0
-        assert row.human_comment_count == 1
-        assert row.comments_total == 3
-        assert row.comments_judged == 2
-        assert row.comments_truncated == 1
+        assert row.conversation_sentiment == "positive"
+        assert row.conversation_comments_bot == 0
+        assert row.conversation_comments_human == 1
+        assert row.conversation_comments_total == 3
+        assert row.conversation_comments_judged == 2
+        assert row.conversation_comments_truncated == 1
         assert json.loads(row.conversation_metadata) == CONVERSATION_METADATA
 
     def test_build_row_carries_diagnosis_labels(self) -> None:
         # The cross-judge close-reason "why" is threaded independently of the
-        # conversation analysis, onto its own repeated column.
+        # conversation analysis, onto its own unprefixed repeated column.
         row = build_pr_metrics_row(
             pull_request=self.pull_request,
             close_action="closed",
@@ -416,6 +416,17 @@ class PrMetricsEmissionTest(TestCase):
             diagnosis_labels=DIAGNOSIS_LABELS,
         )
         assert row.diagnosis_labels == ["trivial"]
+
+    def test_build_row_empty_diagnosis_labels_stays_empty(self) -> None:
+        # An empty list is a valid value (judge ran, no labels) and emits [], not null.
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="closed",
+            attributions=[],
+            group_ids=[],
+            diagnosis_labels=[],
+        )
+        assert row.diagnosis_labels == []
 
     def test_build_row_without_judge_enrichment_leaves_fields_null(self) -> None:
         # The no-judge path / old Seer pods supply nothing — every judge column
@@ -426,8 +437,8 @@ class PrMetricsEmissionTest(TestCase):
             attributions=[],
             group_ids=[],
         )
-        assert row.sentiment is None
-        assert row.bot_comment_count is None
+        assert row.conversation_sentiment is None
+        assert row.conversation_comments_bot is None
         assert row.diagnosis_labels is None
         assert row.conversation_metadata is None
 
@@ -442,7 +453,7 @@ class PrMetricsEmissionTest(TestCase):
             group_ids=[],
             conversation_analysis=conversation_analysis,
         )
-        assert row.sentiment == "neutral"
+        assert row.conversation_sentiment == "neutral"
         assert row.conversation_metadata is None
 
     @patch("sentry.analytics.record")
@@ -454,8 +465,8 @@ class PrMetricsEmissionTest(TestCase):
             diagnosis_labels=DIAGNOSIS_LABELS,
         )
         row = mock_record.call_args[0][0]
-        assert row.sentiment == "positive"
-        assert row.human_comment_count == 1
+        assert row.conversation_sentiment == "positive"
+        assert row.conversation_comments_human == 1
         assert row.diagnosis_labels == ["trivial"]
         assert json.loads(row.conversation_metadata) == CONVERSATION_METADATA
 

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -36,8 +36,8 @@ CLOSED_AT = datetime(2020, 6, 4, 10, 0, 0, tzinfo=timezone.utc)
 # semantic outputs alongside the opaque metadata drill-down bundle.
 CONVERSATION_ANALYSIS = {
     "sentiment": "negative",
-    "bot_comment_count": 0,
-    "human_comment_count": 1,
+    "comments_bot": 0,
+    "comments_human": 1,
     "comments_total": 1,
     "comments_judged": 1,
     "comments_truncated": 0,
@@ -114,9 +114,9 @@ class UpdatePrMetricsTest(TestCase):
         assert result.dict() == {"success": True}
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
         row = _last_row(mock_record)
-        assert row.sentiment == "negative"
-        assert row.bot_comment_count == 0
-        assert row.human_comment_count == 1
+        assert row.conversation_sentiment == "negative"
+        assert row.conversation_comments_bot == 0
+        assert row.conversation_comments_human == 1
         # diagnosis_labels is a cross-judge top-level arg, not part of the analysis.
         assert row.diagnosis_labels == ["out_of_scope_or_unwanted"]
         # The metadata bundle rides through verbatim as the opaque drill-down blob.
@@ -136,7 +136,7 @@ class UpdatePrMetricsTest(TestCase):
 
         assert result.dict() == {"success": True}
         row = _last_row(mock_record)
-        assert row.sentiment == "ambivalent"
+        assert row.conversation_sentiment == "ambivalent"
         assert row.diagnosis_labels == ["brand_new_label"]
 
     @patch("sentry.pr_metrics.judge.metrics")
@@ -159,8 +159,29 @@ class UpdatePrMetricsTest(TestCase):
         )
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
         row = _last_row(mock_record)
-        assert row.sentiment is None
-        assert row.comments_total is None
+        assert row.conversation_sentiment is None
+        assert row.conversation_comments_total is None
+        assert row.conversation_metadata is None
+        mock_metrics.incr.assert_any_call("pr_metrics.update.invalid_conversation_analysis")
+
+    @patch("sentry.pr_metrics.judge.metrics")
+    @patch("sentry.analytics.record")
+    def test_non_serializable_metadata_dropped_but_row_still_emits(
+        self, mock_record: Any, mock_metrics: Any
+    ) -> None:
+        # metadata is emitted as JSON outside the parse guard and after the verdict
+        # commits; a structurally-valid but non-serializable value (a bare object)
+        # must still be dropped gracefully, not raise mid-emit and 500 the callback.
+        self._track()
+        result = self._call(
+            verdict="closed_unmerged",
+            conversation_analysis={"sentiment": "negative", "metadata": {"obj": object()}},
+        )
+
+        assert result.dict() == {"success": True}
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+        row = _last_row(mock_record)
+        assert row.conversation_sentiment is None
         assert row.conversation_metadata is None
         mock_metrics.incr.assert_any_call("pr_metrics.update.invalid_conversation_analysis")
 
@@ -169,13 +190,24 @@ class UpdatePrMetricsTest(TestCase):
     def test_malformed_diagnosis_labels_dropped_but_row_still_emits(
         self, mock_record: Any, mock_metrics: Any
     ) -> None:
-        # diagnosis_labels must be a list of strings; a wrong-typed value is dropped
+        # diagnosis_labels must be a list of strings; a bare string is dropped
         # gracefully (BigQuery-only enrichment) while the row still emits.
         self._track()
         result = self._call(verdict="closed_unmerged", diagnosis_labels="out_of_scope")
 
         assert result.dict() == {"success": True}
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+        assert _last_row(mock_record).diagnosis_labels is None
+        mock_metrics.incr.assert_any_call("pr_metrics.update.invalid_diagnosis_labels")
+
+    @patch("sentry.pr_metrics.judge.metrics")
+    @patch("sentry.analytics.record")
+    def test_mixed_type_diagnosis_labels_dropped(self, mock_record: Any, mock_metrics: Any) -> None:
+        # A list with a non-string element is not a valid label list — dropped whole.
+        self._track()
+        result = self._call(verdict="closed_unmerged", diagnosis_labels=["valid", 2])
+
+        assert result.dict() == {"success": True}
         assert _last_row(mock_record).diagnosis_labels is None
         mock_metrics.incr.assert_any_call("pr_metrics.update.invalid_diagnosis_labels")
 
@@ -188,7 +220,7 @@ class UpdatePrMetricsTest(TestCase):
 
         assert result.dict() == {"success": True}
         row = _last_row(mock_record)
-        assert row.sentiment is None
+        assert row.conversation_sentiment is None
         assert row.diagnosis_labels is None
         assert row.conversation_metadata is None
 

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -120,6 +120,7 @@ class UpdatePrMetricsTest(TestCase):
         # diagnosis_labels is a cross-judge top-level arg, not part of the analysis.
         assert row.diagnosis_labels == ["out_of_scope_or_unwanted"]
         # The metadata bundle rides through verbatim as the opaque drill-down blob.
+        assert row.conversation_metadata is not None
         assert orjson.loads(row.conversation_metadata) == CONVERSATION_ANALYSIS["metadata"]
 
     @patch("sentry.analytics.record")

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -32,6 +32,31 @@ MERGE_SHA = "b" * 40
 OPENED_AT = datetime(2020, 6, 4, 9, 0, 0, tzinfo=timezone.utc)
 CLOSED_AT = datetime(2020, 6, 4, 10, 0, 0, tzinfo=timezone.utc)
 
+# The conversation judge's result as Seer sends it over the RPC: the
+# semantic outputs alongside the opaque metadata drill-down bundle.
+CONVERSATION_ANALYSIS = {
+    "sentiment": "negative",
+    "bot_comment_count": 0,
+    "human_comment_count": 1,
+    "comments_total": 1,
+    "comments_judged": 1,
+    "comments_truncated": 0,
+    "metadata": {
+        "judge": "conversation.v1",
+        "sentiment_reasoning": "reviewer raised an unaddressed objection",
+        "comment_intents": [
+            {
+                "comment_id": "IC_9",
+                "author": "octocat",
+                "author_class": "human",
+                "intent": "objection",
+            },
+        ],
+    },
+}
+# Cross-judge close-reason labels, sent as a top-level arg alongside the verdict.
+DIAGNOSIS_LABELS = ["out_of_scope_or_unwanted"]
+
 
 def _last_row(mock_record: Any) -> PrCloseMetricsEvent:
     return mock_record.call_args_list[-1].args[0]
@@ -76,6 +101,96 @@ class UpdatePrMetricsTest(TestCase):
         )
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
         assert _last_row(mock_record).verdict == "merged_with_iteration"
+
+    @patch("sentry.analytics.record")
+    def test_threads_judge_enrichment_onto_emitted_row(self, mock_record: Any) -> None:
+        self._track()
+        result = self._call(
+            verdict="closed_unmerged",
+            conversation_analysis=CONVERSATION_ANALYSIS,
+            diagnosis_labels=DIAGNOSIS_LABELS,
+        )
+
+        assert result.dict() == {"success": True}
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+        row = _last_row(mock_record)
+        assert row.sentiment == "negative"
+        assert row.bot_comment_count == 0
+        assert row.human_comment_count == 1
+        # diagnosis_labels is a cross-judge top-level arg, not part of the analysis.
+        assert row.diagnosis_labels == ["out_of_scope_or_unwanted"]
+        # The metadata bundle rides through verbatim as the opaque drill-down blob.
+        assert orjson.loads(row.conversation_metadata) == CONVERSATION_ANALYSIS["metadata"]
+
+    @patch("sentry.analytics.record")
+    def test_unknown_sentiment_and_diagnosis_pass_through(self, mock_record: Any) -> None:
+        # sentiment and the diagnosis labels are free strings — a value outside the
+        # v1 vocabulary rides through verbatim, never 422s the row.
+        self._track()
+        conversation_analysis = {**CONVERSATION_ANALYSIS, "sentiment": "ambivalent"}
+        result = self._call(
+            verdict="closed_unmerged",
+            conversation_analysis=conversation_analysis,
+            diagnosis_labels=["brand_new_label"],
+        )
+
+        assert result.dict() == {"success": True}
+        row = _last_row(mock_record)
+        assert row.sentiment == "ambivalent"
+        assert row.diagnosis_labels == ["brand_new_label"]
+
+    @patch("sentry.pr_metrics.judge.metrics")
+    @patch("sentry.analytics.record")
+    def test_malformed_conversation_analysis_dropped_but_row_still_emits(
+        self, mock_record: Any, mock_metrics: Any
+    ) -> None:
+        # conversation_analysis is BigQuery-only enrichment, never persisted — a
+        # wrong-typed payload degrades gracefully: the verdict still settles and the
+        # row emits (without judge columns), rather than 422-ing the whole callback.
+        self._track()
+        result = self._call(
+            verdict="closed_unmerged",
+            conversation_analysis={"comments_total": "not-an-int"},
+        )
+
+        assert result.dict() == {"success": True}
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "closed_unmerged"
+        )
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+        row = _last_row(mock_record)
+        assert row.sentiment is None
+        assert row.comments_total is None
+        assert row.conversation_metadata is None
+        mock_metrics.incr.assert_any_call("pr_metrics.update.invalid_conversation_analysis")
+
+    @patch("sentry.pr_metrics.judge.metrics")
+    @patch("sentry.analytics.record")
+    def test_malformed_diagnosis_labels_dropped_but_row_still_emits(
+        self, mock_record: Any, mock_metrics: Any
+    ) -> None:
+        # diagnosis_labels must be a list of strings; a wrong-typed value is dropped
+        # gracefully (BigQuery-only enrichment) while the row still emits.
+        self._track()
+        result = self._call(verdict="closed_unmerged", diagnosis_labels="out_of_scope")
+
+        assert result.dict() == {"success": True}
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+        assert _last_row(mock_record).diagnosis_labels is None
+        mock_metrics.incr.assert_any_call("pr_metrics.update.invalid_diagnosis_labels")
+
+    @patch("sentry.analytics.record")
+    def test_judge_enrichment_absent_is_back_compat(self, mock_record: Any) -> None:
+        # Old Seer pods (and the no-judge path) send no analysis; the row emits with
+        # every judge column null.
+        self._track()
+        result = self._call(verdict="closed_unmerged")
+
+        assert result.dict() == {"success": True}
+        row = _last_row(mock_record)
+        assert row.sentiment is None
+        assert row.diagnosis_labels is None
+        assert row.conversation_metadata is None
 
     @patch("sentry.analytics.record")
     def test_records_seer_attributions(self, mock_record: Any) -> None:


### PR DESCRIPTION
## Problem

Seer's PR-metrics conversation judge now produces rich per-PR analysis, but the Seer→Sentry callback (`update_pr_metrics`, CORE-217) only carried the bare `verdict`. The structured analysis lived in Seer's run-state only, so it never reached Sentry → the analytics/BigQuery row. This extends the Sentry side to accept and emit it (CORE-250).

## What this adds

Two **optional** args on the `update_pr_metrics` callback — both **BigQuery-only** (never persisted to `PullRequestMetrics`) and **rolling-deploy safe** (null for old Seer pods that predate the sender):

- **`conversation_analysis`** — the conversation judge's result (one of several judges; the diff-similarity judge etc. land their own args + columns later). Its semantically meaningful outputs are promoted to their own **queryable columns**, all prefixed `conversation_` so a future judge's columns sit alongside without collision (and to disambiguate from the webhook `comments_count`): `conversation_sentiment`, `conversation_comments_bot` / `_human` / `_total` / `_judged` / `_truncated`. The per-comment drill-down detail rides along verbatim in a single **`conversation_metadata`** JSON column.
- **`diagnosis_labels`** — the **cross-judge** close-reason "why" (a shared vocabulary), so it stays an unprefixed repeated free-string column.

## Design decisions

- **Queryable columns vs. JSON blob.** The hot dashboard dimensions (close-sentiment, bot-vs-human engagement, why-closed) are real columns; only the long-tail drill-down is JSON. Grounded in the project's stated questions and M5 dashboards.
- **Free-string enums.** `conversation_sentiment` / `diagnosis_labels` are stored as free strings, not closed sets — Seer's vocabularies are v1 and iterate in M4, so a taxonomy change must not 422 the callback.
- **Graceful degradation.** A malformed payload is logged + dropped (the verdict still settles and the row still emits), rather than rejecting the callback. The `metadata` JSON-serializability check runs *inside* the parse guard so a non-serializable value can't raise mid-emit after the verdict commits. Unlike `attributions` (which writes to Postgres and so rejects when malformed), this is fire-and-forget enrichment that never touches durable state.
- **`extra="ignore"` is deliberate** on `PrConversationAnalysis` (pydantic v1's default): old Sentry pods stay forward-compatible with fields a newer Seer adds. The flip side — a near-miss payload matching some field names populates those and silently leaves the rest null — is owned by the Seer-side builder + a shared contract test, **not** `extra="forbid"` (which would fight both forward-compat and graceful-drop).
- **Additive schema.** The BigQuery row is an additive v0 draft (per M0): a future judge lands its own columns + `*_metadata` alongside these. Idempotency (single-emit on the `JUDGE_IN_PROGRESS` transition) unchanged.

## Coordination (Seer side)

Seer's `update_pr_metrics` caller should send `conversation_analysis = {sentiment, comments_bot, comments_human, comments_total, comments_judged, comments_truncated, metadata}` plus a top-level `diagnosis_labels`. This is the `TODO(CW-1436)` flip in `seer/src/seer/pr_metrics/tasks.py` — a separate, coordinated change. (The inbound contract model `PrConversationAnalysis` lives in Sentry's `pr_metrics/emit.py`, beside the row it shapes; the outbound request mirrors live in `judge.py`.)

## Tests

`tests/sentry/pr_metrics/{test_emit,test_judge}.py` cover threading onto the row, unknown-vocabulary pass-through, malformed-payload graceful drop (wrong types, non-serializable metadata, mixed-type diagnosis labels), empty-list handling, and back-compat when the args are absent. Full `pr_metrics` suite (221) passes; prek + mypy clean.

Fixes CORE-250
