### PR TITLE
perf(preprod): Drop redundant images array from diff snapshots

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -637,7 +637,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 vcs_info=vcs_info,
                 app_id=artifact.app_id,
                 is_selective=snapshot_metrics.is_selective,
-                images=image_list,
+                images=image_list if comparison_type != "diff" else [],
                 image_count=snapshot_metrics.image_count,
                 changed=categorized.changed,
                 changed_count=len(categorized.changed),

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -733,6 +733,137 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert response.data["images"][0]["key"] == "img000"
         assert response.data["images"][9]["key"] == "img009"
 
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    def test_get_snapshot_diff_omits_images(self, mock_get_session):
+        from sentry.preprod.snapshots.manifest import (
+            ComparisonImageResult,
+            ComparisonManifest,
+            ComparisonSummary,
+            ImageMetadata,
+            SnapshotManifest,
+        )
+
+        head_images = {
+            "changed.png": {
+                "content_hash": "head_changed",
+                "display_name": "Changed",
+                "width": 100,
+                "height": 100,
+            },
+            "unchanged.png": {
+                "content_hash": "head_unchanged",
+                "display_name": "Unchanged",
+                "width": 100,
+                "height": 100,
+            },
+        }
+        artifact, head_metrics, head_manifest_key, head_manifest_json, _ = (
+            self._create_artifact_with_manifest(images=head_images)
+        )
+
+        base_artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.UPLOADED,
+            app_id="com.example.app",
+        )
+        base_manifest_key = f"{self.org.id}/{self.project.id}/{base_artifact.id}/manifest.json"
+        PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            image_count=2,
+            extras={"manifest_key": base_manifest_key},
+        )
+        base_manifest_json = orjson.dumps(
+            SnapshotManifest(
+                images={
+                    "changed.png": ImageMetadata(
+                        content_hash="base_changed", width=100, height=100
+                    ),
+                    "unchanged.png": ImageMetadata(
+                        content_hash="head_unchanged", width=100, height=100
+                    ),
+                }
+            ).dict()
+        )
+
+        comparison = self.create_preprod_snapshot_comparison(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=PreprodSnapshotMetrics.objects.get(
+                preprod_artifact=base_artifact
+            ),
+            state=PreprodSnapshotComparison.State.SUCCESS,
+            images_changed=1,
+            images_unchanged=1,
+        )
+        comparison_key = (
+            f"{self.org.id}/{self.project.id}/{artifact.id}/{base_artifact.id}/comparison.json"
+        )
+        comparison.extras = {"comparison_key": comparison_key}
+        comparison.save(update_fields=["extras"])
+
+        comparison_manifest_json = orjson.dumps(
+            ComparisonManifest(
+                head_artifact_id=artifact.id,
+                base_artifact_id=base_artifact.id,
+                summary=ComparisonSummary(
+                    total=2,
+                    changed=1,
+                    unchanged=1,
+                    added=0,
+                    removed=0,
+                    errored=0,
+                    renamed=0,
+                    skipped=0,
+                ),
+                images={
+                    "changed.png": ComparisonImageResult(
+                        status="changed",
+                        head_hash="head_changed",
+                        base_hash="base_changed",
+                        changed_pixels=50,
+                        total_pixels=100,
+                        diff_mask_image_id="diff-mask-1",
+                    ),
+                    "unchanged.png": ComparisonImageResult(
+                        status="unchanged",
+                        head_hash="head_unchanged",
+                        base_hash="head_unchanged",
+                    ),
+                },
+            ).dict()
+        )
+
+        manifests_by_key = {
+            head_manifest_key: head_manifest_json,
+            base_manifest_key: base_manifest_json,
+            comparison_key: comparison_manifest_json,
+        }
+
+        def _session_get(key):
+            result = MagicMock()
+            result.payload.read.return_value = manifests_by_key[key]
+            return result
+
+        mock_session = MagicMock()
+        mock_session.get.side_effect = _session_get
+        mock_get_session.return_value = mock_session
+
+        url = self._get_detail_url(artifact.id)
+        with self.feature("organizations:preprod-snapshots"):
+            response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.data["comparison_type"] == "diff"
+        # Categorized arrays are still populated...
+        assert response.data["changed_count"] == 1
+        assert len(response.data["changed"]) == 1
+        assert response.data["changed"][0]["head_image"]["image_file_name"] == "changed.png"
+        assert response.data["unchanged_count"] == 1
+        assert response.data["unchanged"][0]["image_file_name"] == "unchanged.png"
+        # ...but the redundant flat images array is dropped in diff mode.
+        assert response.data["images"] == []
+        # image_count is unaffected.
+        assert response.data["image_count"] == 2
+
     def test_get_snapshot_not_found(self) -> None:
         url = self._get_detail_url(99999)
         with self.feature("organizations:preprod-snapshots"):


### PR DESCRIPTION
## Summary

Companion backend PR to #118178. In `diff` mode the preprod snapshot comparison GET endpoint's top-level `images` array is a byte-identical duplicate of the head-side images already present in the categorized arrays (`unchanged`, `changed.head_image`, `added`, `renamed.head_image`, `errored.head_image`). This drops it for diffs, cutting ~45% of the payload on large comparisons (~13 MB of a ~29 MB / 37k-image response) and avoiding the need to paginate.

`solo` and `waiting_for_base` responses are unchanged — those modes have empty categorized arrays, so `images` remains their only source. `image_count` is unaffected in all modes.

## Change

One line in the response assembly:

```python
images=image_list if comparison_type != "diff" else [],
```

## Tests

New `test_get_snapshot_diff_omits_images`: drives the endpoint into diff mode and asserts the categorized arrays stay populated (`changed` / `unchanged`) while `images == []` and `image_count` stays accurate. This is also the first diff-mode coverage for this GET endpoint.

## ⚠️ Merge ordering

Draft until #118178 (frontend) is deployed. The frontend must stop reading `data.images` in diff mode before this removes it; merging this first would break the live frontend's solo-view toggle during the deploy gap. Mark ready / merge only after the FE PR has shipped.
