### PR TITLE
fix(analytics): Use the same DEBUG_ANALYTICS localstorage key in prod & dev

### DIFF
--- a/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
+++ b/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
@@ -66,8 +66,7 @@ const startAnalyticsSession = () => {
 
 const getAnalyticsSessionId = () => sessionStorageWrapper.getItem(ANALYTICS_SESSION);
 
-const hasAnalyticsDebug = () =>
-  localStorageWrapper.getItem('DEBUG_ANALYTICS_GETSENTRY') === '1';
+const hasAnalyticsDebug = () => localStorageWrapper.getItem('DEBUG_ANALYTICS') === '1';
 
 const getCustomReferrer = () => {
   try {


### PR DESCRIPTION
This is the key that's documented in all the places, lets just keep it consistent. 

In prod people can also use https://chromewebstore.google.com/detail/amplitude-event-explorer/acehfjhnmhbmgkedjmjlobpgdicnhkbp

See:
- https://develop.sentry.dev/development-infrastructure/analytics/#testing-your-analytics-event
- https://github.com/getsentry/sentry/blob/master/.agents/skills/analytics/references/troubleshooting.md#debugging-locally