### PR TITLE
fix(replays): stop refetching replay-count for viewers without access

### DIFF
--- a/static/app/utils/queryClient.spec.tsx
+++ b/static/app/utils/queryClient.spec.tsx
@@ -3,7 +3,8 @@ import {Fragment} from 'react';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {DEFAULT_QUERY_CLIENT_CONFIG, useApiQuery} from 'sentry/utils/queryClient';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 
 type ResponseData = {
   value: number;
@@ -90,6 +91,31 @@ describe('queryClient', () => {
       render(<TestComponent />);
 
       expect(await screen.findByText('something bad happened')).toBeInTheDocument();
+    });
+  });
+
+  describe('default retry', () => {
+    const retry = DEFAULT_QUERY_CLIENT_CONFIG.defaultOptions?.queries?.retry as (
+      failureCount: number,
+      error: Error
+    ) => boolean;
+
+    const errorWithStatus = (status: number) => {
+      const err = new RequestError('GET', '/x/', new Error('request failed'));
+      err.status = status;
+      return err;
+    };
+
+    it.each([400, 401, 403, 404])('does not retry on %s status', status => {
+      expect(retry(0, errorWithStatus(status))).toBe(false);
+    });
+
+    it.each([
+      [0, true],
+      [2, true],
+      [3, false],
+    ])('retries other errors when failureCount is %i', (failureCount, expected) => {
+      expect(retry(failureCount, errorWithStatus(500))).toBe(expected);
     });
   });
 });

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -16,6 +16,8 @@ import {normalizeQueryKey} from 'sentry/utils/api/apiQueryKey';
 import type {ApiQueryKey, QueryKeyEndpointOptions} from 'sentry/utils/api/apiQueryKey';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 
+const nonRetryCodes = new Set<number | undefined>([400, 401, 403, 404]);
+
 // Overrides to the default react-query options.
 // See https://tanstack.com/query/v5/docs/framework/react/guides/important-defaults
 export const DEFAULT_QUERY_CLIENT_CONFIG: QueryClientConfig = {
@@ -24,8 +26,8 @@ export const DEFAULT_QUERY_CLIENT_CONFIG: QueryClientConfig = {
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
       retry: (failureCount, err) => {
-        // Disable retries for 400 status code
-        if (err instanceof RequestError && err.status === 400) {
+        // Disable retries for client errors that won't succeed on retry
+        if (err instanceof RequestError && nonRetryCodes.has(err.status)) {
           return false;
         }
 

--- a/static/app/utils/replayCount/useReplayCount.spec.tsx
+++ b/static/app/utils/replayCount/useReplayCount.spec.tsx
@@ -165,6 +165,50 @@ describe('useReplayCount', () => {
     });
   });
 
+  describe('replay access gating', () => {
+    it('does not request counts when the viewer lacks replay access', async () => {
+      const deniedOrg = OrganizationFixture({
+        hasGranularReplayPermissions: true,
+        replayAccessMembers: [],
+      });
+      const mockRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${deniedOrg.slug}/replay-count/`,
+        body: {'1111': 5},
+      });
+
+      const {result} = renderHookWithProviders(useReplayCount, {
+        organization: deniedOrg,
+        initialProps: {...initialProps, organization: deniedOrg},
+      });
+
+      await waitFor(() => expect(result.current.getOne('1111')).toBeUndefined());
+      expect(result.current.getMany(['1111', '2222'])).toStrictEqual({});
+      expect(result.current.hasOne('1111')).toBeUndefined();
+      expect(result.current.hasMany(['1111', '2222'])).toStrictEqual({});
+      expect(mockRequest).not.toHaveBeenCalled();
+    });
+
+    it('requests counts when the viewer is on the replay allowlist', async () => {
+      const allowedOrg = OrganizationFixture({
+        hasGranularReplayPermissions: true,
+        replayAccessMembers: [1],
+      });
+      const mockRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${allowedOrg.slug}/replay-count/`,
+        body: {'1111': 5},
+      });
+
+      const {result} = renderHookWithProviders(useReplayCount, {
+        organization: allowedOrg,
+        initialProps: {...initialProps, organization: allowedOrg},
+      });
+
+      result.current.getOne('1111');
+
+      await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+    });
+  });
+
   describe('query construction', () => {
     it('should quote ids when fieldName is "transaction"', async () => {
       const mockRequest = getMockRequest({

--- a/static/app/utils/replayCount/useReplayCount.tsx
+++ b/static/app/utils/replayCount/useReplayCount.tsx
@@ -3,6 +3,7 @@ import {useCallback} from 'react';
 import type {Organization} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useAggregatedQueryKeys} from 'sentry/utils/api/useAggregatedQueryKeys';
+import {useHasReplayAccess} from 'sentry/utils/replays/hooks/useHasReplayAccess';
 
 interface Props {
   bufferLimit: number;
@@ -53,6 +54,8 @@ export function useReplayCount({
   start,
   end,
 }: Props) {
+  const hasReplayAccess = useHasReplayAccess();
+
   const _statsPeriod = start && end ? undefined : statsPeriod;
   const cachePeriod = start && end ? `${start}-${end}` : statsPeriod;
 
@@ -89,19 +92,25 @@ export function useReplayCount({
 
   const getMany = useCallback(
     (ids: readonly string[]) => {
+      if (!hasReplayAccess) {
+        return {};
+      }
       cache.buffer(ids);
       return filterKeysInList(cache.data ?? {}, ids);
     },
-    [cache]
+    [cache, hasReplayAccess]
   );
 
   const getOne = useCallback(
     (id: string) => {
+      if (!hasReplayAccess) {
+        return;
+      }
       cache.buffer([id]);
 
       return cache.data?.[id];
     },
-    [cache]
+    [cache, hasReplayAccess]
   );
 
   const hasMany = useCallback(


### PR DESCRIPTION
I'm seeing the occasional user getting hundreds or even thousands of `403 FORBIDDEN` responses within a minute or so. It looks like the problem is we only block retries on 400s, not similar 40*s. This PR does two things to fix that:

* (specific) `useReplayCount`: stops trying to request if `useHasReplayAccess` says the user doesn't have access
* (general) `queryClient`: broadens the default no-retry list from `400` to `400/401/403/404` so client errors that can't succeed on retry aren't requested 3× each.

Closes LOGS-885.