### PR TITLE
fix(seer): Forward attribute context through get_attribute_names RPC

### DIFF
--- a/src/sentry/seer/assisted_query/traces_tools.py
+++ b/src/sentry/seer/assisted_query/traces_tools.py
@@ -106,6 +106,7 @@ def get_attribute_names(
     start: str | None = None,
     end: str | None = None,
     item_type: str = "spans",
+    include_context: bool = False,
 ) -> AttributeNamesResponse:
     """
     Get attribute names for trace items by calling the public API endpoint.
@@ -121,6 +122,10 @@ def get_attribute_names(
         start: Start date for the query (ISO string). Must be provided with end.
         end: End date for the query (ISO string). Must be provided with start.
         item_type: Type of trace item (default: "spans", can be "spans", "logs", etc.)
+        include_context: When True, include the context metadata (brief,
+            examples, deprecation, etc.) for each attribute and attach it to the
+            matching built-in fields in the response. Today the metadata comes
+            from the sentry conventions; custom attribute context is planned.
 
     Returns:
         Dictionary with attributes:
@@ -130,17 +135,27 @@ def get_attribute_names(
                 "number": ["span.duration", ...]
             },
             "built_in_fields": [
-                {"key": "span.op", "type": "string"},
-                {"key": "span.duration", "type": "number"},
+                {"key": "span.op", "type": "string", "context": {...}},
+                {"key": "span.duration", "type": "number", "context": None},
                 ...
             ]
         }
+
+        Each built-in field's "context" is only populated when expand="context"
+        is requested (and the attribute maps to a known convention); otherwise it
+        is None.
     """
     organization = Organization.objects.get(id=org_id)
 
     api_key = ApiKey(organization_id=org_id, scope_list=API_KEY_SCOPES)
 
     fields: dict[str, list[str]] = {"string": [], "number": []}
+    # Maps an attribute name to its context, populated only when the caller
+    # passes include_context=True. Used below to attach context to the built-in
+    # fields (which is where Seer reads attribute context from). Today the
+    # context comes from the sentry conventions, but custom attribute context is
+    # planned, at which point user-defined attributes will be populated too.
+    context_by_name: dict[str, dict[str, Any]] = {}
 
     # Fetch both string and number attributes from the public API
     for attr_type in ["string", "number"]:
@@ -154,8 +169,13 @@ def get_attribute_names(
         else:
             query_params["start"] = start
             query_params["end"] = end
+        # Request per-attribute context from the public endpoint via its `expand`
+        # query param (gated behind the data-browsing-attribute-context feature).
+        if include_context:
+            query_params["expand"] = "context"
 
-        # API returns: [{"key": "...", "name": "span.op", "attributeSource": {...}}, ...]
+        # API returns: [{"key": "...", "name": "span.op", "attributeSource": {...},
+        # "context": {...}}, ...]. "context" is only present when expand="context".
         resp = ApiClient().get(
             auth=api_key,
             user=None,
@@ -164,8 +184,14 @@ def get_attribute_names(
         )
 
         fields[attr_type] = [item["name"] for item in resp.data]
+        for item in resp.data:
+            if "context" in item:
+                context_by_name[item["name"]] = item["context"]
 
-    built_in_fields = [BuiltInField(**f) for f in _get_built_in_fields(item_type)]
+    built_in_fields = [
+        BuiltInField(**f, context=context_by_name.get(f["key"]))
+        for f in _get_built_in_fields(item_type)
+    ]
 
     return AttributeNamesResponse(fields=fields, built_in_fields=built_in_fields)
 

--- a/src/sentry/seer/assisted_query/traces_tools.py
+++ b/src/sentry/seer/assisted_query/traces_tools.py
@@ -185,7 +185,10 @@ def get_attribute_names(
 
         fields[attr_type] = [item["name"] for item in resp.data]
         for item in resp.data:
-            if "context" in item:
+            # The endpoint attaches an (empty) context to every attribute when
+            # requested, so only keep it when there's actual metadata; otherwise
+            # the built-in field's context stays None.
+            if item.get("context"):
                 context_by_name[item["name"]] = item["context"]
 
     built_in_fields = [

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -206,6 +206,13 @@ class SpanAttributesResponse(BaseModel):
 class BuiltInField(BaseModel):
     key: str
     type: str
+    # Attribute metadata (brief, examples, isDeprecated, replacementAttribute,
+    # ...) for the attribute, populated when the caller requests
+    # `expand="context"`; otherwise None. Today the metadata comes from the
+    # sentry conventions, so only attributes that map to a known convention
+    # carry it, but custom attribute context is planned and will populate this
+    # for user-defined attributes too.
+    context: dict[str, Any] | None = None
 
 
 class AttributeNamesResponse(BaseModel):

--- a/tests/snuba/api/endpoints/test_seer_attributes.py
+++ b/tests/snuba/api/endpoints/test_seer_attributes.py
@@ -112,6 +112,11 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         # data for them) carry no context.
         assert built_in_by_key["span.self_time"].context is None
 
+        # Context is either None or populated, never an empty dict (the endpoint
+        # attaches an empty context to attributes without convention metadata).
+        for field in result.built_in_fields:
+            assert field.context is None or field.context != {}
+
     def test_get_attribute_values_with_substring(self) -> None:
         for transaction in ["foo", "bar", "baz"]:
             self.store_segment(

--- a/tests/snuba/api/endpoints/test_seer_attributes.py
+++ b/tests/snuba/api/endpoints/test_seer_attributes.py
@@ -51,25 +51,66 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
                 "number": ["span.duration"],
             },
             "built_in_fields": [
-                {"key": "id", "type": "string"},
-                {"key": "project", "type": "string"},
-                {"key": "span.description", "type": "string"},
-                {"key": "span.op", "type": "string"},
-                {"key": "timestamp", "type": "string"},
-                {"key": "transaction", "type": "string"},
-                {"key": "trace", "type": "string"},
-                {"key": "is_transaction", "type": "string"},
-                {"key": "sentry.normalized_description", "type": "string"},
-                {"key": "release", "type": "string"},
-                {"key": "project.id", "type": "string"},
-                {"key": "sdk.name", "type": "string"},
-                {"key": "sdk.version", "type": "string"},
-                {"key": "span.system", "type": "string"},
-                {"key": "span.category", "type": "string"},
-                {"key": "span.duration", "type": "number"},
-                {"key": "span.self_time", "type": "number"},
+                {"key": "id", "type": "string", "context": None},
+                {"key": "project", "type": "string", "context": None},
+                {"key": "span.description", "type": "string", "context": None},
+                {"key": "span.op", "type": "string", "context": None},
+                {"key": "timestamp", "type": "string", "context": None},
+                {"key": "transaction", "type": "string", "context": None},
+                {"key": "trace", "type": "string", "context": None},
+                {"key": "is_transaction", "type": "string", "context": None},
+                {"key": "sentry.normalized_description", "type": "string", "context": None},
+                {"key": "release", "type": "string", "context": None},
+                {"key": "project.id", "type": "string", "context": None},
+                {"key": "sdk.name", "type": "string", "context": None},
+                {"key": "sdk.version", "type": "string", "context": None},
+                {"key": "span.system", "type": "string", "context": None},
+                {"key": "span.category", "type": "string", "context": None},
+                {"key": "span.duration", "type": "number", "context": None},
+                {"key": "span.self_time", "type": "number", "context": None},
             ],
         }
+
+    def test_get_attribute_names_with_context(self) -> None:
+        self.store_segment(
+            self.project.id,
+            uuid4().hex,
+            uuid4().hex,
+            span_id=uuid4().hex[:16],
+            organization_id=self.organization.id,
+            parent_span_id=None,
+            timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
+            transaction="foo",
+            duration=100,
+            exclusive_time=100,
+        )
+
+        with self.feature(
+            [
+                "organizations:visibility-explore-view",
+                "organizations:data-browsing-attribute-context",
+            ]
+        ):
+            result = get_attribute_names(
+                org_id=self.organization.id,
+                project_ids=[self.project.id],
+                stats_period="7d",
+                include_context=True,
+            )
+
+        built_in_by_key = {field.key: field for field in result.built_in_fields}
+
+        # A deprecated built-in attribute surfaces its conventions context,
+        # including the replacement attribute.
+        transaction_context = built_in_by_key["transaction"].context
+        assert transaction_context is not None
+        assert transaction_context["isDeprecated"] is True
+        assert transaction_context["replacementAttribute"] == "sentry.segment.name"
+        assert transaction_context["brief"]
+
+        # Built-in fields that aren't returned by the public endpoint (e.g. no
+        # data for them) carry no context.
+        assert built_in_by_key["span.self_time"].context is None
 
     def test_get_attribute_values_with_substring(self) -> None:
         for transaction in ["foo", "bar", "baz"]:


### PR DESCRIPTION
Seer's assisted-query feature (getsentry/seer#7084) relies on the seer-rpc `get_attribute_names` method to return per-attribute context (`brief` / `examples` / `isDeprecated` / `replacementAttribute`). The wrapper (`src/sentry/seer/assisted_query/traces_tools.py`) did neither:

1. **Rejected the context request → hard 500.** It had no parameter for the expansion, so the seer-rpc dispatcher's `method(**arguments)` raised `TypeError`, which the endpoint turned into an HTTP 500 on every call.
2. **Discarded all context.** It kept only `item["name"]` from the public `/trace-items/attributes/` response and rebuilt `built_in_fields` from a static `{key, type}` list, so even without the crash Seer's `extract_field_context` found no context and silently no-op'd.

## Changes

- Add an `include_context: bool` flag to `get_attribute_names`. When set, it forwards `expand=context` to the public endpoint (still gated behind the `data-browsing-attribute-context` feature flag) and attaches each attribute's context to the matching `built_in_fields` — which is where Seer reads attribute context from.
- Add a nullable `context` field to the `BuiltInField` seer data model.

Context is sourced from the sentry conventions today, so only attributes that map to a known convention carry it; custom attribute context is planned and will populate the rest later.

### API choice

The wrapper exposes a typed `include_context: bool` rather than the endpoint's stringly-typed `expand="context"` query param. This is a semantic RPC tool boundary (the wrapper already translates the response), and a boolean is safer for an LLM-driven toolcall than a magic string the dispatcher does not validate.

## Coordination

Seer PR getsentry/seer#7084 must call `get_attribute_names(..., include_context=True)` to match this signature. This Sentry change should land and deploy before that Seer PR merges.

BROWSE-583
