### PR TITLE
feat(seer-infra-telemetry): Add auth method field to monitoring provider connections RPC

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -19,6 +19,7 @@ from sentry.constants import ENABLE_SEER_CODING_DEFAULT, ObjectStatus
 from sentry.hybridcloud.rpc.service import RpcException
 from sentry.identity import default_manager as identity_manager
 from sentry.identity.mcp import McpIdentityProvider
+from sentry.identity.oauth2 import OAuth2Provider
 from sentry.identity.services.identity import identity_service
 from sentry.integrations.types import MONITORING_PROVIDERS
 from sentry.models.group import Group
@@ -157,6 +158,7 @@ def get_monitoring_provider_connections(
                     "url": url,
                     "encrypted_access_token": encrypted_access_token,
                     "identity_id": identity.id,
+                    "is_refresh_supported": isinstance(provider, OAuth2Provider),
                 }
             )
 

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -121,6 +121,7 @@ def get_monitoring_provider_connections(
     connections: list[dict[str, Any]] = []
     for provider_type in MONITORING_PROVIDERS:
         provider = identity_manager.get(provider_type)
+        is_oauth_provider = isinstance(provider, OAuth2Provider)
         if not isinstance(provider, McpIdentityProvider):
             continue
 
@@ -158,7 +159,7 @@ def get_monitoring_provider_connections(
                     "url": url,
                     "encrypted_access_token": encrypted_access_token,
                     "identity_id": identity.id,
-                    "auth_method": "oauth" if isinstance(provider, OAuth2Provider) else "pat",
+                    "auth_method": "oauth" if is_oauth_provider else "pat",
                 }
             )
 

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -158,7 +158,7 @@ def get_monitoring_provider_connections(
                     "url": url,
                     "encrypted_access_token": encrypted_access_token,
                     "identity_id": identity.id,
-                    "is_refresh_supported": isinstance(provider, OAuth2Provider),
+                    "auth_method": "oauth" if isinstance(provider, OAuth2Provider) else "pat",
                 }
             )
 

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -874,7 +874,7 @@ class MonitoringProviderConnectionData(BaseModel):
     url: str
     encrypted_access_token: str
     identity_id: int
-    is_refresh_supported: bool
+    auth_method: str
 
     def __getitem__(self, key: str) -> Any:
         return self.dict()[key]

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -874,6 +874,7 @@ class MonitoringProviderConnectionData(BaseModel):
     url: str
     encrypted_access_token: str
     identity_id: int
+    is_refresh_supported: bool
 
     def __getitem__(self, key: str) -> Any:
         return self.dict()[key]

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -1464,20 +1464,3 @@ class TestGetMonitoringProviderConnections(TestCase):
     def test_degrades_when_identity_service_errors(self, mock_get: MagicMock) -> None:
         # A control-silo RPC failure must not propagate (it would stall the outbox shard).
         assert get_monitoring_provider_connections(self.organization, self.user.id) == []
-
-    def test_pat_connection_is_not_refresh_supported(self) -> None:
-        idp = self.create_identity_provider(type="datadog_pat", external_id="org-uuid-1")
-        self.create_identity(
-            user=self.user,
-            identity_provider=idp,
-            external_id="dd-user-1",
-            data={"access_token": "access-token", "site": "datadoghq.com"},
-        )
-
-        result = get_monitoring_provider_connections(self.organization, self.user.id)
-
-        assert len(result) == 1
-        connection = result[0]
-        assert connection["provider_key"] == "datadog_pat"
-        # PAT identities are not OAuth2, so the token cannot be refreshed--only re-authed.
-        assert connection["is_refresh_supported"] is False

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -1375,6 +1375,7 @@ class TestGetMonitoringProviderConnections(TestCase):
         assert connection["provider_key"] == "datadog"
         assert connection["url"] == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
         assert connection["identity_id"] == identity.id
+        assert connection["is_refresh_supported"] is True
         fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
         decrypted_access_token = fernet.decrypt(
             connection["encrypted_access_token"].encode("utf-8")
@@ -1463,3 +1464,20 @@ class TestGetMonitoringProviderConnections(TestCase):
     def test_degrades_when_identity_service_errors(self, mock_get: MagicMock) -> None:
         # A control-silo RPC failure must not propagate (it would stall the outbox shard).
         assert get_monitoring_provider_connections(self.organization, self.user.id) == []
+
+    def test_pat_connection_is_not_refresh_supported(self) -> None:
+        idp = self.create_identity_provider(type="datadog_pat", external_id="org-uuid-1")
+        self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-user-1",
+            data={"access_token": "access-token", "site": "datadoghq.com"},
+        )
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 1
+        connection = result[0]
+        assert connection["provider_key"] == "datadog_pat"
+        # PAT identities are not OAuth2, so the token cannot be refreshed--only re-authed.
+        assert connection["is_refresh_supported"] is False

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -1375,7 +1375,7 @@ class TestGetMonitoringProviderConnections(TestCase):
         assert connection["provider_key"] == "datadog"
         assert connection["url"] == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
         assert connection["identity_id"] == identity.id
-        assert connection["is_refresh_supported"] is True
+        assert connection["auth_method"] == "oauth"
         fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
         decrypted_access_token = fernet.decrypt(
             connection["encrypted_access_token"].encode("utf-8")

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -1720,7 +1720,7 @@ class TestGetMonitoringProviderConnections(APITestCase):
         assert connection.provider_key == "datadog"
         assert connection.url == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
         assert connection.identity_id == identity.id
-        assert connection.is_refresh_supported is True
+        assert connection.auth_method == "oauth"
         decrypted = Fernet(TEST_FERNET_KEY.encode("utf-8")).decrypt(
             connection.encrypted_access_token.encode("utf-8")
         )

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -1720,6 +1720,7 @@ class TestGetMonitoringProviderConnections(APITestCase):
         assert connection.provider_key == "datadog"
         assert connection.url == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
         assert connection.identity_id == identity.id
+        assert connection.is_refresh_supported is True
         decrypted = Fernet(TEST_FERNET_KEY.encode("utf-8")).decrypt(
             connection.encrypted_access_token.encode("utf-8")
         )


### PR DESCRIPTION
Adds an `auth_method` field (`oauth` or `pat`) to each connection returned by the `get_monitoring_provider_connections` RPC, derived from whether the provider uses OAuth2. Seer carries this through to the mid-run re-auth prompt so the frontend knows which flow to render (OAuth redirect vs. pasted token).