### PR TITLE
ref(profiling): document chunks project param as ID-or-slug, not int

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -201,8 +201,8 @@ CHUNKS_PROJECT_PARAM = OpenApiParameter(
     name="project",
     location="query",
     required=True,
-    type=int,
-    description="The ID of the project to fetch chunks for. Exactly one project must be specified.",
+    type=str,
+    description="The ID or slug of the project to fetch chunks for. Exactly one project must be specified.",
 )
 
 


### PR DESCRIPTION
## What

The profiling **chunks** endpoint (`GET /organizations/{org}/profiling/chunks/`) declares its `project` query param as `type=int` ("The ID of the project"), while the sibling **flamegraph** endpoint — same base class (`OrganizationProfilingBaseEndpoint`), same `get_snuba_params` parsing — documents the same `project` param via `OrganizationParams.PROJECT` as accepting **IDs or slugs**.

The runtime already resolves slugs → numeric project ids in `get_snuba_params` (Snuba only ever receives numeric ids), so `type=int` is an **under-specification**, not a real numeric-only contract.

This changes it to `type=str` ("ID or slug"), keeping the existing "exactly one project must be specified" semantics (still enforced in the handler).

## Why it matters (downstream)

The generated [`@sentry/api`](https://github.com/getsentry/sentry-api-schema) SDK typed chunks' `project` as a scalar `number`. Consumers (e.g. **sentry-mcp**) therefore coerced input with `Number(projectId)` — which turns a project **slug** into `NaN` and breaks slug-based profile-chunk lookups. With this change the SDK regenerates `project` as a string, so consumers can forward an ID or slug directly (no coercion, no cast).

## Scope

- Pure OpenAPI-declaration change in one `OpenApiParameter`. **No runtime behavior change** — the handler and `get_snuba_params` are untouched.
- Not a Snuba change: slug→id resolution lives in sentry's `get_snuba_params`; Snuba receives numeric ids regardless.

## Verification

`sentry django spectacular --validate --fail-on-warn` is clean, and the generated `project` param schema is now `{"type": "string"}` (was `integer`), with the description updated to "ID or slug". The frontend calls this endpoint via PageFilters (numeric project ids), which remain valid.

cc @getsentry/profiling (owners) — flagging in case the scalar `int` was intentional; if chunks is meant to be numeric-only, happy to instead align the consumer side, but the shared runtime + the flamegraph sibling suggest IDs-or-slugs is correct.
