### PR TITLE
feat(logs): Validate logs search query fields

### DIFF
--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -85,6 +85,20 @@ describe('LogsPage', () => {
     });
 
     MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      method: 'GET',
+      body: {
+        dataset: [],
+        environment: [],
+        field: [],
+        orderby: [],
+        projects: [],
+        query: {error: null, fields: [], valid: true},
+        valid: true,
+      },
+    });
+
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/stats_v2/`,
       method: 'GET',
       body: {},

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -175,6 +175,19 @@ describe('LogsTabContent', () => {
       method: 'POST',
       body: {attributes: {}},
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      method: 'GET',
+      body: {
+        dataset: [],
+        environment: [],
+        field: [],
+        orderby: [],
+        projects: [],
+        query: {error: null, fields: [], valid: true},
+        valid: true,
+      },
+    });
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/stats_v2/`,

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -75,6 +75,7 @@ import {useLogsSearchQueryBuilderProps} from 'sentry/views/explore/logs/useLogsS
 import {useLogsTimeseries} from 'sentry/views/explore/logs/useLogsTimeseries';
 import {usePersistentLogsPageParameters} from 'sentry/views/explore/logs/usePersistentLogsPageParameters';
 import {useSaveAsItems} from 'sentry/views/explore/logs/useSaveAsItems';
+import {useValidateLogsTab} from 'sentry/views/explore/logs/useValidateLogsTab';
 import {calculateAverageLogsPerSecond} from 'sentry/views/explore/logs/utils';
 import {
   useQueryParamsAggregateSortBys,
@@ -145,6 +146,8 @@ const LogsSearchSection = memo(function LogsSearchSection({
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useLogItemAttributes({}, 'boolean', HiddenLogSearchFields);
 
+  const {data: validatedSearchQueryData} = useValidateLogsTab();
+
   const {tracesItemSearchQueryBuilderProps, searchQueryBuilderProviderProps} =
     useLogsSearchQueryBuilderProps({
       booleanAttributes,
@@ -153,6 +156,7 @@ const LogsSearchSection = memo(function LogsSearchSection({
       booleanSecondaryAliases,
       numberSecondaryAliases,
       stringSecondaryAliases,
+      validatedSearchQueryData,
     });
 
   const organization = useOrganization();

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.spec.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.spec.tsx
@@ -1,0 +1,111 @@
+import type {ReactNode} from 'react';
+import {PageFilterStateFixture, PageFiltersFixture} from 'sentry-fixture/pageFilters';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import {FieldKind} from 'sentry/utils/fields';
+import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
+import {useLogsSearchQueryBuilderProps} from 'sentry/views/explore/logs/useLogsSearchQueryBuilderProps';
+import type {EventValidationData} from 'sentry/views/explore/utils/validateEventParamsOptions';
+
+jest.mock('sentry/components/pageFilters/usePageFilters');
+
+function Wrapper({children}: {children: ReactNode}) {
+  return (
+    <LogsQueryParamsProvider
+      analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+      source="location"
+    >
+      {children}
+    </LogsQueryParamsProvider>
+  );
+}
+
+const validationBody: EventValidationData = {
+  dataset: [],
+  environment: [],
+  field: [],
+  orderby: [],
+  projects: [],
+  query: {
+    error: null,
+    fields: [
+      {attrType: 'string', error: null, name: 'message.template', valid: true},
+      {attrType: 'number', error: null, name: 'message.parameters.0', valid: true},
+      {attrType: 'boolean', error: null, name: 'feature.enabled', valid: true},
+      {attrType: null, error: 'unknown attribute', name: 'missing.key', valid: false},
+    ],
+    valid: false,
+  },
+  valid: false,
+};
+
+describe('useLogsSearchQueryBuilderProps', () => {
+  beforeEach(() => {
+    jest.mocked(usePageFilters).mockReturnValue(
+      PageFilterStateFixture({
+        selection: PageFiltersFixture({
+          datetime: {period: '14d', start: null, end: null, utc: false},
+          environments: [],
+          projects: [1],
+        }),
+      })
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds validated query fields to attributes and marks invalid filter keys', () => {
+    const {result} = renderHookWithProviders(
+      () =>
+        useLogsSearchQueryBuilderProps({
+          booleanAttributes: {},
+          booleanSecondaryAliases: {},
+          numberAttributes: {},
+          numberSecondaryAliases: {},
+          stringAttributes: {},
+          stringSecondaryAliases: {},
+          validatedSearchQueryData: validationBody,
+        }),
+      {additionalWrapper: Wrapper}
+    );
+
+    expect(
+      result.current.tracesItemSearchQueryBuilderProps.stringAttributes[
+        'message.template'
+      ]
+    ).toEqual(
+      expect.objectContaining({
+        kind: FieldKind.TAG,
+        key: 'message.template',
+      })
+    );
+    expect(
+      result.current.tracesItemSearchQueryBuilderProps.numberAttributes[
+        'message.parameters.0'
+      ]
+    ).toEqual(
+      expect.objectContaining({
+        kind: FieldKind.MEASUREMENT,
+        key: 'message.parameters.0',
+      })
+    );
+    expect(
+      result.current.tracesItemSearchQueryBuilderProps.booleanAttributes[
+        'feature.enabled'
+      ]
+    ).toEqual(
+      expect.objectContaining({
+        kind: FieldKind.BOOLEAN,
+        key: 'feature.enabled',
+      })
+    );
+    expect(result.current.tracesItemSearchQueryBuilderProps.invalidFilterKeys).toEqual([
+      'missing.key',
+    ]);
+  });
+});

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
@@ -2,8 +2,10 @@ import {useCallback, useMemo} from 'react';
 
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import type {TagCollection} from 'sentry/types/group';
+import {FieldKind} from 'sentry/utils/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {usePrevious} from 'sentry/utils/usePrevious';
+import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import {
   useTraceItemSearchQueryBuilderProps,
   type TraceItemSearchQueryBuilderProps,
@@ -16,6 +18,7 @@ import {
 } from 'sentry/views/explore/queryParams/context';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {findSuggestedColumns} from 'sentry/views/explore/utils';
+import type {EventValidationData} from 'sentry/views/explore/utils/validateEventParamsOptions';
 
 export function useLogsSearchQueryBuilderProps({
   attributeQuery,
@@ -25,6 +28,7 @@ export function useLogsSearchQueryBuilderProps({
   stringAttributes,
   numberSecondaryAliases,
   stringSecondaryAliases,
+  validatedSearchQueryData,
 }: {
   booleanAttributes: TagCollection;
   booleanSecondaryAliases: TagCollection;
@@ -33,6 +37,7 @@ export function useLogsSearchQueryBuilderProps({
   stringAttributes: TagCollection;
   stringSecondaryAliases: TagCollection;
   attributeQuery?: string;
+  validatedSearchQueryData?: EventValidationData;
 }) {
   const logsSearch = useQueryParamsSearch();
   const oldLogsSearch = usePrevious(logsSearch);
@@ -40,13 +45,73 @@ export function useLogsSearchQueryBuilderProps({
   const setQueryParams = useSetQueryParams();
   const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
 
+  const {
+    validatedBooleanAttributes,
+    validatedNumberAttributes,
+    validatedStringAttributes,
+    invalidFilterKeys,
+  } = useMemo(() => {
+    const localInvalidFilterKeys: string[] = [];
+    const localBooleanAttributes = {...booleanAttributes};
+    const localNumberAttributes = {...numberAttributes};
+    const localStringAttributes = {...stringAttributes};
+
+    if (validatedSearchQueryData?.query.fields.length) {
+      for (const item of validatedSearchQueryData.query.fields) {
+        if (item.valid) {
+          if (item.attrType === 'boolean' && item.name) {
+            localBooleanAttributes[item.name] ??= {
+              key: item.name,
+              name: prettifyAttributeName(item.name),
+              kind: FieldKind.BOOLEAN,
+            };
+          }
+
+          if (item.attrType === 'number' && item.name) {
+            localNumberAttributes[item.name] ??= {
+              key: item.name,
+              name: prettifyAttributeName(item.name),
+              kind: FieldKind.MEASUREMENT,
+            };
+          }
+
+          if (item.attrType === 'string' && item.name) {
+            localStringAttributes[item.name] ??= {
+              key: item.name,
+              name: prettifyAttributeName(item.name),
+              kind: FieldKind.TAG,
+            };
+          }
+
+          continue;
+        }
+
+        if (item.name) {
+          localInvalidFilterKeys.push(item.name);
+        }
+      }
+    }
+
+    return {
+      validatedBooleanAttributes: localBooleanAttributes,
+      validatedNumberAttributes: localNumberAttributes,
+      validatedStringAttributes: localStringAttributes,
+      invalidFilterKeys: localInvalidFilterKeys,
+    };
+  }, [
+    booleanAttributes,
+    numberAttributes,
+    stringAttributes,
+    validatedSearchQueryData?.query.fields,
+  ]);
+
   const onSearch = useCallback(
     (newQuery: string) => {
       const newSearch = new MutableSearch(newQuery);
       const suggestedColumns = findSuggestedColumns(newSearch, oldLogsSearch, {
-        numberAttributes,
-        stringAttributes,
-        booleanAttributes,
+        numberAttributes: validatedNumberAttributes,
+        stringAttributes: validatedStringAttributes,
+        booleanAttributes: validatedBooleanAttributes,
       });
 
       const existingFields = new Set(fields);
@@ -58,12 +123,12 @@ export function useLogsSearchQueryBuilderProps({
       });
     },
     [
-      booleanAttributes,
       fields,
-      numberAttributes,
       oldLogsSearch,
       setQueryParams,
-      stringAttributes,
+      validatedBooleanAttributes,
+      validatedNumberAttributes,
+      validatedStringAttributes,
     ]
   );
 
@@ -73,9 +138,9 @@ export function useLogsSearchQueryBuilderProps({
       initialQuery,
       searchSource: 'ourlogs',
       onSearch,
-      booleanAttributes,
-      numberAttributes,
-      stringAttributes,
+      booleanAttributes: validatedBooleanAttributes,
+      numberAttributes: validatedNumberAttributes,
+      stringAttributes: validatedStringAttributes,
       itemType: TraceItemDataset.LOGS as TraceItemDataset.LOGS,
       booleanSecondaryAliases,
       numberSecondaryAliases,
@@ -86,19 +151,21 @@ export function useLogsSearchQueryBuilderProps({
       matchKeySuggestions: [{key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/}],
       hiddenAttributeKeys: HiddenLogSearchFields,
       attributeQuery,
+      invalidFilterKeys,
     }),
     [
       attributeQuery,
-      booleanAttributes,
       booleanSecondaryAliases,
       caseInsensitive,
       initialQuery,
-      numberAttributes,
       numberSecondaryAliases,
       onSearch,
       setCaseInsensitive,
-      stringAttributes,
       stringSecondaryAliases,
+      invalidFilterKeys,
+      validatedBooleanAttributes,
+      validatedNumberAttributes,
+      validatedStringAttributes,
     ]
   );
 

--- a/static/app/views/explore/logs/useValidateLogsTab.spec.tsx
+++ b/static/app/views/explore/logs/useValidateLogsTab.spec.tsx
@@ -1,0 +1,178 @@
+import type {ReactNode} from 'react';
+import {PageFilterStateFixture, PageFiltersFixture} from 'sentry-fixture/pageFilters';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import {
+  LOGS_FIELDS_KEY,
+  LOGS_QUERY_KEY,
+} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
+import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
+import {useValidateLogsTab} from 'sentry/views/explore/logs/useValidateLogsTab';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+import type {EventValidationData} from 'sentry/views/explore/utils/validateEventParamsOptions';
+
+jest.mock('sentry/components/pageFilters/usePageFilters');
+
+function Wrapper({children}: {children: ReactNode}) {
+  return (
+    <LogsQueryParamsProvider
+      analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+      source="location"
+    >
+      {children}
+    </LogsQueryParamsProvider>
+  );
+}
+
+const validationBody: EventValidationData = {
+  dataset: [],
+  environment: [],
+  field: [],
+  orderby: [],
+  projects: [],
+  query: {
+    error: null,
+    fields: [{attrType: 'string', error: null, name: 'severity', valid: true}],
+    valid: true,
+  },
+  valid: true,
+};
+
+describe('useValidateLogsTab', () => {
+  beforeEach(() => {
+    jest.mocked(usePageFilters).mockReturnValue(
+      PageFilterStateFixture({
+        selection: PageFiltersFixture({
+          datetime: {period: '14d', start: null, end: null, utc: false},
+          environments: ['production'],
+          projects: [1],
+        }),
+      })
+    );
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+  });
+
+  it('returns validation data from the validate endpoint', async () => {
+    const validateMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/validate/',
+      body: validationBody,
+    });
+
+    const {result} = renderHookWithProviders(useValidateLogsTab, {
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/logs/',
+          query: {
+            [LOGS_FIELDS_KEY]: ['timestamp', 'message'],
+            [LOGS_QUERY_KEY]: 'severity:error',
+            [LOGS_SORT_BYS_KEY]: '-timestamp',
+          },
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(validationBody);
+    });
+    expect(validateMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/validate/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          dataset: TraceItemDataset.LOGS,
+          environment: ['production'],
+          field: expect.arrayContaining(['timestamp', 'message', 'count(message)']),
+          orderby: expect.arrayContaining(['-timestamp', '-count(message)']),
+          project: ['1'],
+          query: 'severity:error',
+          statsPeriod: '14d',
+        }),
+      })
+    );
+  });
+
+  it('returns validation details from request errors', async () => {
+    const invalidValidationBody: EventValidationData = {
+      ...validationBody,
+      query: {
+        error: 'unknown attribute',
+        fields: [
+          {attrType: null, error: 'unknown attribute', name: 'missing.key', valid: false},
+        ],
+        valid: false,
+      },
+      valid: false,
+    };
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/validate/',
+      body: invalidValidationBody,
+      statusCode: 400,
+    });
+
+    const {result} = renderHookWithProviders(useValidateLogsTab, {
+      additionalWrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(invalidValidationBody);
+    });
+  });
+
+  it('keeps previous validation details while the next validation loads', async () => {
+    const invalidValidationBody: EventValidationData = {
+      ...validationBody,
+      query: {
+        error: 'unknown attribute',
+        fields: [
+          {attrType: null, error: 'unknown attribute', name: 'missing.key', valid: false},
+        ],
+        valid: false,
+      },
+      valid: false,
+    };
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/validate/',
+      body: invalidValidationBody,
+      statusCode: 400,
+      match: [MockApiClient.matchQuery({query: 'missing.key:foo'})],
+    });
+
+    const {result, router} = renderHookWithProviders(useValidateLogsTab, {
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/logs/',
+          query: {[LOGS_QUERY_KEY]: 'missing.key:foo'},
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(invalidValidationBody);
+    });
+
+    const delayedValidateMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/validate/',
+      body: validationBody,
+      asyncDelay: 100000,
+      match: [MockApiClient.matchQuery({query: 'severity:error'})],
+    });
+
+    router.navigate(
+      `/organizations/org-slug/explore/logs/?${LOGS_QUERY_KEY}=severity%3Aerror`
+    );
+
+    await waitFor(() => {
+      expect(delayedValidateMock).toHaveBeenCalled();
+    });
+    expect(result.current.data).toEqual(invalidValidationBody);
+  });
+});

--- a/static/app/views/explore/logs/useValidateLogsTab.tsx
+++ b/static/app/views/explore/logs/useValidateLogsTab.tsx
@@ -1,0 +1,58 @@
+import {skipToken, useQuery} from '@tanstack/react-query';
+
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  useQueryParamsAggregateSortBys,
+  useQueryParamsFields,
+  useQueryParamsGroupBys,
+  useQueryParamsSearch,
+  useQueryParamsSortBys,
+  useQueryParamsVisualizes,
+} from 'sentry/views/explore/queryParams/context';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+import {validateEventParamsOptions} from 'sentry/views/explore/utils/validateEventParamsOptions';
+
+type UseValidateLogsTabArgs = {
+  enabled?: boolean;
+};
+
+export function useValidateLogsTab({enabled = true}: UseValidateLogsTabArgs = {}) {
+  const {selection} = usePageFilters();
+  const organization = useOrganization();
+
+  const search = useQueryParamsSearch();
+  const fields = useQueryParamsFields();
+  const sortBys = useQueryParamsSortBys();
+  const aggregateSortBys = useQueryParamsAggregateSortBys();
+  const groupBys = useQueryParamsGroupBys();
+  const visualizes = useQueryParamsVisualizes();
+
+  const {data, isLoading} = useQuery({
+    ...validateEventParamsOptions({
+      organization,
+      selection,
+      traceItemType: TraceItemDataset.LOGS,
+      environments: selection.environments,
+      field: Array.from(
+        new Set([
+          ...fields,
+          ...groupBys.filter(groupBy => groupBy !== ''),
+          ...visualizes.map(visualize => visualize.yAxis),
+        ])
+      ),
+      orderBy: [...sortBys, ...aggregateSortBys].map(sortBy =>
+        sortBy.kind === 'desc' ? `-${sortBy.field}` : sortBy.field
+      ),
+      query: search.formatString(),
+      projectIds: selection.projects,
+    }),
+    // using skipToken is the new preferred way to skip a query
+    ...(enabled ? {} : {queryFn: skipToken}),
+  });
+
+  return {
+    data,
+    isLoading,
+  };
+}


### PR DESCRIPTION
The goal of this PR is to introduce a new hook that will validate the logs tab. This builds on the work adding in a base set of query options for events validation.

As an initial use for logs this PR validates the search query (as to knip happy)

Closes EXP-1025