### PR TITLE
fix(traces): Preserve autogroup segment bounds

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/parentAutogroupNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/parentAutogroupNode.spec.tsx
@@ -334,6 +334,47 @@ describe('ParentAutogroupNode', () => {
       // Should include all nodes from head to tail
     });
 
+    it('should preserve the furthest end when grouped segments overlap', () => {
+      const extra = createMockExtra();
+      const autogroupValue = makeParentAutogroup({});
+
+      const headSpanValue = makeEAPSpan({
+        event_id: 'head',
+        start_timestamp: 1000,
+        end_timestamp: 1500,
+      });
+      const middleSpanValue = makeEAPSpan({
+        event_id: 'middle',
+        start_timestamp: 1100,
+        end_timestamp: 1200,
+      });
+      const tailSpanValue = makeEAPSpan({
+        event_id: 'tail',
+        start_timestamp: 1600,
+        end_timestamp: 1700,
+      });
+
+      const headNode = new EapSpanNode(null, headSpanValue, extra);
+      const middleNode = new EapSpanNode(headNode, middleSpanValue, extra);
+      const tailNode = new EapSpanNode(middleNode, tailSpanValue, extra);
+
+      headNode.children = [middleNode];
+      middleNode.children = [tailNode];
+
+      const node = new ParentAutogroupNode(
+        null,
+        autogroupValue,
+        extra,
+        headNode,
+        tailNode
+      );
+
+      expect(node.autogroupedSegments).toEqual([
+        [1000000, 500000],
+        [1600000, 100000],
+      ]);
+    });
+
     it('should cache autogroupedSegments for performance', () => {
       const extra = createMockExtra();
       const autogroupValue = makeParentAutogroup({});

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/utils.tsx
@@ -29,7 +29,7 @@ export function computeCollapsedBarSpace(nodes: BaseNode[]): Array<[number, numb
       end = next.space[0] + next.space[1];
       i++;
     } else {
-      end = next.space[0] + next.space[1];
+      end = Math.max(end, next.space[0] + next.space[1]);
       i++;
     }
   }


### PR DESCRIPTION
Collapsed autogroup bars now preserve the furthest end timestamp when grouped spans overlap. This prevents a shorter nested span from shrinking the merged segment and creating false visual gaps in the trace waterfall.

The regression covers a parent autogroup with an enclosing span, a shorter overlapping child, and a later separated tail span so legitimate gaps remain while artificial ones do not reappear.

**Before:** (ignore the 24ms bar, that is a different autogrouping)
<img width="814" height="245" alt="Screenshot 2026-06-22 at 14 16 38" src="https://github.com/user-attachments/assets/8d1bd501-e15c-4ceb-93d4-018594dd5a88" />

**After:**
<img width="813" height="222" alt="Screenshot 2026-06-22 at 14 16 45" src="https://github.com/user-attachments/assets/5e6a0db3-27c6-4f46-8680-829190e3fee7" />
