### PR TITLE
fix(gitlab): handle non-string externalIssue in get_issue/after_link_issue

### DIFF
--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -124,7 +124,10 @@ class GitlabIssuesSpec(SourceCodeIssueIntegration):
 
     def after_link_issue(self, external_issue, **kwargs):
         data = kwargs["data"]
-        project_id, issue_id = data.get("externalIssue", "").split("#")
+        external_issue_val = str(data.get("externalIssue") or "")
+        if "#" not in external_issue_val:
+            raise IntegrationError("Project and Issue id must be provided")
+        project_id, issue_id = external_issue_val.split("#")
         if not (project_id and issue_id):
             raise IntegrationError("Project and Issue id must be provided")
 
@@ -183,7 +186,10 @@ class GitlabIssuesSpec(SourceCodeIssueIntegration):
         ]
 
     def get_issue(self, issue_id, **kwargs):
-        project_id, issue_num = issue_id.split("#")
+        issue_id_str = str(issue_id)
+        if "#" not in issue_id_str:
+            raise IntegrationError("Issue ID must be in the format project#issue")
+        project_id, issue_num = issue_id_str.split("#")
         client = self.get_client()
 
         if not project_id:

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -226,6 +226,12 @@ class GitlabIssuesTest(GitLabTestCase):
             "metadata": {"display_name": key},
         }
 
+    def test_get_issue_integer_id_raises(self) -> None:
+        # A direct API client may send externalIssue as a bare integer instead of
+        # the expected "project#issue" string. This should be a clean error, not a 500.
+        with pytest.raises(IntegrationError):
+            self.installation.get_issue(issue_id=13, data={})
+
     @responses.activate
     def test_create_issue_default_project_in_group_api_call(self) -> None:
         group_description = (
@@ -456,6 +462,26 @@ class GitlabIssuesTest(GitLabTestCase):
         data = {"externalIssue": "2#231", "comment": "This is not good."}
         external_issue = ExternalIssue.objects.create(
             organization_id=self.organization.id, integration_id=self.integration.id, key="#"
+        )
+        with pytest.raises(IntegrationError):
+            self.installation.after_link_issue(external_issue, data=data)
+
+    def test_after_link_issue_integer_external_issue_raises(self) -> None:
+        # A direct API client may send externalIssue as a bare integer instead of
+        # the expected "project#issue" string. This should be a clean error, not a 500.
+        data = {"externalIssue": 321, "comment": "This is not good."}
+        external_issue = ExternalIssue.objects.create(
+            organization_id=self.organization.id, integration_id=self.integration.id, key="2#321"
+        )
+        with pytest.raises(IntegrationError):
+            self.installation.after_link_issue(external_issue, data=data)
+
+    def test_after_link_issue_missing_external_issue_raises(self) -> None:
+        # A missing externalIssue should raise a clean error rather than crashing
+        # on "".split("#").
+        data = {"comment": "This is not good."}
+        external_issue = ExternalIssue.objects.create(
+            organization_id=self.organization.id, integration_id=self.integration.id, key="2#321"
         )
         with pytest.raises(IntegrationError):
             self.installation.after_link_issue(external_issue, data=data)


### PR DESCRIPTION
## Summary

Fixes SENTRY-5K7S

GitLab's `get_issue` and `after_link_issue` unconditionally call `.split("#")` on the `externalIssue` value. A direct API client to `PUT /api/0/groups/{id}/integrations/{integration_id}/` that sends `externalIssue` as a JSON **integer** (e.g. `12525`) instead of the expected `"project#issue"` string triggers `AttributeError: 'int' object has no attribute 'split'`. The endpoint only catches `IntegrationError`/`IntegrationFormError`, so this escapes as an unhandled **500**.

GitLab is the only SCM integration that overloads `externalIssue` to carry two values (`project#issue_num`) and unpacks via `.split("#")`, which is why it's uniquely exposed.

### Not reachable from the UI

The value chain always produces the `"project_id#iid"` string:
- the autocomplete endpoint emits `"value": "{}#{}".format(i["project_id"], i["iid"])` (`gitlab/search.py`)
- the typed frontend select stores it as `string | null`

So this only affects out-of-band/programmatic API clients.

## Fix

Coerce the value to `str` and reject anything lacking `#` with a clean `IntegrationError` (→ 400) instead of crashing. We intentionally do **not** add a new "bare integer + separate `project` field" linking format — turning the 500 into a proper 400 is the whole fix, with no change to successful-link behavior.

As a bonus, this also fixes a *missing* `externalIssue` in `after_link_issue`, which previously crashed on `"".split("#")` (`ValueError`) rather than raising cleanly.

## Tests

Added 3 tests (all pass; existing `"project#num"` tests unchanged as a regression guard):
- `test_get_issue_integer_id_raises`
- `test_after_link_issue_integer_external_issue_raises`
- `test_after_link_issue_missing_external_issue_raises`
