### PR TITLE
ref(preprod): Remove snapshot feature-flag gating in the UI

### DIFF
--- a/static/app/views/explore/releases/list/index.tsx
+++ b/static/app/views/explore/releases/list/index.tsx
@@ -250,8 +250,6 @@ function ReleasesListInnerPage() {
       : selectedIds.map(id => `${id}`);
   }, [selection.projects]);
 
-  const hasSnapshotsFeature = organization.features?.includes('preprod-snapshots');
-
   const {statsPeriod, start, end, utc} = normalizeDateTimeParams(location.query);
   const buildsProbeQuery = useQuery({
     ...buildDetailsApiOptions({
@@ -287,27 +285,14 @@ function ReleasesListInnerPage() {
     !buildsProbeQuery.isPending && (buildsProbeQuery.data?.length ?? 0) > 0;
 
   const shouldShowMobileBuildsTab = hasBuildsData || hasAnyStrictlyMobileProject;
-  const shouldShowSnapshotsTab = !!hasSnapshotsFeature;
-  const shouldShowPreprodTabs = shouldShowMobileBuildsTab || shouldShowSnapshotsTab;
 
   const selectedTab = useMemo(() => {
-    if (!shouldShowPreprodTabs) {
-      return 'releases';
-    }
     const tab = decodeScalar(location.query.tab) as ReleaseTab | undefined;
-    if (tab === 'snapshots' && !shouldShowSnapshotsTab) {
-      return 'releases';
-    }
     if (tab === 'mobile-builds' && !shouldShowMobileBuildsTab) {
       return 'releases';
     }
     return tab || 'releases';
-  }, [
-    shouldShowPreprodTabs,
-    shouldShowMobileBuildsTab,
-    shouldShowSnapshotsTab,
-    location.query.tab,
-  ]);
+  }, [shouldShowMobileBuildsTab, location.query.tab]);
 
   useLLMContext({
     contextHint:
@@ -472,7 +457,7 @@ function ReleasesListInnerPage() {
       <Stack flex={1}>
         <NoProjectMessage organization={organization}>
           <ReleasesHeader />
-          <ReleasesBodySearch hasTabs={shouldShowPreprodTabs}>
+          <ReleasesBodySearch hasTabs>
             <Layout.Main width="full">
               <Stack gap="md">
                 <PageFilterBar condensed>
@@ -489,62 +474,59 @@ function ReleasesListInnerPage() {
                     )}
                   />
                 </PageFilterBar>
-                {shouldShowPreprodTabs && (
-                  <Tabs value={selectedTab} onChange={handleTabChange}>
-                    <TabList aria-label={t('Releases tab selector')}>
-                      <TabList.Item
-                        key="releases"
-                        to={{
-                          pathname: location.pathname,
-                          query: {
-                            ...location.query,
-                            query: undefined,
-                            tab: undefined,
-                          },
-                        }}
-                        textValue={t('Releases')}
-                      >
-                        {t('Releases')}
-                      </TabList.Item>
-                      <TabList.Item
-                        key="mobile-builds"
-                        hidden={!shouldShowMobileBuildsTab}
-                        to={{
-                          pathname: location.pathname,
-                          query: {
-                            ...location.query,
-                            query: undefined,
-                            tab: 'mobile-builds',
-                          },
-                        }}
-                        textValue={t('Mobile Builds')}
-                      >
-                        <Flex align="center" gap="sm">
-                          {t('Mobile Builds')}
-                          <FeatureBadge type="new" />
-                        </Flex>
-                      </TabList.Item>
-                      <TabList.Item
-                        key="snapshots"
-                        hidden={!shouldShowSnapshotsTab}
-                        to={{
-                          pathname: location.pathname,
-                          query: {
-                            ...location.query,
-                            query: undefined,
-                            tab: 'snapshots',
-                          },
-                        }}
-                        textValue={t('Snapshots')}
-                      >
-                        <Flex align="center" gap="sm">
-                          {t('Snapshots')}
-                          <FeatureBadge type="beta" />
-                        </Flex>
-                      </TabList.Item>
-                    </TabList>
-                  </Tabs>
-                )}
+                <Tabs value={selectedTab} onChange={handleTabChange}>
+                  <TabList aria-label={t('Releases tab selector')}>
+                    <TabList.Item
+                      key="releases"
+                      to={{
+                        pathname: location.pathname,
+                        query: {
+                          ...location.query,
+                          query: undefined,
+                          tab: undefined,
+                        },
+                      }}
+                      textValue={t('Releases')}
+                    >
+                      {t('Releases')}
+                    </TabList.Item>
+                    <TabList.Item
+                      key="mobile-builds"
+                      hidden={!shouldShowMobileBuildsTab}
+                      to={{
+                        pathname: location.pathname,
+                        query: {
+                          ...location.query,
+                          query: undefined,
+                          tab: 'mobile-builds',
+                        },
+                      }}
+                      textValue={t('Mobile Builds')}
+                    >
+                      <Flex align="center" gap="sm">
+                        {t('Mobile Builds')}
+                        <FeatureBadge type="new" />
+                      </Flex>
+                    </TabList.Item>
+                    <TabList.Item
+                      key="snapshots"
+                      to={{
+                        pathname: location.pathname,
+                        query: {
+                          ...location.query,
+                          query: undefined,
+                          tab: 'snapshots',
+                        },
+                      }}
+                      textValue={t('Snapshots')}
+                    >
+                      <Flex align="center" gap="sm">
+                        {t('Snapshots')}
+                        <FeatureBadge type="beta" />
+                      </Flex>
+                    </TabList.Item>
+                  </TabList>
+                </Tabs>
               </Stack>
             </Layout.Main>
           </ReleasesBodySearch>
@@ -557,7 +539,7 @@ function ReleasesListInnerPage() {
                 />
               )}
 
-              {selectedTab === 'snapshots' && shouldShowSnapshotsTab && (
+              {selectedTab === 'snapshots' && (
                 <MobileBuilds
                   organization={organization}
                   selectedProjectIds={selectedProjectIds}

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -163,7 +163,6 @@ export function getNavigationConfiguration({
           path: `${pathPrefix}/snapshots/`,
           title: t('Snapshots'),
           badge: () => 'beta',
-          show: () => !!organization?.features?.includes('preprod-snapshots'),
           description: t('Configure snapshot status checks and PR comments.'),
         },
       ],

--- a/static/app/views/settings/project/preprod/snapshots.tsx
+++ b/static/app/views/settings/project/preprod/snapshots.tsx
@@ -2,12 +2,9 @@ import {Fragment} from 'react';
 
 import {Stack} from '@sentry/scraps/layout';
 
-import Feature from 'sentry/components/acl/feature';
-import {NotFound} from 'sentry/components/errors/notFound';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {TopBar} from 'sentry/views/navigation/topBar';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
@@ -15,12 +12,6 @@ import {SnapshotPrCommentsToggle} from './snapshotPrCommentsToggle';
 import {SnapshotStatusChecks} from './snapshotStatusChecks';
 
 export default function SnapshotSettings() {
-  const organization = useOrganization();
-
-  if (!organization.features.includes('preprod-snapshots')) {
-    return <NotFound />;
-  }
-
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Snapshots')} />
@@ -33,9 +24,7 @@ export default function SnapshotSettings() {
       </TopBar.Slot>
       <Stack gap="lg">
         <SnapshotStatusChecks />
-        <Feature features="organizations:preprod-snapshot-pr-comments">
-          <SnapshotPrCommentsToggle />
-        </Feature>
+        <SnapshotPrCommentsToggle />
       </Stack>
     </Fragment>
   );


### PR DESCRIPTION
The preprod snapshot features are GA, so the frontend no longer gates them behind feature flags. This removes every reference to `preprod-snapshots` and `preprod-snapshot-pr-comments` so the UI renders for all orgs:

- **Project settings → Snapshots** page: drops the `preprod-snapshots` guard that returned `NotFound`, and unwraps the `<Feature organizations:preprod-snapshot-pr-comments>` around the PR-comments toggle so it always shows.
- **Project settings nav**: the Snapshots item no longer has a `show` flag gate.
- **Releases → Snapshots tab**: `shouldShowSnapshotsTab` was always-true once the flag is gone, which also collapsed `shouldShowPreprodTabs` to always-true. Both are removed and the now-dead tab/branch logic is simplified out, so the preprod tab bar and Snapshots tab always render.

This is the bottom of a two-PR stack (web first). Reviewer note: the matching backend gating is removed in the PR stacked on top — until that one also deploys, any org not already on these flags would see the UI but get 403s from the still-gated endpoints, so this is safe to land first only if the flags are at full rollout.