### PR TITLE
feat(ai): Return input and output tokens in conversations response

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -154,6 +154,8 @@ def _build_conversation_response(
     llm_calls: int,
     tool_calls: int,
     total_tokens: int,
+    input_tokens: int,
+    output_tokens: int,
     total_cost: float,
     trace_ids: list[str],
     flow: list[str],
@@ -170,6 +172,8 @@ def _build_conversation_response(
         "llmCalls": llm_calls,
         "toolCalls": tool_calls,
         "totalTokens": total_tokens,
+        "inputTokens": input_tokens,
+        "outputTokens": output_tokens,
         "totalCost": total_cost,
         "startTimestamp": start_timestamp,
         "endTimestamp": end_timestamp,
@@ -315,6 +319,8 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 "count_if(gen_ai.operation.type,equals,ai_client)",
                 "count_if(gen_ai.operation.type,equals,tool)",
                 "sum_if(gen_ai.usage.total_tokens,gen_ai.operation.type,equals,ai_client)",
+                "sum_if(gen_ai.usage.input_tokens,gen_ai.operation.type,equals,ai_client)",
+                "sum_if(gen_ai.usage.output_tokens,gen_ai.operation.type,equals,ai_client)",
                 "sum_if(gen_ai.cost.total_tokens,gen_ai.operation.type,equals,ai_client)",
                 "min(precise.start_ts)",
                 "max(precise.finish_ts)",
@@ -400,6 +406,18 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                     total_tokens=int(
                         row.get(
                             "sum_if(gen_ai.usage.total_tokens,gen_ai.operation.type,equals,ai_client)"
+                        )
+                        or 0
+                    ),
+                    input_tokens=int(
+                        row.get(
+                            "sum_if(gen_ai.usage.input_tokens,gen_ai.operation.type,equals,ai_client)"
+                        )
+                        or 0
+                    ),
+                    output_tokens=int(
+                        row.get(
+                            "sum_if(gen_ai.usage.output_tokens,gen_ai.operation.type,equals,ai_client)"
                         )
                         or 0
                     ),

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -14,6 +14,8 @@ from sentry.testutils.helpers.datetime import before_now
 
 from .test_organization_ai_conversations_base import (
     LLM_COST,
+    LLM_INPUT_TOKENS,
+    LLM_OUTPUT_TOKENS,
     LLM_TOKENS,
     BaseAIConversationsTestCase,
 )
@@ -181,6 +183,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
             op="gen_ai.chat",
             operation_type="ai_client",
             tokens=LLM_TOKENS,
+            input_tokens=LLM_INPUT_TOKENS,
+            output_tokens=LLM_OUTPUT_TOKENS,
             cost=LLM_COST,
             trace_id=trace_id,
             messages=first_messages,
@@ -212,6 +216,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
             status="internal_error",
             operation_type="ai_client",
             tokens=LLM_TOKENS,
+            input_tokens=LLM_INPUT_TOKENS,
+            output_tokens=LLM_OUTPUT_TOKENS,
             cost=LLM_COST,
             trace_id=trace_id,
             messages=[{"role": "user", "content": "Thanks"}],
@@ -234,6 +240,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert conversation["llmCalls"] == 2
         assert conversation["toolCalls"] == 1
         assert conversation["totalTokens"] == LLM_TOKENS * 2
+        assert conversation["inputTokens"] == LLM_INPUT_TOKENS * 2
+        assert conversation["outputTokens"] == LLM_OUTPUT_TOKENS * 2
         assert conversation["totalCost"] == LLM_COST * 2
         assert conversation["traceCount"] == 1
         assert conversation["startTimestamp"] > 0
@@ -427,6 +435,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert conversation["llmCalls"] == 1
         assert conversation["toolCalls"] == 0
         assert conversation["totalTokens"] == 0
+        assert conversation["inputTokens"] == 0
+        assert conversation["outputTokens"] == 0
         assert conversation["totalCost"] == 0.0
         assert conversation["flow"] == []
         assert len(conversation["traceIds"]) == 1
@@ -549,6 +559,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
             op="gen_ai.chat",
             operation_type="ai_client",
             tokens=50,
+            input_tokens=35,
+            output_tokens=15,
             cost=0.005,
             trace_id=trace_id,
             messages=[{"role": "user", "content": "recent request"}],
@@ -569,6 +581,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert conversation["conversationId"] == conversation_id
         assert conversation["llmCalls"] == 1
         assert conversation["totalTokens"] == 50
+        assert conversation["inputTokens"] == 35
+        assert conversation["outputTokens"] == 15
         assert conversation["totalCost"] == 0.005
 
     def test_first_input_last_output(self) -> None:
@@ -1246,6 +1260,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
             agent_name="Test Agent",
             trace_id=trace_id,
             tokens=500,
+            input_tokens=350,
+            output_tokens=150,
             cost=0.05,
         )
 
@@ -1257,6 +1273,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
             operation_type="ai_client",
             trace_id=trace_id,
             tokens=100,
+            input_tokens=70,
+            output_tokens=30,
             cost=0.01,
             messages=[{"role": "user", "content": "test"}],
             response_text="test response",
@@ -1276,6 +1294,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         # Tokens and cost should only come from ai_client span (100, 0.01)
         # NOT the sum of both spans (600, 0.06) which would be double counting
         assert conversation["totalTokens"] == 100
+        assert conversation["inputTokens"] == 70
+        assert conversation["outputTokens"] == 30
         assert conversation["totalCost"] == 0.01
         # Verify counts are correct
         assert conversation["llmCalls"] == 1

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
@@ -2,6 +2,8 @@ from sentry.testutils.cases import APITestCase, BaseSpansTestCase, SpanTestCase
 from sentry.utils import json
 
 LLM_TOKENS = 100
+LLM_INPUT_TOKENS = 70
+LLM_OUTPUT_TOKENS = 30
 LLM_COST = 0.001
 
 
@@ -24,6 +26,8 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
         status="ok",
         operation_type=None,
         tokens=None,
+        input_tokens=None,
+        output_tokens=None,
         cost=None,
         trace_id=None,
         agent_name=None,
@@ -50,6 +54,8 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
             status: Span status (default: "ok")
             operation_type: The gen_ai.operation.type attribute
             tokens: Token count (gen_ai.usage.total_tokens)
+            input_tokens: Input token count (gen_ai.usage.input_tokens)
+            output_tokens: Output token count (gen_ai.usage.output_tokens)
             cost: Cost (gen_ai.cost.total_tokens)
             trace_id: The trace ID for the span
             agent_name: The gen_ai.agent.name attribute
@@ -73,6 +79,10 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
             span_data["gen_ai.operation.type"] = operation_type
         if tokens is not None:
             span_data["gen_ai.usage.total_tokens"] = tokens
+        if input_tokens is not None:
+            span_data["gen_ai.usage.input_tokens"] = input_tokens
+        if output_tokens is not None:
+            span_data["gen_ai.usage.output_tokens"] = output_tokens
         if cost is not None:
             span_data["gen_ai.cost.total_tokens"] = cost
         if agent_name is not None:


### PR DESCRIPTION
Each conversation in the AI conversations endpoint now reports `inputTokens` and `outputTokens` next to the existing `totalTokens`, so clients can break token usage down by direction instead of only seeing the aggregate.

Both new fields sum `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` from `ai_client` spans, reusing the same operation-type filter as `totalTokens` so agent spans are not double-counted.

Per-conversation response object, before:

Closes TET-2551