### PR TITLE
feat(dashboards): Re-add Heat Map widget with heat-map-only config validation

### DIFF
--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -124,6 +124,24 @@ export type WidgetQueryParams = {
   widgetInterval?: string;
 };
 
+/**
+ * Parameters for the heat map query hook — the subset of `WidgetQueryParams`
+ * that applies to heat maps, plus `yBuckets` (the Y-axis bucket count derived
+ * from the rendered chart height).
+ */
+export type HeatmapWidgetQueryParams = Pick<
+  WidgetQueryParams,
+  | 'enabled'
+  | 'organization'
+  | 'pageFilters'
+  | 'widget'
+  | 'dashboardFilters'
+  | 'skipDashboardFilterParens'
+  | 'widgetInterval'
+> & {
+  yBuckets?: number;
+};
+
 export interface DatasetConfig<SeriesResponse, TableResponse> {
   /**
    * Dataset specific search bar for the 'Filter' step in the
@@ -304,6 +322,13 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     widgetQuery: WidgetQuery,
     organization: Organization
   ) => Series[];
+  /**
+   * Hook-based approach for fetching heat map data. Heat maps fetch from a
+   * dedicated endpoint and need the rendered chart dimensions to size their
+   * X/Y buckets. Only datasets that expose `DisplayType.HEATMAP` in
+   * `supportedDisplayTypes` need to implement this.
+   */
+  useHeatmapQuery?: (params: HeatmapWidgetQueryParams) => HookWidgetQueryResult;
   /**
    * Data provider hook that provides methods
    * to retrieve tags and values for the search bar.

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -40,6 +40,7 @@ import {
 } from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {hasMultipleMetricsSelected} from 'sentry/views/dashboards/widgetBuilder/utils/hasMultipleMetricsSelected';
 import {
+  useTraceMetricsHeatmapQuery,
   useTraceMetricsSeriesQuery,
   useTraceMetricsTableQuery,
 } from 'sentry/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery';
@@ -286,10 +287,12 @@ export const TraceMetricsConfig: DatasetConfig<
     DisplayType.BAR,
     DisplayType.BIG_NUMBER,
     DisplayType.CATEGORICAL_BAR,
+    DisplayType.HEATMAP,
     DisplayType.LINE,
   ],
   useSeriesQuery: useTraceMetricsSeriesQuery,
   useTableQuery: useTraceMetricsTableQuery,
+  useHeatmapQuery: useTraceMetricsHeatmapQuery,
   transformTable: (data, widgetQuery) => {
     const transformedData = transformEventsResponseToTable(data, widgetQuery);
 

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -52,6 +52,7 @@ export enum DisplayType {
   CATEGORICAL_BAR = 'categorical_bar',
   AGENTS_TRACES_TABLE = 'agents_traces_table',
   TEXT = 'text',
+  HEATMAP = 'heatmap',
 }
 
 export enum WidgetType {

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -626,6 +626,7 @@ export const usesTimeSeriesData = (displayType?: DisplayType) => {
     DisplayType.RAGE_AND_DEAD_CLICKS,
     DisplayType.AGENTS_TRACES_TABLE,
     DisplayType.TEXT,
+    DisplayType.HEATMAP,
   ].includes(displayType);
 };
 

--- a/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
@@ -1,7 +1,7 @@
 import {WidgetFixture} from 'sentry-fixture/widget';
 import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
 
-import {DisplayType} from 'sentry/views/dashboards/types';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 
 import {getWidgetConfigError} from './getWidgetConfigError';
 
@@ -51,6 +51,51 @@ describe('getWidgetConfigError', () => {
       queries: [
         WidgetQueryFixture({aggregates: []}),
         WidgetQueryFixture({aggregates: ['count()']}),
+      ],
+    });
+
+    expect(getWidgetConfigError(widget)).toBeUndefined();
+  });
+
+  it('returns an error when the dataset does not support the display type', () => {
+    // Issues don't support big number widgets.
+    const widget = WidgetFixture({
+      displayType: DisplayType.BIG_NUMBER,
+      widgetType: WidgetType.ISSUE,
+      queries: [WidgetQueryFixture({aggregates: ['count()']})],
+    });
+
+    expect(getWidgetConfigError(widget)).toBeDefined();
+  });
+
+  it('returns an error for heat map widgets on an unsupported dataset', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.HEATMAP,
+      widgetType: WidgetType.SPANS,
+      queries: [
+        WidgetQueryFixture({aggregates: ['count(value,test_metric,distribution,none)']}),
+      ],
+    });
+
+    expect(getWidgetConfigError(widget)).toBeDefined();
+  });
+
+  it('returns an error for heat map widgets whose aggregate has no metric', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.HEATMAP,
+      widgetType: WidgetType.TRACEMETRICS,
+      queries: [WidgetQueryFixture({aggregates: ['sum(value)']})],
+    });
+
+    expect(getWidgetConfigError(widget)).toBeDefined();
+  });
+
+  it('returns undefined for heat map widgets with a resolvable metric', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.HEATMAP,
+      widgetType: WidgetType.TRACEMETRICS,
+      queries: [
+        WidgetQueryFixture({aggregates: ['count(value,test_metric,distribution,none)']}),
       ],
     });
 

--- a/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
@@ -68,6 +68,26 @@ describe('getWidgetConfigError', () => {
     expect(getWidgetConfigError(widget)).toBeDefined();
   });
 
+  it.each([
+    DisplayType.TEXT,
+    DisplayType.WHEEL,
+    DisplayType.RAGE_AND_DEAD_CLICKS,
+    DisplayType.AGENTS_TRACES_TABLE,
+  ])(
+    'returns undefined for special %s widgets that are not dataset-driven',
+    displayType => {
+      // These widgets aren't backed by a dataset, so the dataset/display-type
+      // compatibility check must not flag them regardless of widgetType.
+      const widget = WidgetFixture({
+        displayType,
+        widgetType: WidgetType.ERRORS,
+        queries: [WidgetQueryFixture({aggregates: []})],
+      });
+
+      expect(getWidgetConfigError(widget)).toBeUndefined();
+    }
+  );
+
   it('returns an error for heat map widgets on an unsupported dataset', () => {
     const widget = WidgetFixture({
       displayType: DisplayType.HEATMAP,

--- a/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.spec.tsx
@@ -57,37 +57,6 @@ describe('getWidgetConfigError', () => {
     expect(getWidgetConfigError(widget)).toBeUndefined();
   });
 
-  it('returns an error when the dataset does not support the display type', () => {
-    // Issues don't support big number widgets.
-    const widget = WidgetFixture({
-      displayType: DisplayType.BIG_NUMBER,
-      widgetType: WidgetType.ISSUE,
-      queries: [WidgetQueryFixture({aggregates: ['count()']})],
-    });
-
-    expect(getWidgetConfigError(widget)).toBeDefined();
-  });
-
-  it.each([
-    DisplayType.TEXT,
-    DisplayType.WHEEL,
-    DisplayType.RAGE_AND_DEAD_CLICKS,
-    DisplayType.AGENTS_TRACES_TABLE,
-  ])(
-    'returns undefined for special %s widgets that are not dataset-driven',
-    displayType => {
-      // These widgets aren't backed by a dataset, so the dataset/display-type
-      // compatibility check must not flag them regardless of widgetType.
-      const widget = WidgetFixture({
-        displayType,
-        widgetType: WidgetType.ERRORS,
-        queries: [WidgetQueryFixture({aggregates: []})],
-      });
-
-      expect(getWidgetConfigError(widget)).toBeUndefined();
-    }
-  );
-
   it('returns an error for heat map widgets on an unsupported dataset', () => {
     const widget = WidgetFixture({
       displayType: DisplayType.HEATMAP,

--- a/static/app/views/dashboards/utils/getWidgetConfigError.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.tsx
@@ -1,6 +1,9 @@
 import {t} from 'sentry/locale';
-import type {Widget} from 'sentry/views/dashboards/types';
+import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
+import {DisplayType, type Widget} from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
+import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
+import {getSelectedAggregate} from 'sentry/views/dashboards/widgetBuilder/utils/getSelectedAggregate';
 
 /**
  * Returns a user-facing error message if the widget has a static config
@@ -8,11 +11,30 @@ import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
  * if the widget config is valid.
  */
 export function getWidgetConfigError(widget: Widget): string | undefined {
+  // Each dataset declares the display types it supports; a widget using an
+  // unsupported combination can't render.
+  if (
+    !getDatasetConfig(widget.widgetType).supportedDisplayTypes.includes(
+      widget.displayType
+    )
+  ) {
+    return t('This dataset does not support this visualization.');
+  }
+
   if (
     usesTimeSeriesData(widget.displayType) &&
     widget.queries.every(q => q.aggregates.length === 0)
   ) {
     return t('The widget configuration is not valid. Please add a "Visualize" field.');
+  }
+
+  // Heat maps plot the metric from their selected "Visualize" aggregate. If
+  // that aggregate doesn't resolve to a metric, the widget can't render.
+  if (widget.displayType === DisplayType.HEATMAP) {
+    const aggregate = getSelectedAggregate(widget);
+    if (!aggregate || !extractTraceMetricFromColumn(aggregate)) {
+      return t('This widget is missing a metric to visualize.');
+    }
   }
 
   return undefined;

--- a/static/app/views/dashboards/utils/getWidgetConfigError.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.tsx
@@ -1,6 +1,6 @@
 import {t} from 'sentry/locale';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
-import {DisplayType, type Widget} from 'sentry/views/dashboards/types';
+import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
 import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {getSelectedAggregate} from 'sentry/views/dashboards/widgetBuilder/utils/getSelectedAggregate';
@@ -12,8 +12,12 @@ import {getSelectedAggregate} from 'sentry/views/dashboards/widgetBuilder/utils/
  */
 export function getWidgetConfigError(widget: Widget): string | undefined {
   // Each dataset declares the display types it supports; a widget using an
-  // unsupported combination can't render.
+  // unsupported combination can't render. Only display types that are actually
+  // dataset-driven are validated here — special widgets (Text/Markdown, Wheel,
+  // Rage & Dead Clicks, Agents traces, etc.) aren't backed by a dataset, so
+  // they're not "supported" by any of them and must be exempt.
   if (
+    isDatasetDrivenDisplayType(widget.displayType) &&
     !getDatasetConfig(widget.widgetType).supportedDisplayTypes.includes(
       widget.displayType
     )
@@ -39,3 +43,16 @@ export function getWidgetConfigError(widget: Widget): string | undefined {
 
   return undefined;
 }
+
+function isDatasetDrivenDisplayType(displayType: DisplayType): boolean {
+  return DATASET_DRIVEN_DISPLAY_TYPES.has(displayType);
+}
+
+// The set of display types that at least one dataset supports. A display type
+// outside this set is a special widget (e.g. Text/Markdown) that doesn't belong
+// to any dataset and therefore can't be flagged as unsupported by one.
+const DATASET_DRIVEN_DISPLAY_TYPES = new Set(
+  Object.values(WidgetType).flatMap(
+    widgetType => getDatasetConfig(widgetType).supportedDisplayTypes
+  )
+);

--- a/static/app/views/dashboards/utils/getWidgetConfigError.tsx
+++ b/static/app/views/dashboards/utils/getWidgetConfigError.tsx
@@ -1,5 +1,4 @@
 import {t} from 'sentry/locale';
-import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
 import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
@@ -11,20 +10,6 @@ import {getSelectedAggregate} from 'sentry/views/dashboards/widgetBuilder/utils/
  * if the widget config is valid.
  */
 export function getWidgetConfigError(widget: Widget): string | undefined {
-  // Each dataset declares the display types it supports; a widget using an
-  // unsupported combination can't render. Only display types that are actually
-  // dataset-driven are validated here — special widgets (Text/Markdown, Wheel,
-  // Rage & Dead Clicks, Agents traces, etc.) aren't backed by a dataset, so
-  // they're not "supported" by any of them and must be exempt.
-  if (
-    isDatasetDrivenDisplayType(widget.displayType) &&
-    !getDatasetConfig(widget.widgetType).supportedDisplayTypes.includes(
-      widget.displayType
-    )
-  ) {
-    return t('This dataset does not support this visualization.');
-  }
-
   if (
     usesTimeSeriesData(widget.displayType) &&
     widget.queries.every(q => q.aggregates.length === 0)
@@ -32,9 +17,13 @@ export function getWidgetConfigError(widget: Widget): string | undefined {
     return t('The widget configuration is not valid. Please add a "Visualize" field.');
   }
 
-  // Heat maps plot the metric from their selected "Visualize" aggregate. If
+  // Heat maps are only offered on the trace-metrics dataset, and plot the metric
+  // from their selected "Visualize" aggregate. If they're on another dataset or
   // that aggregate doesn't resolve to a metric, the widget can't render.
   if (widget.displayType === DisplayType.HEATMAP) {
+    if (widget.widgetType !== WidgetType.TRACEMETRICS) {
+      return t('This dataset does not support this visualization.');
+    }
     const aggregate = getSelectedAggregate(widget);
     if (!aggregate || !extractTraceMetricFromColumn(aggregate)) {
       return t('This widget is missing a metric to visualize.');
@@ -43,16 +32,3 @@ export function getWidgetConfigError(widget: Widget): string | undefined {
 
   return undefined;
 }
-
-function isDatasetDrivenDisplayType(displayType: DisplayType): boolean {
-  return DATASET_DRIVEN_DISPLAY_TYPES.has(displayType);
-}
-
-// The set of display types that at least one dataset supports. A display type
-// outside this set is a special widget (e.g. Text/Markdown) that doesn't belong
-// to any dataset and therefore can't be flagged as unsupported by one.
-const DATASET_DRIVEN_DISPLAY_TYPES = new Set(
-  Object.values(WidgetType).flatMap(
-    widgetType => getDatasetConfig(widgetType).supportedDisplayTypes
-  )
-);

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -63,11 +63,13 @@ export function WidgetBuilderQueryFilterBuilder({
   // - Tables: only one filter (no overlay concept)
   // - Big Numbers: only one filter (single value display)
   // - Bar (Categorical): only one filter allowed, to simplify product for now
+  // - Heat Map: only one filter (single distribution)
   // - Details: only one filter (single query, key-value display)
   const canAddSearchConditions =
     state.displayType !== DisplayType.TABLE &&
     state.displayType !== DisplayType.BIG_NUMBER &&
     state.displayType !== DisplayType.CATEGORICAL_BAR &&
+    state.displayType !== DisplayType.HEATMAP &&
     state.displayType !== DisplayType.DETAILS &&
     state.query &&
     state.query.length < 3;
@@ -78,11 +80,13 @@ export function WidgetBuilderQueryFilterBuilder({
   // - Tables: no legend (data shown in rows)
   // - Big Numbers: no legend (single value)
   // - Bar (Categorical): no aliases (only one filter allowed, no point aliasing it)
+  // - Heat Map: no aliases (only one filter allowed, no point aliasing it)
   // - Details: no legend (single query, data shown in key-value pairs)
   const canHaveAlias =
     state.displayType !== DisplayType.TABLE &&
     state.displayType !== DisplayType.BIG_NUMBER &&
     state.displayType !== DisplayType.CATEGORICAL_BAR &&
+    state.displayType !== DisplayType.HEATMAP &&
     state.displayType !== DisplayType.DETAILS;
 
   const onAddSearchConditions = () => {

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -18,6 +18,7 @@ import {useDashboardWidgetSource} from 'sentry/views/dashboards/widgetBuilder/ho
 import {useIsEditingWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {convertWidgetToBuilderState} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
+import {canUseMetricsHeatMap} from 'sentry/views/explore/metrics/metricsFlags';
 
 export const DISPLAY_TYPE_ICONS: Partial<Record<DisplayType, React.ReactNode>> = {
   [DisplayType.AREA]: <IconGraph key="area" type="area" />,
@@ -27,6 +28,7 @@ export const DISPLAY_TYPE_ICONS: Partial<Record<DisplayType, React.ReactNode>> =
   [DisplayType.BIG_NUMBER]: <IconNumber key="number" />,
   [DisplayType.DETAILS]: <IconSettings key="details" />,
   [DisplayType.CATEGORICAL_BAR]: <IconGraph key="categorical_bar" type="bar" />,
+  [DisplayType.HEATMAP]: <IconGraph key="heatmap" type="heatmap" />,
   [DisplayType.TEXT]: <IconMarkdown key="text" />,
 };
 
@@ -46,6 +48,7 @@ export function WidgetBuilderTypeSelector({
   const organization = useOrganization();
 
   const hasDetailsWidget = organization.features.includes('dashboards-details-widget');
+  const hasHeatMapWidget = canUseMetricsHeatMap(organization);
   // Use an array to define display type order explicitly.
   // Object key ordering in JS is technically specified but easy to break accidentally.
   const displayTypeOrder: Array<{
@@ -68,6 +71,15 @@ export function WidgetBuilderTypeSelector({
       label: t('Bar (Categorical)'),
       details: t('Compare measurements across categories.'),
     },
+    ...(hasHeatMapWidget
+      ? [
+          {
+            type: DisplayType.HEATMAP,
+            label: t('Heat Map'),
+            details: t('Visualize the distribution of a measurement over time.'),
+          },
+        ]
+      : []),
     {
       type: DisplayType.LINE,
       label: t('Line'),
@@ -186,7 +198,9 @@ export function WidgetBuilderTypeSelector({
                 payload: newValue,
               });
               if (
-                (newValue === DisplayType.TABLE || newValue === DisplayType.BIG_NUMBER) &&
+                (newValue === DisplayType.TABLE ||
+                  newValue === DisplayType.BIG_NUMBER ||
+                  newValue === DisplayType.HEATMAP) &&
                 state.query?.length
               ) {
                 dispatch({

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -300,9 +300,15 @@ export function Visualize({error, setError, traceMetricsVisualizeMode}: Visualiz
   const isBigNumberWidget = state.displayType === DisplayType.BIG_NUMBER;
   const isTableWidget = state.displayType === DisplayType.TABLE;
   const isCategoricalBarWidget = state.displayType === DisplayType.CATEGORICAL_BAR;
+  // Heat maps store their single "Visualize" aggregate in state.fields and use
+  // radio selection, mirroring Big Number.
+  const isHeatmapWidget = state.displayType === DisplayType.HEATMAP;
 
+  // Heat maps don't support equations, so the equation mode toggle and the
+  // "Add Equation" affordances are hidden for them.
   const canShowTraceMetricEquations =
     state.dataset === WidgetType.TRACEMETRICS &&
+    !isHeatmapWidget &&
     canUseMetricsEquationsInDashboards(organization);
 
   const {isEquationMode, handleModeToggle, equationSnapshot} =
@@ -428,7 +434,7 @@ export function Visualize({error, setError, traceMetricsVisualizeMode}: Visualiz
   const canAddFields =
     isTimeSeriesWidget ||
     isTableWidget ||
-    ((isBigNumberWidget || isCategoricalBarWidget) &&
+    ((isBigNumberWidget || isCategoricalBarWidget || isHeatmapWidget) &&
       (datasetConfig.enableEquations || canShowTraceMetricEquations));
   // Determines which action to use for updating visualization fields:
   // - Line, Area, Bar (Time Series): SET_Y_AXIS for Y-axis aggregates
@@ -505,7 +511,8 @@ export function Visualize({error, setError, traceMetricsVisualizeMode}: Visualiz
     fields?.length &&
     fields.length > 1 &&
     state.displayType !== DisplayType.BIG_NUMBER &&
-    state.displayType !== DisplayType.CATEGORICAL_BAR;
+    state.displayType !== DisplayType.CATEGORICAL_BAR &&
+    state.displayType !== DisplayType.HEATMAP;
 
   const draggableFieldIds = fields?.map((_field, index) => index.toString()) ?? [];
 
@@ -577,8 +584,13 @@ export function Visualize({error, setError, traceMetricsVisualizeMode}: Visualiz
   }, [isTimeSeriesWidget, isBigNumberWidget, state.dataset, fieldOptions]);
 
   const computedAggregateOptions = useMemo(() => {
-    // Categorical bars only allow aggregates, no field columns
-    if (isTimeSeriesWidget || isBigNumberWidget || isCategoricalBarWidget) {
+    // Categorical bars and heat maps only allow aggregates, no field columns
+    if (
+      isTimeSeriesWidget ||
+      isBigNumberWidget ||
+      isCategoricalBarWidget ||
+      isHeatmapWidget
+    ) {
       return {type: 'chart' as const, options: baseAggregateOptions};
     }
 
@@ -612,6 +624,7 @@ export function Visualize({error, setError, traceMetricsVisualizeMode}: Visualiz
     isTimeSeriesWidget,
     isBigNumberWidget,
     isCategoricalBarWidget,
+    isHeatmapWidget,
     state.dataset,
     baseAggregateOptions,
     traceItemColumnOptions,
@@ -775,7 +788,8 @@ export function Visualize({error, setError, traceMetricsVisualizeMode}: Visualiz
                           <FieldRow>
                             {fields.length > 1 &&
                               (state.displayType === DisplayType.BIG_NUMBER ||
-                                state.displayType === DisplayType.CATEGORICAL_BAR) && (
+                                state.displayType === DisplayType.CATEGORICAL_BAR ||
+                                state.displayType === DisplayType.HEATMAP) && (
                                 <RadioLineItem
                                   index={index}
                                   role="radio"
@@ -871,7 +885,12 @@ export function Visualize({error, setError, traceMetricsVisualizeMode}: Visualiz
                                 <Fragment>
                                   {state.dataset === WidgetType.TRACEMETRICS ? (
                                     <MetricSelectRow
-                                      disabled={disableTransactionWidget}
+                                      // Heat maps always count() the metric, so
+                                      // the aggregate function is locked (only the
+                                      // metric is selectable), mirroring Explore.
+                                      disabled={
+                                        disableTransactionWidget || isHeatmapWidget
+                                      }
                                       field={field}
                                       index={index}
                                     />
@@ -965,7 +984,8 @@ export function Visualize({error, setError, traceMetricsVisualizeMode}: Visualiz
                               compact={
                                 isTimeSeriesWidget ||
                                 isBigNumberWidget ||
-                                isCategoricalBarWidget
+                                isCategoricalBarWidget ||
+                                isHeatmapWidget
                               }
                             >
                               {canHaveAlias && (
@@ -1081,7 +1101,7 @@ export function Visualize({error, setError, traceMetricsVisualizeMode}: Visualiz
                 aria-label={
                   isTimeSeriesWidget
                     ? t('Add Series')
-                    : isBigNumberWidget || isCategoricalBarWidget
+                    : isBigNumberWidget || isCategoricalBarWidget || isHeatmapWidget
                       ? t('Add Field')
                       : t('Add Column')
                 }
@@ -1109,7 +1129,7 @@ export function Visualize({error, setError, traceMetricsVisualizeMode}: Visualiz
               >
                 {isTimeSeriesWidget
                   ? t('+ Add Series')
-                  : isBigNumberWidget || isCategoricalBarWidget
+                  : isBigNumberWidget || isCategoricalBarWidget || isHeatmapWidget
                     ? t('+ Add Field')
                     : t('+ Add Column')}
               </AddButton>

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -577,6 +577,133 @@ describe('useWidgetBuilderState', () => {
       expect(result.current.state.query).toEqual(['event.type:test']);
     });
 
+    it('keeps only aggregates and clears sort when switching to heat map', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            field: ['event.type', 'count()'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.fields).toEqual([
+        {field: 'event.type', alias: undefined, kind: 'field'},
+        {
+          function: ['count', '', undefined, undefined],
+          alias: undefined,
+          kind: 'function',
+        },
+      ]);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.HEATMAP,
+        });
+      });
+
+      // Columns are dropped; only the aggregate ("Visualize") remains.
+      expect(result.current.state.fields).toEqual([
+        {
+          function: ['count', '', undefined, undefined],
+          alias: undefined,
+          kind: 'function',
+        },
+      ]);
+      expect(result.current.state.sort).toEqual([]);
+    });
+
+    it('drops equations when switching to heat map', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            field: ['count()', 'equation|count() * 2'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.HEATMAP,
+        });
+      });
+
+      // Only the non-equation aggregate survives.
+      expect(result.current.state.fields).toEqual([
+        {
+          function: ['count', '', undefined, undefined],
+          alias: undefined,
+          kind: 'function',
+        },
+      ]);
+    });
+
+    it('normalizes the aggregate to count() when switching to heat map', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            field: ['sum(value,test_metric,distribution,none)'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.HEATMAP,
+        });
+      });
+
+      // The metric is preserved but the function becomes count() — heat maps
+      // always count the metric's value, so the chosen function is irrelevant.
+      expect(result.current.state.fields).toEqual([
+        {
+          kind: 'function',
+          function: ['count', 'value', 'test_metric', 'distribution', 'none'],
+          alias: undefined,
+        },
+      ]);
+    });
+
+    it('selects the first filter when switching to heat map', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            field: ['event.type', 'count()'],
+            query: ['event.type:test', 'event.type:test2'],
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.query).toEqual(['event.type:test', 'event.type:test2']);
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.HEATMAP,
+        });
+      });
+
+      expect(result.current.state.query).toEqual(['event.type:test']);
+    });
+
     it('resets selectedAggregate when the display type is switched', () => {
       mockedUsedLocation.mockReturnValue(
         LocationFixture({query: {selectedAggregate: '0'}})

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -12,6 +12,7 @@ import {
   type QueryFieldValue,
   type Sort,
 } from 'sentry/utils/discover/fields';
+import {AggregationKey} from 'sentry/utils/fields';
 import {
   decodeInteger,
   decodeList,
@@ -43,6 +44,7 @@ import {
   DEFAULT_RESULTS_LIMIT,
   getResultsLimit,
 } from 'sentry/views/dashboards/widgetBuilder/utils';
+import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import type {DefaultDetailWidgetFields} from 'sentry/views/dashboards/widgets/detailsWidget/types';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -180,6 +182,10 @@ export interface WidgetBuilderState {
    * - Big Number: aggregate fields
    * - Line, Area, Bar (Time Series): grouping fields (non-aggregates)
    * - Bar (Categorical): one X-axis (FIELD kind) and one or more aggregates (FUNCTION/EQUATION kind)
+   * - Heat Map: one or more aggregates (FUNCTION kind), like Big Number. The
+   *   metric selected by the "Visualize" is the Y axis; the function is always
+   *   count() (the Z axis) and the X axis is always time, so there is no
+   *   grouping/X-axis category. Only a single filter is supported.
    */
   fields?: Column[];
   legendAlias?: string[];
@@ -187,6 +193,12 @@ export interface WidgetBuilderState {
   limit?: number;
   linkedDashboards?: LinkedDashboard[];
   query?: string[];
+  /**
+   * Index into `fields` selecting which single aggregate to plot when a display
+   * type renders one aggregate but several were carried over. Used by Big
+   * Number, Categorical Bar, and Heat Map, and surfaced as a radio in the
+   * builder.
+   */
   selectedAggregate?: number;
   sort?: Sort[];
   textContent?: string;
@@ -194,7 +206,7 @@ export interface WidgetBuilderState {
   title?: string;
   /**
    * Y-axis aggregates for time-series charts (area, bar, line).
-   * Not used by tables, big numbers, or categorical bar widgets.
+   * Not used by tables, big numbers, categorical bar, or heat map widgets.
    */
   yAxis?: Column[];
 }
@@ -398,7 +410,9 @@ export function useWidgetBuilderState(): {
       // if it hasn't been explicitly set.
       // For categorical bar, only count aggregate fields (FUNCTION/EQUATION), not the X-axis FIELD column
       selectedAggregate:
-        displayType === DisplayType.BIG_NUMBER && defined(fields) && fields.length > 1
+        (displayType === DisplayType.BIG_NUMBER || displayType === DisplayType.HEATMAP) &&
+        defined(fields) &&
+        fields.length > 1
           ? (selectedAggregate ?? fields.length - 1)
           : displayType === DisplayType.CATEGORICAL_BAR && defined(fields)
             ? (() => {
@@ -520,14 +534,49 @@ export function useWidgetBuilderState(): {
                 options
               );
             }
-          } else if (action.payload === DisplayType.BIG_NUMBER) {
+          } else if (
+            action.payload === DisplayType.BIG_NUMBER ||
+            action.payload === DisplayType.HEATMAP
+          ) {
             // TODO: Reset the selected aggregate here for widgets with equations
+            // Heat maps behave like Big Number here: aggregates (the "Visualize")
+            // live in fields with radio selection, there's no grouping/X-axis
+            // category, and only a single filter is supported.
             setLimit(undefined, options);
             setSort([], options);
             setYAxis([], options);
             setLegendAlias([], options);
-            // Columns are ignored for big number widgets because there is no grouping
-            setFields([...aggregatesWithoutAlias, ...(yAxisWithoutAlias ?? [])], options);
+            // Columns are ignored because there is no grouping
+            let nextFields = [...aggregatesWithoutAlias, ...(yAxisWithoutAlias ?? [])];
+            if (action.payload === DisplayType.HEATMAP) {
+              // Heat maps always count() the metric's value (the Z axis); the
+              // Visualize only selects the metric (the Y axis). Mirror Explore by
+              // dropping equations and normalizing each aggregate's function to
+              // count() while preserving the metric (the function args).
+              nextFields = nextFields
+                .filter(field => field.kind !== FieldValueKind.EQUATION)
+                .map(field => {
+                  if (
+                    field.kind === FieldValueKind.FUNCTION &&
+                    extractTraceMetricFromColumn(field)
+                  ) {
+                    return {
+                      ...field,
+                      function: [
+                        AggregationKey.COUNT,
+                        field.function[1],
+                        ...field.function.slice(2),
+                      ],
+                    };
+                  }
+                  return field;
+                });
+              // If stripping equations left nothing, fall back to the default.
+              if (nextFields.length === 0) {
+                nextFields.push({...currentDatasetConfig.defaultField, alias: undefined});
+              }
+            }
+            setFields(nextFields, options);
             setQuery(query?.slice(0, 1), options);
           } else if (action.payload === DisplayType.DETAILS) {
             setLimit(1, options);
@@ -717,7 +766,8 @@ export function useWidgetBuilderState(): {
               options
             );
             setSort(
-              nextDisplayType === DisplayType.BIG_NUMBER
+              nextDisplayType === DisplayType.BIG_NUMBER ||
+                nextDisplayType === DisplayType.HEATMAP
                 ? []
                 : decodeSorts(config.defaultWidgetQuery.orderby),
               options
@@ -1165,11 +1215,12 @@ export function useWidgetBuilderState(): {
             }
           }
 
-          // Adjust selectedAggregate index for Big Number and Categorical Bar
-          // (these are the widget types that use radio selection)
+          // Adjust selectedAggregate index for Big Number, Categorical Bar, and
+          // Heat Map (the widget types that use radio selection)
           if (
             (displayType === DisplayType.BIG_NUMBER ||
-              displayType === DisplayType.CATEGORICAL_BAR) &&
+              displayType === DisplayType.CATEGORICAL_BAR ||
+              displayType === DisplayType.HEATMAP) &&
             selectedAggregate !== undefined
           ) {
             if (deleteIndex < selectedAggregate) {

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -80,7 +80,8 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
   const fields =
     state.displayType === DisplayType.TABLE ||
     state.displayType === DisplayType.DETAILS ||
-    state.displayType === DisplayType.BIG_NUMBER
+    state.displayType === DisplayType.BIG_NUMBER ||
+    state.displayType === DisplayType.HEATMAP
       ? state.fields?.map(generateFieldAsString)
       : [...(columns ?? []), ...(aggregates ?? [])];
 
@@ -128,12 +129,17 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
       name: legendAlias[index] ?? '',
       selectedAggregate: state.selectedAggregate,
       linkedDashboards: state.linkedDashboards ?? [],
-      // Big number widgets don't support sorting, so always ignore the sort state
-      orderby: state.displayType === DisplayType.BIG_NUMBER ? '' : sort,
+      // Big number and heat map widgets don't support sorting, so always ignore
+      // the sort state
+      orderby:
+        state.displayType === DisplayType.BIG_NUMBER ||
+        state.displayType === DisplayType.HEATMAP
+          ? ''
+          : sort,
     };
   });
 
-  const limit = [DisplayType.BIG_NUMBER, DisplayType.TABLE].includes(
+  const limit = [DisplayType.BIG_NUMBER, DisplayType.TABLE, DisplayType.HEATMAP].includes(
     state.displayType ?? DisplayType.TABLE
   )
     ? null

--- a/static/app/views/dashboards/widgetBuilder/utils/getSelectedAggregate.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/getSelectedAggregate.ts
@@ -1,0 +1,20 @@
+import {explodeField, type Column} from 'sentry/utils/discover/fields';
+import type {Widget} from 'sentry/views/dashboards/types';
+import {getSelectedAggregateIndex} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
+
+/**
+ * Returns the widget's selected "Visualize" aggregate — the one picked by the
+ * radio selection (`selectedAggregate`) for single-aggregate display types like
+ * heat maps — exploded into a `Column`. Returns undefined when there's no
+ * aggregate. Callers that need the trace metric pass the result to
+ * `extractTraceMetricFromColumn`.
+ */
+export function getSelectedAggregate(widget: Widget): Column | undefined {
+  const query = widget.queries[0];
+  const selectedIndex = getSelectedAggregateIndex(
+    query?.selectedAggregate,
+    query?.aggregates.length ?? 0
+  );
+  const aggregate = query?.aggregates?.[selectedIndex];
+  return aggregate ? explodeField({field: aggregate}) : undefined;
+}

--- a/static/app/views/dashboards/widgetCard/buildHeatmapCellQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/buildHeatmapCellQuery.spec.tsx
@@ -1,0 +1,27 @@
+import {buildHeatmapCellQuery} from 'sentry/views/dashboards/widgetCard/buildHeatmapCellQuery';
+
+describe('buildHeatmapCellQuery', () => {
+  it('uses a range filter when the bucket has width', () => {
+    expect(buildHeatmapCellQuery(undefined, 10, 20)).toBe('value:>=10 value:<20');
+  });
+
+  it('uses a single bound when the bucket is zero-width', () => {
+    expect(buildHeatmapCellQuery(undefined, 10, 10)).toBe('value:<=10');
+  });
+
+  it('treats an empty base query as no base query', () => {
+    expect(buildHeatmapCellQuery('', 10, 20)).toBe('value:>=10 value:<20');
+  });
+
+  it('AND-combines a simple base query with the value filter', () => {
+    expect(buildHeatmapCellQuery('span.op:db', 10, 20)).toBe(
+      '(span.op:db) value:>=10 value:<20'
+    );
+  });
+
+  it('parenthesizes a base query with top-level OR so the value filter is not captured', () => {
+    expect(buildHeatmapCellQuery('url:ABC OR url:XYZ', 10, 20)).toBe(
+      '(url:ABC OR url:XYZ) value:>=10 value:<20'
+    );
+  });
+});

--- a/static/app/views/dashboards/widgetCard/buildHeatmapCellQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/buildHeatmapCellQuery.tsx
@@ -1,0 +1,22 @@
+/**
+ * Builds the search query for a heat map cell's "View connected spans" Explore
+ * link: the cell's value-bucket filter, AND-combined with the widget's own
+ * conditions (`baseQuery`).
+ *
+ * Search terms are space-AND'd, so a top-level `OR` in `baseQuery` (e.g.
+ * `url:ABC OR url:XYZ`) would otherwise capture the appended value filter and
+ * change the meaning. Wrapping `baseQuery` in parentheses keeps the two
+ * fragments logically separate: `(url:ABC OR url:XYZ) value:>=5`.
+ */
+export function buildHeatmapCellQuery(
+  baseQuery: string | undefined,
+  valueMin: number,
+  valueMax: number
+): string {
+  const valueQuery =
+    valueMin === valueMax
+      ? `value:<=${valueMin}`
+      : `value:>=${valueMin} value:<${valueMax}`;
+
+  return [baseQuery && `(${baseQuery})`, valueQuery].filter(Boolean).join(' ');
+}

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -43,7 +43,10 @@ import {
 } from 'sentry/views/dashboards/types';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
 import {getWidgetTableRowExploreUrlFunction} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
+import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {getSelectedAggregateIndex} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
+import {getSelectedAggregate} from 'sentry/views/dashboards/widgetBuilder/utils/getSelectedAggregate';
+import {buildHeatmapCellQuery} from 'sentry/views/dashboards/widgetCard/buildHeatmapCellQuery';
 import type {WidgetLegendSelectionState} from 'sentry/views/dashboards/widgetLegendSelectionState';
 import {AgentsTracesTableWidgetVisualization} from 'sentry/views/dashboards/widgets/agentsTracesTableWidget/agentsTracesTableWidgetVisualization';
 import {BigNumberWidgetVisualization} from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization';
@@ -59,6 +62,9 @@ import type {
 } from 'sentry/views/dashboards/widgets/common/types';
 import {DetailsWidgetVisualization} from 'sentry/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization';
 import type {DefaultDetailWidgetFields} from 'sentry/views/dashboards/widgets/detailsWidget/types';
+import {HeatMapWidgetVisualization} from 'sentry/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization';
+import {HeatMap} from 'sentry/views/dashboards/widgets/heatMapWidget/plottables/heatMap';
+import {HEATMAP_Z_AXIS_SCALE} from 'sentry/views/dashboards/widgets/heatMapWidget/settings';
 import {RageAndDeadClicksWidgetVisualization} from 'sentry/views/dashboards/widgets/rageAndDeadClicksWidget/rageAndDeadClicksVisualization';
 import {ServerTreeWidgetVisualization} from 'sentry/views/dashboards/widgets/serverTreeWidget/serverTreeWidgetVisualization';
 import {TableWidgetVisualization} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
@@ -71,14 +77,18 @@ import {WheelWidgetVisualization} from 'sentry/views/dashboards/widgets/wheelWid
 import {WidgetError} from 'sentry/views/dashboards/widgets/widget/widgetError';
 import {Actions} from 'sentry/views/discover/table/cellAction';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
+import {getExploreUrl as buildExploreUrl} from 'sentry/views/explore/utils';
 import {SpanFields} from 'sentry/views/insights/types';
 import type {SpanResponse} from 'sentry/views/insights/types';
 
-import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
+import {
+  applyDashboardFiltersToWidget,
+  type GenericWidgetQueriesResult,
+} from './genericWidgetQueries';
 
 type TableComponentProps = Pick<
   GenericWidgetQueriesResult,
-  'errorMessage' | 'loading' | 'tableResults'
+  'errorMessage' | 'loading' | 'tableResults' | 'heatmapResults'
 > & {
   selection: PageFilters;
   widget: Widget;
@@ -182,6 +192,15 @@ function WidgetCardChart(props: WidgetCardChartProps) {
       <TransitionChart loading={loading} reloading={loading}>
         <LoadingScreen loading={loading} showLoadingText={showLoadingText} />
         <CategoricalSeriesComponent tableResults={tableResults} {...props} />
+      </TransitionChart>
+    );
+  }
+
+  if (widget.displayType === DisplayType.HEATMAP) {
+    return (
+      <TransitionChart loading={loading} reloading={loading}>
+        <LoadingScreen loading={loading} showLoadingText={showLoadingText} />
+        <HeatmapSeriesComponent {...props} />
       </TransitionChart>
     );
   }
@@ -446,6 +465,76 @@ function CategoricalSeriesComponent(props: TableComponentProps): React.ReactNode
   return (
     <ChartWrapper autoHeightResize>
       <CategoricalSeriesWidgetVisualization plottables={plottables} {...props} />
+    </ChartWrapper>
+  );
+}
+
+function HeatmapSeriesComponent(props: TableComponentProps): React.ReactNode {
+  const {heatmapResults, loading, widget, dashboardFilters, selection} = props;
+  const organization = useOrganization();
+
+  const selectedAggregate = getSelectedAggregate(widget);
+  const traceMetric = selectedAggregate
+    ? extractTraceMetricFromColumn(selectedAggregate)
+    : undefined;
+
+  if (loading || !heatmapResults) {
+    return <LoadingPlaceholder />;
+  }
+
+  if (heatmapResults.values.length === 0) {
+    return (
+      <StyledErrorPanel>
+        <IconWarning variant="primary" size="lg" />
+      </StyledErrorPanel>
+    );
+  }
+
+  // Match the conditions the heat map actually fetched with (dashboard filters
+  // applied), so the cell's Explore link is scoped the same way.
+  const exploreBaseQuery = applyDashboardFiltersToWidget(widget, dashboardFilters)
+    .queries[0]?.conditions;
+
+  return (
+    <ChartWrapper autoHeightResize>
+      <HeatMapWidgetVisualization
+        plottables={[new HeatMap(heatmapResults)]}
+        scale={HEATMAP_Z_AXIS_SCALE}
+        // The heat map links each cell's tooltip to its metric in Explore.
+        renderTooltipActions={({valueMin, valueMax, timestampStart, timestampEnd}) => {
+          if (!traceMetric) {
+            return null;
+          }
+          const tracesUrl = buildExploreUrl({
+            organization,
+            selection: {
+              ...selection,
+              datetime: {
+                ...selection.datetime,
+                start: new Date(timestampStart),
+                end: new Date(timestampEnd),
+                period: null,
+              },
+            },
+            crossEvents: [
+              {
+                type: 'metrics',
+                metric: traceMetric,
+                query: buildHeatmapCellQuery(exploreBaseQuery, valueMin, valueMax),
+              },
+            ],
+          });
+          return (
+            <div>
+              <span className="tooltip-label tooltip-label-centered">
+                <a data-traces-link={tracesUrl} href={tracesUrl}>
+                  {t('View connected spans')}
+                </a>
+              </span>
+            </div>
+          );
+        }}
+      />
     </ChartWrapper>
   );
 }

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -24,6 +24,7 @@ import {
   dashboardFiltersToString,
   usesTimeSeriesData,
 } from 'sentry/views/dashboards/utils';
+import type {HeatMapSeries} from 'sentry/views/dashboards/widgets/common/types';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 export function getReferrer(displayType: DisplayType) {
@@ -43,6 +44,7 @@ export function getReferrer(displayType: DisplayType) {
 export type OnDataFetchedProps = {
   confidence?: Confidence;
   dataScanned?: 'full' | 'partial';
+  heatmapResults?: HeatMapSeries;
   isProgressivelyLoading?: boolean;
   isSampled?: boolean | null;
   pageLinks?: string;
@@ -59,6 +61,7 @@ export type GenericWidgetQueriesResult = {
   confidence?: Confidence;
   dataScanned?: 'full' | 'partial';
   errorMessage?: string;
+  heatmapResults?: HeatMapSeries;
   isProgressivelyLoading?: boolean;
   isSampled?: boolean | null;
   pageLinks?: string;
@@ -114,6 +117,9 @@ type UseGenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
   // Optional override for the widget interval (e.g., '1m', '5m', '1h')
   // If not provided, widget interval will be calculated automatically
   widgetInterval?: string;
+  // Number of buckets to slice a non-time axis into. Used by heat maps for the
+  // Y-axis bucket count, derived from the rendered chart height.
+  yBuckets?: number;
 };
 
 /**
@@ -173,6 +179,7 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
     selection: propsSelection,
     skipDashboardFilterParens,
     widgetInterval,
+    yBuckets,
   } = props;
 
   const organization = useOrganization();
@@ -181,10 +188,13 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
   // Use override selection if provided (for modal zoom), otherwise use hook
   const selection = propsSelection ?? hookPageFilters.selection;
 
+  const isHeatmap = widget.displayType === DisplayType.HEATMAP;
   const isTimeSeriesData = usesTimeSeriesData(widget.displayType);
 
   const enableSeriesHook = isTimeSeriesData && !disabled && !propsLoading;
-  const enableTableHook = !isTimeSeriesData && !disabled && !propsLoading;
+  // Heat maps aren't time-series but fetch via the heat map hook, not the table
+  // hook — so exclude them here to avoid firing a redundant table query.
+  const enableTableHook = !isTimeSeriesData && !isHeatmap && !disabled && !propsLoading;
   const needsBreakdownTable = isTimeSeriesData && widget.legendType === 'breakdown';
 
   const tableWidget = useMemo(
@@ -225,7 +235,22 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
     widgetInterval,
   });
 
-  const hookResults = isTimeSeriesData ? hookSeriesResults : hookTableResults;
+  const hookHeatmapResults = config.useHeatmapQuery?.({
+    widget,
+    organization,
+    pageFilters: selection,
+    dashboardFilters,
+    skipDashboardFilterParens,
+    enabled: isHeatmap && !disabled && !propsLoading,
+    widgetInterval,
+    yBuckets,
+  });
+
+  const hookResults = isHeatmap
+    ? hookHeatmapResults
+    : isTimeSeriesData
+      ? hookSeriesResults
+      : hookTableResults;
 
   // Track previous raw data to detect when new data arrives
   const prevRawDataRef = useRef<any[] | undefined>(undefined);
@@ -258,7 +283,12 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
     prevRawDataRef.current = hookResults.rawData;
 
     // Call afterFetch callbacks with raw data
-    if (isTimeSeriesData) {
+    if (isHeatmap) {
+      // Heat maps have no afterFetch transforms; just surface the result.
+      onDataFetched?.({
+        heatmapResults: (hookResults as any).heatmapResults,
+      });
+    } else if (isTimeSeriesData) {
       hookResults.rawData.forEach((data: any) => {
         afterFetchSeriesData?.(data as SeriesResponse);
       });
@@ -288,6 +318,7 @@ export function useGenericWidgetQueries<SeriesResponse, TableResponse>(
     }
   }, [
     hookResults,
+    isHeatmap,
     isTimeSeriesData,
     afterFetchSeriesData,
     afterFetchTableData,

--- a/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.spec.tsx
@@ -8,6 +8,7 @@ import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
 import {
+  useTraceMetricsHeatmapQuery,
   useTraceMetricsSeriesQuery,
   useTraceMetricsTableQuery,
 } from './useTraceMetricsWidgetQuery';
@@ -288,5 +289,198 @@ describe('useTraceMetricsTableQuery', () => {
         })
       );
     });
+  });
+});
+
+describe('useTraceMetricsHeatmapQuery', () => {
+  const organization = OrganizationFixture();
+  const pageFilters = PageFiltersFixture();
+
+  const heatmapWidget = WidgetFixture({
+    displayType: DisplayType.HEATMAP,
+    queries: [
+      {
+        name: '',
+        fields: ['sum(value,test_metric,millisecond,none)'],
+        aggregates: ['sum(value,test_metric,millisecond,none)'],
+        columns: [],
+        conditions: 'span.op:db',
+        orderby: '',
+      },
+    ],
+  });
+
+  const heatmapResponse = {
+    meta: {
+      xAxis: {valueType: 'date', valueUnit: null},
+      yAxis: {valueType: 'number', valueUnit: null, bucketCount: 10},
+      zAxis: {valueType: 'integer', valueUnit: null},
+    },
+    values: [{xAxis: 1, yAxis: 0, zAxis: 5}],
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(pageFilters);
+  });
+
+  it('does not fetch until the chart is measured, but reports loading', () => {
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-heatmap/',
+      body: heatmapResponse,
+    });
+
+    const {result} = renderHookWithProviders(() =>
+      useTraceMetricsHeatmapQuery({
+        widget: heatmapWidget,
+        organization,
+        pageFilters,
+        enabled: true,
+        widgetInterval: '1h',
+        yBuckets: 0,
+      })
+    );
+
+    // The query stays disabled until the chart is measured, but the hook still
+    // reports loading (like the series/table hooks) so the chart container
+    // doesn't need a heat-map-specific loading branch.
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(true);
+    expect(result.current.heatmapResults).toBeUndefined();
+  });
+
+  it('does not fetch without an interval', () => {
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-heatmap/',
+      body: heatmapResponse,
+    });
+
+    renderHookWithProviders(() =>
+      useTraceMetricsHeatmapQuery({
+        widget: heatmapWidget,
+        organization,
+        pageFilters,
+        enabled: true,
+        widgetInterval: '',
+        yBuckets: 10,
+      })
+    );
+
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when the aggregate does not resolve to a metric', () => {
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-heatmap/',
+      body: heatmapResponse,
+    });
+
+    const misconfiguredWidget = WidgetFixture({
+      displayType: DisplayType.HEATMAP,
+      queries: [
+        {
+          name: '',
+          fields: ['sum(value)'],
+          aggregates: ['sum(value)'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    renderHookWithProviders(() =>
+      useTraceMetricsHeatmapQuery({
+        widget: misconfiguredWidget,
+        organization,
+        pageFilters,
+        enabled: true,
+        widgetInterval: '1h',
+        yBuckets: 10,
+      })
+    );
+
+    // The config error (getWidgetConfigError) stops the widget from rendering,
+    // but the fetch-gate also keeps the request from firing without a metric.
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('fetches the events-heatmap endpoint with the selected metric', async () => {
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-heatmap/',
+      body: heatmapResponse,
+    });
+
+    const {result} = renderHookWithProviders(() =>
+      useTraceMetricsHeatmapQuery({
+        widget: heatmapWidget,
+        organization,
+        pageFilters,
+        enabled: true,
+        widgetInterval: '1h',
+        yBuckets: 10,
+      })
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-heatmap/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: 'tracemetrics',
+            xAxis: 'time',
+            yAxis: 'value',
+            zAxis: 'count()',
+            interval: '1h',
+            yBuckets: 10,
+            query: expect.stringContaining('test_metric'),
+          }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.heatmapResults?.values).toHaveLength(1);
+    });
+  });
+
+  it("patches the Y axis with the selected metric's unit", async () => {
+    const durationWidget = WidgetFixture({
+      displayType: DisplayType.HEATMAP,
+      queries: [
+        {
+          name: '',
+          fields: ['count(value,test_metric,distribution,millisecond)'],
+          aggregates: ['count(value,test_metric,distribution,millisecond)'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-heatmap/',
+      body: heatmapResponse,
+    });
+
+    const {result} = renderHookWithProviders(() =>
+      useTraceMetricsHeatmapQuery({
+        widget: durationWidget,
+        organization,
+        pageFilters,
+        enabled: true,
+        widgetInterval: '1h',
+        yBuckets: 10,
+      })
+    );
+
+    // The API returns the generic `value` field with no unit; the hook patches
+    // the Y axis from the metric's unit (millisecond -> duration).
+    await waitFor(() => {
+      expect(result.current.heatmapResults?.meta.yAxis.valueUnit).toBe('millisecond');
+    });
+    expect(result.current.heatmapResults?.meta.yAxis.valueType).toBe('duration');
   });
 });

--- a/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
@@ -1,5 +1,10 @@
 import {useMemo, useRef} from 'react';
-import {keepPreviousData, queryOptions, useQueries} from '@tanstack/react-query';
+import {
+  keepPreviousData,
+  queryOptions,
+  useQueries,
+  useQuery,
+} from '@tanstack/react-query';
 
 import type {Series} from 'sentry/types/echarts';
 import {apiFetch, type ApiResponse} from 'sentry/utils/api/apiFetch';
@@ -20,19 +25,27 @@ import {decodeSorts} from 'sentry/utils/queryString';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {SERIES_QUERY_DELIMITER} from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
 import type {EventsTimeSeriesResponse} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
-import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
+import type {
+  HeatmapWidgetQueryParams,
+  WidgetQueryParams,
+} from 'sentry/views/dashboards/datasetConfig/base';
 import {TraceMetricsConfig} from 'sentry/views/dashboards/datasetConfig/traceMetrics';
 import {getSeriesRequestData} from 'sentry/views/dashboards/datasetConfig/utils/getSeriesRequestData';
 import {DisplayType} from 'sentry/views/dashboards/types';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
 import {getSeriesQueryPrefix} from 'sentry/views/dashboards/utils/getSeriesQueryPrefix';
 import {useWidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
+import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
+import {getSelectedAggregate} from 'sentry/views/dashboards/widgetBuilder/utils/getSelectedAggregate';
 import type {HookWidgetQueryResult} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import {getWidgetStaleTime} from 'sentry/views/dashboards/widgetCard/hooks/utils/getStaleTime';
+import {mergeMetricUnit} from 'sentry/views/dashboards/widgets/heatMapWidget/utils/mergeMetricUnit';
+import {NONE_UNIT} from 'sentry/views/explore/metrics/constants';
+import {metricHeatmapApiOptions} from 'sentry/views/explore/metrics/hooks/metricHeatmapApiOptions';
 import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 type TraceMetricsSeriesResponse = EventsTimeSeriesResponse;
@@ -413,4 +426,92 @@ export function useTraceMetricsTableQuery(
   })();
 
   return transformedData;
+}
+
+/**
+ * Fetches heat map data for a trace metrics widget. Heat maps render a
+ * time (X) x value-bucket (Y) grid colored by count (Z), so they use the
+ * dedicated `/events-heatmap/` endpoint rather than the timeseries/table flow.
+ *
+ * The X-axis `widgetInterval` and Y-axis `yBuckets` are derived from the
+ * widget's rendered dimensions and passed in from the chart container, since
+ * the query layer has no access to the rendered size.
+ */
+export function useTraceMetricsHeatmapQuery(
+  params: HeatmapWidgetQueryParams
+): HookWidgetQueryResult {
+  const {
+    widget,
+    organization,
+    pageFilters,
+    enabled,
+    dashboardFilters,
+    skipDashboardFilterParens,
+    widgetInterval = '',
+    yBuckets = 0,
+  } = params;
+
+  const filteredWidget = useMemo(
+    () =>
+      applyDashboardFiltersToWidget(widget, dashboardFilters, skipDashboardFilterParens),
+    [widget, dashboardFilters, skipDashboardFilterParens]
+  );
+
+  const query = filteredWidget.queries[0];
+  const selectedAggregate = getSelectedAggregate(widget);
+  const traceMetric = selectedAggregate
+    ? extractTraceMetricFromColumn(selectedAggregate)
+    : undefined;
+
+  // Don't fetch until the widget's aggregate resolves to a real metric —
+  // otherwise we'd request with an empty `metric.name` filter.
+  const heatmapEnabled =
+    enabled && yBuckets > 0 && Boolean(widgetInterval) && Boolean(traceMetric?.name);
+
+  const heatmapApiOptions = metricHeatmapApiOptions({
+    traceMetric: traceMetric ?? {name: '', type: '', unit: NONE_UNIT},
+    enabled: heatmapEnabled,
+    organization,
+    selection: pageFilters,
+    query: query?.conditions ?? '',
+    interval: widgetInterval,
+    yBuckets,
+  });
+
+  // The heatmap API returns the Y axis as the generic `value` field with no
+  // unit, so patch it with the selected metric's unit in `select` (mirroring
+  // Explore). react-query keeps the selected result referentially stable.
+  const {data: heatmapResults, error} = useQuery({
+    ...heatmapApiOptions,
+    select: rawHeatmapData =>
+      mergeMetricUnit(
+        heatmapApiOptions.select!(rawHeatmapData),
+        traceMetric?.unit ?? undefined
+      ),
+  });
+
+  // `genericWidgetQueries` guards its `onDataFetched` effect by reference
+  // (`rawData === prev`); wrapping the single series in a fresh array each
+  // render would defeat that guard and cause an update loop, so memoize it.
+  const rawData = useMemo(
+    () => (heatmapResults ? [heatmapResults] : EMPTY_ARRAY),
+    [heatmapResults]
+  );
+
+  if (error) {
+    return {loading: false, errorMessage: error.message, rawData: EMPTY_ARRAY};
+  }
+
+  // No data yet: the request is in flight, or the chart hasn't been measured
+  // (so the query is still disabled). Report loading like the series/table
+  // hooks do, so the chart container needs no heat-map-specific loading branch.
+  if (!heatmapResults) {
+    return {loading: true, rawData: EMPTY_ARRAY};
+  }
+
+  return {
+    loading: false,
+    heatmapResults,
+    rawData,
+  };
 }

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -33,6 +33,9 @@ type TraceMetricsWidgetQueriesProps = {
   // Optional selection override for widget viewer modal zoom functionality
   selection?: PageFilters;
   widgetInterval?: string;
+  // Number of buckets for a non-time axis. Used by heat maps for the Y-axis
+  // bucket count, derived from the rendered chart height.
+  yBuckets?: number;
 };
 
 type TraceMetricsWidgetQueriesImplProps = TraceMetricsWidgetQueriesProps & {
@@ -80,6 +83,7 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
   getConfidenceInformation,
   selection,
   widgetInterval,
+  yBuckets,
 }: TraceMetricsWidgetQueriesImplProps) {
   const config = TraceMetricsConfig;
   const [confidence, setConfidence] = useState<Confidence | null>(null);
@@ -140,6 +144,7 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
     loading: disabled,
     selection,
     widgetInterval,
+    yBuckets,
   });
 
   return getDynamicText({

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -1,5 +1,7 @@
-import {Fragment} from 'react';
+import {Fragment, useRef} from 'react';
 import type {LegendComponentOption} from 'echarts';
+
+import {Container} from '@sentry/scraps/layout';
 
 import type {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
@@ -13,13 +15,21 @@ import type {
 import type {Confidence} from 'sentry/types/organization';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType, Sort} from 'sentry/utils/discover/fields';
+import {getIntervalOptionsForPageFilter} from 'sentry/utils/useChartInterval';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import {useDimensions} from 'sentry/utils/useDimensions';
 import {useWidgetErrorCallback} from 'sentry/views/dashboards/contexts/widgetErrorContext';
 import type {DashboardFilters, Widget as TWidget} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData, widgetFetchesOwnData} from 'sentry/views/dashboards/utils';
 import {WidgetLegendNameEncoderDecoder} from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 import type {WidgetLegendSelectionState} from 'sentry/views/dashboards/widgetLegendSelectionState';
-import type {TabularColumn} from 'sentry/views/dashboards/widgets/common/types';
+import type {
+  HeatMapSeries,
+  TabularColumn,
+} from 'sentry/views/dashboards/widgets/common/types';
+import {HEATMAP_RESIZE_DEBOUNCE_MS} from 'sentry/views/dashboards/widgets/heatMapWidget/settings';
+import {calculateHeatMapBucketDimensions} from 'sentry/views/dashboards/widgets/heatMapWidget/utils/calculateHeatMapBucketDimensions';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 
 import WidgetCardChart from './chart';
@@ -95,6 +105,8 @@ export function WidgetCardChartContainer({
 }: Props) {
   const onWidgetError = useWidgetErrorCallback();
 
+  const isHeatmap = widget.displayType === DisplayType.HEATMAP;
+
   const keepLegendState: EChartLegendSelectChangeHandler = ({selected}) => {
     widgetLegendState.setWidgetSelectionState(selected, widget);
   };
@@ -103,13 +115,24 @@ export function WidgetCardChartContainer({
     errorMessage: string | undefined,
     timeseriesResults: Series[] | undefined,
     tableResults: TableDataWithTitle[] | undefined,
+    heatmapResults: HeatMapSeries | undefined,
     widgetType: DisplayType
   ) {
-    // non-chart widgets need to look at tableResults
-    const results = usesTimeSeriesData(widgetType) ? timeseriesResults : tableResults;
     if (widgetFetchesOwnData(widgetType)) {
       return;
     }
+
+    // Heat maps return a single series object rather than table/timeseries rows.
+    if (widgetType === DisplayType.HEATMAP) {
+      return errorMessage
+        ? errorMessage
+        : heatmapResults === undefined || heatmapResults.values.length === 0
+          ? t('No data found')
+          : undefined;
+    }
+
+    // non-chart widgets need to look at tableResults
+    const results = usesTimeSeriesData(widgetType) ? timeseriesResults : tableResults;
 
     return errorMessage
       ? errorMessage
@@ -118,7 +141,10 @@ export function WidgetCardChartContainer({
         : undefined;
   }
 
-  return (
+  const renderDataLoader = (
+    resolvedWidgetInterval: string | undefined,
+    yBuckets: number | undefined
+  ) => (
     <WidgetCardDataLoader
       widget={widget}
       selection={selection}
@@ -127,11 +153,13 @@ export function WidgetCardChartContainer({
       onWidgetSplitDecision={onWidgetSplitDecision}
       onDataFetchStart={onDataFetchStart}
       tableItemLimit={tableItemLimit}
-      widgetInterval={widgetInterval}
+      widgetInterval={resolvedWidgetInterval}
+      yBuckets={yBuckets}
     >
       {({
         tableResults,
         timeseriesResults,
+        heatmapResults,
         errorMessage,
         loading,
         timeseriesResultsTypes,
@@ -151,6 +179,7 @@ export function WidgetCardChartContainer({
               errorMessage,
               modifiedTimeseriesResults,
               tableResults,
+              heatmapResults,
               widget.displayType
             );
 
@@ -172,6 +201,7 @@ export function WidgetCardChartContainer({
               disableZoom={disableZoom}
               timeseriesResults={modifiedTimeseriesResults}
               tableResults={tableResults}
+              heatmapResults={heatmapResults}
               errorMessage={errorOrEmptyMessage}
               loading={loading}
               widget={widget}
@@ -209,5 +239,61 @@ export function WidgetCardChartContainer({
         );
       }}
     </WidgetCardDataLoader>
+  );
+
+  // Heat maps size their request from the rendered dimensions, so they go
+  // through a measured wrapper that resolves the bucket interval/count before
+  // the query fires. Everything else doesn't need to be measured.
+  if (isHeatmap) {
+    return (
+      <HeatmapMeasuredArea selection={selection}>
+        {({widgetInterval: heatmapInterval, yBuckets}) =>
+          renderDataLoader(heatmapInterval, yBuckets)
+        }
+      </HeatmapMeasuredArea>
+    );
+  }
+
+  return renderDataLoader(widgetInterval, undefined);
+}
+
+/**
+ * Measures its rendered size and resolves the heat map's X-axis interval and
+ * Y-axis bucket count from it, passing them to `children`. Keeping this in a
+ * dedicated component means the measuring hook only runs for heat maps.
+ */
+function HeatmapMeasuredArea({
+  selection,
+  children,
+}: {
+  children: (params: {
+    widgetInterval: string | undefined;
+    yBuckets: number | undefined;
+  }) => React.ReactNode;
+  selection: PageFilters;
+}) {
+  const chartAreaRef = useRef<HTMLDivElement>(null);
+  const dimensions = useDimensions({elementRef: chartAreaRef});
+  // `leading: true` keeps the first measurement fast; mid-resize churn collapses
+  // into a single trailing update once the drag settles.
+  const debouncedDimensions = useDebouncedValue(dimensions, HEATMAP_RESIZE_DEBOUNCE_MS, {
+    leading: true,
+  });
+
+  // Returns null until the container is measured, which keeps the query
+  // disabled (no interval/yBuckets) until layout settles.
+  const bucketDimensions = calculateHeatMapBucketDimensions(
+    selection,
+    debouncedDimensions,
+    getIntervalOptionsForPageFilter(selection.datetime).map(option => option.value)
+  );
+
+  return (
+    <Container ref={chartAreaRef} height="100%" width="100%">
+      {children({
+        widgetInterval: bucketDimensions?.interval,
+        yBuckets: bucketDimensions?.yBuckets,
+      })}
+    </Container>
   );
 }

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -11,6 +11,7 @@ import {widgetFetchesOwnData} from 'sentry/views/dashboards/utils';
 import {shouldForceQueryToSpans} from 'sentry/views/dashboards/utils/shouldForceQueryToSpans';
 import {SpansWidgetQueries} from 'sentry/views/dashboards/widgetCard/spansWidgetQueries';
 import {TraceMetricsWidgetQueries} from 'sentry/views/dashboards/widgetCard/traceMetricsWidgetQueries';
+import type {HeatMapSeries} from 'sentry/views/dashboards/widgets/common/types';
 
 import {IssueWidgetQueries} from './issueWidgetQueries';
 import {LogsWidgetQueries} from './logsWidgetQueries';
@@ -23,6 +24,7 @@ type Results = {
   confidence?: Confidence;
   dataScanned?: 'full' | 'partial';
   errorMessage?: string;
+  heatmapResults?: HeatMapSeries;
   isProgressivelyLoading?: boolean;
   isSampled?: boolean | null;
   pageLinks?: string;
@@ -58,6 +60,9 @@ type Props = {
   onWidgetSplitDecision?: (splitDecision: WidgetType) => void;
   tableItemLimit?: number;
   widgetInterval?: string;
+  // Number of buckets for a non-time axis. Used by heat maps for the Y-axis
+  // bucket count, derived from the rendered chart height.
+  yBuckets?: number;
 };
 
 export function WidgetCardDataLoader({
@@ -70,6 +75,7 @@ export function WidgetCardDataLoader({
   onWidgetSplitDecision,
   onDataFetchStart,
   widgetInterval,
+  yBuckets,
 }: Props) {
   if (widgetFetchesOwnData(widget.displayType)) {
     return children({loading: false});
@@ -153,6 +159,7 @@ export function WidgetCardDataLoader({
         onDataFetched={onDataFetched}
         dashboardFilters={dashboardFilters}
         widgetInterval={widgetInterval}
+        yBuckets={yBuckets}
       >
         {props => <Fragment>{children({...props})}</Fragment>}
       </TraceMetricsWidgetQueries>

--- a/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
+++ b/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
@@ -27,3 +27,10 @@ export const PIXELS_PER_BUCKET = 15;
  * handles the wide range of counts better than a linear one.
  */
 export const HEATMAP_Z_AXIS_SCALE = 'log' as const;
+
+/**
+ * How long, in milliseconds, to debounce the measured chart dimensions before
+ * refetching. Resizing a widget changes its size every frame, so without this
+ * the heat map would fire a request per pixel.
+ */
+export const HEATMAP_RESIZE_DEBOUNCE_MS = 500;


### PR DESCRIPTION
Re-lands the Dashboards Heat Map widget ([#117939](https://github.com/getsentry/sentry/pull/117939)), which was reverted because of a config-validation regression.

## What caused the revert

#117939 generalized `getWidgetConfigError` to reject any widget whose dataset doesn't list its display type in `supportedDisplayTypes`. That check was too broad: several display types aren't backed by a dataset at all — **Text (Markdown)**, Wheel, Rage & Dead Clicks, Agents traces — so they were flagged with _"This dataset does not support this visualization."_ Editing a Markdown widget surfaced that error in the preview (DAIN-1731).

## This PR

Rather than patch the generalized check, this PR **removes it** and keeps only heat-map-specific validation in `getWidgetConfigError`:

- A heat map must be on the **trace-metrics** dataset.
- Its selected "Visualize" aggregate must resolve to a metric.

A correct generalized "does this dataset support this display type" check needs more work — the dataset configs don't currently model special, non-dataset display types — and is out of scope here. The pre-existing time-series "add a Visualize field" validation is untouched.

## Structure

- **Reapply "feat(dashboards): Add Heat Map widget (#117939)"** — restores the previously-reverted, reviewed feature verbatim.
- **Scope widget config validation to heat maps** — removes the over-broad dataset check; `getWidgetConfigError` now only validates heat maps. Specs cover heat-map-on-wrong-dataset, heat-map-with-no-metric, and the valid case.

The backend enum support ([#117575](https://github.com/getsentry/sentry/pull/117575)) was never reverted, so this PR is frontend-only — consistent with the FE/BE split.

Fixes [DAIN-1731](https://linear.app/getsentry/issue/DAIN-1731). Re-lands [DAIN-1654](https://linear.app/getsentry/issue/DAIN-1654).
