### PR TITLE
feat(agent-monitoring): Improve conversation detail message rendering

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -266,8 +266,8 @@ export function ConversationSummary({
         >
           <Heading as="h2" ellipsis style={{minWidth: 0, flexShrink: 1}}>
             {isUUID(conversationId)
-              ? t('Conversation #%s', conversationId.slice(0, 8))
-              : t('Conversation #%s', conversationId)}
+              ? t('Conversation %s', conversationId.slice(0, 8))
+              : t('Conversation %s', conversationId)}
           </Heading>
         </Tooltip>
         <Tooltip title={t('Copy conversation ID')}>

--- a/static/app/views/explore/conversations/components/messagesPanel.spec.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.spec.tsx
@@ -1,5 +1,6 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import {EMPTY_TEXT_CONTENT} from 'sentry/views/insights/pages/agents/utils/aiMessageNormalizer';
 import {SpanFields} from 'sentry/views/insights/types';
 
 import {MessagesPanel} from './messagesPanel';
@@ -122,6 +123,31 @@ describe('MessagesPanel', () => {
 
     expect(screen.getByText('Hello from OUTPUT messages')).toBeInTheDocument();
     expect(screen.queryByText('Fallback response text')).not.toBeInTheDocument();
+  });
+
+  it('renders a placeholder when output text content is missing', () => {
+    const requestMessages = JSON.stringify([{role: 'user', content: 'User message'}]);
+    const outputMessages = JSON.stringify([
+      {role: 'assistant', content: [{type: 'text', chars: 56}]},
+    ]);
+
+    const node = createMockNode({
+      id: 'span-1',
+      attributes: {
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+        [SpanFields.GEN_AI_OUTPUT_MESSAGES]: outputMessages,
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText(EMPTY_TEXT_CONTENT)).toBeInTheDocument();
   });
 
   it('prefers gen_ai.input.messages over gen_ai.request.messages', () => {

--- a/static/app/views/explore/conversations/components/messagesPanel.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.tsx
@@ -16,6 +16,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {MessageToolCalls} from 'sentry/views/explore/conversations/components/messageToolCalls';
 import type {ConversationMessage} from 'sentry/views/explore/conversations/utils/conversationMessages';
 import {extractMessagesFromNodes} from 'sentry/views/explore/conversations/utils/conversationMessages';
+import {EMPTY_TEXT_CONTENT} from 'sentry/views/insights/pages/agents/utils/aiMessageNormalizer';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
 import {AIContentRenderer} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer';
 
@@ -131,22 +132,30 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
               {isAssistant && message.reasoning && (
                 <ReasoningSection reasoning={message.reasoning} />
               )}
-              {message.content !== '' && (
-                <StyledClippedBox
-                  clipHeight={200}
-                  buttonProps={{variant: 'secondary', size: 'xs'}}
-                  collapsible
-                >
-                  <Container padding="md">
-                    <MessageText size="sm" align="left">
-                      <AIContentRenderer
-                        text={message.content}
-                        inline
-                        autoCollapseLimit={10}
-                      />
-                    </MessageText>
-                  </Container>
-                </StyledClippedBox>
+              {message.content === EMPTY_TEXT_CONTENT ? (
+                <Container padding="md">
+                  <MessageText size="sm" align="left" variant="muted">
+                    {message.content}
+                  </MessageText>
+                </Container>
+              ) : (
+                message.content !== '' && (
+                  <StyledClippedBox
+                    clipHeight={200}
+                    buttonProps={{variant: 'secondary', size: 'xs'}}
+                    collapsible
+                  >
+                    <Container padding="md">
+                      <MessageText size="sm" align="left">
+                        <AIContentRenderer
+                          text={message.content}
+                          inline
+                          autoCollapseLimit={10}
+                        />
+                      </MessageText>
+                    </Container>
+                  </StyledClippedBox>
+                )
               )}
             </MessageBubble>
           );

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -1,5 +1,6 @@
 import {getDuration} from 'sentry/utils/duration/getDuration';
 import {
+  EMPTY_TEXT_CONTENT,
   extractAssistantOutput,
   normalizeToMessages,
 } from 'sentry/views/insights/pages/agents/utils/aiMessageNormalizer';
@@ -173,7 +174,9 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
 
     if (
       turn.userContent &&
-      (turn.userContent === FILTERED || !seenUserContent.has(turn.userContent))
+      (turn.userContent === FILTERED ||
+        turn.userContent === EMPTY_TEXT_CONTENT ||
+        !seenUserContent.has(turn.userContent))
     ) {
       seenUserContent.add(turn.userContent);
       messages.push({
@@ -189,6 +192,7 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
     const hasAssistantContent =
       turn.assistantContent &&
       (turn.assistantContent === FILTERED ||
+        turn.assistantContent === EMPTY_TEXT_CONTENT ||
         !seenAssistantContent.has(turn.assistantContent));
     const hasToolCalls = turn.toolCalls.length > 0;
 

--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.spec.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.spec.ts
@@ -1,4 +1,5 @@
 import {
+  EMPTY_TEXT_CONTENT,
   extractAssistantOutput,
   normalizeToMessages,
 } from 'sentry/views/insights/pages/agents/utils/aiMessageNormalizer';
@@ -126,6 +127,16 @@ describe('normalizeToMessages', () => {
       const {messages} = normalizeToMessages(input, {defaultRole: 'user'});
 
       expect(messages?.[0]?.content).toBe('part one\npart two');
+    });
+
+    it('renders a placeholder for text parts with no usable text', () => {
+      const input = JSON.stringify([
+        {role: 'assistant', content: [{type: 'text', chars: 56}]},
+      ]);
+
+      const {messages} = normalizeToMessages(input, {defaultRole: 'assistant'});
+
+      expect(messages?.[0]?.content).toBe(EMPTY_TEXT_CONTENT);
     });
 
     it('keeps tool role content as-is (not re-rendered)', () => {
@@ -379,6 +390,24 @@ describe('extractAssistantOutput', () => {
         type: 'object',
         data: {k: 'v'},
       });
+    });
+
+    it('returns the placeholder when the only text part has no usable text', () => {
+      const input = JSON.stringify([
+        {role: 'assistant', content: [{type: 'text', chars: 56}]},
+      ]);
+
+      const {responseText} = extractAssistantOutput(input, {defaultRole: 'assistant'});
+
+      expect(responseText).toBe(EMPTY_TEXT_CONTENT);
+    });
+
+    it('returns the placeholder for empty text parts in parts-format output', () => {
+      const input = JSON.stringify([{role: 'assistant', parts: [{type: 'text'}]}]);
+
+      const {responseText} = extractAssistantOutput(input, {defaultRole: 'assistant'});
+
+      expect(responseText).toBe(EMPTY_TEXT_CONTENT);
     });
 
     it('joins text across multiple assistant messages', () => {

--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
@@ -45,6 +45,13 @@ type PartBuckets = {
 // parsers together whenever adding or changing a supported format.
 
 /**
+ * Rendered when a text content part is structurally present but carries no
+ * usable text (e.g. `{type: "text", chars: 56}`). Matches the product-wide
+ * empty-value convention so the message still renders instead of vanishing.
+ */
+export const EMPTY_TEXT_CONTENT = '(no value)';
+
+/**
  * Normalizes AI attribute values into a list of messages.
  *
  * Accepts every shape the codebase supports on supported attributes:
@@ -359,9 +366,7 @@ function bucketParts(parts: unknown[]): PartBuckets {
     if (partType === 'text') {
       buckets.hasRenderableTextPart = true;
       const text = getTextPartContent(part, {trim: true});
-      if (text) {
-        buckets.textParts.push(text);
-      }
+      buckets.textParts.push(text || EMPTY_TEXT_CONTENT);
       continue;
     }
     if (partType === 'reasoning') {
@@ -448,9 +453,7 @@ function appendOutputFromParts(
     const partType = getPartType(part);
     if (partType === 'text' && isRecord(part)) {
       const text = getStringField(part, 'content') ?? getStringField(part, 'text');
-      if (text) {
-        textParts.push(text);
-      }
+      textParts.push(text ?? EMPTY_TEXT_CONTENT);
       continue;
     }
     if (partType === 'reasoning' && isRecord(part)) {


### PR DESCRIPTION
Two small display fixes for the conversation detail view.

AI messages sometimes contain a structurally valid text content part with no usable text — for example `{"type": "text", "chars": 56}`, where the text was stripped upstream and only a length stub remains. Previously the message extracted to empty content and was dropped from the conversation entirely. It now renders a muted `(no value)` placeholder (the product-wide empty-value convention), and the placeholder is exempt from message dedup so repeated empties don't collapse into one. The matching change in the Python normalizer ships in #118235.

Separately, the conversation header now reads "Conversation <id>" without the leading "#".
