### PR TITLE
feat(explore): Add Chartcuterie config for Explore heat maps

### DIFF
--- a/static/app/chartcuterie/config.tsx
+++ b/static/app/chartcuterie/config.tsx
@@ -13,6 +13,7 @@ import {lightTheme} from 'sentry/utils/theme/theme';
 
 import {makeDashboardsWidgetCharts} from './dashboardsWidget';
 import {makeDiscoverCharts} from './discover';
+import {makeHeatmapCharts} from './heatmaps';
 import {makeMetricAlertCharts} from './metricAlert';
 import {makeMetricDetectorCharts} from './metricDetector';
 import {makePerformanceCharts} from './performance';
@@ -49,5 +50,6 @@ makeDashboardsWidgetCharts(lightTheme).forEach(register);
 makeMetricAlertCharts(lightTheme).forEach(register);
 makeMetricDetectorCharts(lightTheme).forEach(register);
 makePerformanceCharts(lightTheme).forEach(register);
+makeHeatmapCharts(lightTheme).forEach(register);
 
 export default config;

--- a/static/app/chartcuterie/heatmaps.tsx
+++ b/static/app/chartcuterie/heatmaps.tsx
@@ -37,6 +37,7 @@ export function buildHeatmapChartOption({
 
   return {
     grid: Grid({left: 10, right: 10, bottom: 10, top: 10}),
+    backgroundColor: theme.tokens.background.primary,
     xAxis: {
       type: 'category',
       axisLabel: {

--- a/static/app/chartcuterie/heatmaps.tsx
+++ b/static/app/chartcuterie/heatmaps.tsx
@@ -1,0 +1,100 @@
+import type {Theme} from '@emotion/react';
+
+import {Grid} from 'sentry/components/charts/components/grid';
+import type {HeatMapSeries} from 'sentry/views/dashboards/widgets/common/types';
+import {formatYAxisValue} from 'sentry/views/dashboards/widgets/heatMapWidget/formatters/formatYAxisValue';
+import {visualMapOptions} from 'sentry/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization';
+import {HeatMap} from 'sentry/views/dashboards/widgets/heatMapWidget/plottables/heatMap';
+import {HEATMAP_Z_AXIS_SCALE} from 'sentry/views/dashboards/widgets/heatMapWidget/settings';
+import {formatXAxisTimestamp} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp';
+
+import {DEFAULT_FONT_FAMILY} from './slack';
+import {CHART_SIZE, FONT_SIZE} from './timeseries';
+import type {RenderDescriptor} from './types';
+import {ChartType} from './types';
+
+type HeatMapChartData = {
+  heatmap: HeatMapSeries;
+};
+
+export function buildHeatmapChartOption({
+  theme,
+  heatMapSeries,
+}: {
+  heatMapSeries: HeatMapSeries;
+  theme: Theme;
+}) {
+  const heatMapPlottable = new HeatMap(heatMapSeries);
+
+  const yAxisDataType = heatMapPlottable.yAxisValueType;
+  const yAxisDataUnit = heatMapPlottable.yAxisValueUnit;
+
+  const scale = HEATMAP_Z_AXIS_SCALE;
+
+  const Zmax =
+    scale === 'log' ? Math.log1p(heatMapPlottable.Zend) : heatMapPlottable.Zend;
+  const series = heatMapPlottable.toSeries({theme, scale: HEATMAP_Z_AXIS_SCALE});
+
+  return {
+    grid: Grid({left: 10, right: 10, bottom: 10, top: 10}),
+    xAxis: {
+      type: 'category',
+      axisLabel: {
+        formatter: (value: string) => {
+          // NOTE: ECharts requires a `"category"` X-axis for heat maps, but we _know_ that we only support time as the X-axis. We need to parse the value here.
+          return formatXAxisTimestamp(parseFloat(value), {
+            utc: true,
+          });
+        },
+        fontSize: FONT_SIZE,
+        fontFamily: DEFAULT_FONT_FAMILY,
+      },
+      axisLine: {
+        show: false,
+      },
+      axisPointer: {
+        show: false,
+      },
+      splitArea: {
+        show: false,
+      },
+    },
+    yAxis: {
+      type: 'category',
+      animation: false,
+      axisLabel: {
+        hideOverlap: true,
+        showMinLabel: true,
+        showMaxLabel: true,
+        formatter: (value: string) => {
+          // NOTE: ECharts requires a `"category"` Y-axis for heat maps, but we _know_ that we only support continuous values for the Y-axis. We need to parse the value here.
+          return formatYAxisValue(
+            parseFloat(value),
+            yAxisDataType,
+            yAxisDataUnit ?? undefined
+          );
+        },
+        fontSize: FONT_SIZE,
+        fontFamily: DEFAULT_FONT_FAMILY,
+      },
+      axisLine: {
+        show: false,
+      },
+    },
+    series,
+    visualMap: visualMapOptions(Zmax),
+    useUTC: true,
+  };
+}
+
+export const makeHeatmapCharts = (theme: Theme): Array<RenderDescriptor<ChartType>> => [
+  {
+    key: ChartType.SLACK_HEATMAP,
+    getOption: (data: HeatMapChartData) =>
+      buildHeatmapChartOption({
+        theme,
+        heatMapSeries: data.heatmap,
+      }),
+    ...CHART_SIZE,
+  },
+];

--- a/static/app/chartcuterie/timeseries.tsx
+++ b/static/app/chartcuterie/timeseries.tsx
@@ -21,7 +21,7 @@ import {ChartType} from './types';
 /**
  * Font size and spacing scaled for the larger timeseries chart canvas (1200x400).
  */
-const FONT_SIZE = 28;
+export const FONT_SIZE = 28;
 export const CHART_SIZE = {width: 1200, height: 400};
 
 export type TimeseriesChartData = {

--- a/static/app/chartcuterie/types.tsx
+++ b/static/app/chartcuterie/types.tsx
@@ -22,6 +22,7 @@ export enum ChartType {
   SLACK_PERFORMANCE_FUNCTION_REGRESSION = 'slack:performance.functionRegression',
   SLACK_TIMESERIES = 'slack:timeseries',
   SLACK_DASHBOARDS_WIDGET = 'slack:dashboardsWidget',
+  SLACK_HEATMAP = 'slack:heatmap',
 }
 
 /**

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -375,7 +375,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
   );
 }
 
-export const visualMapOptions = (Zmax: number) => {
+export const visualMapOptions = (Zmax: number): VisualMapComponentOption[] => {
   return [
     // Zero values are transparent (empty buckets)
     {
@@ -400,7 +400,7 @@ export const visualMapOptions = (Zmax: number) => {
         color: [...HEATMAP_COLORS],
       },
     },
-  ] as VisualMapComponentOption[];
+  ];
 };
 
 /**

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -5,6 +5,7 @@ import {useTheme} from '@emotion/react';
 import type {
   TooltipFormatterCallback,
   TopLevelFormatterParams,
+  VisualMapComponentOption,
 } from 'echarts/types/dist/shared';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -364,31 +365,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
             show: false,
           },
         }}
-        visualMap={[
-          // Zero values are transparent (empty buckets)
-          {
-            type: 'piecewise',
-            show: false,
-            dimension: 2,
-            seriesIndex: 0,
-            pieces: [
-              {value: 0, opacity: 0},
-              {gt: 0, opacity: 1},
-            ],
-          },
-          // All values are plotted against a palette
-          {
-            type: 'continuous',
-            show: false,
-            dimension: 2,
-            seriesIndex: 0,
-            min: 0,
-            max: Zmax,
-            inRange: {
-              color: [...HEATMAP_COLORS],
-            },
-          },
-        ]}
+        visualMap={visualMapOptions(Zmax)}
         start={start ? new Date(start) : undefined}
         end={end ? new Date(end) : undefined}
         period={period}
@@ -397,6 +374,34 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
     </Flex>
   );
 }
+
+export const visualMapOptions = (Zmax: number) => {
+  return [
+    // Zero values are transparent (empty buckets)
+    {
+      type: 'piecewise',
+      show: false,
+      dimension: 2,
+      seriesIndex: 0,
+      pieces: [
+        {value: 0, opacity: 0},
+        {gt: 0, opacity: 1},
+      ],
+    },
+    // All values are plotted against a palette
+    {
+      type: 'continuous',
+      show: false,
+      dimension: 2,
+      seriesIndex: 0,
+      min: 0,
+      max: Zmax,
+      inRange: {
+        color: [...HEATMAP_COLORS],
+      },
+    },
+  ] as VisualMapComponentOption[];
+};
 
 /**
  * Context for the hovered heat map cell, handed to `renderTooltipActions` so the


### PR DESCRIPTION
To render Heat Map charts in Chartcuterie, Sentry must add a configuration for that type. That's what this PR does.

Note that a lot of the configuration code is shared/similar between the Chartcuterie setup and `HeatMapWidgetVisualization` but that's intentional. The _palette_ is shared (important) but Chartcuterie configuration is different since it's always in UTC, it _never_ has any hover actions, and it has slightly different UI due to the server-rendered nature of it.

**e.g.,**
<img width="1200" height="400" alt="heat-map-sample" src="https://github.com/user-attachments/assets/3d2205ff-947d-4dcd-8717-d2c535e2cb57" />
