### PR TITLE
fix(search): keep fuzzy value suggestions populated on empty result (LOGS-876)

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2419,6 +2419,42 @@ describe('SearchQueryBuilder', () => {
       expect(within(option).getByText('1.2K')).toBeInTheDocument();
     });
 
+    it('keeps fuzzy value suggestions when the search resolves to an empty result', async () => {
+      // Server-side value search: returns the real value while the typed text is a
+      // prefix of it, but nothing once the text becomes a typo ("api.acess").
+      const mockGetTagValues = jest.fn(({searchQuery}: {searchQuery: string}) =>
+        Promise.resolve(
+          'api.access'.includes(searchQuery) ? [{value: 'api.access', count: 3300}] : []
+        )
+      );
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="custom_tag_name:"
+          getTagValues={mockGetTagValues}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit value for filter: custom_tag_name'})
+      );
+
+      // Prefix "api.ac" matches -> suggestion shows.
+      await userEvent.type(screen.getByRole('combobox'), 'api.ac');
+      expect(await screen.findByRole('option', {name: /api\.access/})).toBeInTheDocument();
+
+      // Continuing into the typo "api.acess" makes the server return nothing. The
+      // near-match should survive as a fuzzy suggestion rather than disappearing.
+      await userEvent.type(screen.getByRole('combobox'), 'ess');
+
+      await waitFor(() => {
+        expect(mockGetTagValues).toHaveBeenCalledWith(
+          expect.objectContaining({searchQuery: 'api.acess'})
+        );
+      });
+      expect(screen.getByRole('option', {name: /api\.access/})).toBeInTheDocument();
+    });
+
     it('unescapes asterisks before fetching tag value suggestions', async () => {
       const mockGetTagValues = jest.fn().mockResolvedValue([]);
       render(

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -455,6 +455,17 @@ function useFilterSuggestions({
     enabled: shouldFetchTagKeys,
   });
 
+  // Retain the last non-empty value response. The server filters values by the
+  // typed text, so a typo (e.g. "api.acess") makes it return nothing and the
+  // suggestions vanish. We keep the previous results around to fall back to fuzzy
+  // near-matches once the active search resolves to an empty list (LOGS-876).
+  const lastNonEmptyValuesRef = useRef<typeof data>(undefined);
+  useEffect(() => {
+    if (shouldFetchValues && data && data.length > 0) {
+      lastNonEmptyValuesRef.current = data;
+    }
+  }, [data, shouldFetchValues]);
+
   const createItem = useCallback(
     (suggestion: SuggestionItem) => {
       const label = suggestion.label ?? suggestion.value;
@@ -509,7 +520,7 @@ function useFilterSuggestions({
         })) ?? [];
       groups = [{sectionText: '', suggestions}];
     } else if (shouldFetchValues) {
-      const suggestions = data?.map(item => {
+      const toSuggestion = (item: string | {value: string; count?: number}) => {
         const value = typeof item === 'string' ? item : item.value;
         const count = typeof item === 'string' ? undefined : item.count;
         return {
@@ -524,9 +535,19 @@ function useFilterSuggestions({
               </DeviceName>
             ) : undefined,
         };
-      });
+      };
 
-      groups = [{sectionText: '', suggestions: suggestions ?? []}];
+      let suggestions = data?.map(toSuggestion) ?? [];
+
+      // Fall back to fuzzy near-matches from the last non-empty response.
+      if (suggestions.length === 0 && filterValue && lastNonEmptyValuesRef.current?.length) {
+        const query = filterValue.trim().toLowerCase();
+        suggestions = lastNonEmptyValuesRef.current
+          .map(toSuggestion)
+          .filter(suggestion => fzf(suggestion.value, query, false).end !== -1);
+      }
+
+      groups = [{sectionText: '', suggestions}];
     } else {
       groups = predefinedValues ?? [];
     }


### PR DESCRIPTION
Closes LOGS-876. Replaces #117953, which targeted the wrong mechanism.

The value-suggestion dropdown filters values server-side by the typed text. When the input becomes a typo (e.g. `api.acess`), the search returns an empty list, and once that resolves the dropdown collapses to just the raw literal — the populated suggestions disappear mid-type. `keepPreviousData` only retains data while a refetch is in flight, so it can't help the resolved-empty case the ticket is about ("after loading finishes").

This retains the last non-empty value response and, when the active search resolves to nothing, falls back to fuzzy near-matches from it. So typing `api.acess` keeps `api.access` visible as a fuzzy suggestion instead of dropping every suggestion. Lives in the shared `valueCombobox`, so it applies everywhere SearchQueryBuilder is used, not just logs.
