### PR TITLE
ref(project-creation): Extract feature selection into a sibling component

### DIFF
--- a/static/app/views/onboarding/components/scmFeatureSelectionPanel.spec.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionPanel.spec.tsx
@@ -1,0 +1,65 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+
+import {ScmFeatureSelectionPanel} from './scmFeatureSelectionPanel';
+
+const pythonPlatform: OnboardingSelectedSDK = {
+  key: 'python',
+  name: 'Python',
+  language: 'python',
+  type: 'language',
+  link: 'https://docs.sentry.io/platforms/python/',
+  category: 'popular',
+};
+
+function defaultProps(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    analyticsFlow: 'onboarding' as const,
+    selectedRepository: undefined,
+    selectedPlatform: pythonPlatform,
+    selectedFeatures: [ProductSolution.ERROR_MONITORING],
+    onFeaturesChange: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('ScmFeatureSelectionPanel', () => {
+  const organization = OrganizationFixture({
+    features: ['performance-view', 'session-replay', 'profiling-view'],
+  });
+
+  it('shows the trial banner and per-feature volumes during onboarding', async () => {
+    render(
+      <ScmFeatureSelectionPanel {...defaultProps({analyticsFlow: 'onboarding'})} />,
+      {
+        organization,
+      }
+    );
+
+    expect(
+      await screen.findByText('What do you want to instrument?')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/unlimited volume for 14 days/)).toBeInTheDocument();
+    expect(screen.getByText('5,000 errors / mo')).toBeInTheDocument();
+  });
+
+  it('hides the trial banner and per-feature volumes outside onboarding', async () => {
+    render(
+      <ScmFeatureSelectionPanel {...defaultProps({analyticsFlow: 'project-creation'})} />,
+      {organization}
+    );
+
+    // Feature cards still render, just without the trial/billing framing.
+    expect(
+      await screen.findByText('What do you want to instrument?')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', {name: /Tracing/})).toBeInTheDocument();
+
+    expect(screen.queryByText(/unlimited volume for 14 days/)).not.toBeInTheDocument();
+    expect(screen.queryByText('5,000 errors / mo')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/onboarding/components/scmFeatureSelectionPanel.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionPanel.tsx
@@ -1,0 +1,232 @@
+import {useCallback, useMemo} from 'react';
+import {motion} from 'framer-motion';
+
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getDisabledProducts,
+  platformProductAvailability,
+} from 'sentry/components/onboarding/productSelection';
+import {PLATFORM_PRODUCT_INFO} from 'sentry/data/platformProductInfo.generated';
+import {IconBusiness} from 'sentry/icons';
+import {tct} from 'sentry/locale';
+import type {Repository} from 'sentry/types/integrations';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
+import {ScmFeatureInfoCards} from './scmFeatureInfoCards';
+import {ScmFeatureSelectionCards} from './scmFeatureSelectionCards';
+import {
+  FEATURE_DISPLAY_ORDER,
+  getPlatformInfo,
+  getPlatformName,
+  type ResolvedPlatform,
+} from './scmPlatformHelpers';
+import {useScmFeatureMeta} from './useScmFeatureMeta';
+import {useScmPlatformDetection} from './useScmPlatformDetection';
+
+const FEATURE_TOGGLED_EVENT = {
+  onboarding: 'onboarding.scm_platform_feature_toggled',
+  'project-creation': 'project_creation.scm_platform_feature_toggled',
+} as const;
+
+interface ScmFeatureSelectionPanelProps {
+  analyticsFlow: ScmAnalyticsFlow;
+  onFeaturesChange: (features: ProductSolution[] | undefined) => void;
+  selectedFeatures: ProductSolution[] | undefined;
+  selectedPlatform: OnboardingSelectedSDK | undefined;
+  selectedRepository: Repository | undefined;
+}
+
+/**
+ * Feature selection for the resolved platform, rendered as a sibling of
+ * `ScmPlatformFeaturesCore`. Toggleable cards for platforms whose products are
+ * user-configurable, informational cards for wizard-driven platforms, and
+ * nothing when the platform has no product info. The resolved platform is the
+ * host's explicit selection or, before that commits, the first auto-detected
+ * platform — re-derived here from the same (deduped) detection query Core uses.
+ * Owns the feature-toggled analytic; renders nothing for an unresolved platform.
+ */
+export function ScmFeatureSelectionPanel({
+  analyticsFlow,
+  onFeaturesChange,
+  selectedFeatures,
+  selectedPlatform,
+  selectedRepository,
+}: ScmFeatureSelectionPanelProps) {
+  const organization = useOrganization();
+  // Trial/billing framing (the "unlimited volume" banner and per-feature volume
+  // limits) only makes sense during new-org onboarding, where a fresh trial is
+  // always active. In SCM-first project creation the viewer is an existing org
+  // on an unknown plan, so we hide that framing rather than show numbers that
+  // may not apply.
+  const isOnboarding = analyticsFlow === 'onboarding';
+  const {meta: featureMeta, isLoading: isFeatureMetaLoading} = useScmFeatureMeta();
+
+  const {detectedPlatforms} = useScmPlatformDetection(selectedRepository);
+
+  const currentFeatures = useMemo(
+    () => selectedFeatures ?? [ProductSolution.ERROR_MONITORING],
+    [selectedFeatures]
+  );
+
+  // Mirror Core's platform resolution so the cards stay in sync during the brief
+  // window before an auto-detected platform is committed to the host.
+  const detectedPlatformKey = useMemo(
+    () =>
+      detectedPlatforms.reduce<ResolvedPlatform[]>((acc, detected) => {
+        const info = getPlatformInfo(detected.platform);
+        if (info) {
+          acc.push({...detected, info});
+        }
+        return acc;
+      }, [])[0]?.platform,
+    [detectedPlatforms]
+  );
+  const currentPlatformKey = selectedPlatform?.key ?? detectedPlatformKey;
+  const currentPlatformName = getPlatformName(currentPlatformKey);
+
+  // Wizard-driven platforms render an informational variant since the wizard CLI
+  // owns product configuration and toggles aren't actionable.
+  const featureMode = useMemo<'toggleable' | 'informational' | 'none'>(() => {
+    if (!currentPlatformKey) {
+      return 'none';
+    }
+    if (currentPlatformKey in platformProductAvailability) {
+      return 'toggleable';
+    }
+    if (currentPlatformKey in PLATFORM_PRODUCT_INFO) {
+      return 'informational';
+    }
+    return 'none';
+  }, [currentPlatformKey]);
+
+  const availableFeatures = useMemo(() => {
+    if (!currentPlatformKey || featureMode === 'none') {
+      return [];
+    }
+    const sourceProducts =
+      featureMode === 'toggleable'
+        ? platformProductAvailability[currentPlatformKey]
+        : PLATFORM_PRODUCT_INFO[currentPlatformKey];
+    const features = new Set<ProductSolution>([
+      ProductSolution.ERROR_MONITORING,
+      ...(sourceProducts ?? []),
+    ]);
+    return FEATURE_DISPLAY_ORDER.filter(f => features.has(f));
+  }, [currentPlatformKey, featureMode]);
+
+  const disabledProducts = useMemo(
+    () => getDisabledProducts(organization),
+    [organization]
+  );
+
+  const handleToggleFeature = useCallback(
+    (feature: ProductSolution) => {
+      if (disabledProducts[feature]) {
+        disabledProducts[feature]?.onClick?.();
+        return;
+      }
+
+      const wasEnabled = currentFeatures.includes(feature);
+      const newFeatures = new Set(
+        wasEnabled
+          ? currentFeatures.filter(f => f !== feature)
+          : [...currentFeatures, feature]
+      );
+
+      // Profiling requires tracing — mirror the constraint from ProductSelection
+      if (availableFeatures.includes(ProductSolution.PROFILING)) {
+        if (
+          feature === ProductSolution.PROFILING &&
+          newFeatures.has(ProductSolution.PROFILING)
+        ) {
+          newFeatures.add(ProductSolution.PERFORMANCE_MONITORING);
+        } else if (
+          feature === ProductSolution.PERFORMANCE_MONITORING &&
+          !newFeatures.has(ProductSolution.PERFORMANCE_MONITORING)
+        ) {
+          newFeatures.delete(ProductSolution.PROFILING);
+        }
+      }
+
+      onFeaturesChange(Array.from(newFeatures));
+
+      trackAnalytics(FEATURE_TOGGLED_EVENT[analyticsFlow], {
+        organization,
+        feature,
+        enabled: !wasEnabled,
+        platform: currentPlatformKey ?? '',
+      });
+    },
+    [
+      currentFeatures,
+      onFeaturesChange,
+      disabledProducts,
+      availableFeatures,
+      organization,
+      currentPlatformKey,
+      analyticsFlow,
+    ]
+  );
+
+  if (featureMode === 'none') {
+    return null;
+  }
+
+  return (
+    <MotionStack layout="position" width="100%">
+      <Stack gap="2xl" paddingTop="xs">
+        {isOnboarding && (
+          <Flex
+            padding="lg"
+            background="secondary"
+            border="secondary"
+            radius="md"
+            gap="lg"
+          >
+            <IconBusiness size="lg" variant="accent" />
+            <Text size="md" density="comfortable">
+              {tct(
+                'You’ve got [bold:unlimited volume for 14 days] to try out everything. After that, free plan volumes apply ⋅ No credit card required',
+                {
+                  bold: (
+                    <Text as="span" bold variant="accent">
+                      {null}
+                    </Text>
+                  ),
+                }
+              )}
+            </Text>
+          </Flex>
+        )}
+        {featureMode === 'toggleable' ? (
+          <ScmFeatureSelectionCards
+            availableFeatures={availableFeatures}
+            selectedFeatures={currentFeatures}
+            disabledProducts={disabledProducts}
+            onToggleFeature={handleToggleFeature}
+            featureMeta={featureMeta}
+            isVolumeLoading={isFeatureMetaLoading}
+            showVolume={isOnboarding}
+          />
+        ) : (
+          <ScmFeatureInfoCards
+            availableFeatures={availableFeatures}
+            disabledProducts={disabledProducts}
+            featureMeta={featureMeta}
+            platformName={currentPlatformName}
+            isVolumeLoading={isFeatureMetaLoading}
+            showVolume={isOnboarding}
+          />
+        )}
+      </Stack>
+    </MotionStack>
+  );
+}
+
+const MotionStack = motion.create(Stack);

--- a/static/app/views/onboarding/components/scmFeatureSelectionPanel.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionPanel.tsx
@@ -21,13 +21,12 @@ import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
 import {ScmFeatureInfoCards} from './scmFeatureInfoCards';
 import {ScmFeatureSelectionCards} from './scmFeatureSelectionCards';
 import {
+  DEFAULT_SCM_FEATURES,
   FEATURE_DISPLAY_ORDER,
-  getPlatformInfo,
   getPlatformName,
-  type ResolvedPlatform,
 } from './scmPlatformHelpers';
 import {useScmFeatureMeta} from './useScmFeatureMeta';
-import {useScmPlatformDetection} from './useScmPlatformDetection';
+import {useScmResolvedPlatform} from './useScmResolvedPlatform';
 
 const FEATURE_TOGGLED_EVENT = {
   onboarding: 'onboarding.scm_platform_feature_toggled',
@@ -67,27 +66,15 @@ export function ScmFeatureSelectionPanel({
   const isOnboarding = analyticsFlow === 'onboarding';
   const {meta: featureMeta, isLoading: isFeatureMetaLoading} = useScmFeatureMeta();
 
-  const {detectedPlatforms} = useScmPlatformDetection(selectedRepository);
-
   const currentFeatures = useMemo(
-    () => selectedFeatures ?? [ProductSolution.ERROR_MONITORING],
+    () => selectedFeatures ?? DEFAULT_SCM_FEATURES,
     [selectedFeatures]
   );
 
-  // Mirror Core's platform resolution so the cards stay in sync during the brief
-  // window before an auto-detected platform is committed to the host.
-  const detectedPlatformKey = useMemo(
-    () =>
-      detectedPlatforms.reduce<ResolvedPlatform[]>((acc, detected) => {
-        const info = getPlatformInfo(detected.platform);
-        if (info) {
-          acc.push({...detected, info});
-        }
-        return acc;
-      }, [])[0]?.platform,
-    [detectedPlatforms]
-  );
-  const currentPlatformKey = selectedPlatform?.key ?? detectedPlatformKey;
+  const {currentPlatformKey} = useScmResolvedPlatform({
+    selectedPlatform,
+    selectedRepository,
+  });
   const currentPlatformName = getPlatformName(currentPlatformKey);
 
   // Wizard-driven platforms render an informational variant since the wizard CLI

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
@@ -2,8 +2,8 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import * as analytics from 'sentry/utils/analytics';
 
 import {ScmPlatformFeaturesCore} from './scmPlatformFeaturesCore';
 
@@ -50,7 +50,6 @@ function defaultProps(overrides: Partial<Record<string, unknown>> = {}) {
     analyticsFlow: 'onboarding' as const,
     selectedRepository: undefined,
     selectedPlatform: pythonPlatform,
-    selectedFeatures: [ProductSolution.ERROR_MONITORING],
     onPlatformChange: jest.fn(),
     onFeaturesChange: jest.fn(),
     onClearProjectDetailsForm: jest.fn(),
@@ -59,42 +58,30 @@ function defaultProps(overrides: Partial<Record<string, unknown>> = {}) {
 }
 
 describe('ScmPlatformFeaturesCore', () => {
-  const organization = OrganizationFixture({
-    features: ['performance-view', 'session-replay', 'profiling-view'],
+  const organization = OrganizationFixture();
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
-  describe('trial/billing framing', () => {
-    it('shows the trial banner and per-feature volumes during onboarding', async () => {
-      render(
-        <ScmPlatformFeaturesCore {...defaultProps({analyticsFlow: 'onboarding'})} />,
-        {
-          organization,
-        }
-      );
+  it('renders the manual platform picker when no repository is connected', () => {
+    render(<ScmPlatformFeaturesCore {...defaultProps()} />, {organization});
 
-      expect(
-        await screen.findByText('What do you want to instrument?')
-      ).toBeInTheDocument();
-      expect(screen.getByText(/unlimited volume for 14 days/)).toBeInTheDocument();
-      expect(screen.getByText('5,000 errors / mo')).toBeInTheDocument();
-    });
+    expect(screen.getByText('Select a platform')).toBeInTheDocument();
+  });
 
-    it('hides the trial banner and per-feature volumes outside onboarding', async () => {
-      render(
-        <ScmPlatformFeaturesCore
-          {...defaultProps({analyticsFlow: 'project-creation'})}
-        />,
-        {organization}
-      );
+  it('fires step_viewed analytics for the given flow on mount', () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    render(
+      <ScmPlatformFeaturesCore {...defaultProps({analyticsFlow: 'project-creation'})} />,
+      {
+        organization,
+      }
+    );
 
-      // Feature cards still render, just without the trial/billing framing.
-      expect(
-        await screen.findByText('What do you want to instrument?')
-      ).toBeInTheDocument();
-      expect(screen.getByRole('checkbox', {name: /Tracing/})).toBeInTheDocument();
-
-      expect(screen.queryByText(/unlimited volume for 14 days/)).not.toBeInTheDocument();
-      expect(screen.queryByText('5,000 errors / mo')).not.toBeInTheDocument();
-    });
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.scm_platform_features_step_viewed',
+      expect.anything()
+    );
   });
 });

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -10,7 +10,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {closeModal, openConsoleModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {IconBroadcast} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
@@ -23,15 +23,15 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
 import {ScmPlatformCard} from './scmPlatformCard';
 import {
+  DEFAULT_SCM_FEATURES,
   getPlatformInfo,
   platformOptions,
-  type ResolvedPlatform,
   shouldSuggestFramework,
   toSelectedSdk,
 } from './scmPlatformHelpers';
 import {ScmSearchControl} from './scmSearchControl';
 import {ScmVirtualizedMenuList} from './scmVirtualizedMenuList';
-import {useScmPlatformDetection} from './useScmPlatformDetection';
+import {useScmResolvedPlatform} from './useScmResolvedPlatform';
 
 const STEP_VIEWED_EVENT = {
   onboarding: 'onboarding.scm_platform_features_step_viewed',
@@ -114,26 +114,12 @@ export function ScmPlatformFeaturesCore({
   const hasScmConnected = !!selectedRepository;
 
   const {
-    detectedPlatforms,
-    isPending: isDetecting,
-    isError: isDetectionError,
-  } = useScmPlatformDetection(selectedRepository);
-
-  const resolvedPlatforms = useMemo(
-    () =>
-      detectedPlatforms.reduce<ResolvedPlatform[]>((acc, detected) => {
-        const info = getPlatformInfo(detected.platform);
-        if (info) {
-          acc.push({...detected, info});
-        }
-        return acc;
-      }, []),
-    [detectedPlatforms]
-  );
-
-  const detectedPlatformKey = resolvedPlatforms[0]?.platform;
-  // Derive platform from explicit selection, falling back to first detected
-  const currentPlatformKey = selectedPlatform?.key ?? detectedPlatformKey;
+    resolvedPlatforms,
+    detectedPlatformKey,
+    currentPlatformKey,
+    isDetecting,
+    isDetectionError,
+  } = useScmResolvedPlatform({selectedPlatform, selectedRepository});
 
   // Adopt the first detected platform once per repo when the user hasn't
   // explicitly chosen one: commit it to the host so flows without a Continue
@@ -166,7 +152,7 @@ export function ScmPlatformFeaturesCore({
 
   const applyPlatformSelection = (sdk: OnboardingSelectedSDK) => {
     onPlatformChange(sdk);
-    onFeaturesChange([ProductSolution.ERROR_MONITORING]);
+    onFeaturesChange(DEFAULT_SCM_FEATURES);
     onClearProjectDetailsForm();
   };
 
@@ -226,7 +212,7 @@ export function ScmPlatformFeaturesCore({
     }
 
     setPlatform(platformKey);
-    onFeaturesChange([ProductSolution.ERROR_MONITORING]);
+    onFeaturesChange(DEFAULT_SCM_FEATURES);
     onClearProjectDetailsForm();
 
     trackAnalytics(PLATFORM_SELECTED_EVENT[analyticsFlow], {
@@ -241,7 +227,7 @@ export function ScmPlatformFeaturesCore({
       return;
     }
     setPlatform(platformKey);
-    onFeaturesChange([ProductSolution.ERROR_MONITORING]);
+    onFeaturesChange(DEFAULT_SCM_FEATURES);
     onClearProjectDetailsForm();
 
     trackAnalytics(PLATFORM_SELECTED_EVENT[analyticsFlow], {
@@ -270,7 +256,7 @@ export function ScmPlatformFeaturesCore({
     setShowManualPicker(false);
     if (detectedPlatformKey) {
       setPlatform(detectedPlatformKey);
-      onFeaturesChange([ProductSolution.ERROR_MONITORING]);
+      onFeaturesChange(DEFAULT_SCM_FEATURES);
       onClearProjectDetailsForm();
     }
   }

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {motion} from 'framer-motion';
 import {PlatformIcon} from 'platformicons';
 
@@ -11,13 +11,8 @@ import {Text} from '@sentry/scraps/text';
 import {closeModal, openConsoleModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {
-  getDisabledProducts,
-  platformProductAvailability,
-} from 'sentry/components/onboarding/productSelection';
-import {PLATFORM_PRODUCT_INFO} from 'sentry/data/platformProductInfo.generated';
-import {IconBroadcast, IconBusiness} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {IconBroadcast} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {PlatformKey} from 'sentry/types/platform';
@@ -26,13 +21,9 @@ import {isDisabledGamingPlatform} from 'sentry/utils/platform';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
-import {ScmFeatureInfoCards} from './scmFeatureInfoCards';
-import {ScmFeatureSelectionCards} from './scmFeatureSelectionCards';
 import {ScmPlatformCard} from './scmPlatformCard';
 import {
-  FEATURE_DISPLAY_ORDER,
   getPlatformInfo,
-  getPlatformName,
   platformOptions,
   type ResolvedPlatform,
   shouldSuggestFramework,
@@ -40,7 +31,6 @@ import {
 } from './scmPlatformHelpers';
 import {ScmSearchControl} from './scmSearchControl';
 import {ScmVirtualizedMenuList} from './scmVirtualizedMenuList';
-import {useScmFeatureMeta} from './useScmFeatureMeta';
 import {useScmPlatformDetection} from './useScmPlatformDetection';
 
 const STEP_VIEWED_EVENT = {
@@ -50,10 +40,6 @@ const STEP_VIEWED_EVENT = {
 const PLATFORM_SELECTED_EVENT = {
   onboarding: 'onboarding.scm_platform_selected',
   'project-creation': 'project_creation.scm_platform_selected',
-} as const;
-const FEATURE_TOGGLED_EVENT = {
-  onboarding: 'onboarding.scm_platform_feature_toggled',
-  'project-creation': 'project_creation.scm_platform_feature_toggled',
 } as const;
 const CHANGE_PLATFORM_CLICKED_EVENT = {
   onboarding: 'onboarding.scm_platform_change_platform_clicked',
@@ -69,19 +55,18 @@ interface ScmPlatformFeaturesCoreProps {
   onClearProjectDetailsForm: () => void;
   onFeaturesChange: (features: ProductSolution[] | undefined) => void;
   onPlatformChange: (platform: OnboardingSelectedSDK | undefined) => void;
-  selectedFeatures: ProductSolution[] | undefined;
   selectedPlatform: OnboardingSelectedSDK | undefined;
   selectedRepository: Repository | undefined;
 }
 
 /**
- * Core platform-and-features selection slice shared by the SCM onboarding
- * step (`ScmPlatformFeatures`) and the SCM-first project creation surface.
- * Renders the auto-detected platform cards (when an SCM repo is connected
- * and platforms were detected), the manual platform search dropdown, and
- * the feature selection / info cards. Owns platform detection, feature
- * metadata fetching, manual-picker toggle state, and the platform-selected
- * / feature-toggled / step-viewed / change-platform analytics.
+ * Platform-selection slice shared by the SCM onboarding step
+ * (`ScmPlatformFeatures`) and the SCM-first project creation surface. Renders
+ * the auto-detected platform cards (when an SCM repo is connected and platforms
+ * were detected) and the manual platform search dropdown. Feature selection is
+ * rendered separately as a sibling (`ScmFeatureSelectionPanel`). Owns platform
+ * detection, manual-picker toggle state, and the platform-selected /
+ * step-viewed / change-platform analytics.
  *
  * Does NOT render the step's surrounding chrome (page heading, "Choose
  * your SDK" subheading and description, Back / Continue footer). Hosts
@@ -92,21 +77,11 @@ export function ScmPlatformFeaturesCore({
   onClearProjectDetailsForm,
   onFeaturesChange,
   onPlatformChange,
-  selectedFeatures,
   selectedPlatform,
   selectedRepository,
 }: ScmPlatformFeaturesCoreProps) {
   const {openModal} = useModal();
   const organization = useOrganization();
-  // Trial/billing framing (the "unlimited volume" banner and per-feature volume
-  // limits) only makes sense during new-org onboarding, where a fresh trial is
-  // always active. In SCM-first project creation the viewer is an existing org
-  // on an unknown plan, so we hide that framing rather than show numbers that
-  // may not apply.
-  const isOnboarding = analyticsFlow === 'onboarding';
-  // Fetch feature meta at step entry so billing-config is in flight (or cached)
-  // before the user reaches the feature cards below.
-  const {meta: featureMeta, isLoading: isFeatureMetaLoading} = useScmFeatureMeta();
 
   const [showManualPicker, setShowManualPicker] = useState(false);
   // Guards the auto-detect analytics event below so it fires once per repo.
@@ -144,11 +119,6 @@ export function ScmPlatformFeaturesCore({
     isError: isDetectionError,
   } = useScmPlatformDetection(selectedRepository);
 
-  const currentFeatures = useMemo(
-    () => selectedFeatures ?? [ProductSolution.ERROR_MONITORING],
-    [selectedFeatures]
-  );
-
   const resolvedPlatforms = useMemo(
     () =>
       detectedPlatforms.reduce<ResolvedPlatform[]>((acc, detected) => {
@@ -164,8 +134,6 @@ export function ScmPlatformFeaturesCore({
   const detectedPlatformKey = resolvedPlatforms[0]?.platform;
   // Derive platform from explicit selection, falling back to first detected
   const currentPlatformKey = selectedPlatform?.key ?? detectedPlatformKey;
-
-  const currentPlatformName = getPlatformName(currentPlatformKey);
 
   // Adopt the first detected platform once per repo when the user hasn't
   // explicitly chosen one: commit it to the host so flows without a Continue
@@ -195,90 +163,6 @@ export function ScmPlatformFeaturesCore({
     analyticsFlow,
     setPlatform,
   ]);
-
-  // Wizard-driven platforms render an informational variant since the wizard CLI
-  // owns product configuration and toggles aren't actionable.
-  const featureMode = useMemo<'toggleable' | 'informational' | 'none'>(() => {
-    if (!currentPlatformKey) {
-      return 'none';
-    }
-    if (currentPlatformKey in platformProductAvailability) {
-      return 'toggleable';
-    }
-    if (currentPlatformKey in PLATFORM_PRODUCT_INFO) {
-      return 'informational';
-    }
-    return 'none';
-  }, [currentPlatformKey]);
-
-  const availableFeatures = useMemo(() => {
-    if (!currentPlatformKey || featureMode === 'none') {
-      return [];
-    }
-    const sourceProducts =
-      featureMode === 'toggleable'
-        ? platformProductAvailability[currentPlatformKey]
-        : PLATFORM_PRODUCT_INFO[currentPlatformKey];
-    const features = new Set<ProductSolution>([
-      ProductSolution.ERROR_MONITORING,
-      ...(sourceProducts ?? []),
-    ]);
-    return FEATURE_DISPLAY_ORDER.filter(f => features.has(f));
-  }, [currentPlatformKey, featureMode]);
-
-  const disabledProducts = useMemo(
-    () => getDisabledProducts(organization),
-    [organization]
-  );
-
-  const handleToggleFeature = useCallback(
-    (feature: ProductSolution) => {
-      if (disabledProducts[feature]) {
-        disabledProducts[feature]?.onClick?.();
-        return;
-      }
-
-      const wasEnabled = currentFeatures.includes(feature);
-      const newFeatures = new Set(
-        wasEnabled
-          ? currentFeatures.filter(f => f !== feature)
-          : [...currentFeatures, feature]
-      );
-
-      // Profiling requires tracing — mirror the constraint from ProductSelection
-      if (availableFeatures.includes(ProductSolution.PROFILING)) {
-        if (
-          feature === ProductSolution.PROFILING &&
-          newFeatures.has(ProductSolution.PROFILING)
-        ) {
-          newFeatures.add(ProductSolution.PERFORMANCE_MONITORING);
-        } else if (
-          feature === ProductSolution.PERFORMANCE_MONITORING &&
-          !newFeatures.has(ProductSolution.PERFORMANCE_MONITORING)
-        ) {
-          newFeatures.delete(ProductSolution.PROFILING);
-        }
-      }
-
-      onFeaturesChange(Array.from(newFeatures));
-
-      trackAnalytics(FEATURE_TOGGLED_EVENT[analyticsFlow], {
-        organization,
-        feature,
-        enabled: !wasEnabled,
-        platform: currentPlatformKey ?? '',
-      });
-    },
-    [
-      currentFeatures,
-      onFeaturesChange,
-      disabledProducts,
-      availableFeatures,
-      organization,
-      currentPlatformKey,
-      analyticsFlow,
-    ]
-  );
 
   const applyPlatformSelection = (sdk: OnboardingSelectedSDK) => {
     onPlatformChange(sdk);
@@ -428,147 +312,94 @@ export function ScmPlatformFeaturesCore({
     hasDetectedPlatforms &&
     (!currentPlatformKey || currentPlatformIsDetected);
 
-  return (
-    <Fragment>
-      {showDetectedPlatforms ? (
-        <MotionStack
-          key="detected"
-          initial={{opacity: 0}}
-          animate={{opacity: 1}}
-          gap="md"
-          width="100%"
-        >
-          <Flex justify="between" align="center">
-            <Flex align="center" gap="sm">
-              <IconBroadcast size="sm" />
-              <Text bold size="md" density="comfortable">
-                {t('Auto-detected from your repository')}
-              </Text>
-            </Flex>
-            <Button size="xs" variant="link" onClick={handleChangePlatformClick}>
-              {isDetecting
-                ? t('Skip detection and select manually')
-                : t("Doesn't look right? Change platform")}
-            </Button>
+  return showDetectedPlatforms ? (
+    <MotionStack
+      key="detected"
+      initial={{opacity: 0}}
+      animate={{opacity: 1}}
+      gap="md"
+      width="100%"
+    >
+      <Flex justify="between" align="center">
+        <Flex align="center" gap="sm">
+          <IconBroadcast size="sm" />
+          <Text bold size="md" density="comfortable">
+            {t('Auto-detected from your repository')}
+          </Text>
+        </Flex>
+        <Button size="xs" variant="link" onClick={handleChangePlatformClick}>
+          {isDetecting
+            ? t('Skip detection and select manually')
+            : t("Doesn't look right? Change platform")}
+        </Button>
+      </Flex>
+      <Stack gap="lg" width="100%">
+        {isDetecting ? (
+          <Flex justify="center">
+            <LoadingIndicator mini />
           </Flex>
-          <Stack gap="lg" width="100%">
-            {isDetecting ? (
-              <Flex justify="center">
-                <LoadingIndicator mini />
-              </Flex>
-            ) : (
-              <Grid
-                columns={{
-                  xs: '1fr',
-                  md: `repeat(${resolvedPlatforms.length}, minmax(200px, 1fr))`,
-                }}
-                width="100%"
-                justify="center"
-                gap="md"
-                role="radiogroup"
-              >
-                {resolvedPlatforms.map(({platform, info}) => (
-                  <ScmPlatformCard
-                    key={platform}
-                    platform={platform}
-                    name={info.name}
-                    type={info.type}
-                    isSelected={currentPlatformKey === platform}
-                    onClick={() => handleSelectDetectedPlatform(platform)}
-                  />
-                ))}
-              </Grid>
-            )}
-          </Stack>
-        </MotionStack>
-      ) : (
-        <MotionStack
-          key="manual"
-          gap="md"
-          width="100%"
-          initial={{opacity: 0}}
-          animate={{opacity: 1}}
-        >
-          <Flex justify="between" align="center">
-            <Flex align="center" gap="sm">
-              <Text bold size="md" density="comfortable">
-                {t('Select a platform')}
-              </Text>
-            </Flex>
-            {hasScmConnected && !isDetectionError && hasDetectedPlatforms && (
-              <Button size="xs" variant="link" onClick={handleBackToRecommended}>
-                {t('Back to recommended platforms')}
-              </Button>
-            )}
-          </Flex>
-          <Select<(typeof platformOptions)[number]>
-            placeholder={t('Search SDKs...')}
-            options={manualPickerOptions}
-            value={currentPlatformKey ?? null}
-            onChange={option => {
-              if (option) {
-                handleManualPlatformSelect(option);
-              }
+        ) : (
+          <Grid
+            columns={{
+              xs: '1fr',
+              md: `repeat(${resolvedPlatforms.length}, minmax(200px, 1fr))`,
             }}
-            searchable
-            components={{
-              Control: ScmSearchControl,
-              MenuList: ScmVirtualizedMenuList,
-            }}
-            styles={{container: base => ({...base, width: '100%'})}}
-          />
-        </MotionStack>
-      )}
-      {featureMode !== 'none' && (
-        <MotionStack layout="position" width="100%">
-          <Stack gap="2xl" paddingTop="xs">
-            {isOnboarding && (
-              <Flex
-                padding="lg"
-                background="secondary"
-                border="secondary"
-                radius="md"
-                gap="lg"
-              >
-                <IconBusiness size="lg" variant="accent" />
-                <Text size="md" density="comfortable">
-                  {tct(
-                    'You’ve got [bold:unlimited volume for 14 days] to try out everything. After that, free plan volumes apply ⋅ No credit card required',
-                    {
-                      bold: (
-                        <Text as="span" bold variant="accent">
-                          {null}
-                        </Text>
-                      ),
-                    }
-                  )}
-                </Text>
-              </Flex>
-            )}
-            {featureMode === 'toggleable' ? (
-              <ScmFeatureSelectionCards
-                availableFeatures={availableFeatures}
-                selectedFeatures={currentFeatures}
-                disabledProducts={disabledProducts}
-                onToggleFeature={handleToggleFeature}
-                featureMeta={featureMeta}
-                isVolumeLoading={isFeatureMetaLoading}
-                showVolume={isOnboarding}
+            width="100%"
+            justify="center"
+            gap="md"
+            role="radiogroup"
+          >
+            {resolvedPlatforms.map(({platform, info}) => (
+              <ScmPlatformCard
+                key={platform}
+                platform={platform}
+                name={info.name}
+                type={info.type}
+                isSelected={currentPlatformKey === platform}
+                onClick={() => handleSelectDetectedPlatform(platform)}
               />
-            ) : (
-              <ScmFeatureInfoCards
-                availableFeatures={availableFeatures}
-                disabledProducts={disabledProducts}
-                featureMeta={featureMeta}
-                platformName={currentPlatformName}
-                isVolumeLoading={isFeatureMetaLoading}
-                showVolume={isOnboarding}
-              />
-            )}
-          </Stack>
-        </MotionStack>
-      )}
-    </Fragment>
+            ))}
+          </Grid>
+        )}
+      </Stack>
+    </MotionStack>
+  ) : (
+    <MotionStack
+      key="manual"
+      gap="md"
+      width="100%"
+      initial={{opacity: 0}}
+      animate={{opacity: 1}}
+    >
+      <Flex justify="between" align="center">
+        <Flex align="center" gap="sm">
+          <Text bold size="md" density="comfortable">
+            {t('Select a platform')}
+          </Text>
+        </Flex>
+        {hasScmConnected && !isDetectionError && hasDetectedPlatforms && (
+          <Button size="xs" variant="link" onClick={handleBackToRecommended}>
+            {t('Back to recommended platforms')}
+          </Button>
+        )}
+      </Flex>
+      <Select<(typeof platformOptions)[number]>
+        placeholder={t('Search SDKs...')}
+        options={manualPickerOptions}
+        value={currentPlatformKey ?? null}
+        onChange={option => {
+          if (option) {
+            handleManualPlatformSelect(option);
+          }
+        }}
+        searchable
+        components={{
+          Control: ScmSearchControl,
+          MenuList: ScmVirtualizedMenuList,
+        }}
+        styles={{container: base => ({...base, width: '100%'})}}
+      />
+    </MotionStack>
   );
 }
 

--- a/static/app/views/onboarding/components/scmPlatformHelpers.tsx
+++ b/static/app/views/onboarding/components/scmPlatformHelpers.tsx
@@ -22,6 +22,12 @@ export const FEATURE_DISPLAY_ORDER: ProductSolution[] = [
   ProductSolution.METRICS,
 ];
 
+// Selecting or changing a platform resets the feature selection to error
+// monitoring only; the feature panel also falls back to this when nothing is
+// selected yet. Shared so both stay in lockstep. Treat as read-only; callers
+// spread it into new arrays rather than mutating it.
+export const DEFAULT_SCM_FEATURES: ProductSolution[] = [ProductSolution.ERROR_MONITORING];
+
 const platformsByKey = new Map(platforms.map(p => [p.id, p]));
 
 export const getPlatformInfo = (key: PlatformKey) => platformsByKey.get(key);

--- a/static/app/views/onboarding/components/useScmResolvedPlatform.ts
+++ b/static/app/views/onboarding/components/useScmResolvedPlatform.ts
@@ -1,0 +1,55 @@
+import {useMemo} from 'react';
+
+import type {Repository} from 'sentry/types/integrations';
+import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+
+import {getPlatformInfo, type ResolvedPlatform} from './scmPlatformHelpers';
+import {useScmPlatformDetection} from './useScmPlatformDetection';
+
+interface UseScmResolvedPlatformParams {
+  selectedPlatform: OnboardingSelectedSDK | undefined;
+  selectedRepository: Repository | undefined;
+}
+
+/**
+ * Resolves the active platform shared by `ScmPlatformFeaturesCore` (the platform
+ * picker) and `ScmFeatureSelectionPanel` (the feature cards). Both surfaces must
+ * agree on which platform is active during the brief window before an
+ * auto-detected platform is committed to the host, so the derivation lives here
+ * rather than being mirrored in each component. Each call site re-derives from
+ * the (deduped) detection query instead of lifting shared state.
+ */
+export function useScmResolvedPlatform({
+  selectedPlatform,
+  selectedRepository,
+}: UseScmResolvedPlatformParams) {
+  const {
+    detectedPlatforms,
+    isPending: isDetecting,
+    isError: isDetectionError,
+  } = useScmPlatformDetection(selectedRepository);
+
+  const resolvedPlatforms = useMemo(
+    () =>
+      detectedPlatforms.reduce<ResolvedPlatform[]>((acc, detected) => {
+        const info = getPlatformInfo(detected.platform);
+        if (info) {
+          acc.push({...detected, info});
+        }
+        return acc;
+      }, []),
+    [detectedPlatforms]
+  );
+
+  const detectedPlatformKey = resolvedPlatforms[0]?.platform;
+  // Derive platform from explicit selection, falling back to first detected.
+  const currentPlatformKey = selectedPlatform?.key ?? detectedPlatformKey;
+
+  return {
+    resolvedPlatforms,
+    detectedPlatformKey,
+    currentPlatformKey,
+    isDetecting,
+    isDetectionError,
+  };
+}

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -19,6 +19,7 @@ import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
 import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 
+import {ScmFeatureSelectionPanel} from './components/scmFeatureSelectionPanel';
 import {ScmPlatformFeaturesCore} from './components/scmPlatformFeaturesCore';
 import {getPlatformInfo, toSelectedSdk} from './components/scmPlatformHelpers';
 import {useScmPlatformDetection} from './components/useScmPlatformDetection';
@@ -187,10 +188,16 @@ export function ScmPlatformFeatures({
             analyticsFlow="onboarding"
             selectedRepository={selectedRepository}
             selectedPlatform={selectedPlatform}
-            selectedFeatures={selectedFeatures}
             onPlatformChange={onPlatformChange}
             onFeaturesChange={onFeaturesChange}
             onClearProjectDetailsForm={onClearProjectDetailsForm}
+          />
+          <ScmFeatureSelectionPanel
+            analyticsFlow="onboarding"
+            selectedRepository={selectedRepository}
+            selectedPlatform={selectedPlatform}
+            selectedFeatures={selectedFeatures}
+            onFeaturesChange={onFeaturesChange}
           />
           <MotionFlex
             layout="position"

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -6,7 +6,7 @@ import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {useCreateProject} from 'sentry/components/onboarding/useCreateProject';
 import {t} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
@@ -21,7 +21,11 @@ import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 
 import {ScmFeatureSelectionPanel} from './components/scmFeatureSelectionPanel';
 import {ScmPlatformFeaturesCore} from './components/scmPlatformFeaturesCore';
-import {getPlatformInfo, toSelectedSdk} from './components/scmPlatformHelpers';
+import {
+  DEFAULT_SCM_FEATURES,
+  getPlatformInfo,
+  toSelectedSdk,
+} from './components/scmPlatformHelpers';
 import {useScmPlatformDetection} from './components/useScmPlatformDetection';
 import type {StepProps} from './types';
 
@@ -76,7 +80,7 @@ export function ScmPlatformFeatures({
   )?.platform;
   const currentPlatformKey = selectedPlatform?.key ?? detectedPlatformKey;
 
-  const currentFeatures = selectedFeatures ?? [ProductSolution.ERROR_MONITORING];
+  const currentFeatures = selectedFeatures ?? DEFAULT_SCM_FEATURES;
 
   const setPlatform = (platformKey: typeof currentPlatformKey) => {
     if (!platformKey) {

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -23,6 +23,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useSessionStorage, writeStorageValue} from 'sentry/utils/useSessionStorage';
 import {ScmAlertFrequencySection} from 'sentry/views/onboarding/components/scmAlertFrequencySection';
+import {ScmFeatureSelectionPanel} from 'sentry/views/onboarding/components/scmFeatureSelectionPanel';
 import {ScmIntegrationConnect} from 'sentry/views/onboarding/components/scmIntegrationConnect';
 import {ScmPlatformFeaturesCore} from 'sentry/views/onboarding/components/scmPlatformFeaturesCore';
 import {ScmProjectDetailsCore} from 'sentry/views/onboarding/components/scmProjectDetailsCore';
@@ -293,10 +294,16 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                 analyticsFlow="project-creation"
                 selectedRepository={selectedRepository}
                 selectedPlatform={selectedPlatform}
-                selectedFeatures={selectedFeatures}
                 onPlatformChange={handlePlatformChange}
                 onFeaturesChange={handleFeaturesChange}
                 onClearProjectDetailsForm={handleClearProjectDetailsForm}
+              />
+              <ScmFeatureSelectionPanel
+                analyticsFlow="project-creation"
+                selectedRepository={selectedRepository}
+                selectedPlatform={selectedPlatform}
+                selectedFeatures={selectedFeatures}
+                onFeaturesChange={handleFeaturesChange}
               />
             </MotionStack>
 


### PR DESCRIPTION
## TLDR

Extracts the feature-selection cards out of `ScmPlatformFeaturesCore` into a new `ScmFeatureSelectionPanel`, rendered as a sibling rather than nested, and moves the platform-resolution logic the two now share into a `useScmResolvedPlatform` hook. The onboarding flow is unchanged in styling and behavior.

## Details

- `ScmPlatformFeaturesCore` is now platform selection only: the auto-detected platform cards and the manual picker.
- `ScmFeatureSelectionPanel` owns the toggleable / informational feature cards and the onboarding trial banner. It re-derives the resolved platform (via the shared `useScmResolvedPlatform` hook) and feature availability from the same lifted props (`selectedPlatform`, `selectedRepository`, `selectedFeatures`) and the deduped platform-detection and feature-meta queries, so no shared state or state-lifting is introduced.
- The platform resolution both components need (mapping detected platforms to their display info, then falling back from the explicit selection to the first detected) now lives in `useScmResolvedPlatform` rather than being mirrored in each. Both call it independently and rely on the deduped detection query, so the no-state-lifting design holds. The default feature set is centralized as `DEFAULT_SCM_FEATURES`.
- Both hosts render the two side by side at the same level, preserving the original layout: onboarding keeps the platform picker followed by the feature cards in flow; project creation keeps them in the "Platform & features" card.
- Platform-selected and step-viewed analytics (and the auto-adopt-detected-platform effect) stay in Core; the feature-toggled analytic moves to the panel.

## Stack

- [#118208](https://github.com/getsentry/sentry/pull/118208): Extract alert frequency into a sibling (base of this PR)
- **This PR:** Extract feature selection into a sibling

Refs VDY-77
