### PR TITLE
ref(events): Convert RRWebJsonViewer to a function component

### DIFF
--- a/static/app/components/events/attachmentViewers/rrwebJsonViewer.tsx
+++ b/static/app/components/events/attachmentViewers/rrwebJsonViewer.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {JsonViewer} from 'sentry/components/events/attachmentViewers/jsonViewer';
@@ -6,41 +6,23 @@ import type {ViewerProps} from 'sentry/components/events/attachmentViewers/utils
 import {PanelAlert} from 'sentry/components/panels/panelAlert';
 import {tct} from 'sentry/locale';
 
-type State = {
-  showRawJson: boolean;
-};
+export function RRWebJsonViewer(props: ViewerProps) {
+  const [showRawJson, setShowRawJson] = useState(false);
 
-export class RRWebJsonViewer extends Component<ViewerProps, State> {
-  state: State = {
-    showRawJson: false,
-  };
-
-  render() {
-    const {showRawJson} = this.state;
-
-    return (
-      <Fragment>
-        <StyledPanelAlert border={showRawJson} variant="info">
-          {tct(
-            'This is an attachment containing a session replay. [replayLink:View the replay] or [jsonLink:view the raw JSON].',
-            {
-              replayLink: <a href="#context-replay" />,
-              jsonLink: (
-                <a
-                  onClick={() =>
-                    this.setState(state => ({
-                      showRawJson: !state.showRawJson,
-                    }))
-                  }
-                />
-              ),
-            }
-          )}
-        </StyledPanelAlert>
-        {showRawJson && <JsonViewer {...this.props} />}
-      </Fragment>
-    );
-  }
+  return (
+    <Fragment>
+      <StyledPanelAlert border={showRawJson} variant="info">
+        {tct(
+          'This is an attachment containing a session replay. [replayLink:View the replay] or [jsonLink:view the raw JSON].',
+          {
+            replayLink: <a href="#context-replay" />,
+            jsonLink: <a onClick={() => setShowRawJson(value => !value)} />,
+          }
+        )}
+      </StyledPanelAlert>
+      {showRawJson && <JsonViewer {...props} />}
+    </Fragment>
+  );
 }
 
 const StyledPanelAlert = styled(PanelAlert)<{border: boolean}>`


### PR DESCRIPTION
Converts the `RRWebJsonViewer` attachment viewer from a React class component to
a function component, clearing the `no-class-components` lint violation tracked
by FRONTEND-TSC-5Y. The lone piece of state (`showRawJson`, toggled by the "view
the raw JSON" link) now lives in `useState`; rendering and the public
`RRWebJsonViewer` export are unchanged, so the existing `typeof RRWebJsonViewer`
consumer in `previewAttachmentTypes.tsx` keeps working.

Behavior-preserving refactor. `pnpm lint:js` on the file and `pnpm typecheck`
both pass locally.

Fixes FRONTEND-TSC-5Y