### PR TITLE
feat(core): Add xs size variant to Radio

### DIFF
--- a/static/app/components/core/radio/radio.mdx
+++ b/static/app/components/core/radio/radio.mdx
@@ -35,11 +35,12 @@ Use `<Radio>` for forms and settings where users must choose exactly one option 
 
 ## Sizes
 
-`<Radio>` comes in two sizes: `md` (default) and `sm` (small).
+`<Radio>` comes in three sizes: `md` (default), `sm` (small), and `xs` (extra small).
 
 export function SizesDemo() {
   const [md, setMd] = useState(true);
   const [sm, setSm] = useState(true);
+  const [xs, setXs] = useState(true);
   return (
     <Storybook.SideBySide>
       <Flex as="label" align="center" gap="sm">
@@ -49,6 +50,10 @@ export function SizesDemo() {
       <Flex as="label" align="center" gap="sm">
         Small
         <Radio size="sm" checked={sm} onClick={() => setSm(!sm)} />
+      </Flex>
+      <Flex as="label" align="center" gap="sm">
+        Extra small
+        <Radio size="xs" checked={xs} onClick={() => setXs(!xs)} />
       </Flex>
     </Storybook.SideBySide>
   );
@@ -61,6 +66,7 @@ export function SizesDemo() {
 ```jsx
 <Radio checked={checked} onChange={handleChange} />
 <Radio size="sm" checked={checked} onChange={handleChange} />
+<Radio size="xs" checked={checked} onChange={handleChange} />
 ```
 
 ## States

--- a/static/app/components/core/radio/radio.snapshots.tsx
+++ b/static/app/components/core/radio/radio.snapshots.tsx
@@ -9,7 +9,7 @@ const themes = {light: lightTheme, dark: darkTheme};
 
 describe('Radio', () => {
   describe.each(['light', 'dark'] as const)('theme-%s', themeName => {
-    it.snapshot.each<'sm' | 'md'>(['sm', 'md'])(
+    it.snapshot.each<'xs' | 'sm' | 'md'>(['xs', 'sm', 'md'])(
       'size-%s-unchecked',
       size => (
         <ThemeProvider theme={themes[themeName]}>
@@ -21,7 +21,7 @@ describe('Radio', () => {
       size => ({tags: {size, area: 'core'}})
     );
 
-    it.snapshot.each<'sm' | 'md'>(['sm', 'md'])(
+    it.snapshot.each<'xs' | 'sm' | 'md'>(['xs', 'sm', 'md'])(
       'size-%s-checked',
       size => (
         <ThemeProvider theme={themes[themeName]}>

--- a/static/app/components/core/radio/radio.tsx
+++ b/static/app/components/core/radio/radio.tsx
@@ -10,10 +10,14 @@ interface RadioProps extends Omit<
 > {
   nativeSize?: React.InputHTMLAttributes<HTMLInputElement>['size'];
   ref?: React.Ref<HTMLInputElement>;
-  size?: 'sm' | 'md';
+  size?: 'xs' | 'sm' | 'md';
 }
 
 const radioConfig = {
+  xs: {
+    outerSize: '12px',
+    innerSize: '6px',
+  },
   sm: {
     outerSize: '20px',
     innerSize: '10px',


### PR DESCRIPTION
## TLDR

Adds an `xs` size variant to the core `Radio` component with a 12px outer diameter and a 6px inner dot, alongside the existing `sm` (20px) and `md` (24px) sizes.

This new variant is going to be used in the context of an updated version of the project creation flow, the design of which calls for a 12px text label next to a radio button with an outer width of 12px.  If I were to use existing sm radio button, it would appear out of proportion with the text label.

## Details

The new `xs` variant is wired through the `size` prop union and `radioConfig`. Its 6px inner dot keeps the 1:2 inner-to-outer ratio used by the other sizes. The variant is covered in the snapshot tests across both themes and checked/unchecked states, and documented in the component stories.

The auto-generated Code Connect mapping (`radio.figma.tsx`) is left unchanged, since its `size` enum maps to Figma component property values that cannot be added from code.
