### PR TITLE
fix(seer): Skip GitLab MRs authored by the integration itself

### DIFF
--- a/src/sentry/seer/code_review/metrics.py
+++ b/src/sentry/seer/code_review/metrics.py
@@ -19,6 +19,7 @@ class WebhookFilteredReason(StrEnum):
     INVALID_PAYLOAD = "invalid_payload"  # Validation failed
     TRANSFORM_FAILED = "transform_failed"  # Couldn't build Seer payload
     TRIGGER_DISABLED = "trigger_disabled"  # Trigger not enabled in repo settings
+    SELF_AUTHORED = "self_authored"  # MR opened by the integration's own account
 
 
 CodeReviewFilteredReason = WebhookFilteredReason | PreflightDenialReason

--- a/src/sentry/seer/code_review/webhooks/gitlab_identity.py
+++ b/src/sentry/seer/code_review/webhooks/gitlab_identity.py
@@ -1,0 +1,94 @@
+"""
+Resolve the GitLab integration's own actor identity so webhook handlers can skip
+merge requests the integration authored itself.
+
+Without this, an MR opened by the integration's own GitLab account (the OAuth
+token-owner Sentry acts as) would seed/increment an ``OrganizationContributors``
+row for seat billing and trigger a Seer review of our own MR. The alias-based
+``OrganizationContributors.is_bot`` heuristic does not catch this on GitLab,
+which has no ``[bot]`` username convention.
+
+We resolve "our" GitLab user id via ``get_authenticated_actor`` — the same source
+``merge_request.py`` already trusts as our identity for reaction de-duplication —
+and cache it in Redis per ``(organization, integration)`` so it costs at most one
+GitLab API call per TTL window. Every failure path fails **open** (returns
+``None`` / ``False`` so the caller processes the event normally): mistakenly
+processing one self-authored MR is recoverable, silently dropping a real
+contributor is not.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from scm import actions as scm_actions
+from scm.types import GetAuthenticatedActorProtocol
+
+from sentry.models.repository import Repository
+from sentry.scm import factory as scm_factory
+from sentry.utils.redis import redis_clusters
+
+logger = logging.getLogger(__name__)
+
+# Cache the integration's own GitLab user id so we don't call GET /user on every
+# webhook delivery. Keyed per (org, integration) since a token rotation could
+# change the acting user; the TTL bounds how long a stale id can survive.
+ACTOR_CACHE_KEY_PREFIX = "webhook:gitlab:actor:"
+ACTOR_CACHE_TTL_SECONDS = 3600
+
+
+def get_integration_actor_id(organization_id: int, repo: Repository) -> str | None:
+    """
+    Return the GitLab user id the integration authenticates as, or None.
+
+    The result is cached in Redis for ``ACTOR_CACHE_TTL_SECONDS``. Returns None on
+    any cache/API/provider error so callers fail open and process the event.
+    """
+    if repo.integration_id is None:
+        return None
+
+    cache_key = f"{ACTOR_CACHE_KEY_PREFIX}{organization_id}:{repo.integration_id}"
+
+    try:
+        cluster = redis_clusters.get("default")
+        cached = cluster.get(cache_key)
+    except Exception:
+        logger.warning("gitlab.webhook.actor.cache_read_failed")
+        cluster = None
+        cached = None
+
+    if cached is not None:
+        return cached
+
+    try:
+        scm = scm_factory.new(organization_id, repo.id, "code-review-webhook")
+        if not isinstance(scm, GetAuthenticatedActorProtocol):
+            logger.warning("gitlab.webhook.actor.unsupported_provider")
+            return None
+        actor_id = str(scm_actions.get_authenticated_actor(scm)["data"]["id"])
+    except Exception:
+        logger.warning("gitlab.webhook.actor.fetch_failed", exc_info=True)
+        return None
+
+    if cluster is not None:
+        try:
+            cluster.set(cache_key, actor_id, ex=ACTOR_CACHE_TTL_SECONDS)
+        except Exception:
+            logger.warning("gitlab.webhook.actor.cache_write_failed")
+
+    return actor_id
+
+
+def is_self_authored_mr(*, organization_id: int, repo: Repository, author_id: object) -> bool:
+    """
+    True when ``author_id`` is the integration's own GitLab user.
+
+    Fails open (returns False) when the author is unknown or the integration's
+    actor id can't be resolved, so a resolution failure never drops a real MR.
+    """
+    if not author_id:
+        return False
+    actor_id = get_integration_actor_id(organization_id, repo)
+    if actor_id is None:
+        return False
+    return str(author_id) == actor_id

--- a/src/sentry/seer/code_review/webhooks/merge_request.py
+++ b/src/sentry/seer/code_review/webhooks/merge_request.py
@@ -82,6 +82,7 @@ from ..metrics import (
 )
 from ..preflight import CodeReviewPreflightService
 from ..utils import SeerEndpoint, _common_codegen_request_payload
+from .gitlab_identity import is_self_authored_mr
 from .logging import debug_log
 from .task import process_github_webhook_event
 
@@ -426,6 +427,16 @@ def handle_merge_request_event(
         return
 
     author_id = object_attributes.get("author_id")
+
+    # Skip MRs the integration opened itself so we never review our own MR (and
+    # never enqueue a PR-closed task for it on close/merge).
+    if is_self_authored_mr(organization_id=org.id, repo=repo, author_id=author_id):
+        logger.info("gitlab.webhook.merge_request.self_authored_skipped", extra=base_log)
+        record_webhook_filtered(
+            GITLAB_WEBHOOK_EVENT, action_value, WebhookFilteredReason.SELF_AUTHORED
+        )
+        return
+
     preflight = CodeReviewPreflightService(
         organization=org,
         repo=repo,

--- a/src/sentry/seer/code_review/webhooks/seat_tracking.py
+++ b/src/sentry/seer/code_review/webhooks/seat_tracking.py
@@ -52,6 +52,7 @@ from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.seer.code_review.contributor_seats import track_contributor_seat
+from sentry.seer.code_review.webhooks.gitlab_identity import is_self_authored_mr
 from sentry.seer.code_review.webhooks.logging import debug_log
 from sentry.utils.redis import redis_clusters
 
@@ -125,6 +126,13 @@ def track_gitlab_contributor_seat_processor(
         return
 
     base_extra["author_id"] = user_id
+
+    # Skip MRs the integration opened itself: seeding a contributor row (and a
+    # seat) for our own GitLab account would mis-bill the org. Checked before the
+    # dedup key is set so a self MR never consumes the dedup window.
+    if is_self_authored_mr(organization_id=organization.id, repo=repo, author_id=user_id):
+        logger.info("gitlab.webhook.seat_tracking.self_authored_skipped", extra=base_extra)
+        return
 
     # Resolve the Organization before marking the delivery as seen so a missing
     # org does not poison the dedup window and block GitLab redeliveries from

--- a/tests/sentry/seer/code_review/webhooks/test_merge_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_merge_request.py
@@ -16,6 +16,7 @@ from sentry.models.organization import Organization
 from sentry.models.organizationcontributors import OrganizationContributors
 from sentry.models.repositorysettings import CodeReviewTrigger
 from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.seer.code_review.metrics import WebhookFilteredReason
 from sentry.seer.code_review.models import SeerCodeReviewTaskRequestForPrReview
 from sentry.seer.code_review.webhooks.merge_request import (
     WEBHOOK_NOTE_SEEN_KEY_PREFIX,
@@ -1604,3 +1605,66 @@ class MergeRequestReactionTest(_MergeRequestHandlerTestBase):
 
         assert self.mock_scm.create_pull_request_reaction.call_count == 1
         assert self.mock_seer.call_count == 1
+
+
+class MergeRequestSelfAuthoredTest(_MergeRequestHandlerTestBase):
+    """The integration must not review MRs it opened itself.
+
+    ``mock_scm`` (autouse on the base) resolves the integration's own actor id to
+    ``"42"`` via ``get_authenticated_actor``; an MR whose ``author_id`` matches is
+    skipped before preflight, for every action.
+    """
+
+    @with_feature(_MergeRequestHandlerTestBase.CODE_REVIEW_FEATURES)
+    def test_open_by_integration_is_skipped(self) -> None:
+        self._setup_code_review()
+        event = _make_event("open", author_id=42)
+
+        with (
+            patch(
+                "sentry.seer.code_review.webhooks.merge_request.record_webhook_filtered"
+            ) as mock_filtered,
+            self.tasks(),
+        ):
+            self._call_handler(event)
+
+        self.mock_seer.assert_not_called()
+        mock_filtered.assert_called_once_with(
+            "merge_request", "open", WebhookFilteredReason.SELF_AUTHORED
+        )
+
+    @with_feature(_MergeRequestHandlerTestBase.CODE_REVIEW_FEATURES)
+    def test_merge_by_integration_is_skipped(self) -> None:
+        # Close/merge actions enqueue a PR-closed task; a self-authored merge must
+        # be skipped there too.
+        self._setup_code_review()
+        event = _make_event("merge", author_id=42)
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_seer.assert_not_called()
+
+    @with_feature(_MergeRequestHandlerTestBase.CODE_REVIEW_FEATURES)
+    def test_other_author_is_not_skipped(self) -> None:
+        # Author 51 != actor 42, so a normal contributor's MR still gets reviewed.
+        self._setup_code_review()
+        event = _make_event("open", author_id=51)
+
+        with self.tasks():
+            self._call_handler(event)
+
+        self.mock_seer.assert_called_once()
+
+    @with_feature(_MergeRequestHandlerTestBase.CODE_REVIEW_FEATURES)
+    def test_actor_id_is_cached_across_deliveries(self) -> None:
+        # The self-author check resolves our actor once and caches it in Redis, so a
+        # redelivered self MR does not call get_authenticated_actor again.
+        self._setup_code_review()
+        event = _make_event("open", author_id=42)
+
+        with self.tasks():
+            self._call_handler(event)
+            self._call_handler(event)
+
+        assert self.mock_scm.get_authenticated_actor.call_count == 1

--- a/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
+++ b/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
@@ -1,7 +1,9 @@
+from collections.abc import Generator
 from typing import Any
 from unittest.mock import patch
 
 import orjson
+import pytest
 
 from fixtures.gitlab import MERGE_REQUEST_OPENED_EVENT, GitLabTestCase
 from sentry.integrations.gitlab.webhooks import MergeEventWebhook
@@ -45,6 +47,17 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
         super().setUp()
         self.repo = self.create_gitlab_repo("getsentry/sentry")
         self.rpc_organization = _rpc_org(self.organization)
+
+    @pytest.fixture(autouse=True)
+    def mock_actor(self) -> Generator[None]:
+        # Resolve the integration's own GitLab user id without hitting GitLab.
+        # The fixture MR author is 51, so "999" means "not self" by default.
+        with patch(
+            "sentry.seer.code_review.webhooks.gitlab_identity.get_integration_actor_id",
+            return_value="999",
+        ) as mock_actor:
+            self.mock_actor = mock_actor
+            yield
 
     def _call(self, event: dict[str, Any] | None = None) -> None:
         track_gitlab_contributor_seat_processor(
@@ -111,6 +124,24 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
         del event["user"]["username"]
         self._call(event=event)
         mock_track.assert_not_called()
+
+    @with_feature("organizations:seer-gitlab-support")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_no_call_for_self_authored_mr(self, mock_track: Any) -> None:
+        # An MR opened by the integration's own account (author_id == our actor id)
+        # must not seed a contributor row or consume a seat.
+        self.mock_actor.return_value = "999"
+        self._call(event=_make_event(author_id=999))
+        mock_track.assert_not_called()
+
+    @with_feature("organizations:seer-gitlab-support")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_fails_open_when_actor_unresolved(self, mock_track: Any) -> None:
+        # If we can't resolve our own actor id, fail open and still track the
+        # contributor — losing seat tracking is worse than an extra check.
+        self.mock_actor.return_value = None
+        self._call(event=_make_event(author_id=999))
+        mock_track.assert_called_once()
 
     @with_feature("organizations:seer-gitlab-support")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")


### PR DESCRIPTION
## Summary

GitLab `merge_request` webhooks did not check whether an MR was authored by the integration's **own** GitLab account before:
1. seeding/incrementing an `OrganizationContributors` row for seat billing, and
2. enqueuing a Seer code review.

The only related guard, `OrganizationContributors.is_bot`, is an alias-suffix heuristic (`*[bot]`/`Copilot`) that runs *after* the contributor row is created — and GitLab has no `[bot]` username convention, so a self-authored MR would mis-bill a seat and trigger Seer to review our own MR.

## Approach

- New helper `gitlab_identity.py` resolves the integration's own GitLab user id via `get_authenticated_actor` (the same identity the existing reaction de-dup logic already trusts), cached in Redis per `(org, integration)` so it costs at most one API call per TTL window.
- `is_self_authored_mr()` compares that id against the MR `author_id` and **fails open** (processes normally) on any cache/API error — over-tracking once is recoverable; silently dropping a real contributor is not.
- Guard added in **both** the contributor seat processor (`seat_tracking.py`, before the dedup key is set) and the review enqueue handler (`merge_request.py`, before preflight — covers open/update/close/merge). A new `WebhookFilteredReason.SELF_AUTHORED` metric records the skip.
- The note handler is intentionally **not** guarded: it's commenter-driven (`@sentry review`), so a human requesting a review on a bot-authored MR is legitimate.

## Testing

- `test_seat_tracking.py`: self-authored MR not tracked; fail-open still tracks.
- `test_merge_request.py`: self-authored open/merge not reviewed + `SELF_AUTHORED` recorded; other authors still reviewed; actor id cached across redeliveries.
- 89 tests pass; `prek` (ruff/flake8/mypy) clean.