### PR TITLE
fix(trace-waterfall): Use new web vitals

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -920,6 +920,39 @@ describe('TraceTree', () => {
       );
     });
 
+    it('falls back to browser web vital values for zero measurements', () => {
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'eap-span-1',
+            start_timestamp: start,
+            end_timestamp: start + 2,
+            is_transaction: true,
+            measurements: {
+              'measurements.lcp': 0,
+            },
+            browser_web_vital: {
+              'browser.web_vital.lcp.value': 200,
+            },
+            children: [],
+          }),
+        ]),
+        {meta: null, replay: null, organization}
+      );
+
+      const span1 = tree.root.findChild(n => n.id === 'eap-span-1');
+      expect(tree.vitals.get(span1!)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({key: 'lcp', measurement: {value: 200}}),
+        ])
+      );
+      expect(tree.indicators).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({type: 'lcp', measurement: {value: 200}}),
+        ])
+      );
+    });
+
     it('standalone LCP span indicator takes priority over pageload LCP indicator', () => {
       const standaloneStart = start + 1.5;
       const tree = TraceTree.FromTrace(

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -170,6 +170,7 @@ export declare namespace TraceTree {
     transaction: string;
     transaction_id: string;
     additional_attributes?: Record<string, number | string>;
+    browser_web_vital?: Record<string, number>;
     description?: string;
     measurements?: Record<string, number>;
   };

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
@@ -16,6 +16,14 @@ import {BaseNode, type TraceTreeNodeExtra} from './baseNode';
 import {HTTP_ERROR_STATUSES} from './constants';
 import {traceChronologicalSort} from './utils';
 
+const BROWSER_WEB_VITAL_MEASUREMENTS: Record<string, string> = {
+  'browser.web_vital.cls.value': 'cls',
+  'browser.web_vital.fcp.value': 'fcp',
+  'browser.web_vital.inp.value': 'inp',
+  'browser.web_vital.lcp.value': 'lcp',
+  'browser.web_vital.ttfb.value': 'ttfb',
+};
+
 export class EapSpanNode extends BaseNode<TraceTree.EAPSpan> {
   id: string;
   type: TraceTree.NodeType;
@@ -143,6 +151,21 @@ export class EapSpanNode extends BaseNode<TraceTree.EAPSpan> {
         result[normalizedKey] = {value};
       }
     }
+
+    if (this.value.browser_web_vital) {
+      for (const key in this.value.browser_web_vital) {
+        const normalizedKey = BROWSER_WEB_VITAL_MEASUREMENTS[key];
+        const value = this.value.browser_web_vital[key];
+        if (
+          normalizedKey &&
+          typeof value === 'number' &&
+          result[normalizedKey]?.value === 0
+        ) {
+          result[normalizedKey] = {value};
+        }
+      }
+    }
+
     return result;
   }
 


### PR DESCRIPTION
This PR fixes an issue where we're sending web vitals under new `browser.web_vital` attributes, that were added in: https://github.com/getsentry/sentry/pull/117910

Closes EXP-1012

Before:

<img width="1644" height="919" alt="Screenshot 2026-06-18 at 13 59 17" src="https://github.com/user-attachments/assets/484aae7e-f9c8-478e-9da9-fe1aed079263" />

After:


<img width="1646" height="925" alt="Screenshot 2026-06-18 at 13 59 25" src="https://github.com/user-attachments/assets/a2c9090e-091b-41e5-84ed-3a3e2a12e908" />
