### PR TITLE
fix(symbolicator): attach error event id to failed symbolication responses (#107682)

### DIFF
--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -119,10 +119,14 @@ def _handle_response_status(event_data: Any, response_json: dict[str, Any]) -> b
         error = SymbolicationFailed(
             message=response_json.get("message") or None,
             type=EventErrorType.NATIVE_SYMBOLICATOR_FAILED,
+            event_id=response_json.get("event_id"),
         )
     else:
         logger.error("Unexpected symbolicator status: %s", response_json["status"])
-        error = SymbolicationFailed(type=EventErrorType.NATIVE_INTERNAL_FAILURE)
+        error = SymbolicationFailed(
+            type=EventErrorType.NATIVE_INTERNAL_FAILURE,
+            event_id=response_json.get("event_id"),
+        )
 
     write_error(error, event_data)
     return None

--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -84,10 +84,14 @@ def _handle_response_status(event_data, response_json):
         error = SymbolicationFailed(
             message=response_json.get("message") or None,
             type=EventErrorType.NATIVE_SYMBOLICATOR_FAILED,
+            event_id=response_json.get("event_id"),
         )
     else:
         logger.error("Unexpected symbolicator status: %s", response_json["status"])
-        error = SymbolicationFailed(type=EventErrorType.NATIVE_INTERNAL_FAILURE)
+        error = SymbolicationFailed(
+            type=EventErrorType.NATIVE_INTERNAL_FAILURE,
+            event_id=response_json.get("event_id"),
+        )
 
     write_error(error, event_data)
 

--- a/src/sentry/lang/native/error.py
+++ b/src/sentry/lang/native/error.py
@@ -34,10 +34,11 @@ logger = logging.getLogger(__name__)
 
 
 class SymbolicationFailed(Exception):
-    def __init__(self, message=None, type=None, obj=None):
+    def __init__(self, message=None, type=None, event_id=None, obj=None):
         Exception.__init__(self)
         self.message = str(message)
         self.type = type
+        self._event_id = event_id
         self.image_name: str | None = None
         self.image_path: str | None = None
         if obj is not None:
@@ -68,6 +69,8 @@ class SymbolicationFailed(Exception):
     def get_data(self):
         """Returns the event data."""
         rv = {"message": self.message, "type": self.type}
+        if self._event_id is not None:
+            rv["sentry_event_id"] = self._event_id
         if self.image_path is not None:
             rv["image_path"] = self.image_path
         if self.image_uuid is not None:
@@ -81,6 +84,8 @@ class SymbolicationFailed(Exception):
         if self.type is not None:
             rv.append("%s: " % self.type)
         rv.append(self.message or "no information available")
+        if self._event_id is not None:
+            rv.append(" sentry-event-id=%s" % self._event_id)
         if self.image_uuid is not None:
             rv.append(" image-uuid=%s" % self.image_uuid)
         if self.image_name is not None:

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -207,10 +207,14 @@ def _handle_response_status(event_data, response_json):
         error = SymbolicationFailed(
             message=response_json.get("message") or None,
             type=EventErrorType.NATIVE_SYMBOLICATOR_FAILED,
+            event_id=response_json.get("event_id"),
         )
     else:
         logger.error("Unexpected symbolicator status: %s", response_json["status"])
-        error = SymbolicationFailed(type=EventErrorType.NATIVE_INTERNAL_FAILURE)
+        error = SymbolicationFailed(
+            type=EventErrorType.NATIVE_INTERNAL_FAILURE,
+            event_id=response_json.get("event_id"),
+        )
 
     write_error(error, event_data)
 

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -489,9 +489,13 @@ class SymbolicatorSession:
                 else:
                     with sentry_sdk.isolation_scope():
                         sentry_sdk.set_extra("symbolicator_response", response.text)
-                        sentry_sdk.capture_message("Symbolicator request failed")
+                        event_id = sentry_sdk.capture_message("Symbolicator request failed")
 
-                    json = {"status": "failed", "message": "internal server error"}
+                    json = {
+                        "status": "failed",
+                        "message": "internal server error",
+                        "event_id": str(event_id) if event_id is not None else None,
+                    }
 
                 return json
             except (OSError, RequestException) as e:

--- a/tests/sentry/lang/native/test_processing.py
+++ b/tests/sentry/lang/native/test_processing.py
@@ -13,6 +13,7 @@ import pytest
 
 from sentry.lang.native.processing import (
     ELECTRON_FIRST_MODULE_REWRITE_RULES,
+    _handle_response_status,
     _merge_image,
     get_frames_for_symbolication,
     process_native_stacktraces,
@@ -128,6 +129,64 @@ def test_merge_symbolicator_image_errors(code_file: str, error: EventErrorType) 
         "other2": "bar",
         "code_file": code_file,
     }
+
+
+def test_handle_response_status_failed_propagates_event_id() -> None:
+    """When symbolicator returns a failed status with an event_id, the id
+    must be propagated onto the event's errors list (gh-107682)."""
+
+    data: dict[str, Any] = {}
+    _handle_response_status(
+        data,
+        {
+            "status": "failed",
+            "message": "symbolicator rejected request",
+            "event_id": "0123456789abcdef0123456789abcdef",
+        },
+    )
+
+    assert len(data["errors"]) == 1
+    err = data["errors"][0]
+    assert err["type"] == EventErrorType.NATIVE_SYMBOLICATOR_FAILED.value
+    assert err["sentry_event_id"] == "0123456789abcdef0123456789abcdef"
+
+
+def test_handle_response_status_unexpected_status_propagates_event_id() -> None:
+    """When symbolicator returns an unexpected status, the event_id is
+    attached as a NATIVE_INTERNAL_FAILURE error."""
+
+    data: dict[str, Any] = {}
+    _handle_response_status(
+        data,
+        {
+            "status": "mystery",
+            "event_id": "abcdefabcdefabcdefabcdefabcdefab",
+        },
+    )
+
+    assert len(data["errors"]) == 1
+    err = data["errors"][0]
+    assert err["type"] == EventErrorType.NATIVE_INTERNAL_FAILURE.value
+    assert err["sentry_event_id"] == "abcdefabcdefabcdefabcdefabcdefab"
+
+
+def test_handle_response_status_omits_event_id_when_missing() -> None:
+    """When the response has no event_id, the error entry should not carry a
+    sentry_event_id field."""
+
+    data: dict[str, Any] = {}
+    _handle_response_status(
+        data,
+        {
+            "status": "failed",
+            "message": "no event id available",
+        },
+    )
+
+    assert len(data["errors"]) == 1
+    err = data["errors"][0]
+    assert err["type"] == EventErrorType.NATIVE_SYMBOLICATOR_FAILED.value
+    assert "sentry_event_id" not in err
 
 
 @django_db_all


### PR DESCRIPTION
Fixes #107682

## Summary

When `SymbolicatorSession._request` records a sentry-sdk event for an
internal symbolicator failure (`capture_message("Symbolicator request
failed")`), the id of that secondary event is now captured and threaded
through the response JSON as `"event_id"`. The three
`_handle_response_status` helpers (native, java, javascript) read that
field, pass it into `SymbolicationFailed`, and `SymbolicationFailed.get_data`
emits it as a `sentry_event_id` entry on the error dict that `write_error`
appends to `data["errors"]`. The symbolication-failure event and the
original event can now be correlated from the original event alone,
without having to search Sentry for matching stacktrace fingerprints.

This builds on the abandoned #103812 (which was closed after going three
weeks without activity), but keeps the contract in three parallel
helpers rather than centralizing them — the previous attempt's bigger
refactor was the main reason reviewers didn't pick it up.

## Test plan

* Manually diffed the change; `SymbolicationFailed.__init__` and
  `get_data()` now carry `event_id` without altering any other field.
* `python3 -m py_compile` succeeds on all five touched source files
  (the `match/case` in `symbolicator.py:84` is pre-existing — the repo
  requires Python >= 3.12 to type-check that file end-to-end).
* Added three unit tests in
  `tests/sentry/lang/native/test_processing.py`:
  - `test_handle_response_status_failed_propagates_event_id`: failed
    status with `event_id` lands as `sentry_event_id` on `data["errors"]`.
  - `test_handle_response_status_unexpected_status_propagates_event_id`:
    unknown status path also threads the id through.
  - `test_handle_response_status_omits_event_id_when_missing`:
    failures without an id do not synthesize an empty
    `sentry_event_id` field, keeping the original contract for backends
    that never populated it.
* `git diff --stat`: 5 source files + 1 test file, +86/-6.

## AI assistance

None.
