### PR TITLE
build(deps): Bump eslint-plugin-react-you-might-not-need-an-effect to 1.0.1

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -959,8 +959,7 @@ export default typescript.config([
       'react-you-might-not-need-an-effect/no-pass-live-state-to-parent': 'off',
       'react-you-might-not-need-an-effect/no-pass-data-to-parent': 'off',
       'react-you-might-not-need-an-effect/no-initialize-state': 'off',
-      'react-you-might-not-need-an-effect/no-manage-parent': 'off',
-      'react-you-might-not-need-an-effect/no-empty-effect': 'off',
+      'react-you-might-not-need-an-effect/no-external-store-subscription': 'off',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
     "eslint-plugin-no-relative-import-paths": "^1.6.1",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "6.1.0",
-    "eslint-plugin-react-you-might-not-need-an-effect": "0.5.3",
+    "eslint-plugin-react-you-might-not-need-an-effect": "1.0.1",
     "eslint-plugin-regexp": "^3.0.0",
     "eslint-plugin-testing-library": "^7.16.2",
     "eslint-plugin-typescript-sort-keys": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -666,8 +666,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0(eslint@9.34.0(jiti@2.7.0))
       eslint-plugin-react-you-might-not-need-an-effect:
-        specifier: 0.5.3
-        version: 0.5.3(eslint@9.34.0(jiti@2.7.0))
+        specifier: 1.0.1
+        version: 1.0.1(eslint@9.34.0(jiti@2.7.0))
       eslint-plugin-regexp:
         specifier: ^3.0.0
         version: 3.0.0(eslint@9.34.0(jiti@2.7.0))
@@ -5514,8 +5514,8 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
-  eslint-plugin-react-you-might-not-need-an-effect@0.5.3:
-    resolution: {integrity: sha512-/tkUN71PIp5+LVSDb9y3MA4zMyjVGJojfWCeC2NSWhRRBbc0NRR8WnFXe2h3bw6tTcYMack/dlHME5YVu/0Fmw==}
+  eslint-plugin-react-you-might-not-need-an-effect@1.0.1:
+    resolution: {integrity: sha512-oOhQTYhor88Xp8RVytq25tvBfiAjU0r9SCDC51Qop+3Wg5BR1xGMAkM+/dV4MZbcMhdaU1L9bkv6LC95JmiTig==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       eslint: '>=8.40.0'
@@ -5559,16 +5559,6 @@ packages:
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  eslint-utils@3.0.0:
-    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
-    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
-    peerDependencies:
-      eslint: '>=5'
-
-  eslint-visitor-keys@2.1.0:
-    resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
-    engines: {node: '>=10'}
 
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
@@ -14560,10 +14550,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-you-might-not-need-an-effect@0.5.3(eslint@9.34.0(jiti@2.7.0)):
+  eslint-plugin-react-you-might-not-need-an-effect@1.0.1(eslint@9.34.0(jiti@2.7.0)):
     dependencies:
       eslint: 9.34.0(jiti@2.7.0)
-      eslint-utils: 3.0.0(eslint@9.34.0(jiti@2.7.0))
       globals: 16.3.0
 
   eslint-plugin-react@7.37.5(eslint@9.34.0(jiti@2.7.0)):
@@ -14648,13 +14637,6 @@ snapshots:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
-
-  eslint-utils@3.0.0(eslint@9.34.0(jiti@2.7.0)):
-    dependencies:
-      eslint: 9.34.0(jiti@2.7.0)
-      eslint-visitor-keys: 2.1.0
-
-  eslint-visitor-keys@2.1.0: {}
 
   eslint-visitor-keys@3.4.3: {}
 


### PR DESCRIPTION
Updates `eslint-plugin-react-you-might-not-need-an-effect` from 0.5.3 to 1.0.1.

The 1.0 release removed two rules and added one, so the flat config needs adjusting alongside the bump:

- Removed the `no-empty-effect` and `no-manage-parent` rule references. Both rules no longer exist in the plugin, and ESLint errors on references to unknown rules.
- Added `no-external-store-subscription: 'off'`. This is a new rule that the plugin's `recommended` config enables by default; since this config block spreads `...configs.recommended` and intentionally enables only `no-derived-state`, the new rule is disabled to keep current behavior.

No change to which violations are enforced — `no-derived-state` remains the only active rule. Note that 1.0.1 has improved `no-derived-state` detection, so CI may surface new violations in existing code that the older version missed.