### PR TITLE
fix(gitlab): Cap org IDs in webhook debug log attribute

### DIFF
--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -708,8 +708,10 @@ class GitlabWebhookEndpoint(Endpoint):
             "webhook.integration.status": integration.status,  # 0 seems to be active
             # Logs/EAP attributes are scalar-first; a list serializes as an
             # "array" attribute that the Logs explorer won't expose as a
-            # queryable column. Join to a string so it's filterable.
-            "webhook.org_ids": ",".join(str(install.organization_id) for install in installs),
+            # queryable column. Join to a string so it's filterable. Some
+            # integrations are installed on a huge number of orgs, so cap the
+            # list to keep the log attribute from blowing up.
+            "webhook.org_ids": ",".join(str(install.organization_id) for install in installs[:25]),
         }
 
         if not constant_time_compare(secret, integration.metadata["webhook_secret"]):


### PR DESCRIPTION
Cap the `webhook.org_ids` debug log attribute on inbound GitLab webhooks to the first 25 installs. Some integrations are installed on a very large number of organizations, so joining every org ID into a single log attribute could produce an oversized value.

This only affects the debug/EAP log attribute — the webhook event-processing loop still iterates over **all** installs, so no organization is skipped from real event handling.