### PR TITLE
feat(issue-preview): Add autofix tab to issue preview drawer

### DIFF
--- a/static/app/components/events/autofix/v3/autofixStartCard.tsx
+++ b/static/app/components/events/autofix/v3/autofixStartCard.tsx
@@ -1,0 +1,99 @@
+import {type CSSProperties, useState} from 'react';
+import styled from '@emotion/styled';
+
+import seerConfigConnectImg from 'sentry-images/spot/seer-config-connect-2.svg';
+
+import {Button} from '@sentry/scraps/button';
+import {Image} from '@sentry/scraps/image';
+import {Container, Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import type {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {IconBug} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Group} from 'sentry/types/group';
+
+interface AutofixStartCardProps {
+  autofix: ReturnType<typeof useExplorerAutofix>;
+  group: Group;
+  /**
+   * Called after a run has been successfully started. The sidebar uses this to
+   * open the Seer drawer; surfaces that already render the autofix in place
+   * (e.g. the issue preview drawer) can omit it.
+   */
+  onStarted?: () => void;
+  referrer?: string;
+}
+
+export function AutofixStartCard({
+  autofix,
+  group,
+  onStarted,
+  referrer,
+}: AutofixStartCardProps) {
+  // extract startStep first here so we can depend on it directly as `autofix` itself is unstable.
+  const startStep = autofix.startStep;
+
+  const [startingRun, setStartingRun] = useState(false);
+  const handleStartRootCause = async () => {
+    setStartingRun(true);
+    try {
+      await startStep('root_cause');
+    } catch {
+      return;
+    } finally {
+      setStartingRun(false);
+    }
+    onStarted?.();
+  };
+
+  return (
+    <Flex direction="column" gap="md">
+      <Flex
+        border="muted"
+        radius="md"
+        padding="lg"
+        gap="lg"
+        align="center"
+        justify="between"
+      >
+        <Container>
+          <Text>{t('Have Seer...')}</Text>
+          <Container as="ol" margin="0">
+            <li>{t('Determine the root cause of your issue')}</li>
+            <li>{t('Outline a plan')}</li>
+            <li>{t('Create a code fix')}</li>
+          </Container>
+        </Container>
+        <ImageContainer
+          justify="end"
+          align="center"
+          aspectRatio="9 / 16"
+          height={{'2xs': '78px', lg: '98px'}}
+        >
+          <Image src={seerConfigConnectImg} alt="" width="auto" height="100%" />
+        </ImageContainer>
+      </Flex>
+      <Button
+        size="md"
+        icon={startingRun ? <LoadingIndicator size={16} /> : <IconBug />}
+        aria-label={t('Start Analysis')}
+        variant="primary"
+        onClick={handleStartRootCause}
+        analyticsEventKey="autofix.start_fix_clicked"
+        analyticsEventName="Autofix: Start Fix Clicked"
+        analyticsParams={{group_id: group.id, mode: 'explorer', referrer}}
+        disabled={startingRun}
+      >
+        {t('Start Analysis')}
+      </Button>
+    </Flex>
+  );
+}
+
+const ImageContainer = styled(Flex)<{
+  aspectRatio?: CSSProperties['aspectRatio'];
+}>`
+  ${p => p.aspectRatio && `aspect-ratio: ${p.aspectRatio}`};
+`;

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -83,7 +83,7 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
   );
 }
 
-function useHandleCopyMarkdown({
+export function useHandleCopyMarkdown({
   aiAutofix,
 }: {
   aiAutofix: ReturnType<typeof useExplorerAutofix>;
@@ -107,7 +107,7 @@ function useHandleCopyMarkdown({
   }, [aiAutofix, copy]);
 }
 
-function useHandleRestart({
+export function useHandleRestart({
   aiAutofix,
 }: {
   aiAutofix: ReturnType<typeof useExplorerAutofix>;

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofix.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofix.tsx
@@ -1,0 +1,85 @@
+import {useMemo} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+
+import {
+  getOrderedAutofixSections,
+  useExplorerAutofix,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {AutofixStartCard} from 'sentry/components/events/autofix/v3/autofixStartCard';
+import {SeerDrawerContent} from 'sentry/components/events/autofix/v3/content';
+import {
+  useHandleCopyMarkdown,
+  useHandleRestart,
+} from 'sentry/components/events/autofix/v3/drawer';
+import {Placeholder} from 'sentry/components/placeholder';
+import {IconCopy} from 'sentry/icons/iconCopy';
+import {IconRefresh} from 'sentry/icons/iconRefresh';
+import {t} from 'sentry/locale';
+import type {Group} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
+import {useAiConfig} from 'sentry/views/issueDetails/hooks/useAiConfig';
+
+interface IssuePreviewAutofixProps {
+  group: Group;
+  project: Project;
+}
+
+export function IssuePreviewAutofix({group, project}: IssuePreviewAutofixProps) {
+  const aiConfig = useAiConfig(group, project);
+  const autofix = useExplorerAutofix(group.id);
+
+  const handleCopyMarkdown = useHandleCopyMarkdown({aiAutofix: autofix});
+  const handleRestart = useHandleRestart({aiAutofix: autofix});
+
+  const sections = useMemo(
+    () => getOrderedAutofixSections(autofix.runState),
+    [autofix.runState]
+  );
+
+  if (aiConfig.isAutofixSetupLoading) {
+    return (
+      <Flex direction="column" gap="xl">
+        <Placeholder height="10rem" />
+        <Placeholder height="15rem" />
+      </Flex>
+    );
+  }
+
+  // autofix results are loading, or we're polling and no blocks have been added yet
+  if (autofix.isLoading || (autofix.isPolling && !autofix.runState?.blocks?.length)) {
+    return <Placeholder height="15rem" />;
+  }
+
+  // No run yet — show the start-analysis card; it kicks off a run that renders in place.
+  if (!sections.length) {
+    return <AutofixStartCard autofix={autofix} group={group} />;
+  }
+
+  return (
+    <Flex direction="column" gap="lg">
+      <Flex justify="end" gap="xs">
+        <Button
+          size="xs"
+          variant="transparent"
+          icon={<IconRefresh />}
+          onClick={handleRestart}
+          disabled={!handleRestart}
+          tooltipProps={{title: t('Start a new analysis from scratch')}}
+          aria-label={t('Start a new analysis from scratch')}
+        />
+        <Button
+          size="xs"
+          variant="transparent"
+          icon={<IconCopy />}
+          onClick={handleCopyMarkdown}
+          disabled={!handleCopyMarkdown}
+          tooltipProps={{title: t('Copy analysis as Markdown')}}
+          aria-label={t('Copy analysis as Markdown')}
+        />
+      </Flex>
+      <SeerDrawerContent group={group} autofix={autofix} aiConfig={aiConfig} />
+    </Flex>
+  );
+}

--- a/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.spec.tsx
@@ -32,6 +32,18 @@ describe('IssuePreviewDrawer', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/tags/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/autofix/setup/`,
+      body: {
+        integration: {ok: false, reason: null},
+        billing: {hasAutofixQuota: false},
+        seerReposLinked: false,
+      },
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/org-slug/replay-count/`,
       body: {},
     });
@@ -77,6 +89,18 @@ describe('IssuePreviewDrawer', () => {
           event_id: 'abc123',
         },
       ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/tags/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/autofix/setup/`,
+      body: {
+        integration: {ok: false, reason: null},
+        billing: {hasAutofixQuota: false},
+        seerReposLinked: false,
+      },
     });
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/replay-count/`,
@@ -182,5 +206,97 @@ describe('IssuePreviewDrawer', () => {
     });
 
     expect(await screen.findAllByText('Resolved')).not.toHaveLength(0);
+  });
+
+  it('disables the Autofix tab when AI features are unavailable', async () => {
+    const project = ProjectFixture();
+    const group = GroupFixture({id: '123', shortId: 'JAVASCRIPT-6QS', project});
+
+    ProjectsStore.loadInitialData([project]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/`,
+      body: group,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/attachments/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/tags/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/autofix/setup/`,
+      body: {
+        integration: {ok: false, reason: null},
+        billing: {hasAutofixQuota: false},
+        seerReposLinked: false,
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/replay-count/`,
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/members/`,
+      body: [],
+    });
+
+    render(<IssuePreviewDrawer groupId={group.id} />);
+
+    expect(await screen.findByRole('tab', {name: 'Autofix'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+
+  it('opens the Autofix tab and shows the start state', async () => {
+    const organization = OrganizationFixture({features: ['gen-ai-features']});
+    const project = ProjectFixture();
+    const group = GroupFixture({id: '123', shortId: 'JAVASCRIPT-6QS', project});
+
+    ProjectsStore.loadInitialData([project]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/`,
+      body: group,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/attachments/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/tags/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/replay-count/`,
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/members/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/autofix/setup/`,
+      body: {
+        integration: {ok: true, reason: null},
+        billing: {hasAutofixQuota: true},
+        seerReposLinked: true,
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/autofix/`,
+      body: {autofix: null},
+    });
+
+    render(<IssuePreviewDrawer groupId={group.id} />, {organization});
+
+    await userEvent.click(await screen.findByRole('tab', {name: 'Autofix'}));
+
+    expect(
+      await screen.findByRole('button', {name: 'Start Analysis'})
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.spec.tsx
@@ -12,6 +12,29 @@ import {IssueCategory} from 'sentry/types/group';
 import {IssuePreviewDrawer} from 'sentry/views/issueDetails/issuePreview/issuePreviewDrawer';
 
 describe('IssuePreviewDrawer', () => {
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/replay-count/`,
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/members/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/users/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/123/tags/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/123/attachments/',
+      body: [],
+    });
+  });
+
   it('renders the issue short ID and title', async () => {
     const project = ProjectFixture();
     const group = GroupFixture({
@@ -28,32 +51,12 @@ describe('IssuePreviewDrawer', () => {
       body: group,
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/attachments/`,
-      body: [],
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/tags/`,
-      body: [],
-    });
-    MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/autofix/setup/`,
       body: {
         integration: {ok: false, reason: null},
         billing: {hasAutofixQuota: false},
         seerReposLinked: false,
       },
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/replay-count/`,
-      body: {},
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/members/`,
-      body: [],
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/users/`,
-      body: [],
     });
 
     render(<IssuePreviewDrawer groupId={group.id} />);
@@ -91,28 +94,12 @@ describe('IssuePreviewDrawer', () => {
       ],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/tags/`,
-      body: [],
-    });
-    MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/autofix/setup/`,
       body: {
         integration: {ok: false, reason: null},
         billing: {hasAutofixQuota: false},
         seerReposLinked: false,
       },
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/replay-count/`,
-      body: {},
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/members/`,
-      body: [],
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/users/`,
-      body: [],
     });
 
     render(<IssuePreviewDrawer groupId={group.id} />);
@@ -208,7 +195,7 @@ describe('IssuePreviewDrawer', () => {
     expect(await screen.findAllByText('Resolved')).not.toHaveLength(0);
   });
 
-  it('disables the Autofix tab when AI features are unavailable', async () => {
+  it('does not show the Autofix tab when AI features are unavailable', async () => {
     const project = ProjectFixture();
     const group = GroupFixture({id: '123', shortId: 'JAVASCRIPT-6QS', project});
 
@@ -219,14 +206,6 @@ describe('IssuePreviewDrawer', () => {
       body: group,
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/attachments/`,
-      body: [],
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/tags/`,
-      body: [],
-    });
-    MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/autofix/setup/`,
       body: {
         integration: {ok: false, reason: null},
@@ -234,21 +213,11 @@ describe('IssuePreviewDrawer', () => {
         seerReposLinked: false,
       },
     });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/replay-count/`,
-      body: {},
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/members/`,
-      body: [],
-    });
 
     render(<IssuePreviewDrawer groupId={group.id} />);
 
-    expect(await screen.findByRole('tab', {name: 'Autofix'})).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
+    expect(await screen.findByRole('tab', {name: 'Activity'})).toBeInTheDocument();
+    expect(screen.queryByRole('tab', {name: 'Autofix'})).not.toBeInTheDocument();
   });
 
   it('opens the Autofix tab and shows the start state', async () => {
@@ -261,22 +230,6 @@ describe('IssuePreviewDrawer', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/`,
       body: group,
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/attachments/`,
-      body: [],
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/tags/`,
-      body: [],
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/replay-count/`,
-      body: {},
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/members/`,
-      body: [],
     });
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/autofix/setup/`,

--- a/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.tsx
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import {LinkButton} from '@sentry/scraps/button';
 import {DrawerBody, DrawerHeader} from '@sentry/scraps/drawer';
 import {Container, Flex} from '@sentry/scraps/layout';
-import {TabList, Tabs} from '@sentry/scraps/tabs';
+import {TabList, TabPanels, Tabs} from '@sentry/scraps/tabs';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -27,6 +27,8 @@ import {GroupPriority} from 'sentry/views/issueDetails/groupPriority';
 import {GroupHeaderAssigneeSelector} from 'sentry/views/issueDetails/header/assigneeSelector';
 import {GroupStatusSubtitle} from 'sentry/views/issueDetails/header/groupStatusSubtitle';
 import {IssueIdBreadcrumb} from 'sentry/views/issueDetails/header/issueIdBreadcrumb';
+import {useAiConfig} from 'sentry/views/issueDetails/hooks/useAiConfig';
+import {IssuePreviewAutofix} from 'sentry/views/issueDetails/issuePreview/issuePreviewAutofix';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
 import {
   getGroupReprocessingStatus,
@@ -79,6 +81,7 @@ export function IssuePreviewDrawer({groupId}: IssuePreviewDrawerProps) {
 
 function IssuePreviewContent() {
   const {group, project} = useGroupData();
+  const {hasAutofix} = useAiConfig(group, project);
   const {title: primaryTitle} = getTitle(group);
   const secondaryTitle = getMessage(group);
   const disableActions = [
@@ -141,14 +144,12 @@ function IssuePreviewContent() {
           </Flex>
         </Flex>
       </Flex>
-      <Container paddingTop="lg">
-        <Container paddingBottom="lg" borderBottom="muted">
-          <Tabs value="activity">
+      <Container paddingTop="md">
+        <Tabs>
+          <Container paddingBottom="md" borderBottom="muted">
             <TabList variant="floating">
               <TabList.Item key="activity">{t('Activity')}</TabList.Item>
-              <TabList.Item key="autofix" disabled>
-                {t('Autofix')}
-              </TabList.Item>
+              {hasAutofix && <TabList.Item key="autofix">{t('Autofix')}</TabList.Item>}
               <TabList.Item key="details" disabled>
                 {t('Details')}
               </TabList.Item>
@@ -156,16 +157,33 @@ function IssuePreviewContent() {
                 {t('Events')}
               </TabList.Item>
             </TabList>
-          </Tabs>
-        </Container>
-        <Container paddingTop="lg">
-          <ActivitySection
-            group={group}
-            variant="standalone"
-            size="md"
-            placeholder={t('Add a comment. Tag users with @, or teams with #')}
-          />
-        </Container>
+          </Container>
+          <TabPanels>
+            <TabPanels.Item key="activity">
+              <Container paddingTop="md">
+                <ActivitySection
+                  group={group}
+                  variant="standalone"
+                  size="md"
+                  placeholder={t('Add a comment. Tag users with @, or teams with #')}
+                />
+              </Container>
+            </TabPanels.Item>
+            {hasAutofix && (
+              <TabPanels.Item key="autofix">
+                <Container paddingTop="md">
+                  <IssuePreviewAutofix group={group} project={project} />
+                </Container>
+              </TabPanels.Item>
+            )}
+            <TabPanels.Item key="details">
+              <div />
+            </TabPanels.Item>
+            <TabPanels.Item key="events">
+              <div />
+            </TabPanels.Item>
+          </TabPanels>
+        </Tabs>
       </Container>
     </Fragment>
   );

--- a/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.tsx
@@ -149,7 +149,9 @@ function IssuePreviewContent() {
           <Container paddingBottom="md" borderBottom="muted">
             <TabList variant="floating">
               <TabList.Item key="activity">{t('Activity')}</TabList.Item>
-              {hasAutofix && <TabList.Item key="autofix">{t('Autofix')}</TabList.Item>}
+              {hasAutofix ? (
+                <TabList.Item key="autofix">{t('Autofix')}</TabList.Item>
+              ) : null}
               <TabList.Item key="details" disabled>
                 {t('Details')}
               </TabList.Item>
@@ -169,13 +171,13 @@ function IssuePreviewContent() {
                 />
               </Container>
             </TabPanels.Item>
-            {hasAutofix && (
+            {hasAutofix ? (
               <TabPanels.Item key="autofix">
                 <Container paddingTop="md">
                   <IssuePreviewAutofix group={group} project={project} />
                 </Container>
               </TabPanels.Item>
-            )}
+            ) : null}
             <TabPanels.Item key="details">
               <div />
             </TabPanels.Item>

--- a/static/app/views/issueDetails/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.tsx
@@ -1,11 +1,7 @@
-import {type CSSProperties, useMemo, useState} from 'react';
-import styled from '@emotion/styled';
+import {useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
-import seerConfigConnectImg from 'sentry-images/spot/seer-config-connect-2.svg';
-
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Image} from '@sentry/scraps/image';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -31,12 +27,11 @@ import {
   RootCausePreview,
   SolutionPreview,
 } from 'sentry/components/events/autofix/v3/autofixPreviews';
+import {AutofixStartCard} from 'sentry/components/events/autofix/v3/autofixStartCard';
 import {useAutoTriggerAutofix} from 'sentry/components/events/autofix/v3/useAutoTriggerAutofix';
 import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {OverrideOrDefault} from 'sentry/components/overrideOrDefault';
 import {Placeholder} from 'sentry/components/placeholder';
-import {IconBug} from 'sentry/icons';
 import {IconSeer} from 'sentry/icons/iconSeer';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
@@ -253,14 +248,7 @@ function AutofixArtifacts({autofix, group, project}: AutofixArtifactsProps) {
   const referrer = autofix.runState?.blocks?.[0]?.message?.metadata?.referrer;
 
   if (!sections.length) {
-    return (
-      <AutofixEmptyState
-        autofix={autofix}
-        group={group}
-        project={project}
-        referrer={referrer}
-      />
-    );
+    return <AutofixEmptyState autofix={autofix} group={group} project={project} />;
   }
 
   return (
@@ -277,72 +265,23 @@ interface AutofixEmptyStateProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
   group: Group;
   project: Project;
-  referrer?: string;
 }
 
-function AutofixEmptyState({autofix, group, project, referrer}: AutofixEmptyStateProps) {
+function AutofixEmptyState({autofix, group, project}: AutofixEmptyStateProps) {
   const {openSeerDrawer} = useOpenSeerDrawer({
     group,
     project,
   });
 
-  // extract startStep first here so we can depend on it directly as `autofix` itself is unstable.
-  const startStep = autofix.startStep;
-
-  const [startingRun, setStartingRun] = useState(false);
-  const handleStartRootCause = async () => {
-    setStartingRun(true);
-    try {
-      await startStep('root_cause');
-    } catch {
-      return;
-    } finally {
-      setStartingRun(false);
-    }
-    openSeerDrawer();
-  };
+  const referrer = autofix.runState?.blocks?.[0]?.message?.metadata?.referrer;
 
   return (
-    <Flex direction="column" gap="md">
-      <Flex
-        border="muted"
-        radius="md"
-        padding="lg"
-        gap="lg"
-        align="center"
-        justify="between"
-      >
-        <Container>
-          <Text>{t('Have Seer...')}</Text>
-          <Container as="ol" margin="0">
-            <li>{t('Determine the root cause of your issue')}</li>
-            <li>{t('Outline a plan')}</li>
-            <li>{t('Create a code fix')}</li>
-          </Container>
-        </Container>
-        <ImageContainer
-          justify="end"
-          align="center"
-          aspectRatio="9 / 16"
-          height={{'2xs': '78px', lg: '98px'}}
-        >
-          <Image src={seerConfigConnectImg} alt="" width="auto" height="100%" />
-        </ImageContainer>
-      </Flex>
-      <Button
-        size="md"
-        icon={startingRun ? <LoadingIndicator size={16} /> : <IconBug />}
-        aria-label={t('Start Analysis')}
-        variant="primary"
-        onClick={handleStartRootCause}
-        analyticsEventKey="autofix.start_fix_clicked"
-        analyticsEventName="Autofix: Start Fix Clicked"
-        analyticsParams={{group_id: group.id, mode: 'explorer', referrer}}
-        disabled={startingRun}
-      >
-        {t('Start Analysis')}
-      </Button>
-    </Flex>
+    <AutofixStartCard
+      autofix={autofix}
+      group={group}
+      referrer={referrer}
+      onStarted={openSeerDrawer}
+    />
   );
 }
 
@@ -435,9 +374,3 @@ function AutofixPreviews({group, project, sections, referrer}: AutofixPreviewsPr
     </Flex>
   );
 }
-
-const ImageContainer = styled(Flex)<{
-  aspectRatio?: CSSProperties['aspectRatio'];
-}>`
-  ${p => p.aspectRatio && `aspect-ratio: ${p.aspectRatio}`};
-`;

--- a/static/app/views/issueList/pages/awaitingInput.spec.tsx
+++ b/static/app/views/issueList/pages/awaitingInput.spec.tsx
@@ -84,6 +84,14 @@ describe('AwaitingInputPage', () => {
       url: '/organizations/org-slug/replay-count/',
       body: {},
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/autofix/setup/`,
+      body: {
+        integration: {ok: false, reason: null},
+        billing: {hasAutofixQuota: false},
+        seerReposLinked: false,
+      },
+    });
 
     PageFiltersStore.onInitializeUrlState({
       projects: [parseInt(project.id, 10)],

--- a/static/app/views/issueList/pages/useIssuePreviewDrawer.spec.tsx
+++ b/static/app/views/issueList/pages/useIssuePreviewDrawer.spec.tsx
@@ -36,6 +36,14 @@ describe('useIssuePreviewDrawer', () => {
       url: '/organizations/org-slug/members/',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/42/autofix/setup/',
+      body: {
+        integration: {ok: false, reason: null},
+        billing: {hasAutofixQuota: false},
+        seerReposLinked: false,
+      },
+    });
   });
 
   it('sets the preview query param when opening a preview', async () => {


### PR DESCRIPTION
Closes ISWF-2877

This PR adds an "autofix" tab to the issue preview drawer. In order to reuse some of the existing autofix components I added some `export`s and extracted the start card into a new component for importing into the drawer.

There aren't any official designs for this tab yet, so things will change, but this is a minimal starting point.

<img width="1173" height="820" alt="CleanShot 2026-06-23 at 13 32 37" src="https://github.com/user-attachments/assets/b5a3f4f8-3090-49e7-8785-a812b06e03e0" />
