### PR TITLE
feat(issue-search): Add suspect-commit relevance to recommended_v2

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -39,6 +39,7 @@ from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
+from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
@@ -929,6 +930,22 @@ def resolve_assignment_signal(
     return signal
 
 
+def resolve_suspect_commit_signal(
+    actor: Any | None, organization: Organization, group_ids: list[int]
+) -> dict[int, float]:
+    """1.0 for groups where the viewer authored the suspect commit. Unlike assignment,
+    suspect-commit ownership isn't auto-assigned by default, so this surfaces issues the
+    viewer likely introduced even when they're unassigned or assigned elsewhere."""
+    if actor is None or not getattr(actor, "is_authenticated", False):
+        return {}
+    owned = GroupOwner.objects.filter(
+        group_id__in=group_ids,
+        type=GroupOwnerType.SUSPECT_COMMIT.value,
+        user_id=actor.id,
+    ).values_list("group_id", flat=True)
+    return {group_id: 1.0 for group_id in owned}
+
+
 def resolve_issue_agent_signal(
     actor: Any | None, organization: Organization, group_ids: list[int]
 ) -> dict[int, float]:
@@ -959,16 +976,23 @@ def resolve_issue_agent_signal(
 
 def recommended_v2_strategy() -> PostgresSortStrategy:
     """Recommended sort v2: the Snuba recommended score (recency/spike/severity/user
-    impact/event volume) plus additive boosts for viewer assignment, Seer fixability,
-    and Seer agent progress."""
+    impact/event volume) plus additive boosts for viewer relevance (assignment or suspect
+    commit), Seer fixability, and Seer agent progress."""
     assignment_weight = options.get("snuba.search.recommended.assignment-weight")
     fixability_weight = options.get("snuba.search.recommended.fixability-weight")
     agent_weight = options.get("snuba.search.recommended.agent-weight")
 
     def score_fn(data: dict[str, Any]) -> float:
+        # Personal relevance is a max, not a sum: a viewer who is both assignee and suspect
+        # committer shouldn't be double-counted. Suspect-commit (0.8) sits just below direct
+        # assignment (1.0) but above team assignment (0.5).
+        relevance = max(
+            data.get("assignment", 0.0),
+            0.8 * data.get("suspect_commit", 0.0),
+        )
         return (
             (data.get("recommended") or 0.0)
-            + assignment_weight * data.get("assignment", 0.0)
+            + assignment_weight * relevance
             + fixability_weight * (data.get("fixability") or 0.0)
             + agent_weight * data.get("agent", 0.0)
         )
@@ -978,6 +1002,7 @@ def recommended_v2_strategy() -> PostgresSortStrategy:
         snuba_aggregations=["recommended"],
         signal_resolvers={
             "assignment": resolve_assignment_signal,
+            "suspect_commit": resolve_suspect_commit_signal,
             "agent": resolve_issue_agent_signal,
         },
         score_fn=score_fn,

--- a/tests/snuba/search/test_postgres_sort_framework.py
+++ b/tests/snuba/search/test_postgres_sort_framework.py
@@ -11,6 +11,7 @@ from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.issue_search import convert_query_values, parse_search_query
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
+from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.search.snuba.backend import EventsDatasetSnubaSearchBackend
 from sentry.search.snuba.executors import (
     DEFAULT_TRENDS_WEIGHTS,
@@ -380,7 +381,7 @@ class TestFallbackBehavior(PostgresSortTestBase):
 
 class TestRecommendedV2Sort(PostgresSortTestBase):
     """recommended_v2: Snuba recommended base score plus additive boosts for viewer
-    assignment, Seer fixability, and Seer agent progress.
+    relevance (assignment or suspect commit), Seer fixability, and Seer agent progress.
 
     The base fixture's groups have events ~8d, ~5d, and ~3d old, so the recency-driven
     base score orders them [2, 1, 0] with small (<0.03) differences -- each boost below
@@ -454,6 +455,33 @@ class TestRecommendedV2Sort(PostgresSortTestBase):
 
         assert self._query(actor=self.user) == [self.groups[1], self.groups[2], self.groups[0]]
 
+    def _add_suspect_commit(self, group, user):
+        GroupOwner.objects.create(
+            group=group,
+            project=self.project,
+            organization=self.organization,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            user_id=user.id,
+        )
+
+    def test_suspect_commit_boost(self):
+        # groups[0] has the lowest base score; the viewer authored its suspect commit,
+        # which lifts it to the top even though it isn't assigned to them.
+        self._add_suspect_commit(self.groups[0], self.user)
+
+        assert self._query(actor=self.user)[0] == self.groups[0]
+
+    def test_relevance_is_max_not_sum(self):
+        # groups[0] is both assigned to the viewer and authored by them; groups[1] is only
+        # assigned to them. If the two relevance signals summed, groups[0] would win; because
+        # they're combined with max(), both get the same boost and the higher base (groups[1])
+        # stays ahead.
+        GroupAssignee.objects.assign(self.groups[0], self.user)
+        self._add_suspect_commit(self.groups[0], self.user)
+        GroupAssignee.objects.assign(self.groups[1], self.user)
+
+        assert self._query(actor=self.user) == [self.groups[1], self.groups[0], self.groups[2]]
+
 
 class TestProgressSort(PostgresSortTestBase):
     """progress: primary sort by fix-cycle rank (fix_applied > fix_proposed > diagnosed >
@@ -501,7 +529,7 @@ class TestDefaultPostgresSortStrategies(TestCase):
         strategy = strategies["recommended_v2"]
         assert strategy.snuba_aggregations == ["recommended"]
         assert strategy.exclude_null_postgres is False
-        assert set(strategy.signal_resolvers) == {"assignment", "agent"}
+        assert set(strategy.signal_resolvers) == {"assignment", "suspect_commit", "agent"}
 
     def test_progress_registered(self):
         strategies = PostgresSnubaQueryExecutor().postgres_sort_strategies


### PR DESCRIPTION
Adds a suspect-commit signal to the `recommended_v2` issue sort: issues where the viewer authored the suspect commit (`GroupOwner` type `SUSPECT_COMMIT`) get a personal-relevance boost.

It's combined with the existing assignment signal via `max()`, not summed, so being both the assignee and the author isn't double-counted. The suspect-commit strength is hardcoded at 0.8 (between team assignment at 0.5 and direct assignment at 1.0), multiplied by `assignment-weight`.

Adds one bulk `GroupOwner` query in the existing signal-resolver path; no framework changes.