### PR TITLE
fix(issue details): Send time range params for specific event IDs in prev/next navigation

### DIFF
--- a/static/app/views/issueDetails/useGroupEvent.spec.tsx
+++ b/static/app/views/issueDetails/useGroupEvent.spec.tsx
@@ -1,0 +1,137 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useGroupEvent} from './useGroupEvent';
+
+describe('useGroupEvent', () => {
+  const organization = OrganizationFixture();
+  const group = GroupFixture({id: 'group-id'});
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('includes statsPeriod in API request for specific event IDs', async () => {
+    const mockEventRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/events/abc123/`,
+      body: EventFixture(),
+    });
+
+    renderHookWithProviders(useGroupEvent, {
+      initialProps: {
+        groupId: group.id,
+        eventId: 'abc123',
+      },
+      initialRouterConfig: {
+        route: '/organizations/:orgId/issues/:groupId/events/:eventId/',
+        location: {
+          pathname: `/organizations/${organization.slug}/issues/${group.id}/events/abc123/`,
+          query: {statsPeriod: '1h'},
+        },
+      },
+    });
+
+    await waitFor(() => expect(mockEventRequest).toHaveBeenCalled());
+    expect(mockEventRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({statsPeriod: '1h'}),
+      })
+    );
+  });
+
+  it('includes statsPeriod in API request for reserved event IDs', async () => {
+    const mockEventRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/events/latest/`,
+      body: EventFixture(),
+    });
+
+    renderHookWithProviders(useGroupEvent, {
+      initialProps: {
+        groupId: group.id,
+        eventId: 'latest',
+      },
+      initialRouterConfig: {
+        route: '/organizations/:orgId/issues/:groupId/events/:eventId/',
+        location: {
+          pathname: `/organizations/${organization.slug}/issues/${group.id}/events/latest/`,
+          query: {statsPeriod: '1h'},
+        },
+      },
+    });
+
+    await waitFor(() => expect(mockEventRequest).toHaveBeenCalled());
+    expect(mockEventRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({statsPeriod: '1h'}),
+      })
+    );
+  });
+
+  it('uses statsPeriod from URL, not from PageFiltersStore', async () => {
+    const mockEventRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/events/abc123/`,
+      body: EventFixture(),
+    });
+
+    renderHookWithProviders(useGroupEvent, {
+      initialProps: {
+        groupId: group.id,
+        eventId: 'abc123',
+      },
+      initialRouterConfig: {
+        route: '/organizations/:orgId/issues/:groupId/events/:eventId/',
+        location: {
+          pathname: `/organizations/${organization.slug}/issues/${group.id}/events/abc123/`,
+          query: {statsPeriod: '1h'},
+        },
+      },
+    });
+
+    await waitFor(() => expect(mockEventRequest).toHaveBeenCalled());
+    expect(mockEventRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({statsPeriod: '1h'}),
+      })
+    );
+    expect(mockEventRequest).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({statsPeriod: '14d'}),
+      })
+    );
+  });
+
+  it('does not include statsPeriod when not set in URL', async () => {
+    const mockEventRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/events/abc123/`,
+      body: EventFixture(),
+    });
+
+    renderHookWithProviders(useGroupEvent, {
+      initialProps: {
+        groupId: group.id,
+        eventId: 'abc123',
+      },
+      initialRouterConfig: {
+        route: '/organizations/:orgId/issues/:groupId/events/:eventId/',
+        location: {
+          pathname: `/organizations/${organization.slug}/issues/${group.id}/events/abc123/`,
+        },
+      },
+    });
+
+    await waitFor(() => expect(mockEventRequest).toHaveBeenCalled());
+    expect(mockEventRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.not.objectContaining({statsPeriod: expect.anything()}),
+      })
+    );
+  });
+});

--- a/static/app/views/issueDetails/useGroupEvent.tsx
+++ b/static/app/views/issueDetails/useGroupEvent.tsx
@@ -1,7 +1,6 @@
 import {useQuery} from '@tanstack/react-query';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {getPeriod} from 'sentry/utils/duration/getPeriod';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useEventQuery} from 'sentry/views/issueDetails/hooks/useEventQuery';
@@ -33,13 +32,9 @@ export function useGroupEvent({
   const isReservedEventId = RESERVED_EVENT_IDS.has(eventId);
   const isSpecificEventId = eventId && !isReservedEventId;
 
-  const {selection: pageFilters} = usePageFilters();
-
-  const hasSetStatsPeriod =
-    // If we are on a specific event, the endpoint will return it regardless of the time range
-    !isSpecificEventId &&
-    (location.query.statsPeriod || location.query.start || location.query.end);
-  const periodQuery = hasSetStatsPeriod ? getPeriod(pageFilters.datetime) : {};
+  const statsPeriod = decodeScalar(location.query.statsPeriod);
+  const start = decodeScalar(location.query.start);
+  const end = decodeScalar(location.query.end);
 
   const staleTime = isSpecificEventId ? Infinity : 30_000;
 
@@ -50,7 +45,9 @@ export function useGroupEvent({
       eventId,
       environments,
       query: eventQuery,
-      ...periodQuery,
+      statsPeriod,
+      start,
+      end,
     }),
     staleTime,
     enabled: options?.enabled && !!eventId,


### PR DESCRIPTION
Prev/next event navigation on the issue details page was escaping the user's selected time range (e.g. `statsPeriod=1h`). This PR fixes two bugs:
1. A `!isSpecificEventId` guard prevented `statsPeriod`/`start`/`end` from being sent to the backend when viewing a specific event (i.e. after any prev/next click). Without these params, the backend falls back to a ±100 day window for adjacent event lookup
2. Time range values were read from `PageFiltersStore` via `getPeriod()` instead of directly from the URL

These are fixed by reading `statsPeriod`, `start`, and `end` directly from the URL with `decodeScalar` and passing them unconditionally to `groupEventApiOptions`.