### PR TITLE
feat(issue-details): Add details tab to issue preview drawer

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreviewDetails.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewDetails.tsx
@@ -1,0 +1,29 @@
+import {LoadingError} from 'sentry/components/loadingError';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import type {Group} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
+import {EventDetailsContent} from 'sentry/views/issueDetails/groupEventDetails/groupEventDetailsContent';
+import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
+
+interface IssuePreviewDetailsProps {
+  group: Group;
+  project: Project;
+}
+
+export function IssuePreviewDetails({group, project}: IssuePreviewDetailsProps) {
+  const {
+    data: event,
+    isPending,
+    isError,
+  } = useGroupEvent({groupId: group.id, eventId: 'recommended'});
+
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (isError || !event) {
+    return <LoadingError />;
+  }
+
+  return <EventDetailsContent group={group} event={event} project={project} />;
+}

--- a/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.spec.tsx
@@ -1,3 +1,4 @@
+import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
@@ -218,6 +219,73 @@ describe('IssuePreviewDrawer', () => {
 
     expect(await screen.findByRole('tab', {name: 'Activity'})).toBeInTheDocument();
     expect(screen.queryByRole('tab', {name: 'Autofix'})).not.toBeInTheDocument();
+  });
+
+  it('opens the Details tab and renders the event content', async () => {
+    const project = ProjectFixture();
+    const group = GroupFixture({id: '123', shortId: 'JAVASCRIPT-6QS', project});
+    const event = EventFixture({
+      id: 'event-1',
+      entries: [
+        {
+          type: 'message',
+          data: {formatted: 'ReferenceError: foo is not defined'},
+        },
+      ],
+    });
+
+    ProjectsStore.loadInitialData([project]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/`,
+      body: group,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/autofix/setup/`,
+      body: {
+        integration: {ok: false, reason: null},
+        billing: {hasAutofixQuota: false},
+        seerReposLinked: false,
+      },
+    });
+    const eventRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/events/recommended/`,
+      body: event,
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/${project.slug}/events/${event.id}/committers/`,
+      body: {committers: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/${project.slug}/events/${event.id}/owners/`,
+      body: {owners: [], rules: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${group.id}/integrations/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/flags/logs/',
+      body: {data: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/${project.slug}/`,
+      body: project,
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/${project.slug}/events/${event.id}/actionable-items/`,
+      body: {errors: []},
+    });
+
+    render(<IssuePreviewDrawer groupId={group.id} />);
+
+    await userEvent.click(await screen.findByRole('tab', {name: 'Details'}));
+
+    await waitFor(() => expect(eventRequest).toHaveBeenCalled());
+
+    expect(
+      await screen.findByText('ReferenceError: foo is not defined')
+    ).toBeInTheDocument();
   });
 
   it('opens the Autofix tab and shows the start state', async () => {

--- a/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.tsx
@@ -19,6 +19,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {GroupActions} from 'sentry/views/issueDetails/actions/index';
 import {ActivitySection} from 'sentry/views/issueDetails/activitySection';
+import {IssueDetailsContextProvider} from 'sentry/views/issueDetails/context';
 import {
   GroupDataContextProvider,
   useGroupData,
@@ -29,6 +30,7 @@ import {GroupStatusSubtitle} from 'sentry/views/issueDetails/header/groupStatusS
 import {IssueIdBreadcrumb} from 'sentry/views/issueDetails/header/issueIdBreadcrumb';
 import {useAiConfig} from 'sentry/views/issueDetails/hooks/useAiConfig';
 import {IssuePreviewAutofix} from 'sentry/views/issueDetails/issuePreview/issuePreviewAutofix';
+import {IssuePreviewDetails} from 'sentry/views/issueDetails/issuePreview/issuePreviewDetails';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
 import {
   getGroupReprocessingStatus,
@@ -152,9 +154,7 @@ function IssuePreviewContent() {
               {hasAutofix ? (
                 <TabList.Item key="autofix">{t('Autofix')}</TabList.Item>
               ) : null}
-              <TabList.Item key="details" disabled>
-                {t('Details')}
-              </TabList.Item>
+              <TabList.Item key="details">{t('Details')}</TabList.Item>
               <TabList.Item key="events" disabled>
                 {t('Events')}
               </TabList.Item>
@@ -179,7 +179,11 @@ function IssuePreviewContent() {
               </TabPanels.Item>
             ) : null}
             <TabPanels.Item key="details">
-              <div />
+              <Container paddingTop="md">
+                <IssueDetailsContextProvider>
+                  <IssuePreviewDetails group={group} project={project} />
+                </IssueDetailsContextProvider>
+              </Container>
             </TabPanels.Item>
             <TabPanels.Item key="events">
               <div />


### PR DESCRIPTION
Closes ISWF-2878

Simpler than I thought it would be to drop in the event details here

<img width="1450" height="1488" alt="CleanShot 2026-06-23 at 15 36 31@2x" src="https://github.com/user-attachments/assets/9b94aec1-8bfc-403a-b670-0b038d64d3af" />
