### PR TITLE
feat(dashboards): Enable heat map cross-navigation

### DIFF
--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -52,6 +52,7 @@ export enum DisplayType {
   CATEGORICAL_BAR = 'categorical_bar',
   AGENTS_TRACES_TABLE = 'agents_traces_table',
   TEXT = 'text',
+  HEATMAP = 'heatmap',
 }
 
 export enum WidgetType {

--- a/static/app/views/dashboards/utils/getWidgetMetricsUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetMetricsUrl.spec.tsx
@@ -444,6 +444,34 @@ describe('getWidgetMetricsUrl', () => {
       const metricQuery = JSON.parse(metrics[0]!);
       expect(metricQuery.aggregateFields[0].chartType).toBe(ChartType.AREA);
     });
+
+    it('maps HEATMAP display type to HEATMAP chart type', () => {
+      const widget: Widget = {
+        id: '1',
+        title: 'Heat Map',
+        displayType: DisplayType.HEATMAP,
+        interval: '5m',
+        widgetType: WidgetType.TRACEMETRICS,
+        queries: [
+          {
+            name: 'Query 1',
+            fields: [],
+            aggregates: ['count(value,duration,d,none)'],
+            columns: [],
+            conditions: '',
+            orderby: '',
+            fieldAliases: [],
+          },
+        ],
+      };
+
+      const url = getWidgetMetricsUrl(widget, undefined, selection, organization);
+      const {params} = parseMetricsUrl(url);
+
+      const metrics = Array.isArray(params.metric) ? params.metric : [params.metric];
+      const metricQuery = JSON.parse(metrics[0]!);
+      expect(metricQuery.aggregateFields[0].chartType).toBe(ChartType.HEATMAP);
+    });
   });
 
   it('handles empty query conditions', () => {

--- a/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
@@ -127,6 +127,8 @@ function getChartTypeFromDisplayType(displayType: DisplayType): ChartType {
       return ChartType.AREA;
     case DisplayType.BAR:
       return ChartType.BAR;
+    case DisplayType.HEATMAP:
+      return ChartType.HEATMAP;
     case DisplayType.TABLE:
     case DisplayType.BIG_NUMBER:
     default:

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -30,9 +30,7 @@ export const CHART_TYPE_TO_DISPLAY_TYPE: Record<ChartType, DisplayType> = {
   [ChartType.LINE]: DisplayType.LINE,
   [ChartType.BAR]: DisplayType.BAR,
   [ChartType.AREA]: DisplayType.AREA,
-  // Heatmaps are filtered out before reaching dashboard code, but the
-  // mapping must be exhaustive because other consumers index by ChartType.
-  [ChartType.HEATMAP]: DisplayType.LINE,
+  [ChartType.HEATMAP]: DisplayType.HEATMAP,
 };
 
 export function useAddToDashboard() {

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -29,7 +29,6 @@ import {
 } from 'sentry/views/explore/queryParams/visualize';
 import {getVisualizeLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 import {
@@ -197,14 +196,10 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
                     addToDashboard(
                       metricQueries.filter(
                         metricQuery =>
-                          metricQuery.queryParams.visualizes[0]?.chartType !==
-                            ChartType.HEATMAP &&
                           // Allow all charts if you have the flag, otherwise only allow non-equation charts without the flag
-                          (metricsEquationsInDashboardsEnabled ||
-                            (!metricsEquationsInDashboardsEnabled &&
-                              !isVisualizeEquation(
-                                metricQuery.queryParams.visualizes[0]!
-                              )))
+                          metricsEquationsInDashboardsEnabled ||
+                          (!metricsEquationsInDashboardsEnabled &&
+                            !isVisualizeEquation(metricQuery.queryParams.visualizes[0]!))
                       )
                     );
                   },
@@ -214,8 +209,7 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
           ...metricQueries.map((metricQuery, index) => {
             const visualize = metricQuery.queryParams.visualizes[0]!;
             const isUnsupported =
-              (!metricsEquationsInDashboardsEnabled && isVisualizeEquation(visualize)) ||
-              visualize.chartType === ChartType.HEATMAP;
+              !metricsEquationsInDashboardsEnabled && isVisualizeEquation(visualize);
             const label = isVisualizeFunction(visualize)
               ? `${metricQuery.label ?? getVisualizeLabel(index, isVisualizeEquation(visualize))}: ${
                   formatTraceMetricsFunction(
@@ -238,9 +232,7 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
               tooltip:
                 !metricsEquationsInDashboardsEnabled && isVisualizeEquation(visualize)
                   ? t('Equations cannot currently be added to a dashboard')
-                  : visualize.chartType === ChartType.HEATMAP
-                    ? t('Heat maps cannot currently be added to a dashboard')
-                    : undefined,
+                  : undefined,
             };
           }),
         ],


### PR DESCRIPTION
Enables heat map cross-navigation in both directions. Right now this was turned off because there was no support for Heat Map in Dashboards, but we added it in https://github.com/getsentry/sentry/pull/117939

- **Dashboard -> Explore**: opening a dashboard heat map widget in Explore. `getWidgetMetricsUrl` now maps `DisplayType.HEATMAP` -> `ChartType.HEATMAP`.
- **Explore -> Dashboard**: adding an Explore heat map to a dashboard. `useAddToDashboard` maps `ChartType.HEATMAP` -> `DisplayType.HEATMAP`, and `useSaveAsMetricItems` drops its heat-map guards.


Closes DAIN-1725