### PR TITLE
fix(tracemetrics): Filter out and disable rate aggregates in equations

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/index.spec.tsx
@@ -143,6 +143,47 @@ describe('MetricsEquationVisualize', () => {
     expect(equationDeleteButton).toBeDisabled();
   });
 
+  it('replaces rate aggregates with defaults and deduplicates', async () => {
+    render(<MetricsEquationVisualize />, {
+      organization: OrganizationFixture({features: EQUATION_FEATURES}),
+      additionalWrapper: WidgetBuilderProvider,
+      initialRouterConfig: {
+        location: {
+          pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+          query: {
+            dataset: WidgetType.TRACEMETRICS,
+            displayType: DisplayType.LINE,
+            yAxis: [
+              'per_second(value,alpha_metric,counter,none)',
+              'per_minute(value,alpha_metric,counter,none)',
+              'per_second(value,beta_metric,counter,none)',
+            ],
+          },
+        },
+      },
+    });
+
+    const toolbars = await screen.findAllByTestId('metric-toolbar');
+    // per_second and per_minute on alpha_metric both collapse to sum → deduplicated to 1 row
+    // per_second on beta_metric collapses to sum → 1 row
+    // + equation row = 3 total
+    expect(toolbars).toHaveLength(3);
+
+    // Row A: alpha_metric with default aggregate (sum for counter)
+    expect(within(toolbars[0]!).getByText('A')).toBeInTheDocument();
+    expect(
+      within(toolbars[0]!).getByRole('button', {name: 'alpha_metric'})
+    ).toBeInTheDocument();
+    expect(within(toolbars[0]!).getByText('sum')).toBeInTheDocument();
+
+    // Row B: beta_metric with default aggregate (sum for counter)
+    expect(within(toolbars[1]!).getByText('B')).toBeInTheDocument();
+    expect(
+      within(toolbars[1]!).getByRole('button', {name: 'beta_metric'})
+    ).toBeInTheDocument();
+    expect(within(toolbars[1]!).getByText('sum')).toBeInTheDocument();
+  });
+
   it('hydrates initial rows from a saved equation widget', async () => {
     render(<MetricsEquationVisualize />, {
       organization: OrganizationFixture({features: EQUATION_FEATURES}),

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/index.tsx
@@ -4,6 +4,7 @@ import {defined} from 'sentry/utils/defined';
 import {generateFieldAsString} from 'sentry/utils/discover/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {MetricQueryRows} from 'sentry/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricQueryRows';
+import {prepareQueriesForEquationMode} from 'sentry/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/utils';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import type {EquationModeSnapshot} from 'sentry/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState';
 import {getTraceMetricAggregateSource} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
@@ -70,13 +71,15 @@ export function MetricsEquationVisualize({
 
     // Otherwise, we parse each function to get the available metric queries and
     // add a default equation row
-    const metricQueries = (aggregateSource ?? [])
-      .filter(f => f.kind === FieldValueKind.FUNCTION)
-      .map(f => {
-        const parsed = parseAggregateExpression(generateFieldAsString(f));
-        return parsed.metricQueries[0];
-      })
-      .filter(defined);
+    const metricQueries = prepareQueriesForEquationMode(
+      (aggregateSource ?? [])
+        .filter(f => f.kind === FieldValueKind.FUNCTION)
+        .map(f => {
+          const parsed = parseAggregateExpression(generateFieldAsString(f));
+          return parsed.metricQueries[0];
+        })
+        .filter(defined)
+    );
     if (metricQueries.length === 0) {
       metricQueries.push(defaultMetricQuery());
     }

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricToolbar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricToolbar.tsx
@@ -7,6 +7,7 @@ import {Radio} from '@sentry/scraps/radio';
 import {Expression} from 'sentry/components/arithmeticBuilder/expression';
 import {t} from 'sentry/locale';
 import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
+import {RATE_AGGREGATES} from 'sentry/views/explore/metrics/constants';
 import {EquationBuilder} from 'sentry/views/explore/metrics/equationBuilder';
 import {extractReferenceLabels} from 'sentry/views/explore/metrics/equationBuilder/utils';
 import {
@@ -25,6 +26,13 @@ import {
   isVisualizeEquation,
   isVisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
+
+const RATE_AGGREGATE_DISABLED_REASON = t(
+  'Rate aggregates are not supported in equations'
+);
+const DISABLED_EQUATION_AGGREGATES: Record<string, string> = Object.fromEntries(
+  [...RATE_AGGREGATES].map(agg => [agg, RATE_AGGREGATE_DISABLED_REASON])
+);
 
 const GRID_COLUMNS = 'auto 1fr auto';
 
@@ -95,7 +103,11 @@ export function MetricToolbar({
               />
             </Flex>
             <Flex flex="1" minWidth="0">
-              <AggregateDropdown traceMetric={traceMetric} singleSelect />
+              <AggregateDropdown
+                traceMetric={traceMetric}
+                singleSelect
+                disabledAggregates={DISABLED_EQUATION_AGGREGATES}
+              />
             </Flex>
           </Fragment>
         ) : isEquation ? (

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/utils.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/utils.spec.tsx
@@ -1,0 +1,102 @@
+import {defaultMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+
+import {prepareQueriesForEquationMode} from './utils';
+
+function makeQuery(aggregate: string, metricName: string, metricType: string) {
+  return {
+    metric: {name: metricName, type: metricType},
+    queryParams: new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.SAMPLES,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [
+        new VisualizeFunction(`${aggregate}(value,${metricName},${metricType},none)`),
+      ],
+      aggregateSortBys: [
+        {
+          field: `${aggregate}(value,${metricName},${metricType},none)`,
+          kind: 'desc' as const,
+        },
+      ],
+    }),
+  };
+}
+
+describe('prepareQueriesForEquationMode', () => {
+  it('replaces per_second with the default aggregate for the metric type', () => {
+    const queries = [makeQuery('per_second', 'my_counter', 'counter')];
+    const result = prepareQueriesForEquationMode(queries);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.queryParams.visualizes[0]?.yAxis).toBe(
+      'sum(value,my_counter,counter,none)'
+    );
+  });
+
+  it('replaces per_minute with the default aggregate for the metric type', () => {
+    const queries = [makeQuery('per_minute', 'my_gauge', 'gauge')];
+    const result = prepareQueriesForEquationMode(queries);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.queryParams.visualizes[0]?.yAxis).toBe(
+      'avg(value,my_gauge,gauge,none)'
+    );
+  });
+
+  it('does not modify non-rate aggregates', () => {
+    const queries = [
+      makeQuery('sum', 'my_counter', 'counter'),
+      makeQuery('p50', 'my_dist', 'distribution'),
+    ];
+    const result = prepareQueriesForEquationMode(queries);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]!.queryParams.visualizes[0]?.yAxis).toBe(
+      'sum(value,my_counter,counter,none)'
+    );
+    expect(result[1]!.queryParams.visualizes[0]?.yAxis).toBe(
+      'p50(value,my_dist,distribution,none)'
+    );
+  });
+
+  it('deduplicates queries that collapse to the same yAxis after replacement', () => {
+    const queries = [
+      makeQuery('per_second', 'my_counter', 'counter'),
+      makeQuery('per_minute', 'my_counter', 'counter'),
+    ];
+    const result = prepareQueriesForEquationMode(queries);
+
+    // Both collapse to sum(value,my_counter,counter,none)
+    expect(result).toHaveLength(1);
+    expect(result[0]!.queryParams.visualizes[0]?.yAxis).toBe(
+      'sum(value,my_counter,counter,none)'
+    );
+  });
+
+  it('keeps distinct metrics even after rate aggregate replacement', () => {
+    const queries = [
+      makeQuery('per_second', 'metric_a', 'counter'),
+      makeQuery('per_second', 'metric_b', 'counter'),
+    ];
+    const result = prepareQueriesForEquationMode(queries);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]!.metric.name).toBe('metric_a');
+    expect(result[1]!.metric.name).toBe('metric_b');
+  });
+
+  it('passes through equation queries unchanged', () => {
+    const equationQuery = defaultMetricQuery({type: 'equation'});
+    const result = prepareQueriesForEquationMode([equationQuery]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(equationQuery);
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/utils.tsx
@@ -1,9 +1,52 @@
+import uniqBy from 'lodash/uniqBy';
+
 import {explodeFieldString, type Column} from 'sentry/utils/discover/fields';
 import type {DisplayType} from 'sentry/views/dashboards/types';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {getTraceMetricAggregateActionType} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
+import {
+  DEFAULT_YAXIS_BY_TYPE,
+  RATE_AGGREGATES,
+} from 'sentry/views/explore/metrics/constants';
+import type {BaseMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
+import {updateVisualizeYAxis} from 'sentry/views/explore/metrics/utils';
+import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {isVisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+
+/**
+ * Prepares series-mode metric queries for use in equation mode by replacing
+ * rate aggregates with defaults and removing duplicates that result from
+ * the replacement.
+ */
+export function prepareQueriesForEquationMode(
+  queries: BaseMetricQuery[]
+): BaseMetricQuery[] {
+  const replaced = queries.map(query => {
+    const visualize = query.queryParams.visualizes[0];
+    if (!visualize || !isVisualizeFunction(visualize)) {
+      return query;
+    }
+    const aggName = visualize.parsedFunction?.name;
+    if (!aggName || !RATE_AGGREGATES.has(aggName)) {
+      return query;
+    }
+    const defaultAgg = DEFAULT_YAXIS_BY_TYPE[query.metric.type] ?? 'sum';
+    const newVisualize = updateVisualizeYAxis(visualize, defaultAgg, query.metric);
+    return {
+      ...query,
+      queryParams: query.queryParams.replace({
+        aggregateFields: [
+          newVisualize,
+          ...query.queryParams.aggregateFields.filter(isGroupBy),
+        ],
+      }),
+    };
+  });
+
+  return uniqBy(replaced, query => query.queryParams.visualizes[0]?.yAxis);
+}
 
 // Triggers a y-axis update using the correct action type based on the display type.
 export function dispatchYAxisUpdate(

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/utils.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/utils.tsx
@@ -24,28 +24,39 @@ export function prepareQueriesForEquationMode(
   queries: BaseMetricQuery[]
 ): BaseMetricQuery[] {
   const replaced = queries.map(query => {
-    const visualize = query.queryParams.visualizes[0];
-    if (!visualize || !isVisualizeFunction(visualize)) {
+    const visualizes = query.queryParams.visualizes;
+    let changed = false;
+    const newVisualizes = visualizes.map(visualize => {
+      if (!isVisualizeFunction(visualize)) {
+        return visualize;
+      }
+      const aggName = visualize.parsedFunction?.name;
+      if (!aggName || !RATE_AGGREGATES.has(aggName)) {
+        return visualize;
+      }
+      changed = true;
+      const defaultAgg = DEFAULT_YAXIS_BY_TYPE[query.metric.type] ?? 'sum';
+      return updateVisualizeYAxis(visualize, defaultAgg, query.metric);
+    });
+
+    if (!changed) {
       return query;
     }
-    const aggName = visualize.parsedFunction?.name;
-    if (!aggName || !RATE_AGGREGATES.has(aggName)) {
-      return query;
-    }
-    const defaultAgg = DEFAULT_YAXIS_BY_TYPE[query.metric.type] ?? 'sum';
-    const newVisualize = updateVisualizeYAxis(visualize, defaultAgg, query.metric);
+
     return {
       ...query,
       queryParams: query.queryParams.replace({
         aggregateFields: [
-          newVisualize,
+          ...newVisualizes,
           ...query.queryParams.aggregateFields.filter(isGroupBy),
         ],
       }),
     };
   });
 
-  return uniqBy(replaced, query => query.queryParams.visualizes[0]?.yAxis);
+  return uniqBy(replaced, query =>
+    JSON.stringify(query.queryParams.visualizes.map(v => v.yAxis).sort())
+  );
 }
 
 // Triggers a y-axis update using the correct action type based on the display type.

--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
@@ -15,7 +15,10 @@ import {
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {WidgetType} from 'sentry/views/dashboards/types';
-import {dispatchYAxisUpdate} from 'sentry/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/utils';
+import {
+  dispatchYAxisUpdate,
+  prepareQueriesForEquationMode,
+} from 'sentry/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/utils';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {
@@ -146,13 +149,15 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
         state.fields
       );
 
-      const queries = (aggregateSource ?? [])
-        .filter(f => f.kind === FieldValueKind.FUNCTION)
-        .map(f => {
-          const parsed = parseAggregateExpression(generateFieldAsString(f));
-          return parsed.metricQueries[0] ?? defaultMetricQuery();
-        })
-        .filter(Boolean);
+      const queries = prepareQueriesForEquationMode(
+        (aggregateSource ?? [])
+          .filter(f => f.kind === FieldValueKind.FUNCTION)
+          .map(f => {
+            const parsed = parseAggregateExpression(generateFieldAsString(f));
+            return parsed.metricQueries[0] ?? defaultMetricQuery();
+          })
+          .filter(Boolean)
+      );
       if (queries.length === 0) {
         queries.push(defaultMetricQuery());
       }

--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -347,6 +347,8 @@ export const DEFAULT_YAXIS_BY_TYPE: Record<string, string> = {
   gauge: 'avg',
 };
 
+export const RATE_AGGREGATES = new Set(['per_second', 'per_minute']);
+
 /**
  * Query parameter key for controlling the metrics drawer state.
  * When this parameter is set to 'true', the metrics drawer should open automatically.

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
@@ -536,6 +536,52 @@ describe('AggregateDropdown', () => {
     });
   });
 
+  it('disables aggregate options specified in disabledAggregates with tooltips', async () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-enabled'],
+    });
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.SAMPLES,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [new VisualizeFunction('sum(value,test_metric,counter,none)')],
+      aggregateSortBys: [{field: 'sum(value,test_metric,counter,none)', kind: 'desc'}],
+    });
+
+    render(
+      <AggregateDropdown
+        traceMetric={{name: 'test_metric', type: 'counter'}}
+        disabledAggregates={{
+          per_second: 'Rate aggregates are not supported in equations',
+          per_minute: 'Rate aggregates are not supported in equations',
+        }}
+      />,
+      {
+        organization,
+        additionalWrapper: createWrapper({
+          queryParams,
+          traceMetric: {name: 'test_metric', type: 'counter'},
+        }),
+      }
+    );
+
+    const trigger = screen.getByRole('button', {name: /Agg/});
+    await userEvent.click(trigger);
+
+    const perSecondOption = await screen.findByRole('option', {name: 'per_second'});
+    const perMinuteOption = screen.getByRole('option', {name: 'per_minute'});
+    const sumOption = screen.getByRole('option', {name: 'sum'});
+
+    expect(perSecondOption).toHaveAttribute('aria-disabled', 'true');
+    expect(perMinuteOption).toHaveAttribute('aria-disabled', 'true');
+    expect(sumOption).not.toHaveAttribute('aria-disabled');
+  });
+
   it('renders all groups as single-select and keeps only the last selection when singleSelect is passed', async () => {
     const organization = OrganizationFixture({
       features: ['tracemetrics-enabled'],

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useMemo} from 'react';
 
 import {Badge} from '@sentry/scraps/badge';
 import {
@@ -28,8 +28,10 @@ export function AggregateDropdown({
   traceMetric,
   singleSelect = false,
   disabledReason,
+  disabledAggregates,
 }: {
   traceMetric: TraceMetric;
+  disabledAggregates?: Record<string, string>;
   disabledReason?: string;
   singleSelect?: boolean;
 }) {
@@ -38,7 +40,24 @@ export function AggregateDropdown({
   const setMetricVisualizes = useSetMetricVisualizes();
   const isDisabled = disabledReason !== undefined;
 
-  const groups = GROUPED_OPTIONS_BY_TYPE[traceMetric.type] ?? [];
+  const groups = useMemo(() => {
+    const allGroups = GROUPED_OPTIONS_BY_TYPE[traceMetric.type] ?? [];
+    if (!disabledAggregates) {
+      return allGroups;
+    }
+    return allGroups.map(group => ({
+      ...group,
+      options: group.options.map(opt =>
+        disabledAggregates[opt.value]
+          ? {
+              ...opt,
+              disabled: true,
+              tooltip: disabledAggregates[opt.value],
+            }
+          : opt
+      ),
+    }));
+  }, [traceMetric.type, disabledAggregates]);
   const selectedNames = new Set(
     visualizes.map(v => (isVisualizeFunction(v) ? (v.parsedFunction?.name ?? '') : ''))
   );


### PR DESCRIPTION
Rates aren't valid operands for equations, so disable them and replace the aggregations with the defaults when transitioning from series into the initialized equations mode.

This PR adds:
1. A helper that reads the metric queries when switching to Equation mode and replaces rate aggregates with the default for the metric type, and then de-dupes the results
2. Threads through a way to pass disabled aggregates to the aggregate selector and render a tooltip in the UI, preventing users from selecting it
3. Tests for replacement and de-duplication at both the helper and aggregate selector level

This was mostly prompted by Claude but I agree with the implementation