### PR TITLE
fix(trace): Open Span JSON link in a new tab

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1015,6 +1015,8 @@ function NodeActions(props: {
             size="zero"
             aria-label={t('Span JSON (Superuser Only)')}
             icon={<IconTerminal />}
+            target="_blank"
+            rel="noopener noreferrer"
           />
         </Tooltip>
       ) : null}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1015,8 +1015,7 @@ function NodeActions(props: {
             size="zero"
             aria-label={t('Span JSON (Superuser Only)')}
             icon={<IconTerminal />}
-            target="_blank"
-            rel="noopener noreferrer"
+            external
           />
         </Tooltip>
       ) : null}


### PR DESCRIPTION
I like this more 😬 

---  

🤖: The Span JSON (Superuser Only) button in the trace drawer now opens in a new
tab instead of navigating away from the current page.