### PR TITLE
fix(spans): Import span-first detectors rollout controller

### DIFF
--- a/src/sentry/issue_detection/detectors/__init__.py
+++ b/src/sentry/issue_detection/detectors/__init__.py
@@ -1,0 +1,9 @@
+from sentry.issue_detection.detectors.span_first.span_first_utils import (
+    SpanFirstDetectorsRolloutController,
+)
+
+# Dummy assertion just to use the class somehow. If we don't, no module which runs at app startup
+# imports it (consumer factories apparently don't get loaded right away), which means its options
+# never get registered because `SafeRolloutComparator.__init_subclass__` is never run.
+# Once the new span-first detectors are fully rolled out, we can get rid of this.
+assert SpanFirstDetectorsRolloutController  # type: ignore[truthy-function]


### PR DESCRIPTION
Subclasses of `SafeRolloutComparator` register their options in the base class's `__init_subclass__` method. In order for this method to be run, the subclass doesn't have to be instantiated, but its definition does need to run. Our new `SpanFirstDetectorsRolloutController`'s import chain peters out at `src/sentry/spans/consumers/process_segments/factory.py`, whose only public export,`DetectPerformanceIssuesStrategyFactory`, is referred to in this [hard-coded string](https://github.com/getsentry/sentry/blob/f38bd94b4f13baa431b447f35026e506cad18e7e/src/sentry/consumers/__init__.py#L482), but not actually imported anywhere. And whatever happens with that list of Kafka consumers it's a part of, it doesn't appear they get loaded at app startup.

The result of all of this is that when the app is initializing, `SpanFirstDetectorsRolloutController` class definition is never loaded, and thus its associated options never get registered. This in turn confuses options automator, since they have values defined there. To fix this problem, this PR adds a dummy import and assertion at the root of the main issue detectors module, which _does_ get loaded at app startup. This should allow us to successfully set values for the options.