### PR TITLE
fix(onboarding): use skills.sentry.dev URL in AI-assisted setup prompt

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
@@ -87,8 +87,7 @@ export function getUploadSourceMapsStep({
   };
 }
 
-const SENTRY_FOR_AI_BASE_URL =
-  'https://github.com/getsentry/sentry-for-ai/blob/main/skills';
+const SENTRY_FOR_AI_BASE_URL = 'https://skills.sentry.dev';
 
 function CopyPromptButton({prompt}: {prompt: string}) {
   const {copy} = useCopyToClipboard();


### PR DESCRIPTION
Changes `SENTRY_FOR_AI_BASE_URL` from the GitHub repo URL to `https://skills.sentry.dev` so the AI-assisted setup prompt copies a link to the hosted skills site rather than GitHub.

**Before:** `Read and follow: https://github.com/getsentry/sentry-for-ai/blob/main/skills/{skillPath}/SKILL.md`
**After:** `Read and follow: https://skills.sentry.dev/{skillPath}/SKILL.md`

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0ALBU24PC4%3A1782236836.344199%22)