### PR TITLE
feat(cells): Use :7899 instead of :7901 for relay-edge in devservices

### DIFF
--- a/.agents/skills/cell-architecture/SKILL.md
+++ b/.agents/skills/cell-architecture/SKILL.md
@@ -148,7 +148,7 @@ Only cell-scoped API XHRs (`/api/0/organizations/{slug}/*`) cross to Synapse on 
 ### Sending a test envelope
 
 `bin/send-cell-test-event.py` exercises the ingestion path: it resolves a DSN from the
-local dev DB and sends an envelope through the edge relay (`:7901`), which forwards to
+local dev DB and sends an envelope through the edge relay (`:7899`), which forwards to
 relay-cell -> Kafka -> Sentry.
 
 ```bash

--- a/bin/send-cell-test-event.py
+++ b/bin/send-cell-test-event.py
@@ -3,7 +3,7 @@
 
 Pair with `devservices up --mode cell-routing`. Resolves a project key from the
 local dev database (the internal project, id 1, which every dev install
-bootstraps — override with PROJECT_ID), points a DSN at the edge relay on :7901,
+bootstraps — override with PROJECT_ID), points a DSN at the edge relay on :7899,
 and captures an event with sentry_sdk.
 The edge reads the advertised upstream from its project config and forwards the
 envelope there (relay-cell), which processes it to Kafka -> Sentry.
@@ -35,7 +35,7 @@ from sentry.models.projectkey import ProjectKey  # noqa: E402
 
 # Defaults to the edge relay's address from devservices/config.yml (cell-routing
 # mode). Override TARGET to send elsewhere, e.g. straight to relay-cell on :7900.
-target = os.environ.get("TARGET", "127.0.0.1:7901")
+target = os.environ.get("TARGET", "127.0.0.1:7899")
 # The internal project (id 1) is bootstrapped for every dev install.
 project_id = os.environ.get("PROJECT_ID", "1")
 project = Project.objects.filter(id=project_id).first()

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -549,7 +549,7 @@ services:
       timeout: 5s
       retries: 3
     ports:
-      - 127.0.0.1:7901:7901
+      - 127.0.0.1:7899:7899
     volumes:
       - ./config/relay-edge.yml:/etc/relay/config.yml
       - ./config/relay-edge-credentials.json:/etc/relay/credentials.json

--- a/devservices/config/relay-edge.yml
+++ b/devservices/config/relay-edge.yml
@@ -14,7 +14,10 @@
 relay:
   upstream: 'http://synapse-ingest-router:3000/'
   host: 0.0.0.0
-  port: 7901
+  # Reuse the canonical dev relay port. cell-routing mode doesn't start the plain
+  # `relay`, so :7899 is free, and relay-edge becomes a drop-in entrypoint — tools
+  # that expect the dev relay on :7899 (e.g. the webpack ingest proxy) work unchanged
+  port: 7899
 logging:
   # Verbose so the upstream forwarding (to the advertised upstream) is visible.
   # Drop back to INFO once routing is validated.


### PR DESCRIPTION
This allows tools like webpack ingest proxy to work unchanged. Since cell routing mode doesn't run a regular relay on this port there is no conflict.
