### PR TITLE
ref(project-creation): Fire one page-viewed analytic instead of per-step

### DIFF
--- a/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
@@ -22,14 +22,12 @@ export type ProjectCreationEventParameters = {
     provider: string;
     repo: string;
   };
-  'project_creation.scm_connect_step_viewed': Record<string, unknown>;
   'project_creation.scm_platform_change_platform_clicked': Record<string, unknown>;
   'project_creation.scm_platform_feature_toggled': {
     enabled: boolean;
     feature: string;
     platform: string;
   };
-  'project_creation.scm_platform_features_step_viewed': Record<string, unknown>;
   'project_creation.scm_platform_selected': {
     platform: string;
     source: 'detected' | 'manual';
@@ -45,7 +43,6 @@ export type ProjectCreationEventParameters = {
   'project_creation.scm_project_details_name_edited': {
     custom: boolean;
   };
-  'project_creation.scm_project_details_step_viewed': Record<string, unknown>;
   'project_creation.scm_project_details_team_selected': {
     team: string;
   };
@@ -100,13 +97,10 @@ export const projectCreationEventMap: Record<
     'Project Creation: SCM Connect Integration Selected',
   'project_creation.scm_connect_repo_selected':
     'Project Creation: SCM Connect Repo Selected',
-  'project_creation.scm_connect_step_viewed': 'Project Creation: SCM Connect Step Viewed',
   'project_creation.scm_platform_change_platform_clicked':
     'Project Creation: SCM Platform Change Platform Clicked',
   'project_creation.scm_platform_feature_toggled':
     'Project Creation: SCM Platform Feature Toggled',
-  'project_creation.scm_platform_features_step_viewed':
-    'Project Creation: SCM Platform Features Step Viewed',
   'project_creation.scm_platform_selected': 'Project Creation: SCM Platform Selected',
   'project_creation.scm_project_details_alert_selected':
     'Project Creation: SCM Project Details Alert Selected',
@@ -118,8 +112,6 @@ export const projectCreationEventMap: Record<
     'Project Creation: SCM Project Details Create Succeeded',
   'project_creation.scm_project_details_name_edited':
     'Project Creation: SCM Project Details Name Edited',
-  'project_creation.scm_project_details_step_viewed':
-    'Project Creation: SCM Project Details Step Viewed',
   'project_creation.scm_project_details_team_selected':
     'Project Creation: SCM Project Details Team Selected',
   'project_creation.scm_select_framework_modal_rendered':

--- a/static/app/views/onboarding/components/scmIntegrationConnect.tsx
+++ b/static/app/views/onboarding/components/scmIntegrationConnect.tsx
@@ -20,11 +20,6 @@ import {useMultiPlatformDetectionTest} from './useMultiPlatformDetectionTest';
 import {useScmPlatformDetection} from './useScmPlatformDetection';
 import {useScmProviders} from './useScmProviders';
 
-const STEP_VIEWED_EVENT = {
-  onboarding: 'onboarding.scm_connect_step_viewed',
-  'project-creation': 'project_creation.scm_connect_step_viewed',
-} as const;
-
 const INTEGRATION_SELECTED_EVENT = {
   onboarding: 'onboarding.scm_connect_integration_selected',
   'project-creation': 'project_creation.scm_connect_integration_selected',
@@ -96,7 +91,13 @@ export function ScmIntegrationConnect({
   const defaultIntegrationTrackedRef = useRef(false);
 
   useEffect(() => {
-    trackAnalytics(STEP_VIEWED_EVENT[analyticsFlow], {organization});
+    // Onboarding views this as a discrete step. Single-view project creation
+    // shows all sections at once and fires one page-viewed event in
+    // scmCreateProject, so suppress the per-section step_viewed there.
+    if (analyticsFlow !== 'onboarding') {
+      return;
+    }
+    trackAnalytics('onboarding.scm_connect_step_viewed', {organization});
   }, [organization, analyticsFlow]);
 
   // Fire scm_connect_integration_selected once for the integration auto-selected

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
@@ -70,7 +70,19 @@ describe('ScmPlatformFeaturesCore', () => {
     expect(screen.getByText('Select a platform')).toBeInTheDocument();
   });
 
-  it('fires step_viewed analytics for the given flow on mount', () => {
+  it('fires step_viewed analytics in onboarding on mount', () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    render(<ScmPlatformFeaturesCore {...defaultProps({analyticsFlow: 'onboarding'})} />, {
+      organization,
+    });
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'onboarding.scm_platform_features_step_viewed',
+      expect.anything()
+    );
+  });
+
+  it('does not fire step_viewed in project creation (page-viewed fires once upstream)', () => {
     const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
     render(
       <ScmPlatformFeaturesCore {...defaultProps({analyticsFlow: 'project-creation'})} />,
@@ -79,8 +91,8 @@ describe('ScmPlatformFeaturesCore', () => {
       }
     );
 
-    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
-      'project_creation.scm_platform_features_step_viewed',
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'onboarding.scm_platform_features_step_viewed',
       expect.anything()
     );
   });

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -33,10 +33,6 @@ import {ScmSearchControl} from './scmSearchControl';
 import {ScmVirtualizedMenuList} from './scmVirtualizedMenuList';
 import {useScmResolvedPlatform} from './useScmResolvedPlatform';
 
-const STEP_VIEWED_EVENT = {
-  onboarding: 'onboarding.scm_platform_features_step_viewed',
-  'project-creation': 'project_creation.scm_platform_features_step_viewed',
-} as const;
 const PLATFORM_SELECTED_EVENT = {
   onboarding: 'onboarding.scm_platform_selected',
   'project-creation': 'project_creation.scm_platform_selected',
@@ -98,7 +94,13 @@ export function ScmPlatformFeaturesCore({
   }, [selectedRepository?.externalId]);
 
   useEffect(() => {
-    trackAnalytics(STEP_VIEWED_EVENT[analyticsFlow], {organization});
+    // Onboarding views this as a discrete step. Single-view project creation
+    // shows all sections at once and fires one page-viewed event in
+    // scmCreateProject, so suppress the per-section step_viewed there.
+    if (analyticsFlow !== 'onboarding') {
+      return;
+    }
+    trackAnalytics('onboarding.scm_platform_features_step_viewed', {organization});
   }, [organization, analyticsFlow]);
 
   const setPlatform = useCallback(

--- a/static/app/views/onboarding/components/scmProjectDetailsCore.spec.tsx
+++ b/static/app/views/onboarding/components/scmProjectDetailsCore.spec.tsx
@@ -37,12 +37,22 @@ describe('ScmProjectDetailsCore', () => {
     expect(screen.getByPlaceholderText('project-name')).toHaveValue('my-project');
   });
 
-  it('fires step_viewed analytics for the given flow on mount', () => {
+  it('fires step_viewed analytics in onboarding on mount', () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    renderCore({analyticsFlow: 'onboarding'});
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'onboarding.scm_project_details_step_viewed',
+      expect.anything()
+    );
+  });
+
+  it('does not fire step_viewed in project creation (page-viewed fires once upstream)', () => {
     const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
     renderCore({analyticsFlow: 'project-creation'});
 
-    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
-      'project_creation.scm_project_details_step_viewed',
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'onboarding.scm_project_details_step_viewed',
       expect.anything()
     );
   });

--- a/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
+++ b/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
@@ -12,11 +12,6 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
 
-const STEP_VIEWED_EVENT = {
-  onboarding: 'onboarding.scm_project_details_step_viewed',
-  'project-creation': 'project_creation.scm_project_details_step_viewed',
-} as const;
-
 interface ScmProjectDetailsCoreProps {
   analyticsFlow: ScmAnalyticsFlow;
   /** Hides the team selector for a no-access member (see useScmProjectDetails). */
@@ -49,7 +44,13 @@ export function ScmProjectDetailsCore({
   const organization = useOrganization();
 
   useEffect(() => {
-    trackAnalytics(STEP_VIEWED_EVENT[analyticsFlow], {organization});
+    // Onboarding views this as a discrete step. Single-view project creation
+    // shows all sections at once and fires one page-viewed event in
+    // scmCreateProject, so suppress the per-section step_viewed there.
+    if (analyticsFlow !== 'onboarding') {
+      return;
+    }
+    trackAnalytics('onboarding.scm_project_details_step_viewed', {organization});
   }, [organization, analyticsFlow]);
 
   return (

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -17,6 +17,7 @@ import {t} from 'sentry/locale';
 import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import {useCanCreateProject} from 'sentry/utils/useCanCreateProject';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -94,6 +95,16 @@ export function ScmCreateProject() {
   const location = useLocation();
   const referrer = decodeScalar(location.query.referrer);
   const projectId = decodeScalar(location.query.project);
+
+  // Single page-viewed event for the whole flow. Unlike onboarding's discrete
+  // steps, every section renders at once here, so the per-section step_viewed
+  // events the shared cores fire in onboarding are intentionally suppressed in
+  // this flow. Uses an SCM-specific event (not the classic
+  // project_creation_page.viewed) so the SCM-first funnel stays separable.
+  useRouteAnalyticsEventNames(
+    'project_creation.scm_create_project_viewed',
+    'Project Creation: SCM Create Project Viewed'
+  );
 
   // Snapshot of the last completed wizard session, written when a project is
   // created (see handleComplete in the wizard). Restored when this mount is a


### PR DESCRIPTION
## TLDR

Replaces the per-section `*_step_viewed` analytics in single-view project creation with one `project_creation.scm_create_project_viewed` event. Onboarding, which is genuinely stepped, is unchanged.

## Details

- In single-view project creation every section (connect, platform & features, project details) renders at once, so the shared cores each firing a `step_viewed` no longer models a real step.
- The three shared cores (`ScmIntegrationConnect`, `ScmPlatformFeaturesCore`, `ScmProjectDetailsCore`) now fire their `step_viewed` only in onboarding; in project creation it is suppressed.
- `scmCreateProject` fires a single `project_creation.scm_create_project_viewed` event via `useRouteAnalyticsEventNames` — the same route-analytics mechanism as classic `createProject`, but a distinct SCM event so the SCM-first funnel stays separable from the classic create flow.
- Drops the now-unused `project_creation.scm_connect_step_viewed`, `project_creation.scm_platform_features_step_viewed`, and `project_creation.scm_project_details_step_viewed` event registrations.

## Stack

- [#118208](https://github.com/getsentry/sentry/pull/118208): Extract alert frequency into a sibling
- [#118211](https://github.com/getsentry/sentry/pull/118211): Extract feature selection into a sibling (base of this PR)
- **This PR:** One page-viewed analytic for single-view project creation

Refs VDY-77
