### PR TITLE
feat(autofix): Add analytic event for set up seer button

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -148,6 +148,10 @@ export type TeamInsightsEventParameters = {
     has_streamlined_ui: boolean;
     has_summary: boolean;
   };
+  'issue_details.seer_setup_clicked': {
+    group_id: string;
+    setup_type: 'organization' | 'project';
+  };
   'issue_details.suspect_commits.commit_clicked': IssueDetailsWithAlert & {
     has_pull_request: boolean;
     suspect_commit_calculation: string;
@@ -246,6 +250,7 @@ export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
     'Issue Details: Trace Timeline More Events Clicked',
   'issue_details.resources_link_clicked': 'Issue Details: Resources Link Clicked',
   'issue_details.seer_opened': 'Issue Details: Seer Opened',
+  'issue_details.seer_setup_clicked': 'Issue Details: Seer Setup Clicked',
   'issue_details.suspect_commits.commit_clicked': 'Issue Details: Suspect Commit Clicked',
   'issue_details.suspect_commits.pull_request_clicked':
     'Issue Details: Suspect Pull Request Clicked',

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -148,10 +148,6 @@ export type TeamInsightsEventParameters = {
     has_streamlined_ui: boolean;
     has_summary: boolean;
   };
-  'issue_details.seer_setup_clicked': {
-    group_id: string;
-    setup_type: 'organization' | 'project';
-  };
   'issue_details.suspect_commits.commit_clicked': IssueDetailsWithAlert & {
     has_pull_request: boolean;
     suspect_commit_calculation: string;
@@ -250,7 +246,6 @@ export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
     'Issue Details: Trace Timeline More Events Clicked',
   'issue_details.resources_link_clicked': 'Issue Details: Resources Link Clicked',
   'issue_details.seer_opened': 'Issue Details: Seer Opened',
-  'issue_details.seer_setup_clicked': 'Issue Details: Seer Setup Clicked',
   'issue_details.suspect_commits.commit_clicked': 'Issue Details: Suspect Commit Clicked',
   'issue_details.suspect_commits.pull_request_clicked':
     'Issue Details: Suspect Pull Request Clicked',

--- a/static/app/views/issueDetails/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.tsx
@@ -213,6 +213,9 @@ export function AutofixContent({aiConfig, group, project}: AutofixContentProps) 
               <LinkButton
                 to={`/settings/${organization.slug}/seer/onboarding/`}
                 icon={<IconSeer />}
+                analyticsEventKey="issue_details.seer_setup_clicked"
+                analyticsEventName="Issue Details: Seer Setup Clicked"
+                analyticsParams={{group_id: group.id, setup_type: 'organization'}}
               >
                 {t('Set Up Seer')}
               </LinkButton>
@@ -220,6 +223,9 @@ export function AutofixContent({aiConfig, group, project}: AutofixContentProps) 
               <LinkButton
                 to={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
                 icon={<IconSeer />}
+                analyticsEventKey="issue_details.seer_setup_clicked"
+                analyticsEventName="Issue Details: Seer Setup Clicked"
+                analyticsParams={{group_id: group.id, setup_type: 'project'}}
               >
                 {t('Set Up Seer for This Project')}
               </LinkButton>


### PR DESCRIPTION
Emit an analytic event when users click on the set up seer buttons to go to the settings pages.

- `setup_type: "organization"` means they need to configure the org to use seer
- `setup_type: "project"` means the org is configured but they still need to configure the project to use seer