### PR TITLE
chore(seer-activity): Update the alert appearance

### DIFF
--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_base.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_base.py
@@ -5,7 +5,6 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.notifications.platform.types import (
-    BoldTextBlock,
     CodeTextBlock,
     NotificationBodyFormattingBlock,
     NotificationData,
@@ -65,21 +64,24 @@ def extract_models(
     return activity, group, project, organization
 
 
-def get_issue_description(group: Group) -> ParagraphBlock:
-    from sentry.api.serializers.models.group import get_status_label, get_substatus_label
+def get_issue_description(group: Group) -> list[NotificationBodyFormattingBlock]:
+    from sentry.integrations.messaging.message_builder import build_attachment_title
 
-    status_text = get_substatus_label(group) or get_status_label(group)
-    return ParagraphBlock(
-        blocks=[
-            PlainTextBlock(text="This update pertains to the"),
-            CodeTextBlock(text=group.title),
-            PlainTextBlock(text="issue"),
-            CodeTextBlock(text=group.qualified_short_id),
-            PlainTextBlock(text=f"in the '{group.project.name}' project. The issue is"),
-            BoldTextBlock(text=status_text),
-            PlainTextBlock(text=f"and has been seen {group.times_seen} time(s)."),
-        ]
-    )
+    blocks = []
+    title = build_attachment_title(group)
+    if title:
+        blocks.append(PlainTextBlock(text=title))
+    culprit = group.culprit
+    if culprit:
+        if blocks:
+            blocks.append(PlainTextBlock(text="—"))
+        blocks.append(CodeTextBlock(text=culprit))
+    return [ParagraphBlock(blocks=blocks)]
+
+
+def get_subject(label: str, group: Group) -> str:
+    short_id = group.qualified_short_id or "unknown"
+    return f"{label} for {short_id}"
 
 
 def get_seer_link(group: Group) -> str:
@@ -111,18 +113,16 @@ def build_template(
     )
 
 
-def get_example_issue_description() -> ParagraphBlock:
-    return ParagraphBlock(
-        blocks=[
-            PlainTextBlock(text="This update pertains to the"),
-            CodeTextBlock(text="ExampleError: something went wrong"),
-            PlainTextBlock(text="issue"),
-            CodeTextBlock(text="EXAMPLE-1"),
-            PlainTextBlock(text="in the 'example' project. The issue is"),
-            BoldTextBlock(text="Unresolved"),
-            PlainTextBlock(text="and has been seen 42 time(s)."),
-        ]
-    )
+def get_example_issue_description() -> list[NotificationBodyFormattingBlock]:
+    return [
+        ParagraphBlock(
+            blocks=[
+                PlainTextBlock(text="ExampleError: something went wrong"),
+                PlainTextBlock(text="—"),
+                CodeTextBlock(text="example.module.function"),
+            ]
+        ),
+    ]
 
 
 def get_example_actions() -> list[NotificationRenderedAction]:
@@ -139,7 +139,7 @@ def get_example_template(
 ) -> NotificationRenderedTemplate:
     return NotificationRenderedTemplate(
         subject=subject,
-        body=body if body is not None else [get_example_issue_description()],
+        body=body if body is not None else get_example_issue_description(),
         actions=actions if actions is not None else get_example_actions(),
         footer=EXAMPLE_FOOTER,
     )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_base.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_base.py
@@ -7,6 +7,7 @@ from sentry.models.project import Project
 from sentry.notifications.platform.types import (
     CodeTextBlock,
     NotificationBodyFormattingBlock,
+    NotificationBodyTextBlock,
     NotificationData,
     NotificationRenderedAction,
     NotificationRenderedTemplate,
@@ -67,7 +68,7 @@ def extract_models(
 def get_issue_description(group: Group) -> list[NotificationBodyFormattingBlock]:
     from sentry.integrations.messaging.message_builder import build_attachment_title
 
-    blocks = []
+    blocks: list[NotificationBodyTextBlock] = []
     title = build_attachment_title(group)
     if title:
         blocks.append(PlainTextBlock(text=title))
@@ -84,8 +85,9 @@ def get_subject(label: str, group: Group) -> str:
     return f"{label} for {short_id}"
 
 
-def get_seer_link(group: Group) -> str:
-    return f"{absolute_uri(group.get_absolute_url())}?seerDrawer=true"
+def get_view_in_sentry_button(group: Group) -> NotificationRenderedAction:
+    link = f"{absolute_uri(group.get_absolute_url())}?seerDrawer=true"
+    return NotificationRenderedAction(label="View in Sentry", link=link)
 
 
 def build_template(

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_completed.py
@@ -5,12 +5,11 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     extract_models,
     get_example_template,
     get_issue_description,
-    get_seer_link,
     get_subject,
+    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
-    NotificationRenderedAction,
     NotificationRenderedTemplate,
     NotificationSource,
     NotificationTemplate,
@@ -39,7 +38,5 @@ class SeerCodingCompletedActivityTemplate(NotificationTemplate[WorkflowEngineAct
             data=data,
             subject=get_subject("Seer Coding Completed", group),
             body=get_issue_description(group),
-            extra_actions=[
-                NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
-            ],
+            extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_completed.py
@@ -3,10 +3,10 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     WorkflowEngineActivityAction,
     build_template,
     extract_models,
-    get_example_issue_description,
     get_example_template,
     get_issue_description,
     get_seer_link,
+    get_subject,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
@@ -14,8 +14,6 @@ from sentry.notifications.platform.types import (
     NotificationRenderedTemplate,
     NotificationSource,
     NotificationTemplate,
-    ParagraphBlock,
-    PlainTextBlock,
 )
 from sentry.types.activity import ActivityType
 
@@ -33,27 +31,14 @@ class SeerCodingCompletedActivityTemplate(NotificationTemplate[WorkflowEngineAct
     )
 
     def render_example(self) -> NotificationRenderedTemplate:
-        return get_example_template(
-            subject="Seer's code changes are prepared",
-            body=[
-                ParagraphBlock(
-                    blocks=[
-                        PlainTextBlock(
-                            text="You can check out the Seer's suggested diff in Sentry."
-                        )
-                    ]
-                ),
-                get_example_issue_description(),
-            ],
-        )
+        return get_example_template("Seer Coding Completed for EXAMPLE-1")
 
     def render(self, data: WorkflowEngineActivityAction) -> NotificationRenderedTemplate:
         activity, group, project, organization = extract_models(data)
-        text_block = PlainTextBlock(text="You can check out the Seer's suggested diff in Sentry.")
         return build_template(
             data=data,
-            subject="Seer's code changes are prepared",
-            body=[ParagraphBlock(blocks=[text_block]), get_issue_description(group)],
+            subject=get_subject("Seer Coding Completed", group),
+            body=get_issue_description(group),
             extra_actions=[
                 NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
             ],

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_started.py
@@ -6,6 +6,7 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_seer_link,
+    get_subject,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
@@ -30,14 +31,14 @@ class SeerCodingStartedActivityTemplate(NotificationTemplate[WorkflowEngineActiv
     )
 
     def render_example(self) -> NotificationRenderedTemplate:
-        return get_example_template("Seer is writing code changes...")
+        return get_example_template("Seer Coding Started for EXAMPLE-1")
 
     def render(self, data: WorkflowEngineActivityAction) -> NotificationRenderedTemplate:
         activity, group, project, organization = extract_models(data)
         return build_template(
             data=data,
-            subject="Seer is writing code changes...",
-            body=[get_issue_description(group)],
+            subject=get_subject("Seer Coding Started", group),
+            body=get_issue_description(group),
             extra_actions=[
                 NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
             ],

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_started.py
@@ -5,12 +5,11 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     extract_models,
     get_example_template,
     get_issue_description,
-    get_seer_link,
     get_subject,
+    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
-    NotificationRenderedAction,
     NotificationRenderedTemplate,
     NotificationSource,
     NotificationTemplate,
@@ -39,7 +38,5 @@ class SeerCodingStartedActivityTemplate(NotificationTemplate[WorkflowEngineActiv
             data=data,
             subject=get_subject("Seer Coding Started", group),
             body=get_issue_description(group),
-            extra_actions=[
-                NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
-            ],
+            extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_pr_created.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_pr_created.py
@@ -3,21 +3,22 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     WorkflowEngineActivityAction,
     build_template,
     extract_models,
-    get_example_actions,
     get_example_issue_description,
     get_example_template,
     get_issue_description,
     get_seer_link,
+    get_subject,
 )
 from sentry.notifications.platform.types import (
-    BoldTextBlock,
+    LinkTextBlock,
+    NotificationBodyFormattingBlock,
+    NotificationBodyTextBlock,
     NotificationCategory,
     NotificationRenderedAction,
     NotificationRenderedTemplate,
     NotificationSource,
     NotificationTemplate,
     ParagraphBlock,
-    PlainTextBlock,
 )
 from sentry.types.activity import ActivityType
 
@@ -36,61 +37,41 @@ class SeerPrCreatedActivityTemplate(NotificationTemplate[WorkflowEngineActivityA
 
     def render_example(self) -> NotificationRenderedTemplate:
         return get_example_template(
-            subject="Seer has created a pull request",
+            subject="Seer PR Created for EXAMPLE-1",
             body=[
+                *get_example_issue_description(),
                 ParagraphBlock(
                     blocks=[
-                        PlainTextBlock(
-                            text="The pull request(s) were created for the following repositories: "
+                        LinkTextBlock(
+                            text="getsentry/sentry (#1234)",
+                            url="https://github.com/getsentry/sentry/pull/1234",
                         ),
-                        BoldTextBlock(text="getsentry/sentry"),
                     ]
-                ),
-                get_example_issue_description(),
-            ],
-            actions=[
-                *get_example_actions(),
-                NotificationRenderedAction(
-                    label="View PR (#1234)",
-                    link="https://github.com/getsentry/sentry/pull/1234",
                 ),
             ],
         )
 
     def render(self, data: WorkflowEngineActivityAction) -> NotificationRenderedTemplate:
         activity, group, project, organization = extract_models(data)
-        seer_link = get_seer_link(group)
 
-        extra_actions = [NotificationRenderedAction(label="View in Sentry", link=seer_link)]
-        repos: set[str] = set()
+        pr_links: list[NotificationBodyTextBlock] = []
         for pull_request in activity.data.get("pull_requests", []):
-            repo_name = pull_request.get("repo_name")
-            if repo_name:
-                repos.add(repo_name)
+            repo_name = pull_request.get("repo_name", "")
             pr_url = pull_request.get("pull_request", {}).get("pr_url")
             pr_number = pull_request.get("pull_request", {}).get("pr_number")
-            label = f"View PR (#{pr_number})" if pr_number else "View PR"
             if pr_url:
-                extra_actions.append(NotificationRenderedAction(label=label, link=pr_url))
+                label = f"{repo_name} (#{pr_number})" if pr_number else repo_name
+                pr_links.append(LinkTextBlock(text=label, url=pr_url))
 
-        subject = (
-            "Seer has created a pull request"
-            if len(extra_actions) <= 2
-            else "Seer has created some pull requests"
-        )
-
-        repo_body = ParagraphBlock(
-            blocks=[
-                PlainTextBlock(
-                    text="The pull request(s) were created for the following repositories: "
-                ),
-                *[BoldTextBlock(text=repo) for repo in repos],
-            ]
-        )
+        body: list[NotificationBodyFormattingBlock] = [*get_issue_description(group)]
+        if pr_links:
+            body.append(ParagraphBlock(blocks=pr_links))
 
         return build_template(
             data=data,
-            subject=subject,
-            body=[repo_body, get_issue_description(group)],
-            extra_actions=extra_actions,
+            subject=get_subject("Seer PR Created", group),
+            body=body,
+            extra_actions=[
+                NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
+            ],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_pr_created.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_pr_created.py
@@ -6,15 +6,14 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_issue_description,
     get_example_template,
     get_issue_description,
-    get_seer_link,
     get_subject,
+    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     LinkTextBlock,
     NotificationBodyFormattingBlock,
     NotificationBodyTextBlock,
     NotificationCategory,
-    NotificationRenderedAction,
     NotificationRenderedTemplate,
     NotificationSource,
     NotificationTemplate,
@@ -55,13 +54,14 @@ class SeerPrCreatedActivityTemplate(NotificationTemplate[WorkflowEngineActivityA
         activity, group, project, organization = extract_models(data)
 
         pr_links: list[NotificationBodyTextBlock] = []
-        for pull_request in activity.data.get("pull_requests", []):
-            repo_name = pull_request.get("repo_name", "")
-            pr_url = pull_request.get("pull_request", {}).get("pr_url")
-            pr_number = pull_request.get("pull_request", {}).get("pr_number")
-            if pr_url:
-                label = f"{repo_name} (#{pr_number})" if pr_number else repo_name
-                pr_links.append(LinkTextBlock(text=label, url=pr_url))
+        if activity.data:
+            for pull_request in activity.data.get("pull_requests", []):
+                repo_name = pull_request.get("repo_name", "")
+                pr_url = pull_request.get("pull_request", {}).get("pr_url")
+                pr_number = pull_request.get("pull_request", {}).get("pr_number")
+                if pr_url:
+                    label = f"{repo_name} (#{pr_number})" if pr_number else repo_name
+                    pr_links.append(LinkTextBlock(text=label, url=pr_url))
 
         body: list[NotificationBodyFormattingBlock] = [*get_issue_description(group)]
         if pr_links:
@@ -71,7 +71,5 @@ class SeerPrCreatedActivityTemplate(NotificationTemplate[WorkflowEngineActivityA
             data=data,
             subject=get_subject("Seer PR Created", group),
             body=body,
-            extra_actions=[
-                NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
-            ],
+            extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_completed.py
@@ -7,6 +7,7 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_seer_link,
+    get_subject,
 )
 from sentry.notifications.platform.types import (
     CodeBlock,
@@ -34,8 +35,9 @@ class SeerRcaCompletedActivityTemplate(NotificationTemplate[WorkflowEngineActivi
 
     def render_example(self) -> NotificationRenderedTemplate:
         return get_example_template(
-            subject="Seer found the root cause",
+            subject="Seer RCA Completed for EXAMPLE-1",
             body=[
+                *get_example_issue_description(),
                 CodeBlock(
                     blocks=[
                         PlainTextBlock(
@@ -43,18 +45,17 @@ class SeerRcaCompletedActivityTemplate(NotificationTemplate[WorkflowEngineActivi
                         )
                     ]
                 ),
-                get_example_issue_description(),
             ],
         )
 
     def render(self, data: WorkflowEngineActivityAction) -> NotificationRenderedTemplate:
         activity, group, project, organization = extract_models(data)
-        fallback = "Click the link below to view the details in Sentry"
+        fallback = "View the details in Sentry."
         summary_block = PlainTextBlock(text=activity.data.get("summary", fallback))
         return build_template(
             data=data,
-            subject="Seer found the root cause",
-            body=[CodeBlock(blocks=[summary_block]), get_issue_description(group)],
+            subject=get_subject("Seer RCA Completed", group),
+            body=[*get_issue_description(group), CodeBlock(blocks=[summary_block])],
             extra_actions=[
                 NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
             ],

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_completed.py
@@ -6,13 +6,13 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_issue_description,
     get_example_template,
     get_issue_description,
-    get_seer_link,
     get_subject,
+    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     CodeBlock,
+    NotificationBodyFormattingBlock,
     NotificationCategory,
-    NotificationRenderedAction,
     NotificationRenderedTemplate,
     NotificationSource,
     NotificationTemplate,
@@ -51,12 +51,15 @@ class SeerRcaCompletedActivityTemplate(NotificationTemplate[WorkflowEngineActivi
     def render(self, data: WorkflowEngineActivityAction) -> NotificationRenderedTemplate:
         activity, group, project, organization = extract_models(data)
         fallback = "View the details in Sentry."
-        summary_block = PlainTextBlock(text=activity.data.get("summary", fallback))
+        body: list[NotificationBodyFormattingBlock] = [
+            *get_issue_description(group),
+        ]
+        if activity.data:
+            summary_block = PlainTextBlock(text=activity.data.get("summary", fallback))
+            body.append(CodeBlock(blocks=[summary_block]))
         return build_template(
             data=data,
             subject=get_subject("Seer RCA Completed", group),
-            body=[*get_issue_description(group), CodeBlock(blocks=[summary_block])],
-            extra_actions=[
-                NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
-            ],
+            body=body,
+            extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_started.py
@@ -5,12 +5,11 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     extract_models,
     get_example_template,
     get_issue_description,
-    get_seer_link,
     get_subject,
+    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
-    NotificationRenderedAction,
     NotificationRenderedTemplate,
     NotificationSource,
     NotificationTemplate,
@@ -39,7 +38,5 @@ class SeerRcaStartedActivityTemplate(NotificationTemplate[WorkflowEngineActivity
             data=data,
             subject=get_subject("Seer RCA Started", group),
             body=get_issue_description(group),
-            extra_actions=[
-                NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
-            ],
+            extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_started.py
@@ -6,6 +6,7 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_seer_link,
+    get_subject,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
@@ -30,14 +31,14 @@ class SeerRcaStartedActivityTemplate(NotificationTemplate[WorkflowEngineActivity
     )
 
     def render_example(self) -> NotificationRenderedTemplate:
-        return get_example_template("Seer is searching for the root cause...")
+        return get_example_template("Seer RCA Started for EXAMPLE-1")
 
     def render(self, data: WorkflowEngineActivityAction) -> NotificationRenderedTemplate:
         activity, group, project, organization = extract_models(data)
         return build_template(
             data=data,
-            subject="Seer is searching for the root cause...",
-            body=[get_issue_description(group)],
+            subject=get_subject("Seer RCA Started", group),
+            body=get_issue_description(group),
             extra_actions=[
                 NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
             ],

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_completed.py
@@ -6,13 +6,13 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_issue_description,
     get_example_template,
     get_issue_description,
-    get_seer_link,
     get_subject,
+    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     CodeBlock,
+    NotificationBodyFormattingBlock,
     NotificationCategory,
-    NotificationRenderedAction,
     NotificationRenderedTemplate,
     NotificationSource,
     NotificationTemplate,
@@ -51,12 +51,15 @@ class SeerSolutionCompletedActivityTemplate(NotificationTemplate[WorkflowEngineA
     def render(self, data: WorkflowEngineActivityAction) -> NotificationRenderedTemplate:
         activity, group, project, organization = extract_models(data)
         fallback = "View the details in Sentry."
-        summary_block = PlainTextBlock(text=activity.data.get("summary", fallback))
+        body: list[NotificationBodyFormattingBlock] = [
+            *get_issue_description(group),
+        ]
+        if activity.data:
+            summary_block = PlainTextBlock(text=activity.data.get("summary", fallback))
+            body.append(CodeBlock(blocks=[summary_block]))
         return build_template(
             data=data,
             subject=get_subject("Seer Solution Completed", group),
-            body=[*get_issue_description(group), CodeBlock(blocks=[summary_block])],
-            extra_actions=[
-                NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
-            ],
+            body=body,
+            extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_completed.py
@@ -7,6 +7,7 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_seer_link,
+    get_subject,
 )
 from sentry.notifications.platform.types import (
     CodeBlock,
@@ -34,8 +35,9 @@ class SeerSolutionCompletedActivityTemplate(NotificationTemplate[WorkflowEngineA
 
     def render_example(self) -> NotificationRenderedTemplate:
         return get_example_template(
-            subject="Seer has prepared a plan",
+            subject="Seer Solution Completed for EXAMPLE-1",
             body=[
+                *get_example_issue_description(),
                 CodeBlock(
                     blocks=[
                         PlainTextBlock(
@@ -43,18 +45,17 @@ class SeerSolutionCompletedActivityTemplate(NotificationTemplate[WorkflowEngineA
                         )
                     ]
                 ),
-                get_example_issue_description(),
             ],
         )
 
     def render(self, data: WorkflowEngineActivityAction) -> NotificationRenderedTemplate:
         activity, group, project, organization = extract_models(data)
-        fallback = "Click the link below to view the details in Sentry"
+        fallback = "View the details in Sentry."
         summary_block = PlainTextBlock(text=activity.data.get("summary", fallback))
         return build_template(
             data=data,
-            subject="Seer has prepared a plan",
-            body=[CodeBlock(blocks=[summary_block]), get_issue_description(group)],
+            subject=get_subject("Seer Solution Completed", group),
+            body=[*get_issue_description(group), CodeBlock(blocks=[summary_block])],
             extra_actions=[
                 NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
             ],

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_started.py
@@ -6,6 +6,7 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_seer_link,
+    get_subject,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
@@ -30,14 +31,14 @@ class SeerSolutionStartedActivityTemplate(NotificationTemplate[WorkflowEngineAct
     )
 
     def render_example(self) -> NotificationRenderedTemplate:
-        return get_example_template("Seer is working on a plan...")
+        return get_example_template("Seer Solution Started for EXAMPLE-1")
 
     def render(self, data: WorkflowEngineActivityAction) -> NotificationRenderedTemplate:
         activity, group, project, organization = extract_models(data)
         return build_template(
             data=data,
-            subject="Seer is working on a plan...",
-            body=[get_issue_description(group)],
+            subject=get_subject("Seer Solution Started", group),
+            body=get_issue_description(group),
             extra_actions=[
                 NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
             ],

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_started.py
@@ -5,12 +5,11 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     extract_models,
     get_example_template,
     get_issue_description,
-    get_seer_link,
     get_subject,
+    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
-    NotificationRenderedAction,
     NotificationRenderedTemplate,
     NotificationSource,
     NotificationTemplate,
@@ -39,7 +38,5 @@ class SeerSolutionStartedActivityTemplate(NotificationTemplate[WorkflowEngineAct
             data=data,
             subject=get_subject("Seer Solution Started", group),
             body=get_issue_description(group),
-            extra_actions=[
-                NotificationRenderedAction(label="View in Sentry", link=get_seer_link(group))
-            ],
+            extra_actions=[get_view_in_sentry_button(group)],
         )


### PR DESCRIPTION
Updates the appearance of seer activity alerts. The body text is much shorter, only showing the title and culprit. Then has extra content if the activity has any (e.g. PRs, RCA, Solution, etc)

<img width="628" height="499" alt="image" src="https://github.com/user-attachments/assets/6a218463-54a3-4d13-96c7-0e31fdca7e87" />
