### PR TITLE
ref(relay): Remove ingest-through-trusted-relays-only feature flag registration

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -148,10 +148,6 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:dashboards-import": FlagpoleFeature(default=False, api_expose=True),
         # Enable various explore related dev features, may be used by internal branches for testing.
         "organizations:explore-dev-features": FlagpoleFeature(default=False, api_expose=True),
-        # Enable ingestion through trusted relays only
-        "organizations:ingest-through-trusted-relays-only": FlagpoleFeature(
-            default=False, api_expose=True
-        ),
         # Enable the rendering of @sentry/toolbar inside the sentry app. See `useInitSentryToolbar()`
         "organizations:init-sentry-toolbar": FlagpoleFeature(default=False, api_expose=True),
         # Opt orgs in to logging workflow evaluations (bypasses sample rate when enabled).


### PR DESCRIPTION
## Summary

- Removes the `organizations:ingest-through-trusted-relays-only` FlagpoleFeature registration from `permanent.py`
- The feature is now GA — all code checks were removed in #118119 (frontend) and #118120 (backend)
- This is the final cleanup step: the registration itself is no longer needed