### PR TITLE
fix(stats): Handle duplicate user tags

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_stats.py
+++ b/src/sentry/api/endpoints/organization_trace_item_stats.py
@@ -220,12 +220,16 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
                 return {"data": []}, 0
 
             sanitized_keys = []
+            visited_public_keys = []
             for internal_name in internal_alias_attr_keys:
                 public_alias = stats_config.alias_mappings.get("string", {}).get(
                     internal_name, internal_name
                 )
 
-                if public_alias in stats_config.excluded_attributes:
+                if (
+                    public_alias in stats_config.excluded_attributes
+                    or public_alias in visited_public_keys
+                ):
                     continue
 
                 if not can_expose_attribute_to_api(
@@ -237,9 +241,11 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
 
                 if value_substring_match:
                     if value_substring_match in public_alias:
+                        visited_public_keys.append(public_alias)
                         sanitized_keys.append(internal_name)
                     continue
 
+                visited_public_keys.append(public_alias)
                 sanitized_keys.append(internal_name)
 
             # The number of attributes available across all pages drives pagination

--- a/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
@@ -43,13 +43,17 @@ class OrganizationTraceItemsStatsEndpointTest(
 
         return response
 
-    def _store_span(self, description=None, tags=None, duration=None):
-        if tags is None:
-            tags = {"foo": "bar"}
+    def _store_span(self, description=None, sentry_tags=None, tags=None, duration=None):
+        if sentry_tags is None:
+            sentry_tags = {"foo": "bar"}
+
+        data = {"description": description or "foo", "sentry_tags": sentry_tags}
+        if tags is not None:
+            data["tags"] = tags
 
         self.store_span(
             self.create_span(
-                {"description": description or "foo", "sentry_tags": tags},
+                data,
                 start_ts=self.ten_mins_ago,
                 duration=duration or 1000,
             ),
@@ -112,7 +116,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         ]
 
         for tag, duration in tags:
-            self._store_span(tags=tag, duration=duration)
+            self._store_span(sentry_tags=tag, duration=duration)
 
         response = self.do_request(
             query={
@@ -137,7 +141,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         ]
 
         for tag, duration in tags:
-            self._store_span(tags=tag, duration=duration)
+            self._store_span(sentry_tags=tag, duration=duration)
 
         response = self.do_request(
             query={
@@ -157,7 +161,7 @@ class OrganizationTraceItemsStatsEndpointTest(
             {"browser": "chrome", "device": "desktop"},
             {"browser": "firefox", "device": "mobile"},
         ]:
-            self._store_span(tags=tag)
+            self._store_span(sentry_tags=tag)
 
         def can_expose_attribute_to_api(attribute, item_type, include_internal=False):
             return attribute not in {"device", "sentry.device"}
@@ -228,7 +232,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         ]
 
         for tag, duration in tags:
-            self._store_span(tags=tag, duration=duration)
+            self._store_span(sentry_tags=tag, duration=duration)
 
         response = self.do_request(
             query={
@@ -251,7 +255,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         # deterministic total, independent of the default span attributes.
         stored_names = ["pageattra", "pageattrb", "pageattrc", "pageattrd"]
         for name in stored_names:
-            self._store_span(tags={name: "value"})
+            self._store_span(sentry_tags={name: "value"})
 
         # First page: 2 of the 4 attributes, so a next page must be reported.
         response = self.do_request(
@@ -294,7 +298,7 @@ class OrganizationTraceItemsStatsEndpointTest(
         ]
 
         for tag in tags:
-            self._store_span(tags=tag)
+            self._store_span(sentry_tags=tag)
 
         response = self.do_request(
             query={
@@ -361,3 +365,40 @@ class OrganizationTraceItemsStatsEndpointTest(
         labels = {bucket["label"] for bucket in attribute_distribution["level"]}
         assert "error" in labels
         assert "warning" not in labels
+
+    def test_duplicate_tags(self) -> None:
+        tags = [
+            ({"user.geo.subregion": "hello", "user.geo.city": "world"}, 500),
+            ({"user.geo.subregion": "hello", "user.geo.city": "foobar"}, 100),
+            ({"user.geo.subregion": "hello", "user.geo.city": "foobar"}, 100),
+            ({"user.geo.subregion": "hello", "user.geo.city": "world"}, 100),
+            ({"user.geo.subregion": "woop", "user.geo.city": "foobar"}, 100),
+            ({"user.geo.subregion": "hello", "user.geo.city": "world"}, 500),
+            ({"user.geo.subregion": "oop", "user.geo.city": "world"}, 500),
+        ]
+
+        for tag, duration in tags:
+            self._store_span(sentry_tags=tag, tags=tag, duration=duration)
+
+        response = self.do_request(
+            query={
+                "query": "",
+                "statsType": ["attributeDistributions"],
+                "substringMatch": "user.geo",
+                "itemType": "spans",
+            }
+        )
+        assert response.status_code == 200, response.data
+        assert len(response.data["data"]) == 1
+        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+        city_data = attribute_distribution["tags[user.geo.city,string]"]
+        assert {"label": "world", "value": 4.0} in city_data
+        assert {"label": "foobar", "value": 3.0} in city_data
+
+        region_data = attribute_distribution["tags[user.geo.subregion,string]"]
+        assert {"label": "hello", "value": 5.0} in region_data
+        assert {"label": "woop", "value": 1.0} in region_data
+        assert {"label": "oop", "value": 1.0} in region_data
+
+        assert "user.geo.subregion" not in attribute_distribution
+        assert "user.geo.city" not in attribute_distribution


### PR DESCRIPTION
- When a tag is stored as both `tag` and `sentry.tag` its showing up twice in the results. This dedupes them by checking what the public aliases are and ensuring we don't query them twice
- Fixes EXP-1040