### PR TITLE
fix(plugins): Block deprecated plugins from test-fire notifications

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -14,6 +14,7 @@ from sentry.api.serializers.rest_framework import DummyRuleSerializer
 from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY
 from sentry.models.rule import Rule
 from sentry.notifications.types import TEST_NOTIFICATION_ID
+from sentry.plugins import HIDDEN_PLUGINS
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.services.eventstore.models import GroupEvent
 from sentry.shared_integrations.exceptions import (
@@ -123,6 +124,17 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
         )
 
         for action_blob in actions_data:
+            if (
+                action_blob.get("id")
+                == "sentry.rules.actions.notify_event_service.NotifyEventServiceAction"
+                and action_blob.get("service") in HIDDEN_PLUGINS
+            ):
+                service = action_blob.get("service")
+                action_exceptions.append(
+                    f"The {service} plugin has been deprecated and cannot send notifications."
+                )
+                continue
+
             try:
                 notification_actions_data = translate_rule_data_actions_to_notification_actions(
                     [action_blob], skip_failures=False

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -19,6 +19,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.notifications.notification_action.grouptype import get_test_notification_event_data
 from sentry.notifications.types import TEST_NOTIFICATION_ID
+from sentry.plugins import HIDDEN_PLUGINS
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.workflow_engine.endpoints.organization_workflow_index import (
@@ -135,6 +136,13 @@ def test_fire_actions(actions: list[dict[str, Any]], project: Project) -> tuple[
     )
 
     for action_data in actions:
+        target_identifier = action_data.get("config", {}).get("target_identifier")
+        if action_data.get("type") == Action.Type.WEBHOOK and target_identifier in HIDDEN_PLUGINS:
+            action_exceptions.append(
+                f"The {target_identifier} plugin has been deprecated and cannot send notifications."
+            )
+            continue
+
         # Create a temporary Action object (not saved to database)
         action = Action(
             id=TEST_NOTIFICATION_ID,

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -178,6 +178,22 @@ class ProjectRuleActionsEndpointWorkflowEngineTest(APITestCase, BaseWorkflowTest
 
         assert mock_notify.call_count == 1
 
+    def test_deprecated_plugin_returns_400(self) -> None:
+        action_data = [
+            {
+                "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
+                "service": "twilio",
+            }
+        ]
+
+        response = self.get_error_response(
+            self.organization.slug, self.project.slug, actions=action_data
+        )
+        assert response.status_code == 400
+        assert response.data == {
+            "actions": ["The twilio plugin has been deprecated and cannot send notifications."]
+        }
+
     @mock.patch(
         "sentry.rules.actions.sentry_apps.utils.app_service.trigger_sentry_app_action_creators"
     )

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -179,6 +179,8 @@ class ProjectRuleActionsEndpointWorkflowEngineTest(APITestCase, BaseWorkflowTest
         assert mock_notify.call_count == 1
 
     def test_deprecated_plugin_returns_400(self) -> None:
+        self.project.update_option("twilio:enabled", True)
+
         action_data = [
             {
                 "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -263,6 +263,24 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
         )
         assert response.status_code == 400
 
+    def test_deprecated_plugin_returns_400(self) -> None:
+        action_data = [
+            {
+                "type": Action.Type.WEBHOOK.value,
+                "data": {},
+                "config": {
+                    "target_identifier": "twilio",
+                    "target_type": "specific",
+                },
+            }
+        ]
+
+        response = self.get_error_response(self.organization.slug, actions=action_data)
+        assert response.status_code == 400
+        assert response.data == {
+            "actions": ["The twilio plugin has been deprecated and cannot send notifications."]
+        }
+
     @mock.patch(
         "sentry.notifications.notification_action.types.BaseIssueAlertHandler.send_test_notification"
     )

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -264,13 +264,15 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
         assert response.status_code == 400
 
     def test_deprecated_plugin_returns_400(self) -> None:
+        self.project.update_option("twilio:enabled", True)
+
         action_data = [
             {
                 "type": Action.Type.WEBHOOK.value,
                 "data": {},
                 "config": {
                     "target_identifier": "twilio",
-                    "target_type": "specific",
+                    "target_type": None,
                 },
             }
         ]


### PR DESCRIPTION
## Summary

Deprecated notification plugins (e.g. Twilio) can be test-fired via "Send Test Notification" in alert rule configuration.

- Block deprecated plugins (those in `HIDDEN_PLUGINS`) from being test-fired in the legacy `ProjectRuleActions` endpoint
- Block deprecated plugins from being test-fired in the new `OrganizationTestFireActions` endpoint
- Return a clear 400 error with a deprecation message instead of silently succeeding

Complements #118206 which removes deprecated plugins from the available services list.

Fixes ISWF-2908
