### PR TITLE
feat(automations): Support decimal thresholds for percent-sessions count

### DIFF
--- a/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
+++ b/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
@@ -17,34 +17,32 @@ type IntervalChoice = {label: string; value: Interval};
 
 interface BranchProps {
   intervalChoices?: IntervalChoice[];
-  // Minimum allowed comparison value. Defaults to 0, which lets users alert on
-  // "more than 0" (i.e. 1 or more). Percent-sessions passes 1 since its
-  // validator treats 0 as missing.
-  minValue?: number;
 }
 
 export function CountBranch({
   intervalChoices = INTERVAL_CHOICES,
-  minValue = 0,
-}: BranchProps) {
+  maximumFractionDigits,
+}: BranchProps & {maximumFractionDigits?: number}) {
   return tct('more than [value] [interval]', {
-    value: <ValueField minValue={minValue} />,
+    value: <ValueField maximumFractionDigits={maximumFractionDigits} />,
     interval: <IntervalField intervalChoices={intervalChoices} />,
   });
 }
 
-export function PercentBranch({
-  intervalChoices = INTERVAL_CHOICES,
-  minValue = 0,
-}: BranchProps) {
+export function PercentBranch({intervalChoices = INTERVAL_CHOICES}: BranchProps) {
   return tct('[value] higher [interval] compared to [comparison_interval]', {
-    value: <PercentValueField minValue={minValue} />,
+    value: <PercentValueField />,
     interval: <IntervalField intervalChoices={intervalChoices} />,
     comparison_interval: <ComparisonIntervalField />,
   });
 }
 
-function ValueField({minValue = 0}: {minValue?: number}) {
+// Integer count input by default (min 0, stepping by 1). When
+// maximumFractionDigits is set, the input also accepts decimals: typed values
+// are preserved and rounded to that precision on blur, while the stepper buttons
+// still move by whole units. Used by percent-sessions count, where fractional
+// percentages are meaningful.
+function ValueField({maximumFractionDigits}: {maximumFractionDigits?: number}) {
   const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
   const {removeError} = useAutomationBuilderErrorContext();
 
@@ -53,8 +51,12 @@ function ValueField({minValue = 0}: {minValue?: number}) {
       name={`${condition_id}.comparison.value`}
       aria-label={t('Value')}
       value={condition.comparison.value}
-      min={minValue}
-      step={1}
+      // Omitting `step` keeps typed decimals intact on blur — react-aria only
+      // snaps to a step grid when `step` is defined. The buttons still fall back
+      // to stepping by 1.
+      {...(maximumFractionDigits === undefined
+        ? {step: 1}
+        : {formatOptions: {maximumFractionDigits}})}
       onChange={(value: number) => {
         onUpdate({comparison: {...condition.comparison, value}});
         removeError(condition.id);
@@ -63,10 +65,10 @@ function ValueField({minValue = 0}: {minValue?: number}) {
   );
 }
 
-function PercentValueField({minValue = 0}: {minValue?: number}) {
+function PercentValueField() {
   return (
     <PercentWrapper>
-      <ValueField minValue={minValue} />%
+      <ValueField />%
     </PercentWrapper>
   );
 }

--- a/static/app/views/automations/components/actionFilters/percentSessions.tsx
+++ b/static/app/views/automations/components/actionFilters/percentSessions.tsx
@@ -95,10 +95,12 @@ function ComparisonTypeField() {
   const {removeError} = useAutomationBuilderErrorContext();
 
   if (condition.type === DataConditionType.PERCENT_SESSIONS_COUNT) {
-    return <CountBranch intervalChoices={PERCENT_INTERVAL_CHOICES} minValue={1} />;
+    return (
+      <CountBranch intervalChoices={PERCENT_INTERVAL_CHOICES} maximumFractionDigits={3} />
+    );
   }
   if (condition.type === DataConditionType.PERCENT_SESSIONS_PERCENT) {
-    return <PercentBranch intervalChoices={PERCENT_INTERVAL_CHOICES} minValue={1} />;
+    return <PercentBranch intervalChoices={PERCENT_INTERVAL_CHOICES} />;
   }
 
   return (
@@ -136,8 +138,13 @@ export function validatePercentSessionsCondition({
   if (condition.type === DataConditionType.PERCENT_SESSIONS) {
     return t('You must select a comparison type.');
   }
+  const {value} = condition.comparison;
+  // 0 is a valid threshold for both variants (the backend schema allows it), so
+  // only treat null/undefined/NaN as missing.
   if (
-    !condition.comparison.value ||
+    value === null ||
+    value === undefined ||
+    Number.isNaN(value) ||
     !condition.comparison.interval ||
     (condition.type === DataConditionType.PERCENT_SESSIONS_PERCENT &&
       !condition.comparison.comparisonInterval)


### PR DESCRIPTION
## Summary

Follow-up to #118128. Two related improvements to the Automations frequency conditions, both aligning the UI with what the backend already accepts.

### 1. Decimal thresholds for percent-sessions count

`percent_sessions_count` compares an **absolute** session-affected percentage. The backend schema is `number` (0–100) and the measured rate is rounded to 4 decimal places, but the UI input only accepted whole numbers — so sub-1% thresholds like `0.01` couldn't be entered (prod already has ~88 such configs, down to 3 decimal places).

The shared count input now takes an optional `maximumFractionDigits`. When set, react-aria's step snapping is disabled so typed decimals survive blur, while the +/- buttons still move by whole units. Percent-sessions count passes `3`, matching the precision in use today. Values are silently rounded to 3 places on blur; no existing config exceeds that.

> Note: the stepper buttons round away any fractional part on click (`2.75` → `3`). This is an inherent react-aria behavior — `step` controls both the button increment *and* typed-value snapping — so decimal entry is via typing. Whole-number stepping via the buttons is preserved.

### 2. Align min/zero handling with the backend

Every percent-session and event-frequency condition evaluates `value > comparison` and its schema allows `minimum: 0`. The UI now floors uniformly at `0` and treats only `null`/`undefined`/`NaN` as missing, so users can alert on "more than 0" (i.e. 1 or more) anywhere the API supports it — including the relative-increase `*_percent` variants, where `0` means "any increase." This removes the now-redundant `minValue` prop.