### PR TITLE
fix(seer): Inherit org-flag agent run options on the feature-run path

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -474,51 +474,9 @@ class SeerAgentClient:
         if ui_tools:
             chat_body["ui_tools"] = ui_tools
 
-        if _has_context_engine(self.organization, self.user):
-            if random.random() < options.get("seer.explorer.context-engine-rollout"):
-                agent_run_options["is_context_engine_enabled"] = True
-
-        if features.has(
-            "organizations:seer-explorer-context-engine-allow-fe-override",
-            self.organization,
-            actor=self.user,
-        ):
-            agent_run_options["is_context_engine_enabled"] = override_ce_enable
-
-        if features.has(
-            "organizations:seer-agent-source-code-search",
-            self.organization,
-            actor=self.user,
-        ):
-            agent_run_options["enable_frontend_code_search"] = True
-
-        if features.has(
-            "organizations:seer-use-agent-sandbox",
-            self.organization,
-            actor=self.user,
-        ):
-            agent_run_options["use_agent_sandbox"] = True
-
-        if features.has(
-            "organizations:seer-explorer-thinking-summary",
-            self.organization,
-            actor=self.user,
-        ):
-            agent_run_options["enable_tool_summary"] = True
-
-        if features.has(
-            "organizations:seer-explorer-embeds",
-            self.organization,
-            actor=self.user,
-        ):
-            agent_run_options["embed_widgets"] = get_embed_widgets()
-
-        if features.has(
-            "organizations:seer-explorer-stream",
-            self.organization,
-            actor=self.user,
-        ):
-            agent_run_options["enable_streaming"] = True
+        agent_run_options.update(
+            self._build_agent_run_options(override_ce_enable=override_ce_enable)
+        )
 
         user_id = (
             self.user.id
@@ -586,11 +544,67 @@ class SeerAgentClient:
             organization=self.organization,
             run_type=SeerRunType.FEATURE_RUN,
             on_run_created=on_run_created,
-            body=SeerFeatureRunRequest(feature_id=feature_id, payload=payload),
+            body=SeerFeatureRunRequest(
+                feature_id=feature_id,
+                payload=payload,
+                agent_run_options=self._build_agent_run_options(),
+            ),
             viewer_context=self.viewer_context,
             user_id=user_id,
             flush=flush,
         )
+
+    def _build_agent_run_options(self, override_ce_enable: bool = True) -> dict[str, Any]:
+        """Resolve org-flag-driven agent run options, shared by start_run and start_feature_run."""
+        opts: dict[str, Any] = {}
+
+        if _has_context_engine(self.organization, self.user):
+            if random.random() < options.get("seer.explorer.context-engine-rollout"):
+                opts["is_context_engine_enabled"] = True
+
+        if features.has(
+            "organizations:seer-explorer-context-engine-allow-fe-override",
+            self.organization,
+            actor=self.user,
+        ):
+            opts["is_context_engine_enabled"] = override_ce_enable
+
+        if features.has(
+            "organizations:seer-agent-source-code-search",
+            self.organization,
+            actor=self.user,
+        ):
+            opts["enable_frontend_code_search"] = True
+
+        if features.has(
+            "organizations:seer-use-agent-sandbox",
+            self.organization,
+            actor=self.user,
+        ):
+            opts["use_agent_sandbox"] = True
+
+        if features.has(
+            "organizations:seer-explorer-thinking-summary",
+            self.organization,
+            actor=self.user,
+        ):
+            opts["enable_tool_summary"] = True
+
+        if features.has(
+            "organizations:seer-explorer-embeds",
+            self.organization,
+            actor=self.user,
+        ):
+            opts["embed_widgets"] = get_embed_widgets()
+
+        if features.has(
+            "organizations:seer-explorer-stream",
+            self.organization,
+            actor=self.user,
+        ):
+            opts["enable_streaming"] = True
+
+        return opts
 
     def continue_run(
         self,

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -120,6 +120,7 @@ class SeerFeatureRunRequest(TypedDict):
 
     feature_id: str
     payload: dict[str, Any]
+    agent_run_options: NotRequired[dict[str, Any]]
 
 
 class SeerFeatureRunWireRequest(SeerFeatureRunRequest):

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -22,7 +22,7 @@ from sentry.seer.agent.client_models import (
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunMirrorStatus, SeerRunType
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers import override_options, with_feature
 from sentry.testutils.requests import make_request
 
 TEST_FERNET_KEY = Fernet.generate_key().decode("utf-8")
@@ -1303,6 +1303,36 @@ class TestStartFeatureRun(TestCase):
         with pytest.raises(SeerPermissionError):
             SeerAgentClient(self.organization, self.user)
         assert not SeerRun.objects.filter(organization=self.organization).exists()
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
+    @patch("sentry.receivers.outbox.cell.make_feature_run_request")
+    @with_feature("organizations:seer-added")
+    @override_options({"seer.explorer.context-engine-rollout": 1.0})
+    def test_inherits_context_engine_from_org(self, mock_request, _mock_access) -> None:
+        client = SeerAgentClient(self.organization, self.user)
+        run = client.start_feature_run(feature_id="night_shift", payload={}, flush=False)
+
+        body = self._outbox_for(run).payload["body"]
+        assert body["agent_run_options"]["is_context_engine_enabled"] is True
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
+    @patch("sentry.receivers.outbox.cell.make_feature_run_request")
+    @with_feature("organizations:seer-agent-source-code-search")
+    def test_inherits_frontend_code_search_from_org(self, mock_request, _mock_access) -> None:
+        client = SeerAgentClient(self.organization, self.user)
+        run = client.start_feature_run(feature_id="night_shift", payload={}, flush=False)
+
+        body = self._outbox_for(run).payload["body"]
+        assert body["agent_run_options"]["enable_frontend_code_search"] is True
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
+    @patch("sentry.receivers.outbox.cell.make_feature_run_request")
+    def test_agent_run_options_empty_without_org_flags(self, mock_request, _mock_access) -> None:
+        client = SeerAgentClient(self.organization, self.user)
+        run = client.start_feature_run(feature_id="night_shift", payload={}, flush=False)
+
+        body = self._outbox_for(run).payload["body"]
+        assert body["agent_run_options"] == {}
 
 
 @override_settings(SEER_GHE_ENCRYPT_KEY=TEST_FERNET_KEY)

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -1312,7 +1312,9 @@ class TestStartFeatureRun(TestCase):
         client = SeerAgentClient(self.organization, self.user)
         run = client.start_feature_run(feature_id="night_shift", payload={}, flush=False)
 
-        body = self._outbox_for(run).payload["body"]
+        outbox = self._outbox_for(run)
+        assert outbox is not None and outbox.payload is not None
+        body = outbox.payload["body"]
         assert body["agent_run_options"]["is_context_engine_enabled"] is True
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
@@ -1322,7 +1324,9 @@ class TestStartFeatureRun(TestCase):
         client = SeerAgentClient(self.organization, self.user)
         run = client.start_feature_run(feature_id="night_shift", payload={}, flush=False)
 
-        body = self._outbox_for(run).payload["body"]
+        outbox = self._outbox_for(run)
+        assert outbox is not None and outbox.payload is not None
+        body = outbox.payload["body"]
         assert body["agent_run_options"]["enable_frontend_code_search"] is True
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
@@ -1331,7 +1335,9 @@ class TestStartFeatureRun(TestCase):
         client = SeerAgentClient(self.organization, self.user)
         run = client.start_feature_run(feature_id="night_shift", payload={}, flush=False)
 
-        body = self._outbox_for(run).payload["body"]
+        outbox = self._outbox_for(run)
+        assert outbox is not None and outbox.payload is not None
+        body = outbox.payload["body"]
         assert body["agent_run_options"] == {}
 
 


### PR DESCRIPTION
`agent_run_options` enrichment (context engine, frontend code search, sandbox, etc.) was resolved only in `SeerAgentClient.start_run`. The feature-dispatch path (`start_feature_run` → Seer's feature endpoint) dropped it, so #8109 silently turned the Context Engine off for Night Shift triage.

Extract the enrichment into `SeerAgentClient._build_agent_run_options()`, called by both `start_run` (pure refactor) and `start_feature_run`, so every feature inherits it. Adds optional `agent_run_options` to `SeerFeatureRunRequest` (rolling-deploy safe). Seer side handled in a companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)