### PR TITLE
fix(replay): Stop network details content from clipping at the bottom

### DIFF
--- a/static/app/views/explore/replays/detail/network/details/content.tsx
+++ b/static/app/views/explore/replays/detail/network/details/content.tsx
@@ -5,7 +5,6 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getFrameMethod, getFrameStatus} from 'sentry/utils/replays/resourceFrame';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {FluidHeight} from 'sentry/views/explore/replays/detail/layout/fluidHeight';
 import {getOutputType} from 'sentry/views/explore/replays/detail/network/details/getOutputType';
 import {
   Setup,
@@ -118,7 +117,9 @@ export function NetworkDetailsContent(props: Props) {
   }
 }
 
-const OverflowFluidHeight = styled(FluidHeight)`
+const OverflowFluidHeight = styled('div')`
+  flex-grow: 1;
+  height: 100%;
   overflow: auto;
 `;
 const SectionList = styled('dl')`


### PR DESCRIPTION
The network details panel rendered its content inside a flex column (`FluidHeight`). Flex items default to `flex-shrink: 1`, so when the content was taller than the panel the items were squished to fit rather than overflowing — clipping the bottom with no way to scroll to it.

This replaces the flex container with a plain block that keeps `flex-grow` and `height: 100%` (so it still fills the available space), but lets its children keep their natural height. `overflow: auto` then produces a real scrollbar and nothing gets cut off.

Before
<img width="576" height="380" alt="image" src="https://github.com/user-attachments/assets/7483e50b-330b-4017-8d2c-41b19c8f9f77" />

After
<img width="555" height="316" alt="image" src="https://github.com/user-attachments/assets/9f21e61a-0c63-45f4-8014-de8fe8121e6e" />



Fixes REPLAY-866.