### PR TITLE
perf(ui): Animate unread indicator for 30 seconds

### DIFF
--- a/static/app/components/core/statusIndicator/statusIndicator.mdx
+++ b/static/app/components/core/statusIndicator/statusIndicator.mdx
@@ -62,14 +62,14 @@ The background pulse repeats continuously by default. Pass `animationIterationCo
     <StatusIndicator
       variant="accent"
       aria-label="Unread updates"
-      animationIterationCount={3}
+      animationIterationCount={14}
     />
     <Text>Finite pulse</Text>
   </Flex>
 </Storybook.Demo>
 
 ```jsx
-<StatusIndicator variant="accent" animationIterationCount={3} />
+<StatusIndicator variant="accent" animationIterationCount={14} />
 ```
 
 When the user prefers reduced motion, the indicator renders in its settled static state.

--- a/static/app/components/core/statusIndicator/statusIndicator.mdx
+++ b/static/app/components/core/statusIndicator/statusIndicator.mdx
@@ -15,7 +15,7 @@ import * as Storybook from 'sentry/stories';
 
 export const documentation = import('!!type-loader!@sentry/scraps/statusIndicator');
 
-The `StatusIndicator` is a small dot indicator that communicates status or severity. It supports six semantic variants mapped to design tokens. Each dot renders with a subtle muted background pulse behind it.
+The `StatusIndicator` is a small dot indicator that communicates status or severity. It supports six semantic variants mapped to design tokens. By default, each dot renders with a subtle muted background pulse behind it.
 
 Placement is the caller's responsibility — the component renders as an inline element with no positioning of its own.
 
@@ -52,6 +52,27 @@ Placement is the caller's responsibility — the component renders as an inline 
 <StatusIndicator variant="promotion" />
 <StatusIndicator variant="muted" />
 ```
+
+## Animation
+
+The background pulse repeats continuously by default. Pass `animationIterationCount` when the indicator should draw attention briefly, then settle into a static dot.
+
+<Storybook.Demo>
+  <Flex align="center" gap="sm">
+    <StatusIndicator
+      variant="accent"
+      aria-label="Unread updates"
+      animationIterationCount={3}
+    />
+    <Text>Finite pulse</Text>
+  </Flex>
+</Storybook.Demo>
+
+```jsx
+<StatusIndicator variant="accent" animationIterationCount={3} />
+```
+
+When the user prefers reduced motion, the indicator renders in its settled static state.
 
 ## Accessibility
 

--- a/static/app/components/core/statusIndicator/statusIndicator.spec.tsx
+++ b/static/app/components/core/statusIndicator/statusIndicator.spec.tsx
@@ -28,4 +28,14 @@ describe('StatusIndicator', () => {
     expect(dot).toBeInTheDocument();
     expect(dot).not.toHaveAttribute('aria-hidden');
   });
+
+  it('accepts a finite animation iteration count without passing styling props to the DOM', () => {
+    render(
+      <StatusIndicator variant="accent" animationIterationCount={3} data-test-id="dot" />
+    );
+
+    const dot = screen.getByTestId('dot');
+    expect(dot).not.toHaveAttribute('animationIterationCount');
+    expect(dot).not.toHaveAttribute('variant');
+  });
 });

--- a/static/app/components/core/statusIndicator/statusIndicator.tsx
+++ b/static/app/components/core/statusIndicator/statusIndicator.tsx
@@ -1,3 +1,4 @@
+import isPropValid from '@emotion/is-prop-valid';
 import {keyframes, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -13,8 +14,11 @@ type StatusIndicatorVariant =
   | 'promotion'
   | 'muted';
 
+type StatusIndicatorAnimationIterationCount = number | 'infinite';
+
 interface StatusIndicatorProps extends React.HTMLAttributes<HTMLSpanElement> {
   variant: StatusIndicatorVariant;
+  animationIterationCount?: StatusIndicatorAnimationIterationCount;
 }
 
 /**
@@ -33,13 +37,14 @@ interface StatusIndicatorProps extends React.HTMLAttributes<HTMLSpanElement> {
  * Placement is the caller's responsibility — no positioning props are provided.
  */
 export function StatusIndicator(props: StatusIndicatorProps) {
-  const {variant, ...spanProps} = props;
+  const {animationIterationCount = 'infinite', variant, ...spanProps} = props;
   return (
     <Container flexShrink={0}>
       {p => (
         <Dot
           {...p}
           {...spanProps}
+          animationIterationCount={animationIterationCount}
           variant={variant}
           role={spanProps.role ?? (spanProps['aria-label'] ? 'img' : undefined)}
           aria-hidden={!spanProps['aria-label'] && !spanProps.role ? true : undefined}
@@ -105,22 +110,24 @@ const gentlePulse = keyframes`
 const gentleSpin = keyframes`
   0% {
     opacity: 0;
-    border-radius: 6px;
     transform: scale(0.9) rotate(0);
   }
   75% {
     opacity: 1;
-    border-radius: 3px;
     transform: scale(1) rotate(1turn);
   }
   100% {
     opacity: 0;
-    border-radius: 3px;
     transform: scale(1.25) rotate(1turn);
   }
 `;
 
-const Dot = styled('span')<{variant: StatusIndicatorVariant}>`
+const Dot = styled('span', {
+  shouldForwardProp: prop => isPropValid(prop) && prop !== 'animationIterationCount',
+})<{
+  animationIterationCount: StatusIndicatorAnimationIterationCount;
+  variant: StatusIndicatorVariant;
+}>`
   position: relative;
   width: 8px;
   height: 8px;
@@ -133,7 +140,9 @@ const Dot = styled('span')<{variant: StatusIndicatorVariant}>`
     height: 12px;
     border-radius: ${p => p.theme.radius['2xs']};
     background-color: ${p => getDotTokens(p.variant, p.theme).pulse};
-    animation: ${gentleSpin} 2.2s cubic-bezier(0.785, 0.135, 0.15, 0.86) infinite;
+    animation: ${gentleSpin} 2.2s cubic-bezier(0.785, 0.135, 0.15, 0.86)
+      ${p => p.animationIterationCount}
+      ${p => (p.animationIterationCount === 'infinite' ? 'none' : 'forwards')};
   }
   &::after {
     content: '';
@@ -144,6 +153,24 @@ const Dot = styled('span')<{variant: StatusIndicatorVariant}>`
     height: 8px;
     border-radius: ${p => p.theme.radius.xs};
     background-color: ${p => getDotTokens(p.variant, p.theme).dot};
-    animation: ${gentlePulse} 2.2s cubic-bezier(0.445, 0.05, 0.55, 0.95) infinite;
+    animation: ${gentlePulse} 2.2s cubic-bezier(0.445, 0.05, 0.55, 0.95)
+      ${p => p.animationIterationCount}
+      ${p => (p.animationIterationCount === 'infinite' ? 'none' : 'forwards')};
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::before,
+    &::after {
+      animation: none;
+    }
+
+    &::before {
+      opacity: 0;
+      transform: scale(1.25) rotate(1turn);
+    }
+
+    &::after {
+      transform: scale(1);
+    }
   }
 `;

--- a/static/app/views/navigation/primary/components.tsx
+++ b/static/app/views/navigation/primary/components.tsx
@@ -338,6 +338,7 @@ function PrimaryNavigationUnreadIndicator({
       {p => (
         <StatusIndicator
           {...mergeProps(p, props)}
+          animationIterationCount={3}
           variant={variant}
           data-unread-indicator
         />

--- a/static/app/views/navigation/primary/components.tsx
+++ b/static/app/views/navigation/primary/components.tsx
@@ -338,7 +338,7 @@ function PrimaryNavigationUnreadIndicator({
       {p => (
         <StatusIndicator
           {...mergeProps(p, props)}
-          animationIterationCount={3}
+          animationIterationCount={14}
           variant={variant}
           data-unread-indicator
         />


### PR DESCRIPTION
The primary nav unread dot kept animating forever, which meant it kept adding CPU work even after it had done its job of drawing attention.

This adds an opt-in finite animation count to StatusIndicator and uses it in primary nav so the unread indicator settles into a static dot after roughly 30 seconds. Other StatusIndicator usages keep the existing infinite animation.

The trace pointed at the style work as the actual problem: the old halo animation changed paint-affecting properties and Chrome kept repainting the generated dot span on the main thread. This removes the border-radius animation and leaves the active animation on transform/opacity, so the after trace no longer shows main-thread Paint work for that span while the animation is still running.