### PR TITLE
ref(cursorPoller): migrate callback api.request to requestPromise

### DIFF
--- a/static/app/utils/cursorPoller.tsx
+++ b/static/app/utils/cursorPoller.tsx
@@ -1,7 +1,7 @@
-import type {Request} from 'sentry/api';
 import {Client} from 'sentry/api';
 import {defined} from 'sentry/utils/defined';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 
 type Options = {
   linkPreviousHref: string;
@@ -21,7 +21,6 @@ export class CursorPoller {
   options: Options;
   pollingEndpoint = '';
   timeoutId: number | null = null;
-  lastRequest: Request | null = null;
   active = true;
 
   reqsWithoutData = 0;
@@ -62,58 +61,54 @@ export class CursorPoller {
       this.timeoutId = null;
     }
 
-    if (this.lastRequest) {
-      this.lastRequest.cancel();
-    }
+    // Abort any in-flight poll request
+    this.api.clear();
   }
 
-  poll() {
-    this.lastRequest = this.api.request(this.pollingEndpoint, {
-      success: (data, _, resp) => {
-        // cancel in progress operation if disabled
-        if (!this.active) {
-          return;
-        }
+  async poll() {
+    try {
+      const [data, , resp] = await this.api.requestPromise(this.pollingEndpoint, {
+        includeAllArgs: true,
+      });
 
-        // if theres no data, nothing changes
-        if (!data?.length) {
-          this.reqsWithoutData += 1;
-          return;
-        }
+      // cancel in progress operation if disabled
+      if (!this.active) {
+        return;
+      }
 
-        if (this.reqsWithoutData > 0) {
-          this.reqsWithoutData -= 1;
-        }
+      // if theres no data, nothing changes
+      if (!data?.length) {
+        this.reqsWithoutData += 1;
+        return;
+      }
 
-        const linksHeader = resp?.getResponseHeader('Link') ?? null;
-        const hitsHeader = resp?.getResponseHeader('X-Hits') ?? null;
-        const queryCount = defined(hitsHeader) ? parseInt(hitsHeader, 10) || 0 : 0;
-        const links = parseLinkHeader(linksHeader);
-        this.setEndpoint(links.previous!.href);
+      if (this.reqsWithoutData > 0) {
+        this.reqsWithoutData -= 1;
+      }
 
-        this.options.success(data, {queryCount});
-      },
-      error: resp => {
-        if (!resp) {
-          return;
-        }
+      const linksHeader = resp?.getResponseHeader('Link') ?? null;
+      const hitsHeader = resp?.getResponseHeader('X-Hits') ?? null;
+      const queryCount = defined(hitsHeader) ? parseInt(hitsHeader, 10) || 0 : 0;
+      const links = parseLinkHeader(linksHeader);
+      this.setEndpoint(links.previous!.href);
 
-        // If user does not have access to the endpoint, we should halt polling
-        // These errors could mean:
-        // * the user lost access to a project
-        // * project was renamed
-        // * user needs to reauth
-        if (resp.status === 404 || resp.status === 403 || resp.status === 401) {
-          this.disable();
-        }
-      },
-      complete: () => {
-        this.lastRequest = null;
-
-        if (this.active) {
-          this.timeoutId = window.setTimeout(this.poll.bind(this), this.getDelay());
-        }
-      },
-    });
+      this.options.success(data, {queryCount});
+    } catch (error) {
+      // If user does not have access to the endpoint, we should halt polling
+      // These errors could mean:
+      // * the user lost access to a project
+      // * project was renamed
+      // * user needs to reauth
+      if (
+        error instanceof RequestError &&
+        (error.status === 404 || error.status === 403 || error.status === 401)
+      ) {
+        this.disable();
+      }
+    } finally {
+      if (this.active) {
+        this.timeoutId = window.setTimeout(this.poll.bind(this), this.getDelay());
+      }
+    }
   }
 }

--- a/static/app/views/issueList/overview.polling.spec.tsx
+++ b/static/app/views/issueList/overview.polling.spec.tsx
@@ -151,9 +151,9 @@ describe('IssueList -> Polling', () => {
     );
 
     // Each poll request gets delayed by additional 3s, up to max of 60s
-    jest.advanceTimersByTime(3001);
+    await jest.advanceTimersByTimeAsync(3001);
     expect(pollRequest).toHaveBeenCalledTimes(1);
-    jest.advanceTimersByTime(6001);
+    await jest.advanceTimersByTimeAsync(6001);
     expect(pollRequest).toHaveBeenCalledTimes(2);
 
     // Pauses
@@ -161,7 +161,7 @@ describe('IssueList -> Polling', () => {
       delay: null,
     });
 
-    jest.advanceTimersByTime(12001);
+    await jest.advanceTimersByTimeAsync(12001);
     expect(pollRequest).toHaveBeenCalledTimes(2);
   });
 
@@ -186,7 +186,7 @@ describe('IssueList -> Polling', () => {
       {delay: null}
     );
 
-    jest.advanceTimersByTime(3001);
+    await jest.advanceTimersByTimeAsync(3001);
     expect(pollRequest).toHaveBeenCalledTimes(1);
 
     // We mock out the stream group component and only render the ID as a testid
@@ -211,9 +211,9 @@ describe('IssueList -> Polling', () => {
     );
 
     // Each poll request gets delayed by additional 3s, up to max of 60s
-    jest.advanceTimersByTime(3001);
+    await jest.advanceTimersByTimeAsync(3001);
     expect(pollRequest).toHaveBeenCalledTimes(1);
-    jest.advanceTimersByTime(9001);
+    await jest.advanceTimersByTimeAsync(9001);
     expect(pollRequest).toHaveBeenCalledTimes(1);
   });
 
@@ -233,9 +233,9 @@ describe('IssueList -> Polling', () => {
     );
 
     // Each poll request gets delayed by additional 3s, up to max of 60s
-    jest.advanceTimersByTime(3001);
+    await jest.advanceTimersByTimeAsync(3001);
     expect(pollRequest).toHaveBeenCalledTimes(1);
-    jest.advanceTimersByTime(9001);
+    await jest.advanceTimersByTimeAsync(9001);
     expect(pollRequest).toHaveBeenCalledTimes(1);
   });
 
@@ -255,9 +255,9 @@ describe('IssueList -> Polling', () => {
     );
 
     // Each poll request gets delayed by additional 3s, up to max of 60s
-    jest.advanceTimersByTime(3001);
+    await jest.advanceTimersByTimeAsync(3001);
     expect(pollRequest).toHaveBeenCalledTimes(1);
-    jest.advanceTimersByTime(9001);
+    await jest.advanceTimersByTimeAsync(9001);
     expect(pollRequest).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Migrates `CursorPoller.poll()` off the deprecated callback-style `api.request()` to the promise-based `api.requestPromise()`, resolving the `no-callback-api-request` convention violation flagged by frontend-tsc (issues **FRONTEND-TSC-3A** and **FRONTEND-TSC-6Z**, both pointing at `static/app/utils/cursorPoller.tsx:70-71`).

## Changes

- `poll()` is now `async` and awaits `api.requestPromise(this.pollingEndpoint, {includeAllArgs: true})`, with the old `success`/`error`/`complete` callbacks mapped to the `try`/`catch`/`finally` blocks respectively.
- In-flight requests are aborted in `disable()` via `this.api.clear()` (the poller owns its own `Client` instance) instead of holding a `Request` handle and calling `.cancel()`. The `lastRequest` field and the `Request` type import are removed.
- Access errors that should halt polling (401/403/404) are detected by narrowing the rejected value to `RequestError` and checking `.status`.

Behavior is preserved: the `active` guard still short-circuits stale responses, and rescheduling still only happens while `active` in the `finally` block.

## Notes for Seer / reviewers

🤖 Generated as part of the `[no-callback-api-request]` issue-view cleanup. Root-cause analysis from Seer (run 14667509) suggested an `AbortController`; using the poller's existing `Client.clear()` achieves the same cancellation with less surface area.

