### PR TITLE
fix(attribute-breakdown): Lower limit + cleaning up pagination states

### DIFF
--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.spec.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.spec.tsx
@@ -1,0 +1,144 @@
+import type {ReactNode} from 'react';
+
+import {act, render, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {AttributeDistribution} from 'sentry/views/explore/components/attributeBreakdowns/attributeDistributionContent';
+import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
+
+function Wrapper({children}: {children: ReactNode}) {
+  return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
+}
+
+describe('AttributeDistribution', () => {
+  beforeEach(() => {
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState({
+      projects: [1],
+      environments: [],
+      datetime: {period: '14d', start: null, end: null, utc: null},
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      method: 'GET',
+      body: {data: [{'count()': 0}]},
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('clears the attribute breakdowns cursor when the explore query changes', async () => {
+    const traceItemsStatsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/stats/',
+      method: 'GET',
+      body: {data: [{attribute_distributions: {data: {}}}]},
+    });
+
+    const {router} = render(<AttributeDistribution />, {
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/traces/',
+          query: {
+            query: 'span.op:db',
+            attributeBreakdownsCursor: '1:0:0',
+          },
+        },
+      },
+    });
+
+    await waitFor(() => expect(traceItemsStatsRequest).toHaveBeenCalledTimes(1));
+    expect(traceItemsStatsRequest).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/trace-items/stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({cursor: '1:0:0', query: 'span.op:db'}),
+      })
+    );
+
+    act(() => {
+      router.navigate({
+        pathname: '/organizations/org-slug/explore/traces/',
+        search: 'query=span.op%3Ahttp&attributeBreakdownsCursor=1%3A0%3A0',
+      });
+    });
+
+    await waitFor(() =>
+      expect(traceItemsStatsRequest.mock.calls.length).toBeGreaterThanOrEqual(2)
+    );
+    expect(traceItemsStatsRequest).toHaveBeenNthCalledWith(
+      2,
+      '/organizations/org-slug/trace-items/stats/',
+      expect.objectContaining({
+        query: expect.not.objectContaining({cursor: '1:0:0'}),
+      })
+    );
+    expect(traceItemsStatsRequest).toHaveBeenNthCalledWith(
+      2,
+      '/organizations/org-slug/trace-items/stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({query: 'span.op:http'}),
+      })
+    );
+
+    await waitFor(() =>
+      expect(router.location.query.attributeBreakdownsCursor).toBeUndefined()
+    );
+  });
+
+  it('clears the attribute breakdowns cursor when page filters change', async () => {
+    const traceItemsStatsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/stats/',
+      method: 'GET',
+      body: {data: [{attribute_distributions: {data: {}}}]},
+    });
+
+    const {router} = render(<AttributeDistribution />, {
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/traces/',
+          query: {
+            attributeBreakdownsCursor: '1:0:0',
+          },
+        },
+      },
+    });
+
+    await waitFor(() => expect(traceItemsStatsRequest).toHaveBeenCalledTimes(1));
+    expect(traceItemsStatsRequest).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/trace-items/stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({cursor: '1:0:0', project: [1]}),
+      })
+    );
+
+    act(() => {
+      PageFiltersStore.updateProjects([2], null);
+    });
+
+    await waitFor(() =>
+      expect(traceItemsStatsRequest.mock.calls.length).toBeGreaterThanOrEqual(2)
+    );
+    expect(traceItemsStatsRequest).toHaveBeenNthCalledWith(
+      2,
+      '/organizations/org-slug/trace-items/stats/',
+      expect.objectContaining({
+        query: expect.not.objectContaining({cursor: '1:0:0'}),
+      })
+    );
+    expect(traceItemsStatsRequest).toHaveBeenNthCalledWith(
+      2,
+      '/organizations/org-slug/trace-items/stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({project: [2]}),
+      })
+    );
+
+    await waitFor(() =>
+      expect(router.location.query.attributeBreakdownsCursor).toBeUndefined()
+    );
+  });
+});

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo, useState} from 'react';
+import {Fragment, useEffect, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import {useQueryState} from 'nuqs';
 
@@ -36,21 +36,12 @@ export type AttributeDistribution = Array<{
   values: Array<{label: string; value: number}>;
 }>;
 
-type PaginationState = {
-  cursor: string | undefined;
-  page: number;
-};
-
 export function AttributeDistribution() {
   const [searchQuery, setSearchQuery] = useQueryState('attributeBreakdownsSearch');
 
-  // Little unconventional, but the /trace-items/stats/ endpoint but recommends fetching
-  // more data than we need to display the current page. We maintain a cursor to fetch the next page,
-  // and a page index to display the current page, from the accumulated data.
-  const [pagination, setPagination] = useState<PaginationState>({
-    cursor: undefined,
-    page: 0,
-  });
+  // The /trace-items/stats/ endpoint is cursor-paginated. We keep the current page's
+  // cursor in the URL and drive the prev/next buttons off the Link header it returns.
+  const [cursor, setCursor] = useQueryState('attributeBreakdownsCursor');
 
   const query = useQueryParamsQuery();
   const onAction = useAttributeBreakdownsTooltipAction();
@@ -109,7 +100,7 @@ export function AttributeDistribution() {
     isLoading: isAttributeBreakdownsLoading,
     error: attributeBreakdownsError,
   } = useAttributeBreakdowns({
-    cursor: pagination.cursor,
+    cursor: cursor ?? undefined,
     substringMatch: debouncedSearchQuery,
   });
 
@@ -122,10 +113,10 @@ export function AttributeDistribution() {
     }
   }, [attributeBreakdownsData, isAttributeBreakdownsLoading, refetchCohortCount]);
 
-  // Reset pagination on any query change
+  // Reset the cursor back to the first page on any query change
   useEffect(() => {
-    setPagination({cursor: undefined, page: 0});
-  }, [debouncedSearchQuery, selection, query]);
+    setCursor(null);
+  }, [debouncedSearchQuery, selection, query, setCursor]);
 
   const parsedLinks = parseLinkHeader(attributeBreakdownsPageLinks);
 
@@ -177,48 +168,33 @@ export function AttributeDistribution() {
         ) : uniqueAttributeDistribution.length > 0 ? (
           <Fragment>
             <AttributeBreakdownsComponent.ChartsGrid>
-              {uniqueAttributeDistribution
-                .slice(
-                  pagination.page * CHARTS_PER_PAGE,
-                  (pagination.page + 1) * CHARTS_PER_PAGE
-                )
-                .map(distribution => (
-                  <Chart
-                    key={distribution.attributeName}
-                    attributeDistribution={distribution}
-                    cohortCount={cohortCount}
-                    theme={theme}
-                    query={query}
-                    actions={{
-                      htmlRenderer: (value: string) =>
-                        tooltipActionsHtmlRenderer(
-                          value,
-                          distribution.attributeName,
-                          theme
-                        ),
-                      onAction,
-                    }}
-                  />
-                ))}
+              {uniqueAttributeDistribution.slice(0, CHARTS_PER_PAGE).map(distribution => (
+                <Chart
+                  key={distribution.attributeName}
+                  attributeDistribution={distribution}
+                  cohortCount={cohortCount}
+                  theme={theme}
+                  query={query}
+                  actions={{
+                    htmlRenderer: (value: string) =>
+                      tooltipActionsHtmlRenderer(
+                        value,
+                        distribution.attributeName,
+                        theme
+                      ),
+                    onAction,
+                  }}
+                />
+              ))}
             </AttributeBreakdownsComponent.ChartsGrid>
             <AttributeBreakdownsComponent.Pagination
-              isPrevDisabled={pagination.page === 0}
-              isNextDisabled={
-                pagination.page ===
-                Math.ceil(uniqueAttributeDistribution.length / CHARTS_PER_PAGE) - 1
-              }
+              isPrevDisabled={parsedLinks.previous?.results === false}
+              isNextDisabled={parsedLinks.next?.results === false}
               onPrevClick={() => {
-                setPagination({...pagination, page: pagination.page - 1});
+                setCursor(parsedLinks.previous?.cursor ?? null);
               }}
               onNextClick={() => {
-                if (parsedLinks.next?.results) {
-                  setPagination({
-                    cursor: parsedLinks.next?.cursor,
-                    page: pagination.page + 1,
-                  });
-                } else {
-                  setPagination({...pagination, page: pagination.page + 1});
-                }
+                setCursor(parsedLinks.next?.cursor ?? null);
               }}
             />
           </Fragment>

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useEffect, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
+import {useQuery} from '@tanstack/react-query';
 import {useQueryState} from 'nuqs';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -11,10 +12,9 @@ import {Panel} from 'sentry/components/panels/panel';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import type {NewQuery} from 'sentry/types/organization';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {EventView} from 'sentry/utils/discover/eventView';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useDismissAlert} from 'sentry/utils/useDismissAlert';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -69,23 +69,20 @@ export function AttributeDistribution() {
     isLoading: isCohortCountLoading,
     error: cohortCountError,
     refetch: refetchCohortCount,
-  } = useApiQuery<{data: Array<{'count()': number}>}>(
-    [
-      getApiUrl('/organizations/$organizationIdOrSlug/events/', {
-        path: {organizationIdOrSlug: organization.slug},
-      }),
+  } = useQuery(
+    apiOptions.as<{data: Array<{'count()': number}>}>()(
+      '/organizations/$organizationIdOrSlug/events/',
       {
+        path: {organizationIdOrSlug: organization.slug},
+        staleTime: 0,
         query: {
           ...cohortCountEventView.getEventsAPIPayload(location),
           per_page: 1,
           disableAggregateExtrapolation: '1',
           sampling: SAMPLING_MODE.NORMAL,
         },
-      },
-    ],
-    {
-      staleTime: 0,
-    }
+      }
+    )
   );
 
   const cohortCount = cohortCountResponse?.data?.[0]?.['count()'] ?? 0;

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -39,10 +39,6 @@ export type AttributeDistribution = Array<{
 export function AttributeDistribution() {
   const [searchQuery, setSearchQuery] = useQueryState('attributeBreakdownsSearch');
 
-  // The /trace-items/stats/ endpoint is cursor-paginated. We keep the current page's
-  // cursor in the URL and drive the prev/next buttons off the Link header it returns.
-  const [cursor, setCursor] = useQueryState('attributeBreakdownsCursor');
-
   const query = useQueryParamsQuery();
   const onAction = useAttributeBreakdownsTooltipAction();
 
@@ -87,8 +83,7 @@ export function AttributeDistribution() {
 
   const cohortCount = cohortCountResponse?.data?.[0]?.['count()'] ?? 0;
 
-  // Debouncing the search query here to ensure smooth typing, by delaying the re-mounts a little as the user types.
-  // query here to ensure smooth typing, by delaying the re-mounts a little as the user types.
+  // Debouncing the search query here ensures smooth typing by delaying re-mounts a little as the user types.
   const debouncedSearchQuery = useDebouncedValue(searchQuery ?? '', 200);
 
   const {
@@ -96,8 +91,8 @@ export function AttributeDistribution() {
     pageLinks: attributeBreakdownsPageLinks,
     isLoading: isAttributeBreakdownsLoading,
     error: attributeBreakdownsError,
+    setCursor,
   } = useAttributeBreakdowns({
-    cursor: cursor ?? undefined,
     substringMatch: debouncedSearchQuery,
   });
 
@@ -147,9 +142,7 @@ export function AttributeDistribution() {
             placeholder={t('Search keys')}
             onChange={q => {
               setSearchQuery(q);
-              if (cursor !== null) {
-                setCursor(null);
-              }
+              setCursor(null);
             }}
             query={debouncedSearchQuery}
             size="sm"

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -113,11 +113,6 @@ export function AttributeDistribution() {
     }
   }, [attributeBreakdownsData, isAttributeBreakdownsLoading, refetchCohortCount]);
 
-  // Reset the cursor back to the first page on any query change
-  useEffect(() => {
-    setCursor(null);
-  }, [debouncedSearchQuery, selection, query, setCursor]);
-
   const parsedLinks = parseLinkHeader(attributeBreakdownsPageLinks);
 
   const uniqueAttributeDistribution = useMemo(() => {
@@ -155,6 +150,9 @@ export function AttributeDistribution() {
             placeholder={t('Search keys')}
             onChange={q => {
               setSearchQuery(q);
+              if (cursor !== null) {
+                setCursor(null);
+              }
             }}
             query={debouncedSearchQuery}
             size="sm"

--- a/static/app/views/explore/hooks/useAttributeBreakdowns.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdowns.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useRef} from 'react';
+import {useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import {pageFiltersToQueryParams} from 'sentry/components/pageFilters/parse';
@@ -6,7 +6,6 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {usePrevious} from 'sentry/utils/usePrevious';
 import {CHARTS_PER_PAGE} from 'sentry/views/explore/components/attributeBreakdowns/constants';
 
 type AttributeDistributionData = Record<string, Array<{label: string; value: number}>>;
@@ -19,9 +18,8 @@ type AttributeBreakdowns = {
   }>;
 };
 
-// The /trace-items/stats/ endpoint returns a paginated response, but recommends fetching
-//  more data than we need to display the current page. Hence we accumulate the
-// data across paginated requests.
+// The /trace-items/stats/ endpoint returns a cursor-paginated response. We page
+// through it one page (CHARTS_PER_PAGE) at a time using the cursor from the Link header.
 export function useAttributeBreakdowns({
   cursor,
   substringMatch,
@@ -34,27 +32,12 @@ export function useAttributeBreakdowns({
   const {selection: pageFilters, isReady: pageFiltersReady} = usePageFilters();
   const queryString = location.query.query?.toString() ?? '';
 
-  // Ref to accumulate data across paginated requests
-  const accumulatedDataRef = useRef<AttributeDistributionData>({});
-
-  // Clear accumulated data when anything other than cursor changes
-  const previousSubstringMatch = usePrevious(substringMatch);
-  const previousQueryString = usePrevious(queryString);
-  const previousPageFilters = usePrevious(pageFilters);
-  if (
-    previousSubstringMatch !== substringMatch ||
-    previousQueryString !== queryString ||
-    previousPageFilters !== pageFilters
-  ) {
-    accumulatedDataRef.current = {};
-  }
-
   const queryParams = useMemo(() => {
     const params = {
       ...pageFiltersToQueryParams(pageFilters),
       query: queryString,
       statsType: 'attributeDistributions',
-      limit: CHARTS_PER_PAGE * 2,
+      limit: CHARTS_PER_PAGE,
     } as Record<string, any>;
 
     if (cursor !== undefined) {
@@ -86,16 +69,7 @@ export function useAttributeBreakdowns({
   });
 
   const data = useMemo((): AttributeDistributionData | undefined => {
-    const newData = response?.json?.data[0]?.attribute_distributions?.data;
-    if (newData) {
-      accumulatedDataRef.current = {
-        ...accumulatedDataRef.current,
-        ...newData,
-      };
-    }
-    return Object.keys(accumulatedDataRef.current).length > 0
-      ? accumulatedDataRef.current
-      : newData;
+    return response?.json?.data[0]?.attribute_distributions?.data;
   }, [response?.json]);
 
   return {

--- a/static/app/views/explore/hooks/useAttributeBreakdowns.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdowns.tsx
@@ -1,11 +1,13 @@
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
+import {useQueryState} from 'nuqs';
 
 import {pageFiltersToQueryParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {usePrevious} from 'sentry/utils/usePrevious';
 import {CHARTS_PER_PAGE} from 'sentry/views/explore/components/attributeBreakdowns/constants';
 
 type AttributeDistributionData = Record<string, Array<{label: string; value: number}>>;
@@ -20,17 +22,38 @@ type AttributeBreakdowns = {
 
 // The /trace-items/stats/ endpoint returns a cursor-paginated response. We page
 // through it one page (CHARTS_PER_PAGE) at a time using the cursor from the Link header.
-export function useAttributeBreakdowns({
-  cursor,
-  substringMatch,
-}: {
-  cursor: string | undefined;
-  substringMatch: string;
-}) {
+export function useAttributeBreakdowns({substringMatch}: {substringMatch: string}) {
   const organization = useOrganization();
   const location = useLocation();
   const {selection: pageFilters, isReady: pageFiltersReady} = usePageFilters();
+  const [cursor, setCursor] = useQueryState('attributeBreakdownsCursor');
   const queryString = location.query.query?.toString() ?? '';
+
+  const resultSetKey = useMemo(
+    () =>
+      JSON.stringify({
+        query: queryString,
+        substringMatch,
+        projects: pageFilters.projects,
+        environments: pageFilters.environments,
+        datetime: pageFilters.datetime,
+      }),
+    [
+      pageFilters.datetime,
+      pageFilters.environments,
+      pageFilters.projects,
+      queryString,
+      substringMatch,
+    ]
+  );
+  const previousResultSetKey = usePrevious(resultSetKey);
+  const didResultSetChange = previousResultSetKey !== resultSetKey;
+
+  useEffect(() => {
+    if (didResultSetChange && cursor !== null) {
+      setCursor(null);
+    }
+  }, [cursor, didResultSetChange, setCursor]);
 
   const queryParams = useMemo(() => {
     const params = {
@@ -40,8 +63,9 @@ export function useAttributeBreakdowns({
       limit: CHARTS_PER_PAGE,
     } as Record<string, any>;
 
-    if (cursor !== undefined) {
-      params.cursor = cursor;
+    const validCursor = didResultSetChange ? undefined : (cursor ?? undefined);
+    if (validCursor !== undefined) {
+      params.cursor = validCursor;
     }
 
     if (substringMatch) {
@@ -49,7 +73,7 @@ export function useAttributeBreakdowns({
     }
 
     return params;
-  }, [pageFilters, queryString, cursor, substringMatch]);
+  }, [pageFilters, queryString, didResultSetChange, cursor, substringMatch]);
 
   const {
     data: response,
@@ -77,5 +101,6 @@ export function useAttributeBreakdowns({
     isLoading,
     error,
     pageLinks: response?.headers.Link ?? null,
+    setCursor,
   };
 }


### PR DESCRIPTION
This PR removes the artificial limit of 24 attributes for the explore page attribute breakdown. This PR also tidies up some of the state management around tracking the cursor etc.

Closes EXP-1018