### PR TITLE
fix(explore): Wait for org range before spans filters

### DIFF
--- a/static/app/views/explore/spans/content.spec.tsx
+++ b/static/app/views/explore/spans/content.spec.tsx
@@ -7,6 +7,7 @@ import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Organization} from 'sentry/types/organization';
+import {FeatureFlagOverrides} from 'sentry/utils/featureFlagOverrides';
 import {OrganizationContext} from 'sentry/utils/organizationContext';
 import {MAX_PERIOD_FOR_CROSS_EVENTS} from 'sentry/views/explore/constants';
 import {TopBar} from 'sentry/views/navigation/topBar';
@@ -117,6 +118,7 @@ describe('ExploreContent', () => {
     // Suppress console errors from CompactSelect async updates
     jest.spyOn(console, 'error').mockImplementation();
 
+    FeatureFlagOverrides.singleton().clear();
     PageFiltersStore.init();
     OrganizationStore.onUpdate(organization, {replace: true});
 
@@ -137,6 +139,7 @@ describe('ExploreContent', () => {
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
+    FeatureFlagOverrides.singleton().clear();
     OrganizationStore.reset();
     ProjectsStore.reset();
     jest.clearAllMocks();
@@ -227,6 +230,42 @@ describe('ExploreContent', () => {
       initialRouterConfig: {
         location: {
           pathname: '/organizations/org-slug/explore/traces/',
+          query: {statsPeriod: '90d'},
+        },
+      },
+    });
+
+    await screen.findByText('Traces');
+
+    await waitFor(() =>
+      expect(PageFiltersStore.getState().selection.datetime).toEqual({
+        period: '30d',
+        start: null,
+        end: null,
+        utc: null,
+      })
+    );
+  });
+
+  it('does not keep loading when toolbar overrides disable the high range flag', async () => {
+    act(() => ProjectsStore.loadInitialData([highRangeProject]));
+    FeatureFlagOverrides.singleton().setStoredOverride(
+      'visibility-explore-range-high',
+      false
+    );
+
+    const highRangeOrganizationWithOverride = {
+      ...highRangeOrganization,
+      features: ['gen-ai-features'],
+    };
+    OrganizationStore.onUpdate(highRangeOrganizationWithOverride, {replace: true});
+
+    render(<ExploreContent />, {
+      organization: highRangeOrganizationWithOverride,
+      additionalWrapper: TopBarWrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${highRangeOrganization.slug}/explore/traces/`,
           query: {statsPeriod: '90d'},
         },
       },

--- a/static/app/views/explore/spans/content.spec.tsx
+++ b/static/app/views/explore/spans/content.spec.tsx
@@ -4,6 +4,10 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {OrganizationStore} from 'sentry/stores/organizationStore';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {Organization} from 'sentry/types/organization';
+import {OrganizationContext} from 'sentry/utils/organizationContext';
 import {MAX_PERIOD_FOR_CROSS_EVENTS} from 'sentry/views/explore/constants';
 import {TopBar} from 'sentry/views/navigation/topBar';
 
@@ -26,53 +30,67 @@ describe('ExploreContent', () => {
       features: ['gen-ai-features'],
     },
   });
+  const {organization: highRangeOrganization, project: highRangeProject} = initializeOrg({
+    organization: {
+      slug: 'high-range-org',
+      features: ['gen-ai-features', 'visibility-explore-range-high'],
+    },
+  });
 
-  beforeEach(() => {
-    // Suppress console errors from CompactSelect async updates
-    jest.spyOn(console, 'error').mockImplementation();
-
-    PageFiltersStore.init();
+  function addExploreMockResponses({
+    organizationBody,
+    projectBody,
+  }: {
+    organizationBody: Organization;
+    projectBody: typeof project;
+  }) {
+    const organizationSlug = organizationBody.slug;
 
     MockApiClient.addMockResponse({
-      url: `/customers/${organization.slug}/`,
+      url: `/organizations/${organizationSlug}/`,
+      method: 'GET',
+      body: organizationBody,
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organizationSlug}/`,
       method: 'GET',
       body: {},
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/recent-searches/`,
+      url: `/organizations/${organizationSlug}/recent-searches/`,
       method: 'GET',
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/spans/fields/`,
+      url: `/organizations/${organizationSlug}/spans/fields/`,
       method: 'GET',
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
+      url: `/organizations/${organizationSlug}/events/`,
       method: 'GET',
       body: {},
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-timeseries/`,
+      url: `/organizations/${organizationSlug}/events-timeseries/`,
       method: 'GET',
       body: {
         timeSeries: [],
       },
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/traces/`,
+      url: `/organizations/${organizationSlug}/traces/`,
       method: 'GET',
       body: {},
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      url: `/organizations/${organizationSlug}/trace-items/attributes/`,
       method: 'GET',
       body: [],
       match: [MockApiClient.matchQuery({attributeType: 'number'})],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      url: `/organizations/${organizationSlug}/trace-items/attributes/`,
       method: 'GET',
       body: [
         {
@@ -84,17 +102,34 @@ describe('ExploreContent', () => {
       match: [MockApiClient.matchQuery({attributeType: 'string'})],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/projects/`,
+      url: `/organizations/${organizationSlug}/projects/`,
       method: 'GET',
-      body: [project],
+      body: [projectBody],
     });
     MockApiClient.addMockResponse({
-      url: '/assistant/',
+      url: `/organizations/${organizationSlug}/explore/saved/`,
       method: 'GET',
       body: [],
     });
+  }
+
+  beforeEach(() => {
+    // Suppress console errors from CompactSelect async updates
+    jest.spyOn(console, 'error').mockImplementation();
+
+    PageFiltersStore.init();
+    OrganizationStore.onUpdate(organization, {replace: true});
+
+    addExploreMockResponses({
+      organizationBody: organization,
+      projectBody: project,
+    });
+    addExploreMockResponses({
+      organizationBody: highRangeOrganization,
+      projectBody: highRangeProject,
+    });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/explore/saved/`,
+      url: '/assistant/',
       method: 'GET',
       body: [],
     });
@@ -102,7 +137,111 @@ describe('ExploreContent', () => {
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
+    OrganizationStore.reset();
+    ProjectsStore.reset();
     jest.clearAllMocks();
+  });
+
+  it('preserves shared 90 day span links', async () => {
+    act(() => ProjectsStore.loadInitialData([highRangeProject]));
+    OrganizationStore.onUpdate(highRangeOrganization, {replace: true});
+
+    render(<ExploreContent />, {
+      organization: highRangeOrganization,
+      additionalWrapper: TopBarWrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${highRangeOrganization.slug}/explore/traces/`,
+          query: {statsPeriod: '90d'},
+        },
+      },
+    });
+
+    await screen.findByText('Traces');
+
+    await waitFor(() =>
+      expect(PageFiltersStore.getState().selection.datetime).toEqual({
+        period: '90d',
+        start: null,
+        end: null,
+        utc: null,
+      })
+    );
+  });
+
+  it('waits for organization loading before initializing shared date ranges', async () => {
+    act(() => ProjectsStore.loadInitialData([highRangeProject]));
+    OrganizationStore.reset();
+
+    const highRangeOrganizationWithoutFeature = {
+      ...highRangeOrganization,
+      features: ['gen-ai-features'],
+    };
+
+    const {rerender} = render(
+      <OrganizationContext value={highRangeOrganizationWithoutFeature}>
+        <ExploreContent />
+      </OrganizationContext>,
+      {
+        organization: highRangeOrganizationWithoutFeature,
+        additionalWrapper: TopBarWrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${highRangeOrganization.slug}/explore/traces/`,
+            query: {statsPeriod: '90d'},
+          },
+        },
+      }
+    );
+
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('page-filter-timerange-selector')
+    ).not.toBeInTheDocument();
+
+    act(() => OrganizationStore.onUpdate(highRangeOrganization, {replace: true}));
+    rerender(
+      <OrganizationContext value={highRangeOrganization}>
+        <ExploreContent />
+      </OrganizationContext>
+    );
+
+    await screen.findByText('Traces');
+
+    await waitFor(() =>
+      expect(PageFiltersStore.getState().selection.datetime).toEqual({
+        period: '90d',
+        start: null,
+        end: null,
+        utc: null,
+      })
+    );
+  });
+
+  it('clamps shared 90 day span links for 30 day users', async () => {
+    act(() => ProjectsStore.loadInitialData([project]));
+
+    render(<ExploreContent />, {
+      organization,
+      additionalWrapper: TopBarWrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/traces/',
+          query: {statsPeriod: '90d'},
+        },
+      },
+    });
+
+    await screen.findByText('Traces');
+
+    await waitFor(() =>
+      expect(PageFiltersStore.getState().selection.datetime).toEqual({
+        period: '30d',
+        start: null,
+        end: null,
+        utc: null,
+      })
+    );
   });
 
   describe('cross events', () => {

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -21,6 +21,7 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {DataCategory} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {defined} from 'sentry/utils/defined';
+import {FeatureFlagOverrides} from 'sentry/utils/featureFlagOverrides';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {
   useMaxPickableDays,
@@ -81,17 +82,19 @@ function ExploreContentInner() {
     dataCategories: [DataCategory.SPANS],
   });
 
-  const bootstrappedOrganizationHasHighRange = bootstrapOrganization?.features.includes(
-    'visibility-explore-range-high'
-  );
+  const bootstrappedOrganizationHasHighRange = bootstrapOrganization
+    ? FeatureFlagOverrides.singleton()
+        .getEnabledFeatureFlagList(bootstrapOrganization)
+        .includes('visibility-explore-range-high')
+    : undefined;
   const organizationHasHighRange = organization.features.includes(
     'visibility-explore-range-high'
   );
 
   // PageFiltersContainer normalizes URL date params on mount. Wait until the
   // bootstrapped org and OrganizationContext agree on the spans range feature.
-  // The bootstrap query gives us the loaded org feature flags before context
-  // may reflect them, so shared 90d links are not clamped using stale org data.
+  // Compare effective bootstrap flags so stored toolbar overrides do not keep
+  // the bootstrapped org and OrganizationContext permanently out of sync.
   const organizationRangeLoading =
     organizationLoading ||
     isBootstrapOrganizationPending ||

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -82,6 +82,9 @@ function ExploreContentInner() {
     dataCategories: [DataCategory.SPANS],
   });
 
+  // The bootstrap query returns raw API org data, while useOrganization reads
+  // the OrganizationStore value after FeatureFlagOverrides.loadOrg mutates it.
+  // Apply stored toolbar overrides here before comparing these two sources.
   const bootstrappedOrganizationHasHighRange = bootstrapOrganization
     ? FeatureFlagOverrides.singleton()
         .getEnabledFeatureFlagList(bootstrapOrganization)

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -71,16 +71,16 @@ export function ExploreContent() {
 }
 
 function ExploreContentInner() {
-  const organization = useOrganization();
   const hasCrossEvents = useHasCrossEvents();
   const onboardingProject = useOnboardingProject();
-
-  const {loading: organizationLoading} = useLegacyStore(OrganizationStore);
-  const {data: bootstrapOrganization, isPending: isBootstrapOrganizationPending} =
-    useQuery(getBootstrapOrganizationQueryOptions(organization.slug));
   const dataCategoryMaxPickableDays = useMaxPickableDays({
     dataCategories: [DataCategory.SPANS],
   });
+
+  const organization = useOrganization();
+  const {loading: organizationLoading} = useLegacyStore(OrganizationStore);
+  const {data: bootstrapOrganization, isPending: isBootstrapOrganizationPending} =
+    useQuery(getBootstrapOrganizationQueryOptions(organization.slug));
 
   // The bootstrap query returns raw API org data, while useOrganization reads
   // the OrganizationStore value after FeatureFlagOverrides.loadOrg mutates it.

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -1,11 +1,14 @@
 import {Fragment, useEffect, useMemo} from 'react';
 import type {ReactNode} from 'react';
 import * as Sentry from '@sentry/react';
+import {useQuery} from '@tanstack/react-query';
 
 import {Stack} from '@sentry/scraps/layout';
 
+import {getBootstrapOrganizationQueryOptions} from 'sentry/bootstrap/bootstrapRequests';
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {AiQueryProvider} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
@@ -13,6 +16,8 @@ import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {TourContextProvider} from 'sentry/components/tours/components';
 import {useAssistant} from 'sentry/components/tours/useAssistant';
 import {t} from 'sentry/locale';
+import {OrganizationStore} from 'sentry/stores/organizationStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {DataCategory} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {defined} from 'sentry/utils/defined';
@@ -68,9 +73,30 @@ function ExploreContentInner() {
   const organization = useOrganization();
   const hasCrossEvents = useHasCrossEvents();
   const onboardingProject = useOnboardingProject();
+
+  const {loading: organizationLoading} = useLegacyStore(OrganizationStore);
+  const {data: bootstrapOrganization, isPending: isBootstrapOrganizationPending} =
+    useQuery(getBootstrapOrganizationQueryOptions(organization.slug));
   const dataCategoryMaxPickableDays = useMaxPickableDays({
     dataCategories: [DataCategory.SPANS],
   });
+
+  const bootstrappedOrganizationHasHighRange = bootstrapOrganization?.features.includes(
+    'visibility-explore-range-high'
+  );
+  const organizationHasHighRange = organization.features.includes(
+    'visibility-explore-range-high'
+  );
+
+  // PageFiltersContainer normalizes URL date params on mount. Wait until the
+  // bootstrapped org and OrganizationContext agree on the spans range feature.
+  // The bootstrap query gives us the loaded org feature flags before context
+  // may reflect them, so shared 90d links are not clamped using stale org data.
+  const organizationRangeLoading =
+    organizationLoading ||
+    isBootstrapOrganizationPending ||
+    (defined(bootstrappedOrganizationHasHighRange) &&
+      bootstrappedOrganizationHasHighRange !== organizationHasHighRange);
 
   const CROSS_EVENTS_DATE_OVERRIDE: MaxPickableDaysOptions = {
     defaultPeriod: MAX_PERIOD_FOR_CROSS_EVENTS,
@@ -84,6 +110,16 @@ function ExploreContentInner() {
     : dataCategoryMaxPickableDays;
 
   const datePageFilterProps = useDatePageFilterProps(maxPickableDays);
+
+  if (organizationRangeLoading) {
+    return (
+      <SentryDocumentTitle title={t('Traces')} orgSlug={organization?.slug}>
+        <Stack flex={1} padding="2xl 3xl">
+          <LoadingIndicator />
+        </Stack>
+      </SentryDocumentTitle>
+    );
+  }
 
   return (
     <SentryDocumentTitle title={t('Traces')} orgSlug={organization?.slug}>


### PR DESCRIPTION
Trace Explorer now waits for organization range entitlement to settle before mounting `PageFiltersContainer`, preventing shared links with `statsPeriod=90d` from being normalized using stale 30-day org state. Users without the high-range entitlement still clamp to 30d once loaded org data is known.


Closes EXP-1042