### PR TITLE
ref(span-buffer): Opportunistically skip killswitch value_matches call

### DIFF
--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -186,7 +186,7 @@ def process_batch(
                 val = cast(SpanEvent, orjson.loads(payload.value))
             decode_time += time.monotonic() - decode_start
 
-            if killswitches.value_matches(
+            if killswitch_config and killswitches.value_matches(
                 "spans.drop-in-buffer",
                 killswitch_config,
                 {


### PR DESCRIPTION
The killswitch can't execute if none was configured. As far as optimizations go this is a small one. Saving about a microsecond (1% total span time). However, it is called for each span in a loop. The cost accumulates and is noticeable in profiles.