### PR TITLE
chore(cells): Updates error-embed URL to point to control by default 

### DIFF
--- a/src/sentry/feedback/endpoints/error_page_embed.py
+++ b/src/sentry/feedback/endpoints/error_page_embed.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Callable
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
 from django import forms
 from django.conf import settings
@@ -27,7 +27,7 @@ from sentry.signals import user_feedback_received
 from sentry.types.cell import Cell, get_cell_by_name, get_local_locality
 from sentry.utils import json
 from sentry.utils.db import atomic_transaction
-from sentry.utils.http import is_valid_origin, origin_from_request
+from sentry.utils.http import absolute_uri, is_valid_origin, origin_from_request
 from sentry.utils.validators import normalize_event_id
 from sentry.web.frontend.base import cell_silo_view
 from sentry.web.helpers import render_to_response, render_to_string
@@ -266,7 +266,7 @@ class ErrorPageEmbedView(View):
             return self._smart_response(request, {"errors": dict(form.errors)}, status=400)
 
         if sentry_options.get("error-embeds.control-silo-address"):
-            endpoint = urljoin(sentry_options.get("system.url-prefix"), request.get_full_path())
+            endpoint = absolute_uri(request.get_full_path())
         else:
             endpoint = get_local_locality().to_url(request.get_full_path())
         show_branding = (

--- a/src/sentry/feedback/endpoints/error_page_embed.py
+++ b/src/sentry/feedback/endpoints/error_page_embed.py
@@ -24,7 +24,7 @@ from sentry.models.projectkey import ProjectKey
 from sentry.models.userreport import UserReport
 from sentry.services import eventstore
 from sentry.signals import user_feedback_received
-from sentry.types.cell import Cell, get_cell_by_name
+from sentry.types.cell import Cell, get_cell_by_name, get_local_locality
 from sentry.utils import json
 from sentry.utils.db import atomic_transaction
 from sentry.utils.http import is_valid_origin, origin_from_request
@@ -265,7 +265,10 @@ class ErrorPageEmbedView(View):
         elif request.method == "POST":
             return self._smart_response(request, {"errors": dict(form.errors)}, status=400)
 
-        endpoint = urljoin(sentry_options.get("system.url-prefix"), request.get_full_path())
+        if sentry_options.get("error-embeds.control-silo-address"):
+            endpoint = urljoin(sentry_options.get("system.url-prefix"), request.get_full_path())
+        else:
+            endpoint = get_local_locality().to_url(request.get_full_path())
         show_branding = (
             ProjectOption.objects.get_value(
                 project=key.project, key="feedback:branding", default="1"

--- a/src/sentry/feedback/endpoints/error_page_embed.py
+++ b/src/sentry/feedback/endpoints/error_page_embed.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Callable
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 from django import forms
 from django.conf import settings
@@ -14,7 +14,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from rest_framework.request import Request
 
-from sentry import options
+from sentry import options as sentry_options
 from sentry.feedback.lib.utils import FeedbackCreationSource
 from sentry.feedback.usecases.ingest.shim_to_feedback import shim_to_feedback
 from sentry.hybridcloud.apigateway.cell_request_resolvers import CellRequestResolver
@@ -24,7 +24,7 @@ from sentry.models.projectkey import ProjectKey
 from sentry.models.userreport import UserReport
 from sentry.services import eventstore
 from sentry.signals import user_feedback_received
-from sentry.types.cell import Cell, get_cell_by_name, get_local_locality
+from sentry.types.cell import Cell, get_cell_by_name
 from sentry.utils import json
 from sentry.utils.db import atomic_transaction
 from sentry.utils.http import is_valid_origin, origin_from_request
@@ -102,7 +102,7 @@ class ErrorEmbedResolver(CellRequestResolver):
         host = parsed.hostname
         if not host:
             return None
-        app_host = urlparse(options.get("system.url-prefix")).hostname
+        app_host = urlparse(sentry_options.get("system.url-prefix")).hostname
         if not app_host or not host.endswith(app_host):
             # Don't further parse URLs that aren't for us.
             return None
@@ -265,7 +265,7 @@ class ErrorPageEmbedView(View):
         elif request.method == "POST":
             return self._smart_response(request, {"errors": dict(form.errors)}, status=400)
 
-        endpoint = get_local_locality().to_url(request.get_full_path())
+        endpoint = urljoin(sentry_options.get("system.url-prefix"), request.get_full_path())
         show_branding = (
             ProjectOption.objects.get_value(
                 project=key.project, key="feedback:branding", default="1"

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3756,3 +3756,10 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "error-embeds.control-silo-address",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/feedback/endpoints/test_error_page_embed.py
+++ b/tests/sentry/feedback/endpoints/test_error_page_embed.py
@@ -26,7 +26,7 @@ from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.response import close_streaming_response
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
-from sentry.types.cell import Cell, get_cell_by_name, get_local_locality
+from sentry.types.cell import Cell, get_cell_by_name
 from sentry.utils import json
 
 
@@ -91,19 +91,28 @@ class ErrorPageEmbedTest(TestCase):
         assert resp["Access-Control-Allow-Origin"] == "*"
         self.assertTemplateUsed(resp, "sentry/error-page-embed.html")
 
-    def test_endpoint_reflects_region_url(self) -> None:
-        resp = self.client.get(
-            self.path_with_qs,
-            HTTP_REFERER="http://example.com",
-            HTTP_ACCEPT="text/html, text/javascript",
-        )
-        assert resp.status_code == 200, resp.content
-        assert resp["Access-Control-Allow-Origin"] == "*"
-        self.assertTemplateUsed(resp, "sentry/error-page-embed.html")
+    def test_endpoint_reflects_control_silo_url(self) -> None:
+        with mock.patch(
+            "sentry.feedback.endpoints.error_page_embed.sentry_options.get",
+            side_effect=lambda key: "http://controlsilo.testserver"
+            if key == "system.url-prefix"
+            else options.get(key),
+        ):
+            resp = self.client.get(
+                self.path_with_qs,
+                HTTP_REFERER="http://example.com",
+                HTTP_ACCEPT="text/html, text/javascript",
+            )
+            assert resp.status_code == 200, resp.content
+            assert resp["Access-Control-Allow-Origin"] == "*"
+            self.assertTemplateUsed(resp, "sentry/error-page-embed.html")
 
-        region_url = get_local_locality().to_url(self.path_with_qs)
-        body = resp.content.decode("utf8")
-        assert f'endpoint = /**/"{region_url}";/**/' in body
+            from urllib.parse import urljoin
+
+            control_url = urljoin("http://controlsilo.testserver", self.path_with_qs)
+            body = resp.content.decode("utf8")
+            # Endpoint should use the base control silo URL, not a locality-specific one
+            assert f'endpoint = /**/"{control_url}";/**/' in body
 
     def test_uses_locale_from_header(self) -> None:
         resp = self.client.get(

--- a/tests/sentry/feedback/endpoints/test_error_page_embed.py
+++ b/tests/sentry/feedback/endpoints/test_error_page_embed.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Callable
 from unittest import mock
-from urllib.parse import quote, urlencode, urlparse
+from urllib.parse import quote, urlencode, urljoin, urlparse
 from uuid import uuid4
 
 import pytest
@@ -23,6 +23,7 @@ from sentry.silo.base import SiloLimit, SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.apigateway import ApiGatewayTestCase
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.response import close_streaming_response
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
@@ -92,12 +93,7 @@ class ErrorPageEmbedTest(TestCase):
         self.assertTemplateUsed(resp, "sentry/error-page-embed.html")
 
     def test_endpoint_reflects_control_silo_url(self) -> None:
-        with mock.patch(
-            "sentry.feedback.endpoints.error_page_embed.sentry_options.get",
-            side_effect=lambda key: "http://controlsilo.testserver"
-            if key == "system.url-prefix"
-            else options.get(key),
-        ):
+        with override_options({"system.url-prefix": "http://controlsilo.testserver"}):
             resp = self.client.get(
                 self.path_with_qs,
                 HTTP_REFERER="http://example.com",
@@ -106,8 +102,6 @@ class ErrorPageEmbedTest(TestCase):
             assert resp.status_code == 200, resp.content
             assert resp["Access-Control-Allow-Origin"] == "*"
             self.assertTemplateUsed(resp, "sentry/error-page-embed.html")
-
-            from urllib.parse import urljoin
 
             control_url = urljoin("http://controlsilo.testserver", self.path_with_qs)
             body = resp.content.decode("utf8")

--- a/tests/sentry/feedback/endpoints/test_error_page_embed.py
+++ b/tests/sentry/feedback/endpoints/test_error_page_embed.py
@@ -27,7 +27,7 @@ from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.response import close_streaming_response
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
-from sentry.types.cell import Cell, get_cell_by_name
+from sentry.types.cell import Cell, get_cell_by_name, get_local_locality
 from sentry.utils import json
 
 
@@ -92,8 +92,27 @@ class ErrorPageEmbedTest(TestCase):
         assert resp["Access-Control-Allow-Origin"] == "*"
         self.assertTemplateUsed(resp, "sentry/error-page-embed.html")
 
-    def test_endpoint_reflects_control_silo_url(self) -> None:
-        with override_options({"system.url-prefix": "http://controlsilo.testserver"}):
+    def test_endpoint_reflects_region_url_by_default(self) -> None:
+        resp = self.client.get(
+            self.path_with_qs,
+            HTTP_REFERER="http://example.com",
+            HTTP_ACCEPT="text/html, text/javascript",
+        )
+        assert resp.status_code == 200, resp.content
+        assert resp["Access-Control-Allow-Origin"] == "*"
+        self.assertTemplateUsed(resp, "sentry/error-page-embed.html")
+
+        region_url = get_local_locality().to_url(self.path_with_qs)
+        body = resp.content.decode("utf8")
+        assert f'endpoint = /**/"{region_url}";/**/' in body
+
+    def test_endpoint_reflects_control_silo_url_when_option_enabled(self) -> None:
+        with override_options(
+            {
+                "error-embeds.control-silo-address": True,
+                "system.url-prefix": "http://controlsilo.testserver",
+            }
+        ):
             resp = self.client.get(
                 self.path_with_qs,
                 HTTP_REFERER="http://example.com",


### PR DESCRIPTION
Adds a new option `error-embeds.control-silo-address`, which redirects error-embed requests to Control Silo instead of a locality-based address.

Coupled with the routing logic in api-gateway, this should make error-embeds cell safe, at the cost of latency and failure resilience if Control has an outage.