### PR TITLE
ref(api): Reassign release endpoints from TELEMETRY_EXPERIENCE/UNOWNED to COMMUNITY

### DIFF
--- a/src/sentry/core/endpoints/team_release_count.py
+++ b/src/sentry/core/endpoints/team_release_count.py
@@ -8,6 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
@@ -19,6 +20,7 @@ from sentry.utils.dates import floor_to_utc_day
 
 @cell_silo_endpoint
 class TeamReleaseCountEndpoint(TeamEndpoint):
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/issues/endpoints/group_current_release.py
+++ b/src/sentry/issues/endpoints/group_current_release.py
@@ -2,6 +2,7 @@ import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.helpers.deprecation import deprecated
@@ -17,6 +18,7 @@ from sentry.models.releases.release_project import ReleaseProject
 
 @cell_silo_endpoint
 class GroupCurrentReleaseEndpoint(GroupEndpoint):
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/issues/endpoints/group_first_last_release.py
+++ b/src/sentry/issues/endpoints/group_first_last_release.py
@@ -1,6 +1,7 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.helpers.environments import get_environments
@@ -13,6 +14,7 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 @cell_silo_endpoint
 class GroupFirstLastReleaseEndpoint(GroupEndpoint):
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/releases/endpoints/organization_release_assemble.py
+++ b/src/sentry/releases/endpoints/organization_release_assemble.py
@@ -56,7 +56,7 @@ class _AssembleErrorResponse(TypedDict):
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/releases/endpoints/organization_release_commits.py
+++ b/src/sentry/releases/endpoints/organization_release_commits.py
@@ -20,7 +20,7 @@ from sentry.models.releasecommit import ReleaseCommit
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class OrganizationReleaseCommitsEndpoint(OrganizationReleasesBaseEndpoint):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/releases/endpoints/organization_release_details.py
+++ b/src/sentry/releases/endpoints/organization_release_details.py
@@ -307,7 +307,7 @@ class OrganizationReleaseDetailsEndpoint(
     ReleaseAnalyticsMixin,
     OrganizationReleaseDetailsPaginationMixin,
 ):
-    owner = ApiOwner.UNOWNED
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "DELETE": ApiPublishStatus.PUBLIC,
         "GET": ApiPublishStatus.PUBLIC,

--- a/src/sentry/releases/endpoints/organization_release_file_details.py
+++ b/src/sentry/releases/endpoints/organization_release_file_details.py
@@ -32,7 +32,7 @@ from sentry.releases.endpoints.project_release_file_details import (
 class OrganizationReleaseFileDetailsEndpoint(
     OrganizationReleasesBaseEndpoint, ReleaseFileDetailsMixin
 ):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,
         "GET": ApiPublishStatus.PRIVATE,

--- a/src/sentry/releases/endpoints/organization_release_files.py
+++ b/src/sentry/releases/endpoints/organization_release_files.py
@@ -48,7 +48,7 @@ _FILE_CHECKSUM_PARAM = OpenApiParameter(
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseFilesMixin):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
         "POST": ApiPublishStatus.PRIVATE,

--- a/src/sentry/releases/endpoints/organization_release_health_data.py
+++ b/src/sentry/releases/endpoints/organization_release_health_data.py
@@ -28,7 +28,7 @@ class OrganizationReleaseHealthDataEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     permission_classes = (OrganizationAndStaffPermission,)
 
     """

--- a/src/sentry/releases/endpoints/organization_release_meta.py
+++ b/src/sentry/releases/endpoints/organization_release_meta.py
@@ -6,6 +6,7 @@ from typing import TypedDict
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
@@ -31,6 +32,7 @@ class _ProjectDict(TypedDict):
 
 @cell_silo_endpoint
 class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/releases/endpoints/project_release_commits.py
+++ b/src/sentry/releases/endpoints/project_release_commits.py
@@ -22,7 +22,7 @@ from sentry.models.repository import Repository
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/releases/endpoints/project_release_details.py
+++ b/src/sentry/releases/endpoints/project_release_details.py
@@ -37,7 +37,7 @@ from sentry.utils.sdk import bind_organization_context
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,
         "GET": ApiPublishStatus.PRIVATE,

--- a/src/sentry/releases/endpoints/project_release_file_details.py
+++ b/src/sentry/releases/endpoints/project_release_file_details.py
@@ -232,7 +232,7 @@ class ReleaseFileDetailsMixin:
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,
         "GET": ApiPublishStatus.PRIVATE,

--- a/src/sentry/releases/endpoints/project_release_files.py
+++ b/src/sentry/releases/endpoints/project_release_files.py
@@ -276,7 +276,7 @@ def pseudo_releasefile(url, info, dist):
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
         "POST": ApiPublishStatus.PRIVATE,

--- a/src/sentry/releases/endpoints/project_release_repositories.py
+++ b/src/sentry/releases/endpoints/project_release_repositories.py
@@ -20,7 +20,7 @@ from sentry.models.repository import Repository
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseRepositories(ProjectEndpoint):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/releases/endpoints/project_release_setup.py
+++ b/src/sentry/releases/endpoints/project_release_setup.py
@@ -29,7 +29,7 @@ class ReleaseSetupStepResponse(TypedDict):
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseSetupCompletionEndpoint(ProjectEndpoint):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/releases/endpoints/project_release_stats.py
+++ b/src/sentry/releases/endpoints/project_release_stats.py
@@ -64,7 +64,7 @@ def upsert_missing_release(project, version) -> datetime | None:
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleaseStatsEndpoint(ProjectEndpoint):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/releases/endpoints/project_releases.py
+++ b/src/sentry/releases/endpoints/project_releases.py
@@ -49,7 +49,7 @@ from sentry.utils.sdk import bind_organization_context
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ProjectReleasesEndpoint(ProjectEndpoint):
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PRIVATE,

--- a/src/sentry/releases/endpoints/project_releases_token.py
+++ b/src/sentry/releases/endpoints/project_releases_token.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, StrictProjectPermission
@@ -37,6 +38,7 @@ def _get_signature(project_id, plugin_id, token):
 
 @cell_silo_endpoint
 class ProjectReleasesTokenEndpoint(ProjectEndpoint):
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
         "POST": ApiPublishStatus.PRIVATE,

--- a/src/sentry/releases/endpoints/release_deploys.py
+++ b/src/sentry/releases/endpoints/release_deploys.py
@@ -140,7 +140,7 @@ def create_deploy(
 @extend_schema(tags=["Releases"])
 @cell_silo_endpoint
 class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
-    owner = ApiOwner.UNOWNED
+    owner = ApiOwner.COMMUNITY
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PUBLIC,


### PR DESCRIPTION
Migrate all release-related API endpoints to `ApiOwner.COMMUNITY`, which was introduced in #118336. The telemetry-experience team has never owned these endpoints, and several had no explicit owner at all (falling back to the `UNOWNED` default). 


