### PR TITLE
fix(dashboards): Keep legend breakdown when group by changes

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -1780,6 +1780,65 @@ describe('useWidgetBuilderState', () => {
 
       expect(result.current.state.limit).toBe(5);
     });
+
+    it('preserves the breakdown legend type when a group by is removed', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            displayType: DisplayType.LINE,
+            field: ['testField', 'testField2'],
+            yAxis: ['count()'],
+            legendType: 'breakdown',
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.legendType).toBe('breakdown');
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_FIELDS,
+          payload: [{field: 'testField', kind: FieldValueKind.FIELD}],
+        });
+      });
+
+      expect(result.current.state.legendType).toBe('breakdown');
+    });
+
+    it('preserves the breakdown legend type when there are multiple group bys', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            displayType: DisplayType.LINE,
+            field: ['testField'],
+            yAxis: ['count()'],
+            legendType: 'breakdown',
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.legendType).toBe('breakdown');
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_FIELDS,
+          payload: [
+            {field: 'testField', kind: FieldValueKind.FIELD},
+            {field: 'testField2', kind: FieldValueKind.FIELD},
+          ],
+        });
+      });
+
+      expect(result.current.state.legendType).toBe('breakdown');
+    });
   });
 
   describe('yAxis', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -1781,34 +1781,6 @@ describe('useWidgetBuilderState', () => {
       expect(result.current.state.limit).toBe(5);
     });
 
-    it('preserves the breakdown legend type when a group by is removed', () => {
-      mockedUsedLocation.mockReturnValue(
-        LocationFixture({
-          query: {
-            displayType: DisplayType.LINE,
-            field: ['testField', 'testField2'],
-            yAxis: ['count()'],
-            legendType: 'breakdown',
-          },
-        })
-      );
-
-      const {result} = renderHook(() => useWidgetBuilderState(), {
-        wrapper: WidgetBuilderProvider,
-      });
-
-      expect(result.current.state.legendType).toBe('breakdown');
-
-      act(() => {
-        result.current.dispatch({
-          type: BuilderStateAction.SET_FIELDS,
-          payload: [{field: 'testField', kind: FieldValueKind.FIELD}],
-        });
-      });
-
-      expect(result.current.state.legendType).toBe('breakdown');
-    });
-
     it('preserves the breakdown legend type when there are multiple group bys', () => {
       mockedUsedLocation.mockReturnValue(
         LocationFixture({

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -915,11 +915,6 @@ export function useWidgetBuilderState(): {
               options
             );
           }
-
-          // Reset legend breakdown when more than one column is selected
-          if (action.payload.length > 1 && legendType === 'breakdown') {
-            setLegendType(undefined, options);
-          }
           break;
         }
         case BuilderStateAction.SET_Y_AXIS: {


### PR DESCRIPTION
Removing, adding, or editing a group-by field in the widget editor unchecks the "Show legend breakdown" option! This was previously intentional because the "Breakdown" legend type didn't support multiple group-by, but now it does as of [#111245](https://github.com/getsentry/sentry/pull/111245), so we don't have that limitation anymore.

Closes [DAIN-1724](https://linear.app/getsentry/issue/DAIN-1724/removing-group-by-disables-show-legend-breakdown)