### PR TITLE
fix(workflow): Speed up workflow group history count query

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
@@ -157,8 +157,7 @@ def fetch_workflow_groups_paginated(
     ).values("detector_id")[:1]
 
     qs = (
-        filtered_history.select_related("group")
-        .values("group")
+        filtered_history.values("group")
         .annotate(count=Count("group"))
         .annotate(event_id=Subquery(group_max_dates.values("event_id")))
         .annotate(last_triggered=Max("date_added"))
@@ -166,7 +165,7 @@ def fetch_workflow_groups_paginated(
     )
 
     # Count distinct groups for pagination
-    group_count = qs.count()
+    group_count = filtered_history.values("group").distinct().count()
     order_by = _parse_sort(sort)
 
     return cast(


### PR DESCRIPTION
## Summary
- Apparently this is already paginated, but the query is very expensive.
- I asked claude how to improve teh query
  - Replace expensive `qs.count()` on the fully-annotated queryset with a cheap `filtered_history.values("group").distinct().count()`. The old count wrapped two correlated subqueries in a `SELECT COUNT(*)`, forcing the DB to execute all subqueries just to count rows — causing timeouts for alerts with large history.

Fixes https://linear.app/getsentry/issue/ISWF-2913/fix-workflow-history-failing-to-load-for-alerts-with-large-history
