### PR TITLE
ref(preprod): Remove snapshot feature flags and backend gating

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -197,18 +197,12 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-artifact-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod PR comments for build distribution
     manager.add("organizations:preprod-build-distribution-pr-comments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable preprod PR comments for snapshots
-    manager.add("organizations:preprod-snapshot-pr-comments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable enforcement of preprod size quota checks (when disabled, size quota checks always return True)
     manager.add("organizations:preprod-enforce-size-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)
     manager.add("organizations:preprod-enforce-distribution-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable preprod size monitors frontend
     manager.add("organizations:preprod-size-monitors-frontend", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable preprod snapshots product feature
-    manager.add("organizations:preprod-snapshots", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable selective snapshot builds to serve as comparison bases for stacked PRs
-    manager.add("organizations:preprod-selective-base-snapshots", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables the playstation ingestion in relay
     manager.add("organizations:relay-playstation-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable the new apiFetch implementation that uses cell fetch.

--- a/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from django.conf import settings
 from django.urls import reverse
 from objectstore_client import TimeToIdle
 from objectstore_client.metadata import format_expiration
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -30,11 +28,6 @@ class ProjectPreprodUploadOptionsEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
 
     def get(self, request: Request, project: Project) -> Response:
-        if not settings.IS_DEV and not features.has(
-            "organizations:preprod-snapshots", project.organization, actor=request.user
-        ):
-            return Response({"detail": "Feature not enabled"}, status=403)
-
         organization = project.organization
         session = get_preprod_session(org=organization.id, project=project.id)
 

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -9,14 +9,13 @@ import orjson
 import pydantic
 import sentry_sdk
 import zstandard
-from django.conf import settings
 from django.db import IntegrityError, router, transaction
 from django.utils import timezone
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -251,11 +250,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
 
         This endpoint requires a bearer token with `project:write` access.
         """
-        if not settings.IS_DEV and not features.has(
-            "organizations:preprod-snapshots", organization, actor=request.user
-        ):
-            return Response({"detail": "Feature not enabled"}, status=403)
-
         try:
             artifact = PreprodArtifact.objects.select_related("project").get(
                 id=snapshot_id, project__organization_id=organization.id
@@ -357,11 +351,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
 
         This endpoint requires a bearer token with `project:read` access.
         """
-        if not settings.IS_DEV and not features.has(
-            "organizations:preprod-snapshots", organization, actor=request.user
-        ):
-            return Response({"detail": "Feature not enabled"}, status=403)
-
         compact = request.GET.get("compact_metadata", "0") in ("1", "true")
 
         try:
@@ -503,9 +492,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                         app_id=artifact.app_id,
                         artifact_type=artifact.artifact_type,
                         build_configuration=artifact.build_configuration,
-                        allow_selective=features.has(
-                            "organizations:preprod-selective-base-snapshots", organization
-                        ),
                     )
                     is not None
                 )
@@ -726,11 +712,6 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
 
         This endpoint requires a bearer token with `project:write` access.
         """
-        if not settings.IS_DEV and not features.has(
-            "organizations:preprod-snapshots", project.organization, actor=request.user
-        ):
-            return Response({"detail": "Feature not enabled"}, status=403)
-
         request_body, decode_error = decode_preprod_snapshot_request_body(request)
         if request_body is None:
             return Response({"detail": decode_error or "Invalid request body"}, status=400)
@@ -754,9 +735,6 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         pr_number = data.get("pr_number")
 
         selective = data.get("selective", False)
-        allow_selective = features.has(
-            "organizations:preprod-selective-base-snapshots", project.organization
-        )
         all_image_file_names = data.get("all_image_file_names")
 
         if all_image_file_names is not None and not selective:
@@ -907,7 +885,6 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                     app_id=artifact.app_id,
                     artifact_type=artifact.artifact_type,
                     build_configuration=artifact.build_configuration,
-                    allow_selective=allow_selective,
                 )
                 if base_artifact:
                     logger.info(
@@ -971,7 +948,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
 
         # Trigger comparisons for any head artifacts that were uploaded before this base.
         # Handles possible out-of-order uploads where heads arrive before their base build.
-        if commit_comparison is not None and (not selective or allow_selective):
+        if commit_comparison is not None:
             try:
                 waiting_heads = find_head_snapshot_artifacts_awaiting_base(
                     organization_id=project.organization_id,

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -4,14 +4,12 @@ import logging
 from collections.abc import Iterator
 from typing import IO
 
-from django.conf import settings
 from django.http import HttpResponseBase, StreamingHttpResponse
 from drf_spectacular.utils import extend_schema
 from objectstore_client import RequestError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -65,11 +63,6 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
     def _resolve(
         self, request: Request, organization: Organization, snapshot_id: str
     ) -> tuple[PreprodArtifact, PreprodSnapshotMetrics] | Response:
-        if not settings.IS_DEV and not features.has(
-            "organizations:preprod-snapshots", organization, actor=request.user
-        ):
-            return Response({"detail": "Feature not enabled"}, status=403)
-
         try:
             artifact = PreprodArtifact.objects.select_related("project").get(
                 id=snapshot_id, project__organization_id=organization.id

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_image_detail.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_image_detail.py
@@ -4,12 +4,10 @@ import logging
 from typing import cast
 
 import orjson
-from django.conf import settings
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -181,11 +179,6 @@ class OrganizationPreprodSnapshotImageDetailEndpoint(OrganizationEndpoint):
 
         This endpoint requires a bearer token with `project:read` access.
         """
-        if not settings.IS_DEV and not features.has(
-            "organizations:preprod-snapshots", organization, actor=request.user
-        ):
-            return Response({"detail": "Feature not enabled"}, status=403)
-
         try:
             artifact = PreprodArtifact.objects.select_related("project").get(
                 id=snapshot_id, project__organization_id=organization.id

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -4,13 +4,11 @@ import logging
 from typing import Any, cast
 
 import orjson
-from django.conf import settings
 from django.db.models import Q
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -135,11 +133,6 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
 
         This endpoint requires a bearer token with `project:read` access.
         """
-        if not settings.IS_DEV and not features.has(
-            "organizations:preprod-snapshots", organization, actor=request.user
-        ):
-            return Response({"detail": "Feature not enabled"}, status=403)
-
         for param, spec in LATEST_BASE_SNAPSHOT_GET_QUERY_PARAMS.items():
             if spec.get("required") and not request.GET.get(param):
                 return Response({"detail": f"{param} query parameter is required"}, status=400)

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_snapshot_recompare.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_snapshot_recompare.py
@@ -5,7 +5,6 @@ import logging
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -74,9 +73,6 @@ class PreprodSnapshotRecompareEndpoint(OrganizationEndpoint):
                 app_id=artifact.app_id,
                 artifact_type=artifact.artifact_type,
                 build_configuration=artifact.build_configuration,
-                allow_selective=features.has(
-                    "organizations:preprod-selective-base-snapshots", organization
-                ),
             )
             if not base_artifact:
                 return Response({"detail": "No base artifact found"}, status=404)

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -6,7 +6,6 @@ from typing import Annotated, Any, Literal
 from django.utils import timezone
 from pydantic import BaseModel, Field
 
-from sentry import features
 from sentry.preprod.api.models.snapshots.snapshot_status import (
     ApprovalStatusLiteral,
     ComparisonStateLiteral,
@@ -321,10 +320,6 @@ def to_snapshot_comparison_info(head_artifact: PreprodArtifact) -> SnapshotCompa
                     app_id=head_artifact.app_id,
                     artifact_type=head_artifact.artifact_type,
                     build_configuration=head_artifact.build_configuration,
-                    allow_selective=features.has(
-                        "organizations:preprod-selective-base-snapshots",
-                        head_artifact.project.organization,
-                    ),
                 )
                 is not None
             )

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -894,10 +894,6 @@ def compare_snapshots(
             )
             return
 
-        # Not flag-gated here: a selective base only reaches this task when the
-        # feature flag was on at dispatch (find_base_snapshot_artifact/fan-out are gated),
-        # or via staff recompare. An in-flight comparison should finish correctly.
-        #
         # Gate on the manifest, not base_metrics.is_selective: the manifest is the source of
         # truth (reconstruct_base_manifest distrusts the DB flag because it can drift). If the
         # DB flag drifts to False while the manifest is selective, the DB gate would skip

--- a/src/sentry/preprod/snapshots/utils.py
+++ b/src/sentry/preprod/snapshots/utils.py
@@ -15,7 +15,6 @@ def find_base_snapshot_artifact(
     app_id: str | None,
     artifact_type: str | None,
     build_configuration: PreprodBuildConfiguration | None,
-    allow_selective: bool = False,
 ) -> PreprodArtifact | None:
     qs = PreprodArtifact.objects.filter(
         commit_comparison__organization_id=organization_id,
@@ -27,8 +26,6 @@ def find_base_snapshot_artifact(
         artifact_type=artifact_type,
         build_configuration=build_configuration,
     )
-    if not allow_selective:
-        qs = qs.filter(preprodsnapshotmetrics__is_selective=False)
     return qs.order_by("-date_added").first()
 
 

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -6,7 +6,6 @@ from typing import Any
 from django.db import router, transaction
 from taskbroker_client.retry import Retry
 
-from sentry import features
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.organization import Organization
 from sentry.preprod.integration_utils import get_commit_context_client
@@ -35,7 +34,6 @@ POST_ON_ADDED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_added"
 POST_ON_REMOVED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_removed"
 POST_ON_CHANGED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_changed"
 POST_ON_RENAMED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_renamed"
-FEATURE_FLAG = "organizations:preprod-snapshot-pr-comments"
 
 
 @instrumented_task(
@@ -96,13 +94,6 @@ def create_preprod_snapshot_pr_comment_task(
         return
 
     organization = artifact.project.organization
-    if not features.has(FEATURE_FLAG, organization):
-        logger.info(
-            "preprod.snapshot_pr_comments.create.feature_disabled",
-            extra={"preprod_artifact_id": artifact.id, "organization_id": organization.id},
-        )
-        return
-
     client = get_commit_context_client(
         organization, commit_comparison.head_repo_name, commit_comparison.provider
     )

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -51,8 +51,7 @@ class SnapshotArchiveTriggerTest(BaseSnapshotArchiveTest):
     @patch(ENQUEUE_TARGET)
     def test_post_enqueues_build_and_returns_202(self, mock_task):
         artifact = self._artifact()
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(self._url(artifact.id))
+        response = self.client.post(self._url(artifact.id))
         assert response.status_code == 202
         mock_task.apply_async.assert_called_once_with(
             kwargs={
@@ -64,18 +63,10 @@ class SnapshotArchiveTriggerTest(BaseSnapshotArchiveTest):
         )
 
     @patch(ENQUEUE_TARGET)
-    def test_missing_feature_flag_forbidden(self, mock_task):
-        artifact = self._artifact()
-        response = self.client.post(self._url(artifact.id))
-        assert response.status_code == 403
-        mock_task.apply_async.assert_not_called()
-
-    @patch(ENQUEUE_TARGET)
     def test_post_returns_503_when_enqueue_fails(self, mock_task):
         artifact = self._artifact()
         mock_task.apply_async.side_effect = RuntimeError("broker down")
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(self._url(artifact.id))
+        response = self.client.post(self._url(artifact.id))
         assert response.status_code == 503
 
     def test_rate_limit_applies_to_post_only(self):
@@ -93,8 +84,7 @@ class SnapshotArchiveReadinessTest(BaseSnapshotArchiveTest):
         session = MagicMock()
         session.get.return_value = MagicMock()
         mock_session.return_value = session
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(self._url(artifact.id))
+        response = self.client.get(self._url(artifact.id))
         assert response.status_code == 200
         assert response.data["ready"] is True
 
@@ -104,8 +94,7 @@ class SnapshotArchiveReadinessTest(BaseSnapshotArchiveTest):
         session = MagicMock()
         session.get.side_effect = RequestError("not found", status=404, response="")
         mock_session.return_value = session
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(self._url(artifact.id))
+        response = self.client.get(self._url(artifact.id))
         assert response.status_code == 200
         assert response.data["ready"] is False
 
@@ -115,8 +104,7 @@ class SnapshotArchiveReadinessTest(BaseSnapshotArchiveTest):
         session = MagicMock()
         session.get.side_effect = RequestError("unavailable", status=503, response="")
         mock_session.return_value = session
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(self._url(artifact.id))
+        response = self.client.get(self._url(artifact.id))
         assert response.status_code == 200
         assert response.data["ready"] is False
 
@@ -131,8 +119,7 @@ class SnapshotArchiveDownloadTest(BaseSnapshotArchiveTest):
         session = MagicMock()
         session.get.return_value = result
         mock_session.return_value = session
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(self._url(artifact.id, download=True))
+        response = self.client.get(self._url(artifact.id, download=True))
         assert response.status_code == 200
         assert response["Content-Type"] == "application/zip"
         assert b"".join(response.streaming_content) == b"ZIPBYTES"
@@ -143,6 +130,5 @@ class SnapshotArchiveDownloadTest(BaseSnapshotArchiveTest):
         session = MagicMock()
         session.get.side_effect = RequestError("not found", status=404, response="")
         mock_session.return_value = session
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(self._url(artifact.id, download=True))
+        response = self.client.get(self._url(artifact.id, download=True))
         assert response.status_code == 409

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_image_detail.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_image_detail.py
@@ -126,8 +126,7 @@ class OrganizationPreprodSnapshotImageDetailTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session({manifest_key: manifest_json})
 
         url = self._get_url(artifact.id, "components/alert.png")
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         data = response.data
@@ -206,8 +205,7 @@ class OrganizationPreprodSnapshotImageDetailTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(key_to_data)
 
         url = self._get_url(head_artifact.id, "alert.png")
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         data = response.data
@@ -267,8 +265,7 @@ class OrganizationPreprodSnapshotImageDetailTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(key_to_data)
 
         url = self._get_url(head_artifact.id, "new_screen.png")
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         data = response.data
@@ -313,8 +310,7 @@ class OrganizationPreprodSnapshotImageDetailTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(key_to_data)
 
         url = self._get_url(head_artifact.id, "old_screen.png")
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         data = response.data
@@ -369,8 +365,7 @@ class OrganizationPreprodSnapshotImageDetailTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(key_to_data)
 
         url = self._get_url(head_artifact.id, "new_alert.png")
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         data = response.data
@@ -414,8 +409,7 @@ class OrganizationPreprodSnapshotImageDetailTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(key_to_data)
 
         url = self._get_url(head_artifact.id, "stable.png")
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         data = response.data
@@ -459,8 +453,7 @@ class OrganizationPreprodSnapshotImageDetailTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(key_to_data)
 
         url = self._get_url(head_artifact.id, "skipped_screen.png")
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         data = response.data
@@ -488,8 +481,7 @@ class OrganizationPreprodSnapshotImageDetailTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session({manifest_key: manifest_json})
 
         url = self._get_url(artifact.id, "abc123")
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         data = response.data
@@ -513,8 +505,7 @@ class OrganizationPreprodSnapshotImageDetailTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session({manifest_key: manifest_json})
 
         url = self._get_url(artifact.id, "screen.png")
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         head = response.data["head_image"]

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -48,8 +48,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, data, format="json")
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code == 200
         assert "artifactId" in response.data
@@ -82,13 +81,12 @@ class ProjectPreprodSnapshotTest(APITestCase):
         url = self._get_create_url()
         body = zstandard.ZstdCompressor().compress(self._compressible_snapshot_payload())
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(
-                url,
-                data=body,
-                content_type="application/json",
-                HTTP_CONTENT_ENCODING="zstd",
-            )
+        response = self.client.post(
+            url,
+            data=body,
+            content_type="application/json",
+            HTTP_CONTENT_ENCODING="zstd",
+        )
 
         assert response.status_code == 200
         assert response.data["imageCount"] == 1
@@ -96,13 +94,12 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_snapshot_upload_invalid_zstd_payload(self) -> None:
         url = self._get_create_url()
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(
-                url,
-                data=b"this is not a zstd payload",
-                content_type="application/json",
-                HTTP_CONTENT_ENCODING="zstd",
-            )
+        response = self.client.post(
+            url,
+            data=b"this is not a zstd payload",
+            content_type="application/json",
+            HTTP_CONTENT_ENCODING="zstd",
+        )
 
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid zstd payload"
@@ -110,13 +107,12 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_snapshot_upload_unsupported_encoding(self) -> None:
         url = self._get_create_url()
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(
-                url,
-                data=b"anything",
-                content_type="application/json",
-                HTTP_CONTENT_ENCODING="br",
-            )
+        response = self.client.post(
+            url,
+            data=b"anything",
+            content_type="application/json",
+            HTTP_CONTENT_ENCODING="br",
+        )
 
         assert response.status_code == 400
         assert response.data["detail"] == "Unsupported Content-Encoding"
@@ -143,8 +139,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, data, format="json")
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code == 200
 
@@ -173,8 +168,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, data, format="json")
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code == 200
 
@@ -195,8 +189,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "images": {},
         }
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, data, format="json")
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code == 200
         assert response.data["imageCount"] == 0
@@ -205,8 +198,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         url = self._get_create_url()
         data: dict[str, str] = {}
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, data, format="json")
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
         assert "detail" in response.data
@@ -225,8 +217,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, data, format="json")
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code != 400
 
@@ -242,8 +233,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, data, format="json")
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
         assert 'Validation error in image "hash1"' in response.data["detail"]
@@ -260,8 +250,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, data, format="json")
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
         assert 'Validation error in image "screen.png"' in response.data["detail"]
@@ -280,8 +269,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, data, format="json")
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
         assert 'Validation error in image "login.png"' in response.data["detail"]
@@ -301,29 +289,15 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, data, format="json")
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
         assert "detail" in response.data
 
-    def test_snapshot_without_feature_flag(self) -> None:
-        url = self._get_create_url()
-        data = {
-            "app_id": "com.example.app",
-            "images": {},
-        }
-
-        response = self.client.post(url, data, format="json")
-
-        assert response.status_code == 403
-        assert response.data["detail"] == "Feature not enabled"
-
     def test_snapshot_invalid_json(self) -> None:
         url = self._get_create_url()
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, "invalid json", content_type="application/json")
+        response = self.client.post(url, "invalid json", content_type="application/json")
 
         assert response.status_code == 400
         assert "detail" in response.data
@@ -338,8 +312,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "images": {},
         }
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = unauthenticated_client.post(url, data, format="json")
+        response = unauthenticated_client.post(url, data, format="json")
 
         assert response.status_code == 401
 
@@ -353,8 +326,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "images": {},
         }
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, data, format="json")
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code == 403
 
@@ -366,8 +338,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "images": {},
         }
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, data, format="json")
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
 
@@ -387,10 +358,9 @@ class ProjectPreprodSnapshotTest(APITestCase):
         return data
 
     def _post_selective(self, **overrides):
-        with self.feature("organizations:preprod-snapshots"):
-            return self.client.post(
-                self._get_create_url(), self._selective_data(**overrides), format="json"
-            )
+        return self.client.post(
+            self._get_create_url(), self._selective_data(**overrides), format="json"
+        )
 
     def test_all_image_file_names_rejects_empty_list(self):
         response = self._post_selective(images={}, all_image_file_names=[])
@@ -415,8 +385,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_selective_without_all_image_file_names_accepted(self):
         data = self._selective_data()
         del data["all_image_file_names"]
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(self._get_create_url(), data, format="json")
+        response = self.client.post(self._get_create_url(), data, format="json")
         assert response.status_code == 200
 
     def test_selective_with_all_image_file_names_accepted(self):
@@ -485,8 +454,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, data, format="json")
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code == 200
 
@@ -512,13 +480,12 @@ class ProjectPreprodSnapshotTest(APITestCase):
 
     @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
     @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.compare_snapshots")
-    def test_selective_base_requires_feature_flag(
+    def test_selective_base_is_matched_for_comparison(
         self, mock_compare_snapshots, mock_get_session
     ) -> None:
         """
-        A SELECTIVE base build must only be matched as a comparison base when the
-        selective-base feature flag is on. With the flag off, the upload endpoint must
-        behave exactly as today: no comparison is dispatched against the selective base.
+        A SELECTIVE base build is matched as a comparison base and a comparison is
+        dispatched against it when an incoming head references it.
         """
         base_sha = "b" * 40
         head_sha = "a" * 40
@@ -570,27 +537,10 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        # Flag OFF: the selective base must NOT be matched, so no comparison is dispatched.
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.post(url, head_data, format="json")
+        # The selective base IS matched and a comparison is dispatched.
+        response = self.client.post(url, head_data, format="json")
         assert response.status_code == 200
-        head_artifact_off = PreprodArtifact.objects.get(id=response.data["artifactId"])
-        assert not PreprodSnapshotComparison.objects.filter(
-            base_snapshot_metrics__preprod_artifact=base_artifact
-        ).exists()
-        mock_compare_snapshots.apply_async.assert_not_called()
-
-        # Flag ON: the selective base IS matched and a comparison is dispatched.
-        with self.feature(
-            {
-                "organizations:preprod-snapshots": True,
-                "organizations:preprod-selective-base-snapshots": True,
-            }
-        ):
-            response = self.client.post(url, head_data, format="json")
-        assert response.status_code == 200
-        head_artifact_on = PreprodArtifact.objects.get(id=response.data["artifactId"])
-        assert head_artifact_on.id != head_artifact_off.id
+        head_artifact = PreprodArtifact.objects.get(id=response.data["artifactId"])
 
         comparison = PreprodSnapshotComparison.objects.get(
             base_snapshot_metrics__preprod_artifact=base_artifact
@@ -600,7 +550,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             kwargs={
                 "project_id": self.project.id,
                 "org_id": self.org.id,
-                "head_artifact_id": head_artifact_on.id,
+                "head_artifact_id": head_artifact.id,
                 "base_artifact_id": base_artifact.id,
             },
         )
@@ -667,8 +617,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(manifest_json)
 
         url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         assert response.data["head_artifact_id"] == str(artifact.id)
@@ -697,8 +646,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(manifest_json)
 
         url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         vcs_info = response.data["vcs_info"]
@@ -725,8 +673,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(manifest_json)
 
         url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         assert len(response.data["images"]) == 10
@@ -848,8 +795,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         mock_get_session.return_value = mock_session
 
         url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         assert response.data["comparison_type"] == "diff"
@@ -866,8 +812,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
 
     def test_get_snapshot_not_found(self) -> None:
         url = self._get_detail_url(99999)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 404
         assert response.data["detail"] == "Snapshot not found"
@@ -883,19 +828,9 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         )
 
         url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
-
-        assert response.status_code == 404
-
-    def test_get_snapshot_without_feature_flag(self) -> None:
-        artifact, _, _, _, _ = self._create_artifact_with_manifest()
-
-        url = self._get_detail_url(artifact.id)
         response = self.client.get(url)
 
-        assert response.status_code == 403
-        assert response.data["detail"] == "Feature not enabled"
+        assert response.status_code == 404
 
     @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
     def test_get_snapshot_objectstore_error(self, mock_get_session):
@@ -905,8 +840,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         mock_get_session.return_value = mock_session
 
         url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 500
         assert response.data["detail"] == "Internal server error"
@@ -920,8 +854,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         )
 
         url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 404
         assert response.data["detail"] == "Snapshot metrics not found"
@@ -936,8 +869,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         self.login_as(user=outsider)
 
         url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 404
 
@@ -947,8 +879,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(manifest_json)
 
         url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         assert response.data["comparison_state"] is None
@@ -987,8 +918,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(manifest_json)
 
         url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         assert response.data["comparison_state"] == "pending"
@@ -1004,8 +934,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(manifest_json)
 
         url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         assert response.data["approval_status"] == "approved"
@@ -1023,8 +952,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(manifest_json)
 
         url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         assert response.data["approval_status"] == "auto_approved"
@@ -1044,8 +972,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         mock_get_session.return_value = self._create_mock_session(manifest_json)
 
         url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url)
+        response = self.client.get(url)
 
         assert response.status_code == 200
         assert response.data["comparison_state"] == "waiting_for_base"
@@ -1114,11 +1041,10 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         artifact, manifest_key, manifest_json = self._create_base_snapshot()
         mock_get_session.return_value = self._create_mock_session(manifest_json)
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(
-                self._get_url(),
-                {"app_id": "com.example.app", "projectSlug": self.project.slug},
-            )
+        response = self.client.get(
+            self._get_url(),
+            {"app_id": "com.example.app", "projectSlug": self.project.slug},
+        )
 
         assert response.status_code == 200
         assert response.data["head_artifact_id"] == str(artifact.id)
@@ -1134,11 +1060,10 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         artifact, _, manifest_json = self._create_base_snapshot()
         mock_get_session.return_value = self._create_mock_session(manifest_json)
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(
-                self._get_url(),
-                {"app_id": "com.example.app", "project": self.project.slug},
-            )
+        response = self.client.get(
+            self._get_url(),
+            {"app_id": "com.example.app", "project": self.project.slug},
+        )
 
         assert response.status_code == 200
         assert response.data["head_artifact_id"] == str(artifact.id)
@@ -1152,11 +1077,10 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         artifact, _, manifest_json = self._create_base_snapshot()
         mock_get_session.return_value = self._create_mock_session(manifest_json)
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(
-                self._get_url(),
-                {"app_id": "com.example.app", "project": str(self.project.id)},
-            )
+        response = self.client.get(
+            self._get_url(),
+            {"app_id": "com.example.app", "project": str(self.project.id)},
+        )
 
         assert response.status_code == 200
         assert response.data["head_artifact_id"] == str(artifact.id)
@@ -1174,15 +1098,14 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         artifact, _, manifest_json = self._create_base_snapshot(project=other_project)
         mock_get_session.return_value = self._create_mock_session(manifest_json)
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(
-                self._get_url(),
-                {
-                    "app_id": "com.example.app",
-                    "project": self.project.slug,
-                    "projectSlug": other_project.slug,
-                },
-            )
+        response = self.client.get(
+            self._get_url(),
+            {
+                "app_id": "com.example.app",
+                "project": self.project.slug,
+                "projectSlug": other_project.slug,
+            },
+        )
 
         assert response.status_code == 200
         assert response.data["head_artifact_id"] == str(artifact.id)
@@ -1190,41 +1113,37 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         mock_get_session.assert_called_once_with(self.org.id, other_project.id)
 
     def test_get_latest_base_snapshot_rejects_all_project_id_sentinel(self):
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(
-                self._get_url(),
-                {"app_id": "com.example.app", "project": "-1"},
-            )
+        response = self.client.get(
+            self._get_url(),
+            {"app_id": "com.example.app", "project": "-1"},
+        )
 
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid project parameter"
 
     def test_get_latest_base_snapshot_rejects_all_project_slug_sentinel(self):
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(
-                self._get_url(),
-                {"app_id": "com.example.app", "project": "$all"},
-            )
+        response = self.client.get(
+            self._get_url(),
+            {"app_id": "com.example.app", "project": "$all"},
+        )
 
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid project parameter"
 
     def test_get_latest_base_snapshot_rejects_project_slug_all_sentinel(self):
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(
-                self._get_url(),
-                {"app_id": "com.example.app", "projectSlug": "$all"},
-            )
+        response = self.client.get(
+            self._get_url(),
+            {"app_id": "com.example.app", "projectSlug": "$all"},
+        )
 
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid project parameter"
 
     def test_get_latest_base_snapshot_rejects_project_slug_id_sentinel(self):
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(
-                self._get_url(),
-                {"app_id": "com.example.app", "projectSlug": "-1"},
-            )
+        response = self.client.get(
+            self._get_url(),
+            {"app_id": "com.example.app", "projectSlug": "-1"},
+        )
 
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid project parameter"
@@ -1266,8 +1185,7 @@ class ProjectPreprodSnapshotDeleteTest(APITestCase):
         self.login_as(user=outsider)
 
         url = self._delete_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.delete(url)
+        response = self.client.delete(url)
 
         assert response.status_code == 404
         assert PreprodArtifact.objects.filter(id=artifact.id).exists()

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
@@ -25,8 +25,7 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
         mock_session.mint_token.return_value = "fake-token"
         mock_get_session.return_value = mock_session
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(self.url)
+        response = self.client.get(self.url)
 
         assert response.status_code == 200
         data = response.data["objectstore"]
@@ -47,10 +46,7 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
         mock_session.mint_token.return_value = "fake-token"
         mock_get_session.return_value = mock_session
 
-        with (
-            self.feature("organizations:preprod-snapshots"),
-            override_settings(SENTRY_REGION_API_URL_TEMPLATE="https://{region}.testserver"),
-        ):
+        with override_settings(SENTRY_REGION_API_URL_TEMPLATE="https://{region}.testserver"):
             response = self.client.get(self.url)
 
         assert response.status_code == 200
@@ -59,17 +55,10 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
         assert url.startswith(f"https://{region}.testserver/")
         assert url.endswith(f"/api/0/organizations/{self.org.id}/objectstore")
 
-    def test_without_feature_flag(self) -> None:
-        response = self.client.get(self.url)
-
-        assert response.status_code == 403
-        assert response.data["detail"] == "Feature not enabled"
-
     def test_requires_authentication(self) -> None:
         unauthenticated_client = APIClient()
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = unauthenticated_client.get(self.url)
+        response = unauthenticated_client.get(self.url)
 
         assert response.status_code == 401
 
@@ -77,7 +66,6 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
         other_user = self.create_user()
         self.login_as(user=other_user)
 
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(self.url)
+        response = self.client.get(self.url)
 
         assert response.status_code == 403

--- a/tests/sentry/preprod/snapshots/test_utils.py
+++ b/tests/sentry/preprod/snapshots/test_utils.py
@@ -34,15 +34,12 @@ class FindBaseSnapshotArtifactTest(TestCase):
             build_configuration=None,
         )
 
-    def test_selective_base_excluded_by_default(self):
-        assert find_base_snapshot_artifact(**self._args()) is None
-
-    def test_selective_base_allowed_when_opted_in(self):
-        result = find_base_snapshot_artifact(**self._args(), allow_selective=True)
+    def test_selective_base_returned(self):
+        result = find_base_snapshot_artifact(**self._args())
         assert result is not None
         assert result.preprodsnapshotmetrics.is_selective is True
 
-    def test_non_selective_base_returned_with_allow_selective(self):
+    def test_non_selective_base_returned(self):
         cc = CommitComparison.objects.create(
             organization_id=self.organization.id,
             head_repo_name="o/r",
@@ -64,6 +61,4 @@ class FindBaseSnapshotArtifactTest(TestCase):
             artifact_type=artifact.artifact_type,
             build_configuration=None,
         )
-        # A normal full base must be returned regardless of allow_selective.
         assert find_base_snapshot_artifact(**args) is not None
-        assert find_base_snapshot_artifact(**args, allow_selective=True) is not None

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
@@ -28,7 +28,6 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         self.project = self.create_project(
             teams=[self.team], organization=self.organization, name="test_project"
         )
-        self._feature = "organizations:preprod-snapshot-pr-comments"
         self.project.update_option("sentry:preprod_snapshot_pr_comments_enabled", True)
 
     def _create_artifact_with_metrics(
@@ -95,8 +94,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         mock_get_base.return_value = {artifact.id: Mock()}
         mock_build_changes_map.return_value = {artifact.id: True}
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
+        create_preprod_snapshot_pr_comment_task(artifact.id)
 
         assert artifact.commit_comparison is not None
         mock_delay.assert_called_once_with(
@@ -113,8 +111,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
     def test_skips_when_no_commit_comparison(self, mock_get_client):
         artifact, metrics = self._create_artifact_with_metrics(with_commit_comparison=False)
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
+        create_preprod_snapshot_pr_comment_task(artifact.id)
 
         mock_get_client.assert_not_called()
 
@@ -122,8 +119,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
     def test_skips_when_no_pr_number(self, mock_get_client):
         artifact, metrics = self._create_artifact_with_metrics(pr_number=None)
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
+        create_preprod_snapshot_pr_comment_task(artifact.id)
 
         mock_get_client.assert_not_called()
 
@@ -132,8 +128,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         mock_get_client.return_value = None
         artifact, metrics = self._create_artifact_with_metrics()
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
+        create_preprod_snapshot_pr_comment_task(artifact.id)
 
         mock_get_client.assert_called_once()
 
@@ -161,8 +156,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
             commit_comparison=cc,
         )
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
+        create_preprod_snapshot_pr_comment_task(artifact.id)
 
         mock_client.create_comment.assert_not_called()
         mock_client.update_comment.assert_not_called()
@@ -172,8 +166,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         self.project.update_option("sentry:preprod_snapshot_pr_comments_enabled", False)
         artifact, metrics = self._create_artifact_with_metrics()
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
+        create_preprod_snapshot_pr_comment_task(artifact.id)
 
         mock_get_client.assert_not_called()
 
@@ -185,8 +178,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
 
         artifact, metrics = self._create_artifact_with_metrics()
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
+        create_preprod_snapshot_pr_comment_task(artifact.id)
 
         mock_client.create_comment.assert_not_called()
         mock_client.update_comment.assert_not_called()
@@ -209,8 +201,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
             state=PreprodSnapshotComparison.State.FAILED,
         )
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
+        create_preprod_snapshot_pr_comment_task(artifact.id)
 
         mock_delay.assert_called_once()
 
@@ -236,18 +227,9 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
             images_errored=3,
         )
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
-
-        mock_delay.assert_called_once()
-
-    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
-    def test_skips_when_feature_flag_disabled(self, mock_get_client):
-        artifact, metrics = self._create_artifact_with_metrics()
-
         create_preprod_snapshot_pr_comment_task(artifact.id)
 
-        mock_get_client.assert_not_called()
+        mock_delay.assert_called_once()
 
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     def test_skips_nonexistent_artifact(self, mock_get_client):
@@ -275,8 +257,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         mock_get_base.return_value = {artifact.id: Mock()}
         mock_build_changes_map.return_value = {artifact.id: True}
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
+        create_preprod_snapshot_pr_comment_task(artifact.id)
 
         mock_build_changes_map.assert_called_once()
         kwargs = mock_build_changes_map.call_args
@@ -330,8 +311,7 @@ class CreateSnapshotPrCommentSoloTest(CreatePreprodSnapshotPrCommentTaskTest):
 
         artifact, _ = self._create_artifact_with_metrics(commit_comparison=cc)
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
+        create_preprod_snapshot_pr_comment_task(artifact.id)
 
         mock_format_solo.assert_called_once()
         mock_delay.assert_called_once()
@@ -348,8 +328,7 @@ class CreateSnapshotPrCommentSoloTest(CreatePreprodSnapshotPrCommentTaskTest):
 
         artifact, _ = self._create_artifact_with_metrics()
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
+        create_preprod_snapshot_pr_comment_task(artifact.id)
 
         mock_format_solo.assert_called_once()
         mock_delay.assert_called_once()
@@ -369,8 +348,7 @@ class CreateSnapshotPrCommentSoloTest(CreatePreprodSnapshotPrCommentTaskTest):
         self._create_previous_snapshot()
         artifact, _ = self._create_artifact_with_metrics()
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
+        create_preprod_snapshot_pr_comment_task(artifact.id)
 
         mock_format_waiting.assert_called_once()
         mock_delay.assert_called_once()
@@ -388,8 +366,7 @@ class CreateSnapshotPrCommentSoloTest(CreatePreprodSnapshotPrCommentTaskTest):
         self._create_previous_snapshot()
         artifact, _ = self._create_artifact_with_metrics()
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id, is_timeout_check=True)
+        create_preprod_snapshot_pr_comment_task(artifact.id, is_timeout_check=True)
 
         mock_format_missing.assert_called_once()
         mock_delay.assert_called_once()
@@ -410,8 +387,7 @@ class CreateSnapshotPrCommentSoloTest(CreatePreprodSnapshotPrCommentTaskTest):
         mock_get_base.return_value = {head_artifact.id: Mock()}
         mock_build_changes_map.return_value = {head_artifact.id: True}
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(head_artifact.id, is_timeout_check=True)
+        create_preprod_snapshot_pr_comment_task(head_artifact.id, is_timeout_check=True)
 
         mock_format_normal.assert_called_once()
         mock_delay.assert_called_once()
@@ -445,8 +421,7 @@ class CreateSnapshotPrCommentSoloTest(CreatePreprodSnapshotPrCommentTaskTest):
         mock_get_base.return_value = {head_artifact.id: Mock()}
         mock_build_changes_map.return_value = {head_artifact.id: False}
 
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(head_artifact.id)
+        create_preprod_snapshot_pr_comment_task(head_artifact.id)
 
         mock_format.assert_called_once()
         mock_delay.assert_called_once()


### PR DESCRIPTION
The preprod snapshot features are GA, so this unregisters the three flags in `temporary.py` and removes all backend gating on them:

- `organizations:preprod-snapshots`
- `organizations:preprod-snapshot-pr-comments`
- `organizations:preprod-selective-base-snapshots`

Behavior changes:

- The snapshot endpoints (create/detail/delete, archive, image-detail, latest-base, upload-options) no longer short-circuit with `403 {"detail": "Feature not enabled"}` for orgs without `preprod-snapshots` — they now always serve, the same as the existing `IS_DEV` path. Existing auth/project-access checks are unchanged.
- Selective snapshots are now always eligible as comparison bases. `find_base_snapshot_artifact` previously excluded selective bases unless `preprod-selective-base-snapshots` was set; the `allow_selective` parameter and its filter branch are removed, and the now-dead `allow_selective` plumbing in the create handler, recompare, and build-details is gone.
- The snapshot PR-comment task no longer gates on `preprod-snapshot-pr-comments`. Its other early-returns — the `sentry:preprod_snapshot_pr_comments_enabled` project option and the missing-commit-comparison / PR-info / client checks — are kept.

Tests that asserted the old flag-OFF behavior (403 responses, the `feature_disabled` skip, the selective-base-excluded-by-default case) are deleted or updated to the always-on behavior; the remaining tests just lose their `with self.feature(...)` wrappers.

Stacked on top of the frontend flag-removal PR (#118262) and should merge after it.