### PR TITLE
feat(api): Add COMMUNITY ApiOwner for endpoints from disbanded teams

### DIFF
--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -10,6 +10,7 @@ class ApiOwner(Enum):
     ALERTS_MONITORS = "alerts-monitors"
     BILLING = "revenue"
     CODING_WORKFLOWS = "coding-workflows-sentry-backend"
+    COMMUNITY = "app-backend"
     CRONS = "crons"
     DASHBOARDS = "dashboards"
     DATA_BROWSING = "data-browsing"

--- a/src/sentry/api/endpoints/artifact_bundles.py
+++ b/src/sentry/api/endpoints/artifact_bundles.py
@@ -57,7 +57,7 @@ class ArtifactBundlesEndpoint(ProjectEndpoint, ArtifactBundlesMixin):
         "DELETE": ApiPublishStatus.PRIVATE,
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     permission_classes = (ProjectReleasePermission,)
 
     def get(self, request: Request, project) -> Response:

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -313,7 +313,7 @@ def debounce_update_release_health_data(organization, project_ids: list[int]):
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnalyticsMixin):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
         "POST": ApiPublishStatus.PRIVATE,
@@ -949,7 +949,7 @@ class OrganizationReleaseTimeseriesData(TypedDict):
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class OrganizationReleasesStatsEndpoint(OrganizationReleasesBaseEndpoint):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }


### PR DESCRIPTION
Add `ApiOwner.COMMUNITY = "app-backend"` as a catch-all owner for endpoints whose original team no longer exists. The existing `UNOWNED` value implies zero responsibility, but that's not the right semantic for teams that were disbanded — someone should still triage issues and review PRs. `COMMUNITY` maps to `@getsentry/app-backend` in CODEOWNERS, preserving real review routing, while the enum name signals these endpoints are open for contribution from anyone.


As a first use, reassign `OrganizationReleasesEndpoint`, `OrganizationReleasesStatsEndpoint`, and `ArtifactBundlesEndpoint` from `TELEMETRY_EXPERIENCE` to `COMMUNITY`, as the telemetry-experience team has never owned these release-related endpoints.

Closes [TET-2547: Move release endpoints to community owned](https://linear.app/getsentry/issue/TET-2547/move-release-endpoints-to-community-owned)