### PR TITLE
ref(project-creation): Extract alert frequency into a sibling component

### DIFF
--- a/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
@@ -1,0 +1,45 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {DEFAULT_ISSUE_ALERT_OPTIONS_VALUES} from 'sentry/views/projectInstall/issueAlertOptions';
+
+import {ScmAlertFrequencySection} from './scmAlertFrequencySection';
+
+type Props = React.ComponentProps<typeof ScmAlertFrequencySection>;
+
+function renderSection(overrides: Partial<Props> = {}) {
+  const props: Props = {
+    analyticsFlow: 'project-creation',
+    alertRuleConfig: DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
+    onAlertChange: jest.fn(),
+    ...overrides,
+  };
+
+  render(<ScmAlertFrequencySection {...props} />, {organization: OrganizationFixture()});
+  return props;
+}
+
+describe('ScmAlertFrequencySection', () => {
+  it('makes the alert-frequency section a collapsible toggle in project creation', async () => {
+    renderSection({analyticsFlow: 'project-creation'});
+
+    const toggle = screen.getByRole('button', {name: 'Alert frequency'});
+    expect(screen.getByText('Get notified when things go wrong')).toBeInTheDocument();
+
+    await userEvent.click(toggle);
+    expect(
+      screen.queryByText('Get notified when things go wrong')
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the alert-frequency section always expanded in onboarding', () => {
+    renderSection({analyticsFlow: 'onboarding'});
+
+    expect(
+      screen.queryByRole('button', {name: 'Alert frequency'})
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Alert frequency')).toBeInTheDocument();
+    expect(screen.getByText('Get notified when things go wrong')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -1,0 +1,64 @@
+import {Container, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import type {AlertRuleOptions} from 'sentry/views/projectInstall/issueAlertOptions';
+
+import {ScmAlertFrequency} from './scmAlertFrequency';
+import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
+import {ScmCollapsibleSection} from './scmCollapsibleSection';
+
+interface ScmAlertFrequencySectionProps {
+  alertRuleConfig: AlertRuleOptions;
+  analyticsFlow: ScmAnalyticsFlow;
+  onAlertChange: <K extends keyof AlertRuleOptions>(
+    key: K,
+    value: AlertRuleOptions[K]
+  ) => void;
+}
+
+/**
+ * Alert-frequency configuration, rendered as a sibling of `ScmProjectDetailsCore`.
+ * In project creation it folds away behind a collapsible toggle (one of several
+ * stacked config cards); in onboarding it stays always expanded under its own
+ * heading. Presentational only: the alert state and field analytics live in
+ * `useScmProjectDetails`, which the host wires to `alertRuleConfig`/`onAlertChange`.
+ */
+export function ScmAlertFrequencySection({
+  alertRuleConfig,
+  analyticsFlow,
+  onAlertChange,
+}: ScmAlertFrequencySectionProps) {
+  const collapsible = analyticsFlow === 'project-creation';
+
+  if (collapsible) {
+    return (
+      <ScmCollapsibleSection title={t('Alert frequency')}>
+        <Stack gap="md" width="100%">
+          <Text variant="muted" density="comfortable">
+            {t('Get notified when things go wrong')}
+          </Text>
+          <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
+        </Stack>
+      </ScmCollapsibleSection>
+    );
+  }
+
+  return (
+    <Stack gap="md">
+      <Stack gap="xs">
+        <Container>
+          <Text bold size="md" density="comfortable">
+            {t('Alert frequency')}
+          </Text>
+        </Container>
+        <Container>
+          <Text variant="muted" density="comfortable">
+            {t('Get notified when things go wrong')}
+          </Text>
+        </Container>
+      </Stack>
+      <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
+    </Stack>
+  );
+}

--- a/static/app/views/onboarding/components/scmProjectDetailsCore.spec.tsx
+++ b/static/app/views/onboarding/components/scmProjectDetailsCore.spec.tsx
@@ -1,9 +1,8 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import * as analytics from 'sentry/utils/analytics';
-import {DEFAULT_ISSUE_ALERT_OPTIONS_VALUES} from 'sentry/views/projectInstall/issueAlertOptions';
 
 import {ScmProjectDetailsCore} from './scmProjectDetailsCore';
 
@@ -17,8 +16,6 @@ function renderCore(overrides: Partial<CoreProps> = {}) {
     onProjectNameBlur: jest.fn(),
     teamSlug: 'my-team',
     onTeamChange: jest.fn(),
-    alertRuleConfig: DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
-    onAlertChange: jest.fn(),
     isOrgMemberWithNoAccess: false,
     ...overrides,
   };
@@ -32,12 +29,11 @@ describe('ScmProjectDetailsCore', () => {
     jest.restoreAllMocks();
   });
 
-  it('renders the project name, team, and alert-frequency fields', () => {
+  it('renders the project name and team fields', () => {
     renderCore();
 
     expect(screen.getByText('Project name')).toBeInTheDocument();
     expect(screen.getByText('Team')).toBeInTheDocument();
-    expect(screen.getByText('Alert frequency')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('project-name')).toHaveValue('my-project');
   });
 
@@ -56,27 +52,5 @@ describe('ScmProjectDetailsCore', () => {
 
     expect(screen.getByText('Project name')).toBeInTheDocument();
     expect(screen.queryByText('Team')).not.toBeInTheDocument();
-  });
-
-  it('makes the alert-frequency section a collapsible toggle in project creation', async () => {
-    renderCore({analyticsFlow: 'project-creation'});
-
-    const toggle = screen.getByRole('button', {name: 'Alert frequency'});
-    expect(screen.getByText('Get notified when things go wrong')).toBeInTheDocument();
-
-    await userEvent.click(toggle);
-    expect(
-      screen.queryByText('Get notified when things go wrong')
-    ).not.toBeInTheDocument();
-  });
-
-  it('keeps the alert-frequency section always expanded in onboarding', () => {
-    renderCore({analyticsFlow: 'onboarding'});
-
-    expect(
-      screen.queryByRole('button', {name: 'Alert frequency'})
-    ).not.toBeInTheDocument();
-    expect(screen.getByText('Alert frequency')).toBeInTheDocument();
-    expect(screen.getByText('Get notified when things go wrong')).toBeInTheDocument();
   });
 });

--- a/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
+++ b/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
@@ -9,11 +9,8 @@ import {t} from 'sentry/locale';
 import type {Team} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import type {AlertRuleOptions} from 'sentry/views/projectInstall/issueAlertOptions';
 
-import {ScmAlertFrequency} from './scmAlertFrequency';
 import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
-import {ScmCollapsibleSection} from './scmCollapsibleSection';
 
 const STEP_VIEWED_EVENT = {
   onboarding: 'onboarding.scm_project_details_step_viewed',
@@ -21,137 +18,90 @@ const STEP_VIEWED_EVENT = {
 } as const;
 
 interface ScmProjectDetailsCoreProps {
-  alertRuleConfig: AlertRuleOptions;
   analyticsFlow: ScmAnalyticsFlow;
   /** Hides the team selector for a no-access member (see useScmProjectDetails). */
   isOrgMemberWithNoAccess: boolean;
-  onAlertChange: <K extends keyof AlertRuleOptions>(
-    key: K,
-    value: AlertRuleOptions[K]
-  ) => void;
   onProjectNameBlur: () => void;
   onProjectNameChange: (value: string) => void;
   onTeamChange: (option: {value: string}) => void;
   projectName: string;
   teamSlug: string;
-  /** Max width of the field column. Hosts pass their own step/section width. */
-  contentMaxWidth?: string;
 }
 
 /**
- * Presentational project name / team / alert-frequency form shared by the SCM
- * onboarding project-details step and the SCM-first project-creation surface.
+ * Presentational project name / team form shared by the SCM onboarding
+ * project-details step and the SCM-first project-creation surface. Alert
+ * frequency is rendered separately as a sibling (`ScmAlertFrequencySection`).
  * Form state, the create flow, and field analytics live in `useScmProjectDetails`;
  * the host wires that hook to this component and renders its own Create button.
- * This component owns only the rendering and the `step_viewed` analytics, which
- * fires when the step becomes visible.
+ * This component owns the `step_viewed` analytic, which fires when the step
+ * becomes visible.
  */
 export function ScmProjectDetailsCore({
-  alertRuleConfig,
   analyticsFlow,
   isOrgMemberWithNoAccess,
-  onAlertChange,
   onProjectNameBlur,
   onProjectNameChange,
   onTeamChange,
   projectName,
   teamSlug,
-  contentMaxWidth,
 }: ScmProjectDetailsCoreProps) {
   const organization = useOrganization();
-
-  // Match the feature-selection section: the alert-frequency section folds away
-  // in project creation (one of several stacked config cards) but stays always
-  // expanded in onboarding.
-  const collapsible = analyticsFlow === 'project-creation';
 
   useEffect(() => {
     trackAnalytics(STEP_VIEWED_EVENT[analyticsFlow], {organization});
   }, [organization, analyticsFlow]);
 
-  const alertFrequencyBody = (
-    <Stack gap="md" width="100%">
-      <Text variant="muted" density="comfortable">
-        {t('Get notified when things go wrong')}
-      </Text>
-      <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
-    </Stack>
-  );
-
   return (
-    <Stack gap="3xl" width="100%" maxWidth={contentMaxWidth}>
-      <Grid width="100%" columns={{sm: '1fr', md: '1fr 1fr'}} gap="2xl">
+    <Grid width="100%" columns={{sm: '1fr', md: '1fr 1fr'}} gap="2xl">
+      <Stack gap="md">
+        <Stack gap="xs">
+          <Container>
+            <Text bold size="md" density="comfortable">
+              {t('Project name')}
+            </Text>
+          </Container>
+          <Container>
+            <Text variant="muted" density="comfortable">
+              {t('Slug used in URLs and SDK config')}
+            </Text>
+          </Container>
+        </Stack>
+        <Input
+          type="text"
+          placeholder={t('project-name')}
+          value={projectName}
+          onChange={e => onProjectNameChange(e.target.value)}
+          onBlur={onProjectNameBlur}
+        />
+      </Stack>
+
+      {!isOrgMemberWithNoAccess && (
         <Stack gap="md">
           <Stack gap="xs">
             <Container>
               <Text bold size="md" density="comfortable">
-                {t('Project name')}
+                {t('Team')}
               </Text>
             </Container>
             <Container>
               <Text variant="muted" density="comfortable">
-                {t('Slug used in URLs and SDK config')}
+                {t('Set who owns alerts for this project')}
               </Text>
             </Container>
           </Stack>
-          <Input
-            type="text"
-            placeholder={t('project-name')}
-            value={projectName}
-            onChange={e => onProjectNameChange(e.target.value)}
-            onBlur={onProjectNameBlur}
+          <TeamSelector
+            allowCreate
+            name="team"
+            aria-label={t('Select a Team')}
+            clearable={false}
+            placeholder={t('Select a Team')}
+            teamFilter={(tm: Team) => tm.access.includes('team:admin')}
+            value={teamSlug}
+            onChange={onTeamChange}
           />
         </Stack>
-
-        {!isOrgMemberWithNoAccess && (
-          <Stack gap="md">
-            <Stack gap="xs">
-              <Container>
-                <Text bold size="md" density="comfortable">
-                  {t('Team')}
-                </Text>
-              </Container>
-              <Container>
-                <Text variant="muted" density="comfortable">
-                  {t('Set who owns alerts for this project')}
-                </Text>
-              </Container>
-            </Stack>
-            <TeamSelector
-              allowCreate
-              name="team"
-              aria-label={t('Select a Team')}
-              clearable={false}
-              placeholder={t('Select a Team')}
-              teamFilter={(tm: Team) => tm.access.includes('team:admin')}
-              value={teamSlug}
-              onChange={onTeamChange}
-            />
-          </Stack>
-        )}
-      </Grid>
-
-      {collapsible ? (
-        <ScmCollapsibleSection title={t('Alert frequency')}>
-          {alertFrequencyBody}
-        </ScmCollapsibleSection>
-      ) : (
-        <Stack gap="md">
-          <Stack gap="xs">
-            <Container>
-              <Text bold size="md" density="comfortable">
-                {t('Alert frequency')}
-              </Text>
-            </Container>
-            <Container>
-              <Text variant="muted" density="comfortable">
-                {t('Get notified when things go wrong')}
-              </Text>
-            </Container>
-          </Stack>
-          <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
-        </Stack>
       )}
-    </Stack>
+    </Grid>
   );
 }

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -1,7 +1,7 @@
 import {useState} from 'react';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {ProjectDetailsFormState} from 'sentry/components/onboarding/onboardingContext';
@@ -10,6 +10,7 @@ import {t} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {GenericFooter} from 'sentry/views/onboarding/components/genericFooter';
+import {ScmAlertFrequencySection} from 'sentry/views/onboarding/components/scmAlertFrequencySection';
 import {ScmProjectDetailsCore} from 'sentry/views/onboarding/components/scmProjectDetailsCore';
 import {
   type ScmProjectDetailsCompletion,
@@ -81,18 +82,22 @@ export function ScmProjectDetails({
         )}
       />
 
-      <ScmProjectDetailsCore
-        analyticsFlow="onboarding"
-        projectName={form.projectName}
-        onProjectNameChange={form.onProjectNameChange}
-        onProjectNameBlur={form.onProjectNameBlur}
-        teamSlug={form.teamSlug}
-        onTeamChange={form.onTeamChange}
-        alertRuleConfig={form.alertRuleConfig}
-        onAlertChange={form.onAlertChange}
-        isOrgMemberWithNoAccess={form.isOrgMemberWithNoAccess}
-        contentMaxWidth={SCM_STEP_CONTENT_WIDTH}
-      />
+      <Stack gap="3xl" width="100%" maxWidth={SCM_STEP_CONTENT_WIDTH}>
+        <ScmProjectDetailsCore
+          analyticsFlow="onboarding"
+          projectName={form.projectName}
+          onProjectNameChange={form.onProjectNameChange}
+          onProjectNameBlur={form.onProjectNameBlur}
+          teamSlug={form.teamSlug}
+          onTeamChange={form.onTeamChange}
+          isOrgMemberWithNoAccess={form.isOrgMemberWithNoAccess}
+        />
+        <ScmAlertFrequencySection
+          analyticsFlow="onboarding"
+          alertRuleConfig={form.alertRuleConfig}
+          onAlertChange={form.onAlertChange}
+        />
+      </Stack>
 
       <GenericFooter gap="3xl" padding="0 3xl">
         <Flex align="center">{genBackButton?.()}</Flex>

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -308,7 +308,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
               padding="xl"
             >
               <Heading as="h3">{t('Project details')}</Heading>
-              <Stack gap="3xl">
+              <Stack gap="2xl">
                 <ScmProjectDetailsCore
                   analyticsFlow="project-creation"
                   projectName={form.projectName}

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -22,6 +22,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useSessionStorage, writeStorageValue} from 'sentry/utils/useSessionStorage';
+import {ScmAlertFrequencySection} from 'sentry/views/onboarding/components/scmAlertFrequencySection';
 import {ScmIntegrationConnect} from 'sentry/views/onboarding/components/scmIntegrationConnect';
 import {ScmPlatformFeaturesCore} from 'sentry/views/onboarding/components/scmPlatformFeaturesCore';
 import {ScmProjectDetailsCore} from 'sentry/views/onboarding/components/scmProjectDetailsCore';
@@ -307,17 +308,22 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
               padding="xl"
             >
               <Heading as="h3">{t('Project details')}</Heading>
-              <ScmProjectDetailsCore
-                analyticsFlow="project-creation"
-                projectName={form.projectName}
-                onProjectNameChange={form.onProjectNameChange}
-                onProjectNameBlur={form.onProjectNameBlur}
-                teamSlug={form.teamSlug}
-                onTeamChange={form.onTeamChange}
-                alertRuleConfig={form.alertRuleConfig}
-                onAlertChange={form.onAlertChange}
-                isOrgMemberWithNoAccess={form.isOrgMemberWithNoAccess}
-              />
+              <Stack gap="3xl">
+                <ScmProjectDetailsCore
+                  analyticsFlow="project-creation"
+                  projectName={form.projectName}
+                  onProjectNameChange={form.onProjectNameChange}
+                  onProjectNameBlur={form.onProjectNameBlur}
+                  teamSlug={form.teamSlug}
+                  onTeamChange={form.onTeamChange}
+                  isOrgMemberWithNoAccess={form.isOrgMemberWithNoAccess}
+                />
+                <ScmAlertFrequencySection
+                  analyticsFlow="project-creation"
+                  alertRuleConfig={form.alertRuleConfig}
+                  onAlertChange={form.onAlertChange}
+                />
+              </Stack>
             </MotionStack>
           </LayoutGroup>
 


### PR DESCRIPTION
## TLDR

Extracts the alert-frequency section out of `ScmProjectDetailsCore` into a new `ScmAlertFrequencySection`, rendered as a sibling rather than nested. The onboarding flow is unchanged in styling and behavior.

## Details

- `ScmProjectDetailsCore` is now just the project name and team grid; its alert props (`alertRuleConfig`, `onAlertChange`) and `contentMaxWidth` are gone.
- `ScmAlertFrequencySection` owns the collapsible-vs-always-expanded branch: project creation folds it behind a toggle, onboarding keeps it always expanded.
- Both hosts render the two side by side inside a `Stack gap="3xl"`, preserving the original spacing between the field grid and the alert section. The onboarding host also carries the step content max width on that wrapper.
- `step_viewed` analytics stays in `ScmProjectDetailsCore` so the step is counted once; field-level alert analytics already lives in `useScmProjectDetails`.

State ownership is unchanged: `useScmProjectDetails` still owns the form, and the host passes `alertRuleConfig`/`onAlertChange` to the new sibling.

Refs VDY-77
