### PR TITLE
feat(trace-items): Ungate sentry-conventions attribute context

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -194,8 +194,9 @@ EXPAND_QUERY_PARAM = OpenApiParameter(
     many=True,
     type=str,
     enum=["context"],
-    # Internal-only for now: gated behind the data-browsing-attribute-context
-    # feature, so exclude it from the public OpenAPI spec.
+    # Internal-only for now (context is currently limited to sentry conventions;
+    # custom attribute context is still to come), so exclude it from the public
+    # OpenAPI spec.
     exclude=True,
     description=(
         "Optional fields to expand. Pass `context` to include the sentry "
@@ -518,14 +519,12 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         debug = request.user.is_superuser and request.GET.get("debug", False)
         debug_infos: list[dict] = []
 
-        # Only expand the sentry conventions context when explicitly requested
-        # via `expand=context` and the feature is enabled for the org. When the
-        # feature is disabled this is a no-op even if `expand=context` is passed.
-        include_context = "context" in serialized.get("expand", set()) and features.has(
-            "organizations:data-browsing-attribute-context",
-            organization,
-            actor=request.user,
-        )
+        # Expand the sentry conventions context when explicitly requested via
+        # `expand=context`. The conventions metadata is static with no data
+        # implications, so it isn't gated. (Custom attribute context, planned
+        # later, will be gated behind the data-browsing-attribute-context
+        # feature.)
+        include_context = "context" in serialized.get("expand", set())
 
         def data_fn(offset: int, limit: int) -> list[TraceItemAttributeKey]:
             futures = []

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
@@ -10,14 +10,14 @@ class TraceItemAttributeContext(TypedDict):
     """
     Additional, mostly-static metadata about an attribute.
 
-    When ``expand=context`` is requested (and the
-    ``data-browsing-attribute-context`` feature is enabled), context is attached
-    to every attribute. Today the metadata is sourced from the sentry
-    conventions (``sentry_conventions.attributes.ATTRIBUTE_METADATA``), so
-    attributes that map to a known convention carry that metadata (only the
-    fields actually present are included) while custom attributes get an empty
-    context. Serving context for custom attributes is planned, at which point
-    the empty contexts will start to be populated.
+    When ``expand=context`` is requested, context is attached to every
+    attribute. Today the metadata is sourced from the sentry conventions
+    (``sentry_conventions.attributes.ATTRIBUTE_METADATA``), so attributes that
+    map to a known convention carry that metadata (only the fields actually
+    present are included) while custom attributes get an empty context. Serving
+    context for custom attributes is planned (gated behind the
+    ``data-browsing-attribute-context`` feature), at which point the empty
+    contexts will start to be populated.
     """
 
     # A short, human-readable description of the attribute. Present for a known

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -510,10 +510,6 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
 
         response = self.do_request(
             query={"attributeType": "string", "expand": "context"},
-            features={
-                **self.feature_flags,
-                "organizations:data-browsing-attribute-context": True,
-            },
         )
         assert response.status_code == 200, response.data
 
@@ -546,22 +542,23 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
     def test_expand_context_without_feature_flag(self) -> None:
         self._store_basic_segment()
 
-        # expand=context is requested, but the gating feature is disabled.
+        # Context is no longer gated by a feature flag: expand=context alone is
+        # enough, even with the data-browsing-attribute-context flag disabled.
         response = self.do_request(
             query={"attributeType": "string", "expand": "context"},
+            features={
+                **self.feature_flags,
+                "organizations:data-browsing-attribute-context": False,
+            },
         )
         assert response.status_code == 200, response.data
-        assert all("context" not in item for item in response.data)
+        assert all("context" in item for item in response.data)
 
     def test_context_not_included_without_expand(self) -> None:
         self._store_basic_segment()
 
         response = self.do_request(
             query={"attributeType": "string"},
-            features={
-                **self.feature_flags,
-                "organizations:data-browsing-attribute-context": True,
-            },
         )
         assert response.status_code == 200, response.data
         assert all("context" not in item for item in response.data)


### PR DESCRIPTION
The `/trace-items/attributes/` endpoint only attached attribute context (via `expand=context`) when the `organizations:data-browsing-attribute-context` feature flag was enabled.

The flag adds no value for the conventions context we serve today:
- The metadata is sourced statically from the sentry conventions — there are no data/query implications to exposing it.
- The `expand` query param is already `exclude=True`, so it's hidden from the public OpenAPI spec regardless.

## Changes

- Drop the feature-flag check: `expand=context` now returns the sentry-conventions context for any org.
- Update the related comments/docstring to reflect that conventions context is ungated.
- Update tests accordingly (context returns even with the flag explicitly disabled).

The `data-browsing-attribute-context` flag stays **registered** — it will gate **custom attribute** context once that's served.
