### PR TITLE
ref(project-creation): Drop the inert motion wrapper from the SCM connect step

### DIFF
--- a/static/app/views/onboarding/components/scmIntegrationConnect.tsx
+++ b/static/app/views/onboarding/components/scmIntegrationConnect.tsx
@@ -1,5 +1,4 @@
 import {useCallback, useEffect, useRef} from 'react';
-import {motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack, type StackProps} from '@sentry/scraps/layout';
@@ -184,7 +183,7 @@ export function ScmIntegrationConnect({
   }
 
   return effectiveIntegration ? (
-    <MotionStack
+    <Stack
       key="with-integration"
       gap="md"
       width="100%"
@@ -221,12 +220,10 @@ export function ScmIntegrationConnect({
           />
         ) : null}
       </Flex>
-    </MotionStack>
+    </Stack>
   ) : (
-    <MotionStack key="without-integration" gap="2xl" width="100%" maxWidth={maxWidth}>
+    <Stack key="without-integration" gap="2xl" width="100%" maxWidth={maxWidth}>
       <ScmProviderPills providers={scmProviders} onInstall={handleInstall} />
-    </MotionStack>
+    </Stack>
   );
 }
-
-const MotionStack = motion.create(Stack);


### PR DESCRIPTION
## TLDR

Revert ScmIntegrationConnect's no-op motion wrapper to a plain Stack. It carried no animation props so nothing changes visually, and this drops an unused framer-motion import.

## Details

The connected and not-connected branches rendered a `motion.create(Stack)` with only a key and no `layout`, `initial`, `animate`, or `exit`, and there is no `AnimatePresence` around them, so the wrapper produced no animation and behaved as a plain `Stack`. As the first element in its `LayoutGroup` in both hosts nothing above shifts it, so it never needed `layout="position"` either. This reverts it to `Stack` (keeping the keys) and removes the now-unused `framer-motion` import.
