### PR TITLE
ref(resizable-drawer): use pointer drag start

### DIFF
--- a/static/app/components/contentSliderDiff/index.tsx
+++ b/static/app/components/contentSliderDiff/index.tsx
@@ -19,10 +19,10 @@ interface Props {
   before: React.ReactNode;
   minHeight?: CSSProperties['minHeight'];
   /**
-   * A callback function triggered when the divider is clicked (mouse down event).
+   * A callback function triggered when the divider is clicked.
    * Useful when we want to track analytics.
    */
-  onDragHandleMouseDown?: (e: React.MouseEvent) => void;
+  onDragHandleMouseDown?: (e: React.PointerEvent) => void;
 }
 
 /**
@@ -72,7 +72,7 @@ function Sides({onDragHandleMouseDown, viewDimensions, before, after}: SideProps
 
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const {onMouseDown, onDoubleClick, setSize} = useResizableDrawer({
+  const {onPointerDown, onDoubleClick, setSize} = useResizableDrawer({
     direction: 'left',
     initialSize: viewDimensions.width / 2,
     min: 0,
@@ -102,19 +102,23 @@ function Sides({onDragHandleMouseDown, viewDimensions, before, after}: SideProps
     },
   });
 
-  const handleContainerMouseDown = (event: React.MouseEvent<HTMLElement>) => {
-    if (event.button !== 0 || !containerRef.current) {
+  const handleContainerPointerDown = (event: React.PointerEvent<HTMLElement>) => {
+    if (
+      !containerRef.current ||
+      !event.isPrimary ||
+      (event.pointerType === 'mouse' && event.button !== 0)
+    ) {
       return;
     }
     const rect = containerRef.current.getBoundingClientRect();
     const relativeX = event.clientX - rect.left;
     setSize(relativeX, true);
     onDragHandleMouseDown?.(event);
-    onMouseDown(event);
+    onPointerDown(event);
   };
 
   return (
-    <SidesContainer ref={containerRef} onMouseDown={handleContainerMouseDown}>
+    <SidesContainer ref={containerRef} onPointerDown={handleContainerPointerDown}>
       <Cover style={{width}} data-test-id="after-content">
         <Placement style={{width}}>
           <FullHeightContainer>{after}</FullHeightContainer>
@@ -169,6 +173,7 @@ const SidesContainer = styled('div')`
   position: absolute;
   inset: 0;
   cursor: ew-resize;
+  touch-action: none;
 `;
 
 const DragIndicator = styled('div')`

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
@@ -1,4 +1,4 @@
-import type {MouseEventHandler} from 'react';
+import type {MouseEventHandler, PointerEventHandler} from 'react';
 import {memo, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
@@ -40,7 +40,7 @@ interface FlamegraphDrawerProps {
   profileGroup: ProfileGroup;
   referenceNode: FlamegraphFrame;
   rootNodes: FlamegraphFrame[];
-  onResize?: MouseEventHandler<HTMLElement>;
+  onResize?: PointerEventHandler<HTMLElement>;
   onResizeReset?: MouseEventHandler<HTMLElement>;
   transactionSpan?: TransactionSpan;
 }
@@ -192,8 +192,10 @@ const FlamegraphDrawer = memo(function FlamegraphDrawer(props: FlamegraphDrawerP
             flex: '1 1 100%',
             cursor:
               flamegraphPreferences.layout === 'table bottom' ? 'ns-resize' : undefined,
+            touchAction:
+              flamegraphPreferences.layout === 'table bottom' ? 'none' : undefined,
           }}
-          onMouseDown={
+          onPointerDown={
             flamegraphPreferences.layout === 'table bottom' ? props.onResize : undefined
           }
           onDoubleClick={
@@ -277,7 +279,7 @@ const FlamegraphDrawer = memo(function FlamegraphDrawer(props: FlamegraphDrawerP
           {/* The border should be 1px, but we want the actual handler to be wider
           to improve the user experience and not have users have to click on the exact pixel */}
           <InvisibleHandler
-            onMouseDown={props.onResize}
+            onPointerDown={props.onResize}
             onDoubleClick={props.onResizeReset}
           />
         </ResizableVerticalDrawer>
@@ -300,6 +302,7 @@ const InvisibleHandler = styled('div')`
   position: absolute;
   inset: 0;
   cursor: ew-resize;
+  touch-action: none;
   transform: translateX(-50%);
   background-color: transparent;
 `;

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/profileDetails.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/profileDetails.tsx
@@ -112,7 +112,7 @@ export function ProfileDetails(props: ProfileDetailsProps) {
     };
   }, [flamegraphPreferences.layout]);
 
-  const {onMouseDown, onDoubleClick} = useResizableDrawer(resizableOptions);
+  const {onPointerDown, onDoubleClick} = useResizableDrawer(resizableOptions);
 
   return (
     <ProfileDetailsBar ref={detailsBarRef} layout={flamegraphPreferences.layout}>
@@ -147,8 +147,9 @@ export function ProfileDetails(props: ProfileDetailsProps) {
           style={{
             flex: '1 1 100%',
             cursor: isResizableDetailsBar ? 'ns-resize' : undefined,
+            touchAction: isResizableDetailsBar ? 'none' : undefined,
           }}
-          onMouseDown={isResizableDetailsBar ? onMouseDown : undefined}
+          onPointerDown={isResizableDetailsBar ? onPointerDown : undefined}
           onDoubleClick={isResizableDetailsBar ? onDoubleClick : undefined}
         />
       </ProfilingDetailsFrameTabs>

--- a/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
@@ -73,7 +73,7 @@ export function FlamegraphLayout(props: FlamegraphLayoutProps) {
     };
   }, [layout]);
 
-  const {onMouseDown, onDoubleClick} = useResizableDrawer(resizableOptions);
+  const {onPointerDown, onDoubleClick} = useResizableDrawer(resizableOptions);
 
   const onOpenMinimap = useCallback(
     () =>
@@ -291,7 +291,7 @@ export function FlamegraphLayout(props: FlamegraphLayoutProps) {
         </Stack>
         <FlamegraphDrawerContainer ref={flamegraphDrawerRef} layout={layout}>
           {cloneElement(props.flamegraphDrawer, {
-            onResize: onMouseDown,
+            onResize: onPointerDown,
             onResizeReset: onDoubleClick,
           } as any)}
         </FlamegraphDrawerContainer>

--- a/static/app/components/replays/virtualizedGrid/detailsSplitDivider.tsx
+++ b/static/app/components/replays/virtualizedGrid/detailsSplitDivider.tsx
@@ -9,10 +9,7 @@ import {t} from 'sentry/locale';
 import type {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 import {SplitDivider} from 'sentry/views/explore/replays/detail/layout/splitDivider';
 
-interface Props extends Omit<
-  ReturnType<typeof useResizableDrawer>,
-  'onPointerDown' | 'setSize' | 'size'
-> {
+interface Props extends Omit<ReturnType<typeof useResizableDrawer>, 'setSize' | 'size'> {
   onClose: () => void;
   children?: ReactNode;
 }
@@ -22,7 +19,7 @@ export function DetailsSplitDivider({
   isHeld,
   onClose,
   onDoubleClick,
-  onMouseDown,
+  onPointerDown,
 }: Props) {
   return (
     <StyledStacked>
@@ -31,7 +28,7 @@ export function DetailsSplitDivider({
         data-is-held={isHeld}
         data-slide-direction="updown"
         onDoubleClick={onDoubleClick}
-        onMouseDown={onMouseDown}
+        onPointerDown={onPointerDown}
       />
       <CloseButtonWrapper>
         <Button

--- a/static/app/utils/useResizableDrawer.tsx
+++ b/static/app/utils/useResizableDrawer.tsx
@@ -54,10 +54,6 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
    */
   onDoubleClick: React.MouseEventHandler<HTMLElement>;
   /**
-   * Apply to the drag handle element
-   */
-  onMouseDown: React.MouseEventHandler<HTMLElement>;
-  /**
    * Apply to the drag handle element. Supports touch and pen input.
    */
   onPointerDown: React.PointerEventHandler<HTMLElement>;
@@ -184,20 +180,6 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
     currentMouseVectorRaf.current = [clientX, clientY];
   }, []);
 
-  const onMouseDown = useCallback(
-    (evt: React.MouseEvent<HTMLElement>) => {
-      if (evt.button !== 0) {
-        return;
-      }
-
-      evt.preventDefault();
-      startDrag(evt.clientX, evt.clientY);
-      document.addEventListener('mousemove', onDragMove, {passive: false});
-      document.addEventListener('mouseup', onDragEnd);
-    },
-    [onDragMove, onDragEnd, startDrag]
-  );
-
   const onPointerDown = useCallback(
     (evt: React.PointerEvent<HTMLElement>) => {
       if (!evt.isPrimary || (evt.pointerType === 'mouse' && evt.button !== 0)) {
@@ -225,5 +207,5 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
     };
   });
 
-  return {size, isHeld, onMouseDown, onPointerDown, onDoubleClick, setSize: updateSize};
+  return {size, isHeld, onPointerDown, onDoubleClick, setSize: updateSize};
 }

--- a/static/app/views/explore/replays/detail/layout/splitDivider.tsx
+++ b/static/app/views/explore/replays/detail/layout/splitDivider.tsx
@@ -1,4 +1,4 @@
-import type {DOMAttributes, MouseEventHandler} from 'react';
+import type {DOMAttributes, MouseEventHandler, PointerEventHandler} from 'react';
 import styled from '@emotion/styled';
 
 import {IconGrabbable} from 'sentry/icons';
@@ -7,7 +7,7 @@ type Props = {
   'data-is-held': boolean;
   'data-slide-direction': 'leftright' | 'updown';
   onDoubleClick: MouseEventHandler<HTMLElement>;
-  onMouseDown: MouseEventHandler<HTMLElement>;
+  onPointerDown: PointerEventHandler<HTMLElement>;
 };
 
 export const SplitDivider = styled((props: Props & DOMAttributes<HTMLDivElement>) => (
@@ -21,6 +21,7 @@ export const SplitDivider = styled((props: Props & DOMAttributes<HTMLDivElement>
   width: 100%;
 
   user-select: inherit;
+  touch-action: none;
   background: inherit;
 
   &:hover {

--- a/static/app/views/explore/replays/detail/network/details/index.tsx
+++ b/static/app/views/explore/replays/detail/network/details/index.tsx
@@ -17,7 +17,7 @@ type Props = {
   onClose: () => void;
   projectId: undefined | string;
   startTimestampMs: number;
-} & Omit<ReturnType<typeof useResizableDrawer>, 'onPointerDown' | 'size'>;
+} & Omit<ReturnType<typeof useResizableDrawer>, 'size'>;
 
 export function NetworkDetails({
   isHeld,
@@ -26,7 +26,7 @@ export function NetworkDetails({
   item,
   onClose,
   onDoubleClick,
-  onMouseDown,
+  onPointerDown,
   projectId,
   startTimestampMs,
 }: Props) {
@@ -42,7 +42,7 @@ export function NetworkDetails({
         isHeld={isHeld}
         onClose={onClose}
         onDoubleClick={onDoubleClick}
-        onMouseDown={onMouseDown}
+        onPointerDown={onPointerDown}
       >
         <NetworkDetailsTabs />
       </DetailsSplitDivider>

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -46,7 +46,7 @@ export function AppSizeInsightsSidebar({
   const {
     isHeld,
     onDoubleClick,
-    onMouseDown,
+    onPointerDown,
     size: width,
   } = useResizableDrawer({
     direction: 'right',
@@ -115,7 +115,7 @@ export function AppSizeInsightsSidebar({
 
             <Flex flex={1} position="relative" overflow="hidden">
               <ResizeHandle
-                onMouseDown={onMouseDown}
+                onPointerDown={onPointerDown}
                 onDoubleClick={onDoubleClick}
                 data-is-held={isHeld}
                 data-slide-direction="leftright"
@@ -164,6 +164,7 @@ const ResizeHandle = styled(Flex)`
   justify-content: center;
   z-index: 10;
   cursor: ew-resize;
+  touch-action: none;
   background: transparent;
 
   &:hover {

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -255,7 +255,7 @@ export default function SnapshotsPage() {
   const {
     size: sidebarWidth,
     isHeld,
-    onMouseDown,
+    onPointerDown,
     onDoubleClick,
   } = useResizableDrawer({
     direction: 'left',
@@ -801,7 +801,7 @@ export default function SnapshotsPage() {
         </Flex>
         <DragHandle
           data-is-held={isHeld}
-          onMouseDown={onMouseDown}
+          onPointerDown={onPointerDown}
           onDoubleClick={onDoubleClick}
         >
           <IconGrabbable size="sm" />
@@ -898,6 +898,7 @@ const DragHandle = styled('div')`
   width: ${p => p.theme.space.xl};
   height: 100%;
   cursor: ew-resize;
+  touch-action: none;
   user-select: inherit;
   background: linear-gradient(
     to bottom,


### PR DESCRIPTION
## Summary

Follow-up cleanup on top of the SplitPanel pointer-resize PR.

- Removes the mouse-specific drag start returned by useResizableDrawer
- Migrates direct useResizableDrawer consumers to onPointerDown
- Adds touch-action: none to the migrated drag handles

## Test plan

- pnpm test-ci static/app/components/core/splitPanel/splitPanel.spec.tsx static/app/components/contentSliderDiff/index.spec.tsx
- pnpm run lint:js static/app/utils/useResizableDrawer.tsx static/app/components/contentSliderDiff/index.tsx static/app/components/core/splitPanel/splitPanel.tsx static/app/components/core/splitPanel/splitPanel.spec.tsx static/app/components/replays/virtualizedGrid/detailsSplitDivider.tsx static/app/views/explore/replays/detail/layout/splitDivider.tsx static/app/views/explore/replays/detail/network/details/index.tsx static/app/components/profiling/flamegraph/flamegraphLayout.tsx static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx static/app/components/profiling/flamegraph/flamegraphDrawer/profileDetails.tsx static/app/views/preprod/snapshots/snapshots.tsx static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
- pnpm run typecheck
- .venv/bin/prek run -q