### PR TITLE
fix(seer): Link each night shift shard to Seer Explorer in workflows

### DIFF
--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -129,46 +129,7 @@ describe('SeerWorkflows', () => {
     expect(screen.queryByText('seer-1')).not.toBeInTheDocument();
   });
 
-  it('links the Result cell to Seer Explorer when agent_run_id is present', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/seer/workflows/`,
-      body: [
-        {
-          id: '1',
-          dateAdded: '2026-04-20T00:00:00Z',
-          triageStrategy: 'agentic',
-          errorMessage: null,
-          extras: {agent_run_id: 42},
-          issues: [
-            {
-              id: '10',
-              groupId: '100',
-              action: 'autofix_triggered',
-              seerRunId: 'seer-1',
-              dateAdded: '2026-04-20T00:00:01Z',
-            },
-            {
-              id: '11',
-              groupId: '101',
-              action: 'autofix_triggered',
-              seerRunId: 'seer-2',
-              dateAdded: '2026-04-20T00:00:02Z',
-            },
-          ],
-        },
-      ],
-    });
-
-    render(<SeerWorkflows />, {organization});
-
-    const link = await screen.findByRole('link', {name: '2 issues'});
-    expect(link).toHaveAttribute(
-      'href',
-      `/organizations/${organization.slug}/issues/autofix/?explorerRunId=42`
-    );
-  });
-
-  it('renders the Result cell as plain text when agent_run_id is missing', async () => {
+  it('links the Result cell to Seer Explorer once per shard', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/workflows/`,
       body: [
@@ -187,6 +148,74 @@ describe('SeerWorkflows', () => {
               dateAdded: '2026-04-20T00:00:01Z',
             },
           ],
+          shards: [
+            {id: 'a', seerRunId: '42'},
+            {id: 'b', seerRunId: '43'},
+          ],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    expect(await screen.findByText('1 issue')).toBeInTheDocument();
+    const links = screen.getAllByRole('link', {name: 'Open run in Seer Explorer'});
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/autofix/?explorerRunId=42`
+    );
+    expect(links[1]).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/autofix/?explorerRunId=43`
+    );
+  });
+
+  it('falls back to extras.agent_run_id when a run has no shards', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {agent_run_id: 42},
+          issues: [],
+          shards: [],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    const link = await screen.findByRole('link', {name: 'Open run in Seer Explorer'});
+    expect(link).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/autofix/?explorerRunId=42`
+    );
+  });
+
+  it('renders the Result cell as plain text when there is no run to link', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {},
+          issues: [
+            {
+              id: '10',
+              groupId: '100',
+              action: 'autofix_triggered',
+              seerRunId: 'seer-1',
+              dateAdded: '2026-04-20T00:00:01Z',
+            },
+          ],
+          shards: [],
         },
       ],
     });
@@ -194,7 +223,9 @@ describe('SeerWorkflows', () => {
     render(<SeerWorkflows />, {organization});
 
     await screen.findByText('1 issue');
-    expect(screen.queryByRole('link', {name: '1 issue'})).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {name: 'Open run in Seer Explorer'})
+    ).not.toBeInTheDocument();
   });
 
   it('sorts by date desc by default and toggles asc on Date header click', async () => {

--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -129,7 +129,7 @@ describe('SeerWorkflows', () => {
     expect(screen.queryByText('seer-1')).not.toBeInTheDocument();
   });
 
-  it('links the Result cell to Seer Explorer once per shard', async () => {
+  it('links the Result cell to Seer Explorer once per seer run', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/workflows/`,
       body: [
@@ -148,10 +148,7 @@ describe('SeerWorkflows', () => {
               dateAdded: '2026-04-20T00:00:01Z',
             },
           ],
-          shards: [
-            {id: 'a', seerRunId: '42'},
-            {id: 'b', seerRunId: '43'},
-          ],
+          seerRuns: [{seerRunId: '42'}, {seerRunId: '43'}],
         },
       ],
     });
@@ -171,7 +168,7 @@ describe('SeerWorkflows', () => {
     );
   });
 
-  it('falls back to extras.agent_run_id when a run has no shards', async () => {
+  it('falls back to extras.agent_run_id when a run has no seer runs', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/workflows/`,
       body: [
@@ -182,7 +179,7 @@ describe('SeerWorkflows', () => {
           errorMessage: null,
           extras: {agent_run_id: 42},
           issues: [],
-          shards: [],
+          seerRuns: [],
         },
       ],
     });
@@ -215,7 +212,7 @@ describe('SeerWorkflows', () => {
               dateAdded: '2026-04-20T00:00:01Z',
             },
           ],
-          shards: [],
+          seerRuns: [],
         },
       ],
     });

--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -148,7 +148,8 @@ describe('SeerWorkflows', () => {
               dateAdded: '2026-04-20T00:00:01Z',
             },
           ],
-          seerRuns: [{seerRunId: '42'}, {seerRunId: '43'}],
+          // The null-id run (not yet mirrored back from Seer) is skipped.
+          seerRuns: [{seerRunId: '42'}, {seerRunId: '43'}, {seerRunId: null}],
         },
       ],
     });

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -862,7 +862,9 @@ function toWorkflowRow(run: SeerNightShiftRun): WorkflowRow {
 }
 
 function getExplorerRunIds(row: WorkflowRow): Array<number | string> {
-  const seerRunIds = (row.triage?.seerRuns ?? []).map(seerRun => seerRun.seerRunId);
+  const seerRunIds = (row.triage?.seerRuns ?? [])
+    .map(seerRun => seerRun.seerRunId)
+    .filter((id): id is string => id !== null);
   if (seerRunIds.length > 0) {
     return seerRunIds;
   }

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -852,7 +852,7 @@ function toWorkflowRow(run: SeerNightShiftRun): WorkflowRow {
       maxCandidates: run.extras.options?.max_candidates,
       dryRun: run.extras.options?.dry_run,
       issues: run.issues,
-      shards: run.shards ?? [],
+      seerRuns: run.seerRuns ?? [],
       agentRunId:
         typeof agentRunId === 'number' || typeof agentRunId === 'string'
           ? agentRunId
@@ -862,11 +862,9 @@ function toWorkflowRow(run: SeerNightShiftRun): WorkflowRow {
 }
 
 function getExplorerRunIds(row: WorkflowRow): Array<number | string> {
-  const shardRunIds = (row.triage?.shards ?? [])
-    .map(shard => shard.seerRunId)
-    .filter((id): id is string => id !== null);
-  if (shardRunIds.length > 0) {
-    return shardRunIds;
+  const seerRunIds = (row.triage?.seerRuns ?? []).map(seerRun => seerRun.seerRunId);
+  if (seerRunIds.length > 0) {
+    return seerRunIds;
   }
   // Fallback for pre-shard runs, which recorded a single id on the run extras.
   const agentRunId = row.triage?.agentRunId;

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -342,7 +342,7 @@ function SeerWorkflows() {
               ) : (
                 sortedRows.map(row => {
                   const isExpanded = expanded.has(row.id);
-                  const explorerRunId = getExplorerRunId(row);
+                  const explorerRunIds = getExplorerRunIds(row);
                   return (
                     <Fragment key={row.id}>
                       <SimpleTable.Row
@@ -384,7 +384,7 @@ function SeerWorkflows() {
                         <SimpleTable.RowCell>
                           <ResultCell
                             row={row}
-                            explorerRunId={explorerRunId}
+                            explorerRunIds={explorerRunIds}
                             organizationSlug={organization.slug}
                           />
                         </SimpleTable.RowCell>
@@ -514,32 +514,40 @@ function StatusIcon({status}: {status: RunStatus}) {
 
 function ResultCell({
   row,
-  explorerRunId,
+  explorerRunIds,
   organizationSlug,
 }: {
-  explorerRunId: number | string | null;
+  explorerRunIds: Array<number | string>;
   organizationSlug: string;
   row: WorkflowRow;
 }) {
   const content = getResultContent(row);
-  // A failed run shows "Run failed" — don't turn that into a Seer Explorer link
-  // even if the run happens to carry an agent_run_id.
-  if (explorerRunId === null || row.status === 'failed') {
+  // A failed run shows "Run failed" — don't turn that into Seer Explorer links
+  // even if its shards happen to carry run ids.
+  if (explorerRunIds.length === 0 || row.status === 'failed') {
     return content;
   }
+  // Result text once, then one Explorer link per shard.
   return (
-    <Link
-      to={{
-        pathname: `/organizations/${organizationSlug}/issues/autofix/`,
-        query: {explorerRunId},
-      }}
-      onClick={e => e.stopPropagation()}
-    >
-      <Flex gap="sm" align="center">
-        <IconOpen size="xs" variant="accent" aria-hidden />
-        {content}
-      </Flex>
-    </Link>
+    <Flex gap="sm" align="center" wrap="wrap">
+      {content}
+      {explorerRunIds.map((explorerRunId, index) => (
+        <Link
+          key={`${explorerRunId}-${index}`}
+          to={{
+            pathname: `/organizations/${organizationSlug}/issues/autofix/`,
+            query: {explorerRunId},
+          }}
+          onClick={e => e.stopPropagation()}
+        >
+          <IconOpen
+            size="xs"
+            variant="accent"
+            aria-label={t('Open run in Seer Explorer')}
+          />
+        </Link>
+      ))}
+    </Flex>
   );
 }
 
@@ -844,6 +852,7 @@ function toWorkflowRow(run: SeerNightShiftRun): WorkflowRow {
       maxCandidates: run.extras.options?.max_candidates,
       dryRun: run.extras.options?.dry_run,
       issues: run.issues,
+      shards: run.shards ?? [],
       agentRunId:
         typeof agentRunId === 'number' || typeof agentRunId === 'string'
           ? agentRunId
@@ -852,12 +861,19 @@ function toWorkflowRow(run: SeerNightShiftRun): WorkflowRow {
   };
 }
 
-function getExplorerRunId(row: WorkflowRow): number | string | null {
+function getExplorerRunIds(row: WorkflowRow): Array<number | string> {
+  const shardRunIds = (row.triage?.shards ?? [])
+    .map(shard => shard.seerRunId)
+    .filter((id): id is string => id !== null);
+  if (shardRunIds.length > 0) {
+    return shardRunIds;
+  }
+  // Fallback for pre-shard runs, which recorded a single id on the run extras.
   const agentRunId = row.triage?.agentRunId;
   if (typeof agentRunId === 'number' || typeof agentRunId === 'string') {
-    return agentRunId;
+    return [agentRunId];
   }
-  return null;
+  return [];
 }
 
 export default SeerWorkflows;

--- a/static/app/views/seerWorkflows/types.ts
+++ b/static/app/views/seerWorkflows/types.ts
@@ -8,7 +8,7 @@ type SeerNightShiftRunIssue = {
 
 // A Seer run dispatched by a night shift run, openable in Explorer.
 type SeerNightShiftSeerRun = {
-  seerRunId: string;
+  seerRunId: string | null;
 };
 
 type SeerNightShiftRunOptions = {

--- a/static/app/views/seerWorkflows/types.ts
+++ b/static/app/views/seerWorkflows/types.ts
@@ -7,7 +7,7 @@ type SeerNightShiftRunIssue = {
 };
 
 // A Seer run dispatched by a night shift run, openable in Explorer.
-export type SeerNightShiftSeerRun = {
+type SeerNightShiftSeerRun = {
   seerRunId: string;
 };
 

--- a/static/app/views/seerWorkflows/types.ts
+++ b/static/app/views/seerWorkflows/types.ts
@@ -6,6 +6,11 @@ type SeerNightShiftRunIssue = {
   seerRunId: string | null;
 };
 
+export type SeerNightShiftRunShard = {
+  id: string;
+  seerRunId: string | null;
+};
+
 type SeerNightShiftRunOptions = {
   dry_run?: boolean;
   extra_triage_instructions?: string;
@@ -28,6 +33,7 @@ export type SeerNightShiftRun = {
   extras: SeerNightShiftRunExtras;
   id: string;
   issues: SeerNightShiftRunIssue[];
+  shards: SeerNightShiftRunShard[];
   triageStrategy: string;
 };
 
@@ -64,6 +70,7 @@ export type WorkflowRow = {
   summary?: string;
   triage?: {
     issues: SeerNightShiftRunIssue[];
+    shards: SeerNightShiftRunShard[];
     agentRunId?: number | string;
     dryRun?: boolean;
     maxCandidates?: number;

--- a/static/app/views/seerWorkflows/types.ts
+++ b/static/app/views/seerWorkflows/types.ts
@@ -6,9 +6,9 @@ type SeerNightShiftRunIssue = {
   seerRunId: string | null;
 };
 
-export type SeerNightShiftRunShard = {
-  id: string;
-  seerRunId: string | null;
+// A Seer run dispatched by a night shift run, openable in Explorer.
+export type SeerNightShiftSeerRun = {
+  seerRunId: string;
 };
 
 type SeerNightShiftRunOptions = {
@@ -33,7 +33,7 @@ export type SeerNightShiftRun = {
   extras: SeerNightShiftRunExtras;
   id: string;
   issues: SeerNightShiftRunIssue[];
-  shards: SeerNightShiftRunShard[];
+  seerRuns: SeerNightShiftSeerRun[];
   triageStrategy: string;
 };
 
@@ -70,7 +70,7 @@ export type WorkflowRow = {
   summary?: string;
   triage?: {
     issues: SeerNightShiftRunIssue[];
-    shards: SeerNightShiftRunShard[];
+    seerRuns: SeerNightShiftSeerRun[];
     agentRunId?: number | string;
     dryRun?: boolean;
     maxCandidates?: number;


### PR DESCRIPTION
## Summary

The Result column gated its Seer Explorer link on `extras.agent_run_id`, which is no longer written now that night shift runs fan out into shards — so the link disappeared for every post-sharding run.

The Result cell now renders one Explorer link per run from the new `seerRuns` API field (`{seerRunId}[]`), falling back to the legacy `extras.agent_run_id` for pre-shard runs. Layout is intentionally minimal for now.

## Test plan

- `index.spec.tsx`: one link per seer run, legacy fallback, and no link when there's nothing to link.
- `pnpm test-ci static/app/views/seerWorkflows/index.spec.tsx` passes.