### PR TITLE
feat(cells) Add signup_visible to Locality

### DIFF
--- a/src/sentry/conf/types/cell_config.py
+++ b/src/sentry/conf/types/cell_config.py
@@ -18,3 +18,4 @@ class LocalityConfig(TypedDict):
     cells: list[str]
     new_org_cell: str
     visible: NotRequired[bool]
+    signup_visible: NotRequired[bool]

--- a/src/sentry/types/cell.py
+++ b/src/sentry/types/cell.py
@@ -42,6 +42,9 @@ class Locality:
     visible: bool = True
     """Whether the locality is visible in API responses."""
 
+    signup_visible: bool = True
+    """Whether or not a locality should be visible for org signup/relocation."""
+
     def to_url(self, path: str) -> str:
         """Resolve a path into a customer facing URL on this locality.
 
@@ -495,4 +498,15 @@ def find_all_multitenant_locality_names() -> list[str]:
         loc.name
         for loc in get_global_directory().localities
         if loc.category == RegionCategory.MULTI_TENANT and loc.visible
+    ]
+
+
+def find_all_signup_locality_names() -> list[str]:
+    """
+    Return all locality names that are visible to org signup.
+    """
+    return [
+        loc.name
+        for loc in get_global_directory().localities
+        if loc.category == RegionCategory.MULTI_TENANT and loc.visible and loc.signup_visible
     ]

--- a/src/sentry/types/cell.py
+++ b/src/sentry/types/cell.py
@@ -277,6 +277,7 @@ def _parse_locality_config(
             cells=frozenset(config_value["cells"]),
             new_org_cell=config_value["new_org_cell"],
             visible=bool(config_value.get("visible", True)),
+            signup_visible=bool(config_value.get("signup_visible", True)),
         )
 
 

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Iterable, Mapping
 from functools import cached_property
 from typing import Any
 
@@ -37,6 +37,7 @@ from sentry.types.cell import (
     RegionCategory,
     find_all_cell_names,
     find_all_multitenant_locality_names,
+    find_all_signup_locality_names,
     get_cell_by_name,
     get_global_directory,
     get_locality_by_name,
@@ -352,14 +353,6 @@ class _ClientConfig:
             if (loc := directory.get_locality_for_cell(name)) is not None
         )
 
-    @staticmethod
-    def _serialize_localities(
-        locality_names: Iterable[str], display_order: Callable[[Locality], Any]
-    ) -> list[Mapping[str, Any]]:
-        localities = [get_locality_by_name(name) for name in locality_names]
-        localities.sort(key=display_order)
-        return [locality.api_serialize() for locality in localities]
-
     @property
     def localities(self) -> list[Mapping[str, Any]]:
         """
@@ -379,7 +372,21 @@ class _ClientConfig:
                 region.name,  # then sort alphabetically
             )
 
-        return self._serialize_localities(locality_names, region_display_order)
+        localities = [get_locality_by_name(name) for name in locality_names]
+        localities.sort(key=region_display_order)
+
+        return [locality.api_serialize() for locality in localities]
+
+    @property
+    def signup_localities(self) -> list[str]:
+        """
+        The locality names that are available to new orgs
+        """
+        localities = find_all_signup_locality_names()
+        if not localities:
+            monolith_locality = get_locality_name_for_cell(settings.SENTRY_FALLBACK_CELL)
+            return [monolith_locality]
+        return localities
 
     @property
     def cells(self) -> list[Mapping[str, Any]]:
@@ -465,6 +472,7 @@ class _ClientConfig:
             "languageCode": self.language_code,
             "cells": self.cells,
             "localities": self.localities,
+            "signupLocalities": self.signup_localities,
             "userIdentity": dict(self.user_identity),
             "csrfCookieName": settings.CSRF_COOKIE_NAME,
             "superUserCookieName": superuser.COOKIE_NAME,

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -197,6 +197,7 @@ export interface Config {
   // so we can differentiate between "SELF_HOSTED", "SINGLE_TENANT", and "SAAS".
   sentryMode: 'SELF_HOSTED' | 'SINGLE_TENANT' | 'SAAS';
   shouldPreloadData: boolean;
+  signupLocalities: string[];
   singleOrganization: boolean;
   superUserCookieDomain: string | null;
   superUserCookieName: string;

--- a/tests/js/fixtures/config.ts
+++ b/tests/js/fixtures/config.ts
@@ -15,6 +15,7 @@ export function ConfigFixture(params: Partial<Config> = {}): Config {
     validateSUForm: true,
     features: new Set(),
     shouldPreloadData: true,
+    signupLocalities: ['us'],
     singleOrganization: false,
     enableAnalytics: true,
     urlPrefix: 'https://sentry-jest-tests.example.com/',

--- a/tests/sentry/types/test_cell.py
+++ b/tests/sentry/types/test_cell.py
@@ -126,6 +126,32 @@ class CellDirectoryTest(TestCase):
             directory = load_from_config(self._INPUTS, [])
         assert directory.cells == frozenset(self._EXPECTED_OUTPUTS)
 
+    def test_cell_config_parsing_signup_visibility(self) -> None:
+        cells: list[CellConfig] = [
+            {
+                "name": "us",
+                "snowflake_id": 1,
+                "address": "https://us.testserver",
+            },
+        ]
+        localities: list[LocalityConfig] = [
+            {
+                "name": "us",
+                "cells": ["us"],
+                "category": RegionCategory.MULTI_TENANT.name,
+                "new_org_cell": "us",
+                "visible": False,
+                "signup_visible": False,
+            },
+        ]
+        with override_settings(SENTRY_FALLBACK_CELL="us"):
+            directory = load_from_config(cells, localities)
+
+            locality = directory.get_locality_by_name("us")
+            assert locality
+            assert locality.visible is False
+            assert locality.signup_visible is False
+
     @override_settings(SILO_MODE=SiloMode.CELL, SENTRY_LOCAL_CELL="us")
     def test_get_local_cell(self) -> None:
         with override_settings(SENTRY_FALLBACK_CELL="us"):
@@ -355,6 +381,12 @@ class CellDirectoryTest(TestCase):
                 address="10.0.0.2",
                 visible=True,
             ),
+            Cell(
+                name="ja",
+                snowflake_id=4,
+                address="10.0.0.3",
+                visible=False,
+            ),
         ]
         localities = [
             Locality(
@@ -372,10 +404,18 @@ class CellDirectoryTest(TestCase):
                 visible=True,
                 signup_visible=False,
             ),
+            Locality(
+                name="ja",
+                cells=frozenset(["ja"]),
+                category=RegionCategory.MULTI_TENANT,
+                new_org_cell="de",
+                visible=False,
+                signup_visible=True,
+            ),
         ]
         with get_test_env_directory().swap_state(cells=cells, localities=localities):
             all_localities = find_all_multitenant_locality_names()
-            assert all_localities == ["us", "de"]
+            assert set(all_localities) == {"us", "de"}
 
             # Requires both visible + signup_visible
             signup_localities = find_all_signup_locality_names()

--- a/tests/sentry/types/test_cell.py
+++ b/tests/sentry/types/test_cell.py
@@ -21,6 +21,8 @@ from sentry.types.cell import (
     Locality,
     RegionCategory,
     find_all_cell_names,
+    find_all_multitenant_locality_names,
+    find_all_signup_locality_names,
     find_cells_for_sentry_app,
     find_cells_for_user,
     get_cell_by_name,
@@ -338,3 +340,43 @@ class CellDirectoryTest(TestCase):
 
             with pytest.raises(CellResolutionError):
                 get_new_org_cell_for_locality("derp")
+
+    def test_find_all_signup_locality_names(self) -> None:
+        cells = [
+            Cell(
+                name="us",
+                snowflake_id=1,
+                address="10.0.0.1",
+                visible=True,
+            ),
+            Cell(
+                name="de",
+                snowflake_id=3,
+                address="10.0.0.2",
+                visible=True,
+            ),
+        ]
+        localities = [
+            Locality(
+                name="us",
+                cells=frozenset(["us"]),
+                category=RegionCategory.MULTI_TENANT,
+                new_org_cell="us",
+                visible=True,
+            ),
+            Locality(
+                name="de",
+                cells=frozenset(["de"]),
+                category=RegionCategory.MULTI_TENANT,
+                new_org_cell="de",
+                visible=True,
+                signup_visible=False,
+            ),
+        ]
+        with get_test_env_directory().swap_state(cells=cells, localities=localities):
+            all_localities = find_all_multitenant_locality_names()
+            assert all_localities == ["us", "de"]
+
+            # Requires both visible + signup_visible
+            signup_localities = find_all_signup_locality_names()
+            assert signup_localities == ["us"]

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -123,6 +123,7 @@ def test_client_config_in_silo_modes(request_factory: RequestFactory) -> None:
         # Removing the region lists as it varies based on silo mode.
         # See Locality.to_url()
         value.pop("localities")
+        value.pop("signupLocalities")
         value.pop("cells")
         value["links"].pop("regionUrl")
 
@@ -188,6 +189,8 @@ def test_client_config_default_locality_data() -> None:
     localities = result["localities"]
     assert localities[0]["name"] == settings.SENTRY_FALLBACK_CELL
     assert localities[0]["url"] == options.get("system.url-prefix")
+    assert len(result["signupLocalities"]) == 1
+    assert result["signupLocalities"] == [settings.SENTRY_FALLBACK_CELL]
 
     assert len(result["cells"]) == 0, "No staff session"
 
@@ -207,9 +210,12 @@ def test_client_config_empty_region_data() -> None:
 
     assert len(result["cells"]) == 0, "no staff session"
     assert len(result["localities"]) == 1
+    assert len(result["signupLocalities"]) == 1
+
     localities = result["localities"]
     assert localities[0]["name"] == settings.SENTRY_FALLBACK_CELL
     assert localities[0]["url"] == options.get("system.url-prefix")
+    assert result["signupLocalities"][0] == localities[0]["name"]
 
 
 @multiregion_client_config_test
@@ -266,6 +272,9 @@ def test_client_config_with_hidden_cell_membership() -> None:
     assert len(result["localities"]) == 1
     localities = result["localities"]
     assert [r["name"] for r in localities] == ["us"]
+
+    # signup localities don't include hidden items;
+    assert result["signupLocalities"] == ["us"]
 
     # Cell list is hidden for regular users.
     assert len(result["cells"]) == 0


### PR DESCRIPTION
When going reviewing the us2 rollout plan, I noticed that us2 would show up in the in-app org create form, but wouldn't show up for relocation signup flows as there are different visibility options

By introducing `Locality.signup_visible` we can align visibility for relocations + org create and also make us2 'visible' but not include it in the UI options for org create & relocations. This new attribute will also make it possible to remove `relocationConfig` from `__initialData`.

Refs INFRENG-350