### PR TITLE
ref(seer): Remove unused event prop from autofix sidebar

### DIFF
--- a/static/app/views/issueDetails/actions/seerCommandPaletteActions.tsx
+++ b/static/app/views/issueDetails/actions/seerCommandPaletteActions.tsx
@@ -86,7 +86,7 @@ export function SeerCommandPaletteActions({
     hasPR,
   } = useSeerState(group, project);
 
-  const {openSeerDrawer} = useOpenSeerDrawer({group, project, event});
+  const {openSeerDrawer} = useOpenSeerDrawer({group, project});
 
   const {data: codingAgentResponse} = useQuery(
     organizationIntegrationsCodingAgents(organization)

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -619,7 +619,7 @@ function GroupDetailsContentInner({
   const {openSimilarIssuesDrawer} = useSimilarIssuesDrawer({group, project});
   const {openMergedIssuesDrawer} = useMergedIssuesDrawer({group, project});
   const {openIssueActivityDrawer} = useIssueActivityDrawer({group, project});
-  const {openSeerDrawer} = useOpenSeerDrawer({group, project, event});
+  const {openSeerDrawer} = useOpenSeerDrawer({group, project});
   const {isAnyDrawerOpen} = useDrawer();
 
   const {currentTab} = useGroupDetailsRoute();

--- a/static/app/views/issueDetails/sidebar/autofixSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.spec.tsx
@@ -1,6 +1,4 @@
 import {AutofixSetupFixture} from 'sentry-fixture/autofixSetupFixture';
-import {EventFixture} from 'sentry-fixture/event';
-import {FrameFixture} from 'sentry-fixture/frame';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {DetailedProjectFixture} from 'sentry-fixture/project';
@@ -8,7 +6,6 @@ import {DetailedProjectFixture} from 'sentry-fixture/project';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {DiffFileType} from 'sentry/components/events/autofix/types';
-import {EntryType} from 'sentry/types/event';
 import {IssueCategory, type Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {
@@ -22,14 +19,6 @@ import {AutofixSection} from './autofixSection';
 jest.mock('sentry/utils/cells');
 
 describe('AutofixSection', () => {
-  const mockEvent = EventFixture({
-    entries: [
-      {
-        type: EntryType.EXCEPTION,
-        data: {values: [{stacktrace: {frames: [FrameFixture()]}}]},
-      },
-    ],
-  });
   const mockProject = DetailedProjectFixture();
   const organization = OrganizationFixture({
     hideAiFeatures: false,
@@ -74,7 +63,7 @@ describe('AutofixSection', () => {
       body: {whatsWrong: 'Something broke', possibleCause: 'Bad code'},
     });
 
-    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+    render(<AutofixSection group={mockGroup} project={mockProject} />, {
       organization,
     });
 
@@ -99,14 +88,9 @@ describe('AutofixSection', () => {
       platform: 'javascript',
     };
 
-    render(
-      <AutofixSection
-        event={mockEvent}
-        group={performanceGroup}
-        project={javascriptProject}
-      />,
-      {organization: customOrganization}
-    );
+    render(<AutofixSection group={performanceGroup} project={javascriptProject} />, {
+      organization: customOrganization,
+    });
 
     expect(screen.getByText('Resources')).toBeInTheDocument();
   });
@@ -118,7 +102,7 @@ describe('AutofixSection', () => {
     });
 
     const {container} = render(
-      <AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />,
+      <AutofixSection group={mockGroup} project={mockProject} />,
       {organization: customOrganization}
     );
 
@@ -159,7 +143,7 @@ describe('AutofixSection', () => {
       },
     });
 
-    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+    render(<AutofixSection group={mockGroup} project={mockProject} />, {
       organization,
     });
 
@@ -201,7 +185,7 @@ describe('AutofixSection', () => {
       },
     });
 
-    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+    render(<AutofixSection group={mockGroup} project={mockProject} />, {
       organization,
     });
 
@@ -261,7 +245,7 @@ describe('AutofixSection', () => {
       },
     });
 
-    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+    render(<AutofixSection group={mockGroup} project={mockProject} />, {
       organization,
     });
 
@@ -320,7 +304,7 @@ describe('AutofixSection', () => {
       },
     });
 
-    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+    render(<AutofixSection group={mockGroup} project={mockProject} />, {
       organization,
     });
 
@@ -330,65 +314,6 @@ describe('AutofixSection', () => {
     expect(screen.getByRole('button', {name: 'Open Autofix'})).toBeInTheDocument();
   });
 
-  it('shows loading placeholder while event is pending', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
-      body: {
-        autofix: {
-          run_id: 1,
-          status: 'completed',
-          updated_at: new Date().toISOString(),
-          blocks: [
-            {
-              id: 'block-1',
-              message: {
-                content: 'Created PR',
-                role: 'assistant',
-                metadata: {step: 'code_changes'},
-              },
-              timestamp: new Date().toISOString(),
-              merged_file_patches: [
-                {
-                  repo_name: 'org/repo',
-                  patch: {
-                    path: 'src/app.py',
-                    added: 1,
-                    removed: 0,
-                    hunks: [],
-                    source_file: 'src/app.py',
-                    target_file: 'src/app.py',
-                    type: DiffFileType.MODIFIED,
-                  },
-                },
-              ],
-            },
-          ],
-          repo_pr_states: {
-            'org/repo': {
-              repo_name: 'org/repo',
-              pr_number: 42,
-              pr_url: 'https://github.com/org/repo/pull/42',
-              branch_name: 'fix/issue',
-              commit_sha: 'abc123',
-              pr_creation_error: null,
-              pr_creation_status: 'completed',
-              pr_id: 1,
-              title: 'Fix null pointer',
-            },
-          },
-        },
-      },
-    });
-
-    render(<AutofixSection event={undefined} group={mockGroup} project={mockProject} />, {
-      organization,
-    });
-
-    // The Seer title should still render
-    expect(screen.getByText('Seer Autofix')).toBeInTheDocument();
-    expect(await screen.findByTestId('loading-placeholder')).toBeInTheDocument();
-  });
-
   it('shows empty state when autofix returns null', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
@@ -396,7 +321,7 @@ describe('AutofixSection', () => {
       statusCode: 200,
     });
 
-    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+    render(<AutofixSection group={mockGroup} project={mockProject} />, {
       organization,
     });
 
@@ -482,7 +407,7 @@ describe('AutofixSection', () => {
       },
     });
 
-    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+    render(<AutofixSection group={mockGroup} project={mockProject} />, {
       organization,
     });
 
@@ -514,7 +439,7 @@ describe('AutofixSection', () => {
       body: {autofix: null},
     });
 
-    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+    render(<AutofixSection group={mockGroup} project={mockProject} />, {
       organization: seatBasedOrg,
     });
 
@@ -546,7 +471,7 @@ describe('AutofixSection', () => {
       body: {autofix: null},
     });
 
-    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+    render(<AutofixSection group={mockGroup} project={mockProject} />, {
       organization: seatBasedOrg,
     });
 
@@ -577,7 +502,7 @@ describe('AutofixSection', () => {
       body: {autofix: null},
     });
 
-    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+    render(<AutofixSection group={mockGroup} project={mockProject} />, {
       organization,
     });
 
@@ -593,7 +518,7 @@ describe('AutofixSection', () => {
       },
     });
 
-    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
+    render(<AutofixSection group={mockGroup} project={mockProject} />, {
       organization,
     });
 
@@ -674,7 +599,7 @@ describe('AutofixSection', () => {
 
     render(
       <LLMContextProvider>
-        <AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />
+        <AutofixSection group={mockGroup} project={mockProject} />
         <ContextCapture />
       </LLMContextProvider>,
       {organization}

--- a/static/app/views/issueDetails/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.tsx
@@ -39,7 +39,6 @@ import {Placeholder} from 'sentry/components/placeholder';
 import {IconBug} from 'sentry/icons';
 import {IconSeer} from 'sentry/icons/iconSeer';
 import {t} from 'sentry/locale';
-import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {getSeerOnboardingCheckQueryOptions} from 'sentry/utils/getSeerOnboardingCheckQueryOptions';
@@ -58,10 +57,9 @@ import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLM
 interface AutofixSectionProps {
   group: Group;
   project: Project;
-  event?: Event;
 }
 
-export function AutofixSection({group, project, event}: AutofixSectionProps) {
+export function AutofixSection({group, project}: AutofixSectionProps) {
   const aiConfig = useAiConfig(group, project);
 
   const issueTypeConfig = getConfigForIssueType(group, project);
@@ -87,7 +85,7 @@ export function AutofixSection({group, project, event}: AutofixSectionProps) {
       >
         <Resources
           configResources={issueTypeConfig.resources}
-          eventPlatform={event?.platform}
+          platform={group.platform}
           group={group}
         />
       </SidebarFoldSection>
@@ -105,12 +103,7 @@ export function AutofixSection({group, project, event}: AutofixSectionProps) {
       sectionKey={SectionKey.SEER}
       preventCollapse={false}
     >
-      <AutofixContentHook
-        aiConfig={aiConfig}
-        group={group}
-        project={project}
-        event={event}
-      />
+      <AutofixContentHook aiConfig={aiConfig} group={group} project={project} />
     </SidebarFoldSection>
   );
 }
@@ -123,7 +116,7 @@ const AutofixContentHook = registerLLMContext(
   })
 );
 
-export function AutofixContent({aiConfig, group, project, event}: AutofixContentProps) {
+export function AutofixContent({aiConfig, group, project}: AutofixContentProps) {
   const organization = useOrganization();
   const autofix = useExplorerAutofix(group.id);
   const {data: setupCheck, isPending} = useQuery(
@@ -187,8 +180,6 @@ export function AutofixContent({aiConfig, group, project, event}: AutofixContent
     isPending ||
     // autofix results are loading
     autofix.isLoading ||
-    // waiting for the event to load
-    !event ||
     // waiting for the ai configs to load
     aiConfig.isAutofixSetupLoading ||
     // we're polling and no blocks have been added yet
@@ -244,19 +235,16 @@ export function AutofixContent({aiConfig, group, project, event}: AutofixContent
     }
   }
 
-  return (
-    <AutofixArtifacts autofix={autofix} group={group} project={project} event={event} />
-  );
+  return <AutofixArtifacts autofix={autofix} group={group} project={project} />;
 }
 
 interface AutofixArtifactsProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
-  event: Event;
   group: Group;
   project: Project;
 }
 
-function AutofixArtifacts({autofix, group, project, event}: AutofixArtifactsProps) {
+function AutofixArtifacts({autofix, group, project}: AutofixArtifactsProps) {
   const sections = useMemo(
     () => getOrderedAutofixSections(autofix.runState),
     [autofix.runState]
@@ -268,7 +256,6 @@ function AutofixArtifacts({autofix, group, project, event}: AutofixArtifactsProp
     return (
       <AutofixEmptyState
         autofix={autofix}
-        event={event}
         group={group}
         project={project}
         referrer={referrer}
@@ -279,7 +266,6 @@ function AutofixArtifacts({autofix, group, project, event}: AutofixArtifactsProp
   return (
     <AutofixPreviews
       sections={sections}
-      event={event}
       group={group}
       project={project}
       referrer={referrer}
@@ -289,23 +275,15 @@ function AutofixArtifacts({autofix, group, project, event}: AutofixArtifactsProp
 
 interface AutofixEmptyStateProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
-  event: Event;
   group: Group;
   project: Project;
   referrer?: string;
 }
 
-function AutofixEmptyState({
-  autofix,
-  group,
-  event,
-  project,
-  referrer,
-}: AutofixEmptyStateProps) {
+function AutofixEmptyState({autofix, group, project, referrer}: AutofixEmptyStateProps) {
   const {openSeerDrawer} = useOpenSeerDrawer({
     group,
     project,
-    event,
   });
 
   // extract startStep first here so we can depend on it directly as `autofix` itself is unstable.
@@ -369,20 +347,13 @@ function AutofixEmptyState({
 }
 
 interface AutofixPreviewsProps {
-  event: Event;
   group: Group;
   project: Project;
   sections: AutofixSection[];
   referrer?: string;
 }
 
-function AutofixPreviews({
-  event,
-  group,
-  project,
-  sections,
-  referrer,
-}: AutofixPreviewsProps) {
+function AutofixPreviews({group, project, sections, referrer}: AutofixPreviewsProps) {
   const hasRootCause =
     sections.findLast(isRootCauseSection)?.artifacts?.some(isRootCauseArtifact) ?? false;
 
@@ -409,7 +380,6 @@ function AutofixPreviews({
   const {openSeerDrawer} = useOpenSeerDrawer({
     group,
     project,
-    event,
   });
 
   return (

--- a/static/app/views/issueDetails/sidebar/autofixSectionTypes.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSectionTypes.tsx
@@ -1,4 +1,3 @@
-import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import type {useAiConfig} from 'sentry/views/issueDetails/hooks/useAiConfig';
@@ -7,5 +6,4 @@ export interface AutofixContentProps {
   aiConfig: ReturnType<typeof useAiConfig>;
   group: Group;
   project: Project;
-  event?: Event;
 }

--- a/static/app/views/issueDetails/sidebar/resources.tsx
+++ b/static/app/views/issueDetails/sidebar/resources.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
 
-import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {IssueTypeConfig, ResourceLink} from 'sentry/utils/issueTypeConfig/types';
@@ -10,17 +9,15 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 type Props = {
   configResources: NonNullable<IssueTypeConfig['resources']>;
-  eventPlatform: Event['platform'];
   group: Group;
+  platform: Group['platform'];
 };
 
-export function Resources({configResources, eventPlatform, group}: Props) {
+export function Resources({configResources, platform, group}: Props) {
   const organization = useOrganization();
   const links: ResourceLink[] = [
     ...configResources.links,
-    ...(configResources.linksByPlatform[
-      (eventPlatform ?? '') as keyof typeof configResources.linksByPlatform
-    ] ?? []),
+    ...(configResources.linksByPlatform[platform] ?? []),
   ];
 
   return (

--- a/static/app/views/issueDetails/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/sidebar/seerDrawer.tsx
@@ -4,7 +4,6 @@ import {useDrawer} from '@sentry/scraps/drawer';
 
 import {SeerDrawer} from 'sentry/components/events/autofix/v3/drawer';
 import {t} from 'sentry/locale';
-import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
@@ -16,9 +15,7 @@ export {SeerDrawer} from 'sentry/components/events/autofix/v3/drawer';
 export const useOpenSeerDrawer = ({
   group,
   project,
-  event,
 }: {
-  event: Event | null;
   group: Group;
   project: Project;
   buttonRef?: React.RefObject<HTMLButtonElement | null>;
@@ -32,7 +29,6 @@ export const useOpenSeerDrawer = ({
 
   const openSeerDrawer = useCallback(() => {
     if (
-      !event ||
       !organization.features.includes('gen-ai-features') ||
       organization.hideAiFeatures
     ) {
@@ -77,7 +73,7 @@ export const useOpenSeerDrawer = ({
         },
       });
     }
-  }, [openDrawer, event, group, project, navigate, organization]);
+  }, [openDrawer, group, project, navigate, organization]);
 
   return {openSeerDrawer};
 };

--- a/static/app/views/issueDetails/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/sidebar/sidebar.tsx
@@ -95,7 +95,7 @@ export function IssueDetailsSidebar({group, event, project}: Props) {
           <StyledBreak />
           {showSeerSection && (
             <ErrorBoundary mini>
-              <AutofixSection group={group} project={project} event={event} />
+              <AutofixSection group={group} project={project} />
             </ErrorBoundary>
           )}
           {event && (

--- a/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
+++ b/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
@@ -1,4 +1,3 @@
-import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
@@ -33,7 +32,6 @@ function makeAiConfig(
 describe('AiConfigureSeerQuotaSidebar', () => {
   const group = GroupFixture();
   const project = ProjectFixture();
-  const event = EventFixture();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -49,7 +47,6 @@ describe('AiConfigureSeerQuotaSidebar', () => {
         aiConfig={makeAiConfig({isAutofixSetupLoading: true})}
         group={group}
         project={project}
-        event={event}
       />,
       {organization}
     );
@@ -84,7 +81,6 @@ describe('AiConfigureSeerQuotaSidebar', () => {
         aiConfig={makeAiConfig({hasAutofixQuota: true})}
         group={group}
         project={project}
-        event={event}
       />,
       {organization}
     );
@@ -104,7 +100,6 @@ describe('AiConfigureSeerQuotaSidebar', () => {
         aiConfig={makeAiConfig({hasAutofixQuota: false})}
         group={group}
         project={project}
-        event={event}
       />,
       {organization}
     );
@@ -131,7 +126,6 @@ describe('AiConfigureSeerQuotaSidebar', () => {
         aiConfig={makeAiConfig({hasAutofixQuota: false})}
         group={group}
         project={project}
-        event={event}
       />,
       {organization}
     );

--- a/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.tsx
+++ b/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.tsx
@@ -17,7 +17,6 @@ export function AiConfigureSeerQuotaSidebar({
   aiConfig,
   group,
   project,
-  event,
 }: AutofixContentProps) {
   const organization = useOrganization();
   const subscription = useSubscription();
@@ -27,9 +26,7 @@ export function AiConfigureSeerQuotaSidebar({
   }
 
   if (aiConfig.hasAutofixQuota) {
-    return (
-      <AutofixContent aiConfig={aiConfig} group={group} project={project} event={event} />
-    );
+    return <AutofixContent aiConfig={aiConfig} group={group} project={project} />;
   }
 
   const hasBillingPerms = hasAccessToSubscriptionOverview(subscription, organization);


### PR DESCRIPTION
The `event` prop was threaded three levels deep through the autofix sidebar component tree
(`AutofixSection` → `AutofixContent` → `AutofixArtifacts` → empty state / previews) purely
as a readiness gate. Nothing in the subtree read any field off it:

- The two consumers were just guards: a `!event` loading check in `AutofixContent`, and a `!event` early-return in `useOpenSeerDrawer`.
- `useOpenSeerDrawer` never even forwarded `event` to `SeerDrawer` — the v3 drawer derives everything from `group`/`project` + the explorer autofix run state (keyed by `group.id`).

The guard was vestigial. The original drawer (#86354) rendered event-specific autofix content,
so it needed `event`. 

Agent transcript: https://claudescope.sentry.dev/share/jvJv5rEP0Q4oLd7sAQ6CLpDB7k-78NQ7YpPxqBK0yW4