### PR TITLE
ref: Refactor recreateRoute to accept matches or routes

### DIFF
--- a/static/app/components/modals/redirectToProject.spec.tsx
+++ b/static/app/components/modals/redirectToProject.spec.tsx
@@ -5,6 +5,7 @@ import {RedirectToProjectModal} from 'sentry/components/modals/redirectToProject
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 
 jest.mock('sentry/utils/recreateRoute', () => ({
+  ...jest.requireActual('sentry/utils/recreateRoute'),
   recreateRoute: jest.fn(() => '/org-slug/new-slug/'),
 }));
 

--- a/static/app/utils/__mocks__/recreateRoute.tsx
+++ b/static/app/utils/__mocks__/recreateRoute.tsx
@@ -1,1 +1,5 @@
+const actual = jest.requireActual('sentry/utils/recreateRoute');
+
+export const matchesToRoutes = actual.matchesToRoutes;
+
 export const recreateRoute = jest.fn((name: any) => name);

--- a/static/app/utils/recreateRoute.spec.tsx
+++ b/static/app/utils/recreateRoute.spec.tsx
@@ -1,26 +1,61 @@
+import type {UIMatch} from 'react-router-dom';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 
-import {recreateRoute} from 'sentry/utils/recreateRoute';
+import {matchesToRoutes, recreateRoute} from 'sentry/utils/recreateRoute';
 
 jest.unmock('sentry/utils/recreateRoute');
 
-const routes = [
-  {path: '/', childRoutes: []},
-  {childRoutes: []},
-  {path: '/settings/', name: 'Settings'},
-  {name: 'Organizations', path: ':orgId/', childRoutes: []},
-  {childRoutes: []},
-  {path: 'api-keys/', name: 'API Key'},
-];
+function makeMatch(
+  pathname: string,
+  matchParams: Record<string, string>,
+  handle: Record<string, unknown>
+): UIMatch {
+  return {id: pathname, pathname, params: matchParams, data: undefined, handle};
+}
 
-const projectRoutes = [
-  {path: '/', childRoutes: []},
-  {childRoutes: []},
-  {path: '/settings/', name: 'Settings', indexRoute: {}, childRoutes: []},
-  {name: 'Organizations', path: ':orgId/', childRoutes: []},
-  {name: 'Projects', path: ':projectId', childRoutes: []},
-  {name: 'Alerts', path: 'alerts/'},
+const matches: UIMatch[] = [
+  makeMatch('/', {}, {path: '/', childRoutes: []}),
+  makeMatch('/', {}, {childRoutes: []}),
+  makeMatch('/settings/', {}, {path: '/settings/', name: 'Settings'}),
+  makeMatch(
+    '/settings/org-slug/',
+    {orgId: 'org-slug'},
+    {name: 'Organizations', path: ':orgId/', childRoutes: []}
+  ),
+  makeMatch('/settings/org-slug/', {orgId: 'org-slug'}, {childRoutes: []}),
+  makeMatch(
+    '/settings/org-slug/api-keys/',
+    {orgId: 'org-slug'},
+    {path: 'api-keys/', name: 'API Key'}
+  ),
 ];
+const routes = matchesToRoutes(matches);
+
+const projectMatches: UIMatch[] = [
+  makeMatch('/', {}, {path: '/', childRoutes: []}),
+  makeMatch('/', {}, {childRoutes: []}),
+  makeMatch(
+    '/settings/',
+    {},
+    {path: '/settings/', name: 'Settings', indexRoute: {}, childRoutes: []}
+  ),
+  makeMatch(
+    '/settings/org-slug/',
+    {orgId: 'org-slug'},
+    {name: 'Organizations', path: ':orgId/', childRoutes: []}
+  ),
+  makeMatch(
+    '/settings/org-slug/project-slug',
+    {orgId: 'org-slug', projectId: 'project-slug'},
+    {name: 'Projects', path: ':projectId', childRoutes: []}
+  ),
+  makeMatch(
+    '/settings/org-slug/project-slug/alerts/',
+    {orgId: 'org-slug', projectId: 'project-slug'},
+    {name: 'Alerts', path: 'alerts/'}
+  ),
+];
+const projectRoutes = matchesToRoutes(projectMatches);
 
 const params = {
   orgId: 'org-slug',
@@ -34,51 +69,60 @@ const location = {
 
 describe('recreateRoute', () => {
   it('returns correct path to a route object', () => {
-    expect(recreateRoute(routes[0]!, {routes, params})).toBe('/');
-    expect(recreateRoute(routes[1]!, {routes, params})).toBe('/');
-    expect(recreateRoute(routes[2]!, {routes, params})).toBe('/settings/');
-    expect(recreateRoute(routes[3]!, {routes, params})).toBe('/settings/org-slug/');
-    expect(recreateRoute(routes[4]!, {routes, params})).toBe('/settings/org-slug/');
-    expect(recreateRoute(routes[5]!, {routes, params})).toBe(
+    expect(recreateRoute(routes[0]!, {matches, params})).toBe('/');
+    expect(recreateRoute(routes[1]!, {matches, params})).toBe('/');
+    expect(recreateRoute(routes[2]!, {matches, params})).toBe('/settings/');
+    expect(recreateRoute(routes[3]!, {matches, params})).toBe('/settings/org-slug/');
+    expect(recreateRoute(routes[4]!, {matches, params})).toBe('/settings/org-slug/');
+    expect(recreateRoute(routes[5]!, {matches, params})).toBe(
       '/settings/org-slug/api-keys/'
     );
 
     expect(
-      recreateRoute(projectRoutes[5]!, {routes: projectRoutes, location, params})
+      recreateRoute(projectRoutes[5]!, {matches: projectMatches, location, params})
     ).toBe('/settings/org-slug/project-slug/alerts/');
   });
 
   it('has correct path with route object with many roots (starts with "/")', () => {
-    const r = [
-      {path: '/', childRoutes: []},
-      {childRoutes: []},
-      {path: '/foo/', childRoutes: []},
-      {childRoutes: []},
-      {path: 'bar', childRoutes: []},
-      {path: '/settings/', name: 'Settings'},
-      {name: 'Organizations', path: ':orgId/', childRoutes: []},
-      {childRoutes: []},
-      {path: 'api-keys/', name: 'API Key'},
+    const m: UIMatch[] = [
+      makeMatch('/', {}, {path: '/', childRoutes: []}),
+      makeMatch('/', {}, {childRoutes: []}),
+      makeMatch('/foo/', {}, {path: '/foo/', childRoutes: []}),
+      makeMatch('/foo/', {}, {childRoutes: []}),
+      makeMatch('/foo/bar', {}, {path: 'bar', childRoutes: []}),
+      makeMatch('/settings/', {}, {path: '/settings/', name: 'Settings'}),
+      makeMatch(
+        '/settings/org-slug/',
+        {orgId: 'org-slug'},
+        {name: 'Organizations', path: ':orgId/', childRoutes: []}
+      ),
+      makeMatch('/settings/org-slug/', {orgId: 'org-slug'}, {childRoutes: []}),
+      makeMatch(
+        '/settings/org-slug/api-keys/',
+        {orgId: 'org-slug'},
+        {path: 'api-keys/', name: 'API Key'}
+      ),
     ];
+    const r = matchesToRoutes(m);
 
-    expect(recreateRoute(r[4]!, {routes: r, params})).toBe('/foo/bar/');
+    expect(recreateRoute(r[4]!, {matches: m, params})).toBe('/foo/bar/');
   });
 
   it('returns correct path to a string (at the end of the routes)', () => {
-    expect(recreateRoute('test/', {routes, location, params})).toBe(
+    expect(recreateRoute('test/', {matches, location, params})).toBe(
       '/settings/org-slug/api-keys/test/'
     );
   });
 
   it('returns correct path to a string after the 2nd to last route', () => {
-    expect(recreateRoute('test/', {routes, location, params, stepBack: -2})).toBe(
+    expect(recreateRoute('test/', {matches, location, params, stepBack: -2})).toBe(
       '/settings/org-slug/test/'
     );
   });
 
   it('switches to new org but keeps current route', () => {
     expect(
-      recreateRoute(routes[5]!, {routes, location, params: {orgId: 'new-org'}})
+      recreateRoute(routes[5]!, {matches, location, params: {orgId: 'new-org'}})
     ).toBe('/settings/new-org/api-keys/');
   });
 
@@ -88,7 +132,7 @@ describe('recreateRoute', () => {
       search: '?key1=foo&key2=bar',
     };
 
-    expect(recreateRoute(routes[5]!, {routes, params, location: withSearch})).toBe(
+    expect(recreateRoute(routes[5]!, {matches, params, location: withSearch})).toBe(
       '/settings/org-slug/api-keys/?key1=foo&key2=bar'
     );
   });

--- a/static/app/utils/recreateRoute.spec.tsx
+++ b/static/app/utils/recreateRoute.spec.tsx
@@ -108,6 +108,28 @@ describe('recreateRoute', () => {
     expect(recreateRoute(r[4]!, {matches: m, params})).toBe('/foo/bar/');
   });
 
+  it('resolves the correct ancestor when pathless layout routes share a shape', () => {
+    // Pathless layout routes (e.g. produced by translateSentryRoute) carry no
+    // `path`, so `matchesToRoutes` collapses each of them to the identical
+    // `{path: ''}` shape. Here indices 2 and 5 are duplicate-shaped pathless
+    // routes, with real path segments (`:orgId/`, `foo/`) in between them.
+    const m: UIMatch[] = [
+      makeMatch('/', {}, {path: '/'}),
+      makeMatch('/settings/', {}, {path: 'settings/'}),
+      makeMatch('/settings/', {}, {}),
+      makeMatch('/settings/org-slug/', {orgId: 'org-slug'}, {path: ':orgId/'}),
+      makeMatch('/settings/org-slug/foo/', {orgId: 'org-slug'}, {path: 'foo/'}),
+      makeMatch('/settings/org-slug/foo/', {orgId: 'org-slug'}, {}),
+    ];
+    const r = matchesToRoutes(m);
+
+    // Targeting the *second* pathless route (index 5) must rebuild the full
+    // path up to it. The duplicate-shaped pathless route at index 2 must not
+    // shadow it, which would otherwise drop the `:orgId/` and `foo/` segments
+    // and produce a truncated ancestor URL.
+    expect(recreateRoute(r[5]!, {matches: m, params})).toBe('/settings/org-slug/foo/');
+  });
+
   it('returns correct path to a string (at the end of the routes)', () => {
     expect(recreateRoute('test/', {matches, location, params})).toBe(
       '/settings/org-slug/api-keys/test/'

--- a/static/app/utils/recreateRoute.tsx
+++ b/static/app/utils/recreateRoute.tsx
@@ -38,10 +38,22 @@ type Options =
       stepBack?: -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9;
     };
 
+// Cache the routes derived from a given `matches` array so that repeated calls
+// (e.g. `useRoutes` building the list and `recreateRoute` resolving `to` within
+// it) return the *same* route object references. Without this, `recreateRoute`
+// would have to fall back to value comparison, which cannot distinguish two
+// pathless layout routes that collapse to the same `{path: ''}` shape.
+const matchesToRoutesCache = new WeakMap<UIMatch[], PlainRoute[]>();
+
 // XXX(epurkhiser): This transforms react-router 6 style matches back to old
 // style react-router 3 route matches.
 export function matchesToRoutes(matches: UIMatch[]): PlainRoute[] {
-  return matches.map<PlainRoute>(match => {
+  const cached = matchesToRoutesCache.get(matches);
+  if (cached) {
+    return cached;
+  }
+
+  const routes = matches.map<PlainRoute>(match => {
     // We put things like `name` (for breadcrumbs) in the handle. Extract
     // it out here
     const extra: any = match.handle;
@@ -59,14 +71,23 @@ export function matchesToRoutes(matches: UIMatch[]): PlainRoute[] {
 
     return {path, ...extra};
   }, []);
+
+  matchesToRoutesCache.set(matches, routes);
+  return routes;
 }
 
-// `to` and the entries of `routes` are both produced by `matchesToRoutes`, so
-// they share the same shape (including the synthesized `path` key) and preserve
-// nested references via the shallow spread. Match by value here rather than by
-// object identity because `recreateRoute` rebuilds `routes` on every call, so
-// the caller's `to` is never reference-equal to the local `routes` entries.
-function findRouteInRoutes(to: PlainRoute, routes: PlainRoute[]): number {
+// Locate `to` within `routes`. Reference identity is preferred because two
+// distinct routes can produce the same shape (pathless layout routes collapse
+// to `{path: ''}`), and only identity resolves them to the correct position.
+// `matchesToRoutes` is memoized so callers that derive `to` from the same
+// `matches` array hit this fast path. Fall back to value comparison so a
+// separately-constructed `to` still resolves instead of silently truncating.
+function findRouteIndex(to: PlainRoute, routes: PlainRoute[]): number {
+  const byReference = routes.indexOf(to);
+  if (byReference !== -1) {
+    return byReference;
+  }
+
   return routes.findIndex(route => {
     const toKeys = Object.keys(to);
     const routeKeys = Object.keys(route);
@@ -101,7 +122,7 @@ export function recreateRoute(to: string | PlainRoute, options: Options): string
     lastRootIndex = paths.findLastIndex((path: any) => path[0] === '/');
   } else {
     routeIndex = options.matches
-      ? findRouteInRoutes(to, routes) + 1
+      ? findRouteIndex(to, routes) + 1
       : routes.indexOf(to) + 1;
     lastRootIndex = paths
       .slice(0, routeIndex)

--- a/static/app/utils/recreateRoute.tsx
+++ b/static/app/utils/recreateRoute.tsx
@@ -38,22 +38,42 @@ type Options =
       stepBack?: -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9;
     };
 
+// XXX(epurkhiser): This transforms react-router 6 style matches back to old
+// style react-router 3 route matches.
 export function matchesToRoutes(matches: UIMatch[]): PlainRoute[] {
-  return matches.map(m => ({...(m.handle as any)}));
+  return matches.map<PlainRoute>(match => {
+    // We put things like `name` (for breadcrumbs) in the handle. Extract
+    // it out here
+    const extra: any = match.handle;
+
+    // In react-router 6 the match returns a `pathname`, but the route is
+    // resolved, so it does not include the parameter slug (like
+    // `:issueId`) and has the prefixing route, so if the route part is
+    // just `:issueId`, but is nested under `/issues/` it will be
+    // `/issues/:issueId`, which is not what react-router 3 did.
+    //
+    // To shim for this, we are storing the unresolved `path` of the route
+    // in the user-data `handle` object, so we can just extract it from
+    // there
+    const path: string = extra?.path ?? '';
+
+    return {path, ...extra};
+  }, []);
 }
 
-function findRouteInMatches(to: PlainRoute, matches: UIMatch[]): number {
-  return matches.findIndex(m => {
-    const handle = m.handle;
-    if (!handle || typeof handle !== 'object') {
-      return false;
-    }
+// `to` and the entries of `routes` are both produced by `matchesToRoutes`, so
+// they share the same shape (including the synthesized `path` key) and preserve
+// nested references via the shallow spread. Match by value here rather than by
+// object identity because `recreateRoute` rebuilds `routes` on every call, so
+// the caller's `to` is never reference-equal to the local `routes` entries.
+function findRouteInRoutes(to: PlainRoute, routes: PlainRoute[]): number {
+  return routes.findIndex(route => {
     const toKeys = Object.keys(to);
-    const handleKeys = Object.keys(handle);
-    if (toKeys.length !== handleKeys.length) {
+    const routeKeys = Object.keys(route);
+    if (toKeys.length !== routeKeys.length) {
       return false;
     }
-    return toKeys.every(k => (to as any)[k] === (handle as any)[k]);
+    return toKeys.every(k => (to as any)[k] === (route as any)[k]);
   });
 }
 
@@ -81,7 +101,7 @@ export function recreateRoute(to: string | PlainRoute, options: Options): string
     lastRootIndex = paths.findLastIndex((path: any) => path[0] === '/');
   } else {
     routeIndex = options.matches
-      ? findRouteInMatches(to, options.matches) + 1
+      ? findRouteInRoutes(to, routes) + 1
       : routes.indexOf(to) + 1;
     lastRootIndex = paths
       .slice(0, routeIndex)

--- a/static/app/utils/recreateRoute.tsx
+++ b/static/app/utils/recreateRoute.tsx
@@ -1,24 +1,61 @@
+import type {UIMatch} from 'react-router-dom';
 import type {Location} from 'history';
 
 import type {PlainRoute} from 'sentry/types/legacyReactRouter';
 import {replaceRouterParams} from 'sentry/utils/replaceRouterParams';
 
-type Options = {
-  // parameters to replace any route string parameters (e.g. if route is `:orgId`,
-  // params should have `{orgId: slug}`
-  params: Record<string, string | undefined>;
+type Options =
+  | {
+      // parameters to replace any route string parameters (e.g. if route is `:orgId`,
+      // params should have `{orgId: slug}`
+      params: Record<string, string | undefined>;
+      routes: PlainRoute[];
+      location?: Location;
 
-  routes: PlainRoute[];
+      matches?: never;
+      /**
+       * The number of routes to pop off of `routes
+       * Must be < 0
+       *
+       * There's no ts type for negative numbers so we are arbitrarily specifying -1-9
+       */
+      stepBack?: -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9;
+    }
+  | {
+      matches: UIMatch[];
+      // parameters to replace any route string parameters (e.g. if route is `:orgId`,
+      // params should have `{orgId: slug}`
+      params: Record<string, string | undefined>;
+      location?: Location;
 
-  location?: Location;
-  /**
-   * The number of routes to pop off of `routes
-   * Must be < 0
-   *
-   * There's no ts type for negative numbers so we are arbitrarily specifying -1-9
-   */
-  stepBack?: -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9;
-};
+      routes?: never;
+      /**
+       * The number of routes to pop off of `routes
+       * Must be < 0
+       *
+       * There's no ts type for negative numbers so we are arbitrarily specifying -1-9
+       */
+      stepBack?: -1 | -2 | -3 | -4 | -5 | -6 | -7 | -8 | -9;
+    };
+
+export function matchesToRoutes(matches: UIMatch[]): PlainRoute[] {
+  return matches.map(m => ({...(m.handle as any)}));
+}
+
+function findRouteInMatches(to: PlainRoute, matches: UIMatch[]): number {
+  return matches.findIndex(m => {
+    const handle = m.handle;
+    if (!handle || typeof handle !== 'object') {
+      return false;
+    }
+    const toKeys = Object.keys(to);
+    const handleKeys = Object.keys(handle);
+    if (toKeys.length !== handleKeys.length) {
+      return false;
+    }
+    return toKeys.every(k => (to as any)[k] === (handle as any)[k]);
+  });
+}
 
 /**
  * Given a route object or a string and a list of routes + params from router, this will attempt to recreate a location string while replacing url params.
@@ -27,7 +64,8 @@ type Options = {
  * See tests for examples
  */
 export function recreateRoute(to: string | PlainRoute, options: Options): string {
-  const {routes, params, location, stepBack} = options;
+  const {params, location, stepBack} = options;
+  const routes = options.matches ? matchesToRoutes(options.matches) : options.routes;
   const paths = routes.map(({path}) => {
     path = path || '';
     if (path.length > 0 && !path.endsWith('/')) {
@@ -42,7 +80,9 @@ export function recreateRoute(to: string | PlainRoute, options: Options): string
   if (typeof to === 'string') {
     lastRootIndex = paths.findLastIndex((path: any) => path[0] === '/');
   } else {
-    routeIndex = routes.indexOf(to) + 1;
+    routeIndex = options.matches
+      ? findRouteInMatches(to, options.matches) + 1
+      : routes.indexOf(to) + 1;
     lastRootIndex = paths
       .slice(0, routeIndex)
       .findLastIndex((path: any) => path[0] === '/');

--- a/static/app/utils/useRoutes.tsx
+++ b/static/app/utils/useRoutes.tsx
@@ -2,6 +2,7 @@ import {useMemo} from 'react';
 import {useMatches} from 'react-router-dom';
 
 import type {PlainRoute} from 'sentry/types/legacyReactRouter';
+import {matchesToRoutes} from 'sentry/utils/recreateRoute';
 
 /**
  * @deprecated Please do not use this. Switch to useMatches() from 'react-router-dom'
@@ -10,30 +11,5 @@ import type {PlainRoute} from 'sentry/types/legacyReactRouter';
  */
 export function useRoutes(): PlainRoute[] {
   const matches = useMatches();
-
-  // XXX(epurkhiser): This transforms react-router 6 style matches back to old
-  // style react-router 3 rroute matches.
-  //
-  return useMemo(
-    () =>
-      matches.map<PlainRoute>(match => {
-        // We put things like `name` (for breadcrumbs) in the handle. Extract
-        // it out here
-        const extra: any = match.handle;
-
-        // In react-router 6 the match returns a `pathname`, but the route is
-        // resolved, so it does not include the parameter slug (like
-        // `:issueId`) and has the prefixing route, so if the route part is
-        // just `:issueId`, but is nested under `/issues/` it will be
-        // `/issues/:issueId`, which is not what react-router 3 did.
-        //
-        // To shim for this, we are storing the unresolved `path` of the route
-        // in the user-data `handle` object, so we can just extract it from
-        // there
-        const path: string = extra?.path ?? '';
-
-        return {path, ...extra};
-      }, []),
-    [matches]
-  );
+  return useMemo(() => matchesToRoutes(matches), [matches]);
 }


### PR DESCRIPTION
`matches` is the future, but there are a bunch of callsites, so a quick PR to support both will help speed things along.