### PR TITLE
fix(issues): Tighten multi-select form state (jira)

### DIFF
--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.spec.tsx
@@ -293,6 +293,30 @@ describe('BackendJsonSubmitForm', () => {
       expect(onSubmit).not.toHaveBeenCalled();
     });
 
+    it('blocks submission when a required multi-select field is empty', async () => {
+      render(
+        <BackendJsonSubmitForm
+          fields={[
+            {
+              name: 'labels',
+              type: 'select',
+              label: 'Labels',
+              multiple: true,
+              required: true,
+              choices: [['bug', 'Bug']],
+            },
+          ]}
+          onSubmit={onSubmit}
+          submitLabel="Create"
+        />,
+        {organization: org}
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Create'}));
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
     it('blocks submission when required fields contain only whitespace', async () => {
       render(
         <BackendJsonSubmitForm
@@ -681,6 +705,49 @@ describe('BackendJsonSubmitForm', () => {
         expect(onSubmit).toHaveBeenCalledWith(
           expect.objectContaining({title: 'User title', priority: 'high'})
         );
+      });
+    });
+
+    it('resets static select values when fields change and choices become empty', async () => {
+      const firstFields: JsonFormAdapterFieldConfig[] = [
+        {
+          name: 'version',
+          type: 'select',
+          label: 'Version',
+          choices: [['v1', 'Version 1']],
+          default: 'v1',
+        },
+      ];
+      const secondFields: JsonFormAdapterFieldConfig[] = [
+        {
+          name: 'version',
+          type: 'select',
+          label: 'Version',
+          choices: [],
+        },
+      ];
+
+      const {rerender} = render(
+        <BackendJsonSubmitForm
+          fields={firstFields}
+          onSubmit={onSubmit}
+          submitLabel="Create"
+        />,
+        {organization: org}
+      );
+
+      rerender(
+        <BackendJsonSubmitForm
+          fields={secondFields}
+          onSubmit={onSubmit}
+          submitLabel="Create"
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Create'}));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({version: null}));
       });
     });
 

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -137,6 +137,13 @@ function buildValidationSchema(fields: JsonFormAdapterFieldConfig[]) {
           if (val === null || val === undefined) {
             return false;
           }
+          if (
+            (field.type === 'select' || field.type === 'choice') &&
+            field.multiple &&
+            Array.isArray(val)
+          ) {
+            return val.length > 0;
+          }
           if (typeof val === 'string') {
             return val.trim() !== '';
           }

--- a/static/app/components/externalIssues/ticketRuleModal.spec.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.spec.tsx
@@ -225,6 +225,29 @@ describe('ProjectAlerts -> TicketRuleModal', () => {
       await submitSuccess();
     });
 
+    it('should keep available multi select values when saved values are partially unavailable', async () => {
+      await renderTicketRuleModal(
+        {data: {components: ['a', 'stale']}},
+        {
+          name: 'components',
+          label: 'Components',
+          default: undefined,
+          type: 'select',
+          multiple: true,
+          required: false,
+          choices: [
+            ['a', 'a'],
+            ['b', 'b'],
+          ],
+        }
+      );
+
+      await submitSuccess();
+
+      const formData = onSubmitAction.mock.calls[0][0];
+      expect(formData.components).toEqual(['a']);
+    });
+
     it('should not persist value when unavailable in new choices', async () => {
       await renderTicketRuleModal({data: {reporter: 'a'}});
 

--- a/static/app/components/externalIssues/ticketRuleModal.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.tsx
@@ -13,6 +13,11 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import type {RequestOptions} from 'sentry/api';
 import {BackendJsonSubmitForm} from 'sentry/components/backendJsonFormAdapter/backendJsonSubmitForm';
 import type {JsonFormAdapterFieldConfig} from 'sentry/components/backendJsonFormAdapter/types';
+import {
+  applySavedDefaultToField,
+  getSavedChoicesMap,
+  STATIC_TICKET_FIELDS,
+} from 'sentry/components/externalIssues/ticketRuleModalUtils';
 import {useDynamicFields} from 'sentry/components/externalIssues/useDynamicFields';
 import {getConfigName} from 'sentry/components/externalIssues/utils';
 import type {FieldValue} from 'sentry/components/forms/types';
@@ -292,96 +297,25 @@ export function TicketRuleModal({
    * disabled inputs, and use the cached dynamic choices.
    */
   const cleanFields = useMemo((): JsonFormAdapterFieldConfig[] => {
-    const staticFields: JsonFormAdapterFieldConfig[] = [
-      {
-        name: 'title',
-        label: 'Title',
-        type: 'string',
-        default: 'This will be the same as the Sentry Issue.',
-        disabled: true,
-      },
-      {
-        name: 'description',
-        label: 'Description',
-        type: 'string',
-        default: 'This will be generated from the Sentry Issue details.',
-        disabled: true,
-      },
-    ];
-
-    // Build a map of saved choices from instance.dynamic_form_fields so we can
-    // restore async select options that were previously fetched via search.
-    const savedFields = Object.values(instance?.dynamic_form_fields || {});
-    const savedChoicesMap = new Map(
-      savedFields
-        .filter(
-          (f): f is IssueConfigField =>
-            typeof f === 'object' &&
-            f !== null &&
-            'url' in f &&
-            'choices' in f &&
-            Array.isArray(f.choices) &&
-            f.choices.length > 0
-        )
-        .map(f => [f.name, f.choices as Choices])
-    );
-
+    const savedChoicesMap = getSavedChoicesMap(instance);
     const configFields = (integrationDetails?.[getConfigName(action)] ||
       []) as JsonFormAdapterFieldConfig[];
 
     const cleanedFields = configFields
       // Don't overwrite the default values for title and description.
-      .filter(field => !staticFields.some(f => f.name === field.name))
+      .filter(field => !STATIC_TICKET_FIELDS.some(f => f.name === field.name))
       .map(field => {
-        // We only need to do the below operation if the form has not been modified.
         if (!showInstanceValues) {
           return field;
         }
-        // Overwrite defaults with previously selected values if they exist.
-        const prevChoice = instance?.[field.name];
 
-        if (!prevChoice) {
-          return field;
-        }
-
-        let defaultChoice = prevChoice;
-        let shouldDefaultChoice = true;
-
-        if (field.type === 'select' || field.type === 'choice') {
-          // For async select fields, always trust the saved value — choices
-          // are fetched dynamically and won't be in the static choices list.
-          if ('url' in field && field.url) {
-            shouldDefaultChoice = true;
-          } else {
-            const choices = field.choices || [];
-            if (Array.isArray(prevChoice)) {
-              defaultChoice = prevChoice.filter(value =>
-                choices.some(tuple => tuple[0] === value)
-              );
-              shouldDefaultChoice = defaultChoice.length > 0;
-            } else {
-              shouldDefaultChoice = choices.some(item => item[0] === prevChoice);
-            }
-          }
-        }
-
-        if (shouldDefaultChoice) {
-          // For async fields, also restore saved choices so the select can
-          // display the label for the saved value.
-          const savedChoices = savedChoicesMap.get(field.name);
-          if (savedChoices && 'url' in field && field.url) {
-            return {
-              ...field,
-              default: defaultChoice,
-              choices: savedChoices as Array<[string, string]>,
-            };
-          }
-          return {...field, default: defaultChoice};
-        }
-
-        return field;
+        return applySavedDefaultToField({
+          field,
+          savedValue: instance?.[field.name],
+          savedChoicesMap,
+        });
       });
-    return [...staticFields, ...cleanedFields];
+    return [...STATIC_TICKET_FIELDS, ...cleanedFields];
   }, [instance, integrationDetails, showInstanceValues]);
 
   const formErrors = useMemo(() => {

--- a/static/app/components/externalIssues/ticketRuleModal.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.tsx
@@ -344,6 +344,7 @@ export function TicketRuleModal({
           return field;
         }
 
+        let defaultChoice = prevChoice;
         let shouldDefaultChoice = true;
 
         if (field.type === 'select' || field.type === 'choice') {
@@ -353,9 +354,14 @@ export function TicketRuleModal({
             shouldDefaultChoice = true;
           } else {
             const choices = field.choices || [];
-            shouldDefaultChoice = !!(Array.isArray(prevChoice)
-              ? prevChoice.every(value => choices.some(tuple => tuple[0] === value))
-              : choices.some(item => item[0] === prevChoice));
+            if (Array.isArray(prevChoice)) {
+              defaultChoice = prevChoice.filter(value =>
+                choices.some(tuple => tuple[0] === value)
+              );
+              shouldDefaultChoice = defaultChoice.length > 0;
+            } else {
+              shouldDefaultChoice = choices.some(item => item[0] === prevChoice);
+            }
           }
         }
 
@@ -366,11 +372,11 @@ export function TicketRuleModal({
           if (savedChoices && 'url' in field && field.url) {
             return {
               ...field,
-              default: prevChoice,
+              default: defaultChoice,
               choices: savedChoices as Array<[string, string]>,
             };
           }
-          return {...field, default: prevChoice};
+          return {...field, default: defaultChoice};
         }
 
         return field;

--- a/static/app/components/externalIssues/ticketRuleModalUtils.ts
+++ b/static/app/components/externalIssues/ticketRuleModalUtils.ts
@@ -1,0 +1,108 @@
+import type {JsonFormAdapterFieldConfig} from 'sentry/components/backendJsonFormAdapter/types';
+import type {TicketActionData} from 'sentry/types/alerts';
+import type {Choices} from 'sentry/types/core';
+import type {IssueConfigField} from 'sentry/types/integrations';
+
+export const STATIC_TICKET_FIELDS: JsonFormAdapterFieldConfig[] = [
+  {
+    name: 'title',
+    label: 'Title',
+    type: 'string',
+    default: 'This will be the same as the Sentry Issue.',
+    disabled: true,
+  },
+  {
+    name: 'description',
+    label: 'Description',
+    type: 'string',
+    default: 'This will be generated from the Sentry Issue details.',
+    disabled: true,
+  },
+];
+
+function isSelectField(
+  field: JsonFormAdapterFieldConfig
+): field is Extract<JsonFormAdapterFieldConfig, {type: 'select' | 'choice'}> {
+  return field.type === 'select' || field.type === 'choice';
+}
+
+function isAsyncSelectField(field: JsonFormAdapterFieldConfig): field is Extract<
+  JsonFormAdapterFieldConfig,
+  {type: 'select' | 'choice'}
+> & {
+  url: string;
+} {
+  return isSelectField(field) && Boolean(field.url);
+}
+
+export function getSavedChoicesMap(instance: TicketActionData) {
+  const savedFields = Object.values(instance?.dynamic_form_fields || {});
+
+  return new Map(
+    savedFields
+      .filter(
+        (field): field is IssueConfigField =>
+          typeof field === 'object' &&
+          field !== null &&
+          'url' in field &&
+          'choices' in field &&
+          Array.isArray(field.choices) &&
+          field.choices.length > 0
+      )
+      .map(field => [field.name, field.choices as Choices])
+  );
+}
+
+function getSavedDefaultValue(field: JsonFormAdapterFieldConfig, savedValue: unknown) {
+  if (!savedValue) {
+    return null;
+  }
+
+  if (!isSelectField(field) || isAsyncSelectField(field)) {
+    return savedValue;
+  }
+
+  const choices = field.choices || [];
+
+  if (Array.isArray(savedValue)) {
+    const availableValues = savedValue.filter(value =>
+      choices.some(([choiceValue]) => choiceValue === value)
+    );
+    return availableValues.length > 0 ? availableValues : null;
+  }
+
+  return choices.some(([choiceValue]) => choiceValue === savedValue) ? savedValue : null;
+}
+
+function withFieldDefault(
+  field: JsonFormAdapterFieldConfig,
+  defaultValue: unknown
+): JsonFormAdapterFieldConfig {
+  return {...field, default: defaultValue} as JsonFormAdapterFieldConfig;
+}
+
+export function applySavedDefaultToField({
+  field,
+  savedValue,
+  savedChoicesMap,
+}: {
+  field: JsonFormAdapterFieldConfig;
+  savedChoicesMap: Map<string, Choices>;
+  savedValue: unknown;
+}): JsonFormAdapterFieldConfig {
+  const defaultValue = getSavedDefaultValue(field, savedValue);
+
+  if (defaultValue === null) {
+    return field;
+  }
+
+  const savedChoices = savedChoicesMap.get(field.name);
+  if (savedChoices && isAsyncSelectField(field)) {
+    return withFieldDefault(
+      {...field, choices: savedChoices as Array<[string, string]>},
+      defaultValue
+    );
+  }
+
+  return withFieldDefault(field, defaultValue);
+}


### PR DESCRIPTION
- Block required multi-select fields from submitting an empty array.
- Preserve still-valid saved multi-select values when old options disappear.
- Keep async select saved choices available so labels render when reopening ticket rules.
- Move the ticket rule saved-default reconciliation into a small helper module.