### PR TITLE
fix(trace): Expose V2 mobile app vitals for EAP traces

### DIFF
--- a/src/sentry/apidocs/examples/trace_examples.py
+++ b/src/sentry/apidocs/examples/trace_examples.py
@@ -46,6 +46,12 @@ TRACE_SPAN = {
         "browser.web_vital.ttfb.value": 450.0,
         "browser.web_vital.fcp.value": 2258.06,
     },
+    "mobile_app_vital": {
+        "app.vitals.start.cold.value": 1600.0,
+        "app.vitals.start.warm.value": 400.0,
+        "app.vitals.ttid.value": 1200.0,
+        "app.vitals.ttfd.value": 2400.0,
+    },
     "children": [],
     "errors": [],
     "occurrences": [],

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -111,6 +111,8 @@ class Spans(rpc_dataset_common.RPCBase):
             "sdk.name",
             "measurements.time_to_initial_display",
             "measurements.time_to_full_display",
+            "measurements.app_start_cold",
+            "measurements.app_start_warm",
             "measurements.lcp",
             "measurements.score.ratio.lcp",
             "measurements.fcp",
@@ -129,6 +131,11 @@ class Spans(rpc_dataset_common.RPCBase):
             "browser.web_vital.fcp.value",
             # The UI does not currently use FP values, so do not request it yet.
             # "browser.web_vital.fp.value",
+            # span v2 mobile vital values
+            "app.vitals.start.cold.value",
+            "app.vitals.start.warm.value",
+            "app.vitals.ttid.value",
+            "app.vitals.ttfd.value",
             *additional_attributes,
         ]
         resolver = cls.get_resolver(params=params, config=SearchResolverConfig())

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -77,6 +77,7 @@ class SerializedSpan(SerializedEvent):
     end_timestamp: datetime
     measurements: dict[str, Any]
     browser_web_vital: dict[str, Any]
+    mobile_app_vital: dict[str, Any]
     op: str
     name: str
     parent_span_id: str | None
@@ -272,6 +273,9 @@ def _serialize_rpc_event(
         },
         browser_web_vital={
             key: value for key, value in event.items() if key.startswith("browser.web_vital.")
+        },
+        mobile_app_vital={
+            key: value for key, value in event.items() if key.startswith("app.vitals.")
         },
         duration=event["span.duration"],
         transaction=event["transaction"],

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -75,6 +75,10 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointTestBase, Tr
                         "browser.web_vital.inp.value": 120.0,
                         "browser.web_vital.ttfb.value": 450.0,
                         "browser.web_vital.fcp.value": 2258.06,
+                        "app.vitals.start.cold.value": 1600.0,
+                        "app.vitals.start.warm.value": 400.0,
+                        "app.vitals.ttid.value": 1200.0,
+                        "app.vitals.ttfd.value": 2400.0,
                     },
                 }
                 for i, root_span_id in enumerate(self.root_span_ids)

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -345,6 +345,24 @@ class OrganizationEventsTraceEndpointTest(
         }
         assert "browser.web_vital.lcp.value" not in span["measurements"]
 
+    def test_with_mobile_app_vitals(self) -> None:
+        self.load_trace()
+        with self.feature(self.FEATURES):
+            response = self.client_get(
+                data={"timestamp": self.day_ago},
+            )
+        assert response.status_code == 200, response.content
+
+        root = response.data[0]
+        span = next(child for child in root["children"] if child["description"] == "GET gen1-0")
+        assert span["mobile_app_vital"] == {
+            "app.vitals.start.cold.value": 1600.0,
+            "app.vitals.start.warm.value": 400.0,
+            "app.vitals.ttid.value": 1200.0,
+            "app.vitals.ttfd.value": 2400.0,
+        }
+        assert span["measurements"]["measurements.app_start_cold"] == 0.0
+
     def test_with_errors_data(self) -> None:
         self.load_trace()
         _, start = self.get_start_end_from_day_ago(123)


### PR DESCRIPTION
The goal of this PR is to add in support for V2 mobil app vital attributes to the `trace` endpoint. Changes are similar to those made for the browser web vitals where we introduce a new `mobile_app_vital` field on the response. 

Tests are also included
