### PR TITLE
ref(options): Add get_fast method to options

### DIFF
--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -107,8 +107,8 @@ def get_fast(key: str, silent: bool = False) -> Any:
 
     Though this function is faster than the default "get" function the fastest
     alternative is to cache your calls to "options.get" in a local variable, outside
-    your loop, and use the local. This function captures 90% of the performance
-    benefit with 1% the effort (find and replace).
+    your loop, and use the local in your loop. This function captures 90% of the
+    performance benefit with 1% the effort (find and replace).
 
     This function uses a global option TTL policy. Per-option TTLs are not supported. If
     your option's custom TTL is greater than or equal to the DEFAULT_KEY_TTL you will not

--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -91,7 +91,7 @@ def load_defaults() -> None:
 #
 # This cache is unbounded mirroring the behavior of the options cache.
 __get_fast_cache: TTLCache[str, Any] = TTLCache(
-    cast(Cache[str, tuple[int, Any]], {}), ttl=DEFAULT_KEY_TTL + 1
+    cast(Cache[str, tuple[int, Any]], {}), ttl=DEFAULT_KEY_TTL
 )
 
 
@@ -109,6 +109,11 @@ def get_fast(key: str, silent: bool = False) -> Any:
     alternative is to cache your calls to "options.get" in a local variable, outside
     your loop, and use the local. This function captures 90% of the performance
     benefit with 1% the effort (find and replace).
+
+    This function uses a global option TTL policy. Per-option TTLs are not supported. If
+    your option's custom TTL is greater than or equal to the DEFAULT_KEY_TTL you will not
+    experience meaningful degradation. TTLs which are less than the DEFAULT_KEY_TTL will
+    return stale results.
 
     >>> from sentry import options
     >>> options.get_fast('option')

--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -88,6 +88,8 @@ def load_defaults() -> None:
 # This cache is thread-unsafe mirroring the behavior of the options cache. The options
 # cache notes Python's GIL as the serialization provider. Race conditions produce
 # redundant network calls but do not otherwise err.
+#
+# This cache is unbounded mirroring the behavior of the options cache.
 __get_fast_cache: TTLCache[str, Any] = TTLCache(
     cast(Cache[str, tuple[int, Any]], {}), ttl=DEFAULT_KEY_TTL + 1
 )

--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -1,4 +1,9 @@
+from typing import Any, cast
+
 from django.core.signals import request_finished
+
+from sentry.options.manager import DEFAULT_KEY_TTL
+from sentry.utils.local_cache import Cache, TTLCache
 
 from .manager import (
     FLAG_ADMIN_MODIFIABLE,
@@ -78,3 +83,36 @@ def load_defaults() -> None:
     from sentry.hybridcloud import options  # NOQA
 
     from . import defaults  # NOQA
+
+
+# This cache is thread-unsafe mirroring the behavior of the options cache. The options
+# cache notes Python's GIL as the serialization provider. Race conditions produce
+# redundant network calls but do not otherwise err.
+__get_fast_cache: TTLCache[str, Any] = TTLCache(
+    cast(Cache[str, tuple[int, Any]], {}), ttl=DEFAULT_KEY_TTL + 1
+)
+
+
+def get_fast(key: str, silent: bool = False) -> Any:
+    """
+    Get the value of an option, falling back to the local configuration.
+
+    If no value is present for the key, the default Option value is returned.
+
+    The default options "get" method logs, emits a metric, contains four levels of
+    indrection and allocations a set and dictionary. These are unnecessary operations
+    which may need to be skipped in select high-throughput environments.
+
+    Though this function is faster than the default "get" function the fastest
+    alternative is to cache your calls to "options.get" in a local variable, outside
+    your loop, and use the local. This function captures 90% of the performance
+    benefit with 1% the effort (find and replace).
+
+    >>> from sentry import options
+    >>> options.get_fast('option')
+    """
+    try:
+        return __get_fast_cache[key]
+    except KeyError:
+        v = __get_fast_cache[key] = get(key, silent)
+        return v

--- a/src/sentry/utils/local_cache.py
+++ b/src/sentry/utils/local_cache.py
@@ -1,8 +1,11 @@
 import hashlib
 import threading
+import time
 from collections import OrderedDict
 from collections.abc import Iterator
 from typing import Protocol
+
+_now = time.time
 
 
 class Cache[K, V](Protocol):
@@ -108,6 +111,71 @@ class ThreadSafeCache[K, V]:
         with self.lock:
             items = list(self.cache.items())
         yield from items
+
+
+class TTLCache[K, V]:
+    """
+    Wraps any cache implementing the `Cache` protocol and expires entries after
+    a fixed time-to-live. Expired entries are lazily evicted on access.
+    """
+
+    def __init__(self, cache: Cache[K, tuple[int, V]], ttl: int) -> None:
+        self.cache = cache
+        self.ttl = ttl
+
+    def _is_expired(self, expiry: int) -> bool:
+        return expiry <= _now()
+
+    def __contains__(self, key: K) -> bool:
+        try:
+            self[key]
+            return True
+        except KeyError:
+            return False
+
+    def __len__(self) -> int:
+        return len(self.cache)
+
+    def __delitem__(self, key: K) -> None:
+        del self.cache[key]
+
+    def __getitem__(self, key: K) -> V:
+        expiry, value = self.cache[key]
+        if self._is_expired(expiry):
+            del self.cache[key]
+            raise KeyError(key)
+        return value
+
+    def __setitem__(self, key: K, value: V) -> None:
+        self.cache[key] = (_now() + self.ttl, value)
+
+    def get(self, key: K) -> V | None:
+        try:
+            return self[key]
+        except KeyError:
+            return None
+
+    def pop(self, key: K) -> V | None:
+        item = self.cache.pop(key)
+        if item is None:
+            return None
+        expiry, value = item
+        if self._is_expired(expiry):
+            return None
+        return value
+
+    def keys(self) -> Iterator[K]:
+        yield from self.cache.keys()
+
+    def values(self) -> Iterator[V]:
+        for expiry, value in self.cache.values():
+            if not self._is_expired(expiry):
+                yield value
+
+    def items(self) -> Iterator[tuple[K, V]]:
+        for key, (expiry, value) in self.cache.items():
+            if not self._is_expired(expiry):
+                yield key, value
 
 
 class SizedKeyCache[V]:

--- a/tests/sentry/utils/test_local_cache.py
+++ b/tests/sentry/utils/test_local_cache.py
@@ -1,8 +1,29 @@
 import threading
+from unittest import mock
 
 import pytest
 
-from sentry.utils.local_cache import LRUCache, SizedKeyCache, ThreadSafeCache
+from sentry.utils import local_cache
+from sentry.utils.local_cache import LRUCache, SizedKeyCache, ThreadSafeCache, TTLCache
+
+
+@pytest.fixture
+def fake_clock():
+    """Replace the module clock with a manually-advanced one."""
+
+    class Clock:
+        def __init__(self) -> None:
+            self.now = 1000.0
+
+        def __call__(self) -> float:
+            return self.now
+
+        def advance(self, seconds: float) -> None:
+            self.now += seconds
+
+    clock = Clock()
+    with mock.patch.object(local_cache, "_now", clock):
+        yield clock
 
 
 class TestLRUCache:
@@ -223,6 +244,137 @@ class TestThreadSafeCache:
         w.join()
 
         assert errors == []
+
+
+class TestTTLCache:
+    def test_set_and_get_before_expiry(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        assert cache["a"] == 1
+        assert cache.get("a") == 1
+
+    def test_getitem_expires(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        fake_clock.advance(61)
+        with pytest.raises(KeyError):
+            cache["a"]
+
+    def test_expiry_is_inclusive(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        fake_clock.advance(60)
+        with pytest.raises(KeyError):
+            cache["a"]
+
+    def test_still_valid_just_before_expiry(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        fake_clock.advance(59)
+        assert cache["a"] == 1
+
+    def test_get_returns_none_after_expiry(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        fake_clock.advance(61)
+        assert cache.get("a") is None
+
+    def test_get_returns_none_when_missing(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        assert cache.get("missing") is None
+
+    def test_expired_entry_is_evicted_on_access(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        fake_clock.advance(61)
+        assert cache.get("a") is None
+        # The expired entry was deleted from the underlying cache.
+        assert len(cache.cache) == 0
+
+    def test_contains_before_and_after_expiry(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        assert "a" in cache
+        fake_clock.advance(61)
+        assert "a" not in cache
+
+    def test_contains_missing(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        assert "missing" not in cache
+
+    def test_setitem_refreshes_ttl(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        fake_clock.advance(59)
+        cache["a"] = 2
+        # Re-setting resets the expiry window from the new now.
+        fake_clock.advance(59)
+        assert cache["a"] == 2
+
+    def test_len_counts_unexpired_and_expired(self, fake_clock) -> None:
+        # __len__ delegates to the wrapped cache and does not account for expiry.
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        assert len(cache) == 1
+        fake_clock.advance(61)
+        assert len(cache) == 1
+
+    def test_delitem(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        del cache["a"]
+        assert "a" not in cache
+
+    def test_delitem_missing_raises(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        with pytest.raises(KeyError):
+            del cache["missing"]
+
+    def test_pop_returns_value_when_valid(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        assert cache.pop("a") == 1
+        assert "a" not in cache
+
+    def test_pop_returns_none_when_missing(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        assert cache.pop("missing") is None
+
+    def test_pop_returns_none_when_expired(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        fake_clock.advance(61)
+        assert cache.pop("a") is None
+
+    def test_values_excludes_expired(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        fake_clock.advance(30)
+        cache["b"] = 2
+        fake_clock.advance(31)
+        # "a" has expired (61s old), "b" has not (31s old).
+        assert list(cache.values()) == [2]
+
+    def test_items_excludes_expired(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        fake_clock.advance(30)
+        cache["b"] = 2
+        fake_clock.advance(31)
+        assert list(cache.items()) == [("b", 2)]
+
+    def test_keys_includes_expired(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(LRUCache(maxlen=10), ttl=60)
+        cache["a"] = 1
+        fake_clock.advance(61)
+        assert list(cache.keys()) == ["a"]
+
+    def test_wraps_thread_safe_cache(self, fake_clock) -> None:
+        cache: TTLCache[str, int] = TTLCache(ThreadSafeCache(LRUCache(maxlen=10)), ttl=60)
+        cache["a"] = 1
+        assert cache["a"] == 1
+        fake_clock.advance(61)
+        assert cache.get("a") is None
 
 
 class TestSizedKeyCache:


### PR DESCRIPTION
A profile of the high-throughput span-buffer consumer showed option look ups taking 4us (M4 Pro). This is mostly due to [expensive computations](https://github.com/getsentry/sentry/pull/118133), metrics, logs, and indirection overhead. The `get_fast` method skips that and uses a new TTLCache with the same semantics as the default options cache. This wraps the existing `local_cache.py` features.

The cache is intentionally unbounded and thread-unsafe matching the existing semantics of the options cache. We rely on the GIL to make access atomic. Data races result in unnecessary I/O but do not crash or return incorrect values.

This cache is roughly 40x faster than baseline taking only 100 nanoseconds to return a warm value. Cold performance is unchanged.

On a run of 10,000 option look ups the following results were recorded.

`options.get` = 44ms total, 4.5us per op
`options.get_fast` = 2ms total, 249ns per op