### PR TITLE
ref(apiForm): migrate callback api.request to requestPromise

### DIFF
--- a/static/app/components/forms/apiForm.tsx
+++ b/static/app/components/forms/apiForm.tsx
@@ -30,7 +30,7 @@ export function ApiForm({
   const api = useApi();
 
   const handleSubmit = useCallback(
-    (
+    async (
       data: Record<string, any>,
       onSuccess: (response: Record<string, any>) => void,
       onError: (error: any) => void
@@ -41,21 +41,20 @@ export function ApiForm({
       const requestOptions: RequestOptions = {
         method: apiMethod,
         data: transformed ?? data,
-        success: response => {
-          clearIndicators();
-          onSuccess(response);
-        },
-        error: error => {
-          clearIndicators();
-          onError(error);
-        },
       };
 
       if (hostOverride) {
         requestOptions.host = hostOverride;
       }
 
-      api.request(apiEndpoint, requestOptions);
+      try {
+        const response = await api.requestPromise(apiEndpoint, requestOptions);
+        clearIndicators();
+        onSuccess(response);
+      } catch (error) {
+        clearIndicators();
+        onError(error);
+      }
     },
     [api, onSubmit, apiMethod, apiEndpoint, hostOverride]
   );


### PR DESCRIPTION
## Summary

Migrates `ApiForm`'s `handleSubmit` off the deprecated callback-style `api.request()` to the promise-based `api.requestPromise()`, resolving the `no-callback-api-request` convention violation flagged by frontend-tsc (issue **FRONTEND-TSC-34**, `static/app/components/forms/apiForm.tsx:41`).

## Changes

- `handleSubmit` is now `async` and awaits `api.requestPromise(apiEndpoint, requestOptions)` inside a `try`/`catch`.
- The `success` callback body moves into the `try` (after the await) and the `error` callback body into the `catch`. `clearIndicators()` still fires on both paths.
- `onError` now receives the rejected `RequestError`. This is shape-compatible with the previous `ResponseMeta`-style error object: `RequestError` exposes `responseJSON`, `responseText`, `status`, and `statusText`, which are the properties form error handlers read.

No behavior change for callers; `ApiForm` is a deprecated wrapper around `Form`.

## Notes

🤖 Generated as part of the `[no-callback-api-request]` issue-view cleanup (Seer run 14737954).
