### PR TITLE
ref(relay): Remove ingest-through-trusted-relays-only feature flag from frontend

### DIFF
--- a/static/app/views/settings/organizationRelay/relayWrapper.spec.tsx
+++ b/static/app/views/settings/organizationRelay/relayWrapper.spec.tsx
@@ -29,19 +29,8 @@ describe('RelayWrapper', () => {
   }
 
   describe('ingestThroughTrustedRelaysOnly toggle', () => {
-    it('does not render the Data Authenticity section without the feature flag', () => {
+    it('renders the toggle', async () => {
       renderComponent();
-
-      expect(screen.queryByText('Data Authenticity')).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole('checkbox', {
-          name: 'Ingest Through Trusted Relays Only',
-        })
-      ).not.toBeInTheDocument();
-    });
-
-    it('renders the toggle when the feature flag is present', async () => {
-      renderComponent({features: ['ingest-through-trusted-relays-only']});
 
       expect(
         await screen.findByRole('checkbox', {
@@ -53,7 +42,6 @@ describe('RelayWrapper', () => {
 
     it('toggle is unchecked when ingestThroughTrustedRelaysOnly is disabled', async () => {
       renderComponent({
-        features: ['ingest-through-trusted-relays-only'],
         ingestThroughTrustedRelaysOnly: 'disabled',
       });
 
@@ -66,7 +54,6 @@ describe('RelayWrapper', () => {
 
     it('toggle is checked when ingestThroughTrustedRelaysOnly is enabled', async () => {
       renderComponent({
-        features: ['ingest-through-trusted-relays-only'],
         ingestThroughTrustedRelaysOnly: 'enabled',
       });
 
@@ -84,7 +71,6 @@ describe('RelayWrapper', () => {
       });
 
       renderComponent({
-        features: ['ingest-through-trusted-relays-only'],
         ingestThroughTrustedRelaysOnly: 'disabled',
       });
 
@@ -118,7 +104,6 @@ describe('RelayWrapper', () => {
       });
 
       renderComponent({
-        features: ['ingest-through-trusted-relays-only'],
         ingestThroughTrustedRelaysOnly: 'disabled',
       });
 
@@ -145,7 +130,6 @@ describe('RelayWrapper', () => {
       });
 
       renderComponent({
-        features: ['ingest-through-trusted-relays-only'],
         ingestThroughTrustedRelaysOnly: 'enabled',
       });
 
@@ -174,7 +158,6 @@ describe('RelayWrapper', () => {
       });
 
       renderComponent({
-        features: ['ingest-through-trusted-relays-only'],
         ingestThroughTrustedRelaysOnly: 'disabled',
       });
 
@@ -199,7 +182,6 @@ describe('RelayWrapper', () => {
 
     it('toggle is disabled when user lacks org:write permission', async () => {
       renderComponent({
-        features: ['ingest-through-trusted-relays-only'],
         access: [],
       });
 

--- a/static/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/static/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -84,52 +84,50 @@ export function RelayWrapper() {
         )}
       />
       <OrganizationPermissionAlert />
-      {organization.features.includes('ingest-through-trusted-relays-only') && (
-        <FieldGroup title={t('Data Authenticity')}>
-          <AutoSaveForm
-            name="ingestThroughTrustedRelaysOnly"
-            schema={relaySchema}
-            initialValue={organization.ingestThroughTrustedRelaysOnly === 'enabled'}
-            confirm={value =>
-              value
-                ? t(
-                    'Enabling this can lead to data being rejected for ALL projects, are you sure you want to continue?'
-                  )
-                : undefined
-            }
-            mutationOptions={{
-              mutationFn: data =>
-                fetchMutation<Organization>({
-                  url: `/organizations/${organization.slug}/`,
-                  method: 'PUT',
-                  data: {
-                    ingestThroughTrustedRelaysOnly: data.ingestThroughTrustedRelaysOnly
-                      ? 'enabled'
-                      : 'disabled',
-                  },
-                }),
-              onSuccess: updatedOrg => {
-                OrganizationStore.onUpdate(updatedOrg);
-              },
-            }}
-          >
-            {field => (
-              <field.Layout.Row
-                label={t('Ingest Through Trusted Relays Only')}
-                hintText={t(
-                  'Require events to be ingested only through trusted relays. Direct submissions from SDKs or other sources will be rejected unless signed by a registered relay.'
-                )}
-              >
-                <field.Switch
-                  checked={field.state.value}
-                  onChange={field.handleChange}
-                  disabled={disabled}
-                />
-              </field.Layout.Row>
-            )}
-          </AutoSaveForm>
-        </FieldGroup>
-      )}
+      <FieldGroup title={t('Data Authenticity')}>
+        <AutoSaveForm
+          name="ingestThroughTrustedRelaysOnly"
+          schema={relaySchema}
+          initialValue={organization.ingestThroughTrustedRelaysOnly === 'enabled'}
+          confirm={value =>
+            value
+              ? t(
+                  'Enabling this can lead to data being rejected for ALL projects, are you sure you want to continue?'
+                )
+              : undefined
+          }
+          mutationOptions={{
+            mutationFn: data =>
+              fetchMutation<Organization>({
+                url: `/organizations/${organization.slug}/`,
+                method: 'PUT',
+                data: {
+                  ingestThroughTrustedRelaysOnly: data.ingestThroughTrustedRelaysOnly
+                    ? 'enabled'
+                    : 'disabled',
+                },
+              }),
+            onSuccess: updatedOrg => {
+              OrganizationStore.onUpdate(updatedOrg);
+            },
+          }}
+        >
+          {field => (
+            <field.Layout.Row
+              label={t('Ingest Through Trusted Relays Only')}
+              hintText={t(
+                'Require events to be ingested only through trusted relays. Direct submissions from SDKs or other sources will be rejected unless signed by a registered relay.'
+              )}
+            >
+              <field.Switch
+                checked={field.state.value}
+                onChange={field.handleChange}
+                disabled={disabled}
+              />
+            </field.Layout.Row>
+          )}
+        </AutoSaveForm>
+      </FieldGroup>
       {relays.length === 0 ? (
         <EmptyState />
       ) : (


### PR DESCRIPTION
## Summary

- Feature `ingest-through-trusted-relays-only` is now GA — remove the feature flag gate from the frontend
- The Data Authenticity section and toggle are now always rendered on the Relay settings page
- Update tests to remove the feature flag fixture
