### PR TITLE
ref(relay): Remove ingest-through-trusted-relays-only feature flag from backend

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -904,11 +904,10 @@ class OrganizationSerializer(OrganizationSummarySerializer):
                 obj.get_option("sentry:sampling_mode", SAMPLING_MODE_DEFAULT)
             )
 
-        if features.has("organizations:ingest-through-trusted-relays-only", obj):
-            context["ingestThroughTrustedRelaysOnly"] = obj.get_option(
-                "sentry:ingest-through-trusted-relays-only",
-                INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
-            )
+        context["ingestThroughTrustedRelaysOnly"] = obj.get_option(
+            "sentry:ingest-through-trusted-relays-only",
+            INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
+        )
 
         context["enabledConsolePlatforms"] = obj.get_option(
             "sentry:enabled_console_platforms",

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -458,15 +458,6 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         return value
 
     def validate_ingestThroughTrustedRelaysOnly(self, value):
-        organization = self.context["organization"]
-        request = self.context["request"]
-        if not features.has(
-            "organizations:ingest-through-trusted-relays-only", organization, actor=request.user
-        ):
-            # NOTE (vgrozdanic): For now allow access to this setting only to orgs with the feature flag enabled
-            raise serializers.ValidationError(
-                "Organization does not have the ingest through trusted relays only feature enabled."
-            )
         return value
 
     def validate_enabledConsolePlatforms(self, value):

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -457,9 +457,6 @@ class OrganizationSerializer(BaseOrganizationSerializer):
 
         return value
 
-    def validate_ingestThroughTrustedRelaysOnly(self, value):
-        return value
-
     def validate_enabledConsolePlatforms(self, value):
         request = self.context["request"]
 

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -11,6 +11,7 @@ import sentry_sdk
 from sentry import features, killswitches, options, quotas, utils
 from sentry.constants import (
     HEALTH_CHECK_GLOBS,
+    INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
     ObjectStatus,
 )
 from sentry.dynamic_sampling import generate_rules
@@ -853,8 +854,12 @@ def _get_project_config(
 
     config = cfg["config"]
 
-    if project.organization.get_option("sentry:ingest-through-trusted-relays-only") == "enabled":
-        config["trustedRelaySettings"] = {"verifySignature": "enabled"}
+    config["trustedRelaySettings"] = {
+        "verifySignature": project.organization.get_option(
+            "sentry:ingest-through-trusted-relays-only",
+            INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
+        )
+    }
 
     with sentry_sdk.start_span(op="get_exposed_features"):
         if exposed_features := get_exposed_features(project):

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -854,12 +854,14 @@ def _get_project_config(
 
     config = cfg["config"]
 
-    config["trustedRelaySettings"] = {
-        "verifySignature": project.organization.get_option(
-            "sentry:ingest-through-trusted-relays-only",
-            INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
-        )
-    }
+    # Only write trustedRelaySettings when non-default; Relay's normalize_project_config
+    # strips it when verifySignature is "disabled", treating absent and disabled as equivalent.
+    verify_signature = project.organization.get_option(
+        "sentry:ingest-through-trusted-relays-only",
+        INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
+    )
+    if verify_signature != INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT:
+        config["trustedRelaySettings"] = {"verifySignature": verify_signature}
 
     with sentry_sdk.start_span(op="get_exposed_features"):
         if exposed_features := get_exposed_features(project):

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -854,12 +854,12 @@ def _get_project_config(
 
     config = cfg["config"]
 
-    config["trustedRelaySettings"] = {
-        "verifySignature": project.organization.get_option(
-            "sentry:ingest-through-trusted-relays-only",
-            INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
-        )
-    }
+    ingest_through_trusted_relays_only = project.organization.get_option(
+        "sentry:ingest-through-trusted-relays-only",
+        INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
+    )
+    if ingest_through_trusted_relays_only != INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT:
+        config["trustedRelaySettings"] = {"verifySignature": ingest_through_trusted_relays_only}
 
     with sentry_sdk.start_span(op="get_exposed_features"):
         if exposed_features := get_exposed_features(project):

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -854,12 +854,12 @@ def _get_project_config(
 
     config = cfg["config"]
 
-    ingest_through_trusted_relays_only = project.organization.get_option(
-        "sentry:ingest-through-trusted-relays-only",
-        INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
-    )
-    if ingest_through_trusted_relays_only != INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT:
-        config["trustedRelaySettings"] = {"verifySignature": ingest_through_trusted_relays_only}
+    config["trustedRelaySettings"] = {
+        "verifySignature": project.organization.get_option(
+            "sentry:ingest-through-trusted-relays-only",
+            INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
+        )
+    }
 
     with sentry_sdk.start_span(op="get_exposed_features"):
         if exposed_features := get_exposed_features(project):

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -854,13 +854,12 @@ def _get_project_config(
 
     config = cfg["config"]
 
-    if features.has("organizations:ingest-through-trusted-relays-only", project.organization):
-        config["trustedRelaySettings"] = {
-            "verifySignature": project.organization.get_option(
-                "sentry:ingest-through-trusted-relays-only",
-                INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
-            )
-        }
+    config["trustedRelaySettings"] = {
+        "verifySignature": project.organization.get_option(
+            "sentry:ingest-through-trusted-relays-only",
+            INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
+        )
+    }
 
     with sentry_sdk.start_span(op="get_exposed_features"):
         if exposed_features := get_exposed_features(project):

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -11,7 +11,6 @@ import sentry_sdk
 from sentry import features, killswitches, options, quotas, utils
 from sentry.constants import (
     HEALTH_CHECK_GLOBS,
-    INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
     ObjectStatus,
 )
 from sentry.dynamic_sampling import generate_rules
@@ -854,12 +853,8 @@ def _get_project_config(
 
     config = cfg["config"]
 
-    config["trustedRelaySettings"] = {
-        "verifySignature": project.organization.get_option(
-            "sentry:ingest-through-trusted-relays-only",
-            INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
-        )
-    }
+    if project.organization.get_option("sentry:ingest-through-trusted-relays-only") == "enabled":
+        config["trustedRelaySettings"] = {"verifySignature": "enabled"}
 
     with sentry_sdk.start_span(op="get_exposed_features"):
         if exposed_features := get_exposed_features(project):

--- a/tests/relay_integration/test_integration.py
+++ b/tests/relay_integration/test_integration.py
@@ -11,7 +11,6 @@ from sentry_relay.auth import SecretKey, generate_key_pair
 from sentry.models.eventattachment import EventAttachment
 from sentry.tasks.relay import invalidate_project_config
 from sentry.testutils.cases import TransactionTestCase
-from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_kafka
@@ -50,17 +49,14 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
             [{"public_key": str(public_key), "name": "test-trusted-relay"}],
         )
 
-        # Feature flag is required so that the "sentry:ingest-through-trusted-relays-only" option
-        # is properly added to the project config.
-        with Feature({"organizations:ingest-through-trusted-relays-only": True}):
-            self.project.organization.update_option(
-                "sentry:ingest-through-trusted-relays-only", "enabled"
-            )
+        self.project.organization.update_option(
+            "sentry:ingest-through-trusted-relays-only", "enabled"
+        )
 
-            # Invalidate project config cache to ensure Relay gets updated configuration
-            invalidate_project_config(
-                public_key=self.projectkey.public_key, trigger="trusted_relay_test"
-            )
+        # Invalidate project config cache to ensure Relay gets updated configuration
+        invalidate_project_config(
+            public_key=self.projectkey.public_key, trigger="trusted_relay_test"
+        )
 
         return relay_id, secret_key
 
@@ -332,44 +328,41 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
         secret_key, public_key = generate_key_pair()
         relay_id = str(uuid4())
 
-        with Feature({"organizations:ingest-through-trusted-relays-only": True}):
-            self.project.organization.update_option(
-                "sentry:ingest-through-trusted-relays-only", "enabled"
-            )
+        self.project.organization.update_option(
+            "sentry:ingest-through-trusted-relays-only", "enabled"
+        )
 
-            # Invalidate project config cache to ensure Relay gets updated configuration
-            invalidate_project_config(
-                public_key=self.projectkey.public_key, trigger="trusted_relay_test"
-            )
+        # Invalidate project config cache to ensure Relay gets updated configuration
+        invalidate_project_config(
+            public_key=self.projectkey.public_key, trigger="trusted_relay_test"
+        )
 
-            signature = create_trusted_relay_signature(secret_key)
+        signature = create_trusted_relay_signature(secret_key)
 
-            event_data = {
-                "message": "should be rejected because not trusted",
-                "timestamp": before_now(seconds=1).isoformat(),
-            }
+        event_data = {
+            "message": "should be rejected because not trusted",
+            "timestamp": before_now(seconds=1).isoformat(),
+        }
 
-            headers = {
-                "x-sentry-auth": self.auth_header,
-                "x-sentry-relay-signature": signature,
-                "content-type": "application/json",
-                "x-sentry-relay-id": relay_id,
-            }
+        headers = {
+            "x-sentry-auth": self.auth_header,
+            "x-sentry-relay-signature": signature,
+            "content-type": "application/json",
+            "x-sentry-relay-id": relay_id,
+        }
 
-            event = self.post_and_try_retrieve_event(event_data, headers=headers)
-            assert event is None
+        event = self.post_and_try_retrieve_event(event_data, headers=headers)
+        assert event is None
 
-            url = self.get_relay_store_url(self.project.id)
-            resp = requests.post(
-                url,
-                headers=headers,
-                json=event_data,
-            )
-            # Once the project config is fetched it gets rejected in the hot path
-            assert resp.status_code == 403
-            assert resp.json() == {
-                "detail": "event submission rejected with_reason: InvalidSignature"
-            }
+        url = self.get_relay_store_url(self.project.id)
+        resp = requests.post(
+            url,
+            headers=headers,
+            json=event_data,
+        )
+        # Once the project config is fetched it gets rejected in the hot path
+        assert resp.status_code == 403
+        assert resp.json() == {"detail": "event submission rejected with_reason: InvalidSignature"}
 
     def test_expired_signature(self) -> None:
         """

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1238,30 +1238,18 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         # by default option is not set
         assert self.organization.get_option("sentry:ingest-through-trusted-relays-only") is None
 
-        with self.feature("organizations:ingest-through-trusted-relays-only"):
-            data = {"ingestThroughTrustedRelaysOnly": "enabled"}
-            self.get_success_response(self.organization.slug, **data)
-            assert (
-                self.organization.get_option("sentry:ingest-through-trusted-relays-only")
-                == "enabled"
-            )
+        data = {"ingestThroughTrustedRelaysOnly": "enabled"}
+        self.get_success_response(self.organization.slug, **data)
+        assert (
+            self.organization.get_option("sentry:ingest-through-trusted-relays-only") == "enabled"
+        )
 
-        with self.feature("organizations:ingest-through-trusted-relays-only"):
-            data = {"ingestThroughTrustedRelaysOnly": "invalid"}
-            self.get_error_response(self.organization.slug, status_code=400, **data)
+        data = {"ingestThroughTrustedRelaysOnly": "invalid"}
+        self.get_error_response(self.organization.slug, status_code=400, **data)
 
-        with self.feature({"organizations:ingest-through-trusted-relays-only": False}):
-            data = {"ingestThroughTrustedRelaysOnly": "enabled"}
-            self.get_error_response(self.organization.slug, status_code=400, **data)
-
-    @with_feature("organizations:ingest-through-trusted-relays-only")
     def test_get_ingest_through_trusted_relays_only_option(self) -> None:
         response = self.get_success_response(self.organization.slug)
         assert response.data["ingestThroughTrustedRelaysOnly"] == "disabled"
-
-    def test_get_ingest_through_trusted_relays_only_option_without_feature(self) -> None:
-        response = self.get_success_response(self.organization.slug)
-        assert "ingestThroughTrustedRelaysOnly" not in response.data
 
     @with_feature("organizations:dynamic-sampling-custom")
     def test_target_sample_rate_range(self) -> None:

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -92,8 +92,11 @@ def _validate_project_config(config):
     # Relay uses a BTreeSet for features:
     if features := config.get("features"):
         config["features"] = sorted(features)
+    # normalize_project_config strips trustedRelaySettings when verifySignature is "disabled"
+    # (the Relay SDK treats absent and disabled as equivalent), so exclude it from the check.
+    config_without_trusted_relay = {k: v for k, v in config.items() if k != "trustedRelaySettings"}
 
-    assert normalize_project_config(config) == config
+    assert normalize_project_config(config_without_trusted_relay) == config_without_trusted_relay
 
 
 @django_db_all
@@ -1498,7 +1501,9 @@ def test_project_config_trusted_relay_settings_disabled(default_project):
 
     config = get_project_config(default_project).to_dict()
 
-    assert config["config"].get("trustedRelaySettings") is None
+    trusted_relay_settings = config["config"].get("trustedRelaySettings")
+    assert trusted_relay_settings is not None
+    assert trusted_relay_settings["verifySignature"] == "disabled"
 
 
 @django_db_all

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -1477,31 +1477,17 @@ def test_project_config_with_transaction_name_clustering_disabled(
 
 @django_db_all
 @cell_silo_test
-@pytest.mark.parametrize("feature_enabled", [True, False])
 @pytest.mark.parametrize("project_option_value", ["enabled", "disabled"])
-def test_project_config_trusted_relay_settings(
-    default_project, feature_enabled, project_option_value
-):
+def test_project_config_trusted_relay_settings(default_project, project_option_value):
     default_project.organization.update_option(
         "sentry:ingest-through-trusted-relays-only", project_option_value
     )
 
-    features_dict = {}
-    if feature_enabled:
-        features_dict["organizations:ingest-through-trusted-relays-only"] = True
+    config = get_project_config(default_project).to_dict()
 
-    with Feature(features_dict):
-        config = get_project_config(default_project).to_dict()
-
-        trusted_relay_settings = config["config"].get("trustedRelaySettings")
-
-        if feature_enabled:
-            # trustedRelaySettings should be present
-            assert trusted_relay_settings is not None
-            assert trusted_relay_settings["verifySignature"] == project_option_value
-        else:
-            # trustedRelaySettings should not be present
-            assert trusted_relay_settings is None
+    trusted_relay_settings = config["config"].get("trustedRelaySettings")
+    assert trusted_relay_settings is not None
+    assert trusted_relay_settings["verifySignature"] == project_option_value
 
 
 @django_db_all

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -92,14 +92,8 @@ def _validate_project_config(config):
     # Relay uses a BTreeSet for features:
     if features := config.get("features"):
         config["features"] = sorted(features)
-    # normalize_project_config strips trustedRelaySettings when verifySignature is
-    # "disabled" (the default). Remove it before the round-trip check and restore after.
-    trusted_relay_settings = config.pop("trustedRelaySettings", None)
 
     assert normalize_project_config(config) == config
-
-    if trusted_relay_settings is not None:
-        config["trustedRelaySettings"] = trusted_relay_settings
 
 
 @django_db_all
@@ -1504,9 +1498,7 @@ def test_project_config_trusted_relay_settings_disabled(default_project):
 
     config = get_project_config(default_project).to_dict()
 
-    trusted_relay_settings = config["config"].get("trustedRelaySettings")
-    assert trusted_relay_settings is not None
-    assert trusted_relay_settings["verifySignature"] == "disabled"
+    assert config["config"].get("trustedRelaySettings") is None
 
 
 @django_db_all

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -92,8 +92,14 @@ def _validate_project_config(config):
     # Relay uses a BTreeSet for features:
     if features := config.get("features"):
         config["features"] = sorted(features)
+    # normalize_project_config strips trustedRelaySettings when verifySignature is
+    # "disabled" (the default). Remove it before the round-trip check and restore after.
+    trusted_relay_settings = config.pop("trustedRelaySettings", None)
 
     assert normalize_project_config(config) == config
+
+    if trusted_relay_settings is not None:
+        config["trustedRelaySettings"] = trusted_relay_settings
 
 
 @django_db_all
@@ -1498,7 +1504,9 @@ def test_project_config_trusted_relay_settings_disabled(default_project):
 
     config = get_project_config(default_project).to_dict()
 
-    assert config["config"].get("trustedRelaySettings") is None
+    trusted_relay_settings = config["config"].get("trustedRelaySettings")
+    assert trusted_relay_settings is not None
+    assert trusted_relay_settings["verifySignature"] == "disabled"
 
 
 @django_db_all

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -1477,17 +1477,28 @@ def test_project_config_with_transaction_name_clustering_disabled(
 
 @django_db_all
 @cell_silo_test
-@pytest.mark.parametrize("project_option_value", ["enabled", "disabled"])
-def test_project_config_trusted_relay_settings(default_project, project_option_value):
+def test_project_config_trusted_relay_settings_enabled(default_project):
     default_project.organization.update_option(
-        "sentry:ingest-through-trusted-relays-only", project_option_value
+        "sentry:ingest-through-trusted-relays-only", "enabled"
     )
 
     config = get_project_config(default_project).to_dict()
 
     trusted_relay_settings = config["config"].get("trustedRelaySettings")
     assert trusted_relay_settings is not None
-    assert trusted_relay_settings["verifySignature"] == project_option_value
+    assert trusted_relay_settings["verifySignature"] == "enabled"
+
+
+@django_db_all
+@cell_silo_test
+def test_project_config_trusted_relay_settings_disabled(default_project):
+    default_project.organization.update_option(
+        "sentry:ingest-through-trusted-relays-only", "disabled"
+    )
+
+    config = get_project_config(default_project).to_dict()
+
+    assert config["config"].get("trustedRelaySettings") is None
 
 
 @django_db_all

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -92,11 +92,7 @@ def _validate_project_config(config):
     # Relay uses a BTreeSet for features:
     if features := config.get("features"):
         config["features"] = sorted(features)
-    # normalize_project_config strips trustedRelaySettings when verifySignature is "disabled"
-    # (the Relay SDK treats absent and disabled as equivalent), so exclude it from the check.
-    config_without_trusted_relay = {k: v for k, v in config.items() if k != "trustedRelaySettings"}
-
-    assert normalize_project_config(config_without_trusted_relay) == config_without_trusted_relay
+    assert normalize_project_config(config) == config
 
 
 @django_db_all
@@ -1501,9 +1497,9 @@ def test_project_config_trusted_relay_settings_disabled(default_project):
 
     config = get_project_config(default_project).to_dict()
 
-    trusted_relay_settings = config["config"].get("trustedRelaySettings")
-    assert trusted_relay_settings is not None
-    assert trusted_relay_settings["verifySignature"] == "disabled"
+    # "disabled" is the default — Relay treats absent and disabled as equivalent,
+    # so we don't write the key at all.
+    assert config["config"].get("trustedRelaySettings") is None
 
 
 @django_db_all


### PR DESCRIPTION
## Summary

- Feature `ingest-through-trusted-relays-only` is now GA — remove the feature flag checks from the backend
- `ingestThroughTrustedRelaysOnly` is now always included in the org serializer response
- `trustedRelaySettings` is now always included in project configs sent to Relay
- The `validate_ingestThroughTrustedRelaysOnly` validator no longer gates on the feature flag
- Update tests to remove feature flag context managers