### PR TITLE
ref(issues): Remove groups.regression-activity-event-metadata flag guard

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1823,7 +1823,7 @@ def _handle_regression(
             "event_id": event.event_id,
             "version": release.version if release else "",
         }
-        if incoming_group_values and options.get("groups.regression-activity-event-metadata"):
+        if incoming_group_values:
             event_data = incoming_group_values.get("data", {})
             activity_data["event_metadata"] = event_data.get("metadata", {})
             activity_data["event_title"] = event_data.get("title", "")


### PR DESCRIPTION
This has been GA-ed and no need to keep this as a kill switch anymore

Contributes to TET-2494