### PR TITLE
feat(admin): Flag when a user belongs to orgs in other regions

### DIFF
--- a/static/gsAdmin/components/resultGrid.spec.tsx
+++ b/static/gsAdmin/components/resultGrid.spec.tsx
@@ -244,3 +244,88 @@ describe('ResultGrid region probing', () => {
     expect(screen.queryByRole('button', {name: 'View in de'})).not.toBeInTheDocument();
   });
 });
+
+describe('ResultGrid probeAllRegions', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    setupCells();
+  });
+
+  const allRegionsProps = {probeAcrossRegions: false, probeAllRegions: true};
+
+  it('flags other regions even with no search query and results in the active region', async () => {
+    // The active (us) region already has the user's orgs.
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme'}],
+    });
+    // The user also belongs to an org in the de region.
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '2', name: 'Beta'}],
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'View in de'})).toBeInTheDocument();
+  });
+
+  it('flags other regions when the active region is empty', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '2', name: 'Beta'}],
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    expect(await screen.findByRole('button', {name: 'View in de'})).toBeInTheDocument();
+  });
+
+  it('renders the custom hint text', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme'}],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '2', name: 'Beta'}],
+    });
+
+    renderGrid(
+      undefined,
+      {},
+      {
+        ...allRegionsProps,
+        probeAllRegionsHint: 'This user also belongs to orgs in other regions:',
+      }
+    );
+
+    expect(
+      await screen.findByText('This user also belongs to orgs in other regions:')
+    ).toBeInTheDocument();
+  });
+
+  it('does not flag when no other region has matches', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme'}],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [],
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText('Checking other regions…')).not.toBeInTheDocument()
+    );
+    expect(screen.queryByRole('button', {name: 'View in de'})).not.toBeInTheDocument();
+  });
+});

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -245,6 +245,29 @@ interface ResultGridProps {
    */
   probeAcrossRegions?: boolean;
   /**
+   * Always probe every *other* data region for records and surface a hint when
+   * any of them has matches — regardless of whether the active region has
+   * results or a search query is present.
+   *
+   * Use this for cell-scoped detail grids that show a record's presence in the
+   * currently selected region but where the same subject (e.g. a user) may also
+   * belong to records in other regions. It lets an admin viewing a user's
+   * organization memberships know the user also belongs to orgs in other regions
+   * and that they should look there too.
+   *
+   * Unlike `probeAcrossRegions`, this is not search-driven: it fires on every
+   * load. Prefer `probeAcrossRegions` for search grids.
+   *
+   * @default false
+   */
+  probeAllRegions?: boolean;
+  /**
+   * Lead text shown above the cross-region "view in" buttons when
+   * `probeAllRegions` surfaces matches in other regions. Defaults to a generic
+   * message; override it to give context for the specific record type.
+   */
+  probeAllRegionsHint?: string;
+  /**
    * Translates the data object from the request into rows
    */
   rowsFromData?: (data: any, cell: Cell | undefined) => any[];
@@ -311,6 +334,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     isCellScoped: false,
     isRegional: false,
     probeAcrossRegions: false,
+    probeAllRegions: false,
     useQueryString: true,
   };
 
@@ -491,7 +515,10 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
           this.props.onLoad();
         }
 
-        if (missingExactMatch) {
+        // `probeAllRegions` always checks the other regions for presence, even
+        // when the active region has results or no search is active. This flags
+        // that the same subject (e.g. a user) also has records elsewhere.
+        if (missingExactMatch || this.props.probeAllRegions) {
           this.probeOtherRegions({...queryParams, query});
         }
       },
@@ -634,12 +661,19 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
   }
 
   renderRegionHint() {
+    const {probeAcrossRegions, probeAllRegions} = this.props;
+
     if (
-      !this.props.probeAcrossRegions ||
+      (!probeAcrossRegions && !probeAllRegions) ||
       this.state.loading ||
-      this.state.error ||
-      !this.state.missingExactMatch
+      this.state.error
     ) {
+      return null;
+    }
+
+    // The search-driven hint only surfaces when the active region lacked an
+    // exact match. The always-on `probeAllRegions` hint has no such gate.
+    if (!probeAllRegions && !this.state.missingExactMatch) {
       return null;
     }
 
@@ -649,6 +683,28 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
 
     if (this.state.regionMatches.length === 0) {
       return null;
+    }
+
+    if (probeAllRegions) {
+      const lead =
+        this.props.probeAllRegionsHint ??
+        'Also found in other data regions — look there too:';
+      return (
+        <RegionHintAlert variant="info" showIcon>
+          <Flex align="center" gap="md" wrap="wrap">
+            <span>{lead}</span>
+            {this.state.regionMatches.map(cell => (
+              <Button
+                key={cell.locality_url}
+                size="xs"
+                onClick={() => this.onChangeCell(cell.locality_url)}
+              >
+                {`View in ${cell.name}`}
+              </Button>
+            ))}
+          </Flex>
+        </RegionHintAlert>
+      );
     }
 
     const currentName = this.state.cell?.name ?? 'this region';

--- a/static/gsAdmin/components/users/userCustomers.tsx
+++ b/static/gsAdmin/components/users/userCustomers.tsx
@@ -25,6 +25,11 @@ export function UserCustomers({userId}: Props) {
       path={`/_admin/users/${userId}/`}
       endpoint={`/users/${userId}/customers/`}
       isCellScoped
+      // Org memberships are cell-scoped, so this grid only shows the orgs in the
+      // currently selected region. Probe the other regions too and flag when the
+      // user also belongs to orgs elsewhere so admins know to look there.
+      probeAllRegions
+      probeAllRegionsHint="This user also belongs to organizations in other regions — look there too:"
       hasSearch={false}
       sortOptions={undefined}
       filters={undefined}


### PR DESCRIPTION
The `_admin` user detail page lists a user's organization memberships, but that grid is cell-scoped — it only shows orgs in the currently selected region. A user with orgs in other regions gave the admin no signal those memberships existed, so they could easily miss them and assume they'd seen the user's full footprint.

This adds an opt-in `probeAllRegions` mode to `ResultGrid` that, after each load, cheaply probes every *other* data region for presence (`per_page=1`, presence-only) and surfaces an info hint with "View in {region}" buttons when matches exist. The region dropdown also tags matching regions with "found". It's enabled on the user org-membership grid (`UserCustomers`) with copy: *"This user also belongs to organizations in other regions — look there too."* Clicking a button switches the grid to that region.

This reuses the existing cross-region probe infrastructure rather than adding a parallel mechanism. That infra was previously search-driven only (fired on a missing exact match for a query); since the membership grid has no search box, it never probed. `probeAllRegions` generalizes it to fire on every load, independent of any query. The two modes coexist — `probeAcrossRegions` (search) and `probeAllRegions` (always-on) — and the always-on hint takes precedence in rendering.

No backend changes: the probe calls the same `/users/{id}/customers/` cell-scoped endpoint the page already uses, just against other regions' hosts via the existing cell routing.

Note: the feature only surfaces when `getCells()` returns more than one region, so it's best verified on a preview/deploy with real multi-region config and a known multi-region user. Local dev-ui against prod hits a superuser wall on the cell-scoped admin endpoints.