### PR TITLE
feat(ai): Add server-side sorting to AI conversations

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -34,22 +34,14 @@ from sentry.utils.ai_message_normalizer import (
 logger = logging.getLogger("sentry.api.endpoints.organization_ai_conversations")
 
 
-# Conversation-level duration (wall-clock span of the whole conversation).
-# Passed as an equation so it can be ordered on in the conversation-id query.
+# Duration equation used for sorting; passed via the `equations` param.
 _DURATION_EQUATION = "max(precise.finish_ts) - min(precise.start_ts)"
 
-# Always selected (and used as a pagination tiebreaker) in the conversation-id query.
+# Always included as a stable pagination tiebreaker in the sort query.
 _TIMESTAMP_AGGREGATE = "max(precise.finish_ts)"
 
-# Maps an API sort field to the aggregate column that must be selected and
-# ordered on in the paginated conversation-id query. `duration` is handled
-# separately via _DURATION_EQUATION.
-#
-# The conversation-id query filters on has:gen_ai.operation.type, so every
-# gen_ai span (ai_client, tool, invoke_agent) is included and these aggregates
-# are conversation-wide, consistent with the values returned by the aggregation
-# query. `toolErrors` is intentionally absent: it needs a compound condition
-# (operation.type == tool AND a failure status) that count_if cannot express.
+# `toolErrors` is absent: it needs a compound condition (operation.type == tool
+# AND a failure status) that count_if cannot express with a single filter.
 _SORT_FIELD_TO_AGGREGATE = {
     "timestamp": _TIMESTAMP_AGGREGATE,
     "errors": "failure_count()",
@@ -266,18 +258,9 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
         sort: str = "-timestamp",
         sampling_mode: SAMPLING_MODES = "NORMAL",
     ) -> list[dict]:
-        # Filter on has:gen_ai.operation.type (rather than the presence of
-        # messages) so every gen_ai span (ai_client, tool, invoke_agent) is
-        # visible. This makes conversation-wide aggregates correct to sort on.
         base_filter = "has:gen_ai.conversation.id has:gen_ai.operation.type"
         filter_query = _build_conversation_query(base_filter, user_query)
 
-        # Phase 1: find all conversation IDs that match the user query.
-        # Sort aggregates must not be filtered by the user query — the user query
-        # determines which *conversations* qualify, not which spans within them
-        # count toward a metric. Computing sort aggregates over user-query-filtered
-        # spans would cause sort order to disagree with the displayed values (which
-        # are always full-conversation aggregates).
         all_ids_results = self._fetch_qualifying_conversation_ids(
             snuba_params, filter_query, sampling_mode
         )
@@ -289,8 +272,6 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
         if not all_ids:
             return []
 
-        # Phase 2: sort and paginate using full-conversation aggregates scoped
-        # only to the qualifying IDs (no user query in this filter).
         sorted_ids_results = self._fetch_sorted_page(
             snuba_params, all_ids, offset, limit, sort, sampling_mode
         )
@@ -331,16 +312,15 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
         sort: str,
         sampling_mode: SAMPLING_MODES,
     ) -> EAPResponse:
-        """Sort and paginate the given conversation IDs using full-conversation aggregates.
+        """Sort and paginate conversation_ids using full-conversation aggregates.
 
-        The query is scoped only to the provided IDs so that sort aggregates
-        reflect the complete conversation, not a user-query-filtered subset.
+        Scoped to the provided IDs only (no user query) so sort order matches
+        the displayed values, which are also full-conversation aggregates.
         """
         descending = sort.startswith("-")
         field = sort.lstrip("-")
         prefix = "-" if descending else ""
 
-        # max(precise.finish_ts) is always selected as a stable tiebreaker.
         selected_columns = ["gen_ai.conversation.id", _TIMESTAMP_AGGREGATE]
         equations: list[str] | None = None
 

--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -34,6 +34,34 @@ from sentry.utils.ai_message_normalizer import (
 logger = logging.getLogger("sentry.api.endpoints.organization_ai_conversations")
 
 
+# Conversation-level duration (wall-clock span of the whole conversation).
+# Passed as an equation so it can be ordered on in the conversation-id query.
+_DURATION_EQUATION = "max(precise.finish_ts) - min(precise.start_ts)"
+
+# Always selected (and used as a pagination tiebreaker) in the conversation-id query.
+_TIMESTAMP_AGGREGATE = "max(precise.finish_ts)"
+
+# Maps an API sort field to the aggregate column that must be selected and
+# ordered on in the paginated conversation-id query. `duration` is handled
+# separately via _DURATION_EQUATION.
+#
+# The conversation-id query filters on has:gen_ai.operation.type, so every
+# gen_ai span (ai_client, tool, invoke_agent) is included and these aggregates
+# are conversation-wide, consistent with the values returned by the aggregation
+# query. `toolErrors` is intentionally absent: it needs a compound condition
+# (operation.type == tool AND a failure status) that count_if cannot express.
+_SORT_FIELD_TO_AGGREGATE = {
+    "timestamp": _TIMESTAMP_AGGREGATE,
+    "errors": "failure_count()",
+    "llmCalls": "count_if(gen_ai.operation.type,equals,ai_client)",
+    "toolCalls": "count_if(gen_ai.operation.type,equals,tool)",
+    "totalTokens": "sum_if(gen_ai.usage.total_tokens,gen_ai.operation.type,equals,ai_client)",
+    "inputTokens": "sum_if(gen_ai.usage.input_tokens,gen_ai.operation.type,equals,ai_client)",
+    "outputTokens": "sum_if(gen_ai.usage.output_tokens,gen_ai.operation.type,equals,ai_client)",
+    "totalCost": "sum_if(gen_ai.cost.total_tokens,gen_ai.operation.type,equals,ai_client)",
+}
+
+
 def _build_conversation_query(base_query: str, user_query: str) -> str:
     if user_query and user_query.strip():
         return f"{base_query} {user_query.strip()}"
@@ -215,6 +243,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 offset=offset,
                 limit=limit,
                 user_query=validated_data.get("query", ""),
+                sort=validated_data.get("sort", "-timestamp"),
                 sampling_mode=validated_data.get("samplingMode", "NORMAL"),
             )
 
@@ -234,17 +263,18 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
         offset: int,
         limit: int,
         user_query: str,
+        sort: str = "-timestamp",
         sampling_mode: SAMPLING_MODES = "NORMAL",
     ) -> list[dict]:
-        base_filter = (
-            "has:gen_ai.conversation.id"
-            " (has:gen_ai.input.messages OR has:gen_ai.request.messages)"
-            " (has:gen_ai.output.messages OR has:gen_ai.response.text)"
-        )
+        # Filter on has:gen_ai.operation.type (rather than the presence of
+        # messages) so the conversation-id query sees every gen_ai span
+        # (ai_client, tool, invoke_agent). This is what makes conversation-wide
+        # aggregates (errors, toolCalls, duration) correct to sort/paginate on.
+        base_filter = "has:gen_ai.conversation.id has:gen_ai.operation.type"
         query_string = _build_conversation_query(base_filter, user_query)
 
         conversation_ids_results = self._fetch_conversation_ids(
-            snuba_params, query_string, offset, limit, sampling_mode
+            snuba_params, query_string, offset, limit, sort, sampling_mode
         )
         conversation_ids = _extract_conversation_ids(conversation_ids_results)
 
@@ -263,13 +293,38 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
         query_string: str,
         offset: int,
         limit: int,
+        sort: str,
         sampling_mode: SAMPLING_MODES,
     ) -> EAPResponse:
+        descending = sort.startswith("-")
+        field = sort.lstrip("-")
+        prefix = "-" if descending else ""
+
+        # The conversation-id query groups by gen_ai.conversation.id, so we sort
+        # on an aggregate of the matching spans. max(precise.finish_ts) is always
+        # selected and used as a secondary, stable-pagination tiebreaker.
+        selected_columns = ["gen_ai.conversation.id", _TIMESTAMP_AGGREGATE]
+        equations: list[str] | None = None
+
+        if field == "duration":
+            equations = [_DURATION_EQUATION]
+            primary_orderby = f"{prefix}equation|{_DURATION_EQUATION}"
+        else:
+            aggregate = _SORT_FIELD_TO_AGGREGATE[field]
+            if aggregate not in selected_columns:
+                selected_columns.append(aggregate)
+            primary_orderby = f"{prefix}{aggregate}"
+
+        orderby = [primary_orderby]
+        if primary_orderby.lstrip("-") != _TIMESTAMP_AGGREGATE:
+            orderby.append(f"-{_TIMESTAMP_AGGREGATE}")
+
         return Spans.run_table_query(
             params=snuba_params,
             query_string=query_string,
-            selected_columns=["gen_ai.conversation.id", "max(precise.finish_ts)"],
-            orderby=["-max(precise.finish_ts)"],
+            selected_columns=selected_columns,
+            orderby=orderby,
+            equations=equations,
             offset=offset,
             limit=limit,
             referrer=Referrer.API_AI_CONVERSATIONS.value,

--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -267,42 +267,80 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
         sampling_mode: SAMPLING_MODES = "NORMAL",
     ) -> list[dict]:
         # Filter on has:gen_ai.operation.type (rather than the presence of
-        # messages) so the conversation-id query sees every gen_ai span
-        # (ai_client, tool, invoke_agent). This is what makes conversation-wide
-        # aggregates (errors, toolCalls, duration) correct to sort/paginate on.
+        # messages) so every gen_ai span (ai_client, tool, invoke_agent) is
+        # visible. This makes conversation-wide aggregates correct to sort on.
         base_filter = "has:gen_ai.conversation.id has:gen_ai.operation.type"
-        query_string = _build_conversation_query(base_filter, user_query)
+        filter_query = _build_conversation_query(base_filter, user_query)
 
-        conversation_ids_results = self._fetch_conversation_ids(
-            snuba_params, query_string, offset, limit, sort, sampling_mode
+        # Phase 1: find all conversation IDs that match the user query.
+        # Sort aggregates must not be filtered by the user query — the user query
+        # determines which *conversations* qualify, not which spans within them
+        # count toward a metric. Computing sort aggregates over user-query-filtered
+        # spans would cause sort order to disagree with the displayed values (which
+        # are always full-conversation aggregates).
+        all_ids_results = self._fetch_qualifying_conversation_ids(
+            snuba_params, filter_query, sampling_mode
         )
-        conversation_ids = _extract_conversation_ids(conversation_ids_results)
+        all_ids = _extract_conversation_ids(all_ids_results)
 
-        sentry_sdk.set_tag("ai_conversations.count", len(conversation_ids))
-        sentry_sdk.set_attribute("ai_conversations.count", len(conversation_ids))
+        sentry_sdk.set_tag("ai_conversations.count", len(all_ids))
+        sentry_sdk.set_attribute("ai_conversations.count", len(all_ids))
 
-        if not conversation_ids:
+        if not all_ids:
             return []
 
-        return self._get_conversations_data(snuba_params, conversation_ids)
+        # Phase 2: sort and paginate using full-conversation aggregates scoped
+        # only to the qualifying IDs (no user query in this filter).
+        sorted_ids_results = self._fetch_sorted_page(
+            snuba_params, all_ids, offset, limit, sort, sampling_mode
+        )
+        page_ids = _extract_conversation_ids(sorted_ids_results)
+
+        if not page_ids:
+            return []
+
+        return self._get_conversations_data(snuba_params, page_ids)
 
     @sentry_sdk.trace
-    def _fetch_conversation_ids(
+    def _fetch_qualifying_conversation_ids(
         self,
         snuba_params,
-        query_string: str,
+        filter_query: str,
+        sampling_mode: SAMPLING_MODES,
+    ) -> EAPResponse:
+        """Return all conversation IDs matching the user query (no sort, no pagination)."""
+        return Spans.run_table_query(
+            params=snuba_params,
+            query_string=filter_query,
+            selected_columns=["gen_ai.conversation.id", _TIMESTAMP_AGGREGATE],
+            orderby=None,
+            offset=0,
+            limit=10_000,
+            referrer=Referrer.API_AI_CONVERSATIONS_IDS.value,
+            config=SearchResolverConfig(auto_fields=True),
+            sampling_mode=sampling_mode,
+        )
+
+    @sentry_sdk.trace
+    def _fetch_sorted_page(
+        self,
+        snuba_params,
+        conversation_ids: list[str],
         offset: int,
         limit: int,
         sort: str,
         sampling_mode: SAMPLING_MODES,
     ) -> EAPResponse:
+        """Sort and paginate the given conversation IDs using full-conversation aggregates.
+
+        The query is scoped only to the provided IDs so that sort aggregates
+        reflect the complete conversation, not a user-query-filtered subset.
+        """
         descending = sort.startswith("-")
         field = sort.lstrip("-")
         prefix = "-" if descending else ""
 
-        # The conversation-id query groups by gen_ai.conversation.id, so we sort
-        # on an aggregate of the matching spans. max(precise.finish_ts) is always
-        # selected and used as a secondary, stable-pagination tiebreaker.
+        # max(precise.finish_ts) is always selected as a stable tiebreaker.
         selected_columns = ["gen_ai.conversation.id", _TIMESTAMP_AGGREGATE]
         equations: list[str] | None = None
 
@@ -321,7 +359,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
 
         return Spans.run_table_query(
             params=snuba_params,
-            query_string=query_string,
+            query_string=build_escaped_term_filter("gen_ai.conversation.id", conversation_ids),
             selected_columns=selected_columns,
             orderby=orderby,
             equations=equations,

--- a/src/sentry/api/serializers/rest_framework/ai_conversations.py
+++ b/src/sentry/api/serializers/rest_framework/ai_conversations.py
@@ -15,6 +15,14 @@ class OrganizationAIConversationsSerializer(serializers.Serializer):
     )
 
     def validate_sort(self, value):
+        # Sorting happens on the paginated "conversation id" query, which groups
+        # spans by gen_ai.conversation.id and filters on has:gen_ai.operation.type.
+        # Because every gen_ai span is included, the aggregates ordered on there
+        # are conversation-wide and consistent with the returned values.
+        #
+        # toolErrors is intentionally not sortable: it requires a compound
+        # condition (gen_ai.operation.type == tool AND a failure span.status),
+        # which EAP's count_if aggregate cannot express (single filter only).
         allowed_sorts = {
             "timestamp",
             "-timestamp",
@@ -28,10 +36,12 @@ class OrganizationAIConversationsSerializer(serializers.Serializer):
             "-toolCalls",
             "totalTokens",
             "-totalTokens",
+            "inputTokens",
+            "-inputTokens",
+            "outputTokens",
+            "-outputTokens",
             "totalCost",
             "-totalCost",
-            "toolErrors",
-            "-toolErrors",
         }
         if value not in allowed_sorts:
             raise serializers.ValidationError(f"Invalid sort option: {value}")

--- a/src/sentry/api/serializers/rest_framework/ai_conversations.py
+++ b/src/sentry/api/serializers/rest_framework/ai_conversations.py
@@ -15,14 +15,8 @@ class OrganizationAIConversationsSerializer(serializers.Serializer):
     )
 
     def validate_sort(self, value):
-        # Sorting happens on the paginated "conversation id" query, which groups
-        # spans by gen_ai.conversation.id and filters on has:gen_ai.operation.type.
-        # Because every gen_ai span is included, the aggregates ordered on there
-        # are conversation-wide and consistent with the returned values.
-        #
-        # toolErrors is intentionally not sortable: it requires a compound
-        # condition (gen_ai.operation.type == tool AND a failure span.status),
-        # which EAP's count_if aggregate cannot express (single filter only).
+        # toolErrors is not sortable: requires a compound condition that
+        # count_if cannot express (operation.type == tool AND failure status).
         allowed_sorts = {
             "timestamp",
             "-timestamp",

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -497,6 +497,7 @@ class Referrer(StrEnum):
     API_ORGANIZATION_VITALS_PER_PROJECT = "api.organization-vitals-per-project"
     API_ORGANIZATION_VITALS = "api.organization-vitals"
     API_AI_CONVERSATIONS = "api.ai-conversations"
+    API_AI_CONVERSATIONS_IDS = "api.ai-conversations.ids"
     API_AI_CONVERSATIONS_COMPLETE = "api.ai-conversations.complete"
     API_AI_CONVERSATIONS_ENRICHMENT = "api.ai-conversations.enrichment"
     API_AI_CONVERSATIONS_FIRST_LAST_IO = "api.ai-conversations.first-last-io"

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -468,6 +468,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
                 conversation_id=conversation_id,
                 timestamp=now - timedelta(seconds=i),
                 op="gen_ai.chat",
+                operation_type="ai_client",
                 status=span_status,
                 trace_id=trace_id,
                 **extra_kwargs,
@@ -647,26 +648,22 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert conversation["firstInput"] == first_user_content
         assert conversation["lastOutput"] == last_response_text
 
-    def test_no_ai_client_spans_filtered_out(self) -> None:
-        """Test conversations without input/output are filtered out"""
+    def test_spans_without_operation_type_filtered_out(self) -> None:
+        """Conversations whose spans have no gen_ai.operation.type are filtered out.
+
+        Discovery filters on has:gen_ai.operation.type, so spans that only carry
+        gen_ai.conversation.id (no operation type) do not surface a conversation.
+        """
         now = before_now(days=12).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
-        # Only invoke_agent spans, no ai_client spans with input/output
+        # Spans with a conversation id but no gen_ai.operation.type.
         self.store_ai_span(
             conversation_id=conversation_id,
             timestamp=now - timedelta(seconds=2),
             op="gen_ai.invoke_agent",
             agent_name="Test Agent",
-            trace_id=trace_id,
-        )
-
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now - timedelta(seconds=1),
-            op="gen_ai.execute_tool",
-            operation_type="tool",
             trace_id=trace_id,
         )
 
@@ -679,6 +676,49 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         response = self.do_request(query)
         assert response.status_code == 200
         assert len(response.data) == 0
+
+    def test_conversation_surfaced_from_tool_spans(self) -> None:
+        """A conversation with only tool/agent operation spans now surfaces.
+
+        Widening discovery to has:gen_ai.operation.type means conversations are
+        no longer required to carry input/output messages; first/last IO is just
+        empty for them.
+        """
+        now = before_now(days=12).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        trace_id = uuid4().hex
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=2),
+            op="gen_ai.invoke_agent",
+            operation_type="invoke_agent",
+            agent_name="Test Agent",
+            trace_id=trace_id,
+        )
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=1),
+            op="gen_ai.execute_tool",
+            operation_type="tool",
+            tool_name="weather_api",
+            trace_id=trace_id,
+        )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        conversation = response.data[0]
+        assert conversation["conversationId"] == conversation_id
+        assert conversation["toolCalls"] == 1
+        assert conversation["firstInput"] is None
+        assert conversation["lastOutput"] is None
 
     def test_query_filter(self) -> None:
         """Test that query parameter filters conversations"""
@@ -1300,3 +1340,106 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         # Verify counts are correct
         assert conversation["llmCalls"] == 1
         assert conversation["flow"] == ["Test Agent"]
+
+    def _store_sortable_conversations(self, now):
+        """Create three conversations with distinct, monotonic metrics for sort tests.
+
+        conv_low  -> 1 llm call, 1 tool call, smallest tokens/cost, shortest duration
+        conv_mid  -> 2 llm calls, 2 tool calls, mid tokens/cost, mid duration
+        conv_high -> 3 llm calls, 3 tool calls, largest tokens/cost, longest duration
+        """
+        conversations = {}
+        for label, llm_calls, tool_calls, errors, tokens, cost, duration_s in (
+            ("low", 1, 1, 1, 100, 0.01, 1),
+            ("mid", 2, 2, 2, 500, 0.05, 5),
+            ("high", 3, 3, 3, 1000, 0.1, 10),
+        ):
+            conversation_id = uuid4().hex
+            conversations[label] = conversation_id
+            trace_id = uuid4().hex
+            input_tokens = tokens * 7 // 10
+            output_tokens = tokens - input_tokens
+            # First ai_client span establishes the conversation start.
+            start = now - timedelta(minutes=30, seconds=duration_s)
+            for i in range(llm_calls):
+                self.store_ai_span(
+                    conversation_id=conversation_id,
+                    timestamp=start + timedelta(seconds=i),
+                    op="gen_ai.chat",
+                    operation_type="ai_client",
+                    status="internal_error" if i < errors else "ok",
+                    tokens=tokens // llm_calls,
+                    input_tokens=input_tokens // llm_calls,
+                    output_tokens=output_tokens // llm_calls,
+                    cost=cost / llm_calls,
+                    trace_id=trace_id,
+                    messages=[{"role": "user", "content": "hi"}],
+                    response_text="hello",
+                )
+            for i in range(tool_calls):
+                self.store_ai_span(
+                    conversation_id=conversation_id,
+                    timestamp=start + timedelta(seconds=duration_s, milliseconds=i),
+                    op="gen_ai.execute_tool",
+                    operation_type="tool",
+                    status="ok",
+                    trace_id=trace_id,
+                    tool_name=f"tool_{i}",
+                )
+        return conversations
+
+    def _sort_request(self, now, sort):
+        return self.do_request(
+            {
+                "project": [self.project.id],
+                "start": (now - timedelta(hours=1)).isoformat(),
+                "end": (now + timedelta(hours=1)).isoformat(),
+                "sort": sort,
+            }
+        )
+
+    def test_sort_by_aggregates(self) -> None:
+        """Server-side sorting works for conversation-wide aggregate columns."""
+        now = before_now(days=70).replace(microsecond=0)
+        convs = self._store_sortable_conversations(now)
+
+        for sort_field in (
+            "llmCalls",
+            "toolCalls",
+            "errors",
+            "totalTokens",
+            "inputTokens",
+            "outputTokens",
+            "totalCost",
+            "duration",
+        ):
+            response = self._sort_request(now, f"-{sort_field}")
+            assert response.status_code == 200, (sort_field, response.data)
+            ids = [row["conversationId"] for row in response.data]
+            assert ids == [convs["high"], convs["mid"], convs["low"]], sort_field
+
+            response = self._sort_request(now, sort_field)
+            assert response.status_code == 200, (sort_field, response.data)
+            ids = [row["conversationId"] for row in response.data]
+            assert ids == [convs["low"], convs["mid"], convs["high"]], sort_field
+
+    def test_sort_by_timestamp(self) -> None:
+        now = before_now(days=70).replace(microsecond=0)
+        convs = self._store_sortable_conversations(now)
+
+        response = self._sort_request(now, "timestamp")
+        assert response.status_code == 200, response.data
+        ids = [row["conversationId"] for row in response.data]
+        # All three are valid orderings of the same timestamps; just assert all present.
+        assert set(ids) == set(convs.values())
+
+    def test_invalid_sort_rejected(self) -> None:
+        now = before_now(days=70).replace(microsecond=0)
+        response = self._sort_request(now, "bogus")
+        assert response.status_code == 400
+
+    def test_tool_errors_sort_not_supported(self) -> None:
+        """toolErrors needs a compound condition count_if cannot express; reject it."""
+        now = before_now(days=70).replace(microsecond=0)
+        response = self._sort_request(now, "-toolErrors")
+        assert response.status_code == 400


### PR DESCRIPTION
Adds a `sort` query param to the conversations list. The param was already validated by the serializer but never wired through.

**What this adds**

`sort` accepts any column name (prefix `-` for descending, default `-timestamp`):

| Field | Aggregate |
|---|---|
| `timestamp` | `max(finish_ts)` |
| `duration` | `max(finish_ts) - min(start_ts)` |
| `errors` | `failure_count()` |
| `llmCalls` | `count_if(operation.type, ai_client)` |
| `toolCalls` | `count_if(operation.type, tool)` |
| `totalTokens` / `inputTokens` / `outputTokens` | `sum_if(... ai_client)` |
| `totalCost` | `sum_if(... ai_client)` |

`toolErrors` is not sortable — it needs a compound condition (`operation.type == tool` AND failure status) that `count_if` cannot express.

**How it works**

Sorting requires two queries so that the user search filter affects only which conversations appear, not the sort metrics:

1. Run `base_filter + user_query` grouped by `gen_ai.conversation.id` → get all qualifying IDs.
2. Re-run scoped to those IDs only (no user query) with the sort aggregate → paginate.

This matches how `_build_aggregations_query` already computes the displayed values, so sort order and displayed metrics are always consistent.

The discovery filter was also widened from message presence to `has:gen_ai.operation.type`, so tool and agent spans count toward `errors`, `toolCalls`, and `duration`. Side effect: conversations with only tool/agent spans now surface with `firstInput`/`lastOutput` as `null`.

Fixes TET-2555