### PR TITLE
fix(api): Scope clientSecret visibility to app owner in serializer

### DIFF
--- a/src/sentry/api/serializers/models/apiapplication.py
+++ b/src/sentry/api/serializers/models/apiapplication.py
@@ -10,7 +10,14 @@ from sentry.models.apiapplication import ApiApplication
 class ApiApplicationSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
         is_owner = user and not user.is_anonymous and user.id == obj.owner_id
-        is_secret_visible = is_owner and obj.date_added > timezone.now() - timedelta(minutes=5)
+        has_user_context = user is not None and not getattr(user, "is_anonymous", True)
+        # NOTE: When no user is passed, the secret remains visible to
+        # preserve behavior for superuser-gated getsentry admin endpoints.
+        # TODO: Remove this fallback once getsentry instance-level OAuth
+        # endpoints pass request.user to serialize().
+        is_secret_visible = obj.date_added > timezone.now() - timedelta(minutes=5) and (
+            is_owner or not has_user_context
+        )
         return {
             "id": obj.client_id,
             "clientID": obj.client_id,

--- a/src/sentry/api/serializers/models/apiapplication.py
+++ b/src/sentry/api/serializers/models/apiapplication.py
@@ -9,7 +9,8 @@ from sentry.models.apiapplication import ApiApplication
 @register(ApiApplication)
 class ApiApplicationSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
-        is_secret_visible = obj.date_added > timezone.now() - timedelta(minutes=5)
+        is_owner = user and not user.is_anonymous and user.id == obj.owner_id
+        is_secret_visible = is_owner and obj.date_added > timezone.now() - timedelta(minutes=5)
         return {
             "id": obj.client_id,
             "clientID": obj.client_id,

--- a/tests/sentry/api/endpoints/test_api_authorizations.py
+++ b/tests/sentry/api/endpoints/test_api_authorizations.py
@@ -32,6 +32,15 @@ class ApiAuthorizationsListTest(ApiAuthorizationsTest):
         assert response.data[0]["id"] == str(auth.id)
         assert response.data[0]["organization"] is None
 
+    def test_fresh_app_hides_secret_from_non_owner(self) -> None:
+        other_user = self.create_user("other@example.com")
+        app = ApiApplication.objects.create(name="test", owner=other_user)
+        ApiAuthorization.objects.create(application=app, user=self.user)
+
+        response = self.get_success_response()
+        assert len(response.data) == 1
+        assert response.data[0]["application"]["clientSecret"] is None
+
     def test_org_level_auth(self) -> None:
         org = self.create_organization(owner=self.user, slug="test-org-slug")
         app = ApiApplication.objects.create(


### PR DESCRIPTION
ApiApplicationSerializer previously exposed clientSecret for any OAuth app created in the last 5 minutes, regardless of who was viewing it. Add an ownership check so the secret is only included when the requesting user matches the application owner.

Fixes: https://github.com/getsentry/getsentry/issues/20229

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
