### PR TITLE
feat(autofix): make FE changes to match github mentions

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -903,6 +903,11 @@ def build_pr_description_suffix(group: Group) -> str | None:
             linear_id = external_issue.display_name.replace("#", "-")
             lines.append(f"Fixes [{linear_id}]({external_issue.web_url})")
 
+    if features.has("organizations:autofix-pr-iteration", group.organization):
+        lines.append(
+            "\n<sub>Comment `@sentry <feedback>` on this PR to have Autofix iterate on the changes.</sub>"
+        )
+
     if lines:
         return "\n".join(lines)
 

--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -7,6 +7,7 @@ import {DiffFileType, DiffLineType} from 'sentry/components/events/autofix/types
 import {
   collectPatches,
   getOrderedAutofixSections,
+  getPollInterval,
   isCodeChangesArtifact,
   isCodingAgentsArtifact,
   isLastStepPrIteration,
@@ -31,6 +32,51 @@ function makeValidArtifact<T>(data: T): Artifact<T> {
     data,
   };
 }
+
+describe('getPollInterval', () => {
+  function makeState(
+    overrides: Partial<ExplorerAutofixState> = {}
+  ): ExplorerAutofixState {
+    return {
+      run_id: 1,
+      blocks: [],
+      status: 'completed',
+      updated_at: '2026-01-01T00:00:00Z',
+      ...overrides,
+    };
+  }
+
+  const completedPr: ExplorerAutofixState['repo_pr_states'] = {
+    'org/repo': {pr_creation_status: 'completed'} as any,
+  };
+
+  it('polls when pollPR is set and a PR has been created, even when idle', () => {
+    const state = makeState({status: 'completed', repo_pr_states: completedPr});
+    expect(getPollInterval({autofixState: state, runStarted: false, pollPR: true})).toBe(
+      1000
+    );
+  });
+
+  it('does not poll when pollPR is set but no PR has been created', () => {
+    const state = makeState({status: 'completed', repo_pr_states: {}});
+    expect(getPollInterval({autofixState: state, runStarted: false, pollPR: true})).toBe(
+      false
+    );
+  });
+
+  it('ignores PR state when pollPR is not set', () => {
+    const state = makeState({status: 'completed', repo_pr_states: completedPr});
+    expect(getPollInterval({autofixState: state, runStarted: false})).toBe(false);
+  });
+
+  it('polls while processing regardless of pollPR', () => {
+    const state = makeState({status: 'processing'});
+    expect(getPollInterval({autofixState: state, runStarted: false})).toBe(1000);
+    expect(getPollInterval({autofixState: state, runStarted: false, pollPR: true})).toBe(
+      1000
+    );
+  });
+});
 
 describe('isRootCauseArtifact', () => {
   function makeValidRootCauseData(): RootCauseArtifact {

--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -725,6 +725,84 @@ describe('useExplorerAutofix - createPR', () => {
   });
 });
 
+describe('useExplorerAutofix - startStep pr_iteration', () => {
+  const GROUP_ID = '123';
+  const AUTOFIX_URL = `/organizations/org-slug/issues/${GROUP_ID}/autofix/`;
+  const baseState = {
+    run_id: 42,
+    blocks: [],
+    status: 'processing' as const,
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'GET',
+      body: {autofix: baseState},
+    });
+  });
+
+  it('sends the POST with user_context', async () => {
+    const mockPost = MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      body: {run_id: 42},
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(GROUP_ID));
+
+    await act(() =>
+      result.current.startStep('pr_iteration', {runId: 42, userContext: 'make it blue'})
+    );
+
+    expect(mockPost).toHaveBeenCalledWith(
+      AUTOFIX_URL,
+      expect.objectContaining({
+        method: 'POST',
+        query: {mode: 'explorer'},
+        data: {
+          step: 'pr_iteration',
+          run_id: 42,
+          user_context: 'make it blue',
+          referrer: 'api.web',
+        },
+      })
+    );
+  });
+
+  it('awaits the refetch so queued feedback is present once it resolves', async () => {
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      body: {run_id: 42},
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(GROUP_ID));
+
+    await waitFor(() => expect(result.current.runState?.run_id).toBe(42));
+    expect(result.current.runState?.queued_feedback).toBeUndefined();
+
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'GET',
+      body: {
+        autofix: {
+          ...baseState,
+          queued_feedback: [{text: 'make it blue', source: {type: 'user-ui'}}],
+        },
+      },
+    });
+
+    await act(() =>
+      result.current.startStep('pr_iteration', {runId: 42, userContext: 'make it blue'})
+    );
+
+    expect(result.current.runState?.queued_feedback).toHaveLength(1);
+  });
+});
+
 describe('useExplorerAutofix - codingAgentErrors', () => {
   const GROUP_ID = '123';
   const AUTOFIX_URL = `/organizations/org-slug/issues/${GROUP_ID}/autofix/`;

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -125,11 +125,11 @@ export function isCodingAgentsArtifact(
  * State returned from the Explorer autofix endpoint.
  * This extends the SeerExplorer types with autofix-specific data.
  */
-export interface QueuedFeedbackItem {
+export interface RawFeedback {
   text: string;
   source?: {
+    type: string;
     comment?: {html_url?: string; user?: {login: string}};
-    type?: string;
     user?: User;
   };
   timestamp?: string;
@@ -146,7 +146,7 @@ export interface ExplorerAutofixState {
     id: string;
     input_type: 'file_change_approval' | 'ask_user_question';
   } | null;
-  queued_feedback?: QueuedFeedbackItem[];
+  queued_feedback?: RawFeedback[];
   repo_pr_states?: Record<string, RepoPRState>;
 }
 
@@ -226,16 +226,23 @@ const isActivelyProcessing = (
   );
 };
 
+const hasCreatedPullRequest = (autofixState: ExplorerAutofixState | null): boolean =>
+  Object.values(autofixState?.repo_pr_states ?? {}).some(
+    state => state.pr_creation_status === 'completed'
+  );
+
 /**
  * Gets the appropriate poll interval based on state.
- * Returns false to disable polling, or a number for the interval.
  */
 const getPollInterval = (
   autofixState: ExplorerAutofixState | null,
-  runStarted: boolean
+  runStarted: boolean,
+  pollPR = false
 ): number | false => {
-  // Actively processing - poll fast
-  if (isActivelyProcessing(autofixState, runStarted)) {
+  const shouldPollPR = pollPR && hasCreatedPullRequest(autofixState);
+  const shouldPollProcessing = isActivelyProcessing(autofixState, runStarted);
+
+  if (shouldPollPR || shouldPollProcessing) {
     return POLL_INTERVAL;
   }
 
@@ -468,6 +475,11 @@ interface UseExplorerAutofixOptions {
    * Defaults to true.
    */
   enabled?: boolean;
+  /**
+   * Force fast polling while the drawer is mounted. Other observers can keep
+   * their processing-aware intervals.
+   */
+  pollPR?: boolean;
 }
 
 /**
@@ -484,7 +496,7 @@ export function useExplorerAutofix(
 ) {
   const {openModal} = useModal();
 
-  const {enabled = true} = options;
+  const {enabled = true, pollPR = false} = options;
   const api = useApi();
   const queryClient = useQueryClient();
   const organization = useOrganization();
@@ -517,7 +529,9 @@ export function useExplorerAutofix(
       if (!enabled) {
         return false;
       }
-      return getPollInterval(query.state.data?.json?.autofix || null, waitingForResponse);
+
+      const autofixState = query.state.data?.json?.autofix || null;
+      return getPollInterval(autofixState, waitingForResponse, pollPR);
     },
   });
 
@@ -570,9 +584,13 @@ export function useExplorerAutofix(
         );
 
         // Invalidate to fetch fresh data
-        queryClient.invalidateQueries({
+        const invalidation = queryClient.invalidateQueries({
           queryKey: explorerAutofixApiOptions(orgSlug, groupId).queryKey,
         });
+
+        if (step === 'pr_iteration') {
+          await invalidation;
+        }
 
         return response.run_id as number;
       } catch (e: any) {

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -234,11 +234,15 @@ const hasCreatedPullRequest = (autofixState: ExplorerAutofixState | null): boole
 /**
  * Gets the appropriate poll interval based on state.
  */
-const getPollInterval = (
-  autofixState: ExplorerAutofixState | null,
-  runStarted: boolean,
-  pollPR = false
-): number | false => {
+export const getPollInterval = ({
+  autofixState,
+  runStarted,
+  pollPR = false,
+}: {
+  autofixState: ExplorerAutofixState | null;
+  runStarted: boolean;
+  pollPR?: boolean;
+}): number | false => {
   const shouldPollPR = pollPR && hasCreatedPullRequest(autofixState);
   const shouldPollProcessing = isActivelyProcessing(autofixState, runStarted);
 
@@ -531,7 +535,7 @@ export function useExplorerAutofix(
       }
 
       const autofixState = query.state.data?.json?.autofix || null;
-      return getPollInterval(autofixState, waitingForResponse, pollPR);
+      return getPollInterval({autofixState, runStarted: waitingForResponse, pollPR});
     },
   });
 

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -997,7 +997,7 @@ describe('ArtifactCard', () => {
         {organization: prIterationOrganization}
       );
 
-      const row = screen.getByText('fix the CI failure').parentElement!;
+      const row = screen.getByText('fix the CI failure').parentElement!.parentElement!;
       expect(within(row).getByTestId('loading-indicator')).toBeInTheDocument();
       expect(within(row).queryByTestId('icon-check-mark')).not.toBeInTheDocument();
     });

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -997,7 +997,7 @@ describe('ArtifactCard', () => {
         {organization: prIterationOrganization}
       );
 
-      const row = screen.getByText('fix the CI failure').parentElement as HTMLElement;
+      const row = screen.getByText('fix the CI failure').parentElement!;
       expect(within(row).getByTestId('loading-indicator')).toBeInTheDocument();
       expect(within(row).queryByTestId('icon-check-mark')).not.toBeInTheDocument();
     });

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -997,7 +997,9 @@ describe('ArtifactCard', () => {
         {organization: prIterationOrganization}
       );
 
-      const row = screen.getByText('fix the CI failure').parentElement!.parentElement!;
+      const row =
+        screen.getByText('fix the CI failure').parentElement!.parentElement!
+          .parentElement!;
       expect(within(row).getByTestId('loading-indicator')).toBeInTheDocument();
       expect(within(row).queryByTestId('icon-check-mark')).not.toBeInTheDocument();
     });

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -763,7 +763,7 @@ describe('ArtifactCard', () => {
       expect(screen.getByText('"Add a test for this"')).toBeInTheDocument();
     });
 
-    it('shows the iterating loader when feedback is queued', () => {
+    it('shows the iterating loader without replaying the previous step when feedback is queued', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
@@ -779,14 +779,23 @@ describe('ArtifactCard', () => {
         <CodeChangesCard
           groupId="1"
           autofix={autofixWithQueued}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
-          ])}
+          section={makeSection(
+            'code_changes',
+            'completed',
+            [[makePatch('org/repo', 'src/app.py')]],
+            [
+              makePrIterationBlock(0, {text: 'first pass'}),
+              makeAssistantBlock('Previous step output that should not replay'),
+            ]
+          )}
         />,
         {organization: prIterationOrganization}
       );
 
       expect(screen.getByText('Iterating on PR…')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Previous step output that should not replay')
+      ).not.toBeInTheDocument();
       expect(screen.queryByTestId('file-diff-viewer')).not.toBeInTheDocument();
     });
 

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -763,6 +763,43 @@ describe('ArtifactCard', () => {
       expect(screen.getByText('Add a test for this')).toBeInTheDocument();
     });
 
+    it('renders the latest feedback at the top of the list', () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: 'newest queued', source: {type: 'user-ui'}}],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection(
+            'code_changes',
+            'completed',
+            [[makePatch('org/repo', 'src/app.py')]],
+            [
+              makePrIterationBlock(0, {text: 'first pass'}),
+              makePrIterationBlock(1, {text: 'second pass'}),
+            ]
+          )}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      const items = screen.getAllByText(/first pass|second pass|newest queued/);
+      expect(items.map(item => item.textContent)).toEqual([
+        'newest queued',
+        'second pass',
+        'first pass',
+      ]);
+    });
+
     it('shows the iterating loader without replaying the previous step when feedback is queued', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1056,6 +1056,58 @@ describe('ArtifactCard', () => {
       expect(screen.getByRole('button', {name: 'Re-run step'})).toBeEnabled();
     });
 
+    it('disables reset with the feature flag while processing before any PR exists', () => {
+      const autofix: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'processing',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {},
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofix}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeDisabled();
+    });
+
+    it('keeps reset enabled with the feature flag while processing once a PR exists', () => {
+      const autofix: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'processing',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {'org/repo': makePR()},
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofix}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeEnabled();
+    });
+
     it('disables reset without the feature flag when PRs exist', () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1,6 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
 import type {
@@ -760,7 +760,7 @@ describe('ArtifactCard', () => {
       );
 
       expect(screen.getByText('Feedback')).toBeInTheDocument();
-      expect(screen.getByText('"Add a test for this"')).toBeInTheDocument();
+      expect(screen.getByText('Add a test for this')).toBeInTheDocument();
     });
 
     it('shows the iterating loader without replaying the previous step when feedback is queued', () => {
@@ -823,7 +823,7 @@ describe('ArtifactCard', () => {
       );
 
       expect(screen.getByText('Feedback')).toBeInTheDocument();
-      expect(screen.getByText('"Make the button blue"')).toBeInTheDocument();
+      expect(screen.getByText('Make the button blue')).toBeInTheDocument();
     });
 
     it('shows generic processing copy for queued feedback without the feature flag', () => {
@@ -867,7 +867,7 @@ describe('ArtifactCard', () => {
       );
 
       expect(screen.queryByText('Feedback')).not.toBeInTheDocument();
-      expect(screen.queryByText('"Add a test for this"')).not.toBeInTheDocument();
+      expect(screen.queryByText('Add a test for this')).not.toBeInTheDocument();
       expect(screen.queryByText(/- Latest/)).not.toBeInTheDocument();
     });
 
@@ -916,7 +916,7 @@ describe('ArtifactCard', () => {
             'code_changes',
             'processing',
             [],
-            [makePrIterationBlock(0, {text: 'keep going'})]
+            [makePrIterationBlock(0, {text: 'fix the CI failure'})]
           )}
         />,
         {organization: prIterationOrganization}
@@ -924,6 +924,182 @@ describe('ArtifactCard', () => {
 
       expect(screen.getByText('Iterating on PR…')).toBeInTheDocument();
       expect(screen.queryByText('Implementing changes…')).not.toBeInTheDocument();
+    });
+
+    it('marks block feedback as processed when the section is not processing', () => {
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={mockAutofix}
+          section={makeSection(
+            'code_changes',
+            'completed',
+            [[makePatch('org/repo', 'src/app.py')]],
+            [makePrIterationBlock(0, {text: 'first pass'})]
+          )}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByText('first pass')).toBeInTheDocument();
+      expect(screen.getByTestId('icon-check-mark')).toBeInTheDocument();
+    });
+
+    it('marks the current iteration feedback as in progress while processing', () => {
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={mockAutofix}
+          section={makeSection(
+            'code_changes',
+            'processing',
+            [],
+            [makePrIterationBlock(0, {text: 'fix the CI failure'})]
+          )}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      const row = screen.getByText('fix the CI failure').parentElement as HTMLElement;
+      expect(within(row).getByTestId('loading-indicator')).toBeInTheDocument();
+      expect(within(row).queryByTestId('icon-check-mark')).not.toBeInTheDocument();
+    });
+
+    it('marks queued feedback with a queued label and no timestamp', () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: 'Make the button blue', source: {type: 'user-ui'}}],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByText('Make the button blue')).toBeInTheDocument();
+      expect(screen.getByText('Queued')).toBeInTheDocument();
+      expect(screen.queryByTestId('icon-check-mark')).not.toBeInTheDocument();
+    });
+
+    it('keeps reset enabled with the feature flag even when PRs exist', () => {
+      const autofix: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {'org/repo': makePR()},
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofix}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeEnabled();
+    });
+
+    it('disables reset without the feature flag when PRs exist', () => {
+      const autofix: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {'org/repo': makePR()},
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofix}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />
+      );
+
+      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeDisabled();
+    });
+
+    it('disables reset while a coding agent is active', () => {
+      const autofix: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          coding_agents: {a: {} as any},
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofix}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByRole('button', {name: 'Re-run step'})).toBeDisabled();
+    });
+
+    it('shows the PR iteration form mid-run when reset is requested', async () => {
+      const autofix: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'processing',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {'org/repo': makePR()},
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofix}
+          section={makeSection(
+            'code_changes',
+            'processing',
+            [],
+            [makePrIterationBlock(0, {text: 'fix the CI failure'})]
+          )}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Re-run step'}));
+      expect(
+        screen.getByText('Anything else you want to see on your PR?')
+      ).toBeInTheDocument();
     });
   });
 

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -206,7 +206,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
   );
 
   const feedback = useMemo(
-    () => [...blockFeedback, ...queuedFeedback],
+    () => [...blockFeedback, ...queuedFeedback].reverse(),
     [blockFeedback, queuedFeedback]
   );
 

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -476,7 +476,12 @@ function FeedbackStatusIcon({status}: {status: FeedbackStatus}) {
 }
 
 const FeedbackProse = styled(Prose)<{muted?: boolean}>`
-  ${p => (p.muted ? `color: ${p.theme.tokens.content.secondary};` : '')}
+  ${p =>
+    p.muted
+      ? css`
+          color: ${p.theme.tokens.content.secondary};
+        `
+      : ''}
 `;
 
 function FeedbackItem({item}: {item: IterationFeedback}) {

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useMemo} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {UserAvatar} from '@sentry/scraps/avatar';
@@ -141,36 +142,36 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
   // section's code-change artifact by getOrderedAutofixSections. Feedback on a
   // block at/after the current step marker drives the iteration still running
   // (when the section is processing); everything earlier is already pushed.
-  const blockFeedback = useMemo<IterationFeedback[]>(
-    () =>
-      hasPrIterationFeature
-        ? section.blocks.flatMap((block, blockIndex) => {
-            if (!isPrIterationBlock(block)) {
-              return [];
-            }
+  const blockFeedback = useMemo<IterationFeedback[]>(() => {
+    if (!hasPrIterationFeature) {
+      return [];
+    }
 
-            const metadata = block.message.metadata;
-            const value = metadata?.feedback;
-            const iterationIndex = metadata?.iteration_index;
+    return section.blocks.flatMap((block, blockIndex) => {
+      if (!isPrIterationBlock(block)) {
+        return [];
+      }
 
-            if (!value || iterationIndex === undefined) {
-              return [];
-            }
+      const metadata = block.message.metadata;
+      const value = metadata?.feedback;
+      const iterationIndex = metadata?.iteration_index;
 
-            const status: FeedbackStatus =
-              section.status === 'processing' && blockIndex >= currentStepStart
-                ? 'in_progress'
-                : 'processed';
+      if (!value || iterationIndex === undefined) {
+        return [];
+      }
 
-            return parseFeedback(value).map(parsed => ({
-              ...parsed,
-              iterationIndex: Number(iterationIndex),
-              status,
-            }));
-          })
-        : [],
-    [section.blocks, section.status, currentStepStart, hasPrIterationFeature]
-  );
+      const status: FeedbackStatus =
+        section.status === 'processing' && blockIndex >= currentStepStart
+          ? 'in_progress'
+          : 'processed';
+
+      return parseFeedback(value).map(parsed => ({
+        ...parsed,
+        iterationIndex: Number(iterationIndex),
+        status,
+      }));
+    });
+  }, [section.blocks, section.status, currentStepStart, hasPrIterationFeature]);
 
   const latestIterationIndex = useMemo(
     () =>
@@ -184,41 +185,41 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
 
   // Feedback submitted while this run is processing that hasn't been picked up
   // and folded into a block yet. It will become the next iteration.
-  const queuedFeedback = useMemo<IterationFeedback[]>(
-    () =>
-      hasPrIterationFeature
-        ? (autofix.runState?.queued_feedback ?? []).flatMap(raw => {
-            const parsed = parseFeedbackItem(raw);
-            if (!parsed) {
-              return [];
-            }
+  const queuedFeedback = useMemo<IterationFeedback[]>(() => {
+    if (!hasPrIterationFeature) {
+      return [];
+    }
 
-            return [
-              {
-                ...parsed,
-                iterationIndex: (latestIterationIndex ?? -1) + 1,
-                status: 'queued' as const,
-              },
-            ];
-          })
-        : [],
-    [autofix.runState?.queued_feedback, latestIterationIndex, hasPrIterationFeature]
-  );
+    return (autofix.runState?.queued_feedback ?? []).flatMap(raw => {
+      const parsed = parseFeedbackItem(raw);
+      if (!parsed) {
+        return [];
+      }
+
+      return [
+        {
+          ...parsed,
+          iterationIndex: (latestIterationIndex ?? -1) + 1,
+          status: 'queued' as const,
+        },
+      ];
+    });
+  }, [autofix.runState?.queued_feedback, latestIterationIndex, hasPrIterationFeature]);
 
   const feedback = useMemo(
     () => [...blockFeedback, ...queuedFeedback].reverse(),
     [blockFeedback, queuedFeedback]
   );
 
-  const loadingBlocks = useMemo(
-    () =>
-      section.status === 'processing'
-        ? currentStepStart === -1
-          ? section.blocks
-          : section.blocks.slice(currentStepStart)
-        : [],
-    [section.status, section.blocks, currentStepStart]
-  );
+  const loadingBlocks = useMemo(() => {
+    if (section.status !== 'processing') {
+      return [];
+    }
+    if (currentStepStart === -1) {
+      return section.blocks;
+    }
+    return section.blocks.slice(currentStepStart);
+  }, [section.status, section.blocks, currentStepStart]);
 
   const artifact = useMemo(() => {
     const sectionArtifact = getAutofixArtifactFromSection(section);

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -236,7 +236,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
 
   const isResetEligible = prIterationEnabled
-    ? noCodingAgents
+    ? noCodingAgents && (hasPRs || autofix.runState?.status !== 'processing')
     : noCodingAgents && !hasPRs && autofix.runState?.status !== 'processing';
 
   const {canReset, shouldShowReset, setShouldShowReset, handleReset} =

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useMemo} from 'react';
+import styled from '@emotion/styled';
 
 import {UserAvatar} from '@sentry/scraps/avatar';
 import {Tag} from '@sentry/scraps/badge';
@@ -15,7 +16,7 @@ import {
   isCodeChangesArtifact,
   isPrIterationBlock,
   type AutofixSection,
-  type QueuedFeedbackItem,
+  type RawFeedback,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {ArtifactCard} from 'sentry/components/events/autofix/v3/artifactCard';
@@ -25,7 +26,10 @@ import {AutofixResetPrompt} from 'sentry/components/events/autofix/v3/autofixRes
 import {PrIterationFeedbackForm} from 'sentry/components/events/autofix/v3/prIterationFeedbackForm';
 import {useResetAutofixStep} from 'sentry/components/events/autofix/v3/useResetAutofixStep';
 import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {TimeSince} from 'sentry/components/timeSince';
+import {IconCheckmark} from 'sentry/icons/iconCheckmark';
+import {IconClock} from 'sentry/icons/iconClock';
 import {IconCode} from 'sentry/icons/iconCode';
 import {IconGithub} from 'sentry/icons/iconGithub';
 import {IconRefresh} from 'sentry/icons/iconRefresh';
@@ -42,104 +46,66 @@ interface CodeChangesCardProps {
   section: AutofixSection;
 }
 
-interface BaseFeedback {
-  iterationIndex: number;
+/**
+ * - `processed`: the iteration it drove has finished and its changes are pushed.
+ * - `in_progress`: it's driving the iteration currently being processed.
+ * - `queued`: submitted while a run was processing, not yet picked up.
+ */
+type FeedbackStatus = 'processed' | 'in_progress' | 'queued';
+
+interface ParsedBaseFeedback {
   text: string;
   timestamp?: string;
 }
 
-interface UserUiFeedback extends BaseFeedback {
+interface UserUiFeedback extends ParsedBaseFeedback {
   sourceType: 'user-ui';
   user?: User | null;
 }
 
-interface GithubPrCommentFeedback extends BaseFeedback {
+interface GithubPrCommentFeedback extends ParsedBaseFeedback {
+  commentUrl: string;
   sourceType: 'github-pr-comment';
-  commentUrl?: string;
   githubUsername?: string;
 }
 
-type IterationFeedback = UserUiFeedback | GithubPrCommentFeedback;
+// What `parseFeedback` can produce from the stored JSON alone.
+type ParsedFeedback = UserUiFeedback | GithubPrCommentFeedback;
 
-type DistributiveOmit<T, K extends keyof any> = T extends unknown ? Omit<T, K> : never;
+// A parsed feedback enriched with the iteration context the caller supplies.
+type IterationFeedback = ParsedFeedback & {
+  iterationIndex: number;
+  status: FeedbackStatus;
+};
 
-/**
- * Feedback is stored as a JSON object (`{text, source, timestamp}`), where
- * `source` identifies who submitted it: `{type: 'user-ui', user_id, user}` from
- * the Sentry UI (the backend resolves `user_id` into a serialized `user`) or
- * `{type: 'github-pr-comment', comment}` from an `@sentry` PR comment, where
- * `comment` is the raw GitHub comment payload (we read `comment.user.login` for
- * attribution and `comment.html_url` to link back to it).
- *
- * We mux on `source.type` so each variant produces its own discriminated
- * `IterationFeedback`, which `FeedbackItem` then renders per-type. Source types
- * we don't recognize return `null` so a backend change can roll out ahead of the
- * frontend without rendering anything unexpected.
- */
-function parseQueuedFeedback(
-  item: QueuedFeedbackItem,
-  iterationIndex: number
-): IterationFeedback | null {
-  const base = {text: item.text, timestamp: item.timestamp, iterationIndex};
-  switch (item.source?.type) {
+function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {
+  const base = {text: parsed.text, timestamp: parsed.timestamp};
+  switch (parsed.source?.type) {
     case 'user-ui':
-      return {...base, sourceType: 'user-ui', user: item.source.user ?? null};
-    case 'github-pr-comment':
+      return {...base, sourceType: 'user-ui', user: parsed.source?.user};
+    case 'github-pr-comment': {
+      const commentUrl = parsed.source?.comment?.html_url;
+      if (!commentUrl) {
+        return null;
+      }
       return {
         ...base,
         sourceType: 'github-pr-comment',
-        githubUsername: item.source.comment?.user?.login,
-        commentUrl: item.source.comment?.html_url,
+        githubUsername: parsed.source?.comment?.user?.login,
+        commentUrl,
       };
+    }
     default:
       return null;
   }
 }
 
-type FeedbackVariant = DistributiveOmit<IterationFeedback, 'iterationIndex'>;
-
-function parseFeedback(raw: string): FeedbackVariant[] {
-  type ParsedFeedback = {
-    text: string;
-    source?: {
-      type: string;
-      comment?: {html_url?: string; user?: {login: string}};
-      user?: User;
-    };
-    timestamp?: string;
-  };
-  const rawParsed: ParsedFeedback | ParsedFeedback[] = JSON.parse(raw);
-  const items = Array.isArray(rawParsed) ? rawParsed : [rawParsed];
-  return items.flatMap((parsed): FeedbackVariant[] => {
-    if (!parsed) {
-      return [];
-    }
-    const base = {text: parsed.text, timestamp: parsed.timestamp};
-    switch (parsed.source?.type) {
-      case 'user-ui':
-        return [{...base, sourceType: 'user-ui', user: parsed.source?.user}];
-      case 'github-pr-comment':
-        return [
-          {
-            ...base,
-            sourceType: 'github-pr-comment',
-            githubUsername: parsed.source?.comment?.user?.login,
-            commentUrl: parsed.source?.comment?.html_url,
-          },
-        ];
-      default:
-        return [];
-    }
-  });
+function parseFeedback(raw: string): ParsedFeedback[] {
+  const parsed: RawFeedback | RawFeedback[] = JSON.parse(raw);
+  const items = Array.isArray(parsed) ? parsed : [parsed];
+  return items.map(parseFeedbackItem).filter(defined);
 }
 
-/**
- * When the coding step finishes without producing any patches, the agent often
- * still leaves a final assistant message explaining why — e.g. the real fix is a
- * database migration / infra change, or the relevant files aren't in the
- * connected repo. Surface that explanation instead of a generic "this one is on
- * us" message so the user knows a plain re-run won't help.
- */
 function getFinalExplanation(section: AutofixSection): string | null {
   for (let i = section.blocks.length - 1; i >= 0; i--) {
     const block = section.blocks[i];
@@ -158,45 +124,6 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
   const organization = useOrganization();
   const hasPrIterationFeature = organization.features.includes('autofix-pr-iteration');
 
-  // PR iterations are folded into this section's blocks. Surface the feedback
-  // that drove each one — the cumulative diff is already merged into the
-  // section's code-change artifact by getOrderedAutofixSections. Gated behind
-  // the PR iteration feature; when it's off we render the card as if no
-  // iterations exist.
-  const feedback = useMemo<IterationFeedback[]>(() => {
-    if (!hasPrIterationFeature) {
-      return [];
-    }
-    const processed = section.blocks.filter(isPrIterationBlock).flatMap(block => {
-      const metadata = block.message.metadata;
-      const value = metadata?.feedback;
-      const iterationIndex = metadata?.iteration_index;
-      if (!value || iterationIndex === undefined) {
-        return [];
-      }
-      return parseFeedback(value).map(parsed => ({
-        ...parsed,
-        iterationIndex: Number(iterationIndex),
-      }));
-    });
-    const maxIndex = processed.reduce((m, f) => Math.max(m, f.iterationIndex), -1);
-    const queued = (autofix.runState?.queued_feedback ?? []).flatMap((item, i) => {
-      const parsed = parseQueuedFeedback(item, maxIndex + 1 + i);
-      return parsed ? [parsed] : [];
-    });
-    return [...processed, ...queued];
-  }, [section.blocks, hasPrIterationFeature, autofix.runState?.queued_feedback]);
-
-  const latestIterationIndex = useMemo(
-    () =>
-      feedback.reduce<number | null>(
-        (max, item) =>
-          max === null ? item.iterationIndex : Math.max(max, item.iterationIndex),
-        null
-      ),
-    [feedback]
-  );
-
   const hasQueuedFeedback = (autofix.runState?.queued_feedback ?? []).length > 0;
 
   const isIterating =
@@ -204,19 +131,94 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     (hasQueuedFeedback ||
       (section.status === 'processing' && section.blocks.some(isPrIterationBlock)));
 
-  // While processing, only replay the assistant output from the current
-  // in-progress step. Steps (the original coding step plus each PR iteration)
-  // are folded into this section's blocks; the first block of each step carries
-  // a `step` marker and the rest inherit it, so slice from the latest marker to
-  // avoid replaying earlier, already-finished steps.
-  const loadingBlocks = useMemo(() => {
-    const currentStepStart = section.blocks.findLastIndex(block =>
-      defined(block.message.metadata?.step)
-    );
-    return currentStepStart === -1
-      ? section.blocks
-      : section.blocks.slice(currentStepStart);
-  }, [section.blocks]);
+  const currentStepStart = useMemo(
+    () => section.blocks.findLastIndex(block => defined(block.message.metadata?.step)),
+    [section.blocks]
+  );
+
+  // PR iterations are folded into this section's blocks. Surface the feedback
+  // that drove each one — the cumulative diff is already merged into the
+  // section's code-change artifact by getOrderedAutofixSections. Feedback on a
+  // block at/after the current step marker drives the iteration still running
+  // (when the section is processing); everything earlier is already pushed.
+  const blockFeedback = useMemo<IterationFeedback[]>(
+    () =>
+      hasPrIterationFeature
+        ? section.blocks.flatMap((block, blockIndex) => {
+            if (!isPrIterationBlock(block)) {
+              return [];
+            }
+
+            const metadata = block.message.metadata;
+            const value = metadata?.feedback;
+            const iterationIndex = metadata?.iteration_index;
+
+            if (!value || iterationIndex === undefined) {
+              return [];
+            }
+
+            const status: FeedbackStatus =
+              section.status === 'processing' && blockIndex >= currentStepStart
+                ? 'in_progress'
+                : 'processed';
+
+            return parseFeedback(value).map(parsed => ({
+              ...parsed,
+              iterationIndex: Number(iterationIndex),
+              status,
+            }));
+          })
+        : [],
+    [section.blocks, section.status, currentStepStart, hasPrIterationFeature]
+  );
+
+  const latestIterationIndex = useMemo(
+    () =>
+      blockFeedback.reduce<number | null>(
+        (max, item) =>
+          max === null ? item.iterationIndex : Math.max(max, item.iterationIndex),
+        null
+      ),
+    [blockFeedback]
+  );
+
+  // Feedback submitted while this run is processing that hasn't been picked up
+  // and folded into a block yet. It will become the next iteration.
+  const queuedFeedback = useMemo<IterationFeedback[]>(
+    () =>
+      hasPrIterationFeature
+        ? (autofix.runState?.queued_feedback ?? []).flatMap(raw => {
+            const parsed = parseFeedbackItem(raw);
+            if (!parsed) {
+              return [];
+            }
+
+            return [
+              {
+                ...parsed,
+                iterationIndex: (latestIterationIndex ?? -1) + 1,
+                status: 'queued' as const,
+              },
+            ];
+          })
+        : [],
+    [autofix.runState?.queued_feedback, latestIterationIndex, hasPrIterationFeature]
+  );
+
+  const feedback = useMemo(
+    () => [...blockFeedback, ...queuedFeedback],
+    [blockFeedback, queuedFeedback]
+  );
+
+  const loadingBlocks = useMemo(
+    () =>
+      section.status !== 'processing'
+        ? []
+        : currentStepStart === -1
+          ? section.blocks
+          : section.blocks.slice(currentStepStart),
+    [section.status, section.blocks, currentStepStart]
+  );
 
   const artifact = useMemo(() => {
     const sectionArtifact = getAutofixArtifactFromSection(section);
@@ -229,16 +231,22 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     [artifact]
   );
 
+  const prIterationEnabled = hasPrIterationFeature;
+  const hasPRs = Object.keys(autofix.runState?.repo_pr_states ?? {}).length > 0;
+  const noCodingAgents =
+    Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
+
+  const isResetEligible = prIterationEnabled
+    ? noCodingAgents
+    : noCodingAgents && !hasPRs && autofix.runState?.status !== 'processing';
+
   const {canReset, shouldShowReset, setShouldShowReset, handleReset} =
     useResetAutofixStep({
       autofix,
+      canReset: isResetEligible,
       section,
       step: 'code_changes',
     });
-
-  const prIterationEnabled = hasPrIterationFeature;
-  const hasPRs = Object.keys(autofix.runState?.repo_pr_states ?? {}).length > 0;
-
   const patchesByRepo = useMemo(() => collectPatches(artifact ?? []), [artifact]);
 
   const explanation = useMemo(() => getFinalExplanation(section), [section]);
@@ -293,17 +301,30 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
         <ArtifactDetails>
           <Text bold>{t('Feedback')}</Text>
           {feedback.map((item, index) => (
-            <FeedbackItem key={index} item={item} />
+            <FeedbackItem key={`${item.iterationIndex}-${index}`} item={item} />
           ))}
         </ArtifactDetails>
       )}
       {isProcessing ? (
-        <ArtifactLoadingDetails
-          blocks={loadingBlocks}
-          loadingMessage={
-            isIterating ? t('Iterating on PR…') : t('Implementing changes…')
-          }
-        />
+        <Fragment>
+          {/* PR iteration feedback is queued while a run is in progress, so keep
+              the form available even mid-run. */}
+          {shouldShowReset && hasPRs && prIterationEnabled && (
+            <PrIterationFeedbackForm
+              autofix={autofix}
+              groupId={groupId}
+              runId={autofix.runState?.run_id}
+              referrer="code_changes_card_reset"
+              onClose={() => setShouldShowReset(false)}
+            />
+          )}
+          <ArtifactLoadingDetails
+            blocks={loadingBlocks}
+            loadingMessage={
+              isIterating ? t('Iterating on PR…') : t('Implementing changes…')
+            }
+          />
+        </Fragment>
       ) : artifact && patchesByRepo.size ? (
         <Fragment>
           {shouldShowReset &&
@@ -413,20 +434,10 @@ function FeedbackAttribution({item}: {item: IterationFeedback}) {
   switch (item.sourceType) {
     case 'github-pr-comment':
       return (
-        <Tooltip title={t('From a GitHub PR comment')}>
-          <Flex gap="xs" align="center" flex="0 0 auto">
+        <Tooltip title={item.githubUsername ?? t('GitHub PR comment')} skipWrapper>
+          <GithubIconLink href={item.commentUrl}>
             <IconGithub size="md" />
-            {item.githubUsername &&
-              (item.commentUrl ? (
-                <ExternalLink href={item.commentUrl}>
-                  <Text wrap="nowrap">{item.githubUsername}</Text>
-                </ExternalLink>
-              ) : (
-                <Text underline wrap="nowrap">
-                  {item.githubUsername}
-                </Text>
-              ))}
-          </Flex>
+          </GithubIconLink>
         </Tooltip>
       );
     case 'user-ui':
@@ -436,20 +447,69 @@ function FeedbackAttribution({item}: {item: IterationFeedback}) {
   }
 }
 
+function FeedbackStatusIcon({status}: {status: FeedbackStatus}) {
+  switch (status) {
+    case 'processed':
+      return (
+        <Tooltip title={t('Changes from this feedback have been pushed')}>
+          <Tag variant="success" icon={<IconCheckmark />} />
+        </Tooltip>
+      );
+    case 'in_progress':
+      return (
+        <Tooltip title={t('This feedback is being processed')}>
+          <StyledLoadingIndicator size={14} />
+        </Tooltip>
+      );
+    case 'queued':
+      return <Tag variant="muted" icon={<IconClock />} />;
+    default:
+      return null;
+  }
+}
+
 function FeedbackItem({item}: {item: IterationFeedback}) {
+  const isQueued = item.status === 'queued';
   return (
-    <Flex gap="md" align="start" justify="between">
+    <Flex gap="md" align="center" justify="between">
       <Flex gap="md" align="center" flex="1" minWidth={0}>
+        <Flex align="center" justify="center" flex="0 0 28px">
+          <FeedbackStatusIcon status={item.status} />
+        </Flex>
         <FeedbackAttribution item={item} />
-        <Text wordBreak="break-word">{t('"%s"', item.text)}</Text>
+        {item.sourceType === 'github-pr-comment' ? (
+          <ExternalLink href={item.commentUrl}>{item.text}</ExternalLink>
+        ) : (
+          <Text wordBreak="break-word" variant={isQueued ? 'muted' : undefined}>
+            {item.text}
+          </Text>
+        )}
       </Flex>
-      {item.timestamp && (
+      {isQueued ? (
         <Flex flex="0 0 auto" align="center">
           <Text variant="muted" size="sm" wrap="nowrap">
-            <TimeSince date={item.timestamp} />
+            {t('Queued')}
           </Text>
         </Flex>
+      ) : (
+        item.timestamp && (
+          <Flex flex="0 0 auto" align="center">
+            <Text variant="muted" size="sm" wrap="nowrap">
+              <TimeSince date={item.timestamp} />
+            </Text>
+          </Flex>
+        )
       )}
     </Flex>
   );
 }
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  margin: 0;
+`;
+
+const GithubIconLink = styled(ExternalLink)`
+  display: inline-flex;
+  align-items: center;
+  line-height: 0;
+`;

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -212,11 +212,11 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
 
   const loadingBlocks = useMemo(
     () =>
-      section.status !== 'processing'
-        ? []
-        : currentStepStart === -1
+      section.status === 'processing'
+        ? currentStepStart === -1
           ? section.blocks
-          : section.blocks.slice(currentStepStart),
+          : section.blocks.slice(currentStepStart)
+        : [],
     [section.status, section.blocks, currentStepStart]
   );
 

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useMemo} from 'react';
-import styled from '@emotion/styled';
 
 import {UserAvatar} from '@sentry/scraps/avatar';
 import {Tag} from '@sentry/scraps/badge';
@@ -275,20 +274,145 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
 
   const isProcessing = section.status === 'processing' || hasQueuedFeedback;
 
+  const showPrIterationForm = hasPRs && prIterationEnabled;
+  const prIterationForm = (
+    <PrIterationFeedbackForm
+      autofix={autofix}
+      groupId={groupId}
+      runId={autofix.runState?.run_id}
+      referrer="code_changes_card_reset"
+      onClose={() => setShouldShowReset(false)}
+    />
+  );
+
+  let title: React.ReactNode = t('Code Changes');
+  if (latestIterationIndex !== null) {
+    title = (
+      <Flex gap="md" align="center">
+        {t('Code Changes')}
+        {/* `iteration_index` is zero-based; display a one-based version number. */}
+        <Tag variant="muted">{t('v%s - Latest', latestIterationIndex + 1)}</Tag>
+      </Flex>
+    );
+  }
+
+  let content: React.ReactNode;
+  if (isProcessing) {
+    content = (
+      <Fragment>
+        {/* PR iteration feedback is queued while a run is in progress, so keep
+            the form available even mid-run. */}
+        {shouldShowReset && showPrIterationForm && prIterationForm}
+        <ArtifactLoadingDetails
+          blocks={loadingBlocks}
+          loadingMessage={
+            isIterating ? t('Iterating on PR…') : t('Implementing changes…')
+          }
+        />
+      </Fragment>
+    );
+  } else if (artifact && patchesByRepo.size) {
+    let resetSection: React.ReactNode = null;
+    if (shouldShowReset) {
+      if (showPrIterationForm) {
+        resetSection = prIterationForm;
+      } else {
+        resetSection = (
+          <AutofixResetPrompt
+            onClosePrompt={() => setShouldShowReset(false)}
+            onReset={handleReset}
+            placeholder={t('Give seer additional context to improve this code change.')}
+            prompt={t('How can this code change be improved?')}
+          />
+        );
+      }
+    }
+
+    content = (
+      <Fragment>
+        {resetSection}
+        <ArtifactDetails>
+          <Text>{summary}</Text>
+        </ArtifactDetails>
+        {[...patchesByRepo.entries()].map(([repo, patches]) => (
+          <ArtifactDetails key={repo}>
+            <Flex gap="lg">
+              <Text bold>{t('Repository:')}</Text>
+              <Text>{repo}</Text>
+            </Flex>
+            {patches.map((patch, index) => (
+              <FileDiffViewer
+                key={index}
+                patch={patch.patch}
+                showBorder
+                collapsible
+                defaultExpanded={artifact !== null && artifact.length <= 1}
+              />
+            ))}
+          </ArtifactDetails>
+        ))}
+      </Fragment>
+    );
+  } else if (explanation) {
+    let resetSection: React.ReactNode;
+    if (!shouldShowReset) {
+      resetSection = (
+        <Flex>
+          <Button
+            variant="primary"
+            icon={<IconRefresh />}
+            disabled={!canReset}
+            onClick={() => setShouldShowReset(true)}
+          >
+            {t('Add context & retry')}
+          </Button>
+        </Flex>
+      );
+    } else if (showPrIterationForm) {
+      resetSection = prIterationForm;
+    } else {
+      resetSection = (
+        <AutofixResetPrompt
+          onClosePrompt={() => setShouldShowReset(false)}
+          onReset={handleReset}
+          placeholder={t(
+            'Add context that could unblock the change, e.g. the repo or files to edit.'
+          )}
+          prompt={t('What additional context should Seer use?')}
+        />
+      );
+    }
+
+    content = (
+      <ArtifactDetails gap="lg">
+        <Flex direction="column" gap="md">
+          <Text bold>{t("Seer proposed a fix but couldn't apply it automatically")}</Text>
+          <Markdown raw={explanation} />
+        </Flex>
+        {resetSection}
+      </ArtifactDetails>
+    );
+  } else {
+    content = (
+      <ArtifactDetails>
+        <Text>
+          {t(
+            'Seer failed to generate a code change. This one is on us. Try running it again.'
+          )}
+        </Text>
+        <Flex>
+          <Button variant="primary" icon={<IconRefresh />} onClick={() => handleReset()}>
+            {t('Re-run')}
+          </Button>
+        </Flex>
+      </ArtifactDetails>
+    );
+  }
+
   return (
     <ArtifactCard
       icon={<IconCode />}
-      title={
-        latestIterationIndex === null ? (
-          t('Code Changes')
-        ) : (
-          <Flex gap="md" align="center">
-            {t('Code Changes')}
-            {/* `iteration_index` is zero-based; display a one-based version number. */}
-            <Tag variant="muted">{t('v%s - Latest', latestIterationIndex + 1)}</Tag>
-          </Flex>
-        )
-      }
+      title={title}
       onCopy={
         markdown
           ? () => copy(markdown, {successMessage: t('Copied to clipboard.')})
@@ -305,127 +429,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
           ))}
         </ArtifactDetails>
       )}
-      {isProcessing ? (
-        <Fragment>
-          {/* PR iteration feedback is queued while a run is in progress, so keep
-              the form available even mid-run. */}
-          {shouldShowReset && hasPRs && prIterationEnabled && (
-            <PrIterationFeedbackForm
-              autofix={autofix}
-              groupId={groupId}
-              runId={autofix.runState?.run_id}
-              referrer="code_changes_card_reset"
-              onClose={() => setShouldShowReset(false)}
-            />
-          )}
-          <ArtifactLoadingDetails
-            blocks={loadingBlocks}
-            loadingMessage={
-              isIterating ? t('Iterating on PR…') : t('Implementing changes…')
-            }
-          />
-        </Fragment>
-      ) : artifact && patchesByRepo.size ? (
-        <Fragment>
-          {shouldShowReset &&
-            (hasPRs && prIterationEnabled ? (
-              <PrIterationFeedbackForm
-                autofix={autofix}
-                groupId={groupId}
-                runId={autofix.runState?.run_id}
-                referrer="code_changes_card_reset"
-                onClose={() => setShouldShowReset(false)}
-              />
-            ) : (
-              <AutofixResetPrompt
-                onClosePrompt={() => setShouldShowReset(false)}
-                onReset={handleReset}
-                placeholder={t(
-                  'Give seer additional context to improve this code change.'
-                )}
-                prompt={t('How can this code change be improved?')}
-              />
-            ))}
-          <ArtifactDetails>
-            <Text>{summary}</Text>
-          </ArtifactDetails>
-          {[...patchesByRepo.entries()].map(([repo, patches]) => (
-            <ArtifactDetails key={repo}>
-              <Flex gap="lg">
-                <Text bold>{t('Repository:')}</Text>
-                <Text>{repo}</Text>
-              </Flex>
-              {patches.map((patch, index) => (
-                <FileDiffViewer
-                  key={index}
-                  patch={patch.patch}
-                  showBorder
-                  collapsible
-                  defaultExpanded={artifact !== null && artifact.length <= 1}
-                />
-              ))}
-            </ArtifactDetails>
-          ))}
-        </Fragment>
-      ) : explanation ? (
-        <ArtifactDetails gap="lg">
-          <Flex direction="column" gap="md">
-            <Text bold>
-              {t("Seer proposed a fix but couldn't apply it automatically")}
-            </Text>
-            <Markdown raw={explanation} />
-          </Flex>
-
-          {shouldShowReset ? (
-            hasPRs && prIterationEnabled ? (
-              <PrIterationFeedbackForm
-                autofix={autofix}
-                groupId={groupId}
-                runId={autofix.runState?.run_id}
-                referrer="code_changes_card_reset"
-                onClose={() => setShouldShowReset(false)}
-              />
-            ) : (
-              <AutofixResetPrompt
-                onClosePrompt={() => setShouldShowReset(false)}
-                onReset={handleReset}
-                placeholder={t(
-                  'Add context that could unblock the change, e.g. the repo or files to edit.'
-                )}
-                prompt={t('What additional context should Seer use?')}
-              />
-            )
-          ) : (
-            <Flex>
-              <Button
-                variant="primary"
-                icon={<IconRefresh />}
-                disabled={!canReset}
-                onClick={() => setShouldShowReset(true)}
-              >
-                {t('Add context & retry')}
-              </Button>
-            </Flex>
-          )}
-        </ArtifactDetails>
-      ) : (
-        <ArtifactDetails>
-          <Text>
-            {t(
-              'Seer failed to generate a code change. This one is on us. Try running it again.'
-            )}
-          </Text>
-          <div>
-            <Button
-              variant="primary"
-              icon={<IconRefresh />}
-              onClick={() => handleReset()}
-            >
-              {t('Re-run')}
-            </Button>
-          </div>
-        </ArtifactDetails>
-      )}
+      {content}
     </ArtifactCard>
   );
 }
@@ -435,9 +439,11 @@ function FeedbackAttribution({item}: {item: IterationFeedback}) {
     case 'github-pr-comment':
       return (
         <Tooltip title={item.githubUsername ?? t('GitHub PR comment')} skipWrapper>
-          <GithubIconLink href={item.commentUrl}>
-            <IconGithub size="md" />
-          </GithubIconLink>
+          <ExternalLink href={item.commentUrl}>
+            <Flex align="center">
+              <IconGithub size="md" />
+            </Flex>
+          </ExternalLink>
         </Tooltip>
       );
     case 'user-ui':
@@ -458,7 +464,7 @@ function FeedbackStatusIcon({status}: {status: FeedbackStatus}) {
     case 'in_progress':
       return (
         <Tooltip title={t('This feedback is being processed')}>
-          <StyledLoadingIndicator size={14} />
+          <LoadingIndicator size={14} />
         </Tooltip>
       );
     case 'queued':
@@ -471,29 +477,33 @@ function FeedbackStatusIcon({status}: {status: FeedbackStatus}) {
 function FeedbackItem({item}: {item: IterationFeedback}) {
   const isQueued = item.status === 'queued';
   return (
-    <Flex gap="md" align="center" justify="between">
-      <Flex gap="md" align="center" flex="1" minWidth={0}>
-        <Flex align="center" justify="center" flex="0 0 28px">
-          <FeedbackStatusIcon status={item.status} />
+    <Flex gap="md" align="start" justify="between">
+      <Flex gap="md" align="start" flex="1" minWidth={0}>
+        <Flex align="center" gap="md" height="1lh">
+          <Flex align="center" justify="center" flex="0 0 28px">
+            <FeedbackStatusIcon status={item.status} />
+          </Flex>
+          <FeedbackAttribution item={item} />
         </Flex>
-        <FeedbackAttribution item={item} />
-        {item.sourceType === 'github-pr-comment' ? (
-          <ExternalLink href={item.commentUrl}>{item.text}</ExternalLink>
-        ) : (
-          <Text wordBreak="break-word" variant={isQueued ? 'muted' : undefined}>
-            {item.text}
-          </Text>
-        )}
+        <Flex align="center" minWidth={0} minHeight="1lh">
+          {item.sourceType === 'github-pr-comment' ? (
+            <ExternalLink href={item.commentUrl}>{item.text}</ExternalLink>
+          ) : (
+            <Text wordBreak="break-word" variant={isQueued ? 'muted' : undefined}>
+              {item.text}
+            </Text>
+          )}
+        </Flex>
       </Flex>
       {isQueued ? (
-        <Flex flex="0 0 auto" align="center">
+        <Flex flex="0 0 auto" align="center" height="1lh">
           <Text variant="muted" size="sm" wrap="nowrap">
             {t('Queued')}
           </Text>
         </Flex>
       ) : (
         item.timestamp && (
-          <Flex flex="0 0 auto" align="center">
+          <Flex flex="0 0 auto" align="center" height="1lh">
             <Text variant="muted" size="sm" wrap="nowrap">
               <TimeSince date={item.timestamp} />
             </Text>
@@ -503,13 +513,3 @@ function FeedbackItem({item}: {item: IterationFeedback}) {
     </Flex>
   );
 }
-
-const StyledLoadingIndicator = styled(LoadingIndicator)`
-  margin: 0;
-`;
-
-const GithubIconLink = styled(ExternalLink)`
-  display: inline-flex;
-  align-items: center;
-  line-height: 0;
-`;

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useMemo} from 'react';
+import styled from '@emotion/styled';
 
 import {UserAvatar} from '@sentry/scraps/avatar';
 import {Tag} from '@sentry/scraps/badge';
@@ -6,7 +7,7 @@ import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Markdown} from '@sentry/scraps/markdown';
-import {Text} from '@sentry/scraps/text';
+import {Prose, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {
@@ -474,6 +475,10 @@ function FeedbackStatusIcon({status}: {status: FeedbackStatus}) {
   }
 }
 
+const FeedbackProse = styled(Prose)<{muted?: boolean}>`
+  ${p => (p.muted ? `color: ${p.theme.tokens.content.secondary};` : '')}
+`;
+
 function FeedbackItem({item}: {item: IterationFeedback}) {
   const isQueued = item.status === 'queued';
   return (
@@ -489,9 +494,9 @@ function FeedbackItem({item}: {item: IterationFeedback}) {
           {item.sourceType === 'github-pr-comment' ? (
             <ExternalLink href={item.commentUrl}>{item.text}</ExternalLink>
           ) : (
-            <Text wordBreak="break-word" variant={isQueued ? 'muted' : undefined}>
-              {item.text}
-            </Text>
+            <FeedbackProse muted={isQueued}>
+              <p>{item.text}</p>
+            </FeedbackProse>
           )}
         </Flex>
       </Flex>

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -19,6 +19,7 @@ import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils/defined';
 import {useAutoScroll} from 'sentry/utils/useAutoScroll';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useAiConfig} from 'sentry/views/issueDetails/hooks/useAiConfig';
 import {useSeerExplorerDrawer} from 'sentry/views/seerExplorer/components/drawer/useSeerExplorerDrawer';
 
@@ -28,8 +29,11 @@ interface SeerDrawerProps {
 }
 
 export function SeerDrawer({group, project}: SeerDrawerProps) {
+  const organization = useOrganization();
   const aiConfig = useAiConfig(group, project);
-  const aiAutofix = useExplorerAutofix(group.id, {pollPR: true});
+  const aiAutofix = useExplorerAutofix(group.id, {
+    pollPR: organization.features.includes('autofix-pr-iteration'),
+  });
 
   const handleCopyMarkdown = useHandleCopyMarkdown({aiAutofix});
   const handleRestart = useHandleRestart({aiAutofix});

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -29,7 +29,7 @@ interface SeerDrawerProps {
 
 export function SeerDrawer({group, project}: SeerDrawerProps) {
   const aiConfig = useAiConfig(group, project);
-  const aiAutofix = useExplorerAutofix(group.id);
+  const aiAutofix = useExplorerAutofix(group.id, {pollPR: true});
 
   const handleCopyMarkdown = useHandleCopyMarkdown({aiAutofix});
   const handleRestart = useHandleRestart({aiAutofix});

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -552,6 +552,21 @@ describe('SeerDrawerNextStep', () => {
       expect(container).toBeEmptyDOMElement();
     });
 
+    it('keeps the feedback form visible while a run is polling', () => {
+      render(
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('pull_request')]}
+          autofix={makePrIterationAutofix({isPolling: true})}
+        />,
+        {organization: prIterationOrganization}
+      );
+      expect(
+        screen.getByText('Anything else you want to see on your PR?')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
     it('renders the feedback prompt, textarea, and submit button', () => {
       render(
         <SeerDrawerNextStep

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -54,7 +54,24 @@ export function SeerDrawerNextStep({sections, group, autofix}: SeerDrawerNextSte
     return null;
   }
 
-  // needed to hide PR iteration after clicking "submit feedback" button
+  // The PR iteration form stays visible during a run: feedback submitted while
+  // processing is queued for the next iteration rather than dropped, so we want
+  // users to be able to keep submitting even mid-run.
+  if (isPullRequestsSection(section)) {
+    return (
+      <PullRequestNextStep
+        group={group}
+        autofix={autofix}
+        runId={runId}
+        section={section}
+        referrer={referrer}
+      />
+    );
+  }
+
+  // Every other next-step action kicks off a fresh run and can't be queued, so
+  // hide them while a run is in progress (also hides them right after clicking a
+  // next-step button).
   if (autofix.isPolling) {
     return null;
   }
@@ -86,18 +103,6 @@ export function SeerDrawerNextStep({sections, group, autofix}: SeerDrawerNextSte
   if (isCodeChangesSection(section)) {
     return (
       <CodeChangesNextStep
-        group={group}
-        autofix={autofix}
-        runId={runId}
-        section={section}
-        referrer={referrer}
-      />
-    );
-  }
-
-  if (isPullRequestsSection(section)) {
-    return (
-      <PullRequestNextStep
         group={group}
         autofix={autofix}
         runId={runId}

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
@@ -1,0 +1,90 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import type {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {PrIterationFeedbackForm} from 'sentry/components/events/autofix/v3/prIterationFeedbackForm';
+import {trackAnalytics} from 'sentry/utils/analytics';
+
+jest.mock('sentry/utils/analytics');
+jest.mock('sentry/actionCreators/indicator');
+
+function makeAutofix(
+  overrides: Partial<ReturnType<typeof useExplorerAutofix>> = {}
+): ReturnType<typeof useExplorerAutofix> {
+  return {
+    runState: {run_id: 1, blocks: []} as any,
+    startStep: jest.fn().mockResolvedValue(undefined),
+    createPR: jest.fn(),
+    reset: jest.fn(),
+    triggerCodingAgentHandoff: jest.fn(),
+    codingAgentErrors: [],
+    dismissCodingAgentError: jest.fn(),
+    isLoading: false,
+    isPolling: false,
+    ...overrides,
+  };
+}
+
+describe('PrIterationFeedbackForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps the submit button enabled while a run is polling', async () => {
+    const autofix = makeAutofix({isPolling: true});
+    render(
+      <PrIterationFeedbackForm autofix={autofix} groupId="1" runId={1} />
+    );
+
+    await userEvent.type(screen.getByRole('textbox'), 'make it blue');
+    expect(screen.getByRole('button', {name: 'Submit'})).toBeEnabled();
+  });
+
+  it('clears the input, resets state, and calls onClose after submitting', async () => {
+    const autofix = makeAutofix();
+    const onClose = jest.fn();
+    render(
+      <PrIterationFeedbackForm
+        autofix={autofix}
+        groupId="1"
+        runId={1}
+        onClose={onClose}
+      />
+    );
+
+    const textbox = screen.getByRole('textbox');
+    await userEvent.type(textbox, 'make it blue');
+    await userEvent.click(screen.getByRole('button', {name: 'Submit'}));
+
+    expect(autofix.startStep).toHaveBeenCalledWith('pr_iteration', {
+      runId: 1,
+      userContext: 'make it blue',
+    });
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(textbox).toHaveValue('');
+    expect(screen.getByRole('button', {name: 'Submit'})).toBeInTheDocument();
+  });
+
+  it('keeps the feedback and surfaces an error when submit fails', async () => {
+    const autofix = makeAutofix({
+      startStep: jest.fn().mockRejectedValue(new Error('boom')),
+    });
+    const onClose = jest.fn();
+    render(
+      <PrIterationFeedbackForm
+        autofix={autofix}
+        groupId="1"
+        runId={1}
+        onClose={onClose}
+      />
+    );
+
+    await userEvent.type(screen.getByRole('textbox'), 'make it blue');
+    await userEvent.click(screen.getByRole('button', {name: 'Submit'}));
+
+    await waitFor(() => expect(addErrorMessage).toHaveBeenCalled());
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole('textbox')).toHaveValue('make it blue');
+    expect(trackAnalytics).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
@@ -32,9 +32,7 @@ describe('PrIterationFeedbackForm', () => {
 
   it('keeps the submit button enabled while a run is polling', async () => {
     const autofix = makeAutofix({isPolling: true});
-    render(
-      <PrIterationFeedbackForm autofix={autofix} groupId="1" runId={1} />
-    );
+    render(<PrIterationFeedbackForm autofix={autofix} groupId="1" runId={1} />);
 
     await userEvent.type(screen.getByRole('textbox'), 'make it blue');
     expect(screen.getByRole('button', {name: 'Submit'})).toBeEnabled();

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
@@ -31,7 +31,7 @@ export function PrIterationFeedbackForm({
   onClose,
 }: PrIterationFeedbackFormProps) {
   const organization = useOrganization();
-  const {isPolling, startStep} = autofix;
+  const {startStep} = autofix;
   const [feedback, setFeedback] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const submitButtonRef = useRef<HTMLButtonElement>(null);
@@ -42,11 +42,9 @@ export function PrIterationFeedbackForm({
     if (!feedback.trim()) {
       return;
     }
-    // Show the loader immediately on click. We don't reuse `isPolling` here
-    // because submitting kicks off a run that flips it, which can hide the
-    // surrounding UI before a polling-driven busy state could render. The
-    // component unmounts and remounts fresh (resetting this flag) once the run
-    // completes.
+    // Briefly show the loader while the request is in flight to guard against a
+    // double submit. Feedback submitted while a run is in progress is queued for
+    // the next iteration rather than dropped, so this form stays usable mid-run.
     setIsSubmitting(true);
     try {
       await startStep('pr_iteration', {runId, userContext: feedback});
@@ -61,9 +59,11 @@ export function PrIterationFeedbackForm({
       mode: 'explorer',
       referrer,
     });
-    // Dismiss the reset UI for callers that render this inline (e.g. the code
-    // changes card) so it doesn't reappear after the run completes. Callers
-    // without an onClose (e.g. the next-step view) keep relying on isSubmitting.
+    // Clear the input and reset the busy state so further feedback can be queued
+    // while the run continues. Callers that render this inline (e.g. the code
+    // changes card) pass an onClose to dismiss the form after submitting.
+    setFeedback('');
+    setIsSubmitting(false);
     onClose?.();
   };
 
@@ -106,7 +106,7 @@ export function PrIterationFeedbackForm({
         <Button
           ref={submitButtonRef}
           icon={isSubmitting ? undefined : <IconArrow size="md" direction="right" />}
-          disabled={isSubmitting || isPolling || !feedback.trim()}
+          disabled={isSubmitting || !feedback.trim()}
           onClick={handleSubmit}
         >
           {isSubmitting ? t('Submitting feedback') : t('Submit')}

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
@@ -1,5 +1,3 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-
 import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import type {
@@ -105,7 +103,7 @@ describe('useResetAutofixStep', () => {
       expect(result.current.canReset).toBe(false);
     });
 
-    it('allows code_changes reset after a PR only with the autofix-pr-iteration feature', () => {
+    it('uses the canReset override when provided', () => {
       const autofix = makeAutofix({
         runState: {
           run_id: 1,
@@ -129,17 +127,20 @@ describe('useResetAutofixStep', () => {
         },
       });
 
-      const withoutFeature = renderHookWithProviders(() =>
+      const withoutOverride = renderHookWithProviders(() =>
         useResetAutofixStep({autofix, section: makeSection(), step: 'code_changes'})
       );
-      expect(withoutFeature.result.current.canReset).toBe(false);
+      expect(withoutOverride.result.current.canReset).toBe(false);
 
-      const withFeature = renderHookWithProviders(
-        () =>
-          useResetAutofixStep({autofix, section: makeSection(), step: 'code_changes'}),
-        {organization: OrganizationFixture({features: ['autofix-pr-iteration']})}
+      const withOverride = renderHookWithProviders(() =>
+        useResetAutofixStep({
+          autofix,
+          canReset: true,
+          section: makeSection(),
+          step: 'code_changes',
+        })
       );
-      expect(withFeature.result.current.canReset).toBe(true);
+      expect(withOverride.result.current.canReset).toBe(true);
     });
 
     it('returns false when coding agents have been started', () => {

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
@@ -2,31 +2,36 @@ import {useMemo, useState} from 'react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {
-  isRunValidForPrIteration,
   type AutofixExplorerStep,
   type AutofixSection,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {t} from 'sentry/locale';
-import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface UseResetAutofixStepOptions {
   autofix: ReturnType<typeof useExplorerAutofix>;
   section: AutofixSection;
   step: AutofixExplorerStep;
+  canReset?: boolean;
 }
 
 export function useResetAutofixStep({
   autofix,
+  canReset,
   section,
   step,
 }: UseResetAutofixStepOptions) {
   const [shouldShowReset, setShouldShowReset] = useState(false);
 
-  const organization = useOrganization();
   const {runState, startStep} = autofix;
   const runId = runState?.run_id;
-  const allowResetAfterPRs = isRunValidForPrIteration(organization);
+  const notProcessing = autofix.runState?.status !== 'processing';
+  const noPRs = Object.values(autofix.runState?.repo_pr_states ?? {}).length === 0;
+  const noCodingAgents =
+    Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
+  const defaultCanReset = notProcessing && noPRs && noCodingAgents;
+
+  const isResetEligible = canReset ?? defaultCanReset;
 
   const handleReset = useMemo(() => {
     return async (userContext?: string) => {
@@ -45,17 +50,7 @@ export function useResetAutofixStep({
   return {
     canReset:
       // can only reset if reset prompt is not showing
-      !shouldShowReset &&
-      // can only reset if run state is not processing
-      autofix.runState?.status !== 'processing' &&
-      // can only reset if PRs states are empty (i.e. no PR have been created),
-      // except on code_changes card where PR iteration is supported
-      (step === 'code_changes'
-        ? allowResetAfterPRs ||
-          Object.values(autofix.runState?.repo_pr_states ?? {}).length === 0
-        : Object.values(autofix.runState?.repo_pr_states ?? {}).length === 0) &&
-      // can only reset if coding agents are empty (i.e. no coding agents have been started)
-      Object.values(autofix.runState?.coding_agents ?? {}).length === 0,
+      !shouldShowReset && isResetEligible,
     shouldShowReset,
     setShouldShowReset,
     handleReset,

--- a/static/app/views/issueDetails/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/seerDrawer.spec.tsx
@@ -317,4 +317,61 @@ describe('SeerDrawer', () => {
       await screen.findByText('A null pointer dereference in the auth module')
     ).toBeInTheDocument();
   });
+
+  describe('PR polling', () => {
+    const autofixUrl = `/organizations/${DetailedProjectFixture().organization.slug}/issues/${GroupFixture().id}/autofix/`;
+
+    function mockAutofixWithPr() {
+      return MockApiClient.addMockResponse({
+        url: autofixUrl,
+        body: {
+          autofix: {
+            ...makeExplorerAutofixData({status: 'completed'}),
+            repo_pr_states: {
+              'org/repo': {pr_creation_status: 'completed'},
+            },
+          },
+        },
+      });
+    }
+
+    it('does not poll the autofix endpoint when autofix-pr-iteration is disabled', async () => {
+      const getMock = mockAutofixWithPr();
+
+      render(<SeerDrawer group={mockGroup} project={mockProject} />, {organization});
+
+      await waitForElementToBeRemoved(() =>
+        screen.queryByTestId('ai-setup-loading-indicator')
+      );
+
+      const callsAfterLoad = getMock.mock.calls.length;
+      await new Promise(resolve => setTimeout(resolve, 1500));
+
+      expect(getMock.mock.calls.length).toBe(callsAfterLoad);
+    });
+
+    it('polls the autofix endpoint when autofix-pr-iteration is enabled and a PR exists', async () => {
+      const getMock = mockAutofixWithPr();
+
+      render(<SeerDrawer group={mockGroup} project={mockProject} />, {
+        organization: OrganizationFixture({
+          hideAiFeatures: false,
+          features: ['gen-ai-features', 'autofix-pr-iteration'],
+        }),
+      });
+
+      await waitForElementToBeRemoved(() =>
+        screen.queryByTestId('ai-setup-loading-indicator')
+      );
+
+      const callsAfterLoad = getMock.mock.calls.length;
+
+      await waitFor(
+        () => {
+          expect(getMock.mock.calls.length).toBeGreaterThan(callsAfterLoad);
+        },
+        {timeout: 5000}
+      );
+    });
+  });
 });

--- a/static/app/views/issueDetails/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/seerDrawer.spec.tsx
@@ -347,7 +347,7 @@ describe('SeerDrawer', () => {
       const callsAfterLoad = getMock.mock.calls.length;
       await new Promise(resolve => setTimeout(resolve, 1500));
 
-      expect(getMock.mock.calls.length).toBe(callsAfterLoad);
+      expect(getMock.mock.calls).toHaveLength(callsAfterLoad);
     });
 
     it('polls the autofix endpoint when autofix-pr-iteration is enabled and a PR exists', async () => {


### PR DESCRIPTION
- update feedback section in code changes card to reflect feedback queueing status:
  - we made a change to queue feedback that's received while the autofix agent is already running to avoid concurrency issues, and we want to update the feedback section to  reflect this change by showing feedback in 3 different statuses
      - processed
      - processing
      - queued
- poll autofix state when autofix drawer is open, a PR has been created and PR iteration is enabled
  - Before, we polled for autofix state while the autofix run was processing
  - now, since we can receive feedback from github we need to poll while:
    - a PR is created for this run
    - PR iteration as a feature is enabled
    - the drawer is open
  - if we don't do this, then a user in the UI won't be able to see in real time that feedback has come in from Github

<img width="683" height="309" alt="image" src="https://github.com/user-attachments/assets/4f63e158-dac6-44d5-808b-b68757e3833e" />
