### PR TITLE
feat(ourlogs): clarify export form columns and format

### DIFF
--- a/static/app/views/explore/logs/exports/logsExportModal.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.spec.tsx
@@ -166,18 +166,6 @@ describe('LogsExportModal', () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows a tooltip on the disabled CSV option when the 'All Columns' switch is on", async () => {
-    mockTimeseriesCount();
-    renderModal();
-
-    await userEvent.click(await screen.findByRole('checkbox', {name: 'All Columns?'}));
-    await userEvent.hover(screen.getByText('CSV'));
-
-    expect(
-      await screen.findByText('All columns are only supported by JSONL.')
-    ).toBeInTheDocument();
-  });
-
   it("POSTs with trace_item_full_export query type and jsonl format when the 'All Columns' switch is on", async () => {
     mockTimeseriesCount();
     const dataExportMock = MockApiClient.addMockResponse({

--- a/static/app/views/explore/logs/exports/logsExportModal.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.spec.tsx
@@ -151,6 +151,33 @@ describe('LogsExportModal', () => {
     expect(screen.getByRole('radio', {name: 'JSONL'})).toBeChecked();
   });
 
+  it("shows the column hint when the 'All Columns' switch is off and hides it when on", async () => {
+    mockTimeseriesCount();
+    renderModal();
+
+    expect(
+      await screen.findByText('Defaults to columns visible on table.')
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('checkbox', {name: 'All Columns?'}));
+
+    expect(
+      screen.queryByText('Defaults to columns visible on table.')
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a tooltip on the disabled CSV option when the 'All Columns' switch is on", async () => {
+    mockTimeseriesCount();
+    renderModal();
+
+    await userEvent.click(await screen.findByRole('checkbox', {name: 'All Columns?'}));
+    await userEvent.hover(screen.getByText('CSV'));
+
+    expect(
+      await screen.findByText('All columns are only supported by JSONL.')
+    ).toBeInTheDocument();
+  });
+
   it("POSTs with trace_item_full_export query type and jsonl format when the 'All Columns' switch is on", async () => {
     mockTimeseriesCount();
     const dataExportMock = MockApiClient.addMockResponse({

--- a/static/app/views/explore/logs/exports/logsExportModal.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.spec.tsx
@@ -151,15 +151,6 @@ describe('LogsExportModal', () => {
     expect(screen.getByRole('radio', {name: 'JSONL'})).toBeChecked();
   });
 
-  it("shows the All Columns hint", async () => {
-    mockTimeseriesCount();
-    renderModal();
-
-    expect(
-      await screen.findByText('All columns are only supported by JSONL.')
-    ).toBeInTheDocument();
-  });
-
   it("POSTs with trace_item_full_export query type and jsonl format when the 'All Columns' switch is on", async () => {
     mockTimeseriesCount();
     const dataExportMock = MockApiClient.addMockResponse({

--- a/static/app/views/explore/logs/exports/logsExportModal.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.spec.tsx
@@ -151,19 +151,13 @@ describe('LogsExportModal', () => {
     expect(screen.getByRole('radio', {name: 'JSONL'})).toBeChecked();
   });
 
-  it("shows the column hint when the 'All Columns' switch is off and hides it when on", async () => {
+  it("shows the All Columns hint", async () => {
     mockTimeseriesCount();
     renderModal();
 
     expect(
-      await screen.findByText('Defaults to columns visible on table.')
+      await screen.findByText('All columns are only supported by JSONL.')
     ).toBeInTheDocument();
-
-    await userEvent.click(screen.getByRole('checkbox', {name: 'All Columns?'}));
-
-    expect(
-      screen.queryByText('Defaults to columns visible on table.')
-    ).not.toBeInTheDocument();
   });
 
   it("POSTs with trace_item_full_export query type and jsonl format when the 'All Columns' switch is on", async () => {

--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -7,6 +7,7 @@ import {defaultFormOptions, useScrapsForm, useStore} from '@sentry/scraps/form';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Heading, Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -148,20 +149,6 @@ export function LogsExportModal({
               'When a high number of rows is selected and events are large, the results may be sent to your email.'
             )}
           </Text>
-          <form.AppField name="columns">
-            {field => (
-              <field.Layout.Stack label={t('All Columns?')}>
-                <field.Switch
-                  checked={field.state.value === ModalColumnValue.ALL}
-                  onChange={checked =>
-                    field.handleChange(
-                      checked ? ModalColumnValue.ALL : ModalColumnValue.SELECTED
-                    )
-                  }
-                />
-              </field.Layout.Stack>
-            )}
-          </form.AppField>
           <form.AppField name="format">
             {field => (
               <field.Radio.Group
@@ -176,14 +163,40 @@ export function LogsExportModal({
                 disabled={columnsValue === ModalColumnValue.ALL}
               >
                 <field.Layout.Stack label={t('Format')}>
-                  <field.Radio.Item value={ModalColumnFormat.CSV}>
-                    {t('CSV')}
-                  </field.Radio.Item>
+                  <Tooltip
+                    title={t('All columns are only supported by JSONL.')}
+                    disabled={columnsValue !== ModalColumnValue.ALL}
+                  >
+                    <field.Radio.Item value={ModalColumnFormat.CSV}>
+                      {t('CSV')}
+                    </field.Radio.Item>
+                  </Tooltip>
                   <field.Radio.Item value={ModalColumnFormat.JSONL}>
                     {t('JSONL')}
                   </field.Radio.Item>
                 </field.Layout.Stack>
               </field.Radio.Group>
+            )}
+          </form.AppField>
+          <form.AppField name="columns">
+            {field => (
+              <field.Layout.Stack
+                label={t('All Columns?')}
+                hintText={
+                  field.state.value === ModalColumnValue.ALL
+                    ? undefined
+                    : t('Defaults to columns visible on table.')
+                }
+              >
+                <field.Switch
+                  checked={field.state.value === ModalColumnValue.ALL}
+                  onChange={checked =>
+                    field.handleChange(
+                      checked ? ModalColumnValue.ALL : ModalColumnValue.SELECTED
+                    )
+                  }
+                />
+              </field.Layout.Stack>
             )}
           </form.AppField>
           <form.AppField name="limit">

--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -7,7 +7,6 @@ import {defaultFormOptions, useScrapsForm, useStore} from '@sentry/scraps/form';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Heading, Text} from '@sentry/scraps/text';
-import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -87,7 +86,6 @@ export function LogsExportModal({
       const isAllColumns = value.columns === 'all';
       const passedSyncLimit = value.limit > ROW_COUNT_VALUE_SYNC_LIMIT;
 
-      // The backend only supports exporting all columns in JSONL format.
       const format = isAllColumns ? 'jsonl' : value.format;
 
       trackAnalytics('explore.table_exported', {
@@ -163,14 +161,9 @@ export function LogsExportModal({
                 disabled={columnsValue === ModalColumnValue.ALL}
               >
                 <field.Layout.Stack label={t('Format')}>
-                  <Tooltip
-                    title={t('All columns are only supported by JSONL.')}
-                    disabled={columnsValue !== ModalColumnValue.ALL}
-                  >
-                    <field.Radio.Item value={ModalColumnFormat.CSV}>
-                      {t('CSV')}
-                    </field.Radio.Item>
-                  </Tooltip>
+                  <field.Radio.Item value={ModalColumnFormat.CSV}>
+                    {t('CSV')}
+                  </field.Radio.Item>
                   <field.Radio.Item value={ModalColumnFormat.JSONL}>
                     {t('JSONL')}
                   </field.Radio.Item>

--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -175,12 +175,8 @@ export function LogsExportModal({
           <form.AppField name="columns">
             {field => (
               <field.Layout.Stack
-                label={
-                  <Flex gap="md" align="center">
-                    {t('All Columns?')}
-                    <InfoTip title={t('All columns are only supported by JSONL.')} />
-                  </Flex>
-                }
+                hintText={t('All columns are only supported by JSONL.')}
+                label={t('All Columns?')}
               >
                 <field.Switch
                   checked={field.state.value === ModalColumnValue.ALL}

--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -4,6 +4,7 @@ import {z} from 'zod';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {defaultFormOptions, useScrapsForm, useStore} from '@sentry/scraps/form';
+import {InfoText, InfoTip} from '@sentry/scraps/info';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Heading, Text} from '@sentry/scraps/text';
@@ -174,11 +175,11 @@ export function LogsExportModal({
           <form.AppField name="columns">
             {field => (
               <field.Layout.Stack
-                label={t('All Columns?')}
-                hintText={
-                  field.state.value === ModalColumnValue.ALL
-                    ? undefined
-                    : t('Defaults to columns visible on table.')
+                label={
+                  <Flex gap="md" align="center">
+                    {t('All Columns?')}
+                    <InfoTip title={t('All columns are only supported by JSONL.')} />
+                  </Flex>
                 }
               >
                 <field.Switch

--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -4,7 +4,6 @@ import {z} from 'zod';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {defaultFormOptions, useScrapsForm, useStore} from '@sentry/scraps/form';
-import {InfoText, InfoTip} from '@sentry/scraps/info';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Heading, Text} from '@sentry/scraps/text';


### PR DESCRIPTION
Makes most of the very good changes suggested by @sfanahata for the modal.

<img width="620" height="520" alt="image" src="https://github.com/user-attachments/assets/6bceab99-dcf5-4e52-87bf-e71627dd8ac8" />

Closes LOGS-886.