### PR TITLE
Add a handler for AlertRuleWorkflow.DoesNotExist, 

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -49,6 +49,7 @@ from sentry.workflow_engine.migration_helpers.alert_rule import (
     dual_update_alert_rule,
     dual_write_alert_rule,
 )
+from sentry.workflow_engine.types import AlertRuleNotDualWritten
 
 from .alert_rule_trigger import AlertRuleTriggerSerializer
 
@@ -408,6 +409,10 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
             self._handle_triggers(alert_rule, triggers)
             try:
                 dual_update_alert_rule(alert_rule)
+            except AlertRuleNotDualWritten:
+                raise serializers.ValidationError(
+                    "This Alert cannot be modified with the legacy API. See: https://docs.sentry.io/api/monitors/"
+                )
             except Exception:
                 sentry_sdk.capture_exception()
                 raise BadRequest(message="Error when updating alert rule")

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -55,6 +55,10 @@ from .alert_rule_trigger import AlertRuleTriggerSerializer
 
 logger = logging.getLogger(__name__)
 
+UNSUPPORTED_LEGACY_API = (
+    "This Alert cannot be modified with the legacy API. See: https://docs.sentry.io/api/monitors/"
+)
+
 
 class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRule]):
     """
@@ -410,9 +414,7 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
             try:
                 dual_update_alert_rule(alert_rule)
             except AlertRuleNotDualWritten:
-                raise serializers.ValidationError(
-                    "This Alert cannot be modified with the legacy API. See: https://docs.sentry.io/api/monitors/"
-                )
+                raise serializers.ValidationError(UNSUPPORTED_LEGACY_API)
             except Exception:
                 sentry_sdk.capture_exception()
                 raise BadRequest(message="Error when updating alert rule")
@@ -444,7 +446,11 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
             )
             for trigger in triggers_to_delete:
                 with transaction.atomic(router.db_for_write(AlertRuleTrigger)):
-                    dual_delete_migrated_alert_rule_trigger(trigger)
+                    try:
+                        dual_delete_migrated_alert_rule_trigger(trigger)
+                    except AlertRuleNotDualWritten:
+                        raise serializers.ValidationError(UNSUPPORTED_LEGACY_API)
+
                     delete_alert_rule_trigger(trigger)
 
             for trigger_data in triggers:

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -40,7 +40,7 @@ from sentry.workflow_engine.models import (
     WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import DetectorPriorityLevel
+from sentry.workflow_engine.types import AlertRuleNotDualWritten, DetectorPriorityLevel
 from sentry.workflow_engine.typings.notification_action import OnCallDataBlob, SentryAppDataBlob
 
 logger = logging.getLogger(__name__)
@@ -201,7 +201,12 @@ def get_action_filter(
     Raises an exception if the action filter cannot be found.
     """
     alert_rule = alert_rule_trigger.alert_rule
-    alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule_id=alert_rule.id)
+
+    try:
+        alert_rule_workflow = AlertRuleWorkflow.objects.get(alert_rule_id=alert_rule.id)
+    except AlertRuleWorkflow.DoesNotExist:
+        raise AlertRuleNotDualWritten()
+
     workflow = alert_rule_workflow.workflow
     workflow_dcgs = DataConditionGroup.objects.filter(workflowdataconditiongroup__workflow=workflow)
     action_filter = DataCondition.objects.get(

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -50,6 +50,10 @@ GroupId: TypeAlias = int
 WorkflowId: TypeAlias = int
 
 
+class AlertRuleNotDualWritten(Exception):
+    pass
+
+
 class DetectorException(Exception):
     pass
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -85,6 +85,7 @@ from sentry.workflow_engine.models import (
     WorkflowActionGroupStatus,
 )
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
+from sentry.workflow_engine.models.alertrule_workflow import AlertRuleWorkflow
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.incidents.endpoints.test_organization_alert_rule_index import AlertRuleBase
@@ -984,6 +985,36 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             resp.renderer_context["request"].META["REMOTE_ADDR"]
             == list(audit_log_entry)[0].ip_address
         )
+
+    def test_update_alert_not_dual_written_returns_400(self) -> None:
+        """
+        If an alert rule was only partially dual written (its AlertRuleDetector exists but
+        the AlertRuleWorkflow is missing), dual_update_alert_rule reaches get_action_filter
+        and raises AlertRuleNotDualWritten. The legacy API must surface this as a 400 rather
+        than a 500.
+        """
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+        alert_rule = self.alert_rule
+        serialized_alert_rule = self.get_serialized_alert_rule()
+        serialized_alert_rule["name"] = "what"
+
+        # Remove only the AlertRuleWorkflow so the AlertRuleDetector guard passes but
+        # get_action_filter cannot find the workflow.
+        assert AlertRuleDetector.objects.filter(alert_rule_id=alert_rule.id).exists()
+        AlertRuleWorkflow.objects.filter(alert_rule_id=alert_rule.id).delete()
+
+        with self.feature("organizations:incidents"), outbox_runner():
+            resp = self.get_error_response(
+                self.organization.slug,
+                alert_rule.id,
+                status_code=400,
+                **serialized_alert_rule,
+            )
+
+        assert "legacy API" in str(resp.data)
 
     @patch("sentry.incidents.serializers.alert_rule.are_any_projects_error_upsampled")
     def test_update_to_count_converts_internally_but_shows_count_on_upsampled_project(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -44,6 +44,7 @@ from sentry.incidents.models.alert_rule import (
 )
 from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.incidents.serializers import ACTION_TARGET_TYPE_TO_STRING, AlertRuleSerializer
+from sentry.incidents.serializers.alert_rule import UNSUPPORTED_LEGACY_API
 from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
     find_channel_id_for_alert_rule,
 )
@@ -1014,7 +1015,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
                 **serialized_alert_rule,
             )
 
-        assert "legacy API" in str(resp.data)
+        assert UNSUPPORTED_LEGACY_API in str(resp.data)
 
     @patch("sentry.incidents.serializers.alert_rule.are_any_projects_error_upsampled")
     def test_update_to_count_converts_internally_but_shows_count_on_upsampled_project(
@@ -1247,6 +1248,39 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             )
 
         assert len(resp.data["triggers"]) == 1
+
+    def test_delete_trigger_not_dual_written_returns_400(self) -> None:
+        """
+        Deleting a trigger on an alert rule that was only partially dual written
+        (AlertRuleDetector exists but AlertRuleWorkflow is missing) makes
+        dual_delete_migrated_alert_rule_trigger raise AlertRuleNotDualWritten.
+        The legacy API must surface this as a 400, not a 500.
+        """
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+        alert_rule = self.alert_rule
+        serialized_alert_rule = self.get_serialized_alert_rule()
+
+        # Drop the "warning" trigger so it lands in triggers_to_delete, which
+        # routes through dual_delete_migrated_alert_rule_trigger.
+        serialized_alert_rule["triggers"].pop(1)
+
+        # Remove only the AlertRuleWorkflow so get_detector_trigger still finds the
+        # detector but get_action_filter raises AlertRuleNotDualWritten.
+        assert AlertRuleDetector.objects.filter(alert_rule_id=alert_rule.id).exists()
+        AlertRuleWorkflow.objects.filter(alert_rule_id=alert_rule.id).delete()
+
+        with self.feature("organizations:incidents"), outbox_runner():
+            resp = self.get_error_response(
+                self.organization.slug,
+                alert_rule.id,
+                status_code=400,
+                **serialized_alert_rule,
+            )
+
+        assert UNSUPPORTED_LEGACY_API in str(resp.data)
 
     @mock.patch("sentry.incidents.serializers.alert_rule.dual_delete_migrated_alert_rule_trigger")
     def test_dual_delete_trigger(self, mock_dual_delete: MagicMock) -> None:

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -70,7 +70,7 @@ from sentry.workflow_engine.models import (
     WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.types import DetectorPriorityLevel
+from sentry.workflow_engine.types import AlertRuleNotDualWritten, DetectorPriorityLevel
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -1433,13 +1433,13 @@ class DataConditionLookupHelpersTest(BaseMetricAlertMigrationTest):
 
     def test_get_action_filter_no_workflow(self) -> None:
         """
-        Test that we raise an exception if the corresponding workflow for an
+        Test that we raise AlertRuleNotDualWritten if the corresponding workflow for an
         alert rule trigger action does not exist.
         """
         workflow = AlertRuleWorkflow.objects.get(alert_rule_id=self.metric_alert.id).workflow
         workflow.delete()
 
-        with pytest.raises(AlertRuleWorkflow.DoesNotExist):
+        with pytest.raises(AlertRuleNotDualWritten):
             get_action_filter(self.alert_rule_trigger, DetectorPriorityLevel.HIGH)
 
     def test_get_action_filter_no_action_filter(self) -> None:


### PR DESCRIPTION
# Description
If an alert is created using the new UI, but accessed or updated through the old API it will throw an exception AlertRuleWorkflow.DoesNotExist.

This PR will wrap the lookup an re-raise a custom error, `AlertRuleDualWritten`.  This exception is only handled with the update scenario, and will help uncover and isolate any other potential cases.

Fixes SENTRY-5PD3