### PR TITLE
ref(relay): Remove ingest-through-trusted-relays-only feature flag registration

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -904,11 +904,10 @@ class OrganizationSerializer(OrganizationSummarySerializer):
                 obj.get_option("sentry:sampling_mode", SAMPLING_MODE_DEFAULT)
             )
 
-        if features.has("organizations:ingest-through-trusted-relays-only", obj):
-            context["ingestThroughTrustedRelaysOnly"] = obj.get_option(
-                "sentry:ingest-through-trusted-relays-only",
-                INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
-            )
+        context["ingestThroughTrustedRelaysOnly"] = obj.get_option(
+            "sentry:ingest-through-trusted-relays-only",
+            INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
+        )
 
         context["enabledConsolePlatforms"] = obj.get_option(
             "sentry:enabled_console_platforms",

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -458,15 +458,6 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         return value
 
     def validate_ingestThroughTrustedRelaysOnly(self, value):
-        organization = self.context["organization"]
-        request = self.context["request"]
-        if not features.has(
-            "organizations:ingest-through-trusted-relays-only", organization, actor=request.user
-        ):
-            # NOTE (vgrozdanic): For now allow access to this setting only to orgs with the feature flag enabled
-            raise serializers.ValidationError(
-                "Organization does not have the ingest through trusted relays only feature enabled."
-            )
         return value
 
     def validate_enabledConsolePlatforms(self, value):

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -148,10 +148,6 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:dashboards-import": FlagpoleFeature(default=False, api_expose=True),
         # Enable various explore related dev features, may be used by internal branches for testing.
         "organizations:explore-dev-features": FlagpoleFeature(default=False, api_expose=True),
-        # Enable ingestion through trusted relays only
-        "organizations:ingest-through-trusted-relays-only": FlagpoleFeature(
-            default=False, api_expose=True
-        ),
         # Enable the rendering of @sentry/toolbar inside the sentry app. See `useInitSentryToolbar()`
         "organizations:init-sentry-toolbar": FlagpoleFeature(default=False, api_expose=True),
         # Opt orgs in to logging workflow evaluations (bypasses sample rate when enabled).

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -854,13 +854,12 @@ def _get_project_config(
 
     config = cfg["config"]
 
-    if features.has("organizations:ingest-through-trusted-relays-only", project.organization):
-        config["trustedRelaySettings"] = {
-            "verifySignature": project.organization.get_option(
-                "sentry:ingest-through-trusted-relays-only",
-                INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
-            )
-        }
+    config["trustedRelaySettings"] = {
+        "verifySignature": project.organization.get_option(
+            "sentry:ingest-through-trusted-relays-only",
+            INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
+        )
+    }
 
     with sentry_sdk.start_span(op="get_exposed_features"):
         if exposed_features := get_exposed_features(project):

--- a/tests/relay_integration/test_integration.py
+++ b/tests/relay_integration/test_integration.py
@@ -11,7 +11,6 @@ from sentry_relay.auth import SecretKey, generate_key_pair
 from sentry.models.eventattachment import EventAttachment
 from sentry.tasks.relay import invalidate_project_config
 from sentry.testutils.cases import TransactionTestCase
-from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.testutils.skips import requires_kafka
@@ -50,17 +49,14 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
             [{"public_key": str(public_key), "name": "test-trusted-relay"}],
         )
 
-        # Feature flag is required so that the "sentry:ingest-through-trusted-relays-only" option
-        # is properly added to the project config.
-        with Feature({"organizations:ingest-through-trusted-relays-only": True}):
-            self.project.organization.update_option(
-                "sentry:ingest-through-trusted-relays-only", "enabled"
-            )
+        self.project.organization.update_option(
+            "sentry:ingest-through-trusted-relays-only", "enabled"
+        )
 
-            # Invalidate project config cache to ensure Relay gets updated configuration
-            invalidate_project_config(
-                public_key=self.projectkey.public_key, trigger="trusted_relay_test"
-            )
+        # Invalidate project config cache to ensure Relay gets updated configuration
+        invalidate_project_config(
+            public_key=self.projectkey.public_key, trigger="trusted_relay_test"
+        )
 
         return relay_id, secret_key
 
@@ -332,44 +328,41 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
         secret_key, public_key = generate_key_pair()
         relay_id = str(uuid4())
 
-        with Feature({"organizations:ingest-through-trusted-relays-only": True}):
-            self.project.organization.update_option(
-                "sentry:ingest-through-trusted-relays-only", "enabled"
-            )
+        self.project.organization.update_option(
+            "sentry:ingest-through-trusted-relays-only", "enabled"
+        )
 
-            # Invalidate project config cache to ensure Relay gets updated configuration
-            invalidate_project_config(
-                public_key=self.projectkey.public_key, trigger="trusted_relay_test"
-            )
+        # Invalidate project config cache to ensure Relay gets updated configuration
+        invalidate_project_config(
+            public_key=self.projectkey.public_key, trigger="trusted_relay_test"
+        )
 
-            signature = create_trusted_relay_signature(secret_key)
+        signature = create_trusted_relay_signature(secret_key)
 
-            event_data = {
-                "message": "should be rejected because not trusted",
-                "timestamp": before_now(seconds=1).isoformat(),
-            }
+        event_data = {
+            "message": "should be rejected because not trusted",
+            "timestamp": before_now(seconds=1).isoformat(),
+        }
 
-            headers = {
-                "x-sentry-auth": self.auth_header,
-                "x-sentry-relay-signature": signature,
-                "content-type": "application/json",
-                "x-sentry-relay-id": relay_id,
-            }
+        headers = {
+            "x-sentry-auth": self.auth_header,
+            "x-sentry-relay-signature": signature,
+            "content-type": "application/json",
+            "x-sentry-relay-id": relay_id,
+        }
 
-            event = self.post_and_try_retrieve_event(event_data, headers=headers)
-            assert event is None
+        event = self.post_and_try_retrieve_event(event_data, headers=headers)
+        assert event is None
 
-            url = self.get_relay_store_url(self.project.id)
-            resp = requests.post(
-                url,
-                headers=headers,
-                json=event_data,
-            )
-            # Once the project config is fetched it gets rejected in the hot path
-            assert resp.status_code == 403
-            assert resp.json() == {
-                "detail": "event submission rejected with_reason: InvalidSignature"
-            }
+        url = self.get_relay_store_url(self.project.id)
+        resp = requests.post(
+            url,
+            headers=headers,
+            json=event_data,
+        )
+        # Once the project config is fetched it gets rejected in the hot path
+        assert resp.status_code == 403
+        assert resp.json() == {"detail": "event submission rejected with_reason: InvalidSignature"}
 
     def test_expired_signature(self) -> None:
         """

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1238,30 +1238,18 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         # by default option is not set
         assert self.organization.get_option("sentry:ingest-through-trusted-relays-only") is None
 
-        with self.feature("organizations:ingest-through-trusted-relays-only"):
-            data = {"ingestThroughTrustedRelaysOnly": "enabled"}
-            self.get_success_response(self.organization.slug, **data)
-            assert (
-                self.organization.get_option("sentry:ingest-through-trusted-relays-only")
-                == "enabled"
-            )
+        data = {"ingestThroughTrustedRelaysOnly": "enabled"}
+        self.get_success_response(self.organization.slug, **data)
+        assert (
+            self.organization.get_option("sentry:ingest-through-trusted-relays-only") == "enabled"
+        )
 
-        with self.feature("organizations:ingest-through-trusted-relays-only"):
-            data = {"ingestThroughTrustedRelaysOnly": "invalid"}
-            self.get_error_response(self.organization.slug, status_code=400, **data)
+        data = {"ingestThroughTrustedRelaysOnly": "invalid"}
+        self.get_error_response(self.organization.slug, status_code=400, **data)
 
-        with self.feature({"organizations:ingest-through-trusted-relays-only": False}):
-            data = {"ingestThroughTrustedRelaysOnly": "enabled"}
-            self.get_error_response(self.organization.slug, status_code=400, **data)
-
-    @with_feature("organizations:ingest-through-trusted-relays-only")
     def test_get_ingest_through_trusted_relays_only_option(self) -> None:
         response = self.get_success_response(self.organization.slug)
         assert response.data["ingestThroughTrustedRelaysOnly"] == "disabled"
-
-    def test_get_ingest_through_trusted_relays_only_option_without_feature(self) -> None:
-        response = self.get_success_response(self.organization.slug)
-        assert "ingestThroughTrustedRelaysOnly" not in response.data
 
     @with_feature("organizations:dynamic-sampling-custom")
     def test_target_sample_rate_range(self) -> None:

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -1477,31 +1477,17 @@ def test_project_config_with_transaction_name_clustering_disabled(
 
 @django_db_all
 @cell_silo_test
-@pytest.mark.parametrize("feature_enabled", [True, False])
 @pytest.mark.parametrize("project_option_value", ["enabled", "disabled"])
-def test_project_config_trusted_relay_settings(
-    default_project, feature_enabled, project_option_value
-):
+def test_project_config_trusted_relay_settings(default_project, project_option_value):
     default_project.organization.update_option(
         "sentry:ingest-through-trusted-relays-only", project_option_value
     )
 
-    features_dict = {}
-    if feature_enabled:
-        features_dict["organizations:ingest-through-trusted-relays-only"] = True
+    config = get_project_config(default_project).to_dict()
 
-    with Feature(features_dict):
-        config = get_project_config(default_project).to_dict()
-
-        trusted_relay_settings = config["config"].get("trustedRelaySettings")
-
-        if feature_enabled:
-            # trustedRelaySettings should be present
-            assert trusted_relay_settings is not None
-            assert trusted_relay_settings["verifySignature"] == project_option_value
-        else:
-            # trustedRelaySettings should not be present
-            assert trusted_relay_settings is None
+    trusted_relay_settings = config["config"].get("trustedRelaySettings")
+    assert trusted_relay_settings is not None
+    assert trusted_relay_settings["verifySignature"] == project_option_value
 
 
 @django_db_all


### PR DESCRIPTION
## Summary

- Feature `ingest-through-trusted-relays-only` is now GA — remove the Flagpole registration from `permanent.py`
- Stacked on top of #118120 which removes all code checks first

## Test plan

- [ ] Merge #118120 first, then merge this