### PR TITLE
feat(dashboards): Improve heat map color scaling

### DIFF
--- a/static/app/chartcuterie/heatmaps.tsx
+++ b/static/app/chartcuterie/heatmaps.tsx
@@ -5,7 +5,10 @@ import type {HeatMapSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {formatYAxisValue} from 'sentry/views/dashboards/widgets/heatMapWidget/formatters/formatYAxisValue';
 import {visualMapOptions} from 'sentry/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization';
 import {HeatMap} from 'sentry/views/dashboards/widgets/heatMapWidget/plottables/heatMap';
-import {HEATMAP_Z_AXIS_SCALE} from 'sentry/views/dashboards/widgets/heatMapWidget/settings';
+import {
+  HEATMAP_COLORS_DARK,
+  HEATMAP_COLORS_LIGHT,
+} from 'sentry/views/dashboards/widgets/heatMapWidget/settings';
 import {formatXAxisTimestamp} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp';
 
 import {DEFAULT_FONT_FAMILY} from './slack';
@@ -29,11 +32,8 @@ export function buildHeatmapChartOption({
   const yAxisDataType = heatMapPlottable.yAxisValueType;
   const yAxisDataUnit = heatMapPlottable.yAxisValueUnit;
 
-  const scale = HEATMAP_Z_AXIS_SCALE;
-
-  const Zmax =
-    scale === 'log' ? Math.log1p(heatMapPlottable.Zend) : heatMapPlottable.Zend;
-  const series = heatMapPlottable.toSeries({theme, scale: HEATMAP_Z_AXIS_SCALE});
+  const colors = theme.type === 'dark' ? HEATMAP_COLORS_DARK : HEATMAP_COLORS_LIGHT;
+  const series = heatMapPlottable.toSeries({theme});
 
   return {
     grid: Grid({left: 10, right: 10, bottom: 10, top: 10}),
@@ -83,7 +83,7 @@ export function buildHeatmapChartOption({
       },
     },
     series,
-    visualMap: visualMapOptions(Zmax),
+    visualMap: visualMapOptions(colors),
     useUTC: true,
   };
 }

--- a/static/app/chartcuterie/heatmaps.tsx
+++ b/static/app/chartcuterie/heatmaps.tsx
@@ -5,10 +5,7 @@ import type {HeatMapSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {formatYAxisValue} from 'sentry/views/dashboards/widgets/heatMapWidget/formatters/formatYAxisValue';
 import {visualMapOptions} from 'sentry/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization';
 import {HeatMap} from 'sentry/views/dashboards/widgets/heatMapWidget/plottables/heatMap';
-import {
-  HEATMAP_COLORS_DARK,
-  HEATMAP_COLORS_LIGHT,
-} from 'sentry/views/dashboards/widgets/heatMapWidget/settings';
+import {getHeatMapColors} from 'sentry/views/dashboards/widgets/heatMapWidget/settings';
 import {formatXAxisTimestamp} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp';
 
 import {DEFAULT_FONT_FAMILY} from './slack';
@@ -32,7 +29,7 @@ export function buildHeatmapChartOption({
   const yAxisDataType = heatMapPlottable.yAxisValueType;
   const yAxisDataUnit = heatMapPlottable.yAxisValueUnit;
 
-  const colors = theme.type === 'dark' ? HEATMAP_COLORS_DARK : HEATMAP_COLORS_LIGHT;
+  const colors = getHeatMapColors(theme.type);
   const series = heatMapPlottable.toSeries({theme});
 
   return {

--- a/static/app/chartcuterie/heatmaps.tsx
+++ b/static/app/chartcuterie/heatmaps.tsx
@@ -5,7 +5,7 @@ import type {HeatMapSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {formatYAxisValue} from 'sentry/views/dashboards/widgets/heatMapWidget/formatters/formatYAxisValue';
 import {visualMapOptions} from 'sentry/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization';
 import {HeatMap} from 'sentry/views/dashboards/widgets/heatMapWidget/plottables/heatMap';
-import {getHeatMapColors} from 'sentry/views/dashboards/widgets/heatMapWidget/settings';
+import {HEATMAP_COLORS} from 'sentry/views/dashboards/widgets/heatMapWidget/settings';
 import {formatXAxisTimestamp} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp';
 
 import {DEFAULT_FONT_FAMILY} from './slack';
@@ -29,7 +29,6 @@ export function buildHeatmapChartOption({
   const yAxisDataType = heatMapPlottable.yAxisValueType;
   const yAxisDataUnit = heatMapPlottable.yAxisValueUnit;
 
-  const colors = getHeatMapColors(theme.type);
   const series = heatMapPlottable.toSeries({theme});
 
   return {
@@ -80,7 +79,7 @@ export function buildHeatmapChartOption({
       },
     },
     series,
-    visualMap: visualMapOptions(colors),
+    visualMap: visualMapOptions(HEATMAP_COLORS),
     useUTC: true,
   };
 }

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -64,7 +64,6 @@ import {DetailsWidgetVisualization} from 'sentry/views/dashboards/widgets/detail
 import type {DefaultDetailWidgetFields} from 'sentry/views/dashboards/widgets/detailsWidget/types';
 import {HeatMapWidgetVisualization} from 'sentry/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization';
 import {HeatMap} from 'sentry/views/dashboards/widgets/heatMapWidget/plottables/heatMap';
-import {HEATMAP_Z_AXIS_SCALE} from 'sentry/views/dashboards/widgets/heatMapWidget/settings';
 import {RageAndDeadClicksWidgetVisualization} from 'sentry/views/dashboards/widgets/rageAndDeadClicksWidget/rageAndDeadClicksVisualization';
 import {ServerTreeWidgetVisualization} from 'sentry/views/dashboards/widgets/serverTreeWidget/serverTreeWidgetVisualization';
 import {TableWidgetVisualization} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
@@ -499,7 +498,6 @@ function HeatmapSeriesComponent(props: TableComponentProps): React.ReactNode {
     <ChartWrapper autoHeightResize>
       <HeatMapWidgetVisualization
         plottables={[new HeatMap(heatmapResults)]}
-        scale={HEATMAP_Z_AXIS_SCALE}
         // The heat map links each cell's tooltip to its metric in Explore.
         renderTooltipActions={({valueMin, valueMax, timestampStart, timestampEnd}) => {
           if (!traceMetric) {

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -29,7 +29,7 @@ import {FALLBACK_TYPE} from 'sentry/views/dashboards/widgets/timeSeriesWidget/se
 
 import {HeatMap} from './plottables/heatMap';
 import type {HeatMapPlottable} from './plottables/heatMapPlottable';
-import {HEATMAP_COLORS_DARK, HEATMAP_COLORS_LIGHT} from './settings';
+import {getHeatMapColors} from './settings';
 
 // This is the ECharts default font size for axis labels. We need to use this number to do axis label frequency calculations
 // Source: https://echarts.apache.org/en/option.html#yAxis.axisLabel.fontSize
@@ -133,7 +133,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
   const yAxisDataType = heatMapPlottable.yAxisValueType;
   const yAxisDataUnit = heatMapPlottable.yAxisValueUnit;
 
-  const colors = theme.type === 'dark' ? HEATMAP_COLORS_DARK : HEATMAP_COLORS_LIGHT;
+  const colors = getHeatMapColors(theme.type);
 
   /** Extract the numeric value from ECharts tooltip param.value. */
   function extractValue(data: unknown): number | null {

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -29,7 +29,7 @@ import {FALLBACK_TYPE} from 'sentry/views/dashboards/widgets/timeSeriesWidget/se
 
 import {HeatMap} from './plottables/heatMap';
 import type {HeatMapPlottable} from './plottables/heatMapPlottable';
-import {HEATMAP_COLORS} from './settings';
+import {HEATMAP_COLORS_DARK, HEATMAP_COLORS_LIGHT} from './settings';
 
 // This is the ECharts default font size for axis labels. We need to use this number to do axis label frequency calculations
 // Source: https://echarts.apache.org/en/option.html#yAxis.axisLabel.fontSize
@@ -48,10 +48,6 @@ interface HeatMapWidgetVisualizationProps {
    * actions. The matching `tooltipActionHandlers[id]` is called with the value.
    */
   renderTooltipActions?: (context: HeatMapTooltipContext) => ReactNode;
-  /**
-   * Experimental! Specify the Z-axis scale type. Logarithmic scales can be much more useful for values with a high range.
-   */
-  scale?: 'linear' | 'log';
   /**
    * Handlers for caller-rendered tooltip actions, keyed by the button's
    * `data-tooltip-action` id. Clicking such a button calls the matching handler
@@ -126,12 +122,9 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
   // TODO: Would be wise to guard against Y-axis type mismatches, we don't want
   // to support multi-axis here.
 
-  const {scale = 'linear'} = props;
-
   const series = plottables.flatMap(plottable =>
     plottable.toSeries({
       theme,
-      scale,
     })
   );
 
@@ -140,8 +133,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
   const yAxisDataType = heatMapPlottable.yAxisValueType;
   const yAxisDataUnit = heatMapPlottable.yAxisValueUnit;
 
-  const Zmax =
-    scale === 'log' ? Math.log1p(heatMapPlottable.Zend) : heatMapPlottable.Zend;
+  const colors = theme.type === 'dark' ? HEATMAP_COLORS_DARK : HEATMAP_COLORS_LIGHT;
 
   /** Extract the numeric value from ECharts tooltip param.value. */
   function extractValue(data: unknown): number | null {
@@ -171,8 +163,8 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
 
     // Filter null values from tooltip
     const filteredParams = seriesParams.filter(param => {
-      // @ts-expect-error ECharts types param.value as unknown, but we know it's [xAxis, yAxis, zAxis] from our HeatMap plottable
-      const value = extractValue(param.value[2]);
+      // @ts-expect-error ECharts types param.value as unknown, but we know it's [xAxis, yAxis, colorPosition, rawCount] from our HeatMap plottable
+      const value = extractValue(param.value[3]);
       return value !== null;
     });
 
@@ -191,8 +183,10 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
 
             let formattedYValue = ECHARTS_MISSING_DATA_VALUE;
             let formattedZValue = ECHARTS_MISSING_DATA_VALUE;
-            if (Array.isArray(param.value) && param.value.length === 3) {
-              const [xValue, yValue, zValue] = param.value;
+            if (Array.isArray(param.value) && param.value.length === 4) {
+              // [xAxis, yAxis, colorPosition, rawCount] — index 2 is the
+              // equalized color position; the true count lives at index 3.
+              const [xValue, yValue, , zValue] = param.value;
 
               if (defined(xValue) && typeof xValue === 'number') {
                 rawXValue = xValue;
@@ -229,13 +223,10 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
               }
 
               if (defined(zValue) && typeof zValue === 'number') {
-                // when the z-axis is in log scale, the values are log values and don't reflect the actual value
-                // so we need to convert them back to the actual value
-                formattedZValue = formatAbbreviatedNumber(
-                  scale === 'log' ? Math.expm1(zValue) : zValue,
-                  4,
-                  false
-                );
+                // `zValue` is the raw count carried through on dim 3, so it can
+                // be formatted directly (the color position on dim 2 is what's
+                // been transformed, not this).
+                formattedZValue = formatAbbreviatedNumber(zValue, 4, false);
               }
             }
 
@@ -365,7 +356,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
             show: false,
           },
         }}
-        visualMap={visualMapOptions(Zmax)}
+        visualMap={visualMapOptions(colors)}
         start={start ? new Date(start) : undefined}
         end={end ? new Date(end) : undefined}
         period={period}
@@ -375,7 +366,9 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
   );
 }
 
-export const visualMapOptions = (Zmax: number): VisualMapComponentOption[] => {
+export const visualMapOptions = (
+  colors: readonly string[]
+): VisualMapComponentOption[] => {
   return [
     // Zero values are transparent (empty buckets)
     {
@@ -388,16 +381,17 @@ export const visualMapOptions = (Zmax: number): VisualMapComponentOption[] => {
         {gt: 0, opacity: 1},
       ],
     },
-    // All values are plotted against a palette
+    // Color positions are already equalized into [0, 1] by `heatMapColorScale`,
+    // so the continuous map just spans the palette across that fixed range.
     {
       type: 'continuous',
       show: false,
       dimension: 2,
       seriesIndex: 0,
       min: 0,
-      max: Zmax,
+      max: 1,
       inRange: {
-        color: [...HEATMAP_COLORS],
+        color: [...colors],
       },
     },
   ];

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -29,7 +29,7 @@ import {FALLBACK_TYPE} from 'sentry/views/dashboards/widgets/timeSeriesWidget/se
 
 import {HeatMap} from './plottables/heatMap';
 import type {HeatMapPlottable} from './plottables/heatMapPlottable';
-import {getHeatMapColors} from './settings';
+import {HEATMAP_COLORS} from './settings';
 
 // This is the ECharts default font size for axis labels. We need to use this number to do axis label frequency calculations
 // Source: https://echarts.apache.org/en/option.html#yAxis.axisLabel.fontSize
@@ -132,8 +132,6 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
 
   const yAxisDataType = heatMapPlottable.yAxisValueType;
   const yAxisDataUnit = heatMapPlottable.yAxisValueUnit;
-
-  const colors = getHeatMapColors(theme.type);
 
   /** Extract the numeric value from ECharts tooltip param.value. */
   function extractValue(data: unknown): number | null {
@@ -356,7 +354,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
             show: false,
           },
         }}
-        visualMap={visualMapOptions(colors)}
+        visualMap={visualMapOptions(HEATMAP_COLORS)}
         start={start ? new Date(start) : undefined}
         end={end ? new Date(end) : undefined}
         period={period}

--- a/static/app/views/dashboards/widgets/heatMapWidget/plottables/heatMap.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/plottables/heatMap.tsx
@@ -7,18 +7,13 @@ import type {
   HeatMapSeries,
   HeatMapValueUnit,
 } from 'sentry/views/dashboards/widgets/common/types';
+import {createHeatMapColorScale} from 'sentry/views/dashboards/widgets/heatMapWidget/utils/heatMapColorScale';
 import {FALLBACK_TYPE} from 'sentry/views/dashboards/widgets/timeSeriesWidget/settings';
 
 import type {HeatMapPlottable, PlottableTimeSeriesValueType} from './heatMapPlottable';
 
 type HeatMapPlottingOptions = {
   theme: Theme;
-  /**
-   * The Z-axis scale type. `'log'` applies `Math.log1p` to Z values so the
-   * color gradient distributes logarithmically. Useful when the Z range is
-   * very wide and low values would otherwise be invisible.
-   */
-  scale?: 'linear' | 'log';
 };
 
 export class HeatMap implements HeatMapPlottable {
@@ -49,18 +44,40 @@ export class HeatMap implements HeatMapPlottable {
 
   toSeries(plottingOptions: HeatMapPlottingOptions): SeriesOption[] {
     const {heatMapSeries} = this;
-    const {scale = 'linear', theme} = plottingOptions;
+    const {theme} = plottingOptions;
+
+    // Color is driven by each cell's *rank* among populated cells (histogram
+    // equalization) rather than its raw magnitude — see `heatMapColorScale` for
+    // why. Build the scale once from the whole series.
+    const colorScale = createHeatMapColorScale(
+      heatMapSeries.values.map(item => item.zAxis)
+    );
 
     return [
       {
         name: 'heatmap', // Only one heat map is allowed per visualization, so this name doesn't have to be unique
         type: 'heatmap',
+        // Each datum is `[x, y, colorPosition, rawCount]`. `colorPosition` (dim
+        // 2) drives the color via `visualMap`; `rawCount` (dim 3) is carried
+        // through untouched so the tooltip can show the true value. `encode`
+        // tells ECharts which dim is the value so the extra dim is just payload.
+        dimensions: ['x', 'y', 'colorPosition', 'rawCount'],
+        encode: {x: 0, y: 1, value: 2, tooltip: [3]},
         data: heatMapSeries.values.map(item => {
-          const zValue = item.zAxis ?? ECHARTS_MISSING_DATA_VALUE;
+          if (item.zAxis === null) {
+            // Empty bucket: nothing to color or report.
+            return [
+              item.xAxis,
+              item.yAxis,
+              ECHARTS_MISSING_DATA_VALUE,
+              ECHARTS_MISSING_DATA_VALUE,
+            ];
+          }
           return [
             item.xAxis,
             item.yAxis,
-            scale === 'log' && typeof zValue === 'number' ? Math.log1p(zValue) : zValue,
+            colorScale.toColorPosition(item.zAxis),
+            item.zAxis,
           ];
         }),
         emphasis: {

--- a/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
+++ b/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
@@ -1,21 +1,16 @@
 // Heat map color ramps (low → high). ECharts' continuous `visualMap`
 // interpolates between whatever stops it's given, so a ramp is just an ordered
-// list of ~10 hex stops — swapping schemes is a one-line change here.
-//
-// These are perceptually-uniform colormaps (viridis for light, magma for dark):
-// each step is roughly equal in perceived lightness, and — crucially — the high
-// end is bright and distinct. The previous purple→magenta ramp packed its top
-// half into similarly-dark stops, so high-magnitude cells (e.g. 1M vs 18M) were
-// indistinguishable. Per the Datadog heatmap write-up, human brightness
-// perception follows a power law (we discriminate poorly among dark shades), so
-// ending bright keeps the hottest cells legible.
-//
-// The ramp variant is chosen per theme so the low end stays visible against the
-// chart background. Empty/zero buckets are NOT part of the palette — they're
-// rendered transparent by a piecewise `visualMap` in `HeatMapWidgetVisualization`.
+// list of ~10 hex stops. Each ramp here aims for the same properties: lightness
+// that climbs steadily and a bright, distinct top end, so high-magnitude cells
+// (e.g. 1M vs 18M) stay distinguishable. The previous purple→magenta ramp packed
+// its top half into similarly-dark stops, so they all looked the same. Per the
+// Datadog heatmap write-up, human brightness perception follows a power law (we
+// discriminate poorly among dark shades), so ending bright keeps hot cells
+// legible. Empty/zero buckets are NOT part of the palette — they're rendered
+// transparent by a piecewise `visualMap` in `HeatMapWidgetVisualization`.
 
-/** Viridis, sampled at 10 stops. Used on light backgrounds. */
-export const HEATMAP_COLORS_LIGHT = [
+/** Viridis, sampled at 10 stops. */
+const VIRIDIS = [
   '#440154',
   '#482878',
   '#3e4a89',
@@ -28,8 +23,8 @@ export const HEATMAP_COLORS_LIGHT = [
   '#fde725',
 ] as const;
 
-/** Magma, sampled at 10 stops. Used on dark backgrounds. */
-export const HEATMAP_COLORS_DARK = [
+/** Magma, sampled at 10 stops. */
+const MAGMA = [
   '#0a0a23',
   '#231151',
   '#410f75',
@@ -41,6 +36,47 @@ export const HEATMAP_COLORS_DARK = [
   '#f97a5d',
   '#fea772',
 ] as const;
+
+/**
+ * Sentry brand ramp: deep indigo → blurple → magenta → pink → salmon → orange →
+ * yellow. Built from the theme's blue ramp (low end) and the categorical
+ * data-viz palette (warm end), so it traces a magma-like arc in brand hues.
+ */
+const SENTRY_BRAND = [
+  '#24006c',
+  '#3f00a7',
+  '#5827d6',
+  '#7553ff',
+  '#b82d90',
+  '#f0369a',
+  '#fa6769',
+  '#ff9838',
+  '#ffd00e',
+] as const;
+
+/** Every selectable heat map palette, keyed by name. */
+export const HEATMAP_PALETTES = {
+  viridis: VIRIDIS,
+  magma: MAGMA,
+  brand: SENTRY_BRAND,
+} as const;
+
+export type HeatMapPaletteName = keyof typeof HEATMAP_PALETTES;
+
+/**
+ * Which palette to use for each theme. Change these two values to re-skin the
+ * heat map — pick a low end that's visible against that theme's background and a
+ * top end that contrasts it.
+ */
+export const HEATMAP_PALETTE_BY_THEME: Record<'light' | 'dark', HeatMapPaletteName> = {
+  light: 'brand',
+  dark: 'magma',
+};
+
+/** Resolve the heat map color ramp for a theme (`theme.type`). */
+export function getHeatMapColors(themeType: 'light' | 'dark'): readonly string[] {
+  return HEATMAP_PALETTES[HEATMAP_PALETTE_BY_THEME[themeType]];
+}
 
 /**
  * Target size, in pixels, of a single heat map bucket along each axis. Both the

--- a/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
+++ b/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
@@ -74,21 +74,21 @@ const OLD_SENTRY = [
 ] as const;
 
 /** Every selectable heat map palette, keyed by name. */
-export const HEATMAP_PALETTES = {
+const HEATMAP_PALETTES = {
   viridis: VIRIDIS,
   magma: MAGMA,
   brand: SENTRY_BRAND,
   old: OLD_SENTRY,
 } as const;
 
-export type HeatMapPaletteName = keyof typeof HEATMAP_PALETTES;
+type HeatMapPaletteName = keyof typeof HEATMAP_PALETTES;
 
 /**
  * Which palette to use for each theme. Change these two values to re-skin the
  * heat map — pick a low end that's visible against that theme's background and a
  * top end that contrasts it.
  */
-export const HEATMAP_PALETTE_BY_THEME: Record<'light' | 'dark', HeatMapPaletteName> = {
+const HEATMAP_PALETTE_BY_THEME: Record<'light' | 'dark', HeatMapPaletteName> = {
   light: 'brand',
   dark: 'brand',
 };

--- a/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
+++ b/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
@@ -1,13 +1,20 @@
 // Heat map color ramps (low → high). ECharts' continuous `visualMap`
 // interpolates between whatever stops it's given, so a ramp is just an ordered
-// list of ~10 hex stops. Each ramp here aims for the same properties: lightness
-// that climbs steadily and a bright, distinct top end, so high-magnitude cells
-// (e.g. 1M vs 18M) stay distinguishable. The previous purple→magenta ramp packed
-// its top half into similarly-dark stops, so they all looked the same. Per the
-// Datadog heatmap write-up, human brightness perception follows a power law (we
-// discriminate poorly among dark shades), so ending bright keeps hot cells
-// legible. Empty/zero buckets are NOT part of the palette — they're rendered
-// transparent by a piecewise `visualMap` in `HeatMapWidgetVisualization`.
+// list of ~10 hex stops.
+//
+// Each ramp targets two properties so that cells of different magnitude stay
+// distinguishable:
+//   1. Lightness climbs steadily from one end to the other, giving a "brighter =
+//      more" cue that's readable on its own (and survives greyscale).
+//   2. The high end is bright and high-contrast. Human brightness perception
+//      follows a power law — we resolve bright shades far better than dark ones
+//      — so a ramp that ends bright keeps the busiest cells legible instead of
+//      letting them blur together at a murky top end.
+// Wandering through several hues along the way (rather than a single hue getting
+// lighter) packs in more perceptually-distinct steps for the same lightness range.
+//
+// Empty/zero buckets are NOT part of the palette — they're rendered transparent
+// by a piecewise `visualMap` in `HeatMapWidgetVisualization`.
 
 /** Viridis, sampled at 10 stops. */
 const VIRIDIS = [

--- a/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
+++ b/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
@@ -1,8 +1,8 @@
-// Heat map color ramps (low → high). ECharts' continuous `visualMap`
-// interpolates between whatever stops it's given, so a ramp is just an ordered
-// list of ~10 hex stops.
+// Heat map color ramp (low → high): magma, sampled at 10 stops. ECharts'
+// continuous `visualMap` interpolates between whatever stops it's given, so a
+// ramp is just an ordered list of hex stops.
 //
-// Each ramp targets two properties so that cells of different magnitude stay
+// Magma is chosen for two properties that keep cells of different magnitude
 // distinguishable:
 //   1. Lightness climbs steadily from one end to the other, giving a "brighter =
 //      more" cue that's readable on its own (and survives greyscale).
@@ -10,28 +10,13 @@
 //      follows a power law — we resolve bright shades far better than dark ones
 //      — so a ramp that ends bright keeps the busiest cells legible instead of
 //      letting them blur together at a murky top end.
-// Wandering through several hues along the way (rather than a single hue getting
-// lighter) packs in more perceptually-distinct steps for the same lightness range.
+// It also wanders through several hues (rather than a single hue getting
+// lighter), packing in more perceptually-distinct steps for the same lightness
+// range.
 //
 // Empty/zero buckets are NOT part of the palette — they're rendered transparent
 // by a piecewise `visualMap` in `HeatMapWidgetVisualization`.
-
-/** Viridis, sampled at 10 stops. */
-const VIRIDIS = [
-  '#440154',
-  '#482878',
-  '#3e4a89',
-  '#31688e',
-  '#26828e',
-  '#1f9e89',
-  '#35b779',
-  '#6ece58',
-  '#b5de2b',
-  '#fde725',
-] as const;
-
-/** Magma, sampled at 10 stops. */
-const MAGMA = [
+export const HEATMAP_COLORS = [
   '#0a0a23',
   '#231151',
   '#410f75',
@@ -43,60 +28,6 @@ const MAGMA = [
   '#f97a5d',
   '#fea772',
 ] as const;
-
-/**
- * Sentry brand ramp: deep indigo → blurple → magenta → pink → salmon → orange →
- * yellow. Built from the theme's blue ramp (low end) and the categorical
- * data-viz palette (warm end), so it traces a magma-like arc in brand hues.
- */
-const SENTRY_BRAND = [
-  '#24006c',
-  '#3f00a7',
-  '#5827d6',
-  '#7553ff',
-  '#b82d90',
-  '#f0369a',
-  '#fa6769',
-  '#ff9838',
-  '#ffd00e',
-] as const;
-
-const OLD_SENTRY = [
-  '#eeefff',
-  '#d0c8ff',
-  '#b2a1ff',
-  '#937aff',
-  '#7c42dd',
-  '#8332bb',
-  '#8b219a',
-  '#921178',
-  '#990056',
-] as const;
-
-/** Every selectable heat map palette, keyed by name. */
-const HEATMAP_PALETTES = {
-  viridis: VIRIDIS,
-  magma: MAGMA,
-  brand: SENTRY_BRAND,
-  old: OLD_SENTRY,
-} as const;
-
-type HeatMapPaletteName = keyof typeof HEATMAP_PALETTES;
-
-/**
- * Which palette to use for each theme. Change these two values to re-skin the
- * heat map — pick a low end that's visible against that theme's background and a
- * top end that contrasts it.
- */
-const HEATMAP_PALETTE_BY_THEME: Record<'light' | 'dark', HeatMapPaletteName> = {
-  light: 'brand',
-  dark: 'brand',
-};
-
-/** Resolve the heat map color ramp for a theme (`theme.type`). */
-export function getHeatMapColors(themeType: 'light' | 'dark'): readonly string[] {
-  return HEATMAP_PALETTES[HEATMAP_PALETTE_BY_THEME[themeType]];
-}
 
 /**
  * Target size, in pixels, of a single heat map bucket along each axis. Both the

--- a/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
+++ b/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
@@ -90,7 +90,7 @@ export type HeatMapPaletteName = keyof typeof HEATMAP_PALETTES;
  */
 export const HEATMAP_PALETTE_BY_THEME: Record<'light' | 'dark', HeatMapPaletteName> = {
   light: 'brand',
-  dark: 'old',
+  dark: 'brand',
 };
 
 /** Resolve the heat map color ramp for a theme (`theme.type`). */

--- a/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
+++ b/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
@@ -1,18 +1,45 @@
-// Color scale interpolated across three design stops: #EEEFFF (low) → #7553FF
-// (mid) → #990056 (high) Steps 1–5: segment 1, steps 6–10: segment 2 N.B.
-// Missing values are not part of the palette here, they are filled in by the
-// `HeatMapWidgetVisualization` component.
-export const HEATMAP_COLORS = [
-  '#eeefff',
-  '#d0c8ff',
-  '#b2a1ff',
-  '#937aff',
-  '#7553ff',
-  '#7c42dd',
-  '#8332bb',
-  '#8b219a',
-  '#921178',
-  '#990056',
+// Heat map color ramps (low → high). ECharts' continuous `visualMap`
+// interpolates between whatever stops it's given, so a ramp is just an ordered
+// list of ~10 hex stops — swapping schemes is a one-line change here.
+//
+// These are perceptually-uniform colormaps (viridis for light, magma for dark):
+// each step is roughly equal in perceived lightness, and — crucially — the high
+// end is bright and distinct. The previous purple→magenta ramp packed its top
+// half into similarly-dark stops, so high-magnitude cells (e.g. 1M vs 18M) were
+// indistinguishable. Per the Datadog heatmap write-up, human brightness
+// perception follows a power law (we discriminate poorly among dark shades), so
+// ending bright keeps the hottest cells legible.
+//
+// The ramp variant is chosen per theme so the low end stays visible against the
+// chart background. Empty/zero buckets are NOT part of the palette — they're
+// rendered transparent by a piecewise `visualMap` in `HeatMapWidgetVisualization`.
+
+/** Viridis, sampled at 10 stops. Used on light backgrounds. */
+export const HEATMAP_COLORS_LIGHT = [
+  '#440154',
+  '#482878',
+  '#3e4a89',
+  '#31688e',
+  '#26828e',
+  '#1f9e89',
+  '#35b779',
+  '#6ece58',
+  '#b5de2b',
+  '#fde725',
+] as const;
+
+/** Magma, sampled at 10 stops. Used on dark backgrounds. */
+export const HEATMAP_COLORS_DARK = [
+  '#0a0a23',
+  '#231151',
+  '#410f75',
+  '#5f187f',
+  '#812581',
+  '#a3307e',
+  '#c83e73',
+  '#e95462',
+  '#f97a5d',
+  '#fea772',
 ] as const;
 
 /**
@@ -21,12 +48,6 @@ export const HEATMAP_COLORS = [
  * are roughly this size, keeping them approximately square.
  */
 export const PIXELS_PER_BUCKET = 15;
-
-/**
- * Scale used for the heat map's Z axis (the cell color). A logarithmic scale
- * handles the wide range of counts better than a linear one.
- */
-export const HEATMAP_Z_AXIS_SCALE = 'log' as const;
 
 /**
  * How long, in milliseconds, to debounce the measured chart dimensions before

--- a/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
+++ b/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
@@ -54,11 +54,24 @@ const SENTRY_BRAND = [
   '#ffd00e',
 ] as const;
 
+const OLD_SENTRY = [
+  '#eeefff',
+  '#d0c8ff',
+  '#b2a1ff',
+  '#937aff',
+  '#7c42dd',
+  '#8332bb',
+  '#8b219a',
+  '#921178',
+  '#990056',
+] as const;
+
 /** Every selectable heat map palette, keyed by name. */
 export const HEATMAP_PALETTES = {
   viridis: VIRIDIS,
   magma: MAGMA,
   brand: SENTRY_BRAND,
+  old: OLD_SENTRY,
 } as const;
 
 export type HeatMapPaletteName = keyof typeof HEATMAP_PALETTES;
@@ -70,7 +83,7 @@ export type HeatMapPaletteName = keyof typeof HEATMAP_PALETTES;
  */
 export const HEATMAP_PALETTE_BY_THEME: Record<'light' | 'dark', HeatMapPaletteName> = {
   light: 'brand',
-  dark: 'magma',
+  dark: 'old',
 };
 
 /** Resolve the heat map color ramp for a theme (`theme.type`). */

--- a/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapColorScale.spec.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapColorScale.spec.tsx
@@ -1,0 +1,72 @@
+import {createHeatMapColorScale} from 'sentry/views/dashboards/widgets/heatMapWidget/utils/heatMapColorScale';
+
+describe('createHeatMapColorScale', () => {
+  it('maps non-positive values and nulls to position 0', () => {
+    const scale = createHeatMapColorScale([1, 2, 3]);
+
+    expect(scale.toColorPosition(0)).toBe(0);
+    expect(scale.toColorPosition(-5)).toBe(0);
+  });
+
+  it('returns 0 for everything when there is no populated data', () => {
+    const scale = createHeatMapColorScale([null, 0, null]);
+
+    expect(scale.toColorPosition(0)).toBe(0);
+    expect(scale.toColorPosition(100)).toBe(0);
+  });
+
+  it('places the only populated cell at the top of the palette', () => {
+    const scale = createHeatMapColorScale([42]);
+
+    expect(scale.toColorPosition(42)).toBe(1);
+  });
+
+  it('equalizes by rank rather than magnitude', () => {
+    // Four populated cells: 1, 2, 1_000_000, 18_000_000. The two large values —
+    // which collapsed together under log scaling — land at distinct positions.
+    const scale = createHeatMapColorScale([1, 2, 1_000_000, 18_000_000]);
+
+    expect(scale.toColorPosition(1)).toBe(0.25);
+    expect(scale.toColorPosition(2)).toBe(0.5);
+    expect(scale.toColorPosition(1_000_000)).toBe(0.75);
+    expect(scale.toColorPosition(18_000_000)).toBe(1);
+  });
+
+  it('is monotonically non-decreasing', () => {
+    const scale = createHeatMapColorScale([5, 1, 3, 9, 7]);
+
+    let previous = -Infinity;
+    for (const z of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) {
+      const position = scale.toColorPosition(z);
+      expect(position).toBeGreaterThanOrEqual(previous);
+      previous = position;
+    }
+  });
+
+  it('gives tied values the same position (top of their rank group)', () => {
+    // Three of five values equal 5; all should share position 4/5.
+    const scale = createHeatMapColorScale([1, 5, 5, 5, 9]);
+
+    expect(scale.toColorPosition(5)).toBe(0.8);
+  });
+
+  it('maps all-equal data to the top position', () => {
+    const scale = createHeatMapColorScale([7, 7, 7, 7]);
+
+    expect(scale.toColorPosition(7)).toBe(1);
+  });
+
+  it('ignores nulls and non-positive values when equalizing', () => {
+    // Only 10 and 20 are populated, so they split the palette in half.
+    const scale = createHeatMapColorScale([null, 0, 10, 20, null, -3]);
+
+    expect(scale.toColorPosition(10)).toBe(0.5);
+    expect(scale.toColorPosition(20)).toBe(1);
+  });
+
+  it('keeps the lowest populated value opaque (position > 0)', () => {
+    const scale = createHeatMapColorScale([10, 20, 30, 40]);
+
+    expect(scale.toColorPosition(10)).toBeGreaterThan(0);
+  });
+});

--- a/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapColorScale.ts
+++ b/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapColorScale.ts
@@ -50,7 +50,7 @@
  * constant — but we intentionally do not build that yet.
  */
 
-export interface HeatMapColorScale {
+interface HeatMapColorScale {
   /**
    * Maps a raw Z value to a color position in `[0, 1]`, where `0` is the bottom
    * of the palette (and, for `z <= 0`, transparent) and `1` is the top. Returns

--- a/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapColorScale.ts
+++ b/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapColorScale.ts
@@ -9,9 +9,9 @@
  * linear (`z / zMax`) and logarithmic (`log1p(z) / log1p(zMax)`) — both fail on
  * the long-tailed distributions we actually see: a handful of huge buckets
  * stretch the scale so that everything else collapses into one or two colors.
- * Concretely, a cell of 1,000,000 and a cell of 18,000,000 ended up nearly
- * identical because, even in log space, they both sit near the very top of the
- * range and the palette has little contrast there.
+ * Concretely, a cell of 1,000,000 and one of 18,000,000 map to nearly the same
+ * position because, even in log space, both sit at the very top of the range
+ * with almost no room between them.
  *
  * ## The approach: equalize by rank, not by magnitude
  *

--- a/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapColorScale.ts
+++ b/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapColorScale.ts
@@ -1,0 +1,121 @@
+/**
+ * Heat map color scaling via histogram equalization.
+ *
+ * ## The problem this solves
+ *
+ * A heat map colors each cell by its Z value (here, a count of events in a
+ * time/value bucket). To turn a Z value into a color we need to map it onto a
+ * position in `[0, 1]` and let the palette interpolate. The obvious mappings —
+ * linear (`z / zMax`) and logarithmic (`log1p(z) / log1p(zMax)`) — both fail on
+ * the long-tailed distributions we actually see: a handful of huge buckets
+ * stretch the scale so that everything else collapses into one or two colors.
+ * Concretely, a cell of 1,000,000 and a cell of 18,000,000 ended up nearly
+ * identical because, even in log space, they both sit near the very top of the
+ * range and the palette has little contrast there.
+ *
+ * ## The approach: equalize by rank, not by magnitude
+ *
+ * Instead of mapping by *how big* a value is, we map by *what fraction of the
+ * data is at or below it* — its empirical CDF (a.k.a. fractional rank, a.k.a.
+ * histogram equalization). If a value is greater than 90% of all populated
+ * cells, it sits at position 0.9 regardless of whether the spread is 1→100 or
+ * 1→18,000,000. This spreads the data evenly across the whole palette, so two
+ * values in different percentiles always get visibly different colors.
+ *
+ * ## How it's computed
+ *
+ *   position(z) = (number of populated cells with value <= z) / (number of
+ *                 populated cells)
+ *
+ * We sort the populated (non-zero, non-null) values once up front, then each
+ * lookup is a binary search — O(n log n) to build, O(log n) per cell.
+ *
+ * ## Why only non-zero, non-null values?
+ *
+ * Empty buckets (`z === null`) and true-zero buckets are rendered transparent
+ * by a separate piecewise `visualMap` that keys off position `0`. So this scale
+ * deliberately maps any `z <= 0` (or null) to position `0` and equalizes only
+ * over the populated cells. That also means the *lowest* populated value maps to
+ * a small but non-zero position (`>= 1/n`), keeping it opaque and visible rather
+ * than collapsing into the transparent "empty" bucket.
+ *
+ * ## Trade-off / escape hatch
+ *
+ * Pure equalization can *exaggerate* tiny differences when the data is nearly
+ * uniform (adjacent ranks get pushed apart even if their values are almost
+ * equal). For our long-tailed count data that's a minor, secondary concern, so
+ * we keep the simple version. If a future chart looks too flat or misleading,
+ * the documented next step is to blend this rank position with a `log1p`
+ * magnitude position (Datadog's "linear weighting of the two") behind a weight
+ * constant — but we intentionally do not build that yet.
+ */
+
+export interface HeatMapColorScale {
+  /**
+   * Maps a raw Z value to a color position in `[0, 1]`, where `0` is the bottom
+   * of the palette (and, for `z <= 0`, transparent) and `1` is the top. Returns
+   * `0` for non-positive values and when there is no populated data to equalize
+   * over.
+   */
+  toColorPosition(z: number): number;
+}
+
+/**
+ * Builds a {@link HeatMapColorScale} from a series' Z values. Pass the raw cell
+ * values (`null` for empty buckets); the scale equalizes over the positive ones.
+ */
+export function createHeatMapColorScale(
+  values: ReadonlyArray<number | null>
+): HeatMapColorScale {
+  // Keep only populated cells: drop nulls (empty buckets) and non-positive
+  // counts, which we render transparent rather than color. Sort ascending so we
+  // can answer "how many values are <= z?" with a binary search.
+  const sorted = values
+    .filter((value): value is number => value !== null && value > 0)
+    .sort((a, b) => a - b);
+
+  const total = sorted.length;
+
+  return {
+    toColorPosition(z: number): number {
+      // Non-positive values (and the empty-bucket case below) sit at position 0,
+      // where the piecewise visualMap makes them transparent.
+      if (z <= 0) {
+        return 0;
+      }
+
+      // No populated cells to equalize against — everything is position 0.
+      if (total === 0) {
+        return 0;
+      }
+
+      // Count of populated values <= z, found via upper-bound binary search.
+      // Using "<= z" (rather than "< z") means tied values share the same
+      // position: the top of their rank group.
+      const countAtOrBelow = upperBound(sorted, z);
+
+      return countAtOrBelow / total;
+    },
+  };
+}
+
+/**
+ * Returns the number of elements in the ascending-sorted `sorted` that are
+ * `<= target` — i.e. the index of the first element strictly greater than
+ * `target`. Plain binary search, no dependencies.
+ */
+function upperBound(sorted: readonly number[], target: number): number {
+  let low = 0;
+  let high = sorted.length;
+
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (sorted[mid]! <= target) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+
+  return low;
+}

--- a/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapColorScale.ts
+++ b/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapColorScale.ts
@@ -110,7 +110,10 @@ function upperBound(sorted: readonly number[], target: number): number {
 
   while (low < high) {
     const mid = (low + high) >> 1;
-    if (sorted[mid]! <= target) {
+    // `mid` is always in range, so `value` is never undefined; the guard just
+    // satisfies `noUncheckedIndexedAccess` without a non-null assertion.
+    const value = sorted[mid];
+    if (value !== undefined && value <= target) {
       low = mid + 1;
     } else {
       high = mid;

--- a/static/app/views/explore/metrics/metricsHeatMap.tsx
+++ b/static/app/views/explore/metrics/metricsHeatMap.tsx
@@ -8,7 +8,6 @@ import type {HeatMapSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {WidgetLoadingPanel} from 'sentry/views/dashboards/widgets/common/widgetLoadingPanel';
 import {HeatMapWidgetVisualization} from 'sentry/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization';
 import {HeatMap} from 'sentry/views/dashboards/widgets/heatMapWidget/plottables/heatMap';
-import {HEATMAP_Z_AXIS_SCALE} from 'sentry/views/dashboards/widgets/heatMapWidget/settings';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {WidgetWrapper} from 'sentry/views/explore/metrics/metricGraph/styles';
 import {
@@ -76,7 +75,6 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
           ) : (
             <HeatMapWidgetVisualization
               plottables={[new HeatMap(heatMapSeries)]}
-              scale={HEATMAP_Z_AXIS_SCALE}
               tooltipActionHandlers={{[ADD_TO_FILTER_ACTION]: updateMetricQuery}}
               renderTooltipActions={({
                 valueMin,


### PR DESCRIPTION
Improves the visual scaling of the Explore → Metrics heat map so cell color reflects magnitude.

The current heat map has a problem in which the differences in magnitude are really hard to see. In the screenshot below, the data varies from ~1M to about ~30M but all the cells look the same! In the "After" example, the difference is much more visible.

**Before:**
<img width="707" height="338" alt="Screenshot 2026-06-23 at 8 55 58 PM" src="https://github.com/user-attachments/assets/84894cf3-ed23-4bb2-a4ee-011437c23f59" />

**After:**
<img width="680" height="323" alt="Screenshot 2026-06-23 at 9 01 59 PM" src="https://github.com/user-attachments/assets/0018a421-85a3-416f-83b6-892f387b61e7" />

This is done with two fixes.

1. A new palette. We're going with a known palette called "magma", which was designed for heat maps. In the future we'll probably tweak it a bit to fit Sentry's brand colours.
2. CDF calculation. Instead of linearly interpolation the palette onto the Z-axis range, we compute the CDF and assign the palette based on rank (i.e., percentiles) which lifts up rarer measurements and makes it a bit easier to spot some patterns.

This is not necessarily the state of the art for heat maps, but it's pretty good, and the difference is clear! If we want to do even better here, we'd probably gather some specific cases of features we'd like heat maps to make legible, and evaluate them, but this is a good first step.

Closes DAIN-1642
