### PR TITLE
ref(project-creation): Allow clearing the SCM platform selection

### DIFF
--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
@@ -1,6 +1,8 @@
+import {DetectedPlatformFixture} from 'sentry-fixture/detectedPlatform';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {RepositoryFixture} from 'sentry-fixture/repository';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import * as analytics from 'sentry/utils/analytics';
@@ -95,5 +97,56 @@ describe('ScmPlatformFeaturesCore', () => {
       'onboarding.scm_platform_features_step_viewed',
       expect.anything()
     );
+  });
+
+  it('clears the selected platform from the manual picker', async () => {
+    const onPlatformChange = jest.fn();
+    const onFeaturesChange = jest.fn();
+    const onClearProjectDetailsForm = jest.fn();
+    render(
+      <ScmPlatformFeaturesCore
+        {...defaultProps({
+          onPlatformChange,
+          onFeaturesChange,
+          onClearProjectDetailsForm,
+        })}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(await screen.findByTestId('icon-close'));
+
+    expect(onPlatformChange).toHaveBeenCalledWith(undefined);
+    expect(onFeaturesChange).toHaveBeenCalledWith(undefined);
+    expect(onClearProjectDetailsForm).toHaveBeenCalled();
+  });
+
+  it('does not offer a clear button when a platform was auto-detected', async () => {
+    const repository = RepositoryFixture({
+      id: '123',
+      provider: {id: 'integrations:github', name: 'GitHub'},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/${repository.id}/platforms/`,
+      body: {platforms: [DetectedPlatformFixture({platform: 'python'})]},
+    });
+
+    render(
+      <ScmPlatformFeaturesCore {...defaultProps({selectedRepository: repository})} />,
+      {organization}
+    );
+
+    // Detection resolves to the auto-detected view; switch into the manual picker.
+    await userEvent.click(
+      await screen.findByRole('button', {name: "Doesn't look right? Change platform"})
+    );
+
+    // The manual picker is showing (with a route back to the recommendation),
+    // but the clear control is suppressed: clearing would desync the picker from
+    // the detected fallback.
+    expect(
+      screen.getByRole('button', {name: 'Back to recommended platforms'})
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('icon-close')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -159,6 +159,20 @@ export function ScmPlatformFeaturesCore({
     onClearProjectDetailsForm();
   };
 
+  // Inverse of a platform selection: drop the platform and everything derived
+  // from it (the default features and the platform-seeded project name).
+  // Mirrors the repo selector's clearable Select. Only offered when there is no
+  // detected platform to fall back to (see the Select's clearable below):
+  // otherwise currentPlatformKey would keep showing the detected key while the
+  // committed selectedPlatform went empty, desyncing the picker from the form
+  // and stranding Create behind a "select a platform" tooltip. Reverting to a
+  // detected platform is handled by "Back to recommended platforms" instead.
+  const handleClearPlatform = () => {
+    onPlatformChange(undefined);
+    onFeaturesChange(undefined);
+    onClearProjectDetailsForm();
+  };
+
   const handleManualPlatformSelect = async (option: {value: string}) => {
     const platformKey = option.value as PlatformKey;
     if (platformKey === selectedPlatform?.key) {
@@ -263,6 +277,16 @@ export function ScmPlatformFeaturesCore({
       onClearProjectDetailsForm();
     }
   }
+
+  // Shared by both manual-picker variants. A null option is the clear action,
+  // which is only reachable from the clearable variant (no detected fallback).
+  const handleManualPickerChange = (option: (typeof platformOptions)[number] | null) => {
+    if (option) {
+      handleManualPlatformSelect(option);
+    } else {
+      handleClearPlatform();
+    }
+  };
 
   // Ensure the selected platform is always present in the dropdown options
   // so the Select can resolve and display it. When the framework suggestion
@@ -375,22 +399,36 @@ export function ScmPlatformFeaturesCore({
           </Button>
         )}
       </Flex>
-      <Select<(typeof platformOptions)[number]>
-        placeholder={t('Search SDKs...')}
-        options={manualPickerOptions}
-        value={currentPlatformKey ?? null}
-        onChange={option => {
-          if (option) {
-            handleManualPlatformSelect(option);
-          }
-        }}
-        searchable
-        components={{
-          Control: ScmSearchControl,
-          MenuList: ScmVirtualizedMenuList,
-        }}
-        styles={{container: base => ({...base, width: '100%'})}}
-      />
+      {/* Two literal variants instead of clearable={!detectedPlatformKey}: the
+          core Select types `clearable` as a discriminated-union literal (`?: false`
+          vs `: true`, which also selects the onChange signature), so a dynamic
+          boolean is not assignable and will not typecheck. Each branch passes a
+          literal. Clear is only offered when no platform was detected: a detected
+          one re-resolves into currentPlatformKey, so clearing would leave the
+          picker (and the feature panel) showing it while the committed selection
+          is empty. "Back to recommended platforms" covers reverting. */}
+      {detectedPlatformKey ? (
+        <Select<(typeof platformOptions)[number]>
+          placeholder={t('Search SDKs...')}
+          options={manualPickerOptions}
+          value={currentPlatformKey ?? null}
+          onChange={handleManualPickerChange}
+          searchable
+          components={{Control: ScmSearchControl, MenuList: ScmVirtualizedMenuList}}
+          styles={{container: base => ({...base, width: '100%'})}}
+        />
+      ) : (
+        <Select<(typeof platformOptions)[number]>
+          placeholder={t('Search SDKs...')}
+          options={manualPickerOptions}
+          value={currentPlatformKey ?? null}
+          onChange={handleManualPickerChange}
+          clearable
+          searchable
+          components={{Control: ScmSearchControl, MenuList: ScmVirtualizedMenuList}}
+          styles={{container: base => ({...base, width: '100%'})}}
+        />
+      )}
     </MotionStack>
   );
 }

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -168,6 +168,11 @@ export function ScmPlatformFeaturesCore({
   // and stranding Create behind a "select a platform" tooltip. Reverting to a
   // detected platform is handled by "Back to recommended platforms" instead.
   const handleClearPlatform = () => {
+    // Treat the clear as resolving auto-adoption for this repo, so a detection
+    // request that finishes *after* an explicit clear (reachable via "Skip
+    // detection and select manually" while detection is still pending) does not
+    // re-adopt the detected platform and silently undo the clear.
+    autoDetectionTrackedRef.current = true;
     onPlatformChange(undefined);
     onFeaturesChange(undefined);
     onClearProjectDetailsForm();


### PR DESCRIPTION
## TLDR

Make the manual platform picker clearable, mirroring the repo selector.

## Details

The manual platform Select now sets `clearable` and routes a null change to a new `handleClearPlatform`, which drops the platform and the state derived from it (the default features and the platform-seeded project name), the inverse of a selection.

Clear is only offered when no detected platform would fall back into the picker. With a connected repo whose platform was auto-detected, `currentPlatformKey` re-resolves from the detection while the committed selection is empty, which would desync the picker from the form and strand Create behind a "select a platform" tooltip. The picker omits clear in that case, and "Back to recommended platforms" covers reverting. Specs cover both the clear path (no detection) and the suppressed-clear path (detection present).
