### PR TITLE
fix(automations): Allow value of 0 for frequency conditions

### DIFF
--- a/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
+++ b/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
@@ -17,24 +17,34 @@ type IntervalChoice = {label: string; value: Interval};
 
 interface BranchProps {
   intervalChoices?: IntervalChoice[];
+  // Minimum allowed comparison value. Defaults to 0, which lets users alert on
+  // "more than 0" (i.e. 1 or more). Percent-sessions passes 1 since its
+  // validator treats 0 as missing.
+  minValue?: number;
 }
 
-export function CountBranch({intervalChoices = INTERVAL_CHOICES}: BranchProps) {
+export function CountBranch({
+  intervalChoices = INTERVAL_CHOICES,
+  minValue = 0,
+}: BranchProps) {
   return tct('more than [value] [interval]', {
-    value: <ValueField />,
+    value: <ValueField minValue={minValue} />,
     interval: <IntervalField intervalChoices={intervalChoices} />,
   });
 }
 
-export function PercentBranch({intervalChoices = INTERVAL_CHOICES}: BranchProps) {
+export function PercentBranch({
+  intervalChoices = INTERVAL_CHOICES,
+  minValue = 0,
+}: BranchProps) {
   return tct('[value] higher [interval] compared to [comparison_interval]', {
-    value: <PercentValueField />,
+    value: <PercentValueField minValue={minValue} />,
     interval: <IntervalField intervalChoices={intervalChoices} />,
     comparison_interval: <ComparisonIntervalField />,
   });
 }
 
-function ValueField() {
+function ValueField({minValue = 0}: {minValue?: number}) {
   const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
   const {removeError} = useAutomationBuilderErrorContext();
 
@@ -43,7 +53,7 @@ function ValueField() {
       name={`${condition_id}.comparison.value`}
       aria-label={t('Value')}
       value={condition.comparison.value}
-      min={0}
+      min={minValue}
       step={1}
       onChange={(value: number) => {
         onUpdate({comparison: {...condition.comparison, value}});
@@ -53,10 +63,10 @@ function ValueField() {
   );
 }
 
-function PercentValueField() {
+function PercentValueField({minValue = 0}: {minValue?: number}) {
   return (
     <PercentWrapper>
-      <ValueField />%
+      <ValueField minValue={minValue} />%
     </PercentWrapper>
   );
 }

--- a/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
+++ b/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
@@ -43,7 +43,7 @@ function ValueField() {
       name={`${condition_id}.comparison.value`}
       aria-label={t('Value')}
       value={condition.comparison.value}
-      min={1}
+      min={0}
       step={1}
       onChange={(value: number) => {
         onUpdate({comparison: {...condition.comparison, value}});

--- a/static/app/views/automations/components/actionFilters/eventFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventFrequency.tsx
@@ -134,7 +134,9 @@ export function validateEventFrequencyCondition({
     return t('You must select a comparison type.');
   }
   if (
-    !condition.comparison.value ||
+    condition.comparison.value === null ||
+    condition.comparison.value === undefined ||
+    Number.isNaN(condition.comparison.value) ||
     !condition.comparison.interval ||
     (condition.type === DataConditionType.EVENT_FREQUENCY_PERCENT &&
       !condition.comparison.comparisonInterval)

--- a/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
@@ -146,7 +146,9 @@ export function validateEventUniqueUserFrequencyCondition({
     return t('You must select a comparison type.');
   }
   if (
-    !condition.comparison.value ||
+    condition.comparison.value === null ||
+    condition.comparison.value === undefined ||
+    Number.isNaN(condition.comparison.value) ||
     !condition.comparison.interval ||
     (condition.type === DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT &&
       !condition.comparison.comparisonInterval)

--- a/static/app/views/automations/components/actionFilters/percentSessions.tsx
+++ b/static/app/views/automations/components/actionFilters/percentSessions.tsx
@@ -95,10 +95,10 @@ function ComparisonTypeField() {
   const {removeError} = useAutomationBuilderErrorContext();
 
   if (condition.type === DataConditionType.PERCENT_SESSIONS_COUNT) {
-    return <CountBranch intervalChoices={PERCENT_INTERVAL_CHOICES} />;
+    return <CountBranch intervalChoices={PERCENT_INTERVAL_CHOICES} minValue={1} />;
   }
   if (condition.type === DataConditionType.PERCENT_SESSIONS_PERCENT) {
-    return <PercentBranch intervalChoices={PERCENT_INTERVAL_CHOICES} />;
+    return <PercentBranch intervalChoices={PERCENT_INTERVAL_CHOICES} minValue={1} />;
   }
 
   return (


### PR DESCRIPTION
## Summary

The new Automations UI made it impossible to configure an **event-count** or **unique-user** frequency condition with a comparison value of `0`. Because these conditions evaluate `value > comparison`, a value of `0` is required to express *"alert on 1 or more events/users in the interval"* — and the backend already permits it (`minimum: 0` in the condition schema).

Two things blocked it in the frontend:

1. The shared count input (`comparisonBranches.tsx`) was hard-floored at `min={1}`, so the react-aria `NumberInput` clamped a typed `0` up to `1` (and the stepper wouldn't go below `1`).
2. The validators used `!condition.comparison.value`, which is falsy for `0`, so even a typed `0` failed with *"Ensure all fields are filled in."*

## Changes

- `comparisonBranches.tsx`: lower the shared count input to `min={0}`.
- `eventFrequency.tsx` and `eventUniqueUserFrequency.tsx`: validators now reject only `null` / `undefined` / `NaN`, preserving the empty-field error while allowing a legitimate `0`.
- `percentSessions.tsx` is intentionally left unchanged (its validator still treats `0` as missing).
- `issueOccurrences` is untouched — it evaluates `value >= comparison` ("at least N times"), so `min={1}` is correct there and `0` would be meaningless.