### PR TITLE
fix(vercel): redirect sentry.dev root to sentry.io

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,15 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
 
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "has": [{"type": "host", "value": "sentry.dev"}],
+      "destination": "https://sentry.io/$1",
+      "permanent": false
+    }
+  ],
+
   "rewrites": [
     {
       "source": "/(api|organization-avatar|team-avatar|avatar)/(.*)",


### PR DESCRIPTION
Visitors to `sentry.dev` (no subdomain) currently land on the Vercel preview deployment of the app, which is confusing — it looks like the real product but isn't.

This adds a host-scoped redirect rule so bare `sentry.dev` traffic is sent to `sentry.io`. PR preview subdomains (e.g. `pr-1234.sentry.dev`) are unaffected because the `has` host condition matches exactly on `sentry.dev`.

Using a temporary (307) redirect since we may want to revisit this if the domain gets repurposed.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC8V02RHC7%3A1781819110.636419%22)