### PR TITLE
test(symbolicator): Stop skipping Unreal attachments tests

### DIFF
--- a/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
@@ -15,11 +15,6 @@ contexts:
     name: macOS
     type: os
     version: 10.14.0
-  trace:
-    span_id: acc006c41ee3430e
-    status: unknown
-    trace_id: acc006c41ee3430ebb3b455c6759f0fd
-    type: trace
   unreal:
     app_default_locate: en-AT
     base_dir: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/YetAnotherMac/Binaries/Mac/

--- a/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
@@ -1,7 +1,5 @@
 ---
-created: '2023-06-19T11:19:37.050282Z'
-creator: sentry
-source: tests/symbolicator/test_unreal_full.py
+source: tests/symbolicator/test_unreal_full.py::test_unreal_apple_crash_with_attachments
 ---
 contexts:
   device:
@@ -17,6 +15,11 @@ contexts:
     name: macOS
     type: os
     version: 10.14.0
+  trace:
+    span_id: acc006c41ee3430e
+    status: unknown
+    trace_id: acc006c41ee3430ebb3b455c6759f0fd
+    type: trace
   unreal:
     app_default_locate: en-AT
     base_dir: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/YetAnotherMac/Binaries/Mac/

--- a/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
@@ -15,11 +15,6 @@ contexts:
     raw_description: Windows 10
     type: os
     version: '10'
-  trace:
-    span_id: a1c0f38835ac4a05
-    status: unknown
-    trace_id: a1c0f38835ac4a05b1a79f3838183678
-    type: trace
   unreal:
     app_default_locate: en-US
     base_dir: //Mac/Home/Desktop/WindowsNoEditor/YetAnother/Binaries/Win64/

--- a/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
@@ -1,7 +1,5 @@
 ---
-created: '2023-06-19T11:19:44.780868Z'
-creator: sentry
-source: tests/symbolicator/test_unreal_full.py
+source: tests/symbolicator/test_unreal_full.py::test_unreal_crash_with_attachments
 ---
 contexts:
   device:
@@ -16,7 +14,12 @@ contexts:
     os: Windows 10
     raw_description: Windows 10
     type: os
-    version: 10
+    version: '10'
+  trace:
+    span_id: a1c0f38835ac4a05
+    status: unknown
+    trace_id: a1c0f38835ac4a05b1a79f3838183678
+    type: trace
   unreal:
     app_default_locate: en-US
     base_dir: //Mac/Home/Desktop/WindowsNoEditor/YetAnother/Binaries/Win64/
@@ -128,168 +131,6 @@ exception:
       type: minidump
     stacktrace:
       frames:
-      - data:
-          category: internals
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ffe100d1471'
-        package: C:\Windows\System32\ntdll.dll
-        trust: scan
-      - data:
-          category: internals
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ffe0fd53034'
-        package: C:\Windows\System32\kernel32.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: truncated
-        in_app: false
-        instruction_addr: '0x7ff7548229e5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: <truncated>
-        symbol: <truncated>
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: truncated
-        in_app: false
-        instruction_addr: '0x7ff754814ea9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: <truncated>
-        symbol: <truncated>
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: truncated
-        in_app: false
-        instruction_addr: '0x7ff754814e4b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: <truncated>
-        symbol: <truncated>
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: truncated
-        in_app: false
-        instruction_addr: '0x7ff75480faff'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: <truncated>
-        symbol: <truncated>
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: truncated
-        in_app: false
-        instruction_addr: '0x7ff754802a17'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: <truncated>
-        symbol: <truncated>
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: truncated
-        in_app: false
-        instruction_addr: '0x7ff754808327'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: <truncated>
-        symbol: <truncated>
-        trust: scan
-      - data:
-          category: internals
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ffe0c94e265'
-        package: C:\Windows\System32\bcryptPrimitives.dll
-        trust: scan
-      - data:
-          category: internals
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ffe0c94e4ac'
-        package: C:\Windows\System32\bcryptPrimitives.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: truncated
-        in_app: false
-        instruction_addr: '0x7ff754805257'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: <truncated>
-        symbol: <truncated>
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: truncated
-        in_app: false
-        instruction_addr: '0x7ff75483137f'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: <truncated>
-        symbol: <truncated>
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: truncated
-        in_app: false
-        instruction_addr: '0x7ff7548149a7'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: <truncated>
-        symbol: <truncated>
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: truncated
-        in_app: false
-        instruction_addr: '0x7ff75480facf'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: <truncated>
-        symbol: <truncated>
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: truncated
-        in_app: false
-        instruction_addr: '0x7ff7548221de'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: <truncated>
-        symbol: <truncated>
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: truncated
-        in_app: false
-        instruction_addr: '0x7ff75480faef'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: <truncated>
-        symbol: <truncated>
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: truncated
-        in_app: false
-        instruction_addr: '0x7ff75481f05c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: <truncated>
-        symbol: <truncated>
-        trust: scan
       - data:
           orig_in_app: -1
           symbolicator_status: symbolicated

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -88,7 +88,9 @@ class SymbolicatorUnrealIntegrationTest(RelayStoreHelper, TransactionTestCase):
         def make_snapshot(subname=None):
             self.insta_snapshot(
                 {
-                    "contexts": event.data.get("contexts"),
+                    "contexts": {
+                        k: v for k, v in (event.data.get("contexts") or {}).items() if k != "trace"
+                    },
                     "exception": {
                         "values": [
                             normalize_native_exception(x)

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -107,7 +107,6 @@ class SymbolicatorUnrealIntegrationTest(RelayStoreHelper, TransactionTestCase):
 
         return sorted(EventAttachment.objects.filter(event_id=event.event_id), key=lambda x: x.name)
 
-    @pytest.mark.skip(reason="temporary because of Relay change")
     def test_unreal_crash_with_attachments(self) -> None:
         attachments = self.unreal_crash_test_impl(get_unreal_crash_file())
         assert len(attachments) == 4
@@ -125,7 +124,6 @@ class SymbolicatorUnrealIntegrationTest(RelayStoreHelper, TransactionTestCase):
         assert log.name == "YetAnother.log"  # Log file is named after the project
         assert log.sha1 == "24d1c5f75334cd0912cc2670168d593d5fe6c081"
 
-    @pytest.mark.skip(reason="temporary because of Relay change")
     def test_unreal_apple_crash_with_attachments(self) -> None:
         attachments = self.unreal_crash_test_impl(get_unreal_crash_apple_file())
 


### PR DESCRIPTION
I want to run all tests that exercise debug files for the new objectstore-backed path, and I noticed these were disabled in https://github.com/getsentry/sentry/pull/94767.
As I would like to run these, this PR re-enables them.