### PR TITLE
ref(seer): Remove GPU connection pools and CPU rollout options for severity/fixability

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -115,7 +115,6 @@ from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.net.http import connection_from_url
-from sentry.options.rollout import in_random_rollout
 from sentry.plugins.base import plugins
 from sentry.quotas.base import index_data_category
 from sentry.receivers.features import record_event_processed
@@ -1964,12 +1963,6 @@ def _process_existing_aggregate(
 
 
 severity_connection_pool = connection_from_url(
-    settings.SEER_SCORING_URL,
-    retries=settings.SEER_SEVERITY_RETRIES,
-    timeout=settings.SEER_SEVERITY_TIMEOUT,  # Defaults to 300 milliseconds
-)
-
-severity_connection_pool_cpu = connection_from_url(
     settings.SEER_SUMMARIZATION_URL,
     retries=settings.SEER_SEVERITY_RETRIES,
     timeout=settings.SEER_SEVERITY_TIMEOUT,
@@ -2223,15 +2216,10 @@ def _get_severity_score(event: Event) -> tuple[float, str]:
                     "issues.severity.seer-timeout",
                     settings.SEER_SEVERITY_TIMEOUT,
                 )
-                pool = (
-                    severity_connection_pool_cpu
-                    if in_random_rollout("seer.severity.cpu-rollout")
-                    else severity_connection_pool
-                )
                 viewer_context = SeerViewerContext(organization_id=event.project.organization_id)
                 response = make_severity_score_request(
                     payload,
-                    connection_pool=pool,
+                    connection_pool=severity_connection_pool,
                     timeout=timeout,
                     viewer_context=viewer_context,
                 )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1113,18 +1113,6 @@ register(
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "seer.severity.cpu-rollout",
-    type=Float,
-    default=0.0,
-    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "seer.fixability.cpu-rollout",
-    type=Float,
-    default=0.0,
-    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "seer.night_shift.enable",
     type=Bool,
     default=False,

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -19,7 +19,6 @@ from sentry.constants import DataCategory
 from sentry.locks import locks
 from sentry.models.group import Group
 from sentry.net.http import connection_from_url
-from sentry.options.rollout import in_random_rollout
 from sentry.seer.autofix.autofix import get_trace_tree_for_event
 from sentry.seer.autofix.autofix_agent import (
     AutofixStep,
@@ -254,12 +253,7 @@ def _call_seer(
     return SummarizeIssueResponse.validate(response.json())
 
 
-fixability_connection_pool_gpu = connection_from_url(
-    settings.SEER_SCORING_URL,
-    timeout=settings.SEER_FIXABILITY_TIMEOUT,
-)
-
-fixability_connection_pool_cpu = connection_from_url(
+fixability_connection_pool = connection_from_url(
     settings.SEER_SUMMARIZATION_URL,
     timeout=settings.SEER_FIXABILITY_TIMEOUT,
 )
@@ -280,7 +274,7 @@ def make_fixability_score_request(
     viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
-        connection_pool or fixability_connection_pool_gpu,
+        connection_pool or fixability_connection_pool,
         "/v1/automation/summarize/fixability",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
         timeout=timeout,
@@ -300,15 +294,10 @@ def _generate_fixability_score(
     )
     if summary is not None:
         body["summary"] = summary
-    pool = (
-        fixability_connection_pool_cpu
-        if in_random_rollout("seer.fixability.cpu-rollout")
-        else fixability_connection_pool_gpu
-    )
     viewer_context = SeerViewerContext(organization_id=group.organization.id)
     response = make_fixability_score_request(
         body,
-        connection_pool=pool,
+        connection_pool=fixability_connection_pool,
         timeout=settings.SEER_FIXABILITY_TIMEOUT,
         viewer_context=viewer_context,
     )


### PR DESCRIPTION
+ The severity and fixability scoring migration from GPU to CPU pods is complete at 100% rollout. Remove the now-unnecessary rollout options (seer.severity.cpu-rollout, seer.fixability.cpu-rollout), the GPU connection pools, and the in_random_rollout pool selection logic. Rename the CPU pools to be the sole connection pools.
