### PR TITLE
feat(seer): add seer_project_repos_linked to issue details analytics

### DIFF
--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -533,10 +533,14 @@ interface ProjectAnalyticsData {
   project_has_replay: boolean;
   project_id: number;
   project_platform: string;
+  // Whether the project has repos linked in Seer settings, which allows Autofix to run.
+  // Populated from the autofix setup API; undefined when the data has not been fetched.
+  seer_project_repos_linked?: boolean;
 }
 
 export function getAnalyicsDataForProject(
-  project?: Project | null
+  project?: Project | null,
+  {seerReposLinked}: {seerReposLinked?: boolean} = {}
 ): ProjectAnalyticsData {
   return {
     project_has_replay: project?.hasReplays ?? false,
@@ -544,5 +548,6 @@ export function getAnalyicsDataForProject(
     project_age: project ? getDaysSinceDate(project.dateCreated) : -1,
     project_id: project ? parseInt(project.id, 10) : -1,
     project_platform: project?.platform ?? '',
+    seer_project_repos_linked: seerReposLinked,
   };
 }

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -469,11 +469,13 @@ function useTrackView({
   tab,
   organization,
   hasAutofixQuota,
+  seerReposLinked,
 }: {
   event: Event | null;
   group: Group | null;
   hasAutofixQuota: boolean;
   organization: Organization;
+  seerReposLinked: boolean;
   tab: Tab;
   project?: Project;
 }) {
@@ -487,7 +489,7 @@ function useTrackView({
   useRouteAnalyticsParams({
     ...getAnalyticsDataForGroup(group),
     ...getAnalyticsDataForEvent(event),
-    ...getAnalyicsDataForProject(project),
+    ...getAnalyicsDataForProject(project, {seerReposLinked}),
     tab,
     query: typeof query === 'string' ? query : undefined,
     // Alert properties track if the user came from email/slack alerts
@@ -631,7 +633,7 @@ function GroupDetailsContentInner({
     },
   });
 
-  const {hasAutofixQuota} = useAiConfig(group, project);
+  const {hasAutofixQuota, seerReposLinked} = useAiConfig(group, project);
 
   useEffect(() => {
     if (isAnyDrawerOpen) {
@@ -671,6 +673,7 @@ function GroupDetailsContentInner({
     tab: currentTab,
     organization,
     hasAutofixQuota,
+    seerReposLinked,
   });
 
   useEngagedViewTracking({group, project});


### PR DESCRIPTION
## Summary

Adds a `seer_project_repos_linked` field to the `issue_details.viewed` analytics event so we can segment whether a project has repos configured in Seer settings — the prerequisite for Autofix to actually run.

Without this, `has_seer_access` (billing quota) and `seer_project_repos_linked` (repos linked) were conflated, making it impossible to tell if a customer had set up the project for Autofix vs. just having quota.

## Changes

**`static/app/utils/projects.tsx`**
- Added `seer_project_repos_linked?: boolean` to `ProjectAnalyticsData`
- Extended `getAnalyicsDataForProject` with an optional second arg `{ seerReposLinked }` to thread the value in when available

**`static/app/views/issueDetails/groupDetails.tsx`**
- Destructures `seerReposLinked` from `useAiConfig` (already fetched via `useAutofixSetup`)
- Threads it through `useTrackView` → `getAnalyicsDataForProject`

## How `seerReposLinked` is determined

`useAutofixSetup` calls `/organizations/{org}/issues/{group}/autofix/setup/` which returns a `seerReposLinked` boolean — `true` when the project has at least one repo linked in Seer settings. This is already fetched on every issue details page load.

## Verified

- TypeScript types are consistent — `seer_project_repos_linked` is optional so existing callers of `getAnalyicsDataForProject` are unaffected
- No existing tests cover `getAnalyicsDataForProject` directly

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0AAF0JD0GK%3A1782250265.085419%22)