### PR TITLE
fix(seer): Surface night shift shard seer run ids in the workflows API

### DIFF
--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -23,7 +23,7 @@ class SeerNightShiftRunResultResponse(TypedDict):
     dateAdded: str
 
 
-# TODO(seer): legacy alias for the frontend. Drop this, the `issues` key, and
+# TODO(telkins): legacy alias for the frontend. Drop this, the `issues` key, and
 # `_serialize_legacy_issue` once the UI reads `results` instead (filtering to
 # kind=agentic_triage). The frontend migration must deploy before the removal.
 class SeerNightShiftRunIssueResponse(TypedDict):

--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -23,7 +23,9 @@ class SeerNightShiftRunResultResponse(TypedDict):
     dateAdded: str
 
 
-# Legacy alias for the frontend; drop once it migrates to `results`.
+# TODO(seer): legacy alias for the frontend. Drop this, the `issues` key, and
+# `_serialize_legacy_issue` once the UI reads `results` instead (filtering to
+# kind=agentic_triage). The frontend migration must deploy before the removal.
 class SeerNightShiftRunIssueResponse(TypedDict):
     id: str
     groupId: str

--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -9,6 +9,7 @@ from sentry.api.serializers import Serializer, register
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
     SeerNightShiftRunResult,
+    SeerNightShiftRunShard,
 )
 from sentry.seer.models.workflow import SeerWorkflowStrategy
 
@@ -31,6 +32,11 @@ class SeerNightShiftRunIssueResponse(TypedDict):
     dateAdded: str
 
 
+class SeerNightShiftRunShardResponse(TypedDict):
+    id: str
+    seerRunId: str | None  # the shard's seer_run_state_id; the UI's explorerRunId
+
+
 class SeerNightShiftRunResponse(TypedDict):
     id: str
     dateAdded: str
@@ -38,6 +44,7 @@ class SeerNightShiftRunResponse(TypedDict):
     errorMessage: str | None
     results: list[SeerNightShiftRunResultResponse]
     issues: list[SeerNightShiftRunIssueResponse]
+    shards: list[SeerNightShiftRunShardResponse]
     triageStrategy: str
 
 
@@ -46,7 +53,7 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
     def get_attrs(
         self, item_list: Sequence[SeerNightShiftRun], user: Any, **kwargs: Any
     ) -> dict[SeerNightShiftRun, dict[str, Any]]:
-        prefetch_related_objects(item_list, "results", "shards")
+        prefetch_related_objects(item_list, "results", "shards__seer_run")
         return {}
 
     def serialize(
@@ -76,6 +83,8 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             "errorMessage": extras.get("error_message") or shard_error,
             "results": [_serialize_result(r) for r in all_results],
             "issues": [_serialize_legacy_issue(r) for r in triage_results],
+            # sorted() in Python, not .order_by, to keep using the prefetch cache
+            "shards": [_serialize_shard(s) for s in sorted(obj.shards.all(), key=lambda s: s.id)],
             # Match the pre-migration column behavior: always "agentic_triage"
             # in this PR. The multi-kind feature PR will refine this once
             # other kinds can produce runs.
@@ -91,6 +100,15 @@ def _serialize_result(result: SeerNightShiftRunResult) -> SeerNightShiftRunResul
         "seerRunId": result.seer_run_id,
         "extras": result.extras or {},
         "dateAdded": result.date_added.isoformat(),
+    }
+
+
+def _serialize_shard(shard: SeerNightShiftRunShard) -> SeerNightShiftRunShardResponse:
+    seer_run = shard.seer_run
+    state_id = seer_run.seer_run_state_id if seer_run is not None else None
+    return {
+        "id": str(shard.id),
+        "seerRunId": str(state_id) if state_id is not None else None,
     }
 
 

--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any, TypedDict
 
-from django.db.models import prefetch_related_objects
+from django.db.models import Prefetch, prefetch_related_objects
 
-from sentry.api.serializers import Serializer, register
+from sentry.api.serializers import Serializer, register, serialize
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
     SeerNightShiftRunResult,
+    SeerNightShiftRunShard,
 )
 from sentry.seer.models.workflow import SeerWorkflowStrategy
 
@@ -33,9 +34,16 @@ class SeerNightShiftRunIssueResponse(TypedDict):
     dateAdded: str
 
 
-# A Seer run dispatched by a night shift run (one per shard), openable in Explorer.
 class SeerNightShiftSeerRunResponse(TypedDict):
-    seerRunId: str
+    seerRunId: str | None
+
+
+class SeerNightShiftShardSerializer(Serializer[SeerNightShiftSeerRunResponse]):
+    def serialize(
+        self, obj: SeerNightShiftRunShard, attrs: Mapping[str, Any], user: Any, **kwargs: Any
+    ) -> SeerNightShiftSeerRunResponse:
+        state_id = obj.seer_run.seer_run_state_id if obj.seer_run is not None else None
+        return {"seerRunId": str(state_id) if state_id is not None else None}
 
 
 class SeerNightShiftRunResponse(TypedDict):
@@ -54,7 +62,14 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
     def get_attrs(
         self, item_list: Sequence[SeerNightShiftRun], user: Any, **kwargs: Any
     ) -> dict[SeerNightShiftRun, dict[str, Any]]:
-        prefetch_related_objects(item_list, "results", "shards__seer_run")
+        prefetch_related_objects(
+            item_list,
+            "results",
+            Prefetch(
+                "shards",
+                queryset=SeerNightShiftRunShard.objects.order_by("id").select_related("seer_run"),
+            ),
+        )
         return {}
 
     def serialize(
@@ -84,7 +99,7 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             "errorMessage": extras.get("error_message") or shard_error,
             "results": [_serialize_result(r) for r in all_results],
             "issues": [_serialize_legacy_issue(r) for r in triage_results],
-            "seerRuns": _serialize_seer_runs(obj),
+            "seerRuns": serialize(list(obj.shards.all()), user, SeerNightShiftShardSerializer()),
             # Match the pre-migration column behavior: always "agentic_triage"
             # in this PR. The multi-kind feature PR will refine this once
             # other kinds can produce runs.
@@ -101,16 +116,6 @@ def _serialize_result(result: SeerNightShiftRunResult) -> SeerNightShiftRunResul
         "extras": result.extras or {},
         "dateAdded": result.date_added.isoformat(),
     }
-
-
-def _serialize_seer_runs(run: SeerNightShiftRun) -> list[SeerNightShiftSeerRunResponse]:
-    # sorted() in Python, not .order_by, to keep using the prefetch cache.
-    shards = sorted(run.shards.all(), key=lambda s: s.id)
-    return [
-        {"seerRunId": str(s.seer_run.seer_run_state_id)}
-        for s in shards
-        if s.seer_run is not None and s.seer_run.seer_run_state_id is not None
-    ]
 
 
 def _serialize_legacy_issue(result: SeerNightShiftRunResult) -> SeerNightShiftRunIssueResponse:

--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -9,7 +9,6 @@ from sentry.api.serializers import Serializer, register
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
     SeerNightShiftRunResult,
-    SeerNightShiftRunShard,
 )
 from sentry.seer.models.workflow import SeerWorkflowStrategy
 
@@ -34,9 +33,9 @@ class SeerNightShiftRunIssueResponse(TypedDict):
     dateAdded: str
 
 
-class SeerNightShiftRunShardResponse(TypedDict):
-    id: str
-    seerRunId: str | None  # the shard's seer_run_state_id; the UI's explorerRunId
+# A Seer run dispatched by a night shift run (one per shard), openable in Explorer.
+class SeerNightShiftSeerRunResponse(TypedDict):
+    seerRunId: str
 
 
 class SeerNightShiftRunResponse(TypedDict):
@@ -46,7 +45,7 @@ class SeerNightShiftRunResponse(TypedDict):
     errorMessage: str | None
     results: list[SeerNightShiftRunResultResponse]
     issues: list[SeerNightShiftRunIssueResponse]
-    shards: list[SeerNightShiftRunShardResponse]
+    seerRuns: list[SeerNightShiftSeerRunResponse]
     triageStrategy: str
 
 
@@ -85,8 +84,7 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             "errorMessage": extras.get("error_message") or shard_error,
             "results": [_serialize_result(r) for r in all_results],
             "issues": [_serialize_legacy_issue(r) for r in triage_results],
-            # sorted() in Python, not .order_by, to keep using the prefetch cache
-            "shards": [_serialize_shard(s) for s in sorted(obj.shards.all(), key=lambda s: s.id)],
+            "seerRuns": _serialize_seer_runs(obj),
             # Match the pre-migration column behavior: always "agentic_triage"
             # in this PR. The multi-kind feature PR will refine this once
             # other kinds can produce runs.
@@ -105,13 +103,14 @@ def _serialize_result(result: SeerNightShiftRunResult) -> SeerNightShiftRunResul
     }
 
 
-def _serialize_shard(shard: SeerNightShiftRunShard) -> SeerNightShiftRunShardResponse:
-    seer_run = shard.seer_run
-    state_id = seer_run.seer_run_state_id if seer_run is not None else None
-    return {
-        "id": str(shard.id),
-        "seerRunId": str(state_id) if state_id is not None else None,
-    }
+def _serialize_seer_runs(run: SeerNightShiftRun) -> list[SeerNightShiftSeerRunResponse]:
+    # sorted() in Python, not .order_by, to keep using the prefetch cache.
+    shards = sorted(run.shards.all(), key=lambda s: s.id)
+    return [
+        {"seerRunId": str(s.seer_run.seer_run_state_id)}
+        for s in shards
+        if s.seer_run is not None and s.seer_run.seer_run_state_id is not None
+    ]
 
 
 def _serialize_legacy_issue(result: SeerNightShiftRunResult) -> SeerNightShiftRunIssueResponse:

--- a/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
@@ -60,16 +60,14 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         seer_run_b = self.create_seer_run(organization=self.organization, seer_run_state_id=222)
         SeerNightShiftRunShard.objects.create(run=run, seer_run=seer_run_a)
         SeerNightShiftRunShard.objects.create(run=run, seer_run=seer_run_b)
-        # A shard with no mirrored state id still serializes.
+        # A shard with no mirrored state id is omitted (nothing to link to).
         SeerNightShiftRunShard.objects.create(run=run)
 
         with self.feature("organizations:seer-night-shift"):
             response = self.get_success_response(self.organization.slug)
 
-        shards = response.data[0]["shards"]
-        assert len(shards) == 3
-        assert sorted(s["seerRunId"] for s in shards if s["seerRunId"]) == ["111", "222"]
-        assert any(s["seerRunId"] is None for s in shards)
+        seer_runs = response.data[0]["seerRuns"]
+        assert sorted(r["seerRunId"] for r in seer_runs) == ["111", "222"]
 
     def test_surfaces_shard_error_message(self) -> None:
         # Per-shard delivery errors live on the shard; the run API must still

--- a/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
@@ -60,14 +60,14 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         seer_run_b = self.create_seer_run(organization=self.organization, seer_run_state_id=222)
         SeerNightShiftRunShard.objects.create(run=run, seer_run=seer_run_a)
         SeerNightShiftRunShard.objects.create(run=run, seer_run=seer_run_b)
-        # A shard with no mirrored state id is omitted (nothing to link to).
+        # A shard with no mirrored state id serializes with a null seerRunId.
         SeerNightShiftRunShard.objects.create(run=run)
 
         with self.feature("organizations:seer-night-shift"):
             response = self.get_success_response(self.organization.slug)
 
-        seer_runs = response.data[0]["seerRuns"]
-        assert sorted(r["seerRunId"] for r in seer_runs) == ["111", "222"]
+        seer_run_ids = [r["seerRunId"] for r in response.data[0]["seerRuns"]]
+        assert seer_run_ids == ["111", "222", None]
 
     def test_surfaces_shard_error_message(self) -> None:
         # Per-shard delivery errors live on the shard; the run API must still

--- a/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
@@ -54,6 +54,23 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         assert legacy["groupId"] == str(group.id)
         assert legacy["action"] == "autofix_triggered"
 
+    def test_surfaces_shard_seer_run_ids(self) -> None:
+        run = SeerNightShiftRun.objects.create(organization=self.organization)
+        seer_run_a = self.create_seer_run(organization=self.organization, seer_run_state_id=111)
+        seer_run_b = self.create_seer_run(organization=self.organization, seer_run_state_id=222)
+        SeerNightShiftRunShard.objects.create(run=run, seer_run=seer_run_a)
+        SeerNightShiftRunShard.objects.create(run=run, seer_run=seer_run_b)
+        # A shard with no mirrored state id still serializes.
+        SeerNightShiftRunShard.objects.create(run=run)
+
+        with self.feature("organizations:seer-night-shift"):
+            response = self.get_success_response(self.organization.slug)
+
+        shards = response.data[0]["shards"]
+        assert len(shards) == 3
+        assert sorted(s["seerRunId"] for s in shards if s["seerRunId"]) == ["111", "222"]
+        assert any(s["seerRunId"] is None for s in shards)
+
     def test_surfaces_shard_error_message(self) -> None:
         # Per-shard delivery errors live on the shard; the run API must still
         # surface them so a failed shard doesn't read as a healthy run.


### PR DESCRIPTION
## Summary

Night shift runs fan out into shards, each owning its own `SeerRun`. The serializer never exposed those, so the Workflows page lost the Seer Explorer link for every post-sharding run.

Adds a `seerRuns` list to the serialized run (`{seerRunId}[]`, one per dispatched run), prefetched via `shards__seer_run`. The frontend that consumes it ships separately.

## Test plan

- `pytest tests/sentry/seer/endpoints/test_organization_seer_workflows.py` passes.