### PR TITLE
fix(vercel): Upsert env vars instead of read-back-and-patch

### DIFF
--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -34,12 +34,8 @@ class VercelClient(ApiClient):
     GET_PROJECTS_URL = "/v9/projects/"
 
     # Project Environment Variables API Scope (Read/Write)
-    # https://vercel.com/docs/rest-api#endpoints/projects/retrieve-the-environment-variables-of-a-project-by-id-or-name
-    GET_ENV_VAR_URL = "/v9/projects/%s/env"
     # https://vercel.com/docs/rest-api#endpoints/projects/create-one-or-more-environment-variables
     CREATE_ENV_VAR_URL = "/v9/projects/%s/env"
-    # https://vercel.com/docs/rest-api#endpoints/projects/edit-an-environment-variable
-    UPDATE_ENV_VAR_URL = "/v9/projects/%s/env/%s"
 
     # Integration Configuration API Scope (Read/Write)
     # https://vercel.com/docs/rest-api#endpoints/integrations/delete-an-integration-configuration
@@ -89,14 +85,13 @@ class VercelClient(ApiClient):
     def get_project(self, vercel_project_id):
         return self.get(self.GET_PROJECT_URL % vercel_project_id)
 
-    def get_env_vars(self, vercel_project_id):
-        return self.get(self.GET_ENV_VAR_URL % vercel_project_id)
-
-    def create_env_variable(self, vercel_project_id, data):
-        return self.post(self.CREATE_ENV_VAR_URL % vercel_project_id, data=data)
-
-    def update_env_variable(self, vercel_project_id, env_var_id, data):
-        return self.patch(self.UPDATE_ENV_VAR_URL % (vercel_project_id, env_var_id), data=data)
+    def create_env_variable(self, vercel_project_id, data, upsert=False):
+        # `upsert=true` makes Vercel update the value in place when the env var
+        # already exists rather than returning ENV_ALREADY_EXISTS. This avoids a
+        # read-back-and-patch dance that cannot find env vars Vercel hides from
+        # the listing endpoint (e.g. hidden production vars).
+        params = {"upsert": "true"} if upsert else None
+        return self.post(self.CREATE_ENV_VAR_URL % vercel_project_id, data=data, params=params)
 
     def uninstall(self, configuration_id):
         return self.delete(self.UNINSTALL % configuration_id)

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -39,7 +39,7 @@ from sentry.sentry_apps.models.sentry_app_installation_for_provider import (
     SentryAppInstallationForProvider,
 )
 from sentry.sentry_apps.models.sentry_app_installation_token import SentryAppInstallationToken
-from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.users.models.user import User
 from sentry.utils.http import absolute_uri
 
@@ -393,32 +393,20 @@ class VercelIntegration(IntegrationInstallation):
             "target": target,
             "type": type,
         }
+        # `upsert=True` lets Vercel update the value in place when the env var
+        # already exists, so we don't need to look up its id to update it. That
+        # lookup could not find env vars Vercel omits from the listing endpoint
+        # (e.g. hidden production vars), which surfaced as a confusing
+        # "Could not update environment variable" error.
         try:
-            return client.create_env_variable(vercel_project_id, data)
+            return client.create_env_variable(vercel_project_id, data, upsert=True)
         except ApiError as e:
-            if e.json and e.json.get("error", {}).get("code") == "ENV_ALREADY_EXISTS":
-                try:
-                    return self.update_env_variable(client, vercel_project_id, data)
-                except ApiError as e:
-                    error_message = (
-                        e.json.get("error", {}).get("message")
-                        if e.json
-                        else f"Could not update environment variable {key}."
-                    )
-                    raise ValidationError({"project_mappings": [error_message]})
-            raise
-
-    def update_env_variable(self, client, vercel_project_id, data):
-        envs = client.get_env_vars(vercel_project_id)["envs"]
-
-        env_var_ids = [env_var["id"] for env_var in envs if env_var["key"] == data["key"]]
-        if env_var_ids:
-            return client.update_env_variable(vercel_project_id, env_var_ids[0], data)
-
-        key = data["key"]
-        raise IntegrationError(
-            f"Could not update environment variable {key} in Vercel project {vercel_project_id}."
-        )
+            error_message = (
+                e.json.get("error", {}).get("message")
+                if e.json
+                else f"Could not create or update environment variable {key}."
+            )
+            raise ValidationError({"project_mappings": [error_message]})
 
     def uninstall(self):
         client = self.get_client()

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -194,6 +194,9 @@ class VercelIntegrationTest(IntegrationTestCase):
         assert req_params["value"] == enabled_dsn
         assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
+        # env vars are created with upsert so Vercel updates them in place if they
+        # already exist, rather than requiring a separate update call
+        assert "upsert=true" in responses.calls[3].request.url
 
         req_params = orjson.loads(responses.calls[4].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
@@ -226,7 +229,15 @@ class VercelIntegrationTest(IntegrationTestCase):
 
     @responses.activate
     def test_update_org_config_vars_exist(self) -> None:
-        """Test the case wherein the secret and env vars already exist"""
+        """Existing env vars are upserted in a single call, not read back and patched.
+
+        Vercel omits some env vars (e.g. hidden production vars) from its listing
+        endpoint, so the old create -> find id -> patch flow could fail to locate a
+        var that already existed and raise a misleading error. With `upsert=true`
+        Vercel updates the value in place, so we only ever issue the create call.
+        This test registers no GET-env/PATCH mocks: if the integration tried to read
+        back or patch, `responses` would raise on the unregistered request.
+        """
 
         with self.tasks():
             self.install_integration()
@@ -236,93 +247,20 @@ class VercelIntegrationTest(IntegrationTestCase):
         with assume_test_silo_mode(SiloMode.CELL):
             project_key = ProjectKey.get_default(project=Project.objects.get(id=project_id))
             enabled_dsn = project_key.get_dsn(public=True)
-            integration_endpoint = project_key.integration_endpoint
-            public_key = project_key.public_key
 
-        sentry_auth_token = SentryAppInstallationToken.objects.get_token(org.id, "vercel")
-
-        env_var_map = {
-            "SENTRY_ORG": {
-                "type": "encrypted",
-                "value": org.slug,
-                "target": ["production", "preview"],
-            },
-            "SENTRY_PROJECT": {
-                "type": "encrypted",
-                "value": self.project.slug,
-                "target": ["production", "preview"],
-            },
-            "SENTRY_DSN": {
-                "type": "encrypted",
-                "value": enabled_dsn,
-                "target": [
-                    "production",
-                    "preview",
-                    "development",
-                ],
-            },
-            "SENTRY_AUTH_TOKEN": {
-                "type": "encrypted",
-                "value": sentry_auth_token,
-                "target": ["production", "preview"],
-            },
-            "VERCEL_GIT_COMMIT_SHA": {
-                "type": "system",
-                "value": "VERCEL_GIT_COMMIT_SHA",
-                "target": ["production", "preview"],
-            },
-            "SENTRY_VERCEL_LOG_DRAIN_URL": {
-                "type": "encrypted",
-                "value": f"{integration_endpoint}vercel/logs/",
-                "target": ["production", "preview"],
-            },
-            "SENTRY_OTLP_TRACES_URL": {
-                "type": "encrypted",
-                "value": f"{integration_endpoint}otlp/v1/traces",
-                "target": ["production", "preview"],
-            },
-            "SENTRY_PUBLIC_KEY": {
-                "type": "encrypted",
-                "value": public_key,
-                "target": ["production", "preview"],
-            },
-        }
-
-        # mock get_project API call
+        # mock get_project API call (gatsby -> SENTRY_DSN rather than NEXT_PUBLIC_SENTRY_DSN)
         responses.add(
             responses.GET,
             f"{VercelClient.base_url}{VercelClient.GET_PROJECT_URL % self.project_id}",
             json={"link": {"type": "github"}, "framework": "gatsby"},
         )
 
-        # mock update env vars
-        count = 0
-        for env_var, details in env_var_map.items():
-            # mock try to create env var
-            responses.add(
-                responses.POST,
-                f"{VercelClient.base_url}{VercelClient.CREATE_ENV_VAR_URL % self.project_id}",
-                json={"error": {"code": "ENV_ALREADY_EXISTS"}},
-                status=400,
-            )
-            # mock get env var
-            responses.add(
-                responses.GET,
-                f"{VercelClient.base_url}{VercelClient.GET_ENV_VAR_URL % self.project_id}",
-                json={"envs": [{"id": count, "key": env_var}]},
-            )
-            # mock update env var
-            responses.add(
-                responses.PATCH,
-                f"{VercelClient.base_url}{VercelClient.UPDATE_ENV_VAR_URL % (self.project_id, count)}",
-                json={
-                    "key": env_var,
-                    "value": details["value"],
-                    "target": details["target"],
-                    "type": details["type"],
-                },
-            )
-            count += 1
+        # mock the create-or-update (upsert) env var call
+        responses.add(
+            responses.POST,
+            f"{VercelClient.base_url}{VercelClient.CREATE_ENV_VAR_URL % self.project_id}",
+            json={"key": "placeholder", "value": "placeholder"},
+        )
 
         data = {"project_mappings": [[project_id, self.project_id]]}
         integration = Integration.objects.get(provider=self.provider.key)
@@ -337,52 +275,20 @@ class VercelIntegrationTest(IntegrationTestCase):
         )
         assert org_integration.config == {"project_mappings": [[project_id, self.project_id]]}
 
-        req_params = orjson.loads(responses.calls[1].request.body)
-        assert req_params["key"] == "SENTRY_ORG"
-        assert req_params["value"] == org.slug
-        assert req_params["target"] == ["production", "preview"]
-        assert req_params["type"] == "encrypted"
+        # one GET for the project, then one upsert POST per env var, with no
+        # follow-up GET-env/PATCH calls
+        assert responses.calls[0].request.method == responses.GET
+        post_calls = [call for call in responses.calls if call.request.method == responses.POST]
+        assert len(responses.calls) == 1 + len(post_calls)
+        for call in post_calls:
+            assert "upsert=true" in call.request.url
 
-        req_params = orjson.loads(responses.calls[4].request.body)
-        assert req_params["key"] == "SENTRY_PROJECT"
-        assert req_params["value"] == self.project.slug
-        assert req_params["target"] == ["production", "preview"]
-        assert req_params["type"] == "encrypted"
-
-        req_params = orjson.loads(responses.calls[7].request.body)
-        assert req_params["key"] == "SENTRY_DSN"
-        assert req_params["value"] == enabled_dsn
-        assert req_params["target"] == ["production", "preview", "development"]
-        assert req_params["type"] == "encrypted"
-
-        req_params = orjson.loads(responses.calls[10].request.body)
-        assert req_params["key"] == "SENTRY_AUTH_TOKEN"
-        assert req_params["target"] == ["production", "preview"]
-        assert req_params["type"] == "encrypted"
-
-        req_params = orjson.loads(responses.calls[13].request.body)
-        assert req_params["key"] == "VERCEL_GIT_COMMIT_SHA"
-        assert req_params["value"] == "VERCEL_GIT_COMMIT_SHA"
-        assert req_params["target"] == ["production", "preview"]
-        assert req_params["type"] == "system"
-
-        req_params = orjson.loads(responses.calls[16].request.body)
-        assert req_params["key"] == "SENTRY_VERCEL_LOG_DRAIN_URL"
-        assert req_params["value"] == f"{integration_endpoint}vercel/logs/"
-        assert req_params["target"] == ["production", "preview"]
-        assert req_params["type"] == "encrypted"
-
-        req_params = orjson.loads(responses.calls[19].request.body)
-        assert req_params["key"] == "SENTRY_OTLP_TRACES_URL"
-        assert req_params["value"] == f"{integration_endpoint}otlp/v1/traces"
-        assert req_params["target"] == ["production", "preview"]
-        assert req_params["type"] == "encrypted"
-
-        req_params = orjson.loads(responses.calls[22].request.body)
-        assert req_params["key"] == "SENTRY_PUBLIC_KEY"
-        assert req_params["value"] == public_key
-        assert req_params["target"] == ["production", "preview"]
-        assert req_params["type"] == "encrypted"
+        # SENTRY_DSN is upserted in a single POST rather than read back and patched
+        dsn_calls = [
+            call for call in post_calls if orjson.loads(call.request.body)["key"] == "SENTRY_DSN"
+        ]
+        assert len(dsn_calls) == 1
+        assert orjson.loads(dsn_calls[0].request.body)["value"] == enabled_dsn
 
     @responses.activate
     def test_upgrade_org_config_no_dsn(self) -> None:


### PR DESCRIPTION
## Summary

Linking a Sentry project to a Vercel project (the **Connect your projects** form on the Vercel integration config page) pushes env vars to Vercel — `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, etc. The previous flow:

1. `POST /v9/projects/{id}/env` to create each var
2. on `ENV_ALREADY_EXISTS`, `GET /v9/projects/{id}/env` to find the var's id
3. `PATCH .../env/{id}` to update it

Vercel **omits some env vars from the listing endpoint** (they're only counted in `hiddenProductionEnvCount`). So when an existing var was hidden, step 2 returned a list without it, the id lookup found nothing, and we raised:

> Could not update environment variable SENTRY_DSN in Vercel project prj_...

…which blocked project linking even though the var clearly existed (that's why the create returned `ENV_ALREADY_EXISTS` in the first place).

## Fix

Pass [`upsert=true`](https://vercel.com/docs/rest-api/projects/create-one-or-more-environment-variables) on the create call. Vercel then updates the value in place when the var already exists, so we never need to look up its id. This removes the read-back-and-patch path entirely, along with the now-dead `get_env_vars` / `update_env_variable` client methods and their URL constants.

Only the legacy OAuth integration is affected. The Vercel Marketplace flow (in getsentry) returns secrets in its provisioning response and never calls Vercel's env API, so it was never affected.

## Test plan

- `test_update_organization_config` now also asserts the create call carries `upsert=true`.
- `test_update_org_config_vars_exist` is rewritten as a regression test: it registers **no** GET-env/PATCH mocks, so if the integration tried to read back or patch, `responses` would raise on the unregistered request. It verifies the previously-failing "already exists" scenario now succeeds via a single upsert POST per var.

```
.venv/bin/pytest -n3 -svv --reuse-db tests/sentry/integrations/vercel/test_integration.py
```
