### PR TITLE
fix(issues): Truncate long release names

### DIFF
--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import {Button} from '@sentry/scraps/button';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {useModal} from '@sentry/scraps/modal';
+import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {useFetchEventAttachments} from 'sentry/actionCreators/events';
@@ -19,7 +20,6 @@ import {
   ScreenshotModal,
 } from 'sentry/components/events/eventTagsAndScreenshot/screenshot/modal';
 import {getRuntimeLabelAndTooltip} from 'sentry/components/events/highlights/util';
-import {Text} from 'sentry/components/replays/virtualizedGrid/bodyCell';
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
 import {Version} from 'sentry/components/version';
 import {VersionHoverCard} from 'sentry/components/versionHoverCard';

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -3,7 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {useModal} from '@sentry/scraps/modal';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -122,7 +122,9 @@ export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps
           {runtimeInfo && (
             <Fragment>
               <Tooltip title={runtimeInfo.tooltip} isHoverable>
-                <StyledRuntimeText>{runtimeInfo.label}</StyledRuntimeText>
+                <Container as="span" padding="xs 0">
+                  <Text>{runtimeInfo.label}</Text>
+                </Container>
               </Tooltip>
               <DividerWrapper>
                 <Divider />
@@ -204,20 +206,23 @@ function ReleaseHighlight({
   }
 
   return (
-    <Flex align="center" flexShrink={0} gap="md" minHeight="24px" key="release">
+    <ReleaseHighlightItem key="release">
       <IconWrapper>
         <IconReleases size="sm" variant="muted" />
       </IconWrapper>
-      <IconDescription aria-label={t('Event release')}>
-        <VersionHoverCard
-          organization={organization}
-          projectSlug={projectSlug}
-          releaseVersion={releaseTag.value}
-        >
-          <StyledVersion version={releaseTag.value} projectId={projectId} />
-        </VersionHoverCard>
-      </IconDescription>
-    </Flex>
+      <ReleaseIconDescription aria-label={t('Event release')}>
+        <ReleaseVersionWrapper>
+          <VersionHoverCard
+            organization={organization}
+            projectSlug={projectSlug}
+            releaseVersion={releaseTag.value}
+            containerDisplayMode="block"
+          >
+            <StyledVersion version={releaseTag.value} projectId={projectId} truncate />
+          </VersionHoverCard>
+        </ReleaseVersionWrapper>
+      </ReleaseIconDescription>
+    </ReleaseHighlightItem>
   );
 }
 
@@ -259,7 +264,36 @@ const IconSubtitle = styled(Tooltip)`
   color: ${p => p.theme.tokens.content.secondary};
 `;
 
+const ReleaseHighlightItem = styled('div')`
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: ${p => p.theme.space.md};
+  min-height: 24px;
+  max-width: 240px;
+  min-width: 0;
+  overflow: hidden;
+`;
+
+const ReleaseIconDescription = styled(IconDescription)`
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+`;
+
+const ReleaseVersionWrapper = styled('span')`
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  width: 100%;
+  overflow: hidden;
+`;
+
 const StyledVersion = styled(Version)`
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  width: 100%;
   font-size: ${p => p.theme.font.size.md};
   color: ${p => p.theme.tokens.content.primary};
   &:hover {
@@ -275,8 +309,4 @@ const DividerWrapper = styled('div')`
   display: flex;
   align-items: center;
   font-size: 1.25rem;
-`;
-
-const StyledRuntimeText = styled(Text)`
-  padding: ${p => p.theme.space.xs} 0;
 `;

--- a/static/app/views/explore/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/explore/releases/detail/header/releaseHeader.tsx
@@ -5,7 +5,6 @@ import type {Location} from 'history';
 import pick from 'lodash/pick';
 
 import {Badge, FeatureBadge} from '@sentry/scraps/badge';
-import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {TabList} from '@sentry/scraps/tabs';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -16,13 +15,13 @@ import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {IdBadge} from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {URL_PARAM} from 'sentry/components/pageFilters/constants';
-import {Version} from 'sentry/components/version';
 import {IconOpen} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Release, ReleaseMeta, ReleaseProject} from 'sentry/types/release';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {isMobileRelease} from 'sentry/views/explore/releases/utils';
 import {makeReleasesPathname} from 'sentry/views/explore/releases/utils/pathnames';
 import {TopBar} from 'sentry/views/navigation/topBar';
@@ -48,30 +47,6 @@ export function ReleaseHeader({
 }: Props) {
   const {version, url} = release;
   const {commitCount, commitFilesChanged} = releaseMeta;
-
-  const titleContent = (
-    <Fragment>
-      <IdBadge project={project} avatarSize={16} hideName />
-      <Version version={version} anchor={false} truncate />
-      <CopyToClipboardButton
-        className="release-copy-button"
-        variant="transparent"
-        size="zero"
-        text={version}
-        tooltipProps={{title: version}}
-        aria-label={t('Copy release version to clipboard')}
-      />
-      {!!url && (
-        <IconWrapper>
-          <Tooltip title={url}>
-            <ExternalLink href={url}>
-              <IconOpen />
-            </ExternalLink>
-          </Tooltip>
-        </IconWrapper>
-      )}
-    </Fragment>
-  );
 
   const releasePath = makeReleasesPathname({
     organization,
@@ -154,22 +129,38 @@ export function ReleaseHeader({
     <Layout.Header>
       <Layout.HeaderContent>
         <TopBar.Slot name="title">
-          <Breadcrumbs
-            crumbs={[
-              {
-                to: makeReleasesPathname({organization, path: '/'}),
-                label: t('Releases'),
-                preservePageFilters: true,
-              },
-              {
-                label: (
-                  <Flex align="center" gap="md" minWidth={0} css={titleWrapperStyles}>
-                    {titleContent}
-                  </Flex>
-                ),
-              },
-            ]}
-          />
+          <ReleaseTitleContent css={titleWrapperStyles}>
+            <IdBadge project={project} avatarSize={16} hideName />
+            <Breadcrumbs
+              crumbs={[
+                {
+                  to: makeReleasesPathname({organization, path: '/'}),
+                  label: t('Releases'),
+                  preservePageFilters: true,
+                },
+                {
+                  label: formatVersion(version),
+                },
+              ]}
+            />
+            <CopyToClipboardButton
+              className="release-copy-button"
+              variant="transparent"
+              size="zero"
+              text={version}
+              tooltipProps={{title: t('Copy release version')}}
+              aria-label={t('Copy release version to clipboard')}
+            />
+            {!!url && (
+              <IconWrapper>
+                <Tooltip title={url}>
+                  <ExternalLink href={url}>
+                    <IconOpen />
+                  </ExternalLink>
+                </Tooltip>
+              </IconWrapper>
+            )}
+          </ReleaseTitleContent>
         </TopBar.Slot>
       </Layout.HeaderContent>
       <TopBar.Slot name="actions">
@@ -206,15 +197,32 @@ const titleWrapperStyles = css`
   line-height: 1;
 
   .release-copy-button {
-    display: none;
+    visibility: hidden;
+    pointer-events: none;
   }
 
-  &:hover .release-copy-button {
-    display: inline-flex;
+  &:hover .release-copy-button,
+  &:focus-within .release-copy-button {
+    visibility: visible;
+    pointer-events: auto;
+  }
+`;
+
+const ReleaseTitleContent = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+
+  [data-test-id='breadcrumb-list'] {
+    min-width: 0;
   }
 `;
 
 const IconWrapper = styled('span')`
+  flex-shrink: 0;
   transition: color 0.3s ease-in-out;
 
   &,

--- a/static/app/views/explore/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/explore/releases/detail/header/releaseHeader.tsx
@@ -5,6 +5,7 @@ import type {Location} from 'history';
 import pick from 'lodash/pick';
 
 import {Badge, FeatureBadge} from '@sentry/scraps/badge';
+import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {TabList} from '@sentry/scraps/tabs';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -15,13 +16,13 @@ import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {IdBadge} from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {URL_PARAM} from 'sentry/components/pageFilters/constants';
+import {Version} from 'sentry/components/version';
 import {IconOpen} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Release, ReleaseMeta, ReleaseProject} from 'sentry/types/release';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
-import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {isMobileRelease} from 'sentry/views/explore/releases/utils';
 import {makeReleasesPathname} from 'sentry/views/explore/releases/utils/pathnames';
 import {TopBar} from 'sentry/views/navigation/topBar';
@@ -47,6 +48,30 @@ export function ReleaseHeader({
 }: Props) {
   const {version, url} = release;
   const {commitCount, commitFilesChanged} = releaseMeta;
+
+  const titleContent = (
+    <Fragment>
+      <IdBadge project={project} avatarSize={16} hideName />
+      <Version version={version} anchor={false} truncate />
+      <CopyToClipboardButton
+        className="release-copy-button"
+        variant="transparent"
+        size="zero"
+        text={version}
+        tooltipProps={{title: version}}
+        aria-label={t('Copy release version to clipboard')}
+      />
+      {!!url && (
+        <IconWrapper>
+          <Tooltip title={url}>
+            <ExternalLink href={url}>
+              <IconOpen />
+            </ExternalLink>
+          </Tooltip>
+        </IconWrapper>
+      )}
+    </Fragment>
+  );
 
   const releasePath = makeReleasesPathname({
     organization,
@@ -129,38 +154,22 @@ export function ReleaseHeader({
     <Layout.Header>
       <Layout.HeaderContent>
         <TopBar.Slot name="title">
-          <ReleaseTitleContent css={titleWrapperStyles}>
-            <IdBadge project={project} avatarSize={16} hideName />
-            <Breadcrumbs
-              crumbs={[
-                {
-                  to: makeReleasesPathname({organization, path: '/'}),
-                  label: t('Releases'),
-                  preservePageFilters: true,
-                },
-                {
-                  label: formatVersion(version),
-                },
-              ]}
-            />
-            <CopyToClipboardButton
-              className="release-copy-button"
-              variant="transparent"
-              size="zero"
-              text={version}
-              tooltipProps={{title: t('Copy release version')}}
-              aria-label={t('Copy release version to clipboard')}
-            />
-            {!!url && (
-              <IconWrapper>
-                <Tooltip title={url}>
-                  <ExternalLink href={url}>
-                    <IconOpen />
-                  </ExternalLink>
-                </Tooltip>
-              </IconWrapper>
-            )}
-          </ReleaseTitleContent>
+          <Breadcrumbs
+            crumbs={[
+              {
+                to: makeReleasesPathname({organization, path: '/'}),
+                label: t('Releases'),
+                preservePageFilters: true,
+              },
+              {
+                label: (
+                  <Flex align="center" gap="md" minWidth={0} css={titleWrapperStyles}>
+                    {titleContent}
+                  </Flex>
+                ),
+              },
+            ]}
+          />
         </TopBar.Slot>
       </Layout.HeaderContent>
       <TopBar.Slot name="actions">
@@ -197,32 +206,15 @@ const titleWrapperStyles = css`
   line-height: 1;
 
   .release-copy-button {
-    visibility: hidden;
-    pointer-events: none;
+    display: none;
   }
 
-  &:hover .release-copy-button,
-  &:focus-within .release-copy-button {
-    visibility: visible;
-    pointer-events: auto;
-  }
-`;
-
-const ReleaseTitleContent = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.md};
-  min-width: 0;
-  max-width: 100%;
-  overflow: hidden;
-
-  [data-test-id='breadcrumb-list'] {
-    min-width: 0;
+  &:hover .release-copy-button {
+    display: inline-flex;
   }
 `;
 
 const IconWrapper = styled('span')`
-  flex-shrink: 0;
   transition: color 0.3s ease-in-out;
 
   &,

--- a/static/app/views/explore/releases/drawer/releasesDrawerDetails.tsx
+++ b/static/app/views/explore/releases/drawer/releasesDrawerDetails.tsx
@@ -6,6 +6,7 @@ import {LinkButton} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Select} from '@sentry/scraps/select';
+import {Text} from '@sentry/scraps/text';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {
@@ -68,7 +69,7 @@ function ReleasesDrawerContent({
       <EventNavigator>
         <ErrorBoundary mini>
           <HeaderToolbar>
-            <Flex align="center" gap="md">
+            <Flex align="center" gap="md" minWidth={0} maxWidth="100%">
               <ErrorBoundary mini>
                 <SelectableProjectBadges>
                   {releaseMeta?.projects?.map(releaseProject => (
@@ -93,10 +94,12 @@ function ReleasesDrawerContent({
                   ))}
                 </SelectableProjectBadges>
               </ErrorBoundary>
-              {formatVersion(release)}
+              <Text size="xl" bold ellipsis>
+                {formatVersion(release)}
+              </Text>
             </Flex>
 
-            <LinkButton
+            <FullDetailsButton
               to={normalizeUrl({
                 pathname: makeReleasesPathname({
                   path: `/${encodeURIComponent(release)}/`,
@@ -115,7 +118,7 @@ function ReleasesDrawerContent({
               }}
             >
               {t('View Full Details')}
-            </LinkButton>
+            </FullDetailsButton>
           </HeaderToolbar>
         </ErrorBoundary>
       </EventNavigator>
@@ -347,8 +350,13 @@ const SelectableProjectBadge = styled(Link)`
   }
 `;
 
+const FullDetailsButton = styled(LinkButton)`
+  flex-shrink: 0;
+`;
+
 const HeaderToolbar = styled(Header)`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: ${p => p.theme.space.md};
 `;

--- a/static/app/views/explore/releases/drawer/releasesDrawerDetails.tsx
+++ b/static/app/views/explore/releases/drawer/releasesDrawerDetails.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Select} from '@sentry/scraps/select';
 import {Text} from '@sentry/scraps/text';
@@ -94,9 +94,11 @@ function ReleasesDrawerContent({
                   ))}
                 </SelectableProjectBadges>
               </ErrorBoundary>
-              <Text size="xl" bold ellipsis>
-                {formatVersion(release)}
-              </Text>
+              <Container minWidth={0} maxWidth="100%">
+                <Text size="xl" bold ellipsis>
+                  {formatVersion(release)}
+                </Text>
+              </Container>
             </Flex>
 
             <FullDetailsButton

--- a/static/app/views/issueDetails/issueFirstLastReleaseQueryOptions.tsx
+++ b/static/app/views/issueDetails/issueFirstLastReleaseQueryOptions.tsx
@@ -2,8 +2,8 @@ import type {Release} from 'sentry/types/release';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 
 interface GroupRelease {
-  firstRelease: Release;
-  lastRelease: Release;
+  firstRelease: Release | null;
+  lastRelease: Release | null;
 }
 
 type FirstLastReleaseQueryOptions = {

--- a/static/app/views/issueDetails/sidebar/firstLastSeenSection.tsx
+++ b/static/app/views/issueDetails/sidebar/firstLastSeenSection.tsx
@@ -5,9 +5,11 @@ import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {SeenInfo} from 'sentry/components/group/seenInfo';
+import {Placeholder} from 'sentry/components/placeholder';
 import {Version} from 'sentry/components/version';
 import {VersionHoverCard} from 'sentry/components/versionHoverCard';
 import {t} from 'sentry/locale';
+import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {OrganizationSummary} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -30,15 +32,16 @@ function useFetchAllEnvsGroupData(organization: OrganizationSummary, group: Grou
   });
 }
 
-export function FirstLastSeenSection({group}: {group: Group}) {
+export function FirstLastSeenSection({event, group}: {group: Group; event?: Event}) {
   const organization = useOrganization();
   const {project} = group;
   const issueTypeConfig = getConfigForIssueType(group, group.project);
+  const shouldReserveReleaseSpace = !!event?.release;
 
   const environments = useEnvironmentsFromUrl();
 
   const {data: allEnvsGroupData} = useFetchAllEnvsGroupData(organization, group);
-  const {data: groupReleaseData} = useQuery(
+  const {data: groupReleaseData, isPending: isReleaseDataPending} = useQuery(
     issueFirstLastReleaseQueryOptions({
       groupId: group.id,
       organizationSlug: organization.slug,
@@ -80,7 +83,11 @@ export function FirstLastSeenSection({group}: {group: Group}) {
           />
         </Flex>
         {lastSeen && (
-          <ReleaseText project={group.project} release={groupReleaseData?.lastRelease} />
+          <ReleaseText
+            project={group.project}
+            release={groupReleaseData?.lastRelease}
+            preserveSpace={isReleaseDataPending && shouldReserveReleaseSpace}
+          />
         )}
       </Stack>
       <Stack>
@@ -96,18 +103,30 @@ export function FirstLastSeenSection({group}: {group: Group}) {
           />
         </Flex>
         {group.firstSeen && (
-          <ReleaseText project={group.project} release={groupReleaseData?.firstRelease} />
+          <ReleaseText
+            project={group.project}
+            release={groupReleaseData?.firstRelease}
+            preserveSpace={isReleaseDataPending && shouldReserveReleaseSpace}
+          />
         )}
       </Stack>
     </Flex>
   );
 }
 
-function ReleaseText({project, release}: {project: Project; release?: Release}) {
+function ReleaseText({
+  project,
+  release,
+  preserveSpace,
+}: {
+  project: Project;
+  preserveSpace?: boolean;
+  release?: Release | null;
+}) {
   const organization = useOrganization();
 
   if (!release) {
-    return null;
+    return preserveSpace ? <ReleaseTextPlaceholder /> : null;
   }
 
   return (
@@ -133,6 +152,14 @@ function ReleaseText({project, release}: {project: Project; release?: Release}) 
         </VersionHoverCard>
       </ReleaseVersionWrapper>
     </Grid>
+  );
+}
+
+function ReleaseTextPlaceholder() {
+  return (
+    <Container aria-hidden="true" maxWidth="100%">
+      <Placeholder height="20px" />
+    </Container>
   );
 }
 

--- a/static/app/views/issueDetails/sidebar/firstLastSeenSection.tsx
+++ b/static/app/views/issueDetails/sidebar/firstLastSeenSection.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {SeenInfo} from 'sentry/components/group/seenInfo';
@@ -111,20 +111,44 @@ function ReleaseText({project, release}: {project: Project; release?: Release}) 
   }
 
   return (
-    <Text size="sm" variant="muted">
-      {t('in release')}{' '}
-      <VersionHoverCard
-        organization={organization}
-        projectSlug={project.slug}
-        releaseVersion={release.version}
-      >
-        <ReleaseVersion version={release.version} projectId={project.id} />
-      </VersionHoverCard>
-    </Text>
+    <Grid
+      columns="max-content minmax(0, 1fr)"
+      align="center"
+      gap="xs"
+      minWidth={0}
+      maxWidth="100%"
+    >
+      <Container as="span" whiteSpace="nowrap">
+        <Text size="sm" variant="muted">
+          {t('in release')}{' '}
+        </Text>
+      </Container>
+      <ReleaseVersionWrapper>
+        <VersionHoverCard
+          organization={organization}
+          projectSlug={project.slug}
+          releaseVersion={release.version}
+        >
+          <ReleaseVersion version={release.version} projectId={project.id} truncate />
+        </VersionHoverCard>
+      </ReleaseVersionWrapper>
+    </Grid>
   );
 }
 
+const ReleaseVersionWrapper = styled('span')`
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+`;
+
 const ReleaseVersion = styled(Version)`
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  width: 100%;
   color: ${p => p.theme.tokens.content.secondary};
   text-decoration: underline;
   text-decoration-style: dotted;

--- a/static/app/views/issueDetails/sidebar/sidebar.tsx
+++ b/static/app/views/issueDetails/sidebar/sidebar.tsx
@@ -91,7 +91,7 @@ export function IssueDetailsSidebar({group, event, project}: Props) {
     >
       {tourProps => (
         <Side {...tourProps}>
-          <FirstLastSeenSection group={group} />
+          <FirstLastSeenSection group={group} event={event} />
           <StyledBreak />
           {showSeerSection && (
             <ErrorBoundary mini>


### PR DESCRIPTION
Long release names were pushing around compact release UI instead of truncating. This constrains the sidebar, highlights, drawer header, and release detail header so they ellipsize without changing the surrounding controls.

Attempted to reduce CLS from the first/last seen in the sidebar.

before sidebar

<img width="318" height="147" alt="image" src="https://github.com/user-attachments/assets/efe870a5-b326-4edc-bba6-43cac75e18d2" />

after sidebar

<img width="310" height="129" alt="image" src="https://github.com/user-attachments/assets/432b5088-3e7f-4d0a-b0fb-234d050f04dc" />

before issue details top bar thing

<img width="1040" height="171" alt="image" src="https://github.com/user-attachments/assets/e149da29-f6b5-4433-a28d-8470216171da" />

after

<img width="1020" height="147" alt="image" src="https://github.com/user-attachments/assets/0a5dba8d-73c0-4a29-8042-83d85e3882bf" />

before release drawer

<img width="804" height="147" alt="image" src="https://github.com/user-attachments/assets/0d0d439d-49dc-46db-be17-6db311b0cca7" />

after release drawer

<img width="808" height="178" alt="image" src="https://github.com/user-attachments/assets/f6f9dfe8-3f19-489c-a059-43220bdbf4fd" />
