### PR TITLE
ref(preprod): Derive solo snapshot list from categorized arrays

### DIFF
--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -53,6 +53,7 @@ import {
   type SidebarSection,
   SnapshotSidebarContent,
 } from './sidebar/snapshotSidebarContent';
+import {buildSoloImages} from './soloImages';
 import {TagFilterProvider} from './tagFilterContext';
 import {narrowItemByTags} from './tagFiltering';
 
@@ -336,7 +337,7 @@ export default function SnapshotsPage() {
       return items;
     }
 
-    return [...groupByKey(data.images, imageGroupKey).entries()]
+    return [...groupByKey(buildSoloImages(data), imageGroupKey).entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([groupKey, images]) => ({
         type: 'solo' as const,

--- a/static/app/views/preprod/snapshots/soloImages.spec.ts
+++ b/static/app/views/preprod/snapshots/soloImages.spec.ts
@@ -1,0 +1,97 @@
+import {buildSoloImages} from 'sentry/views/preprod/snapshots/soloImages';
+import type {
+  SnapshotDetailsApiResponse,
+  SnapshotDiffPair,
+  SnapshotImage,
+} from 'sentry/views/preprod/types/snapshotTypes';
+
+function img(name: string, key = name): SnapshotImage {
+  return {
+    image_file_name: name,
+    display_name: name,
+    key,
+    width: 10,
+    height: 10,
+    tags: null,
+  };
+}
+
+function pair(name: string): SnapshotDiffPair {
+  return {
+    head_image: img(name, `${name}-head`),
+    base_image: img(name, `${name}-base`),
+    diff: 0.1,
+    diff_image_key: null,
+  };
+}
+
+function response(
+  overrides: Partial<SnapshotDetailsApiResponse>
+): SnapshotDetailsApiResponse {
+  return {
+    comparison_type: 'diff',
+    images: [],
+    added: [],
+    changed: [],
+    removed: [],
+    unchanged: [],
+    ...overrides,
+  } as SnapshotDetailsApiResponse;
+}
+
+describe('buildSoloImages', () => {
+  it('returns data.images unchanged for a solo comparison', () => {
+    const images = [img('b.png'), img('a.png')];
+    expect(buildSoloImages(response({comparison_type: 'solo', images}))).toBe(images);
+  });
+
+  it('returns data.images for waiting_for_base', () => {
+    const images = [img('a.png')];
+    expect(buildSoloImages(response({comparison_type: 'waiting_for_base', images}))).toBe(
+      images
+    );
+  });
+
+  it('derives the head-side union sorted by image_file_name for a diff', () => {
+    const result = buildSoloImages(
+      response({
+        comparison_type: 'diff',
+        unchanged: [img('c.png')],
+        changed: [pair('a.png')],
+        added: [img('b.png')],
+      })
+    );
+    expect(result.map(i => i.image_file_name)).toEqual(['a.png', 'b.png', 'c.png']);
+    // changed entries use head_image
+    expect(result[0]!.key).toBe('a.png-head');
+  });
+
+  it('excludes removed (base-only) images in a diff', () => {
+    const result = buildSoloImages(
+      response({
+        comparison_type: 'diff',
+        unchanged: [img('keep.png')],
+        removed: [img('gone.png')],
+      })
+    );
+    expect(result.map(i => i.image_file_name)).toEqual(['keep.png']);
+  });
+
+  it('ignores data.images when deriving a diff (backward compatible)', () => {
+    const result = buildSoloImages(
+      response({
+        comparison_type: 'diff',
+        images: [img('stale.png')],
+        unchanged: [img('real.png')],
+      })
+    );
+    expect(result.map(i => i.image_file_name)).toEqual(['real.png']);
+  });
+
+  it('handles missing optional renamed/errored arrays', () => {
+    const result = buildSoloImages(
+      response({comparison_type: 'diff', unchanged: [img('a.png')]})
+    );
+    expect(result.map(i => i.image_file_name)).toEqual(['a.png']);
+  });
+});

--- a/static/app/views/preprod/snapshots/soloImages.ts
+++ b/static/app/views/preprod/snapshots/soloImages.ts
@@ -1,0 +1,17 @@
+import type {
+  SnapshotDetailsApiResponse,
+  SnapshotImage,
+} from 'sentry/views/preprod/types/snapshotTypes';
+
+export function buildSoloImages(data: SnapshotDetailsApiResponse): SnapshotImage[] {
+  if (data.comparison_type === 'diff') {
+    return [
+      ...data.unchanged,
+      ...data.changed.map(p => p.head_image),
+      ...data.added,
+      ...(data.renamed ?? []).map(p => p.head_image),
+      ...(data.errored ?? []).map(p => p.head_image),
+    ].sort((a, b) => a.image_file_name.localeCompare(b.image_file_name));
+  }
+  return data.images ?? [];
+}

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -36,7 +36,7 @@ export interface SnapshotDetailsApiResponse {
   comparison_type: 'solo' | 'diff' | 'waiting_for_base';
   head_artifact_id: string;
   image_count: number;
-  images: SnapshotImage[];
+  images?: SnapshotImage[];
   project_id: string;
   state: string;
   vcs_info: BuildDetailsVcsInfo;


### PR DESCRIPTION
## Summary

The preprod snapshot comparison GET endpoint returns a top-level `images` array with the full head-snapshot image list. In `diff` mode this is pure redundancy: every head image already appears in the categorized arrays (`unchanged`, `changed.head_image`, `added`, `renamed.head_image`, `errored.head_image`). On large diffs that duplicate array is ~45% of the payload (e.g. ~13 MB of a ~29 MB response on a 37k-image build).

This PR makes the frontend stop depending on the top-level `images` array in `diff` mode so a follow-up backend PR can drop it entirely — avoiding having to paginate these responses.

## What changed

- Add `buildSoloImages(data)`: for a `diff` comparison it derives the solo-view image list from the categorized arrays (head-side only, sorted by `image_file_name` to match the backend's current emission order); for `solo`/`waiting_for_base` it returns `data.images` unchanged.
- Route the solo-view `useMemo` through `buildSoloImages(data)` instead of reading `data.images` directly. This also covers the `?view=solo` toggle on a diff comparison.
- Make `SnapshotDetailsApiResponse.images` optional, anticipating the backend dropping it for diffs.

## Why the reconstruction is faithful

`skipped` and `removed` are always base-only (subsets of base image names, disjoint from head names — see `categorize.py`), so excluding them drops nothing head-side. Every head-manifest image lands in exactly one of `{unchanged, changed, added, renamed, errored}` by name, so the derived union equals the head manifest exactly — identical to today's `data.images`.

## Deploy ordering

Frontend-first, intentionally. This is the FE half of a 2-PR change; the backend removal of `images` for diffs lands in a stacked follow-up **after** this deploys. In this order the redundant field is merely ignored during the deploy gap rather than missing.

## Tests

New `soloImages.spec.ts` (6 cases): solo/waiting passthrough, diff derivation + sort order, `head_image` selection for pairs, `removed` exclusion, backward-compat (ignores stale `images` in diff mode), and missing optional arrays.
