### PR TITLE
feat(weekly-report): Add actionability scoring for top issues (1/3)

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -370,6 +370,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:weekly-report-batched-key-errors", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Show combined resolved "past issues" section instead of separate key errors / performance issues
     manager.add("organizations:weekly-report-past-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Show top actionable issues section combining errors and performance issues
+    manager.add("organizations:weekly-report-top-actionable-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable week-over-week percentage change metric in weekly email reports
     manager.add("organizations:weekly-report-week-over-week-metric", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable logging to debug workflow engine process workflows

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -854,12 +854,12 @@ register(
 # Weekly report actionability scoring weights (adapted recommended sort for batch reports)
 register(
     "weekly-report.actionability.event-volume-weight",
-    default=0.30,
+    default=0.25,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "weekly-report.actionability.recency-weight",
-    default=0.25,
+    default=0.20,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
@@ -869,7 +869,12 @@ register(
 )
 register(
     "weekly-report.actionability.severity-weight",
-    default=0.20,
+    default=0.15,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "weekly-report.actionability.newness-weight",
+    default=0.15,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -858,23 +858,18 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "weekly-report.actionability.user-impact-weight",
+    "weekly-report.actionability.recency-weight",
     default=0.25,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "weekly-report.actionability.recency-weight",
-    default=0.15,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "weekly-report.actionability.substatus-weight",
-    default=0.15,
+    default=0.25,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "weekly-report.actionability.severity-weight",
-    default=0.15,
+    default=0.20,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -851,6 +851,38 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Weekly report actionability scoring weights (adapted recommended sort for batch reports)
+register(
+    "weekly-report.actionability.event-volume-weight",
+    default=0.30,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "weekly-report.actionability.user-impact-weight",
+    default=0.25,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "weekly-report.actionability.recency-weight",
+    default=0.15,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "weekly-report.actionability.substatus-weight",
+    default=0.15,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "weekly-report.actionability.severity-weight",
+    default=0.15,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "weekly-report.actionability.candidate-limit",
+    default=10,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # The percentage of tagkeys that we want to cache. Set to 1.0 in order to cache everything, <=0.0 to stop caching
 register(
     "snuba.tagstore.cache-tagkeys-rate",

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -785,7 +785,6 @@ class Referrer(StrEnum):
     REPLAYS_SCRIPTS_DELETE_REPLAYS = "replays.scripts.delete_replays"
     FEEDBACKS_LABEL_QUERY = "feedbacks.label_query"
     EU_DATA_EXPORT = "sentry.internal.eu-compliance-data-export"
-    REPORTS_TOP_ACTIONABLE_ISSUES = "reports.top_actionable_issues"
     REPORTS_KEY_ERRORS = "reports.key_errors"
     REPORTS_KEY_ERRORS_BATCHED = "reports.key_errors.batched"
     REPORTS_KEY_PERFORMANCE_ISSUES = "reports.key_performance_issues"

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -785,6 +785,7 @@ class Referrer(StrEnum):
     REPLAYS_SCRIPTS_DELETE_REPLAYS = "replays.scripts.delete_replays"
     FEEDBACKS_LABEL_QUERY = "feedbacks.label_query"
     EU_DATA_EXPORT = "sentry.internal.eu-compliance-data-export"
+    REPORTS_TOP_ACTIONABLE_ISSUES = "reports.top_actionable_issues"
     REPORTS_KEY_ERRORS = "reports.key_errors"
     REPORTS_KEY_ERRORS_BATCHED = "reports.key_errors.batched"
     REPORTS_KEY_PERFORMANCE_ISSUES = "reports.key_performance_issues"

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -98,8 +98,8 @@ class ProjectContext:
         self.key_performance_issues = []
         # Array of (Group, event_count, has_linked_pr_or_commit)
         self.past_resolved_issues: list[tuple[Group, int, bool]] = []
-        # Array of (Group, event_count, user_count, actionability_score)
-        self.top_actionable_issues: list[tuple[Group, int, int, float]] = []
+        # Array of (Group, actionability_score)
+        self.top_actionable_issues: list[tuple[Group, float]] = []
 
         self.key_replay_events = []
 
@@ -951,24 +951,18 @@ _SUBSTATUS_SCORE: dict[int, float] = {
     GroupSubStatus.ONGOING: 0.3,
 }
 
-_ACTIONABLE_CANDIDATES_CHUNK_SIZE = 100
-
 
 def compute_actionability_score(
-    event_count: int,
-    user_count: int,
     group: Group,
     window_start: datetime,
     window_end: datetime,
 ) -> float:
     event_volume_weight = options.get("weekly-report.actionability.event-volume-weight")
-    user_impact_weight = options.get("weekly-report.actionability.user-impact-weight")
     recency_weight = options.get("weekly-report.actionability.recency-weight")
     substatus_weight = options.get("weekly-report.actionability.substatus-weight")
     severity_weight = options.get("weekly-report.actionability.severity-weight")
 
-    event_volume = min(1.0, math.log(event_count + 1) / math.log(10001))
-    user_impact = min(1.0, math.log(user_count + 1) / math.log(1001))
+    event_volume = min(1.0, math.log(group.times_seen + 1) / math.log(10001))
 
     window_duration = (window_end - window_start).total_seconds()
     if window_duration > 0 and group.last_seen:
@@ -984,211 +978,42 @@ def compute_actionability_score(
 
     return (
         event_volume_weight * event_volume
-        + user_impact_weight * user_impact
         + recency_weight * recency
         + substatus_weight * substatus
         + severity_weight * severity
     )
 
 
-def _org_actionable_error_candidates_chunk(
-    ctx: OrganizationReportContext,
-    project_ids: Sequence[int],
-    referrer: str,
-    per_project_limit: int,
-) -> dict[int, list[dict[str, Any]]]:
-    events_entity = Entity("events", alias="events")
-    group_attributes_entity = Entity("group_attributes", alias="group_attributes")
-    query = Query(
-        match=Join([Relationship(events_entity, "attributes", group_attributes_entity)]),
-        select=[
-            Column("project_id", entity=events_entity),
-            Column("group_id", entity=events_entity),
-            Function("count", [], alias="count"),
-            Function(
-                "uniq",
-                [Column("tags[sentry:user]", entity=events_entity)],
-                alias="user_count",
-            ),
-        ],
-        where=[
-            Condition(Column("timestamp", entity=events_entity), Op.GTE, ctx.start),
-            Condition(
-                Column("timestamp", entity=events_entity),
-                Op.LT,
-                ctx.end + timedelta(days=1),
-            ),
-            Condition(
-                Column("project_id", entity=events_entity),
-                Op.IN,
-                project_ids,
-            ),
-            Condition(
-                Column("project_id", entity=group_attributes_entity),
-                Op.IN,
-                project_ids,
-            ),
-            Condition(
-                Column("group_status", entity=group_attributes_entity),
-                Op.EQ,
-                GroupStatus.UNRESOLVED,
-            ),
-            Condition(Column("level", entity=events_entity), Op.EQ, "error"),
-        ],
-        groupby=[
-            Column("project_id", entity=events_entity),
-            Column("group_id", entity=events_entity),
-        ],
-        orderby=[OrderBy(Function("count", []), Direction.DESC)],
-        limitby=LimitBy([Column("project_id", entity=events_entity)], per_project_limit),
-        limit=Limit(len(project_ids) * per_project_limit),
-    )
-
-    request = Request(
-        dataset=Dataset.Events.value,
-        app_id="reports",
-        query=query,
-        tenant_ids={"organization_id": ctx.organization.id},
-    )
-    rows = raw_snql_query(request, referrer=referrer)["data"]
-
-    results: dict[int, list[dict[str, Any]]] = {}
-    for row in rows:
-        pid = row["events.project_id"]
-        results.setdefault(pid, []).append(
-            {
-                "group_id": row["events.group_id"],
-                "count": row["count"],
-                "user_count": row["user_count"],
-            }
-        )
-    return results
-
-
-def _org_actionable_error_candidates(
-    ctx: OrganizationReportContext,
-    project_ids: Sequence[int],
-    referrer: str,
-) -> dict[int, list[dict[str, Any]]]:
-    per_project_limit = options.get("weekly-report.actionability.candidate-limit")
-    results: dict[int, list[dict[str, Any]]] = {}
-    for i in range(0, len(project_ids), _ACTIONABLE_CANDIDATES_CHUNK_SIZE):
-        chunk = project_ids[i : i + _ACTIONABLE_CANDIDATES_CHUNK_SIZE]
-        chunk_results = _org_actionable_error_candidates_chunk(
-            ctx, chunk, referrer, per_project_limit
-        )
-        results.update(chunk_results)
-    return results
-
-
-def _org_actionable_perf_candidates(
-    ctx: OrganizationReportContext,
-    project_ids: Sequence[int],
-    referrer: str,
-) -> dict[int, list[dict[str, Any]]]:
-    per_project_limit = options.get("weekly-report.actionability.candidate-limit")
-
-    candidate_groups = list(
-        Group.objects.filter(
-            project_id__in=project_ids,
-            status=GroupStatus.UNRESOLVED,
-            last_seen__gte=ctx.end - timedelta(days=30),
-            type__gte=1000,
-            type__lt=2000,
-        ).order_by("-times_seen")[: 50 * len(project_ids)]
-    )
-
-    if not candidate_groups:
-        return {}
-
-    group_id_to_project: dict[int, int] = {g.id: g.project_id for g in candidate_groups}
-    candidate_group_ids = list(group_id_to_project.keys())
-
-    query = Query(
-        match=Entity("search_issues"),
-        select=[
-            Column("project_id"),
-            Column("group_id"),
-            Function("count", [], alias="count"),
-            Function("uniq", [Column("tags[sentry:user]")], alias="user_count"),
-        ],
-        where=[
-            Condition(Column("group_id"), Op.IN, candidate_group_ids),
-            Condition(Column("project_id"), Op.IN, project_ids),
-            Condition(Column("timestamp"), Op.GTE, ctx.start),
-            Condition(Column("timestamp"), Op.LT, ctx.end + timedelta(days=1)),
-        ],
-        groupby=[Column("project_id"), Column("group_id")],
-        orderby=[OrderBy(Function("count", []), Direction.DESC)],
-        limitby=LimitBy([Column("project_id")], per_project_limit),
-        limit=Limit(len(project_ids) * per_project_limit),
-    )
-    request = Request(
-        dataset=Dataset.IssuePlatform.value,
-        app_id="reports",
-        query=query,
-        tenant_ids={"organization_id": ctx.organization.id},
-    )
-    rows = raw_snql_query(request, referrer=referrer)["data"]
-
-    results: dict[int, list[dict[str, Any]]] = {}
-    for row in rows:
-        pid = row["project_id"]
-        results.setdefault(pid, []).append(
-            {
-                "group_id": row["group_id"],
-                "count": row["count"],
-                "user_count": row["user_count"],
-            }
-        )
-    return results
-
-
 def org_top_actionable_issues(
     ctx: OrganizationReportContext,
     project_ids: Sequence[int],
 ) -> None:
-    referrer = Referrer.REPORTS_TOP_ACTIONABLE_ISSUES.value
+    per_project_limit = options.get("weekly-report.actionability.candidate-limit")
 
     with sentry_sdk.start_span(op="weekly_reports.org_top_actionable_issues"):
-        error_candidates = _org_actionable_error_candidates(ctx, project_ids, referrer)
-        perf_candidates = _org_actionable_perf_candidates(ctx, project_ids, referrer)
+        candidates = list(
+            Group.objects.filter(
+                project_id__in=project_ids,
+                status=GroupStatus.UNRESOLVED,
+                last_seen__gte=ctx.start,
+            )
+            .order_by("-times_seen")
+            .only("id", "project_id", "times_seen", "level", "substatus", "last_seen")[
+                : per_project_limit * len(project_ids)
+            ]
+        )
 
-        all_group_ids: set[int] = set()
-        for candidates in (error_candidates, perf_candidates):
-            for rows in candidates.values():
-                all_group_ids.update(row["group_id"] for row in rows)
-
-        if not all_group_ids:
+        if not candidates:
             return
 
-        groups_by_id = {g.id: g for g in Group.objects.filter(id__in=all_group_ids)}
-
-        for project_id in project_ids:
-            if project_id not in ctx.projects_context_map:
+        per_project: dict[int, list[tuple[Group, float]]] = {}
+        for group in candidates:
+            if group.project_id not in ctx.projects_context_map:
                 continue
+            score = compute_actionability_score(group, ctx.start, ctx.end)
+            per_project.setdefault(group.project_id, []).append((group, score))
 
-            merged: dict[int, dict[str, Any]] = {}
-            for candidates in (error_candidates, perf_candidates):
-                for row in candidates.get(project_id, []):
-                    gid = row["group_id"]
-                    if gid not in merged:
-                        merged[gid] = row
-
-            scored: list[tuple[Group, int, int, float]] = []
-            for row in merged.values():
-                group = groups_by_id.get(row["group_id"])
-                if group is None:
-                    continue
-                score = compute_actionability_score(
-                    event_count=row["count"],
-                    user_count=row["user_count"],
-                    group=group,
-                    window_start=ctx.start,
-                    window_end=ctx.end,
-                )
-                scored.append((group, row["count"], row["user_count"], score))
-
+        for project_id, scored in per_project.items():
             ctx.projects_context_map[project_id].top_actionable_issues = heapq.nlargest(
-                3, scored, key=lambda x: x[3]
+                3, scored, key=lambda x: x[1]
             )

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -936,7 +936,8 @@ def fetch_past_resolved_issue_links(ctx: OrganizationReportContext) -> None:
         project_ctx.past_resolved_issues = project_ctx.past_resolved_issues[:3]
 
 
-_SEVERITY_SCORE: dict[int, float] = {
+# Mirrors log_level_score in recommended sort (see executors.py _recommended_aggregation)
+SEVERITY_SCORE: dict[int, float] = {
     logging.FATAL: 1.0,
     logging.ERROR: 0.75,
     logging.WARNING: 0.5,
@@ -944,7 +945,9 @@ _SEVERITY_SCORE: dict[int, float] = {
     logging.DEBUG: 0.0,
 }
 
-_SUBSTATUS_SCORE: dict[int, float] = {
+# Higher = more urgent to act on. Escalating/regressed issues need attention
+# before new/ongoing ones.
+SUBSTATUS_SCORE: dict[int, float] = {
     GroupSubStatus.ESCALATING: 1.0,
     GroupSubStatus.REGRESSED: 0.8,
     GroupSubStatus.NEW: 0.6,
@@ -957,13 +960,20 @@ def compute_actionability_score(
     window_start: datetime,
     window_end: datetime,
 ) -> float:
+    """
+    Scores an issue 0-1 for the weekly report's "top issues to act on" section.
+    All inputs come from Postgres (Group model) — no Snuba queries.
+    Weights are tunable via options (weekly-report.actionability.*).
+    """
     event_volume_weight = options.get("weekly-report.actionability.event-volume-weight")
     recency_weight = options.get("weekly-report.actionability.recency-weight")
     substatus_weight = options.get("weekly-report.actionability.substatus-weight")
     severity_weight = options.get("weekly-report.actionability.severity-weight")
 
+    # Log-scaled all-time event count, normalized to 0-1 (10k events = 1.0)
     event_volume = min(1.0, math.log(group.times_seen + 1) / math.log(10001))
 
+    # Linear position of last_seen within the report window (0 = start, 1 = end)
     window_duration = (window_end - window_start).total_seconds()
     if window_duration > 0 and group.last_seen:
         recency = max(
@@ -973,8 +983,8 @@ def compute_actionability_score(
     else:
         recency = 0.0
 
-    substatus = _SUBSTATUS_SCORE.get(group.substatus, 0.0)
-    severity = _SEVERITY_SCORE.get(group.level, 0.0)
+    substatus = SUBSTATUS_SCORE.get(group.substatus, 0.0)
+    severity = SEVERITY_SCORE.get(group.level, 0.0)
 
     return (
         event_volume_weight * event_volume

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -1,6 +1,8 @@
+import heapq
 import logging
+import math
 from collections.abc import Sequence
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 import sentry_sdk
@@ -15,6 +17,7 @@ from snuba_sdk.orderby import Direction, LimitBy, OrderBy
 from snuba_sdk.query import Join, Limit, Query
 from snuba_sdk.relationships import Relationship
 
+from sentry import options
 from sentry.constants import DataCategory
 from sentry.issues.grouptype import (
     PERFORMANCE_ISSUE_CATEGORIES,
@@ -95,6 +98,8 @@ class ProjectContext:
         self.key_performance_issues = []
         # Array of (Group, event_count, has_linked_pr_or_commit)
         self.past_resolved_issues: list[tuple[Group, int, bool]] = []
+        # Array of (Group, event_count, user_count, actionability_score)
+        self.top_actionable_issues: list[tuple[Group, int, int, float]] = []
 
         self.key_replay_events = []
 
@@ -929,3 +934,261 @@ def fetch_past_resolved_issue_links(ctx: OrganizationReportContext) -> None:
             reverse=True,
         )
         project_ctx.past_resolved_issues = project_ctx.past_resolved_issues[:3]
+
+
+_SEVERITY_SCORE: dict[int, float] = {
+    logging.FATAL: 1.0,
+    logging.ERROR: 0.75,
+    logging.WARNING: 0.5,
+    logging.INFO: 0.25,
+    logging.DEBUG: 0.0,
+}
+
+_SUBSTATUS_SCORE: dict[int, float] = {
+    GroupSubStatus.ESCALATING: 1.0,
+    GroupSubStatus.REGRESSED: 0.8,
+    GroupSubStatus.NEW: 0.6,
+    GroupSubStatus.ONGOING: 0.3,
+}
+
+_ACTIONABLE_CANDIDATES_CHUNK_SIZE = 100
+
+
+def compute_actionability_score(
+    event_count: int,
+    user_count: int,
+    group: Group,
+    window_start: datetime,
+    window_end: datetime,
+) -> float:
+    event_volume_weight = options.get("weekly-report.actionability.event-volume-weight")
+    user_impact_weight = options.get("weekly-report.actionability.user-impact-weight")
+    recency_weight = options.get("weekly-report.actionability.recency-weight")
+    substatus_weight = options.get("weekly-report.actionability.substatus-weight")
+    severity_weight = options.get("weekly-report.actionability.severity-weight")
+
+    event_volume = min(1.0, math.log(event_count + 1) / math.log(10001))
+    user_impact = min(1.0, math.log(user_count + 1) / math.log(1001))
+
+    window_duration = (window_end - window_start).total_seconds()
+    if window_duration > 0 and group.last_seen:
+        recency = max(
+            0.0,
+            min(1.0, (group.last_seen - window_start).total_seconds() / window_duration),
+        )
+    else:
+        recency = 0.0
+
+    substatus = _SUBSTATUS_SCORE.get(group.substatus, 0.0)
+    severity = _SEVERITY_SCORE.get(group.level, 0.0)
+
+    return (
+        event_volume_weight * event_volume
+        + user_impact_weight * user_impact
+        + recency_weight * recency
+        + substatus_weight * substatus
+        + severity_weight * severity
+    )
+
+
+def _org_actionable_error_candidates_chunk(
+    ctx: OrganizationReportContext,
+    project_ids: Sequence[int],
+    referrer: str,
+    per_project_limit: int,
+) -> dict[int, list[dict[str, Any]]]:
+    events_entity = Entity("events", alias="events")
+    group_attributes_entity = Entity("group_attributes", alias="group_attributes")
+    query = Query(
+        match=Join([Relationship(events_entity, "attributes", group_attributes_entity)]),
+        select=[
+            Column("project_id", entity=events_entity),
+            Column("group_id", entity=events_entity),
+            Function("count", [], alias="count"),
+            Function(
+                "uniq",
+                [Column("tags[sentry:user]", entity=events_entity)],
+                alias="user_count",
+            ),
+        ],
+        where=[
+            Condition(Column("timestamp", entity=events_entity), Op.GTE, ctx.start),
+            Condition(
+                Column("timestamp", entity=events_entity),
+                Op.LT,
+                ctx.end + timedelta(days=1),
+            ),
+            Condition(
+                Column("project_id", entity=events_entity),
+                Op.IN,
+                project_ids,
+            ),
+            Condition(
+                Column("project_id", entity=group_attributes_entity),
+                Op.IN,
+                project_ids,
+            ),
+            Condition(
+                Column("group_status", entity=group_attributes_entity),
+                Op.EQ,
+                GroupStatus.UNRESOLVED,
+            ),
+            Condition(Column("level", entity=events_entity), Op.EQ, "error"),
+        ],
+        groupby=[
+            Column("project_id", entity=events_entity),
+            Column("group_id", entity=events_entity),
+        ],
+        orderby=[OrderBy(Function("count", []), Direction.DESC)],
+        limitby=LimitBy([Column("project_id", entity=events_entity)], per_project_limit),
+        limit=Limit(len(project_ids) * per_project_limit),
+    )
+
+    request = Request(
+        dataset=Dataset.Events.value,
+        app_id="reports",
+        query=query,
+        tenant_ids={"organization_id": ctx.organization.id},
+    )
+    rows = raw_snql_query(request, referrer=referrer)["data"]
+
+    results: dict[int, list[dict[str, Any]]] = {}
+    for row in rows:
+        pid = row["events.project_id"]
+        results.setdefault(pid, []).append(
+            {
+                "group_id": row["events.group_id"],
+                "count": row["count"],
+                "user_count": row["user_count"],
+            }
+        )
+    return results
+
+
+def _org_actionable_error_candidates(
+    ctx: OrganizationReportContext,
+    project_ids: Sequence[int],
+    referrer: str,
+) -> dict[int, list[dict[str, Any]]]:
+    per_project_limit = options.get("weekly-report.actionability.candidate-limit")
+    results: dict[int, list[dict[str, Any]]] = {}
+    for i in range(0, len(project_ids), _ACTIONABLE_CANDIDATES_CHUNK_SIZE):
+        chunk = project_ids[i : i + _ACTIONABLE_CANDIDATES_CHUNK_SIZE]
+        chunk_results = _org_actionable_error_candidates_chunk(
+            ctx, chunk, referrer, per_project_limit
+        )
+        results.update(chunk_results)
+    return results
+
+
+def _org_actionable_perf_candidates(
+    ctx: OrganizationReportContext,
+    project_ids: Sequence[int],
+    referrer: str,
+) -> dict[int, list[dict[str, Any]]]:
+    per_project_limit = options.get("weekly-report.actionability.candidate-limit")
+
+    candidate_groups = list(
+        Group.objects.filter(
+            project_id__in=project_ids,
+            status=GroupStatus.UNRESOLVED,
+            last_seen__gte=ctx.end - timedelta(days=30),
+            type__gte=1000,
+            type__lt=2000,
+        ).order_by("-times_seen")[: 50 * len(project_ids)]
+    )
+
+    if not candidate_groups:
+        return {}
+
+    group_id_to_project: dict[int, int] = {g.id: g.project_id for g in candidate_groups}
+    candidate_group_ids = list(group_id_to_project.keys())
+
+    query = Query(
+        match=Entity("search_issues"),
+        select=[
+            Column("project_id"),
+            Column("group_id"),
+            Function("count", [], alias="count"),
+            Function("uniq", [Column("tags[sentry:user]")], alias="user_count"),
+        ],
+        where=[
+            Condition(Column("group_id"), Op.IN, candidate_group_ids),
+            Condition(Column("project_id"), Op.IN, project_ids),
+            Condition(Column("timestamp"), Op.GTE, ctx.start),
+            Condition(Column("timestamp"), Op.LT, ctx.end + timedelta(days=1)),
+        ],
+        groupby=[Column("project_id"), Column("group_id")],
+        orderby=[OrderBy(Function("count", []), Direction.DESC)],
+        limitby=LimitBy([Column("project_id")], per_project_limit),
+        limit=Limit(len(project_ids) * per_project_limit),
+    )
+    request = Request(
+        dataset=Dataset.IssuePlatform.value,
+        app_id="reports",
+        query=query,
+        tenant_ids={"organization_id": ctx.organization.id},
+    )
+    rows = raw_snql_query(request, referrer=referrer)["data"]
+
+    results: dict[int, list[dict[str, Any]]] = {}
+    for row in rows:
+        pid = row["project_id"]
+        results.setdefault(pid, []).append(
+            {
+                "group_id": row["group_id"],
+                "count": row["count"],
+                "user_count": row["user_count"],
+            }
+        )
+    return results
+
+
+def org_top_actionable_issues(
+    ctx: OrganizationReportContext,
+    project_ids: Sequence[int],
+) -> None:
+    referrer = Referrer.REPORTS_TOP_ACTIONABLE_ISSUES.value
+
+    with sentry_sdk.start_span(op="weekly_reports.org_top_actionable_issues"):
+        error_candidates = _org_actionable_error_candidates(ctx, project_ids, referrer)
+        perf_candidates = _org_actionable_perf_candidates(ctx, project_ids, referrer)
+
+        all_group_ids: set[int] = set()
+        for candidates in (error_candidates, perf_candidates):
+            for rows in candidates.values():
+                all_group_ids.update(row["group_id"] for row in rows)
+
+        if not all_group_ids:
+            return
+
+        groups_by_id = {g.id: g for g in Group.objects.filter(id__in=all_group_ids)}
+
+        for project_id in project_ids:
+            if project_id not in ctx.projects_context_map:
+                continue
+
+            merged: dict[int, dict[str, Any]] = {}
+            for candidates in (error_candidates, perf_candidates):
+                for row in candidates.get(project_id, []):
+                    gid = row["group_id"]
+                    if gid not in merged:
+                        merged[gid] = row
+
+            scored: list[tuple[Group, int, int, float]] = []
+            for row in merged.values():
+                group = groups_by_id.get(row["group_id"])
+                if group is None:
+                    continue
+                score = compute_actionability_score(
+                    event_count=row["count"],
+                    user_count=row["user_count"],
+                    group=group,
+                    window_start=ctx.start,
+                    window_end=ctx.end,
+                )
+                scored.append((group, row["count"], row["user_count"], score))
+
+            ctx.projects_context_map[project_id].top_actionable_issues = heapq.nlargest(
+                3, scored, key=lambda x: x[3]
+            )

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -969,6 +969,7 @@ def compute_actionability_score(
     recency_weight = options.get("weekly-report.actionability.recency-weight")
     substatus_weight = options.get("weekly-report.actionability.substatus-weight")
     severity_weight = options.get("weekly-report.actionability.severity-weight")
+    newness_weight = options.get("weekly-report.actionability.newness-weight")
 
     # Log-scaled all-time event count, normalized to 0-1 (10k events = 1.0)
     event_volume = min(1.0, math.log(group.times_seen + 1) / math.log(10001))
@@ -986,11 +987,15 @@ def compute_actionability_score(
     substatus = SUBSTATUS_SCORE.get(group.substatus, 0.0)
     severity = SEVERITY_SCORE.get(group.level, 0.0)
 
+    # Binary: was this issue first seen during the report window?
+    newness = 1.0 if group.first_seen and group.first_seen >= window_start else 0.0
+
     return (
         event_volume_weight * event_volume
         + recency_weight * recency
         + substatus_weight * substatus
         + severity_weight * severity
+        + newness_weight * newness
     )
 
 
@@ -1008,9 +1013,9 @@ def org_top_actionable_issues(
                 last_seen__gte=ctx.start,
             )
             .order_by("-times_seen")
-            .only("id", "project_id", "times_seen", "level", "substatus", "last_seen")[
-                : per_project_limit * len(project_ids)
-            ]
+            .only(
+                "id", "project_id", "times_seen", "level", "substatus", "last_seen", "first_seen"
+            )[: per_project_limit * len(project_ids)]
         )
 
         if not candidates:

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -824,7 +824,34 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
             "total_substatus_count": total_substatus_count,
         }
 
+    def top_actionable_issues():
+        def all_actionable_issues():
+            for project_ctx in user_projects:
+                for group, event_count, user_count, score in project_ctx.top_actionable_issues:
+                    display = get_group_display(group)
+                    (
+                        substatus,
+                        substatus_color,
+                        substatus_text_color,
+                    ) = get_group_status_badge(group)
+                    yield {
+                        "count": event_count,
+                        "user_count": user_count,
+                        "score": score,
+                        "group": group,
+                        "title": display["title"],
+                        "message": display["message"],
+                        "group_substatus": substatus,
+                        "group_substatus_color": substatus_color,
+                        "group_substatus_text_color": substatus_text_color,
+                    }
+
+        return heapq.nlargest(3, all_actionable_issues(), lambda d: d["score"])
+
     show_past_issues = features.has("organizations:weekly-report-past-issues", ctx.organization)
+    show_top_actionable = features.has(
+        "organizations:weekly-report-top-actionable-issues", ctx.organization
+    )
 
     return {
         "organization": ctx.organization,
@@ -834,6 +861,8 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
         "key_errors": key_errors(),
         "key_transactions": key_transactions(),
         "key_performance_issues": key_performance_issues(),
+        "top_actionable_issues": top_actionable_issues() if show_top_actionable else [],
+        "show_top_actionable_issues": show_top_actionable,
         "past_issues": past_issues() if show_past_issues else [],
         "show_past_issues": show_past_issues,
         "issue_summary": issue_summary(),

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -827,7 +827,7 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
     def top_actionable_issues():
         def all_actionable_issues():
             for project_ctx in user_projects:
-                for group, event_count, user_count, score in project_ctx.top_actionable_issues:
+                for group, score in project_ctx.top_actionable_issues:
                     display = get_group_display(group)
                     (
                         substatus,
@@ -835,8 +835,6 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
                         substatus_text_color,
                     ) = get_group_status_badge(group)
                     yield {
-                        "count": event_count,
-                        "user_count": user_count,
                         "score": score,
                         "group": group,
                         "title": display["title"],

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -2059,6 +2059,7 @@ class WeeklyReportsTest(
             status=GroupStatus.UNRESOLVED,
             substatus=GroupSubStatus.ESCALATING,
             last_seen=self.now - timedelta(days=1),
+            first_seen=self.now - timedelta(days=2),
             level=40,  # logging.ERROR
             times_seen=1000,
             data={"type": "error", "metadata": {"type": "ValueError"}},
@@ -2071,11 +2072,12 @@ class WeeklyReportsTest(
         )
 
         assert score > 0
-        # Event volume: ln(1001)/ln(10001) ≈ 0.75 -> 0.30 * 0.75 = 0.225
-        # Recency: 6/7 ≈ 0.857 -> 0.25 * 0.857 = 0.214
+        # Event volume: ln(1001)/ln(10001) ≈ 0.75 -> 0.25 * 0.75 = 0.188
+        # Recency: 6/7 ≈ 0.857 -> 0.20 * 0.857 = 0.171
         # Substatus: escalating=1.0 -> 0.25 * 1.0 = 0.25
-        # Severity: error=0.75 -> 0.20 * 0.75 = 0.15
-        # Total ≈ 0.839
+        # Severity: error=0.75 -> 0.15 * 0.75 = 0.113
+        # Newness: first_seen in window=1.0 -> 0.15 * 1.0 = 0.15
+        # Total ≈ 0.872
         assert 0.7 < score < 0.95
 
     def test_compute_actionability_score_low_signals(self) -> None:
@@ -2087,6 +2089,7 @@ class WeeklyReportsTest(
             status=GroupStatus.UNRESOLVED,
             substatus=GroupSubStatus.ONGOING,
             last_seen=window_start + timedelta(hours=1),
+            first_seen=self.now - timedelta(days=30),
             level=20,  # logging.INFO (performance issue level)
             times_seen=5,
             type=PerformanceNPlusOneGroupType.type_id,
@@ -2137,6 +2140,40 @@ class WeeklyReportsTest(
         )
 
         assert score_escalating > score_ongoing
+
+    def test_compute_actionability_score_new_issue_boost(self) -> None:
+        window_start = self.now - timedelta(days=7)
+        window_end = self.now
+
+        new_issue = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.NEW,
+            last_seen=self.now - timedelta(days=1),
+            first_seen=self.now - timedelta(days=2),
+            level=40,
+            times_seen=100,
+            data={"type": "error", "metadata": {"type": "ValueError"}},
+        )
+        old_issue = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.NEW,
+            last_seen=self.now - timedelta(days=1),
+            first_seen=self.now - timedelta(days=30),
+            level=40,
+            times_seen=100,
+            data={"type": "error", "metadata": {"type": "TypeError"}},
+        )
+
+        score_new = compute_actionability_score(
+            group=new_issue, window_start=window_start, window_end=window_end
+        )
+        score_old = compute_actionability_score(
+            group=old_issue, window_start=window_start, window_end=window_end
+        )
+
+        assert score_new > score_old
 
     @with_feature({"organizations:weekly-report-top-actionable-issues": True})
     def test_top_actionable_issues_renders_in_template(self) -> None:

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -36,6 +36,7 @@ from sentry.tasks.summaries.utils import (
     _project_key_errors_snuba,
     _project_key_performance_issues_eap,
     _project_key_performance_issues_snuba,
+    compute_actionability_score,
     fetch_past_resolved_issue_links,
     org_key_errors,
     organization_project_issue_substatus_summaries,
@@ -2048,3 +2049,150 @@ class WeeklyReportsTest(
             assert context["show_past_issues"] is False
             assert len(context["past_issues"]) == 0
             assert len(context["key_errors"]) == 1
+
+    def test_compute_actionability_score(self) -> None:
+        window_start = self.now - timedelta(days=7)
+        window_end = self.now
+
+        group = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ESCALATING,
+            last_seen=self.now - timedelta(days=1),
+            level=40,  # logging.ERROR
+            data={"type": "error", "metadata": {"type": "ValueError"}},
+        )
+
+        score = compute_actionability_score(
+            event_count=1000,
+            user_count=100,
+            group=group,
+            window_start=window_start,
+            window_end=window_end,
+        )
+
+        assert score > 0
+        # Event volume: ln(1001)/ln(10001) ≈ 0.75 -> 0.30 * 0.75 = 0.225
+        # User impact: ln(101)/ln(1001) ≈ 0.67 -> 0.25 * 0.67 = 0.167
+        # Recency: 6/7 ≈ 0.857 -> 0.15 * 0.857 = 0.129
+        # Substatus: escalating=1.0 -> 0.15 * 1.0 = 0.15
+        # Severity: error=0.75 -> 0.15 * 0.75 = 0.1125
+        # Total ≈ 0.783
+        assert 0.7 < score < 0.9
+
+    def test_compute_actionability_score_low_signals(self) -> None:
+        window_start = self.now - timedelta(days=7)
+        window_end = self.now
+
+        group = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ONGOING,
+            last_seen=window_start + timedelta(hours=1),
+            level=20,  # logging.INFO (performance issue level)
+            type=PerformanceNPlusOneGroupType.type_id,
+            data={"type": "transaction", "metadata": {"title": "N+1 Query"}},
+        )
+
+        score = compute_actionability_score(
+            event_count=5,
+            user_count=2,
+            group=group,
+            window_start=window_start,
+            window_end=window_end,
+        )
+
+        assert score > 0
+        # All signals are low — this should score well below the escalating error
+        assert score < 0.3
+
+    def test_compute_actionability_score_escalating_beats_ongoing(self) -> None:
+        window_start = self.now - timedelta(days=7)
+        window_end = self.now
+
+        escalating = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ESCALATING,
+            last_seen=self.now - timedelta(days=1),
+            level=40,
+            data={"type": "error", "metadata": {"type": "ValueError"}},
+        )
+        ongoing = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ONGOING,
+            last_seen=self.now - timedelta(days=1),
+            level=40,
+            data={"type": "error", "metadata": {"type": "TypeError"}},
+        )
+
+        score_escalating = compute_actionability_score(
+            event_count=100,
+            user_count=50,
+            group=escalating,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        score_ongoing = compute_actionability_score(
+            event_count=100,
+            user_count=50,
+            group=ongoing,
+            window_start=window_start,
+            window_end=window_end,
+        )
+
+        assert score_escalating > score_ongoing
+
+    @with_feature({"organizations:weekly-report-top-actionable-issues": True})
+    def test_top_actionable_issues_renders_in_template(self) -> None:
+        user = self.create_user()
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+
+        error_group = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ESCALATING,
+            data={"type": "error", "metadata": {"type": "ValueError", "value": "bad value"}},
+        )
+        perf_group = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ONGOING,
+            type=PerformanceNPlusOneGroupType.type_id,
+            data={"type": "transaction", "metadata": {"title": "N+1 Query", "value": "slow"}},
+        )
+
+        ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
+        project_context = ProjectContext(self.project)
+        project_context.top_actionable_issues = [
+            (error_group, 500, 100, 0.85),
+            (perf_group, 200, 50, 0.65),
+        ]
+        project_context.accepted_error_count = 1000
+        ctx.projects_context_map = {self.project.id: project_context}
+        ctx.project_ownership[user.id] = {self.project.id}
+
+        rendered = render_template_context(ctx, user.id)
+
+        assert rendered is not None
+        assert len(rendered["top_actionable_issues"]) == 2
+        assert rendered["top_actionable_issues"][0]["score"] == 0.85
+        assert rendered["top_actionable_issues"][0]["count"] == 500
+        assert rendered["top_actionable_issues"][1]["score"] == 0.65
+
+    def test_top_actionable_issues_feature_flag_gated(self) -> None:
+        user = self.create_user()
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+
+        ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
+        project_context = ProjectContext(self.project)
+        project_context.accepted_error_count = 1000
+        ctx.projects_context_map = {self.project.id: project_context}
+        ctx.project_ownership[user.id] = {self.project.id}
+
+        rendered = render_template_context(ctx, user.id)
+
+        assert rendered is not None
+        assert rendered["top_actionable_issues"] == []
+        assert rendered["show_top_actionable_issues"] is False

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -2060,12 +2060,11 @@ class WeeklyReportsTest(
             substatus=GroupSubStatus.ESCALATING,
             last_seen=self.now - timedelta(days=1),
             level=40,  # logging.ERROR
+            times_seen=1000,
             data={"type": "error", "metadata": {"type": "ValueError"}},
         )
 
         score = compute_actionability_score(
-            event_count=1000,
-            user_count=100,
             group=group,
             window_start=window_start,
             window_end=window_end,
@@ -2073,12 +2072,11 @@ class WeeklyReportsTest(
 
         assert score > 0
         # Event volume: ln(1001)/ln(10001) ≈ 0.75 -> 0.30 * 0.75 = 0.225
-        # User impact: ln(101)/ln(1001) ≈ 0.67 -> 0.25 * 0.67 = 0.167
-        # Recency: 6/7 ≈ 0.857 -> 0.15 * 0.857 = 0.129
-        # Substatus: escalating=1.0 -> 0.15 * 1.0 = 0.15
-        # Severity: error=0.75 -> 0.15 * 0.75 = 0.1125
-        # Total ≈ 0.783
-        assert 0.7 < score < 0.9
+        # Recency: 6/7 ≈ 0.857 -> 0.25 * 0.857 = 0.214
+        # Substatus: escalating=1.0 -> 0.25 * 1.0 = 0.25
+        # Severity: error=0.75 -> 0.20 * 0.75 = 0.15
+        # Total ≈ 0.839
+        assert 0.7 < score < 0.95
 
     def test_compute_actionability_score_low_signals(self) -> None:
         window_start = self.now - timedelta(days=7)
@@ -2090,20 +2088,18 @@ class WeeklyReportsTest(
             substatus=GroupSubStatus.ONGOING,
             last_seen=window_start + timedelta(hours=1),
             level=20,  # logging.INFO (performance issue level)
+            times_seen=5,
             type=PerformanceNPlusOneGroupType.type_id,
             data={"type": "transaction", "metadata": {"title": "N+1 Query"}},
         )
 
         score = compute_actionability_score(
-            event_count=5,
-            user_count=2,
             group=group,
             window_start=window_start,
             window_end=window_end,
         )
 
         assert score > 0
-        # All signals are low — this should score well below the escalating error
         assert score < 0.3
 
     def test_compute_actionability_score_escalating_beats_ongoing(self) -> None:
@@ -2116,6 +2112,7 @@ class WeeklyReportsTest(
             substatus=GroupSubStatus.ESCALATING,
             last_seen=self.now - timedelta(days=1),
             level=40,
+            times_seen=100,
             data={"type": "error", "metadata": {"type": "ValueError"}},
         )
         ongoing = self.create_group(
@@ -2124,19 +2121,16 @@ class WeeklyReportsTest(
             substatus=GroupSubStatus.ONGOING,
             last_seen=self.now - timedelta(days=1),
             level=40,
+            times_seen=100,
             data={"type": "error", "metadata": {"type": "TypeError"}},
         )
 
         score_escalating = compute_actionability_score(
-            event_count=100,
-            user_count=50,
             group=escalating,
             window_start=window_start,
             window_end=window_end,
         )
         score_ongoing = compute_actionability_score(
-            event_count=100,
-            user_count=50,
             group=ongoing,
             window_start=window_start,
             window_end=window_end,
@@ -2166,8 +2160,8 @@ class WeeklyReportsTest(
         ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
         project_context = ProjectContext(self.project)
         project_context.top_actionable_issues = [
-            (error_group, 500, 100, 0.85),
-            (perf_group, 200, 50, 0.65),
+            (error_group, 0.85),
+            (perf_group, 0.65),
         ]
         project_context.accepted_error_count = 1000
         ctx.projects_context_map = {self.project.id: project_context}
@@ -2178,7 +2172,6 @@ class WeeklyReportsTest(
         assert rendered is not None
         assert len(rendered["top_actionable_issues"]) == 2
         assert rendered["top_actionable_issues"][0]["score"] == 0.85
-        assert rendered["top_actionable_issues"][0]["count"] == 500
         assert rendered["top_actionable_issues"][1]["score"] == 0.65
 
     def test_top_actionable_issues_feature_flag_gated(self) -> None:


### PR DESCRIPTION
Addresses 1/3 of [ID-1645](https://linear.app/getsentry/issue/ID-1645/add-future-issues-section)

- Add Postgres-only scoring logic to rank unresolved issues by actionability for "top 3 issues to act on" section
- Score combines 4 weighted factors: event volume (times_seen), recency (last_seen), substatus (escalating > regressed > new > ongoing), severity (log level)
- Single Postgres query fetches candidates — no new Snuba queries 
- Gated by `organizations:weekly-report-top-actionable-issues feature flag`

**What this PR does NOT do (deferred to PRs 2 & 3)**
- PR 2: Wire org_top_actionable_issues() into the context factory pipeline
- PR 3: Add frontend template rendering + fetch Snuba display counts for just the top 3 winners

**Changes**

- `src/sentry/tasks/summaries/utils.py` — Add `org_top_actionable_issues()` (Postgres query) and `compute_actionability_score()` (4-factor scoring)
- `src/sentry/options/defaults.py` — Register weight options (event-volume, recency, substatus, severity, candidate-limit)
- `src/sentry/tasks/summaries/weekly_reports.py` — Update `top_actionable_issues()` template helper for new tuple shape

**Scoring factors**

| Factor       | Weight | Source                                              |
| ------------ | ------ | --------------------------------------------------- |
| Event volume | 0.30   | `log(Group.times_seen)` normalized to 0–1           |
| Recency      | 0.25   | Linear position of `last_seen` in 7-day window      |
| Substatus    | 0.25   | Escalating=1.0, Regressed=0.8, New=0.6, Ongoing=0.3 |
| Severity     | 0.20   | Fatal=1.0, Error=0.75, Warning=0.5, Info=0.25       |
