### PR TITLE
fix(query-builder): Move logging out of loop

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -893,7 +893,7 @@ export function replaceFreeTextTokens(
     }
 
     const value = escapeTagValue(token.text.trim());
-    freeTextTokens.push(value.slice(1, -1));
+    freeTextTokens.push(token.text.trim());
 
     // We don't want to break user flows, so if they include an asterisk in their free
     // text value, leave it as an `is` filter.

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -867,6 +867,8 @@ export function replaceFreeTextTokens(
 
   const primarySearchKey = replaceRawSearchKeys[0] ?? '';
   const replacedQuery: string[] = [];
+  const freeTextTokens: string[] = [];
+
   for (const token of currentQueryTokens) {
     if (token.type === Token.L_PAREN) {
       replacedQuery.push('(');
@@ -891,28 +893,7 @@ export function replaceFreeTextTokens(
     }
 
     const value = escapeTagValue(token.text.trim());
-
-    // We're doing an experiment here to see if we can detect natural language queries
-    // and attempt to track them.
-    if (value.includes(' ')) {
-      const valueWithNoQuotes = value.slice(1, -1);
-      const wordCount = countWords(valueWithNoQuotes);
-
-      Sentry.logger.info(Sentry.logger.fmt`Found potential natural language query`, {
-        source: searchSource,
-        wordCount,
-      });
-
-      Sentry.metrics.count('search_query_builder.potential_natural_language_query', 1, {
-        attributes: {source: searchSource},
-      });
-
-      Sentry.metrics.gauge(
-        'search_query_builder.potential_natural_language_query_word_count',
-        wordCount,
-        {attributes: {source: searchSource}}
-      );
-    }
+    freeTextTokens.push(value.slice(1, -1));
 
     // We don't want to break user flows, so if they include an asterisk in their free
     // text value, leave it as an `is` filter.
@@ -933,6 +914,27 @@ export function replaceFreeTextTokens(
     } else {
       replacedQuery.push(`${primarySearchKey}:${WildcardOperators.CONTAINS}${value}`);
     }
+  }
+
+  // We're doing an experiment here to see if we can detect natural language queries
+  // and attempt to track them.
+  if (freeTextTokens.length > 0) {
+    const wordCount = freeTextTokens.reduce((acc, value) => acc + countWords(value), 0);
+
+    Sentry.logger.info(Sentry.logger.fmt`Found potential natural language query`, {
+      source: searchSource,
+      wordCount,
+    });
+
+    Sentry.metrics.count('search_query_builder.potential_natural_language_query', 1, {
+      attributes: {source: searchSource},
+    });
+
+    Sentry.metrics.gauge(
+      'search_query_builder.potential_natural_language_query_word_count',
+      wordCount,
+      {attributes: {source: searchSource}}
+    );
   }
 
   const finalQuery = replacedQuery.join(' ').trim();


### PR DESCRIPTION
Made the mistake of including this log line inside of the loop, so moving it out afterwards and tracking all of the potential free text tokens in one go.