### PR TITLE
ref: Remove `organizations:issue-details-new-stack-trace`

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -318,8 +318,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:session-replay-ui", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable v2 issue activity feed UI
     manager.add("organizations:issue-activity-feed-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable new stack trace component for issue details
-    manager.add("organizations:issue-details-new-stack-trace", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable double-reading from EAP for issue feed search queries
     manager.add("organizations:issue-feed.eap-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Remove trace and breadcrumbs from issue summary input


### PR DESCRIPTION
Remove `organizations:issue-details-new-stack-trace`. This flag was fully GA'd on 2026-05-13 and has had zero code/frontend/test usage since (a previous removal in #116668 was reverted but code references have since been cleaned up).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqXM6dQRzhezRfKgN5XV45)_