### PR TITLE
feat(dynamic-sampling): Add generic metrics volume to sliding window comparison

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -27,6 +27,7 @@ from sentry.dynamic_sampling.per_org.queries import (
     ProjectTransactionCounts,
     ProjectVolume,
     get_eap_organization_volume,
+    get_generic_metrics_organization_volume,
     get_outcomes_organization_volume,
 )
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
@@ -66,6 +67,9 @@ def compare_organization_sliding_window_sample_rates(
     end = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
     eap_volume = get_eap_organization_volume(config, time_interval=window, end=end)
     outcomes_volume = get_outcomes_organization_volume(config, time_interval=window, end=end)
+    generic_metrics_volume = get_generic_metrics_organization_volume(
+        config.organization.id, time_interval=window, end=end
+    )
 
     def sample_rate_for(volume: OrganizationDataVolume | None) -> float | None:
         if volume is None:
@@ -79,6 +83,7 @@ def compare_organization_sliding_window_sample_rates(
 
     eap_sample_rate = sample_rate_for(eap_volume)
     outcomes_sample_rate = sample_rate_for(outcomes_volume)
+    generic_metrics_sample_rate = sample_rate_for(generic_metrics_volume)
 
     tags = {"ds_org": str(config.organization.id)}
     if eap_sample_rate is not None:
@@ -95,6 +100,13 @@ def compare_organization_sliding_window_sample_rates(
             sample_rate=1.0,
             tags=tags,
         )
+    if generic_metrics_sample_rate is not None:
+        metrics.distribution(
+            f"{SLIDING_WINDOW_METRIC_PREFIX}.generic_metrics_sample_rate",
+            generic_metrics_sample_rate,
+            sample_rate=1.0,
+            tags=tags,
+        )
     if eap_volume is not None:
         metrics.distribution(
             f"{SLIDING_WINDOW_METRIC_PREFIX}.eap_volume",
@@ -106,6 +118,13 @@ def compare_organization_sliding_window_sample_rates(
         metrics.distribution(
             f"{SLIDING_WINDOW_METRIC_PREFIX}.outcomes_volume",
             outcomes_volume.total,
+            sample_rate=1.0,
+            tags=tags,
+        )
+    if generic_metrics_volume is not None:
+        metrics.distribution(
+            f"{SLIDING_WINDOW_METRIC_PREFIX}.generic_metrics_volume",
+            generic_metrics_volume.total,
             sample_rate=1.0,
             tags=tags,
         )

--- a/src/sentry/dynamic_sampling/per_org/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/queries.py
@@ -12,16 +12,21 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import ExtrapolationMode
 from sentry.dynamic_sampling.rules.utils import ProjectId
 from sentry.dynamic_sampling.tasks.common import (
     ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL,
+    MEASURE_CONFIGS,
     OrganizationDataVolume,
 )
+from sentry.dynamic_sampling.types import SamplingMeasure
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.search.eap.constants import SAMPLING_MODE_HIGHEST_ACCURACY
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
+from sentry.sentry_metrics import indexer
+from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.outcomes import QueryDefinition, run_outcomes_query_totals
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
+from sentry.utils.snuba import raw_snql_query
 
 
 class OrganizationVolumeConfig(Protocol):
@@ -164,6 +169,64 @@ def get_outcomes_organization_volume(
         return None
 
     return OrganizationDataVolume(org_id=config.organization.id, total=total, indexed=None)
+
+
+def get_generic_metrics_organization_volume(
+    org_id: int,
+    time_interval: timedelta = ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL,
+    end: datetime | None = None,
+) -> OrganizationDataVolume | None:
+    from snuba_sdk import Column, Condition, Entity, Function, Granularity, Op, Query, Request
+
+    end_time = end or datetime.now(UTC)
+    start_time = end_time - time_interval
+
+    config = MEASURE_CONFIGS[SamplingMeasure.SEGMENTS]
+    metric_id = indexer.resolve_shared_org(str(config["mri"]))
+
+    where: list[Condition] = [
+        Condition(Column("timestamp"), Op.GTE, start_time),
+        Condition(Column("timestamp"), Op.LT, end_time),
+        Condition(Column("metric_id"), Op.EQ, metric_id),
+        Condition(Column("org_id"), Op.IN, [org_id]),
+    ]
+    for tag_name, tag_value in config["tags"].items():
+        tag_string_id = indexer.resolve_shared_org(tag_name)
+        tag_column = f"tags_raw[{tag_string_id}]"
+        where.append(Condition(Column(tag_column), Op.EQ, tag_value))
+
+    query = Query(
+        match=Entity(EntityKey.GenericOrgMetricsCounters.value),
+        select=[
+            Function("sum", [Column("value")], "total_count"),
+            Column("org_id"),
+        ],
+        groupby=[Column("org_id")],
+        where=where,
+        granularity=Granularity(60),
+    )
+    request = Request(
+        dataset=Dataset.PerformanceMetrics.value,
+        app_id="dynamic_sampling",
+        query=query,
+        tenant_ids={
+            "use_case_id": config["use_case_id"].value,
+            "cross_org_query": 1,
+        },
+    )
+    data = raw_snql_query(
+        request,
+        referrer=Referrer.DYNAMIC_SAMPLING_COUNTERS_GET_ORG_TRANSACTION_VOLUMES.value,
+    )["data"]
+
+    if not data:
+        return None
+
+    total = int(data[0]["total_count"])
+    if total <= 0:
+        return None
+
+    return OrganizationDataVolume(org_id=org_id, total=total, indexed=None)
 
 
 def get_eap_project_volumes(


### PR DESCRIPTION
compare_organization_sliding_window_sample_rates now also queries the generic
metrics volume for the org and computes its sample rate. A new
`get_generic_metrics_organization_volume` query function in the per-org pipeline
queries `GenericOrgMetricsCounters` directly with an explicit end time, keeping
the time window aligned with the EAP and outcomes queries.

Two new metrics are emitted alongside the existing ones:

- `dynamic_sampling.per_org.sliding_window.generic_metrics_sample_rate`
- `dynamic_sampling.per_org.sliding_window.generic_metrics_volume`