### PR TITLE
ref(profiles): bump processing deadline 60s --> 80s

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -157,7 +157,7 @@ logger = logging.getLogger(__name__)
 @instrumented_task(
     name="sentry.profiles.task.process_profile_from_kafka",
     namespace=ingest_profiling_passthrough_tasks,
-    processing_deadline_duration=60,
+    processing_deadline_duration=80,
     retry=Retry(times=2, delay=5),
     compression_type=CompressionType.ZSTD,
     silo_mode=SiloMode.CELL,
@@ -176,7 +176,7 @@ def process_profile_from_kafka(
 @instrumented_task(
     name="sentry.profiles.task.process_profile",
     namespace=ingest_profiling_tasks,
-    processing_deadline_duration=60,
+    processing_deadline_duration=80,
     retry=Retry(times=2, delay=5),
     compression_type=CompressionType.ZSTD,
     silo_mode=SiloMode.CELL,


### PR DESCRIPTION
This PR bumps the processing deadline of `profiles` tasks from 60s to 80s.
This is to accommodate `TaskProducer` potentially increasing the processing time of a task, as:
- previously, tasks would be marked as `Complete` immediately after the task function finishes execution
- now, tasks that produce messages need to wait until their futures are complete before being marked as `Complete`
  - note that while `TaskProducer` can increase the time until a task is marked as `Complete`, it shouldn't affect the execution _rate_ of a task, as the worker is still processing other tasks while waiting for futures to complete
- large profiling tasks were already coming close to hitting the processing deadline before the addition of `TaskProducer`