### PR TITLE
feat(eap): Add failure_count_if formula for spans

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -213,6 +213,7 @@ class ArithmeticVisitor(NodeVisitor):
         "avg_if",
         "division_if",
         "failure_rate_if",
+        "failure_count_if",
         # Mobile vitals uses these functions
         "ttid_contribution_rate",
         "ttfd_contribution_rate",

--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -734,6 +734,52 @@ def tpm(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormul
     )
 
 
+def failure_count_if(args: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
+    extrapolation_mode = settings["extrapolation_mode"]
+    key = cast(AttributeKey, args[0])
+    operator = cast(str, args[1])
+    value = cast(str, args[2])
+
+    (_, key_equal_value_filter) = resolve_key_eq_value_filter([key, key, operator, value])
+
+    return Column.BinaryFormula(
+        default_value_double=0.0,
+        left=Column(
+            conditional_aggregation=AttributeConditionalAggregation(
+                aggregate=Function.FUNCTION_COUNT,
+                key=AttributeKey(
+                    name="sentry.status",
+                    type=AttributeKey.TYPE_STRING,
+                ),
+                filter=TraceItemFilter(
+                    and_filter=AndFilter(
+                        filters=[
+                            TraceItemFilter(
+                                comparison_filter=ComparisonFilter(
+                                    key=AttributeKey(
+                                        name="sentry.status",
+                                        type=AttributeKey.TYPE_STRING,
+                                    ),
+                                    op=ComparisonFilter.OP_NOT_IN,
+                                    value=AttributeValue(
+                                        val_str_array=StrArray(
+                                            values=["ok", "cancelled", "unknown"],
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            key_equal_value_filter,
+                        ]
+                    )
+                ),
+                extrapolation_mode=extrapolation_mode,
+            ),
+        ),
+        op=Column.BinaryFormula.OP_MULTIPLY,
+        right=Column(literal=LiteralValue(val_double=1.0)),
+    )
+
+
 def failure_count(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
     extrapolation_mode = settings["extrapolation_mode"]
 
@@ -1197,6 +1243,20 @@ SPAN_FORMULA_DEFINITIONS = {
         default_search_type="integer",
         arguments=[],
         formula_resolver=failure_count,
+        is_aggregate=True,
+    ),
+    "failure_count_if": FormulaDefinition(
+        default_search_type="integer",
+        infer_search_type_from_arguments=False,
+        arguments=[
+            AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(["equals", "notEquals"]),
+            ),
+            ValueArgumentDefinition(argument_types={"string"}),
+        ],
+        formula_resolver=failure_count_if,
         is_aggregate=True,
     ),
     "eps": FormulaDefinition(

--- a/tests/sentry/discover/test_arithmetic.py
+++ b/tests/sentry/discover/test_arithmetic.py
@@ -248,6 +248,7 @@ def test_field_values(a, op, b) -> None:
         (100, "-", 'count_if(some_tag,notEquals,"something(really)annoying,like\\"this\\"")'),
         ("p50_if(span.duration,is_transaction,equals,true)", "/", 2),
         ("tpm()", "+", "failure_rate_if(is_transaction,equals,true)"),
+        ("failure_count_if(is_transaction,equals,true)", "+", 0),
         ("avg_if(span.duration,is_transaction,equals,true)", "*", 100),
         ("ttid_contribution_rate()", "+", "ttfd_contribution_rate()"),
         (100, "*", "ttid_contribution_rate()"),

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -6166,6 +6166,80 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert meta["fields"]["failure_count()"] == "integer"
         assert meta["units"]["failure_count()"] is None
 
+    def test_failure_count_if(self) -> None:
+        trace_statuses = ["ok", "cancelled", "unknown", "failure"]
+
+        spans = [
+            self.create_span(
+                {
+                    "sentry_tags": {"status": status},
+                    "is_segment": True,
+                },
+                start_ts=self.ten_mins_ago,
+            )
+            for status in trace_statuses
+        ]
+        # non-transaction span with failure status — should NOT be counted
+        spans.append(
+            self.create_span(
+                {
+                    "sentry_tags": {"status": "failure"},
+                    "is_segment": False,
+                },
+                start_ts=self.ten_mins_ago,
+            )
+        )
+
+        self.store_spans(spans)
+
+        response = self.do_request(
+            {
+                "field": ["failure_count_if(is_transaction, equals, true)"],
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["failure_count_if(is_transaction, equals, true)"] == 1
+        assert meta["dataset"] == "spans"
+        assert meta["fields"] == {
+            "failure_count_if(is_transaction, equals, true)": "integer",
+        }
+        assert meta["units"] == {
+            "failure_count_if(is_transaction, equals, true)": None,
+        }
+
+    def test_failure_count_if_no_matches(self) -> None:
+        # Only non-transaction spans — failure_count_if(is_transaction, equals, true) should return 0
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "sentry_tags": {"status": "failure"},
+                        "is_segment": False,
+                    },
+                    start_ts=self.ten_mins_ago,
+                )
+            ],
+        )
+
+        response = self.do_request(
+            {
+                "field": ["failure_count_if(is_transaction, equals, true)"],
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["failure_count_if(is_transaction, equals, true)"] == 0
+
     def test_trace_id_glob(self) -> None:
         response = self.do_request(
             {


### PR DESCRIPTION
Add `failure_count_if(key, operator, value)` as a conditional variant of `failure_count`. It counts spans where `sentry.status` is not in `["ok", "cancelled", "unknown"]` and the user-supplied condition also holds, defaulting to `0` when no spans qualify.

This mirrors the relationship between `failure_rate` and `failure_rate_if` — the new formula is the numerator of `failure_rate_if` wrapped in the same `* 1.0` BinaryFormula structure as `failure_count`. Useful when you want a raw failure count scoped to a subset of spans rather than relying on an outer query filter.