### PR TITLE
chore(billing): Added snapshot tests for billing details widget(REVENG-245)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1212,6 +1212,7 @@ export default typescript.config([
           type: 'test-getsentry',
           pattern: [
             'static/gsApp/**/*.spec.{ts,js,tsx,jsx}',
+            'static/gsApp/**/*.snapshots.tsx',
             'tests/js/getsentry-test/**/*.*',
           ],
           mode: 'full',

--- a/static/gsApp/components/billingDetails/panel.snapshots.tsx
+++ b/static/gsApp/components/billingDetails/panel.snapshots.tsx
@@ -103,6 +103,6 @@ describe('BillingDetailsPanel', () => {
         </ThemeProvider>
       );
     },
-    name => ({tags: {area: 'billing', scenario: name}})
+    () => ({tags: {area: 'billing'}})
   );
 });

--- a/static/gsApp/components/billingDetails/panel.snapshots.tsx
+++ b/static/gsApp/components/billingDetails/panel.snapshots.tsx
@@ -1,0 +1,108 @@
+import {ThemeProvider} from '@emotion/react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {BillingDetailsFixture} from 'getsentry-test/fixtures/billingDetails';
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+
+// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
+import {lightTheme} from 'sentry/utils/theme/theme';
+
+import {BillingDetailsPanel} from 'getsentry/components/billingDetails/panel';
+import {useBillingDetails} from 'getsentry/hooks/useBillingDetails';
+import type {BillingDetails, Subscription} from 'getsentry/types';
+
+jest.mock('getsentry/hooks/useBillingDetails');
+
+const mockUseBillingDetails = jest.mocked(useBillingDetails);
+
+const organization = OrganizationFixture();
+
+const emptyDetails: BillingDetails = {
+  addressLine1: null,
+  addressLine2: null,
+  city: null,
+  countryCode: null,
+  postalCode: null,
+  region: null,
+  addressType: null,
+  billingEmail: null,
+  companyName: null,
+  displayAddress: null,
+  taxNumber: null,
+};
+
+type Scenario = {
+  details: BillingDetails;
+  subscription: Subscription;
+};
+
+const SCENARIOS: Record<string, Scenario> = {
+  empty: {
+    details: emptyDetails,
+    subscription: SubscriptionFixture({organization, accountBalance: 0}),
+  },
+  'full-with-address': {
+    details: BillingDetailsFixture(),
+    subscription: SubscriptionFixture({organization, accountBalance: -2500}),
+  },
+  'address-only': {
+    details: BillingDetailsFixture({
+      billingEmail: null,
+      companyName: null,
+      taxNumber: null,
+    }),
+    subscription: SubscriptionFixture({organization, accountBalance: 0}),
+  },
+  'email-only-no-address': {
+    details: {...emptyDetails, billingEmail: 'billing@example.com'},
+    subscription: SubscriptionFixture({organization, accountBalance: 0}),
+  },
+  'without-email': {
+    details: BillingDetailsFixture({billingEmail: null}),
+    subscription: SubscriptionFixture({organization, accountBalance: 0}),
+  },
+  'tax-number-vat': {
+    details: BillingDetailsFixture({countryCode: 'GB', taxNumber: 'GB123456789'}),
+    subscription: SubscriptionFixture({organization, accountBalance: 0}),
+  },
+  'no-tax-country': {
+    details: BillingDetailsFixture({countryCode: 'US', taxNumber: 'IGNORED'}),
+    subscription: SubscriptionFixture({organization, accountBalance: 0}),
+  },
+  'balance-credit': {
+    details: BillingDetailsFixture(),
+    subscription: SubscriptionFixture({organization, accountBalance: -10000}),
+  },
+  'balance-zero': {
+    details: BillingDetailsFixture(),
+    subscription: SubscriptionFixture({organization, accountBalance: 0}),
+  },
+};
+
+describe('BillingDetailsPanel', () => {
+  it.snapshot.each<string>(Object.keys(SCENARIOS))(
+    '%s',
+    name => {
+      const scenario = SCENARIOS[name]!;
+      mockUseBillingDetails.mockReturnValue({
+        data: scenario.details,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as unknown as ReturnType<typeof useBillingDetails>);
+
+      return (
+        <ThemeProvider theme={lightTheme}>
+          <div style={{padding: 8, width: 400}}>
+            <BillingDetailsPanel
+              organization={organization}
+              subscription={scenario.subscription}
+            />
+          </div>
+        </ThemeProvider>
+      );
+    },
+    name => ({tags: {area: 'billing', scenario: name}})
+  );
+});

--- a/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-image-metadata.ts
@@ -9,7 +9,7 @@ export interface SnapshotImageMetadata {
   // Skip height, width and image_file_name as they're handled by the CLI
 }
 
-type SnapshotArea = 'core' | 'snapshots';
+type SnapshotArea = 'core' | 'snapshots' | 'billing';
 
 type SnapshotTags = {area: SnapshotArea} & Record<string, string>;
 


### PR DESCRIPTION
https://linear.app/getsentry/issue/REVENG-245/add-snapshot-tests-to-billing-details-widget-and-enable-ci

This PR adds snapshot tests to cover multiple scenarios for the billing details widget on the subscription page, and integrates these snapshots with CI for automatic diffing. 