### PR TITLE
feat(options): let the automator bypass the dual-read hook

### DIFF
--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -309,7 +309,7 @@ class OptionsManager:
         """
         return key in settings.SENTRY_OPTIONS
 
-    def get(self, key: str, silent=False):
+    def get(self, key: str, silent=False, *, use_read_hook: bool = True):
         """
         Get the value of an option, falling back to the local configuration.
 
@@ -317,6 +317,11 @@ class OptionsManager:
 
         >>> from sentry import options
         >>> options.get('option')
+
+        Pass ``use_read_hook=False`` to skip the read hook and resolve only the
+        legacy store/disk/default chain. The options automator uses this so its
+        update decisions are judged against what is actually in the legacy store,
+        not a dual-read override (the same reasoning as ``can_update``).
         """
         # TODO(mattrobenolt): Perform validation on key returned for type Justin Case
         # values change. This case is unlikely, but good to cover our bases.
@@ -333,7 +338,7 @@ class OptionsManager:
         ) as tags:
             opt = self.lookup_key(key)
 
-            if self._read_hook is not None:
+            if use_read_hook and self._read_hook is not None:
                 result = self._read_hook(key, opt)
                 if result is not READ_HOOK_FALLBACK:
                     tags["source"] = "hook"
@@ -552,6 +557,13 @@ class OptionsManager:
         if not include_drift:
             return None
 
+        # isset() consults the read hook, so it can report True while the legacy
+        # store is empty (a dual-read value is being served). That is benign for
+        # drift: an empty store falls through to store.get() and
+        # get_last_update_channel() below, both of which read the legacy store
+        # directly and funnel an unstored key back to "writable" — the same
+        # verdict this early return gives. Drift is always judged against the
+        # legacy store, never the hook value.
         if not self.isset(key):
             # If the option is not readonly and it is not stored in the
             # option store it means we are relying on default. So we can

--- a/src/sentry/runner/commands/configoptions.py
+++ b/src/sentry/runner/commands/configoptions.py
@@ -27,7 +27,10 @@ def _attempt_update(
 
     opt = options.lookup_key(key)
 
-    db_value = options.get(key)
+    # Read the legacy stored value, never a dual-read override: the automator
+    # maintains the legacy store, so its update/no-op decision and the "old
+    # value" it reports must reflect what is actually stored there.
+    db_value = options.get(key, use_read_hook=False)
     db_value_to_print = "[REDACTED]" if opt.has_any_flag({options.FLAG_CREDENTIAL}) else db_value
     if key in drifted_options:
         if hide_drift:
@@ -344,10 +347,10 @@ def sync(ctx: click.Context) -> None:
                             raise
                     presenter_delegator.unset(opt.name)
                 elif last_updated == options.UpdateChannel.CLI:
-                    presenter_delegator.drift(opt.name, options.get(opt.name))
+                    presenter_delegator.drift(opt.name, options.get(opt.name, use_read_hook=False))
                     drift_found = True
                 elif last_updated == options.UpdateChannel.UNKNOWN:
-                    presenter_delegator.drift(opt.name, options.get(opt.name))
+                    presenter_delegator.drift(opt.name, options.get(opt.name, use_read_hook=False))
                     drift_found = True
                 else:
                     continue

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -449,6 +449,25 @@ class OptionsManagerTest(TestCase):
             self.manager.set_read_hook(None)
             self.manager.unregister("hooked")
 
+    def test_get_use_read_hook_false_bypasses_hook(self) -> None:
+        # use_read_hook=False resolves the legacy store/disk/default chain only,
+        # ignoring the hook — the write path relies on this to see the real
+        # stored value. A bypassed read of an unset key still returns the
+        # registered default, not None (unlike a raw store.get).
+        self.manager.register("hooked", type=String, flags=FLAG_AUTOMATOR_MODIFIABLE)
+        self.manager.set("hooked", "stored", channel=UpdateChannel.CLI)
+        self.manager.set_read_hook(
+            lambda key, opt: "hook-value" if key == "hooked" else READ_HOOK_FALLBACK
+        )
+        try:
+            assert self.manager.get("hooked") == "hook-value"
+            assert self.manager.get("hooked", use_read_hook=False) == "stored"
+            self.manager.delete("hooked")
+            assert self.manager.get("hooked", use_read_hook=False) == ""
+        finally:
+            self.manager.set_read_hook(None)
+            self.manager.unregister("hooked")
+
     def test_read_hook_fallback_uses_legacy(self) -> None:
         self.manager.set_read_hook(lambda key, opt: READ_HOOK_FALLBACK)
         try:

--- a/tests/sentry/runner/commands/test_configoptions.py
+++ b/tests/sentry/runner/commands/test_configoptions.py
@@ -10,6 +10,7 @@ from sentry.options.manager import (
     FLAG_AUTOMATOR_MODIFIABLE,
     FLAG_IMMUTABLE,
     FLAG_PRIORITIZE_DISK,
+    READ_HOOK_FALLBACK,
     UpdateChannel,
 )
 from sentry.runner.commands.configoptions import configoptions
@@ -198,6 +199,32 @@ class ConfigOptionsTest(CliTestCase):
         assert options.get("drifted_option") == [1, 2, 3]
 
         assert not options.isset("to_unset_option")
+
+    def test_sync_ignores_read_hook(self) -> None:
+        # During the options dual-read cutover a read hook can already serve the
+        # target value for an FLAG_AUTOMATOR_MODIFIABLE option. The automator
+        # maintains the *legacy* store, so it must judge its update against the
+        # stored value, not the hook value. Here str_option is stored as
+        # "old value" but the hook serves "new value" (the yaml target). If the
+        # automator read the hook it would see db_value == value and skip the
+        # write, silently leaving the legacy store stale.
+        options.default_manager.set_read_hook(
+            lambda key, opt: "new value" if key == "str_option" else READ_HOOK_FALLBACK
+        )
+        try:
+            rv = self.invoke(
+                "-f",
+                "tests/sentry/runner/commands/valid_patch.yaml",
+                "sync",
+            )
+            assert rv.exit_code == 2, rv.output
+            assert (
+                ConsolePresenter.UPDATE_MSG % ("str_option", "old value", "new value") in rv.output
+            )
+            # The legacy store was actually updated, not skipped.
+            assert options.get("str_option", use_read_hook=False) == "new value"
+        finally:
+            options.default_manager.set_read_hook(None)
 
     def test_bad_sync(self) -> None:
         rv = self.invoke(


### PR DESCRIPTION
#117547 added a dual-read hook activated by https://github.com/getsentry/getsentry/pull/20665 

that hook routes `options.get()` and `isset()` through the dual read hook which is what we want for normal reads

buuuut i forgot about options automator - it owns the legacy store and writes into it. during `can_update` it should be comparing against what's actually in the legacy store, so need a way to bypass the dual read hook

same bypass needs to be applied to `_attempt_update` and `presenter_delegator.drift`

---

the failure mode during cutover: legacy store has `A`, sentry-options already serves the target `B`, and the automator config wants `B`. the hooked `get()` returns `B`, so `db_value == value` is true, the automator thinks "already set" and skips the write. the legacy store silently stays `A` and stops getting maintained — exactly the fallback we're relying on while we cut over.

fix is a keyword escape hatch: `options.get(key, use_read_hook=False)` skips the hook and resolves the plain legacy store/disk/default chain (still returns the registered default for an unset key, unlike a raw `store.get`). the automator's three write-decision reads use it. everything else stays on the hooked path.

display-only readers (`system_options`, `config options list`, `client_config`) are left hooked on purpose — they *should* show the dual read value.

notes:
- no behavior change for self-hosted / OSS: the hook is never installed there, so `use_read_hook=False` resolves the same chain `get` always did
- no getsentry change needed — the hook callable is untouched, getsentry just needs to run a sentry with this in it
- `use_read_hook` is keyword-only with a `True` default, so every existing `get()` call is unaffected

also added a comment in `can_update` explaining why the `isset()` it calls (which is hooked) is harmless: an empty legacy store falls through to `store.get`/`get_last_update_channel`, which both read the store directly and land on "writable" anyway — same verdict as the early return.

