### PR TITLE
ref(spans): Bump `sentry-kafka-schemas` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dependencies = [
   "sentry-arroyo>=2.40.3",
   "sentry-conventions>=0.12.0",
   "sentry-forked-email-reply-parser>=0.5.12.post1",
-  "sentry-kafka-schemas>=2.1.33",
+  "sentry-kafka-schemas>=2.1.36",
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.0.13",

--- a/uv.lock
+++ b/uv.lock
@@ -2409,7 +2409,7 @@ requires-dist = [
     { name = "sentry-arroyo", specifier = ">=2.40.3" },
     { name = "sentry-conventions", specifier = ">=0.12.0" },
     { name = "sentry-forked-email-reply-parser", specifier = ">=0.5.12.post1" },
-    { name = "sentry-kafka-schemas", specifier = ">=2.1.33" },
+    { name = "sentry-kafka-schemas", specifier = ">=2.1.36" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.0.13" },
     { name = "sentry-protos", specifier = ">=0.32.4" },
@@ -2559,7 +2559,7 @@ wheels = [
 
 [[package]]
 name = "sentry-kafka-schemas"
-version = "2.1.33"
+version = "2.1.36"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "fastjsonschema", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2570,7 +2570,7 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_kafka_schemas-2.1.33-py2.py3-none-any.whl", hash = "sha256:5ddadce9456acb140db31774f801d8b4bac7dffd14ac74c6711534b6f3474b2a" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_kafka_schemas-2.1.36-py2.py3-none-any.whl", hash = "sha256:f3f5c1aa16e9972840d06038c7085a5e1bd50e1fdbdbf42e99b33ec56ccb4ace" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow up to #109174 this now bumps `sentry-kafka-schemas` to a version that no longer contains the `accepted_outcome_emitted property` property for spans, as it is no longer needed (Part of the cleanup specified here: https://linear.app/getsentry/issue/INGEST-806)