### PR TITLE
ref(features): remove `organizations:intercom-support`

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -81,8 +81,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:data-secrecy", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Data Secrecy v2 (with Break the Glass feature)
     manager.add("organizations:data-secrecy-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Intercom support widget (replaces Zendesk when enabled)
-    manager.add("organizations:intercom-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable default anomaly detection metric monitor for new projects
     manager.add("organizations:default-anomaly-detector", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Don't use plugin infra for language plugins/preprocessor logic


### PR DESCRIPTION
Remove `organizations:intercom-support`. This flag was fully rolled out (GA'd) and its code usage was already removed in #116738. Only the registration remained.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8mnoTpqJG3LjZMUKGW5yR)_