### PR TITLE
feat(cells): Set CSRF trusted origins for cell-routing mode

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3393,3 +3393,8 @@ if IS_DEV and os.environ.get("SENTRY_CELL_ROUTING"):
     SENTRY_ORGANIZATION_URL_TEMPLATE = "http://{hostname}"
     SENTRY_FEATURES["system:multi-region"] = True
     SENTRY_LOCAL_CELL = SENTRY_LOCAL_CELL or "--monolith--"
+
+    # The browser sits on the org subdomain ({slug}.dev.getsentry.net:8000) while
+    # cell-scoped API XHRs cross to Synapse on :13000, so Django's CSRF origin check
+    # needs the page origin trusted explicitly.
+    CSRF_TRUSTED_ORIGINS = ["http://*.dev.getsentry.net:8000", "http://dev.getsentry.net:8000"]


### PR DESCRIPTION
Since cell-routing mode points the region API at Synapse on port :13000 Django's same-origin check no longer covers them. This change ensures the :8000 page origins are trusted. This implementation is similar to the ngrok configuration.
