### PR TITLE
feat(admin): Probe other regions when org search lacks an exact slug match

### DIFF
--- a/static/gsAdmin/components/customerGrid.tsx
+++ b/static/gsAdmin/components/customerGrid.tsx
@@ -83,6 +83,12 @@ export function CustomerGrid(props: Props) {
       inPanel
       isCellScoped
       probeAcrossRegions
+      // An exact match is an org whose slug equals the searched term, so we can
+      // surface the cross-region hint even when only similar slugs come back in
+      // the current region. Org slugs are always lower-cased.
+      exactMatchQuery={(row: Subscription, query: string) =>
+        row.slug === query.toLowerCase()
+      }
       path="/_admin/customers/"
       method="GET"
       columns={[

--- a/static/gsAdmin/components/customerGrid.tsx
+++ b/static/gsAdmin/components/customerGrid.tsx
@@ -85,10 +85,9 @@ export function CustomerGrid(props: Props) {
       probeAcrossRegions
       // An exact match is an org whose slug equals the searched term, so we can
       // surface the cross-region hint even when only similar slugs come back in
-      // the current region. Org slugs are always lower-cased.
-      exactMatchQuery={(row: Subscription, query: string) =>
-        row.slug === query.toLowerCase()
-      }
+      // the current region. `query` arrives trimmed + lower-cased; org slugs are
+      // always lower-case, so a direct comparison is correct.
+      exactMatchQuery={(row: Subscription, query: string) => row.slug === query}
       path="/_admin/customers/"
       method="GET"
       columns={[

--- a/static/gsAdmin/components/resultGrid.spec.tsx
+++ b/static/gsAdmin/components/resultGrid.spec.tsx
@@ -157,6 +157,34 @@ describe('ResultGrid region probing', () => {
     await waitFor(() => expect(deRequest).toHaveBeenCalled());
   });
 
+  it('does not probe when results span multiple pages (exact slug may be on a later page)', async () => {
+    const exactMatchQuery = (row: any, query: string) => row.slug === query;
+
+    // The first page has only a similar slug, but a next page exists — the
+    // exact slug could live there, so we must not claim "no exact match".
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme Inc', slug: 'acme-inc'}],
+      headers: {
+        Link:
+          '<https://us.example.com/api/0/_admin/cells/us/customers/?cursor=0:0:1>; ' +
+          'rel="previous"; results="false"; cursor="0:0:1", ' +
+          '<https://us.example.com/api/0/_admin/cells/us/customers/?cursor=0:100:0>; ' +
+          'rel="next"; results="true"; cursor="0:100:0"',
+      },
+    });
+    const deRequest = MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '2', name: 'Acme', slug: 'acme'}],
+    });
+
+    renderGrid('acme', {}, {exactMatchQuery});
+
+    expect(await screen.findByText('Acme Inc')).toBeInTheDocument();
+    expect(deRequest).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', {name: 'View in de'})).not.toBeInTheDocument();
+  });
+
   it('does not probe when the exact slug is returned in the current region', async () => {
     const exactMatchQuery = (row: any, query: string) => row.slug === query;
 

--- a/static/gsAdmin/components/resultGrid.spec.tsx
+++ b/static/gsAdmin/components/resultGrid.spec.tsx
@@ -204,6 +204,27 @@ describe('ResultGrid region probing', () => {
     expect(screen.queryByRole('button', {name: 'View in de'})).not.toBeInTheDocument();
   });
 
+  it('normalizes the query before exactMatchQuery (uppercase search matches a lowercase slug)', async () => {
+    // The predicate compares against the query as-is; ResultGrid is responsible
+    // for trimming + lower-casing, so an uppercase search still matches.
+    const exactMatchQuery = (row: any, query: string) => row.slug === query;
+
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme', slug: 'acme'}],
+    });
+    const deRequest = MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '2', name: 'Acme', slug: 'acme'}],
+    });
+
+    renderGrid('  ACME  ', {}, {exactMatchQuery});
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+    expect(deRequest).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', {name: 'View in de'})).not.toBeInTheDocument();
+  });
+
   it('does not show a hint when another region is also empty', async () => {
     MockApiClient.addMockResponse({
       url: '/_admin/cells/us/customers/',

--- a/static/gsAdmin/components/resultGrid.spec.tsx
+++ b/static/gsAdmin/components/resultGrid.spec.tsx
@@ -14,7 +14,11 @@ function setupCells() {
   ] as any);
 }
 
-function renderGrid(query?: string, extraQuery: Record<string, string> = {}) {
+function renderGrid(
+  query?: string,
+  extraQuery: Record<string, string> = {},
+  extraProps: Record<string, any> = {}
+) {
   return render(
     <ResultGrid
       inPanel
@@ -26,6 +30,7 @@ function renderGrid(query?: string, extraQuery: Record<string, string> = {}) {
       method="GET"
       columns={[<th key="name">Customer</th>]}
       columnsForRow={(row: any) => [<td key="name">{row.name}</td>]}
+      {...extraProps}
     />,
     {
       initialRouterConfig: {
@@ -118,6 +123,55 @@ describe('ResultGrid region probing', () => {
     renderGrid('acme', {cursor: '0:100:0'});
 
     expect(await screen.findByText('No results')).toBeInTheDocument();
+    expect(deRequest).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', {name: 'View in de'})).not.toBeInTheDocument();
+  });
+
+  it('probes other regions when only a similar (non-exact) slug is returned', async () => {
+    const exactMatchQuery = (row: any, query: string) => row.slug === query;
+
+    // The current region returns a similar org, but not the exact slug.
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme Inc', slug: 'acme-inc'}],
+    });
+    // The exact org lives in the de region.
+    const deRequest = MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '2', name: 'Acme', slug: 'acme'}],
+    });
+
+    renderGrid('acme', {}, {exactMatchQuery});
+
+    expect(await screen.findByRole('button', {name: 'View in de'})).toBeInTheDocument();
+    // The hint text is split across a <span>/<strong>, so match on the
+    // combined textContent rather than a single text node.
+    expect(
+      screen.getByText(
+        (_content, element) => /No exact match in/.test(element?.textContent ?? ''),
+        {selector: 'span'}
+      )
+    ).toBeInTheDocument();
+    // The similar local result is still shown.
+    expect(screen.getByText('Acme Inc')).toBeInTheDocument();
+    await waitFor(() => expect(deRequest).toHaveBeenCalled());
+  });
+
+  it('does not probe when the exact slug is returned in the current region', async () => {
+    const exactMatchQuery = (row: any, query: string) => row.slug === query;
+
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme', slug: 'acme'}],
+    });
+    const deRequest = MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '2', name: 'Acme', slug: 'acme'}],
+    });
+
+    renderGrid('acme', {}, {exactMatchQuery});
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
     expect(deRequest).not.toHaveBeenCalled();
     expect(screen.queryByRole('button', {name: 'View in de'})).not.toBeInTheDocument();
   });

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -19,6 +19,7 @@ import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {IconList, IconSearch} from 'sentry/icons';
 import type {Cell} from 'sentry/types/system';
 import {getCells} from 'sentry/utils/cells';
+import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
@@ -445,10 +446,17 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
         // component state — fall back so probes always carry the search term.
         const query = queryParams.query ?? this.state.query;
         const normalizedQuery = extractQuery(query).trim();
-        // Only probe on the first page. A paginated empty page (cursor set) does
-        // not mean the current region has no matches — it has results on earlier
-        // pages — so probing there would falsely report "no results in <region>".
+
+        const pageLinks = resp?.getResponseHeader('Link') ?? '';
+        // We can only conclude that a region lacks an exact match when we're
+        // looking at its *complete* result set: the first page with no further
+        // pages. If results span multiple pages the exact slug could live on a
+        // page we haven't loaded, which would both produce a misleading "No
+        // exact match" hint and make the hint vanish the moment the user
+        // paginates. An empty result is naturally a complete set.
         const isFirstPage = !extractQuery(queryParams.cursor);
+        const hasNextPage = parseLinkHeader(pageLinks).next?.results === true;
+        const isCompleteResultSet = isFirstPage && !hasNextPage;
 
         // Probe other regions whenever the active region lacks an *exact* match
         // for the search. With an `exactMatchQuery` predicate this includes the
@@ -458,7 +466,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
         const isEmpty = rowsArray.length === 0;
         const missingExactMatch = Boolean(
           this.props.probeAcrossRegions &&
-          isFirstPage &&
+          isCompleteResultSet &&
           hasSearchQuery(query) &&
           (this.props.exactMatchQuery
             ? !rowsArray.some(row => this.props.exactMatchQuery!(row, normalizedQuery))
@@ -469,7 +477,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
           loading: false,
           error: false,
           rows,
-          pageLinks: resp?.getResponseHeader('Link') ?? '',
+          pageLinks,
           regionMatches: [],
           missingExactMatch,
         });

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -168,6 +168,10 @@ interface ResultGridProps {
    *
    * When omitted, cross-region probing falls back to the original behavior of
    * only probing when the active region returns no results at all.
+   *
+   * `query` is passed pre-normalized: trimmed and lower-cased. Implementations
+   * should compare against an already-normalized field (e.g. an org slug, which
+   * is always lower-case) and must not re-normalize the query themselves.
    */
   exactMatchQuery?: (row: any, query: string) => boolean;
   /**
@@ -445,7 +449,9 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
         // The query lives in the URL when useQueryString is on, otherwise in
         // component state — fall back so probes always carry the search term.
         const query = queryParams.query ?? this.state.query;
-        const normalizedQuery = extractQuery(query).trim();
+        // Normalize once (trim + lower-case) so `exactMatchQuery` implementations
+        // can compare against an already-normalized field without re-normalizing.
+        const normalizedQuery = extractQuery(query).trim().toLowerCase();
 
         const pageLinks = resp?.getResponseHeader('Link') ?? '';
         // We can only conclude that a region lacks an exact match when we're

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -156,6 +156,20 @@ interface ResultGridProps {
    */
   defaultSort?: string;
   /**
+   * Predicate that reports whether a returned row is an *exact* match for the
+   * active search query (e.g. an org whose slug equals the searched term).
+   *
+   * When provided alongside `probeAcrossRegions`, the cross-region probe also
+   * fires when the active region returns only fuzzy/similar matches but no
+   * exact match — not just when it returns zero results. This surfaces the
+   * "this org may live in another region" hint even when a similar slug is
+   * returned in the current region.
+   *
+   * When omitted, cross-region probing falls back to the original behavior of
+   * only probing when the active region returns no results at all.
+   */
+  exactMatchQuery?: (row: any, query: string) => boolean;
+  /**
    * A definition of filters
    */
   filters?: Record<string, FilterDescriptor>;
@@ -245,9 +259,15 @@ export type State = {
   error: boolean;
   filters: Location['query'];
   loading: boolean;
+  /**
+   * Whether the active region returned no exact match for the current search
+   * (either no results at all, or only fuzzy/similar matches). Drives whether
+   * the cross-region hint should be surfaced.
+   */
+  missingExactMatch: boolean;
   pageLinks: string | null;
   /**
-   * Whether we are currently probing other regions after an empty result.
+   * Whether we are currently probing other regions after a missing exact match.
    */
   probingRegions: boolean;
   query: string;
@@ -314,6 +334,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       filters: Object.assign({}, queryParams),
       regionMatches: [],
       probingRegions: false,
+      missingExactMatch: false,
     };
   }
 
@@ -355,6 +376,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
         error: false,
         regionMatches: [],
         probingRegions: false,
+        missingExactMatch: false,
       },
       this.fetchData
     );
@@ -389,8 +411,16 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     // the token) and clear its UI state here, the single entry point for fetches,
     // so it's reset regardless of which caller (refresh/onCursor/onSearch) we hit.
     this.probeToken += 1;
-    if (this.state.probingRegions || this.state.regionMatches.length > 0) {
-      this.setState({probingRegions: false, regionMatches: []});
+    if (
+      this.state.probingRegions ||
+      this.state.regionMatches.length > 0 ||
+      this.state.missingExactMatch
+    ) {
+      this.setState({
+        probingRegions: false,
+        regionMatches: [],
+        missingExactMatch: false,
+      });
     }
 
     // TODO(dcramer): this should whitelist filters/sortBy/cursor/perPage
@@ -409,33 +439,45 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       data: queryParams,
       success: (data, _, resp) => {
         const rows = this.props.rowsFromData?.(data, this.state.cell) ?? data;
+        const rowsArray = Array.isArray(rows) ? rows : [];
+
+        // The query lives in the URL when useQueryString is on, otherwise in
+        // component state — fall back so probes always carry the search term.
+        const query = queryParams.query ?? this.state.query;
+        const normalizedQuery = extractQuery(query).trim();
+        // Only probe on the first page. A paginated empty page (cursor set) does
+        // not mean the current region has no matches — it has results on earlier
+        // pages — so probing there would falsely report "no results in <region>".
+        const isFirstPage = !extractQuery(queryParams.cursor);
+
+        // Probe other regions whenever the active region lacks an *exact* match
+        // for the search. With an `exactMatchQuery` predicate this includes the
+        // case where the region returns only fuzzy/similar matches (e.g. a
+        // look-alike org slug) but not the exact slug searched. Without the
+        // predicate we fall back to probing only on a completely empty result.
+        const isEmpty = rowsArray.length === 0;
+        const missingExactMatch = Boolean(
+          this.props.probeAcrossRegions &&
+          isFirstPage &&
+          hasSearchQuery(query) &&
+          (this.props.exactMatchQuery
+            ? !rowsArray.some(row => this.props.exactMatchQuery!(row, normalizedQuery))
+            : isEmpty)
+        );
+
         this.setState({
           loading: false,
           error: false,
           rows,
           pageLinks: resp?.getResponseHeader('Link') ?? '',
           regionMatches: [],
+          missingExactMatch,
         });
         if (this.props.onLoad) {
           this.props.onLoad();
         }
 
-        // When a region-scoped search comes up empty, check whether the org
-        // lives in another data region so we can point the user there.
-        const isEmpty = !Array.isArray(rows) || rows.length === 0;
-        // The query lives in the URL when useQueryString is on, otherwise in
-        // component state — fall back so probes always carry the search term.
-        const query = queryParams.query ?? this.state.query;
-        // Only probe on the first page. A paginated empty page (cursor set) does
-        // not mean the current region has no matches — it has results on earlier
-        // pages — so probing there would falsely report "no results in <region>".
-        const isFirstPage = !extractQuery(queryParams.cursor);
-        if (
-          this.props.probeAcrossRegions &&
-          isEmpty &&
-          isFirstPage &&
-          hasSearchQuery(query)
-        ) {
+        if (missingExactMatch) {
           this.probeOtherRegions({...queryParams, query});
         }
       },
@@ -582,7 +624,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       !this.props.probeAcrossRegions ||
       this.state.loading ||
       this.state.error ||
-      this.state.rows.length > 0
+      !this.state.missingExactMatch
     ) {
       return null;
     }
@@ -596,12 +638,16 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     }
 
     const currentName = this.state.cell?.name ?? 'this region';
+    // The active region returned similar (but not exact) matches — make it
+    // clear the exact record was not found here, rather than implying no
+    // results at all.
+    const leadText = this.state.rows.length > 0 ? 'No exact match in' : 'No results in';
 
     return (
       <RegionHintAlert variant="info" showIcon>
         <Flex align="center" gap="md" wrap="wrap">
           <span>
-            No results in <strong>{currentName}</strong>. Found results in another data
+            {leadText} <strong>{currentName}</strong>. Found results in another data
             region:
           </span>
           {this.state.regionMatches.map(cell => (


### PR DESCRIPTION
The admin customer search only checked other data regions when the active region returned **zero** results. When a search returned a similar but non-exact slug — e.g. searching `acme` surfaced `acme-inc` — the user was never told the exact org might live in another region, since the region probe never fired.

This adds an optional `exactMatchQuery` predicate to `ResultGrid`. When provided alongside `probeAcrossRegions`, the cross-region probe now also fires when the active region returns only fuzzy/similar matches but no exact match — not just on empty results. The same "found in another data region" hint is surfaced, with copy that distinguishes the two cases ("No exact match in `<region>`" vs. "No results in `<region>`"). The probe is still gated to the first page and a non-empty search query.

When the predicate is omitted, behavior is unchanged: the probe only fires on a completely empty result. `CustomerGrid` wires the predicate to match on org slug (`row.slug === query.toLowerCase()`).

### Notes for reviewers
- The new behavior is driven by a `missingExactMatch` state flag set in the fetch success handler; `renderRegionHint` now gates on it instead of `rows.length === 0`, so the hint can show alongside similar local results.
- Tested via `resultGrid.spec.tsx`: added cases for "similar-but-not-exact slug → probe + hint" and "exact slug present → no probe", alongside the existing empty/paginated/no-query cases.