### PR TITLE
fix(replay): surface recording-segment fetch errors with a Retry button

### DIFF
--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
-import type {LinkButtonProps} from '@sentry/scraps/button';
+import {Alert} from '@sentry/scraps/alert';
+import {Button, type LinkButtonProps} from '@sentry/scraps/button';
 
 import {NegativeSpaceContainer} from 'sentry/components/container/negativeSpaceContainer';
 import {REPLAY_LOADING_HEIGHT} from 'sentry/components/events/eventReplay/constants';
@@ -39,6 +40,21 @@ export function ReplayClipPreviewPlayer({
       readerResult={replayReaderResult}
       renderArchived={() => (
         <ArchivedReplayAlert message={t('The replay for this event has been deleted.')} />
+      )}
+      renderError={({onRetry}) => (
+        <Alert.Container>
+          <Alert
+            variant="danger"
+            data-test-id="replay-error"
+            trailingItems={
+              <Button size="xs" onClick={onRetry}>
+                {t('Retry')}
+              </Button>
+            }
+          >
+            {t('There was an error loading the replay.')}
+          </Alert>
+        </Alert.Container>
       )}
       renderLoading={() => (
         <StyledNegativeSpaceContainer data-test-id="replay-loading-placeholder">

--- a/static/app/components/replays/player/replayLoadingState.spec.tsx
+++ b/static/app/components/replays/player/replayLoadingState.spec.tsx
@@ -1,0 +1,87 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {ReplayLoadingState} from 'sentry/components/replays/player/replayLoadingState';
+import type {useLoadReplayReader} from 'sentry/utils/replays/hooks/useLoadReplayReader';
+import type {ReplayReader} from 'sentry/utils/replays/replayReader';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+
+type ReaderResult = ReturnType<typeof useLoadReplayReader>;
+
+function makeReaderResult(overrides: Partial<ReaderResult> = {}): ReaderResult {
+  return {
+    attachments: [],
+    attachmentError: undefined,
+    errors: [],
+    feedbackEvents: [],
+    fetchError: undefined,
+    isError: false,
+    isPending: false,
+    onRetry: jest.fn(),
+    projectSlug: 'project-slug',
+    replay: {hasProcessingErrors: () => 0} as unknown as ReplayReader,
+    replayId: 'replay-id',
+    replayRecord: undefined,
+    status: 'success',
+    ...overrides,
+  } as ReaderResult;
+}
+
+function requestError(status: number) {
+  return new RequestError('GET', '/path', new Error('boom'), {
+    status,
+    statusText: '',
+    responseText: '',
+    responseJSON: {detail: 'boom'},
+    getResponseHeader: () => null,
+  });
+}
+
+function renderState(readerResult: ReaderResult) {
+  return render(
+    <ReplayLoadingState
+      readerResult={readerResult}
+      renderError={() => <div>Error state</div>}
+      renderThrottled={() => <div>Throttled state</div>}
+      renderLoading={() => <div>Loading state</div>}
+      renderMissing={() => <div>Missing state</div>}
+    >
+      {() => <div>Player</div>}
+    </ReplayLoadingState>
+  );
+}
+
+describe('ReplayLoadingState', () => {
+  it('renders the player when there are no errors', () => {
+    renderState(makeReaderResult());
+
+    expect(screen.getByText('Player')).toBeInTheDocument();
+  });
+
+  it('renders the error state when the recording-segment fetch fails with a 5xx', () => {
+    renderState(makeReaderResult({attachmentError: [requestError(500)]}));
+
+    expect(screen.getByText('Error state')).toBeInTheDocument();
+  });
+
+  it('renders the throttled state when the recording-segment fetch is rate-limited', () => {
+    renderState(makeReaderResult({attachmentError: [requestError(429)]}));
+
+    expect(screen.getByText('Throttled state')).toBeInTheDocument();
+  });
+
+  it('renders the error state when the replay record fetch fails', () => {
+    renderState(makeReaderResult({fetchError: requestError(500)}));
+
+    expect(screen.getByText('Error state')).toBeInTheDocument();
+  });
+
+  it('falls back to the missing-replay alert when a segment error has no custom error renderer', () => {
+    render(
+      <ReplayLoadingState readerResult={makeReaderResult({attachmentError: [requestError(500)]})}>
+        {() => <div>Player</div>}
+      </ReplayLoadingState>
+    );
+
+    expect(screen.getByTestId('replay-error')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/replays/player/replayLoadingState.spec.tsx
+++ b/static/app/components/replays/player/replayLoadingState.spec.tsx
@@ -77,7 +77,9 @@ describe('ReplayLoadingState', () => {
 
   it('falls back to the missing-replay alert when a segment error has no custom error renderer', () => {
     render(
-      <ReplayLoadingState readerResult={makeReaderResult({attachmentError: [requestError(500)]})}>
+      <ReplayLoadingState
+        readerResult={makeReaderResult({attachmentError: [requestError(500)]})}
+      >
         {() => <div>Player</div>}
       </ReplayLoadingState>
     );

--- a/static/app/components/replays/player/replayLoadingState.spec.tsx
+++ b/static/app/components/replays/player/replayLoadingState.spec.tsx
@@ -4,6 +4,7 @@ import {ReplayLoadingState} from 'sentry/components/replays/player/replayLoading
 import type {useLoadReplayReader} from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import type {ReplayReader} from 'sentry/utils/replays/replayReader';
 import {RequestError} from 'sentry/utils/requestError/requestError';
+import type {ReplayRecord} from 'sentry/views/explore/replays/types';
 
 type ReaderResult = ReturnType<typeof useLoadReplayReader>;
 
@@ -18,7 +19,7 @@ function makeReaderResult(overrides: Partial<ReaderResult> = {}): ReaderResult {
     isPending: false,
     onRetry: jest.fn(),
     projectSlug: 'project-slug',
-    replay: {hasProcessingErrors: () => 0} as unknown as ReplayReader,
+    replay: {hasProcessingErrors: () => 0} as ReplayReader,
     replayId: 'replay-id',
     replayRecord: undefined,
     status: 'success',
@@ -40,6 +41,7 @@ function renderState(readerResult: ReaderResult) {
   return render(
     <ReplayLoadingState
       readerResult={readerResult}
+      renderArchived={() => <div>Archived state</div>}
       renderError={() => <div>Error state</div>}
       renderThrottled={() => <div>Throttled state</div>}
       renderLoading={() => <div>Loading state</div>}
@@ -67,6 +69,17 @@ describe('ReplayLoadingState', () => {
     renderState(makeReaderResult({attachmentError: [requestError(429)]}));
 
     expect(screen.getByText('Throttled state')).toBeInTheDocument();
+  });
+
+  it('renders the archived state when the replay is archived even if a segment fetch failed', () => {
+    renderState(
+      makeReaderResult({
+        attachmentError: [requestError(500)],
+        replayRecord: {is_archived: true} as ReplayRecord,
+      })
+    );
+
+    expect(screen.getByText('Archived state')).toBeInTheDocument();
   });
 
   it('renders the error state when the replay record fetch fails', () => {

--- a/static/app/components/replays/player/replayLoadingState.tsx
+++ b/static/app/components/replays/player/replayLoadingState.tsx
@@ -47,15 +47,15 @@ export function ReplayLoadingState({
       <ReplayRequestsThrottledAlert />
     );
   }
+  if (readerResult.replayRecord?.is_archived) {
+    return renderArchived ? renderArchived(readerResult) : <ArchivedReplayAlert />;
+  }
   if (readerResult.fetchError || readerResult.attachmentError?.length) {
     return renderError ? (
       renderError(readerResult)
     ) : (
       <MissingReplayAlert orgSlug={organization.slug} />
     );
-  }
-  if (readerResult.replayRecord?.is_archived) {
-    return renderArchived ? renderArchived(readerResult) : <ArchivedReplayAlert />;
   }
   if (readerResult.isPending) {
     return renderLoading ? renderLoading(readerResult) : <LoadingIndicator />;

--- a/static/app/components/replays/player/replayLoadingState.tsx
+++ b/static/app/components/replays/player/replayLoadingState.tsx
@@ -47,7 +47,7 @@ export function ReplayLoadingState({
       <ReplayRequestsThrottledAlert />
     );
   }
-  if (readerResult.fetchError) {
+  if (readerResult.fetchError || readerResult.attachmentError?.length) {
     return renderError ? (
       renderError(readerResult)
     ) : (

--- a/static/app/views/issueDetails/groupReplays/groupReplaysPlayer.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplaysPlayer.spec.tsx
@@ -8,6 +8,7 @@ import {render as baseRender, screen, userEvent} from 'sentry-test/reactTestingL
 
 import type {Organization} from 'sentry/types/organization';
 import {ReplayReader} from 'sentry/utils/replays/replayReader';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 
 import {GroupReplaysPlayer} from './groupReplaysPlayer';
 
@@ -104,5 +105,35 @@ describe('GroupReplaysPlayer', () => {
     expect(handleBackClick).toHaveBeenCalled();
     await userEvent.click(screen.getByRole('button', {name: 'Next Clip'}));
     expect(handleForwardClick).toHaveBeenCalled();
+  });
+
+  it('shows a retryable error when the recording-segment fetch fails', async () => {
+    const onRetry = jest.fn();
+
+    render(
+      <GroupReplaysPlayer
+        {...defaultProps}
+        handleBackClick={undefined}
+        handleForwardClick={undefined}
+        replayReaderResult={{
+          ...defaultProps.replayReaderResult,
+          attachmentError: [
+            new RequestError('GET', '/recording-segments/', new Error('boom'), {
+              status: 500,
+              statusText: '',
+              responseText: '',
+              responseJSON: {detail: 'boom'},
+              getResponseHeader: () => null,
+            }),
+          ],
+          isError: true,
+          status: 'error' as const,
+          onRetry,
+        }}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Retry'}));
+    expect(onRetry).toHaveBeenCalled();
   });
 });

--- a/static/app/views/issueDetails/groupReplays/groupReplaysPlayer.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplaysPlayer.tsx
@@ -1,6 +1,9 @@
 import styled from '@emotion/styled';
 import type {Query} from 'history';
 
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+
 import {NegativeSpaceContainer} from 'sentry/components/container/negativeSpaceContainer';
 import {REPLAY_LOADING_HEIGHT_LARGE} from 'sentry/components/events/eventReplay/constants';
 import {ReplayPreviewPlayer} from 'sentry/components/events/eventReplay/replayPreviewPlayer';
@@ -42,6 +45,21 @@ export function GroupReplaysPlayer({
       readerResult={replayReaderResult}
       renderArchived={() => (
         <ArchivedReplayAlert message={t('The replay for this event has been deleted.')} />
+      )}
+      renderError={({onRetry}) => (
+        <Alert.Container>
+          <Alert
+            variant="danger"
+            data-test-id="replay-error"
+            trailingItems={
+              <Button size="xs" onClick={onRetry}>
+                {t('Retry')}
+              </Button>
+            }
+          >
+            {t('There was an error loading the replay.')}
+          </Alert>
+        </Alert.Container>
       )}
       renderLoading={() => (
         <StyledNegativeSpaceContainer data-test-id="replay-loading-placeholder">


### PR DESCRIPTION
The replay player only handles fetch failures (`readerResult.fetchError`) and 429 throttling as error states. Everything else falls through to the generic error state. But, if we get a non-429 failure on the recording-segments fetch (e.g. a Snuba read timeout → 500), it lands in `readerResult.attachmentError`, which the gate never checks. 

This:

* Adds Snuba failures to that gate, which allows a failed recording-segments fetch to surface the error state & show the existing Retry button
* Adds more Retry buttons to the views

<table>
<thead>
<tr>
<th>Area</th>
<th>State</th>
</tr>
</thead>
<tbody>
<tr>
<td>Issue</td>
<td>
<img width="772" height="215" alt="image" src="https://github.com/user-attachments/assets/129f75ee-2dd0-4a45-9fad-f179eb6bce59" />
</td>
</tr>
<tr>
<td>Replay</td>
<td>
<img width="982" height="438" alt="image" src="https://github.com/user-attachments/assets/b5acc263-213a-4b4d-a6fb-325aaaa87818" />
</td>
</tr>
</tbody>
</table>

Backend root cause of the 5xx that motivated this: [SENTRY-56CY](https://sentry.sentry.io/issues/6905210369). Backend fixes are separate.

Closes REPLAY-939.