### PR TITLE
ref(dashboards): Use a render prop for heat map tooltip actions

### DIFF
--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.stories.tsx
@@ -111,68 +111,49 @@ export default Storybook.story('HeatMapWidgetVisualization', story => {
       return (
         <Fragment>
           <p>
-            <Storybook.JSXNode name="HeatMapWidgetVisualization" /> supports two optional
-            tooltip action props. Click a cell to open the tooltip and see the links.
+            By default a cell's tooltip shows its Y-axis bucket range and Z-axis count.
+            Click a cell to open the tooltip.
           </p>
           <p>
-            With no extra props, the tooltip shows the Y-axis bucket range and the Z-axis
-            count for the clicked cell.
+            Pass <code>renderTooltipActions</code> to add action rows (e.g. an Explore
+            link). It receives the cell's value-range query (<code>cellQuery</code>) and a{' '}
+            <code>selection</code> narrowed to the cell's time bucket, and returns the
+            extra rows — so the visualization stays agnostic about what the actions are.
           </p>
           <p>
-            Pass <code>makeExploreUrl</code> to add a <em>View connected spans</em> link
-            in the tooltip. The callback receives the Y-axis filter query (e.g.{' '}
-            <code>value:&gt;=200 value:&lt;250</code>) and a <code>PageFilters</code>{' '}
-            object whose datetime is narrowed to the clicked X-axis bucket. Use these to
-            build a cross-event query link into Explore.
-          </p>
-          <p>
-            <CodeBlock language="jsx">
-              {`<HeatMapWidgetVisualization
-  plottables={[new HeatMap(heatMapData)]}
-  makeExploreUrl={(query, filteredSelection) =>
-    getExploreUrl({
-      organization,
-      selection: filteredSelection,
-      crossEvents: [{
-            type: 'metrics',
-            metric,
-            query,
-      }]
-    })
-  }
-/>`}
-            </CodeBlock>
-          </p>
-
-          <p>
-            Pass <code>updateLocalFilterQuery</code> to add an <em>Add to filter</em> link
-            in the tooltip. The callback receives the Y-axis filter query and should apply
-            that filter to the current view. Navigation is handled however you choose in
-            the passing function (most likely will use hooks).
+            Because ECharts renders the tooltip to an HTML string, React click handlers
+            don't survive. Use <code>data-traces-link</code> for navigations, and{' '}
+            <code>data-local-query</code> for "add to filter" actions (routed through{' '}
+            <code>updateLocalFilterQuery</code>).
           </p>
           <p>
             <CodeBlock language="jsx">
               {`<HeatMapWidgetVisualization
   plottables={[new HeatMap(heatMapData)]}
-  updateLocalFilterQuery={(query) =>
-    setLocalFilterQuery(query)
-  }
+  updateLocalFilterQuery={query => setLocalFilterQuery(query)}
+  renderTooltipActions={({cellQuery, selection}) => (
+    <Fragment>
+      <a data-traces-link={getExploreUrl({organization, selection, crossEvents: [...]})}>
+        View connected spans
+      </a>
+      <a data-local-query={cellQuery}>Add to filter</a>
+    </Fragment>
+  )}
 />`}
             </CodeBlock>
-          </p>
-
-          <p>
-            Both props can be used together. The tooltip shows{' '}
-            <em>View related traces</em> and <em>Add to filter</em> as separate actions.
           </p>
           <LargeWidget>
             <p>{`Local Filter Query: ${localFilterQuery}`}</p>
             <HeatMapWidgetVisualization
               plottables={[new HeatMap(sampleLatencyHeatMap)]}
-              makeExploreUrl={(query, filteredSelection) =>
-                `/explore/traces/?query=${encodeURIComponent(query)}&start=${filteredSelection.datetime.start}&end=${filteredSelection.datetime.end}`
-              }
               updateLocalFilterQuery={query => setLocalFilterQuery(query)}
+              renderTooltipActions={({cellQuery}) => (
+                <div>
+                  <span className="tooltip-label tooltip-label-centered">
+                    <a data-local-query={cellQuery}>Add to filter</a>
+                  </span>
+                </div>
+              )}
             />
           </LargeWidget>
         </Fragment>

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.stories.tsx
@@ -26,8 +26,9 @@ export default Storybook.story('HeatMapWidgetVisualization', story => {
         <LargeWidget>
           <HeatMapWidgetVisualization plottables={[new HeatMap(sampleLatencyHeatMap)]} />
         </LargeWidget>
+
         <p>
-          <strong>Hint:</strong> clicking on the chart will display the x-, y-, and z-axis
+          <strong>Hint:</strong> clicking on the chart will display the X-, Y-, and Z-axis
           values in the tooltip.
         </p>
       </Fragment>
@@ -103,11 +104,12 @@ export default Storybook.story('HeatMapWidgetVisualization', story => {
     );
   });
 
-  story('Tooltip Options', () => {
-    function TooltipOptionsStory() {
+  story('Tooltip Actions', () => {
+    function TooltipActionsStory() {
       const [localFilterQuery, setLocalFilterQuery] = useState<string | undefined>(
         undefined
       );
+
       return (
         <Fragment>
           <p>
@@ -115,19 +117,19 @@ export default Storybook.story('HeatMapWidgetVisualization', story => {
             Click a cell to open the tooltip.
           </p>
           <p>
-            Pass <code>renderTooltipActions</code> to add action rows (e.g. an Explore
+            Pass <code>renderTooltipActions</code> to add action rows (e.g., an Explore
             link). It receives the hovered cell's raw bounds — <code>valueMin</code>/
-            <code>valueMax</code> (Y axis) and <code>timestampStart</code>/
-            <code>timestampEnd</code> (X axis) — and returns the extra rows. The caller
-            turns those into whatever query or URL it needs, so the visualization stays
-            agnostic.
+            <code>valueMax</code> (Y-axis) and <code>timestampStart</code>/
+            <code>timestampEnd</code> (X-axis). It should return a React fragment that
+            will be rendered in the tooltip.
           </p>
           <p>
             Because ECharts renders the tooltip to an HTML string, React click handlers
-            don't survive — the visualization routes clicks for you. Use{' '}
-            <code>data-traces-link</code> for navigations, and{' '}
-            <code>data-tooltip-action</code> + <code>data-tooltip-action-value</code> for
-            actions (dispatched to the matching <code>tooltipActionHandlers</code> entry).
+            don't work in that context. Instead, the visualization routes clicks for you.
+            Annotate your links with <code>data-traces-link</code> for navigations, and{' '}
+            <code>data-tooltip-action</code> with <code>data-tooltip-action-value</code>{' '}
+            for actions. These will be dispatched to the matching{' '}
+            <code>tooltipActionHandlers</code> entry.
           </p>
           <p>
             <CodeBlock language="jsx">
@@ -174,7 +176,7 @@ export default Storybook.story('HeatMapWidgetVisualization', story => {
         </Fragment>
       );
     }
-    return <TooltipOptionsStory />;
+    return <TooltipActionsStory />;
   });
 });
 

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.stories.tsx
@@ -116,9 +116,11 @@ export default Storybook.story('HeatMapWidgetVisualization', story => {
           </p>
           <p>
             Pass <code>renderTooltipActions</code> to add action rows (e.g. an Explore
-            link). It receives the cell's value-range query (<code>cellQuery</code>) and a{' '}
-            <code>selection</code> narrowed to the cell's time bucket, and returns the
-            extra rows — so the visualization stays agnostic about what the actions are.
+            link). It receives the hovered cell's raw bounds — <code>valueMin</code>/
+            <code>valueMax</code> (Y axis) and <code>timestampStart</code>/
+            <code>timestampEnd</code> (X axis) — and returns the extra rows. The caller
+            turns those into whatever query or URL it needs, so the visualization stays
+            agnostic.
           </p>
           <p>
             Because ECharts renders the tooltip to an HTML string, React click handlers
@@ -132,16 +134,19 @@ export default Storybook.story('HeatMapWidgetVisualization', story => {
               {`<HeatMapWidgetVisualization
   plottables={[new HeatMap(heatMapData)]}
   tooltipActionHandlers={{'add-to-filter': query => setLocalFilterQuery(query)}}
-  renderTooltipActions={({cellQuery, selection}) => (
-    <Fragment>
-      <a data-traces-link={getExploreUrl({organization, selection, crossEvents: [...]})}>
-        View connected spans
-      </a>
-      <a data-tooltip-action="add-to-filter" data-tooltip-action-value={cellQuery}>
-        Add to filter
-      </a>
-    </Fragment>
-  )}
+  renderTooltipActions={({valueMin, valueMax, timestampStart, timestampEnd}) => {
+    const valueQuery = \`value:>=\${valueMin} value:<\${valueMax}\`;
+    return (
+      <Fragment>
+        <a data-traces-link={getExploreUrl({organization, selection, crossEvents: [...]})}>
+          View connected spans
+        </a>
+        <a data-tooltip-action="add-to-filter" data-tooltip-action-value={valueQuery}>
+          Add to filter
+        </a>
+      </Fragment>
+    );
+  }}
 />`}
             </CodeBlock>
           </p>
@@ -152,12 +157,12 @@ export default Storybook.story('HeatMapWidgetVisualization', story => {
               tooltipActionHandlers={{
                 'add-to-filter': query => setLocalFilterQuery(query),
               }}
-              renderTooltipActions={({cellQuery}) => (
+              renderTooltipActions={({valueMin, valueMax}) => (
                 <div>
                   <span className="tooltip-label tooltip-label-centered">
                     <a
                       data-tooltip-action="add-to-filter"
-                      data-tooltip-action-value={cellQuery}
+                      data-tooltip-action-value={`value:>=${valueMin} value:<${valueMax}`}
                     >
                       Add to filter
                     </a>

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.stories.tsx
@@ -122,21 +122,24 @@ export default Storybook.story('HeatMapWidgetVisualization', story => {
           </p>
           <p>
             Because ECharts renders the tooltip to an HTML string, React click handlers
-            don't survive. Use <code>data-traces-link</code> for navigations, and{' '}
-            <code>data-local-query</code> for "add to filter" actions (routed through{' '}
-            <code>updateLocalFilterQuery</code>).
+            don't survive — the visualization routes clicks for you. Use{' '}
+            <code>data-traces-link</code> for navigations, and{' '}
+            <code>data-tooltip-action</code> + <code>data-tooltip-action-value</code> for
+            actions (dispatched to the matching <code>tooltipActionHandlers</code> entry).
           </p>
           <p>
             <CodeBlock language="jsx">
               {`<HeatMapWidgetVisualization
   plottables={[new HeatMap(heatMapData)]}
-  updateLocalFilterQuery={query => setLocalFilterQuery(query)}
+  tooltipActionHandlers={{'add-to-filter': query => setLocalFilterQuery(query)}}
   renderTooltipActions={({cellQuery, selection}) => (
     <Fragment>
       <a data-traces-link={getExploreUrl({organization, selection, crossEvents: [...]})}>
         View connected spans
       </a>
-      <a data-local-query={cellQuery}>Add to filter</a>
+      <a data-tooltip-action="add-to-filter" data-tooltip-action-value={cellQuery}>
+        Add to filter
+      </a>
     </Fragment>
   )}
 />`}
@@ -146,11 +149,18 @@ export default Storybook.story('HeatMapWidgetVisualization', story => {
             <p>{`Local Filter Query: ${localFilterQuery}`}</p>
             <HeatMapWidgetVisualization
               plottables={[new HeatMap(sampleLatencyHeatMap)]}
-              updateLocalFilterQuery={query => setLocalFilterQuery(query)}
+              tooltipActionHandlers={{
+                'add-to-filter': query => setLocalFilterQuery(query),
+              }}
               renderTooltipActions={({cellQuery}) => (
                 <div>
                   <span className="tooltip-label tooltip-label-centered">
-                    <a data-local-query={cellQuery}>Add to filter</a>
+                    <a
+                      data-tooltip-action="add-to-filter"
+                      data-tooltip-action-value={cellQuery}
+                    >
+                      Add to filter
+                    </a>
                   </span>
                 </div>
               )}

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -14,7 +14,6 @@ import {BaseChart} from 'sentry/components/charts/baseChart';
 import {defaultFormatAxisLabel} from 'sentry/components/charts/components/tooltip';
 import {isChartHovered} from 'sentry/components/charts/utils';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import type {PageFilters} from 'sentry/types/core';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils/defined';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
@@ -40,10 +39,14 @@ const Y_AXIS_LABEL_FONT_SIZE = 12;
  * caller can build its own tooltip actions (e.g. links into Explore).
  */
 interface HeatMapTooltipContext {
-  /** Value-range filter for the hovered cell, e.g. `value:>=200 value:<250`. */
-  cellQuery: string;
-  /** Page filters narrowed to the hovered cell's X-axis (time) bucket. */
-  selection: PageFilters;
+  /** End of the cell's X-axis (time) bucket, as a millisecond timestamp. */
+  timestampEnd: number;
+  /** Start of the cell's X-axis (time) bucket, as a millisecond timestamp. */
+  timestampStart: number;
+  /** Upper bound of the cell's Y-axis (value) bucket (equals `valueMin` for a zero-width bucket). */
+  valueMax: number;
+  /** Inclusive lower bound of the cell's Y-axis (value) bucket. */
+  valueMin: number;
 }
 
 interface HeatMapWidgetVisualizationProps {
@@ -245,24 +248,17 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
               }
             }
 
-            // The caller renders any cell actions (e.g. an Explore link) from
-            // the cell's value-range query and time-narrowed selection.
+            // The caller renders any cell actions (e.g. an Explore link) from the
+            // cell's raw value/time bounds — the visualization doesn't know what
+            // a "query" or "selection" should look like.
             let tooltipActions: ReactNode = null;
             if (defined(rawXValue) && defined(rawYValue) && renderTooltipActions) {
-              const cellQuery =
-                yAxisBucketSize === 0
-                  ? `value:<=${rawYValue}`
-                  : `value:>=${rawYValue} value:<${rawYValue + yAxisBucketSize}`;
-              const selection = {
-                ...pageFilters.selection,
-                datetime: {
-                  ...pageFilters.selection.datetime,
-                  start: new Date(rawXValue),
-                  end: new Date(rawXValue + xAxisBucketSize * 1000),
-                  period: null,
-                },
-              };
-              tooltipActions = renderTooltipActions({cellQuery, selection});
+              tooltipActions = renderTooltipActions({
+                valueMin: rawYValue,
+                valueMax: rawYValue + yAxisBucketSize,
+                timestampStart: rawXValue,
+                timestampEnd: rawXValue + xAxisBucketSize * 1000,
+              });
             }
 
             return (

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -55,10 +55,10 @@ interface HeatMapWidgetVisualizationProps {
    * Renders extra action rows in a cell's tooltip (e.g. an Explore link). The
    * visualization stays agnostic about what those actions are; the caller builds
    * them from the cell context. Because ECharts renders the tooltip to an HTML
-   * string (no live React handlers), use `data-traces-link="<url>"` for
-   * navigations and `data-local-query="<query>"` for "add to filter" actions —
-   * the visualization routes clicks on those (the latter via
-   * `updateLocalFilterQuery`).
+   * string (no live React handlers), the visualization routes clicks for you:
+   * use `data-traces-link="<url>"` for navigations, and
+   * `data-tooltip-action="<id>"` with `data-tooltip-action-value="<value>"` for
+   * actions — the matching `tooltipActionHandlers[id]` is called with the value.
    */
   renderTooltipActions?: (context: HeatMapTooltipContext) => ReactNode;
   /**
@@ -66,14 +66,15 @@ interface HeatMapWidgetVisualizationProps {
    */
   scale?: 'linear' | 'log';
   /**
-   * Handles clicks on `data-local-query` tooltip actions, updating the local
-   * filter to include the given Y-axis query.
+   * Handlers for caller-rendered tooltip actions, keyed by the button's
+   * `data-tooltip-action` id. Clicking such a button calls the matching handler
+   * with its `data-tooltip-action-value`.
    */
-  updateLocalFilterQuery?: (query: string) => void;
+  tooltipActionHandlers?: Record<string, (value: string) => void>;
 }
 
 export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProps) {
-  const {plottables, updateLocalFilterQuery, renderTooltipActions} = props;
+  const {plottables, tooltipActionHandlers, renderTooltipActions} = props;
   const theme = useTheme();
   const renderToString = useRenderToString();
   const navigate = useNavigate();
@@ -93,18 +94,17 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
       if (!chartRef.current?.ele?.contains(e.target as Node)) {
         return;
       }
-      const localQueryUpdateTarget = (e.target as Element).closest('[data-local-query]');
+      const actionTarget = (e.target as Element).closest('[data-tooltip-action]');
       const tracesLinkTarget = (e.target as Element).closest('[data-traces-link]');
-      if (!localQueryUpdateTarget && !tracesLinkTarget) {
+      if (!actionTarget && !tracesLinkTarget) {
         return;
       }
       e.preventDefault();
       const openInNewTab = e.metaKey || e.ctrlKey;
-      if (localQueryUpdateTarget) {
-        const localQuery = localQueryUpdateTarget.getAttribute('data-local-query');
-        if (localQuery && updateLocalFilterQuery) {
-          updateLocalFilterQuery(localQuery);
-        }
+      if (actionTarget) {
+        const actionId = actionTarget.getAttribute('data-tooltip-action');
+        const handler = actionId ? tooltipActionHandlers?.[actionId] : undefined;
+        handler?.(actionTarget.getAttribute('data-tooltip-action-value') ?? '');
       }
       if (tracesLinkTarget) {
         const tracesUrl = tracesLinkTarget.getAttribute('data-traces-link');
@@ -117,7 +117,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
         }
       }
     },
-    [navigate, updateLocalFilterQuery]
+    [navigate, tooltipActionHandlers]
   );
 
   useEffect(() => {

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -1,6 +1,6 @@
 import 'echarts/lib/chart/heatmap';
 
-import {Fragment, useCallback, useEffect, useRef} from 'react';
+import {Fragment, useCallback, useEffect, useRef, type ReactNode} from 'react';
 import {useTheme} from '@emotion/react';
 import type {
   TooltipFormatterCallback,
@@ -14,7 +14,6 @@ import {BaseChart} from 'sentry/components/charts/baseChart';
 import {defaultFormatAxisLabel} from 'sentry/components/charts/components/tooltip';
 import {isChartHovered} from 'sentry/components/charts/utils';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils/defined';
@@ -36,27 +35,45 @@ import {HEATMAP_COLORS} from './settings';
 // Source: https://echarts.apache.org/en/option.html#yAxis.axisLabel.fontSize
 const Y_AXIS_LABEL_FONT_SIZE = 12;
 
+/**
+ * Context for the hovered heat map cell, handed to `renderTooltipActions` so the
+ * caller can build its own tooltip actions (e.g. links into Explore).
+ */
+interface HeatMapTooltipContext {
+  /** Value-range filter for the hovered cell, e.g. `value:>=200 value:<250`. */
+  cellQuery: string;
+  /** Page filters narrowed to the hovered cell's X-axis (time) bucket. */
+  selection: PageFilters;
+}
+
 interface HeatMapWidgetVisualizationProps {
   /**
    * An single `HeatMap` object to render on the chart, and any number of other compatible Heat Map plottables.
    */
   plottables: [HeatMap, ...HeatMapPlottable[]];
   /**
-   * Callback that returns an explore URL for a given query and filtered datetime selection
+   * Renders extra action rows in a cell's tooltip (e.g. an Explore link). The
+   * visualization stays agnostic about what those actions are; the caller builds
+   * them from the cell context. Because ECharts renders the tooltip to an HTML
+   * string (no live React handlers), use `data-traces-link="<url>"` for
+   * navigations and `data-local-query="<query>"` for "add to filter" actions —
+   * the visualization routes clicks on those (the latter via
+   * `updateLocalFilterQuery`).
    */
-  makeExploreUrl?: (query: string, filteredSelection: PageFilters) => string;
+  renderTooltipActions?: (context: HeatMapTooltipContext) => ReactNode;
   /**
    * Experimental! Specify the Z-axis scale type. Logarithmic scales can be much more useful for values with a high range.
    */
   scale?: 'linear' | 'log';
   /**
-   * Callback that updates the local filter to include the given Y-axis query.
+   * Handles clicks on `data-local-query` tooltip actions, updating the local
+   * filter to include the given Y-axis query.
    */
   updateLocalFilterQuery?: (query: string) => void;
 }
 
 export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProps) {
-  const {plottables, updateLocalFilterQuery, makeExploreUrl} = props;
+  const {plottables, updateLocalFilterQuery, renderTooltipActions} = props;
   const theme = useTheme();
   const renderToString = useRenderToString();
   const navigate = useNavigate();
@@ -228,29 +245,24 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
               }
             }
 
-            let tracesLink: string | undefined;
-            const metricsQuery = defined(rawYValue)
-              ? yAxisBucketSize === 0
-                ? `value:<=${rawYValue}`
-                : `value:>=${rawYValue} value:<${rawYValue + yAxisBucketSize}`
-              : undefined;
-
-            if (defined(rawXValue) && defined(rawYValue)) {
-              const xAxisMaxValue = rawXValue + xAxisBucketSize * 1000;
-
-              const filteredSelection = {
+            // The caller renders any cell actions (e.g. an Explore link) from
+            // the cell's value-range query and time-narrowed selection.
+            let tooltipActions: ReactNode = null;
+            if (defined(rawXValue) && defined(rawYValue) && renderTooltipActions) {
+              const cellQuery =
+                yAxisBucketSize === 0
+                  ? `value:<=${rawYValue}`
+                  : `value:>=${rawYValue} value:<${rawYValue + yAxisBucketSize}`;
+              const selection = {
                 ...pageFilters.selection,
                 datetime: {
                   ...pageFilters.selection.datetime,
                   start: new Date(rawXValue),
-                  end: new Date(xAxisMaxValue),
+                  end: new Date(rawXValue + xAxisBucketSize * 1000),
                   period: null,
                 },
               };
-
-              if (makeExploreUrl && metricsQuery) {
-                tracesLink = makeExploreUrl(metricsQuery, filteredSelection);
-              }
+              tooltipActions = renderTooltipActions({cellQuery, selection});
             }
 
             return (
@@ -261,22 +273,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
                   </span>{' '}
                   {formattedZValue}
                 </div>
-                {makeExploreUrl && defined(tracesLink) && (
-                  <div>
-                    <span className="tooltip-label tooltip-label-centered">
-                      <a data-traces-link={tracesLink} href={tracesLink}>
-                        {t('View connected spans')}
-                      </a>
-                    </span>
-                  </div>
-                )}
-                {updateLocalFilterQuery && defined(metricsQuery) && (
-                  <div>
-                    <span className="tooltip-label tooltip-label-centered">
-                      <a data-local-query={metricsQuery}>{t('Add to filter')}</a>
-                    </span>
-                  </div>
-                )}
+                {tooltipActions}
               </Fragment>
             );
           })}

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -34,34 +34,17 @@ import {HEATMAP_COLORS} from './settings';
 // Source: https://echarts.apache.org/en/option.html#yAxis.axisLabel.fontSize
 const Y_AXIS_LABEL_FONT_SIZE = 12;
 
-/**
- * Context for the hovered heat map cell, handed to `renderTooltipActions` so the
- * caller can build its own tooltip actions (e.g. links into Explore).
- */
-interface HeatMapTooltipContext {
-  /** End of the cell's X-axis (time) bucket, as a millisecond timestamp. */
-  timestampEnd: number;
-  /** Start of the cell's X-axis (time) bucket, as a millisecond timestamp. */
-  timestampStart: number;
-  /** Upper bound of the cell's Y-axis (value) bucket (equals `valueMin` for a zero-width bucket). */
-  valueMax: number;
-  /** Inclusive lower bound of the cell's Y-axis (value) bucket. */
-  valueMin: number;
-}
-
 interface HeatMapWidgetVisualizationProps {
   /**
    * An single `HeatMap` object to render on the chart, and any number of other compatible Heat Map plottables.
    */
   plottables: [HeatMap, ...HeatMapPlottable[]];
   /**
-   * Renders extra action rows in a cell's tooltip (e.g. an Explore link). The
-   * visualization stays agnostic about what those actions are; the caller builds
-   * them from the cell context. Because ECharts renders the tooltip to an HTML
-   * string (no live React handlers), the visualization routes clicks for you:
-   * use `data-traces-link="<url>"` for navigations, and
+   * Renders extra content in a cell's tooltip. Because ECharts renders the
+   * tooltip to an HTML string (no live React handlers), the visualization
+   * routes clicks for you: use `data-traces-link="<url>"` for navigations, and
    * `data-tooltip-action="<id>"` with `data-tooltip-action-value="<value>"` for
-   * actions — the matching `tooltipActionHandlers[id]` is called with the value.
+   * actions. The matching `tooltipActionHandlers[id]` is called with the value.
    */
   renderTooltipActions?: (context: HeatMapTooltipContext) => ReactNode;
   /**
@@ -97,18 +80,25 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
       if (!chartRef.current?.ele?.contains(e.target as Node)) {
         return;
       }
+
       const actionTarget = (e.target as Element).closest('[data-tooltip-action]');
+
       const tracesLinkTarget = (e.target as Element).closest('[data-traces-link]');
+
       if (!actionTarget && !tracesLinkTarget) {
         return;
       }
+
       e.preventDefault();
+
       const openInNewTab = e.metaKey || e.ctrlKey;
+
       if (actionTarget) {
         const actionId = actionTarget.getAttribute('data-tooltip-action');
         const handler = actionId ? tooltipActionHandlers?.[actionId] : undefined;
         handler?.(actionTarget.getAttribute('data-tooltip-action-value') ?? '');
       }
+
       if (tracesLinkTarget) {
         const tracesUrl = tracesLinkTarget.getAttribute('data-traces-link');
         if (tracesUrl) {
@@ -406,4 +396,15 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
       />
     </Flex>
   );
+}
+
+/**
+ * Context for the hovered heat map cell, handed to `renderTooltipActions` so the
+ * caller can build its own tooltip actions (e.g. links into Explore).
+ */
+interface HeatMapTooltipContext {
+  timestampEnd: number;
+  timestampStart: number;
+  valueMax: number;
+  valueMin: number;
 }

--- a/static/app/views/explore/metrics/metricsHeatMap.tsx
+++ b/static/app/views/explore/metrics/metricsHeatMap.tsx
@@ -1,8 +1,7 @@
-import {useCallback} from 'react';
+import {Fragment, useCallback} from 'react';
 import type {UseQueryResult} from '@tanstack/react-query';
 
 import {t} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {HeatMapSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {WidgetLoadingPanel} from 'sentry/views/dashboards/widgets/common/widgetLoadingPanel';
@@ -39,7 +38,6 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
   const metric = useTraceMetric();
   const userQuery = useQueryParamsQuery();
   const setMetricQuery = useSetQueryParamsQuery();
-
   const organization = useOrganization();
 
   const {data: heatMapSeries, isPending, error} = heatmapResult;
@@ -49,23 +47,6 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
     visualizes.length > 1
       ? metricName
       : (title ?? metricLabel ?? prettifyAggregation(aggregate) ?? aggregate);
-
-  const getFilteredExploreUrl = useCallback(
-    (query: string, filteredSelection: PageFilters) => {
-      return getExploreUrl({
-        organization,
-        selection: filteredSelection,
-        crossEvents: [
-          {
-            type: 'metrics',
-            metric,
-            query,
-          },
-        ],
-      });
-    },
-    [metric, organization]
-  );
 
   const updateMetricQuery = useCallback(
     (query: string) => {
@@ -90,8 +71,30 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
             <HeatMapWidgetVisualization
               plottables={[new HeatMap(heatMapSeries)]}
               scale={HEATMAP_Z_AXIS_SCALE}
-              makeExploreUrl={getFilteredExploreUrl}
               updateLocalFilterQuery={updateMetricQuery}
+              renderTooltipActions={({cellQuery, selection}) => {
+                const tracesUrl = getExploreUrl({
+                  organization,
+                  selection,
+                  crossEvents: [{type: 'metrics', metric, query: cellQuery}],
+                });
+                return (
+                  <Fragment>
+                    <div>
+                      <span className="tooltip-label tooltip-label-centered">
+                        <a data-traces-link={tracesUrl} href={tracesUrl}>
+                          {t('View connected spans')}
+                        </a>
+                      </span>
+                    </div>
+                    <div>
+                      <span className="tooltip-label tooltip-label-centered">
+                        <a data-local-query={cellQuery}>{t('Add to filter')}</a>
+                      </span>
+                    </div>
+                  </Fragment>
+                );
+              }}
             />
           )
         }

--- a/static/app/views/explore/metrics/metricsHeatMap.tsx
+++ b/static/app/views/explore/metrics/metricsHeatMap.tsx
@@ -24,6 +24,10 @@ import {
 } from 'sentry/views/explore/queryParams/context';
 import {getExploreUrl, prettifyAggregation} from 'sentry/views/explore/utils';
 
+// Tooltip action id for the "Add to filter" button, wired to a handler via
+// `tooltipActionHandlers`.
+const ADD_TO_FILTER_ACTION = 'add-to-filter';
+
 interface MetricsHeatMapProps {
   actions: React.ReactNode;
   heatmapResult: UseQueryResult<HeatMapSeries>;
@@ -71,7 +75,7 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
             <HeatMapWidgetVisualization
               plottables={[new HeatMap(heatMapSeries)]}
               scale={HEATMAP_Z_AXIS_SCALE}
-              updateLocalFilterQuery={updateMetricQuery}
+              tooltipActionHandlers={{[ADD_TO_FILTER_ACTION]: updateMetricQuery}}
               renderTooltipActions={({cellQuery, selection}) => {
                 const tracesUrl = getExploreUrl({
                   organization,
@@ -89,7 +93,12 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
                     </div>
                     <div>
                       <span className="tooltip-label tooltip-label-centered">
-                        <a data-local-query={cellQuery}>{t('Add to filter')}</a>
+                        <a
+                          data-tooltip-action={ADD_TO_FILTER_ACTION}
+                          data-tooltip-action-value={cellQuery}
+                        >
+                          {t('Add to filter')}
+                        </a>
                       </span>
                     </div>
                   </Fragment>

--- a/static/app/views/explore/metrics/metricsHeatMap.tsx
+++ b/static/app/views/explore/metrics/metricsHeatMap.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback} from 'react';
 import type {UseQueryResult} from '@tanstack/react-query';
 
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {HeatMapSeries} from 'sentry/views/dashboards/widgets/common/types';
@@ -43,6 +44,7 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
   const userQuery = useQueryParamsQuery();
   const setMetricQuery = useSetQueryParamsQuery();
   const organization = useOrganization();
+  const {selection} = usePageFilters();
 
   const {data: heatMapSeries, isPending, error} = heatmapResult;
 
@@ -76,11 +78,28 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
               plottables={[new HeatMap(heatMapSeries)]}
               scale={HEATMAP_Z_AXIS_SCALE}
               tooltipActionHandlers={{[ADD_TO_FILTER_ACTION]: updateMetricQuery}}
-              renderTooltipActions={({cellQuery, selection}) => {
+              renderTooltipActions={({
+                valueMin,
+                valueMax,
+                timestampStart,
+                timestampEnd,
+              }) => {
+                const valueQuery =
+                  valueMin === valueMax
+                    ? `value:<=${valueMin}`
+                    : `value:>=${valueMin} value:<${valueMax}`;
                 const tracesUrl = getExploreUrl({
                   organization,
-                  selection,
-                  crossEvents: [{type: 'metrics', metric, query: cellQuery}],
+                  selection: {
+                    ...selection,
+                    datetime: {
+                      ...selection.datetime,
+                      start: new Date(timestampStart),
+                      end: new Date(timestampEnd),
+                      period: null,
+                    },
+                  },
+                  crossEvents: [{type: 'metrics', metric, query: valueQuery}],
                 });
                 return (
                   <Fragment>
@@ -95,7 +114,7 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
                       <span className="tooltip-label tooltip-label-centered">
                         <a
                           data-tooltip-action={ADD_TO_FILTER_ACTION}
-                          data-tooltip-action-value={cellQuery}
+                          data-tooltip-action-value={valueQuery}
                         >
                           {t('Add to filter')}
                         </a>


### PR DESCRIPTION
Replace `HeatMapWidgetVisualization`'s `makeExploreUrl` callback prop with a `renderTooltipActions` render prop. Instead of building the cell tooltip's "View connected spans" / "Add to filter" links itself, the visualization now hands the caller the hovered cell's value-range query and time-narrowed selection and lets the caller render its own tooltip action rows. The visualization no longer needs to know about metrics or Explore URLs.

This makes it a lot easier to adapt this to Dashboards, because now the visualization doesn't need _any_ external information, but it can still do things like route to Explore URLs without having to know the specifics of what the query is, for example.

This is behavior-preserving for Explore: its metric panel (`metricsHeatMap.tsx`) builds the same two links via the render prop, so the rendered tooltip is unchanged.

Refs DAIN-1654