### PR TITLE
fix(issues): Tweak linked pull request rows

### DIFF
--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -3,7 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PullRequestFixture} from 'sentry-fixture/pullRequest';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 
-import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {LinkedPullRequests} from './linkedPullRequests';
 
@@ -56,7 +56,7 @@ describe('LinkedPullRequests', () => {
 
     const list = await screen.findByRole('list', {name: 'Linked pull requests'});
     const linkedPullRequest = within(list).getByRole('link', {
-      name: /Fix widget crash on startup/,
+      name: /Pull request #123 in example\/widget-app/,
     });
 
     expect(linkedPullRequest).toHaveAttribute(
@@ -64,18 +64,23 @@ describe('LinkedPullRequests', () => {
       'https://github.com/example/widget-app/pull/123'
     );
     expect(linkedPullRequest).toHaveAccessibleName(
-      `Fix widget crash on startup, pull request #123, Merged in ${REPOSITORY_NAME}`
+      `Pull request #123 in ${REPOSITORY_NAME}, Merged, Fix widget crash on startup`
     );
+    await userEvent.hover(within(linkedPullRequest).getByText('#123'));
+    expect(await screen.findByText('Fix widget crash on startup')).toBeInTheDocument();
     expect(within(list).getAllByRole('listitem')).toHaveLength(2);
     expect(within(list).getByText('#123')).toBeInTheDocument();
     expect(within(list).getByText('#124')).toBeInTheDocument();
     expect(within(list).getAllByText(REPOSITORY_NAME)).toHaveLength(2);
-    expect(
-      within(list).getByTestId('linked-pull-request-status-merged')
-    ).toBeInTheDocument();
-    expect(
-      within(list).getByTestId('linked-pull-request-status-closed')
-    ).toBeInTheDocument();
+    expect(linkedPullRequest.querySelectorAll('svg')).toHaveLength(2);
+    expect(within(list).getByText('Merged')).toBeInTheDocument();
+    expect(within(list).getByText('Closed')).toBeInTheDocument();
+    const mergedStatus = within(list).getByTestId('linked-pull-request-status-merged');
+    const closedStatus = within(list).getByTestId('linked-pull-request-status-closed');
+    expect(mergedStatus).toBeInTheDocument();
+    expect(closedStatus).toBeInTheDocument();
+    expect(mergedStatus.querySelector('svg')).toBeInTheDocument();
+    expect(closedStatus.querySelector('svg')).toBeInTheDocument();
     expect(pullRequestsMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -5,7 +5,9 @@ import {RepositoryFixture} from 'sentry-fixture/repository';
 
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
-import {LinkedPullRequests} from './linkedPullRequests';
+import {GroupActivityType} from 'sentry/types/group';
+
+import {getLinkedPullRequestActivityIds, LinkedPullRequests} from './linkedPullRequests';
 
 const LINKED_PULL_REQUESTS_FEATURE = 'issue-details-linked-pull-requests';
 const REPOSITORY_NAME = 'example/widget-app';
@@ -82,5 +84,32 @@ describe('LinkedPullRequests', () => {
     expect(mergedStatus.querySelector('svg')).toBeInTheDocument();
     expect(closedStatus.querySelector('svg')).toBeInTheDocument();
     expect(pullRequestsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates pull request ids from group activity', () => {
+    const activityGroup = GroupFixture({
+      activity: [
+        {
+          type: GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST,
+          id: 'activity-1',
+          dateCreated: '2026-06-08T23:11:32.000000Z',
+          data: {
+            pullRequest: PullRequestFixture({id: '123'}),
+          },
+          user: null,
+        },
+        {
+          type: GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST,
+          id: 'activity-2',
+          dateCreated: '2026-06-08T23:12:32.000000Z',
+          data: {
+            pullRequest: PullRequestFixture({id: '123'}),
+          },
+          user: null,
+        },
+      ],
+    });
+
+    expect([...getLinkedPullRequestActivityIds(activityGroup)]).toEqual(['123']);
   });
 });

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -75,8 +75,8 @@ describe('LinkedPullRequests', () => {
     expect(linkedPullRequest.querySelectorAll('svg')).toHaveLength(2);
     expect(within(list).getByText('Merged')).toBeInTheDocument();
     expect(within(list).getByText('Closed')).toBeInTheDocument();
-    const mergedStatus = within(list).getByTestId('linked-pull-request-status-merged');
-    const closedStatus = within(list).getByTestId('linked-pull-request-status-closed');
+    const mergedStatus = within(list).getByLabelText('Pull request status: Merged');
+    const closedStatus = within(list).getByLabelText('Pull request status: Closed');
     expect(mergedStatus).toBeInTheDocument();
     expect(closedStatus).toBeInTheDocument();
     expect(mergedStatus.querySelector('svg')).toBeInTheDocument();

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -8,6 +8,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Placeholder} from 'sentry/components/placeholder';
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
+import {TimeSince} from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
 import {GroupActivityType, type Group} from 'sentry/types/group';
 import type {
@@ -101,8 +102,16 @@ function LinkedPullRequestRow({
                 {pullRequest.repository.name}
               </Text>
             </PullRequestTitle>
-            <Flex align="center">
+            <Flex align="center" gap="xs">
               <PullRequestStatusBadge status={pullRequest.status} />
+              <Text as="span" size="sm" variant="muted">
+                <TimeSince
+                  date={pullRequest.dateLinked}
+                  suffix={t('ago')}
+                  tooltipPrefix={t('Linked')}
+                  unitStyle="short"
+                />
+              </Text>
             </Flex>
           </Flex>
         </Grid>

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -6,9 +6,10 @@ import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {Placeholder} from 'sentry/components/placeholder';
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
 import {t} from 'sentry/locale';
-import type {Group} from 'sentry/types/group';
+import {GroupActivityType, type Group} from 'sentry/types/group';
 import type {
   LinkedPullRequest,
   LinkedPullRequestsResponse,
@@ -24,6 +25,17 @@ import {
 } from './pullRequestStatusBadge';
 
 const LINKED_PULL_REQUESTS_FEATURE = 'issue-details-linked-pull-requests';
+
+export function getLinkedPullRequestActivityIds(group: Group) {
+  return new Set(
+    group.activity
+      .filter(
+        activity => activity.type === GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST
+      )
+      .map(activity => activity.data.pullRequest?.id)
+      .filter(id => id !== undefined)
+  );
+}
 
 interface LinkedPullRequestsProps {
   group: Group;
@@ -73,7 +85,7 @@ function LinkedPullRequestRow({
         }
       >
         <Grid columns="max-content minmax(0, 1fr)" gap="sm" padding="sm">
-          <Flex as="span" aria-hidden align="start" paddingTop="2xs">
+          <Flex as="span" aria-hidden align="start">
             <RepoProviderIcon
               provider={pullRequest.repository.provider.id}
               size="sm"
@@ -119,10 +131,15 @@ export function useLinkedPullRequests({group}: {group: Group}) {
 export function LinkedPullRequests({group, showEmptyState}: LinkedPullRequestsProps) {
   const organization = useOrganization();
   const hasFeature = organization.features.includes(LINKED_PULL_REQUESTS_FEATURE);
-  const {data, isError} = useLinkedPullRequests({group});
+  const {data, isError, isPending} = useLinkedPullRequests({group});
+  const activityPullRequestIds = getLinkedPullRequestActivityIds(group);
 
   if (!hasFeature || isError) {
     return null;
+  }
+
+  if (isPending && activityPullRequestIds.size > 0) {
+    return <Placeholder height="40px" />;
   }
 
   if (data?.pullRequests.length === 0) {

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -9,7 +9,10 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
-import type {LinkedPullRequest} from 'sentry/types/integrations';
+import type {
+  LinkedPullRequest,
+  LinkedPullRequestsResponse,
+} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getAnalyticsDataForGroup} from 'sentry/utils/events';
@@ -21,10 +24,6 @@ import {
 } from './pullRequestStatusBadge';
 
 const LINKED_PULL_REQUESTS_FEATURE = 'issue-details-linked-pull-requests';
-
-type LinkedPullRequestsResponse = {
-  pullRequests: LinkedPullRequest[];
-};
 
 interface LinkedPullRequestsProps {
   group: Group;

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -1,31 +1,26 @@
 import styled from '@emotion/styled';
 import {skipToken, useQuery} from '@tanstack/react-query';
 
-import {Badge} from '@sentry/scraps/badge';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
-import {IconMerge, IconPullRequest, IconPullRequestClosed} from 'sentry/icons';
-import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
-import type {PullRequest} from 'sentry/types/integrations';
+import type {LinkedPullRequest} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
+import {
+  getPullRequestStatusLabel,
+  PullRequestStatusBadge,
+} from './pullRequestStatusBadge';
+
 const LINKED_PULL_REQUESTS_FEATURE = 'issue-details-linked-pull-requests';
-
-type LinkedPullRequestStatus = 'closed' | 'draft' | 'merged' | 'open' | 'unknown';
-
-type LinkedPullRequest = PullRequest & {
-  dateLinked: string;
-  status: LinkedPullRequestStatus;
-};
 
 type LinkedPullRequestsResponse = {
   pullRequests: LinkedPullRequest[];
@@ -34,48 +29,6 @@ type LinkedPullRequestsResponse = {
 interface LinkedPullRequestsProps {
   group: Group;
   showEmptyState?: boolean;
-}
-
-const STATUS_ICONS = {
-  closed: IconPullRequestClosed,
-  draft: IconPullRequest,
-  merged: IconMerge,
-  open: IconPullRequest,
-  unknown: IconPullRequest,
-} satisfies Record<LinkedPullRequestStatus, React.ComponentType<SVGIconProps>>;
-
-function getStatusLabel(status: LinkedPullRequestStatus) {
-  switch (status) {
-    case 'closed':
-      return t('Closed');
-    case 'draft':
-      return t('Draft');
-    case 'merged':
-      return t('Merged');
-    case 'open':
-      return t('Open');
-    case 'unknown':
-      return t('Unknown status');
-    default:
-      return status satisfies never;
-  }
-}
-
-function getStatusBadgeVariant(status: LinkedPullRequestStatus) {
-  switch (status) {
-    case 'closed':
-      return 'danger';
-    case 'draft':
-      return 'muted';
-    case 'merged':
-      return 'info';
-    case 'open':
-      return 'success';
-    case 'unknown':
-      return 'muted';
-    default:
-      return status satisfies never;
-  }
 }
 
 function LinkedPullRequestRow({
@@ -87,49 +40,48 @@ function LinkedPullRequestRow({
 }) {
   const organization = useOrganization();
   const title = pullRequest.title ?? t('Pull request #%s', pullRequest.id);
-  const statusLabel = getStatusLabel(pullRequest.status);
+  const statusLabel = getPullRequestStatusLabel(pullRequest.status);
   const pullRequestLabel = t('#%s', pullRequest.id);
-  const StatusIcon = STATUS_ICONS[pullRequest.status];
 
   return (
-    <PullRequestRow
-      aria-label={t(
-        'Pull request #%s in %s, %s, %s',
-        pullRequest.id,
-        pullRequest.repository.name,
-        statusLabel,
-        title
-      )}
-      href={pullRequest.externalUrl}
-      onClick={() =>
-        trackAnalytics('issue_details.external_issue_pull_request_clicked', {
-          organization,
-          pull_request_id: pullRequest.id,
-          pull_request_status: pullRequest.status,
-          repository_id: pullRequest.repository.id,
-          repository_provider: pullRequest.repository.provider.id,
-          ...getAnalyticsDataForGroup(group),
-        })
+    <Tooltip
+      title={
+        <Text as="span" align="left" wordBreak="break-word">
+          {title}
+        </Text>
       }
+      maxWidth={275}
+      skipWrapper
     >
-      <Grid columns="max-content minmax(0, 1fr)" gap="sm" padding="sm">
-        <Flex as="span" aria-hidden align="start" paddingTop="2xs">
-          <RepoProviderIcon
-            provider={pullRequest.repository.provider.id}
-            size="sm"
-            variant="muted"
-          />
-        </Flex>
-        <Flex direction="column" gap="2xs" minWidth={0}>
-          <Tooltip
-            title={
-              <Text as="span" align="left" wordBreak="break-word">
-                {title}
-              </Text>
-            }
-            maxWidth={275}
-            skipWrapper
-          >
+      <PullRequestRow
+        aria-label={t(
+          'Pull request #%s in %s, %s, %s',
+          pullRequest.id,
+          pullRequest.repository.name,
+          statusLabel,
+          title
+        )}
+        href={pullRequest.externalUrl}
+        onClick={() =>
+          trackAnalytics('issue_details.external_issue_pull_request_clicked', {
+            organization,
+            pull_request_id: pullRequest.id,
+            pull_request_status: pullRequest.status,
+            repository_id: pullRequest.repository.id,
+            repository_provider: pullRequest.repository.provider.id,
+            ...getAnalyticsDataForGroup(group),
+          })
+        }
+      >
+        <Grid columns="max-content minmax(0, 1fr)" gap="sm" padding="sm">
+          <Flex as="span" aria-hidden align="start" paddingTop="2xs">
+            <RepoProviderIcon
+              provider={pullRequest.repository.provider.id}
+              size="sm"
+              variant="muted"
+            />
+          </Flex>
+          <Flex direction="column" gap="xs" minWidth={0}>
             <PullRequestTitle>
               <Text as="span" bold textWrap="nowrap">
                 {pullRequestLabel}
@@ -138,19 +90,13 @@ function LinkedPullRequestRow({
                 {pullRequest.repository.name}
               </Text>
             </PullRequestTitle>
-          </Tooltip>
-          <Flex align="center">
-            <StatusBadge
-              data-test-id={`linked-pull-request-status-${pullRequest.status}`}
-              variant={getStatusBadgeVariant(pullRequest.status)}
-            >
-              <StatusIcon aria-hidden size="xs" />
-              {statusLabel}
-            </StatusBadge>
+            <Flex align="center">
+              <PullRequestStatusBadge status={pullRequest.status} />
+            </Flex>
           </Flex>
-        </Flex>
-      </Grid>
-    </PullRequestRow>
+        </Grid>
+      </PullRequestRow>
+    </Tooltip>
   );
 }
 
@@ -229,10 +175,6 @@ const PullRequestRow = styled(ExternalLink)`
 
 const EmptyLinksText = styled(Text)`
   margin: 0;
-`;
-
-const StatusBadge = styled(Badge)`
-  gap: ${p => p.theme.space['2xs']};
 `;
 
 const PullRequestTitle = styled('span')`

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -1,17 +1,14 @@
 import styled from '@emotion/styled';
 import {skipToken, useQuery} from '@tanstack/react-query';
 
+import {Badge} from '@sentry/scraps/badge';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
-import {
-  IconMerge,
-  IconPullRequest,
-  IconPullRequestClosed,
-  IconRepository,
-} from 'sentry/icons';
+import {IconMerge, IconPullRequest, IconPullRequestClosed} from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
@@ -39,30 +36,13 @@ interface LinkedPullRequestsProps {
   showEmptyState?: boolean;
 }
 
-type StatusIconConfig = {
-  Icon: React.ComponentType<SVGIconProps>;
-  variant: SVGIconProps['variant'];
-};
-
-const STATUS_ICON_CONFIG = {
-  closed: {Icon: IconPullRequestClosed, variant: 'danger'},
-  draft: {Icon: IconPullRequest, variant: 'muted'},
-  merged: {Icon: IconMerge, variant: 'accent'},
-  open: {Icon: IconPullRequest, variant: 'success'},
-  unknown: {Icon: IconPullRequest, variant: 'muted'},
-} satisfies Record<LinkedPullRequestStatus, StatusIconConfig>;
-
-function getStatusIcon(status: LinkedPullRequestStatus) {
-  const {Icon, variant} = STATUS_ICON_CONFIG[status];
-  return (
-    <Icon
-      aria-hidden
-      data-test-id={`linked-pull-request-status-${status}`}
-      size="xs"
-      variant={variant}
-    />
-  );
-}
+const STATUS_ICONS = {
+  closed: IconPullRequestClosed,
+  draft: IconPullRequest,
+  merged: IconMerge,
+  open: IconPullRequest,
+  unknown: IconPullRequest,
+} satisfies Record<LinkedPullRequestStatus, React.ComponentType<SVGIconProps>>;
 
 function getStatusLabel(status: LinkedPullRequestStatus) {
   switch (status) {
@@ -81,6 +61,23 @@ function getStatusLabel(status: LinkedPullRequestStatus) {
   }
 }
 
+function getStatusBadgeVariant(status: LinkedPullRequestStatus) {
+  switch (status) {
+    case 'closed':
+      return 'danger';
+    case 'draft':
+      return 'muted';
+    case 'merged':
+      return 'info';
+    case 'open':
+      return 'success';
+    case 'unknown':
+      return 'muted';
+    default:
+      return status satisfies never;
+  }
+}
+
 function LinkedPullRequestRow({
   group,
   pullRequest,
@@ -91,15 +88,17 @@ function LinkedPullRequestRow({
   const organization = useOrganization();
   const title = pullRequest.title ?? t('Pull request #%s', pullRequest.id);
   const statusLabel = getStatusLabel(pullRequest.status);
+  const pullRequestLabel = t('#%s', pullRequest.id);
+  const StatusIcon = STATUS_ICONS[pullRequest.status];
 
   return (
     <PullRequestRow
       aria-label={t(
-        '%s, pull request #%s, %s in %s',
-        title,
+        'Pull request #%s in %s, %s, %s',
         pullRequest.id,
+        pullRequest.repository.name,
         statusLabel,
-        pullRequest.repository.name
+        title
       )}
       href={pullRequest.externalUrl}
       onClick={() =>
@@ -122,25 +121,32 @@ function LinkedPullRequestRow({
           />
         </Flex>
         <Flex direction="column" gap="2xs" minWidth={0}>
-          <PullRequestTitle>{title}</PullRequestTitle>
-          <Flex align="center" gap="sm">
-            <Flex as="span" align="center" gap="xs" minWidth={0}>
-              {getStatusIcon(pullRequest.status)}
-              <Text as="span" textWrap="nowrap" variant="muted">
-                #{pullRequest.id}
+          <Tooltip
+            title={
+              <Text as="span" align="left" wordBreak="break-word">
+                {title}
               </Text>
-            </Flex>
-            <Flex as="span" align="center" gap="xs" minWidth={0}>
-              <RepositoryIcon size="xs" variant="muted" />
-              <Text
-                as="span"
-                ellipsis
-                title={pullRequest.repository.name}
-                variant="muted"
-              >
+            }
+            maxWidth={275}
+            skipWrapper
+          >
+            <PullRequestTitle>
+              <Text as="span" bold textWrap="nowrap">
+                {pullRequestLabel}
+              </Text>
+              <Text as="span" ellipsis>
                 {pullRequest.repository.name}
               </Text>
-            </Flex>
+            </PullRequestTitle>
+          </Tooltip>
+          <Flex align="center">
+            <StatusBadge
+              data-test-id={`linked-pull-request-status-${pullRequest.status}`}
+              variant={getStatusBadgeVariant(pullRequest.status)}
+            >
+              <StatusIcon aria-hidden size="xs" />
+              {statusLabel}
+            </StatusBadge>
           </Flex>
         </Flex>
       </Grid>
@@ -225,15 +231,15 @@ const EmptyLinksText = styled(Text)`
   margin: 0;
 `;
 
-const RepositoryIcon = styled(IconRepository)`
-  transform: translateY(1px);
+const StatusBadge = styled(Badge)`
+  gap: ${p => p.theme.space['2xs']};
 `;
 
 const PullRequestTitle = styled('span')`
-  display: block;
+  align-items: center;
+  display: flex;
+  gap: ${p => p.theme.space.xs};
+  min-width: 0;
   overflow: hidden;
   width: 100%;
-  font-weight: ${p => p.theme.font.weight.sans.medium};
-  text-overflow: ellipsis;
-  white-space: nowrap;
 `;

--- a/static/app/components/group/externalIssuesList/pullRequestStatusBadge.tsx
+++ b/static/app/components/group/externalIssuesList/pullRequestStatusBadge.tsx
@@ -1,0 +1,59 @@
+import {Badge} from '@sentry/scraps/badge';
+import {Grid} from '@sentry/scraps/layout';
+
+import {IconMerge, IconPullRequest, IconPullRequestClosed} from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
+import {t} from 'sentry/locale';
+import type {PullRequestStatus} from 'sentry/types/integrations';
+
+type PullRequestStatusConfig = {
+  icon: React.ComponentType<SVGIconProps>;
+  label: () => string;
+  variant: React.ComponentProps<typeof Badge>['variant'];
+};
+
+const STATUS_CONFIG = {
+  closed: {
+    icon: IconPullRequestClosed,
+    label: () => t('Closed'),
+    variant: 'danger',
+  },
+  draft: {
+    icon: IconPullRequest,
+    label: () => t('Draft'),
+    variant: 'muted',
+  },
+  merged: {
+    icon: IconMerge,
+    label: () => t('Merged'),
+    variant: 'info',
+  },
+  open: {
+    icon: IconPullRequest,
+    label: () => t('Open'),
+    variant: 'success',
+  },
+  unknown: {
+    icon: IconPullRequest,
+    label: () => t('Unknown status'),
+    variant: 'muted',
+  },
+} satisfies Record<PullRequestStatus, PullRequestStatusConfig>;
+
+export function getPullRequestStatusLabel(status: PullRequestStatus) {
+  return STATUS_CONFIG[status].label();
+}
+
+export function PullRequestStatusBadge({status}: {status: PullRequestStatus}) {
+  const {icon: StatusIcon, variant} = STATUS_CONFIG[status];
+  const statusLabel = getPullRequestStatusLabel(status);
+
+  return (
+    <Badge aria-label={t('Pull request status: %s', statusLabel)} variant={variant}>
+      <Grid as="span" align="center" columns="max-content max-content" gap="2xs">
+        <StatusIcon aria-hidden size="xs" />
+        {statusLabel}
+      </Grid>
+    </Badge>
+  );
+}

--- a/static/app/components/group/externalIssuesList/pullRequestStatusBadge.tsx
+++ b/static/app/components/group/externalIssuesList/pullRequestStatusBadge.tsx
@@ -35,7 +35,7 @@ const STATUS_CONFIG = {
   },
   unknown: {
     icon: IconPullRequest,
-    label: () => t('Unknown status'),
+    label: () => t('Unknown'),
     variant: 'muted',
   },
 } satisfies Record<PullRequestStatus, PullRequestStatusConfig>;

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -143,7 +143,7 @@ export type CommitFile = {
   type: string;
 };
 
-export type PullRequest = {
+export interface PullRequest {
   dateCreated: string;
   externalUrl: string;
   id: string;
@@ -151,14 +151,18 @@ export type PullRequest = {
   repository: Repository;
   title: string | null;
   author?: CommitAuthor;
-};
+}
 
 export type PullRequestStatus = 'merged' | 'open' | 'closed' | 'draft' | 'unknown';
 
-export type LinkedPullRequest = PullRequest & {
+export interface LinkedPullRequest extends PullRequest {
   dateLinked: string;
   status: PullRequestStatus;
-};
+}
+
+export interface LinkedPullRequestsResponse {
+  pullRequests: LinkedPullRequest[];
+}
 
 /**
  * Sentry Apps

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -153,6 +153,13 @@ export type PullRequest = {
   author?: CommitAuthor;
 };
 
+export type PullRequestStatus = 'merged' | 'open' | 'closed' | 'draft' | 'unknown';
+
+export type LinkedPullRequest = PullRequest & {
+  dateLinked: string;
+  status: PullRequestStatus;
+};
+
 /**
  * Sentry Apps
  */

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
@@ -6,6 +6,7 @@ import {ExternalIssueListContent} from 'sentry/components/group/externalIssuesLi
 import {useGroupExternalIssues} from 'sentry/components/group/externalIssuesList/hooks/useGroupExternalIssues';
 import {IssueTrackerActionDropdown} from 'sentry/components/group/externalIssuesList/issueTrackerActions';
 import {
+  getLinkedPullRequestActivityIds,
   LinkedPullRequests,
   useLinkedPullRequests,
 } from 'sentry/components/group/externalIssuesList/linkedPullRequests';
@@ -31,10 +32,11 @@ export function ExternalIssueSidebarList({event, group, project}: Props) {
   const externalIssueData = useGroupExternalIssues({group, event, project});
   const {data: linkedPullRequestsData, isPending: isLinkedPullRequestsLoading} =
     useLinkedPullRequests({group});
+  const hasLinkedPullRequestActivity = getLinkedPullRequestActivityIds(group).size > 0;
   const showEmptyIssueTrackerAction =
     hasLinkedPullRequestsFeature &&
     !externalIssueData.isLoading &&
-    !isLinkedPullRequestsLoading &&
+    !(hasLinkedPullRequestActivity && isLinkedPullRequestsLoading) &&
     externalIssueData.integrations.length > 0 &&
     externalIssueData.linkedIssues.length === 0 &&
     linkedPullRequestsData?.pullRequests.length === 0;


### PR DESCRIPTION
Show the PR number and repo on the first line, move the title into the tooltip, and keep status as a badge with the state icon.

Also uses group activity as a signal that linked pull requests should exist and adds a loading state.

before

<img width="344" height="227" alt="image" src="https://github.com/user-attachments/assets/7ad37af3-54a0-4711-887f-ba52c937cf5b" />


after

<img width="340" height="223" alt="image" src="https://github.com/user-attachments/assets/25fc48da-e087-432e-8c94-d32b522d229e" />
