### PR TITLE
fix(nav-tour): Navigate to Sentry Built dashboards in step 4

### DIFF
--- a/static/app/views/navigation/navigationTour.tsx
+++ b/static/app/views/navigation/navigationTour.tsx
@@ -194,14 +194,22 @@ export function NavigationTourProvider({children}: {children: React.ReactNode}) 
           }
           break;
         case NavigationTour.INSIGHTS: {
-          const target = normalizeUrl({
-            pathname: `/${prefix}/dashboards/`,
-            query: {
-              filter: DashboardFilter.ONLY_PREBUILT,
-              sort: DEFAULT_PREBUILT_SORT,
-              referrer: NAVIGATION_TOUR_REFERRER,
-            },
-          });
+          const hasPrebuiltDashboards = organization.features.includes(
+            'dashboards-prebuilt-insights-dashboards'
+          );
+          const target = hasPrebuiltDashboards
+            ? normalizeUrl({
+                pathname: `/${prefix}/dashboards/`,
+                query: {
+                  filter: DashboardFilter.ONLY_PREBUILT,
+                  sort: DEFAULT_PREBUILT_SORT,
+                  referrer: NAVIGATION_TOUR_REFERRER,
+                },
+              })
+            : normalizeUrl({
+                pathname: `/${prefix}/insights/frontend/`,
+                query: {referrer: NAVIGATION_TOUR_REFERRER},
+              });
           navigate(target, {replace: true});
           break;
         }

--- a/static/app/views/navigation/navigationTour.tsx
+++ b/static/app/views/navigation/navigationTour.tsx
@@ -30,6 +30,8 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
+import {DEFAULT_PREBUILT_SORT} from 'sentry/views/dashboards/manage/settings';
+import {DashboardFilter} from 'sentry/views/dashboards/types';
 import {getDefaultExploreRoute} from 'sentry/views/explore/utils';
 import {usePrimaryNavigation} from 'sentry/views/navigation/primaryNavigationContext';
 
@@ -191,15 +193,18 @@ export function NavigationTourProvider({children}: {children: React.ReactNode}) 
             navigate(target, {replace: true});
           }
           break;
-        case NavigationTour.INSIGHTS:
-          if (activeGroup !== 'insights') {
-            const target = normalizeUrl({
-              pathname: `/${prefix}/insights/frontend/`,
-              query: {referrer: NAVIGATION_TOUR_REFERRER},
-            });
-            navigate(target, {replace: true});
-          }
+        case NavigationTour.INSIGHTS: {
+          const target = normalizeUrl({
+            pathname: `/${prefix}/dashboards/`,
+            query: {
+              filter: DashboardFilter.ONLY_PREBUILT,
+              sort: DEFAULT_PREBUILT_SORT,
+              referrer: NAVIGATION_TOUR_REFERRER,
+            },
+          });
+          navigate(target, {replace: true});
           break;
+        }
         case NavigationTour.SETTINGS:
           if (activeGroup !== 'settings') {
             const target = normalizeUrl({

--- a/static/app/views/navigation/navigationTour.tsx
+++ b/static/app/views/navigation/navigationTour.tsx
@@ -184,15 +184,14 @@ export function NavigationTourProvider({children}: {children: React.ReactNode}) 
             navigate(target, {replace: true});
           }
           break;
-        case NavigationTour.DASHBOARDS:
-          if (activeGroup !== 'dashboards') {
-            const target = normalizeUrl({
-              pathname: `/${prefix}/dashboards/`,
-              query: {referrer: NAVIGATION_TOUR_REFERRER},
-            });
-            navigate(target, {replace: true});
-          }
+        case NavigationTour.DASHBOARDS: {
+          const target = normalizeUrl({
+            pathname: `/${prefix}/dashboards/`,
+            query: {referrer: NAVIGATION_TOUR_REFERRER},
+          });
+          navigate(target, {replace: true});
           break;
+        }
         case NavigationTour.INSIGHTS: {
           const hasPrebuiltDashboards = organization.features.includes(
             'dashboards-prebuilt-insights-dashboards'


### PR DESCRIPTION
## Summary

Step 4 of the navigation tour now navigates to the Sentry Built dashboards tab (`?filter=onlyPrebuilt&sort=mostPopular`) instead of `/insights/frontend/`, so that the **Sentry Built** secondary nav item is highlighted — consistent with how **Custom Dashboards** is highlighted in step 3.

I suspect this step used to select "Insights" when it was still a top level nav item and the tour wasn't fully updated with the change.

## Screenshot

<img width="634" height="180" alt="Sentry Built" src="https://github.com/user-attachments/assets/56fe3e71-34b1-4b42-908a-b3298d5be1cc" />

## Test plan

- [x] Start the navigation tour via Help menu → "Tour the new navigation"
- [x] Advance to step 4 and confirm "Sentry Built" is highlighted in the secondary nav
- [x] Confirm step 3 still highlights "Custom Dashboards"
- [x] Confirm step 5 (Settings) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)