### PR TITLE
fix(scm): Update error handling in project webhook task

### DIFF
--- a/src/sentry/integrations/gitlab/tasks.py
+++ b/src/sentry/integrations/gitlab/tasks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import logging
 
 from rest_framework import status
@@ -32,6 +33,7 @@ GITLAB_RETRY_CODES = (
     status.HTTP_502_BAD_GATEWAY,
     status.HTTP_503_SERVICE_UNAVAILABLE,
     status.HTTP_504_GATEWAY_TIMEOUT,
+    errno.ECONNRESET,
 )
 
 

--- a/src/sentry/integrations/gitlab/tasks.py
+++ b/src/sentry/integrations/gitlab/tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from rest_framework import status
 from taskbroker_client.retry import Retry
 
 from sentry.constants import ObjectStatus
@@ -14,11 +15,24 @@ from sentry.integrations.gitlab.metrics import (
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.repository import repository_service
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    ApiForbiddenError,
+    ApiUnauthorized,
+)
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_tasks
 
 logger = logging.getLogger(__name__)
+
+GITLAB_RETRY_CODES = (
+    status.HTTP_429_TOO_MANY_REQUESTS,
+    status.HTTP_500_INTERNAL_SERVER_ERROR,
+    status.HTTP_502_BAD_GATEWAY,
+    status.HTTP_503_SERVICE_UNAVAILABLE,
+    status.HTTP_504_GATEWAY_TIMEOUT,
+)
 
 
 @instrumented_task(
@@ -55,47 +69,56 @@ def update_project_webhook(integration_id: int, organization_id: int, repository
             organization_id=organization_id,
             id=repository_id,
         )
+
+        lifecycle.add_extras(
+            {
+                "integration_id": integration_id,
+                "organization_id": organization_id,
+                "repository_id": repository_id,
+            }
+        )
+
         if not repo or repo.status != ObjectStatus.ACTIVE:
             lifecycle.record_halt(
                 GitLabWebhookUpdateHaltReason.REPOSITORY_NOT_FOUND,
-                extra={
-                    "integration_id": integration_id,
-                    "organization_id": organization_id,
-                    "repository_id": repository_id,
-                },
             )
             return
-
-        lifecycle.add_extra("repository_id", repository_id)
 
         webhook_id = repo.config.get("webhook_id")
         project_id = repo.config.get("project_id")
 
+        lifecycle.add_extras(
+            {
+                "repository_id": repo.id,
+                "webhook_id": webhook_id,
+                "project_id": project_id,
+            }
+        )
+
         if not webhook_id or not project_id:
             lifecycle.record_halt(
                 GitLabWebhookUpdateHaltReason.MISSING_WEBHOOK_CONFIG,
-                extra={
-                    "repository_id": repo.id,
-                    "repository_name": repo.name,
-                    "has_webhook_id": bool(webhook_id),
-                    "has_project_id": bool(project_id),
-                },
             )
             return
 
         installation = integration.get_installation(organization_id=organization_id)
         client = installation.get_client()
 
-        client.update_project_webhook(project_id, webhook_id)
-        logger.info(
-            "update-project-webhook.webhook-updated",
-            extra={
-                "repository_id": repo.id,
-                "repository_name": repo.name,
-                "project_id": project_id,
-                "webhook_id": webhook_id,
-            },
-        )
+        try:
+            client.update_project_webhook(project_id, webhook_id)
+        except (ApiUnauthorized, ApiForbiddenError) as e:
+            lifecycle.record_halt(e)
+            # Don't retry if we've lost access
+            return
+
+        except ApiError as e:
+            # Raise for retry on a small number of transient errors
+            if e.code in GITLAB_RETRY_CODES:
+                raise
+
+            # Anything not in the retry list should be considered a hard-stop
+            # failure.
+            lifecycle.record_failure(e)
 
 
 @instrumented_task(

--- a/tests/sentry/integrations/gitlab/tasks/test_update_all_project_webhooks.py
+++ b/tests/sentry/integrations/gitlab/tasks/test_update_all_project_webhooks.py
@@ -368,6 +368,54 @@ class UpdateProjectWebhookTest(GitLabTestCase):
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @responses.activate
+    def test_task_handles_auth_errors(self, mock_record_event):
+        """Test that the task retries on API failures"""
+        responses.add(
+            responses.PUT,
+            "https://example.gitlab.com/api/v4/projects/101/hooks/webhook-1",
+            json={"error": "Unauthorized"},
+            status=401,
+        )
+
+        # This should fail, but not raise as the exception is swallowed.
+        update_project_webhook(
+            integration_id=self.integration.id,
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+        )
+
+        # Verify API call was attempted
+        assert len(responses.calls) == 1
+
+        # Verify SLO halted metric was recorded
+        assert_slo_metric(mock_record_event, event_outcome=EventLifecycleOutcome.HALTED)
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @responses.activate
+    def test_task_handles_not_found_errors(self, mock_record_event):
+        """Test that the task retries on API failures"""
+        responses.add(
+            responses.PUT,
+            "https://example.gitlab.com/api/v4/projects/101/hooks/webhook-1",
+            json={"error": "Not Found"},
+            status=404,
+        )
+
+        # This should fail, but not raise as the exception is swallowed.
+        update_project_webhook(
+            integration_id=self.integration.id,
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+        )
+
+        # Verify API call was attempted
+        assert len(responses.calls) == 1
+
+        # Verify SLO failure metric was recorded
+        assert_slo_metric(mock_record_event, event_outcome=EventLifecycleOutcome.FAILURE)
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @responses.activate
     def test_task_updates_webhook_with_correct_data(self, mock_record_event):
         """Test that webhook update includes correct event subscriptions"""
         responses.add(
@@ -392,38 +440,6 @@ class UpdateProjectWebhookTest(GitLabTestCase):
         assert b"push_events" in request_body
         assert b"issues_events" in request_body
         assert b"note_events" in request_body
-
-        # Verify SLO metrics were recorded
-        assert_slo_metric(mock_record_event)
-
-    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    @responses.activate
-    def test_task_logs_success(self, mock_record_event):
-        """Test that the task logs successful updates"""
-        responses.add(
-            responses.PUT,
-            "https://example.gitlab.com/api/v4/projects/101/hooks/webhook-1",
-            json={"id": "webhook-1"},
-            status=200,
-        )
-
-        with patch("sentry.integrations.gitlab.tasks.logger") as mock_logger:
-            update_project_webhook(
-                integration_id=self.integration.id,
-                organization_id=self.organization.id,
-                repository_id=self.repo.id,
-            )
-
-            # Verify success was logged
-            mock_logger.info.assert_called_once_with(
-                "update-project-webhook.webhook-updated",
-                extra={
-                    "repository_id": self.repo.id,
-                    "repository_name": self.repo.name,
-                    "project_id": "101",
-                    "webhook_id": "webhook-1",
-                },
-            )
 
         # Verify SLO metrics were recorded
         assert_slo_metric(mock_record_event)


### PR DESCRIPTION
Adds better error handling to GitLab's `update_project_wehook` task. These tasks can fail for a variety of reasons, many of which are not retriable in any way. This should handle the majority of those cases, though it will still allow retries on rate limits, which we may want to rescind if this continues to be problematic.

Also reworks the logging to include integration, webhook, repository, and project ID by default for easier triage.

PR 1/2
