### PR TITLE
chore: Bump sentry-protos to 0.32.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.0.13",
-  "sentry-protos>=0.32.4",
+  "sentry-protos>=0.32.5",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm==0.22.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2412,7 +2412,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.1.36" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.0.13" },
-    { name = "sentry-protos", specifier = ">=0.32.4" },
+    { name = "sentry-protos", specifier = ">=0.32.5" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = "==0.22.0" },
@@ -2596,7 +2596,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.32.4"
+version = "0.32.5"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2604,7 +2604,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.32.4-py3-none-any.whl", hash = "sha256:046a0d29e7ad43594cf1a6d47f5dcb0607f2db0e7aab11837de2bb7a6f0d1a17" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.32.5-py3-none-any.whl", hash = "sha256:a5c83fdf65875ed858e4c4ee7b4bdc908814640ce5db57cce00e92e7c4f0cae4" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps the `sentry-protos` dependency from `0.32.4` to `0.32.5` (latest stable).

## What changed

[`sentry-protos@0.32.5`](https://github.com/getsentry/sentry-protos/releases/tag/0.32.5) is a purely additive release. It adds an optional `tax_transaction_code` (`optional string`) field to two billing-platform contract request messages:

- `CreateContractRequest` (field 9)
- `RolloverContractRequest` (field 7)

No existing field semantics change; nothing is removed.

Upstream PR: getsentry/sentry-protos#319

## Files

- `pyproject.toml` — bump the `sentry-protos` specifier to `>=0.32.5`
- `uv.lock` — regenerated via `uv lock --upgrade-package sentry-protos`
