### PR TITLE
fix(explore): clarify logs export modal email copy

### DIFF
--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -143,7 +143,11 @@ export function LogsExportModal({
       </Header>
       <Body>
         <Stack gap="xl">
-          <Text>{t('Large data export files will be sent to your email address.')}</Text>
+          <Text>
+            {t(
+              'When a high number of rows is selected and entries are large, the results may be sent to your email.'
+            )}
+          </Text>
           <form.AppField name="columns">
             {field => (
               <field.Layout.Stack label={t('All Columns?')}>

--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -145,7 +145,7 @@ export function LogsExportModal({
         <Stack gap="xl">
           <Text>
             {t(
-              'When a high number of rows is selected and entries are large, the results may be sent to your email.'
+              'When a high number of rows is selected and events are large, the results may be sent to your email.'
             )}
           </Text>
           <form.AppField name="columns">


### PR DESCRIPTION
Out of conversation with @bcoe, new snazzier copy:

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="626" height="474" alt="image" src="https://github.com/user-attachments/assets/746e76d9-a7b2-446f-8b5f-7901e74c0112" />
</td>
<td>
<img width="626" height="496" alt="image" src="https://github.com/user-attachments/assets/caab100b-d21f-4ca0-8d3f-75cec7eaddf2" />
</td>
</tr>
</tbody>
</table>

_(I updated from "entries" to "events" after taking that screenshot)_

Closes EXP-1036