### PR TITLE
fix(apigateway): Preserve Content-Encoding when proxying snapshot create

### DIFF
--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -26,6 +26,7 @@ from sentry import options
 from sentry.objectstore.endpoints.organization import ChunkedEncodingDecoder, get_raw_body
 from sentry.options.rollout import in_random_rollout
 from sentry.silo.util import (
+    PRESERVE_CONTENT_ENCODING_URL_NAMES,
     PROXY_APIGATEWAY_HEADER,
     PROXY_DIRECT_LOCATION_HEADER,
     clean_outbound_headers,
@@ -191,10 +192,11 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
     if settings.APIGATEWAY_PROXY_SKIP_RELAY and request.path.startswith("/api/0/relays/"):
         return StreamingHttpResponse(streaming_content="relay proxy skipped", status=404)
 
+    if content_encoding and url_name in PRESERVE_CONTENT_ENCODING_URL_NAMES:
+        header_dict["Content-Encoding"] = content_encoding
+
     data: bytes | Generator[bytes] | ChunkedEncodingDecoder | BodyWithLength | None = None
     if url_name == "sentry-api-0-organization-objectstore":
-        if content_encoding:
-            header_dict["Content-Encoding"] = content_encoding
         data = get_raw_body(request)
     else:
         data = BodyWithLength(request)

--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -19,6 +19,7 @@ from django.http.response import HttpResponseBase
 from sentry import options
 from sentry.objectstore.endpoints.organization import get_raw_body_async
 from sentry.silo.util import (
+    PRESERVE_CONTENT_ENCODING_URL_NAMES,
     PROXY_APIGATEWAY_HEADER,
     PROXY_DIRECT_LOCATION_HEADER,
     clean_outbound_headers,
@@ -151,9 +152,10 @@ async def proxy_cell_request(
 
     try:
         async with circuitbreakers.get(cell.name) as circuitbreaker:
+            if content_encoding and url_name in PRESERVE_CONTENT_ENCODING_URL_NAMES:
+                header_dict["Content-Encoding"] = content_encoding
+
             if url_name == "sentry-api-0-organization-objectstore":
-                if content_encoding:
-                    header_dict["Content-Encoding"] = content_encoding
                 data = get_raw_body_async(request)
             else:
                 data = BodyAsyncWrapper(request.body)

--- a/src/sentry/silo/util.py
+++ b/src/sentry/silo/util.py
@@ -26,6 +26,16 @@ INVALID_OUTBOUND_HEADERS = INVALID_PROXY_HEADERS | {
     PROXY_TIMEOUT_HEADER,
 }
 
+# url_names whose request body is forwarded raw through the gateway and whose
+# Content-Encoding header must therefore be preserved (it is otherwise stripped
+# by clean_proxy_headers via INVALID_PROXY_HEADERS).
+PRESERVE_CONTENT_ENCODING_URL_NAMES = frozenset(
+    {
+        "sentry-api-0-organization-objectstore",
+        "sentry-api-0-project-preprod-snapshots-create",
+    }
+)
+
 DEFAULT_REQUEST_BODY = b""
 
 

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -395,6 +395,92 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert isinstance(resp, JsonResponse)
         assert json.loads(resp.content)["detail"] == "Downstream service unavailable"
 
+    @responses.activate
+    def test_sync_preserves_content_encoding_for_snapshot_create(self) -> None:
+        captured: dict[str, str | None] = {}
+
+        def request_callback(request: PreparedRequest) -> tuple[int, dict[str, str], str]:
+            captured["content_encoding"] = request.headers.get("Content-Encoding")
+            return 200, {"Content-Type": "application/json"}, json.dumps({"proxy": True})
+
+        responses.add_callback(
+            responses.POST, "http://us.internal.sentry.io/post", callback=request_callback
+        )
+
+        request = RequestFactory().post(
+            "http://sentry.io/post",
+            data={"foo": "bar"},
+            content_type="application/json",
+            headers={"Content-Encoding": "zstd"},
+        )
+        resp = sync_proxy.proxy_request(
+            request, self.organization.slug, "sentry-api-0-project-preprod-snapshots-create"
+        )
+        close_streaming_response(resp)
+        assert captured["content_encoding"] == "zstd"
+
+    @responses.activate
+    def test_sync_strips_content_encoding_for_other_routes(self) -> None:
+        captured: dict[str, str | None] = {}
+
+        def request_callback(request: PreparedRequest) -> tuple[int, dict[str, str], str]:
+            captured["content_encoding"] = request.headers.get("Content-Encoding")
+            return 200, {"Content-Type": "application/json"}, json.dumps({"proxy": True})
+
+        responses.add_callback(
+            responses.POST, "http://us.internal.sentry.io/post", callback=request_callback
+        )
+
+        request = RequestFactory().post(
+            "http://sentry.io/post",
+            data={"foo": "bar"},
+            content_type="application/json",
+            headers={"Content-Encoding": "zstd"},
+        )
+        resp = sync_proxy.proxy_request(request, self.organization.slug, url_name)
+        close_streaming_response(resp)
+        assert captured["content_encoding"] is None
+
+    def test_async_preserves_content_encoding_for_snapshot_create(self) -> None:
+        captured: dict[str, str | None] = {}
+
+        def callback(request: httpx.Request) -> tuple[int, dict[str, str], str]:
+            captured["content_encoding"] = request.headers.get("content-encoding")
+            return 200, {}, json.dumps({"proxy": True})
+
+        self.httpx_router.add_callback("POST", "http://us.internal.sentry.io/post", callback)
+
+        request = RequestFactory().post(
+            "http://sentry.io/post",
+            data={"foo": "bar"},
+            content_type="application/json",
+            headers={"Content-Encoding": "zstd"},
+        )
+        resp = proxy_request(
+            request, self.organization.slug, "sentry-api-0-project-preprod-snapshots-create"
+        )
+        close_streaming_response(resp)
+        assert captured["content_encoding"] == "zstd"
+
+    def test_async_strips_content_encoding_for_other_routes(self) -> None:
+        captured: dict[str, str | None] = {}
+
+        def callback(request: httpx.Request) -> tuple[int, dict[str, str], str]:
+            captured["content_encoding"] = request.headers.get("content-encoding")
+            return 200, {}, json.dumps({"proxy": True})
+
+        self.httpx_router.add_callback("POST", "http://us.internal.sentry.io/post", callback)
+
+        request = RequestFactory().post(
+            "http://sentry.io/post",
+            data={"foo": "bar"},
+            content_type="application/json",
+            headers={"Content-Encoding": "zstd"},
+        )
+        resp = proxy_request(request, self.organization.slug, url_name)
+        close_streaming_response(resp)
+        assert captured["content_encoding"] is None
+
 
 api_gateway_address_cell = Cell(
     name="us",


### PR DESCRIPTION
## Summary

The hybrid-cloud API gateway strips the `Content-Encoding` request header when proxying a control-silo request to a region — it's in `INVALID_PROXY_HEADERS` (`sentry/silo/util.py`) and removed by `clean_proxy_headers` — while forwarding the request body **raw**. Only the `objectstore` route re-added it.

The preprod snapshot **create** endpoint (`POST /api/0/projects/{org}/{project}/preprodartifacts/snapshots/`) receives its manifest zstd-compressed (`Content-Encoding: zstd`). When that POST is proxied control→region, the region gets still-compressed bytes with **no** encoding header, so `decode_preprod_snapshot_request_body` takes the `identity` branch, runs `orjson.loads` on zstd bytes, and returns `400 {"detail":"Invalid json body"}`.

## Fix

- Add a shared `PRESERVE_CONTENT_ENCODING_URL_NAMES` allowlist in `sentry/silo/util.py` (`objectstore` + snapshot create).
- In **both** proxies (sync `apigateway/proxy.py` and async `apigateway_async/proxy.py`), re-add `Content-Encoding` for allowlisted routes *before* the body-transport branch, keeping each route's existing transport — including the async `else` branch's `Content-Length` re-add (which prevents httpx falling back to chunked transfer encoding). The objectstore branch is unchanged (still allowlisted, still `get_raw_body`).

## Scope

Snapshots-only. `chunk-upload` signals gzip via the multipart `file_gzip` field name (not the `Content-Encoding` header), so it is unaffected and intentionally left out of the allowlist.

## Tests

Added preserve + strip tests for both proxies in `tests/sentry/hybridcloud/apigateway/test_proxy.py` (assert the proxied request retains `Content-Encoding: zstd` for the snapshot route and still strips it for other routes). Full `test_proxy.py` passes (51 tests).

## Context

This is the durable server-side fix behind the snapshot-upload routing issue. It lets the snapshot create POST route through the gateway like any other endpoint (the previous nginx `$upload_upstream` carve-out, getsentry/ops #21425, was reverted in #21427 because routing through the gateway exposed exactly this header-stripping bug).
