### PR TITLE
feat(preprod): Record approval analytics for web UI and auto approvals with source

### DIFF
--- a/src/sentry/preprod/analytics.py
+++ b/src/sentry/preprod/analytics.py
@@ -164,6 +164,7 @@ class PreprodStatusCheckApprovalCreatedEvent(analytics.Event):
     project_id: int
     artifact_id: int
     product: Literal["size", "snapshots"]
+    source: Literal["web", "vcs", "auto"]
 
 
 analytics.register(PreprodArtifactApiAssembleEvent)

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_approve.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_approve.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -15,6 +16,7 @@ from sentry.api.bases.organization import (
 )
 from sentry.auth.staff import is_active_staff
 from sentry.models.organization import Organization
+from sentry.preprod.analytics import PreprodStatusCheckApprovalCreatedEvent
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.preprod.vcs.tasks import update_preprod_snapshot_vcs
@@ -74,6 +76,16 @@ class OrganizationPreprodArtifactApproveEndpoint(OrganizationEndpoint):
             approved_by_id=request.user.id,
             approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
             approved_at=datetime.now(timezone.utc),
+        )
+
+        analytics.record(
+            PreprodStatusCheckApprovalCreatedEvent(
+                organization_id=organization.id,
+                project_id=artifact.project_id,
+                artifact_id=artifact.id,
+                product=feature_type_str,
+                source="web",
+            )
         )
 
         PreprodComparisonApproval.objects.filter(

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -16,7 +16,9 @@ from objectstore_client import RequestError, Session
 from pydantic import BaseModel, ValidationError
 from taskbroker_client.retry import Retry
 
+from sentry import analytics
 from sentry.objectstore import get_preprod_session
+from sentry.preprod.analytics import PreprodStatusCheckApprovalCreatedEvent
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.categorize import categorize_image_sets
 from sentry.preprod.snapshots.constants import (
@@ -409,6 +411,16 @@ def _try_auto_approve_snapshot(
             "auto_approval": True,
             "prev_approved_artifact_id": approved_sibling.id,
         },
+    )
+
+    analytics.record(
+        PreprodStatusCheckApprovalCreatedEvent(
+            organization_id=head_artifact.project.organization_id,
+            project_id=head_artifact.project_id,
+            artifact_id=head_artifact.id,
+            product="snapshots",
+            source="auto",
+        )
     )
 
     logger.info(

--- a/src/sentry/preprod/vcs/webhooks/github_check_run.py
+++ b/src/sentry/preprod/vcs/webhooks/github_check_run.py
@@ -211,6 +211,7 @@ def handle_preprod_check_run_event(
                 project_id=artifact.project_id,
                 artifact_id=artifact.id,
                 product=product_name,
+                source="vcs",
             )
         )
 

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_approve.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_approve.py
@@ -1,6 +1,14 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
+from sentry.preprod.analytics import PreprodStatusCheckApprovalCreatedEvent
+from sentry.preprod.models import PreprodComparisonApproval
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.analytics import (
+    assert_any_analytics_event,
+    assert_not_analytics_event,
+)
 
 
 class OrganizationPreprodArtifactApproveTest(APITestCase):
@@ -40,3 +48,82 @@ class OrganizationPreprodArtifactApproveTest(APITestCase):
         )
 
         assert response.status_code == 404
+
+    @patch("sentry.preprod.api.endpoints.preprod_artifact_approve.create_preprod_status_check_task")
+    @patch("sentry.analytics.record")
+    def test_approve_size_records_analytics(self, mock_analytics, mock_task) -> None:
+        self.login_as(user=self.owner)
+
+        response = self.client.post(
+            self._approve_url(self.artifact.id),
+            data={"feature_type": "size"},
+            format="json",
+        )
+
+        assert response.status_code == 201
+        assert_any_analytics_event(
+            mock_analytics,
+            PreprodStatusCheckApprovalCreatedEvent(
+                organization_id=self.org.id,
+                project_id=self.project_b.id,
+                artifact_id=self.artifact.id,
+                product="size",
+                source="web",
+            ),
+        )
+
+    @patch("sentry.preprod.api.endpoints.preprod_artifact_approve.update_preprod_snapshot_vcs")
+    @patch("sentry.analytics.record")
+    def test_approve_snapshots_records_analytics(self, mock_analytics, mock_task) -> None:
+        self.login_as(user=self.owner)
+
+        response = self.client.post(
+            self._approve_url(self.artifact.id),
+            data={"feature_type": "snapshots"},
+            format="json",
+        )
+
+        assert response.status_code == 201
+        assert_any_analytics_event(
+            mock_analytics,
+            PreprodStatusCheckApprovalCreatedEvent(
+                organization_id=self.org.id,
+                project_id=self.project_b.id,
+                artifact_id=self.artifact.id,
+                product="snapshots",
+                source="web",
+            ),
+        )
+
+    @patch("sentry.preprod.api.endpoints.preprod_artifact_approve.create_preprod_status_check_task")
+    @patch("sentry.analytics.record")
+    def test_already_approved_does_not_record_analytics(self, mock_analytics, mock_task) -> None:
+        self.login_as(user=self.owner)
+        self.create_preprod_comparison_approval(
+            preprod_artifact=self.artifact,
+            preprod_feature_type=PreprodComparisonApproval.FeatureType.SIZE,
+            approved_by_id=self.owner.id,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+        )
+
+        response = self.client.post(
+            self._approve_url(self.artifact.id),
+            data={"feature_type": "size"},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert_not_analytics_event(mock_analytics, PreprodStatusCheckApprovalCreatedEvent)
+
+    @patch("sentry.analytics.record")
+    def test_invalid_feature_type_does_not_record_analytics(self, mock_analytics) -> None:
+        self.login_as(user=self.owner)
+
+        response = self.client.post(
+            self._approve_url(self.artifact.id),
+            data={"feature_type": "bogus"},
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert_not_analytics_event(mock_analytics, PreprodStatusCheckApprovalCreatedEvent)

--- a/tests/sentry/preprod/snapshots/test_auto_approve.py
+++ b/tests/sentry/preprod/snapshots/test_auto_approve.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import orjson
 
+from sentry.preprod.analytics import PreprodStatusCheckApprovalCreatedEvent
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.manifest import (
     ComparisonImageResult,
@@ -17,6 +18,10 @@ from sentry.preprod.snapshots.tasks import (
     _try_auto_approve_snapshot,
 )
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.analytics import (
+    assert_any_analytics_event,
+    assert_not_analytics_event,
+)
 from sentry.testutils.silo import cell_silo_test
 
 
@@ -212,7 +217,8 @@ class TryAutoApproveSnapshotTest(TestCase):
             images=images,
         )
 
-    def test_auto_approves_when_fingerprints_match(self):
+    @patch("sentry.analytics.record")
+    def test_auto_approves_when_fingerprints_match(self, mock_analytics):
         shared_images = {
             "screen1.png": ComparisonImageResult(
                 status="changed", head_hash="abc", base_hash="old1"
@@ -265,7 +271,19 @@ class TryAutoApproveSnapshotTest(TestCase):
         assert approval.extras["auto_approval"] is True
         assert approval.extras["prev_approved_artifact_id"] == sibling.id
 
-    def test_no_auto_approve_when_fingerprints_differ(self):
+        assert_any_analytics_event(
+            mock_analytics,
+            PreprodStatusCheckApprovalCreatedEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                artifact_id=head_artifact.id,
+                product="snapshots",
+                source="auto",
+            ),
+        )
+
+    @patch("sentry.analytics.record")
+    def test_no_auto_approve_when_fingerprints_differ(self, mock_analytics):
         sibling_images = {
             "screen1.png": ComparisonImageResult(
                 status="changed", head_hash="abc", base_hash="old1"
@@ -302,6 +320,8 @@ class TryAutoApproveSnapshotTest(TestCase):
             preprod_artifact=head_artifact,
             approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
         ).exists()
+
+        assert_not_analytics_event(mock_analytics, PreprodStatusCheckApprovalCreatedEvent)
 
     def test_no_auto_approve_when_no_pr_number(self):
         cc = self.create_commit_comparison(

--- a/tests/sentry/preprod/vcs/webhooks/test_github_check_run.py
+++ b/tests/sentry/preprod/vcs/webhooks/test_github_check_run.py
@@ -7,10 +7,12 @@ from unittest.mock import patch
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.repository import Repository
+from sentry.preprod.analytics import PreprodStatusCheckApprovalCreatedEvent
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.vcs.status_checks.size.tasks import APPROVE_SIZE_ACTION_IDENTIFIER
 from sentry.preprod.vcs.webhooks.github_check_run import handle_preprod_check_run_event
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.silo import cell_silo_test
 
 
@@ -162,7 +164,8 @@ class HandlePreprodCheckRunEventTest(TestCase):
             == 0
         )
 
-    def test_creates_approval_for_valid_request(self) -> None:
+    @patch("sentry.analytics.record")
+    def test_creates_approval_for_valid_request(self, mock_analytics) -> None:
         artifact = self._create_preprod_artifact()
         event = self._create_webhook_event(
             action="requested_action",
@@ -196,6 +199,17 @@ class HandlePreprodCheckRunEventTest(TestCase):
         mock_task.assert_called_once_with(
             preprod_artifact_id=artifact.id,
             caller="github_approve_webhook",
+        )
+
+        assert_any_analytics_event(
+            mock_analytics,
+            PreprodStatusCheckApprovalCreatedEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                artifact_id=artifact.id,
+                product="size",
+                source="vcs",
+            ),
         )
 
     def test_creates_approvals_for_all_sibling_artifacts(self) -> None:


### PR DESCRIPTION
`preprod_status_check.approval_created` now fires from every path that creates a `PreprodComparisonApproval` row and carries a `source` telling you where the approval came from. Previously the event only fired from the GitHub check-run webhook; the web UI approve endpoint and the snapshot auto-approval task wrote approval rows but recorded nothing, so approval volume could only be reconstructed by querying `sentry_preprodcomparisonapproval` directly.

The event gains one field, `source: Literal["web", "vcs", "auto"]`, emitted from each writer (the webhook path uses `vcs` rather than a GitHub-specific value since the module is provider-agnostic). The existing `product` (`size` / `snapshots`) distinction is unchanged, so approvals are now splittable by both origin and product from analytics.

```python
@analytics.eventclass("preprod_status_check.approval_created")
class PreprodStatusCheckApprovalCreatedEvent(analytics.Event):
    organization_id: int
    project_id: int
    artifact_id: int
    product: Literal["size", "snapshots"]
    source: Literal["web", "vcs", "auto"]  # new
```

The three writers each still create their rows inline rather than through a shared helper; consolidating them is left out of scope to keep this additive.

Refs EME-1214