### PR TITLE
fix(processing-errors): drop null entries from event errors

### DIFF
--- a/src/sentry/processing_errors/detection.py
+++ b/src/sentry/processing_errors/detection.py
@@ -19,6 +19,7 @@ from sentry.processing_errors.grouptype import (
 from sentry.processing_errors.provisioning import ensure_detector
 from sentry.tasks.post_process import PostProcessJob
 from sentry.utils import metrics
+from sentry.utils.safe import get_path
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
 from sentry.workflow_engine.models import DataPacket, DetectorState
 from sentry.workflow_engine.processors.detector import process_detectors
@@ -220,7 +221,7 @@ def detect_processing_issues(job: PostProcessJob) -> None:
         return
 
     event = job["event"]
-    errors = event.data.get("errors", [])
+    errors = get_path(event.data, "errors", filter=True, default=[])
     if not errors:
         return
 

--- a/src/sentry/processing_errors/grouptype.py
+++ b/src/sentry/processing_errors/grouptype.py
@@ -16,6 +16,7 @@ from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.eventerror import EventErrorType
 from sentry.types.group import PriorityLevel
 from sentry.utils import metrics
+from sentry.utils.safe import get_path
 from sentry.workflow_engine.handlers.detector.base import (
     DetectorOccurrence,
     EventData,
@@ -108,7 +109,7 @@ class ProcessingErrorDetectorHandler(
     def extract_value(
         self, data_packet: DataPacket[ProcessingErrorPacketValue]
     ) -> ProcessingErrorCheckStatus:
-        errors = data_packet.packet.event_data.get("errors", [])
+        errors = get_path(data_packet.packet.event_data, "errors", filter=True, default=[])
         has_errors = any(e.get("type") in self.error_types for e in errors)
         return (
             ProcessingErrorCheckStatus.FAILURE if has_errors else ProcessingErrorCheckStatus.SUCCESS
@@ -131,7 +132,7 @@ class ProcessingErrorDetectorHandler(
         priority: DetectorPriorityLevel,
     ) -> tuple[DetectorOccurrence, EventData]:
         event_data_dict = data_packet.packet.event_data
-        errors = event_data_dict.get("errors", [])
+        errors = get_path(event_data_dict, "errors", filter=True, default=[])
         matching_errors = [e for e in errors if e.get("type") in self.error_types]
         error_types = {e.get("type", "unknown") for e in matching_errors}
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1271,7 +1271,7 @@ def process_processing_errors_eap(job: PostProcessJob) -> None:
 
     event = job["event"]
 
-    processing_errors = event.data.get("errors", [])
+    processing_errors = get_path(event.data, "errors", filter=True, default=[])
     if not processing_errors:
         return
 

--- a/tests/sentry/processing_errors/test_detection.py
+++ b/tests/sentry/processing_errors/test_detection.py
@@ -64,6 +64,25 @@ class TestDetectSourcemapIssues(TestCase):
         config = _sourcemap_config()
         assert cache.get(_cache_key_triggered(config.slug, self.project.id)) is not None
 
+    def test_none_entries_in_errors_are_filtered(self) -> None:
+        event = _FakeEvent(
+            self.project,
+            errors=[
+                None,
+                {"type": "js_no_source", "url": "https://example.com/app.js"},
+                None,
+            ],
+        )
+
+        with self.feature("organizations:sourcemap-issue-detection"):
+            detect_processing_issues(_make_job(event))
+
+        state = DetectorState.objects.get(
+            detector__type=SourcemapConfigurationType.slug,
+            detector__project=self.project,
+        )
+        assert state.is_triggered is True
+
     def test_no_errors_does_not_trigger(self) -> None:
         event = _FakeEvent(self.project, errors=[])
 


### PR DESCRIPTION
Sometimes we see `event.data` not have the `errors` field. I suspect the issue is related to Relay normalizing + nulling them, but either way, we can be a bit more defensive in this check and filter out null errors.

Fixes SENTRY-5PWB and SENTRY-5M9Q