### PR TITLE
feat(autofix): Add route analytics params for Seer setup state

### DIFF
--- a/static/app/views/issueDetails/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.tsx
@@ -180,7 +180,8 @@ export function AutofixContent({aiConfig, group, project}: AutofixContentProps) 
 
   useRouteAnalyticsParams({
     seerNeedOrgSetup: isPending ? undefined : needOrgSetup,
-    seerNeedProjSetup: isPending ? undefined : needProjSetup,
+    seerNeedProjSetup:
+      isPending || aiConfig.isAutofixSetupLoading ? undefined : needProjSetup,
   });
 
   if (

--- a/static/app/views/issueDetails/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.tsx
@@ -170,6 +170,19 @@ export function AutofixContent({aiConfig, group, project}: AutofixContentProps) 
 
   useLLMContext(autofixContextData);
 
+  const needOrgSetup =
+    // scm integration doesn't exist
+    !setupCheck?.hasSupportedScmIntegration;
+
+  const needProjSetup =
+    // scm integration not linked to project
+    !aiConfig.seerReposLinked;
+
+  useRouteAnalyticsParams({
+    seerNeedOrgSetup: isPending ? undefined : needOrgSetup,
+    seerNeedProjSetup: isPending ? undefined : needProjSetup,
+  });
+
   if (
     // waiting on the onboarding checks to load
     isPending ||
@@ -182,14 +195,6 @@ export function AutofixContent({aiConfig, group, project}: AutofixContentProps) 
   ) {
     return <Placeholder height="160px" />;
   }
-
-  const needOrgSetup =
-    // scm integration doesn't exist
-    !setupCheck?.hasSupportedScmIntegration;
-
-  const needProjSetup =
-    // scm integration not linked to project
-    !aiConfig.seerReposLinked;
 
   // non seat based seer plans are allowed to run autofix without the SCM integration
   if (organization.features.includes('seat-based-seer-enabled')) {

--- a/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.tsx
+++ b/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.tsx
@@ -23,7 +23,7 @@ export function AiConfigureSeerQuotaSidebar({
   const subscription = useSubscription();
 
   useRouteAnalyticsParams({
-    seerNeedQuota: !aiConfig.hasAutofixQuota,
+    seerNeedQuota: aiConfig.isAutofixSetupLoading ? undefined : !aiConfig.hasAutofixQuota,
   });
 
   if (aiConfig.isAutofixSetupLoading) {

--- a/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.tsx
+++ b/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.tsx
@@ -6,6 +6,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconOpen} from 'sentry/icons/iconOpen';
 import {t} from 'sentry/locale';
+import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {AutofixContent} from 'sentry/views/issueDetails/sidebar/autofixSection';
 import type {AutofixContentProps} from 'sentry/views/issueDetails/sidebar/autofixSectionTypes';
@@ -20,6 +21,10 @@ export function AiConfigureSeerQuotaSidebar({
 }: AutofixContentProps) {
   const organization = useOrganization();
   const subscription = useSubscription();
+
+  useRouteAnalyticsParams({
+    seerNeedQuota: !aiConfig.hasAutofixQuota,
+  });
 
   if (aiConfig.isAutofixSetupLoading) {
     return <Placeholder height="160px" />;


### PR DESCRIPTION
Track whether users need org-level SCM setup, project-level repo linking, or Seer quota on the issue details page. These params feed into the issue details route analytics event.

The org/project setup params emit undefined while the onboarding check query is still loading to avoid false positives. The quota param is negated from hasAutofixQuota so true means the user needs quota.