### PR TITLE
ref(trace): Extract trace view calculations

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceViewCalculations.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceViewCalculations.spec.tsx
@@ -1,0 +1,113 @@
+import {mat3} from 'gl-matrix';
+
+import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
+import {TraceTimeCompression} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceTimeCompression';
+import {TraceView} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceView';
+import {
+  CompressedTraceViewCalculations,
+  NormalTraceViewCalculations,
+  type CompressedView,
+  type SpanMatrix,
+  type TraceViewCalculationContext,
+} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceViewCalculations';
+
+function makeCalculationContext({
+  timeCompression = TraceTimeCompression.Disabled([0, 1000]),
+}: {
+  timeCompression?: TraceTimeCompression;
+} = {}): TraceViewCalculationContext {
+  const view = new TraceView();
+  const spanToPx = mat3.create();
+
+  view.setTraceSpace([0, 0, 1000, 1]);
+  view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+
+  return {
+    getCompressedView: (): CompressedView => {
+      const start = view.to_origin + view.trace_view.x;
+      const end = start + view.trace_view.width;
+      const left = timeCompression.toCompressedOffset(start);
+      const right = timeCompression.toCompressedOffset(end);
+
+      return {
+        left,
+        right,
+        width: Math.max(right - left, Number.EPSILON),
+      };
+    },
+    getConfigSpacePerPx: (): number => {
+      if (view.trace_physical_space.width === 0) {
+        return spanToPx[0] || 1;
+      }
+
+      return view.trace_view.width / view.trace_physical_space.width;
+    },
+    spanMatrix: [1, 0, 0, 1, 0, 0] satisfies SpanMatrix,
+    spanToPx,
+    timeCompression,
+    view,
+  };
+}
+
+function makeCompressedContext(): TraceViewCalculationContext {
+  return makeCalculationContext({
+    timeCompression: TraceTimeCompression.FromVisibleItems({
+      enabled: true,
+      traceSpace: [0, 1000],
+      physicalWidth: 1000,
+      nodes: [
+        {type: 'transaction', space: [0, 100]} as unknown as BaseNode,
+        {type: 'span', space: [500, 100]} as unknown as BaseNode,
+      ],
+      indicators: [],
+    }),
+  });
+}
+
+describe('TraceViewCalculations', () => {
+  describe('NormalTraceViewCalculations', () => {
+    it('uses trace view duration for horizontal panning', () => {
+      const calculations = new NormalTraceViewCalculations();
+      const context = makeCalculationContext();
+
+      context.view.setTraceView({x: 100, width: 200});
+
+      expect(calculations.computeWheelPanView(context, 0.5)).toEqual({x: 200});
+      expect(calculations.getConfigSpaceCursor(context, {x: 250, y: 0})).toEqual([
+        150, 0,
+      ]);
+    });
+  });
+
+  describe('CompressedTraceViewCalculations', () => {
+    it('keeps the cursor anchored when zooming through compressed time', () => {
+      const calculations = new CompressedTraceViewCalculations();
+      const context = makeCompressedContext();
+      const cursorX = 165;
+      const timestampBefore =
+        calculations.getConfigSpaceCursor(context, {x: cursorX, y: 0})[0] +
+        context.view.to_origin;
+
+      const nextView = calculations.computeWheelZoomView(context, cursorX, 0.9);
+      context.view.setTraceView({x: nextView[0], width: nextView[2]});
+
+      const timestampAfter =
+        calculations.getConfigSpaceCursor(context, {x: cursorX, y: 0})[0] +
+        context.view.to_origin;
+
+      expect(timestampAfter).toBeCloseTo(timestampBefore);
+    });
+
+    it('computes relative positions in compressed space', () => {
+      const calculations = new CompressedTraceViewCalculations();
+      const context = makeCompressedContext();
+
+      expect(
+        calculations.computeRelativeLeftPositionFromOrigin(context, 500, [0, 1000])
+      ).not.toBe(0.5);
+      expect(
+        calculations.computeRelativeWidth(context, [100, 400], [0, 1000])
+      ).toBeLessThan(0.4);
+    });
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceViewCalculations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceViewCalculations.tsx
@@ -17,49 +17,82 @@ export type TraceViewCalculationContext = {
 };
 
 export interface TraceViewCalculations {
+  /**
+   * Return the visual left position of a timestamp within a parent span.
+   */
   computeRelativeLeftPositionFromOrigin(
     context: TraceViewCalculationContext,
     timestamp: number,
     entireSpace: [number, number]
   ): number;
+  /**
+   * Return the visual width of a child span relative to a parent span.
+   */
   computeRelativeWidth(
     context: TraceViewCalculationContext,
     space: [number, number],
     entireSpace: [number, number]
   ): number;
+  /**
+   * Build the CSS matrix used to position and scale a span bar in the timeline.
+   */
   computeSpanCSSMatrixTransform(
     context: TraceViewCalculationContext,
     space: [number, number]
   ): SpanMatrix;
+  /**
+   * Convert a fixed-width icon around a timestamp into trace-space bounds.
+   */
   computeTraceIconBounds(
     context: TraceViewCalculationContext,
     anchorTimestamp: number,
     iconWidthPx: number,
     edge: TraceIconEdge
   ): [number, number];
+  /**
+   * Compute the next trace view after a horizontal wheel pan.
+   */
   computeWheelPanView(
     context: TraceViewCalculationContext,
     physicalDeltaPct: number
   ): {x: number; width?: number};
+  /**
+   * Compute the next trace view after wheel zooming around a physical x position.
+   */
   computeWheelZoomView(
     context: TraceViewCalculationContext,
     x: number,
     scale: number
   ): [number, number, number, number];
+  /**
+   * Convert a cursor position in physical pixels to the trace view's config space.
+   */
   getConfigSpaceCursor(
     context: TraceViewCalculationContext,
     cursor: {x: number; y: number}
   ): [number, number];
+  /**
+   * Expand a zoom target so text near the selected span remains visible.
+   */
   padZoomIntoSpace(
     context: TraceViewCalculationContext,
     x: number,
     width: number
   ): {width: number; x: number};
+  /**
+   * Recompute the matrix that maps trace-space duration to physical pixels.
+   */
   recomputeSpanToPXMatrix(context: TraceViewCalculationContext): mat3;
+  /**
+   * Recompute timeline tick offsets for the current visible view.
+   */
   recomputeTimelineIntervals(
     context: TraceViewCalculationContext,
     intervals: Array<number | undefined>
   ): void;
+  /**
+   * Convert an absolute timestamp to a physical x offset in the visible timeline.
+   */
   transformXFromTimestamp(
     context: TraceViewCalculationContext,
     timestamp: number

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceViewCalculations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceViewCalculations.tsx
@@ -1,0 +1,475 @@
+import {mat3, vec2} from 'gl-matrix';
+
+import {TraceTimeCompression} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceTimeCompression';
+import type {TraceView} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceView';
+
+export type CompressedView = {left: number; right: number; width: number};
+export type SpanMatrix = [number, number, number, number, number, number];
+export type TraceIconEdge = 'start' | 'end' | null;
+
+export type TraceViewCalculationContext = {
+  getCompressedView: () => CompressedView;
+  getConfigSpacePerPx: () => number;
+  spanMatrix: SpanMatrix;
+  spanToPx: mat3;
+  timeCompression: TraceTimeCompression;
+  view: TraceView;
+};
+
+export interface TraceViewCalculations {
+  computeRelativeLeftPositionFromOrigin(
+    context: TraceViewCalculationContext,
+    timestamp: number,
+    entireSpace: [number, number]
+  ): number;
+  computeRelativeWidth(
+    context: TraceViewCalculationContext,
+    space: [number, number],
+    entireSpace: [number, number]
+  ): number;
+  computeSpanCSSMatrixTransform(
+    context: TraceViewCalculationContext,
+    space: [number, number]
+  ): SpanMatrix;
+  computeTraceIconBounds(
+    context: TraceViewCalculationContext,
+    anchorTimestamp: number,
+    iconWidthPx: number,
+    edge: TraceIconEdge
+  ): [number, number];
+  computeWheelPanView(
+    context: TraceViewCalculationContext,
+    physicalDeltaPct: number
+  ): {x: number; width?: number};
+  computeWheelZoomView(
+    context: TraceViewCalculationContext,
+    x: number,
+    scale: number
+  ): [number, number, number, number];
+  getConfigSpaceCursor(
+    context: TraceViewCalculationContext,
+    cursor: {x: number; y: number}
+  ): [number, number];
+  padZoomIntoSpace(
+    context: TraceViewCalculationContext,
+    x: number,
+    width: number
+  ): {width: number; x: number};
+  recomputeSpanToPXMatrix(context: TraceViewCalculationContext): mat3;
+  recomputeTimelineIntervals(
+    context: TraceViewCalculationContext,
+    intervals: Array<number | undefined>
+  ): void;
+  transformXFromTimestamp(
+    context: TraceViewCalculationContext,
+    timestamp: number
+  ): number;
+}
+
+export class NormalTraceViewCalculations implements TraceViewCalculations {
+  computeWheelZoomView(
+    context: TraceViewCalculationContext,
+    x: number,
+    scale: number
+  ): [number, number, number, number] {
+    const configSpaceCursor = this.getConfigSpaceCursor(context, {x, y: 0});
+    const center = vec2.fromValues(configSpaceCursor[0], 0);
+    const centerScaleMatrix = mat3.create();
+
+    mat3.fromTranslation(centerScaleMatrix, center);
+    mat3.scale(centerScaleMatrix, centerScaleMatrix, vec2.fromValues(scale, 1));
+    mat3.translate(centerScaleMatrix, centerScaleMatrix, vec2.fromValues(-center[0], 0));
+
+    return context.view.trace_view.transform(centerScaleMatrix);
+  }
+
+  computeWheelPanView(
+    context: TraceViewCalculationContext,
+    physicalDeltaPct: number
+  ): {x: number} {
+    return {
+      x: context.view.trace_view.x + physicalDeltaPct * context.view.trace_view.width,
+    };
+  }
+
+  padZoomIntoSpace(
+    context: TraceViewCalculationContext,
+    x: number,
+    width: number
+  ): {width: number; x: number} {
+    const mat = context.view.getSpanToPxForSpace([x, width]);
+    const offsetInConfigSpace = 74 * mat[0];
+
+    return {
+      x: x - offsetInConfigSpace,
+      width: width + offsetInConfigSpace * 2,
+    };
+  }
+
+  getConfigSpaceCursor(
+    context: TraceViewCalculationContext,
+    cursor: {x: number; y: number}
+  ): [number, number] {
+    return context.view.getConfigSpaceCursor(cursor);
+  }
+
+  recomputeSpanToPXMatrix(context: TraceViewCalculationContext): mat3 {
+    const traceViewToSpace = context.view.trace_space.between(context.view.trace_view);
+    const tracePhysicalToView = context.view.trace_physical_space.between(
+      context.view.trace_space
+    );
+
+    return mat3.multiply(context.spanToPx, traceViewToSpace, tracePhysicalToView);
+  }
+
+  computeSpanCSSMatrixTransform(
+    context: TraceViewCalculationContext,
+    space: [number, number]
+  ): SpanMatrix {
+    const visibleView = context.getCompressedView();
+    const start = context.timeCompression.toCompressedOffset(space[0]);
+    const end = context.timeCompression.toCompressedOffset(space[0] + space[1]);
+    const duration = Math.max(end - start, 0);
+    const scale = duration / visibleView.width;
+    context.spanMatrix[0] = Math.max(scale, context.spanToPx[0] / visibleView.width);
+    context.spanMatrix[4] = (start - visibleView.left) / context.spanToPx[0];
+
+    const traceEnd = context.timeCompression.toCompressedOffset(
+      context.view.to_origin + context.view.trace_space.width
+    );
+    if (
+      space[0] - context.view.to_origin > context.view.trace_space.width / 2 &&
+      (traceEnd - end) / context.spanToPx[0] <= 1
+    ) {
+      context.spanMatrix[4] = context.spanMatrix[4] - 2;
+    }
+
+    return context.spanMatrix;
+  }
+
+  transformXFromTimestamp(
+    context: TraceViewCalculationContext,
+    timestamp: number
+  ): number {
+    const configSpacePerPx = context.getConfigSpacePerPx();
+    return (
+      (timestamp - context.view.to_origin - context.view.trace_view.x) / configSpacePerPx
+    );
+  }
+
+  computeRelativeLeftPositionFromOrigin(
+    _context: TraceViewCalculationContext,
+    timestamp: number,
+    entireSpace: [number, number]
+  ): number {
+    const range = entireSpace[1];
+    if (range === 0) {
+      return 0;
+    }
+    return (timestamp - entireSpace[0]) / range;
+  }
+
+  computeRelativeWidth(
+    _context: TraceViewCalculationContext,
+    space: [number, number],
+    entireSpace: [number, number]
+  ): number {
+    if (entireSpace[1] === 0) {
+      return 0;
+    }
+    return space[1] / entireSpace[1];
+  }
+
+  computeTraceIconBounds(
+    context: TraceViewCalculationContext,
+    anchorTimestamp: number,
+    iconWidthPx: number,
+    edge: TraceIconEdge
+  ): [number, number] {
+    const iconWidth = iconWidthPx * context.getConfigSpacePerPx();
+    if (edge === 'start') {
+      return [anchorTimestamp, anchorTimestamp + iconWidth];
+    }
+    if (edge === 'end') {
+      return [anchorTimestamp - iconWidth, anchorTimestamp];
+    }
+    return [anchorTimestamp - iconWidth / 2, anchorTimestamp + iconWidth / 2];
+  }
+
+  recomputeTimelineIntervals(
+    context: TraceViewCalculationContext,
+    intervals: Array<number | undefined>
+  ): void {
+    const timeAt100 =
+      (110 * window.devicePixelRatio * context.view.trace_view.width) /
+      Math.max(context.view.trace_physical_space.width, 1);
+
+    computeTimelineIntervals(context.view, timeAt100, intervals);
+  }
+}
+
+export class CompressedTraceViewCalculations implements TraceViewCalculations {
+  computeWheelZoomView(
+    context: TraceViewCalculationContext,
+    x: number,
+    scale: number
+  ): [number, number, number, number] {
+    const compressedView = context.getCompressedView();
+    const leftPercentage = x / context.view.trace_physical_space.width;
+    const compressedCursor = compressedView.left + leftPercentage * compressedView.width;
+    const nextCompressedLeft =
+      compressedCursor + (compressedView.left - compressedCursor) * scale;
+    const nextCompressedRight =
+      compressedCursor + (compressedView.right - compressedCursor) * scale;
+    const nextRealLeft = context.timeCompression.toRealTimestamp(nextCompressedLeft);
+    const nextRealRight = context.timeCompression.toRealTimestamp(nextCompressedRight);
+
+    return [
+      nextRealLeft - context.view.to_origin,
+      context.view.trace_view.y,
+      nextRealRight - nextRealLeft,
+      context.view.trace_view.height,
+    ];
+  }
+
+  computeWheelPanView(
+    context: TraceViewCalculationContext,
+    physicalDeltaPct: number
+  ): {width: number; x: number} {
+    const compressedView = context.getCompressedView();
+    const compressedDelta = physicalDeltaPct * compressedView.width;
+    const nextCompressedLeft = compressedView.left + compressedDelta;
+    const nextCompressedRight = compressedView.right + compressedDelta;
+    const nextRealLeft = context.timeCompression.toRealTimestamp(nextCompressedLeft);
+    const nextRealRight = context.timeCompression.toRealTimestamp(nextCompressedRight);
+
+    return {
+      x: nextRealLeft - context.view.to_origin,
+      width: nextRealRight - nextRealLeft,
+    };
+  }
+
+  padZoomIntoSpace(
+    context: TraceViewCalculationContext,
+    x: number,
+    width: number
+  ): {width: number; x: number} {
+    const compressedPxRatio = context.spanToPx[0];
+    const paddingCompressedMs = 74 * compressedPxRatio;
+    const realStart = x + context.view.to_origin;
+    const realEnd = realStart + width;
+    const compressedStart = context.timeCompression.toCompressedOffset(realStart);
+    const compressedEnd = context.timeCompression.toCompressedOffset(realEnd);
+    const paddedStart = context.timeCompression.toRealTimestamp(
+      compressedStart - paddingCompressedMs
+    );
+    const paddedEnd = context.timeCompression.toRealTimestamp(
+      compressedEnd + paddingCompressedMs
+    );
+
+    return {
+      x: paddedStart - context.view.to_origin,
+      width: paddedEnd - paddedStart,
+    };
+  }
+
+  getConfigSpaceCursor(
+    context: TraceViewCalculationContext,
+    cursor: {x: number; y: number}
+  ): [number, number] {
+    const leftPercentage = cursor.x / context.view.trace_physical_space.width;
+    const compressedView = context.getCompressedView();
+    const compressedCursor = compressedView.left + leftPercentage * compressedView.width;
+    return [
+      context.timeCompression.toRealTimestamp(compressedCursor) - context.view.to_origin,
+      0,
+    ];
+  }
+
+  recomputeSpanToPXMatrix(context: TraceViewCalculationContext): mat3 {
+    const compressedView = context.getCompressedView();
+    const spanToPx = mat3.identity(context.spanToPx);
+    spanToPx[0] =
+      compressedView.width / Math.max(context.view.trace_physical_space.width, 1);
+    return spanToPx;
+  }
+
+  computeSpanCSSMatrixTransform(
+    context: TraceViewCalculationContext,
+    space: [number, number]
+  ): SpanMatrix {
+    const compressedView = context.getCompressedView();
+    const compressedStart = context.timeCompression.toCompressedOffset(space[0]);
+    const compressedEnd = context.timeCompression.toCompressedOffset(space[0] + space[1]);
+    const compressedDuration = Math.max(compressedEnd - compressedStart, 0);
+    const scale = compressedDuration / compressedView.width;
+    context.spanMatrix[0] = Math.max(scale, context.spanToPx[0] / compressedView.width);
+    context.spanMatrix[4] = (compressedStart - compressedView.left) / context.spanToPx[0];
+
+    const compressedTraceEnd = context.timeCompression.toCompressedOffset(
+      context.view.to_origin + context.view.trace_space.width
+    );
+    if (
+      space[0] - context.view.to_origin > context.view.trace_space.width / 2 &&
+      (compressedTraceEnd - compressedEnd) / context.spanToPx[0] <= 1
+    ) {
+      context.spanMatrix[4] = context.spanMatrix[4] - 2;
+    }
+    return context.spanMatrix;
+  }
+
+  transformXFromTimestamp(
+    context: TraceViewCalculationContext,
+    timestamp: number
+  ): number {
+    return (
+      (context.timeCompression.toCompressedOffset(timestamp) -
+        context.getCompressedView().left) /
+      context.spanToPx[0]
+    );
+  }
+
+  computeRelativeLeftPositionFromOrigin(
+    context: TraceViewCalculationContext,
+    timestamp: number,
+    entireSpace: [number, number]
+  ): number {
+    const compressedStart = context.timeCompression.toCompressedOffset(entireSpace[0]);
+    const compressedEnd = context.timeCompression.toCompressedOffset(
+      entireSpace[0] + entireSpace[1]
+    );
+    const compressedTimestamp = context.timeCompression.toCompressedOffset(timestamp);
+    const compressedRange = compressedEnd - compressedStart;
+    if (compressedRange === 0) {
+      return 0;
+    }
+    return (compressedTimestamp - compressedStart) / compressedRange;
+  }
+
+  computeRelativeWidth(
+    context: TraceViewCalculationContext,
+    space: [number, number],
+    entireSpace: [number, number]
+  ): number {
+    const compressedStart = context.timeCompression.toCompressedOffset(space[0]);
+    const compressedEnd = context.timeCompression.toCompressedOffset(space[0] + space[1]);
+    const compressedEntireStart = context.timeCompression.toCompressedOffset(
+      entireSpace[0]
+    );
+    const compressedEntireEnd = context.timeCompression.toCompressedOffset(
+      entireSpace[0] + entireSpace[1]
+    );
+    const compressedEntireRange = compressedEntireEnd - compressedEntireStart;
+    if (compressedEntireRange === 0) {
+      return 0;
+    }
+    return (compressedEnd - compressedStart) / compressedEntireRange;
+  }
+
+  computeTraceIconBounds(
+    context: TraceViewCalculationContext,
+    anchorTimestamp: number,
+    iconWidthPx: number,
+    edge: TraceIconEdge
+  ): [number, number] {
+    const compressedAnchor = context.timeCompression.toCompressedOffset(anchorTimestamp);
+    const iconWidthCompressed = iconWidthPx * context.spanToPx[0];
+
+    if (edge === 'start') {
+      return [
+        anchorTimestamp,
+        context.timeCompression.toRealTimestamp(compressedAnchor + iconWidthCompressed),
+      ];
+    }
+    if (edge === 'end') {
+      return [
+        context.timeCompression.toRealTimestamp(compressedAnchor - iconWidthCompressed),
+        anchorTimestamp,
+      ];
+    }
+    const half = iconWidthCompressed / 2;
+    return [
+      context.timeCompression.toRealTimestamp(compressedAnchor - half),
+      context.timeCompression.toRealTimestamp(compressedAnchor + half),
+    ];
+  }
+
+  recomputeTimelineIntervals(
+    context: TraceViewCalculationContext,
+    intervals: Array<number | undefined>
+  ): void {
+    const compressedView = context.getCompressedView();
+    const targetInterval =
+      (110 * window.devicePixelRatio * compressedView.width) /
+      Math.max(context.view.trace_physical_space.width, 1);
+
+    computeCompressedTimelineIntervals(
+      compressedView,
+      targetInterval,
+      context.timeCompression,
+      context.view.to_origin,
+      intervals
+    );
+  }
+}
+
+function computeTimelineIntervals(
+  view: TraceView,
+  targetInterval: number,
+  results: Array<number | undefined>
+): void {
+  const minInterval = Math.pow(10, Math.floor(Math.log10(targetInterval)));
+  let interval = minInterval;
+
+  if (targetInterval / interval > 5) {
+    interval *= 5;
+  } else if (targetInterval / interval > 2) {
+    interval *= 2;
+  }
+
+  let x = Math.ceil(view.trace_view.x / interval) * interval;
+  let idx = -1;
+  if (x > 0) {
+    x -= interval;
+  }
+  while (x <= view.trace_view.right) {
+    results[++idx] = x;
+    x += interval;
+  }
+
+  while (idx < results.length - 1 && results[idx + 1] !== undefined) {
+    results[++idx] = undefined;
+  }
+}
+
+function computeCompressedTimelineIntervals(
+  compressedView: CompressedView,
+  targetInterval: number,
+  compression: TraceTimeCompression,
+  toOrigin: number,
+  results: Array<number | undefined>
+): void {
+  const minInterval = Math.pow(10, Math.floor(Math.log10(targetInterval)));
+  let interval = minInterval;
+
+  if (targetInterval / interval > 5) {
+    interval *= 5;
+  } else if (targetInterval / interval > 2) {
+    interval *= 2;
+  }
+
+  let x = Math.ceil(compressedView.left / interval) * interval;
+  let idx = -1;
+  if (x > compressedView.left) {
+    x -= interval;
+  }
+  while (x <= compressedView.right) {
+    const realTimestamp = compression.toRealTimestamp(x);
+    results[++idx] = realTimestamp - toOrigin;
+    x += interval;
+  }
+
+  while (idx < results.length - 1 && results[idx + 1] !== undefined) {
+    results[++idx] = undefined;
+  }
+}

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceViewCalculations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceViewCalculations.tsx
@@ -159,25 +159,7 @@ export class NormalTraceViewCalculations implements TraceViewCalculations {
     context: TraceViewCalculationContext,
     space: [number, number]
   ): SpanMatrix {
-    const visibleView = context.getCompressedView();
-    const start = context.timeCompression.toCompressedOffset(space[0]);
-    const end = context.timeCompression.toCompressedOffset(space[0] + space[1]);
-    const duration = Math.max(end - start, 0);
-    const scale = duration / visibleView.width;
-    context.spanMatrix[0] = Math.max(scale, context.spanToPx[0] / visibleView.width);
-    context.spanMatrix[4] = (start - visibleView.left) / context.spanToPx[0];
-
-    const traceEnd = context.timeCompression.toCompressedOffset(
-      context.view.to_origin + context.view.trace_space.width
-    );
-    if (
-      space[0] - context.view.to_origin > context.view.trace_space.width / 2 &&
-      (traceEnd - end) / context.spanToPx[0] <= 1
-    ) {
-      context.spanMatrix[4] = context.spanMatrix[4] - 2;
-    }
-
-    return context.spanMatrix;
+    return computeSpanCSSMatrixTransformInVisibleSpace(context, space);
   }
 
   transformXFromTimestamp(
@@ -331,24 +313,7 @@ export class CompressedTraceViewCalculations implements TraceViewCalculations {
     context: TraceViewCalculationContext,
     space: [number, number]
   ): SpanMatrix {
-    const compressedView = context.getCompressedView();
-    const compressedStart = context.timeCompression.toCompressedOffset(space[0]);
-    const compressedEnd = context.timeCompression.toCompressedOffset(space[0] + space[1]);
-    const compressedDuration = Math.max(compressedEnd - compressedStart, 0);
-    const scale = compressedDuration / compressedView.width;
-    context.spanMatrix[0] = Math.max(scale, context.spanToPx[0] / compressedView.width);
-    context.spanMatrix[4] = (compressedStart - compressedView.left) / context.spanToPx[0];
-
-    const compressedTraceEnd = context.timeCompression.toCompressedOffset(
-      context.view.to_origin + context.view.trace_space.width
-    );
-    if (
-      space[0] - context.view.to_origin > context.view.trace_space.width / 2 &&
-      (compressedTraceEnd - compressedEnd) / context.spanToPx[0] <= 1
-    ) {
-      context.spanMatrix[4] = context.spanMatrix[4] - 2;
-    }
-    return context.spanMatrix;
+    return computeSpanCSSMatrixTransformInVisibleSpace(context, space);
   }
 
   transformXFromTimestamp(
@@ -446,19 +411,37 @@ export class CompressedTraceViewCalculations implements TraceViewCalculations {
   }
 }
 
+function computeSpanCSSMatrixTransformInVisibleSpace(
+  context: TraceViewCalculationContext,
+  space: [number, number]
+): SpanMatrix {
+  const visibleView = context.getCompressedView();
+  const start = context.timeCompression.toCompressedOffset(space[0]);
+  const end = context.timeCompression.toCompressedOffset(space[0] + space[1]);
+  const duration = Math.max(end - start, 0);
+  const scale = duration / visibleView.width;
+  context.spanMatrix[0] = Math.max(scale, context.spanToPx[0] / visibleView.width);
+  context.spanMatrix[4] = (start - visibleView.left) / context.spanToPx[0];
+
+  const traceEnd = context.timeCompression.toCompressedOffset(
+    context.view.to_origin + context.view.trace_space.width
+  );
+  if (
+    space[0] - context.view.to_origin > context.view.trace_space.width / 2 &&
+    (traceEnd - end) / context.spanToPx[0] <= 1
+  ) {
+    context.spanMatrix[4] = context.spanMatrix[4] - 2;
+  }
+
+  return context.spanMatrix;
+}
+
 function computeTimelineIntervals(
   view: TraceView,
   targetInterval: number,
   results: Array<number | undefined>
 ): void {
-  const minInterval = Math.pow(10, Math.floor(Math.log10(targetInterval)));
-  let interval = minInterval;
-
-  if (targetInterval / interval > 5) {
-    interval *= 5;
-  } else if (targetInterval / interval > 2) {
-    interval *= 2;
-  }
+  const interval = computeTimelineTickInterval(targetInterval);
 
   let x = Math.ceil(view.trace_view.x / interval) * interval;
   let idx = -1;
@@ -470,9 +453,7 @@ function computeTimelineIntervals(
     x += interval;
   }
 
-  while (idx < results.length - 1 && results[idx + 1] !== undefined) {
-    results[++idx] = undefined;
-  }
+  clearRemainingTimelineIntervals(results, idx);
 }
 
 function computeCompressedTimelineIntervals(
@@ -482,14 +463,7 @@ function computeCompressedTimelineIntervals(
   toOrigin: number,
   results: Array<number | undefined>
 ): void {
-  const minInterval = Math.pow(10, Math.floor(Math.log10(targetInterval)));
-  let interval = minInterval;
-
-  if (targetInterval / interval > 5) {
-    interval *= 5;
-  } else if (targetInterval / interval > 2) {
-    interval *= 2;
-  }
+  const interval = computeTimelineTickInterval(targetInterval);
 
   let x = Math.ceil(compressedView.left / interval) * interval;
   let idx = -1;
@@ -502,6 +476,26 @@ function computeCompressedTimelineIntervals(
     x += interval;
   }
 
+  clearRemainingTimelineIntervals(results, idx);
+}
+
+function computeTimelineTickInterval(targetInterval: number): number {
+  const minInterval = Math.pow(10, Math.floor(Math.log10(targetInterval)));
+  let interval = minInterval;
+
+  if (targetInterval / interval > 5) {
+    interval *= 5;
+  } else if (targetInterval / interval > 2) {
+    interval *= 2;
+  }
+
+  return interval;
+}
+
+function clearRemainingTimelineIntervals(
+  results: Array<number | undefined>,
+  idx: number
+): void {
   while (idx < results.length - 1 && results[idx + 1] !== undefined) {
     results[++idx] = undefined;
   }

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1,5 +1,5 @@
 import type {Theme} from '@emotion/react';
-import {mat3, vec2} from 'gl-matrix';
+import {mat3} from 'gl-matrix';
 import * as qs from 'query-string';
 
 import {getDuration} from 'sentry/utils/duration/getDuration';
@@ -25,13 +25,21 @@ import {
 } from 'sentry/views/performance/newTraceDetails/traceRenderers/traceTimeCompression';
 import type {TraceTimeCompressionGap} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceTimeCompression';
 import type {TraceView} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceView';
+import {
+  CompressedTraceViewCalculations,
+  NormalTraceViewCalculations,
+  type CompressedView,
+  type SpanMatrix,
+  type TraceIconEdge,
+  type TraceViewCalculationContext,
+  type TraceViewCalculations,
+} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceViewCalculations';
 
 import type {TraceScheduler} from './traceScheduler';
 
 const DIVIDER_WIDTH = 6;
 const COLLAPSED_GAP_MARKER_CLEARANCE_PX = 8;
 
-type TraceIconEdge = 'start' | 'end' | null;
 export type TraceTimeCompressionManagerOptions = {
   enabled: boolean;
   indicators: TraceTree['indicators'];
@@ -69,6 +77,7 @@ type VerticalIndicator = {
   timestamp: number | undefined;
 };
 type SpanTextPlacement = [inside: number, textTransform: number];
+
 /**
  * Tracks the state of the virtualized view and manages the resizing of the columns.
  * Children components should call the appropriate register*Ref methods to register their
@@ -139,11 +148,10 @@ export class VirtualizedViewManager {
   // the transformation matrix that is used to render scaled elements to the DOM
   private span_to_px: mat3 = mat3.create();
   private readonly ROW_PADDING_PX = 16;
-  private readonly span_matrix: [number, number, number, number, number, number] = [
-    1, 0, 0, 1, 0, 0,
-  ];
-  private _compressedViewCache: {left: number; right: number; width: number} | null =
-    null;
+  private readonly span_matrix: SpanMatrix = [1, 0, 0, 1, 0, 0];
+  private _compressedViewCache: CompressedView | null = null;
+  private readonly compressedViewCalculations = new CompressedTraceViewCalculations();
+  private readonly normalViewCalculations = new NormalTraceViewCalculations();
 
   timers: {
     onFovChange: {id: number} | null;
@@ -576,41 +584,11 @@ export class VirtualizedViewManager {
 
       const scale = 1 - event.deltaY * 0.01 * -1;
       const x = offsetX > 0 ? event.clientX - offsetX : event.offsetX;
-      let newView: [number, number, number, number];
-
-      if (this.time_compression.enabled) {
-        const compressedView = this.getCompressedView();
-        const leftPercentage = x / this.view.trace_physical_space.width;
-        const compressedCursor =
-          compressedView.left + leftPercentage * compressedView.width;
-        const nextCompressedLeft =
-          compressedCursor + (compressedView.left - compressedCursor) * scale;
-        const nextCompressedRight =
-          compressedCursor + (compressedView.right - compressedCursor) * scale;
-        const nextRealLeft = this.time_compression.toRealTimestamp(nextCompressedLeft);
-        const nextRealRight = this.time_compression.toRealTimestamp(nextCompressedRight);
-
-        newView = [
-          nextRealLeft - this.view.to_origin,
-          this.view.trace_view.y,
-          nextRealRight - nextRealLeft,
-          this.view.trace_view.height,
-        ];
-      } else {
-        const configSpaceCursor = this.getConfigSpaceCursor({x, y: 0});
-        const center = vec2.fromValues(configSpaceCursor[0], 0);
-        const centerScaleMatrix = mat3.create();
-
-        mat3.fromTranslation(centerScaleMatrix, center);
-        mat3.scale(centerScaleMatrix, centerScaleMatrix, vec2.fromValues(scale, 1));
-        mat3.translate(
-          centerScaleMatrix,
-          centerScaleMatrix,
-          vec2.fromValues(-center[0], 0)
-        );
-
-        newView = this.view.trace_view.transform(centerScaleMatrix);
-      }
+      const newView = this.getViewCalculations().computeWheelZoomView(
+        this.getViewCalculationContext(),
+        x,
+        scale
+      );
 
       // When users zoom in, the matrix will compute a width value that is lower than the min,
       // which results in the value of x being incorrectly set and the view moving to the right.
@@ -642,25 +620,13 @@ export class VirtualizedViewManager {
 
       const physicalDeltaPct = distance / this.view.trace_physical_space.width;
 
-      if (this.time_compression.enabled) {
-        const compressedView = this.getCompressedView();
-        const compressedDelta = physicalDeltaPct * compressedView.width;
-        const nextCompressedLeft = compressedView.left + compressedDelta;
-        const nextCompressedRight = compressedView.right + compressedDelta;
-        const nextRealLeft = this.time_compression.toRealTimestamp(nextCompressedLeft);
-        const nextRealRight = this.time_compression.toRealTimestamp(nextCompressedRight);
-
-        this.scheduler.dispatch('set trace view', {
-          x: nextRealLeft - this.view.to_origin,
-          width: nextRealRight - nextRealLeft,
-        });
-      } else {
-        const view_delta = physicalDeltaPct * this.view.trace_view.width;
-
-        this.scheduler.dispatch('set trace view', {
-          x: this.view.trace_view.x + view_delta,
-        });
-      }
+      this.scheduler.dispatch(
+        'set trace view',
+        this.getViewCalculations().computeWheelPanView(
+          this.getViewCalculationContext(),
+          physicalDeltaPct
+        )
+      );
     }
   }
 
@@ -708,28 +674,13 @@ export class VirtualizedViewManager {
     // to move the duration label insdie the bar and can preserve
     // some context around the star/end time of a span
     if (this.view.trace_physical_space.width > 300) {
-      if (this.time_compression.enabled) {
-        const compressedPxRatio = this.span_to_px[0];
-        const paddingCompressedMs = 74 * compressedPxRatio;
-        const realStart = final_x + this.view.to_origin;
-        const realEnd = realStart + final_width;
-        const compressedStart = this.time_compression.toCompressedOffset(realStart);
-        const compressedEnd = this.time_compression.toCompressedOffset(realEnd);
-        const paddedStart = this.time_compression.toRealTimestamp(
-          compressedStart - paddingCompressedMs
-        );
-        const paddedEnd = this.time_compression.toRealTimestamp(
-          compressedEnd + paddingCompressedMs
-        );
-        final_x = paddedStart - this.view.to_origin;
-        final_width = paddedEnd - paddedStart;
-      } else {
-        const mat = this.view.getSpanToPxForSpace([final_x, final_width]);
-        const offsetInConfigSpace = 74 * mat[0];
-
-        final_x -= offsetInConfigSpace;
-        final_width += offsetInConfigSpace * 2;
-      }
+      const paddedSpace = this.getViewCalculations().padZoomIntoSpace(
+        this.getViewCalculationContext(),
+        final_x,
+        final_width
+      );
+      final_x = paddedSpace.x;
+      final_width = paddedSpace.width;
     }
 
     const start_x = this.view.trace_view.x;
@@ -1046,7 +997,24 @@ export class VirtualizedViewManager {
     return transform;
   }
 
-  getCompressedView(): {left: number; right: number; width: number} {
+  private getViewCalculationContext(): TraceViewCalculationContext {
+    return {
+      getCompressedView: () => this.getCompressedView(),
+      getConfigSpacePerPx: () => this.getConfigSpacePerPx(),
+      spanMatrix: this.span_matrix,
+      spanToPx: this.span_to_px,
+      timeCompression: this.time_compression,
+      view: this.view,
+    };
+  }
+
+  private getViewCalculations(): TraceViewCalculations {
+    return this.time_compression.enabled
+      ? this.compressedViewCalculations
+      : this.normalViewCalculations;
+  }
+
+  getCompressedView(): CompressedView {
     if (this._compressedViewCache) {
       return this._compressedViewCache;
     }
@@ -1064,37 +1032,15 @@ export class VirtualizedViewManager {
   }
 
   getConfigSpaceCursor(cursor: {x: number; y: number}): [number, number] {
-    if (!this.time_compression.enabled) {
-      return this.view.getConfigSpaceCursor(cursor);
-    }
-
-    const leftPercentage = cursor.x / this.view.trace_physical_space.width;
-    const compressedView = this.getCompressedView();
-    const compressedCursor = compressedView.left + leftPercentage * compressedView.width;
-    return [
-      this.time_compression.toRealTimestamp(compressedCursor) - this.view.to_origin,
-      0,
-    ];
+    return this.getViewCalculations().getConfigSpaceCursor(
+      this.getViewCalculationContext(),
+      cursor
+    );
   }
 
   recomputeSpanToPXMatrix() {
-    if (this.time_compression.enabled) {
-      const compressedView = this.getCompressedView();
-      this.span_to_px = mat3.identity(this.span_to_px);
-      this.span_to_px[0] =
-        compressedView.width / Math.max(this.view.trace_physical_space.width, 1);
-      return;
-    }
-
-    const traceViewToSpace = this.view.trace_space.between(this.view.trace_view);
-    const tracePhysicalToView = this.view.trace_physical_space.between(
-      this.view.trace_space
-    );
-
-    this.span_to_px = mat3.multiply(
-      this.span_to_px,
-      traceViewToSpace,
-      tracePhysicalToView
+    this.span_to_px = this.getViewCalculations().recomputeSpanToPXMatrix(
+      this.getViewCalculationContext()
     );
   }
 
@@ -1109,40 +1055,16 @@ export class VirtualizedViewManager {
   computeSpanCSSMatrixTransform(
     space: [number, number]
   ): [number, number, number, number, number, number] {
-    const compressedView = this.getCompressedView();
-    const compressedStart = this.time_compression.toCompressedOffset(space[0]);
-    const compressedEnd = this.time_compression.toCompressedOffset(space[0] + space[1]);
-    const compressedDuration = Math.max(compressedEnd - compressedStart, 0);
-    const scale = compressedDuration / compressedView.width;
-    this.span_matrix[0] = Math.max(scale, this.span_to_px[0] / compressedView.width);
-    this.span_matrix[4] = (compressedStart - compressedView.left) / this.span_to_px[0];
-
-    // if span ends less than 1px before the end of the view, we move it back by 1px and prevent it from being clipped
-    const compressedTraceEnd = this.time_compression.toCompressedOffset(
-      this.view.to_origin + this.view.trace_space.width
+    return this.getViewCalculations().computeSpanCSSMatrixTransform(
+      this.getViewCalculationContext(),
+      space
     );
-    if (
-      space[0] - this.view.to_origin > this.view.trace_space.width / 2 &&
-      (compressedTraceEnd - compressedEnd) / this.span_to_px[0] <= 1
-    ) {
-      // 1px for the span and 1px for the border
-      this.span_matrix[4] = this.span_matrix[4] - 2;
-    }
-    return this.span_matrix;
   }
 
   transformXFromTimestamp(timestamp: number): number {
-    if (!this.time_compression.enabled) {
-      const config_space_per_px = this.getConfigSpacePerPx();
-      return (
-        (timestamp - this.view.to_origin - this.view.trace_view.x) / config_space_per_px
-      );
-    }
-
-    return (
-      (this.time_compression.toCompressedOffset(timestamp) -
-        this.getCompressedView().left) /
-      this.span_to_px[0]
+    return this.getViewCalculations().transformXFromTimestamp(
+      this.getViewCalculationContext(),
+      timestamp
     );
   }
 
@@ -1315,32 +1237,19 @@ export class VirtualizedViewManager {
     timestamp: number,
     entire_space: [number, number]
   ) {
-    const compressedStart = this.time_compression.toCompressedOffset(entire_space[0]);
-    const compressedEnd = this.time_compression.toCompressedOffset(
-      entire_space[0] + entire_space[1]
+    return this.getViewCalculations().computeRelativeLeftPositionFromOrigin(
+      this.getViewCalculationContext(),
+      timestamp,
+      entire_space
     );
-    const compressedTimestamp = this.time_compression.toCompressedOffset(timestamp);
-    const compressedRange = compressedEnd - compressedStart;
-    if (compressedRange === 0) {
-      return 0;
-    }
-    return (compressedTimestamp - compressedStart) / compressedRange;
   }
 
   computeRelativeWidth(space: [number, number], entire_space: [number, number]) {
-    const compressedStart = this.time_compression.toCompressedOffset(space[0]);
-    const compressedEnd = this.time_compression.toCompressedOffset(space[0] + space[1]);
-    const compressedEntireStart = this.time_compression.toCompressedOffset(
-      entire_space[0]
+    return this.getViewCalculations().computeRelativeWidth(
+      this.getViewCalculationContext(),
+      space,
+      entire_space
     );
-    const compressedEntireEnd = this.time_compression.toCompressedOffset(
-      entire_space[0] + entire_space[1]
-    );
-    const compressedEntireRange = compressedEntireEnd - compressedEntireStart;
-    if (compressedEntireRange === 0) {
-      return 0;
-    }
-    return (compressedEnd - compressedStart) / compressedEntireRange;
   }
 
   computeTraceIconPlacement(
@@ -1367,37 +1276,12 @@ export class VirtualizedViewManager {
     iconWidthPx: number,
     edge: TraceIconEdge
   ): [number, number] {
-    if (!this.time_compression.enabled) {
-      const iconWidth = iconWidthPx * this.getConfigSpacePerPx();
-      if (edge === 'start') {
-        return [anchorTimestamp, anchorTimestamp + iconWidth];
-      }
-      if (edge === 'end') {
-        return [anchorTimestamp - iconWidth, anchorTimestamp];
-      }
-      return [anchorTimestamp - iconWidth / 2, anchorTimestamp + iconWidth / 2];
-    }
-
-    const compressedAnchor = this.time_compression.toCompressedOffset(anchorTimestamp);
-    const iconWidthCompressed = iconWidthPx * this.span_to_px[0];
-
-    if (edge === 'start') {
-      return [
-        anchorTimestamp,
-        this.time_compression.toRealTimestamp(compressedAnchor + iconWidthCompressed),
-      ];
-    }
-    if (edge === 'end') {
-      return [
-        this.time_compression.toRealTimestamp(compressedAnchor - iconWidthCompressed),
-        anchorTimestamp,
-      ];
-    }
-    const half = iconWidthCompressed / 2;
-    return [
-      this.time_compression.toRealTimestamp(compressedAnchor - half),
-      this.time_compression.toRealTimestamp(compressedAnchor + half),
-    ];
+    return this.getViewCalculations().computeTraceIconBounds(
+      this.getViewCalculationContext(),
+      anchorTimestamp,
+      iconWidthPx,
+      edge
+    );
   }
 
   private computeTraceIconEdge(timestamp: number, iconWidthPx: number): TraceIconEdge {
@@ -1440,27 +1324,10 @@ export class VirtualizedViewManager {
       return;
     }
 
-    if (this.time_compression.enabled) {
-      const compressedView = this.getCompressedView();
-      const targetInterval =
-        (110 * window.devicePixelRatio * compressedView.width) /
-        Math.max(this.view.trace_physical_space.width, 1);
-
-      computeCompressedTimelineIntervals(
-        compressedView,
-        targetInterval,
-        this.time_compression,
-        this.view.to_origin,
-        this.intervals
-      );
-      return;
-    }
-
-    const time_at_100 =
-      (110 * window.devicePixelRatio * this.view.trace_view.width) /
-      Math.max(this.view.trace_physical_space.width, 1);
-
-    computeTimelineIntervals(this.view, time_at_100, this.intervals);
+    this.getViewCalculations().recomputeTimelineIntervals(
+      this.getViewCalculationContext(),
+      this.intervals
+    );
   }
 
   scrollToRow(index: number, anchor?: ViewManagerScrollAnchor) {
@@ -2316,74 +2183,6 @@ function getIconTimestamps(
   );
 
   return [min_icon_timestamp, max_icon_timestamp];
-}
-
-/**
- * Finds timeline intervals based off the current zoom level.
- */
-function computeTimelineIntervals(
-  view: TraceView,
-  targetInterval: number,
-  results: Array<number | undefined>
-): void {
-  const minInterval = Math.pow(10, Math.floor(Math.log10(targetInterval)));
-  let interval = minInterval;
-
-  if (targetInterval / interval > 5) {
-    interval *= 5;
-  } else if (targetInterval / interval > 2) {
-    interval *= 2;
-  }
-
-  let x = Math.ceil(view.trace_view.x / interval) * interval;
-  let idx = -1;
-  if (x > 0) {
-    x -= interval;
-  }
-  while (x <= view.trace_view.right) {
-    results[++idx] = x;
-    x += interval;
-  }
-
-  while (idx < results.length - 1 && results[idx + 1] !== undefined) {
-    results[++idx] = undefined;
-  }
-}
-
-/**
- * Computes timeline intervals in compressed space so ticks are visually
- * evenly spaced, then converts each tick back to a real-time offset.
- */
-function computeCompressedTimelineIntervals(
-  compressedView: {left: number; right: number; width: number},
-  targetInterval: number,
-  compression: TraceTimeCompression,
-  toOrigin: number,
-  results: Array<number | undefined>
-): void {
-  const minInterval = Math.pow(10, Math.floor(Math.log10(targetInterval)));
-  let interval = minInterval;
-
-  if (targetInterval / interval > 5) {
-    interval *= 5;
-  } else if (targetInterval / interval > 2) {
-    interval *= 2;
-  }
-
-  let x = Math.ceil(compressedView.left / interval) * interval;
-  let idx = -1;
-  if (x > compressedView.left) {
-    x -= interval;
-  }
-  while (x <= compressedView.right) {
-    const realTimestamp = compression.toRealTimestamp(x);
-    results[++idx] = realTimestamp - toOrigin;
-    x += interval;
-  }
-
-  while (idx < results.length - 1 && results[idx + 1] !== undefined) {
-    results[++idx] = undefined;
-  }
 }
 
 export class VirtualizedList {


### PR DESCRIPTION
Trace view rendering now delegates normal and compressed timeline math to dedicated calculation classes instead of keeping the branching logic inside VirtualizedViewManager. The behavior stays scoped to the existing compressed timeline implementation, but the manager can call the same operations for zooming, panning, span transforms, icon bounds, and timeline ticks through a small strategy interface.

The new tests cover normal panning, compressed cursor anchoring while zooming, and compressed relative sizing so the extracted calculations remain pinned to the existing renderer behavior.

Closes EXP-1035