### PR TITLE
fix(uptime): Use safe HTTP for robots.txt fetch in autodetect

### DIFF
--- a/src/sentry/uptime/autodetect/tasks.py
+++ b/src/sentry/uptime/autodetect/tasks.py
@@ -292,7 +292,12 @@ def check_url_robots_txt(url: str) -> bool:
 
 def get_robots_txt_parser(url: str) -> RobotFileParser:
     robots_url = urljoin(url, "robots.txt")
-    response = safe_urlopen(robots_url, timeout=10)
+    response = safe_urlopen(robots_url, timeout=10, allow_redirects=True)
     robot_parser = RobotFileParser(url=robots_url)
-    robot_parser.parse(response.text.splitlines())
+    if response.status_code in (401, 403):
+        robot_parser.parse(["User-agent: *", "Disallow: /"])
+    elif response.status_code >= 400:
+        robot_parser.parse([])
+    else:
+        robot_parser.parse(response.text.splitlines())
     return robot_parser

--- a/src/sentry/uptime/autodetect/tasks.py
+++ b/src/sentry/uptime/autodetect/tasks.py
@@ -8,6 +8,8 @@ from dateutil.parser import parse as parse_datetime
 from django.utils import timezone
 
 from sentry import features, options
+from sentry.exceptions import RestrictedIPAddress
+from sentry.http import safe_urlopen
 from sentry.locks import locks
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -280,12 +282,17 @@ def get_failed_url_key(url: str) -> str:
 def check_url_robots_txt(url: str) -> bool:
     try:
         return get_robots_txt_parser(url).can_fetch(UPTIME_USER_AGENT, url)
+    except RestrictedIPAddress:
+        logger.warning("Blocked robots.txt fetch to restricted IP", exc_info=True)
+        return False
     except Exception:
         logger.warning("Failed to check robots.txt", exc_info=True)
         return True
 
 
 def get_robots_txt_parser(url: str) -> RobotFileParser:
-    robot_parser = RobotFileParser(url=urljoin(url, "robots.txt"))
-    robot_parser.read()
+    robots_url = urljoin(url, "robots.txt")
+    response = safe_urlopen(robots_url, timeout=10)
+    robot_parser = RobotFileParser(url=robots_url)
+    robot_parser.parse(response.text.splitlines())
     return robot_parser

--- a/tests/sentry/uptime/autodetect/test_tasks.py
+++ b/tests/sentry/uptime/autodetect/test_tasks.py
@@ -13,7 +13,7 @@ from sentry.locks import locks
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.testutils.cases import UptimeTestCase
-from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers import override_blocklist, with_feature
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.uptime.autodetect.ranking import (
     NUMBER_OF_BUCKETS,
@@ -25,6 +25,8 @@ from sentry.uptime.autodetect.tasks import (
     LAST_PROCESSED_KEY,
     ONBOARDING_SUBSCRIPTION_INTERVAL_SECONDS,
     SCHEDULER_LOCK_KEY,
+    check_url_robots_txt,
+    get_robots_txt_parser,
     is_failed_url,
     monitor_url_for_project,
     process_autodetection_bucket,
@@ -353,6 +355,76 @@ class TestFailedUrl(UptimeTestCase):
         set_failed_url(url)
         assert is_failed_url(url)
         assert not is_failed_url(make_unique_test_url())
+
+
+class TestCheckUrlRobotsTxt(UptimeTestCase):
+    @override_blocklist("127.0.0.0/8")
+    def test_loopback_blocked(self) -> None:
+        assert check_url_robots_txt("http://127.0.0.1/page") is False
+
+    @override_blocklist("10.0.0.0/8")
+    def test_private_10_network_blocked(self) -> None:
+        assert check_url_robots_txt("http://10.0.0.1/page") is False
+
+    @override_blocklist("172.16.0.0/12")
+    def test_private_172_network_blocked(self) -> None:
+        assert check_url_robots_txt("http://172.16.0.1/page") is False
+
+    @override_blocklist("192.168.0.0/16")
+    def test_private_192_168_network_blocked(self) -> None:
+        assert check_url_robots_txt("http://192.168.1.1/page") is False
+
+    def test_public_robots_txt_allowed(self) -> None:
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.text = "User-agent: *\nAllow: /"
+        with mock.patch(
+            "sentry.uptime.autodetect.tasks.safe_urlopen",
+            return_value=mock_response,
+        ):
+            assert check_url_robots_txt("https://example.com/page") is True
+
+    def test_public_robots_txt_disallowed(self) -> None:
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.text = "User-agent: *\nDisallow: /"
+        with mock.patch(
+            "sentry.uptime.autodetect.tasks.safe_urlopen",
+            return_value=mock_response,
+        ):
+            assert check_url_robots_txt("https://example.com/page") is False
+
+
+class TestGetRobotsTxtParser(UptimeTestCase):
+    def test_401_treated_as_disallow_all(self) -> None:
+        mock_response = mock.Mock()
+        mock_response.status_code = 401
+        with mock.patch(
+            "sentry.uptime.autodetect.tasks.safe_urlopen",
+            return_value=mock_response,
+        ):
+            parser = get_robots_txt_parser("https://example.com/page")
+            assert parser.can_fetch("SentryUptimeBot", "https://example.com/page") is False
+
+    def test_403_treated_as_disallow_all(self) -> None:
+        mock_response = mock.Mock()
+        mock_response.status_code = 403
+        with mock.patch(
+            "sentry.uptime.autodetect.tasks.safe_urlopen",
+            return_value=mock_response,
+        ):
+            parser = get_robots_txt_parser("https://example.com/page")
+            assert parser.can_fetch("SentryUptimeBot", "https://example.com/page") is False
+
+    def test_404_treated_as_allow_all(self) -> None:
+        mock_response = mock.Mock()
+        mock_response.status_code = 404
+        with mock.patch(
+            "sentry.uptime.autodetect.tasks.safe_urlopen",
+            return_value=mock_response,
+        ):
+            parser = get_robots_txt_parser("https://example.com/page")
+            assert parser.can_fetch("SentryUptimeBot", "https://example.com/page") is True
 
 
 class TestMonitorUrlForProject(UptimeTestCase):


### PR DESCRIPTION
Replace RobotFileParser.read() with safe_urlopen() so the robots.txt fetch goes through SafeSession with DNS/IP validation. Explicitly reject candidate URLs when the fetch is blocked by restricted-IP checks instead of falling through to the permissive catch-all handler.

Fixes: https://github.com/getsentry/getsentry/issues/20230
