### PR TITLE
feat(preprod): Add tracing spans to snapshot details GET handler

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -383,10 +383,13 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             session = get_preprod_session(organization.id, artifact.project_id)
             get_response = session.get(manifest_key)
             with sentry_sdk.start_span(
+                op="preprod.snapshot.read_manifest", name="read_head_manifest"
+            ):
+                raw_manifest = get_response.payload.read()
+            with sentry_sdk.start_span(
                 op="preprod.snapshot.parse_manifest", name="parse_head_manifest"
             ) as span:
-                manifest_data = orjson.loads(get_response.payload.read())
-                manifest = SnapshotManifest(**manifest_data)
+                manifest = SnapshotManifest(**orjson.loads(raw_manifest))
                 span.set_data("image_count", len(manifest.images))
         except Exception:
             logger.exception(
@@ -431,10 +434,14 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             if comparison_key:
                 try:
                     with sentry_sdk.start_span(
+                        op="preprod.snapshot.read_manifest", name="read_comparison_manifest"
+                    ):
+                        raw_comparison_manifest = session.get(comparison_key).payload.read()
+                    with sentry_sdk.start_span(
                         op="preprod.snapshot.parse_manifest", name="parse_comparison_manifest"
                     ) as span:
                         comparison_manifest = ComparisonManifest(
-                            **orjson.loads(session.get(comparison_key).payload.read())
+                            **orjson.loads(raw_comparison_manifest)
                         )
                         span.set_data("image_count", len(comparison_manifest.images))
                 except Exception:
@@ -451,11 +458,13 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             if base_manifest_key:
                 try:
                     with sentry_sdk.start_span(
+                        op="preprod.snapshot.read_manifest", name="read_base_manifest"
+                    ):
+                        raw_base_manifest = session.get(base_manifest_key).payload.read()
+                    with sentry_sdk.start_span(
                         op="preprod.snapshot.parse_manifest", name="parse_base_manifest"
                     ) as span:
-                        base_manifest = SnapshotManifest(
-                            **orjson.loads(session.get(base_manifest_key).payload.read())
-                        )
+                        base_manifest = SnapshotManifest(**orjson.loads(raw_base_manifest))
                         span.set_data("image_count", len(base_manifest.images))
                 except Exception:
                     logger.exception(

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 import jsonschema
 import orjson
 import pydantic
+import sentry_sdk
 import zstandard
 from django.conf import settings
 from django.db import IntegrityError, router, transaction
@@ -381,8 +382,12 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         try:
             session = get_preprod_session(organization.id, artifact.project_id)
             get_response = session.get(manifest_key)
-            manifest_data = orjson.loads(get_response.payload.read())
-            manifest = SnapshotManifest(**manifest_data)
+            with sentry_sdk.start_span(
+                op="preprod.snapshot.parse_manifest", name="parse_head_manifest"
+            ) as span:
+                manifest_data = orjson.loads(get_response.payload.read())
+                manifest = SnapshotManifest(**manifest_data)
+                span.set_data("image_count", len(manifest.images))
         except Exception:
             logger.exception(
                 "Failed to retrieve snapshot manifest",
@@ -425,9 +430,13 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             comparison_key = (comparison.extras or {}).get("comparison_key")
             if comparison_key:
                 try:
-                    comparison_manifest = ComparisonManifest(
-                        **orjson.loads(session.get(comparison_key).payload.read())
-                    )
+                    with sentry_sdk.start_span(
+                        op="preprod.snapshot.parse_manifest", name="parse_comparison_manifest"
+                    ) as span:
+                        comparison_manifest = ComparisonManifest(
+                            **orjson.loads(session.get(comparison_key).payload.read())
+                        )
+                        span.set_data("image_count", len(comparison_manifest.images))
                 except Exception:
                     comparison_manifest = None
                     logger.exception(
@@ -441,9 +450,13 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             base_manifest_key = (comparison.base_snapshot_metrics.extras or {}).get("manifest_key")
             if base_manifest_key:
                 try:
-                    base_manifest = SnapshotManifest(
-                        **orjson.loads(session.get(base_manifest_key).payload.read())
-                    )
+                    with sentry_sdk.start_span(
+                        op="preprod.snapshot.parse_manifest", name="parse_base_manifest"
+                    ) as span:
+                        base_manifest = SnapshotManifest(
+                            **orjson.loads(session.get(base_manifest_key).payload.read())
+                        )
+                        span.set_data("image_count", len(base_manifest.images))
                 except Exception:
                     logger.exception(
                         "Failed to fetch base manifest",
@@ -484,10 +497,14 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                     is not None
                 )
 
-        image_list = [
-            build_snapshot_image_response(key, metadata, manifest.diff_threshold)
-            for key, metadata in sorted(manifest.images.items())
-        ]
+        with sentry_sdk.start_span(
+            op="preprod.snapshot.serialize_images", name="serialize_head_images"
+        ) as span:
+            span.set_data("image_count", len(manifest.images))
+            image_list = [
+                build_snapshot_image_response(key, metadata, manifest.diff_threshold)
+                for key, metadata in sorted(manifest.images.items())
+            ]
 
         images_by_file_name: dict[str, SnapshotImageResponse] = {
             img.image_file_name: img for img in image_list
@@ -497,9 +514,13 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
 
         if comparison_manifest is not None:
             base_artifact_id = str(comparison_manifest.base_artifact_id)
-            categorized = categorize_comparison_images(
-                comparison_manifest, images_by_file_name, base_manifest
-            )
+            with sentry_sdk.start_span(
+                op="preprod.snapshot.categorize_comparison", name="categorize_comparison_images"
+            ) as span:
+                span.set_data("image_count", len(comparison_manifest.images))
+                categorized = categorize_comparison_images(
+                    comparison_manifest, images_by_file_name, base_manifest
+                )
         else:
             if comparison is not None:
                 base_artifact_id = str(comparison.base_snapshot_metrics.preprod_artifact_id)
@@ -594,45 +615,49 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             )
         )
 
-        response_data = SnapshotDetailsApiResponse(
-            head_artifact_id=str(artifact.id),
-            base_artifact_id=base_artifact_id,
-            project_id=str(artifact.project_id),
-            comparison_type=comparison_type,
-            state=artifact.state,
-            vcs_info=vcs_info,
-            app_id=artifact.app_id,
-            is_selective=snapshot_metrics.is_selective,
-            images=image_list,
-            image_count=snapshot_metrics.image_count,
-            changed=categorized.changed,
-            changed_count=len(categorized.changed),
-            added=categorized.added,
-            added_count=len(categorized.added),
-            removed=categorized.removed,
-            removed_count=len(categorized.removed),
-            renamed=categorized.renamed,
-            renamed_count=len(categorized.renamed),
-            unchanged=categorized.unchanged,
-            unchanged_count=len(categorized.unchanged),
-            errored=categorized.errored,
-            errored_count=len(categorized.errored),
-            skipped=categorized.skipped,
-            skipped_count=len(categorized.skipped),
-            diff_threshold=manifest.diff_threshold,
-            comparison_state=derived_status.comparison_state,
-            approval_status=derived_status.approval_status,
-            comparison_error_message=derived_status.comparison_error_message,
-            approvers=approver_list if approved else [],
-        ).dict()
+        with sentry_sdk.start_span(
+            op="preprod.snapshot.serialize_response", name="serialize_response_body"
+        ) as span:
+            span.set_data("image_count", len(image_list))
+            response_data = SnapshotDetailsApiResponse(
+                head_artifact_id=str(artifact.id),
+                base_artifact_id=base_artifact_id,
+                project_id=str(artifact.project_id),
+                comparison_type=comparison_type,
+                state=artifact.state,
+                vcs_info=vcs_info,
+                app_id=artifact.app_id,
+                is_selective=snapshot_metrics.is_selective,
+                images=image_list,
+                image_count=snapshot_metrics.image_count,
+                changed=categorized.changed,
+                changed_count=len(categorized.changed),
+                added=categorized.added,
+                added_count=len(categorized.added),
+                removed=categorized.removed,
+                removed_count=len(categorized.removed),
+                renamed=categorized.renamed,
+                renamed_count=len(categorized.renamed),
+                unchanged=categorized.unchanged,
+                unchanged_count=len(categorized.unchanged),
+                errored=categorized.errored,
+                errored_count=len(categorized.errored),
+                skipped=categorized.skipped,
+                skipped_count=len(categorized.skipped),
+                diff_threshold=manifest.diff_threshold,
+                comparison_state=derived_status.comparison_state,
+                approval_status=derived_status.approval_status,
+                comparison_error_message=derived_status.comparison_error_message,
+                approvers=approver_list if approved else [],
+            ).dict()
 
-        if compact:
-            for key in _COMPACT_IMAGE_LIST_KEYS:
-                response_data[key] = [_strip_to_compact(img) for img in response_data[key]]
-            for key in _COMPACT_PAIR_LIST_KEYS:
-                for pair in response_data[key]:
-                    pair["base_image"] = _strip_to_compact(pair["base_image"])
-                    pair["head_image"] = _strip_to_compact(pair["head_image"])
+            if compact:
+                for key in _COMPACT_IMAGE_LIST_KEYS:
+                    response_data[key] = [_strip_to_compact(img) for img in response_data[key]]
+                for key in _COMPACT_PAIR_LIST_KEYS:
+                    for pair in response_data[key]:
+                        pair["base_image"] = _strip_to_compact(pair["base_image"])
+                        pair["head_image"] = _strip_to_compact(pair["head_image"])
 
         # cast() sanctioned here: pydantic .dict() returns dict[str, Any] with no
         # static link back to SnapshotDetailsResponseDict. The TypedDict and the


### PR DESCRIPTION
The CPU-bound work in the snapshot details GET handler (`OrganizationPreprodSnapshotEndpoint.get`) was entirely uninstrumented. In production traces, `base.dispatch.execute` ran for multiple seconds (~2.5s and ~5.2s in two sampled traces) while DB, cache, and objectstore HTTP spans accounted for only a few hundred milliseconds — the rest showed up as one flat, unattributed gap.

This wraps each per-image hot region in a `sentry_sdk` span so that gap becomes legible: the three manifest decodes (`parse_head_manifest` / `parse_comparison_manifest` / `parse_base_manifest`), head-image serialization (`serialize_head_images`), comparison categorization (`categorize_comparison_images`), and the final response-body assembly (`serialize_response_body`). Each span records an `image_count` attribute so cost can be correlated with snapshot size.

This is purely additive observability with no behavior change. The intent is to identify which region dominates before making a targeted optimization in a follow-up — the suspected hot spots are the per-image Pydantic serialization passes, which these spans will confirm.