### PR TITLE
fix(vercel): Use upsert to set env vars when linking projects

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -118,6 +118,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:indexed-spans-extraction", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("organizations:integrations-github-platform-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-slack-staging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:integrations-vercel-upsert-env-var", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable GitHub Enterprise to accept github.com as a valid Installation URL
     manager.add("organizations:github-enterprise-github-com-source", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # API-driven integration setup pipeline (per-provider rollout)

--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -92,8 +92,9 @@ class VercelClient(ApiClient):
     def get_env_vars(self, vercel_project_id):
         return self.get(self.GET_ENV_VAR_URL % vercel_project_id)
 
-    def create_env_variable(self, vercel_project_id, data):
-        return self.post(self.CREATE_ENV_VAR_URL % vercel_project_id, data=data)
+    def create_env_variable(self, vercel_project_id, data, upsert=False):
+        params = {"upsert": "true"} if upsert else None
+        return self.post(self.CREATE_ENV_VAR_URL % vercel_project_id, data=data, params=params)
 
     def update_env_variable(self, vercel_project_id, env_var_id, data):
         return self.patch(self.UPDATE_ENV_VAR_URL % (vercel_project_id, env_var_id), data=data)

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework.fields import CharField
 from rest_framework.serializers import ValidationError
 
-from sentry import options
+from sentry import features, options
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.constants import ObjectStatus
 from sentry.identity.oauth2 import OAuth2ApiStep
@@ -393,6 +393,23 @@ class VercelIntegration(IntegrationInstallation):
             "target": target,
             "type": type,
         }
+
+        use_upsert = features.has(
+            "organizations:integrations-vercel-upsert-env-var",
+            self.organization,
+        )
+
+        if use_upsert:
+            try:
+                return client.create_env_variable(vercel_project_id, data, upsert=True)
+            except ApiError as e:
+                error_message = (
+                    e.json.get("error", {}).get("message")
+                    if e.json
+                    else f"Could not create or update environment variable {key}."
+                )
+                raise ValidationError({"project_mappings": [error_message]})
+
         try:
             return client.create_env_variable(vercel_project_id, data)
         except ApiError as e:

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -385,6 +385,156 @@ class VercelIntegrationTest(IntegrationTestCase):
         assert req_params["type"] == "encrypted"
 
     @responses.activate
+    @with_feature("organizations:integrations-vercel-upsert-env-var")
+    def test_update_org_config_vars_exist_with_upsert(self) -> None:
+        """Test that env vars are upserted when the feature flag is enabled,
+        bypassing the legacy get+patch fallback."""
+
+        with self.tasks():
+            self.install_integration()
+
+        org = self.organization
+        project_id = self.project.id
+        with assume_test_silo_mode(SiloMode.CELL):
+            project_key = ProjectKey.get_default(project=Project.objects.get(id=project_id))
+            enabled_dsn = project_key.get_dsn(public=True)
+            integration_endpoint = project_key.integration_endpoint
+            public_key = project_key.public_key
+
+        sentry_auth_token = SentryAppInstallationToken.objects.get_token(org.id, "vercel")
+
+        env_var_map = {
+            "SENTRY_ORG": {
+                "type": "encrypted",
+                "value": org.slug,
+                "target": ["production", "preview"],
+            },
+            "SENTRY_PROJECT": {
+                "type": "encrypted",
+                "value": self.project.slug,
+                "target": ["production", "preview"],
+            },
+            "SENTRY_DSN": {
+                "type": "encrypted",
+                "value": enabled_dsn,
+                "target": [
+                    "production",
+                    "preview",
+                    "development",
+                ],
+            },
+            "SENTRY_AUTH_TOKEN": {
+                "type": "encrypted",
+                "value": sentry_auth_token,
+                "target": ["production", "preview"],
+            },
+            "VERCEL_GIT_COMMIT_SHA": {
+                "type": "system",
+                "value": "VERCEL_GIT_COMMIT_SHA",
+                "target": ["production", "preview"],
+            },
+            "SENTRY_VERCEL_LOG_DRAIN_URL": {
+                "type": "encrypted",
+                "value": f"{integration_endpoint}vercel/logs/",
+                "target": ["production", "preview"],
+            },
+            "SENTRY_OTLP_TRACES_URL": {
+                "type": "encrypted",
+                "value": f"{integration_endpoint}otlp/v1/traces",
+                "target": ["production", "preview"],
+            },
+            "SENTRY_PUBLIC_KEY": {
+                "type": "encrypted",
+                "value": public_key,
+                "target": ["production", "preview"],
+            },
+        }
+
+        # mock get_project API call
+        responses.add(
+            responses.GET,
+            f"{VercelClient.base_url}{VercelClient.GET_PROJECT_URL % self.project_id}",
+            json={"link": {"type": "github"}, "framework": "gatsby"},
+        )
+
+        # mock upsert env vars (all succeed directly via POST with upsert=true)
+        for env_var, details in env_var_map.items():
+            responses.add(
+                responses.POST,
+                f"{VercelClient.base_url}{VercelClient.CREATE_ENV_VAR_URL % self.project_id}",
+                json={
+                    "key": env_var,
+                    "value": details["value"],
+                    "target": details["target"],
+                    "type": details["type"],
+                },
+            )
+
+        data = {"project_mappings": [[project_id, self.project_id]]}
+        integration = Integration.objects.get(provider=self.provider.key)
+        installation = integration.get_installation(org.id)
+        org_integration = OrganizationIntegration.objects.get(
+            organization_id=org.id, integration_id=integration.id
+        )
+        assert org_integration.config == {}
+        installation.update_organization_config(data)
+        org_integration = OrganizationIntegration.objects.get(
+            organization_id=org.id, integration_id=integration.id
+        )
+        assert org_integration.config == {"project_mappings": [[project_id, self.project_id]]}
+
+        # calls[0] = GET project, calls[1..8] = POST env vars with upsert
+        for i in range(1, 9):
+            assert "upsert=true" in responses.calls[i].request.url
+
+        req_params = orjson.loads(responses.calls[1].request.body)
+        assert req_params["key"] == "SENTRY_ORG"
+        assert req_params["value"] == org.slug
+        assert req_params["target"] == ["production", "preview"]
+        assert req_params["type"] == "encrypted"
+
+        req_params = orjson.loads(responses.calls[2].request.body)
+        assert req_params["key"] == "SENTRY_PROJECT"
+        assert req_params["value"] == self.project.slug
+        assert req_params["target"] == ["production", "preview"]
+        assert req_params["type"] == "encrypted"
+
+        req_params = orjson.loads(responses.calls[3].request.body)
+        assert req_params["key"] == "SENTRY_DSN"
+        assert req_params["value"] == enabled_dsn
+        assert req_params["target"] == ["production", "preview", "development"]
+        assert req_params["type"] == "encrypted"
+
+        req_params = orjson.loads(responses.calls[4].request.body)
+        assert req_params["key"] == "SENTRY_AUTH_TOKEN"
+        assert req_params["target"] == ["production", "preview"]
+        assert req_params["type"] == "encrypted"
+
+        req_params = orjson.loads(responses.calls[5].request.body)
+        assert req_params["key"] == "VERCEL_GIT_COMMIT_SHA"
+        assert req_params["value"] == "VERCEL_GIT_COMMIT_SHA"
+        assert req_params["target"] == ["production", "preview"]
+        assert req_params["type"] == "system"
+
+        req_params = orjson.loads(responses.calls[6].request.body)
+        assert req_params["key"] == "SENTRY_VERCEL_LOG_DRAIN_URL"
+        assert req_params["value"] == f"{integration_endpoint}vercel/logs/"
+        assert req_params["target"] == ["production", "preview"]
+        assert req_params["type"] == "encrypted"
+
+        req_params = orjson.loads(responses.calls[7].request.body)
+        assert req_params["key"] == "SENTRY_OTLP_TRACES_URL"
+        assert req_params["value"] == f"{integration_endpoint}otlp/v1/traces"
+        assert req_params["target"] == ["production", "preview"]
+        assert req_params["type"] == "encrypted"
+
+        req_params = orjson.loads(responses.calls[8].request.body)
+        assert req_params["key"] == "SENTRY_PUBLIC_KEY"
+        assert req_params["value"] == public_key
+        assert req_params["target"] == ["production", "preview"]
+        assert req_params["type"] == "encrypted"
+
+    @responses.activate
     def test_upgrade_org_config_no_dsn(self) -> None:
         """Test that the function doesn't progress if there is no active DSN"""
 


### PR DESCRIPTION
Attempt to fix the attached linear issue by upserting instead of the current POST -> UPDATE if that failed flow when setting env vars



Fixes ISWF-2889