### PR TITLE
ref: Remove organizations:seer-explorer-persistent-sidebar flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -277,8 +277,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-autofix-code-review", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the PR iteration feedback flow in the explorer autofix drawer
     manager.add("organizations:autofix-pr-iteration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable showing seer in a persistent sidebar
-    manager.add("organizations:seer-explorer-persistent-sidebar", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Show Seer run ID in Slack notification footers
     manager.add("organizations:seer-run-id-in-slack", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Gate display of Seer action events in the issue activity timeline


### PR DESCRIPTION
Remove `organizations:seer-explorer-persistent-sidebar`. This flag was never referenced in code (frontend, backend, or tests), so only its registration is removed here.

Flagpole config removed in getsentry/sentry-options-automator#8340.

---
_Generated by [Claude Code](https://claude.ai/code/session_0119FtRrWxBAtA3mWiGBmnNM)_