### PR TITLE
feat(conversations): Add conversations-redesign feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -422,7 +422,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable selectable/filterable columns for the AI Conversations table
     manager.add("organizations:gen-ai-conversations-columns", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the redesigned Conversations product experience
-    manager.add("organizations:conversations-redesign", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:gen-ai-conversations-redesign", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Conduit demo endpoint and UI
     manager.add("organizations:conduit-demo", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -421,6 +421,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:gen-ai-conversations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable selectable/filterable columns for the AI Conversations table
     manager.add("organizations:gen-ai-conversations-columns", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable the redesigned Conversations product experience
+    manager.add("organizations:conversations-redesign", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Conduit demo endpoint and UI
     manager.add("organizations:conduit-demo", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 


### PR DESCRIPTION
Register the `organizations:conversations-redesign` FlagPole feature flag to gate the redesigned Conversations product experience.

This is the first step of the Conversations product redesign — the flag lets us develop the new experience behind a gate and roll it out incrementally. It's `api_expose=True` so the frontend can check it via `organization.features.includes('conversations-redesign')`.

Rollout configuration (FlagPole YAML) will be managed separately in the `sentry-options-automator` repo.