### PR TITLE
feat(trace-items): Always return context key when expand=context

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -397,8 +397,9 @@ def as_attribute_key(
 
     if include_context:
         # When context is requested we always attach it, even for custom
-        # (non-sentry-convention) attributes. Attributes that don't map to a
-        # known convention get an empty context.
+        # (non-sentry-convention) attributes. Today only sentry-convention
+        # attributes have metadata to surface, so custom attributes get an empty
+        # context for now; serving custom attribute context is planned.
         context: TraceItemAttributeContext = {}
         if serialized_source["source_type"] == AttributeSourceType.SENTRY.value:
             context = build_sentry_convention_context(public_name, name) or {}

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -395,10 +395,14 @@ def as_attribute_key(
     if secondary_aliases:
         attribute_key["secondaryAliases"] = sorted(secondary_aliases)
 
-    if include_context and serialized_source["source_type"] == AttributeSourceType.SENTRY.value:
-        context = build_sentry_convention_context(public_name, name)
-        if context is not None:
-            attribute_key["context"] = context
+    if include_context:
+        # When context is requested we always attach it, even for custom
+        # (non-sentry-convention) attributes. Attributes that don't map to a
+        # known convention get an empty context.
+        context: TraceItemAttributeContext = {}
+        if serialized_source["source_type"] == AttributeSourceType.SENTRY.value:
+            context = build_sentry_convention_context(public_name, name) or {}
+        attribute_key["context"] = context
 
     return attribute_key
 

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
@@ -11,19 +11,19 @@ class TraceItemAttributeContext(TypedDict):
     Additional, mostly-static metadata about an attribute sourced from the
     sentry conventions (``sentry_conventions.attributes.ATTRIBUTE_METADATA``).
 
-    Only attributes that map to a known sentry convention have context, and
-    within the context only the fields actually present in the conventions
-    metadata are included. This is only attached when the caller passes
-    ``expand=context`` and the ``data-browsing-attribute-context`` feature is
-    enabled.
+    When ``expand=context`` is requested (and the
+    ``data-browsing-attribute-context`` feature is enabled), context is attached
+    to every attribute. Attributes that map to a known sentry convention carry
+    the convention metadata (only the fields actually present are included);
+    custom attributes get an empty context.
     """
 
-    # A short, human-readable description of the attribute. Always present for a
-    # known convention.
-    brief: str
-    # Whether the convention has been deprecated. Always present for a known
+    # A short, human-readable description of the attribute. Present for a known
     # convention.
-    isDeprecated: bool
+    brief: NotRequired[str]
+    # Whether the convention has been deprecated. Present for a known
+    # convention.
+    isDeprecated: NotRequired[bool]
     # Longer-form notes that add nuance beyond the brief (e.g. caveats,
     # double-counting warnings). Sourced from the convention's
     # ``additional_context``.
@@ -41,5 +41,6 @@ class TraceItemAttributeKey(TypedDict):
     attributeSource: TraceItemAttributeSource
     attributeType: Literal["string", "number", "boolean"]
     # Sentry conventions metadata, only present when requested via
-    # ``expand=context`` (and gated behind the feature flag).
+    # ``expand=context`` (and gated behind the feature flag). Attached to every
+    # attribute when requested; empty for custom (non-convention) attributes.
     context: NotRequired[TraceItemAttributeContext]

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
@@ -8,14 +8,16 @@ class TraceItemAttributeSource(TypedDict):
 
 class TraceItemAttributeContext(TypedDict):
     """
-    Additional, mostly-static metadata about an attribute sourced from the
-    sentry conventions (``sentry_conventions.attributes.ATTRIBUTE_METADATA``).
+    Additional, mostly-static metadata about an attribute.
 
     When ``expand=context`` is requested (and the
     ``data-browsing-attribute-context`` feature is enabled), context is attached
-    to every attribute. Attributes that map to a known sentry convention carry
-    the convention metadata (only the fields actually present are included);
-    custom attributes get an empty context.
+    to every attribute. Today the metadata is sourced from the sentry
+    conventions (``sentry_conventions.attributes.ATTRIBUTE_METADATA``), so
+    attributes that map to a known convention carry that metadata (only the
+    fields actually present are included) while custom attributes get an empty
+    context. Serving context for custom attributes is planned, at which point
+    the empty contexts will start to be populated.
     """
 
     # A short, human-readable description of the attribute. Present for a known
@@ -40,7 +42,8 @@ class TraceItemAttributeKey(TypedDict):
     secondaryAliases: NotRequired[list[str]]
     attributeSource: TraceItemAttributeSource
     attributeType: Literal["string", "number", "boolean"]
-    # Sentry conventions metadata, only present when requested via
-    # ``expand=context`` (and gated behind the feature flag). Attached to every
-    # attribute when requested; empty for custom (non-convention) attributes.
+    # Attribute context, only present when requested via ``expand=context`` (and
+    # gated behind the feature flag). Attached to every attribute when
+    # requested; currently empty for custom (non-convention) attributes, which
+    # will be populated once custom attribute context is served.
     context: NotRequired[TraceItemAttributeContext]

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -535,7 +535,8 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             "isDeprecated": True,
             "replacementAttribute": "sentry.segment.name",
         }
-        # User tags are not sentry conventions, so they get an empty context.
+        # Custom attribute context isn't served yet, so user tags get an empty
+        # context for now.
         assert attributes["foo"]["context"] == {}
         # A user tag whose name collides with a sentry convention still gets an
         # empty context, because only `sentry`-source attributes are expanded.

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -535,12 +535,12 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             "isDeprecated": True,
             "replacementAttribute": "sentry.segment.name",
         }
-        # User tags are not sentry conventions, so they have no context.
-        assert "context" not in attributes["foo"]
-        # A user tag whose name collides with a sentry convention still gets no
-        # context, because only `sentry`-source attributes are expanded.
+        # User tags are not sentry conventions, so they get an empty context.
+        assert attributes["foo"]["context"] == {}
+        # A user tag whose name collides with a sentry convention still gets an
+        # empty context, because only `sentry`-source attributes are expanded.
         assert attributes["gen_ai.request.model"]["attributeSource"]["source_type"] == "user"
-        assert "context" not in attributes["gen_ai.request.model"]
+        assert attributes["gen_ai.request.model"]["context"] == {}
 
     def test_expand_context_without_feature_flag(self) -> None:
         self._store_basic_segment()


### PR DESCRIPTION
When `expand=context` is requested on `GET /organizations/{org}/trace-items/attributes/` (and the `organizations:data-browsing-attribute-context` feature is enabled), the endpoint now attaches a `context` object to **every** attribute, not just those that map to a known sentry convention.

Previously, custom (non-convention) attributes had no `context` key at all, so clients had to special-case its absence. Now they receive an empty `context` (`{}`), giving a consistent response shape. Today only sentry-convention attributes have metadata to surface (`brief`, `examples`, `isDeprecated`, etc.); serving context for custom attributes is planned, at which point the empty contexts will start to be populated.

This remains gated behind the feature flag and only applies when `expand=context` is passed — behavior is unchanged otherwise.

Refs BROWSE-580
