### PR TITLE
fix(dashboards): Keep saved column in widget builder dropdown when missing from attributes

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -1406,6 +1406,34 @@ describe('Visualize', () => {
       expect(within(listbox).getByText('anotherNumericTag')).toBeInTheDocument();
     });
 
+    it('shows the saved column in the trigger even when missing from attributes', async () => {
+      render(
+        <WidgetBuilderProvider>
+          <Visualize />
+        </WidgetBuilderProvider>,
+        {
+          organization,
+          initialRouterConfig: {
+            location: {
+              pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+              query: {
+                dataset: WidgetType.SPANS,
+                displayType: DisplayType.TABLE,
+                // The saved column argument is not returned by the attributes call
+                field: ['p90(my.missing.field)'],
+              },
+            },
+            route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+          },
+        }
+      );
+
+      // The column dropdown should reflect the saved state instead of "None"
+      expect(
+        await screen.findByRole('button', {name: 'Column Selection'})
+      ).toHaveTextContent('my.missing.field');
+    });
+
     it('shows the correct column options for the non-aggregate field type', async () => {
       render(
         <WidgetBuilderProvider>

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
@@ -16,7 +16,7 @@ import {
   type AggregationRefinement,
   type QueryFieldValue,
 } from 'sentry/utils/discover/fields';
-import {AggregationKey} from 'sentry/utils/fields';
+import {AggregationKey, prettifyTagKey} from 'sentry/utils/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -191,6 +191,23 @@ export function SelectRow({
     field.kind === FieldValueKind.FUNCTION
       ? (parsedFunction?.arguments[0] ?? '')
       : field.field;
+
+  // Ensure the currently selected column is always present in the options so the
+  // dropdown reflects the saved state instead of showing "None" when the field is
+  // missing from the fetched attributes (e.g. a saved field no longer returned by
+  // the /attributes call).
+  const columnOptionsWithSelected = useMemo(() => {
+    if (columnValue && !columnOptions.some(option => option.value === columnValue)) {
+      return [
+        ...columnOptions,
+        {
+          label: prettifyTagKey(columnValue),
+          value: columnValue,
+        },
+      ];
+    }
+    return columnOptions;
+  }, [columnValue, columnOptions]);
 
   return (
     <PrimarySelectRow hasColumnParameter={hasColumnParameter}>
@@ -454,7 +471,7 @@ export function SelectRow({
         <SelectWrapper ref={columnSelectRef}>
           <ColumnCompactSelect
             search
-            options={sortSelectedFirst(columnValue, columnOptions)}
+            options={sortSelectedFirst(columnValue, columnOptionsWithSelected)}
             value={columnValue}
             onChange={newField => {
               const newFields = cloneDeep(fields);


### PR DESCRIPTION
In the dashboards widget builder, the aggregate column dropdown displayed **"None"** whenever the saved column value was not present in its options. `CompactSelect` renders "None" as the trigger label when the `value` prop matches none of the available options.

This happened when a saved field — including a function's column argument like `p90(my_field)` — was not returned by the `/trace-items/attributes/` call. The existing "old tags" fallback only re-injected top-level field columns, so aggregate column arguments missing from attributes still fell through to "None".

Before
<img width="607" height="137" alt="image" src="https://github.com/user-attachments/assets/430220b6-af11-41d7-a03a-8dfadaaad536" />

After
<img width="578" height="122" alt="image" src="https://github.com/user-attachments/assets/ebe82d6c-8cec-4a04-905b-4d0bb08e30f7" />


## Changes

- `selectRow.tsx`: Always include the currently selected `columnValue` in the column dropdown's options when it's not already present, so the dropdown reflects the saved state instead of showing "None". Scoped to the column dropdown only — the aggregate dropdown and other `sortSelectedFirst` callers are unaffected.

DAIN-1726

fixes https://github.com/getsentry/sentry/issues/118150
