### PR TITLE
fix(trace-item-stats): Resolve issue with pagination

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_stats.py
+++ b/src/sentry/api/endpoints/organization_trace_item_stats.py
@@ -100,7 +100,9 @@ class TraceItemStatsPaginator:
             raise ValueError(f"invalid limit for paginator, expected >0, got {limit}")
 
         offset = cursor.offset if cursor is not None else 0
-        # Request 1 more than limit so we can tell if there is another page
+        # data_fn returns (payload, total_count), where total_count is the number of
+        # attributes available across all pages. There is a next page whenever the total
+        # extends at least one attribute past the end of the current page (offset + limit).
         data = self.data_fn(offset=offset, limit=limit)
         has_more = data[1] >= offset + limit + 1
 
@@ -240,13 +242,16 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
 
                 sanitized_keys.append(internal_name)
 
-            sanitized_keys = sanitized_keys[offset : offset + limit]
+            # The number of attributes available across all pages drives pagination
+            # (see TraceItemStatsPaginator), so capture the total before slicing.
+            total_attributes = len(sanitized_keys)
+            paginated_keys = sanitized_keys[offset : offset + limit]
 
-            if not sanitized_keys:
-                return {"data": []}, 0
+            if not paginated_keys:
+                return {"data": []}, total_attributes
 
             request_attrs_list = []
-            for requested_key in sanitized_keys:
+            for requested_key in paginated_keys:
                 request_attrs_list.append(
                     AttributeKey(name=requested_key, type=AttributeKey.TYPE_STRING)
                 )
@@ -273,7 +278,7 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
                         for stats_type, data in stats.items():
                             stats_results[stats_type]["data"].update(data["data"])
 
-            return {"data": [{k: v} for k, v in stats_results.items()]}, len(request_attrs_list)
+            return {"data": [{k: v} for k, v in stats_results.items()]}, total_attributes
 
         return self.paginate(
             request=request,

--- a/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
@@ -67,6 +67,13 @@ class OrganizationTraceItemsStatsEndpointTest(
         self.store_eap_items([occ])
         return occ
 
+    def _parse_links(self, response):
+        links = {}
+        for url, attrs in parse_link_header(response["Link"]).items():
+            attrs["href"] = url
+            links[attrs["rel"]] = attrs
+        return links
+
     def test_no_project(self) -> None:
         response = self.do_request()
         assert response.status_code == 200, response.data
@@ -239,37 +246,44 @@ class OrganizationTraceItemsStatsEndpointTest(
             item["label"] == "mobile" or item["label"] == "tablet" for item in device_data
         )
 
-    @override_options({"explore.trace-items.keys.max": 3})
-    def test_pagination_with_limit(self) -> None:
-        tags = [
-            {"attr1": "value1"},
-            {"attr2": "value2"},
-            {"attr3": "value3"},
-            {"attr4": "value4"},
-        ]
+    def test_pagination_traverses_all_pages(self) -> None:
+        # Four custom attributes sharing a prefix so substringMatch yields a
+        # deterministic total, independent of the default span attributes.
+        stored_names = ["pageattra", "pageattrb", "pageattrc", "pageattrd"]
+        for name in stored_names:
+            self._store_span(tags={name: "value"})
 
-        for tag in tags:
-            self._store_span(tags=tag)
-
+        # First page: 2 of the 4 attributes, so a next page must be reported.
         response = self.do_request(
             query={
                 "statsType": ["attributeDistributions"],
+                "substringMatch": "pageattr",
+                "limit": 2,
             }
         )
         assert response.status_code == 200, response.data
+        first_page = response.data["data"][0]["attribute_distributions"]["data"]
+        assert len(first_page) == 2
 
-        links = {}
-        if "Link" in response:
-            for url, attrs in parse_link_header(response["Link"]).items():
-                links[attrs["rel"]] = attrs
-                attrs["href"] = url
+        links = self._parse_links(response)
+        assert links["previous"]["results"] == "false"
+        assert links["next"]["results"] == "true"
 
-            assert links["previous"]["results"] == "false"
+        # Second page: the remaining 2 attributes, with no further pages.
+        next_response = self.client.get(links["next"]["href"], format="json")
+        assert next_response.status_code == 200, next_response.content
+        second_page = next_response.data["data"][0]["attribute_distributions"]["data"]
+        assert len(second_page) == 2
 
-            if links.get("next", {}).get("results") == "true":
-                assert links["next"]["href"] is not None
-                next_response = self.client.get(links["next"]["href"], format="json")
-                assert next_response.status_code == 200, next_response.content
+        next_links = self._parse_links(next_response)
+        assert next_links["previous"]["results"] == "true"
+        assert next_links["next"]["results"] == "false"
+
+        # Together the two pages cover every attribute exactly once. Custom span
+        # tags are exposed under the "sentry." namespace.
+        expected_attributes = {f"sentry.{name}" for name in stored_names}
+        assert set(first_page).isdisjoint(second_page)
+        assert set(first_page) | set(second_page) == expected_attributes
 
     @override_options({"explore.trace-items.keys.max": 2})
     def test_custom_limit_parameter(self) -> None:


### PR DESCRIPTION
**Problem**
The `/organizations/{org}/trace-items/stats/` endpoint never reported a next page, so clients could only ever see the first page of attribute breakdowns.

`TraceItemStatsPaginator` decides whether there's another page with `has_more = data[1] >= offset + limit + 1`, where `data[1]` is the count returned by `data_fn`. But `data_fn` returned `len(request_attrs_list)`, the page length after slicing `sanitized_keys[offset : offset + limit]`, which is always ≤ `limit`. That makes `has_more` always `False`, so the `Link` header always emitted `next; results="false"`.

**Fix**
- Capture `total_attributes = len(sanitized_keys)` before slicing and return that as the paginator count, so `has_more` reflects whether attributes exist beyond the current page.
- Updated the misleading "Request 1 more than limit" comment to document the real `(payload, total_count)` contract `data_fn` must satisfy.

Closes EXP-1017