### PR TITLE
ref(issue-details): Make comment create/update/delete behavior non-optimistic

### DIFF
--- a/static/app/components/activity/note/compact.tsx
+++ b/static/app/components/activity/note/compact.tsx
@@ -27,8 +27,8 @@ type Props = {
   noteId?: string;
   onCancel?: () => void;
   onChange?: (e: MentionChangeEvent, extra: {updating?: boolean}) => void;
-  onCreate?: (data: NoteType) => void;
-  onUpdate?: (data: NoteType) => void;
+  onCreate?: (data: NoteType) => Promise<void>;
+  onUpdate?: (data: NoteType) => Promise<void>;
   placeholder?: string;
   /**
    * The note text itself
@@ -61,6 +61,7 @@ export function CompactNoteInput({
   const [memberMentions, setMemberMentions] = useState<Mentioned[]>([]);
   const [teamMentions, setTeamMentions] = useState<Mentioned[]>([]);
   const [isSubmitVisible, setIsSubmitVisible] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const canSubmit = value.trim() !== '';
 
@@ -75,13 +76,19 @@ export function CompactNoteInput({
     .filter(mention => value.includes(mention[1]))
     .map(mention => mention[0]);
 
-  const submitForm = useCallback(
-    () =>
-      existingItem
+  const submitForm = useCallback(async () => {
+    setIsSubmitting(true);
+    try {
+      await (existingItem
         ? onUpdate?.({text: cleanMarkdown, mentions: finalizedMentions})
-        : onCreate?.({text: cleanMarkdown, mentions: finalizedMentions}),
-    [existingItem, onUpdate, cleanMarkdown, finalizedMentions, onCreate]
-  );
+        : onCreate?.({text: cleanMarkdown, mentions: finalizedMentions}));
+    } catch {
+      // An error indicator is surfaced by the parent component. Keep this
+      // open so the user can retry without losing their draft.
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [existingItem, onUpdate, cleanMarkdown, finalizedMentions, onCreate]);
 
   const displaySubmitButton = useCallback(() => {
     setIsSubmitVisible(true);
@@ -179,14 +186,15 @@ export function CompactNoteInput({
       {(isSubmitVisible || existingItem) && (
         <Grid flow="column" align="center" gap="xs">
           {existingItem && (
-            <Button size="xs" onClick={onCancel}>
+            <Button size="xs" onClick={onCancel} disabled={isSubmitting}>
               {t('Cancel')}
             </Button>
           )}
           <Button
             variant="primary"
             size="xs"
-            disabled={!canSubmit}
+            busy={isSubmitting}
+            disabled={!canSubmit || isSubmitting}
             aria-label={existingItem ? t('Save comment') : t('Submit comment')}
             type="submit"
           >

--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -40,8 +40,8 @@ type Props = {
   noteId?: string;
   onCancel?: () => void;
   onChange?: (e: MentionChangeEvent, extra: {updating?: boolean}) => void;
-  onCreate?: (data: NoteType) => void;
-  onUpdate?: (data: NoteType) => void;
+  onCreate?: (data: NoteType) => Promise<void>;
+  onUpdate?: (data: NoteType) => Promise<void>;
   placeholder?: string;
   /**
    * The note text itself
@@ -91,16 +91,21 @@ export function NoteInput({
       .replace(/\[sentry\.strip:team\]/g, '');
 
   const submitNote = useCallback(
-    (comment: string) => {
+    async (comment: string) => {
       const cleanMarkdown = getCleanMarkdown(comment);
       // each mention looks like [id, display]
       const finalizedMentions = [...memberMentions, ...teamMentions]
         .filter(mention => comment.includes(mention[1]))
         .map(mention => mention[0]);
 
-      return existingItem
-        ? onUpdate?.({text: cleanMarkdown, mentions: finalizedMentions})
-        : onCreate?.({text: cleanMarkdown, mentions: finalizedMentions});
+      try {
+        await (existingItem
+          ? onUpdate?.({text: cleanMarkdown, mentions: finalizedMentions})
+          : onCreate?.({text: cleanMarkdown, mentions: finalizedMentions}));
+      } catch {
+        // An error indicator is surfaced by the parent component. Keep this
+        // open so the user can retry without losing their draft.
+      }
     },
     [existingItem, memberMentions, onCreate, onUpdate, teamMentions]
   );
@@ -249,9 +254,13 @@ export function NoteInput({
                 )}
                 <Flex gap="sm">
                   {existingItem && (
-                    <Button size="xs" onClick={handleCancel}>
-                      {t('Cancel')}
-                    </Button>
+                    <form.Subscribe selector={state => state.isSubmitting}>
+                      {isSubmitting => (
+                        <Button size="xs" onClick={handleCancel} disabled={isSubmitting}>
+                          {t('Cancel')}
+                        </Button>
+                      )}
+                    </form.Subscribe>
                   )}
                   <form.Subscribe selector={state => state.values.text.trim() === ''}>
                     {isEmpty => (

--- a/static/app/components/activity/note/inputWithStorage.spec.tsx
+++ b/static/app/components/activity/note/inputWithStorage.spec.tsx
@@ -1,3 +1,5 @@
+import {GroupFixture} from 'sentry-fixture/group';
+
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {NoteInputWithStorage} from 'sentry/components/activity/note/inputWithStorage';
@@ -26,9 +28,7 @@ describe('NoteInputWithStorage', () => {
   const defaultProps = {
     storageKey: 'storage',
     itemKey: 'item1',
-    group: {project: {}, id: 'groupId'},
-    memberList: [],
-    teams: [],
+    group: GroupFixture(),
   };
 
   it('loads draft item from local storage when mounting', async () => {

--- a/static/app/components/activity/note/inputWithStorage.spec.tsx
+++ b/static/app/components/activity/note/inputWithStorage.spec.tsx
@@ -3,6 +3,7 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {NoteInputWithStorage} from 'sentry/components/activity/note/inputWithStorage';
+import {GroupActivityType} from 'sentry/types/group';
 import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 jest.mock('sentry/utils/localStorage');
@@ -62,14 +63,27 @@ describe('NoteInputWithStorage', () => {
         JSON.stringify({item1: 'draft item', item2: 'item2', item3: 'item3'})
       );
 
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/1/comments/',
+      method: 'POST',
+      body: {
+        id: '1',
+        type: GroupActivityType.NOTE,
+        data: {text: 'new comment'},
+        dateCreated: '2024-01-01T00:00:00Z',
+      },
+    });
+
     render(<NoteInputWithStorage {...defaultProps} />);
 
     await changeReactMentionsInput('new comment');
     await userEvent.type(screen.getByRole('textbox'), '{Control>}{enter}{/Control}');
 
-    expect(localStorageWrapper.setItem).toHaveBeenLastCalledWith(
-      'storage',
-      JSON.stringify({item2: 'item2', item3: 'item3'})
-    );
+    await waitFor(() => {
+      expect(localStorageWrapper.setItem).toHaveBeenLastCalledWith(
+        'storage',
+        JSON.stringify({item2: 'item2', item3: 'item3'})
+      );
+    });
   });
 });

--- a/static/app/components/activity/note/inputWithStorage.tsx
+++ b/static/app/components/activity/note/inputWithStorage.tsx
@@ -126,6 +126,7 @@ function NoteInputWithStorage({
 
   const handleCreate = useCallback(
     async (data: NoteType) => {
+      save.cancel();
       const result = await mutators.handleCreate(data, group.activity, {
         onSuccess: () => {
           addSuccessMessage(t('Comment posted'));
@@ -150,6 +151,7 @@ function NoteInputWithStorage({
       onCommentCreated?.([result, ...group.activity]);
     },
     [
+      save,
       itemKey,
       storageKey,
       mutators,

--- a/static/app/components/activity/note/inputWithStorage.tsx
+++ b/static/app/components/activity/note/inputWithStorage.tsx
@@ -6,7 +6,6 @@ import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicato
 import {CompactNoteInput} from 'sentry/components/activity/note/compact';
 import {NoteInput} from 'sentry/components/activity/note/input';
 import type {MentionChangeEvent} from 'sentry/components/activity/note/types';
-import {useMutateActivity} from 'sentry/components/feedback/useMutateActivity';
 import {t, tct} from 'sentry/locale';
 import {GroupStore} from 'sentry/stores/groupStore';
 import type {NoteType} from 'sentry/types/alerts';
@@ -14,6 +13,7 @@ import type {Group, GroupActivityNote} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useMutateActivity} from 'sentry/views/issueDetails/activitySection/useMutateActivity';
 
 type InputProps = React.ComponentProps<typeof NoteInput>;
 

--- a/static/app/components/activity/note/inputWithStorage.tsx
+++ b/static/app/components/activity/note/inputWithStorage.tsx
@@ -2,22 +2,32 @@ import {useCallback, useMemo} from 'react';
 import * as Sentry from '@sentry/react';
 import debounce from 'lodash/debounce';
 
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {CompactNoteInput} from 'sentry/components/activity/note/compact';
 import {NoteInput} from 'sentry/components/activity/note/input';
 import type {MentionChangeEvent} from 'sentry/components/activity/note/types';
+import {useMutateActivity} from 'sentry/components/feedback/useMutateActivity';
+import {t, tct} from 'sentry/locale';
+import {GroupStore} from 'sentry/stores/groupStore';
 import type {NoteType} from 'sentry/types/alerts';
+import type {Group, GroupActivityNote} from 'sentry/types/group';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {localStorageWrapper} from 'sentry/utils/localStorage';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 type InputProps = React.ComponentProps<typeof NoteInput>;
 
 type Props = {
+  group: Group;
   itemKey: string;
   storageKey: string;
+  onCommentCreated?: () => void;
+  onCommentEdited?: () => void;
   onLoad?: (data: string) => string;
   onSave?: (data: string) => string;
   text?: string;
   variant?: 'compact' | 'full';
-} & InputProps;
+} & Omit<InputProps, 'onCreate' | 'onUpdate'>;
 
 function fetchFromStorage(storageKey: string) {
   const storage = localStorageWrapper.getItem(storageKey);
@@ -52,13 +62,19 @@ function NoteInputWithStorage({
   itemKey,
   storageKey,
   onChange,
-  onCreate,
   onLoad,
   onSave,
   text,
   variant,
+  group,
+  onCommentCreated,
+  onCommentEdited,
+  noteId,
   ...props
 }: Props) {
+  const organization = useOrganization();
+  const mutators = useMutateActivity({organization, group});
+
   const value = useMemo(() => {
     if (text) {
       return text;
@@ -108,29 +124,62 @@ function NoteInputWithStorage({
     [onChange, save]
   );
 
-  /**
-   * Handler when note is created.
-   *
-   * Remove in progress item from local storage if it exists
-   */
   const handleCreate = useCallback(
-    (data: NoteType) => {
-      onCreate?.(data);
+    async (data: NoteType) => {
+      const result = await mutators.handleCreate(data, group.activity, {
+        onSuccess: () => {
+          addSuccessMessage(t('Comment posted'));
+        },
+        onError: error => {
+          const errMessage = error.responseJSON?.detail
+            ? tct('Error: [msg]', {msg: error.responseJSON?.detail as string})
+            : t('Unable to post comment');
+          addErrorMessage(errMessage);
+        },
+      });
 
-      // Remove from local storage
+      // Clear the localStorage draft on success
       const storageObj = fetchFromStorage(storageKey) ?? {};
-
-      // Nothing from this `itemKey` is saved to storage, do nothing
-      if (!Object.hasOwn(storageObj, itemKey)) {
-        return;
+      if (Object.hasOwn(storageObj, itemKey)) {
+        const {[itemKey]: _oldItem, ...newStorageObj} = storageObj;
+        saveToStorage(storageKey, newStorageObj);
       }
 
-      // Remove `itemKey` from stored object and save to storage
-
-      const {[itemKey]: _oldItem, ...newStorageObj} = storageObj;
-      saveToStorage(storageKey, newStorageObj);
+      GroupStore.addActivity(group.id, result);
+      trackAnalytics('issue_details.comment_created', {organization});
+      onCommentCreated?.();
     },
-    [itemKey, onCreate, storageKey]
+    [
+      itemKey,
+      storageKey,
+      mutators,
+      group.activity,
+      group.id,
+      organization,
+      onCommentCreated,
+    ]
+  );
+
+  const handleUpdate = useCallback(
+    async (data: NoteType) => {
+      if (!noteId) {
+        return;
+      }
+      const result = await mutators.handleUpdate(data, noteId, group.activity, {
+        onSuccess: () => {
+          addSuccessMessage(t('Comment updated'));
+        },
+        onError: () => {
+          addErrorMessage(t('Unable to update comment'));
+        },
+      });
+
+      const d = result as GroupActivityNote;
+      GroupStore.updateActivity(group.id, result.id, {text: d.data.text});
+      trackAnalytics('issue_details.comment_updated', {organization});
+      onCommentEdited?.();
+    },
+    [mutators, noteId, group.activity, group.id, organization, onCommentEdited]
   );
 
   if (variant === 'compact') {
@@ -138,17 +187,24 @@ function NoteInputWithStorage({
       <CompactNoteInput
         text={value}
         onCreate={handleCreate}
+        onUpdate={handleUpdate}
         onChange={handleChange}
         placeholder={props.placeholder}
-        noteId={props.noteId}
-        onUpdate={props.onUpdate}
+        noteId={noteId}
         onCancel={props.onCancel}
       />
     );
   }
 
   return (
-    <NoteInput {...props} text={value} onCreate={handleCreate} onChange={handleChange} />
+    <NoteInput
+      {...props}
+      text={value}
+      noteId={noteId}
+      onCreate={handleCreate}
+      onUpdate={handleUpdate}
+      onChange={handleChange}
+    />
   );
 }
 

--- a/static/app/components/activity/note/inputWithStorage.tsx
+++ b/static/app/components/activity/note/inputWithStorage.tsx
@@ -9,7 +9,7 @@ import type {MentionChangeEvent} from 'sentry/components/activity/note/types';
 import {t, tct} from 'sentry/locale';
 import {GroupStore} from 'sentry/stores/groupStore';
 import type {NoteType} from 'sentry/types/alerts';
-import type {Group, GroupActivityNote} from 'sentry/types/group';
+import type {Group, GroupActivity, GroupActivityNote} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -21,8 +21,8 @@ type Props = {
   group: Group;
   itemKey: string;
   storageKey: string;
-  onCommentCreated?: () => void;
-  onCommentEdited?: () => void;
+  onCommentCreated?: (activity: GroupActivity[]) => void;
+  onCommentEdited?: (activity: GroupActivity[]) => void;
   onLoad?: (data: string) => string;
   onSave?: (data: string) => string;
   text?: string;
@@ -147,7 +147,7 @@ function NoteInputWithStorage({
 
       GroupStore.addActivity(group.id, result);
       trackAnalytics('issue_details.comment_created', {organization});
-      onCommentCreated?.();
+      onCommentCreated?.([result, ...group.activity]);
     },
     [
       itemKey,
@@ -177,7 +177,7 @@ function NoteInputWithStorage({
       const d = result as GroupActivityNote;
       GroupStore.updateActivity(group.id, result.id, {text: d.data.text});
       trackAnalytics('issue_details.comment_updated', {organization});
-      onCommentEdited?.();
+      onCommentEdited?.(group.activity.map(a => (a.id === result.id ? result : a)));
     },
     [mutators, noteId, group.activity, group.id, organization, onCommentEdited]
   );

--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -257,9 +257,9 @@ function ConfirmModal({
   closeModal,
 }: ModalProps) {
   const confirmCallbackRef = useRef<() => void>(() => {});
-  const isConfirmingRef = useRef(false);
   const [shouldDisableConfirmButton, setShouldDisableConfirmButton] =
     useState(disableConfirmButton);
+  const [isConfirming, setIsConfirming] = useState(false);
   const [isError, setIsError] = useState(false);
 
   const handleClose = () => {
@@ -267,27 +267,25 @@ function ConfirmModal({
     setShouldDisableConfirmButton(disableConfirmButton ?? false);
 
     // always reset `confirming` when modal visibility changes
-    isConfirmingRef.current = false;
+    setIsConfirming(false);
     closeModal();
   };
 
   const handleConfirm = async () => {
-    if (isConfirmingRef.current) {
+    if (isConfirming) {
       return;
     }
 
-    isConfirmingRef.current = true;
-    setShouldDisableConfirmButton(true);
+    setIsConfirming(true);
 
     if (onConfirm) {
       try {
         await onConfirm();
       } catch (error) {
         setIsError(true);
-        setShouldDisableConfirmButton(disableConfirmButton ?? false);
         return;
       } finally {
-        isConfirmingRef.current = false;
+        setIsConfirming(false);
       }
     }
 
@@ -351,6 +349,7 @@ function ConfirmModal({
             <Button
               data-test-id="confirm-button"
               disabled={shouldDisableConfirmButton}
+              busy={isConfirming}
               variant={priority}
               onClick={handleConfirm}
               autoFocus={!isDangerous}

--- a/static/app/components/feedback/feedbackItem/feedbackActivitySection.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActivitySection.tsx
@@ -2,7 +2,7 @@ import {useCallback} from 'react';
 
 import {useFeedbackCache} from 'sentry/components/feedback/useFeedbackCache';
 import {t} from 'sentry/locale';
-import {GroupActivityType, type Group} from 'sentry/types/group';
+import {GroupActivityType, type Group, type GroupActivity} from 'sentry/types/group';
 import {ActivitySection} from 'sentry/views/issueDetails/activitySection';
 
 type Props = {
@@ -12,11 +12,15 @@ type Props = {
 export function FeedbackActivitySection(props: Props) {
   const {feedbackItem} = props;
 
-  const {invalidateCached} = useFeedbackCache();
+  const {updateCached, invalidateCached} = useFeedbackCache();
 
-  const invalidateCache = useCallback(() => {
-    invalidateCached([feedbackItem.id]);
-  }, [invalidateCached, feedbackItem.id]);
+  const handleCommentChange = useCallback(
+    (activity: GroupActivity[]) => {
+      updateCached([feedbackItem.id], {activity});
+      invalidateCached([feedbackItem.id]);
+    },
+    [updateCached, invalidateCached, feedbackItem.id]
+  );
 
   const filteredActivity = feedbackItem.activity.filter(
     a => a.type !== GroupActivityType.FIRST_SEEN
@@ -25,9 +29,9 @@ export function FeedbackActivitySection(props: Props) {
   return (
     <ActivitySection
       group={{...feedbackItem, activity: filteredActivity} as unknown as Group}
-      onCommentCreated={invalidateCache}
-      onCommentDeleted={invalidateCache}
-      onCommentEdited={invalidateCache}
+      onCommentCreated={handleCommentChange}
+      onCommentDeleted={handleCommentChange}
+      onCommentEdited={handleCommentChange}
       variant="standalone"
       placeholder={t(
         'Add details or updates to this feedback, visible only to your organization. \nTag users with @, or teams with #'

--- a/static/app/components/feedback/feedbackItem/feedbackActivitySection.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActivitySection.tsx
@@ -1,19 +1,8 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback} from 'react';
 
-import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {useFeedbackCache} from 'sentry/components/feedback/useFeedbackCache';
-import {useMutateActivity} from 'sentry/components/feedback/useMutateActivity';
 import {t} from 'sentry/locale';
-import type {NoteType} from 'sentry/types/alerts';
-import {
-  GroupActivityType,
-  type Group,
-  type GroupActivity,
-  type GroupActivityNote,
-} from 'sentry/types/group';
-import type {User} from 'sentry/types/user';
-import {uniqueId} from 'sentry/utils/guid';
-import {useOrganization} from 'sentry/utils/useOrganization';
+import {GroupActivityType, type Group} from 'sentry/types/group';
 import {ActivitySection} from 'sentry/views/issueDetails/activitySection';
 
 type Props = {
@@ -22,85 +11,12 @@ type Props = {
 
 export function FeedbackActivitySection(props: Props) {
   const {feedbackItem} = props;
-  const organization = useOrganization();
 
-  const {updateCached, invalidateCached} = useFeedbackCache();
+  const {invalidateCached} = useFeedbackCache();
 
-  const mutators = useMutateActivity({
-    onMutate: ([{activity}, _method]) => {
-      updateCached([feedbackItem.id], {activity});
-    },
-    onSettled: (_resp, _error, _var, _context) => {
-      invalidateCached([feedbackItem.id]);
-    },
-    organization,
-    group: feedbackItem,
-  });
-
-  const deleteOptions = useMemo(() => {
-    return {
-      onError: () => {
-        addErrorMessage(t('An error occurred while removing the comment.'));
-      },
-      onSuccess: () => {
-        addSuccessMessage(t('Comment removed'));
-      },
-    };
-  }, []);
-
-  const createOptions = useMemo(() => {
-    return {
-      onError: () => {
-        addErrorMessage(t('An error occurred while posting the comment.'));
-      },
-      onSuccess: () => {
-        addSuccessMessage(t('Comment posted'));
-      },
-    };
-  }, []);
-
-  const updateOptions = useMemo(() => {
-    return {
-      onError: () => {
-        addErrorMessage(t('An error occurred while updating the comment.'));
-      },
-      onSuccess: () => {
-        addSuccessMessage(t('Comment updated'));
-      },
-    };
-  }, []);
-
-  const handleDelete = useCallback(
-    (item: GroupActivity) => {
-      mutators.handleDelete(
-        item.id,
-        feedbackItem.activity.filter(a => a.id !== item.id),
-        deleteOptions
-      );
-    },
-    [deleteOptions, feedbackItem.activity, mutators]
-  );
-
-  const handleCreate = useCallback(
-    (n: NoteType, me: User) => {
-      const newActivity: GroupActivityNote = {
-        id: uniqueId(), // temporary unique id, for cache use only
-        data: n,
-        type: GroupActivityType.NOTE,
-        dateCreated: new Date().toISOString(),
-        user: me,
-      };
-      mutators.handleCreate(n, [newActivity, ...feedbackItem.activity], createOptions);
-    },
-    [createOptions, feedbackItem.activity, mutators]
-  );
-
-  const handleUpdate = useCallback(
-    (item: GroupActivity, n: NoteType) => {
-      mutators.handleUpdate(n, item.id, feedbackItem.activity, updateOptions);
-    },
-    [updateOptions, feedbackItem.activity, mutators]
-  );
+  const invalidateCache = useCallback(() => {
+    invalidateCached([feedbackItem.id]);
+  }, [invalidateCached, feedbackItem.id]);
 
   const filteredActivity = feedbackItem.activity.filter(
     a => a.type !== GroupActivityType.FIRST_SEEN
@@ -109,9 +25,9 @@ export function FeedbackActivitySection(props: Props) {
   return (
     <ActivitySection
       group={{...feedbackItem, activity: filteredActivity} as unknown as Group}
-      onDelete={handleDelete}
-      onCreate={handleCreate}
-      onUpdate={handleUpdate}
+      onCommentCreated={invalidateCache}
+      onCommentDeleted={invalidateCache}
+      onCommentEdited={invalidateCache}
       variant="standalone"
       placeholder={t(
         'Add details or updates to this feedback, visible only to your organization. \nTag users with @, or teams with #'

--- a/static/app/components/feedback/useMutateActivity.tsx
+++ b/static/app/components/feedback/useMutateActivity.tsx
@@ -17,25 +17,24 @@ type DeleteCommentCallback = (
   noteId: string,
   activity: GroupActivity[],
   options?: MutateOptions<TData, TError, TVariables>
-) => void;
+) => Promise<TData>;
 
 type CreateCommentCallback = (
   note: NoteType,
   activity: GroupActivity[],
   options?: MutateOptions<TData, TError, TVariables>
-) => void;
+) => Promise<TData>;
 
 type UpdateCommentCallback = (
   note: NoteType,
   noteId: string,
   activity: GroupActivity[],
   options?: MutateOptions<TData, TError, TVariables>
-) => void;
+) => Promise<TData>;
 
 interface Props {
   group: Group;
   organization: Organization;
-  onMutate?: (variables: TVariables) => unknown | undefined;
   onSettled?:
     | ((
         data: unknown,
@@ -46,9 +45,8 @@ interface Props {
     | undefined;
 }
 
-export function useMutateActivity({organization, group, onMutate, onSettled}: Props) {
-  const {mutate} = useMutation<TData, TError, TVariables>({
-    onMutate: onMutate ?? undefined,
+export function useMutateActivity({organization, group, onSettled}: Props) {
+  const {mutateAsync} = useMutation<TData, TError, TVariables>({
     mutationFn: ([{note, noteId}, method]) => {
       const url =
         method === 'PUT' || method === 'DELETE'
@@ -68,23 +66,23 @@ export function useMutateActivity({organization, group, onMutate, onSettled}: Pr
 
   const handleUpdate = useCallback<UpdateCommentCallback>(
     (note, noteId, activity, options) => {
-      mutate([{note, noteId, activity}, 'PUT'], options);
+      return mutateAsync([{note, noteId, activity}, 'PUT'], options);
     },
-    [mutate]
+    [mutateAsync]
   );
 
   const handleCreate = useCallback<CreateCommentCallback>(
     (note, activity, options) => {
-      mutate([{note, activity}, 'POST'], options);
+      return mutateAsync([{note, activity}, 'POST'], options);
     },
-    [mutate]
+    [mutateAsync]
   );
 
   const handleDelete = useCallback<DeleteCommentCallback>(
     (noteId, activity, options) => {
-      mutate([{noteId, activity}, 'DELETE'], options);
+      return mutateAsync([{noteId, activity}, 'DELETE'], options);
     },
-    [mutate]
+    [mutateAsync]
   );
 
   return {

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -87,18 +87,9 @@ export type IssueEventParameters = {
   'issue_details.activity_drawer.filter_changed': {
     filter: string;
   };
-  'issue_details.comment_created': {
-    org_streamline_only: boolean | undefined;
-    streamline: boolean;
-  };
-  'issue_details.comment_deleted': {
-    org_streamline_only: boolean | undefined;
-    streamline: boolean;
-  };
-  'issue_details.comment_updated': {
-    org_streamline_only: boolean | undefined;
-    streamline: boolean;
-  };
+  'issue_details.comment_created': Record<string, never>;
+  'issue_details.comment_deleted': Record<string, never>;
+  'issue_details.comment_updated': Record<string, never>;
   'issue_details.copy_event_id_clicked': StreamlineGroupEventParams;
   'issue_details.copy_event_link_clicked': StreamlineGroupEventParams;
   'issue_details.copy_issue_details_as_markdown': {

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -87,9 +87,9 @@ export type IssueEventParameters = {
   'issue_details.activity_drawer.filter_changed': {
     filter: string;
   };
-  'issue_details.comment_created': Record<string, never>;
-  'issue_details.comment_deleted': Record<string, never>;
-  'issue_details.comment_updated': Record<string, never>;
+  'issue_details.comment_created': Record<string, unknown>;
+  'issue_details.comment_deleted': Record<string, unknown>;
+  'issue_details.comment_updated': Record<string, unknown>;
   'issue_details.copy_event_id_clicked': StreamlineGroupEventParams;
   'issue_details.copy_event_link_clicked': StreamlineGroupEventParams;
   'issue_details.copy_issue_details_as_markdown': {

--- a/static/app/views/issueDetails/activitySection/commentActionsDropdown.tsx
+++ b/static/app/views/issueDetails/activitySection/commentActionsDropdown.tsx
@@ -6,7 +6,7 @@ import type {User} from 'sentry/types/user';
 import {useUser} from 'sentry/utils/useUser';
 
 type Props = {
-  onDelete: () => void;
+  onDelete: () => Promise<void>;
   onEdit: () => void;
   user?: User | null;
 };
@@ -54,6 +54,7 @@ export function CommentActionsDropdown({
                 <strong>{t('Are you sure you want to remove this comment?')}</strong>
               ),
               confirmText: t('Remove comment'),
+              errorMessage: t('Failed to remove comment'),
               onConfirm: onDelete,
             }),
           tooltip: activeUser.isSuperuser

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -11,6 +11,7 @@ import {
   renderGlobalModal,
   screen,
   userEvent,
+  waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
 import * as indicators from 'sentry/actionCreators/indicator';
@@ -188,9 +189,49 @@ describe('ActivitySection', () => {
     ).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', {name: 'Remove comment'}));
 
-    expect(deleteMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(deleteMock).toHaveBeenCalledTimes(1));
 
-    expect(screen.queryByText('Test Note')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('Test Note')).not.toBeInTheDocument());
+  });
+
+  it('keeps the comment and modal open when deletion fails', async () => {
+    const errorGroup = GroupFixture({
+      id: '1400',
+      activity: [
+        {
+          type: GroupActivityType.NOTE,
+          id: 'note-1',
+          data: {text: 'Undeletable Note'},
+          dateCreated: '2020-01-01T00:00:00',
+          user,
+        },
+      ],
+      project,
+    });
+    GroupStore.add([errorGroup]);
+    const deleteMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/1400/comments/note-1/',
+      method: 'DELETE',
+      statusCode: 500,
+    });
+
+    render(
+      <GroupDataContextProvider group={errorGroup} project={errorGroup.project}>
+        <ActivitySection group={errorGroup} />
+      </GroupDataContextProvider>
+    );
+    renderGlobalModal();
+    expect(await screen.findByText('Undeletable Note')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Comment Actions'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Remove'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Remove comment'}));
+
+    await waitFor(() => expect(deleteMock).toHaveBeenCalledTimes(1));
+
+    // The modal stays open with an error, and the comment is still present.
+    expect(await screen.findByText('Failed to remove comment')).toBeInTheDocument();
+    expect(screen.getByText('Undeletable Note')).toBeInTheDocument();
   });
 
   it('renders note markdown', async () => {
@@ -495,8 +536,13 @@ describe('ActivitySection', () => {
     await userEvent.type(screen.getByDisplayValue('Group Test'), ' Updated');
     await userEvent.click(screen.getByRole('button', {name: 'Save comment'}));
 
-    expect(editMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(editMock).toHaveBeenCalledTimes(1));
     expect(indicators.addSuccessMessage).toHaveBeenCalledWith('Comment updated');
+
+    // Editor closes only after the update succeeds.
+    await waitFor(() =>
+      expect(screen.queryByRole('button', {name: 'Save comment'})).not.toBeInTheDocument()
+    );
   });
 
   it('renders note from a sentry app', async () => {

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -7,26 +7,23 @@ import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {NoteBody} from 'sentry/components/activity/note/body';
 import {NoteInputWithStorage} from 'sentry/components/activity/note/inputWithStorage';
 import {useMutateActivity} from 'sentry/components/feedback/useMutateActivity';
 import {Timeline} from 'sentry/components/timeline';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconEllipsis} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {GroupStore} from 'sentry/stores/groupStore';
-import type {NoteType} from 'sentry/types/alerts';
-import type {Group, GroupActivity, GroupActivityNote} from 'sentry/types/group';
+import type {Group, GroupActivity} from 'sentry/types/group';
 import {GroupActivityType, SEER_ACTIVITY_TYPES} from 'sentry/types/group';
 import type {Team} from 'sentry/types/organization';
-import type {User} from 'sentry/types/user';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {uniqueId} from 'sentry/utils/guid';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTeamsById} from 'sentry/utils/useTeamsById';
-import {useUser} from 'sentry/utils/useUser';
 import {getActivityColorConfig} from 'sentry/views/issueDetails/activitySection/activityColorConfig';
 import {ActivityMarker} from 'sentry/views/issueDetails/activitySection/activityMarker';
 import {CommentActionsDropdown} from 'sentry/views/issueDetails/activitySection/commentActionsDropdown';
@@ -41,7 +38,7 @@ import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRou
 function TimelineItem({
   item,
   handleDelete,
-  handleUpdate,
+  onCommentEdited,
   group,
   teams,
   size,
@@ -49,12 +46,12 @@ function TimelineItem({
   timestampUnitStyle,
 }: {
   group: Group;
-  handleDelete: (item: GroupActivity) => void;
-  handleUpdate: (item: GroupActivity, n: NoteType) => void;
+  handleDelete: (item: GroupActivity) => Promise<void>;
   inputVariant: 'compact' | 'full';
   item: GroupActivity;
   size: 'sm' | 'md';
   teams: Team[];
+  onCommentEdited?: () => void;
   timestampUnitStyle?: React.ComponentProps<typeof TimeSince>['unitStyle'];
 }) {
   const organization = useOrganization();
@@ -124,8 +121,9 @@ function TimelineItem({
           variant={inputVariant}
           text={item.data.text}
           noteId={item.id}
-          onUpdate={n => {
-            handleUpdate(item, n);
+          group={group}
+          onCommentEdited={() => {
+            onCommentEdited?.();
             setEditing(false);
           }}
           onCancel={() => setEditing(false)}
@@ -156,9 +154,9 @@ interface ActivitySectionProps {
    */
   filterComments?: boolean;
   minHeight?: number;
-  onCreate?: (n: NoteType, me: User) => void;
-  onDelete?: (item: GroupActivity) => void;
-  onUpdate?: (item: GroupActivity, n: NoteType) => void;
+  onCommentCreated?: () => void;
+  onCommentDeleted?: () => void;
+  onCommentEdited?: () => void;
   /**
    * Controls layout and input style.
    * - `sidebar` (default): fold section, compact input, collapses at 5 items
@@ -172,9 +170,9 @@ interface ActivitySectionProps {
 export function ActivitySection({
   group,
   filterComments,
-  onCreate: onCreateProp,
-  onDelete: onDeleteProp,
-  onUpdate: onUpdateProp,
+  onCommentCreated,
+  onCommentDeleted,
+  onCommentEdited,
   variant = 'sidebar',
   size = 'sm',
   minHeight = 96,
@@ -187,12 +185,9 @@ export function ActivitySection({
   const location = useLocation();
   const [inputId, setInputId] = useState(() => uniqueId());
 
-  const activeUser = useUser();
-  const projectSlugs = group?.project ? [group.project.slug] : [];
   const noteProps = {
     minHeight,
     group,
-    projectSlugs,
     placeholder,
   };
 
@@ -202,90 +197,22 @@ export function ActivitySection({
   });
 
   const handleDelete = useCallback(
-    (item: GroupActivity) => {
-      if (onDeleteProp) {
-        onDeleteProp(item);
-        return;
-      }
-
-      const restore = group.activity.find(activity => activity.id === item.id);
-      const index = GroupStore.removeActivity(group.id, item.id);
-
-      if (index === -1 || restore === undefined) {
-        addErrorMessage(t('Failed to delete comment'));
-        return;
-      }
-      mutators.handleDelete(
+    async (item: GroupActivity): Promise<void> => {
+      await mutators.handleDelete(
         item.id,
         group.activity.filter(a => a.id !== item.id),
         {
-          onError: () => {
-            addErrorMessage(t('Failed to delete comment'));
-          },
           onSuccess: () => {
-            trackAnalytics('issue_details.comment_deleted', {
-              organization,
-              streamline: true,
-              org_streamline_only: organization.streamlineOnly ?? undefined,
-            });
+            GroupStore.removeActivity(group.id, item.id);
+            trackAnalytics('issue_details.comment_deleted', {organization});
             addSuccessMessage(t('Comment removed'));
+            onCommentDeleted?.();
           },
         }
       );
     },
-    [onDeleteProp, group.activity, mutators, group.id, organization]
+    [group.activity, mutators, group.id, organization, onCommentDeleted]
   );
-
-  const handleUpdate = useCallback(
-    (item: GroupActivity, n: NoteType) => {
-      if (onUpdateProp) {
-        onUpdateProp(item, n);
-        return;
-      }
-
-      mutators.handleUpdate(n, item.id, group.activity, {
-        onError: () => {
-          addErrorMessage(t('Unable to update comment'));
-        },
-        onSuccess: data => {
-          const d = data as GroupActivityNote;
-          GroupStore.updateActivity(group.id, data.id, {text: d.data.text});
-          addSuccessMessage(t('Comment updated'));
-          trackAnalytics('issue_details.comment_updated', {
-            organization,
-            streamline: true,
-            org_streamline_only: organization.streamlineOnly ?? undefined,
-          });
-        },
-      });
-    },
-    [onUpdateProp, group.activity, mutators, group.id, organization]
-  );
-
-  const handleCreate = (n: NoteType, me: User) => {
-    if (onCreateProp) {
-      onCreateProp(n, me);
-      return;
-    }
-
-    mutators.handleCreate(n, group.activity, {
-      onError: err => {
-        const errMessage = err.responseJSON?.detail
-          ? tct('Error: [msg]', {msg: err.responseJSON?.detail as string})
-          : t('Unable to post comment');
-        addErrorMessage(errMessage);
-      },
-      onSuccess: data => {
-        GroupStore.addActivity(group.id, data);
-        trackAnalytics('issue_details.comment_created', {
-          organization,
-          streamline: true,
-          org_streamline_only: organization.streamlineOnly ?? undefined,
-        });
-        addSuccessMessage(t('Comment posted'));
-      },
-    });
-  };
 
   const activityLink = {
     pathname: `${baseUrl}${TabPaths[Tab.ACTIVITY]}`,
@@ -312,7 +239,7 @@ export function ActivitySection({
     <TimelineItem
       item={item}
       handleDelete={handleDelete}
-      handleUpdate={handleUpdate}
+      onCommentEdited={onCommentEdited}
       group={group}
       teams={teams}
       key={item.id}
@@ -327,8 +254,8 @@ export function ActivitySection({
       key={inputId}
       storageKey="groupinput:latest"
       itemKey={group.id}
-      onCreate={n => {
-        handleCreate(n, activeUser);
+      onCommentCreated={() => {
+        onCommentCreated?.();
         setInputId(uniqueId());
       }}
       variant={inputVariant}

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -10,7 +10,6 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {NoteBody} from 'sentry/components/activity/note/body';
 import {NoteInputWithStorage} from 'sentry/components/activity/note/inputWithStorage';
-import {useMutateActivity} from 'sentry/components/feedback/useMutateActivity';
 import {Timeline} from 'sentry/components/timeline';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconEllipsis} from 'sentry/icons';
@@ -29,6 +28,7 @@ import {ActivityMarker} from 'sentry/views/issueDetails/activitySection/activity
 import {CommentActionsDropdown} from 'sentry/views/issueDetails/activitySection/commentActionsDropdown';
 import {groupActivityTypeIconMapping} from 'sentry/views/issueDetails/activitySection/groupActivityIcons';
 import {getGroupActivityItem} from 'sentry/views/issueDetails/activitySection/groupActivityItem';
+import {useMutateActivity} from 'sentry/views/issueDetails/activitySection/useMutateActivity';
 import {SectionKey} from 'sentry/views/issueDetails/context';
 import {SidebarFoldSection} from 'sentry/views/issueDetails/foldSection';
 import {SidebarSectionTitle} from 'sentry/views/issueDetails/sidebar/sidebar';

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -51,7 +51,7 @@ function TimelineItem({
   item: GroupActivity;
   size: 'sm' | 'md';
   teams: Team[];
-  onCommentEdited?: () => void;
+  onCommentEdited?: (activity: GroupActivity[]) => void;
   timestampUnitStyle?: React.ComponentProps<typeof TimeSince>['unitStyle'];
 }) {
   const organization = useOrganization();
@@ -122,8 +122,8 @@ function TimelineItem({
           text={item.data.text}
           noteId={item.id}
           group={group}
-          onCommentEdited={() => {
-            onCommentEdited?.();
+          onCommentEdited={activity => {
+            onCommentEdited?.(activity);
             setEditing(false);
           }}
           onCancel={() => setEditing(false)}
@@ -154,9 +154,9 @@ interface ActivitySectionProps {
    */
   filterComments?: boolean;
   minHeight?: number;
-  onCommentCreated?: () => void;
-  onCommentDeleted?: () => void;
-  onCommentEdited?: () => void;
+  onCommentCreated?: (activity: GroupActivity[]) => void;
+  onCommentDeleted?: (activity: GroupActivity[]) => void;
+  onCommentEdited?: (activity: GroupActivity[]) => void;
   /**
    * Controls layout and input style.
    * - `sidebar` (default): fold section, compact input, collapses at 5 items
@@ -198,18 +198,15 @@ export function ActivitySection({
 
   const handleDelete = useCallback(
     async (item: GroupActivity): Promise<void> => {
-      await mutators.handleDelete(
-        item.id,
-        group.activity.filter(a => a.id !== item.id),
-        {
-          onSuccess: () => {
-            GroupStore.removeActivity(group.id, item.id);
-            trackAnalytics('issue_details.comment_deleted', {organization});
-            addSuccessMessage(t('Comment removed'));
-            onCommentDeleted?.();
-          },
-        }
-      );
+      const filteredActivity = group.activity.filter(a => a.id !== item.id);
+      await mutators.handleDelete(item.id, filteredActivity, {
+        onSuccess: () => {
+          GroupStore.removeActivity(group.id, item.id);
+          trackAnalytics('issue_details.comment_deleted', {organization});
+          addSuccessMessage(t('Comment removed'));
+          onCommentDeleted?.(filteredActivity);
+        },
+      });
     },
     [group.activity, mutators, group.id, organization, onCommentDeleted]
   );
@@ -254,8 +251,8 @@ export function ActivitySection({
       key={inputId}
       storageKey="groupinput:latest"
       itemKey={group.id}
-      onCommentCreated={() => {
-        onCommentCreated?.();
+      onCommentCreated={activity => {
+        onCommentCreated?.(activity);
         setInputId(uniqueId());
       }}
       variant={inputVariant}

--- a/static/app/views/issueDetails/activitySection/useMutateActivity.tsx
+++ b/static/app/views/issueDetails/activitySection/useMutateActivity.tsx
@@ -35,17 +35,9 @@ type UpdateCommentCallback = (
 interface Props {
   group: Group;
   organization: Organization;
-  onSettled?:
-    | ((
-        data: unknown,
-        error: unknown,
-        variables: TVariables,
-        context: unknown
-      ) => unknown)
-    | undefined;
 }
 
-export function useMutateActivity({organization, group, onSettled}: Props) {
+export function useMutateActivity({organization, group}: Props) {
   const {mutateAsync} = useMutation<TData, TError, TVariables>({
     mutationFn: ([{note, noteId}, method]) => {
       const url =
@@ -60,7 +52,6 @@ export function useMutateActivity({organization, group, onSettled}: Props) {
         data: {text: note?.text, mentions: note?.mentions},
       });
     },
-    onSettled: onSettled ?? undefined,
     gcTime: 0,
   });
 


### PR DESCRIPTION
Motivation for the change:

- The old behavior is a bit janky (submission appears to happen instantly, but there is a delay before the feed updates)
- If an error happens, the old behavior would lose your draft
- I want to remove the dependency on GroupStore here, which will be easier if the logic is simpler (make request, wait, then update the cache)

While making this change, I further simplified things by making `InputNoteWithStorage` own the mutation requests rather than being passed the mutation functions from parent components (which were passing the same thing). This way we can also keep the success/error indicators consistent between implementations.

Old vs new:

https://github.com/user-attachments/assets/2d87ce9e-2bb4-47fe-aa21-ca88791169df

https://github.com/user-attachments/assets/9d156379-efc4-41ec-af20-23bcb87a9061

