### PR TITLE
fix(seer): show GitLab icon for GitLab SCM links in evidence UI

### DIFF
--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -3,10 +3,9 @@ import type {LocationDescriptor} from 'history';
 
 import {LinkButton} from '@sentry/scraps/button';
 
+import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
 import {IconCompass} from 'sentry/icons/iconCompass';
 import {IconFile} from 'sentry/icons/iconFile';
-import {IconGithub} from 'sentry/icons/iconGithub';
-import {IconGitlab} from 'sentry/icons/iconGitlab';
 import {IconIssues} from 'sentry/icons/iconIssues';
 import {IconPlay} from 'sentry/icons/iconPlay';
 import {IconProfiling} from 'sentry/icons/iconProfiling';
@@ -310,13 +309,6 @@ function getCodeSearchEvidenceProps({
   return null;
 }
 
-function getScmIcon(provider: string | undefined): ReactNode {
-  if (provider === 'integrations:gitlab') {
-    return <IconGitlab />;
-  }
-  return <IconGithub />;
-}
-
 function getGitSearchEvidenceProps({
   toolLink,
 }: GetEvidencePropsPayload): EvidenceButtonProps | null {
@@ -334,7 +326,7 @@ function getGitSearchEvidenceProps({
   if (typeof commit_url === 'string' && typeof sha === 'string') {
     return {
       href: commit_url,
-      icon: getScmIcon(provider),
+      icon: <RepoProviderIcon provider={provider ?? 'integrations:github'} />,
       label: t('Commit: %s', truncateText(getShortCommitHash(sha))),
       tooltip: sha,
     };
@@ -350,7 +342,7 @@ function getGitSearchEvidenceProps({
       typeof file_path === 'string' ? extractFileName(file_path) : undefined;
     return {
       href: commits_url,
-      icon: getScmIcon(provider),
+      icon: <RepoProviderIcon provider={provider ?? 'integrations:github'} />,
       label: t('Commits: %s', fileName ? truncateText(fileName) : repo_name),
       tooltip: (
         <Fragment>

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -310,14 +310,9 @@ function getCodeSearchEvidenceProps({
   return null;
 }
 
-function getScmIcon(url: string): ReactNode {
-  try {
-    const {hostname} = new URL(url);
-    if (hostname.includes('gitlab')) {
-      return <IconGitlab />;
-    }
-  } catch {
-    // fall through to default
+function getScmIcon(provider: string | undefined): ReactNode {
+  if (provider === 'integrations:gitlab') {
+    return <IconGitlab />;
   }
   return <IconGithub />;
 }
@@ -325,13 +320,13 @@ function getScmIcon(url: string): ReactNode {
 function getGitSearchEvidenceProps({
   toolLink,
 }: GetEvidencePropsPayload): EvidenceButtonProps | null {
-  const {repo_name, commit_url, sha, commits_url, start_date, end_date, file_path} =
+  const {repo_name, commit_url, sha, commits_url, start_date, end_date, file_path, provider} =
     toolLink?.params ?? {};
 
   if (typeof commit_url === 'string' && typeof sha === 'string') {
     return {
       href: commit_url,
-      icon: getScmIcon(commit_url),
+      icon: getScmIcon(provider),
       label: t('Commit: %s', truncateText(getShortCommitHash(sha))),
       tooltip: sha,
     };
@@ -347,7 +342,7 @@ function getGitSearchEvidenceProps({
       typeof file_path === 'string' ? extractFileName(file_path) : undefined;
     return {
       href: commits_url,
-      icon: getScmIcon(commits_url),
+      icon: getScmIcon(provider),
       label: t('Commits: %s', fileName ? truncateText(fileName) : repo_name),
       tooltip: (
         <Fragment>

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -6,6 +6,7 @@ import {LinkButton} from '@sentry/scraps/button';
 import {IconCompass} from 'sentry/icons/iconCompass';
 import {IconFile} from 'sentry/icons/iconFile';
 import {IconGithub} from 'sentry/icons/iconGithub';
+import {IconGitlab} from 'sentry/icons/iconGitlab';
 import {IconIssues} from 'sentry/icons/iconIssues';
 import {IconPlay} from 'sentry/icons/iconPlay';
 import {IconProfiling} from 'sentry/icons/iconProfiling';
@@ -309,6 +310,18 @@ function getCodeSearchEvidenceProps({
   return null;
 }
 
+function getScmIcon(url: string): ReactNode {
+  try {
+    const {hostname} = new URL(url);
+    if (hostname.includes('gitlab')) {
+      return <IconGitlab />;
+    }
+  } catch {
+    // fall through to default
+  }
+  return <IconGithub />;
+}
+
 function getGitSearchEvidenceProps({
   toolLink,
 }: GetEvidencePropsPayload): EvidenceButtonProps | null {
@@ -318,7 +331,7 @@ function getGitSearchEvidenceProps({
   if (typeof commit_url === 'string' && typeof sha === 'string') {
     return {
       href: commit_url,
-      icon: <IconGithub />, // TODO: support other SCMs
+      icon: getScmIcon(commit_url),
       label: t('Commit: %s', truncateText(getShortCommitHash(sha))),
       tooltip: sha,
     };
@@ -334,7 +347,7 @@ function getGitSearchEvidenceProps({
       typeof file_path === 'string' ? extractFileName(file_path) : undefined;
     return {
       href: commits_url,
-      icon: <IconGithub />, // TODO: support other SCMs
+      icon: getScmIcon(commits_url),
       label: t('Commits: %s', fileName ? truncateText(fileName) : repo_name),
       tooltip: (
         <Fragment>

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -320,8 +320,16 @@ function getScmIcon(provider: string | undefined): ReactNode {
 function getGitSearchEvidenceProps({
   toolLink,
 }: GetEvidencePropsPayload): EvidenceButtonProps | null {
-  const {repo_name, commit_url, sha, commits_url, start_date, end_date, file_path, provider} =
-    toolLink?.params ?? {};
+  const {
+    repo_name,
+    commit_url,
+    sha,
+    commits_url,
+    start_date,
+    end_date,
+    file_path,
+    provider,
+  } = toolLink?.params ?? {};
 
   if (typeof commit_url === 'string' && typeof sha === 'string') {
     return {


### PR DESCRIPTION
## Problem

`git_search` tool links hardcoded `<IconGithub />` for all SCM providers.

## Change

Reads `params.provider` (e.g. `'integrations:gitlab'`) from the tool link params and passes it to `getScmIcon()`. Returns `<IconGitlab />` for GitLab, `<IconGithub />` for everything else.

Using the explicit provider string (rather than URL hostname sniffing) means this works correctly for self-hosted GitLab instances whose domain doesn't contain `'gitlab'`.

Depends on getsentry/seer#7031 which adds `provider` to the `git_search` tool link params.

Companion backend fix: #118054

Fixes https://linear.app/getsentry/issue/CW-1528

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC013P75SQUB%3A1781810595.615099%22)