### PR TITLE
feat(seer-infra-telemetry): Add get monitoring provider connections RPC

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -62,6 +62,7 @@ from sentry.models.pullrequest import (
     PullRequestAttributionSource,
 )
 from sentry.models.repository import Repository
+from sentry.organizations.services.organization import organization_service
 from sentry.pr_metrics.attribution import (
     DELEGATED_SIGNAL_TYPES,
     DelegatedAgentSignalDetails,
@@ -947,8 +948,17 @@ def get_monitoring_provider_connections(
     except Organization.DoesNotExist:
         return MonitoringProviderConnectionsResponse(connections=[])
 
-    connections = fetch_monitoring_provider_connections(organization, user_id)
-    return MonitoringProviderConnectionsResponse(connections=connections)
+    if (
+        organization_service.check_membership_by_id(
+            organization_id=organization_id, user_id=user_id
+        )
+        is None
+    ):
+        return MonitoringProviderConnectionsResponse(connections=[])
+
+    return MonitoringProviderConnectionsResponse(
+        connections=fetch_monitoring_provider_connections(organization, user_id)
+    )
 
 
 def refresh_monitoring_provider_token(

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -73,6 +73,9 @@ from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
 from sentry.search.events.types import SnubaParams
+from sentry.seer.agent.client import (
+    get_monitoring_provider_connections as fetch_monitoring_provider_connections,
+)
 from sentry.seer.agent.custom_tool_utils import call_custom_tool
 from sentry.seer.agent.feature_delivery import DELIVERY_HANDLERS, FeatureRunStatus
 from sentry.seer.agent.index_data import (
@@ -138,6 +141,7 @@ from sentry.seer.sentry_data_models import (
     GitHubEnterpriseConfigErrorResponse,
     GitHubEnterpriseConfigSuccessResponse,
     HasRepoCodeMappingsResponse,
+    MonitoringProviderConnectionsResponse,
     OrganizationAutofixConsentResponse,
     OrganizationFeaturesResponse,
     OrganizationProject,
@@ -934,6 +938,19 @@ def deliver_feature_result(
     handler(organization_id, run_uuid, status, result, error)
 
 
+def get_monitoring_provider_connections(
+    *, organization_id: int, user_id: int
+) -> MonitoringProviderConnectionsResponse:
+    """Fetch the user's connected monitoring provider identities."""
+    try:
+        organization = Organization.objects.get_from_cache(id=organization_id)
+    except Organization.DoesNotExist:
+        return MonitoringProviderConnectionsResponse(connections=[])
+
+    connections = fetch_monitoring_provider_connections(organization, user_id)
+    return MonitoringProviderConnectionsResponse(connections=connections)
+
+
 def refresh_monitoring_provider_token(
     *, identity_id: int
 ) -> RefreshMonitoringProviderTokenSuccessResponse | RefreshMonitoringProviderTokenErrorResponse:
@@ -1149,6 +1166,7 @@ seer_method_registry: dict[str, SeerRpcMethod] = {  # return type must be serial
     "update_pr_metrics": seer_rpc(update_pr_metrics),
     #
     # Monitoring provider tokens (MCP)
+    "get_monitoring_provider_connections": seer_rpc(get_monitoring_provider_connections),
     "refresh_monitoring_provider_token": seer_rpc(refresh_monitoring_provider_token),
     #
     # LLM Proxy

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -869,6 +869,27 @@ class ExecuteTimeseriesQueryErrorResponse(BaseModel):
         return id(self)
 
 
+class MonitoringProviderConnectionData(BaseModel):
+    provider_key: str
+    url: str
+    encrypted_access_token: str
+    identity_id: int
+
+    def __getitem__(self, key: str) -> Any:
+        return self.dict()[key]
+
+
+class MonitoringProviderConnectionsResponse(BaseModel):
+    """`get_monitoring_provider_connections` success: the caller's connected
+    monitoring provider identities, each carrying a freshly-encrypted access
+    token."""
+
+    connections: list[MonitoringProviderConnectionData]
+
+    def __getitem__(self, key: str) -> Any:
+        return self.dict()[key]
+
+
 class RefreshMonitoringProviderTokenSuccessResponse(BaseModel):
     """`refresh_monitoring_provider_token` success: the freshly-encrypted access
     token plus the Unix-second expiry the OAuth2 base helper stamps onto

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -27,6 +27,7 @@ from sentry.seer.endpoints.seer_rpc import (
     generate_request_signature,
     get_attributes_for_span,
     get_github_enterprise_integration_config,
+    get_monitoring_provider_connections,
     get_organization_features,
     get_project_preferences,
     get_repo_installation_id,
@@ -1695,6 +1696,39 @@ class TestGetOrganizationFeatures(APITestCase):
         with self.feature("organizations:seer-agent-source-code-search"):
             result = get_organization_features(org_id=self.organization.id, user_id=0)
         assert result.dict() == {"features": ["seer-agent-source-code-search"]}
+
+
+@override_settings(SEER_GHE_ENCRYPT_KEY=TEST_FERNET_KEY)
+@with_feature("organizations:seer-infra-telemetry")
+@cell_silo_test
+class TestGetMonitoringProviderConnections(APITestCase):
+    def test_returns_connections(self) -> None:
+        idp = self.create_identity_provider(type="datadog", external_id="org-uuid-1")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-user-1",
+            data={"access_token": "access-token", "site": "datadoghq.com"},
+        )
+
+        result = get_monitoring_provider_connections(
+            organization_id=self.organization.id, user_id=self.user.id
+        )
+
+        assert len(result.connections) == 1
+        connection = result.connections[0]
+        assert connection.provider_key == "datadog"
+        assert connection.url == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+        assert connection.identity_id == identity.id
+        decrypted = Fernet(TEST_FERNET_KEY.encode("utf-8")).decrypt(
+            connection.encrypted_access_token.encode("utf-8")
+        )
+        assert decrypted.decode("utf-8") == "access-token"
+
+    def test_unknown_organization_returns_empty(self) -> None:
+        result = get_monitoring_provider_connections(organization_id=999999, user_id=self.user.id)
+
+        assert result.connections == []
 
 
 @override_settings(SEER_GHE_ENCRYPT_KEY=TEST_FERNET_KEY)

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -1730,6 +1730,22 @@ class TestGetMonitoringProviderConnections(APITestCase):
 
         assert result.connections == []
 
+    def test_non_member_returns_empty(self) -> None:
+        other_org = self.create_organization()
+        idp = self.create_identity_provider(type="datadog", external_id="org-uuid-2")
+        self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-user-2",
+            data={"access_token": "access-token", "site": "datadoghq.com"},
+        )
+
+        result = get_monitoring_provider_connections(
+            organization_id=other_org.id, user_id=self.user.id
+        )
+
+        assert result.connections == []
+
 
 @override_settings(SEER_GHE_ENCRYPT_KEY=TEST_FERNET_KEY)
 @cell_silo_test


### PR DESCRIPTION
relates to CW-1513, CW-1512

Add an RPC for getting monitoring provider connections. Seer can use this to get a new list of connections after a refresh fails or we have no connections and the user updates their connections mid-run. Seer followup: https://github.com/getsentry/seer/pull/7074