### PR TITLE
fix(tracemetrics): Disable equation field if loading metrics

### DIFF
--- a/static/app/components/arithmeticBuilder/index.tsx
+++ b/static/app/components/arithmeticBuilder/index.tsx
@@ -94,6 +94,7 @@ export function ArithmeticBuilder({
           aria-disabled={disabled}
           data-test-id={dataTestId ?? 'arithmetic-builder'}
           state={state.expression.isValid ? 'valid' : 'invalid'}
+          disabled={disabled}
         >
           <TokenGrid tokens={state.expression.tokens} />
         </Wrapper>
@@ -110,6 +111,12 @@ const Wrapper = styled(Input.withComponent('div'))<{state: 'valid' | 'invalid'}>
   position: relative;
   font-size: ${p => p.theme.font.size.md};
   cursor: text;
+
+  ${p =>
+    p.disabled &&
+    css`
+      pointer-events: none;
+    `}
 
   ${p =>
     p.state === 'valid'

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricQueryRows.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricQueryRows.tsx
@@ -214,6 +214,10 @@ export function MetricQueryRows({
     }
   }
 
+  // If any of the metric names are undefined, then we're still loading in a selection.
+  // Equations should be disabled if there are any unresolved metric selections.
+  const hasUnresolvedMetrics = functionQueries.some(q => !q.metric?.name);
+
   return (
     <Stack gap="lg" flex="1">
       {functionQueries.map(metricQuery => {
@@ -254,6 +258,7 @@ export function MetricQueryRows({
             onRowSelection={onRowSelection}
             onReferenceLabelsChange={setEquationReferencedLabels}
             deleteDisabledReason={t('An equation is required')}
+            disabled={hasUnresolvedMetrics}
           />
         </BuilderStateMetricsQueryParamsProvider>
       )}

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricToolbar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricToolbar.tsx
@@ -43,12 +43,14 @@ export function MetricToolbar({
   isSelected,
   onRowSelection,
   onReferenceLabelsChange,
+  disabled,
 }: {
   isSelected: boolean;
   label: string;
   onRowSelection: (label: string) => void;
   referenceMap: Record<string, string>;
   deleteDisabledReason?: string;
+  disabled?: boolean;
   onReferenceLabelsChange?: (labels: string[]) => void;
 }) {
   const visualize = useMetricVisualize();
@@ -115,6 +117,7 @@ export function MetricToolbar({
             expression={visualize.expression.text}
             referenceMap={referenceMap}
             handleExpressionChange={handleExpressionChange}
+            disabled={disabled}
           />
         ) : null}
         <Flex flex="1 1 100%" minWidth="0">
@@ -122,6 +125,7 @@ export function MetricToolbar({
             traceMetric={traceMetric}
             skipTraceMetricFilter={isEquation}
             portalTarget={document.body}
+            disabled={disabled}
           />
         </Flex>
       </Flex>

--- a/static/app/views/explore/hooks/useMetricOptions.tsx
+++ b/static/app/views/explore/hooks/useMetricOptions.tsx
@@ -108,7 +108,6 @@ export function useMetricOptions({
 
     refetchOnWindowFocus: false,
     refetchOnMount: false,
-    retry: false,
     enabled,
   });
 

--- a/static/app/views/explore/metrics/equationBuilder/index.tsx
+++ b/static/app/views/explore/metrics/equationBuilder/index.tsx
@@ -21,9 +21,11 @@ export function EquationBuilder({
   referenceMap,
   handleExpressionChange,
   onReferenceLabelsChange,
+  disabled,
 }: {
   expression: string;
   handleExpressionChange: (resolved: Expression, internalText: string) => void;
+  disabled?: boolean;
   onReferenceLabelsChange?: (labels: string[]) => void;
   referenceMap?: Record<string, string>;
 }) {
@@ -67,6 +69,7 @@ export function EquationBuilder({
       getFieldDefinition={() => null}
       references={references}
       setExpression={handleInternalExpressionChange}
+      disabled={disabled}
     />
   );
 }

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -38,6 +38,7 @@ const EMPTY_ALIASES: TagCollection = {};
 
 interface FilterProps {
   traceMetric: TraceMetric;
+  disabled?: boolean;
   environments?: string[];
   portalTarget?: HTMLElement;
   projectIds?: number[];
@@ -68,6 +69,7 @@ export function Filter({
   projectIds,
   environments,
   portalTarget,
+  disabled,
 }: FilterProps) {
   const query = useQueryParamsQuery();
   const setQuery = useSetQueryParamsQuery();
@@ -96,7 +98,8 @@ export function Filter({
     enabled: skipTraceMetricFilter || Boolean(traceMetricFilter),
     select: selectTraceItemTagCollection(),
   });
-  const isSearchBarDisabled = isLoading || (!skipTraceMetricFilter && !traceMetricFilter);
+  const isSearchBarDisabled =
+    isLoading || (!skipTraceMetricFilter && !traceMetricFilter) || disabled;
 
   const visibleNumberTags = useMemo(() => {
     const staticNumberTags = SENTRY_TRACEMETRIC_NUMBER_TAGS.reduce<TagCollection>(

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -64,6 +64,10 @@ export function MetricToolbar({
     ? t('Not configurable for Heat Map visualizations')
     : undefined;
 
+  const hasUnresolvedMetrics = metricQueries.some(
+    q => !isVisualizeEquation(q.queryParams.visualizes[0]!) && !q.metric?.name
+  );
+
   // We need at least one metric visualized, but equations should always
   // be removable.
   const canRemoveMetric =
@@ -154,6 +158,7 @@ export function MetricToolbar({
                 referenceMap={referenceMap}
                 handleExpressionChange={handleExpressionChange}
                 onReferenceLabelsChange={handleReferenceLabelsChange}
+                disabled={hasUnresolvedMetrics}
               />
             </Flex>
             <Flex flex="9 1 0" minWidth={0}>
@@ -161,7 +166,11 @@ export function MetricToolbar({
             </Flex>
             {!isNarrow && (
               <Flex flex="30 1 0" minWidth={0}>
-                <Filter traceMetric={traceMetric} skipTraceMetricFilter />
+                <Filter
+                  traceMetric={traceMetric}
+                  disabled={hasUnresolvedMetrics}
+                  skipTraceMetricFilter
+                />
               </Flex>
             )}
           </Flex>

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -187,6 +187,7 @@ export function MetricToolbar({
         <Filter
           traceMetric={traceMetric}
           skipTraceMetricFilter={isVisualizeEquation(visualize)}
+          disabled={isVisualizeEquation(visualize) && hasUnresolvedMetrics}
         />
       )}
     </Flex>


### PR DESCRIPTION
When other metric fields are loading, disable the equation field or else the user may be able to enter an invalid metric selection to their equation.

Applies changes to both explore and dashboards. I had to update some components to acccept `disabled` as a prop and apply `pointer-events: none` to the equation input field. The way that it's built right now doesn't apply the same disabled state as e.g. the filter field