### PR TITLE
feat(pr-metrics): Capture check_suite/check_run CI status for the judge

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -64,6 +64,8 @@ from sentry.plugins.providers.integration_repository import (
 )
 from sentry.pr_metrics.webhooks import handle_activity as pr_metrics_handle_activity
 from sentry.pr_metrics.webhooks import handle_attribution as pr_metrics_handle_attribution
+from sentry.pr_metrics.webhooks import handle_check_run as pr_metrics_handle_check_run
+from sentry.pr_metrics.webhooks import handle_check_suite as pr_metrics_handle_check_suite
 from sentry.pr_metrics.webhooks import handle_comment as pr_metrics_handle_comment
 from sentry.pr_metrics.webhooks import handle_emission as pr_metrics_handle_emission
 from sentry.pr_metrics.webhooks import handle_metrics as pr_metrics_handle_metrics
@@ -1137,6 +1139,7 @@ class CheckRunEventWebhook(GitHubWebhook):
     WEBHOOK_EVENT_PROCESSORS = (
         code_review_handle_webhook_event,
         handle_preprod_check_run_event,
+        pr_metrics_handle_check_run,
     )
 
 
@@ -1176,7 +1179,7 @@ class PullRequestReviewThreadEventWebhook(GitHubWebhook):
 
 class CheckSuiteWebhook(GitHubWebhook):
     EVENT_TYPE = IntegrationWebhookEventType.CHECK_SUITE
-    WEBHOOK_EVENT_PROCESSORS = ()
+    WEBHOOK_EVENT_PROCESSORS = (pr_metrics_handle_check_suite,)
 
 
 @all_silo_endpoint

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -273,6 +273,8 @@ class PullRequestComment(Model):
 
 class PullRequestActivityType(models.TextChoices):
     ASSIGNED = "assigned"
+    CHECK_RUN_COMPLETED = "check_run_completed"
+    CHECK_SUITE_COMPLETED = "check_suite_completed"
     CLOSED = "closed"
     COMMENT_CREATED = "comment_created"
     COMMENT_DELETED = "comment_deleted"

--- a/src/sentry/pr_metrics/activity_types.py
+++ b/src/sentry/pr_metrics/activity_types.py
@@ -154,3 +154,27 @@ class ReviewThreadPayload(BaseActivityPayload):
     # GitHub node_id of the review thread (the thread object has no numeric id).
     thread_id: str = ""
     is_resolved: bool = False
+
+
+@dataclass
+class CheckSuiteCompletedPayload(BaseActivityPayload):
+    action: str = "completed"
+    # Aggregate outcome of the suite: "success", "failure", "neutral",
+    # "cancelled", "timed_out", "action_required", "stale", "skipped",
+    # "startup_failure". The judge's "was CI green or red at close" signal.
+    conclusion: str = ""
+    # Slug of the GitHub App that owns the suite (e.g. "github-actions") —
+    # a bounded identifier for the CI provider, never the check's display name.
+    app_slug: str = ""
+    check_runs_count: int = 0
+
+
+@dataclass
+class CheckRunCompletedPayload(BaseActivityPayload):
+    action: str = "completed"
+    # Name of the individual check (e.g. "build", "test (3.11)"). A structural
+    # label like a status context, not free-form text.
+    check_name: str = ""
+    # Outcome of this run: same vocabulary as CheckSuiteCompletedPayload.conclusion.
+    conclusion: str = ""
+    app_slug: str = ""

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -23,6 +23,7 @@ from urllib3.exceptions import HTTPError
 from sentry.models.pullrequest import (
     PullRequest,
     PullRequestActivity,
+    PullRequestActivityType,
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
     PullRequestMetrics,
@@ -65,9 +66,38 @@ seer_pr_metrics_connection_pool = connection_from_url(
 RESULT_VERDICTS = frozenset(PullRequestVerdict.values) - {PullRequestVerdict.JUDGE_IN_PROGRESS}
 
 
+# check_run fires per check per push, so a busy PR can accumulate far more check
+# rows than the aggregate "was CI green or red at close" signal needs. Lifecycle
+# rows (reviews, labels, the close itself) are bounded in practice and forwarded
+# in full; only the most recent check rows are forwarded, which preserves the
+# final CI state while keeping the request from ballooning.
+_CHECK_EVENT_TYPES = frozenset(
+    {
+        PullRequestActivityType.CHECK_RUN_COMPLETED,
+        PullRequestActivityType.CHECK_SUITE_COMPLETED,
+    }
+)
+_MAX_FORWARDED_CHECK_ROWS = 100
+
+
 def _pr_activity_timeline(pull_request: PullRequest) -> list[PrActivityEvent]:
-    """The PR's captured activity rows, oldest first, projected for the judge."""
-    rows = PullRequestActivity.objects.filter(pull_request=pull_request).order_by("date_added")
+    """The PR's captured activity rows, oldest first, projected for the judge.
+
+    All lifecycle rows are forwarded; check rows are capped to the most recent
+    ``_MAX_FORWARDED_CHECK_ROWS`` (see comment above) so CI noise on busy PRs
+    can't balloon the Seer request.
+    """
+    rows = list(
+        PullRequestActivity.objects.filter(pull_request=pull_request).order_by("date_added")
+    )
+    check_rows = [row for row in rows if row.event_type in _CHECK_EVENT_TYPES]
+    if len(check_rows) > _MAX_FORWARDED_CHECK_ROWS:
+        kept_check_ids = {row.id for row in check_rows[-_MAX_FORWARDED_CHECK_ROWS:]}
+        rows = [
+            row
+            for row in rows
+            if row.event_type not in _CHECK_EVENT_TYPES or row.id in kept_check_ids
+        ]
     return [
         PrActivityEvent(
             event_type=row.event_type, timestamp=row.date_added.isoformat(), payload=row.payload

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -92,6 +92,19 @@ def _pr_activity_timeline(pull_request: PullRequest) -> list[PrActivityEvent]:
     )
     check_rows = [row for row in rows if row.event_type in _CHECK_EVENT_TYPES]
     if len(check_rows) > _MAX_FORWARDED_CHECK_ROWS:
+        # The cap is sized above what a normal PR produces, so hitting it is a
+        # signal worth watching: it means CI noise is dropping rows from the
+        # forward, and a persistently high rate would argue for raising the cap.
+        dropped = len(check_rows) - _MAX_FORWARDED_CHECK_ROWS
+        logger.warning(
+            "pr_metrics.judge.check_rows_capped",
+            extra={
+                "pull_request_id": pull_request.id,
+                "check_rows": len(check_rows),
+                "dropped": dropped,
+            },
+        )
+        metrics.incr("pr_metrics.judge.check_rows_capped")
         kept_check_ids = {row.id for row in check_rows[-_MAX_FORWARDED_CHECK_ROWS:]}
         rows = [
             row

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -43,6 +43,8 @@ from sentry.models.pullrequest import (
 from sentry.models.repository import Repository
 from sentry.pr_metrics.activity_types import (
     AssignedPayload,
+    CheckRunCompletedPayload,
+    CheckSuiteCompletedPayload,
     ClosedPayload,
     CommentCreatedPayload,
     CommentEditedPayload,
@@ -595,6 +597,116 @@ def handle_review_thread(
     if not webhook_id:
         return
     _write_activity_row(pr, webhook_id, event_type, payload)
+
+
+def handle_check_suite(
+    *,
+    github_event: GithubWebhookType,
+    event: Mapping[str, Any],
+    organization: Organization,
+    repo: Repository,
+    integration: RpcIntegration | None = None,
+    **kwargs: Any,
+) -> None:
+    """Record the aggregate CI outcome from a completed check_suite event.
+
+    Only ``completed`` carries a conclusion; ``requested``/``rerequested`` are
+    ignored. The suite's ``pull_requests`` array lists the same-repo PRs the run
+    pertains to (empty for fork PRs) — one activity row is written per PR.
+    """
+    if event.get("action") != "completed":
+        return
+
+    if not is_activity_tracking_enabled(organization):
+        return
+
+    webhook_id: str | None = kwargs.get("github_delivery_id")
+    if not webhook_id:
+        return
+
+    check_suite = event.get("check_suite") or {}
+    sender = event.get("sender") or {}
+    app = check_suite.get("app") or {}
+    payload = asdict(
+        CheckSuiteCompletedPayload(
+            sender_login=sender.get("login", ""),
+            sender_type=sender.get("type", ""),
+            head_sha=check_suite.get("head_sha"),
+            conclusion=check_suite.get("conclusion") or "",
+            app_slug=app.get("slug", ""),
+            check_runs_count=check_suite.get("latest_check_runs_count") or 0,
+        )
+    )
+
+    for pr in _prs_from_check_payload(organization, repo, check_suite, webhook_id):
+        _write_activity_row(pr, webhook_id, PullRequestActivityType.CHECK_SUITE_COMPLETED, payload)
+
+
+def handle_check_run(
+    *,
+    github_event: GithubWebhookType,
+    event: Mapping[str, Any],
+    organization: Organization,
+    repo: Repository,
+    integration: RpcIntegration | None = None,
+    **kwargs: Any,
+) -> None:
+    """Record an individual CI check outcome from a completed check_run event.
+
+    Per-check granularity beneath ``check_suite``; only ``completed`` carries a
+    conclusion. ``check_run.pull_requests`` resolves the affected same-repo PRs.
+    """
+    if event.get("action") != "completed":
+        return
+
+    if not is_activity_tracking_enabled(organization):
+        return
+
+    webhook_id: str | None = kwargs.get("github_delivery_id")
+    if not webhook_id:
+        return
+
+    check_run = event.get("check_run") or {}
+    sender = event.get("sender") or {}
+    app = check_run.get("app") or {}
+    payload = asdict(
+        CheckRunCompletedPayload(
+            sender_login=sender.get("login", ""),
+            sender_type=sender.get("type", ""),
+            head_sha=check_run.get("head_sha"),
+            check_name=check_run.get("name", ""),
+            conclusion=check_run.get("conclusion") or "",
+            app_slug=app.get("slug", ""),
+        )
+    )
+
+    for pr in _prs_from_check_payload(organization, repo, check_run, webhook_id):
+        _write_activity_row(pr, webhook_id, PullRequestActivityType.CHECK_RUN_COMPLETED, payload)
+
+
+def _prs_from_check_payload(
+    organization: Organization,
+    repo: Repository,
+    container: Mapping[str, Any],
+    webhook_id: str,
+) -> list[PullRequest]:
+    """Resolve the tracked PRs a check_suite/check_run payload references.
+
+    Both events carry a ``pull_requests`` array of same-repo PR refs (empty for
+    fork PRs, and a suite can span more than one PR). Numbers are deduped before
+    resolving each to its stored row; unknown PRs are dropped by ``_get_pull_request``.
+    """
+    seen: set[str] = set()
+    prs: list[PullRequest] = []
+    for ref in container.get("pull_requests") or ():
+        number = ref.get("number")
+        if number is None or str(number) in seen:
+            continue
+        seen.add(str(number))
+        pr = _get_pull_request(organization, repo, {"number": number}, webhook_id)
+        if pr is not None:
+            prs.append(pr)
+    return prs
 
 
 def _get_pull_request(

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -41,6 +41,7 @@ from sentry.models.commitfilechange import CommitFileChange
 from sentry.models.grouplink import GroupLink
 from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
 from sentry.models.repository import Repository
+from sentry.pr_metrics.webhooks import handle_check_suite as pr_metrics_handle_check_suite
 from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_failure_metric, assert_success_metric
 from sentry.testutils.cases import APITestCase
@@ -158,7 +159,7 @@ class SCMOnlyWebhookTest(APITestCase):
 
     @patch("sentry.integrations.github.webhook.produce_event_to_scm_stream")
     @patch.object(CheckSuiteWebhook, "_handle", autospec=True)
-    def test_check_suite_handler_is_noop_and_publishes_to_scm_stream(
+    def test_check_suite_routes_to_handler_and_publishes_to_scm_stream(
         self, mock_handle: MagicMock, mock_produce: MagicMock
     ) -> None:
         self.create_github_integration_and_repo()
@@ -173,7 +174,9 @@ class SCMOnlyWebhookTest(APITestCase):
         )
 
         assert response.status_code == 204
-        assert CheckSuiteWebhook.WEBHOOK_EVENT_PROCESSORS == ()
+        # check_suite now feeds the PR-metrics activity timeline in addition to
+        # being republished to the SCM stream.
+        assert pr_metrics_handle_check_suite in CheckSuiteWebhook.WEBHOOK_EVENT_PROCESSORS
         mock_handle.assert_called_once()
         mock_produce.assert_called_once()
 

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -17,7 +17,11 @@ from sentry.models.pullrequest import (
     PullRequestVerdict,
 )
 from sentry.pr_metrics.attribution import record_attribution_signal
-from sentry.pr_metrics.judge import forward_pr_to_seer_judge, update_pr_metrics
+from sentry.pr_metrics.judge import (
+    _MAX_FORWARDED_CHECK_ROWS,
+    forward_pr_to_seer_judge,
+    update_pr_metrics,
+)
 from sentry.seer.sentry_data_models import (
     UpdatePrMetricsErrorResponse,
     UpdatePrMetricsSuccessResponse,
@@ -518,6 +522,55 @@ class ForwardPrToSeerJudgeTest(TestCase):
         assert len(activity) == 2
         assert by_type["synchronized"]["sender_type"] == "Bot"
         assert by_type["review_submitted"]["review_state"] == "changes_requested"
+
+    @patch("sentry.pr_metrics.judge.make_signed_seer_api_request")
+    def test_forwarded_check_rows_are_capped(self, mock_request: Any) -> None:
+        # check_run fires per check per push, so a busy PR's CI noise must not
+        # balloon the request: lifecycle rows ride along in full, check rows are
+        # capped to the most recent _MAX_FORWARDED_CHECK_ROWS.
+        mock_request.return_value = self._response(202)
+        base = datetime(2023, 1, 1, tzinfo=timezone.utc)
+        dropped = 5
+        total_checks = _MAX_FORWARDED_CHECK_ROWS + dropped
+
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id="opened",
+            event_type=PullRequestActivityType.OPENED,
+            payload={},
+            date_added=base,
+        )
+        for i in range(total_checks):
+            PullRequestActivity.objects.create(
+                pull_request=self.pull_request,
+                webhook_id=f"check-{i}",
+                event_type=PullRequestActivityType.CHECK_RUN_COMPLETED,
+                payload={"index": i},
+                date_added=base + timedelta(minutes=i + 1),
+            )
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id="merged",
+            event_type=PullRequestActivityType.MERGED,
+            payload={},
+            date_added=base + timedelta(hours=10),
+        )
+
+        forward_pr_to_seer_judge(self.pull_request, self.repo)
+
+        activity = orjson.loads(mock_request.call_args.kwargs["body"])["activity"]
+        check_events = [e for e in activity if e["event_type"] == "check_run_completed"]
+        lifecycle = [e for e in activity if e["event_type"] != "check_run_completed"]
+
+        # All lifecycle rows kept; check rows capped to the most recent N.
+        assert {e["event_type"] for e in lifecycle} == {"opened", "merged"}
+        assert len(check_events) == _MAX_FORWARDED_CHECK_ROWS
+        # The oldest `dropped` check rows are trimmed; the most recent N remain.
+        kept_indexes = {e["payload"]["index"] for e in check_events}
+        assert kept_indexes == set(range(dropped, total_checks))
+        # Overall chronological order is preserved.
+        timestamps = [e["timestamp"] for e in activity]
+        assert timestamps == sorted(timestamps)
 
     @patch("sentry.pr_metrics.judge.make_signed_seer_api_request")
     def test_close_action_is_closed_when_unmerged(self, mock_request: Any) -> None:

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -523,8 +523,12 @@ class ForwardPrToSeerJudgeTest(TestCase):
         assert by_type["synchronized"]["sender_type"] == "Bot"
         assert by_type["review_submitted"]["review_state"] == "changes_requested"
 
+    @patch("sentry.pr_metrics.judge.logger")
+    @patch("sentry.pr_metrics.judge.metrics")
     @patch("sentry.pr_metrics.judge.make_signed_seer_api_request")
-    def test_forwarded_check_rows_are_capped(self, mock_request: Any) -> None:
+    def test_forwarded_check_rows_are_capped(
+        self, mock_request: Any, mock_metrics: Any, mock_logger: Any
+    ) -> None:
         # check_run fires per check per push, so a busy PR's CI noise must not
         # balloon the request: lifecycle rows ride along in full, check rows are
         # capped to the most recent _MAX_FORWARDED_CHECK_ROWS.
@@ -571,6 +575,17 @@ class ForwardPrToSeerJudgeTest(TestCase):
         # Overall chronological order is preserved.
         timestamps = [e["timestamp"] for e in activity]
         assert timestamps == sorted(timestamps)
+        # Hitting the cap is observable: it emits a metric and a warning so a
+        # persistently high rate can argue for raising the cap.
+        mock_metrics.incr.assert_any_call("pr_metrics.judge.check_rows_capped")
+        mock_logger.warning.assert_any_call(
+            "pr_metrics.judge.check_rows_capped",
+            extra={
+                "pull_request_id": self.pull_request.id,
+                "check_rows": total_checks,
+                "dropped": dropped,
+            },
+        )
 
     @patch("sentry.pr_metrics.judge.make_signed_seer_api_request")
     def test_close_action_is_closed_when_unmerged(self, mock_request: Any) -> None:

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -22,6 +22,8 @@ from sentry.models.pullrequest import (
 from sentry.pr_metrics.webhooks import (
     handle_activity,
     handle_attribution,
+    handle_check_run,
+    handle_check_suite,
     handle_comment,
     handle_emission,
     handle_metrics,
@@ -1346,6 +1348,177 @@ class HandleReviewThreadForPrMetricsTest(TestCase):
     def test_no_seer_access_skips_thread_event(self) -> None:
         with self.feature({"organizations:gen-ai-features": False}):
             self._call()
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+
+@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
+@cell_silo_test
+class HandleCheckEventsForPrMetricsTest(TestCase):
+    def setUp(self) -> None:
+        self.project = self.create_project(organization=self.organization)
+        self.repo = self.create_repo(self.project, provider="integrations:github", external_id="99")
+        self.pr = self.create_pull_request(
+            repository_id=self.repo.id,
+            organization_id=self.organization.id,
+            key="42",
+        )
+
+    def _call_suite(
+        self,
+        action: str = "completed",
+        conclusion: str = "success",
+        head_sha: str = "headsha1",
+        app_slug: str = "github-actions",
+        check_runs_count: int = 4,
+        pr_numbers: tuple[int, ...] = (42,),
+        webhook_id: str | None = "delivery-1",
+    ) -> None:
+        event: dict[str, Any] = {
+            "action": action,
+            "check_suite": {
+                "head_sha": head_sha,
+                "status": "completed",
+                "conclusion": conclusion,
+                "app": {"slug": app_slug},
+                "latest_check_runs_count": check_runs_count,
+                "pull_requests": [{"number": n} for n in pr_numbers],
+            },
+            "sender": {"id": 5, "login": "ci-bot", "type": "Bot"},
+        }
+        handle_check_suite(
+            github_event=GithubWebhookType.CHECK_SUITE,
+            event=event,
+            organization=self.organization,
+            repo=self.repo,
+            github_delivery_id=webhook_id,
+        )
+
+    def _call_run(
+        self,
+        action: str = "completed",
+        conclusion: str = "failure",
+        check_name: str = "build",
+        head_sha: str = "headsha1",
+        app_slug: str = "github-actions",
+        pr_numbers: tuple[int, ...] = (42,),
+        webhook_id: str | None = "delivery-1",
+    ) -> None:
+        event: dict[str, Any] = {
+            "action": action,
+            "check_run": {
+                "name": check_name,
+                "head_sha": head_sha,
+                "status": "completed",
+                "conclusion": conclusion,
+                "app": {"slug": app_slug},
+                "pull_requests": [{"number": n} for n in pr_numbers],
+            },
+            "sender": {"id": 5, "login": "ci-bot", "type": "Bot"},
+        }
+        handle_check_run(
+            github_event=GithubWebhookType.CHECK_RUN,
+            event=event,
+            organization=self.organization,
+            repo=self.repo,
+            github_delivery_id=webhook_id,
+        )
+
+    # --- check_suite ---
+
+    def test_check_suite_completed_writes_activity(self) -> None:
+        self._call_suite(conclusion="success", app_slug="github-actions", check_runs_count=6)
+
+        activity = PullRequestActivity.objects.get(pull_request=self.pr)
+        assert activity.event_type == PullRequestActivityType.CHECK_SUITE_COMPLETED
+        assert activity.webhook_id == "delivery-1"
+        assert activity.payload["conclusion"] == "success"
+        assert activity.payload["app_slug"] == "github-actions"
+        assert activity.payload["check_runs_count"] == 6
+        assert activity.payload["head_sha"] == "headsha1"
+        assert activity.payload["sender_type"] == "Bot"
+
+    def test_check_suite_non_completed_action_skipped(self) -> None:
+        for action in ("requested", "rerequested"):
+            self._call_suite(action=action, webhook_id=f"delivery-{action}")
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_check_suite_writes_row_per_referenced_pr(self) -> None:
+        other_pr = self.create_pull_request(
+            repository_id=self.repo.id,
+            organization_id=self.organization.id,
+            key="77",
+        )
+        self._call_suite(pr_numbers=(42, 77))
+
+        assert PullRequestActivity.objects.filter(pull_request=self.pr).count() == 1
+        assert PullRequestActivity.objects.filter(pull_request=other_pr).count() == 1
+
+    def test_check_suite_duplicate_pr_numbers_deduped(self) -> None:
+        self._call_suite(pr_numbers=(42, 42))
+
+        assert PullRequestActivity.objects.filter(pull_request=self.pr).count() == 1
+
+    def test_check_suite_without_prs_writes_nothing(self) -> None:
+        self._call_suite(pr_numbers=())
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_check_suite_unknown_pr_skipped(self) -> None:
+        self._call_suite(pr_numbers=(9999,))
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_check_suite_no_activity_without_webhook_id(self) -> None:
+        self._call_suite(webhook_id=None)
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_check_suite_redelivery_deduplicated(self) -> None:
+        self._call_suite(webhook_id="delivery-dup")
+        self._call_suite(webhook_id="delivery-dup")
+
+        assert PullRequestActivity.objects.filter(pull_request=self.pr).count() == 1
+
+    def test_check_suite_flag_off_skips(self) -> None:
+        with self.feature({"organizations:pr-metrics-activity": False}):
+            self._call_suite()
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_check_suite_no_seer_access_skips(self) -> None:
+        with self.feature({"organizations:gen-ai-features": False}):
+            self._call_suite()
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    # --- check_run ---
+
+    def test_check_run_completed_writes_activity(self) -> None:
+        self._call_run(conclusion="failure", check_name="lint", app_slug="github-actions")
+
+        activity = PullRequestActivity.objects.get(pull_request=self.pr)
+        assert activity.event_type == PullRequestActivityType.CHECK_RUN_COMPLETED
+        assert activity.payload["check_name"] == "lint"
+        assert activity.payload["conclusion"] == "failure"
+        assert activity.payload["app_slug"] == "github-actions"
+        assert activity.payload["head_sha"] == "headsha1"
+
+    def test_check_run_non_completed_action_skipped(self) -> None:
+        for action in ("created", "rerequested", "requested_action"):
+            self._call_run(action=action, webhook_id=f"delivery-{action}")
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_check_run_without_prs_writes_nothing(self) -> None:
+        self._call_run(pr_numbers=())
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_check_run_flag_off_skips(self) -> None:
+        with self.feature({"organizations:pr-metrics-activity": False}):
+            self._call_run()
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 


### PR DESCRIPTION
## Summary

The PR-close judge consumes the captured `PullRequestActivity` timeline, but CI outcome was missing from it. Whether a PR's checks were green or red at close is a strong "why unmerged" signal, so this captures completed `check_suite` (aggregate conclusion) and `check_run` (per-check outcome) events into the timeline.

Part of CORE-245. `status` (legacy commit-status API) is intentionally **not** included — it would require a new GitHub App webhook subscription. `check_suite` and `check_run` are already received, so no subscription change is needed, and the captured rows ride to Seer via the existing forward with **no contract change**.

## Changes

- **New activity types** `CHECK_SUITE_COMPLETED` / `CHECK_RUN_COMPLETED` on `PullRequestActivityType` (no migration — choices are not tracked in migration state).
- **New webhook processors** `handle_check_suite` / `handle_check_run`, gated on `is_activity_tracking_enabled` and the `completed` action, resolving the affected PR(s) from each payload's `pull_requests[]` array (one row per PR, deduped by delivery id). Wired onto the existing `CheckRunEventWebhook` and the previously no-op `CheckSuiteWebhook`.
- **Structural-only payloads** (`conclusion`, `app_slug`, `head_sha`, check name/count) — no titles, bodies, or comment text, consistent with the existing capture rule.
- **Bounded Seer forward**: `check_run` fires per check per push, so the forwarded timeline now caps check rows to the most recent N while keeping all lifecycle rows, so CI noise on busy PRs can't balloon `PrCloseJudgeRequest`.

## Follow-up

A separate PR will add review `dismissed` and intent signals (`auto_merge_enabled/disabled`, merge-queue `enqueued`/`dequeued`) — all on `pull_request`/`pull_request_review` events already processed.

Refs CORE-245
