### PR TITLE
fix(weekly-report): Prevent recording delivery on dry runs

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -332,14 +332,16 @@ class OrganizationReportBatch:
             if template_context and user_id:
                 dupe_check = _DuplicateDeliveryCheck(self, user_id, self.ctx.timestamp)
                 if not dupe_check.check_for_duplicate_delivery():
-                    self.send_email(template_ctx=template_context, user_id=user_id)
-                    dupe_check.record_delivery()
+                    was_sent = self.send_email(template_ctx=template_context, user_id=user_id)
+
+                    # Record delivery if email was sent successfully
+                    if was_sent:
+                        dupe_check.record_delivery()
                 else:
                     lifecycle.record_halt(WeeklyReportHaltReason.DUPLICATE_DELIVERY)
                     metrics.incr("weekly_report.email.skipped", tags={"reason": "duplicate"})
 
-    def send_email(self, template_ctx: Mapping[str, Any], user_id: int) -> None:
-        # get user options timezone for this user, then format the timestamp according to the timezone
+    def send_email(self, template_ctx: Mapping[str, Any], user_id: int) -> bool:
         local_start, local_end = get_local_dates(self.ctx, user_id)
 
         message = MessageBuilder(
@@ -352,11 +354,12 @@ class OrganizationReportBatch:
         )
         if self.dry_run:
             metrics.incr("weekly_report.email.skipped", tags={"reason": "dry_run"})
-            return
+            return False
 
         if self.email_override:
             message.send(to=(self.email_override,))
             metrics.incr("weekly_report.email.sent")
+            return True
         else:
             try:
                 analytics.record(
@@ -385,8 +388,10 @@ class OrganizationReportBatch:
             if message._send_to:
                 message.send_async()
                 metrics.incr("weekly_report.email.sent")
+                return True
             else:
                 metrics.incr("weekly_report.email.skipped", tags={"reason": "no_email"})
+                return False
 
 
 class _DuplicateDeliveryCheck:

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -1357,6 +1357,38 @@ class WeeklyReportsTest(
 
         message_builder.return_value.send.assert_not_called()
 
+    @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
+    def test_dry_run_does_not_block_subsequent_send(self, message_builder: mock.MagicMock) -> None:
+        """A dry_run send should not poison the duplicate delivery check."""
+        user = self.create_user(email="dio@speedwagon.org")
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+        self.store_event_outcomes(
+            self.organization.id, self.project.id, self.two_days_ago, num_times=2
+        )
+
+        prepare_organization_report(
+            self.timestamp,
+            ONE_DAY * 7,
+            self.organization.id,
+            self._dummy_batch_id,
+            dry_run=True,
+            target_user=user.id,
+            email_override="dio@speedwagon.org",
+        )
+        message_builder.return_value.send.assert_not_called()
+
+        message_builder.reset_mock()
+        prepare_organization_report(
+            self.timestamp,
+            ONE_DAY * 7,
+            self.organization.id,
+            self._dummy_batch_id,
+            dry_run=False,
+            target_user=user.id,
+            email_override="dio@speedwagon.org",
+        )
+        message_builder.return_value.send.assert_called_once_with(to=("dio@speedwagon.org",))
+
     @mock.patch("sentry.tasks.summaries.weekly_reports.logger")
     @mock.patch("sentry.tasks.summaries.weekly_reports.prepare_template_context")
     @mock.patch("sentry.tasks.summaries.weekly_reports.OrganizationReportBatch.send_email")


### PR DESCRIPTION
Problem statement: record_delivery() runs even when send_email() doesn't actually send. This means that when you do a dry run, you won't be able to send subsequent emails for 3 days (TTL of Redis cache for preventing duplicate deliveries).

**Fix**: Two changes to src/sentry/tasks/summaries/weekly_reports.py:

1. `send_email()` now returns `bool` — True only when the email was actually sent, False for dry_run or no-email cases
2. `record_delivery()` only runs when `send_email()` returns `True`

Added test `test_dry_run_does_not_block_subsequent_send` that reproduces the exact scenario.




