### PR TITLE
ref(migrations): Add to_jsonb utility to new_migrations.operations

### DIFF
--- a/src/sentry/new_migrations/operations.py
+++ b/src/sentry/new_migrations/operations.py
@@ -1,0 +1,15 @@
+from typing import LiteralString
+
+from sentry.new_migrations.monkey.special import SafeRunSQL
+
+
+def to_jsonb(table: LiteralString, column: LiteralString) -> SafeRunSQL:
+    """
+    Returns a SafeRunSQL operation that converts a column from text to jsonb in-place.
+    Use inside SeparateDatabaseAndState.database_operations.
+    """
+    return SafeRunSQL(
+        f"ALTER TABLE {table} ALTER COLUMN {column} TYPE jsonb USING {column}::jsonb;",
+        reverse_sql=f"ALTER TABLE {table} ALTER COLUMN {column} TYPE text;",
+        hints={"tables": [table]},
+    )


### PR DESCRIPTION
`to_jsonb` is a helper that produces a `SafeRunSQL` operation to convert a column from `text` to `jsonb` in-place. It currently lives as a module-level function inside a specific migration file (`0929_no_pickle_authenticator`), and getsentry imports it from there by name using `__import__`. This blocks migration squashing in sentry: when migrations are squashed that file is renamed, which breaks the getsentry import.

To fix it, we need to move it to "utils" file first, from where it can safely be used in other existing and future migrations