### PR TITLE
prototype(conversations): Overhaul AI conversations list and detail views

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -442,10 +442,9 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 if trace_id:
                     traces_by_conversation[conv_id].add(trace_id)
 
-                if row.get("gen_ai.operation.type") == "invoke_agent":
-                    agent_name = row.get("gen_ai.agent.name", "")
-                    if agent_name:
-                        flows_by_conversation[conv_id].append(agent_name)
+                agent_name = row.get("gen_ai.agent.name", "")
+                if agent_name and agent_name not in flows_by_conversation[conv_id]:
+                    flows_by_conversation[conv_id].append(agent_name)
 
                 if row.get("gen_ai.operation.type") == "tool":
                     tool_name = row.get("gen_ai.tool.name")

--- a/static/app/views/explore/conversations/components/conversationHeaderV2.tsx
+++ b/static/app/views/explore/conversations/components/conversationHeaderV2.tsx
@@ -1,0 +1,243 @@
+import {useMemo} from 'react';
+
+import {ProjectAvatar} from '@sentry/scraps/avatar';
+import {Tag} from '@sentry/scraps/badge';
+import {Button} from '@sentry/scraps/button';
+import {LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {Placeholder} from 'sentry/components/placeholder';
+import {IconCopy, IconOpen, IconUser} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {isUUID} from 'sentry/utils/string/isUUID';
+import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjectFromSlug} from 'sentry/utils/useProjectFromSlug';
+import {
+  getNumberAttr,
+  getStringAttr,
+  hasError,
+} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
+import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
+import {
+  getIsAiGenerationSpan,
+  getIsExecuteToolSpan,
+} from 'sentry/views/insights/pages/agents/utils/query';
+import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
+import {SpanFields} from 'sentry/views/insights/types';
+
+interface ConversationHeaderV2Props {
+  conversationId: string;
+  nodeTraceMap: Map<string, string>;
+  nodes: AITraceSpanNode[];
+  isLoading?: boolean;
+}
+
+function getGenAiOpType(node: AITraceSpanNode): string | undefined {
+  return getStringAttr(node, SpanFields.GEN_AI_OPERATION_TYPE);
+}
+
+function calculateAggregates(nodes: AITraceSpanNode[]) {
+  let llmCalls = 0;
+  let toolCalls = 0;
+  let errorCount = 0;
+  let totalTokens = 0;
+  let totalCost = 0;
+  const toolNameSet = new Set<string>();
+  let userEmail: string | undefined;
+  let projectSlug: string | undefined;
+
+  for (const node of nodes) {
+    const opType = getGenAiOpType(node);
+
+    if (getIsAiGenerationSpan(opType)) {
+      llmCalls++;
+      totalTokens += getNumberAttr(node, SpanFields.GEN_AI_USAGE_TOTAL_TOKENS) ?? 0;
+      totalCost += getNumberAttr(node, SpanFields.GEN_AI_COST_TOTAL_TOKENS) ?? 0;
+    } else if (getIsExecuteToolSpan(opType)) {
+      toolCalls++;
+      const toolName = getStringAttr(node, SpanFields.GEN_AI_TOOL_NAME);
+      if (toolName) {
+        toolNameSet.add(toolName);
+      }
+    }
+
+    if (hasError(node)) {
+      errorCount++;
+    }
+
+    if (!userEmail) {
+      userEmail = getStringAttr(node, SpanFields.USER_EMAIL) || undefined;
+    }
+    if (!projectSlug) {
+      projectSlug = node.projectSlug || undefined;
+    }
+  }
+
+  return {
+    llmCalls,
+    toolCalls,
+    errorCount,
+    totalTokens,
+    totalCost,
+    toolNames: Array.from(toolNameSet).sort(),
+    userEmail,
+    projectSlug,
+  };
+}
+
+function formatTokenCount(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(count >= 10000 ? 0 : 1)}k`;
+  }
+  return String(count);
+}
+
+export function ConversationHeaderV2({
+  conversationId,
+  nodes,
+  nodeTraceMap,
+  isLoading,
+}: ConversationHeaderV2Props) {
+  const organization = useOrganization();
+  const aggregates = useMemo(() => calculateAggregates(nodes), [nodes]);
+
+  const uniqueTraces = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const [spanId, traceId] of nodeTraceMap) {
+      if (!seen.has(traceId)) {
+        seen.set(traceId, spanId);
+      }
+    }
+    return Array.from(seen, ([traceId, spanId]) => ({traceId, spanId}));
+  }, [nodeTraceMap]);
+  const project = useProjectFromSlug({
+    organization,
+    projectSlug: aggregates.projectSlug,
+  });
+
+  const handleCopyConversationId = () => {
+    trackAnalytics('conversations.detail.copy-conversation-id', {
+      organization,
+    });
+    copyToClipboard(conversationId, {
+      successMessage: t('Copied conversation ID to clipboard'),
+    });
+  };
+
+  const displayId = isUUID(conversationId) ? conversationId.slice(0, 10) : conversationId;
+
+  return (
+    <Flex align="center" justify="between" gap="lg" flex={1}>
+      <Flex direction="column" gap="sm" minWidth={0} flex={1}>
+        <Flex align="center" gap="md" flexShrink={0}>
+          <Text size="xl" bold>
+            {displayId}
+          </Text>
+          <Tooltip title={t('Copy conversation ID')}>
+            <Button
+              size="zero"
+              variant="transparent"
+              aria-label={t('Copy conversation ID')}
+              icon={<IconCopy size="xs" />}
+              onClick={handleCopyConversationId}
+            />
+          </Tooltip>
+        </Flex>
+        <Flex align="center" gap="md" wrap="wrap">
+          {project && (
+            <Flex align="center" gap="xs">
+              <ProjectAvatar size={16} project={project} />
+              <Text size="sm">{project.slug}</Text>
+            </Flex>
+          )}
+          {aggregates.userEmail && (
+            <Flex align="center" gap="xs">
+              <IconUser size="xs" />
+              <Text size="xs" variant="muted">
+                {aggregates.userEmail}
+              </Text>
+            </Flex>
+          )}
+          {!isLoading && uniqueTraces.length > 0 && (
+            <Flex align="center" gap="xs">
+              {uniqueTraces.length === 1 ? (
+                <LinkButton
+                  size="xs"
+                  variant="link"
+                  icon={<IconOpen size="xs" />}
+                  to={`/organizations/${organization.slug}/explore/traces/trace/${uniqueTraces[0].traceId}/?node=span-${uniqueTraces[0].spanId}`}
+                >
+                  {t('View Trace')}
+                </LinkButton>
+              ) : (
+                <DropdownMenu
+                  triggerProps={{
+                    size: 'xs',
+                    variant: 'link',
+                    icon: <IconOpen size="xs" />,
+                  }}
+                  triggerLabel={tn('%s Trace', '%s Traces', uniqueTraces.length)}
+                  items={uniqueTraces.map((trace, i) => ({
+                    key: trace.traceId,
+                    label: `${t('Trace')} ${i + 1} — ${trace.traceId.slice(0, 8)}`,
+                    to: `/organizations/${organization.slug}/explore/traces/trace/${trace.traceId}/?node=span-${trace.spanId}`,
+                  }))}
+                />
+              )}
+            </Flex>
+          )}
+          {!isLoading && aggregates.toolNames.length > 0 && (
+            <Flex align="center" gap="xs" wrap="wrap">
+              {aggregates.toolNames.slice(0, 6).map(name => (
+                <Tag key={name} variant="muted">
+                  {name}
+                </Tag>
+              ))}
+              {aggregates.toolNames.length > 6 && (
+                <Text size="sm" variant="muted">
+                  {t('+%s more', aggregates.toolNames.length - 6)}
+                </Text>
+              )}
+            </Flex>
+          )}
+        </Flex>
+      </Flex>
+      <Flex align="start" gap="lg" flexShrink={0}>
+        {isLoading ? (
+          <Flex gap="lg">
+            <Placeholder height="40px" width="60px" />
+            <Placeholder height="40px" width="60px" />
+            <Placeholder height="40px" width="60px" />
+            <Placeholder height="40px" width="60px" />
+          </Flex>
+        ) : (
+          <Flex align="start" gap="lg">
+            <StatItem label={t('Messages')} value={String(aggregates.llmCalls)} />
+            <StatItem label={t('Errors')} value={String(aggregates.errorCount)} />
+            <StatItem
+              label={t('Tokens')}
+              value={formatTokenCount(aggregates.totalTokens)}
+            />
+            <StatItem label={t('Cost')} value={formatLLMCosts(aggregates.totalCost)} />
+          </Flex>
+        )}
+      </Flex>
+    </Flex>
+  );
+}
+
+function StatItem({label, value}: {label: string; value: string}) {
+  return (
+    <Flex direction="column" align="start" gap="xs">
+      <Text size="sm" variant="muted" bold>
+        {label}
+      </Text>
+      <Text size="2xl">{value}</Text>
+    </Flex>
+  );
+}

--- a/static/app/views/explore/conversations/components/conversationTranscript.tsx
+++ b/static/app/views/explore/conversations/components/conversationTranscript.tsx
@@ -1,0 +1,490 @@
+import {useCallback, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Tag} from '@sentry/scraps/badge';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {ClippedBox} from 'sentry/components/clippedBox';
+import {IconChat, IconChevron, IconFire, IconFix} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {getDuration} from 'sentry/utils/duration/getDuration';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {
+  ConversationMessage,
+  ToolCall,
+} from 'sentry/views/explore/conversations/utils/conversationMessages';
+import {extractMessagesFromNodes} from 'sentry/views/explore/conversations/utils/conversationMessages';
+import {getFirstToolInputValue} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
+import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
+import {AIContentRenderer} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer';
+
+const COLLAPSED_TOOL_THRESHOLD = 4;
+
+function getNodeDuration(node: AITraceSpanNode): number | undefined {
+  const start =
+    'start_timestamp' in node.value ? (node.value.start_timestamp as number) : 0;
+  const end = 'end_timestamp' in node.value ? (node.value.end_timestamp as number) : 0;
+  if (end > start) {
+    return end - start;
+  }
+  return undefined;
+}
+
+function formatDuration(seconds: number): string {
+  return getDuration(seconds, 1, true);
+}
+
+interface ConversationTranscriptProps {
+  nodes: AITraceSpanNode[];
+  onSelectNode: (node: AITraceSpanNode) => void;
+  selectedNodeId: string | null;
+  hoveredNodeId?: string | null;
+  onHoverNode?: (nodeId: string | null) => void;
+  showToolCalls?: boolean;
+}
+
+export function ConversationTranscript({
+  nodes,
+  selectedNodeId,
+  hoveredNodeId,
+  onSelectNode,
+  onHoverNode,
+  showToolCalls = true,
+}: ConversationTranscriptProps) {
+  const organization = useOrganization();
+  const messages = useMemo(() => extractMessagesFromNodes(nodes), [nodes]);
+
+  const nodeMap = useMemo(() => {
+    const map = new Map<string, AITraceSpanNode>();
+    for (const node of nodes) {
+      map.set(node.id, node);
+    }
+    return map;
+  }, [nodes]);
+
+  const handleMessageClick = useCallback(
+    (message: ConversationMessage) => {
+      trackAnalytics('conversations.message.click', {organization});
+      const node = nodeMap.get(message.nodeId);
+      if (node) {
+        onSelectNode(node);
+      }
+    },
+    [nodeMap, onSelectNode, organization]
+  );
+
+  const handleToolClick = useCallback(
+    (tool: ToolCall) => {
+      trackAnalytics('conversations.message.click-tool-call', {organization});
+      const node = nodeMap.get(tool.nodeId);
+      if (node) {
+        onSelectNode(node);
+      }
+    },
+    [nodeMap, onSelectNode, organization]
+  );
+
+  if (messages.length === 0) {
+    return (
+      <TranscriptRoot>
+        <Text size="sm" variant="muted">
+          {t('No messages found')}
+        </Text>
+      </TranscriptRoot>
+    );
+  }
+
+  return (
+    <TranscriptRoot>
+      {messages.map(message => {
+        if (message.role === 'user') {
+          return <UserMessage key={message.id} message={message} />;
+        }
+        return (
+          <AssistantTurn
+            key={message.id}
+            message={message}
+            nodeMap={nodeMap}
+            selectedNodeId={selectedNodeId}
+            hoveredNodeId={hoveredNodeId}
+            onMessageClick={handleMessageClick}
+            onToolClick={handleToolClick}
+            onHoverNode={onHoverNode}
+            showToolCalls={showToolCalls}
+          />
+        );
+      })}
+    </TranscriptRoot>
+  );
+}
+
+function UserMessage({message}: {message: ConversationMessage}) {
+  return (
+    <UserBubble>
+      <StyledClippedBox
+        clipHeight={500}
+        buttonProps={{variant: 'secondary', size: 'xs'}}
+        clipFade={({showMoreButton}) => (
+          <NoFadeClipAction>{showMoreButton}</NoFadeClipAction>
+        )}
+        collapsible
+      >
+        <ResponseContent>
+          <AIContentRenderer text={message.content} inline autoCollapseLimit={10} />
+        </ResponseContent>
+      </StyledClippedBox>
+    </UserBubble>
+  );
+}
+
+function AssistantTurn({
+  message,
+  nodeMap,
+  selectedNodeId,
+  hoveredNodeId,
+  onMessageClick,
+  onToolClick,
+  onHoverNode,
+  showToolCalls,
+}: {
+  message: ConversationMessage;
+  nodeMap: Map<string, AITraceSpanNode>;
+  onMessageClick: (message: ConversationMessage) => void;
+  onToolClick: (tool: ToolCall) => void;
+  selectedNodeId: string | null;
+  showToolCalls: boolean;
+  hoveredNodeId?: string | null;
+  onHoverNode?: (nodeId: string | null) => void;
+}) {
+  const toolCalls = message.toolCalls ?? [];
+  const hasContent = message.content !== '';
+
+  const isMessageHighlighted =
+    hoveredNodeId === message.nodeId || toolCalls.some(tc => tc.nodeId === hoveredNodeId);
+
+  return (
+    <Flex direction="column" gap="xl" width="100%">
+      {showToolCalls && toolCalls.length > 0 && (
+        <ToolCallGroup
+          toolCalls={toolCalls}
+          nodeMap={nodeMap}
+          selectedNodeId={selectedNodeId}
+          hoveredNodeId={hoveredNodeId}
+          onToolClick={onToolClick}
+          onHoverNode={onHoverNode}
+        />
+      )}
+      {hasContent && (
+        <RowWithDuration>
+          <ChatIconContainer>
+            <IconChat size="sm" />
+          </ChatIconContainer>
+          <AssistantResponseBlock
+            onClick={() => onMessageClick(message)}
+            onMouseEnter={() => onHoverNode?.(message.nodeId)}
+            onMouseLeave={() => onHoverNode?.(null)}
+            isSelected={
+              message.nodeId === selectedNodeId ||
+              toolCalls.some(tc => tc.nodeId === selectedNodeId)
+            }
+            isHighlighted={isMessageHighlighted}
+          >
+            <StyledClippedBox
+              clipHeight={500}
+              buttonProps={{variant: 'secondary', size: 'xs'}}
+              collapsible
+            >
+              <ResponseContent>
+                <AIContentRenderer text={message.content} inline autoCollapseLimit={10} />
+              </ResponseContent>
+            </StyledClippedBox>
+          </AssistantResponseBlock>
+          <DurationText size="sm" monospace variant="muted">
+            {message.duration !== undefined && message.duration > 0
+              ? formatDuration(message.duration)
+              : ''}
+          </DurationText>
+        </RowWithDuration>
+      )}
+    </Flex>
+  );
+}
+
+function ToolCallGroup({
+  toolCalls,
+  nodeMap,
+  selectedNodeId,
+  hoveredNodeId,
+  onToolClick,
+  onHoverNode,
+}: {
+  nodeMap: Map<string, AITraceSpanNode>;
+  onToolClick: (tool: ToolCall) => void;
+  selectedNodeId: string | null;
+  toolCalls: ToolCall[];
+  hoveredNodeId?: string | null;
+  onHoverNode?: (nodeId: string | null) => void;
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const shouldCollapse = toolCalls.length > COLLAPSED_TOOL_THRESHOLD;
+
+  if (shouldCollapse && !isExpanded) {
+    return (
+      <CollapsedToolRow onClick={() => setIsExpanded(true)}>
+        <ToggleIconContainer>
+          <IconChevron size="sm" direction="right" />
+        </ToggleIconContainer>
+        <Text size="sm" monospace>
+          {tn('%s tool call', '%s tool calls', toolCalls.length)}
+        </Text>
+      </CollapsedToolRow>
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="xl" width="100%">
+      {shouldCollapse && (
+        <CollapsedToolRow onClick={() => setIsExpanded(false)}>
+          <ToggleIconContainer>
+            <IconChevron size="sm" direction="down" />
+          </ToggleIconContainer>
+          <Text size="sm" monospace>
+            {tn('%s tool call', '%s tool calls', toolCalls.length)}
+          </Text>
+        </CollapsedToolRow>
+      )}
+      {toolCalls.map(tool => (
+        <ToolCallRow
+          key={tool.nodeId}
+          tool={tool}
+          nodeMap={nodeMap}
+          isSelected={tool.nodeId === selectedNodeId}
+          isHighlighted={tool.nodeId === hoveredNodeId}
+          onToolClick={onToolClick}
+          onHoverNode={onHoverNode}
+        />
+      ))}
+    </Flex>
+  );
+}
+
+function ToolCallRow({
+  tool,
+  nodeMap,
+  isSelected,
+  isHighlighted,
+  onToolClick,
+  onHoverNode,
+}: {
+  isSelected: boolean;
+  nodeMap: Map<string, AITraceSpanNode>;
+  onToolClick: (tool: ToolCall) => void;
+  tool: ToolCall;
+  isHighlighted?: boolean;
+  onHoverNode?: (nodeId: string | null) => void;
+}) {
+  const toolNode = nodeMap.get(tool.nodeId);
+  const inputPreview = toolNode ? getFirstToolInputValue(toolNode) : undefined;
+  const duration = toolNode ? getNodeDuration(toolNode) : undefined;
+
+  return (
+    <RowWithDuration>
+      <ToolRow
+        onClick={() => onToolClick(tool)}
+        onMouseEnter={() => onHoverNode?.(tool.nodeId)}
+        onMouseLeave={() => onHoverNode?.(null)}
+        isSelected={isSelected}
+        isHighlighted={isHighlighted}
+        hasError={tool.hasError}
+      >
+        <IconContainer>
+          {tool.hasError ? <IconFire size="sm" /> : <IconFix size="sm" />}
+        </IconContainer>
+        <Tag variant={tool.hasError ? 'danger' : 'muted'}>{tool.name}</Tag>
+        {inputPreview && (
+          <ToolPreviewText size="sm" monospace variant="muted">
+            {inputPreview}
+          </ToolPreviewText>
+        )}
+      </ToolRow>
+      <DurationText size="sm" monospace variant="muted">
+        {duration !== undefined ? formatDuration(duration) : ''}
+      </DurationText>
+    </RowWithDuration>
+  );
+}
+
+const TranscriptRoot = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.xl};
+  align-items: flex-end;
+  padding: ${p => p.theme.space.xl};
+  background: ${p => p.theme.tokens.background.primary};
+`;
+
+const UserBubble = styled('div')`
+  background: ${p => p.theme.tokens.background.secondary};
+  border: 1px solid ${p => p.theme.tokens.border.secondary};
+  border-radius: ${p => p.theme.radius.md};
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.md};
+  max-width: 80%;
+  align-self: flex-end;
+`;
+
+const AssistantResponseBlock = styled('div')<{
+  isHighlighted?: boolean;
+  isSelected?: boolean;
+}>`
+  background: ${p => p.theme.tokens.background.primary};
+  border: 1px solid ${p => p.theme.tokens.border.secondary};
+  border-radius: 4px;
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.md};
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+  word-break: break-word;
+
+  &:hover {
+    border-color: ${p => p.theme.tokens.border.accent.moderate};
+  }
+
+  ${p =>
+    p.isHighlighted &&
+    `
+    border-color: ${p.theme.tokens.border.accent.moderate};
+  `}
+
+  ${p =>
+    p.isSelected &&
+    `
+    border-color: ${p.theme.tokens.focus.default};
+    &:hover {
+      border-color: ${p.theme.tokens.focus.default};
+    }
+  `}
+`;
+
+const ResponseContent = styled('div')`
+  font-size: ${p => p.theme.font.size.md};
+  line-height: 1.4;
+  color: ${p => p.theme.tokens.content.primary};
+`;
+
+const ToolRow = styled('div')<{
+  hasError?: boolean;
+  isHighlighted?: boolean;
+  isSelected?: boolean;
+}>`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 2px 4px;
+  margin: -2px -4px;
+
+  &:hover {
+    background: ${p => p.theme.tokens.background.secondary};
+  }
+
+  ${p =>
+    p.isHighlighted &&
+    `
+    background: ${p.theme.tokens.background.secondary};
+  `}
+
+  ${p =>
+    p.isSelected &&
+    `
+    background: ${p.theme.tokens.background.transparent.accent.muted};
+  `}
+`;
+
+const CollapsedToolRow = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+  width: 100%;
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 2px 4px;
+  margin: -2px -4px;
+
+  &:hover {
+    background: ${p => p.theme.tokens.background.secondary};
+  }
+`;
+
+const IconContainer = styled('div')`
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 20px;
+  flex-shrink: 0;
+  padding-top: 2px;
+  color: ${p => p.theme.tokens.dataviz.categorical[5][0]};
+`;
+
+const ChatIconContainer = styled('div')`
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 20px;
+  flex-shrink: 0;
+  padding-top: 2px;
+  color: ${p => p.theme.tokens.dataviz.categorical[5][5]};
+`;
+
+const RowWithDuration = styled('div')`
+  display: flex;
+  align-items: start;
+  gap: ${p => p.theme.space.md};
+  width: 100%;
+`;
+
+const DurationText = styled(Text)`
+  flex-shrink: 0;
+  white-space: nowrap;
+  width: 55px;
+  text-align: right;
+`;
+
+const ToolPreviewText = styled(Text)`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+`;
+
+const ToggleIconContainer = styled('div')`
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 20px;
+  flex-shrink: 0;
+  padding-top: 2px;
+  color: ${p => p.theme.tokens.content.primary};
+`;
+
+const StyledClippedBox = styled(ClippedBox)`
+  padding: 0;
+`;
+
+const NoFadeClipAction = styled('div')`
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  text-align: center;
+  padding: ${p => p.theme.space.xs} 0;
+  pointer-events: none;
+  & > * {
+    pointer-events: auto;
+  }
+`;

--- a/static/app/views/explore/conversations/components/conversationViewV2.tsx
+++ b/static/app/views/explore/conversations/components/conversationViewV2.tsx
@@ -1,0 +1,559 @@
+import {memo, useCallback, useEffect, useMemo, useState} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
+
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {TabList, TabPanels, Tabs} from '@sentry/scraps/tabs';
+import {Text} from '@sentry/scraps/text';
+
+import {CopyAsDropdown} from 'sentry/components/copyAsDropdown';
+import {EmptyMessage} from 'sentry/components/emptyMessage';
+import {Placeholder} from 'sentry/components/placeholder';
+import {SearchBar} from 'sentry/components/searchBar';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {getDuration} from 'sentry/utils/duration/getDuration';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import {ConversationTranscript} from 'sentry/views/explore/conversations/components/conversationTranscript';
+import {
+  useConversation,
+  type UseConversationsOptions,
+} from 'sentry/views/explore/conversations/hooks/useConversation';
+import {useConversationSelection} from 'sentry/views/explore/conversations/hooks/useConversationSelection';
+import {
+  extractMessagesFromNodes,
+  messagesToMarkdown,
+} from 'sentry/views/explore/conversations/utils/conversationMessages';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {AISpanList} from 'sentry/views/insights/pages/agents/components/aiSpanList';
+import {
+  getNumberAttr,
+  getStringAttr,
+  getTraceNodeAttribute,
+  resolveAgentName,
+} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
+import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
+import {AIContentRenderer} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer';
+import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
+import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
+
+interface ConversationViewV2ContentProps {
+  conversation: UseConversationsOptions;
+  focusedTool?: string | null;
+  onSelectSpan?: (spanId: string) => void;
+  selectedSpanId?: string | null;
+}
+
+export const ConversationViewV2Content = memo(function ConversationViewV2Content({
+  conversation,
+  selectedSpanId,
+  onSelectSpan,
+  focusedTool,
+}: ConversationViewV2ContentProps) {
+  const {nodes, isLoading, error} = useConversation(conversation);
+  const {selectedNode, handleSelectNode} = useConversationSelection({
+    nodes,
+    selectedSpanId,
+    onSelectSpan,
+    focusedTool,
+    isLoading,
+  });
+
+  return (
+    <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
+      <ConversationViewV2
+        nodes={nodes}
+        selectedNode={selectedNode}
+        onSelectNode={handleSelectNode}
+        isLoading={isLoading}
+        error={error}
+      />
+    </TraceStateProvider>
+  );
+});
+
+function ConversationViewV2({
+  nodes,
+  selectedNode,
+  onSelectNode,
+  isLoading,
+  error,
+}: {
+  error: boolean;
+  isLoading: boolean;
+  nodes: AITraceSpanNode[];
+  onSelectNode: (node: AITraceSpanNode) => void;
+  selectedNode: AITraceSpanNode | undefined;
+}) {
+  const organization = useOrganization();
+  const [showDetailPanel, setShowDetailPanel] = useState(false);
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isLoading && !error && nodes.length === 0) {
+      Sentry.captureMessage('User landed on empty conversation detail page (v2)', {
+        level: 'warning',
+      });
+    }
+  }, [isLoading, error, nodes.length]);
+
+  const handleSelectNodeWithPanel = useCallback(
+    (node: AITraceSpanNode) => {
+      setShowDetailPanel(true);
+      onSelectNode(node);
+    },
+    [onSelectNode]
+  );
+
+  const messages = useMemo(() => extractMessagesFromNodes(nodes), [nodes]);
+
+  if (isLoading) {
+    return <ConversationViewV2Skeleton />;
+  }
+
+  if (error) {
+    return <EmptyMessage>{t('Failed to load conversation')}</EmptyMessage>;
+  }
+
+  if (nodes.length === 0) {
+    return <EmptyMessage>{t('No AI spans found in this conversation')}</EmptyMessage>;
+  }
+
+  return (
+    <ViewWrapper>
+      <TwoCardLayout>
+        <LeftCard>
+          {messages.length > 0 && (
+            <Flex
+              flexShrink={0}
+              align="center"
+              justify="end"
+              padding="xs sm"
+              borderBottom="primary"
+            >
+              <CopyAsDropdown
+                size="xs"
+                items={CopyAsDropdown.makeDefaultCopyAsOptions({
+                  markdown: () => {
+                    trackAnalytics('conversations.detail.copy-conversation', {
+                      organization,
+                    });
+                    return messagesToMarkdown(messages);
+                  },
+                  text: undefined,
+                  json: undefined,
+                })}
+              />
+            </Flex>
+          )}
+          <ChatContent>
+            <ConversationTranscript
+              nodes={nodes}
+              selectedNodeId={selectedNode?.id ?? null}
+              hoveredNodeId={hoveredNodeId}
+              onSelectNode={handleSelectNodeWithPanel}
+              onHoverNode={setHoveredNodeId}
+              showToolCalls
+            />
+          </ChatContent>
+        </LeftCard>
+
+        <RightCard>
+          <Container padding="md lg md lg" width="100%">
+            <AISpanList
+              nodes={nodes}
+              selectedNodeKey={selectedNode?.id ?? ''}
+              hoveredNodeKey={hoveredNodeId}
+              onSelectNode={handleSelectNodeWithPanel}
+              onHoverNode={setHoveredNodeId}
+              compressGaps
+            />
+          </Container>
+        </RightCard>
+      </TwoCardLayout>
+
+      {showDetailPanel && selectedNode && (
+        <BottomCard>
+          <SpanDetailPanel
+            node={selectedNode}
+            onClose={() => setShowDetailPanel(false)}
+          />
+        </BottomCard>
+      )}
+    </ViewWrapper>
+  );
+}
+
+function ConversationViewV2Skeleton() {
+  return (
+    <ViewWrapper>
+      <TwoCardLayout>
+        <LeftCard>
+          <ChatContent>
+            <Flex direction="column" flex="1" gap="xl" padding="xl" align="end">
+              <Placeholder height="32px" width="60%" />
+              <Flex direction="column" gap="md" width="100%">
+                <Placeholder height="14px" width="200px" />
+                <Placeholder height="14px" width="300px" />
+                <Placeholder height="14px" width="250px" />
+              </Flex>
+              <Placeholder height="80px" width="100%" />
+              <Placeholder height="32px" width="40%" />
+              <Flex direction="column" gap="md" width="100%">
+                <Placeholder height="14px" width="180px" />
+              </Flex>
+              <Placeholder height="60px" width="100%" />
+            </Flex>
+          </ChatContent>
+        </LeftCard>
+        <RightCard>
+          <Flex direction="column" gap="md" padding="lg">
+            <Placeholder height="14px" width="180px" />
+            <Placeholder height="14px" width="140px" />
+            <Placeholder height="14px" width="160px" />
+            <Placeholder height="14px" width="120px" />
+          </Flex>
+        </RightCard>
+      </TwoCardLayout>
+    </ViewWrapper>
+  );
+}
+
+function getSpanDuration(node: AITraceSpanNode): number | undefined {
+  const start =
+    'start_timestamp' in node.value ? (node.value.start_timestamp as number) : 0;
+  const end = 'end_timestamp' in node.value ? (node.value.end_timestamp as number) : 0;
+  if (end > start) {
+    return end - start;
+  }
+  return undefined;
+}
+
+function formatTokenCount(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}k`;
+  }
+  return count.toString();
+}
+
+const INPUT_ATTRIBUTES = [
+  'gen_ai.input.messages',
+  'gen_ai.request.messages',
+  'ai.input_messages',
+  'ai.prompt',
+  'gen_ai.system_instructions',
+  'gen_ai.tool.call.arguments',
+  'gen_ai.tool.input',
+  'gen_ai.embeddings.input',
+] as const;
+
+const OUTPUT_ATTRIBUTES = [
+  'gen_ai.output.messages',
+  'gen_ai.response.text',
+  'gen_ai.response.object',
+  'gen_ai.response.tool_calls',
+  'gen_ai.tool.call.result',
+  'gen_ai.tool.output',
+] as const;
+
+function getRawContent(
+  node: AITraceSpanNode,
+  attributes: readonly string[]
+): string | undefined {
+  for (const key of attributes) {
+    const val = getTraceNodeAttribute(key, node);
+    if (val !== undefined && val !== null && val !== '') {
+      return String(val);
+    }
+  }
+  return undefined;
+}
+
+function SpanDetailPanel({node, onClose}: {node: AITraceSpanNode; onClose: () => void}) {
+  const [activeTab, setActiveTab] = useState<string>('input');
+
+  const rawOp = node.op ?? 'default';
+  const description =
+    node.description || ('name' in node.value ? (node.value.name as string) : rawOp);
+  const duration = getSpanDuration(node);
+
+  const agentName = resolveAgentName(node.attributes ?? {});
+  const inputTokens = getNumberAttr(node, 'gen_ai.usage.input_tokens');
+  const outputTokens = getNumberAttr(node, 'gen_ai.usage.output_tokens');
+  const totalTokens = getNumberAttr(node, 'gen_ai.usage.total_tokens');
+  const cost = getNumberAttr(node, 'ai.total_cost');
+  const model = getStringAttr(node, 'gen_ai.request.model');
+
+  const tokenDisplay = totalTokens
+    ? formatTokenCount(totalTokens)
+    : inputTokens !== undefined || outputTokens !== undefined
+      ? formatTokenCount((inputTokens ?? 0) + (outputTokens ?? 0))
+      : undefined;
+
+  const inputContent = getRawContent(node, INPUT_ATTRIBUTES);
+  const outputContent = getRawContent(node, OUTPUT_ATTRIBUTES);
+
+  return (
+    <PanelWrapper>
+      <Flex justify="between" align="start" padding="xl" gap="md" flexShrink={0}>
+        <Flex direction="column" gap="md" flex="1" minWidth="0">
+          <Flex align="center" gap="md">
+            <SpanColorDot />
+            <Text size="md" bold>
+              {description}
+            </Text>
+          </Flex>
+          {duration !== undefined && (
+            <Text size="md">{getDuration(duration, 2, true)}</Text>
+          )}
+          <MetadataGrid>
+            {agentName && <MetadataRow label={t('Agent Name')} value={agentName} />}
+            {tokenDisplay && <MetadataRow label={t('Tokens')} value={tokenDisplay} />}
+            {cost !== undefined && (
+              <MetadataRow label={t('Spend')} value={`$${cost.toFixed(2)}`} />
+            )}
+            {model && <MetadataRow label={t('Model')} value={model} />}
+          </MetadataGrid>
+        </Flex>
+        <Button
+          size="zero"
+          variant="transparent"
+          aria-label={t('Close detail panel')}
+          icon={<IconClose size="xs" />}
+          onClick={onClose}
+        />
+      </Flex>
+
+      <TabsWrapper>
+        <StyledTabs value={activeTab} onChange={key => setActiveTab(String(key))}>
+          <StyledTabList>
+            <TabList.Item key="input">{t('Input')}</TabList.Item>
+            <TabList.Item key="output" hidden={!outputContent}>
+              {t('Output')}
+            </TabList.Item>
+            <TabList.Item key="attributes">{t('Attributes')}</TabList.Item>
+          </StyledTabList>
+          <TabPanelsWrapper>
+            <TabPanels.Item key="input">
+              <TabContent>
+                {inputContent ? (
+                  <AIContentRenderer text={inputContent} />
+                ) : (
+                  <Text size="sm" variant="muted">
+                    {t('No input data')}
+                  </Text>
+                )}
+              </TabContent>
+            </TabPanels.Item>
+            <TabPanels.Item key="output">
+              <TabContent>
+                {outputContent ? (
+                  <AIContentRenderer text={outputContent} />
+                ) : (
+                  <Text size="sm" variant="muted">
+                    {t('No output data')}
+                  </Text>
+                )}
+              </TabContent>
+            </TabPanels.Item>
+            <TabPanels.Item key="attributes">
+              <TabContent>
+                <SpanAttributes node={node} />
+              </TabContent>
+            </TabPanels.Item>
+          </TabPanelsWrapper>
+        </StyledTabs>
+      </TabsWrapper>
+    </PanelWrapper>
+  );
+}
+
+function MetadataRow({label, value}: {label: string; value: string}) {
+  return (
+    <MetadataRowWrapper>
+      <Text size="xs" variant="muted">
+        {label}
+      </Text>
+      <Text size="xs">{value}</Text>
+    </MetadataRowWrapper>
+  );
+}
+
+function SpanAttributes({node}: {node: AITraceSpanNode}) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const organization = useOrganization();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const theme = useTheme();
+
+  const attributes: TraceItemResponseAttribute[] = useMemo(() => {
+    const attrs = node.attributes ?? {};
+    return Object.entries(attrs)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, value]) => {
+        if (typeof value === 'number') {
+          return Number.isInteger(value)
+            ? {name, type: 'int' as const, value}
+            : {name, type: 'float' as const, value};
+        }
+        if (typeof value === 'boolean') {
+          return {name, type: 'bool' as const, value};
+        }
+        return {name, type: 'str' as const, value: String(value)};
+      });
+  }, [node.attributes]);
+
+  const filteredAttributes = useMemo(() => {
+    if (!searchQuery.trim()) {
+      return attributes;
+    }
+    const q = searchQuery.toLowerCase().trim();
+    return attributes.filter(a => a.name.toLowerCase().includes(q));
+  }, [attributes, searchQuery]);
+
+  return (
+    <Stack gap="md">
+      <SearchBar
+        query={searchQuery}
+        onChange={setSearchQuery}
+        placeholder={t('Search')}
+      />
+      <AttributesTree
+        attributes={filteredAttributes}
+        rendererExtra={{organization, location, navigate, theme}}
+        columnCount={1}
+      />
+    </Stack>
+  );
+}
+
+const PanelWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+`;
+
+const SpanColorDot = styled('div')`
+  width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  flex-shrink: 0;
+  background: ${p => p.theme.tokens.background.accent.vibrant};
+`;
+
+const MetadataGrid = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.md};
+`;
+
+const MetadataRowWrapper = styled('div')`
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: ${p => p.theme.space.xs};
+  align-items: baseline;
+`;
+
+const TabsWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding: 0 ${p => p.theme.space.xl} ${p => p.theme.space.xl};
+`;
+
+const StyledTabs = styled(Tabs)`
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+` as typeof Tabs;
+
+const StyledTabList = styled(TabList)`
+  flex-shrink: 0;
+`;
+
+const TabPanelsWrapper = styled(TabPanels)`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+
+  > [role='tabpanel'] {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+`;
+
+const TabContent = styled('div')`
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding: ${p => p.theme.space.xl};
+  background: ${p => p.theme.tokens.background.secondary};
+  border-radius: ${p => p.theme.radius.md};
+`;
+
+const ViewWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  gap: ${p => p.theme.space.md};
+`;
+
+const TwoCardLayout = styled('div')`
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  gap: ${p => p.theme.space.md};
+`;
+
+const cardStyles = (p: {theme: any}) => `
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  background: ${p.theme.tokens.background.primary};
+  border: 1px solid ${p.theme.tokens.border.primary};
+  border-radius: ${p.theme.radius.md};
+`;
+
+const LeftCard = styled('div')`
+  ${cardStyles}
+  flex: 1;
+`;
+
+const RightCard = styled('div')`
+  ${cardStyles}
+  width: 360px;
+  flex-shrink: 0;
+  overflow-y: auto;
+`;
+
+const BottomCard = styled('div')`
+  ${cardStyles}
+  flex: 0 0 auto;
+  height: 45%;
+`;
+
+const ChatContent = styled('div')`
+  flex: 1;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+`;

--- a/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
@@ -1,49 +1,34 @@
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {InputOutputTooltipCell} from 'sentry/views/explore/conversations/components/conversationsTable';
+import {Count} from 'sentry/components/count';
 
-function mockOverflow(width: number, containerWidth: number) {
-  Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
-    configurable: true,
-    value: width,
-  });
-  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
-    configurable: true,
-    value: containerWidth,
-  });
-}
+describe('ConversationsTable columns', () => {
+  describe('Messages/Errors display', () => {
+    it('renders messages and zero errors without error styling', () => {
+      const {container} = render(
+        <div>
+          <Count value={12} />
+          {'/'}
+          <Count value={0} />
+        </div>
+      );
 
-describe('InputOutputTooltipCell', () => {
-  afterEach(() => {
-    // @ts-expect-error cleanup previously mocked properties
-    delete HTMLElement.prototype.scrollWidth;
-    // @ts-expect-error cleanup previously mocked properties
-    delete HTMLElement.prototype.clientWidth;
-  });
+      expect(container.textContent).toBe('12/0');
+    });
 
-  it('does not show the tooltip when the cell content fits', async () => {
-    mockOverflow(80, 120);
+    it('renders messages with non-zero errors', () => {
+      const {container} = render(
+        <div>
+          <Count value={12} />
+          {'/'}
+          <span data-test-id="error-count">
+            <Count value={3} />
+          </span>
+        </div>
+      );
 
-    render(
-      <InputOutputTooltipCell text={'Conversation preview\n\n```js\ntooltip only\n```'} />
-    );
-
-    await userEvent.hover(screen.getByText('Conversation preview'));
-
-    expect(screen.queryByText('tooltip only')).not.toBeInTheDocument();
-  });
-
-  it('shows the tooltip when the cell content overflows', async () => {
-    mockOverflow(180, 100);
-
-    render(
-      <InputOutputTooltipCell text={'Conversation preview\n\n```js\ntooltip only\n```'} />
-    );
-
-    await userEvent.hover(screen.getByText('Conversation preview'));
-
-    await waitFor(() => {
-      expect(screen.getByText('tooltip only')).toBeInTheDocument();
+      expect(container.textContent).toBe('12/3');
+      expect(screen.getByTestId('error-count')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -1,45 +1,65 @@
-import {Fragment, memo, useCallback, type ComponentPropsWithRef} from 'react';
+import {Fragment, memo, useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
+import {parseAsString, useQueryState} from 'nuqs';
 
+import {Button} from '@sentry/scraps/button';
+import {Checkbox} from '@sentry/scraps/checkbox';
 import {InfoText} from '@sentry/scraps/info';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
 import {Pagination} from '@sentry/scraps/pagination';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Count} from 'sentry/components/count';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {
-  COL_WIDTH_UNDEFINED,
   GridEditable,
   type GridColumnHeader,
   type GridColumnOrder,
 } from 'sentry/components/tables/gridEditable';
 import {useStateBasedColumnResize} from 'sentry/components/tables/gridEditable/useStateBasedColumnResize';
 import {TimeSince} from 'sentry/components/timeSince';
-import {IconArrow, IconUser} from 'sentry/icons';
+import {IconArrow, IconEdit, IconUser} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {MarkedText} from 'sentry/utils/marked/markedText';
-import {ellipsize} from 'sentry/utils/string/ellipsize';
 import {isUUID} from 'sentry/utils/string/isUUID';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
-import {useNavigate} from 'sentry/utils/useNavigate';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {ToolTags} from 'sentry/views/explore/conversations/components/toolTags';
+import {USER_FILTER_PARAM} from 'sentry/views/explore/conversations/components/userFilterSelector';
+import {useConversationAgents} from 'sentry/views/explore/conversations/hooks/useConversationAgents';
 import {
   useConversations,
   type Conversation,
   type ConversationUser,
 } from 'sentry/views/explore/conversations/hooks/useConversations';
+import {
+  useConversationToolStats,
+  type ToolStat,
+} from 'sentry/views/explore/conversations/hooks/useConversationToolStats';
 import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/explore/conversations/settings';
 import {hasGenAiConversationsFeature} from 'sentry/views/explore/conversations/utils/features';
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
-import {AIContentRenderer} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer';
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
+const VISIBLE_PAGE_SIZE = 25;
+
+function buildLocalPageLinks({
+  hasPrev,
+  hasNext,
+}: {
+  hasNext: boolean;
+  hasPrev: boolean;
+}): string {
+  const prev = `<http://localhost/api/0/prev>; rel="previous"; results="${hasPrev}"; cursor="0:0:1"`;
+  const next = `<http://localhost/api/0/next>; rel="next"; results="${hasNext}"; cursor="0:0:0"`;
+  return `${prev}, ${next}`;
+}
 
 function getConversationDetailUrl(
   orgSlug: string,
@@ -77,63 +97,278 @@ export function ConversationsTable() {
 const EMPTY_ARRAY: never[] = [];
 
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
-  {key: 'conversationId', name: t('Conv. ID'), width: 0},
-  {key: 'inputOutput', name: t('First Input / Last Output'), width: COL_WIDTH_UNDEFINED},
-  {key: 'user', name: t('User'), width: 120},
-  {key: 'steps', name: t('Steps'), width: 80},
-  {key: 'toolsUsed', name: t('Tools'), width: 140},
-  {key: 'tokensAndCost', name: t('Total Tokens / Cost'), width: 170},
-  {key: 'timestamp', name: t('Last Message'), width: 120},
+  {key: 'conversationId', name: t('Conv. ID'), width: 120},
+  {key: 'user', name: t('User'), width: 160},
+  {key: 'agent', name: t('Agent'), width: 180},
+  {key: 'toolsUsed', name: t('Tools'), width: 280},
+  {key: 'messagesErrors', name: t('Messages / Errors'), width: 170},
+  {key: 'tokensAndCost', name: t('Total Tokens / Cost'), width: 190},
+  {key: 'timestamp', name: t('Last Message'), width: 140},
 ];
 
-const rightAlignColumns = new Set(['steps', 'tokensAndCost', 'timestamp']);
+const rightAlignColumns = new Set(['messagesErrors', 'tokensAndCost', 'timestamp']);
+
+type SortState = {
+  direction: 'asc' | 'desc';
+  key: string;
+};
+
+const SORTABLE_COLUMNS = new Set(['messagesErrors', 'tokensAndCost', 'timestamp']);
+
+const SORT_ACCESSORS: Record<string, (c: Conversation) => number> = {
+  messagesErrors: c => c.llmCalls,
+  tokensAndCost: c => c.totalTokens,
+  timestamp: c => c.endTimestamp,
+};
+
+const DEFAULT_SORT: SortState = {key: 'timestamp', direction: 'desc'};
+
+const REQUIRED_COLUMN = 'conversationId';
+const DEFAULT_VISIBLE_KEYS = defaultColumnOrder.map(c => c.key);
+
+function ColumnEditorModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  visibleKeys,
+  onApply,
+}: ModalRenderProps & {
+  onApply: (keys: string[]) => void;
+  visibleKeys: string[];
+}) {
+  const [tempKeys, setTempKeys] = useState<string[]>(visibleKeys);
+
+  const toggleColumn = (key: string) => {
+    setTempKeys(prev =>
+      prev.includes(key) ? prev.filter(k => k !== key) : [...prev, key]
+    );
+  };
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <h4>{t('Edit Table')}</h4>
+      </Header>
+      <Body>
+        <Stack gap="md">
+          {defaultColumnOrder.map(col => (
+            <Flex key={col.key} align="center" gap="xs" as="label">
+              <Checkbox
+                checked={tempKeys.includes(col.key)}
+                disabled={col.key === REQUIRED_COLUMN}
+                onChange={() => toggleColumn(col.key)}
+              />
+              <Text>{col.name}</Text>
+            </Flex>
+          ))}
+        </Stack>
+      </Body>
+      <Footer>
+        <Flex gap="md" justify="end">
+          <Button size="sm" onClick={closeModal}>
+            {t('Cancel')}
+          </Button>
+          <Button
+            size="sm"
+            variant="primary"
+            onClick={() => {
+              onApply(tempKeys);
+              closeModal();
+            }}
+          >
+            {t('Apply')}
+          </Button>
+        </Flex>
+      </Footer>
+    </Fragment>
+  );
+}
+
+function useColumnVisibility() {
+  const organization = useOrganization();
+  return useLocalStorageState<string[]>(
+    `conversations-table-columns:${organization.slug}`,
+    DEFAULT_VISIBLE_KEYS
+  );
+}
+
+export function EditTableButton() {
+  const {openModal} = useModal();
+  const [visibleColumnKeys, setVisibleColumnKeys] = useColumnVisibility();
+
+  const openColumnEditor = () => {
+    openModal(
+      modalProps => (
+        <ColumnEditorModal
+          {...modalProps}
+          visibleKeys={visibleColumnKeys}
+          onApply={setVisibleColumnKeys}
+        />
+      ),
+      {closeEvents: 'escape-key'}
+    );
+  };
+
+  return (
+    <Button size="sm" icon={<IconEdit />} onClick={openColumnEditor}>
+      {t('Edit Table')}
+    </Button>
+  );
+}
 
 function ConversationsTableInner() {
   const organization = useOrganization();
+  const [visibleColumnKeys] = useColumnVisibility();
+
+  const activeColumns = useMemo(
+    () => defaultColumnOrder.filter(col => visibleColumnKeys.includes(col.key)),
+    [visibleColumnKeys]
+  );
+
   const {columns: columnOrder, handleResizeColumn} = useStateBasedColumnResize({
-    columns: defaultColumnOrder,
+    columns: activeColumns,
   });
 
   const {data, isLoading, error, pageLinks, setCursor} = useConversations();
+  const {agentsByConversation} = useConversationAgents();
+  const {toolStatsByConversation} = useConversationToolStats();
+  const [sort, setSort] = useState<SortState>(DEFAULT_SORT);
+  const [localPage, setLocalPage] = useState(0);
+  const [userFilter] = useQueryState(USER_FILTER_PARAM, parseAsString.withDefault(''));
 
-  const handlePaginate: typeof setCursor = (cursor, path, query, pageDelta) => {
-    trackAnalytics('conversations.table.paginate', {
-      organization,
-      direction: pageDelta > 0 ? 'next' : 'previous',
+  const filteredData = useMemo(() => {
+    if (userFilter === 'has_user') {
+      return data.filter(
+        c => c.user !== null && (c.user.email || c.user.username || c.user.ip_address)
+      );
+    }
+    if (userFilter === 'no_user') {
+      return data.filter(
+        c => c.user === null || !(c.user.email || c.user.username || c.user.ip_address)
+      );
+    }
+    return data;
+  }, [data, userFilter]);
+
+  useEffect(() => {
+    setLocalPage(0);
+  }, [userFilter, data]);
+
+  const sortedData = useMemo(() => {
+    const accessor = SORT_ACCESSORS[sort.key];
+    if (!accessor) {
+      return filteredData;
+    }
+    return [...filteredData].sort((a, b) => {
+      const diff = accessor(a) - accessor(b);
+      return sort.direction === 'asc' ? diff : -diff;
     });
-    setCursor(cursor, path, query, pageDelta);
+  }, [filteredData, sort]);
+
+  const totalLocalPages = Math.ceil(sortedData.length / VISIBLE_PAGE_SIZE);
+  const clampedPage = Math.min(localPage, Math.max(0, totalLocalPages - 1));
+  const pageData = useMemo(
+    () =>
+      sortedData.slice(
+        clampedPage * VISIBLE_PAGE_SIZE,
+        (clampedPage + 1) * VISIBLE_PAGE_SIZE
+      ),
+    [sortedData, clampedPage]
+  );
+
+  const hasNextServerPage = pageLinks?.includes('rel="next"; results="true"') ?? false;
+  const hasPrevServerPage =
+    pageLinks?.includes('rel="previous"; results="true"') ?? false;
+  const isLastLocalPage = clampedPage >= totalLocalPages - 1;
+  const isFirstLocalPage = clampedPage <= 0;
+
+  const handlePaginate: typeof setCursor = (_cursor, path, query, pageDelta) => {
+    if (pageDelta > 0) {
+      if (!isLastLocalPage) {
+        setLocalPage(prev => prev + 1);
+      } else if (hasNextServerPage) {
+        setLocalPage(0);
+        trackAnalytics('conversations.table.paginate', {
+          organization,
+          direction: 'next',
+        });
+        setCursor(_cursor, path, query, pageDelta);
+      }
+    } else {
+      if (!isFirstLocalPage) {
+        setLocalPage(prev => prev - 1);
+      } else if (hasPrevServerPage) {
+        setLocalPage(0);
+        trackAnalytics('conversations.table.paginate', {
+          organization,
+          direction: 'previous',
+        });
+        setCursor(_cursor, path, query, pageDelta);
+      }
+    }
   };
 
-  const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {
-    return (
-      <Flex
-        flex="1"
-        align="center"
-        gap="xs"
-        justify={rightAlignColumns.has(column.key) ? 'end' : 'start'}
-      >
-        {column.key === 'steps' ? (
-          <Tooltip title={t('LLM calls + Tool calls')}>
-            <DashedUnderline>{column.name}</DashedUnderline>
-          </Tooltip>
-        ) : (
-          column.name
-        )}
-        {column.key === 'timestamp' && <IconArrow direction="down" size="xs" />}
-        {column.key === 'inputOutput' && (
-          // Force the cell to take as much width as possible in the table
-          // layout, otherwise GridEditable will let the last column grow.
-          <Container width="100vw" />
-        )}
-      </Flex>
-    );
+  const localPageLinks = buildLocalPageLinks({
+    hasPrev: !isFirstLocalPage || hasPrevServerPage,
+    hasNext: !isLastLocalPage || hasNextServerPage,
+  });
+
+  const handleSort = useCallback((columnKey: string) => {
+    setSort(prev => {
+      if (prev.key === columnKey) {
+        return {key: columnKey, direction: prev.direction === 'asc' ? 'desc' : 'asc'};
+      }
+      return {key: columnKey, direction: 'desc'};
+    });
   }, []);
+
+  const renderHeadCell = useCallback(
+    (column: GridColumnHeader<string>) => {
+      const isSortable = SORTABLE_COLUMNS.has(column.key);
+      const isActive = sort.key === column.key;
+
+      return (
+        <SortableHeader
+          onClick={isSortable ? () => handleSort(column.key) : undefined}
+          isSortable={isSortable}
+          role={isSortable ? 'button' : undefined}
+        >
+          <Flex
+            flex="1"
+            align="center"
+            gap="xs"
+            justify={rightAlignColumns.has(column.key) ? 'end' : 'start'}
+          >
+            {column.key === 'messagesErrors' ? (
+              <Tooltip title={t('LLM calls / Errors')}>
+                <DashedUnderline>{column.name}</DashedUnderline>
+              </Tooltip>
+            ) : (
+              column.name
+            )}
+            {isActive && (
+              <IconArrow direction={sort.direction === 'asc' ? 'up' : 'down'} size="xs" />
+            )}
+          </Flex>
+        </SortableHeader>
+      );
+    },
+    [sort, handleSort]
+  );
 
   const renderBodyCell = useCallback(
     (column: GridColumnOrder<string>, dataRow: Conversation) => {
-      return <BodyCell column={column} dataRow={dataRow} />;
+      return (
+        <BodyCell
+          column={column}
+          dataRow={dataRow}
+          agentNames={agentsByConversation[dataRow.conversationId]}
+          toolStats={toolStatsByConversation[dataRow.conversationId]}
+        />
+      );
     },
-    []
+    [agentsByConversation, toolStatsByConversation]
   );
 
   return (
@@ -142,7 +377,7 @@ function ConversationsTableInner() {
         <GridEditable
           isLoading={isLoading}
           error={error}
-          data={data}
+          data={pageData}
           columnOrder={columnOrder}
           columnSortBy={EMPTY_ARRAY}
           stickyHeader
@@ -153,60 +388,20 @@ function ConversationsTableInner() {
           }}
         />
       </Container>
-      <Pagination pageLinks={pageLinks} onCursor={handlePaginate} />
+      <Pagination pageLinks={localPageLinks} onCursor={handlePaginate} />
     </Fragment>
   );
 }
 
+function isBlank(value: string | null): boolean {
+  return !value || value === 'None';
+}
+
 function getUserDisplayName(user: ConversationUser): string {
-  return user.email || user.username || user.ip_address || t('Unknown');
-}
-
-const TOOLTIP_MAX_CHARS = 2048;
-const CELL_MAX_CHARS = 256;
-
-function TooltipContent({text}: {text: string}) {
-  return (
-    <TooltipTextContainer>
-      <AIContentRenderer text={ellipsize(text, TOOLTIP_MAX_CHARS)} inline />
-    </TooltipTextContainer>
-  );
-}
-
-function cleanMarkdownForCell(text: string): string {
-  return text
-    .replace(/```[\s\S]*?```/g, '') // fenced code blocks
-    .replace(/^#{1,6}\s+(.+)$/gm, '**$1**') // headings -> bold text
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-type CellContentProps = ComponentPropsWithRef<'div'> & {
-  text: string;
-};
-
-function CellContent({text, ref, ...props}: CellContentProps) {
-  const cleanedText = cleanMarkdownForCell(text);
-  return (
-    <SingleLineMarkdown ref={ref} {...props}>
-      <MarkedText text={ellipsize(cleanedText, CELL_MAX_CHARS)} />
-    </SingleLineMarkdown>
-  );
-}
-
-export function InputOutputTooltipCell({text}: {text: string}) {
-  return (
-    <Tooltip
-      title={<TooltipContent text={text} />}
-      showOnlyOnOverflow
-      maxWidth={800}
-      isHoverable
-      skipWrapper
-      position="right"
-    >
-      <CellContent text={text} />
-    </Tooltip>
-  );
+  if (!isBlank(user.email)) return user.email!;
+  if (!isBlank(user.username)) return user.username!;
+  if (!isBlank(user.ip_address)) return user.ip_address!;
+  return '—';
 }
 
 function UserNotInstrumentedTooltip() {
@@ -228,12 +423,15 @@ function UserNotInstrumentedTooltip() {
 const BodyCell = memo(function BodyCell({
   column,
   dataRow,
+  agentNames,
+  toolStats,
 }: {
+  agentNames: string[] | undefined;
   column: GridColumnHeader<string>;
   dataRow: Conversation;
+  toolStats: ToolStat[] | undefined;
 }) {
   const organization = useOrganization();
-  const navigate = useNavigate();
   const {selection} = usePageFilters();
 
   const detailUrl = getConversationDetailUrl(
@@ -241,11 +439,6 @@ const BodyCell = memo(function BodyCell({
     dataRow,
     selection.projects
   );
-
-  const navigateToDetail = (source: 'table_input' | 'table_output') => {
-    trackAnalytics('conversations.table.open', {organization, source});
-    navigate(detailUrl);
-  };
 
   switch (column.key) {
     case 'conversationId':
@@ -277,52 +470,54 @@ const BodyCell = memo(function BodyCell({
         );
       }
       const displayName = getUserDisplayName(dataRow.user);
+      const hasIdentity =
+        !isBlank(dataRow.user.email) ||
+        !isBlank(dataRow.user.username) ||
+        !isBlank(dataRow.user.ip_address);
       return (
         <Tooltip title={displayName} showOnlyOnOverflow>
           <Flex align="center" gap="xs" minWidth={0}>
-            <IconUser size="md" variant="muted" />
-            <Text ellipsis>{displayName}</Text>
+            {hasIdentity && <IconUser size="md" variant="muted" />}
+            <Text ellipsis variant={hasIdentity ? undefined : 'muted'}>
+              {displayName}
+            </Text>
           </Flex>
         </Tooltip>
       );
     }
-    case 'inputOutput': {
+    case 'agent': {
+      const names = agentNames?.length ? agentNames : dataRow.flow;
+      const agentName = names?.[0] ?? null;
+      if (!agentName) {
+        return <Text variant="muted">&mdash;</Text>;
+      }
       return (
-        <Stack width="100%">
-          <InputOutputRow type="button" onClick={() => navigateToDetail('table_input')}>
-            <InputOutputLabel variant="muted">{t('Input')}</InputOutputLabel>
-            <Flex flex="1" minWidth="0">
-              {dataRow.firstInput ? (
-                <InputOutputTooltipCell text={dataRow.firstInput} />
-              ) : (
-                <Text variant="muted">&mdash;</Text>
-              )}
-            </Flex>
-          </InputOutputRow>
-          <InputOutputRow type="button" onClick={() => navigateToDetail('table_output')}>
-            <InputOutputLabel variant="muted">{t('Output')}</InputOutputLabel>
-            <Flex flex="1" minWidth="0">
-              {dataRow.lastOutput ? (
-                <InputOutputTooltipCell text={dataRow.lastOutput} />
-              ) : (
-                <Text variant="muted">&mdash;</Text>
-              )}
-            </Flex>
-          </InputOutputRow>
-        </Stack>
+        <Tooltip title={agentName} showOnlyOnOverflow skipWrapper>
+          <Text ellipsis>{agentName}</Text>
+        </Tooltip>
       );
     }
-    case 'steps':
+    case 'messagesErrors': {
+      const hasErrors = dataRow.errors > 0;
       return (
         <Text as="div" align="right">
-          <Count value={dataRow.llmCalls + dataRow.toolCalls} />
+          <Count value={dataRow.llmCalls} />
+          {'/'}
+          {hasErrors ? (
+            <ErrorCount>
+              <Count value={dataRow.errors} />
+            </ErrorCount>
+          ) : (
+            <Count value={dataRow.errors} />
+          )}
         </Text>
       );
+    }
     case 'toolsUsed':
       if (dataRow.toolNames.length === 0) {
         return <Text variant="muted">&mdash;</Text>;
       }
-      return <ToolTags toolNames={dataRow.toolNames} />;
+      return <ToolTags toolNames={dataRow.toolNames} toolStats={toolStats} />;
     case 'tokensAndCost':
       return (
         <Text as="div" align="right">
@@ -345,34 +540,6 @@ const BodyCell = memo(function BodyCell({
   }
 });
 
-const TooltipTextContainer = styled('div')`
-  text-align: left;
-  max-width: min(800px, 60vw);
-  max-height: 50vh;
-  overflow: hidden;
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-size: inherit;
-    font-weight: bold;
-    margin: 0;
-  }
-`;
-
-const SingleLineMarkdown = styled('div')`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-
-  * {
-    display: inline;
-  }
-`;
-
 const ConversationIdLink = styled(Link)`
   color: ${p => p.theme.tokens.interactive.link.accent.rest};
   font-weight: normal;
@@ -384,30 +551,14 @@ const ConversationIdText = styled(Text)`
   color: inherit;
 `;
 
-const InputOutputRow = styled('button')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.md};
-  background: transparent;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  text-align: left;
-  width: 100%;
-
-  &:hover {
-    background-color: ${p =>
-      p.theme.tokens.interactive.transparent.neutral.background.hover};
-  }
-
-  &:active {
-    background-color: ${p =>
-      p.theme.tokens.interactive.transparent.neutral.background.active};
-  }
+const ErrorCount = styled('span')`
+  color: ${p => p.theme.tokens.content.danger};
 `;
 
-const InputOutputLabel = styled(Text)`
-  width: 4em;
+const SortableHeader = styled('div')<{isSortable: boolean}>`
+  cursor: ${p => (p.isSortable ? 'pointer' : 'default')};
+  user-select: none;
+  width: 100%;
 `;
 
 const DashedUnderline = styled('span')`

--- a/static/app/views/explore/conversations/components/toolSelector.tsx
+++ b/static/app/views/explore/conversations/components/toolSelector.tsx
@@ -7,77 +7,67 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/useCompactSelectOptionsCache';
 import {useWasSearchSpaceExhausted} from 'sentry/views/insights/common/utils/useWasSearchSpaceExhausted';
-import {
-  AGENT_NAME_FIELDS,
-  resolveAgentName,
-} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
-import {
-  getAgentNameSearchFilter,
-  getHasAgentNameFilter,
-} from 'sentry/views/insights/pages/agents/utils/query';
+import {getToolSpansFilter} from 'sentry/views/insights/pages/agents/utils/query';
 import {TableUrlParams} from 'sentry/views/insights/pages/agents/utils/urlParams';
+import {SpanFields} from 'sentry/views/insights/types';
 
 const LIMIT = 100;
-const AGENT_URL_PARAM = 'agent';
+export const TOOL_URL_PARAM = 'tool';
 
-interface AgentSelectorProps {
+const TOOL_NAME_FIELDS = [SpanFields.GEN_AI_TOOL_NAME] as const;
+
+interface ToolSelectorProps {
   referrer: string;
   storageKeyPrefix: string;
 }
 
-export function AgentSelector({storageKeyPrefix, referrer}: AgentSelectorProps) {
+export function ToolSelector({storageKeyPrefix, referrer}: ToolSelectorProps) {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
 
-  // Project-scoped storage key - automatically resets when projects change
   const projectKey = [...pageFilters.selection.projects].sort().join(',');
   const storageKey = `${storageKeyPrefix}:${organization.slug}:${projectKey}`;
 
-  const [storedAgents, setStoredAgents] = useLocalStorageState<string[]>(storageKey, []);
+  const [storedTools, setStoredTools] = useLocalStorageState<string[]>(storageKey, []);
 
-  // Use nuqs to manage both agent and cursor state
-  const [{agent: urlAgents}, setQueryStates] = useQueryStates(
+  const [{tool: urlTools}, setQueryStates] = useQueryStates(
     {
-      [AGENT_URL_PARAM]: parseAsArrayOf(parseAsString),
+      [TOOL_URL_PARAM]: parseAsArrayOf(parseAsString),
       [TableUrlParams.CURSOR]: parseAsString,
     },
     {history: 'replace'}
   );
 
-  // On mount: restore stored agents to URL if URL is empty
   const hasInitialized = useRef(false);
   useEffect(() => {
     if (!hasInitialized.current) {
       hasInitialized.current = true;
-      if (!urlAgents?.length && storedAgents.length > 0) {
-        setQueryStates({[AGENT_URL_PARAM]: storedAgents});
+      if (!urlTools?.length && storedTools.length > 0) {
+        setQueryStates({[TOOL_URL_PARAM]: storedTools});
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Reset when project changes
   const prevProjectKey = useRef(projectKey);
   useEffect(() => {
     if (prevProjectKey.current !== projectKey) {
       prevProjectKey.current = projectKey;
-      setQueryStates({[AGENT_URL_PARAM]: null, [TableUrlParams.CURSOR]: null});
+      setQueryStates({[TOOL_URL_PARAM]: null, [TableUrlParams.CURSOR]: null});
     }
   }, [projectKey, setQueryStates]);
 
-  const selectedAgents = useMemo(() => {
-    // Prevent cache pollution during project transitions
+  const selectedTools = useMemo(() => {
     if (prevProjectKey.current !== projectKey) {
       return [];
     }
-    return urlAgents ?? [];
-  }, [urlAgents, projectKey]);
+    return urlTools ?? [];
+  }, [urlTools, projectKey]);
 
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -90,15 +80,15 @@ export function AgentSelector({storageKeyPrefix, referrer}: AgentSelectorProps) 
   );
 
   const query = useMemo(() => {
-    const parts = [getHasAgentNameFilter()];
+    const parts = [getToolSpansFilter(), `has:${SpanFields.GEN_AI_TOOL_NAME}`];
     if (searchQuery) {
-      parts.push(getAgentNameSearchFilter(searchQuery));
+      parts.push(`${SpanFields.GEN_AI_TOOL_NAME}:*${searchQuery}*`);
     }
     return parts.join(' ');
   }, [searchQuery]);
 
   const {
-    data: agentData,
+    data: toolData,
     isPending,
     pageLinks,
   } = useSpans(
@@ -106,7 +96,7 @@ export function AgentSelector({storageKeyPrefix, referrer}: AgentSelectorProps) 
       limit: LIMIT,
       search: query,
       sorts: [{field: 'count()', kind: 'desc'}],
-      fields: [...AGENT_NAME_FIELDS, 'count()'],
+      fields: [...TOOL_NAME_FIELDS, 'count()'],
     },
     referrer
   );
@@ -117,39 +107,38 @@ export function AgentSelector({storageKeyPrefix, referrer}: AgentSelectorProps) 
     pageLinks,
   });
 
-  const agentList = useMemo(() => {
-    const uniqueAgents = new Set<string>();
+  const toolList = useMemo(() => {
+    const uniqueTools = new Set<string>();
     const list: Array<{label: string; value: string}> = [];
 
-    agentData?.forEach(row => {
-      const agentName = resolveAgentName(row);
-      if (!agentName || uniqueAgents.has(agentName)) {
+    toolData?.forEach(row => {
+      const toolName = row[SpanFields.GEN_AI_TOOL_NAME] as string | undefined;
+      if (!toolName || uniqueTools.has(toolName)) {
         return;
       }
-      uniqueAgents.add(agentName);
-      list.push({label: agentName, value: agentName});
+      uniqueTools.add(toolName);
+      list.push({label: toolName, value: toolName});
     });
 
-    // Ensure selected values are in the list
-    selectedAgents.forEach(agent => {
-      if (agent && !uniqueAgents.has(agent)) {
-        list.push({label: agent, value: agent});
+    selectedTools.forEach(tool => {
+      if (tool && !uniqueTools.has(tool)) {
+        list.push({label: tool, value: tool});
       }
     });
 
     return list;
-  }, [agentData, selectedAgents]);
+  }, [toolData, selectedTools]);
 
   const cacheKey = [...pageFilters.selection.projects].sort().join(' ');
-  const {options} = useCompactSelectOptionsCache(agentList, cacheKey);
+  const {options} = useCompactSelectOptionsCache(toolList, cacheKey);
 
   return (
     <CompactSelect
       multiple
       style={{maxWidth: '200px'}}
-      value={selectedAgents}
+      value={selectedTools}
       options={options}
-      emptyMessage={t('No agents found')}
+      emptyMessage={t('No tools found')}
       loading={isPending}
       search={{
         onChange: newValue => {
@@ -158,36 +147,32 @@ export function AgentSelector({storageKeyPrefix, referrer}: AgentSelectorProps) 
           }
         },
       }}
-      menuTitle={t('Agent')}
+      menuTitle={t('Tools called')}
       menuHeaderTrailingItems={
-        selectedAgents.length > 0 ? (
+        selectedTools.length > 0 ? (
           <MenuComponents.ResetButton
             onClick={() => {
-              setStoredAgents([]);
+              setStoredTools([]);
               setQueryStates({
-                [AGENT_URL_PARAM]: null,
+                [TOOL_URL_PARAM]: null,
                 [TableUrlParams.CURSOR]: null,
               });
             }}
           />
         ) : null
       }
-      data-test-id="agent-selector"
+      data-test-id="tool-selector"
       trigger={triggerProps => (
-        <OverlayTrigger.Button {...triggerProps} prefix={t('Agent')}>
-          {selectedAgents.length ? triggerProps.children : t('All')}
+        <OverlayTrigger.Button {...triggerProps} prefix={t('Tools called')}>
+          {selectedTools.length ? triggerProps.children : t('All')}
         </OverlayTrigger.Button>
       )}
       onChange={newValue => {
         const values = newValue.map(v => v.value).filter(Boolean);
-        setStoredAgents(values);
+        setStoredTools(values);
         setQueryStates({
-          [AGENT_URL_PARAM]: values.length > 0 ? values : null,
+          [TOOL_URL_PARAM]: values.length > 0 ? values : null,
           [TableUrlParams.CURSOR]: null,
-        });
-        trackAnalytics('agent-monitoring.page-filter-change', {
-          organization,
-          filter: 'agent',
         });
       }}
     />

--- a/static/app/views/explore/conversations/components/toolTags.tsx
+++ b/static/app/views/explore/conversations/components/toolTags.tsx
@@ -1,112 +1,114 @@
-import {useEffect, useRef, useState} from 'react';
+import styled from '@emotion/styled';
 
-import {Tag} from '@sentry/scraps/badge';
-import {Button} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {t} from 'sentry/locale';
-
-// Height for 2 rows of tags (22px per row + 6px gap)
-const TWO_ROW_HEIGHT = 50;
+import {tn} from 'sentry/locale';
+import type {ToolStat} from 'sentry/views/explore/conversations/hooks/useConversationToolStats';
 
 interface ToolTagsProps {
   toolNames: string[];
+  toolStats?: ToolStat[];
 }
 
-export function ToolTags({toolNames}: ToolTagsProps) {
-  const [expanded, setExpanded] = useState(false);
-  const [hiddenCount, setHiddenCount] = useState(0);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const tagRefs = useRef(new Map<number, HTMLElement>());
-  const toggleButtonRef = useRef<HTMLDivElement>(null);
+function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`;
+  }
+  const seconds = ms / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  return `${minutes}m ${remainingSeconds}s`;
+}
 
-  // Calculate how many tags are hidden (overflow beyond 2 rows, or overlapped by the "+N more" button)
-  useEffect(() => {
-    const container = containerRef.current;
-    if (expanded || !container) {
-      return;
-    }
-
-    const calculateHidden = () => {
-      const buttonWidth = toggleButtonRef.current?.offsetWidth ?? 0;
-      const containerWidth = container.offsetWidth;
-
-      let hidden = 0;
-      tagRefs.current.forEach(tagEl => {
-        if (tagEl.offsetTop >= TWO_ROW_HEIGHT) {
-          hidden++;
-        } else if (
-          buttonWidth > 0 &&
-          tagEl.offsetLeft + tagEl.offsetWidth > containerWidth - buttonWidth
-        ) {
-          // Tag on the last visible row is partially covered by the "+N more" button
-          hidden++;
-        }
-      });
-      setHiddenCount(hidden);
-    };
-
-    const rafId = requestAnimationFrame(calculateHidden);
-    const observer = new ResizeObserver(() => requestAnimationFrame(calculateHidden));
-    observer.observe(container);
-
-    return () => {
-      cancelAnimationFrame(rafId);
-      observer.disconnect();
-    };
-    // hiddenCount is included so we re-check after the button appears (it only renders when hiddenCount > 0)
-  }, [toolNames, expanded, hiddenCount]);
+function ToolDropdown({
+  toolNames,
+  toolStats,
+}: {
+  toolNames: string[];
+  toolStats?: ToolStat[];
+}) {
+  const statsByName = new Map(toolStats?.map(s => [s.name, s]) ?? []);
 
   return (
-    <Flex
-      ref={containerRef}
-      align="center"
-      gap="sm"
-      wrap="wrap"
-      overflow="hidden"
-      position="relative"
-      maxHeight={expanded ? '500px' : `${TWO_ROW_HEIGHT}px`}
-      style={{transition: 'max-height 0.2s ease-in-out'}}
-    >
-      {toolNames.map((toolName, index) => (
-        <Tag
-          key={toolName}
-          ref={el => {
-            if (el) {
-              tagRefs.current.set(index, el);
-            } else {
-              tagRefs.current.delete(index);
-            }
-          }}
-          variant="info"
-          style={{maxWidth: '100%', minWidth: 0}}
-        >
-          {toolName}
-        </Tag>
-      ))}
-      {hiddenCount > 0 && !expanded && (
-        <Flex
-          ref={toggleButtonRef}
-          align="center"
-          position="absolute"
-          right="0"
-          bottom="4px"
-          height="22px"
-          background="primary"
-          paddingLeft="sm"
-        >
-          <Button variant="link" size="xs" onClick={() => setExpanded(prev => !prev)}>
-            {t('+%s more', hiddenCount)}
-          </Button>
-        </Flex>
-      )}
-      {expanded && (
-        <Container flexShrink={0}>
-          <Button variant="link" size="xs" onClick={() => setExpanded(prev => !prev)}>
-            {t('Show less')}
-          </Button>
-        </Container>
-      )}
-    </Flex>
+    <DropdownTable>
+      {toolNames.map(name => {
+        const stat = statsByName.get(name);
+        return (
+          <DropdownRow key={name}>
+            <ToolNameCell>{name}</ToolNameCell>
+            <CallsCell>
+              {stat
+                ? tn('%s call', '%s calls', stat.calls)
+                : tn('%s call', '%s calls', 1)}
+            </CallsCell>
+            <DurationCell>
+              {stat && stat.totalDuration > 0 ? formatDuration(stat.totalDuration) : '—'}
+            </DurationCell>
+          </DropdownRow>
+        );
+      })}
+    </DropdownTable>
   );
 }
+
+export function ToolTags({toolNames, toolStats}: ToolTagsProps) {
+  const statsByName = new Map(toolStats?.map(s => [s.name, s]) ?? []);
+
+  let totalCalls = 0;
+  let totalDuration = 0;
+  for (const name of toolNames) {
+    const stat = statsByName.get(name);
+    totalCalls += stat?.calls ?? 1;
+    totalDuration += stat?.totalDuration ?? 0;
+  }
+
+  return (
+    <Tooltip
+      title={<ToolDropdown toolNames={toolNames} toolStats={toolStats} />}
+      skipWrapper
+      isHoverable
+    >
+      <SummaryText>
+        <Text variant="muted">
+          {tn('%s call', '%s calls', totalCalls)}
+          {totalDuration > 0 ? `  ${formatDuration(totalDuration)}` : ''}
+        </Text>
+      </SummaryText>
+    </Tooltip>
+  );
+}
+
+const SummaryText = styled('div')`
+  cursor: default;
+`;
+
+const DropdownTable = styled('div')`
+  display: grid;
+  grid-template-columns: auto auto auto;
+  gap: 4px 16px;
+  padding: 4px 0;
+  align-items: center;
+`;
+
+const DropdownRow = styled('div')`
+  display: contents;
+`;
+
+const ToolNameCell = styled('span')`
+  font-weight: 600;
+  white-space: nowrap;
+`;
+
+const CallsCell = styled('span')`
+  white-space: nowrap;
+  text-align: right;
+`;
+
+const DurationCell = styled('span')`
+  white-space: nowrap;
+  text-align: right;
+`;

--- a/static/app/views/explore/conversations/components/userFilterSelector.tsx
+++ b/static/app/views/explore/conversations/components/userFilterSelector.tsx
@@ -1,0 +1,40 @@
+import {parseAsString, useQueryState} from 'nuqs';
+
+import {CompactSelect, MenuComponents} from '@sentry/scraps/compactSelect';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+
+import {t} from 'sentry/locale';
+
+export const USER_FILTER_PARAM = 'userFilter';
+
+export type UserFilterValue = '' | 'has_user' | 'no_user';
+
+const OPTIONS: Array<{label: string; value: UserFilterValue}> = [
+  {value: '', label: t('All')},
+  {value: 'has_user', label: t('Has user')},
+  {value: 'no_user', label: t('No user')},
+];
+
+export function UserFilterSelector() {
+  const [value, setValue] = useQueryState(
+    USER_FILTER_PARAM,
+    parseAsString.withDefault('').withOptions({history: 'replace'})
+  );
+
+  return (
+    <CompactSelect
+      value={value}
+      options={OPTIONS}
+      menuTitle={t('User')}
+      menuHeaderTrailingItems={
+        value ? <MenuComponents.ResetButton onClick={() => setValue(null)} /> : null
+      }
+      trigger={triggerProps => (
+        <OverlayTrigger.Button {...triggerProps} prefix={t('User')} />
+      )}
+      onChange={option => {
+        setValue(option.value || null);
+      }}
+    />
+  );
+}

--- a/static/app/views/explore/conversations/conversationDetail.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.tsx
@@ -1,4 +1,3 @@
-import type React from 'react';
 import {useCallback, useEffect, useMemo} from 'react';
 import {parseAsString, useQueryStates} from 'nuqs';
 
@@ -8,8 +7,8 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {ViewportConstrainedPage} from 'sentry/views/explore/components/viewportConstrainedPage';
-import {ConversationSummary} from 'sentry/views/explore/conversations/components/conversationSummary';
-import {ConversationViewContent} from 'sentry/views/explore/conversations/components/conversationView';
+import {ConversationHeaderV2} from 'sentry/views/explore/conversations/components/conversationHeaderV2';
+import {ConversationViewV2Content} from 'sentry/views/explore/conversations/components/conversationViewV2';
 import {useConversation} from 'sentry/views/explore/conversations/hooks/useConversation';
 
 function useConversationDetailQueryState() {
@@ -35,7 +34,9 @@ function ConversationDetailPage() {
     trackAnalytics('conversations.detail.page-view', {
       organization,
     });
-  }, [organization, conversationId]);
+    setQueryState({spanId: null, focusedTool: null});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conversationId]);
 
   const handleSelectSpan = useCallback(
     (spanId: string) => {
@@ -49,43 +50,30 @@ function ConversationDetailPage() {
 
   return (
     <ViewportConstrainedPage background="secondary">
-      <Stack flex={1} minHeight="0" overflow="hidden" padding="md 2xl" gap="md">
-        <Flex direction="column" gap="md" flexShrink={0}>
-          <ConversationSummary
+      <Stack flex={1} minHeight="0" overflow="hidden" gap="0">
+        <Container
+          background="primary"
+          padding="md 2xl"
+          flexShrink={0}
+          borderBottom="primary"
+        >
+          <ConversationHeaderV2
             nodes={nodes}
-            nodeTraceMap={nodeTraceMap}
             conversationId={conversationId}
+            nodeTraceMap={nodeTraceMap}
             isLoading={isLoading}
           />
-        </Flex>
-        <ConversationViewContainer>
-          <ConversationViewContent
+        </Container>
+        <Flex flex={1} minHeight="0" padding="md 2xl" gap="md" direction="column">
+          <ConversationViewV2Content
             conversation={conversation}
             selectedSpanId={queryState.spanId}
             onSelectSpan={handleSelectSpan}
             focusedTool={queryState.focusedTool}
           />
-        </ConversationViewContainer>
+        </Flex>
       </Stack>
     </ViewportConstrainedPage>
-  );
-}
-
-function ConversationViewContainer({children}: {children: React.ReactNode}) {
-  return (
-    <Container
-      flex={1}
-      minHeight="0"
-      overflow="hidden"
-      border="primary"
-      radius="md"
-      background="primary"
-      display="flex"
-    >
-      <Flex flex={1} minHeight="0" height="100%">
-        {children}
-      </Flex>
-    </Container>
   );
 }
 

--- a/static/app/views/explore/conversations/hooks/useConversationAgents.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationAgents.tsx
@@ -1,0 +1,43 @@
+import {useMemo} from 'react';
+
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import type {SpanProperty} from 'sentry/views/insights/types';
+
+export function useConversationAgents(): {
+  agentsByConversation: Record<string, string[]>;
+  isLoading: boolean;
+} {
+  const {data, isPending} = useSpans(
+    {
+      limit: 500,
+      search: `has:gen_ai.conversation.id has:gen_ai.agent.name`,
+      sorts: [{field: 'count()', kind: 'desc'}],
+      fields: [
+        'gen_ai.conversation.id' as SpanProperty,
+        'gen_ai.agent.name' as SpanProperty,
+        'count()' as SpanProperty,
+      ],
+    },
+    'api.insights.conversations.get-agent-names-direct'
+  );
+
+  const agentsByConversation = useMemo(() => {
+    const map: Record<string, string[]> = {};
+    data?.forEach(row => {
+      const r = row as Record<string, unknown>;
+      const convId = r['gen_ai.conversation.id'] as string | undefined;
+      const agentName = r['gen_ai.agent.name'] as string | undefined;
+      if (convId && agentName) {
+        if (!map[convId]) {
+          map[convId] = [];
+        }
+        if (!map[convId].includes(agentName)) {
+          map[convId].push(agentName);
+        }
+      }
+    });
+    return map;
+  }, [data]);
+
+  return {agentsByConversation, isLoading: isPending};
+}

--- a/static/app/views/explore/conversations/hooks/useConversationSelection.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationSelection.tsx
@@ -53,21 +53,20 @@ export function useConversationSelection({
   }, [nodes]);
 
   const selectedNode = useMemo(() => {
-    return (
-      nodes.find(node => node.id === selectedSpanId) ??
-      nodes.find(node => node.id === defaultNodeId)
-    );
-  }, [nodes, selectedSpanId, defaultNodeId]);
+    if (!selectedSpanId) {
+      return undefined;
+    }
+    return nodes.find(node => node.id === selectedSpanId);
+  }, [nodes, selectedSpanId]);
 
   useEffect(() => {
-    if (isLoading || !defaultNodeId || focusedTool) {
+    if (isLoading || !selectedSpanId || focusedTool) {
       return;
     }
 
-    const isCurrentSpanValid =
-      selectedSpanId && nodes.some(node => node.id === selectedSpanId);
+    const isCurrentSpanValid = nodes.some(node => node.id === selectedSpanId);
 
-    if (!isCurrentSpanValid) {
+    if (!isCurrentSpanValid && defaultNodeId) {
       onSelectSpan?.(defaultNodeId);
     }
   }, [isLoading, defaultNodeId, selectedSpanId, nodes, onSelectSpan, focusedTool]);

--- a/static/app/views/explore/conversations/hooks/useConversationToolStats.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationToolStats.tsx
@@ -1,0 +1,59 @@
+import {useMemo} from 'react';
+
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {getToolSpansFilter} from 'sentry/views/insights/pages/agents/utils/query';
+import type {SpanProperty} from 'sentry/views/insights/types';
+
+export interface ToolStat {
+  avgDuration: number;
+  calls: number;
+  name: string;
+  totalDuration: number;
+}
+
+export function useConversationToolStats(): {
+  isLoading: boolean;
+  toolStatsByConversation: Record<string, ToolStat[]>;
+} {
+  const query = `has:gen_ai.conversation.id ${getToolSpansFilter()} has:gen_ai.tool.name`;
+
+  const {data, isPending} = useSpans(
+    {
+      limit: 1000,
+      search: query,
+      sorts: [{field: 'count()', kind: 'desc'}],
+      fields: [
+        'gen_ai.conversation.id' as SpanProperty,
+        'gen_ai.tool.name' as SpanProperty,
+        'count()' as SpanProperty,
+        'avg(span.duration)' as SpanProperty,
+        'sum(span.duration)' as SpanProperty,
+      ],
+    },
+    'api.insights.conversations.get-tool-stats'
+  );
+
+  const toolStatsByConversation = useMemo(() => {
+    const map: Record<string, ToolStat[]> = {};
+    data?.forEach(row => {
+      const r = row as Record<string, unknown>;
+      const convId = r['gen_ai.conversation.id'] as string | undefined;
+      const toolName = r['gen_ai.tool.name'] as string | undefined;
+      if (!convId || !toolName) {
+        return;
+      }
+      if (!map[convId]) {
+        map[convId] = [];
+      }
+      map[convId].push({
+        name: toolName,
+        calls: (r['count()'] as number) ?? 0,
+        avgDuration: (r['avg(span.duration)'] as number) ?? 0,
+        totalDuration: (r['sum(span.duration)'] as number) ?? 0,
+      });
+    });
+    return map;
+  }, [data]);
+
+  return {toolStatsByConversation, isLoading: isPending};
+}

--- a/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
@@ -9,6 +9,7 @@ const BASE_CONVERSATION = {
   duration: 1000,
   endTimestamp: 2000,
   errors: 0,
+  flow: ['Seer Explorer'],
   llmCalls: 1,
   startTimestamp: 1000,
   toolCalls: 0,

--- a/static/app/views/explore/conversations/hooks/useConversations.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.tsx
@@ -5,6 +5,7 @@ import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useToolFilter} from 'sentry/views/explore/conversations/hooks/useToolFilter';
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
 
@@ -21,6 +22,7 @@ export interface Conversation {
   endTimestamp: number;
   errors: number;
   firstInput: string | null;
+  flow: string[];
   lastOutput: string | null;
   llmCalls: number;
   startTimestamp: number;
@@ -47,6 +49,9 @@ export function useConversations() {
   const {cursor, setCursor} = useTableCursor();
   const pageFilters = usePageFilters();
   const combinedQuery = useCombinedQuery();
+  const {toolQuery} = useToolFilter();
+
+  const fullQuery = [combinedQuery, toolQuery].filter(Boolean).join(' ');
 
   const {
     data: response,
@@ -59,7 +64,8 @@ export function useConversations() {
         path: {organizationIdOrSlug: organization.slug},
         query: {
           cursor,
-          query: combinedQuery,
+          per_page: 50,
+          query: fullQuery,
           project: pageFilters.selection.projects,
           environment: pageFilters.selection.environments,
           ...normalizeDateTimeParams(pageFilters.selection.datetime),

--- a/static/app/views/explore/conversations/hooks/useToolFilter.tsx
+++ b/static/app/views/explore/conversations/hooks/useToolFilter.tsx
@@ -1,0 +1,19 @@
+import {parseAsArrayOf, parseAsString, useQueryState} from 'nuqs';
+
+import {escapeDoubleQuotes} from 'sentry/utils';
+import {SpanFields} from 'sentry/views/insights/types';
+
+export function useToolFilter() {
+  const [toolFilters] = useQueryState(
+    'tool',
+    parseAsArrayOf(parseAsString).withDefault([])
+  );
+
+  let toolQuery = '';
+  if (toolFilters.length > 0) {
+    const values = toolFilters.map(v => `"${escapeDoubleQuotes(v)}"`).join(', ');
+    toolQuery = `${SpanFields.GEN_AI_TOOL_NAME}:[${values}]`;
+  }
+
+  return {toolQuery};
+}

--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -17,23 +17,23 @@ import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/c
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {SchemaHintsList} from 'sentry/views/explore/components/schemaHints/schemaHintsList';
-import {SchemaHintsSources} from 'sentry/views/explore/components/schemaHints/schemaHintsUtils';
 import {
   ExploreBodyContent,
   ExploreBodySearch,
 } from 'sentry/views/explore/components/styles';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
-import {ConversationsTable} from 'sentry/views/explore/conversations/components/conversationsTable';
+import {
+  ConversationsTable,
+  EditTableButton,
+} from 'sentry/views/explore/conversations/components/conversationsTable';
+import {ToolSelector} from 'sentry/views/explore/conversations/components/toolSelector';
+import {UserFilterSelector} from 'sentry/views/explore/conversations/components/userFilterSelector';
 import {useShowConversationOnboarding} from 'sentry/views/explore/conversations/hooks/useShowConversationOnboarding';
 import {ConversationOnboarding} from 'sentry/views/explore/conversations/onboarding';
 import {MAX_PICKABLE_DAYS} from 'sentry/views/explore/conversations/settings';
-import {useSpanItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
 import {AgentSelector} from 'sentry/views/insights/common/components/agentSelector';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
 import {TableUrlParams} from 'sentry/views/insights/pages/agents/utils/urlParams';
-
-const DISABLE_AGGREGATES: never[] = [];
 
 function ConversationsOverviewPage() {
   const organization = useOrganization();
@@ -58,19 +58,6 @@ function ConversationsOverviewPage() {
       organization,
     });
   }, [organization]);
-
-  const {attributes: numberTags, isLoading: numberTagsLoading} = useSpanItemAttributes(
-    {},
-    'number'
-  );
-  const {attributes: stringTags, isLoading: stringTagsLoading} = useSpanItemAttributes(
-    {},
-    'string'
-  );
-  const {attributes: booleanTags, isLoading: booleanTagsLoading} = useSpanItemAttributes(
-    {},
-    'boolean'
-  );
 
   const searchQueryBuilderProps: UseSpanSearchQueryBuilderProps = useMemo(
     () => ({
@@ -100,20 +87,14 @@ function ConversationsOverviewPage() {
         <Layout.Main width="full">
           <Stack gap="md">
             <Flex gap="md" align="center" wrap="wrap">
-              <Flex gap="md" align="center">
-                <PageFilterBar condensed>
-                  <ProjectPageFilter resetParamsOnChange={[TableUrlParams.CURSOR]} />
-                  <EnvironmentPageFilter resetParamsOnChange={[TableUrlParams.CURSOR]} />
-                  <DatePageFilter
-                    {...datePageFilterProps}
-                    resetParamsOnChange={[TableUrlParams.CURSOR]}
-                  />
-                </PageFilterBar>
-                <AgentSelector
-                  storageKeyPrefix="conversations:agent-filter"
-                  referrer="api.insights.conversations.get-agent-names"
+              <PageFilterBar condensed>
+                <ProjectPageFilter resetParamsOnChange={[TableUrlParams.CURSOR]} />
+                <EnvironmentPageFilter resetParamsOnChange={[TableUrlParams.CURSOR]} />
+                <DatePageFilter
+                  {...datePageFilterProps}
+                  resetParamsOnChange={[TableUrlParams.CURSOR]}
                 />
-              </Flex>
+              </PageFilterBar>
               {!showOnboarding && !isOnboardingLoading && (
                 <Flex flex={1} minWidth="300px">
                   <TraceItemSearchQueryBuilder {...spanSearchQueryBuilderProps} />
@@ -121,15 +102,20 @@ function ConversationsOverviewPage() {
               )}
             </Flex>
             {!showOnboarding && !isOnboardingLoading && (
-              <SchemaHintsList
-                supportedAggregates={DISABLE_AGGREGATES}
-                booleanTags={booleanTags}
-                numberTags={numberTags}
-                stringTags={stringTags}
-                isLoading={numberTagsLoading || stringTagsLoading || booleanTagsLoading}
-                exploreQuery={searchQuery ?? ''}
-                source={SchemaHintsSources.CONVERSATIONS}
-              />
+              <Flex gap="md" align="center">
+                <AgentSelector
+                  storageKeyPrefix="conversations:agent-filter"
+                  referrer="api.insights.conversations.get-agent-names"
+                />
+                <ToolSelector
+                  storageKeyPrefix="conversations:tool-filter"
+                  referrer="api.insights.conversations.get-tool-names"
+                />
+                <UserFilterSelector />
+                <Flex flex={1} justify="end">
+                  <EditTableButton />
+                </Flex>
+              </Flex>
             )}
           </Stack>
         </Layout.Main>

--- a/static/app/views/insights/pages/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanList.tsx
@@ -70,13 +70,17 @@ function getNodeTimeBounds(node: AITraceSpanNode | AITraceSpanNode[]) {
 export function AISpanList({
   nodes,
   selectedNodeKey,
+  hoveredNodeKey,
   onSelectNode,
+  onHoverNode,
   compressGaps = false,
 }: {
   nodes: AITraceSpanNode[];
   onSelectNode: (node: AITraceSpanNode) => void;
   selectedNodeKey: string | null;
   compressGaps?: boolean;
+  hoveredNodeKey?: string | null;
+  onHoverNode?: (nodeId: string | null) => void;
 }) {
   const nodesByTransaction = useMemo(() => {
     const result = new Map<
@@ -110,6 +114,8 @@ export function AISpanList({
           nodes={transactionNodes}
           onSelectNode={onSelectNode}
           selectedNodeKey={selectedNodeKey}
+          hoveredNodeKey={hoveredNodeKey}
+          onHoverNode={onHoverNode}
           compressGaps={compressGaps}
         />
       ))}
@@ -122,6 +128,8 @@ function TransactionWrapper({
   nodes,
   onSelectNode,
   selectedNodeKey,
+  hoveredNodeKey,
+  onHoverNode,
   transaction,
   compressGaps = false,
 }: {
@@ -131,6 +139,8 @@ function TransactionWrapper({
   selectedNodeKey: string | null;
   transaction: TransactionNode | EapSpanNode | AITraceSpanNode;
   compressGaps?: boolean;
+  hoveredNodeKey?: string | null;
+  onHoverNode?: (nodeId: string | null) => void;
 }) {
   const [isExpanded, setIsExpanded] = useState(true);
 
@@ -180,18 +190,18 @@ function TransactionWrapper({
         nodes.map(node => {
           const aiRunNode = nodeAiRunParentsMap[node.id];
 
-          // Only indent if the node is not the ai run node
-          const shouldIndent = aiRunNode && aiRunNode !== node;
-
           const uniqueKey = node.id;
           return (
             <TraceListItem
-              indent={shouldIndent ? 1 : 0}
+              indent={0}
               traceBounds={timeBounds}
               key={uniqueKey}
               node={node}
               onClick={() => onSelectNode(node)}
               isSelected={uniqueKey === selectedNodeKey}
+              isHighlighted={uniqueKey === hoveredNodeKey}
+              onMouseEnter={() => onHoverNode?.(uniqueKey)}
+              onMouseLeave={() => onHoverNode?.(null)}
               compressedStartByNodeId={compressedBounds?.compressedStartByNodeId}
             />
           );
@@ -204,6 +214,9 @@ const TraceListItem = memo(function TraceListItem({
   node,
   onClick,
   isSelected,
+  isHighlighted,
+  onMouseEnter,
+  onMouseLeave,
   traceBounds,
   indent,
   compressedStartByNodeId,
@@ -214,16 +227,19 @@ const TraceListItem = memo(function TraceListItem({
   onClick: () => void;
   traceBounds: TraceBounds;
   compressedStartByNodeId?: Map<string, number>;
+  isHighlighted?: boolean;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
 }) {
   const theme = useTheme();
   const hasErrors = hasError(node);
   const colorByOpType = useMemo(() => {
     const palette = theme.tokens.dataviz.categorical[5];
     return {
-      [GenAiOperationType.AGENT]: palette[0],
-      [GenAiOperationType.AI_CLIENT]: palette[2],
+      [GenAiOperationType.AGENT]: palette[5],
+      [GenAiOperationType.AI_CLIENT]: palette[5],
       [GenAiOperationType.HANDOFF]: palette[4],
-      [GenAiOperationType.TOOL]: palette[5],
+      [GenAiOperationType.TOOL]: palette[0],
       default: palette[1],
       error: theme.tokens.graphics.danger.vibrant,
     };
@@ -240,7 +256,10 @@ const TraceListItem = memo(function TraceListItem({
     <ListItemContainer
       hasErrors={hasErrors}
       isSelected={isSelected}
+      isHighlighted={isHighlighted}
       onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       indent={indent}
     >
       <Flex align="center" position="relative" style={{color}}>
@@ -528,6 +547,7 @@ function getSpanPresentation(
 const ListItemContainer = styled('div')<{
   hasErrors: boolean;
   indent: number;
+  isHighlighted?: boolean;
   isSelected: boolean;
 }>`
   display: flex;
@@ -538,7 +558,7 @@ const ListItemContainer = styled('div')<{
   border-radius: ${p => p.theme.radius.md};
   cursor: pointer;
   --row-bg: ${p =>
-    p.isSelected
+    p.isSelected || p.isHighlighted
       ? p.theme.tokens.background.secondary
       : p.theme.tokens.background.primary};
   background-color: var(--row-bg);
@@ -547,7 +567,9 @@ const ListItemContainer = styled('div')<{
       ? p.hasErrors
         ? `2px solid ${p.theme.tokens.focus.invalid}`
         : `2px solid ${p.theme.tokens.focus.default}`
-      : 'none'};
+      : p.isHighlighted
+        ? `1px solid ${p.theme.tokens.border.accent.moderate}`
+        : 'none'};
 
   &:hover {
     background-color: ${p =>


### PR DESCRIPTION
Redesigns the conversations list table with new columns (Agent, Tools summary, Messages/Errors), tool filter selector, and user filter. Adds a conversation detail view with transcript + waterfall layout, highlight linking between panels, trace links in the header, and consistent color mapping (blurple for tools, green for agents/LLM calls) across both views.

Key changes:
- List view: tool column shows summary ("N calls Xm Ys") with hover breakdown
- List view: user column handles "None"/unknown gracefully with em dash
- Detail view: new ConversationHeaderV2 with stats and trace links
- Detail view: ConversationTranscript with collapsible tool calls
- Detail view: bidirectional hover highlighting between transcript and waterfall
- Waterfall: removed indentation, fixed color consistency

