### PR TITLE
feat(notif-platform): Support in-paragraph link blocks

### DIFF
--- a/src/sentry/notifications/platform/discord/provider.py
+++ b/src/sentry/notifications/platform/discord/provider.py
@@ -17,6 +17,7 @@ from sentry.notifications.platform.target import (
 )
 from sentry.notifications.platform.threading import ThreadContext
 from sentry.notifications.platform.types import (
+    LinkTextBlock,
     NotificationBodyFormattingBlock,
     NotificationBodyFormattingBlockType,
     NotificationBodyTextBlock,
@@ -119,6 +120,10 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
                 texts.append(f"**{block.text}**")
             elif block.type == NotificationBodyTextBlockType.CODE:
                 texts.append(f"`{block.text}`")
+            elif block.type == NotificationBodyTextBlockType.LINK and isinstance(
+                block, LinkTextBlock
+            ):
+                texts.append(f"[{block.text}]({block.url})")
         return " ".join(texts)
 
 

--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -14,6 +14,7 @@ from sentry.notifications.platform.renderer import NotificationRenderer
 from sentry.notifications.platform.target import GenericNotificationTarget
 from sentry.notifications.platform.threading import ThreadContext
 from sentry.notifications.platform.types import (
+    LinkTextBlock,
     NotificationBodyFormattingBlock,
     NotificationBodyFormattingBlockType,
     NotificationBodyTextBlock,
@@ -107,10 +108,14 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
             if block.type == NotificationBodyTextBlockType.PLAIN_TEXT:
                 texts.append(escaped_text)
             elif block.type == NotificationBodyTextBlockType.BOLD_TEXT:
-                # HTML tags are safe, content is escaped
                 texts.append(f"<strong>{escaped_text}</strong>")
             elif block.type == NotificationBodyTextBlockType.CODE:
                 texts.append(f"<code>{escaped_text}</code>")
+            elif block.type == NotificationBodyTextBlockType.LINK and isinstance(
+                block, LinkTextBlock
+            ):
+                escaped_url = escape(block.url)
+                texts.append(f'<a href="{escaped_url}">{escaped_text}</a>')
 
         return " ".join(texts)
 
@@ -134,6 +139,10 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
                 texts.append(f"**{block.text}**")
             elif block.type == NotificationBodyTextBlockType.CODE:
                 texts.append(f"`{block.text}`")
+            elif block.type == NotificationBodyTextBlockType.LINK and isinstance(
+                block, LinkTextBlock
+            ):
+                texts.append(f"{block.text} ({block.url})")
         return " ".join(texts)
 
 

--- a/src/sentry/notifications/platform/msteams/provider.py
+++ b/src/sentry/notifications/platform/msteams/provider.py
@@ -17,6 +17,7 @@ from sentry.notifications.platform.target import (
 )
 from sentry.notifications.platform.threading import ThreadContext
 from sentry.notifications.platform.types import (
+    LinkTextBlock,
     NotificationBodyFormattingBlock,
     NotificationBodyFormattingBlockType,
     NotificationBodyTextBlock,
@@ -117,6 +118,10 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
                 texts.append(f"**{block.text}**")
             elif block.type == NotificationBodyTextBlockType.CODE:
                 texts.append(f"`{block.text}`")
+            elif block.type == NotificationBodyTextBlockType.LINK and isinstance(
+                block, LinkTextBlock
+            ):
+                texts.append(f"[{block.text}]({block.url})")
         return " ".join(texts)
 
 

--- a/src/sentry/notifications/platform/slack/provider.py
+++ b/src/sentry/notifications/platform/slack/provider.py
@@ -31,6 +31,7 @@ from sentry.notifications.platform.target import (
 )
 from sentry.notifications.platform.threading import ThreadContext
 from sentry.notifications.platform.types import (
+    LinkTextBlock,
     NotificationBodyFormattingBlock,
     NotificationBodyFormattingBlockType,
     NotificationBodyTextBlock,
@@ -115,6 +116,10 @@ class SlackRenderer(NotificationRenderer[SlackRenderable]):
                 texts.append(f"*{block.text}*")
             elif block.type == NotificationBodyTextBlockType.CODE:
                 texts.append(f"`{block.text}`")
+            elif block.type == NotificationBodyTextBlockType.LINK and isinstance(
+                block, LinkTextBlock
+            ):
+                texts.append(f"<{block.url}|{block.text}>")
         return " ".join(texts)
 
 

--- a/src/sentry/notifications/platform/templates/seer.py
+++ b/src/sentry/notifications/platform/templates/seer.py
@@ -44,6 +44,7 @@ class SeerAutofixErrorTemplate(NotificationTemplate[SeerAutofixError]):
         source=NotificationSource.SEER_AUTOFIX_ERROR,
         error_message="(401): Could not connect to your GitHub repository for this project.",
     )
+    hide_from_debugger = True
 
     def render(self, data: SeerAutofixError) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -288,6 +288,10 @@ class NotificationBodyTextBlockType(StrEnum):
     """
     Inline block of code.
     """
+    LINK = "link"
+    """
+    A hyperlink with display text.
+    """
 
 
 class NotificationBodyFormattingBlockType(StrEnum):
@@ -369,6 +373,13 @@ class PlainTextBlock(NotificationBodyTextBlock):
     type: Literal[NotificationBodyTextBlockType.PLAIN_TEXT] = (
         NotificationBodyTextBlockType.PLAIN_TEXT
     )
+
+
+@dataclass
+class LinkTextBlock(NotificationBodyTextBlock):
+    text: str
+    url: str
+    type: Literal[NotificationBodyTextBlockType.LINK] = NotificationBodyTextBlockType.LINK
 
 
 class NotificationTemplate[T: NotificationData](abc.ABC):

--- a/tests/sentry/notifications/platform/discord/test_provider.py
+++ b/tests/sentry/notifications/platform/discord/test_provider.py
@@ -15,17 +15,31 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.platform.discord.provider import (
     DiscordNotificationProvider,
     DiscordRenderable,
+    DiscordRenderer,
 )
 from sentry.notifications.platform.target import IntegrationNotificationTarget
+from sentry.notifications.platform.types import (
+    LinkTextBlock,
+    NotificationBodyFormattingBlockType,
+    NotificationBodyTextBlockType,
+    NotificationCategory,
+    NotificationProviderKey,
+    NotificationRenderedAction,
+    NotificationRenderedImage,
+    NotificationRenderedTemplate,
+    NotificationTargetResourceType,
+    ParagraphBlock,
+    PlainTextBlock,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
 
 
 def is_action_row(component: DiscordMessageComponentDict) -> TypeGuard[DiscordActionRowDict]:
-    """Type guard to check if component is an action row."""
     return component.get("type") == 1
 
 
 def is_button(component: DiscordMessageComponentDict) -> TypeGuard[DiscordButtonDict]:
-    """Type guard to check if component is a button."""
     return component.get("type") == 2
 
 
@@ -34,23 +48,38 @@ def assert_button_properties(
     expected_label: str,
     expected_url: str,
 ) -> None:
-    """Helper function to assert discord link button properties."""
     assert is_button(button)
     assert button["label"] == expected_label
     assert button["url"] == expected_url
     assert button["style"] == DiscordButtonStyle.LINK
 
 
-from sentry.notifications.platform.types import (
-    NotificationCategory,
-    NotificationProviderKey,
-    NotificationTargetResourceType,
-)
-from sentry.testutils.cases import TestCase
-from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
-
-
 class DiscordRendererTest(TestCase):
+    def test_link_text_block_rendering(self) -> None:
+        rendered_template = NotificationRenderedTemplate(
+            subject="Test Link",
+            body=[
+                ParagraphBlock(
+                    blocks=[
+                        PlainTextBlock(text="PR:"),
+                        LinkTextBlock(
+                            text="getsentry/sentry (#1234)",
+                            url="https://github.com/getsentry/sentry/pull/1234",
+                        ),
+                    ],
+                )
+            ],
+        )
+
+        data = MockNotification(message="test")
+        renderable = DiscordRenderer.render(data=data, rendered_template=rendered_template)
+
+        embed = renderable["embeds"][0]
+        assert (
+            "[getsentry/sentry (#1234)](https://github.com/getsentry/sentry/pull/1234)"
+            in embed["description"]
+        )
+
     def test_default_renderer(self) -> None:
         data = MockNotification(message="test")
         template = MockNotificationTemplate()
@@ -91,16 +120,6 @@ class DiscordRendererTest(TestCase):
         assert_button_properties(button, "Visit Sentry", "https://www.sentry.io")
 
     def test_renderer_without_chart(self) -> None:
-        """Test rendering when no chart is provided"""
-        from sentry.notifications.platform.types import (
-            NotificationBodyFormattingBlockType,
-            NotificationBodyTextBlockType,
-            NotificationRenderedAction,
-            NotificationRenderedTemplate,
-            ParagraphBlock,
-            PlainTextBlock,
-        )
-
         rendered_template = NotificationRenderedTemplate(
             subject="Test Without Chart",
             body=[
@@ -132,17 +151,6 @@ class DiscordRendererTest(TestCase):
         assert "image" not in embed or embed.get("image") is None
 
     def test_renderer_without_footer(self) -> None:
-        """Test rendering when no footer is provided"""
-        from sentry.notifications.platform.types import (
-            NotificationBodyFormattingBlockType,
-            NotificationBodyTextBlockType,
-            NotificationRenderedAction,
-            NotificationRenderedImage,
-            NotificationRenderedTemplate,
-            ParagraphBlock,
-            PlainTextBlock,
-        )
-
         rendered_template = NotificationRenderedTemplate(
             subject="Test Without Footer",
             body=[
@@ -177,16 +185,6 @@ class DiscordRendererTest(TestCase):
         assert "footer" not in embed or embed.get("footer") is None
 
     def test_renderer_without_actions(self) -> None:
-        """Test rendering when no actions are provided"""
-        from sentry.notifications.platform.types import (
-            NotificationBodyFormattingBlockType,
-            NotificationBodyTextBlockType,
-            NotificationRenderedImage,
-            NotificationRenderedTemplate,
-            ParagraphBlock,
-            PlainTextBlock,
-        )
-
         rendered_template = NotificationRenderedTemplate(
             subject="Test Without Actions",
             body=[
@@ -220,17 +218,6 @@ class DiscordRendererTest(TestCase):
         assert len(components) == 0
 
     def test_renderer_multiple_actions(self) -> None:
-        """Test rendering with multiple action buttons"""
-        from sentry.notifications.platform.types import (
-            NotificationBodyFormattingBlockType,
-            NotificationBodyTextBlockType,
-            NotificationRenderedAction,
-            NotificationRenderedImage,
-            NotificationRenderedTemplate,
-            ParagraphBlock,
-            PlainTextBlock,
-        )
-
         actions = [
             NotificationRenderedAction(label="Action 1", link="https://example1.com"),
             NotificationRenderedAction(label="Action 2", link="https://example2.com"),

--- a/tests/sentry/notifications/platform/email/test_provider.py
+++ b/tests/sentry/notifications/platform/email/test_provider.py
@@ -6,12 +6,17 @@ from sentry import options
 from sentry.notifications.platform.email.provider import EmailNotificationProvider, EmailRenderer
 from sentry.notifications.platform.target import GenericNotificationTarget
 from sentry.notifications.platform.types import (
+    BoldTextBlock,
+    LinkTextBlock,
     NotificationBodyFormattingBlock,
     NotificationBodyFormattingBlockType,
     NotificationBodyTextBlock,
     NotificationBodyTextBlockType,
     NotificationProviderKey,
+    NotificationRenderedTemplate,
     NotificationTargetResourceType,
+    ParagraphBlock,
+    PlainTextBlock,
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
@@ -84,17 +89,35 @@ class EmailRendererTest(TestCase):
             for text_block in block.blocks:
                 validate_text_block(text_block, str(text_content), str(html_content))
 
-    def test_xss_protection(self) -> None:
-        from sentry.notifications.platform.types import (
-            BoldTextBlock,
-            NotificationBodyFormattingBlockType,
-            NotificationBodyTextBlockType,
-            NotificationRenderedTemplate,
-            ParagraphBlock,
-            PlainTextBlock,
+    def test_link_text_block_rendering(self) -> None:
+        rendered_template = NotificationRenderedTemplate(
+            subject="Test Link",
+            body=[
+                ParagraphBlock(
+                    blocks=[
+                        PlainTextBlock(text="Check out"),
+                        LinkTextBlock(
+                            text="getsentry/sentry (#1234)",
+                            url="https://github.com/getsentry/sentry/pull/1234",
+                        ),
+                    ],
+                )
+            ],
         )
 
-        # Create template with XSS attempt in user content
+        email = EmailRenderer.render(data=self.data, rendered_template=rendered_template)
+        [html_content, _] = email.alternatives[0]
+        text_content = email.body
+
+        html_str = str(html_content)
+        assert 'href="https://github.com/getsentry/sentry/pull/1234"' in html_str
+        assert "getsentry/sentry (#1234)" in html_str
+        assert (
+            "getsentry/sentry (#1234) (https://github.com/getsentry/sentry/pull/1234)"
+            in text_content
+        )
+
+    def test_xss_protection(self) -> None:
         xss_template = NotificationRenderedTemplate(
             subject="Test XSS",
             body=[
@@ -129,6 +152,27 @@ class EmailRendererTest(TestCase):
 
         # Malicious tags should NOT be present in unescaped form
         assert "<script>" not in str(html_content)
+
+    def test_xss_protection_link_block(self) -> None:
+        xss_template = NotificationRenderedTemplate(
+            subject="Test XSS Link",
+            body=[
+                ParagraphBlock(
+                    blocks=[
+                        LinkTextBlock(
+                            text='<script>alert("xss")</script>',
+                            url="https://example.com/<script>",
+                        ),
+                    ],
+                )
+            ],
+        )
+
+        email = EmailRenderer.render(data=self.data, rendered_template=xss_template)
+        [html_content, _] = email.alternatives[0]
+
+        assert "<script>" not in str(html_content)
+        assert "&lt;script&gt;" in str(html_content)
 
 
 class EmailNotificationProviderTest(TestCase):

--- a/tests/sentry/notifications/platform/msteams/test_provider.py
+++ b/tests/sentry/notifications/platform/msteams/test_provider.py
@@ -11,14 +11,18 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.platform.msteams.provider import (
     MSTeamsNotificationProvider,
     MSTeamsRenderable,
+    MSTeamsRenderer,
 )
 from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.types import (
+    LinkTextBlock,
     NotificationCategory,
     NotificationProviderKey,
     NotificationRenderedAction,
     NotificationRenderedTemplate,
     NotificationTargetResourceType,
+    ParagraphBlock,
+    PlainTextBlock,
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
@@ -26,6 +30,33 @@ from tests.sentry.integrations.msteams.test_message_builder import _is_open_url_
 
 
 class MSTeamsRendererTest(TestCase):
+    def test_link_text_block_rendering(self) -> None:
+        rendered_template = NotificationRenderedTemplate(
+            subject="Test Link",
+            body=[
+                ParagraphBlock(
+                    blocks=[
+                        PlainTextBlock(text="PR:"),
+                        LinkTextBlock(
+                            text="getsentry/sentry (#1234)",
+                            url="https://github.com/getsentry/sentry/pull/1234",
+                        ),
+                    ],
+                )
+            ],
+        )
+
+        data = MockNotification(message="test")
+        renderable = MSTeamsRenderer.render(data=data, rendered_template=rendered_template)
+
+        body_blocks = renderable["body"]
+        body_text_block = body_blocks[1]
+        assert body_text_block["type"] == "TextBlock"
+        assert (
+            "[getsentry/sentry (#1234)](https://github.com/getsentry/sentry/pull/1234)"
+            in body_text_block["text"]
+        )
+
     def test_default_renderer(self) -> None:
         data = MockNotification(message="test")
         template = MockNotificationTemplate()

--- a/tests/sentry/notifications/platform/slack/test_provider.py
+++ b/tests/sentry/notifications/platform/slack/test_provider.py
@@ -18,23 +18,58 @@ from sentry.notifications.platform.provider import (
     SendFailureStatus,
     SendSuccessResult,
 )
-from sentry.notifications.platform.slack.provider import SlackNotificationProvider, SlackRenderable
+from sentry.notifications.platform.slack.provider import (
+    SlackNotificationProvider,
+    SlackRenderable,
+    SlackRenderer,
+)
 from sentry.notifications.platform.target import (
     GenericNotificationTarget,
     IntegrationNotificationTarget,
 )
 from sentry.notifications.platform.threading import ThreadContext, ThreadKey
 from sentry.notifications.platform.types import (
+    LinkTextBlock,
     NotificationCategory,
     NotificationProviderKey,
+    NotificationRenderedTemplate,
     NotificationSource,
     NotificationTargetResourceType,
+    ParagraphBlock,
+    PlainTextBlock,
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
 
 
 class SlackRendererTest(TestCase):
+    def test_link_text_block_rendering(self) -> None:
+        rendered_template = NotificationRenderedTemplate(
+            subject="Test Link",
+            body=[
+                ParagraphBlock(
+                    blocks=[
+                        PlainTextBlock(text="PR:"),
+                        LinkTextBlock(
+                            text="getsentry/sentry (#1234)",
+                            url="https://github.com/getsentry/sentry/pull/1234",
+                        ),
+                    ],
+                )
+            ],
+        )
+
+        renderable = SlackRenderer.render(
+            data=MockNotification(message="test"), rendered_template=rendered_template
+        )
+        body_block = renderable["blocks"][1]
+        assert isinstance(body_block, SectionBlock)
+        assert body_block.text is not None
+        assert (
+            "<https://github.com/getsentry/sentry/pull/1234|getsentry/sentry (#1234)>"
+            in body_block.text.text
+        )
+
     def test_default_renderer(self) -> None:
         data = MockNotification(message="test")
         template = MockNotificationTemplate()
@@ -119,14 +154,6 @@ class SlackNotificationProviderSendTest(TestCase):
         return target
 
     def _create_renderable(self) -> SlackRenderable:
-        """Create a sample SlackRenderable for testing"""
-        from slack_sdk.models.blocks import (
-            HeaderBlock,
-            MarkdownTextObject,
-            PlainTextObject,
-            SectionBlock,
-        )
-
         return SlackRenderable(
             blocks=[
                 HeaderBlock(text=PlainTextObject(text="Test Notification")),


### PR DESCRIPTION
Needed for seer activity since we don't want buttons for PR links. Also omits the seer error renderable from the debugger (since its only set up for slack)