### PR TITLE
feat(fetch): Implement a new function to replace `requestPromise` that allows configuring error handlers

### DIFF
--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -17,12 +17,18 @@ import {SENTRY_RELEASE_VERSION, USE_TANSTACK_DEVTOOL} from 'sentry/constants';
 import {preload} from 'sentry/router/preload';
 import {RouteConfigProvider} from 'sentry/router/routeConfigContext';
 import {routes} from 'sentry/router/routes';
+import {configureRequestFetch} from 'sentry/utils/api/requestFetch';
+import {createDefaultErrorHandlers} from 'sentry/utils/api/requestFetchErrorHandlers';
 import {createReactRouter3Navigate} from 'sentry/utils/useNavigate';
 
 function buildRouter() {
   const sentryCreateBrowserRouter = wrapCreateBrowserRouterV6(createBrowserRouter);
   const router = sentryCreateBrowserRouter(routes());
-  setApiNavigate(createReactRouter3Navigate(router));
+  const navigate = createReactRouter3Navigate(router);
+  setApiNavigate(navigate);
+  configureRequestFetch({
+    errorHandlers: createDefaultErrorHandlers({navigate}),
+  });
 
   return router;
 }

--- a/static/app/utils/api/apiFetch.tsx
+++ b/static/app/utils/api/apiFetch.tsx
@@ -1,7 +1,9 @@
 import {useEffect} from 'react';
 import type {QueryFunctionContext, UseInfiniteQueryResult} from '@tanstack/react-query';
 
+import {ConfigStore} from 'sentry/stores/configStore';
 import type {ApiQueryKey, InfiniteApiQueryKey} from 'sentry/utils/api/apiQueryKey';
+import {requestFetch} from 'sentry/utils/api/requestFetch';
 import type {ParsedHeader} from 'sentry/utils/parseLinkHeader';
 import {QUERY_API_CLIENT} from 'sentry/utils/queryClient';
 
@@ -17,6 +19,13 @@ export type ApiResponse<TResponseData = unknown> = {
 export async function apiFetch<TQueryFnData = unknown>(
   context: QueryFunctionContext<ApiQueryKey>
 ): Promise<ApiResponse<TQueryFnData>> {
+  const systemFeatures = ConfigStore.get('features');
+  const isCellFetchEnabled = systemFeatures.has('organizations:api-fetch-v2');
+  if (isCellFetchEnabled) {
+    const [url, options] = context.queryKey;
+    return requestFetch(url, options, context.signal);
+  }
+
   const [url, options] = context.queryKey;
 
   const [json, , response] = await QUERY_API_CLIENT.requestPromise(url, {
@@ -44,6 +53,23 @@ export async function apiFetch<TQueryFnData = unknown>(
 export async function apiFetchInfinite<TQueryFnData = unknown>(
   context: QueryFunctionContext<InfiniteApiQueryKey, null | undefined | ParsedHeader>
 ): Promise<ApiResponse<TQueryFnData>> {
+  const systemFeatures = ConfigStore.get('features');
+  const isCellFetchEnabled = systemFeatures.has('organizations:api-fetch-v2');
+  if (isCellFetchEnabled) {
+    const [url, options] = context.queryKey;
+    return requestFetch(
+      url,
+      {
+        ...options,
+        query: {
+          ...options?.query,
+          cursor: context.pageParam?.cursor ?? options?.query?.cursor,
+        },
+      },
+      context.signal
+    );
+  }
+
   const [url, options] = context.queryKey;
 
   const [json, , response] = await QUERY_API_CLIENT.requestPromise(url, {

--- a/static/app/utils/api/requestFetch.spec.tsx
+++ b/static/app/utils/api/requestFetch.spec.tsx
@@ -1,0 +1,287 @@
+import type {QueryClient, QueryFunctionContext} from '@tanstack/react-query';
+
+import {
+  PROJECT_MOVED,
+  SUDO_REQUIRED,
+  SUPERUSER_REQUIRED,
+} from 'sentry/constants/apiErrorCodes';
+import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+
+import {configureRequestFetch, requestFetch} from './requestFetch';
+
+// Unmock so we test the real implementation
+jest.unmock('sentry/utils/api/requestFetch');
+
+function makeContext(
+  queryKey: ApiQueryKey,
+  options?: {signal?: AbortSignal}
+): QueryFunctionContext<ApiQueryKey> {
+  return {
+    queryKey,
+    signal: options?.signal ?? new AbortController().signal,
+    meta: undefined,
+    client: {} as QueryClient,
+  };
+}
+
+function mockFetchResponse(
+  body: unknown,
+  init?: {headers?: Record<string, string>; status?: number; statusText?: string}
+) {
+  const status = init?.status ?? 200;
+  const statusText = init?.statusText ?? 'OK';
+  const responseHeaders = new Headers({
+    'content-type': 'application/json',
+    ...init?.headers,
+  });
+
+  return jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    headers: responseHeaders,
+    text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+  });
+}
+
+describe('requestFetch', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    configureRequestFetch({});
+    fetchSpy = jest.spyOn(window, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('returns ApiResponse on successful JSON response', async () => {
+    const body = [{id: 1, name: 'test'}];
+    fetchSpy.mockImplementation(mockFetchResponse(body));
+
+    const context = makeContext(['/projects/' as ApiQueryKey[0]]);
+    const [url, options] = context.queryKey;
+    const result = await requestFetch(url, options, context.signal);
+
+    expect(result.json).toEqual(body);
+    expect(result.headers).toBeDefined();
+  });
+
+  it('includes response headers in result', async () => {
+    fetchSpy.mockImplementation(
+      mockFetchResponse([], {
+        headers: {
+          Link: '<url>; rel="next"',
+          'X-Hits': '42',
+          'X-Max-Hits': '1000',
+        },
+      })
+    );
+
+    const context = makeContext(['/items/' as ApiQueryKey[0]]);
+    const [url, options] = context.queryKey;
+    const result = await requestFetch(url, options, context.signal);
+
+    expect(result.headers.Link).toBe('<url>; rel="next"');
+    expect(result.headers['X-Hits']).toBe(42);
+    expect(result.headers['X-Max-Hits']).toBe(1000);
+  });
+
+  it('serializes query params into the URL', async () => {
+    fetchSpy.mockImplementation(mockFetchResponse([]));
+
+    const context = makeContext([
+      '/projects/' as ApiQueryKey[0],
+      {query: {per_page: 25, cursor: 'abc'}},
+    ]);
+    const [url, options] = context.queryKey;
+    await requestFetch(url, options, context.signal);
+
+    const calledUrl = fetchSpy.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('per_page=25');
+    expect(calledUrl).toContain('cursor=abc');
+  });
+
+  it('sends JSON body for POST requests', async () => {
+    fetchSpy.mockImplementation(mockFetchResponse({id: 1}));
+
+    const context = makeContext([
+      '/projects/' as ApiQueryKey[0],
+      {method: 'POST', data: {name: 'new'}},
+    ]);
+    const [url, options] = context.queryKey;
+    await requestFetch(url, options, context.signal);
+
+    const fetchInit = fetchSpy.mock.calls[0][1];
+    expect(fetchInit.method).toBe('POST');
+    expect(fetchInit.body).toBe(JSON.stringify({name: 'new'}));
+  });
+
+  it('passes context.signal to fetch', async () => {
+    fetchSpy.mockImplementation(mockFetchResponse([]));
+    const controller = new AbortController();
+
+    const context = makeContext(['/projects/' as ApiQueryKey[0]], {
+      signal: controller.signal,
+    });
+    const [url, options] = context.queryKey;
+    await requestFetch(url, options, context.signal);
+
+    expect(fetchSpy.mock.calls[0][1].signal).toBe(controller.signal);
+  });
+
+  it('throws RequestError on non-ok response with no handlers', async () => {
+    fetchSpy.mockImplementation(
+      mockFetchResponse({detail: 'Not found'}, {status: 404, statusText: 'Not Found'})
+    );
+
+    const context = makeContext(['/missing/' as ApiQueryKey[0]]);
+    const [url, options] = context.queryKey;
+    await expect(requestFetch(url, options, context.signal)).rejects.toThrow(
+      RequestError
+    );
+  });
+
+  describe('error handlers', () => {
+    it('calls onAuthError for 401 responses and throws', async () => {
+      const onAuthError = jest.fn().mockReturnValue(true);
+      configureRequestFetch({errorHandlers: {onAuthError}});
+      fetchSpy.mockImplementation(
+        mockFetchResponse({detail: 'Unauthorized'}, {status: 401})
+      );
+
+      const context = makeContext(['/projects/' as ApiQueryKey[0]]);
+      const [url, options] = context.queryKey;
+      await expect(requestFetch(url, options, context.signal)).rejects.toThrow(
+        RequestError
+      );
+      expect(onAuthError).toHaveBeenCalled();
+    });
+
+    it('throws when onAuthError returns false', async () => {
+      const onAuthError = jest.fn().mockReturnValue(false);
+      configureRequestFetch({errorHandlers: {onAuthError}});
+      fetchSpy.mockImplementation(
+        mockFetchResponse({detail: 'Unauthorized'}, {status: 401})
+      );
+
+      const context = makeContext(['/projects/' as ApiQueryKey[0]]);
+      const [url, options] = context.queryKey;
+      await expect(requestFetch(url, options, context.signal)).rejects.toThrow(
+        RequestError
+      );
+    });
+
+    it('calls onSudoRequired for sudo-required errors', async () => {
+      const retryBody = [{id: 1}];
+      const onSudoRequired = jest.fn().mockImplementation((_resp, retry) => retry());
+      configureRequestFetch({errorHandlers: {onSudoRequired}});
+
+      // First call returns sudo-required, second (retry) succeeds
+      fetchSpy
+        .mockImplementationOnce(
+          mockFetchResponse(
+            {detail: {code: SUDO_REQUIRED, message: 'Sudo required'}},
+            {status: 403}
+          )
+        )
+        .mockImplementationOnce(mockFetchResponse(retryBody));
+
+      const context = makeContext(['/admin/' as ApiQueryKey[0]]);
+      const [url, options] = context.queryKey;
+      const result = await requestFetch(url, options, context.signal);
+
+      expect(onSudoRequired).toHaveBeenCalledTimes(1);
+      expect(result.json).toEqual(retryBody);
+    });
+
+    it('calls onSudoRequired for superuser-required errors', async () => {
+      const onSudoRequired = jest.fn().mockImplementation((_resp, retry) => retry());
+      configureRequestFetch({errorHandlers: {onSudoRequired}});
+
+      fetchSpy
+        .mockImplementationOnce(
+          mockFetchResponse(
+            {detail: {code: SUPERUSER_REQUIRED, message: 'Superuser required'}},
+            {status: 403}
+          )
+        )
+        .mockImplementationOnce(mockFetchResponse({ok: true}));
+
+      const context = makeContext(['/admin/' as ApiQueryKey[0]]);
+      const [url, options] = context.queryKey;
+      await requestFetch(url, options, context.signal);
+
+      expect(onSudoRequired).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onProjectRenamed for project-moved errors and throws', async () => {
+      const onProjectRenamed = jest.fn().mockReturnValue(true);
+      configureRequestFetch({errorHandlers: {onProjectRenamed}});
+      fetchSpy.mockImplementation(
+        mockFetchResponse(
+          {detail: {code: PROJECT_MOVED, extra: {slug: 'new-slug'}}},
+          {status: 404}
+        )
+      );
+
+      const context = makeContext(['/projects/old-slug/' as ApiQueryKey[0]]);
+      const [url, options] = context.queryKey;
+      await expect(requestFetch(url, options, context.signal)).rejects.toThrow(
+        RequestError
+      );
+      expect(onProjectRenamed).toHaveBeenCalled();
+    });
+
+    it('calls onError as catch-all for unhandled errors and throws', async () => {
+      const onError = jest.fn().mockReturnValue(true);
+      configureRequestFetch({errorHandlers: {onError}});
+      fetchSpy.mockImplementation(
+        mockFetchResponse({detail: 'Server error'}, {status: 500})
+      );
+
+      const context = makeContext(['/projects/' as ApiQueryKey[0]]);
+      const [url, options] = context.queryKey;
+      await expect(requestFetch(url, options, context.signal)).rejects.toThrow(
+        RequestError
+      );
+      expect(onError).toHaveBeenCalled();
+    });
+
+    it('does not call onAuthError for non-401 errors', async () => {
+      const onAuthError = jest.fn().mockReturnValue(true);
+      const onError = jest.fn().mockReturnValue(true);
+      configureRequestFetch({errorHandlers: {onAuthError, onError}});
+      fetchSpy.mockImplementation(
+        mockFetchResponse({detail: 'Forbidden'}, {status: 403})
+      );
+
+      const context = makeContext(['/projects/' as ApiQueryKey[0]]);
+      const [url, options] = context.queryKey;
+      await expect(requestFetch(url, options, context.signal)).rejects.toThrow(
+        RequestError
+      );
+      expect(onAuthError).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalled();
+    });
+
+    it('named handlers take priority over onError', async () => {
+      const onAuthError = jest.fn().mockReturnValue(true);
+      const onError = jest.fn().mockReturnValue(true);
+      configureRequestFetch({errorHandlers: {onAuthError, onError}});
+      fetchSpy.mockImplementation(
+        mockFetchResponse({detail: 'Unauthorized'}, {status: 401})
+      );
+
+      const context = makeContext(['/projects/' as ApiQueryKey[0]]);
+      const [url, options] = context.queryKey;
+      await expect(requestFetch(url, options, context.signal)).rejects.toThrow(
+        RequestError
+      );
+      expect(onAuthError).toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/static/app/utils/api/requestFetch.tsx
+++ b/static/app/utils/api/requestFetch.tsx
@@ -1,0 +1,246 @@
+import * as qs from 'query-string';
+
+import {
+  PROJECT_MOVED,
+  SUDO_REQUIRED,
+  SUPERUSER_REQUIRED,
+} from 'sentry/constants/apiErrorCodes';
+import type {ResponseMeta} from 'sentry/types/api';
+import type {QueryKeyEndpointOptions} from 'sentry/utils/api/apiQueryKey';
+import {isSimilarOrigin} from 'sentry/utils/api/isSimilarOrigin';
+import {resolveHostname} from 'sentry/utils/api/resolveHostname';
+import {getCsrfToken} from 'sentry/utils/getCsrfToken';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+
+export type ApiResponse<TResponseData = unknown> = {
+  headers: {
+    Link?: string;
+    'X-Hits'?: number;
+    'X-Max-Hits'?: number;
+  };
+  json: TResponseData;
+};
+
+export interface RequestFetchErrorHandlers {
+  /**
+   * Called on 401 responses. Return true to suppress the error (e.g., after
+   * handling via redirect). Called BEFORE the generic onError handler.
+   */
+  onAuthError?: (
+    response: ResponseMeta,
+    requestOptions: QueryKeyEndpointOptions
+  ) => boolean;
+
+  /**
+   * Generic catch-all error handler. Called for ALL error responses not already
+   * suppressed by a named handler. Return true to suppress, false to throw.
+   */
+  onError?: (response: ResponseMeta, requestOptions: QueryKeyEndpointOptions) => boolean;
+
+  /**
+   * Called when response has PROJECT_MOVED code. Return true to suppress the
+   * error and handle the redirect externally.
+   */
+  onProjectRenamed?: (response: ResponseMeta) => boolean;
+
+  /**
+   * Called on 403 with SUDO_REQUIRED or SUPERUSER_REQUIRED code. Receives a
+   * retry function that re-issues the same request. Should return a promise
+   * that resolves with the retry result, or rejects on failure.
+   */
+  onSudoRequired?: (
+    response: ResponseMeta,
+    retry: () => Promise<ApiResponse>
+  ) => Promise<ApiResponse>;
+}
+
+interface RequestFetchConfig {
+  baseUrl?: string;
+  credentials?: RequestCredentials;
+  errorHandlers?: RequestFetchErrorHandlers;
+  headers?: Record<string, string>;
+}
+
+const JSON_HEADERS: Record<string, string> = {
+  Accept: 'application/json; charset=utf-8',
+  'Content-Type': 'application/json',
+};
+
+let currentConfig: RequestFetchConfig = {};
+
+export function configureRequestFetch(newConfig: RequestFetchConfig): void {
+  currentConfig = newConfig;
+}
+
+const csrfSafeMethods = new Set(['GET', 'HEAD', 'OPTIONS', 'TRACE']);
+
+function buildUrl(
+  path: string,
+  query: Record<string, unknown> | undefined,
+  host: string | undefined
+): string {
+  const baseUrl = currentConfig.baseUrl ?? '/api/0';
+  let fullUrl = path.includes(baseUrl) ? path : baseUrl + path;
+
+  fullUrl = resolveHostname(fullUrl, host);
+
+  if (query) {
+    const params = qs.stringify(query);
+    if (params) {
+      fullUrl += fullUrl.includes('?') ? `&${params}` : `?${params}`;
+    }
+  }
+
+  return fullUrl;
+}
+
+function buildResponseHeaders(response: Response): ApiResponse['headers'] {
+  const hits = response.headers.get('X-Hits');
+  const maxHits = response.headers.get('X-Max-Hits');
+  return {
+    Link: response.headers.get('Link') ?? undefined,
+    'X-Hits': typeof hits === 'string' ? Number(hits) : undefined,
+    'X-Max-Hits': typeof maxHits === 'string' ? Number(maxHits) : undefined,
+  };
+}
+
+async function executeFetch(
+  fullUrl: string,
+  options: QueryKeyEndpointOptions,
+  signal?: AbortSignal
+): Promise<ApiResponse> {
+  const method = options.method ?? 'GET';
+
+  let body: BodyInit | undefined;
+  if (options.data !== undefined && method !== 'GET') {
+    body = JSON.stringify(options.data);
+  }
+
+  const baseHeaders = currentConfig.headers ?? JSON_HEADERS;
+  const requestHeaders = new Headers({...baseHeaders, ...options.headers});
+
+  if (!csrfSafeMethods.has(method) && isSimilarOrigin(fullUrl, window.location.origin)) {
+    requestHeaders.set('X-CSRFToken', getCsrfToken());
+  }
+
+  const response = await fetch(fullUrl, {
+    method,
+    body,
+    headers: requestHeaders,
+    credentials: currentConfig.credentials ?? 'include',
+    signal,
+  });
+
+  // Parse response body
+  let responseJSON: any;
+  let responseText = '';
+  let {ok} = response;
+  const {status, statusText} = response;
+
+  try {
+    responseText = await response.text();
+  } catch {
+    ok = false;
+  }
+
+  const responseContentType = response.headers.get('content-type');
+  const isResponseJSON = responseContentType?.includes('json');
+  const isStatus3XX = status >= 300 && status < 400;
+
+  if (status !== 204 && !isStatus3XX) {
+    try {
+      responseJSON = JSON.parse(responseText);
+    } catch (error: unknown) {
+      if (isResponseJSON && error instanceof SyntaxError) {
+        ok = false;
+      } else if (
+        responseText.length > 0 &&
+        requestHeaders.get('Accept') === JSON_HEADERS.Accept &&
+        error instanceof SyntaxError
+      ) {
+        ok = false;
+      }
+    }
+  }
+
+  const responseMeta: ResponseMeta = {
+    status,
+    statusText,
+    responseJSON,
+    responseText,
+    getResponseHeader: (header: string) => response.headers.get(header),
+  };
+
+  if (!ok) {
+    return handleErrorResponse(responseMeta, options, fullUrl);
+  }
+
+  const responseData = isResponseJSON ? responseJSON : responseText;
+  return {
+    headers: buildResponseHeaders(response),
+    json: responseData,
+  };
+}
+
+async function handleErrorResponse(
+  responseMeta: ResponseMeta,
+  options: QueryKeyEndpointOptions,
+  fullUrl: string
+): Promise<ApiResponse> {
+  const errorHandlers = currentConfig.errorHandlers;
+  const code = responseMeta.responseJSON?.detail?.code;
+  const method = options.method ?? 'GET';
+
+  // 1. Sudo/superuser — handler owns the retry and promise resolution
+  if (
+    (code === SUDO_REQUIRED || code === SUPERUSER_REQUIRED) &&
+    errorHandlers?.onSudoRequired
+  ) {
+    return errorHandlers.onSudoRequired(responseMeta, () =>
+      executeFetch(fullUrl, options, undefined)
+    );
+  }
+
+  // 2. Project renamed — handler does the redirect
+  if (code === PROJECT_MOVED && errorHandlers?.onProjectRenamed?.(responseMeta)) {
+    throw new RequestError(method, fullUrl, new Error('Project renamed'), responseMeta);
+  }
+
+  // 3. Auth error (401) — handler does the redirect
+  if (
+    responseMeta.status === 401 &&
+    errorHandlers?.onAuthError?.(responseMeta, options)
+  ) {
+    throw new RequestError(method, fullUrl, new Error('Auth redirect'), responseMeta);
+  }
+
+  // 4. Generic catch-all
+  if (errorHandlers?.onError?.(responseMeta, options)) {
+    throw new RequestError(method, fullUrl, new Error('Request failed'), responseMeta);
+  }
+
+  // 5. Nothing handled it — throw
+  throw new RequestError(method, fullUrl, new Error('Request failed'), responseMeta);
+}
+
+export async function requestFetch<TQueryFnData = unknown>(
+  url: string,
+  options: QueryKeyEndpointOptions = {},
+  signal?: AbortSignal
+): Promise<ApiResponse<TQueryFnData>> {
+  const fullUrl = buildUrl(url, options.query, options.host);
+
+  const result = await executeFetch(
+    fullUrl,
+    {
+      allowAuthError: options.allowAuthError,
+      host: options.host,
+      method: options.method,
+      data: options.data,
+      headers: options.headers,
+    },
+    signal
+  );
+
+  return result as ApiResponse<TQueryFnData>;
+}

--- a/static/app/utils/api/requestFetchErrorHandlers.spec.tsx
+++ b/static/app/utils/api/requestFetchErrorHandlers.spec.tsx
@@ -1,0 +1,276 @@
+import Cookies from 'js-cookie';
+
+import {setWindowLocation} from 'sentry-test/utils';
+
+import {redirectToProject} from 'sentry/actionCreators/redirectToProject';
+import {openSudo} from 'sentry/actionCreators/sudoModal';
+import type {ResponseMeta} from 'sentry/types/api';
+import type {QueryKeyEndpointOptions} from 'sentry/utils/api/apiQueryKey';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
+
+import type {ApiResponse} from './requestFetch';
+import {
+  createDefaultAuthErrorHandler,
+  createDefaultErrorHandlers,
+  createDefaultProjectRenamedHandler,
+  createDefaultSudoHandler,
+} from './requestFetchErrorHandlers';
+
+jest.mock('sentry/actionCreators/sudoModal');
+jest.mock('sentry/actionCreators/redirectToProject');
+
+function makeResponse(overrides: Partial<ResponseMeta> = {}): ResponseMeta {
+  return {
+    status: 401,
+    statusText: 'Unauthorized',
+    responseJSON: undefined,
+    responseText: '',
+    getResponseHeader: jest.fn().mockReturnValue(null),
+    ...overrides,
+  };
+}
+
+function makeOptions(
+  overrides: Partial<QueryKeyEndpointOptions> = {}
+): QueryKeyEndpointOptions {
+  return {
+    method: 'GET',
+    ...overrides,
+  };
+}
+
+describe('createDefaultAuthErrorHandler', () => {
+  const navigate = jest.fn();
+  let handler: ReturnType<typeof createDefaultAuthErrorHandler>;
+
+  beforeEach(() => {
+    navigate.mockReset();
+    handler = createDefaultAuthErrorHandler({navigate});
+    jest.mocked(testableWindowLocation.assign).mockReset();
+    jest.mocked(testableWindowLocation.reload).mockReset();
+  });
+
+  afterEach(() => {
+    setWindowLocation('http://localhost/');
+  });
+
+  it('returns false for allowed anonymous pages', () => {
+    setWindowLocation('http://localhost/accept/123/');
+
+    const result = handler(makeResponse(), makeOptions());
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when allowAuthError is set', () => {
+    const result = handler(makeResponse(), makeOptions({allowAuthError: true}));
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false for sudo-required code', () => {
+    const response = makeResponse({
+      responseJSON: {detail: {code: 'sudo-required'}},
+    });
+
+    expect(handler(response, makeOptions())).toBe(false);
+  });
+
+  it('returns false for 2fa-required code', () => {
+    const response = makeResponse({
+      responseJSON: {detail: {code: '2fa-required'}},
+    });
+
+    expect(handler(response, makeOptions())).toBe(false);
+  });
+
+  it('returns false for ignore code', () => {
+    const response = makeResponse({
+      responseJSON: {detail: {code: 'ignore'}},
+    });
+
+    expect(handler(response, makeOptions())).toBe(false);
+  });
+
+  it('returns false for app-connect-authentication-error code', () => {
+    const response = makeResponse({
+      responseJSON: {detail: {code: 'app-connect-authentication-error'}},
+    });
+
+    expect(handler(response, makeOptions())).toBe(false);
+  });
+
+  it('redirects to SSO login URL for sso-required code', () => {
+    const response = makeResponse({
+      responseJSON: {
+        detail: {code: 'sso-required', extra: {loginUrl: 'https://sso.example.com'}},
+      },
+    });
+
+    const result = handler(response, makeOptions());
+
+    expect(result).toBe(true);
+    expect(testableWindowLocation.assign).toHaveBeenCalledWith('https://sso.example.com');
+  });
+
+  it('navigates for member-disabled-over-limit code', () => {
+    const response = makeResponse({
+      responseJSON: {
+        detail: {code: 'member-disabled-over-limit', extra: {next: '/disabled/'}},
+      },
+    });
+
+    const result = handler(response, makeOptions());
+
+    expect(result).toBe(true);
+    expect(navigate).toHaveBeenCalledWith('/disabled/', {replace: true});
+  });
+
+  it('sets session_expired cookie for general auth failure', () => {
+    const cookieSpy = jest.spyOn(Cookies, 'set');
+
+    const result = handler(makeResponse(), makeOptions());
+
+    expect(result).toBe(true);
+    expect(cookieSpy).toHaveBeenCalledWith('session_expired', '1');
+
+    cookieSpy.mockRestore();
+  });
+
+  it('calls reload for general auth failure in non-SPA mode', () => {
+    handler(makeResponse(), makeOptions());
+
+    expect(testableWindowLocation.reload).toHaveBeenCalled();
+  });
+});
+
+describe('createDefaultSudoHandler', () => {
+  const mockedOpenSudo = jest.mocked(openSudo);
+  let handler: ReturnType<typeof createDefaultSudoHandler>;
+
+  beforeEach(() => {
+    mockedOpenSudo.mockReset();
+    handler = createDefaultSudoHandler();
+  });
+
+  it('opens sudo modal with correct flags for sudo-required', () => {
+    const response = makeResponse({
+      status: 403,
+      responseJSON: {detail: {code: 'sudo-required'}},
+    });
+    const retry = jest.fn();
+
+    handler(response, retry);
+
+    expect(mockedOpenSudo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sudo: true,
+        isSuperuser: false,
+      })
+    );
+  });
+
+  it('opens sudo modal with correct flags for superuser-required', () => {
+    const response = makeResponse({
+      status: 403,
+      responseJSON: {detail: {code: 'superuser-required'}},
+    });
+    const retry = jest.fn();
+
+    handler(response, retry);
+
+    expect(mockedOpenSudo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sudo: false,
+        isSuperuser: true,
+      })
+    );
+  });
+
+  it('resolves with retry result on successful retry', async () => {
+    const retryResult: ApiResponse = {headers: {}, json: {id: 1}};
+    const retry = jest.fn().mockResolvedValue(retryResult);
+
+    mockedOpenSudo.mockImplementation(opts => {
+      opts?.retryRequest?.();
+      return Promise.resolve();
+    });
+
+    const response = makeResponse({
+      status: 403,
+      responseJSON: {detail: {code: 'sudo-required'}},
+    });
+
+    const result = await handler(response, retry);
+
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(result).toBe(retryResult);
+  });
+
+  it('rejects when retry fails', async () => {
+    const retryError = new Error('Retry failed');
+    const retry = jest.fn().mockRejectedValue(retryError);
+
+    mockedOpenSudo.mockImplementation(opts => {
+      opts?.retryRequest?.();
+      return Promise.resolve();
+    });
+
+    const response = makeResponse({
+      status: 403,
+      responseJSON: {detail: {code: 'sudo-required'}},
+    });
+
+    await expect(handler(response, retry)).rejects.toBe(retryError);
+  });
+
+  it('rejects with RequestError when modal is closed without retry', async () => {
+    mockedOpenSudo.mockImplementation(opts => {
+      opts?.onClose?.();
+      return Promise.resolve();
+    });
+
+    const response = makeResponse({
+      status: 403,
+      responseJSON: {detail: {code: 'sudo-required'}},
+    });
+    const retry = jest.fn();
+
+    await expect(handler(response, retry)).rejects.toThrow(RequestError);
+    expect(retry).not.toHaveBeenCalled();
+  });
+});
+
+describe('createDefaultProjectRenamedHandler', () => {
+  const mockedRedirect = jest.mocked(redirectToProject);
+  let handler: ReturnType<typeof createDefaultProjectRenamedHandler>;
+
+  beforeEach(() => {
+    mockedRedirect.mockReset();
+    handler = createDefaultProjectRenamedHandler();
+  });
+
+  it('calls redirectToProject with the new slug', () => {
+    const response = makeResponse({
+      responseJSON: {
+        detail: {code: 'project-moved', extra: {slug: 'new-project-slug'}},
+      },
+    });
+
+    const result = handler(response);
+
+    expect(result).toBe(true);
+    expect(mockedRedirect).toHaveBeenCalledWith('new-project-slug');
+  });
+});
+
+describe('createDefaultErrorHandlers', () => {
+  it('returns all three handlers', () => {
+    const handlers = createDefaultErrorHandlers({navigate: jest.fn()});
+
+    expect(handlers.onAuthError).toBeInstanceOf(Function);
+    expect(handlers.onSudoRequired).toBeInstanceOf(Function);
+    expect(handlers.onProjectRenamed).toBeInstanceOf(Function);
+  });
+});

--- a/static/app/utils/api/requestFetchErrorHandlers.tsx
+++ b/static/app/utils/api/requestFetchErrorHandlers.tsx
@@ -1,0 +1,129 @@
+import Cookies from 'js-cookie';
+
+import {redirectToProject} from 'sentry/actionCreators/redirectToProject';
+import {openSudo} from 'sentry/actionCreators/sudoModal';
+import {EXPERIMENTAL_SPA} from 'sentry/constants';
+import {SUDO_REQUIRED, SUPERUSER_REQUIRED} from 'sentry/constants/apiErrorCodes';
+import {isDemoModeActive} from 'sentry/utils/demoMode';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+
+import type {ApiResponse, RequestFetchErrorHandlers} from './requestFetch';
+
+const ALLOWED_ANON_PAGES = [
+  /^\/accept\//,
+  /^\/share\//,
+  /^\/auth\/login\//,
+  /^\/join-request\//,
+  /^\/unsubscribe\//,
+];
+
+const CODES_TO_SKIP = [
+  'sudo-required',
+  'ignore',
+  '2fa-required',
+  'app-connect-authentication-error',
+];
+
+interface DefaultErrorHandlerOptions {
+  navigate: ReactRouter3Navigate;
+}
+
+export function createDefaultAuthErrorHandler(
+  options: DefaultErrorHandlerOptions
+): NonNullable<RequestFetchErrorHandlers['onAuthError']> {
+  return (response, requestOptions) => {
+    const pageAllowsAnon = ALLOWED_ANON_PAGES.some(regex =>
+      regex.test(window.location.pathname)
+    );
+    if (pageAllowsAnon) {
+      return false;
+    }
+
+    if (requestOptions.allowAuthError) {
+      return false;
+    }
+
+    const code = response?.responseJSON?.detail?.code;
+    const extra = response?.responseJSON?.detail?.extra;
+
+    if (CODES_TO_SKIP.includes(code)) {
+      return false;
+    }
+
+    if (code === 'sso-required') {
+      testableWindowLocation.assign(extra.loginUrl);
+      return true;
+    }
+
+    if (code === 'member-disabled-over-limit') {
+      options.navigate(extra.next, {replace: true});
+      return true;
+    }
+
+    if (!isDemoModeActive()) {
+      Cookies.set('session_expired', '1');
+    }
+
+    if (EXPERIMENTAL_SPA) {
+      options.navigate('/auth/login/', {replace: true});
+    } else {
+      testableWindowLocation.reload();
+    }
+    return true;
+  };
+}
+
+export function createDefaultSudoHandler(): NonNullable<
+  RequestFetchErrorHandlers['onSudoRequired']
+> {
+  return (response, retry) => {
+    const code = response?.responseJSON?.detail?.code;
+
+    return new Promise<ApiResponse>((resolve, reject) => {
+      let didSuccessfullyRetry = false;
+
+      openSudo({
+        isSuperuser: code === SUPERUSER_REQUIRED,
+        sudo: code === SUDO_REQUIRED,
+        retryRequest: async () => {
+          try {
+            const result = await retry();
+            didSuccessfullyRetry = true;
+            resolve(result);
+          } catch (err) {
+            reject(err instanceof Error ? err : new Error(String(err)));
+          }
+        },
+        onClose: () => {
+          if (!didSuccessfullyRetry) {
+            reject(
+              new RequestError(undefined, '', new Error('Sudo modal closed'), response)
+            );
+          }
+        },
+      });
+    });
+  };
+}
+
+export function createDefaultProjectRenamedHandler(): NonNullable<
+  RequestFetchErrorHandlers['onProjectRenamed']
+> {
+  return response => {
+    const slug = response?.responseJSON?.detail?.extra?.slug;
+    redirectToProject(slug);
+    return true;
+  };
+}
+
+export function createDefaultErrorHandlers(
+  options: DefaultErrorHandlerOptions
+): RequestFetchErrorHandlers {
+  return {
+    onAuthError: createDefaultAuthErrorHandler(options),
+    onSudoRequired: createDefaultSudoHandler(),
+    onProjectRenamed: createDefaultProjectRenamedHandler(),
+  };
+}

--- a/static/gsAdmin/init.tsx
+++ b/static/gsAdmin/init.tsx
@@ -11,6 +11,8 @@ import {initializeSdk} from 'sentry/bootstrap/initializeSdk';
 import {DocumentTitleManager} from 'sentry/components/sentryDocumentTitle/documentTitleManager';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
+import {configureRequestFetch} from 'sentry/utils/api/requestFetch';
+import {createDefaultErrorHandlers} from 'sentry/utils/api/requestFetchErrorHandlers';
 import {DEFAULT_QUERY_CLIENT_CONFIG} from 'sentry/utils/queryClient';
 import {createReactRouter3Navigate} from 'sentry/utils/useNavigate';
 
@@ -30,7 +32,11 @@ const queryClient = new QueryClient(DEFAULT_QUERY_CLIENT_CONFIG);
 const sentryCreateBrowserRouter = wrapCreateBrowserRouterV6(createBrowserRouter);
 const router = sentryCreateBrowserRouter(routes);
 
-setApiNavigate(createReactRouter3Navigate(router));
+const navigate = createReactRouter3Navigate(router);
+setApiNavigate(navigate);
+configureRequestFetch({
+  errorHandlers: createDefaultErrorHandlers({navigate}),
+});
 
 export function renderApp() {
   const rootEl = document.getElementById('blk_router')!;

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -70,6 +70,7 @@ jest.mock('lodash/debounce', () =>
 );
 jest.mock('sentry/utils/recreateRoute');
 jest.mock('sentry/api');
+jest.mock('sentry/utils/api/requestFetch');
 jest
   .spyOn(performanceForSentry, 'VisuallyCompleteWithData')
   .mockImplementation(props => props.children as ReactElement);


### PR DESCRIPTION
It turns out that a few special cases are handled inside of https://github.com/getsentry/sentry/blob/master/static/app/api.tsx 
This re-creates those, but splits up some of the error handling that relies on UI into it's own file; these handlers are then injected into the app at the entrypoints. 

The end-state is that we'll have a new fetch system that can be de-coupled from the UI, slightly easier to read, all behind a flagpole flag to test with.

Related to ENG-7768