### PR TITLE
fix(explore): Make missing description rendering consistent

### DIFF
--- a/static/app/utils/discover/emptyFieldValues.tsx
+++ b/static/app/utils/discover/emptyFieldValues.tsx
@@ -1,11 +1,14 @@
-import styled from '@emotion/styled';
+import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
 
-const EmptyValueContainer = styled('span')`
-  color: ${p => p.theme.tokens.content.secondary};
-`;
-export const emptyValue = <EmptyValueContainer>{t('(no value)')}</EmptyValueContainer>;
+export const emptyValue = (
+  <Text as="span" variant="muted">
+    {t('(no value)')}
+  </Text>
+);
 export const emptyStringValue = (
-  <EmptyValueContainer>{t('(empty string)')}</EmptyValueContainer>
+  <Text as="span" variant="muted">
+    {t('(empty string)')}
+  </Text>
 );

--- a/static/app/utils/discover/emptyFieldValues.tsx
+++ b/static/app/utils/discover/emptyFieldValues.tsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+import {t} from 'sentry/locale';
+
+const EmptyValueContainer = styled('span')`
+  color: ${p => p.theme.tokens.content.secondary};
+`;
+export const emptyValue = <EmptyValueContainer>{t('(no value)')}</EmptyValueContainer>;
+export const emptyStringValue = (
+  <EmptyValueContainer>{t('(empty string)')}</EmptyValueContainer>
+);

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -89,6 +89,7 @@ import {
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
 import {ArrayValue} from './arrayValue';
+import {emptyValue, emptyStringValue} from './emptyFieldValues';
 import {
   BarContainer,
   Container,
@@ -165,13 +166,6 @@ type FieldFormatters = {
   string: FieldFormatter;
 };
 
-const EmptyValueContainer = styled('span')`
-  color: ${p => p.theme.tokens.content.secondary};
-`;
-const emptyValue = <EmptyValueContainer>{t('(no value)')}</EmptyValueContainer>;
-export const emptyStringValue = (
-  <EmptyValueContainer>{t('(empty string)')}</EmptyValueContainer>
-);
 const missingUserMisery = tct(
   'We were unable to calculate User Misery. A likely cause of this is that the user was not set. [link:Read the docs]',
   {
@@ -583,7 +577,7 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
       if (op === ModuleName.DB || op === ModuleName.RESOURCE) {
         return (
           <SpanDescriptionCell
-            description={value ?? ''}
+            description={value}
             moduleName={op}
             projectId={projectId}
             group={spanGroup}

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -19,12 +19,13 @@ import type {
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
+import {emptyStringValue} from 'sentry/utils/discover/emptyFieldValues';
 import type {EventData, MetaType} from 'sentry/utils/discover/eventView';
 import type {
   FieldFormatterRenderFunctionPartial,
   RenderFunctionBaggage,
 } from 'sentry/utils/discover/fieldRenderers';
-import {emptyStringValue, getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {AggregationOutputType, QueryFieldValue} from 'sentry/utils/discover/fields';
 import {
   errorsAndTransactionsAggregateFunctionOutputType,

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -11,9 +11,10 @@ import type {
 } from 'sentry/types/organization';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
+import {emptyStringValue} from 'sentry/utils/discover/emptyFieldValues';
 import type {EventData} from 'sentry/utils/discover/eventView';
 import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
-import {emptyStringValue, getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {
   AGGREGATIONS,
   stripEquationPrefix,

--- a/static/app/views/insights/common/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/spanDescriptionCell.tsx
@@ -37,11 +37,7 @@ export function SpanDescriptionCell({
   extraLinkQueryParams,
 }: Props) {
   const formatterDescription = useMemo(() => {
-    if (!rawDescription) {
-      return rawDescription === '' ? emptyStringValue : emptyValue;
-    }
-
-    if (moduleName !== ModuleName.DB) {
+    if (!rawDescription || moduleName !== ModuleName.DB) {
       return rawDescription;
     }
 
@@ -51,6 +47,10 @@ export function SpanDescriptionCell({
 
     return formatter.toSimpleMarkup(rawDescription);
   }, [moduleName, rawDescription, spanAction, system]);
+
+  if (!rawDescription) {
+    return rawDescription === '' ? emptyStringValue : emptyValue;
+  }
 
   const descriptionLink = (
     <SpanGroupDetailsLink

--- a/static/app/views/insights/common/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/spanDescriptionCell.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {Hovercard} from 'sentry/components/hovercard';
 import {t} from 'sentry/locale';
+import {emptyStringValue, emptyValue} from 'sentry/utils/discover/emptyFieldValues';
 import {SQLishFormatter} from 'sentry/utils/sqlish';
 import {FullSpanDescription} from 'sentry/views/insights/common/components/fullSpanDescription';
 import {SpanGroupDetailsLink} from 'sentry/views/insights/common/components/spanGroupDetailsLink';
@@ -15,9 +16,9 @@ const formatter = new SQLishFormatter();
 const {SPAN_OP} = SpanFields;
 
 interface Props {
-  description: string;
   moduleName: ModuleName.DB | ModuleName.RESOURCE;
   projectId: number;
+  description?: string;
   extraLinkQueryParams?: Record<string, string>;
   group?: string | null;
   spanAction?: string;
@@ -36,6 +37,10 @@ export function SpanDescriptionCell({
   extraLinkQueryParams,
 }: Props) {
   const formatterDescription = useMemo(() => {
+    if (!rawDescription) {
+      return rawDescription === '' ? emptyStringValue : emptyValue;
+    }
+
     if (moduleName !== ModuleName.DB) {
       return rawDescription;
     }
@@ -46,10 +51,6 @@ export function SpanDescriptionCell({
 
     return formatter.toSimpleMarkup(rawDescription);
   }, [moduleName, rawDescription, spanAction, system]);
-
-  if (!rawDescription) {
-    return NULL_DESCRIPTION;
-  }
 
   const descriptionLink = (
     <SpanGroupDetailsLink
@@ -102,8 +103,6 @@ export function SpanDescriptionCell({
 
   return descriptionLink;
 }
-
-const NULL_DESCRIPTION = <span>&lt;null&gt;</span>;
 
 export const WiderHovercard = styled(
   ({children, className, ...props}: React.ComponentProps<typeof Hovercard>) => (

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -686,8 +686,9 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
           );
         case PerformanceWidgetSetting.MOST_TIME_SPENT_DB_QUERIES:
         case PerformanceWidgetSetting.MOST_TIME_CONSUMING_RESOURCES: {
-          const description = (listItem[SpanFields.NORMALIZED_DESCRIPTION] ??
-            '') as string;
+          const description = listItem[SpanFields.NORMALIZED_DESCRIPTION] as
+            | string
+            | undefined;
           const group = listItem[SpanFields.SPAN_GROUP] as string;
           const projectID = listItem['project.id'] as number;
           const timeSpentPercentage = listItem[fieldString] as number;


### PR DESCRIPTION
A completely missing description value was showing up as `<null>` for database spans, unlike every other span where it would show up as `(no value)`. Make DB spans consistent with other spans.

Extracted the empty values into their own file to avoid a circular reference between `fieldRenderers.tsx` and `spanDescriptionCell.tsx`.

Before:
<img width="715" height="192" alt="Screenshot 2026-06-23 at 11 24 45" src="https://github.com/user-attachments/assets/23618de4-59dd-4433-b0ad-315b4c4926fc" />

After:
<img width="719" height="198" alt="Screenshot 2026-06-23 at 11 25 28" src="https://github.com/user-attachments/assets/dd31a871-1846-4212-b072-2ad0df3c0919" />