### PR TITLE
chore(weekly-report): Add padding to issue status legend

### DIFF
--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -162,6 +162,10 @@
         text-align: center !important;
       }
 
+      .legend-inbox {
+        text-align: center !important;
+      }
+
       #events-by-issue-type .quantity {
         display: none;
       }

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -42,6 +42,7 @@
     .legend-inbox {
       font-size: 12px;
       text-align: right;
+      padding-bottom: 8px;
     }
     .legend-inbox span.swatch {
       width: 14px;


### PR DESCRIPTION
Problem statement: Issue status bar legend overlaps with the status bar on mobile devices

Before: 
<img width="786" height="148" alt="image" src="https://github.com/user-attachments/assets/23bb0186-3507-4098-97ea-11ba4139c89c" />

After:
<img width="782" height="180" alt="image" src="https://github.com/user-attachments/assets/7c7c0970-c5a5-4f64-bede-d4869e0a3f64" />

