### PR TITLE
fix(issue-search): Prevent overflow crash in recommended_v2 sort

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -102,6 +102,10 @@ class PostgresSortStrategy:
         dataclass_field(default_factory=dict)
     )
     score_fn: Callable[[dict[str, Any]], float] = lambda data: 0.0
+    # Score to use when score_fn raises on a row. Dropping the row would make the issue
+    # vanish from the stream entirely; instead we keep it with a base score (e.g. the
+    # Snuba recommended value) so it still appears, just without the boosts score_fn adds.
+    fallback_score_fn: Callable[[dict[str, Any]], float] = lambda data: 0.0
     exclude_null_postgres: bool = True
 
 
@@ -1002,7 +1006,9 @@ def recommended_v2_strategy() -> PostgresSortStrategy:
         newness = 0.0
         if first_seen is not None and newness_halflife_hours > 0:
             hours = max(0.0, (now - first_seen).total_seconds() / 3600)
-            newness = 1.0 / 2.0 ** (hours / newness_halflife_hours)
+            # Negative exponent so very old issues underflow to 0.0 rather than
+            # overflowing the float (1.0 / 2.0**x blows up once x exceeds ~1024).
+            newness = 2.0 ** -(hours / newness_halflife_hours)
         regressed = 1.0 if data.get("substatus") == GroupSubStatus.REGRESSED else 0.0
         return (
             (data.get("recommended") or 0.0)
@@ -1026,6 +1032,9 @@ def recommended_v2_strategy() -> PostgresSortStrategy:
             "agent": resolve_issue_agent_signal,
         },
         score_fn=score_fn,
+        # If a boost calculation ever fails, keep the issue in the stream ranked by its
+        # base Snuba recommended score rather than dropping it.
+        fallback_score_fn=lambda data: data.get("recommended") or 0.0,
         # seer_fixability_score is null for most groups; score those as 0 rather
         # than excluding them.
         exclude_null_postgres=False,
@@ -1267,8 +1276,25 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                 }
                 try:
                     score = strategy.score_fn(merged)
-                except (TypeError, KeyError):
-                    continue
+                except (TypeError, KeyError, ArithmeticError) as e:
+                    # A single malformed/extreme row must never 500 the whole issue stream
+                    # (ArithmeticError covers overflow/underflow/zero-division in score
+                    # math). Rather than drop the issue -- which removes it from the view
+                    # entirely -- fall back to the strategy's base score so it still shows,
+                    # just without the boosts. Logged so a recurring bug stays discoverable.
+                    self.logger.warning(
+                        "postgres_sort.score_fn_failed",
+                        extra={
+                            "sort_by": sort_by,
+                            "group_id": gid,
+                            "error": str(e),
+                            "error_type": type(e).__name__,
+                        },
+                    )
+                    try:
+                        score = strategy.fallback_score_fn(merged)
+                    except (TypeError, KeyError, ArithmeticError):
+                        continue
                 scored_groups.append((score, gid))
 
         if not scored_groups:

--- a/tests/snuba/search/test_postgres_sort_framework.py
+++ b/tests/snuba/search/test_postgres_sort_framework.py
@@ -195,6 +195,33 @@ class TestPostgresSortWithoutSnuba(PostgresSortTestBase):
             results = list(self.make_query("test_sort"))
         assert results == [self.groups[1], self.groups[2], self.groups[0]]
 
+    def test_score_fn_error_falls_back_not_drops(self):
+        # A score_fn that raises on one row must not 500 the whole sort, and the issue must
+        # not vanish from the stream: it falls back to fallback_score_fn and stays in the
+        # results. Regression for an OverflowError in the recommended_v2 newness boost that
+        # took down the entire issue stream.
+        for group in self.groups:
+            group.update(seer_fixability_score=float(group.id))
+        bad_id = self.groups[0].id
+
+        def score_fn(data):
+            if data["fix"] == bad_id:
+                raise OverflowError("boom")
+            return data["fix"]
+
+        strategy = PostgresSortStrategy(
+            postgres_fields={"fix": "seer_fixability_score"},
+            score_fn=score_fn,
+            # groups[0] fails score_fn but falls back to a high base score, so it survives
+            # and sorts to the top rather than being dropped.
+            fallback_score_fn=lambda data: 10**9,
+            exclude_null_postgres=False,
+        )
+        with _patch_pg_strategies({"test_sort": strategy}):
+            results = list(self.make_query("test_sort"))
+        assert set(results) == set(self.groups)
+        assert results[0] == self.groups[0]
+
 
 class TestExecutePostgresSort(PostgresSortTestBase):
     def test_snuba_filter_narrows_candidates(self):
@@ -469,6 +496,13 @@ class TestRecommendedV2Sort(PostgresSortTestBase):
         self.groups[0].update(first_seen=before_now(hours=1))
 
         assert self._query(actor=self.user)[0] == self.groups[0]
+
+    def test_very_old_first_seen_does_not_overflow(self):
+        # first_seen far enough back that hours/halflife exceeds ~1024 used to overflow
+        # the float in 1.0 / 2.0**x. The query must still succeed (newness underflows to 0).
+        self.groups[0].update(first_seen=before_now(days=3000))
+
+        assert set(self._query(actor=self.user)) == set(self.groups)
 
     def _add_suspect_commit(self, group, user):
         GroupOwner.objects.create(


### PR DESCRIPTION
The `recommended_v2` newness boost computed `1.0 / 2.0 ** (hours / halflife)`. For issues whose `first_seen` is more than ~2.9 years old, the exponent exceeds ~1024 and `2.0 ** x` overflows the float *before* the division runs, raising `OverflowError`. That bubbled all the way up and 500'd the entire issue stream — not just the one offending group. The `sentry` org has issues dating back to 2017, so any `recommended_v2` query there reliably hit it.

This makes a few changes:

- **Fix the math at the source.** Use a negative exponent (`2.0 ** -x`) instead of `1.0 / 2.0 ** x`. It's mathematically identical but underflows to `0.0` for very old issues rather than overflowing.
- **Harden the per-row guard.** The scoring loop already wrapped `score_fn` in `except (TypeError, KeyError)`, but `OverflowError` slipped past it — which is why one bad row took down the whole request. Broadened to also catch `ArithmeticError` (overflow/underflow/zero-division).
- **Fall back instead of dropping.** Previously a row whose `score_fn` raised was dropped — which removes the issue from the stream entirely. Instead we now fall back to the strategy's base score (the Snuba `recommended` value for `recommended_v2`), so the issue still appears, just without the personalization boosts. Added an optional `fallback_score_fn` to `PostgresSortStrategy` for this (defaults to `0.0`).
- **Log it.** When the fallback is taken, log at warning with the sort name, group id, and error, so a recurring scoring bug stays discoverable instead of silently degrading.

Found via SENTRY-5QTG, triggered by sorting the `sentry` org's issues by `recommended_v2`.

Fixes SENTRY-5QTG