### PR TITLE
fix(action-log): Only send updates for columns that change

### DIFF
--- a/src/sentry/issues/derived/framework.py
+++ b/src/sentry/issues/derived/framework.py
@@ -144,10 +144,19 @@ class StateUpdate(_FeatureStore):
 class State(_FeatureStore):
     """Complete pipeline state."""
 
+    def __init__(self, data: dict[Feature[Any], Any] | None = None) -> None:
+        super().__init__(data)
+        self._dirty: set[Feature[Any]] = set()
+
+    @property
+    def dirty(self) -> frozenset[Feature[Any]]:
+        return frozenset(self._dirty)
+
     def view(self, allowed: frozenset[Feature[Any]]) -> "StateView":
         return StateView(self._data, allowed)
 
     def merge(self, update: StateUpdate) -> None:
+        self._dirty.update(update._data)
         self._data.update(update._data)
 
     def items(self) -> Iterator[tuple[str, Any]]:

--- a/src/sentry/issues/derived/framework.py
+++ b/src/sentry/issues/derived/framework.py
@@ -146,17 +146,18 @@ class State(_FeatureStore):
 
     def __init__(self, data: dict[Feature[Any], Any] | None = None) -> None:
         super().__init__(data)
-        self._dirty: set[Feature[Any]] = set()
+        self._updated: set[Feature[Any]] = set()
 
     @property
-    def dirty(self) -> frozenset[Feature[Any]]:
-        return frozenset(self._dirty)
+    def updated(self) -> frozenset[Feature[Any]]:
+        """Features that aggregators have provided updates for via merge()."""
+        return frozenset(self._updated)
 
     def view(self, allowed: frozenset[Feature[Any]]) -> "StateView":
         return StateView(self._data, allowed)
 
     def merge(self, update: StateUpdate) -> None:
-        self._dirty.update(update._data)
+        self._updated.update(update._data)
         self._data.update(update._data)
 
     def items(self) -> Iterator[tuple[str, Any]]:

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -109,6 +109,11 @@ def _process_batch(
     ).update(cursor_date=last_date, cursor_id=last_id, **state_update)
 
     if updated:
+        # Features updated in this batch (not total; a feature appears at most once per batch)
+        for f in result.updated:
+            metrics.incr(
+                "issues.derived.feature_updated", sample_rate=1.0, tags={"feature": f.name}
+            )
         derived.cursor_date = last_date
         derived.cursor_id = last_id
         GroupDerivedDataStore.apply_to_instance(derived, state_update)
@@ -146,7 +151,7 @@ def process_group_log_batch(
     batch_size: int = INLINE_BATCH_SIZE,
     target_pipeline: Pipeline[GroupActionLogEntry] | None = None,
 ) -> ProcessResult:
-    """Process a single batch of pending entries. Schedules a task if not caught up.
+    """Process a single batch of pending entries.
 
     Raises Group.DoesNotExist if the group has been deleted.
     """

--- a/src/sentry/issues/derived/store.py
+++ b/src/sentry/issues/derived/store.py
@@ -47,16 +47,21 @@ class GroupDerivedDataStore:
     @staticmethod
     def build_update(pipeline: Pipeline[Any], state: State) -> dict[str, Any]:
         fields_by_name = {f.name: f for f in pipeline.features}
+        dirty = state.dirty
         json_data: dict[str, Any] = {}
+        has_json = False
         update: dict[str, Any] = {}
         for name, val in state.items():
             f = fields_by_name[name]
             column = COLUMN_MAP.get(f)
             if column:
-                update[column] = f.dump(val)
+                if f in dirty:
+                    update[column] = f.dump(val)
             else:
                 json_data[name] = f.dump(val)
-        update["data"] = json_data
+                has_json = True
+        if has_json:
+            update["data"] = json_data
         return update
 
     @staticmethod

--- a/src/sentry/issues/derived/store.py
+++ b/src/sentry/issues/derived/store.py
@@ -46,22 +46,22 @@ class GroupDerivedDataStore:
 
     @staticmethod
     def build_update(pipeline: Pipeline[Any], state: State) -> dict[str, Any]:
-        fields_by_name = {f.name: f for f in pipeline.features}
-        dirty = state.dirty
-        json_data: dict[str, Any] = {}
-        has_json = False
+        """Build a dict of model fields to persist.
+
+        Only includes columns and JSON-blob data that aggregators actually
+        updated.
+        """
+        updated = state.updated
+        json_features = [f for f in pipeline.features if f not in COLUMN_MAP]
+
         update: dict[str, Any] = {}
-        for name, val in state.items():
-            f = fields_by_name[name]
+        for f in pipeline.features:
             column = COLUMN_MAP.get(f)
-            if column:
-                if f in dirty:
-                    update[column] = f.dump(val)
-            else:
-                json_data[name] = f.dump(val)
-                has_json = True
-        if has_json:
-            update["data"] = json_data
+            if column and f in updated:
+                update[column] = f.dump(state[f])
+        # If any JSON feature was updated, include all of them (the blob is replaced wholesale)
+        if updated.intersection(json_features):
+            update["data"] = {f.name: f.dump(state[f]) for f in json_features}
         return update
 
     @staticmethod

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -26,6 +26,7 @@ from sentry.issues.derived.framework import (
     AggregatorResult,
     Feature,
     Pipeline,
+    StateUpdate,
     StateView,
     aggregator,
 )
@@ -343,15 +344,39 @@ class GroupDerivedDataStoreTest(TestCase):
 
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(user.id))
         _publish(group=group, action=ResolveAction(), actor=GroupActionActor.user(user.id))
-        derived = process_group_log(group.id)
+        first = process_group_log(group.id)
 
-        state = GroupDerivedDataStore.load(PIPELINE, derived)
+        first_data = first.data.copy()
+        first_view_count = first.view_count
+        first_progress = first.progress
+        first_last_progressed_at = first.last_progressed_at
+
+        invalidate_group_derived_data(group.id)
+        second = process_group_log(group.id)
+
+        assert second.data == first_data
+        assert second.view_count == first_view_count
+        assert second.progress == first_progress
+        assert second.last_progressed_at == first_last_progressed_at
+
+    def test_build_update_excludes_unchanged_columns(self) -> None:
+        state = PIPELINE.initial_state()
+
+        # Dirty only STATUS (lives in JSON) — column features stay clean
+        state.merge(StateUpdate({STATUS: IssueStatus.CLOSED}))
+
         update = GroupDerivedDataStore.build_update(PIPELINE, state)
 
-        assert update["data"] == derived.data
-        assert update["view_count"] == derived.view_count
-        assert update["progress"] == derived.progress
-        assert update["last_progressed_at"] == derived.last_progressed_at
+        assert "view_count" not in update
+        assert "progress" not in update
+        assert "last_progressed_at" not in update
+        assert "data" in update
+        assert update["data"]["status"] == "closed"
+
+        # Dirty a column-mapped feature — it should appear in the update
+        state.merge(StateUpdate({VIEW_COUNT: 5}))
+        update = GroupDerivedDataStore.build_update(PIPELINE, state)
+        assert update["view_count"] == 5
 
     def test_progress_round_trip(self) -> None:
         group = self.create_group()

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -26,6 +26,7 @@ from sentry.issues.derived.framework import (
     AggregatorResult,
     Feature,
     Pipeline,
+    State,
     StateUpdate,
     StateView,
     aggregator,
@@ -163,7 +164,8 @@ class ProcessGroupLogTest(TestCase):
 
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
         derived = process_group_log(group.id)
-        assert derived.data["status"] == "open"
+        state = GroupDerivedDataStore.load(PIPELINE, derived)
+        assert state[STATUS] == IssueStatus.OPEN
 
     def test_resolve_closes(self) -> None:
         group = self.create_group()
@@ -197,7 +199,8 @@ class ProcessGroupLogTest(TestCase):
 
         _publish(group=group, action=UnresolveAction(), actor=GroupActionActor.user(user.id))
         derived = process_group_log(group.id)
-        assert derived.data["status"] == "open"
+        state = GroupDerivedDataStore.load(PIPELINE, derived)
+        assert state[STATUS] == IssueStatus.OPEN
 
     def test_status_toggle(self) -> None:
         group = self.create_group()
@@ -287,6 +290,37 @@ def test_mutation_checking_catches_in_place_mutation() -> None:
         p.step(state, FakeEntry())
 
 
+def test_state_updated_tracks_merged_features() -> None:
+    A = Feature[int]("a", default=0)
+    B = Feature[int]("b", default=0)
+    state = State({A: 0, B: 0})
+
+    assert state.updated == frozenset()
+
+    state.merge(StateUpdate({A: 1}))
+    assert state.updated == frozenset({A})
+    assert state[A] == 1
+    assert state[B] == 0
+
+
+def test_build_update_json_blob_includes_all_json_features() -> None:
+    A = Feature[int]("a", default=0)
+    B = Feature[int]("b", default=0)
+
+    @aggregator((A, B))
+    def compute(state: StateView, entry: object) -> AggregatorResult:
+        return None
+
+    pipeline = Pipeline([compute], version=1)
+    state = pipeline.initial_state()
+
+    # Update only A — blob should still contain both A and B
+    state.merge(StateUpdate({A: 1}))
+    update = GroupDerivedDataStore.build_update(pipeline, state)
+
+    assert update["data"] == {"a": 1, "b": 0}
+
+
 def test_store_apply_to_instance() -> None:
     derived = GroupDerivedData()
     derived.data = {}
@@ -359,10 +393,10 @@ class GroupDerivedDataStoreTest(TestCase):
         assert second.progress == first_progress
         assert second.last_progressed_at == first_last_progressed_at
 
-    def test_build_update_excludes_unchanged_columns(self) -> None:
+    def test_build_update_only_includes_updated_features(self) -> None:
         state = PIPELINE.initial_state()
 
-        # Dirty only STATUS (lives in JSON) — column features stay clean
+        # Update only STATUS (lives in JSON) — column features stay clean
         state.merge(StateUpdate({STATUS: IssueStatus.CLOSED}))
 
         update = GroupDerivedDataStore.build_update(PIPELINE, state)
@@ -373,10 +407,21 @@ class GroupDerivedDataStoreTest(TestCase):
         assert "data" in update
         assert update["data"]["status"] == "closed"
 
-        # Dirty a column-mapped feature — it should appear in the update
+        # Update a column-mapped feature — it should appear in the update
         state.merge(StateUpdate({VIEW_COUNT: 5}))
         update = GroupDerivedDataStore.build_update(PIPELINE, state)
         assert update["view_count"] == 5
+
+    def test_build_update_excludes_json_blob_when_no_json_features_updated(self) -> None:
+        state = PIPELINE.initial_state()
+
+        # Update only a column-mapped feature — JSON blob should be excluded
+        state.merge(StateUpdate({VIEW_COUNT: 3}))
+
+        update = GroupDerivedDataStore.build_update(PIPELINE, state)
+
+        assert update["view_count"] == 3
+        assert "data" not in update
 
     def test_progress_round_trip(self) -> None:
         group = self.create_group()


### PR DESCRIPTION
This isn't particularly important in terms of performance or correctness; the columns are small and postgres can do no-op updates efficiently, and this isn't expected to change behavior.
Still, it seems odd to update everything every time when it's easy not to, and minimal updates make it possible for us to add tracking for which specific features were modified trivially.

Fixes ISWF-2900.
