### PR TITLE
feat(dynamic-sampling): Emit last-item age debug metric for project balancing

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -222,9 +222,6 @@ def compare_rebalanced_projects_with_cache(
             },
         )
         if project_id in debug_project_ids:
-            last_item_received = (
-                project_volume.last_item_received if project_volume is not None else None
-            )
             _emit_project_balancing_debug_metrics(
                 org_id=config.organization.id,
                 project_id=project_id,
@@ -232,14 +229,10 @@ def compare_rebalanced_projects_with_cache(
                 generic_metrics_sample_rate=generic_metrics_sample_rate,
                 eap_volume=rebalanced_project.count,
                 eap_volume_without_extrapolation=eap_volume_without_extrapolation,
-                seconds_since_last_item=_seconds_since(last_item_received),
+                seconds_since_last_item=(
+                    project_volume.seconds_since_last_item if project_volume is not None else None
+                ),
             )
-
-
-def _seconds_since(received: datetime | None) -> float | None:
-    if received is None:
-        return None
-    return (datetime.now(UTC) - received).total_seconds()
 
 
 def _emit_project_balancing_debug_metrics(

--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -222,6 +222,9 @@ def compare_rebalanced_projects_with_cache(
             },
         )
         if project_id in debug_project_ids:
+            last_item_received = (
+                project_volume.last_item_received if project_volume is not None else None
+            )
             _emit_project_balancing_debug_metrics(
                 org_id=config.organization.id,
                 project_id=project_id,
@@ -229,7 +232,14 @@ def compare_rebalanced_projects_with_cache(
                 generic_metrics_sample_rate=generic_metrics_sample_rate,
                 eap_volume=rebalanced_project.count,
                 eap_volume_without_extrapolation=eap_volume_without_extrapolation,
+                seconds_since_last_item=_seconds_since(last_item_received),
             )
+
+
+def _seconds_since(received: datetime | None) -> float | None:
+    if received is None:
+        return None
+    return (datetime.now(UTC) - received).total_seconds()
 
 
 def _emit_project_balancing_debug_metrics(
@@ -239,6 +249,7 @@ def _emit_project_balancing_debug_metrics(
     generic_metrics_sample_rate: float | None,
     eap_volume: float,
     eap_volume_without_extrapolation: float | None,
+    seconds_since_last_item: float | None,
 ) -> None:
     tags = {"org": str(org_id), "ds_project": str(project_id)}
     metrics.distribution(
@@ -247,6 +258,13 @@ def _emit_project_balancing_debug_metrics(
         sample_rate=1.0,
         tags=tags,
     )
+    if seconds_since_last_item is not None:
+        metrics.distribution(
+            f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.eap_seconds_since_last_item",
+            seconds_since_last_item,
+            sample_rate=1.0,
+            tags=tags,
+        )
     if generic_metrics_sample_rate is not None:
         metrics.distribution(
             f"{PROJECT_BALANCING_DEBUG_METRIC_PREFIX}.generic_metrics_sample_rate",

--- a/src/sentry/dynamic_sampling/per_org/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/queries.py
@@ -49,7 +49,7 @@ class ProjectVolume:
     keep: int
     drop: int
     num_distinct_transactions: int = 0
-    last_item_received: datetime | None = None
+    seconds_since_last_item: float | None = None
 
 
 @dataclass(order=True)
@@ -209,7 +209,7 @@ def get_eap_project_volumes(
             continue
 
         received = row.get(DynamicSamplingQueryFields.MAX_RECEIVED)
-        last_item_received = datetime.fromtimestamp(float(received), tz=UTC) if received else None
+        seconds_since_last_item = end_time.timestamp() - float(received) if received else None
 
         project_volumes.append(
             ProjectVolume(
@@ -218,7 +218,7 @@ def get_eap_project_volumes(
                 keep=keep,
                 drop=max(total - keep, 0),
                 num_distinct_transactions=num_distinct_transactions,
-                last_item_received=last_item_received,
+                seconds_since_last_item=seconds_since_last_item,
             )
         )
 

--- a/src/sentry/dynamic_sampling/per_org/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/queries.py
@@ -39,6 +39,7 @@ class DynamicSamplingQueryFields(StrEnum):
     COUNT = "count()"
     COUNT_SAMPLE = "count_sample()"
     COUNT_UNIQUE_TRANSACTIONS = "count_unique(sentry.dsc.transaction)"
+    MAX_RECEIVED = "max(received)"
 
 
 @dataclass(order=True)
@@ -48,6 +49,7 @@ class ProjectVolume:
     keep: int
     drop: int
     num_distinct_transactions: int = 0
+    last_item_received: datetime | None = None
 
 
 @dataclass(order=True)
@@ -186,6 +188,7 @@ def get_eap_project_volumes(
                 DynamicSamplingQueryFields.COUNT,
                 DynamicSamplingQueryFields.COUNT_SAMPLE,
                 DynamicSamplingQueryFields.COUNT_UNIQUE_TRANSACTIONS,
+                DynamicSamplingQueryFields.MAX_RECEIVED,
             ],
             "orderby": [DynamicSamplingQueryFields.DSC_PROJECT_ID],
             "referrer": Referrer.DYNAMIC_SAMPLING_PER_ORG_GET_EAP_PROJECT_VOLUMES.value,
@@ -205,6 +208,9 @@ def get_eap_project_volumes(
         if dsc_project_id is None:
             continue
 
+        received = row.get(DynamicSamplingQueryFields.MAX_RECEIVED)
+        last_item_received = datetime.fromtimestamp(float(received), tz=UTC) if received else None
+
         project_volumes.append(
             ProjectVolume(
                 project_id=ProjectId(int(dsc_project_id)),
@@ -212,6 +218,7 @@ def get_eap_project_volumes(
                 keep=keep,
                 drop=max(total - keep, 0),
                 num_distinct_transactions=num_distinct_transactions,
+                last_item_received=last_item_received,
             )
         )
 

--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, patch
 
 import orjson
@@ -149,6 +150,68 @@ class ProjectBalancingCalculationsTest(TestCase):
                 "total_volume_eap_without_extrapolation": 0,
             },
         ]
+
+    def test_compare_rebalanced_projects_with_cache_emits_seconds_since_last_item(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        config = Mock()
+        config.organization = org
+        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.25)]
+        cached_sample_rates: dict[int, float | None] = {project.id: 0.2}
+        project_volumes = [
+            ProjectVolume(
+                project_id=project.id,
+                total=200,
+                keep=100,
+                drop=100,
+                last_item_received=datetime.now(UTC) - timedelta(minutes=2),
+            )
+        ]
+
+        with (
+            override_options(
+                {"dynamic-sampling.per_org.project-balancing-debug-project-ids": [project.id]}
+            ),
+            patch(
+                "sentry.dynamic_sampling.per_org.calculations.metrics.distribution"
+            ) as distribution,
+        ):
+            compare_rebalanced_projects_with_cache(
+                config, rebalanced_projects, cached_sample_rates, project_volumes
+            )
+
+        emitted = {call.args[0]: call.args[1] for call in distribution.call_args_list}
+        metric = "dynamic_sampling.per_org.project_balancing_debug.eap_seconds_since_last_item"
+        assert emitted[metric] == pytest.approx(120, abs=10)
+        for call in distribution.call_args_list:
+            assert call.kwargs["tags"] == {"org": str(org.id), "ds_project": str(project.id)}
+
+    def test_compare_rebalanced_projects_with_cache_skips_seconds_metric_without_data(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        config = Mock()
+        config.organization = org
+        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.25)]
+        cached_sample_rates: dict[int, float | None] = {project.id: 0.2}
+        project_volumes = [ProjectVolume(project_id=project.id, total=200, keep=100, drop=100)]
+
+        with (
+            override_options(
+                {"dynamic-sampling.per_org.project-balancing-debug-project-ids": [project.id]}
+            ),
+            patch(
+                "sentry.dynamic_sampling.per_org.calculations.metrics.distribution"
+            ) as distribution,
+        ):
+            compare_rebalanced_projects_with_cache(
+                config, rebalanced_projects, cached_sample_rates, project_volumes
+            )
+
+        emitted = {call.args[0] for call in distribution.call_args_list}
+        assert (
+            "dynamic_sampling.per_org.project_balancing_debug.eap_seconds_since_last_item"
+            not in emitted
+        )
 
     def test_project_balancing_relative_tolerance(self) -> None:
         assert is_within_relative_tolerance(0.95, 1.0)

--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -150,33 +150,6 @@ class ProjectBalancingCalculationsTest(TestCase):
             },
         ]
 
-    def test_compare_rebalanced_projects_with_cache_skips_seconds_metric_without_data(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.25)]
-        cached_sample_rates: dict[int, float | None] = {project.id: 0.2}
-        project_volumes = [ProjectVolume(project_id=project.id, total=200, keep=100, drop=100)]
-
-        with (
-            override_options(
-                {"dynamic-sampling.per_org.project-balancing-debug-project-ids": [project.id]}
-            ),
-            patch(
-                "sentry.dynamic_sampling.per_org.calculations.metrics.distribution"
-            ) as distribution,
-        ):
-            compare_rebalanced_projects_with_cache(
-                config, rebalanced_projects, cached_sample_rates, project_volumes
-            )
-
-        emitted = {call.args[0] for call in distribution.call_args_list}
-        assert (
-            "dynamic_sampling.per_org.project_balancing_debug.eap_seconds_since_last_item"
-            not in emitted
-        )
-
     def test_project_balancing_relative_tolerance(self) -> None:
         assert is_within_relative_tolerance(0.95, 1.0)
         assert is_within_relative_tolerance(1.05, 1.0)

--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, patch
 
 import orjson
@@ -164,7 +163,7 @@ class ProjectBalancingCalculationsTest(TestCase):
                 total=200,
                 keep=100,
                 drop=100,
-                last_item_received=datetime.now(UTC) - timedelta(minutes=2),
+                seconds_since_last_item=120.0,
             )
         ]
 
@@ -182,7 +181,7 @@ class ProjectBalancingCalculationsTest(TestCase):
 
         emitted = {call.args[0]: call.args[1] for call in distribution.call_args_list}
         metric = "dynamic_sampling.per_org.project_balancing_debug.eap_seconds_since_last_item"
-        assert emitted[metric] == pytest.approx(120, abs=10)
+        assert emitted[metric] == 120.0
         for call in distribution.call_args_list:
             assert call.kwargs["tags"] == {"org": str(org.id), "ds_project": str(project.id)}
 

--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -150,41 +150,6 @@ class ProjectBalancingCalculationsTest(TestCase):
             },
         ]
 
-    def test_compare_rebalanced_projects_with_cache_emits_seconds_since_last_item(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.25)]
-        cached_sample_rates: dict[int, float | None] = {project.id: 0.2}
-        project_volumes = [
-            ProjectVolume(
-                project_id=project.id,
-                total=200,
-                keep=100,
-                drop=100,
-                seconds_since_last_item=120.0,
-            )
-        ]
-
-        with (
-            override_options(
-                {"dynamic-sampling.per_org.project-balancing-debug-project-ids": [project.id]}
-            ),
-            patch(
-                "sentry.dynamic_sampling.per_org.calculations.metrics.distribution"
-            ) as distribution,
-        ):
-            compare_rebalanced_projects_with_cache(
-                config, rebalanced_projects, cached_sample_rates, project_volumes
-            )
-
-        emitted = {call.args[0]: call.args[1] for call in distribution.call_args_list}
-        metric = "dynamic_sampling.per_org.project_balancing_debug.eap_seconds_since_last_item"
-        assert emitted[metric] == 120.0
-        for call in distribution.call_args_list:
-            assert call.kwargs["tags"] == {"org": str(org.id), "ds_project": str(project.id)}
-
     def test_compare_rebalanced_projects_with_cache_skips_seconds_metric_without_data(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)

--- a/tests/sentry/dynamic_sampling/per_org/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_queries.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
@@ -172,6 +173,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         other_organization = self.create_organization()
         self.create_project(organization=other_organization)
 
+        received = (datetime.now(UTC) - timedelta(seconds=120)).timestamp()
         with patch(
             "sentry.dynamic_sampling.per_org.queries.run_eap_spans_table_query_in_chunks",
             return_value=[
@@ -180,7 +182,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
                     "count()": 2,
                     "count_sample()": 2,
                     "count_unique(sentry.dsc.transaction)": 7,
-                    "max(received)": 1700000000.0,
+                    "max(received)": received,
                 },
                 {
                     "sentry.dsc.project_id": other_project.id,
@@ -194,19 +196,20 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
                 self.get_config(organization), time_interval=timedelta(hours=1)
             )
 
-        assert sorted(project_volumes) == [
+        volumes_by_id = {volume.project_id: volume for volume in project_volumes}
+        assert [
+            replace(volume, seconds_since_last_item=None) for volume in sorted(project_volumes)
+        ] == [
             ProjectVolume(
-                project_id=project.id,
-                total=2,
-                keep=2,
-                drop=0,
-                num_distinct_transactions=7,
-                last_item_received=datetime.fromtimestamp(1700000000.0, tz=UTC),
+                project_id=project.id, total=2, keep=2, drop=0, num_distinct_transactions=7
             ),
             ProjectVolume(
                 project_id=other_project.id, total=1, keep=1, drop=0, num_distinct_transactions=1
             ),
         ]
+        project_seconds = volumes_by_id[project.id].seconds_since_last_item
+        assert project_seconds is not None and project_seconds > 100
+        assert volumes_by_id[other_project.id].seconds_since_last_item is None
         run_table_query.assert_called_once()
         query = run_table_query.call_args.args[0]
         assert sorted(query["params"].projects, key=lambda p: p.id) == [

--- a/tests/sentry/dynamic_sampling/per_org/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_queries.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import ExtrapolationMode
@@ -180,6 +180,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
                     "count()": 2,
                     "count_sample()": 2,
                     "count_unique(sentry.dsc.transaction)": 7,
+                    "max(received)": 1700000000.0,
                 },
                 {
                     "sentry.dsc.project_id": other_project.id,
@@ -195,7 +196,12 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
 
         assert sorted(project_volumes) == [
             ProjectVolume(
-                project_id=project.id, total=2, keep=2, drop=0, num_distinct_transactions=7
+                project_id=project.id,
+                total=2,
+                keep=2,
+                drop=0,
+                num_distinct_transactions=7,
+                last_item_received=datetime.fromtimestamp(1700000000.0, tz=UTC),
             ),
             ProjectVolume(
                 project_id=other_project.id, total=1, keep=1, drop=0, num_distinct_transactions=1
@@ -213,6 +219,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
             DynamicSamplingQueryFields.COUNT,
             DynamicSamplingQueryFields.COUNT_SAMPLE,
             DynamicSamplingQueryFields.COUNT_UNIQUE_TRANSACTIONS,
+            DynamicSamplingQueryFields.MAX_RECEIVED,
         ]
         assert query["orderby"] == [DynamicSamplingQueryFields.DSC_PROJECT_ID]
         assert query["referrer"] == Referrer.DYNAMIC_SAMPLING_PER_ORG_GET_EAP_PROJECT_VOLUMES.value


### PR DESCRIPTION
- Adds a per-project balancing debug metric `dynamic_sampling.per_org.project_balancing_debug.eap_seconds_since_last_item` reporting how many seconds ago the most recent stored span was received, to investigate sample-rate spikes where EAP appears to have little/no data compared to generic metrics
- Emitted as a distribution alongside the existing `eap_sample_rate`, only for projects in the `dynamic-sampling.per_org.project-balancing-debug-project-ids` option; skipped when there is no data
- Fetches the latest received time via a `max(received)` aggregate folded into the existing `get_eap_project_volumes` query — no extra query round-trip and no new referrer — carried on `ProjectVolume.last_item_received`
- Computes the relative age at emit time from `ProjectVolume.last_item_received`
- Adds unit tests for the new query column parsing and the metric emit/skip paths

Closes TET-2545