### PR TITLE
ref(seer-activity): Use each action's own validation

### DIFF
--- a/src/sentry/notifications/notification_action/activity_registry/base.py
+++ b/src/sentry/notifications/notification_action/activity_registry/base.py
@@ -58,16 +58,3 @@ def send_activity_notification(
 ) -> None:
     data = build_activity_data(invocation, activity)
     NotificationService[WorkflowEngineActivityAction](data=data).notify_sync(targets=[target])
-
-
-def require_config(action: Action, key: str) -> str:
-    value = action.config.get(key)
-    if not value:
-        raise ValueError(f"No {key} for action {action.id}")
-    return value
-
-
-def require_integration_id(action: Action) -> int:
-    if action.integration_id is None:
-        raise ValueError(f"No integration_id for action {action.id}")
-    return action.integration_id

--- a/src/sentry/notifications/notification_action/activity_registry/discord.py
+++ b/src/sentry/notifications/notification_action/activity_registry/discord.py
@@ -1,8 +1,6 @@
 from sentry.models.activity import Activity
 from sentry.notifications.notification_action.activity_registry.base import (
     NOTIFICATION_PLATFORM_COMPATIBLE_ACTIVITIES,
-    require_config,
-    require_integration_id,
     send_activity_notification,
 )
 from sentry.notifications.notification_action.registry import activity_handler_registry
@@ -26,8 +24,8 @@ class DiscordActivityHandler(ActivityHandler):
         target = IntegrationNotificationTarget(
             provider_key=NotificationProviderKey.DISCORD,
             resource_type=NotificationTargetResourceType.CHANNEL,
-            resource_id=require_config(action, "target_identifier"),
-            integration_id=require_integration_id(action),
+            resource_id=action.config["target_identifier"],
+            integration_id=action.integration_id,
             organization_id=invocation.detector.project.organization.id,
         )
         send_activity_notification(invocation, activity, target)

--- a/src/sentry/notifications/notification_action/activity_registry/email.py
+++ b/src/sentry/notifications/notification_action/activity_registry/email.py
@@ -1,7 +1,6 @@
 from sentry.models.activity import Activity
 from sentry.notifications.notification_action.activity_registry.base import (
     NOTIFICATION_PLATFORM_COMPATIBLE_ACTIVITIES,
-    require_config,
     send_activity_notification,
 )
 from sentry.notifications.notification_action.registry import activity_handler_registry
@@ -27,6 +26,6 @@ class EmailActivityHandler(ActivityHandler):
         target = GenericNotificationTarget(
             provider_key=NotificationProviderKey.EMAIL,
             resource_type=NotificationTargetResourceType.EMAIL,
-            resource_id=require_config(action, "target_identifier"),
+            resource_id=action.config["target_identifier"],
         )
         send_activity_notification(invocation, activity, target)

--- a/src/sentry/notifications/notification_action/activity_registry/msteams.py
+++ b/src/sentry/notifications/notification_action/activity_registry/msteams.py
@@ -1,8 +1,6 @@
 from sentry.models.activity import Activity
 from sentry.notifications.notification_action.activity_registry.base import (
     NOTIFICATION_PLATFORM_COMPATIBLE_ACTIVITIES,
-    require_config,
-    require_integration_id,
     send_activity_notification,
 )
 from sentry.notifications.notification_action.registry import activity_handler_registry
@@ -26,8 +24,8 @@ class MSTeamsActivityHandler(ActivityHandler):
         target = IntegrationNotificationTarget(
             provider_key=NotificationProviderKey.MSTEAMS,
             resource_type=NotificationTargetResourceType.CHANNEL,
-            resource_id=require_config(action, "target_identifier"),
-            integration_id=require_integration_id(action),
+            resource_id=action.config["target_identifier"],
+            integration_id=action.integration_id,
             organization_id=invocation.detector.project.organization.id,
         )
         send_activity_notification(invocation, activity, target)

--- a/src/sentry/notifications/notification_action/activity_registry/slack.py
+++ b/src/sentry/notifications/notification_action/activity_registry/slack.py
@@ -2,8 +2,6 @@ from sentry.integrations.slack.utils.channel import is_input_a_user_id
 from sentry.models.activity import Activity
 from sentry.notifications.notification_action.activity_registry.base import (
     NOTIFICATION_PLATFORM_COMPATIBLE_ACTIVITIES,
-    require_config,
-    require_integration_id,
     send_activity_notification,
 )
 from sentry.notifications.notification_action.registry import activity_handler_registry
@@ -25,7 +23,7 @@ class SlackActivityHandler(ActivityHandler):
     @classmethod
     def invoke_action(cls, invocation: ActionInvocation, activity: Activity) -> None:
         action = invocation.action
-        resource_id = require_config(action, "target_identifier")
+        resource_id = action.config["target_identifier"]
         resource_type = (
             NotificationTargetResourceType.DIRECT_MESSAGE
             if is_input_a_user_id(input_id=resource_id)
@@ -40,7 +38,7 @@ class SlackActivityHandler(ActivityHandler):
             provider_key=provider_key,
             resource_type=resource_type,
             resource_id=resource_id,
-            integration_id=require_integration_id(action),
+            integration_id=action.integration_id,
             organization_id=invocation.detector.project.organization.id,
         )
         send_activity_notification(invocation, activity, target)

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -240,6 +240,13 @@ def execute_via_activity_type_registry(invocation: ActionInvocation) -> None:
         raise
 
     try:
+        action_handler = invocation.action.get_handler()
+        invocation.action.validate_config(action_handler.config_schema)
+    except Exception:
+        logger.exception("Error validating action config for activity handler", extra=logging_ctx)
+        raise
+
+    try:
         handler.invoke_action(invocation=invocation, activity=activity)
     except Exception:
         logger.exception("Error invoking action via activity handler", extra=logging_ctx)

--- a/tests/sentry/notifications/notification_action/test_activity_handler.py
+++ b/tests/sentry/notifications/notification_action/test_activity_handler.py
@@ -87,11 +87,17 @@ class TestExecuteViaActivityTypeRegistry(ActivityHandlerTest):
         self.mock_handler.validate_activity.return_value = self.activity
 
     def test_happy_path(self) -> None:
-        with mock.patch.object(
-            activity_handler_registry, "get", return_value=self.mock_handler
-        ) as mock_get:
+        mock_action_handler = mock.MagicMock()
+        with (
+            mock.patch.object(
+                activity_handler_registry, "get", return_value=self.mock_handler
+            ) as mock_get,
+            mock.patch.object(self.action, "get_handler", return_value=mock_action_handler),
+            mock.patch.object(self.action, "validate_config") as mock_validate_config,
+        ):
             execute_via_activity_type_registry(self.invocation)
             mock_get.assert_called_once_with(self.action.type)
+            mock_validate_config.assert_called_once_with(mock_action_handler.config_schema)
 
         self.mock_handler.validate_activity.assert_called_once_with(invocation=self.invocation)
         self.mock_handler.invoke_action.assert_called_once_with(


### PR DESCRIPTION
I would have liked to have been able to use concrete types for each action, but the config shapes only exist as a `JSONSchema` that we validate when we deserialize requests from the API/frontend, so we're kinda stuck with `dict[str, Any]`. It's probably a bigger refactor to overhaul that, and keeping the JSONSchema and type in parallel could just be another point where we drift.

That said, I did find that the handlers each implement their own validation, so I can invoke those methods and then avoid any riskiness with accessing keys i know about (e.g. `action.config["target_identifier"]`)