### PR TITLE
fix(weekly-reports): Cache event counts after successfully sending emails

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -222,6 +222,18 @@ def prepare_organization_report(
             lifecycle.record_halt(WeeklyReportHaltReason.EMPTY_REPORT)
             return
 
+    # Deliver the reports
+    batch = OrganizationReportBatch(ctx, batch_id, dry_run, target_user, email_override)
+    with sentry_sdk.start_span(op="weekly_reports.deliver_reports"):
+        logger.info(
+            "weekly_reports.deliver_reports",
+            extra={"batch_id": str(batch_id), "organization": organization_id},
+        )
+        with metrics.timer("weekly_report.deliver_reports.duration"):
+            batch.deliver_reports()
+
+    # Cache after delivery so a failed attempt doesn't poison the
+    # previous-week lookup on retry.
     if not dry_run:
         try:
             project_metrics: dict[int, dict[str, int]] = {}
@@ -235,16 +247,6 @@ def prepare_organization_report(
                 cache_project_metrics(organization_id, project_metrics)
         except Exception:
             sentry_sdk.capture_exception()
-
-    # Finally, deliver the reports
-    batch = OrganizationReportBatch(ctx, batch_id, dry_run, target_user, email_override)
-    with sentry_sdk.start_span(op="weekly_reports.deliver_reports"):
-        logger.info(
-            "weekly_reports.deliver_reports",
-            extra={"batch_id": str(batch_id), "organization": organization_id},
-        )
-        with metrics.timer("weekly_report.deliver_reports.duration"):
-            batch.deliver_reports()
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Problem statement: we cache the current week's event counts before sending emails (via `deliver_reports()`). 

This means that if we retry `deliver_reports()`, we incorrectly retrieve the current week's event counts (as opposed to the previous week) which causes the percentage change to be 0. When the percentage change is 0, the WoW changes don't show up. 

What changed: moved email sending logic before caching logic

More robust fix is to add timestamps to cache key, but this addresses incorrect behavior anyway. 