### PR TITLE
ref(pr-metrics): Extract Seer contract models into contracts.py

### DIFF
--- a/src/sentry/pr_metrics/contracts.py
+++ b/src/sentry/pr_metrics/contracts.py
@@ -1,0 +1,111 @@
+"""Wire contracts for the PR-metrics ↔ Seer round-trip.
+
+The pydantic models here are a manual mirror of Seer's PR-metrics contract — keep
+them in sync with getsentry/seer:src/seer/pr_metrics/models.py. There's no shared
+package or codegen; both sides validate with pydantic, so drift surfaces as a
+``ValidationError`` here or a 4xx from Seer rather than silent corruption.
+https://github.com/getsentry/seer/blob/main/src/seer/pr_metrics/models.py
+
+- ``PrCloseJudgeRequest`` / ``PrActivityEvent`` shape the outbound forward
+  (Sentry → Seer) assembled in ``judge.py``.
+- ``PrConversationAnalysis`` mirrors the ``conversation_analysis`` Seer returns on
+  the inbound callback (Seer → Sentry); it shapes the emitted ``PrCloseMetricsEvent``
+  analytics row in ``emit.py`` and is never persisted.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final, Literal
+
+from pydantic import BaseModel
+
+from sentry.seer.code_review.models import SeerCodeReviewRepoDefinition
+
+# GitHub fires a single ``closed`` action for both outcomes; a set ``merged_at``
+# on the PR row disambiguates a merge from a plain close.
+CLOSE_ACTION_CLOSED: Final = "closed"
+CLOSE_ACTION_MERGED: Final = "merged"
+
+CloseAction = Literal["closed", "merged"]
+
+
+class PrConversationAnalysis(BaseModel):
+    """The conversation judge's analysis of a closed/merged PR — one of several
+    judges, each with its own result type and columns.
+
+    Mirrors the ``conversation_analysis`` Seer sends to ``update_pr_metrics`` — the
+    inbound-callback half of the contract. BigQuery-only: it shapes the emitted
+    ``PrCloseMetricsEvent`` (in ``emit.py``) and is never persisted. Enum-like
+    values stay free strings, so a Seer vocabulary change can't fail validation.
+
+    Extra keys are ignored (pydantic v1's default), deliberately: it keeps old
+    Sentry pods forward-compatible with fields a newer Seer adds. The flip side — a
+    near-miss payload that matches some field names populates those and silently
+    leaves the rest null — is owned by the Seer-side builder + a shared contract
+    test, not tightened here: ``extra="forbid"`` would fight both that forward-compat
+    and the graceful-drop behavior (it'd drop the whole analysis on any new field).
+    """
+
+    # positive | neutral | negative | mixed. Null when there was nothing to judge
+    # (no comments) or the judge couldn't run; comments_total disambiguates.
+    sentiment: str | None = None
+    # Comments split by author class.
+    comments_bot: int | None = None
+    comments_human: int | None = None
+    # comments_truncated > 0 means a chatty PR was capped before judging.
+    comments_total: int | None = None
+    comments_judged: int | None = None
+    comments_truncated: int | None = None
+    # Opaque drill-down stored verbatim: per-comment intents, reasoning, version
+    # markers, intent counts.
+    metadata: dict[str, Any] | None = None
+
+
+class PrActivityEvent(BaseModel):
+    """One captured ``PullRequestActivity`` row, projected for the judge.
+
+    The stored payloads are structural-only — titles, bodies, and comment text are
+    excluded at capture — so the whole payload is safe to forward as-is.
+    """
+
+    event_type: str
+    # When Sentry recorded the activity (≈ webhook arrival); preserves event order.
+    timestamp: str
+    payload: dict[str, Any]
+
+
+class PrCloseJudgeRequest(BaseModel):
+    """The Sentry → Seer judge request body; mirrors Seer's ``PrCloseJudgeRequest``.
+
+    A pydantic model rather than a bare dict so the assembled body — including the
+    ``repo`` sub-shape that ``build_repo_definition`` produces — is validated before
+    send, catching contract drift here instead of as a Seer-side rejection.
+    """
+
+    organization_id: int
+    repository_id: int
+    pull_request_id: int
+    # Reuses the shared repo-definition model (the validated shape of
+    # build_repo_definition's output), so a dropped/renamed repo field is caught.
+    repo: SeerCodeReviewRepoDefinition
+    pr_number: str
+    close_action: CloseAction
+    head_commit_sha: str
+    merge_commit_sha: str | None
+    opened_at: str | None
+    closed_at: str
+    merged_at: str | None
+    draft: bool
+    additions: int
+    deletions: int
+    files_changed: int
+    commits_count: int
+    comments_count: int
+    review_comments_count: int
+    is_assigned: bool
+    attributions: list[dict[str, Any]]
+    group_ids: list[int]
+    # The captured activity timeline, oldest first. Carries the event sequence and
+    # actors that the end-state counters above flatten away: who pushed the
+    # post-open commits (Bot vs human), review outcomes, labels, draft transitions.
+    activity: list[PrActivityEvent]

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -9,9 +9,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import Any, Final, Literal
-
-from pydantic import BaseModel
+from typing import Any
 
 from sentry import analytics
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
@@ -26,51 +24,16 @@ from sentry.models.pullrequest import (
     PullRequestVerdict,
 )
 from sentry.pr_metrics.attribution import SIGNAL_TYPE_CONFIDENCE
+from sentry.pr_metrics.contracts import (
+    CLOSE_ACTION_CLOSED,
+    CLOSE_ACTION_MERGED,
+    CloseAction,
+    PrConversationAnalysis,
+)
 from sentry.pr_metrics.utils import is_activity_tracking_enabled, iso_or_none, resolved_group_ids
 from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
-
-# GitHub fires a single ``closed`` action for both outcomes; a set ``merged_at``
-# on the PR row disambiguates a merge from a plain close.
-CLOSE_ACTION_CLOSED: Final = "closed"
-CLOSE_ACTION_MERGED: Final = "merged"
-
-CloseAction = Literal["closed", "merged"]
-
-
-class PrConversationAnalysis(BaseModel):
-    """The conversation judge's analysis of a closed/merged PR — one of several
-    judges, each with its own result type and columns.
-
-    Mirrors the ``conversation_analysis`` Seer sends to ``update_pr_metrics`` — the
-    inbound-callback half of the contract, so it lives here beside the row it
-    shapes, separate from the outbound request mirrors in ``judge.py``; keep both in
-    sync with getsentry/seer:src/seer/pr_metrics/models.py. BigQuery-only: it shapes
-    the emitted ``PrCloseMetricsEvent`` and is never persisted. Enum-like values
-    stay free strings, so a Seer vocabulary change can't fail validation.
-
-    Extra keys are ignored (pydantic v1's default), deliberately: it keeps old
-    Sentry pods forward-compatible with fields a newer Seer adds. The flip side — a
-    near-miss payload that matches some field names populates those and silently
-    leaves the rest null — is owned by the Seer-side builder + a shared contract
-    test, not tightened here: ``extra="forbid"`` would fight both that forward-compat
-    and the graceful-drop behavior (it'd drop the whole analysis on any new field).
-    """
-
-    # positive | neutral | negative | mixed. Null when there was nothing to judge
-    # (no comments) or the judge couldn't run; comments_total disambiguates.
-    sentiment: str | None = None
-    # Comments split by author class.
-    comments_bot: int | None = None
-    comments_human: int | None = None
-    # comments_truncated > 0 means a chatty PR was capped before judging.
-    comments_total: int | None = None
-    comments_judged: int | None = None
-    comments_truncated: int | None = None
-    # Opaque drill-down stored verbatim: per-comment intents, reasoning, version
-    # markers, intent counts.
-    metadata: dict[str, Any] | None = None
 
 
 def select_verdict(

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -17,7 +17,7 @@ from typing import Any
 from django.conf import settings
 from django.db import router, transaction
 from django.db.models import Q
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 from urllib3.exceptions import HTTPError
 
 from sentry.models.pullrequest import (
@@ -31,12 +31,13 @@ from sentry.models.pullrequest import (
 from sentry.models.repository import Repository
 from sentry.net.http import connection_from_url
 from sentry.pr_metrics.attribution import record_attribution_signal
-from sentry.pr_metrics.emit import (
+from sentry.pr_metrics.contracts import (
     CloseAction,
+    PrActivityEvent,
+    PrCloseJudgeRequest,
     PrConversationAnalysis,
-    active_attributions,
-    emit_pr_metrics_row,
 )
+from sentry.pr_metrics.emit import active_attributions, emit_pr_metrics_row
 from sentry.pr_metrics.utils import iso_or_none, resolved_group_ids
 from sentry.seer.code_review.models import SeerCodeReviewRepoDefinition
 from sentry.seer.code_review.utils import build_repo_definition
@@ -62,62 +63,6 @@ seer_pr_metrics_connection_pool = connection_from_url(
 # The verdicts Seer may return: every real outcome, never the internal forward
 # sentinel. The callback rejects JUDGE_IN_PROGRESS coming back from Seer.
 RESULT_VERDICTS = frozenset(PullRequestVerdict.values) - {PullRequestVerdict.JUDGE_IN_PROGRESS}
-
-
-# The models below are a manual mirror of Seer's PR-metrics contract — keep them
-# in sync with getsentry/seer:src/seer/pr_metrics/models.py. There's no shared
-# package or codegen; both sides validate with pydantic, so drift surfaces as a
-# ValidationError here or a 4xx from Seer rather than silent corruption.
-# https://github.com/getsentry/seer/blob/main/src/seer/pr_metrics/models.py
-# TODO move this to a new file "contracts.py" and PrConversationAnalysis there as well
-class PrActivityEvent(BaseModel):
-    """One captured ``PullRequestActivity`` row, projected for the judge.
-
-    The stored payloads are structural-only — titles, bodies, and comment text are
-    excluded at capture — so the whole payload is safe to forward as-is.
-    """
-
-    event_type: str
-    # When Sentry recorded the activity (≈ webhook arrival); preserves event order.
-    timestamp: str
-    payload: dict[str, Any]
-
-
-class PrCloseJudgeRequest(BaseModel):
-    """The Sentry → Seer judge request body; mirrors Seer's ``PrCloseJudgeRequest``.
-
-    A pydantic model rather than a bare dict so the assembled body — including the
-    ``repo`` sub-shape that ``build_repo_definition`` produces — is validated before
-    send, catching contract drift here instead of as a Seer-side rejection.
-    """
-
-    organization_id: int
-    repository_id: int
-    pull_request_id: int
-    # Reuses the shared repo-definition model (the validated shape of
-    # build_repo_definition's output), so a dropped/renamed repo field is caught.
-    repo: SeerCodeReviewRepoDefinition
-    pr_number: str
-    close_action: CloseAction
-    head_commit_sha: str
-    merge_commit_sha: str | None
-    opened_at: str | None
-    closed_at: str
-    merged_at: str | None
-    draft: bool
-    additions: int
-    deletions: int
-    files_changed: int
-    commits_count: int
-    comments_count: int
-    review_comments_count: int
-    is_assigned: bool
-    attributions: list[dict[str, Any]]
-    group_ids: list[int]
-    # The captured activity timeline, oldest first. Carries the event sequence and
-    # actors that the end-state counters above flatten away: who pushed the
-    # post-open commits (Bot vs human), review outcomes, labels, draft transitions.
-    activity: list[PrActivityEvent]
 
 
 def _pr_activity_timeline(pull_request: PullRequest) -> list[PrActivityEvent]:

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -15,8 +15,8 @@ from sentry.models.pullrequest import (
     PullRequestMetrics,
     PullRequestVerdict,
 )
+from sentry.pr_metrics.contracts import PrConversationAnalysis
 from sentry.pr_metrics.emit import (
-    PrConversationAnalysis,
     active_attributions,
     build_pr_metrics_row,
     emit_pr_metrics_row,


### PR DESCRIPTION
## Problem

The Sentry-side mirror of Seer's PR-metrics wire contract was split across two modules: the outbound `PrCloseJudgeRequest` / `PrActivityEvent` lived in `judge.py`, while the inbound `PrConversationAnalysis` lived in `emit.py`. A `# TODO move this to a new file "contracts.py"` marked the intent. The split made the contract surface hard to find and forced `judge.py` to re-import the conversation model from `emit.py`, coupling the two modules through a shape neither owns.

## Approach

Extract all three contract mirrors — plus the shared `CloseAction` vocabulary (`CloseAction` type + `CLOSE_ACTION_CLOSED` / `CLOSE_ACTION_MERGED`) — into a dedicated `src/sentry/pr_metrics/contracts.py`. The whole manual mirror of `getsentry/seer:src/seer/pr_metrics/models.py` now sits in one place, documented by a module docstring.

`CloseAction` moves with the models because `PrCloseJudgeRequest.close_action` depends on it; leaving it in `emit.py` would create an import cycle once `emit.py` imports `PrConversationAnalysis` from `contracts.py`. After the move, both `emit.py` and `judge.py` depend on `contracts.py`, which depends on neither.

**No behavior change** — pure refactor. The conversation-analysis docstring was lightly updated to reflect its new home.

## Testing

- `pytest tests/sentry/pr_metrics/` — 221 passed
- `ruff`, `ruff-format`, `mypy` clean on changed files

## Stacking

Stacked on top of `ivandlugos/core-250-sentry-accept-verdict_details-on-update_pr_metrics-and-emit`. Review/merge that PR first.
