### PR TITLE
deps: Remove most references to rediscluster

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -10,7 +10,7 @@ from typing import Any, TypeVar
 
 import rb
 from django.utils.encoding import force_bytes, force_str
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry.buffer.base import Buffer, BufferField
 from sentry.db import models

--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.db import router
 from django.db.models import Count, Exists, OuterRef
 from django.utils import timezone
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry import options
 from sentry.models.artifactbundle import (

--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -42,7 +42,7 @@ INDEXING_CACHE_TIMEOUT = 600
 
 def get_redis_cluster_for_artifact_bundles() -> RedisCluster:
     cluster_key = settings.SENTRY_ARTIFACT_BUNDLES_INDEXING_REDIS_CLUSTER
-    return redis.redis_clusters.get(cluster_key)  # type: ignore[return-value]
+    return redis.redis_clusters.get(cluster_key)
 
 
 def get_refresh_key() -> str:

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -50,7 +50,7 @@ def _get_projects_key(namespace: ClustererNamespace) -> str:
 
 def get_redis_client() -> RedisCluster:
     cluster_key = settings.SENTRY_TRANSACTION_NAMES_REDIS_CLUSTER
-    return redis.redis_clusters.get(cluster_key)  # type: ignore[return-value]
+    return redis.redis_clusters.get(cluster_key)
 
 
 def _get_all_keys(namespace: ClustererNamespace) -> Iterator[str]:

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -7,8 +7,8 @@ from typing import Any
 import orjson
 import sentry_sdk
 from django.conf import settings
-from rediscluster import RedisCluster
 from sentry_conventions.attributes import ATTRIBUTE_NAMES
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.ingest.transaction_clusterer.datasource import (

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -66,7 +66,7 @@ class RedisRuleStore:
             # to be consistent with other stores, clear previous hash entries:
             p.delete(key)
             if len(rules) > 0:
-                p.hmset(name=key, mapping=rules)  # type: ignore[arg-type]
+                p.hmset(name=key, mapping=rules)
             p.execute()
 
     def update_rule(self, project: Project, rule: str, last_used: int) -> None:

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -12,7 +12,7 @@ import sentry_sdk
 from django.apps import apps
 from django.db.models import Q
 from redis.client import StrictRedis
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry import features
 from sentry.features.base import OrganizationFeature

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.urls import reverse
 from google.auth import impersonated_credentials
 from google.auth.transport.requests import Request
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry import features, options
 from sentry.auth.system import get_system_token

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -263,7 +263,7 @@ TOKEN_TTL_SECONDS = 3600
 
 def _get_cluster() -> RedisCluster:
     cluster_key = settings.SENTRY_DEBUG_FILES_REDIS_CLUSTER
-    return redis.redis_clusters.get(cluster_key)  # type: ignore[return-value]
+    return redis.redis_clusters.get(cluster_key)
 
 
 def _last_upload_key(project_id: int) -> str:

--- a/src/sentry/models/featureadoption.py
+++ b/src/sentry/models/featureadoption.py
@@ -5,7 +5,7 @@ import rb
 from django.conf import settings
 from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry.adoption import manager
 from sentry.adoption.manager import UnknownFeature

--- a/src/sentry/monitors/processing_errors/manager.py
+++ b/src/sentry/monitors/processing_errors/manager.py
@@ -9,7 +9,7 @@ from itertools import chain
 import sentry_sdk
 from django.conf import settings
 from redis.client import StrictRedis
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry import analytics
 from sentry.analytics.events.checkin_processing_error_stored import CheckinProcessingErrorStored

--- a/src/sentry/processing/backpressure/memory.py
+++ b/src/sentry/processing/backpressure/memory.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 
 import rb
 from redis import StrictRedis
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 
 @dataclass

--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -5,7 +5,7 @@ from time import time
 
 import rb
 import sentry_sdk
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry.constants import DataCategory
 from sentry.models.project import Project

--- a/src/sentry/relay/projectconfig_debounce_cache/redis.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/redis.py
@@ -1,5 +1,5 @@
 import rb
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry.relay.projectconfig_debounce_cache.base import ProjectConfigDebounceCache
 from sentry.utils import metrics

--- a/src/sentry/seer/code_review/webhooks/handlers.py
+++ b/src/sentry/seer/code_review/webhooks/handlers.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import sentry_sdk
 from redis.client import StrictRedis
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry import features
 from sentry.integrations.github.webhook_types import GithubWebhookType

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -16,7 +16,7 @@ from arroyo.processing.strategies.unfold import Unfold
 from arroyo.types import BrokerValue, Commit, FilteredPayload, Message, Partition, Value
 from django.conf import settings
 from redis.client import StrictRedis
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry import options
 from sentry.conf.types.kafka_definition import Topic

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -44,7 +44,7 @@ from sentry.utils.sdk import bind_organization_context
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from rediscluster import RedisCluster
+    from sentry_redis_tools.clients import RedisCluster
 
 
 class ChunkFileState:

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -185,7 +185,7 @@ def _get_cache_key(task, scope, checksum):
 
 def _get_redis_cluster_for_assemble() -> RedisCluster:
     cluster_key = settings.SENTRY_ASSEMBLE_CLUSTER
-    return redis.redis_clusters.get(cluster_key)  # type: ignore[return-value]
+    return redis.redis_clusters.get(cluster_key)
 
 
 @sentry_sdk.tracing.trace

--- a/src/sentry/tasks/seer/night_shift/skip_cache.py
+++ b/src/sentry/tasks/seer/night_shift/skip_cache.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from datetime import timedelta
 
 from redis.client import StrictRedis
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry.utils.redis import redis_clusters
 

--- a/src/sentry/uptime/config_producer.py
+++ b/src/sentry/uptime/config_producer.py
@@ -7,7 +7,7 @@ import jsonschema
 import msgpack
 from django.conf import settings
 from redis import StrictRedis
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.uptime.config_schema import CHECK_CONFIG_SCHEMA

--- a/src/sentry/uptime/utils.py
+++ b/src/sentry/uptime/utils.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from redis.client import StrictRedis
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry.utils import redis
 from sentry.workflow_engine.models.detector import Detector

--- a/src/sentry/utils/kvstore/redis.py
+++ b/src/sentry/utils/kvstore/redis.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from typing import TypeVar
 
 from redis import StrictRedis
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry.utils.kvstore.abstract import KVStorage
 

--- a/src/sentry/utils/locking/backends/redis.py
+++ b/src/sentry/utils/locking/backends/redis.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 import rb
 from redis.client import StrictRedis
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry.utils import redis
 from sentry.utils.locking.backends import LockBackend

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -196,7 +196,7 @@ class RedisClusterManager:
                 return FailoverRedis(**host, **client_args)
 
         # losing some type safety: SimpleLazyObject acts like the underlying type
-        return SimpleLazyObject(cluster_factory)  # type: ignore[return-value]
+        return SimpleLazyObject(cluster_factory)
 
     def get(self, key: str) -> RedisCluster[str] | StrictRedis[str]:
         try:

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -10,7 +10,7 @@ import rb
 from django.utils.functional import SimpleLazyObject
 from redis.client import Script, StrictRedis
 from redis.connection import ConnectionPool
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 from sentry_redis_tools.failover_redis import FailoverRedis
 from sentry_redis_tools.retrying_cluster import RetryingRedisCluster
 

--- a/tests/sentry/uptime/subscriptions/test_tasks.py
+++ b/tests/sentry/uptime/subscriptions/test_tasks.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.test import override_settings
 from django.utils import timezone
 from redis import StrictRedis
-from rediscluster import RedisCluster
+from sentry_redis_tools.clients import RedisCluster
 
 from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.constants import ObjectStatus

--- a/tests/sentry/utils/kvstore/test_compat.py
+++ b/tests/sentry/utils/kvstore/test_compat.py
@@ -16,7 +16,7 @@ def test_redis_cache_compat() -> None:
         CommonRedisCache(client=redis, raw_client=redis, version=version, prefix=prefix)
     )
     redis_backend = KVStorageCodecWrapper(
-        CacheKeyWrapper(RedisKVStorage(redis), version=version, prefix=prefix),
+        CacheKeyWrapper(RedisKVStorage[bytes](redis), version=version, prefix=prefix),
         JSONCodec() | BytesCodec(),
     )
 

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -49,9 +49,9 @@ class ClusterManagerTestCase(TestCase):
         # object to verify it's correct.
 
         # cluster foo is fine since it's a single node
-        assert isinstance(manager.get("foo")._setupfunc(), FailoverRedis)  # type: ignore[attr-defined]
+        assert isinstance(manager.get("foo")._setupfunc(), FailoverRedis)  # type: ignore[union-attr]
         # baz works becasue it's explicitly is_redis_cluster
-        assert manager.get("baz")._setupfunc() is RetryingRedisCluster.return_value  # type: ignore[attr-defined]
+        assert manager.get("baz")._setupfunc() is RetryingRedisCluster.return_value  # type: ignore[union-attr]
 
         # bar is not a valid redis or redis cluster definition
         # becasue it is two hosts, without explicitly saying is_redis_cluster


### PR DESCRIPTION
Remove most references to `rediscluster` dependency. In preparation for a redis library upgrade.