### PR TITLE
feat(explore): add search suggestions to trace logs view

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceOurlogs.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.spec.tsx
@@ -22,6 +22,24 @@ function Component({traceSlug}: {traceSlug: string}) {
 beforeEach(mockGetBoundingClientRect);
 
 describe('TraceViewLogsSection', () => {
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/validate/',
+      method: 'POST',
+      body: {attributes: {}},
+    });
+  });
+
   it('renders empty logs', async () => {
     const organization = OrganizationFixture({features: ['ourlogs-enabled']});
     const mockRequest = MockApiClient.addMockResponse({
@@ -66,6 +84,24 @@ describe('TraceViewLogsSection', () => {
 
     expect(await screen.findByText(/i am a log/)).toBeInTheDocument();
     expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows filter key suggestions when the search is focused', async () => {
+    const organization = OrganizationFixture({features: ['ourlogs-enabled']});
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-logs/`,
+      body: {
+        data: [],
+        meta: {},
+      },
+    });
+    render(<Component traceSlug={TRACE_SLUG} />, {organization});
+
+    await userEvent.click(
+      await screen.findByRole('combobox', {name: 'Add a search term'})
+    );
+
+    expect(await screen.findByRole('option', {name: 'severity'})).toBeInTheDocument();
   });
 
   it('shows the similar spans log row action', async () => {

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.spec.tsx
@@ -33,11 +33,6 @@ describe('TraceViewLogsSection', () => {
       method: 'GET',
       body: [],
     });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/trace-items/attributes/validate/',
-      method: 'POST',
-      body: {attributes: {}},
-    });
   });
 
   it('renders empty logs', async () => {

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -7,19 +7,18 @@ import {Flex} from '@sentry/scraps/layout';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Panel} from 'sentry/components/panels/panel';
-import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {t} from 'sentry/locale';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageData';
+import {useLogItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
+import {HiddenLogSearchFields} from 'sentry/views/explore/logs/constants';
 import {useLogsFrozenTraceIds} from 'sentry/views/explore/logs/logsFrozenContext';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {LogsInfiniteTable} from 'sentry/views/explore/logs/tables/logsInfiniteTable';
+import {useLogsSearchQueryBuilderProps} from 'sentry/views/explore/logs/useLogsSearchQueryBuilderProps';
 import {adjustLogTraceID, getLogsUrl} from 'sentry/views/explore/logs/utils';
-import {
-  useQueryParamsSearch,
-  useSetQueryParamsQuery,
-} from 'sentry/views/explore/queryParams/context';
 
 type UseTraceViewLogsDataProps = {
   children: React.ReactNode;
@@ -53,8 +52,22 @@ function LogsSectionContent() {
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const traceIds = useLogsFrozenTraceIds();
-  const setLogsQuery = useSetQueryParamsQuery();
-  const logsSearch = useQueryParamsSearch();
+
+  const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
+    useLogItemAttributes({}, 'string', HiddenLogSearchFields);
+  const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
+    useLogItemAttributes({}, 'number', HiddenLogSearchFields);
+  const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
+    useLogItemAttributes({}, 'boolean', HiddenLogSearchFields);
+
+  const {tracesItemSearchQueryBuilderProps} = useLogsSearchQueryBuilderProps({
+    booleanAttributes,
+    numberAttributes,
+    stringAttributes,
+    booleanSecondaryAliases,
+    numberSecondaryAliases,
+    stringSecondaryAliases,
+  });
 
   const traceId = traceIds?.[0] && adjustLogTraceID(traceIds[0]);
   const logsUrl = getLogsUrl({
@@ -66,13 +79,9 @@ function LogsSectionContent() {
   return (
     <Fragment>
       <Flex gap="lg">
-        <SearchQueryBuilder
+        <TraceItemSearchQueryBuilder
+          {...tracesItemSearchQueryBuilderProps}
           placeholder={t('Search logs for this event')}
-          filterKeys={{}}
-          getTagValues={() => new Promise<string[]>(() => [])}
-          initialQuery={logsSearch.formatString()}
-          searchSource="ourlogs"
-          onSearch={query => setLogsQuery(query)}
         />
         <LinkButton to={logsUrl}>{t('Open in Logs')}</LinkButton>
       </Flex>


### PR DESCRIPTION
Adds the nice dropdown from Explore > Logs to individual trace views under Explore > Traces > (trace).

Example from https://sentry.sentry.io/explore/traces/trace/292886fea77a4827a0098cf51332f516/?crossEvents=%5B%7B%22query%22%3A%22%22%2C%22type%22%3A%22logs%22%7D%5D&node=span-a20e982c5376bb31&project=-1&source=traces&statsPeriod=24h&tab=logs&targetId=9da9393fc820ba62&timestamp=1782140362:

<img width="957" height="685" alt="image" src="https://github.com/user-attachments/assets/937b2714-5a82-4a11-9a9f-337afbb63c48" />

This reuses the same search machinery the Explore › Logs page already has so the trace logs search gets a rich suggestions dropdown:

- Fetch log attributes via `useLogItemAttributes` (string/number/boolean) and feed them through `useLogsSearchQueryBuilderProps`.
- Render `TraceItemSearchQueryBuilder` instead of the bare `SearchQueryBuilder`, providing filter keys, real tag values, the filter-section tabs, and recent searches.

I held off adding AI search ("Ask AI to build your query") because the existing Seer combobox is coupled to the Explore page's location-based query params, while the trace logs tab uses state-based query params.

Closes EXP-711.