### PR TITLE
ref(project-creation): Rework the SCM project-creation page UI

### DIFF
--- a/static/app/views/onboarding/components/newWelcomeProductCard.tsx
+++ b/static/app/views/onboarding/components/newWelcomeProductCard.tsx
@@ -1,7 +1,7 @@
 import type {ReactNode} from 'react';
 
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import {OnboardingWelcomeProductId} from 'sentry/views/onboarding/types';
 
@@ -36,9 +36,7 @@ export function NewWelcomeProductCard({product}: NewWelcomeProductCardProps) {
       </Flex>
       <Flex area="cell2" gap="md">
         <Container>
-          <Text bold size="md" density="comfortable">
-            {title}
-          </Text>
+          <Heading as="h4">{title}</Heading>
         </Container>
         {badge}
       </Flex>

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -3,7 +3,6 @@ import {Container, Grid, Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Text} from '@sentry/scraps/text';
 
-import {IconClock, IconFix, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {ScmAlertOptionCard} from 'sentry/views/onboarding/components/scmAlertOptionCard';
 import {
@@ -35,16 +34,12 @@ export function ScmAlertFrequency({
     <Stack gap="xl" role="radiogroup" aria-label={t('Alert frequency')}>
       <ScmAlertOptionCard
         label={t('High priority issues')}
-        icon={
-          <IconWarning size="md" variant={isDefaultSelected ? 'accent' : 'secondary'} />
-        }
         isSelected={isDefaultSelected}
         onSelect={() => onFieldChange('alertSetting', RuleAction.DEFAULT_ALERT)}
       />
 
       <ScmAlertOptionCard
         label={t('Custom')}
-        icon={<IconFix size="md" variant={isCustomSelected ? 'accent' : 'secondary'} />}
         isSelected={isCustomSelected}
         onSelect={() => onFieldChange('alertSetting', RuleAction.CUSTOMIZED_ALERTS)}
       >
@@ -99,7 +94,6 @@ export function ScmAlertFrequency({
 
       <ScmAlertOptionCard
         label={t("I'll create my own alerts later")}
-        icon={<IconClock size="md" variant={isLaterSelected ? 'accent' : 'secondary'} />}
         isSelected={isLaterSelected}
         onSelect={() => onFieldChange('alertSetting', RuleAction.CREATE_ALERT_LATER)}
       />

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
@@ -27,11 +27,11 @@ describe('ScmAlertFrequencySection', () => {
     const toggle = screen.getByRole('button', {name: 'Alert frequency'});
     // Starts collapsed in project creation: the body is hidden until opened.
     expect(
-      screen.queryByText('Get notified when things go wrong')
+      screen.queryByRole('radiogroup', {name: 'Alert frequency'})
     ).not.toBeInTheDocument();
 
     await userEvent.click(toggle);
-    expect(screen.getByText('Get notified when things go wrong')).toBeInTheDocument();
+    expect(screen.getByRole('radiogroup', {name: 'Alert frequency'})).toBeInTheDocument();
   });
 
   it('keeps the alert-frequency section always expanded in onboarding', () => {

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
@@ -25,12 +25,13 @@ describe('ScmAlertFrequencySection', () => {
     renderSection({analyticsFlow: 'project-creation'});
 
     const toggle = screen.getByRole('button', {name: 'Alert frequency'});
-    expect(screen.getByText('Get notified when things go wrong')).toBeInTheDocument();
-
-    await userEvent.click(toggle);
+    // Starts collapsed in project creation: the body is hidden until opened.
     expect(
       screen.queryByText('Get notified when things go wrong')
     ).not.toBeInTheDocument();
+
+    await userEvent.click(toggle);
+    expect(screen.getByText('Get notified when things go wrong')).toBeInTheDocument();
   });
 
   it('keeps the alert-frequency section always expanded in onboarding', () => {

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -44,7 +44,12 @@ export function ScmAlertFrequencySection({
       [RuleAction.CREATE_ALERT_LATER]: [t('Off'), 'muted'],
     };
 
-    const [label, variant] = alertSettingLabel[alertRuleConfig.alertSetting];
+    // alertRuleConfig can come from restored session storage, so fall back to
+    // the default if alertSetting holds an unknown value (avoids destructuring
+    // undefined).
+    const [label, variant] =
+      alertSettingLabel[alertRuleConfig.alertSetting] ??
+      alertSettingLabel[RuleAction.DEFAULT_ALERT];
 
     return (
       <ScmCollapsibleSection

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -50,11 +50,15 @@ export function ScmAlertFrequencySection({
       <ScmCollapsibleSection
         title={t('Alert frequency')}
         defaultExpanded={false}
-        trailing={<Tag variant={variant}>{label}</Tag>}
+        trailing={
+          <Tag style={{minWidth: '0px'}} variant={variant}>
+            <Text ellipsis variant="inherit">
+              {label}
+            </Text>
+          </Tag>
+        }
       >
-        <Stack gap="md" width="100%">
-          <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
-        </Stack>
+        <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
       </ScmCollapsibleSection>
     );
   }

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -33,7 +33,7 @@ export function ScmAlertFrequencySection({
 
   if (collapsible) {
     return (
-      <ScmCollapsibleSection title={t('Alert frequency')}>
+      <ScmCollapsibleSection title={t('Alert frequency')} defaultExpanded={false}>
         <Stack gap="md" width="100%">
           <Text variant="muted" density="comfortable">
             {t('Get notified when things go wrong')}

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -1,8 +1,13 @@
+import {Tag} from '@sentry/scraps/badge';
 import {Container, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
-import type {AlertRuleOptions} from 'sentry/views/projectInstall/issueAlertOptions';
+import type {TagVariant} from 'sentry/utils/theme';
+import {
+  type AlertRuleOptions,
+  RuleAction,
+} from 'sentry/views/projectInstall/issueAlertOptions';
 
 import {ScmAlertFrequency} from './scmAlertFrequency';
 import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
@@ -32,8 +37,21 @@ export function ScmAlertFrequencySection({
   const collapsible = analyticsFlow === 'project-creation';
 
   if (collapsible) {
+    // Summarize the current selection in the collapsed header.
+    const alertSettingLabel: Record<RuleAction, [string, TagVariant]> = {
+      [RuleAction.DEFAULT_ALERT]: [t('High priority issues'), 'info'],
+      [RuleAction.CUSTOMIZED_ALERTS]: [t('Custom'), 'info'],
+      [RuleAction.CREATE_ALERT_LATER]: [t('Off'), 'muted'],
+    };
+
+    const [label, variant] = alertSettingLabel[alertRuleConfig.alertSetting];
+
     return (
-      <ScmCollapsibleSection title={t('Alert frequency')} defaultExpanded={false}>
+      <ScmCollapsibleSection
+        title={t('Alert frequency')}
+        defaultExpanded={false}
+        trailing={<Tag variant={variant}>{label}</Tag>}
+      >
         <Stack gap="md" width="100%">
           <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
         </Stack>

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -35,9 +35,6 @@ export function ScmAlertFrequencySection({
     return (
       <ScmCollapsibleSection title={t('Alert frequency')} defaultExpanded={false}>
         <Stack gap="md" width="100%">
-          <Text variant="muted" density="comfortable">
-            {t('Get notified when things go wrong')}
-          </Text>
           <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
         </Stack>
       </ScmCollapsibleSection>

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -1,4 +1,4 @@
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Grid, Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
 
@@ -6,7 +6,6 @@ import {ScmCardButton} from 'sentry/views/onboarding/components/scmCardButton';
 import {ScmSelectableContainer} from 'sentry/views/onboarding/components/scmSelectableContainer';
 
 interface ScmAlertOptionCardProps {
-  icon: React.ReactNode;
   isSelected: boolean;
   label: string;
   onSelect: () => void;
@@ -15,7 +14,6 @@ interface ScmAlertOptionCardProps {
 
 export function ScmAlertOptionCard({
   label,
-  icon,
   isSelected,
   onSelect,
   children,
@@ -24,12 +22,11 @@ export function ScmAlertOptionCard({
     <Stack gap="lg">
       <ScmCardButton role="radio" aria-checked={isSelected} onClick={onSelect}>
         <ScmSelectableContainer isSelected={isSelected} padding="lg">
-          <Grid gap="md" align="center" columns="min-content 1fr min-content">
+          <Grid gap="md" align="center" columns="min-content 1fr">
             <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
             <Text bold={isSelected} size="md" density="comfortable">
               {label}
             </Text>
-            <Flex align="center">{icon}</Flex>
           </Grid>
         </ScmSelectableContainer>
       </ScmCardButton>

--- a/static/app/views/onboarding/components/scmCollapsibleSection.tsx
+++ b/static/app/views/onboarding/components/scmCollapsibleSection.tsx
@@ -46,7 +46,7 @@ export function ScmCollapsibleSection({
 
   return (
     <Stack gap="0" width="100%">
-      <Flex justify="between" align="center" width="100%">
+      <Flex justify="between" align="center" width="100%" gap="md">
         <ToggleButton
           variant="transparent"
           size="md"

--- a/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
@@ -1,6 +1,6 @@
 import {Tag} from '@sentry/scraps/badge';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
+import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -36,7 +36,7 @@ export function ScmFeatureInfoCards({
     <Stack gap="xl" width="100%" justify="center">
       <Stack gap="md">
         {platformName ? (
-          <Text bold size="md" density="comfortable">
+          <Heading as="h4">
             {tct('Available with [platformName]', {
               platformName: (
                 <Text as="span" bold variant="accent">
@@ -44,7 +44,7 @@ export function ScmFeatureInfoCards({
                 </Text>
               ),
             })}
-          </Text>
+          </Heading>
         ) : null}
         <Text size="md" variant="secondary" density="comfortable">
           {t('In the next step, run our setup wizard to choose what to instrument')}

--- a/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureInfoCards.tsx
@@ -14,9 +14,9 @@ interface ScmFeatureInfoCardsProps {
   availableFeatures: ProductSolution[];
   disabledProducts: DisabledProducts;
   featureMeta: Record<ProductSolution, FeatureMeta>;
+  isOnboarding: boolean;
   isVolumeLoading?: boolean;
   platformName?: string;
-  showVolume?: boolean;
 }
 
 // Informational variant of the SCM feature card list. Renders the products
@@ -30,26 +30,29 @@ export function ScmFeatureInfoCards({
   featureMeta,
   platformName,
   isVolumeLoading,
-  showVolume = true,
+  isOnboarding,
 }: ScmFeatureInfoCardsProps) {
   return (
     <Stack gap="xl" width="100%" justify="center">
-      <Stack gap="md">
-        {platformName ? (
-          <Heading as="h4">
-            {tct('Available with [platformName]', {
-              platformName: (
-                <Text as="span" bold variant="accent">
-                  {platformName}
-                </Text>
-              ),
-            })}
-          </Heading>
-        ) : null}
-        <Text size="md" variant="secondary" density="comfortable">
-          {t('In the next step, run our setup wizard to choose what to instrument')}
-        </Text>
-      </Stack>
+      {isOnboarding ? (
+        <Stack gap="md">
+          {platformName ? (
+            <Heading as="h4">
+              {tct('Available with [platformName]', {
+                platformName: (
+                  <Text as="span" bold variant="accent">
+                    {platformName}
+                  </Text>
+                ),
+              })}
+            </Heading>
+          ) : null}
+          <Text size="md" variant="secondary" density="comfortable">
+            {t('In the next step, run our setup wizard to choose what to instrument')}
+          </Text>
+        </Stack>
+      ) : null}
+
       <Grid
         gap="2xl"
         columns={{xs: '1fr', sm: '1fr 1fr'}}
@@ -103,7 +106,7 @@ export function ScmFeatureInfoCards({
                   >
                     {meta.description}
                   </Text>
-                  {showVolume ? (
+                  {isOnboarding ? (
                     <Container>
                       {isVolumeLoading ? (
                         <Placeholder height="20px" width="100px" />

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.spec.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.spec.tsx
@@ -26,6 +26,7 @@ describe('ScmFeatureSelectionCards', () => {
         disabledProducts={NO_DISABLED}
         onToggleFeature={jest.fn()}
         featureMeta={FALLBACK_FEATURE_META}
+        isOnboarding
       />
     );
 
@@ -48,6 +49,7 @@ describe('ScmFeatureSelectionCards', () => {
         disabledProducts={NO_DISABLED}
         onToggleFeature={jest.fn()}
         featureMeta={FALLBACK_FEATURE_META}
+        isOnboarding
       />
     );
 
@@ -64,6 +66,7 @@ describe('ScmFeatureSelectionCards', () => {
         disabledProducts={NO_DISABLED}
         onToggleFeature={onToggleFeature}
         featureMeta={FALLBACK_FEATURE_META}
+        isOnboarding
       />
     );
 
@@ -89,6 +92,7 @@ describe('ScmFeatureSelectionCards', () => {
         disabledProducts={NO_DISABLED}
         onToggleFeature={onToggleFeature}
         featureMeta={FALLBACK_FEATURE_META}
+        isOnboarding
       />
     );
 
@@ -111,6 +115,7 @@ describe('ScmFeatureSelectionCards', () => {
         }}
         onToggleFeature={jest.fn()}
         featureMeta={FALLBACK_FEATURE_META}
+        isOnboarding
       />
     );
 
@@ -127,6 +132,7 @@ describe('ScmFeatureSelectionCards', () => {
         disabledProducts={NO_DISABLED}
         onToggleFeature={jest.fn()}
         featureMeta={FALLBACK_FEATURE_META}
+        isOnboarding
       />
     );
 
@@ -144,6 +150,7 @@ describe('ScmFeatureSelectionCards', () => {
         disabledProducts={NO_DISABLED}
         onToggleFeature={jest.fn()}
         featureMeta={FALLBACK_FEATURE_META}
+        isOnboarding
       />
     );
 
@@ -160,6 +167,7 @@ describe('ScmFeatureSelectionCards', () => {
         disabledProducts={NO_DISABLED}
         onToggleFeature={jest.fn()}
         featureMeta={FALLBACK_FEATURE_META}
+        isOnboarding
         isVolumeLoading
       />
     );

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -1,5 +1,5 @@
 import {Flex, Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {DisabledProducts} from 'sentry/components/onboarding/productSelection';
@@ -30,9 +30,7 @@ export function ScmFeatureSelectionCards({
   return (
     <Stack gap="xl" width="100%" justify="center">
       <Flex justify="between" align="center">
-        <Text bold size="md" density="comfortable">
-          {t('What do you want to instrument?')}
-        </Text>
+        <Heading as="h4">{t('What do you want to instrument?')}</Heading>
         {availableFeatures.length > 1 ? (
           <Text size="sm" variant="secondary">
             {t('Choose one or more')}

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -12,10 +12,10 @@ interface ScmFeatureSelectionCardsProps {
   availableFeatures: ProductSolution[];
   disabledProducts: DisabledProducts;
   featureMeta: Record<ProductSolution, FeatureMeta>;
+  isOnboarding: boolean;
   onToggleFeature: (feature: ProductSolution) => void;
   selectedFeatures: ProductSolution[];
   isVolumeLoading?: boolean;
-  showVolume?: boolean;
 }
 
 export function ScmFeatureSelectionCards({
@@ -25,18 +25,21 @@ export function ScmFeatureSelectionCards({
   onToggleFeature,
   featureMeta,
   isVolumeLoading,
-  showVolume = true,
+  isOnboarding,
 }: ScmFeatureSelectionCardsProps) {
   return (
     <Stack gap="xl" width="100%" justify="center">
-      <Flex justify="between" align="center">
-        <Heading as="h4">{t('What do you want to instrument?')}</Heading>
-        {availableFeatures.length > 1 ? (
-          <Text size="sm" variant="secondary">
-            {t('Choose one or more')}
-          </Text>
-        ) : null}
-      </Flex>
+      {isOnboarding ? (
+        <Flex justify="between" align="center">
+          <Heading as="h4">{t('What do you want to instrument?')}</Heading>
+          {availableFeatures.length > 1 ? (
+            <Text size="sm" variant="secondary">
+              {t('Choose one or more')}
+            </Text>
+          ) : null}
+        </Flex>
+      ) : null}
+
       <Stack gap="md">
         {availableFeatures.map(feature => {
           const meta = featureMeta[feature];
@@ -57,7 +60,7 @@ export function ScmFeatureSelectionCards({
               volume={meta.volume}
               volumeTooltip={meta.volumeTooltip}
               isVolumeLoading={isVolumeLoading}
-              showVolume={showVolume}
+              showVolume={isOnboarding}
             />
           );
         })}

--- a/static/app/views/onboarding/components/scmFeatureSelectionPanel.spec.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionPanel.spec.tsx
@@ -53,10 +53,9 @@ describe('ScmFeatureSelectionPanel', () => {
       {organization}
     );
 
-    // Feature cards still render, just without the trial/billing framing.
-    expect(
-      await screen.findByText('What do you want to instrument?')
-    ).toBeInTheDocument();
+    // Feature cards still render under a Products header, without the
+    // trial/billing framing.
+    expect(await screen.findByText('Products')).toBeInTheDocument();
     expect(screen.getByRole('checkbox', {name: /Tracing/})).toBeInTheDocument();
 
     expect(screen.queryByText(/unlimited volume for 14 days/)).not.toBeInTheDocument();

--- a/static/app/views/onboarding/components/scmFeatureSelectionPanel.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionPanel.tsx
@@ -1,8 +1,9 @@
 import {useCallback, useMemo} from 'react';
 import {motion} from 'framer-motion';
 
+import {Tag} from '@sentry/scraps/badge';
 import {Flex, Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
@@ -10,8 +11,8 @@ import {
   platformProductAvailability,
 } from 'sentry/components/onboarding/productSelection';
 import {PLATFORM_PRODUCT_INFO} from 'sentry/data/platformProductInfo.generated';
-import {IconBusiness} from 'sentry/icons';
-import {tct} from 'sentry/locale';
+import {IconBusiness, IconInfo} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -161,14 +162,17 @@ export function ScmFeatureSelectionPanel({
     ]
   );
 
-  if (featureMode === 'none') {
+  if (featureMode === 'none' && isOnboarding) {
     return null;
   }
 
   return (
     <MotionStack layout="position" width="100%">
-      <Stack gap="2xl" paddingTop="xs">
-        {isOnboarding && (
+      <Stack
+        gap={isOnboarding ? '2xl' : 'lg'}
+        paddingTop={isOnboarding ? 'xs' : undefined}
+      >
+        {isOnboarding ? (
           <Flex
             padding="lg"
             background="secondary"
@@ -190,7 +194,19 @@ export function ScmFeatureSelectionPanel({
               )}
             </Text>
           </Flex>
+        ) : null}
+
+        {isOnboarding ? null : (
+          <Flex justify="between" align="center">
+            <Heading as="h4">{t('Products')}</Heading>
+            {featureMode === 'none' ? (
+              <Tag variant="muted" icon={<IconInfo />}>
+                {t('Select a platform to configure products')}
+              </Tag>
+            ) : null}
+          </Flex>
         )}
+
         {featureMode === 'toggleable' ? (
           <ScmFeatureSelectionCards
             availableFeatures={availableFeatures}
@@ -199,18 +215,18 @@ export function ScmFeatureSelectionPanel({
             onToggleFeature={handleToggleFeature}
             featureMeta={featureMeta}
             isVolumeLoading={isFeatureMetaLoading}
-            showVolume={isOnboarding}
+            isOnboarding={isOnboarding}
           />
-        ) : (
+        ) : featureMode === 'informational' ? (
           <ScmFeatureInfoCards
             availableFeatures={availableFeatures}
             disabledProducts={disabledProducts}
             featureMeta={featureMeta}
             platformName={currentPlatformName}
             isVolumeLoading={isFeatureMetaLoading}
-            showVolume={isOnboarding}
+            isOnboarding={isOnboarding}
           />
-        )}
+        ) : null}
       </Stack>
     </MotionStack>
   );

--- a/static/app/views/onboarding/components/scmFeatureSelectionPanel.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionPanel.tsx
@@ -197,11 +197,13 @@ export function ScmFeatureSelectionPanel({
         ) : null}
 
         {isOnboarding ? null : (
-          <Flex justify="between" align="center">
+          <Flex justify="between" align="center" gap="md">
             <Heading as="h4">{t('Products')}</Heading>
             {featureMode === 'none' ? (
-              <Tag variant="muted" icon={<IconInfo />}>
-                {t('Select a platform to configure products')}
+              <Tag variant="muted" icon={<IconInfo />} style={{minWidth: 0}}>
+                <Text ellipsis variant="inherit">
+                  {t('Select a platform to configure products')}
+                </Text>
               </Tag>
             ) : null}
           </Flex>

--- a/static/app/views/onboarding/components/scmFeatureSelectionPanel.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionPanel.tsx
@@ -199,13 +199,13 @@ export function ScmFeatureSelectionPanel({
         {isOnboarding ? null : (
           <Flex justify="between" align="center" gap="md">
             <Heading as="h4">{t('Products')}</Heading>
-            {featureMode === 'none' ? (
+            {currentPlatformKey ? null : (
               <Tag variant="muted" icon={<IconInfo />} style={{minWidth: 0}}>
                 <Text ellipsis variant="inherit">
                   {t('Select a platform to configure products')}
                 </Text>
               </Tag>
-            ) : null}
+            )}
           </Flex>
         )}
 

--- a/static/app/views/onboarding/components/scmIntegrationConnect.tsx
+++ b/static/app/views/onboarding/components/scmIntegrationConnect.tsx
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useRef} from 'react';
 import {motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, Stack, type StackProps} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack, type StackProps} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -191,13 +191,7 @@ export function ScmIntegrationConnect({
       maxWidth={maxWidth}
       paddingTop={allowIntegrationSwitching ? undefined : '2xl'}
     >
-      {allowIntegrationSwitching ? (
-        <ScmIntegrationSelect
-          integrations={activeIntegrations}
-          selectedIntegration={effectiveIntegration}
-          onChange={handleIntegrationSelect}
-        />
-      ) : (
+      {allowIntegrationSwitching ? null : (
         <Text bold size="sm" density="compressed" uppercase>
           {t(
             'Connected to %s / %s',
@@ -206,13 +200,27 @@ export function ScmIntegrationConnect({
           )}
         </Text>
       )}
-      <ScmRepoSelector
-        analyticsFlow={analyticsFlow}
-        integration={effectiveIntegration}
-        selectedRepository={selectedRepository}
-        onRepositoryChange={onRepositoryChange}
-        onClearDerivedState={onClearDerivedState}
-      />
+      <Grid
+        columns={allowIntegrationSwitching ? '1fr min-content' : '1fr'}
+        width="100%"
+        gap="md"
+        align="center"
+      >
+        <ScmRepoSelector
+          analyticsFlow={analyticsFlow}
+          integration={effectiveIntegration}
+          selectedRepository={selectedRepository}
+          onRepositoryChange={onRepositoryChange}
+          onClearDerivedState={onClearDerivedState}
+        />
+        {allowIntegrationSwitching ? (
+          <ScmIntegrationSelect
+            integrations={activeIntegrations}
+            selectedIntegration={effectiveIntegration}
+            onChange={handleIntegrationSelect}
+          />
+        ) : null}
+      </Grid>
     </MotionStack>
   ) : (
     <MotionStack key="without-integration" gap="2xl" width="100%" maxWidth={maxWidth}>

--- a/static/app/views/onboarding/components/scmIntegrationConnect.tsx
+++ b/static/app/views/onboarding/components/scmIntegrationConnect.tsx
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useRef} from 'react';
 import {motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, Grid, Stack, type StackProps} from '@sentry/scraps/layout';
+import {Flex, Stack, type StackProps} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -200,11 +200,11 @@ export function ScmIntegrationConnect({
           )}
         </Text>
       )}
-      <Grid
-        columns={allowIntegrationSwitching ? '1fr min-content' : '1fr'}
+      <Flex
+        direction={{sm: 'column-reverse', md: 'row'}}
         width="100%"
         gap="md"
-        align="center"
+        align={{sm: 'start', md: 'center'}}
       >
         <ScmRepoSelector
           analyticsFlow={analyticsFlow}
@@ -220,7 +220,7 @@ export function ScmIntegrationConnect({
             onChange={handleIntegrationSelect}
           />
         ) : null}
-      </Grid>
+      </Flex>
     </MotionStack>
   ) : (
     <MotionStack key="without-integration" gap="2xl" width="100%" maxWidth={maxWidth}>

--- a/static/app/views/onboarding/components/scmIntegrationSelect.tsx
+++ b/static/app/views/onboarding/components/scmIntegrationSelect.tsx
@@ -1,5 +1,4 @@
 import {CompactSelect, MenuComponents} from '@sentry/scraps/compactSelect';
-import {Flex} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {IconSettings} from 'sentry/icons';
@@ -38,35 +37,33 @@ export function ScmIntegrationSelect({
   }));
 
   return (
-    <Flex justify="start">
-      <CompactSelect
-        size="sm"
-        value={selectedIntegration.id}
-        options={options}
-        onChange={option => {
-          const next = integrations.find(integration => integration.id === option.value);
-          if (next) {
-            onChange(next);
-          }
-        }}
-        trigger={triggerProps => (
-          <OverlayTrigger.Button
-            {...triggerProps}
-            icon={getIntegrationIcon(selectedIntegration.provider.key, 'sm')}
-          >
-            {selectedIntegration.name}
-          </OverlayTrigger.Button>
-        )}
-        menuFooter={({closeOverlay}) => (
-          <MenuComponents.CTALinkButton
-            icon={<IconSettings />}
-            to={`/settings/${organization.slug}/integrations/?category=source%20code%20management`}
-            onClick={closeOverlay}
-          >
-            {t('Manage providers')}
-          </MenuComponents.CTALinkButton>
-        )}
-      />
-    </Flex>
+    <CompactSelect
+      size="md"
+      value={selectedIntegration.id}
+      options={options}
+      onChange={option => {
+        const next = integrations.find(integration => integration.id === option.value);
+        if (next) {
+          onChange(next);
+        }
+      }}
+      trigger={triggerProps => (
+        <OverlayTrigger.Button
+          {...triggerProps}
+          icon={getIntegrationIcon(selectedIntegration.provider.key, 'sm')}
+        >
+          {selectedIntegration.name}
+        </OverlayTrigger.Button>
+      )}
+      menuFooter={({closeOverlay}) => (
+        <MenuComponents.CTALinkButton
+          icon={<IconSettings />}
+          to={`/settings/${organization.slug}/integrations/?category=source%20code%20management`}
+          onClick={closeOverlay}
+        >
+          {t('Manage providers')}
+        </MenuComponents.CTALinkButton>
+      )}
+    />
   );
 }

--- a/static/app/views/onboarding/components/scmPlatformCard.tsx
+++ b/static/app/views/onboarding/components/scmPlatformCard.tsx
@@ -1,6 +1,6 @@
 import {PlatformIcon} from 'platformicons';
 
-import {Grid, Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {getPlatformKind, type PlatformKind} from 'sentry/data/platformKinds';
@@ -35,17 +35,19 @@ export function ScmPlatformCard({
   return (
     <ScmCardButton onClick={onClick} role="radio" aria-checked={isSelected}>
       <ScmSelectableContainer isSelected={isSelected} padding="lg">
-        <Grid gap="md" align="center" columns="max-content min-content">
-          <PlatformIcon platform={platform} size={28} />
-          <Stack>
-            <Text bold textWrap="nowrap">
+        <Flex gap="md" align="center">
+          <Flex flexShrink={0}>
+            <PlatformIcon platform={platform} size={28} />
+          </Flex>
+          <Stack maxWidth="100%" flexShrink={1} flexGrow={1} overflow="hidden">
+            <Text bold textWrap="nowrap" ellipsis>
               {name}
             </Text>
-            <Text variant="muted" size="sm" textWrap="nowrap">
+            <Text variant="muted" size="sm" textWrap="nowrap" ellipsis>
               {KIND_LABELS[getPlatformKind(platform, type)]}
             </Text>
           </Stack>
-        </Grid>
+        </Flex>
       </ScmSelectableContainer>
     </ScmCardButton>
   );

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -6,7 +6,7 @@ import {Button} from '@sentry/scraps/button';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {useModal} from '@sentry/scraps/modal';
 import {Select} from '@sentry/scraps/select';
-import {Text} from '@sentry/scraps/text';
+import {Heading} from '@sentry/scraps/text';
 
 import {closeModal, openConsoleModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -311,9 +311,7 @@ export function ScmPlatformFeaturesCore({
       <Flex justify="between" align="center">
         <Flex align="center" gap="sm">
           <IconBroadcast size="sm" />
-          <Text bold size="md" density="comfortable">
-            {t('Auto-detected from your repository')}
-          </Text>
+          <Heading as="h4">{t('Auto-detected from your repository')}</Heading>
         </Flex>
         <Button size="xs" variant="link" onClick={handleChangePlatformClick}>
           {isDetecting
@@ -330,9 +328,10 @@ export function ScmPlatformFeaturesCore({
           <Grid
             columns={{
               xs: '1fr',
-              md: `repeat(${resolvedPlatforms.length}, minmax(200px, 1fr))`,
+              md: `repeat(${resolvedPlatforms.length}, minmax(100px, 1fr))`,
             }}
-            width="100%"
+            maxWidth="100%"
+            alignSelf="center"
             justify="center"
             gap="md"
             role="radiogroup"
@@ -361,9 +360,7 @@ export function ScmPlatformFeaturesCore({
     >
       <Flex justify="between" align="center">
         <Flex align="center" gap="sm">
-          <Text bold size="md" density="comfortable">
-            {t('Select a platform')}
-          </Text>
+          <Heading as="h4">{t('Select a platform')}</Heading>
         </Flex>
         {hasScmConnected && !isDetectionError && hasDetectedPlatforms && (
           <Button size="xs" variant="link" onClick={handleBackToRecommended}>

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -6,7 +6,7 @@ import {Button} from '@sentry/scraps/button';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {useModal} from '@sentry/scraps/modal';
 import {Select} from '@sentry/scraps/select';
-import {Heading} from '@sentry/scraps/text';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import {closeModal, openConsoleModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -76,6 +76,7 @@ export function ScmPlatformFeaturesCore({
   selectedPlatform,
   selectedRepository,
 }: ScmPlatformFeaturesCoreProps) {
+  const isOnboarding = analyticsFlow === 'onboarding';
   const {openModal} = useModal();
   const organization = useOrganization();
 
@@ -97,11 +98,11 @@ export function ScmPlatformFeaturesCore({
     // Onboarding views this as a discrete step. Single-view project creation
     // shows all sections at once and fires one page-viewed event in
     // scmCreateProject, so suppress the per-section step_viewed there.
-    if (analyticsFlow !== 'onboarding') {
+    if (!isOnboarding) {
       return;
     }
     trackAnalytics('onboarding.scm_platform_features_step_viewed', {organization});
-  }, [organization, analyticsFlow]);
+  }, [organization, isOnboarding]);
 
   const setPlatform = useCallback(
     (platformKey: PlatformKey) => {
@@ -203,7 +204,7 @@ export function ScmPlatformFeaturesCore({
               applyPlatformSelection(baseSdk);
               closeModal();
             }}
-            newOrg={analyticsFlow === 'onboarding'}
+            newOrg={isOnboarding}
             hasScmOnboarding
             analyticsFlow={analyticsFlow}
           />
@@ -328,11 +329,10 @@ export function ScmPlatformFeaturesCore({
           <Grid
             columns={{
               xs: '1fr',
-              md: `repeat(${resolvedPlatforms.length}, minmax(100px, 1fr))`,
+              md: `repeat(${resolvedPlatforms.length}, .5fr)`,
             }}
-            maxWidth="100%"
-            alignSelf="center"
-            justify="center"
+            width="100%"
+            justify="start"
             gap="md"
             role="radiogroup"
           >
@@ -358,9 +358,16 @@ export function ScmPlatformFeaturesCore({
       initial={{opacity: 0}}
       animate={{opacity: 1}}
     >
-      <Flex justify="between" align="center">
-        <Flex align="center" gap="sm">
-          <Heading as="h4">{t('Select a platform')}</Heading>
+      <Flex justify="between" align="end">
+        <Flex gap="sm" direction={isOnboarding ? undefined : 'column'}>
+          <Heading as="h4">
+            {isOnboarding ? t('Select a platform') : t('Platform')}
+          </Heading>
+          {isOnboarding ? null : (
+            <Text variant="secondary" density="comfortable" size="sm">
+              {t('Determines your SDK and available monitoring features')}
+            </Text>
+          )}
         </Flex>
         {hasScmConnected && !isDetectionError && hasDetectedPlatforms && (
           <Button size="xs" variant="link" onClick={handleBackToRecommended}>

--- a/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
+++ b/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
@@ -56,47 +56,49 @@ export function ScmProjectDetailsCore({
   return (
     <Grid width="100%" columns={{sm: '1fr', md: '1fr 1fr'}} gap="2xl">
       <Stack gap="md">
+        <Container>
+          <Heading as="h4">{t('Project name')}</Heading>
+        </Container>
+
         <Stack gap="xs">
+          <Input
+            type="text"
+            placeholder={t('project-name')}
+            value={projectName}
+            onChange={e => onProjectNameChange(e.target.value)}
+            onBlur={onProjectNameBlur}
+          />
           <Container>
-            <Heading as="h4">{t('Project name')}</Heading>
-          </Container>
-          <Container>
-            <Text variant="muted" density="comfortable">
+            <Text variant="muted" density="comfortable" size="sm">
               {t('Slug used in URLs and SDK config')}
             </Text>
           </Container>
         </Stack>
-        <Input
-          type="text"
-          placeholder={t('project-name')}
-          value={projectName}
-          onChange={e => onProjectNameChange(e.target.value)}
-          onBlur={onProjectNameBlur}
-        />
       </Stack>
 
       {!isOrgMemberWithNoAccess && (
         <Stack gap="md">
+          <Container>
+            <Heading as="h4">{t('Team')}</Heading>
+          </Container>
+
           <Stack gap="xs">
+            <TeamSelector
+              allowCreate
+              name="team"
+              aria-label={t('Select a Team')}
+              clearable={false}
+              placeholder={t('Select a Team')}
+              teamFilter={(tm: Team) => tm.access.includes('team:admin')}
+              value={teamSlug}
+              onChange={onTeamChange}
+            />
             <Container>
-              <Heading as="h4">{t('Team')}</Heading>
-            </Container>
-            <Container>
-              <Text variant="muted" density="comfortable">
+              <Text variant="muted" density="comfortable" size="sm">
                 {t('Set who owns alerts for this project')}
               </Text>
             </Container>
           </Stack>
-          <TeamSelector
-            allowCreate
-            name="team"
-            aria-label={t('Select a Team')}
-            clearable={false}
-            placeholder={t('Select a Team')}
-            teamFilter={(tm: Team) => tm.access.includes('team:admin')}
-            value={teamSlug}
-            onChange={onTeamChange}
-          />
         </Stack>
       )}
     </Grid>

--- a/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
+++ b/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
@@ -2,7 +2,7 @@ import {useEffect} from 'react';
 
 import {Input} from '@sentry/scraps/input';
 import {Container, Grid, Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import {TeamSelector} from 'sentry/components/teamSelector';
 import {t} from 'sentry/locale';
@@ -58,9 +58,7 @@ export function ScmProjectDetailsCore({
       <Stack gap="md">
         <Stack gap="xs">
           <Container>
-            <Text bold size="md" density="comfortable">
-              {t('Project name')}
-            </Text>
+            <Heading as="h4">{t('Project name')}</Heading>
           </Container>
           <Container>
             <Text variant="muted" density="comfortable">
@@ -81,9 +79,7 @@ export function ScmProjectDetailsCore({
         <Stack gap="md">
           <Stack gap="xs">
             <Container>
-              <Text bold size="md" density="comfortable">
-                {t('Team')}
-              </Text>
+              <Heading as="h4">{t('Team')}</Heading>
             </Container>
             <Container>
               <Text variant="muted" density="comfortable">

--- a/static/app/views/onboarding/components/scmRepoSelector.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.tsx
@@ -107,6 +107,7 @@ export function ScmRepoSelector({
       clearable
       searchable
       components={{Control: ScmSearchControl, MenuList: ScmVirtualizedMenuList}}
+      styles={{container: base => ({...base, width: '100%'})}}
     />
   );
 }

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -101,11 +101,11 @@ describe('ScmCreateProject', () => {
   it('shows all steps with the Create CTA disabled on a fresh visit', async () => {
     render(<ScmCreateProject />, {organization});
 
-    // All sections render up front (no progressive disclosure).
-    expect(
-      await screen.findByRole('heading', {name: 'Platform & features'})
-    ).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Project details'})).toBeInTheDocument();
+    // All sections render up front (no progressive disclosure): the repository,
+    // platform, and project-details sections are all present at once.
+    expect(await screen.findByRole('heading', {name: 'Repository'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Select a platform'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Project name'})).toBeInTheDocument();
 
     // Nothing is filled in yet, so the primary action stays disabled.
     expect(screen.getByRole('button', {name: 'Create project'})).toBeDisabled();
@@ -135,7 +135,7 @@ describe('ScmCreateProject', () => {
     });
 
     expect(
-      await screen.findByRole('heading', {name: 'Project details'})
+      await screen.findByRole('heading', {name: 'Project name'})
     ).toBeInTheDocument();
     expect(screen.getByPlaceholderText('project-name')).toHaveValue('my-restored-name');
   });

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -104,7 +104,7 @@ describe('ScmCreateProject', () => {
     // All sections render up front (no progressive disclosure): the repository,
     // platform, and project-details sections are all present at once.
     expect(await screen.findByRole('heading', {name: 'Repository'})).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Select a platform'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Platform'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Project name'})).toBeInTheDocument();
 
     // Nothing is filled in yet, so the primary action stays disabled.

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -3,6 +3,8 @@ import {LayoutGroup, motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Separator} from '@sentry/scraps/separator';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -13,7 +15,7 @@ import type {ProjectDetailsFormState} from 'sentry/components/onboarding/onboard
 import {ProjectCreationErrorAlert} from 'sentry/components/onboarding/projectCreationErrorAlert';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {IconProject} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -36,7 +38,7 @@ import {
 import {useScmProviders} from 'sentry/views/onboarding/components/useScmProviders';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
-const CREATE_PROJECT_MAX_WIDTH = '760px';
+const CREATE_PROJECT_MAX_WIDTH = '700px';
 const WIZARD_STORAGE_KEY = 'project-creation-wizard';
 
 interface WizardState {
@@ -255,78 +257,68 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
   return (
     <SentryDocumentTitle title={t('Create a new project')}>
       <Access access={canUserCreateProject ? ['project:read'] : ['project:admin']}>
-        <Stack
-          flexGrow={1}
-          gap="lg"
-          padding="2xl"
-          alignSelf="center"
-          maxWidth={CREATE_PROJECT_MAX_WIDTH}
-          width="100%"
-        >
-          <LayoutGroup>
-            <Layout.Title>{t('Create a new project')}</Layout.Title>
-            <Stack paddingBottom="lg" gap="md">
-              <Heading as="h1">{t('Create a new project')}</Heading>
-              <Text size="lg">
-                {t('Pick a platform, name your project, and choose what to monitor.')}
-              </Text>
-            </Stack>
+        <Stack padding="3xl" gap="2xl" align="center">
+          <Stack
+            flexGrow={1}
+            gap="2xl"
+            padding="2xl"
+            maxWidth={CREATE_PROJECT_MAX_WIDTH}
+            width="100%"
+            border="primary"
+            radius="lg"
+          >
+            <LayoutGroup>
+              <Layout.Title withMargins>{t('Create a new project')}</Layout.Title>
 
-            <MotionStack
-              gap="xl"
-              border="primary"
-              radius="lg"
-              padding="xl"
-              layout="position"
-            >
-              <Heading as="h3">{t('Connect your Git repository')}</Heading>
+              <Stack paddingBottom="lg" gap="md">
+                <Heading as="h1">{t('Create a project')}</Heading>
+                <Text variant="secondary" density="comfortable">
+                  {tct(
+                    'Set up a separate project for each part of your application (for example, your API server and frontend client), to quickly pinpoint which part of your application errors are coming from. [link: Read the docs].',
+                    {
+                      link: (
+                        <ExternalLink href="https://docs.sentry.io/product/sentry-basics/integrate-frontend/create-new-project/" />
+                      ),
+                    }
+                  )}
+                </Text>
+              </Stack>
 
-              <ScmIntegrationConnect
-                analyticsFlow="project-creation"
-                allowIntegrationSwitching
-                selectedIntegration={selectedIntegration}
-                selectedRepository={selectedRepository}
-                onIntegrationChange={handleIntegrationChange}
-                onRepositoryChange={handleRepositoryChange}
-                onClearDerivedState={handleClearDerivedState}
-                maxWidth={CREATE_PROJECT_MAX_WIDTH}
-              />
-            </MotionStack>
+              <MotionStack gap="md" layout="position">
+                <Heading as="h4">{t('Repository')}</Heading>
 
-            <MotionStack
-              layout="position"
-              gap="2xl"
-              border="primary"
-              radius="lg"
-              padding="xl"
-            >
-              <Heading as="h3">{t('Platform & features')}</Heading>
-              <ScmPlatformFeaturesCore
-                analyticsFlow="project-creation"
-                selectedRepository={selectedRepository}
-                selectedPlatform={selectedPlatform}
-                onPlatformChange={handlePlatformChange}
-                onFeaturesChange={handleFeaturesChange}
-                onClearProjectDetailsForm={handleClearProjectDetailsForm}
-              />
-              <ScmFeatureSelectionPanel
-                analyticsFlow="project-creation"
-                selectedRepository={selectedRepository}
-                selectedPlatform={selectedPlatform}
-                selectedFeatures={selectedFeatures}
-                onFeaturesChange={handleFeaturesChange}
-              />
-            </MotionStack>
+                <ScmIntegrationConnect
+                  analyticsFlow="project-creation"
+                  allowIntegrationSwitching
+                  selectedIntegration={selectedIntegration}
+                  selectedRepository={selectedRepository}
+                  onIntegrationChange={handleIntegrationChange}
+                  onRepositoryChange={handleRepositoryChange}
+                  onClearDerivedState={handleClearDerivedState}
+                  maxWidth={CREATE_PROJECT_MAX_WIDTH}
+                />
+              </MotionStack>
 
-            <MotionStack
-              layout="position"
-              gap="2xl"
-              border="primary"
-              radius="lg"
-              padding="xl"
-            >
-              <Heading as="h3">{t('Project details')}</Heading>
-              <Stack gap="2xl">
+              <MotionStack layout="position" gap="2xl">
+                <ScmPlatformFeaturesCore
+                  analyticsFlow="project-creation"
+                  selectedRepository={selectedRepository}
+                  selectedPlatform={selectedPlatform}
+                  onPlatformChange={handlePlatformChange}
+                  onFeaturesChange={handleFeaturesChange}
+                  onClearProjectDetailsForm={handleClearProjectDetailsForm}
+                />
+                <ScmFeatureSelectionPanel
+                  analyticsFlow="project-creation"
+                  selectedRepository={selectedRepository}
+                  selectedPlatform={selectedPlatform}
+                  selectedFeatures={selectedFeatures}
+                  onFeaturesChange={handleFeaturesChange}
+                />
+              </MotionStack>
+
+              <MotionStack layout="position" gap="2xl">
+                <Separator orientation="horizontal" />
                 <ScmProjectDetailsCore
                   analyticsFlow="project-creation"
                   projectName={form.projectName}
@@ -341,13 +333,12 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                   alertRuleConfig={form.alertRuleConfig}
                   onAlertChange={form.onAlertChange}
                 />
-              </Stack>
-            </MotionStack>
-          </LayoutGroup>
-
+              </MotionStack>
+            </LayoutGroup>
+          </Stack>
           {/* Page-level CTA: disabled until a platform and project details are
               ready. */}
-          <Stack gap="md">
+          <Stack gap="md" maxWidth={CREATE_PROJECT_MAX_WIDTH} width="100%">
             <ProjectCreationErrorAlert error={form.error} />
             <Flex justify="end">
               <Tooltip title={submitTooltipText} disabled={!submitTooltipText}>

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useState} from 'react';
 import {LayoutGroup, motion} from 'framer-motion';
 
+import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
@@ -285,7 +286,17 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
               </Stack>
 
               <MotionStack gap="md" layout="position">
-                <Heading as="h4">{t('Repository')}</Heading>
+                <Flex justify="between" align="center">
+                  <Stack gap="sm">
+                    <Heading as="h4">{t('Repository')}</Heading>
+                    <Text variant="secondary" density="comfortable" size="sm">
+                      {t(
+                        'Source context in stack traces, suspect commits, and deploy tracking'
+                      )}
+                    </Text>
+                  </Stack>
+                  <Tag variant="muted">{t('Optional')}</Tag>
+                </Flex>
 
                 <ScmIntegrationConnect
                   analyticsFlow="project-creation"
@@ -308,6 +319,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                   onFeaturesChange={handleFeaturesChange}
                   onClearProjectDetailsForm={handleClearProjectDetailsForm}
                 />
+                <Separator orientation="horizontal" />
                 <ScmFeatureSelectionPanel
                   analyticsFlow="project-creation"
                   selectedRepository={selectedRepository}
@@ -328,6 +340,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                   onTeamChange={form.onTeamChange}
                   isOrgMemberWithNoAccess={form.isOrgMemberWithNoAccess}
                 />
+                <Separator orientation="horizontal" />
                 <ScmAlertFrequencySection
                   analyticsFlow="project-creation"
                   alertRuleConfig={form.alertRuleConfig}

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -310,7 +310,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                 />
               </MotionStack>
 
-              <MotionStack layout="position" gap="2xl">
+              <motion.div layout="position">
                 <ScmPlatformFeaturesCore
                   analyticsFlow="project-creation"
                   selectedRepository={selectedRepository}
@@ -319,7 +319,13 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                   onFeaturesChange={handleFeaturesChange}
                   onClearProjectDetailsForm={handleClearProjectDetailsForm}
                 />
+              </motion.div>
+
+              <motion.div layout="position">
                 <Separator orientation="horizontal" />
+              </motion.div>
+
+              <motion.div layout="position">
                 <ScmFeatureSelectionPanel
                   analyticsFlow="project-creation"
                   selectedRepository={selectedRepository}
@@ -327,10 +333,13 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                   selectedFeatures={selectedFeatures}
                   onFeaturesChange={handleFeaturesChange}
                 />
-              </MotionStack>
+              </motion.div>
 
-              <MotionStack layout="position" gap="2xl">
+              <motion.div layout="position">
                 <Separator orientation="horizontal" />
+              </motion.div>
+
+              <motion.div layout="position">
                 <ScmProjectDetailsCore
                   analyticsFlow="project-creation"
                   projectName={form.projectName}
@@ -340,13 +349,19 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                   onTeamChange={form.onTeamChange}
                   isOrgMemberWithNoAccess={form.isOrgMemberWithNoAccess}
                 />
+              </motion.div>
+
+              <motion.div layout="position">
                 <Separator orientation="horizontal" />
+              </motion.div>
+
+              <motion.div layout="position">
                 <ScmAlertFrequencySection
                   analyticsFlow="project-creation"
                   alertRuleConfig={form.alertRuleConfig}
                   onAlertChange={form.onAlertChange}
                 />
-              </MotionStack>
+              </motion.div>
             </LayoutGroup>
           </Stack>
           {/* Page-level CTA: disabled until a platform and project details are

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -269,7 +269,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
             radius="lg"
           >
             <LayoutGroup>
-              <Layout.Title withMargins>{t('Create a new project')}</Layout.Title>
+              <Layout.Title>{t('Create a new project')}</Layout.Title>
 
               <Stack paddingBottom="lg" gap="md">
                 <Heading as="h1">{t('Create a project')}</Heading>


### PR DESCRIPTION
## TLDR

Reworks the SCM project-creation page into a single centered bordered card with stacked, separated sections and polishes each section's UI. The integration switcher now sits inline beside the repo selector, and the page is responsive down to mobile. Onboarding rendering is unchanged.

## Details

- Wrap the create-project view in one centered, bordered card (700px max width). The repository, platform/features, and project-details sections read as stacked blocks under h4 headings, divided by horizontal separators rather than per-section borders.
- Repository: the integration switcher moves inline next to the repo selector in a flex row that reverses to switcher-above-selector on mobile, and the repo Select now fills the available width. The step also gains a short description and an Optional tag.
- Platform and features: the platform picker shows a Platform header with a one-line description in project creation, and the feature cards render as a Products section that stays visible with a select-a-platform empty state. The trial banner and per-feature volumes are hidden outside onboarding.
- Project details: per-field helper text moves below its input.
- Alert frequency: collapses behind a toggle in project creation, with a trailing tag summarizing the current setting (High priority issues, Custom, or Off).
- Section tags that can overflow on narrow widths now truncate with an ellipsis, and each section animates its position independently as content above it changes.

Refs VDY-77
