### PR TITLE
ref(cells) Use signupLocalities in UI code

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -491,6 +491,7 @@ class _ClientConfig:
                 "allowUrls": self.allow_list,
                 "tracePropagationTargets": settings.SENTRY_FRONTEND_TRACE_PROPAGATION_TARGETS or [],
             },
+            # TODO(cells) remove this after UI changes are out.
             "relocationConfig": {"selectableRegions": options.get("relocation.selectable-regions")},
             "demoMode": is_demo_mode_enabled() and is_demo_user(self.user),
             "enableAnalytics": settings.ENABLE_ANALYTICS,

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -229,9 +229,6 @@ export interface Config {
     agreements: ParntershipAgreementType[];
     partnerDisplayName: string;
   } | null;
-  relocationConfig?: {
-    selectableRegions: string[];
-  };
   shouldShowBeaconConsentPrompt?: boolean;
   statuspage?: {
     api_host: string;

--- a/static/app/utils/cells/index.spec.tsx
+++ b/static/app/utils/cells/index.spec.tsx
@@ -1,6 +1,10 @@
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
-import {getLocalityUrlOptions, getLocalityNameOptions} from 'sentry/utils/cells';
+import {
+  getLocalityUrlOptions,
+  getLocalityNameOptions,
+  getSignupLocalities,
+} from 'sentry/utils/cells';
 
 describe('getLocalityUrlOptions', () => {
   let configstate: Config;
@@ -80,5 +84,51 @@ describe('getLocalityNameOptions', () => {
     expect(res[2]).toEqual({value: 'de', label: '🇪🇺 European Union (EU)'});
     // No defined label name
     expect(res[3]).toEqual({value: 'ja', label: 'ja'});
+  });
+});
+
+describe('getSignupLocalities', () => {
+  let configstate: Config;
+
+  beforeEach(() => {
+    configstate = ConfigStore.getState();
+  });
+
+  afterEach(() => {
+    ConfigStore.loadInitialData(configstate);
+  });
+  it('returns options', () => {
+    ConfigStore.set('signupLocalities', ['us', 'us2', 'de', 'ja']);
+    ConfigStore.set('localities', [
+      {name: 'us', url: 'https://us.sentry.io'},
+      {name: 'us2', url: 'https://us2.sentry.io'},
+      {name: 'de', url: 'https://de.sentry.io'},
+      {name: 'ja', url: 'https://ja.sentry.io'},
+    ]);
+
+    const res = getSignupLocalities();
+    expect(res).toHaveLength(4);
+
+    expect(res[0]).toEqual({value: 'us', label: '🇺🇸 United States of America (US)'});
+    expect(res[1]).toEqual({value: 'us2', label: '🇺🇸 United States of America (US2)'});
+    expect(res[2]).toEqual({value: 'de', label: '🇪🇺 European Union (EU)'});
+    // No defined label name
+    expect(res[3]).toEqual({value: 'ja', label: 'ja'});
+  });
+
+  it('filters to signupLocalities', () => {
+    ConfigStore.set('signupLocalities', ['us', 'de']);
+    ConfigStore.set('localities', [
+      {name: 'us', url: 'https://us.sentry.io'},
+      {name: 'us2', url: 'https://us2.sentry.io'},
+      {name: 'de', url: 'https://de.sentry.io'},
+      {name: 'ja', url: 'https://ja.sentry.io'},
+    ]);
+
+    const res = getSignupLocalities();
+    expect(res).toHaveLength(2);
+
+    expect(res[0]).toEqual({value: 'us', label: '🇺🇸 United States of America (US)'});
+    expect(res[1]).toEqual({value: 'de', label: '🇪🇺 European Union (EU)'});
   });
 });

--- a/static/app/utils/cells/index.spec.tsx
+++ b/static/app/utils/cells/index.spec.tsx
@@ -109,11 +109,23 @@ describe('getSignupLocalities', () => {
     const res = getSignupLocalities();
     expect(res).toHaveLength(4);
 
-    expect(res[0]).toEqual({value: 'us', label: '🇺🇸 United States of America (US)'});
-    expect(res[1]).toEqual({value: 'us2', label: '🇺🇸 United States of America (US2)'});
-    expect(res[2]).toEqual({value: 'de', label: '🇪🇺 European Union (EU)'});
+    expect(res[0]).toEqual({
+      value: 'us',
+      url: 'https://us.sentry.io',
+      label: '🇺🇸 United States of America (US)',
+    });
+    expect(res[1]).toEqual({
+      value: 'us2',
+      url: 'https://us2.sentry.io',
+      label: '🇺🇸 United States of America (US2)',
+    });
+    expect(res[2]).toEqual({
+      value: 'de',
+      url: 'https://de.sentry.io',
+      label: '🇪🇺 European Union (EU)',
+    });
     // No defined label name
-    expect(res[3]).toEqual({value: 'ja', label: 'ja'});
+    expect(res[3]).toEqual({value: 'ja', url: 'https://ja.sentry.io', label: 'ja'});
   });
 
   it('filters to signupLocalities', () => {
@@ -128,7 +140,15 @@ describe('getSignupLocalities', () => {
     const res = getSignupLocalities();
     expect(res).toHaveLength(2);
 
-    expect(res[0]).toEqual({value: 'us', label: '🇺🇸 United States of America (US)'});
-    expect(res[1]).toEqual({value: 'de', label: '🇪🇺 European Union (EU)'});
+    expect(res[0]).toEqual({
+      value: 'us',
+      url: 'https://us.sentry.io',
+      label: '🇺🇸 United States of America (US)',
+    });
+    expect(res[1]).toEqual({
+      value: 'de',
+      url: 'https://de.sentry.io',
+      label: '🇪🇺 European Union (EU)',
+    });
   });
 });

--- a/static/app/utils/cells/index.spec.tsx
+++ b/static/app/utils/cells/index.spec.tsx
@@ -1,10 +1,6 @@
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
-import {
-  getLocalityUrlOptions,
-  getLocalityNameOptions,
-  getSignupLocalities,
-} from 'sentry/utils/cells';
+import {getLocalityUrlOptions, getSignupLocalities} from 'sentry/utils/cells';
 
 describe('getLocalityUrlOptions', () => {
   let configstate: Config;
@@ -55,35 +51,6 @@ describe('getLocalityUrlOptions', () => {
       value: 'https://us.sentry.io',
       label: '🇺🇸 United States of America (US)',
     });
-  });
-});
-
-describe('getLocalityNameOptions', () => {
-  let configstate: Config;
-
-  beforeEach(() => {
-    configstate = ConfigStore.getState();
-  });
-
-  afterEach(() => {
-    ConfigStore.loadInitialData(configstate);
-  });
-  it('returns options', () => {
-    ConfigStore.set('localities', [
-      {name: 'us', url: 'https://us.sentry.io'},
-      {name: 'us2', url: 'https://us2.sentry.io'},
-      {name: 'de', url: 'https://de.sentry.io'},
-      {name: 'ja', url: 'https://ja.sentry.io'},
-    ]);
-
-    const res = getLocalityNameOptions();
-    expect(res).toHaveLength(4);
-
-    expect(res[0]).toEqual({value: 'us', label: '🇺🇸 United States of America (US)'});
-    expect(res[1]).toEqual({value: 'us2', label: '🇺🇸 United States of America (US2)'});
-    expect(res[2]).toEqual({value: 'de', label: '🇪🇺 European Union (EU)'});
-    // No defined label name
-    expect(res[3]).toEqual({value: 'ja', label: 'ja'});
   });
 });
 

--- a/static/app/utils/cells/index.tsx
+++ b/static/app/utils/cells/index.tsx
@@ -118,11 +118,15 @@ export function getLocalityNameOptions(): Array<SelectValue<string>> {
   });
 }
 
+interface LocalitySelectValue extends SelectValue<string> {
+  url: string;
+}
+
 /**
  * Get a list of option objects with {label: displayName: value: locality.name}
  * for all the localities that are available for signups.
  */
-export function getSignupLocalities(): Array<SelectValue<string>> {
+export function getSignupLocalities(): LocalitySelectValue[] {
   const signupLocalities = ConfigStore.get('signupLocalities');
   const localities = getLocalities();
 
@@ -131,6 +135,7 @@ export function getSignupLocalities(): Array<SelectValue<string>> {
     .map(locality => {
       return {
         value: locality.name,
+        url: locality.url,
         label:
           `${getLocalityFlagIndicator(locality)} ${getLocalityDisplayName(locality)}`.trim(),
       };

--- a/static/app/utils/cells/index.tsx
+++ b/static/app/utils/cells/index.tsx
@@ -118,6 +118,25 @@ export function getLocalityNameOptions(): Array<SelectValue<string>> {
   });
 }
 
+/**
+ * Get a list of option objects with {label: displayName: value: locality.name}
+ * for all the localities that are available for signups.
+ */
+export function getSignupLocalities(): Array<SelectValue<string>> {
+  const signupLocalities = ConfigStore.get('signupLocalities');
+  const localities = getLocalities();
+
+  return localities
+    .filter(locality => signupLocalities.includes(locality.name))
+    .map(locality => {
+      return {
+        value: locality.name,
+        label:
+          `${getLocalityFlagIndicator(locality)} ${getLocalityDisplayName(locality)}`.trim(),
+      };
+    });
+}
+
 export function shouldDisplayLocalities(): boolean {
   return getLocalities().length > 1;
 }

--- a/static/app/utils/cells/index.tsx
+++ b/static/app/utils/cells/index.tsx
@@ -103,21 +103,6 @@ export function getLocalityUrlOptions(
     });
 }
 
-/**
- * Create a list of option objects with {label: displayName, value: name}
- */
-export function getLocalityNameOptions(): Array<SelectValue<string>> {
-  const localities = getLocalities();
-
-  return localities.map(locality => {
-    return {
-      value: locality.name,
-      label:
-        `${getLocalityFlagIndicator(locality)} ${getLocalityDisplayName(locality)}`.trim(),
-    };
-  });
-}
-
 interface LocalitySelectValue extends SelectValue<string> {
   url: string;
 }

--- a/static/app/views/organizationCreate/index.spec.tsx
+++ b/static/app/views/organizationCreate/index.spec.tsx
@@ -21,6 +21,7 @@ describe('OrganizationCreate', () => {
 
     // Set only a single locality in the config store by default
     ConfigStore.set('localities', [{name: '--monolith--', url: 'https://example.com'}]);
+    ConfigStore.set('signupLocalities', ['--monolith--']);
   });
 
   afterEach(() => {
@@ -146,6 +147,7 @@ describe('OrganizationCreate', () => {
         name: 'de',
       },
     ]);
+    ConfigStore.set('signupLocalities', ['us', 'de']);
 
     return orgCreateMock;
   }
@@ -154,6 +156,7 @@ describe('OrganizationCreate', () => {
     const orgCreateMock = multiLocalitySetup();
     // Set only a single region in the config store
     ConfigStore.set('localities', [{name: '--monolith--', url: 'https://example.com'}]);
+    ConfigStore.set('signupLocalities', ['--monolith--']);
     ConfigStore.set('features', new Set(['system:multi-region']));
 
     render(<OrganizationCreate />);
@@ -256,6 +259,7 @@ describe('OrganizationCreate', () => {
         name: 'de',
       },
     ]);
+    ConfigStore.set('signupLocalities', ['us', 'de']);
     const orgCreateMock = MockApiClient.addMockResponse({
       host: ConfigStore.get('links').sentryUrl,
       url: '/organizations/',

--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -16,7 +16,7 @@ import {t, tct} from 'sentry/locale';
 import {getOverride} from 'sentry/overrideRegistry';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {OrganizationSummary} from 'sentry/types/organization';
-import {getSignupLocalities, shouldDisplayLocalities} from 'sentry/utils/cells';
+import {getSignupLocalities} from 'sentry/utils/cells';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
@@ -111,7 +111,7 @@ function OrganizationCreate() {
             stacked
             required
           />
-          {shouldDisplayLocalities() && (
+          {localityOptions.length > 1 && (
             <SelectField
               name="dataStorageLocation"
               label={t('Data Storage Location')}

--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -16,7 +16,7 @@ import {t, tct} from 'sentry/locale';
 import {getOverride} from 'sentry/overrideRegistry';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {OrganizationSummary} from 'sentry/types/organization';
-import {getLocalityNameOptions, shouldDisplayLocalities} from 'sentry/utils/cells';
+import {getSignupLocalities, shouldDisplayLocalities} from 'sentry/utils/cells';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
@@ -34,7 +34,7 @@ function OrganizationCreate() {
   const privacyUrl = ConfigStore.get('privacyUrl');
   const isSelfHosted = ConfigStore.get('isSelfHosted');
   const relocationUrl = normalizeUrl('/relocation/');
-  const localityOptions = getLocalityNameOptions();
+  const localityOptions = getSignupLocalities();
   const client = useApi();
 
   const hasDataConsent =

--- a/static/app/views/relocation/getStarted.tsx
+++ b/static/app/views/relocation/getStarted.tsx
@@ -7,8 +7,7 @@ import {Select} from '@sentry/scraps/select';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
-import {ConfigStore} from 'sentry/stores/configStore';
-import {getLocalityUrlOptions, getSignupLocalities} from 'sentry/utils/cells';
+import {getSignupLocalities} from 'sentry/utils/cells';
 import {useApi} from 'sentry/utils/useApi';
 import {ContinueButton} from 'sentry/views/relocation/components/continueButton';
 import {StepHeading} from 'sentry/views/relocation/components/stepHeading';

--- a/static/app/views/relocation/getStarted.tsx
+++ b/static/app/views/relocation/getStarted.tsx
@@ -8,7 +8,7 @@ import {Select} from '@sentry/scraps/select';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
-import {getLocalityUrlOptions} from 'sentry/utils/cells';
+import {getLocalityUrlOptions, getSignupLocalities} from 'sentry/utils/cells';
 import {useApi} from 'sentry/utils/useApi';
 import {ContinueButton} from 'sentry/views/relocation/components/continueButton';
 import {StepHeading} from 'sentry/views/relocation/components/stepHeading';
@@ -25,10 +25,9 @@ export function GetStarted({
   onComplete,
 }: StepProps) {
   const api = useApi();
-  const {orgSlugs, regionUrl, promoCode} = relocationState;
+  const {orgSlugs, localityName, promoCode} = relocationState;
   const [showPromoCode, setShowPromoCode] = useState(!!promoCode);
-  const selectableRegions = ConfigStore.get('relocationConfig')?.selectableRegions || [];
-  const localityOptions = getLocalityUrlOptions([], selectableRegions);
+  const localityOptions = getSignupLocalities();
 
   const handleContinue = async (event: any) => {
     event.preventDefault();
@@ -76,16 +75,16 @@ export function GetStarted({
           />
           <Label>{t('Choose a datacenter location')}</Label>
           <RegionSelect
-            value={regionUrl}
+            value={localityName}
             name="region"
             aria-label={t('region')}
             placeholder="Select Location"
             options={localityOptions}
             onChange={(opt: any) => {
-              onUpdateRelocationState({regionUrl: opt.value});
+              onUpdateRelocationState({localityName: opt.value});
             }}
           />
-          {regionUrl && (
+          {localityName && (
             <p>{t('This is an important decision and cannot be changed.')}</p>
           )}
           <DatacenterTextBlock>
@@ -121,7 +120,7 @@ export function GetStarted({
             </TogglePromoCode>
           )}
           <ContinueButton
-            disabled={!orgSlugs || !regionUrl}
+            disabled={!orgSlugs || !localityName}
             variant="primary"
             type="submit"
           />

--- a/static/app/views/relocation/publicKey.tsx
+++ b/static/app/views/relocation/publicKey.tsx
@@ -12,8 +12,8 @@ import {Wrapper} from 'sentry/views/relocation/components/wrapper';
 import type {StepProps} from './types';
 
 export function PublicKey({publicKeys, relocationState, onComplete}: StepProps) {
-  const {regionUrl} = relocationState;
-  const publicKey = publicKeys.get(regionUrl);
+  const {localityName} = relocationState;
+  const publicKey = publicKeys.get(localityName);
   const handleContinue = (event: any) => {
     event.preventDefault();
     onComplete();

--- a/static/app/views/relocation/relocation.spec.tsx
+++ b/static/app/views/relocation/relocation.spec.tsx
@@ -47,9 +47,7 @@ describe('Relocation', () => {
       {name: fakeLocalities.Earth!.name, url: fakeLocalities.Earth!.url},
       {name: fakeLocalities.Moon!.name, url: fakeLocalities.Moon!.url},
     ]);
-    ConfigStore.set('relocationConfig', {
-      selectableRegions: [fakeLocalities.Earth!.name, fakeLocalities.Moon!.name],
-    });
+    ConfigStore.set('signupLocalities', ['earth', 'moon']);
 
     // For tests that don't care about the difference between our "earth" and "moon" regions, we can
     // re-use the same mock responses, with the same generic public key for both.
@@ -173,7 +171,7 @@ describe('Relocation', () => {
         JSON.stringify({
           orgSlugs: fakeOrgSlug,
           promoCode: fakePromoCode,
-          regionUrl: fakeLocalities.Earth!.url,
+          localityName: fakeLocalities.Earth!.name,
         })
       );
 
@@ -271,7 +269,7 @@ describe('Relocation', () => {
         JSON.stringify({
           orgSlugs: fakeOrgSlug,
           promoCode: fakePromoCode,
-          regionUrl: fakeLocalities.Earth!.url,
+          localityName: fakeLocalities.Earth!.name,
         })
       );
     });
@@ -340,7 +338,7 @@ describe('Relocation', () => {
         'relocationOnboarding',
         JSON.stringify({
           orgSlugs: fakeOrgSlug,
-          // regionUrl missing
+          // localityName missing
         })
       );
 
@@ -362,7 +360,7 @@ describe('Relocation', () => {
         'relocationOnboarding',
         JSON.stringify({
           orgSlugs: fakeOrgSlug,
-          regionUrl: fakeLocalities.Earth!.url,
+          localityName: fakeLocalities.Earth!.name,
         })
       );
     });
@@ -383,7 +381,7 @@ describe('Relocation', () => {
         'relocationOnboarding',
         JSON.stringify({
           // orgSlugs missing
-          regionUrl: fakeLocalities.Earth!.url,
+          localityName: fakeLocalities.Earth!.name,
         })
       );
 
@@ -406,7 +404,7 @@ describe('Relocation', () => {
         JSON.stringify({
           orgSlugs: fakeOrgSlug,
           promoCode: fakePromoCode,
-          regionUrl: fakeLocalities.Earth!.url,
+          localityName: fakeLocalities.Earth!.name,
         })
       );
     });
@@ -606,7 +604,7 @@ describe('Relocation', () => {
         'relocationOnboarding',
         JSON.stringify({
           orgSlugs: fakeOrgSlug,
-          regionUrl: fakeLocalities.Earth!.url,
+          localityName: fakeLocalities.Earth!.name,
         })
       );
     });

--- a/static/app/views/relocation/relocation.tsx
+++ b/static/app/views/relocation/relocation.tsx
@@ -12,7 +12,7 @@ import {Redirect} from 'sentry/components/redirect';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {getLocalityUrlOptions} from 'sentry/utils/cells';
+import {getSignupLocalities} from 'sentry/utils/cells';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -76,7 +76,7 @@ export function RelocationOnboarding() {
   const stepObj = onboardingSteps.find(({id}) => stepId === id);
   const stepIndex = onboardingSteps.findIndex(({id}) => stepId === id);
   const api = useApi();
-  const localityOptions = getLocalityUrlOptions();
+  const localityOptions = getSignupLocalities();
   const [existingRelocationState, setExistingRelocationState] = useState(
     LoadingState.FETCHING
   );
@@ -87,7 +87,7 @@ export function RelocationOnboarding() {
     'relocationOnboarding',
     {
       orgSlugs: '',
-      regionUrl: '',
+      localityName: '',
       promoCode: '',
     }
   );
@@ -130,8 +130,8 @@ export function RelocationOnboarding() {
 
         // The user tried to view a later step, but at least one bit of required data was missing in
         // their local storage. Take them back to the first screen.
-        const {orgSlugs, regionUrl} = relocationState;
-        if (stepId !== 'get-started' && (!orgSlugs || !regionUrl)) {
+        const {orgSlugs, localityName} = relocationState;
+        if (stepId !== 'get-started' && (!orgSlugs || !localityName)) {
           navigate('/relocation/get-started/');
         }
 
@@ -263,13 +263,15 @@ export function RelocationOnboarding() {
             stepIndex={stepIndex}
             onUpdateRelocationState={({
               orgSlugs,
-              regionUrl,
+              localityName,
               promoCode,
             }: MaybeUpdateRelocationState) => {
               setRelocationState({
                 orgSlugs: orgSlugs === undefined ? relocationState.orgSlugs : orgSlugs,
-                regionUrl:
-                  regionUrl === undefined ? relocationState.regionUrl : regionUrl,
+                localityName:
+                  localityName === undefined
+                    ? relocationState.localityName
+                    : localityName,
                 promoCode:
                   promoCode === undefined ? relocationState.promoCode : promoCode,
               });

--- a/static/app/views/relocation/relocation.tsx
+++ b/static/app/views/relocation/relocation.tsx
@@ -76,7 +76,6 @@ export function RelocationOnboarding() {
   const stepObj = onboardingSteps.find(({id}) => stepId === id);
   const stepIndex = onboardingSteps.findIndex(({id}) => stepId === id);
   const api = useApi();
-  const localityOptions = getSignupLocalities();
   const [existingRelocationState, setExistingRelocationState] = useState(
     LoadingState.FETCHING
   );
@@ -91,16 +90,17 @@ export function RelocationOnboarding() {
       promoCode: '',
     }
   );
+  const localityOptions = getSignupLocalities();
 
   const fetchExistingRelocation = useCallback(() => {
     setExistingRelocationState(LoadingState.FETCHING);
     return Promise.all(
-      localityOptions.map(option =>
-        api.requestPromise('/relocations/', {
+      localityOptions.map(option => {
+        return api.requestPromise('/relocations/', {
           method: 'GET',
-          host: option.value,
-        })
-      )
+          host: option.url,
+        });
+      })
     )
       .then(responses => {
         const response = responses.flat(1);
@@ -154,7 +154,7 @@ export function RelocationOnboarding() {
       localityOptions.map(option =>
         api.requestPromise('/publickeys/relocations/', {
           method: 'GET',
-          host: option.value,
+          host: option.url,
         })
       )
     )

--- a/static/app/views/relocation/types.ts
+++ b/static/app/views/relocation/types.ts
@@ -1,13 +1,13 @@
 type RelocationState = {
+  localityName: string;
   orgSlugs: string;
   promoCode: string;
-  regionUrl: string;
 };
 
 export type MaybeUpdateRelocationState = {
+  localityName?: string;
   orgSlugs?: string;
   promoCode?: string;
-  regionUrl?: string;
 };
 
 export type StepProps = {

--- a/static/app/views/relocation/uploadBackup.tsx
+++ b/static/app/views/relocation/uploadBackup.tsx
@@ -9,6 +9,7 @@ import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicato
 import {Client} from 'sentry/api';
 import {IconDelete, IconFile, IconUpload} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {getLocalities} from 'sentry/utils/cells';
 import {useApi} from 'sentry/utils/useApi';
 import {useUser} from 'sentry/utils/useUser';
 import {StepHeading} from 'sentry/views/relocation/components/stepHeading';
@@ -67,8 +68,13 @@ export function UploadBackup({relocationState, onComplete}: StepProps) {
   };
 
   const handleStartRelocation = async () => {
-    const {orgSlugs, regionUrl, promoCode} = relocationState;
-    if (!orgSlugs || !regionUrl || !file) {
+    const {orgSlugs, localityName, promoCode} = relocationState;
+    if (!orgSlugs || localityName || !file) {
+      addErrorMessage(DEFAULT_ERROR_MSG);
+      return;
+    }
+    const locality = getLocalities().find(candidate => candidate.name == localityName);
+    if (!locality) {
       addErrorMessage(DEFAULT_ERROR_MSG);
       return;
     }
@@ -82,7 +88,7 @@ export function UploadBackup({relocationState, onComplete}: StepProps) {
     try {
       const result = await api.requestPromise('/relocations/', {
         method: 'POST',
-        host: regionUrl,
+        host: locality.url,
         data: formData,
       });
 

--- a/static/app/views/relocation/uploadBackup.tsx
+++ b/static/app/views/relocation/uploadBackup.tsx
@@ -69,11 +69,11 @@ export function UploadBackup({relocationState, onComplete}: StepProps) {
 
   const handleStartRelocation = async () => {
     const {orgSlugs, localityName, promoCode} = relocationState;
-    if (!orgSlugs || localityName || !file) {
+    if (!orgSlugs || !localityName || !file) {
       addErrorMessage(DEFAULT_ERROR_MSG);
       return;
     }
-    const locality = getLocalities().find(candidate => candidate.name == localityName);
+    const locality = getLocalities().find(candidate => candidate.name === localityName);
     if (!locality) {
       addErrorMessage(DEFAULT_ERROR_MSG);
       return;


### PR DESCRIPTION
Update relocations and organization create to use the `singupLocalities` attribute that will be exposed in `__initialData` #118204.

These changes also remove `relocationConfig` as with `signup_visible` we can make `relocationConfig` redundant. I have also converted relocations from storing URLs in its state to using locality names. This aligns the implementation between relocations and org create.

Refs INFRENG-350