### PR TITLE
fix(trace-waterfall): Handle V2 mobile app vitals for EAP traces

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
@@ -8,7 +8,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils/defined';
 import {getDuration} from 'sentry/utils/duration/getDuration';
-import type {MobileVital, WebVital} from 'sentry/utils/fields';
+import {MobileVital, type WebVital} from 'sentry/utils/fields';
 import {VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import type {Vital, Vital as VitalDetails} from 'sentry/utils/performance/vitals/types';
 import {VITAL_DESCRIPTIONS} from 'sentry/views/insights/browser/webVitals/components/webVitalDescription';
@@ -36,6 +36,13 @@ type Props = {
   containerWidth: number | undefined;
   rootEventResults: TraceRootEventQueryResults;
   tree: TraceTree;
+};
+
+const MOBILE_VITAL_MEASUREMENTS: Record<string, MobileVital> = {
+  'app.vitals.start.cold.value': MobileVital.APP_START_COLD,
+  'app.vitals.start.warm.value': MobileVital.APP_START_WARM,
+  'app.vitals.ttfd.value': MobileVital.TIME_TO_FULL_DISPLAY,
+  'app.vitals.ttid.value': MobileVital.TIME_TO_INITIAL_DISPLAY,
 };
 
 export function TraceContextVitals({rootEventResults, tree, containerWidth}: Props) {
@@ -262,12 +269,14 @@ function getMobileVitalsFromRootEventResults(
 
   return data.attributes
     .map(attribute => {
+      const mobileVital =
+        MOBILE_VITAL_MEASUREMENTS[attribute.name] ?? (attribute.name as MobileVital);
       if (
-        TRACE_VIEW_MOBILE_VITALS.includes(attribute.name as MobileVital) &&
+        TRACE_VIEW_MOBILE_VITALS.includes(mobileVital) &&
         typeof attribute.value === 'number'
       ) {
         return {
-          key: attribute.name.replace('measurements.', ''),
+          key: mobileVital.replace('measurements.', ''),
           measurement: {value: attribute.value},
           score: undefined,
         };

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -946,11 +946,56 @@ describe('TraceTree', () => {
           expect.objectContaining({key: 'lcp', measurement: {value: 200}}),
         ])
       );
+      expect(tree.vital_types).toEqual(new Set(['web']));
       expect(tree.indicators).toEqual(
         expect.arrayContaining([
           expect.objectContaining({type: 'lcp', measurement: {value: 200}}),
         ])
       );
+    });
+
+    it('collects mobile vitals from app vital values', () => {
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'eap-span-1',
+            start_timestamp: start,
+            end_timestamp: start + 2,
+            is_transaction: true,
+            mobile_app_vital: {
+              'app.vitals.start.cold.value': 1600,
+              'app.vitals.start.warm.value': 400,
+              'app.vitals.ttid.value': 1200,
+              'app.vitals.ttfd.value': 2400,
+            },
+            children: [],
+          }),
+        ]),
+        {meta: null, replay: null, organization}
+      );
+
+      const span1 = tree.root.findChild(n => n.id === 'eap-span-1');
+      expect(tree.vitals.get(span1!)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: 'app_start_cold',
+            measurement: {value: 1600},
+          }),
+          expect.objectContaining({
+            key: 'app_start_warm',
+            measurement: {value: 400},
+          }),
+          expect.objectContaining({
+            key: 'time_to_initial_display',
+            measurement: {value: 1200},
+          }),
+          expect.objectContaining({
+            key: 'time_to_full_display',
+            measurement: {value: 2400},
+          }),
+        ])
+      );
+      expect(tree.vital_types).toEqual(new Set(['mobile']));
     });
 
     it('standalone LCP span indicator takes priority over pageload LCP indicator', () => {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -173,6 +173,7 @@ export declare namespace TraceTree {
     browser_web_vital?: Record<string, number>;
     description?: string;
     measurements?: Record<string, number>;
+    mobile_app_vital?: Record<string, number>;
   };
 
   type UptimeCheck = {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode.tsx
@@ -24,6 +24,13 @@ const BROWSER_WEB_VITAL_MEASUREMENTS: Record<string, string> = {
   'browser.web_vital.ttfb.value': 'ttfb',
 };
 
+const MOBILE_VITAL_MEASUREMENTS: Record<string, string> = {
+  'app.vitals.start.cold.value': 'app_start_cold',
+  'app.vitals.start.warm.value': 'app_start_warm',
+  'app.vitals.ttfd.value': 'time_to_full_display',
+  'app.vitals.ttid.value': 'time_to_initial_display',
+};
+
 export class EapSpanNode extends BaseNode<TraceTree.EAPSpan> {
   id: string;
   type: TraceTree.NodeType;
@@ -149,6 +156,20 @@ export class EapSpanNode extends BaseNode<TraceTree.EAPSpan> {
       if (typeof value === 'number') {
         const normalizedKey = key.replace('measurements.', '');
         result[normalizedKey] = {value};
+      }
+    }
+
+    if (this.value.mobile_app_vital) {
+      for (const key in this.value.mobile_app_vital) {
+        const normalizedKey = MOBILE_VITAL_MEASUREMENTS[key];
+        const value = this.value.mobile_app_vital[key];
+        if (
+          normalizedKey &&
+          typeof value === 'number' &&
+          (!result[normalizedKey] || result[normalizedKey].value === 0)
+        ) {
+          result[normalizedKey] = {value};
+        }
       }
     }
 


### PR DESCRIPTION
The goal of this PR is to update the trace waterfall to handle the changes made in: https://github.com/getsentry/sentry/pull/118238 to support mobile vitals V2, while still supporting previous measurement fallbacks.
