### PR TITLE
ref(devenv): Replace subscriptions consumers with tasks

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -96,6 +96,8 @@ x-sentry-service-config:
     # support passing custom environment variables to remote services (DI-1956).
     ingest-profiles:
       description: Kafka consumer for processing profiling data via taskbroker passthrough mode
+    subscriptions:
+      description: Kafka consumer for processing subscription results via taskbroker passthrough mode
     memcached:
       description: Memcached used for caching
     spotlight:
@@ -135,10 +137,12 @@ x-sentry-service-config:
       description: Dedicated taskworker for eval issue-side tasks
     taskworker-evals-relay:
       description: Dedicated taskworker for eval Relay project config tasks
-    taskworker-scheduler:
-      description: Task scheduler that can spawn tasks based on their schedules
     taskworker-ingest-profiles:
       description: Taskworker for ingest-profiles passthrough broker
+    taskworker-scheduler:
+      description: Task scheduler that can spawn tasks based on their schedules
+    taskworker-subscriptions:
+      description: Taskworker for subscriptions passthrough broker
     # Kafka consumer services for event ingestion
     ingest-events:
       description: Kafka consumer for processing ingested events
@@ -180,13 +184,6 @@ x-sentry-service-config:
       description: Post-process forwarder for transaction events
     post-process-forwarder-issue-platform:
       description: Post-process forwarder for issue platform events
-    # Subscription results consumers
-    subscription-results-eap-items:
-      description: Kafka consumer for processing subscription results for eap items
-    metrics-subscription-results:
-      description: Kafka consumer for processing subscription results for metrics
-    generic-metrics-subscription-results:
-      description: Kafka consumer for processing subscription results for generic metrics
     # Uptime monitoring
     uptime-results:
       description: Kafka consumer for uptime monitoring results
@@ -218,9 +215,8 @@ x-sentry-service-config:
         post-process-forwarder-errors,
         post-process-forwarder-transactions,
         post-process-forwarder-issue-platform,
-        subscription-results-eap-items,
-        metrics-subscription-results,
-        generic-metrics-subscription-results,
+        subscriptions,
+        taskworker-subscriptions,
         process-spans,
         ingest-occurrences,
         process-segments,
@@ -417,6 +413,8 @@ x-programs:
     command: sentry run taskworker-scheduler
   taskworker-ingest-profiles:
     command: sentry run taskworker --rpc-host localhost:50052 --namespace ingest.profiling.passthrough
+  taskworker-subscriptions:
+    command: sentry run taskworker --rpc-host localhost:50053 --processing-pool-name subscriptions
   ingest-events:
     command: sentry run consumer ingest-events --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
   ingest-attachments:
@@ -455,13 +453,6 @@ x-programs:
     command: sentry run consumer ingest-feedback-events --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
   ingest-replay-recordings:
     command: sentry run consumer ingest-replay-recordings --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
-  subscription-results-eap-items:
-    command: sentry run consumer subscription-results-eap-items --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
-  metrics-subscription-results:
-    command: sentry run consumer metrics-subscription-results --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
-  generic-metrics-subscription-results:
-    command: sentry run consumer generic-metrics-subscription-results --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
-
 services:
   bigtable:
     image: 'ghcr.io/getsentry/cbtemulator:d28ad6b63e461e8c05084b8c83f1c06627068c04'
@@ -595,6 +586,22 @@ services:
       TASKBROKER_LOG_FILTER: 'debug'
     ports:
       - '127.0.0.1:50052:50051'
+    networks:
+      - devservices
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    labels:
+      - orchestrator=devservices
+    restart: unless-stopped
+    platform: linux/amd64
+  # Taskbroker in passthrough mode for subscription result topics.
+  subscriptions:
+    image: ghcr.io/getsentry/taskbroker:nightly
+    command: ['/opt/taskbroker', '--config', '/etc/taskbroker/config.yml']
+    ports:
+      - '127.0.0.1:50053:50051'
+    volumes:
+      - ./config/taskbroker-subscriptions.yml:/etc/taskbroker/config.yml
     networks:
       - devservices
     extra_hosts:

--- a/devservices/config/taskbroker-subscriptions.yml
+++ b/devservices/config/taskbroker-subscriptions.yml
@@ -1,0 +1,58 @@
+kafka_deadletter_topic: taskworker_dlq
+kafka_retry_topic: taskworker
+create_missing_topics: true
+log_filter: debug
+
+kafka_clusters:
+  default:
+    address: kafka-kafka-1:9093
+
+kafka_topics:
+  events-subscription-results:
+    cluster: default
+    consumer_group: sentry-consumer
+    raw:
+      namespace: snuba.subscriptions.events.raw
+      application: sentry
+      taskname: sentry.snuba.query_subscriptions.run.process_events_subscription_from_kafka
+      processing_deadline_duration: 60
+  transactions-subscription-results:
+    cluster: default
+    consumer_group: sentry-consumer
+    raw:
+      namespace: snuba.subscriptions.transactions.raw
+      application: sentry
+      taskname: sentry.snuba.query_subscriptions.run.process_transactions_subscription_from_kafka
+      processing_deadline_duration: 60
+  metrics-subscription-results:
+    cluster: default
+    consumer_group: sentry-consumer
+    raw:
+      namespace: snuba.subscriptions.metrics.raw
+      application: sentry
+      taskname: sentry.snuba.query_subscriptions.run.process_metrics_subscription_from_kafka
+      processing_deadline_duration: 60
+  generic-metrics-subscription-results:
+    cluster: default
+    consumer_group: sentry-consumer
+    raw:
+      namespace: snuba.subscriptions.generic_metrics.raw
+      application: sentry
+      taskname: sentry.snuba.query_subscriptions.run.process_generic_metrics_subscription_from_kafka
+      processing_deadline_duration: 60
+  subscription-results-eap-items:
+    cluster: default
+    consumer_group: sentry-consumer
+    raw:
+      namespace: snuba.subscriptions.eap.raw
+      application: sentry
+      taskname: sentry.snuba.query_subscriptions.run.process_eap_subscription_from_kafka
+      processing_deadline_duration: 60
+  taskworker:
+    cluster: default
+    consumer_group: sentry-consumer
+    produce_only: true
+  taskworker_dlq:
+    cluster: default
+    consumer_group: sentry-consumer
+    produce_only: true

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -24,14 +24,6 @@ _DEFAULT_DAEMONS = {
     "taskworker-scheduler": ["sentry", "run", "taskworker-scheduler"],
 }
 
-_SUBSCRIPTION_RESULTS_CONSUMERS = [
-    "events-subscription-results",
-    "transactions-subscription-results",
-    "generic-metrics-subscription-results",
-    "metrics-subscription-results",
-    "subscription-results-eap-items",
-]
-
 
 def add_daemon(name: str, command: list[str]) -> None:
     """
@@ -311,9 +303,6 @@ def devserver(
                 kafka_consumers.add("post-process-forwarder-issue-platform")
 
             daemons.extend([_get_daemon(name) for name in settings.SENTRY_EXTRA_WORKERS])
-
-            if settings.SENTRY_DEV_PROCESS_SUBSCRIPTIONS:
-                kafka_consumers.update(_SUBSCRIPTION_RESULTS_CONSUMERS)
 
             if settings.SENTRY_USE_METRICS_DEV and settings.SENTRY_USE_RELAY:
                 kafka_consumers.add("ingest-metrics")


### PR DESCRIPTION
Refs STREAM-1207

Replace the subscriptions consumers in devenv with a taskbroker pool.