### PR TITLE
feat(inbound-filters): Add custom inbound filter audit log event

### DIFF
--- a/src/sentry/audit_log/events.py
+++ b/src/sentry/audit_log/events.py
@@ -224,6 +224,41 @@ class ProjectDisableAuditLogEvent(AuditLogEvent):
         return render_project_action(audit_log_entry, "disable")
 
 
+class CustomInboundFilterAuditLogEvent(AuditLogEvent):
+    """A single audit log event covering all custom inbound filter operations.
+
+    The specific operation (add/edit/remove) is carried in ``data["operation"]``.
+    """
+
+    OPERATION_VERBS = {
+        "add": "added",
+        "edit": "edited",
+        "remove": "removed",
+    }
+
+    def __init__(self) -> None:
+        super().__init__(
+            event_id=218,
+            name="CUSTOM_INBOUND_FILTER",
+            api_name="custom-inbound-filter",
+        )
+
+    def _display(self, audit_log_entry: AuditLogEntry) -> str:
+        filter_name = audit_log_entry.data.get("filter_name", "unknown")
+        project_slug = audit_log_entry.data.get("project_slug", "unknown")
+        return f'custom inbound filter "{filter_name}" for project {project_slug}'
+
+    def render(self, audit_log_entry: AuditLogEntry) -> str:
+        target = self._display(audit_log_entry)
+        operation = audit_log_entry.data.get("operation")
+        verb = self.OPERATION_VERBS.get(operation, "updated")
+        if operation == "edit":
+            changes = audit_log_entry.data.get("changes", {})
+            changed_fields = ", ".join(sorted(changes)) if changes else "unknown fields"
+            return f"{verb} {target}: {changed_fields}"
+        return f"{verb} {target}"
+
+
 class ProjectOwnershipRuleEditAuditLogEvent(AuditLogEvent):
     def __init__(self) -> None:
         super().__init__(

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -105,6 +105,7 @@ default_manager.add(
 )
 default_manager.add(events.ProjectEnableAuditLogEvent())
 default_manager.add(events.ProjectDisableAuditLogEvent())
+default_manager.add(events.CustomInboundFilterAuditLogEvent())
 default_manager.add(
     AuditLogEvent(
         event_id=40,


### PR DESCRIPTION
- Register a single `CUSTOM_INBOUND_FILTER` audit log event (id 218) covering add/edit/remove
- Operation carried in entry data; render produces a human-readable description, including changed fields on edits
- Split out ahead of the CRUD endpoints that record against it

- First in a stack of 3 PRs
	- (this one)
	- https://github.com/getsentry/sentry/pull/118142
	- https://github.com/getsentry/sentry/pull/118143

Contributes to TET-2379