### PR TITLE
feat(weekly-report): Link issues to PRs, commits, and releases

### DIFF
--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -9,9 +9,9 @@ from sentry.snuba.referrer import Referrer
 from sentry.tasks.summaries.utils import (
     OrganizationReportContext,
     ProjectContext,
+    enrich_past_resolved_issues,
     fetch_key_error_groups,
     fetch_key_performance_issue_groups,
-    fetch_past_resolved_issue_links,
     org_key_errors,
     organization_project_issue_substatus_summaries,
     project_event_counts_for_organization,
@@ -225,7 +225,7 @@ class OrganizationReportContextFactory:
                 if resolved:
                     project_ctx.past_resolved_issues = resolved
 
-            fetch_past_resolved_issue_links(ctx)
+            enrich_past_resolved_issues(ctx)
 
     def create_context(self) -> OrganizationReportContext:
         ctx = OrganizationReportContext(self.timestamp, self.duration, self.organization)

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -46,6 +46,16 @@ from sentry.utils.tracing import start_span
 ONE_DAY = int(timedelta(days=1).total_seconds())
 logger = logging.getLogger(__name__)
 
+RESOLVED_STATUSES = frozenset(
+    {
+        GroupHistoryStatus.RESOLVED,
+        GroupHistoryStatus.SET_RESOLVED_IN_RELEASE,
+        GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
+        GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST,
+        GroupHistoryStatus.AUTO_RESOLVED,
+    }
+)
+
 
 class OrganizationReportContext:
     def __init__(self, timestamp: float, duration: int, organization: Organization):
@@ -972,7 +982,11 @@ def enrich_past_resolved_issues(ctx: OrganizationReportContext) -> None:
     )
 
     group_history_qs = (
-        GroupHistory.objects.filter(group_id__in=all_group_ids, organization_id=ctx.organization.id)
+        GroupHistory.objects.filter(
+            group_id__in=all_group_ids,
+            organization_id=ctx.organization.id,
+            status__in=RESOLVED_STATUSES,
+        )
         .select_related("release")
         .order_by("group_id", "-date_added")
         .distinct("group_id")

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -90,8 +90,8 @@ class ProjectContext:
         self.key_errors_by_group: list[tuple[Group, int]] = []
         # Array of (Group, count)
         self.key_performance_issues = []
-        # Array of (Group, event_count, has_linked_pr_or_commit)
-        self.past_resolved_issues: list[tuple[Group, int, bool]] = []
+        # Array of (Group, GroupHistory | None, event_count, has_linked_pr_or_commit)
+        self.past_resolved_issues: list[tuple[Group, GroupHistory | None, int, bool]] = []
 
         self.key_replay_events = []
 
@@ -684,7 +684,7 @@ PAST_ISSUES_LINK_BOOST = 2
 
 def project_past_resolved_issues(
     ctx: OrganizationReportContext, project: Project, referrer: str
-) -> list[tuple[Group, int, bool]]:
+) -> list[tuple[Group, GroupHistory | None, int, bool]]:
     if not project.first_event:
         return []
 
@@ -744,15 +744,16 @@ def project_past_resolved_issues(
             perf_counts = _past_resolved_perf_counts(ctx, project, perf_group_ids, referrer)
             event_counts.update(perf_counts)
 
-        # has_link is initially False; updated by fetch_past_resolved_issue_links at org level
-        scored = []
+        # has_link and group_history are initially None/False;
+        # updated by enrich_past_resolved_issues at the org level
+        scored: list[tuple[Group, GroupHistory | None, int, bool]] = []
         for group_id, count in event_counts.items():
             group = group_id_to_group.get(group_id)
             if group is None:
                 continue
-            scored.append((group, count, False))
+            scored.append((group, None, count, False))
 
-        scored.sort(key=lambda x: x[1], reverse=True)
+        scored.sort(key=lambda x: x[2], reverse=True)
         return scored
 
 
@@ -835,7 +836,7 @@ def fetch_past_resolved_issue_links(ctx: OrganizationReportContext) -> None:
     all_group_ids: list[int] = []
     for project_ctx in ctx.projects_context_map.values():
         all_group_ids.extend(
-            group.id for group, _count, _has_link in project_ctx.past_resolved_issues
+            group.id for group, _history, _count, _has_link in project_ctx.past_resolved_issues
         )
 
     if not all_group_ids:
@@ -851,14 +852,40 @@ def fetch_past_resolved_issue_links(ctx: OrganizationReportContext) -> None:
 
     for project_ctx in ctx.projects_context_map.values():
         project_ctx.past_resolved_issues = [
-            (group, count, group.id in groups_with_links)
-            for group, count, _has_link in project_ctx.past_resolved_issues
+            (group, history, count, group.id in groups_with_links)
+            for group, history, count, _has_link in project_ctx.past_resolved_issues
         ]
 
     # Re-sort with link boost applied, then truncate to top 3
     for project_ctx in ctx.projects_context_map.values():
         project_ctx.past_resolved_issues.sort(
-            key=lambda x: x[1] * (PAST_ISSUES_LINK_BOOST if x[2] else 1),
+            key=lambda x: x[2] * (PAST_ISSUES_LINK_BOOST if x[3] else 1),
             reverse=True,
         )
         project_ctx.past_resolved_issues = project_ctx.past_resolved_issues[:3]
+
+
+def fetch_past_resolved_issue_group_history(ctx: OrganizationReportContext) -> None:
+    all_group_ids: list[int] = []
+    for project_ctx in ctx.projects_context_map.values():
+        all_group_ids.extend(
+            group.id for group, _history, _count, _has_link in project_ctx.past_resolved_issues
+        )
+
+    if not all_group_ids:
+        return
+
+    group_history = (
+        GroupHistory.objects.filter(group_id__in=all_group_ids, organization_id=ctx.organization.id)
+        .select_related("release")
+        .order_by("group_id", "-date_added")
+        .distinct("group_id")
+        .all()
+    )
+    group_id_to_group_history = {g.group_id: g for g in group_history}
+
+    for project_ctx in ctx.projects_context_map.values():
+        project_ctx.past_resolved_issues = [
+            (group, group_id_to_group_history.get(group.id), count, has_link)
+            for group, _history, count, has_link in project_ctx.past_resolved_issues
+        ]

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -915,6 +915,7 @@ def batch_resolve_group_urls(
             GroupLink.objects.filter(
                 group_id__in=link_group_ids,
                 linked_type__in=[GroupLink.LinkedType.pull_request, GroupLink.LinkedType.commit],
+                relationship=GroupLink.Relationship.resolves,
             )
             .order_by("group_id", "linked_type", "-datetime")
             .distinct("group_id", "linked_type")

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -601,6 +601,7 @@ def fetch_key_performance_issue_groups(ctx: OrganizationReportContext):
         GroupHistory.objects.filter(
             group_id__in=group_id_to_group.keys(), organization_id=ctx.organization.id
         )
+        .select_related("release")
         .order_by("group_id", "-date_added")
         .distinct("group_id")
         .all()

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -20,12 +20,15 @@ from sentry.issues.grouptype import (
     GroupCategory,
     InvalidGroupTypeError,
 )
+from sentry.models.commit import Commit
 from sentry.models.group import Group, GroupStatus
-from sentry.models.grouphistory import GroupHistory
+from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
 from sentry.models.grouplink import GroupLink
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
+from sentry.models.pullrequest import PullRequest
+from sentry.models.repository import Repository
 from sentry.models.team import TeamStatus
 from sentry.search.eap.occurrences.query_utils import keyed_counts_subset_match
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
@@ -35,6 +38,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.occurrences_rpc import OccurrenceCategory, Occurrences
 from sentry.types.group import GroupSubStatus
 from sentry.utils.dates import to_datetime
+from sentry.utils.http import absolute_uri
 from sentry.utils.outcomes import Outcome
 from sentry.utils.snuba import raw_snql_query
 from sentry.utils.tracing import start_span
@@ -55,6 +59,7 @@ class OrganizationReportContext:
         self.projects_context_map: dict[int, ProjectContext] = {}  # { project_id: ProjectContext }
 
         self.project_ownership: dict[int, set[int]] = {}  # { user_id: set<project_id> }
+        self.resolved_issue_urls: dict[int, str | None] = {}  # { group_id: external_url }
         for project in organization.project_set.all():
             self.projects_context_map[project.id] = ProjectContext(project)
 
@@ -830,6 +835,122 @@ def _past_resolved_perf_counts(
     )
     rows = raw_snql_query(request, referrer=referrer)["data"]
     return {row["group_id"]: row["count()"] for row in rows}
+
+
+def _construct_group_url(
+    group_history: GroupHistory,
+    group: Group,
+    org_slug: str,
+    group_id_to_link: dict[int, GroupLink],
+    prs_by_id: dict[int, PullRequest],
+    commits_by_id: dict[int, Commit],
+    repos_by_id: dict[int, Repository],
+) -> str | None:
+    gid = group.id
+    status = group_history.status
+
+    if status == GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST:
+        gl = group_id_to_link.get(gid)
+        if gl is None:
+            return None
+        pr = prs_by_id.get(gl.linked_id)
+        if pr is None:
+            return None
+        try:
+            return pr.get_external_url()
+        except Exception:
+            return None
+
+    if status == GroupHistoryStatus.SET_RESOLVED_IN_COMMIT:
+        gl = group_id_to_link.get(gid)
+        if gl is None:
+            return None
+        commit = commits_by_id.get(gl.linked_id)
+        if commit is None:
+            return None
+        repo = repos_by_id.get(commit.repository_id)
+        if repo is None or not repo.url:
+            return None
+        return f"{repo.url}/commit/{commit.key}"
+
+    if status == GroupHistoryStatus.SET_RESOLVED_IN_RELEASE:
+        if group_history.release is None:
+            return None
+        return absolute_uri(
+            f"/organizations/{org_slug}/releases/{group_history.release.version}/"
+            f"?project={group.project_id}"
+        )
+
+    return None
+
+
+def batch_resolve_group_urls(
+    ctx: OrganizationReportContext,
+    group_id_to_group_history: dict[int, GroupHistory],
+    group_id_to_group: dict[int, Group],
+) -> None:
+    """Batch-resolve external URLs for resolved groups and store in ctx.resolved_issue_urls."""
+    if not group_id_to_group_history:
+        return
+
+    link_group_ids = [
+        gid
+        for gid, gh in group_id_to_group_history.items()
+        if gh.status
+        in (
+            GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST,
+            GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
+        )
+    ]
+
+    group_id_to_link: dict[int, GroupLink] = {}
+    prs_by_id: dict[int, PullRequest] = {}
+    commits_by_id: dict[int, Commit] = {}
+    repos_by_id: dict[int, Repository] = {}
+
+    if link_group_ids:
+        group_links = list(
+            GroupLink.objects.filter(
+                group_id__in=link_group_ids,
+                linked_type__in=[GroupLink.LinkedType.pull_request, GroupLink.LinkedType.commit],
+            )
+            .order_by("group_id", "-datetime")
+            .distinct("group_id")
+        )
+        group_id_to_link = {gl.group_id: gl for gl in group_links}
+
+        pr_linked_ids = [
+            gl.linked_id
+            for gl in group_links
+            if gl.linked_type == GroupLink.LinkedType.pull_request
+        ]
+        commit_linked_ids = [
+            gl.linked_id for gl in group_links if gl.linked_type == GroupLink.LinkedType.commit
+        ]
+
+        if pr_linked_ids:
+            prs_by_id = {pr.id: pr for pr in PullRequest.objects.filter(id__in=pr_linked_ids)}
+        if commit_linked_ids:
+            commits_by_id = {c.id: c for c in Commit.objects.filter(id__in=commit_linked_ids)}
+            commit_repo_ids = {c.repository_id for c in commits_by_id.values()}
+            if commit_repo_ids:
+                repos_by_id = {r.id: r for r in Repository.objects.filter(id__in=commit_repo_ids)}
+
+    for gid, gh in group_id_to_group_history.items():
+        group = group_id_to_group.get(gid)
+        if group is None:
+            continue
+        url = _construct_group_url(
+            gh,
+            group,
+            ctx.organization.slug,
+            group_id_to_link,
+            prs_by_id,
+            commits_by_id,
+            repos_by_id,
+        )
+        if url:
+            ctx.resolved_issue_urls[gid] = url
 
 
 def enrich_past_resolved_issues(ctx: OrganizationReportContext) -> None:

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -940,7 +940,7 @@ def batch_resolve_group_urls(
         group = group_id_to_group.get(gid)
         if group is None:
             continue
-        url = _construct_group_url(
+        ctx.resolved_issue_urls[gid] = _construct_group_url(
             gh,
             group,
             ctx.organization.slug,
@@ -950,8 +950,6 @@ def batch_resolve_group_urls(
             commits_by_id,
             repos_by_id,
         )
-        if url:
-            ctx.resolved_issue_urls[gid] = url
 
 
 def enrich_past_resolved_issues(ctx: OrganizationReportContext) -> None:

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -832,7 +832,7 @@ def _past_resolved_perf_counts(
     return {row["group_id"]: row["count()"] for row in rows}
 
 
-def fetch_past_resolved_issue_links(ctx: OrganizationReportContext) -> None:
+def enrich_past_resolved_issues(ctx: OrganizationReportContext) -> None:
     all_group_ids: list[int] = []
     for project_ctx in ctx.projects_context_map.values():
         all_group_ids.extend(
@@ -850,10 +850,19 @@ def fetch_past_resolved_issue_links(ctx: OrganizationReportContext) -> None:
         ).values_list("group_id", flat=True)
     )
 
+    group_history_qs = (
+        GroupHistory.objects.filter(group_id__in=all_group_ids, organization_id=ctx.organization.id)
+        .select_related("release")
+        .order_by("group_id", "-date_added")
+        .distinct("group_id")
+        .all()
+    )
+    group_id_to_group_history = {g.group_id: g for g in group_history_qs}
+
     for project_ctx in ctx.projects_context_map.values():
         project_ctx.past_resolved_issues = [
-            (group, history, count, group.id in groups_with_links)
-            for group, history, count, _has_link in project_ctx.past_resolved_issues
+            (group, group_id_to_group_history.get(group.id), count, group.id in groups_with_links)
+            for group, _history, count, _has_link in project_ctx.past_resolved_issues
         ]
 
     # Re-sort with link boost applied, then truncate to top 3
@@ -863,29 +872,3 @@ def fetch_past_resolved_issue_links(ctx: OrganizationReportContext) -> None:
             reverse=True,
         )
         project_ctx.past_resolved_issues = project_ctx.past_resolved_issues[:3]
-
-
-def fetch_past_resolved_issue_group_history(ctx: OrganizationReportContext) -> None:
-    all_group_ids: list[int] = []
-    for project_ctx in ctx.projects_context_map.values():
-        all_group_ids.extend(
-            group.id for group, _history, _count, _has_link in project_ctx.past_resolved_issues
-        )
-
-    if not all_group_ids:
-        return
-
-    group_history = (
-        GroupHistory.objects.filter(group_id__in=all_group_ids, organization_id=ctx.organization.id)
-        .select_related("release")
-        .order_by("group_id", "-date_added")
-        .distinct("group_id")
-        .all()
-    )
-    group_id_to_group_history = {g.group_id: g for g in group_history}
-
-    for project_ctx in ctx.projects_context_map.values():
-        project_ctx.past_resolved_issues = [
-            (group, group_id_to_group_history.get(group.id), count, has_link)
-            for group, _history, count, has_link in project_ctx.past_resolved_issues
-        ]

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -841,7 +841,8 @@ def _construct_group_url(
     group_history: GroupHistory,
     group: Group,
     org_slug: str,
-    group_id_to_link: dict[int, GroupLink],
+    group_id_to_pr_link: dict[int, GroupLink],
+    group_id_to_commit_link: dict[int, GroupLink],
     prs_by_id: dict[int, PullRequest],
     commits_by_id: dict[int, Commit],
     repos_by_id: dict[int, Repository],
@@ -850,7 +851,7 @@ def _construct_group_url(
     status = group_history.status
 
     if status == GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST:
-        gl = group_id_to_link.get(gid)
+        gl = group_id_to_pr_link.get(gid)
         if gl is None:
             return None
         pr = prs_by_id.get(gl.linked_id)
@@ -862,7 +863,7 @@ def _construct_group_url(
             return None
 
     if status == GroupHistoryStatus.SET_RESOLVED_IN_COMMIT:
-        gl = group_id_to_link.get(gid)
+        gl = group_id_to_commit_link.get(gid)
         if gl is None:
             return None
         commit = commits_by_id.get(gl.linked_id)
@@ -903,7 +904,8 @@ def batch_resolve_group_urls(
         )
     ]
 
-    group_id_to_link: dict[int, GroupLink] = {}
+    group_id_to_pr_link: dict[int, GroupLink] = {}
+    group_id_to_commit_link: dict[int, GroupLink] = {}
     prs_by_id: dict[int, PullRequest] = {}
     commits_by_id: dict[int, Commit] = {}
     repos_by_id: dict[int, Repository] = {}
@@ -914,19 +916,17 @@ def batch_resolve_group_urls(
                 group_id__in=link_group_ids,
                 linked_type__in=[GroupLink.LinkedType.pull_request, GroupLink.LinkedType.commit],
             )
-            .order_by("group_id", "-datetime")
-            .distinct("group_id")
+            .order_by("group_id", "linked_type", "-datetime")
+            .distinct("group_id", "linked_type")
         )
-        group_id_to_link = {gl.group_id: gl for gl in group_links}
+        for gl in group_links:
+            if gl.linked_type == GroupLink.LinkedType.pull_request:
+                group_id_to_pr_link[gl.group_id] = gl
+            else:
+                group_id_to_commit_link[gl.group_id] = gl
 
-        pr_linked_ids = [
-            gl.linked_id
-            for gl in group_links
-            if gl.linked_type == GroupLink.LinkedType.pull_request
-        ]
-        commit_linked_ids = [
-            gl.linked_id for gl in group_links if gl.linked_type == GroupLink.LinkedType.commit
-        ]
+        pr_linked_ids = [gl.linked_id for gl in group_id_to_pr_link.values()]
+        commit_linked_ids = [gl.linked_id for gl in group_id_to_commit_link.values()]
 
         if pr_linked_ids:
             prs_by_id = {pr.id: pr for pr in PullRequest.objects.filter(id__in=pr_linked_ids)}
@@ -944,7 +944,8 @@ def batch_resolve_group_urls(
             gh,
             group,
             ctx.organization.slug,
-            group_id_to_link,
+            group_id_to_pr_link,
+            group_id_to_commit_link,
             prs_by_id,
             commits_by_id,
             repos_by_id,

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -560,7 +560,10 @@ def get_group_pull_request_url(group: Group) -> str | None:
     if pull_request is None:
         return None
 
-    return pull_request.get_external_url()
+    try:
+        return pull_request.get_external_url()
+    except Exception:
+        return None
 
 
 def get_group_commit_url(group: Group) -> str | None:

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -688,19 +688,18 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
     else:
         return None
 
-    if not ctx.resolved_issue_urls:
-        group_id_to_group_history: dict[int, GroupHistory] = {}
-        group_id_to_group: dict[int, Group] = {}
-        for project_ctx in user_projects:
-            for group, group_history, _count in project_ctx.key_performance_issues:
-                if group_history:
-                    group_id_to_group_history[group.id] = group_history
-                    group_id_to_group[group.id] = group
-            for group, group_history, _count, _has_link in project_ctx.past_resolved_issues:
-                if group_history:
-                    group_id_to_group_history[group.id] = group_history
-                    group_id_to_group[group.id] = group
-        batch_resolve_group_urls(ctx, group_id_to_group_history, group_id_to_group)
+    group_id_to_group_history: dict[int, GroupHistory] = {}
+    group_id_to_group: dict[int, Group] = {}
+    for project_ctx in user_projects:
+        for group, group_history, _count in project_ctx.key_performance_issues:
+            if group_history and group.id not in ctx.resolved_issue_urls:
+                group_id_to_group_history[group.id] = group_history
+                group_id_to_group[group.id] = group
+        for group, group_history, _count, _has_link in project_ctx.past_resolved_issues:
+            if group_history and group.id not in ctx.resolved_issue_urls:
+                group_id_to_group_history[group.id] = group_history
+                group_id_to_group[group.id] = group
+    batch_resolve_group_urls(ctx, group_id_to_group_history, group_id_to_group)
 
     notification_uuid = str(uuid.uuid4())
     local_start, local_end = get_local_dates(ctx, user_id)

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -40,7 +40,12 @@ from sentry.tasks.summaries.metrics import (
 from sentry.tasks.summaries.organization_report_context_factory import (
     OrganizationReportContextFactory,
 )
-from sentry.tasks.summaries.utils import ONE_DAY, PAST_ISSUES_LINK_BOOST, OrganizationReportContext
+from sentry.tasks.summaries.utils import (
+    ONE_DAY,
+    PAST_ISSUES_LINK_BOOST,
+    OrganizationReportContext,
+    batch_resolve_group_urls,
+)
 from sentry.tasks.summaries.weekly_report_cache import cache_project_metrics
 from sentry.taskworker.namespaces import reports_tasks
 from sentry.types.group import GroupSubStatus
@@ -599,6 +604,20 @@ def get_group_release_url(group: Group, group_history: GroupHistory) -> str | No
     )
 
 
+def get_group_history_status_label(group_history: GroupHistory) -> str:
+    status = group_history.status
+    if status == GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST:
+        return "Resolved in PR"
+    if status == GroupHistoryStatus.SET_RESOLVED_IN_COMMIT:
+        return "Resolved in Commit"
+    if status == GroupHistoryStatus.SET_RESOLVED_IN_RELEASE:
+        return "Resolved in Release"
+
+    choices = GroupHistory._meta.get_field("status").choices
+    label = dict(choices).get(status, status) if choices else status
+    return str(label)
+
+
 def get_group_history_status(group: Group, group_history: GroupHistory) -> tuple[str, str | None]:
     status = group_history.status
     if status == GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST:
@@ -668,6 +687,20 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
             return None
     else:
         return None
+
+    if not ctx.resolved_issue_urls:
+        group_id_to_group_history: dict[int, GroupHistory] = {}
+        group_id_to_group: dict[int, Group] = {}
+        for project_ctx in user_projects:
+            for group, group_history, _count in project_ctx.key_performance_issues:
+                if group_history:
+                    group_id_to_group_history[group.id] = group_history
+                    group_id_to_group[group.id] = group
+            for group, group_history, _count, _has_link in project_ctx.past_resolved_issues:
+                if group_history:
+                    group_id_to_group_history[group.id] = group_history
+                    group_id_to_group[group.id] = group
+        batch_resolve_group_urls(ctx, group_id_to_group_history, group_id_to_group)
 
     notification_uuid = str(uuid.uuid4())
     local_start, local_end = get_local_dates(ctx, user_id)
@@ -826,19 +859,16 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                         substatus_color,
                         substatus_text_color,
                     ) = get_group_status_badge(group)
-                    status, status_url = (
-                        get_group_history_status(group, group_history)
-                        if group_history
-                        else ("Unresolved", None)
-                    )
                     if group_history:
+                        status_label = get_group_history_status_label(group_history)
+                        status_url = ctx.resolved_issue_urls.get(group.id)
                         resolved_badge = get_group_status_badge(Group(status=GroupStatus.RESOLVED))
                         yield {
                             "count": count,
                             "group": group,
                             "title": display["title"],
                             "message": display["message"],
-                            "status": status,
+                            "status": status_label,
                             "status_url": status_url,
                             "status_color": resolved_badge[1],
                             "status_text_color": resolved_badge[2],
@@ -873,17 +903,18 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                 ) in project_ctx.past_resolved_issues:
                     display = get_group_display(group)
                     resolved_badge = get_group_status_badge(Group(status=GroupStatus.RESOLVED))
-                    status, status_url = (
-                        get_group_history_status(group, group_history)
+                    status_label = (
+                        get_group_history_status_label(group_history)
                         if group_history
-                        else ("Resolved", None)
+                        else "Resolved"
                     )
+                    status_url = ctx.resolved_issue_urls.get(group.id)
                     yield {
                         "count": count,
                         "group": group,
                         "title": display["title"],
                         "message": display["message"],
-                        "status": status,
+                        "status": status_label,
                         "status_url": status_url,
                         "status_color": resolved_badge[1],
                         "status_text_color": resolved_badge[2],

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -43,6 +43,7 @@ from sentry.tasks.summaries.organization_report_context_factory import (
 from sentry.tasks.summaries.utils import (
     ONE_DAY,
     PAST_ISSUES_LINK_BOOST,
+    RESOLVED_STATUSES,
     OrganizationReportContext,
     batch_resolve_group_urls,
 )
@@ -62,16 +63,6 @@ from sentry.utils.tracing import start_span
 date_format = partial(dateformat.format, format_string="F jS, Y")
 
 logger = logging.getLogger(__name__)
-
-RESOLVED_STATUSES = frozenset(
-    {
-        GroupHistoryStatus.RESOLVED,
-        GroupHistoryStatus.SET_RESOLVED_IN_RELEASE,
-        GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
-        GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST,
-        GroupHistoryStatus.AUTO_RESOLVED,
-    }
-)
 
 
 @dataclass

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -22,9 +22,11 @@ from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 from sentry import analytics, features
 from sentry.analytics.events.weekly_report import WeeklyReportSent
 from sentry.models.group import Group, GroupStatus
-from sentry.models.grouphistory import GroupHistoryStatus
+from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
+from sentry.models.grouplink import GroupLink
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmember import OrganizationMember
+from sentry.models.pullrequest import PullRequest
 from sentry.notifications.services import notifications_service
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -538,6 +540,33 @@ def get_group_status_badge(group: Group) -> tuple[str, str, str]:
     return ("Ongoing", "#F0F0F2", "#6A6772")
 
 
+def get_group_pull_request_url(group: Group) -> str | None:
+    group_link = (
+        GroupLink.objects.filter(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.pull_request,
+        )
+        .order_by("-datetime")
+        .first()
+    )
+    if group_link is None:
+        return None
+
+    pull_request = PullRequest.objects.filter(id=group_link.linked_id).first()
+    if pull_request is None:
+        return None
+
+    return pull_request.get_external_url()
+
+
+def get_group_history_status(group: Group, status: int) -> tuple[str, str | None]:
+    if status == GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST:
+        return "Resolved in PR", get_group_pull_request_url(group)
+
+    return str(dict(GroupHistory._meta.get_field("status").choices).get(status, status)), None
+
+
 def get_group_display(group: Group) -> dict[str, str]:
     metadata = group.get_event_metadata()
     event_type = group.get_event_type()
@@ -732,6 +761,7 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                         "title": display["title"],
                         "message": display["message"],
                         "status": "Unresolved",
+                        "status_url": None,
                         "status_color": (group_status_to_color[GroupHistoryStatus.NEW]),
                         "group_substatus": substatus,
                         "group_substatus_color": substatus_color,
@@ -750,22 +780,28 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                         substatus_color,
                         substatus_text_color,
                     ) = get_group_status_badge(group)
+                    status, status_url = (
+                        get_group_history_status(group, group_history.status)
+                        if group_history
+                        else ("Unresolved", None)
+                    )
                     yield {
                         "count": count,
                         "group": group,
                         "title": display["title"],
                         "message": display["message"],
-                        "status": (
-                            group_history.get_status_display() if group_history else "Unresolved"
-                        ),
+                        "status": status,
+                        "status_url": status_url,
                         "status_color": (
                             group_status_to_color[group_history.status]
                             if group_history
                             else group_status_to_color[GroupHistoryStatus.NEW]
                         ),
-                        "group_substatus": substatus,
-                        "group_substatus_color": substatus_color,
-                        "group_substatus_text_color": substatus_text_color,
+                        "group_substatus": None if group_history else substatus,
+                        "group_substatus_color": None if group_history else substatus_color,
+                        "group_substatus_text_color": (
+                            None if group_history else substatus_text_color
+                        ),
                     }
 
         return heapq.nlargest(3, all_key_performance_issues(), lambda d: d["count"])

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -21,12 +21,14 @@ from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 from sentry import analytics, features
 from sentry.analytics.events.weekly_report import WeeklyReportSent
+from sentry.models.commit import Commit
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
 from sentry.models.grouplink import GroupLink
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.pullrequest import PullRequest
+from sentry.models.repository import Repository
 from sentry.notifications.services import notifications_service
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -48,6 +50,7 @@ from sentry.utils import json, metrics, redis
 from sentry.utils.dates import floor_to_utc_day, to_datetime
 from sentry.utils.email import MessageBuilder
 from sentry.utils.email.sanitize import sanitize_outbound_name
+from sentry.utils.http import absolute_uri
 from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.tracing import start_span
 
@@ -560,11 +563,51 @@ def get_group_pull_request_url(group: Group) -> str | None:
     return pull_request.get_external_url()
 
 
-def get_group_history_status(group: Group, status: int) -> tuple[str, str | None]:
+def get_group_commit_url(group: Group) -> str | None:
+    group_link = (
+        GroupLink.objects.filter(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.commit,
+        )
+        .order_by("-datetime")
+        .first()
+    )
+    if group_link is None:
+        return None
+
+    commit = Commit.objects.filter(id=group_link.linked_id).first()
+    if commit is None:
+        return None
+
+    repo = Repository.objects.filter(id=commit.repository_id).first()
+    if repo is None or not repo.url:
+        return None
+
+    return f"{repo.url}/commit/{commit.key}"
+
+
+def get_group_release_url(group: Group, group_history: GroupHistory) -> str | None:
+    release = group_history.release
+    if release is None:
+        return None
+    return absolute_uri(
+        f"/organizations/{group.project.organization.slug}/releases/{release.version}/?project={group.project_id}"
+    )
+
+
+def get_group_history_status(group: Group, group_history: GroupHistory) -> tuple[str, str | None]:
+    status = group_history.status
     if status == GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST:
         return "Resolved in PR", get_group_pull_request_url(group)
+    if status == GroupHistoryStatus.SET_RESOLVED_IN_COMMIT:
+        return "Resolved in Commit", get_group_commit_url(group)
+    if status == GroupHistoryStatus.SET_RESOLVED_IN_RELEASE:
+        return "Resolved in Release", get_group_release_url(group, group_history)
 
-    return str(dict(GroupHistory._meta.get_field("status").choices).get(status, status)), None
+    choices = GroupHistory._meta.get_field("status").choices
+    label = dict(choices).get(status, status) if choices else status
+    return str(label), None
 
 
 def get_group_display(group: Group) -> dict[str, str]:
@@ -781,28 +824,38 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                         substatus_text_color,
                     ) = get_group_status_badge(group)
                     status, status_url = (
-                        get_group_history_status(group, group_history.status)
+                        get_group_history_status(group, group_history)
                         if group_history
                         else ("Unresolved", None)
                     )
-                    yield {
-                        "count": count,
-                        "group": group,
-                        "title": display["title"],
-                        "message": display["message"],
-                        "status": status,
-                        "status_url": status_url,
-                        "status_color": (
-                            group_status_to_color[group_history.status]
-                            if group_history
-                            else group_status_to_color[GroupHistoryStatus.NEW]
-                        ),
-                        "group_substatus": None if group_history else substatus,
-                        "group_substatus_color": None if group_history else substatus_color,
-                        "group_substatus_text_color": (
-                            None if group_history else substatus_text_color
-                        ),
-                    }
+                    if group_history:
+                        resolved_badge = get_group_status_badge(Group(status=GroupStatus.RESOLVED))
+                        yield {
+                            "count": count,
+                            "group": group,
+                            "title": display["title"],
+                            "message": display["message"],
+                            "status": status,
+                            "status_url": status_url,
+                            "status_color": resolved_badge[1],
+                            "status_text_color": resolved_badge[2],
+                            "group_substatus": None,
+                            "group_substatus_color": None,
+                            "group_substatus_text_color": None,
+                        }
+                    else:
+                        yield {
+                            "count": count,
+                            "group": group,
+                            "title": display["title"],
+                            "message": display["message"],
+                            "status": "Unresolved",
+                            "status_url": None,
+                            "status_color": group_status_to_color[GroupHistoryStatus.NEW],
+                            "group_substatus": substatus,
+                            "group_substatus_color": substatus_color,
+                            "group_substatus_text_color": substatus_text_color,
+                        }
 
         return heapq.nlargest(3, all_key_performance_issues(), lambda d: d["count"])
 

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -862,13 +862,28 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
     def past_issues():
         def all_past_issues():
             for project_ctx in user_projects:
-                for group, count, has_linked_pr_or_commit in project_ctx.past_resolved_issues:
+                for (
+                    group,
+                    group_history,
+                    count,
+                    has_linked_pr_or_commit,
+                ) in project_ctx.past_resolved_issues:
                     display = get_group_display(group)
+                    resolved_badge = get_group_status_badge(Group(status=GroupStatus.RESOLVED))
+                    status, status_url = (
+                        get_group_history_status(group, group_history)
+                        if group_history
+                        else ("Resolved", None)
+                    )
                     yield {
                         "count": count,
                         "group": group,
                         "title": display["title"],
                         "message": display["message"],
+                        "status": status,
+                        "status_url": status_url,
+                        "status_color": resolved_badge[1],
+                        "status_text_color": resolved_badge[2],
                         "has_linked_pr_or_commit": has_linked_pr_or_commit,
                         "_relevance": count
                         * (PAST_ISSUES_LINK_BOOST if has_linked_pr_or_commit else 1),

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -63,6 +63,16 @@ date_format = partial(dateformat.format, format_string="F jS, Y")
 
 logger = logging.getLogger(__name__)
 
+RESOLVED_STATUSES = frozenset(
+    {
+        GroupHistoryStatus.RESOLVED,
+        GroupHistoryStatus.SET_RESOLVED_IN_RELEASE,
+        GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
+        GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST,
+        GroupHistoryStatus.AUTO_RESOLVED,
+    }
+)
+
 
 @dataclass
 class WeeklyReportProgressTracker:
@@ -858,7 +868,7 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                         substatus_color,
                         substatus_text_color,
                     ) = get_group_status_badge(group)
-                    if group_history:
+                    if group_history and group_history.status in RESOLVED_STATUSES:
                         status_label = get_group_history_status_label(group_history)
                         status_url = ctx.resolved_issue_urls.get(group.id)
                         resolved_badge = get_group_status_badge(Group(status=GroupStatus.RESOLVED))

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -3,11 +3,38 @@
 {% load sentry_helpers %}
 {% load sentry_assets %}
 
+{% block bodyclass %}weekly-report{% endblock %}
+
 {% block head %}
 
   {{ block.super }}
 
   <style type="text/css">
+    body.weekly-report,
+    body.weekly-report .main {
+      font-family: Rubik, "Helvetica Neue", helvetica, sans-serif;
+      font-weight: 400;
+    }
+
+    body.weekly-report a,
+    body.weekly-report strong,
+    body.weekly-report .btn {
+      font-weight: 400;
+    }
+
+    body.weekly-report h1,
+    body.weekly-report h2,
+    body.weekly-report h3,
+    body.weekly-report h4,
+    body.weekly-report h5,
+    body.weekly-report h6,
+    body.weekly-report .header strong {
+      font-weight: 500;
+    }
+
+    body.weekly-report .total-count {
+      font-weight: 400;
+    }
 
     .container {
       padding-top: 18px;
@@ -141,6 +168,8 @@
   </style>
 
   <style type="text/css" inline="false">
+    @import url(https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;700&display=swap);
+
     @media only screen and (max-device-width: 480px) {
 
       .mobile-full-width > th,
@@ -284,7 +313,7 @@
       <td class="project-breakdown-graph-cell transactions-empty">
         <div style="border: 1px solid #c4c4cc; border-radius: 4px; padding: 24px 16px; text-align: center; height: 170px;">
           <img src="{% absolute_asset_url 'sentry' 'images/email/icon-circle-lightning.png' %}" width="32px" height="32px" alt="Sentry">
-          <h1 style="font-weight: bold; font-size: 17px;">Something slow?</h1>
+          <h1 style="font-weight: 500; font-size: 17px;">Something slow?</h1>
           <p style="font-size: 11px;">Trace those 10-second page loads to poor-performing API calls.</p>
           {% url 'sentry-organization-performance' organization.slug as performance_landing %}
           {% querystring referrer="weekly_report_upsell" notification_uuid=notification_uuid as query %}

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -453,9 +453,9 @@
       <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; width: 96px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">{{a.group_substatus}}</span>
       {% else %}
         {% if a.status_url %}
-        <a href="{{a.status_url}}" style="background-color: {{a.status_color}}; border-radius: 8px; color: #2f2936; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; text-decoration: none; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</a>
+        <a href="{{a.status_url}}" style="background-color: {{a.status_color}}; color: {{a.status_text_color}}; border-radius: 8px; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; text-decoration: none; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</a>
         {% else %}
-        <span style="background-color: {{a.status_color}}; border-radius: 8px; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</span>
+        <span style="background-color: {{a.status_color}}; color: {{a.status_text_color}}; border-radius: 8px; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</span>
         {% endif %}
       {% endif %}
       </div>
@@ -480,9 +480,9 @@
       <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; width: 96px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">{{a.group_substatus}}</span>
       {% else %}
         {% if a.status_url %}
-        <a href="{{a.status_url}}" style="background-color: {{a.status_color}}; border-radius: 8px; color: #2f2936; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; text-decoration: none; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</a>
+        <a href="{{a.status_url}}" style="background-color: {{a.status_color}}; color: {{a.status_text_color}}; border-radius: 8px; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; text-decoration: none; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</a>
         {% else %}
-        <span style="background-color: {{a.status_color}}; border-radius: 8px; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</span>
+        <span style="background-color: {{a.status_color}}; color: {{a.status_text_color}}; border-radius: 8px; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</span>
         {% endif %}
       {% endif %}
     </div>

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -503,7 +503,11 @@
         <div title="{{a.message}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; width: auto; max-width: 100%; max-height: 38px; line-height: 1.2; font-size: 14px; color: #80708F; margin-bottom: 2px;">{{a.message}}</div>
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
-      <span style="background-color: #E3F7E3; color: #008900; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">Resolved</span>
+      {% if a.status_url %}
+      <a href="{{a.status_url}}" style="background-color: {{a.status_color}}; border-radius: 8px; color: {{a.status_text_color}}; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; text-decoration: none; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</a>
+      {% else %}
+      <span style="background-color: {{a.status_color}}; color: {{a.status_text_color}}; border-radius: 8px; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</span>
+      {% endif %}
     </div>
     {% endfor %}
   </div>

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -450,9 +450,13 @@
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
       {% if a.group_substatus and a.group_substatus_color %}
-      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">{{a.group_substatus}}</span>
+      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; width: 96px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">{{a.group_substatus}}</span>
       {% else %}
-      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">{{a.status}}</span>
+        {% if a.status_url %}
+        <a href="{{a.status_url}}" style="background-color: {{a.status_color}}; border-radius: 8px; color: #2f2936; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; text-decoration: none; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</a>
+        {% else %}
+        <span style="background-color: {{a.status_color}}; border-radius: 8px; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</span>
+        {% endif %}
       {% endif %}
       </div>
     {% endfor %}
@@ -473,9 +477,13 @@
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
       {% if a.group_substatus and a.group_substatus_color %}
-      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">{{a.group_substatus}}</span>
+      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; width: 96px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">{{a.group_substatus}}</span>
       {% else %}
-      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">{{a.status}}</span>
+        {% if a.status_url %}
+        <a href="{{a.status_url}}" style="background-color: {{a.status_color}}; border-radius: 8px; color: #2f2936; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; text-decoration: none; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</a>
+        {% else %}
+        <span style="background-color: {{a.status_color}}; border-radius: 8px; display: inline-block; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; line-height: 1.2; text-align: center; width: 96px; white-space: normal; overflow-wrap: break-word;">{{a.status}}</span>
+        {% endif %}
       {% endif %}
     </div>
     {% endfor %}

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -19,7 +19,12 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.tasks.summaries.utils import ONE_DAY, OrganizationReportContext, ProjectContext
-from sentry.tasks.summaries.weekly_reports import get_group_display, render_template_context
+from sentry.tasks.summaries.weekly_reports import (
+    get_group_display,
+    get_group_history_status,
+    get_group_status_badge,
+    render_template_context,
+)
 from sentry.types.group import GroupSubStatus
 from sentry.utils import loremipsum
 from sentry.utils.auth import AuthenticatedHttpRequest
@@ -210,26 +215,33 @@ class DebugWeeklyReportView(MailPreviewView):
                     (group, group_history, random.randint(100, 1000))
                 )
 
-            project_context.past_resolved_issues = [
-                (
-                    make_debug_group(
-                        group_id=30000 + (project.id * 100) + group_index,
-                        project=project,
-                        title=make_debug_issue_title(
-                            random,
-                            random.choice(["TypeError", "ValueError", "RuntimeError"]),
-                        ),
-                        message=make_debug_issue_message(random),
-                        group_type=ErrorGroupType,
-                        event_type="error",
-                        status=GroupStatus.RESOLVED,
-                        substatus=GroupSubStatus.NEW,
-                    ),
-                    random.randint(100, 5000),
-                    random.choice([True, False]),
-                )
-                for group_index in range(3)
+            resolved_history_statuses: list[int] = [
+                GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST,
+                GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
+                GroupHistoryStatus.SET_RESOLVED_IN_RELEASE,
             ]
+            project_context.past_resolved_issues = []
+            for group_index in range(3):
+                group = make_debug_group(
+                    group_id=30000 + (project.id * 100) + group_index,
+                    project=project,
+                    title=make_debug_issue_title(
+                        random,
+                        random.choice(["TypeError", "ValueError", "RuntimeError"]),
+                    ),
+                    message=make_debug_issue_message(random),
+                    group_type=ErrorGroupType,
+                    event_type="error",
+                    status=GroupStatus.RESOLVED,
+                    substatus=GroupSubStatus.NEW,
+                )
+                resolved_gh: GroupHistory | None = GroupHistory(
+                    status=resolved_history_statuses[group_index % len(resolved_history_statuses)],
+                    organization_id=organization.id,
+                )
+                project_context.past_resolved_issues.append(
+                    (group, resolved_gh, random.randint(100, 5000), random.choice([True, False]))
+                )
 
             ctx.projects_context_map[project.id] = project_context
 
@@ -243,14 +255,22 @@ class DebugWeeklyReportView(MailPreviewView):
             context["show_past_issues"] = True
             past_issues: list[dict[str, Any]] = []
             for project_ctx in ctx.projects_context_map.values():
-                for group, count, has_link in project_ctx.past_resolved_issues:
+                for group, gh, count, has_link in project_ctx.past_resolved_issues:
                     display = get_group_display(group)
+                    resolved_badge = get_group_status_badge(Group(status=GroupStatus.RESOLVED))
+                    resolved_label, resolved_url = (
+                        get_group_history_status(group, gh) if gh else ("Resolved", None)
+                    )
                     past_issues.append(
                         {
                             "count": count,
                             "group": group,
                             "title": display["title"],
                             "message": display["message"],
+                            "status": resolved_label,
+                            "status_url": resolved_url,
+                            "status_color": resolved_badge[1],
+                            "status_text_color": resolved_badge[2],
                             "has_linked_pr_or_commit": has_link,
                         }
                     )

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -17,6 +17,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.models.release import Release
 from sentry.tasks.summaries.utils import ONE_DAY, OrganizationReportContext, ProjectContext
 from sentry.tasks.summaries.weekly_reports import get_group_display, render_template_context
 from sentry.types.group import GroupSubStatus
@@ -165,14 +166,18 @@ class DebugWeeklyReportView(MailPreviewView):
                 PerformanceSlowDBQueryGroupType,
                 PerformanceNPlusOneGroupType,
                 PerformanceP95EndpointRegressionGroupType,
+                PerformanceSlowDBQueryGroupType,
             ]
+            debug_release = Release(organization_id=organization.id, version="1.0.0")
             performance_issue_statuses = [
                 None,
                 GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST,
                 GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
+                GroupHistoryStatus.SET_RESOLVED_IN_RELEASE,
             ]
             project_context.key_performance_issues = []
             for group_index, performance_issue_type in enumerate(performance_issue_types):
+                sub_index = group_index % len(substatuses)
                 group = make_debug_group(
                     group_id=20000 + (project.id * 100) + group_index,
                     project=project,
@@ -180,20 +185,27 @@ class DebugWeeklyReportView(MailPreviewView):
                     message=make_debug_issue_message(random),
                     group_type=performance_issue_type,
                     event_type="transaction",
-                    status=substatuses[group_index][0],
-                    substatus=substatuses[group_index][1],
+                    status=substatuses[sub_index][0],
+                    substatus=substatuses[sub_index][1],
                 )
                 status = performance_issue_statuses[group_index]
-                group_history = (
-                    GroupHistory(
+                if status == GroupHistoryStatus.SET_RESOLVED_IN_RELEASE:
+                    group_history = GroupHistory(
+                        group=group,
+                        project=project,
+                        organization=organization,
+                        status=status,
+                        release=debug_release,
+                    )
+                elif status is not None:
+                    group_history = GroupHistory(
                         group=group,
                         project=project,
                         organization=organization,
                         status=status,
                     )
-                    if status is not None
-                    else None
-                )
+                else:
+                    group_history = None
                 project_context.key_performance_issues.append(
                     (group, group_history, random.randint(100, 1000))
                 )

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -14,6 +14,7 @@ from sentry.issues.grouptype import (
     PerformanceSlowDBQueryGroupType,
 )
 from sentry.models.group import Group, GroupStatus
+from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.tasks.summaries.utils import ONE_DAY, OrganizationReportContext, ProjectContext
@@ -165,23 +166,37 @@ class DebugWeeklyReportView(MailPreviewView):
                 PerformanceNPlusOneGroupType,
                 PerformanceP95EndpointRegressionGroupType,
             ]
-            project_context.key_performance_issues = [
-                (
-                    make_debug_group(
-                        group_id=20000 + (project.id * 100) + group_index,
-                        project=project,
-                        title=make_debug_issue_title(random, performance_issue_type.description),
-                        message=make_debug_issue_message(random),
-                        group_type=performance_issue_type,
-                        event_type="transaction",
-                        status=substatuses[group_index][0],
-                        substatus=substatuses[group_index][1],
-                    ),
-                    None,
-                    random.randint(100, 1000),
-                )
-                for group_index, performance_issue_type in enumerate(performance_issue_types)
+            performance_issue_statuses = [
+                None,
+                GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST,
+                GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
             ]
+            project_context.key_performance_issues = []
+            for group_index, performance_issue_type in enumerate(performance_issue_types):
+                group = make_debug_group(
+                    group_id=20000 + (project.id * 100) + group_index,
+                    project=project,
+                    title=make_debug_issue_title(random, performance_issue_type.description),
+                    message=make_debug_issue_message(random),
+                    group_type=performance_issue_type,
+                    event_type="transaction",
+                    status=substatuses[group_index][0],
+                    substatus=substatuses[group_index][1],
+                )
+                status = performance_issue_statuses[group_index]
+                group_history = (
+                    GroupHistory(
+                        group=group,
+                        project=project,
+                        organization=organization,
+                        status=status,
+                    )
+                    if status is not None
+                    else None
+                )
+                project_context.key_performance_issues.append(
+                    (group, group_history, random.randint(100, 1000))
+                )
 
             project_context.past_resolved_issues = [
                 (

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -1176,6 +1176,56 @@ class WeeklyReportsTest(
             field: performance_issue[field] for field in substatus_fields
         }
 
+    @mock.patch("sentry.models.pullrequest.PullRequest.get_external_url")
+    def test_key_performance_issue_resolved_in_pr_status_links_pull_request(
+        self, get_external_url: mock.MagicMock
+    ) -> None:
+        get_external_url.return_value = "https://github.com/example/example/pull/1"
+        user = self.create_user()
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+        group = self.create_group(
+            project=self.project,
+            message="performance message",
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ONGOING,
+            type=PerformanceNPlusOneGroupType.type_id,
+            data={
+                "type": "transaction",
+                "metadata": {"title": "N+1 Query", "value": "performance message"},
+            },
+        )
+        repo = self.create_repo(project=self.project)
+        pull_request = self.create_pull_request(
+            repository_id=repo.id,
+            organization_id=self.organization.id,
+            key="1",
+            title="Fix N+1 query",
+        )
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.pull_request,
+            linked_id=pull_request.id,
+            relationship=GroupLink.Relationship.resolves,
+        )
+        group_history = self.create_group_history(
+            group=group,
+            status=GroupHistoryStatus.SET_RESOLVED_IN_PULL_REQUEST,
+        )
+        ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
+        project_context = ProjectContext(self.project)
+        project_context.key_performance_issues = [(group, group_history, 10)]
+        ctx.projects_context_map = {self.project.id: project_context}
+        ctx.project_ownership[user.id] = {self.project.id}
+
+        rendered_context = render_template_context(ctx, user.id)
+
+        assert rendered_context is not None
+        performance_issue = rendered_context["key_performance_issues"][0]
+        assert performance_issue["status"] == "Resolved in PR"
+        assert performance_issue["status_url"] == "https://github.com/example/example/pull/1"
+        assert performance_issue["group_substatus"] is None
+
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_email_override_simple(

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -1226,6 +1226,91 @@ class WeeklyReportsTest(
         assert performance_issue["status_url"] == "https://github.com/example/example/pull/1"
         assert performance_issue["group_substatus"] is None
 
+    def test_key_performance_issue_resolved_in_commit_status_links_commit(self) -> None:
+        user = self.create_user()
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+        group = self.create_group(
+            project=self.project,
+            message="performance message",
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ONGOING,
+            type=PerformanceNPlusOneGroupType.type_id,
+            data={
+                "type": "transaction",
+                "metadata": {"title": "N+1 Query", "value": "performance message"},
+            },
+        )
+        repo = self.create_repo(project=self.project, url="https://github.com/example/example")
+        commit = self.create_commit(repo=repo, key="abc123def456")
+        GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            linked_type=GroupLink.LinkedType.commit,
+            linked_id=commit.id,
+            relationship=GroupLink.Relationship.resolves,
+        )
+        group_history = self.create_group_history(
+            group=group,
+            status=GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
+        )
+        ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
+        project_context = ProjectContext(self.project)
+        project_context.key_performance_issues = [(group, group_history, 10)]
+        ctx.projects_context_map = {self.project.id: project_context}
+        ctx.project_ownership[user.id] = {self.project.id}
+
+        rendered_context = render_template_context(ctx, user.id)
+
+        assert rendered_context is not None
+        performance_issue = rendered_context["key_performance_issues"][0]
+        assert performance_issue["status"] == "Resolved in Commit"
+        assert (
+            performance_issue["status_url"]
+            == "https://github.com/example/example/commit/abc123def456"
+        )
+        assert performance_issue["group_substatus"] is None
+
+    def test_key_performance_issue_resolved_in_release_status_links_release(self) -> None:
+        user = self.create_user()
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+        group = self.create_group(
+            project=self.project,
+            message="performance message",
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ONGOING,
+            type=PerformanceNPlusOneGroupType.type_id,
+            data={
+                "type": "transaction",
+                "metadata": {"title": "N+1 Query", "value": "performance message"},
+            },
+        )
+        release = self.create_release(
+            project=self.project,
+            version="1.0.0",
+        )
+        group_history = self.create_group_history(
+            group=group,
+            status=GroupHistoryStatus.SET_RESOLVED_IN_RELEASE,
+            release=release,
+        )
+        ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
+        project_context = ProjectContext(self.project)
+        project_context.key_performance_issues = [(group, group_history, 10)]
+        ctx.projects_context_map = {self.project.id: project_context}
+        ctx.project_ownership[user.id] = {self.project.id}
+
+        rendered_context = render_template_context(ctx, user.id)
+
+        assert rendered_context is not None
+        performance_issue = rendered_context["key_performance_issues"][0]
+        assert performance_issue["status"] == "Resolved in Release"
+        assert performance_issue["status_url"] is not None
+        assert (
+            f"/organizations/{self.organization.slug}/releases/1.0.0/"
+            in performance_issue["status_url"]
+        )
+        assert performance_issue["group_substatus"] is None
+
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_email_override_simple(

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -36,7 +36,7 @@ from sentry.tasks.summaries.utils import (
     _project_key_errors_snuba,
     _project_key_performance_issues_eap,
     _project_key_performance_issues_snuba,
-    fetch_past_resolved_issue_links,
+    enrich_past_resolved_issues,
     org_key_errors,
     organization_project_issue_substatus_summaries,
     project_key_errors,
@@ -1952,8 +1952,9 @@ class WeeklyReportsTest(
         )
         assert len(results) == 1
         assert results[0][0].id == group1.id
-        assert results[0][1] >= 1
-        assert results[0][2] is False
+        assert results[0][1] is None
+        assert results[0][2] >= 1
+        assert results[0][3] is False
 
     @mock.patch("sentry.tasks.summaries.utils._past_resolved_perf_counts")
     @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
@@ -1980,7 +1981,7 @@ class WeeklyReportsTest(
             ctx, self.project, Referrer.REPORTS_PAST_RESOLVED_ISSUES.value
         )
 
-        assert results == [(group, 1, False)]
+        assert results == [(group, None, 1, False)]
         mock_perf_counts.assert_called_once()
         assert mock_perf_counts.call_args.args[2] == [group.id]
 
@@ -2103,10 +2104,10 @@ class WeeklyReportsTest(
         )
         ctx.projects_context_map[self.project.id].past_resolved_issues = results
 
-        fetch_past_resolved_issue_links(ctx)
+        enrich_past_resolved_issues(ctx)
 
         updated = ctx.projects_context_map[self.project.id].past_resolved_issues
-        has_link_by_group = {group.id: has_link for group, _count, has_link in updated}
+        has_link_by_group = {group.id: has_link for group, _history, _count, has_link in updated}
         assert has_link_by_group[group1.id] is True
         assert has_link_by_group[group2.id] is False
 


### PR DESCRIPTION
Resolves [ID-1624](https://linear.app/getsentry/issue/ID-1624/link-to-pr-when-issue-is-resolved-in-pull-request-in-weekly-report)

Goal: link "Resolved in Pull Request", "Resolved in Commit", and " Resolved in Release" back to the PR, commit, and release, respectively

Changes
- find PR/commit/release links in `src/sentry/tasks/summaries/weekly_reports.py`
- add consistent styling to resolved buttons (screenshot at bottom)


To test:
- Start dev environment
- Go to `debug/mail/weekly-reports/?seed=123`

<img width="1288" height="488" alt="image" src="https://github.com/user-attachments/assets/497f3d86-267b-4fc4-9da9-d5740e74a137" />

