### PR TITLE
ref(pr-metrics): Standardize log event names and enrich context

### DIFF
--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -161,7 +161,7 @@ def _attribute_pull_request(
     # A present-but-unrecognized provider means the source sent something we don't
     # map — warn so it can be corrected upstream, but still attempt to resolve.
     if normalized_provider is not None and normalized_provider not in _KNOWN_SCM_PROVIDERS:
-        logger.warning("seer.pr_attribution.unrecognized_provider", extra=log_context)
+        logger.warning("pr_metrics.attribution.unrecognized_provider", extra=log_context)
 
     repository, resolution = _resolve_repository(
         organization_id=organization_id,
@@ -170,10 +170,13 @@ def _attribute_pull_request(
     )
     if repository is None:
         if resolution == "ambiguous":
-            logger.warning("seer.pr_attribution.repo_ambiguous", extra=log_context)
+            logger.warning("pr_metrics.attribution.repo_ambiguous", extra=log_context)
         else:
-            logger.warning("seer.pr_attribution.repo_not_found", extra=log_context)
+            logger.warning("pr_metrics.attribution.repo_not_found", extra=log_context)
         return
+
+    # The repo is resolved now, so its id sharpens every log from here on.
+    log_context = {**log_context, "repository_id": repository.id}
 
     # get_or_create is race-safe via the unique constraints — Django retries the
     # get on IntegrityError.
@@ -190,10 +193,13 @@ def _attribute_pull_request(
             signal_details=signal_details,
         )
     except Exception:
-        logger.exception("seer.pr_attribution.record_failed", extra=log_context)
+        logger.exception("pr_metrics.attribution.record_failed", extra=log_context)
         return
 
-    logger.info("seer.pr_attribution.recorded", extra=log_context)
+    logger.info(
+        "pr_metrics.attribution.recorded",
+        extra={**log_context, "pull_request_id": pull_request.id},
+    )
 
 
 def attribute_seer_created_pull_requests(
@@ -228,7 +234,7 @@ def attribute_seer_created_pull_requests(
         }
 
         if not repo_name or pr_number is None:
-            logger.warning("seer.pr_attribution.missing_fields", extra=log_context)
+            logger.warning("pr_metrics.attribution.missing_fields", extra=log_context)
             continue
 
         _attribute_pull_request(
@@ -315,12 +321,13 @@ def attribute_delegated_agent_pull_request(
         "signal_type": signal_type,
         "agent_id": agent_id,
         "repo_name": repo_full_name,
+        "provider": repo_provider,
         "pr_url": pr_url,
         "pr_number": pr_number,
     }
 
     if pr_number is None:
-        logger.warning("seer.pr_attribution.invalid_pr_url", extra=log_context)
+        logger.warning("pr_metrics.attribution.invalid_pr_url", extra=log_context)
         return
 
     _attribute_pull_request(

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -110,6 +110,7 @@ def select_verdict(
             "pr_metrics.select_verdict.metrics_row_missing",
             extra={
                 "organization_id": pull_request.organization_id,
+                "repository_id": pull_request.repository_id,
                 "pull_request_id": pull_request.id,
             },
         )

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -200,6 +200,7 @@ def forward_pr_to_seer_judge(pull_request: PullRequest, repository: Repository) 
     log_extra = {
         "organization_id": pull_request.organization_id,
         "repository_id": pull_request.repository_id,
+        "repo_name": repository.name,
         "pull_request_id": pull_request.id,
     }
     response = make_signed_seer_api_request(

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -133,7 +133,7 @@ def handle_attribution(
     if not features.has("organizations:pr-metrics-attribution", organization):
         return
 
-    pr = _get_pull_request(organization, repo, pull_request)
+    pr = _get_pull_request(organization, repo, pull_request, kwargs.get("github_delivery_id"))
     if pr is None:
         return
 
@@ -205,6 +205,7 @@ def _forward_to_judge(pr: PullRequest, organization: Organization) -> None:
             "pr_metrics.emit.needs_judge",
             extra={
                 "organization_id": organization.id,
+                "repository_id": pr.repository_id,
                 "pull_request_id": pr.id,
                 "reason": "no_seer_access",
             },
@@ -221,6 +222,7 @@ def _forward_to_judge(pr: PullRequest, organization: Organization) -> None:
             "pr_metrics.emit.needs_judge",
             extra={
                 "organization_id": organization.id,
+                "repository_id": pr.repository_id,
                 "pull_request_id": pr.id,
                 "reason": "not_agent_attribution",
             },
@@ -233,6 +235,7 @@ def _forward_to_judge(pr: PullRequest, organization: Organization) -> None:
             "pr_metrics.emit.needs_judge",
             extra={
                 "organization_id": organization.id,
+                "repository_id": pr.repository_id,
                 "pull_request_id": pr.id,
                 "reason": "blocked_by_flag",
             },
@@ -257,7 +260,14 @@ def _forward_to_judge(pr: PullRequest, organization: Organization) -> None:
             pull_request=pr, verdict=PullRequestVerdict.JUDGE_IN_PROGRESS
         ).update(verdict=None)
         metrics.incr("pr_metrics.judge.enqueue_failed")
-        logger.exception("pr_metrics.judge.enqueue_failed", extra={"pull_request_id": pr.id})
+        logger.exception(
+            "pr_metrics.judge.enqueue_failed",
+            extra={
+                "organization_id": organization.id,
+                "repository_id": pr.repository_id,
+                "pull_request_id": pr.id,
+            },
+        )
         return
     metrics.incr("pr_metrics.judge.enqueued")
 
@@ -291,7 +301,9 @@ def handle_emission(
     if not features.has("organizations:pr-metrics-emit", organization):
         return
 
-    pr = _get_pull_request(organization, repo, event.get("pull_request"))
+    pr = _get_pull_request(
+        organization, repo, event.get("pull_request"), kwargs.get("github_delivery_id")
+    )
     if pr is None:
         return
 
@@ -340,7 +352,7 @@ def handle_metrics(
     if not features.has("organizations:pr-metrics-emit", organization):
         return
 
-    pr = _get_pull_request(organization, repo, pull_request)
+    pr = _get_pull_request(organization, repo, pull_request, kwargs.get("github_delivery_id"))
     if pr is None:
         return
 
@@ -365,7 +377,7 @@ def handle_activity(
     if not action or action not in _ACTIVITY_ACTIONS:
         return
 
-    pr = _get_pull_request(organization, repo, pull_request_data)
+    pr = _get_pull_request(organization, repo, pull_request_data, kwargs.get("github_delivery_id"))
     if pr is None:
         return
 
@@ -401,6 +413,7 @@ def handle_comment(
     if not issue.get("pull_request"):
         return
 
+    webhook_id: str | None = kwargs.get("github_delivery_id")
     try:
         pr = PullRequest.objects.get(
             organization_id=organization.id,
@@ -409,8 +422,15 @@ def handle_comment(
         )
     except PullRequest.DoesNotExist:
         logger.warning(
-            "github.pr_metrics.comment.pr_not_found",
-            extra={"repository_id": repo.id, "issue_number": issue["number"]},
+            "pr_metrics.comment.pr_not_found",
+            extra={
+                "organization_id": organization.id,
+                "repository_id": repo.id,
+                "repo_name": repo.name,
+                "pr_number": issue["number"],
+                "action": action,
+                "github_delivery_id": webhook_id,
+            },
         )
         return
 
@@ -432,7 +452,6 @@ def handle_comment(
             author_association=comment.get("author_association", "NONE"),
         )
 
-    webhook_id: str | None = kwargs.get("github_delivery_id")
     if not webhook_id:
         return
 
@@ -456,7 +475,9 @@ def handle_review(
     if not is_activity_tracking_enabled(organization):
         return
 
-    pr = _get_pull_request(organization, repo, event.get("pull_request"))
+    pr = _get_pull_request(
+        organization, repo, event.get("pull_request"), kwargs.get("github_delivery_id")
+    )
     if pr is None:
         return
 
@@ -495,7 +516,9 @@ def handle_review_comment(
     if not is_activity_tracking_enabled(organization):
         return
 
-    pr = _get_pull_request(organization, repo, event.get("pull_request"))
+    pr = _get_pull_request(
+        organization, repo, event.get("pull_request"), kwargs.get("github_delivery_id")
+    )
     if pr is None:
         return
 
@@ -544,7 +567,9 @@ def handle_review_thread(
     if not is_activity_tracking_enabled(organization):
         return
 
-    pr = _get_pull_request(organization, repo, event.get("pull_request"))
+    pr = _get_pull_request(
+        organization, repo, event.get("pull_request"), kwargs.get("github_delivery_id")
+    )
     if pr is None:
         return
 
@@ -573,13 +598,17 @@ def handle_review_thread(
 
 
 def _get_pull_request(
-    organization: Organization, repo: Repository, pull_request: dict[str, Any] | None
+    organization: Organization,
+    repo: Repository,
+    pull_request: dict[str, Any] | None,
+    github_delivery_id: str | None = None,
 ) -> PullRequest | None:
     """Resolve the canonical PullRequest row for a webhook payload, or None.
 
     Returns None when the event carries no pull_request. Otherwise the row is
     upserted by ``PullRequestEventWebhook._handle`` before processors run, so a
-    miss is unexpected — log it and let the caller bail.
+    miss is unexpected — log it (with the delivery id, to pull the raw payload)
+    and let the caller bail.
     """
     if not pull_request:
         return None
@@ -591,8 +620,14 @@ def _get_pull_request(
         )
     except PullRequest.DoesNotExist:
         logger.warning(
-            "github.pr_metrics.pr_not_found",
-            extra={"repository_id": repo.id, "pr_number": pull_request["number"]},
+            "pr_metrics.pr_not_found",
+            extra={
+                "organization_id": organization.id,
+                "repository_id": repo.id,
+                "repo_name": repo.name,
+                "pr_number": pull_request["number"],
+                "github_delivery_id": github_delivery_id,
+            },
         )
         return None
 

--- a/tests/sentry/pr_metrics/test_attribution.py
+++ b/tests/sentry/pr_metrics/test_attribution.py
@@ -106,7 +106,7 @@ class AttributeSeerCreatedPullRequestsTest(TestCase):
 
         assert not PullRequest.objects.filter(repository_id=self.repo.id).exists()
         assert not PullRequestAttribution.objects.exists()
-        assert "seer.pr_attribution.repo_not_found" in _warning_events(mock_logger)
+        assert "pr_metrics.attribution.repo_not_found" in _warning_events(mock_logger)
 
     def test_skips_other_orgs_repository(self) -> None:
         other_org = self.create_organization()
@@ -139,7 +139,7 @@ class AttributeSeerCreatedPullRequestsTest(TestCase):
         # "UNKNOWN" must be treated as the unknown sentinel, not a real provider:
         # the single same-named repo resolves and no unrecognized warning fires.
         assert PullRequest.objects.filter(repository_id=self.repo.id, key="42").exists()
-        assert "seer.pr_attribution.unrecognized_provider" not in _warning_events(mock_logger)
+        assert "pr_metrics.attribution.unrecognized_provider" not in _warning_events(mock_logger)
 
     def test_skips_unknown_provider_when_ambiguous(self) -> None:
         self.create_repo(self.project, name=REPO_NAME, provider="integrations:gitlab")
@@ -150,14 +150,14 @@ class AttributeSeerCreatedPullRequestsTest(TestCase):
         # Two same-named repos under different providers — refuse to guess, warn.
         assert not PullRequest.objects.exists()
         assert not PullRequestAttribution.objects.exists()
-        assert "seer.pr_attribution.repo_ambiguous" in _warning_events(mock_logger)
+        assert "pr_metrics.attribution.repo_ambiguous" in _warning_events(mock_logger)
 
     def test_warns_on_unrecognized_provider(self) -> None:
         with patch("sentry.pr_metrics.attribution.logger") as mock_logger:
             self._attribute(self._payload(provider="subversion"))
 
         # An unmapped provider is flagged so it can be fixed upstream in Seer.
-        assert "seer.pr_attribution.unrecognized_provider" in _warning_events(mock_logger)
+        assert "pr_metrics.attribution.unrecognized_provider" in _warning_events(mock_logger)
 
     def test_one_entry_failure_does_not_drop_the_batch(self) -> None:
         payload = self._payload(pr_number=1) + self._payload(pr_number=2)
@@ -174,7 +174,7 @@ class AttributeSeerCreatedPullRequestsTest(TestCase):
         # The second entry is still attempted after the first one raises.
         assert mock_record.call_count == 2
         exception_events = [call.args[0] for call in mock_logger.exception.call_args_list]
-        assert "seer.pr_attribution.record_failed" in exception_events
+        assert "pr_metrics.attribution.record_failed" in exception_events
 
     def test_skips_entries_missing_fields(self) -> None:
         self._attribute(
@@ -277,7 +277,7 @@ class AttributeDelegatedAgentPullRequestTest(TestCase):
             self._attribute(pr_url="https://github.com/getsentry/sentry/pulls")
 
         assert not PullRequestAttribution.objects.exists()
-        assert "seer.pr_attribution.invalid_pr_url" in _warning_events(mock_logger)
+        assert "pr_metrics.attribution.invalid_pr_url" in _warning_events(mock_logger)
 
     def test_skips_branch_url(self) -> None:
         # A delegated agent can report a branch/tree URL; its trailing segment must
@@ -286,14 +286,14 @@ class AttributeDelegatedAgentPullRequestTest(TestCase):
             self._attribute(pr_url="https://github.com/getsentry/sentry/tree/123")
 
         assert not PullRequestAttribution.objects.exists()
-        assert "seer.pr_attribution.invalid_pr_url" in _warning_events(mock_logger)
+        assert "pr_metrics.attribution.invalid_pr_url" in _warning_events(mock_logger)
 
     def test_skips_when_repository_not_found(self) -> None:
         with patch("sentry.pr_metrics.attribution.logger") as mock_logger:
             self._attribute(repo_full_name="getsentry/does-not-exist")
 
         assert not PullRequestAttribution.objects.exists()
-        assert "seer.pr_attribution.repo_not_found" in _warning_events(mock_logger)
+        assert "pr_metrics.attribution.repo_not_found" in _warning_events(mock_logger)
 
     def test_attributes_against_the_given_org_only(self) -> None:
         other_org = self.create_organization()

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -173,6 +173,7 @@ class PrMetricsEmissionTest(TestCase):
             "pr_metrics.select_verdict.metrics_row_missing",
             extra={
                 "organization_id": self.organization.id,
+                "repository_id": self.pull_request.repository_id,
                 "pull_request_id": self.pull_request.id,
             },
         )
@@ -188,6 +189,7 @@ class PrMetricsEmissionTest(TestCase):
             "pr_metrics.select_verdict.metrics_row_missing",
             extra={
                 "organization_id": self.organization.id,
+                "repository_id": self.pull_request.repository_id,
                 "pull_request_id": self.pull_request.id,
             },
         )

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -248,8 +248,14 @@ class HandleWebhookForPrMetricsTest(TestCase):
             )
 
         mock_logger.warning.assert_called_once_with(
-            "github.pr_metrics.pr_not_found",
-            extra={"repository_id": self.repo.id, "pr_number": 9999},
+            "pr_metrics.pr_not_found",
+            extra={
+                "organization_id": self.organization.id,
+                "repository_id": self.repo.id,
+                "repo_name": self.repo.name,
+                "pr_number": 9999,
+                "github_delivery_id": None,
+            },
         )
         assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
 
@@ -442,8 +448,14 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
             repo=self.repo,
         )
         mock_logger.warning.assert_called_once_with(
-            "github.pr_metrics.pr_not_found",
-            extra={"repository_id": self.repo.id, "pr_number": 9999},
+            "pr_metrics.pr_not_found",
+            extra={
+                "organization_id": self.organization.id,
+                "repository_id": self.repo.id,
+                "repo_name": self.repo.name,
+                "pr_number": 9999,
+                "github_delivery_id": None,
+            },
         )
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
 
@@ -995,8 +1007,15 @@ class HandleCommentForPrMetricsTest(TestCase):
             )
 
         mock_logger.warning.assert_called_once_with(
-            "github.pr_metrics.comment.pr_not_found",
-            extra={"repository_id": self.repo.id, "issue_number": 9999},
+            "pr_metrics.comment.pr_not_found",
+            extra={
+                "organization_id": self.organization.id,
+                "repository_id": self.repo.id,
+                "repo_name": self.repo.name,
+                "pr_number": 9999,
+                "action": "created",
+                "github_delivery_id": "delivery-unknown",
+            },
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
@@ -1110,8 +1129,14 @@ class HandleReviewForPrMetricsTest(TestCase):
             )
 
         mock_logger.warning.assert_called_once_with(
-            "github.pr_metrics.pr_not_found",
-            extra={"repository_id": self.repo.id, "pr_number": 9999},
+            "pr_metrics.pr_not_found",
+            extra={
+                "organization_id": self.organization.id,
+                "repository_id": self.repo.id,
+                "repo_name": self.repo.name,
+                "pr_number": 9999,
+                "github_delivery_id": "delivery-x",
+            },
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
@@ -1209,8 +1234,14 @@ class HandleReviewCommentForPrMetricsTest(TestCase):
             )
 
         mock_logger.warning.assert_called_once_with(
-            "github.pr_metrics.pr_not_found",
-            extra={"repository_id": self.repo.id, "pr_number": 9999},
+            "pr_metrics.pr_not_found",
+            extra={
+                "organization_id": self.organization.id,
+                "repository_id": self.repo.id,
+                "repo_name": self.repo.name,
+                "pr_number": 9999,
+                "github_delivery_id": "delivery-x",
+            },
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
@@ -1301,8 +1332,14 @@ class HandleReviewThreadForPrMetricsTest(TestCase):
             )
 
         mock_logger.warning.assert_called_once_with(
-            "github.pr_metrics.pr_not_found",
-            extra={"repository_id": self.repo.id, "pr_number": 9999},
+            "pr_metrics.pr_not_found",
+            extra={
+                "organization_id": self.organization.id,
+                "repository_id": self.repo.id,
+                "repo_name": self.repo.name,
+                "pr_number": 9999,
+                "github_delivery_id": "delivery-x",
+            },
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 


### PR DESCRIPTION
## Problem

The PR-metrics pipeline's logs were hard to discover and correlate:

- **Three different event-name roots** — `seer.pr_attribution.*`, `github.pr_metrics.*`, and `pr_metrics.*` — so finding everything required a wildcard rather than a single prefix.
- **Diverging keys for the same concept** — the GitHub PR number was logged as `issue_number` in the comment handler but `pr_number` everywhere else.
- **Too little context to triage** — the two high-volume webhook warnings (`pr_not_found`, `comment.pr_not_found`) carried only `repository_id`, with no `organization_id` (so they couldn't be filtered by org under the percentage rollout) and no way to tie a miss back to the raw GitHub delivery.

## Approach

- **Unify every event under the `pr_metrics.*` root** (`seer.pr_attribution.*` → `pr_metrics.attribution.*`, `github.pr_metrics.*` → `pr_metrics.*`), so a single `message:"pr_metrics.*"` prefix finds them all.
- **Apply one canonical `extra` schema**: `organization_id`, `repository_id`, `repo_name`, `pull_request_id`, `pr_number`, plus webhook `action` / `github_delivery_id`.
- **Enrich the live warnings**: add `organization_id`, `repo_name`, the webhook `action`, and `github_delivery_id` (threaded through `_get_pull_request`) to both `pr_not_found` variants — so an unexpected miss can be traced to the exact GitHub delivery. The `enqueue_failed` error and the `needs_judge` / `metrics_row_missing` / `recorded` logs gain the same identifiers; delegated-agent attribution gains `provider`.

No behavior change beyond logging.

## Notes

- The renamed event names will orphan any saved query/alert keyed on the old `github.pr_metrics.*` / `seer.pr_attribution.*` names (none known to exist yet).
- The webhooks logger name (`sentry.webhooks`) is intentionally left unchanged to avoid colliding with the shared GitHub-webhook logging config; the event-name unification provides discoverability regardless.