### PR TITLE
ci(snapshots): Run frontend snapshots on all PRs

### DIFF
--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -14,25 +14,7 @@ env:
   NODE_OPTIONS: '--max-old-space-size=4096'
   SNAPSHOT_OUTPUT_DIR: .artifacts/snapshots
 jobs:
-  files-changed:
-    name: detect what files changed
-    runs-on: ubuntu-24.04
-    timeout-minutes: 3
-    outputs:
-      frontend_all: ${{ steps.changes.outputs.frontend_all }}
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Check for frontend file changes
-        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
-        id: changes
-        with:
-          token: ${{ github.token }}
-          filters: .github/file-filters.yml
-
   snapshots:
-    if: github.event_name != 'pull_request' || needs.files-changed.outputs.frontend_all == 'true'
-    needs: files-changed
     name: snapshot tests
     runs-on: ubuntu-24.04
     timeout-minutes: 20


### PR DESCRIPTION
## Summary

The `frontend-snapshots` workflow previously skipped its `snapshots` job on PRs that contained no frontend file changes. This left gaps in the stored snapshot history: backend-only PRs uploaded no base snapshots, which broke snapshot comparisons for subsequent frontend PRs that relied on those bases existing.

This change runs snapshot generation and upload unconditionally on every PR (master pushes were already always run), so every PR base has snapshots stored and the comparison chain stays complete.

## Changes

- Remove the `if:` gate (`github.event_name != 'pull_request' || frontend_all == 'true'`) from the `snapshots` job so it runs for all PRs.
- Delete the `files-changed` detection job, which existed solely to feed that gate.

## Tradeoff

Backend-only PRs now run the full snapshot job (Playwright + Chromium install, ~20 min timeout). This is intentional to keep the snapshot history complete, but is worth monitoring for CI cost.