### PR TITLE
feat(issue-details): Add activity feed to issue preview drawer

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.tsx
@@ -3,6 +3,7 @@ import {Fragment} from 'react';
 import {LinkButton} from '@sentry/scraps/button';
 import {DrawerBody, DrawerHeader} from '@sentry/scraps/drawer';
 import {Container, Flex} from '@sentry/scraps/layout';
+import {TabList, Tabs} from '@sentry/scraps/tabs';
 import {Heading} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -17,6 +18,7 @@ import {getMessage, getTitle} from 'sentry/utils/events';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {ActivitySection} from 'sentry/views/issueDetails/activitySection';
 import {GroupStatusSubtitle} from 'sentry/views/issueDetails/header/groupStatusSubtitle';
 import {IssueIdBreadcrumb} from 'sentry/views/issueDetails/header/issueIdBreadcrumb';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
@@ -74,24 +76,56 @@ function IssuePreviewContent({
   const secondaryTitle = getMessage(group);
 
   return (
-    <Container paddingBottom="lg" borderBottom="muted">
-      <Flex direction="column" gap="xs">
-        <div>
-          <Tooltip
-            title={primaryTitle}
-            skipWrapper
-            isHoverable
-            showOnlyOnOverflow
-            delay={1000}
-          >
-            <Heading as="h3" size="lg" ellipsis>
-              {primaryTitle}
-            </Heading>
-          </Tooltip>
-          <EventMessage level={group.level} message={secondaryTitle} type={group.type} />
-        </div>
-        <GroupStatusSubtitle group={group} project={project} />
-      </Flex>
-    </Container>
+    <Fragment>
+      <Container paddingBottom="lg" borderBottom="muted">
+        <Flex direction="column" gap="xs">
+          <div>
+            <Tooltip
+              title={primaryTitle}
+              skipWrapper
+              isHoverable
+              showOnlyOnOverflow
+              delay={1000}
+            >
+              <Heading as="h3" size="lg" ellipsis>
+                {primaryTitle}
+              </Heading>
+            </Tooltip>
+            <EventMessage
+              level={group.level}
+              message={secondaryTitle}
+              type={group.type}
+            />
+          </div>
+          <GroupStatusSubtitle group={group} project={project} />
+        </Flex>
+      </Container>
+      <Container paddingTop="lg">
+        <Container paddingBottom="lg" borderBottom="muted">
+          <Tabs value="activity">
+            <TabList variant="floating">
+              <TabList.Item key="activity">{t('Activity')}</TabList.Item>
+              <TabList.Item key="autofix" disabled>
+                {t('Autofix')}
+              </TabList.Item>
+              <TabList.Item key="details" disabled>
+                {t('Details')}
+              </TabList.Item>
+              <TabList.Item key="events" disabled>
+                {t('Events')}
+              </TabList.Item>
+            </TabList>
+          </Tabs>
+        </Container>
+        <Container paddingTop="lg">
+          <ActivitySection
+            group={group}
+            variant="standalone"
+            size="md"
+            placeholder={t('Add a comment. Tag users with @, or teams with #')}
+          />
+        </Container>
+      </Container>
+    </Fragment>
   );
 }

--- a/static/app/views/issueList/pages/useIssuePreviewDrawer.spec.tsx
+++ b/static/app/views/issueList/pages/useIssuePreviewDrawer.spec.tsx
@@ -1,4 +1,5 @@
 import {GroupFixture} from 'sentry-fixture/group';
+import {UserFixture} from 'sentry-fixture/user';
 
 import {
   act,
@@ -8,6 +9,7 @@ import {
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
+import {GroupActivityType} from 'sentry/types/group';
 import {useIssuePreviewDrawer} from 'sentry/views/issueList/pages/useIssuePreviewDrawer';
 
 const AWAITING_INPUT_PATH = '/organizations/org-slug/issues/awaiting-input/';
@@ -25,6 +27,10 @@ describe('useIssuePreviewDrawer', () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/replay-count/',
       body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/members/',
+      body: [],
     });
   });
 
@@ -54,6 +60,40 @@ describe('useIssuePreviewDrawer', () => {
     expect(
       await screen.findByRole('complementary', {name: 'Issue preview'})
     ).toBeInTheDocument();
+  });
+
+  it('displays the issue activity', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/42/',
+      body: GroupFixture({
+        id: '42',
+        activity: [
+          {
+            id: '1',
+            type: GroupActivityType.NOTE,
+            data: {text: 'This is a comment'},
+            dateCreated: '2024-01-01T00:00:00Z',
+            user: UserFixture(),
+          },
+          {
+            id: '2',
+            type: GroupActivityType.FIRST_SEEN,
+            data: {},
+            dateCreated: '2024-01-01T00:00:00Z',
+            user: null,
+          },
+        ],
+      }),
+    });
+
+    renderHookWithProviders(() => useIssuePreviewDrawer(), {
+      initialRouterConfig: {
+        location: {pathname: AWAITING_INPUT_PATH, query: {preview: '42'}},
+      },
+    });
+
+    expect(await screen.findByText('This is a comment')).toBeInTheDocument();
+    expect(screen.getByText('First Seen')).toBeInTheDocument();
   });
 
   it('removes the preview param when the drawer is closed', async () => {


### PR DESCRIPTION
Ref ISWF-2830

Renders the activity feed in the new issue preview drawer, reusing the components which is used in issue details.

One known bug: posting, editing, or deleting a comment from the drawer does not currently refresh the feed (but it does save the comment if you refresh). The drawer reads its group from `useGroup` (React Query) while `ActivitySection`'s default handlers mutate the `GroupStore`, and unlike the main issue details page the drawer does not run the store-to-query sync. That will be fixed in a separate PR (hopefully I can remove GroupStore usage entirely).

<img width="954" height="614" alt="CleanShot 2026-06-18 at 13 30 10" src="https://github.com/user-attachments/assets/39e34d53-19b7-4cbe-b519-92f58a0f9476" />
