### PR TITLE
feat(integrations): customizable install modal title and description

### DIFF
--- a/static/app/components/pipeline/integrationSlack/index.tsx
+++ b/static/app/components/pipeline/integrationSlack/index.tsx
@@ -14,6 +14,7 @@ function SlackOAuthLoginStep({
   stepData,
   advance,
   isAdvancing,
+  description,
 }: PipelineStepProps<{oauthUrl?: string}, {code: string; state: string}>) {
   const handleOAuthCallback = useCallback(
     (data: OAuthCallbackData) => {
@@ -29,6 +30,7 @@ function SlackOAuthLoginStep({
       serviceName="Slack"
       onOAuthCallback={handleOAuthCallback}
       popup={{height: 900}}
+      description={description}
     />
   );
 }

--- a/static/app/components/pipeline/modal.tsx
+++ b/static/app/components/pipeline/modal.tsx
@@ -26,8 +26,12 @@ interface PipelineModalProps<
 > extends ModalRenderProps {
   provider: P;
   type: T;
+  /** Overrides the step's default descriptive copy. */
+  description?: string;
   initialData?: Record<string, string>;
   onComplete?: (data: CompletionDataFor<T, P>) => void;
+  /** Overrides the header title (defaults to the pipeline's `actionTitle`). */
+  title?: string;
 }
 
 function PipelineModal<
@@ -41,6 +45,8 @@ function PipelineModal<
   provider,
   initialData,
   onComplete,
+  title,
+  description,
 }: PipelineModalProps<T, P>) {
   const handleComplete = (data: CompletionDataFor<T, P>) => {
     onComplete?.(data);
@@ -50,6 +56,7 @@ function PipelineModal<
   const pipeline = usePipeline(type, provider, {
     onComplete: handleComplete,
     initialData,
+    description,
   });
   const {stepDefinition} = pipeline;
 
@@ -69,7 +76,7 @@ function PipelineModal<
   return (
     <Fragment>
       <Header closeButton>
-        <Text size="lg">{pipeline.definition.actionTitle}</Text>
+        <Text size="lg">{title ?? pipeline.definition.actionTitle}</Text>
       </Header>
       <Body>
         <Stack gap="2xl">
@@ -142,15 +149,25 @@ interface OpenPipelineModalOptions<
 > {
   provider: P;
   type: T;
+  description?: string;
   initialData?: Record<string, string>;
   onClose?: () => void;
   onComplete?: (data: CompletionDataFor<T, P>) => void;
+  title?: string;
 }
 
 export function openPipelineModal<
   T extends RegisteredPipelineType,
   P extends ProvidersByType[T] = ProvidersByType[T],
->({type, provider, initialData, onComplete, onClose}: OpenPipelineModalOptions<T, P>) {
+>({
+  type,
+  provider,
+  initialData,
+  onComplete,
+  onClose,
+  title,
+  description,
+}: OpenPipelineModalOptions<T, P>) {
   openModal(
     deps => (
       <PipelineModal
@@ -159,6 +176,8 @@ export function openPipelineModal<
         provider={provider}
         initialData={initialData}
         onComplete={onComplete}
+        title={title}
+        description={description}
       />
     ),
     {onClose, closeEvents: 'none'}

--- a/static/app/components/pipeline/shared/oauthLoginStep.spec.tsx
+++ b/static/app/components/pipeline/shared/oauthLoginStep.spec.tsx
@@ -37,6 +37,28 @@ describe('OAuthLoginStep', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders a custom description in place of the default intro copy', () => {
+    render(
+      <OAuthLoginStep
+        serviceName="Slack"
+        oauthUrl="https://slack.com/oauth/authorize"
+        onOAuthCallback={mockOnOAuthCallback}
+        description="Reauthorize the Sentry app in your Slack Workspace so you can chat with Seer directly"
+      />
+    );
+
+    expect(
+      screen.getByText(
+        'Reauthorize the Sentry app in your Slack Workspace so you can chat with Seer directly'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Authorize your Slack account with Sentry to complete the integration setup.'
+      )
+    ).not.toBeInTheDocument();
+  });
+
   it('disables the authorize button when no oauthUrl is provided', () => {
     render(<OAuthLoginStep serviceName="GitHub" onOAuthCallback={mockOnOAuthCallback} />);
 

--- a/static/app/components/pipeline/shared/oauthLoginStep.tsx
+++ b/static/app/components/pipeline/shared/oauthLoginStep.tsx
@@ -17,6 +17,8 @@ export interface OAuthCallbackData {
 interface OAuthLoginStepProps {
   onOAuthCallback: (data: OAuthCallbackData) => void;
   serviceName: string;
+  /** Overrides the default intro copy */
+  description?: string;
   isLoading?: boolean;
   oauthUrl?: string;
   popup?: PopupOptions;
@@ -28,6 +30,7 @@ export function OAuthLoginStep({
   serviceName,
   onOAuthCallback,
   popup,
+  description,
 }: OAuthLoginStepProps) {
   const handleCallback = useCallback(
     (raw: Record<string, string>) => {
@@ -47,10 +50,11 @@ export function OAuthLoginStep({
     <Stack gap="lg" align="start">
       <Stack gap="sm">
         <Text>
-          {tct(
-            'Authorize your [service] account with Sentry to complete the integration setup.',
-            {service: serviceName}
-          )}
+          {description ??
+            tct(
+              'Authorize your [service] account with Sentry to complete the integration setup.',
+              {service: serviceName}
+            )}
         </Text>
         {popupStatus === 'popup-open' && (
           <Text variant="muted" size="sm">

--- a/static/app/components/pipeline/types.tsx
+++ b/static/app/components/pipeline/types.tsx
@@ -89,6 +89,7 @@ export interface PipelineStepProps<
   stepData: D | null;
   stepIndex: number;
   totalSteps: number;
+  description?: string;
 }
 
 /**

--- a/static/app/components/pipeline/usePipeline.tsx
+++ b/static/app/components/pipeline/usePipeline.tsx
@@ -66,6 +66,10 @@ interface UsePipelineOptions<
   T extends RegisteredPipelineType,
   P extends ProvidersByType[T],
 > {
+  /**
+   * Copy override forwarded to step components that render descriptive intro text.
+   */
+  description?: string;
   enabled?: boolean;
   /**
    * Data that will be passed through to the initialization call.
@@ -135,7 +139,7 @@ export function usePipeline<
   onCompleteRef.current = options.onComplete;
   const generationRef = useRef(0);
 
-  const {enabled = true, initialData} = options;
+  const {enabled = true, initialData, description} = options;
 
   const pipelineName = getBackendPipelineType(type);
   const apiUrl = getApiUrl(
@@ -333,6 +337,7 @@ export function usePipeline<
             isAdvancing: isAdvancePending,
             isInitializing: false,
             advanceError,
+            description,
           }
         : {
             stepIndex: 0,
@@ -342,6 +347,7 @@ export function usePipeline<
             isAdvancing: false,
             isInitializing: true,
             advanceError: null,
+            description,
           };
 
     return <Component {...stepProps} />;
@@ -353,6 +359,7 @@ export function usePipeline<
     isAdvancePending,
     advanceError,
     finish,
+    description,
   ]);
 
   const {stepIndex, totalSteps} =

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -27,8 +27,14 @@ export interface AddIntegrationParams {
       | 'test_analytics_onboarding'
       | 'test_analytics_org_selector';
   };
-  modalDescription?: string;
-  modalTitle?: string;
+  /**
+   * Overrides for the install modal's copy. Passed straight through to
+   * `openPipelineModal`; this hook does not read them.
+   */
+  modalParams?: {
+    description?: string;
+    title?: string;
+  };
   /**
    * When true, the "%s added" success toast is not shown on install.
    * Use when the surrounding UI already communicates the connected state.
@@ -55,8 +61,7 @@ export function useAddIntegration() {
       analyticsParams,
       suppressSuccessMessage,
       urlParams,
-      modalTitle,
-      modalDescription,
+      modalParams,
     } = params;
 
     const is_scm = isScmProvider(provider);
@@ -73,8 +78,7 @@ export function useAddIntegration() {
       type: 'integration',
       provider: provider.key as ProvidersByType['integration'],
       initialData: urlParams,
-      title: modalTitle,
-      description: modalDescription,
+      ...modalParams,
       onComplete: data => {
         trackIntegrationAnalytics('integrations.installation_complete', {
           integration: provider.key,

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -27,6 +27,8 @@ export interface AddIntegrationParams {
       | 'test_analytics_onboarding'
       | 'test_analytics_org_selector';
   };
+  modalDescription?: string;
+  modalTitle?: string;
   /**
    * When true, the "%s added" success toast is not shown on install.
    * Use when the surrounding UI already communicates the connected state.
@@ -53,6 +55,8 @@ export function useAddIntegration() {
       analyticsParams,
       suppressSuccessMessage,
       urlParams,
+      modalTitle,
+      modalDescription,
     } = params;
 
     const is_scm = isScmProvider(provider);
@@ -69,6 +73,8 @@ export function useAddIntegration() {
       type: 'integration',
       provider: provider.key as ProvidersByType['integration'],
       initialData: urlParams,
+      title: modalTitle,
+      description: modalDescription,
       onComplete: data => {
         trackIntegrationAnalytics('integrations.installation_complete', {
           integration: provider.key,

--- a/static/app/utils/integrations/useAutoOpenInstallModal.tsx
+++ b/static/app/utils/integrations/useAutoOpenInstallModal.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useRef} from 'react';
 import {useQueryState} from 'nuqs';
 
+import {t} from 'sentry/locale';
 import type {IntegrationProvider} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import type {AddIntegrationParams} from 'sentry/utils/integrations/useAddIntegration';
@@ -54,12 +55,19 @@ export function useAutoOpenInstallModal({
 
     autoOpenedForRef.current = provider.key;
 
+    const isSlack = provider.key === 'slack';
     startFlow({
       provider,
       organization,
       onInstall,
       analyticsParams,
       suppressSuccessMessage,
+      ...(isSlack && {
+        modalTitle: t('Upgrade Slack Integration'),
+        modalDescription: t(
+          'Reauthorize the Sentry app in your Slack Workspace so you can chat with Seer directly.'
+        ),
+      }),
     });
 
     setShowInstallModal(null);

--- a/static/app/utils/integrations/useAutoOpenInstallModal.tsx
+++ b/static/app/utils/integrations/useAutoOpenInstallModal.tsx
@@ -55,18 +55,24 @@ export function useAutoOpenInstallModal({
 
     autoOpenedForRef.current = provider.key;
 
-    const isSlack = provider.key === 'slack';
+    // NOTE: The `?showInstallModal=1` entry point is currently only used by the
+    // Slack reinstall/upgrade nudge, so we override the generic install modal
+    // copy to frame it as a reauthorization. `useAddIntegration` itself is
+    // provider-agnostic and may outlive this usage; if other providers start
+    // auto-opening, lift this out rather than hardcoding it to Slack here.
     startFlow({
       provider,
       organization,
       onInstall,
       analyticsParams,
       suppressSuccessMessage,
-      ...(isSlack && {
-        modalTitle: t('Upgrade Slack Integration'),
-        modalDescription: t(
-          'Reauthorize the Sentry app in your Slack Workspace so you can chat with Seer directly.'
-        ),
+      ...(provider.key === 'slack' && {
+        modalParams: {
+          title: t('Upgrade Slack Integration'),
+          description: t(
+            'Reauthorize the Sentry app in your Slack Workspace so you can chat with Seer directly.'
+          ),
+        },
       }),
     });
 

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -322,6 +322,29 @@ describe('IntegrationDetailedView', () => {
       );
     });
 
+    it('passes the upgrade copy for the Slack provider', async () => {
+      const openPipelineModalSpy = jest
+        .spyOn(pipelineModal, 'openPipelineModal')
+        .mockImplementation(() => {});
+
+      render(<IntegrationDetailedView />, {
+        initialRouterConfig: createRouterConfig('slack', {showInstallModal: '1'}),
+        organization,
+      });
+
+      await waitFor(() => {
+        expect(openPipelineModalSpy).toHaveBeenCalledTimes(1);
+      });
+      expect(openPipelineModalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'slack',
+          title: 'Upgrade Slack Integration',
+          description:
+            'Reauthorize the Sentry app in your Slack Workspace so you can chat with Seer directly.',
+        })
+      );
+    });
+
     it('does not auto-open without the param', async () => {
       const openPipelineModalSpy = jest
         .spyOn(pipelineModal, 'openPipelineModal')


### PR DESCRIPTION
We want to be able to customize the text when someone opens the modal by the query param introduced in #118285. This will allow us to customize the CTA for when a user clicks a nudge in the Slack notification which is implemented in #118288.