### PR TITLE
docs(preprod): Clarify diff snapshots omit top-level images array

### DIFF
--- a/src/sentry/apidocs/examples/preprod_examples.py
+++ b/src/sentry/apidocs/examples/preprod_examples.py
@@ -361,7 +361,7 @@ class PreprodExamples:
         "vcs_info": _SNAPSHOT_VCS_INFO,
         "app_id": "com.example.app",
         "is_selective": False,
-        "images": [_SNAPSHOT_IMAGE],
+        "images": [],
         "image_count": 1,
         "added": [],
         "added_count": 0,

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -344,9 +344,13 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         Retrieve full details for a snapshot, including categorized image lists
         and comparison status.
 
-        When a comparison exists, images are categorized into `changed`, `added`,
-        `removed`, `renamed`, `unchanged`, `errored`, and `skipped` lists with
-        counts. Without a comparison, only the `images` list is populated.
+        When a comparison exists (`comparison_type` is `diff`), images are
+        categorized into `changed`, `added`, `removed`, `renamed`, `unchanged`,
+        `errored`, and `skipped` lists with counts, and the top-level `images`
+        array is empty because those images are already present in the
+        categorized lists. For `solo` and `waiting_for_base` snapshots the
+        categorized lists are empty and `images` is the only populated source.
+        `image_count` is accurate in all modes.
 
         Use `compact_metadata=1` to strip image objects down to `display_name`,
         `image_file_name`, `group`, and `description` only.


### PR DESCRIPTION
## Summary

Documentation-only follow-up to #118180, which dropped the redundant top-level `images` array from `diff`-mode snapshot detail responses.

The GET docstring for the snapshot details endpoint still claimed that "without a comparison, only the `images` list is populated," which no longer matches the endpoint's behavior. This updates the docstring (which feeds the public OpenAPI schema and the [docs.sentry.io API page](https://docs.sentry.io/api/snapshots/retrieve-snapshot-details/)) to reflect the current contract:

- In `diff` mode the top-level `images` array is empty — those images are already present in the categorized lists (`changed`, `added`, `removed`, `renamed`, `unchanged`, `errored`, `skipped`).
- `solo` and `waiting_for_base` snapshots have empty categorized lists, so `images` remains their only source.
- `image_count` is accurate in all modes.

No behavior change.

Addresses the review question on #118180 (https://github.com/getsentry/sentry/pull/118180#discussion_r3455468451).

Refs #118180
