### PR TITLE
fix(deps): add requires-python to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "sentry"
 # see setup.cfg for versioning; we only have this here to make uv happy
 # which we intend to use for dependency management, not packaging
 version = "0.0.0"
+requires-python = ">=3.13"
 dependencies = [
   "asyncpg>=0.31.0",
   "backports-zstd>=1.3.0",


### PR DESCRIPTION
## Problem

`bump-version.yml` fails with:

```
× No solution found when resolving dependencies for split (markers:
│ (python_full_version >= '3.15' and sys_platform == 'darwin') or ...):
╰─▶ Because only taskbroker-client<=0.19.3 is available and your project
    depends on taskbroker-client>=0.20.0
hint: Consider limiting your project's supported Python versions using `requires-python`.
```

Without `requires-python`, uv resolves dependencies for **all** Python versions including >=3.15. The internal PyPI index may not serve newer packages under 3.15+ markers at resolution time (e.g. due to build propagation lag), causing the workflow to fail even when the package is available for the active Python version.

## Fix

Add `requires-python = ">=3.13"` to `pyproject.toml`, matching the existing `python_requires = >=3.13` in `setup.cfg`. This constrains uv's resolver to the actual supported range and avoids spurious resolution failures.

Refs: https://github.com/getsentry/sentry/actions/runs/27843448342

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AD0B0XMY6PHC%3A1781098448.772909%22)