### PR TITLE
fix(chartcuterie): Use Rubik font for rendered charts

### DIFF
--- a/static/app/chartcuterie/metricAlert.tsx
+++ b/static/app/chartcuterie/metricAlert.tsx
@@ -11,7 +11,12 @@ import {
   transformSessionResponseToSeries,
 } from 'sentry/views/alerts/rules/metric/details/metricChartOption';
 
-import {DEFAULT_FONT_FAMILY, makeSlackChartDefaults, slackChartSize} from './slack';
+import {
+  DEFAULT_FONT_FAMILY,
+  FALLBACK_FONT_FAMILY,
+  makeSlackChartDefaults,
+  slackChartSize,
+} from './slack';
 import type {RenderDescriptor} from './types';
 import {ChartType} from './types';
 
@@ -35,7 +40,7 @@ function transformAreaSeries(series: AreaChartSeries[]): LineSeriesOption[] {
 
     // Fix incident label font family, cannot use Rubik
     if (areaSeries.markLine?.label) {
-      areaSeries.markLine.label.fontFamily = DEFAULT_FONT_FAMILY;
+      areaSeries.markLine.label.fontFamily = FALLBACK_FONT_FAMILY;
     }
 
     return areaSeries;

--- a/static/app/chartcuterie/metricDetector.tsx
+++ b/static/app/chartcuterie/metricDetector.tsx
@@ -11,7 +11,12 @@ import {
   type MetricDetectorChartData,
 } from 'sentry/views/detectors/components/details/metric/charts/metricDetectorChartOptions';
 
-import {DEFAULT_FONT_FAMILY, makeSlackChartDefaults, slackChartSize} from './slack';
+import {
+  DEFAULT_FONT_FAMILY,
+  FALLBACK_FONT_FAMILY,
+  makeSlackChartDefaults,
+  slackChartSize,
+} from './slack';
 import type {RenderDescriptor} from './types';
 import {ChartType} from './types';
 
@@ -35,7 +40,7 @@ function transformAreaSeries(series: AreaChartSeries[]): LineSeriesOption[] {
 
     // Fix incident label font family, cannot use Rubik
     if (areaSeries.markLine?.label) {
-      areaSeries.markLine.label.fontFamily = DEFAULT_FONT_FAMILY;
+      areaSeries.markLine.label.fontFamily = FALLBACK_FONT_FAMILY;
     }
 
     return areaSeries;

--- a/static/app/chartcuterie/slack.tsx
+++ b/static/app/chartcuterie/slack.tsx
@@ -5,7 +5,18 @@ import {Legend} from 'sentry/components/charts/components/legend';
 import {XAxis} from 'sentry/components/charts/components/xAxis';
 import {YAxis} from 'sentry/components/charts/components/yAxis';
 
-export const DEFAULT_FONT_FAMILY = 'sans-serif';
+/**
+ * Rubik is registered with node-canvas by the chartcuterie service (see
+ * ``registerCanvasFonts`` in the getsentry/chartcuterie repo), so charts
+ * render with the same typeface as the Sentry UI.
+ */
+export const DEFAULT_FONT_FAMILY = 'Rubik';
+
+/**
+ * Built-in echarts fallback font for the handful of places that can't use
+ * Rubik (e.g. incident marker labels in metric alert/detector charts).
+ */
+export const FALLBACK_FONT_FAMILY = 'sans-serif';
 
 /**
  * Size configuration for SLACK_* type charts


### PR DESCRIPTION
## Summary

Chartcuterie-rendered charts (Slack unfurls, etc.) use `sans-serif` instead of Rubik, so they don't match the Sentry UI.

`DEFAULT_FONT_FAMILY` was hardcoded to `'sans-serif'` as a temporary workaround in #31554 (2022), back when the chartcuterie service wasn't loading fonts correctly. The service now registers Rubik with node-canvas (`registerCanvasFonts` in `getsentry/chartcuterie`, `src/utils.ts`, called at startup in `src/render.ts`), so every config has been overriding an already-available Rubik back to the built-in fallback.

## Changes

- `slack.tsx`: `DEFAULT_FONT_FAMILY` → `'Rubik'`. Flows into timeseries, discover, performance, and all axis/legend labels.
- Added `FALLBACK_FONT_FAMILY = 'sans-serif'` for the metric alert/detector incident marker labels that intentionally avoid Rubik — their behavior is unchanged.

## Notes

- The Rubik bundled with the chartcuterie service is **Latin-only** (`rubik-regular.woff` / `rubik-medium.woff`). Non-Latin glyphs in labels fall back per-glyph to node-canvas's default — strictly no worse than today's all-sans-serif rendering, and likely the original reason the incident marker labels were pinned off Rubik.
- No deploy-ordering hazard: the font is already deployed service-side; this only takes effect once the new config bundle (versioned by `COMMIT_SHA`) rolls out.

Fixes DAIN-1710