### PR TITLE
ref(buttonTracking): Refactor buttonTracking to remove extra indirection

### DIFF
--- a/static/app/components/core/button/useButtonFunctionality.tsx
+++ b/static/app/components/core/button/useButtonFunctionality.tsx
@@ -13,16 +13,7 @@ export function useButtonFunctionality(props: ButtonProps | LinkButtonProps) {
     props['aria-label'] ??
     (typeof props.children === 'string' ? props.children : undefined);
 
-  const buttonTracking = useButtonTracking({
-    analyticsEventName: props.analyticsEventName,
-    analyticsEventKey: props.analyticsEventKey,
-    analyticsParams: {
-      variant: props.variant,
-      href: 'href' in props ? props.href : undefined,
-      ...props.analyticsParams,
-    },
-    'aria-label': accessibleLabel || '',
-  });
+  const buttonTracking = useButtonTracking();
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
     // Don't allow clicks when disabled or busy
@@ -32,7 +23,16 @@ export function useButtonFunctionality(props: ButtonProps | LinkButtonProps) {
       return;
     }
 
-    buttonTracking();
+    buttonTracking({
+      analyticsEventName: props.analyticsEventName,
+      analyticsEventKey: props.analyticsEventKey,
+      analyticsParams: {
+        variant: props.variant,
+        href: 'href' in props ? props.href : undefined,
+        ...props.analyticsParams,
+      },
+      'aria-label': accessibleLabel || '',
+    });
     // @ts-expect-error at this point, we don't know if the button is a button or a link
     props.onClick?.(e);
   };

--- a/static/app/components/core/trackingContext.tsx
+++ b/static/app/components/core/trackingContext.tsx
@@ -2,32 +2,10 @@ import {createContext, useContext} from 'react';
 
 import type {DO_NOT_USE_ButtonProps as ButtonProps} from './button/types';
 
-const defaultButtonTracking = (props: ButtonProps) => {
-  const hasAnalyticsDebug = window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
-  return () => {
-    const hasCustomAnalytics =
-      props.analyticsEventName || props.analyticsEventKey || props.analyticsParams;
-    if (hasCustomAnalytics && hasAnalyticsDebug) {
-      // eslint-disable-next-line no-console
-      console.log('buttonAnalyticsEvent', {
-        eventKey: props.analyticsEventKey,
-        eventName: props.analyticsEventName,
-        variant: props.variant,
-        href: 'href' in props ? props.href : undefined,
-        ...props.analyticsParams,
-      });
-    }
-  };
-};
-
-const TrackingContext = createContext<{
-  useButtonTracking?: (props: ButtonProps) => () => void;
-}>({});
+const TrackingContext = createContext<(props: ButtonProps) => void>(() => {});
 
 export const TrackingContextProvider = TrackingContext.Provider;
 
-export const useButtonTracking = (props: ButtonProps) => {
-  const context = useContext(TrackingContext);
-
-  return context.useButtonTracking?.(props) ?? defaultButtonTracking(props);
+export const useButtonTracking = () => {
+  return useContext(TrackingContext);
 };

--- a/static/app/components/core/trackingContext.tsx
+++ b/static/app/components/core/trackingContext.tsx
@@ -2,10 +2,10 @@ import {createContext, useContext} from 'react';
 
 import type {DO_NOT_USE_ButtonProps as ButtonProps} from './button/types';
 
-const TrackingContext = createContext<(props: ButtonProps) => void>(() => {});
+const TrackingContext = createContext<() => (props: ButtonProps) => void>(() => () => {});
 
 export const TrackingContextProvider = TrackingContext.Provider;
 
 export const useButtonTracking = () => {
-  return useContext(TrackingContext);
+  return useContext(TrackingContext)();
 };

--- a/static/app/scrapsProviders/tracking.tsx
+++ b/static/app/scrapsProviders/tracking.tsx
@@ -1,15 +1,29 @@
-import {useMemo} from 'react';
-
+import type {ButtonProps} from '@sentry/scraps/button';
 import {TrackingContextProvider} from '@sentry/scraps/trackingContext';
 
 import {getOverride} from 'sentry/overrideRegistry';
 
+function defaultButtonTracking(props: ButtonProps) {
+  const hasAnalyticsDebug = window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
+  const hasCustomAnalytics =
+    props.analyticsEventName || props.analyticsEventKey || props.analyticsParams;
+  if (hasCustomAnalytics && hasAnalyticsDebug) {
+    // eslint-disable-next-line no-console
+    console.log('buttonAnalyticsEvent', {
+      eventKey: props.analyticsEventKey,
+      eventName: props.analyticsEventName,
+      variant: props.variant,
+      href: 'href' in props ? props.href : undefined,
+      ...props.analyticsParams,
+    });
+  }
+}
 export function SentryTrackingProvider({children}: {children: React.ReactNode}) {
-  const useButtonTracking = getOverride('react-hook:use-button-tracking');
-  const trackingContextValue = useMemo(() => ({useButtonTracking}), [useButtonTracking]);
+  const useButtonTracking =
+    getOverride('react-hook:use-button-tracking') ?? defaultButtonTracking;
 
   return (
-    <TrackingContextProvider value={trackingContextValue}>
+    <TrackingContextProvider value={useButtonTracking}>
       {children}
     </TrackingContextProvider>
   );

--- a/static/app/scrapsProviders/tracking.tsx
+++ b/static/app/scrapsProviders/tracking.tsx
@@ -18,12 +18,12 @@ function defaultButtonTracking(props: ButtonProps) {
     });
   }
 }
-export function SentryTrackingProvider({children}: {children: React.ReactNode}) {
-  const useButtonTracking =
-    getOverride('react-hook:use-button-tracking') ?? defaultButtonTracking;
 
+export function SentryTrackingProvider({children}: {children: React.ReactNode}) {
   return (
-    <TrackingContextProvider value={useButtonTracking}>
+    <TrackingContextProvider
+      value={getOverride('react-hook:use-button-tracking') ?? defaultButtonTracking}
+    >
       {children}
     </TrackingContextProvider>
   );

--- a/static/app/scrapsProviders/tracking.tsx
+++ b/static/app/scrapsProviders/tracking.tsx
@@ -3,26 +3,30 @@ import {TrackingContextProvider} from '@sentry/scraps/trackingContext';
 
 import {getOverride} from 'sentry/overrideRegistry';
 
-function defaultButtonTracking(props: ButtonProps) {
-  const hasAnalyticsDebug = window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
-  const hasCustomAnalytics =
-    props.analyticsEventName || props.analyticsEventKey || props.analyticsParams;
-  if (hasCustomAnalytics && hasAnalyticsDebug) {
+function useDefaultButtonTracking() {
+  return (props: ButtonProps) => {
+    const hasAnalyticsDebug = window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
+    const hasCustomAnalytics =
+      props.analyticsEventName || props.analyticsEventKey || props.analyticsParams;
     // eslint-disable-next-line no-console
-    console.log('buttonAnalyticsEvent', {
-      eventKey: props.analyticsEventKey,
-      eventName: props.analyticsEventName,
-      variant: props.variant,
-      href: 'href' in props ? props.href : undefined,
-      ...props.analyticsParams,
-    });
-  }
+    console.log('hasCustomAnalytics', hasCustomAnalytics);
+    if (hasCustomAnalytics && hasAnalyticsDebug) {
+      // eslint-disable-next-line no-console
+      console.log('buttonAnalyticsEvent', {
+        eventKey: props.analyticsEventKey,
+        eventName: props.analyticsEventName,
+        variant: props.variant,
+        href: 'href' in props ? props.href : undefined,
+        ...props.analyticsParams,
+      });
+    }
+  };
 }
 
 export function SentryTrackingProvider({children}: {children: React.ReactNode}) {
   return (
     <TrackingContextProvider
-      value={getOverride('react-hook:use-button-tracking') ?? defaultButtonTracking}
+      value={getOverride('react-hook:use-button-tracking') ?? useDefaultButtonTracking}
     >
       {children}
     </TrackingContextProvider>

--- a/static/app/scrapsProviders/tracking.tsx
+++ b/static/app/scrapsProviders/tracking.tsx
@@ -8,8 +8,6 @@ function useDefaultButtonTracking() {
     const hasAnalyticsDebug = window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
     const hasCustomAnalytics =
       props.analyticsEventName || props.analyticsEventKey || props.analyticsParams;
-    // eslint-disable-next-line no-console
-    console.log('hasCustomAnalytics', hasCustomAnalytics);
     if (hasCustomAnalytics && hasAnalyticsDebug) {
       // eslint-disable-next-line no-console
       console.log('buttonAnalyticsEvent', {

--- a/static/app/types/overrides.tsx
+++ b/static/app/types/overrides.tsx
@@ -318,7 +318,7 @@ type ReactHookOverrides = {
     matches: UIMatch[];
   }) => React.ContextType<typeof RouteAnalyticsContext>;
   'react-hook:use-billing-navigation-config': () => NavigationSection | null;
-  'react-hook:use-button-tracking': (props: ButtonProps) => () => void;
+  'react-hook:use-button-tracking': (props: ButtonProps) => void;
   'react-hook:use-dashboard-dataset-retention-limit': (props: {
     dataset: WidgetType;
   }) => number;

--- a/static/app/types/overrides.tsx
+++ b/static/app/types/overrides.tsx
@@ -318,7 +318,7 @@ type ReactHookOverrides = {
     matches: UIMatch[];
   }) => React.ContextType<typeof RouteAnalyticsContext>;
   'react-hook:use-billing-navigation-config': () => NavigationSection | null;
-  'react-hook:use-button-tracking': (props: ButtonProps) => void;
+  'react-hook:use-button-tracking': () => (props: ButtonProps) => void;
   'react-hook:use-dashboard-dataset-retention-limit': (props: {
     dataset: WidgetType;
   }) => number;

--- a/static/gsApp/overrides/useButtonTracking.spec.tsx
+++ b/static/gsApp/overrides/useButtonTracking.spec.tsx
@@ -60,11 +60,10 @@ describe('buttonTracking', () => {
 
   it('calls rawTrackAnalyticsEvent with default values', () => {
     const {result} = renderHook(useButtonTracking, {
-      initialProps: {'aria-label': 'Create Alert'},
       wrapper,
     });
 
-    result.current();
+    result.current({'aria-label': 'Create Alert'});
 
     expect(rawTrackAnalyticsEvent).toHaveBeenCalledWith({
       eventName: null,
@@ -78,16 +77,15 @@ describe('buttonTracking', () => {
 
   it('calls rawTrackAnalyticsEvent with data', () => {
     const {result} = renderHook(useButtonTracking, {
-      initialProps: {
-        'aria-label': 'Create Alert',
-        analyticsEventKey: 'settings.create_alert',
-        analyticsEventName: 'Settings: Create Alert',
-        analyticsParams: {priority: 'primary', href: 'sentry.io/settings/create_alert'},
-      },
       wrapper,
     });
 
-    result.current();
+    result.current({
+      'aria-label': 'Create Alert',
+      analyticsEventKey: 'settings.create_alert',
+      analyticsEventName: 'Settings: Create Alert',
+      analyticsParams: {priority: 'primary', href: 'sentry.io/settings/create_alert'},
+    });
 
     expect(rawTrackAnalyticsEvent).toHaveBeenCalledWith({
       eventName: 'Settings: Create Alert',
@@ -103,15 +101,14 @@ describe('buttonTracking', () => {
 
   it('calls rawTrackAnalyticsEvent with new event names', () => {
     const {result} = renderHook(useButtonTracking, {
-      initialProps: {
-        'aria-label': 'Create Alert',
-        analyticsEventKey: 'settings.create_alert',
-        analyticsEventName: 'Settings: Create Alert',
-      },
       wrapper,
     });
 
-    result.current();
+    result.current({
+      'aria-label': 'Create Alert',
+      analyticsEventKey: 'settings.create_alert',
+      analyticsEventName: 'Settings: Create Alert',
+    });
 
     expect(rawTrackAnalyticsEvent).toHaveBeenCalledWith({
       eventName: 'Settings: Create Alert',

--- a/static/gsApp/overrides/useButtonTracking.tsx
+++ b/static/gsApp/overrides/useButtonTracking.tsx
@@ -1,4 +1,3 @@
-import {useCallback} from 'react';
 import {useMatches} from 'react-router-dom';
 
 import type {ButtonProps} from '@sentry/scraps/button';
@@ -8,18 +7,16 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {rawTrackAnalyticsEvent} from 'getsentry/utils/rawTrackAnalyticsEvent';
 import {convertToReloadPath, getEventPath} from 'getsentry/utils/routeAnalytics';
 
-type Props = ButtonProps;
-
-export function useButtonTracking({
-  analyticsEventName,
-  analyticsEventKey,
-  analyticsParams,
-  'aria-label': ariaLabel,
-}: Props) {
+export function useButtonTracking() {
   const organization = useOrganization({allowNull: true});
   const matches = useMatches();
 
-  const trackButton = useCallback(() => {
+  return ({
+    analyticsEventName,
+    analyticsEventKey,
+    analyticsParams,
+    'aria-label': ariaLabel,
+  }: ButtonProps) => {
     const considerSendingAnalytics = organization && Boolean(matches);
 
     if (considerSendingAnalytics) {
@@ -45,14 +42,5 @@ export function useButtonTracking({
         ...analyticsParams,
       });
     }
-  }, [
-    analyticsEventKey,
-    analyticsEventName,
-    analyticsParams,
-    ariaLabel,
-    organization,
-    matches,
-  ]);
-
-  return trackButton;
+  };
 }


### PR DESCRIPTION
This moves `defaultButtonTracking()` nearer the override inside SentryTrackingProvider, and streamlines useButtonFunctionality and TrackingContextProvider a lot imo. 

Now `TrackingContextProvider` is just a context provider that's passing a value along. SentryTrackingProvider is going to set reasonable values, and i want to followup in that area to that the button-prop munging and debug calls are the same between `defaultButtonTracking()` and the `useButtonTracking()` override.

