### PR TITLE
feat(agents): Promote reasoning effort in span details UI

### DIFF
--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -100,6 +100,7 @@ export enum SpanFields {
   GEN_AI_AGENT_NAME = 'gen_ai.agent.name',
   GEN_AI_FUNCTION_ID = 'gen_ai.function_id',
   GEN_AI_REQUEST_MODEL = 'gen_ai.request.model',
+  GEN_AI_REQUEST_REASONING_EFFORT = 'gen_ai.request.reasoning_effort',
   GEN_AI_REQUEST_MESSAGES = 'gen_ai.request.messages',
   GEN_AI_RESPONSE_TEXT = 'gen_ai.response.text',
   GEN_AI_RESPONSE_OBJECT = 'gen_ai.response.object',

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
@@ -177,6 +177,35 @@ describe('getHighlightedSpanAttributes', () => {
     expect(result.find(attr => attr.name === 'Cost')).toBeDefined();
   });
 
+  it('should include reasoning effort when attribute is present', () => {
+    const attributes = {
+      'gen_ai.operation.type': 'ai_client',
+      'gen_ai.request.reasoning_effort': 'high',
+    };
+
+    const result = getHighlightedSpanAttributes({
+      spanId: '123',
+      attributes,
+    });
+
+    const reasoningEffort = result.find(attr => attr.name === 'Reasoning Effort');
+    expect(reasoningEffort).toBeDefined();
+    expect(reasoningEffort?.value).toBe('high');
+  });
+
+  it('should not include reasoning effort when attribute is absent', () => {
+    const attributes = {
+      'gen_ai.operation.type': 'ai_client',
+    };
+
+    const result = getHighlightedSpanAttributes({
+      spanId: '123',
+      attributes,
+    });
+
+    expect(result.find(attr => attr.name === 'Reasoning Effort')).toBeUndefined();
+  });
+
   it('should include tokens attribute when values are present', () => {
     const attributes = {
       'gen_ai.operation.type': 'ai_client',

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -132,6 +132,14 @@ function getAISpanAttributes({
     });
   }
 
+  const reasoningEffort = attributes[SpanFields.GEN_AI_REQUEST_REASONING_EFFORT];
+  if (reasoningEffort) {
+    highlightedAttributes.push({
+      name: t('Reasoning Effort'),
+      value: reasoningEffort.toString(),
+    });
+  }
+
   const inputTokens = attributes['gen_ai.usage.input_tokens'];
   const cachedTokens =
     attributes['gen_ai.usage.cache_read.input_tokens'] ??


### PR DESCRIPTION
Surface the `gen_ai.request.reasoning_effort` attribute as a highlighted attribute in the trace drawer span details for AI client spans. The reasoning effort parameter (e.g. `low`, `medium`, `high`) sent to reasoning-capable models now appears alongside the model name, only when present.

**New Highlighted Attribute**

Adds `GEN_AI_REQUEST_REASONING_EFFORT` to `SpanFields` and renders a "Reasoning Effort" row in the AI span highlights, placed right after the Model attribute.

Relates to https://github.com/getsentry/sentry-conventions/pull/334

Refs TET-2506