### PR TITLE
ref(project-creation): Polish the SCM alert frequency component

### DIFF
--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -1,8 +1,9 @@
 import {Input} from '@sentry/scraps/input';
-import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Text} from '@sentry/scraps/text';
 
+import {IconInfo} from 'sentry/icons/iconInfo';
 import {t} from 'sentry/locale';
 import {ScmAlertOptionCard} from 'sentry/views/onboarding/components/scmAlertOptionCard';
 import {
@@ -31,72 +32,71 @@ export function ScmAlertFrequency({
   const isLaterSelected = alertSetting === RuleAction.CREATE_ALERT_LATER;
 
   return (
-    <Stack gap="xl" role="radiogroup" aria-label={t('Alert frequency')}>
-      <ScmAlertOptionCard
-        label={t('High priority issues')}
-        isSelected={isDefaultSelected}
-        onSelect={() => onFieldChange('alertSetting', RuleAction.DEFAULT_ALERT)}
-      />
+    <Stack gap="lg">
+      <Stack gap="md" role="radiogroup" aria-label={t('Alert frequency')}>
+        <ScmAlertOptionCard
+          label={t('High priority issues')}
+          description={t('Alert on new, regressed, and escalating issues')}
+          isSelected={isDefaultSelected}
+          onSelect={() => onFieldChange('alertSetting', RuleAction.DEFAULT_ALERT)}
+        />
 
-      <ScmAlertOptionCard
-        label={t('Custom')}
-        isSelected={isCustomSelected}
-        onSelect={() => onFieldChange('alertSetting', RuleAction.CUSTOMIZED_ALERTS)}
-      >
-        <Container paddingLeft="2xl">
-          <Stack
-            gap="lg"
-            padding="sm 0 0 2xl"
-            borderLeft={isCustomSelected ? 'accent' : 'secondary'}
-          >
-            <Stack gap="xs">
-              <Container>
+        <ScmAlertOptionCard
+          label={t('Custom threshold')}
+          isSelected={isCustomSelected}
+          onSelect={() => onFieldChange('alertSetting', RuleAction.CUSTOMIZED_ALERTS)}
+        >
+          {isCustomSelected && (
+            <Stack gap="lg">
+              <Stack gap="xs">
                 <Text size="md" density="comfortable">
                   {t('When there are more than')}
                 </Text>
-              </Container>
-              <Grid gap="md" columns=".35fr .65fr">
-                <Input
-                  size="sm"
-                  type="number"
-                  min="0"
-                  placeholder="10"
-                  value={threshold}
-                  onChange={e => onFieldChange('threshold', e.target.value)}
-                  disabled={!isCustomSelected}
-                />
-                <Select
-                  size="sm"
-                  value={metric}
-                  options={METRIC_CHOICES}
-                  onChange={option => onFieldChange('metric', option.value)}
-                  disabled={!isCustomSelected}
-                />
-              </Grid>
-            </Stack>
-            <Stack gap="xs">
-              <Container>
+                <Grid gap="xl" columns="1fr 1fr">
+                  <Input
+                    size="md"
+                    type="number"
+                    min="0"
+                    placeholder="10"
+                    value={threshold}
+                    onChange={e => onFieldChange('threshold', e.target.value)}
+                  />
+                  <Select
+                    size="md"
+                    value={metric}
+                    options={METRIC_CHOICES}
+                    onChange={option => onFieldChange('metric', option.value)}
+                  />
+                </Grid>
+              </Stack>
+              <Stack gap="xs">
                 <Text size="md" density="comfortable">
                   {t('a unique error in')}
                 </Text>
-              </Container>
-              <Select
-                size="sm"
-                value={interval}
-                options={INTERVAL_CHOICES}
-                onChange={option => onFieldChange('interval', option.value)}
-                disabled={!isCustomSelected}
-              />
+                <Select
+                  size="md"
+                  value={interval}
+                  options={INTERVAL_CHOICES}
+                  onChange={option => onFieldChange('interval', option.value)}
+                />
+              </Stack>
             </Stack>
-          </Stack>
-        </Container>
-      </ScmAlertOptionCard>
+          )}
+        </ScmAlertOptionCard>
 
-      <ScmAlertOptionCard
-        label={t("I'll create my own alerts later")}
-        isSelected={isLaterSelected}
-        onSelect={() => onFieldChange('alertSetting', RuleAction.CREATE_ALERT_LATER)}
-      />
+        <ScmAlertOptionCard
+          label={t("I'll set up alerts later")}
+          isSelected={isLaterSelected}
+          onSelect={() => onFieldChange('alertSetting', RuleAction.CREATE_ALERT_LATER)}
+        />
+      </Stack>
+
+      <Flex gap="sm" align="center">
+        <IconInfo size="sm" variant="secondary" />
+        <Text variant="secondary" size="sm" density="comfortable">
+          {t('You can always change alerts after project creation')}
+        </Text>
+      </Flex>
     </Stack>
   );
 }

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -66,6 +66,7 @@ export function ScmAlertFrequency({
                     value={metric}
                     options={METRIC_CHOICES}
                     onChange={option => onFieldChange('metric', option.value)}
+                    menuPortalTarget={document.body}
                   />
                 </Grid>
               </Stack>
@@ -78,6 +79,7 @@ export function ScmAlertFrequency({
                   value={interval}
                   options={INTERVAL_CHOICES}
                   onChange={option => onFieldChange('interval', option.value)}
+                  menuPortalTarget={document.body}
                 />
               </Stack>
             </Stack>

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -94,8 +94,8 @@ export function ScmAlertFrequency({
       </Stack>
 
       <Flex gap="sm" align="center">
-        <IconInfo size="sm" variant="secondary" />
-        <Text variant="secondary" size="sm" density="comfortable">
+        <IconInfo size="md" variant="secondary" />
+        <Text variant="secondary" size="md" density="comfortable">
           {t('You can always change alerts after project creation')}
         </Text>
       </Flex>

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -52,7 +52,7 @@ export function ScmAlertFrequency({
                 <Text size="md" density="comfortable">
                   {t('When there are more than')}
                 </Text>
-                <Grid gap="xl" columns="1fr 1fr">
+                <Grid gap="xl" columns={{sm: '1fr', md: '1fr 1fr'}}>
                   <Input
                     size="md"
                     type="number"

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -1,4 +1,4 @@
-import {Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Grid, Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
 
@@ -10,27 +10,41 @@ interface ScmAlertOptionCardProps {
   label: string;
   onSelect: () => void;
   children?: React.ReactNode;
+  description?: string;
 }
 
 export function ScmAlertOptionCard({
   label,
+  description,
   isSelected,
   onSelect,
   children,
 }: ScmAlertOptionCardProps) {
   return (
-    <Stack gap="lg">
-      <ScmCardButton role="radio" aria-checked={isSelected} onClick={onSelect}>
-        <ScmSelectableContainer isSelected={isSelected} padding="lg">
-          <Grid gap="md" align="center" columns="min-content 1fr">
+    <ScmSelectableContainer isSelected={isSelected} padding="lg">
+      <Stack gap="md">
+        <ScmCardButton
+          role="radio"
+          aria-checked={isSelected}
+          onClick={onSelect}
+          style={{width: '100%'}}
+        >
+          <Grid gap="md" align="start" columns="min-content 1fr">
             <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
-            <Text bold={isSelected} size="md" density="comfortable">
-              {label}
-            </Text>
+            <Stack gap="xs">
+              <Text bold={isSelected} size="md" density="comfortable">
+                {label}
+              </Text>
+              {description && (
+                <Text variant="secondary" size="sm" density="comfortable">
+                  {description}
+                </Text>
+              )}
+            </Stack>
           </Grid>
-        </ScmSelectableContainer>
-      </ScmCardButton>
-      {children}
-    </Stack>
+        </ScmCardButton>
+        {children && <Container paddingLeft="2xl">{children}</Container>}
+      </Stack>
+    </ScmSelectableContainer>
   );
 }

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -1,3 +1,5 @@
+import {AnimatePresence, motion} from 'framer-motion';
+
 import {Container, Grid, Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
@@ -22,7 +24,7 @@ export function ScmAlertOptionCard({
 }: ScmAlertOptionCardProps) {
   return (
     <ScmSelectableContainer isSelected={isSelected} padding="lg">
-      <Stack gap="md">
+      <Stack gap="0">
         <ScmCardButton
           role="radio"
           aria-checked={isSelected}
@@ -43,7 +45,28 @@ export function ScmAlertOptionCard({
             </Stack>
           </Grid>
         </ScmCardButton>
-        {children && <Container paddingLeft="2xl">{children}</Container>}
+        {/* Selecting the card expands its body; the height tween mirrors
+            ScmCollapsibleSection so cards in scmCreateProject's
+            layout="position" group reflow smoothly. initial={false} keeps a
+            preselected card expanded without animating on mount. */}
+        <AnimatePresence initial={false}>
+          {children && (
+            <motion.div
+              key="content"
+              initial={{height: 0, opacity: 0}}
+              animate={{height: 'auto', opacity: 1}}
+              exit={{height: 0, opacity: 0}}
+              transition={{duration: 0.2, ease: 'easeOut'}}
+              style={{overflow: 'hidden', width: '100%'}}
+            >
+              {/* padding-top lives inside the animated body so the gap collapses
+                  with the height tween; padding-left aligns it under the label. */}
+              <Container paddingTop="md" paddingLeft="2xl">
+                {children}
+              </Container>
+            </motion.div>
+          )}
+        </AnimatePresence>
       </Stack>
     </ScmSelectableContainer>
   );

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -73,11 +73,11 @@ export function ScmAlertOptionCard({
   );
 }
 
-// The body indents to line up under the label (button padding + radio width +
-// grid column gap) and carries its own right/bottom padding so input focus
-// rings clear the animated overflow:hidden bounds. The top gap comes from the
-// header button's own bottom padding.
+// The body indents to line up under the label (button padding + the md radio's
+// 24px width + grid column gap) and carries its own right/bottom padding so
+// input focus rings clear the animated overflow:hidden bounds. The top gap
+// comes from the header button's own bottom padding.
 const ExpandedBody = styled('div')`
   padding: 0 ${p => p.theme.space.lg} ${p => p.theme.space.lg};
-  padding-left: calc(${p => p.theme.space.lg} + 20px + ${p => p.theme.space.md});
+  padding-left: calc(${p => p.theme.space.lg} + 24px + ${p => p.theme.space.md});
 `;

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -37,7 +37,7 @@ export function ScmAlertOptionCard({
           <Container padding="lg">
             <Grid
               columns="min-content 1fr"
-              gap="xs md"
+              gap="0 md"
               align="center"
               areas={`
                 "radio label"
@@ -45,16 +45,16 @@ export function ScmAlertOptionCard({
               `}
             >
               <Container area="radio">
-                <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
+                <Radio size="md" readOnly checked={isSelected} tabIndex={-1} />
               </Container>
               <Container area="label">
-                <Text bold size="sm" density="comfortable">
+                <Text bold size="md" density="comfortable">
                   {label}
                 </Text>
               </Container>
               {description && (
                 <Container area="description">
-                  <Text variant="secondary" size="sm" density="comfortable">
+                  <Text variant="secondary" size="md" density="comfortable">
                     {description}
                   </Text>
                 </Container>

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 
 import {Container, Grid, Stack} from '@sentry/scraps/layout';
@@ -23,27 +24,43 @@ export function ScmAlertOptionCard({
   children,
 }: ScmAlertOptionCardProps) {
   return (
-    <ScmSelectableContainer isSelected={isSelected} padding="lg">
+    <ScmSelectableContainer isSelected={isSelected}>
       <Stack gap="0">
+        {/* The padding lives on the button (not the card) so the whole header,
+            edge to edge, is part of the click target. */}
         <ScmCardButton
           role="radio"
           aria-checked={isSelected}
           onClick={onSelect}
           style={{width: '100%'}}
         >
-          <Grid gap="md" align="start" columns="min-content 1fr">
-            <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
-            <Stack gap="xs">
-              <Text bold={isSelected} size="md" density="comfortable">
-                {label}
-              </Text>
-              {description && (
-                <Text variant="secondary" size="sm" density="comfortable">
-                  {description}
+          <Container padding="lg">
+            <Grid
+              columns="min-content 1fr"
+              gap="xs md"
+              align="center"
+              areas={`
+                "radio label"
+                ".     description"
+              `}
+            >
+              <Container area="radio">
+                <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
+              </Container>
+              <Container area="label">
+                <Text bold={isSelected} size="md" density="comfortable">
+                  {label}
                 </Text>
+              </Container>
+              {description && (
+                <Container area="description">
+                  <Text variant="secondary" size="sm" density="comfortable">
+                    {description}
+                  </Text>
+                </Container>
               )}
-            </Stack>
-          </Grid>
+            </Grid>
+          </Container>
         </ScmCardButton>
         {/* Selecting the card expands its body; the height tween mirrors
             ScmCollapsibleSection so cards in scmCreateProject's
@@ -59,11 +76,7 @@ export function ScmAlertOptionCard({
               transition={{duration: 0.2, ease: 'easeOut'}}
               style={{overflow: 'hidden', width: '100%'}}
             >
-              {/* padding-top lives inside the animated body so the gap collapses
-                  with the height tween; padding-left aligns it under the label. */}
-              <Container paddingTop="md" paddingLeft="2xl">
-                {children}
-              </Container>
+              <ExpandedBody>{children}</ExpandedBody>
             </motion.div>
           )}
         </AnimatePresence>
@@ -71,3 +84,12 @@ export function ScmAlertOptionCard({
     </ScmSelectableContainer>
   );
 }
+
+// The body indents to line up under the label (button padding + radio width +
+// grid column gap) and carries its own right/bottom padding so input focus
+// rings clear the animated overflow:hidden bounds. The top gap comes from the
+// header button's own bottom padding.
+const ExpandedBody = styled('div')`
+  padding: 0 ${p => p.theme.space.lg} ${p => p.theme.space.lg};
+  padding-left: calc(${p => p.theme.space.lg} + 20px + ${p => p.theme.space.md});
+`;

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -72,10 +72,10 @@ export function ScmAlertOptionCard({
   );
 }
 
-// The body indents to line up under the label (button padding + the xs radio's
-// 12px width + grid column gap) and carries its own right/bottom padding so
-// input focus rings clear the animated overflow:hidden bounds. The top gap
-// comes from the header button's own bottom padding.
+// The body indents to line up under the label (header button padding + the xs
+// radio's 12px width + grid column gap) and insets its right/bottom to match
+// the header's padding, since the card itself carries none. The top gap comes
+// from the header button's own bottom padding.
 const ExpandedBody = styled('div')`
   padding: 0 ${p => p.theme.space.lg} ${p => p.theme.space.lg};
   padding-left: calc(${p => p.theme.space.lg} + 12px + ${p => p.theme.space.md});

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
 
@@ -38,23 +38,22 @@ export function ScmAlertOptionCard({
             <Grid
               columns="min-content 1fr"
               gap="0 md"
-              align="center"
               areas={`
                 "radio label"
                 ".     description"
               `}
             >
-              <Container area="radio">
-                <Radio size="md" readOnly checked={isSelected} tabIndex={-1} />
-              </Container>
+              <Flex area="radio" align="center">
+                <Radio size="xs" readOnly checked={isSelected} tabIndex={-1} />
+              </Flex>
               <Container area="label">
-                <Text bold size="md" density="comfortable">
+                <Text bold size="sm" density="comfortable">
                   {label}
                 </Text>
               </Container>
               {description && (
                 <Container area="description">
-                  <Text variant="secondary" size="md" density="comfortable">
+                  <Text variant="secondary" size="sm" density="comfortable">
                     {description}
                   </Text>
                 </Container>
@@ -73,11 +72,11 @@ export function ScmAlertOptionCard({
   );
 }
 
-// The body indents to line up under the label (button padding + the md radio's
-// 24px width + grid column gap) and carries its own right/bottom padding so
+// The body indents to line up under the label (button padding + the xs radio's
+// 12px width + grid column gap) and carries its own right/bottom padding so
 // input focus rings clear the animated overflow:hidden bounds. The top gap
 // comes from the header button's own bottom padding.
 const ExpandedBody = styled('div')`
   padding: 0 ${p => p.theme.space.lg} ${p => p.theme.space.lg};
-  padding-left: calc(${p => p.theme.space.lg} + 24px + ${p => p.theme.space.md});
+  padding-left: calc(${p => p.theme.space.lg} + 12px + ${p => p.theme.space.md});
 `;

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
-import {AnimatePresence, motion} from 'framer-motion';
 
 import {Container, Grid, Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
 
 import {ScmCardButton} from 'sentry/views/onboarding/components/scmCardButton';
+import {ScmCollapsibleReveal} from 'sentry/views/onboarding/components/scmCollapsibleReveal';
 import {ScmSelectableContainer} from 'sentry/views/onboarding/components/scmSelectableContainer';
 
 interface ScmAlertOptionCardProps {
@@ -48,7 +48,7 @@ export function ScmAlertOptionCard({
                 <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
               </Container>
               <Container area="label">
-                <Text bold={isSelected} size="md" density="comfortable">
+                <Text bold size="sm" density="comfortable">
                   {label}
                 </Text>
               </Container>
@@ -62,24 +62,12 @@ export function ScmAlertOptionCard({
             </Grid>
           </Container>
         </ScmCardButton>
-        {/* Selecting the card expands its body; the height tween mirrors
-            ScmCollapsibleSection so cards in scmCreateProject's
-            layout="position" group reflow smoothly. initial={false} keeps a
-            preselected card expanded without animating on mount. */}
-        <AnimatePresence initial={false}>
-          {children && (
-            <motion.div
-              key="content"
-              initial={{height: 0, opacity: 0}}
-              animate={{height: 'auto', opacity: 1}}
-              exit={{height: 0, opacity: 0}}
-              transition={{duration: 0.2, ease: 'easeOut'}}
-              style={{overflow: 'hidden', width: '100%'}}
-            >
-              <ExpandedBody>{children}</ExpandedBody>
-            </motion.div>
-          )}
-        </AnimatePresence>
+        {/* Selecting the card expands its body; ScmCollapsibleReveal's height
+            tween lets cards in scmCreateProject's layout="position" group
+            reflow smoothly. */}
+        <ScmCollapsibleReveal open={Boolean(children)}>
+          <ExpandedBody>{children}</ExpandedBody>
+        </ScmCollapsibleReveal>
       </Stack>
     </ScmSelectableContainer>
   );

--- a/static/app/views/onboarding/components/scmCollapsibleReveal.tsx
+++ b/static/app/views/onboarding/components/scmCollapsibleReveal.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useRef, useState} from 'react';
 import {AnimatePresence, motion} from 'framer-motion';
 
 interface ScmCollapsibleRevealProps {
@@ -24,6 +24,11 @@ export function ScmCollapsibleReveal({open, id, children}: ScmCollapsibleRevealP
   const [overflow, setOverflow] = useState<'hidden' | 'visible'>(
     open ? 'visible' : 'hidden'
   );
+  // On collapse, AnimatePresence keeps a frozen snapshot of the last open
+  // render, so a closure over `open` reads a stale `true` and never resets
+  // overflow. Read the live value through a ref so completion settles correctly.
+  const openRef = useRef(open);
+  openRef.current = open;
 
   return (
     <AnimatePresence initial={false}>
@@ -37,9 +42,7 @@ export function ScmCollapsibleReveal({open, id, children}: ScmCollapsibleRevealP
           transition={{duration: 0.2, ease: 'easeOut'}}
           onAnimationStart={() => setOverflow('hidden')}
           onAnimationComplete={() => {
-            if (open) {
-              setOverflow('visible');
-            }
+            setOverflow(openRef.current ? 'visible' : 'hidden');
           }}
           style={{overflow, width: '100%'}}
         >

--- a/static/app/views/onboarding/components/scmCollapsibleReveal.tsx
+++ b/static/app/views/onboarding/components/scmCollapsibleReveal.tsx
@@ -1,0 +1,36 @@
+import {AnimatePresence, motion} from 'framer-motion';
+
+interface ScmCollapsibleRevealProps {
+  children: React.ReactNode;
+  /** When true the content is shown; toggling tweens height and opacity. */
+  open: boolean;
+  /** Forwarded to the animated element, e.g. as an aria-controls target. */
+  id?: string;
+}
+
+/**
+ * Reveals or hides content with a height + fade tween. Shared by
+ * ScmCollapsibleSection and ScmAlertOptionCard so their expand/collapse timing
+ * stays in sync. Animating height (rather than display) lets sibling cards in a
+ * framer-motion layout="position" group reflow via normal document flow.
+ * initial={false} renders the open state without animating on mount.
+ */
+export function ScmCollapsibleReveal({open, id, children}: ScmCollapsibleRevealProps) {
+  return (
+    <AnimatePresence initial={false}>
+      {open && (
+        <motion.div
+          key="content"
+          id={id}
+          initial={{height: 0, opacity: 0}}
+          animate={{height: 'auto', opacity: 1}}
+          exit={{height: 0, opacity: 0}}
+          transition={{duration: 0.2, ease: 'easeOut'}}
+          style={{overflow: 'hidden', width: '100%'}}
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/static/app/views/onboarding/components/scmCollapsibleReveal.tsx
+++ b/static/app/views/onboarding/components/scmCollapsibleReveal.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {AnimatePresence, motion} from 'framer-motion';
 
 interface ScmCollapsibleRevealProps {
@@ -16,6 +17,14 @@ interface ScmCollapsibleRevealProps {
  * initial={false} renders the open state without animating on mount.
  */
 export function ScmCollapsibleReveal({open, id, children}: ScmCollapsibleRevealProps) {
+  // overflow:hidden is needed while the height tween runs so the content clips
+  // cleanly, but kept on it would also clip anything that extends past the
+  // settled bounds, e.g. a focus ring at the edge or an open select menu below.
+  // Switch to visible once open and settled, back to hidden whenever animating.
+  const [overflow, setOverflow] = useState<'hidden' | 'visible'>(
+    open ? 'visible' : 'hidden'
+  );
+
   return (
     <AnimatePresence initial={false}>
       {open && (
@@ -26,7 +35,13 @@ export function ScmCollapsibleReveal({open, id, children}: ScmCollapsibleRevealP
           animate={{height: 'auto', opacity: 1}}
           exit={{height: 0, opacity: 0}}
           transition={{duration: 0.2, ease: 'easeOut'}}
-          style={{overflow: 'hidden', width: '100%'}}
+          onAnimationStart={() => setOverflow('hidden')}
+          onAnimationComplete={() => {
+            if (open) {
+              setOverflow('visible');
+            }
+          }}
+          style={{overflow, width: '100%'}}
         >
           {children}
         </motion.div>

--- a/static/app/views/onboarding/components/scmCollapsibleSection.tsx
+++ b/static/app/views/onboarding/components/scmCollapsibleSection.tsx
@@ -1,12 +1,12 @@
 import {useId, useState} from 'react';
 import styled from '@emotion/styled';
-import {AnimatePresence, motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {IconChevron} from 'sentry/icons';
+import {ScmCollapsibleReveal} from 'sentry/views/onboarding/components/scmCollapsibleReveal';
 
 interface ScmCollapsibleSectionProps {
   children: React.ReactNode;
@@ -64,21 +64,9 @@ export function ScmCollapsibleSection({
         </ToggleButton>
         {trailing}
       </Flex>
-      <AnimatePresence initial={false}>
-        {expanded && (
-          <motion.div
-            id={contentId}
-            key="content"
-            initial={{height: 0, opacity: 0}}
-            animate={{height: 'auto', opacity: 1}}
-            exit={{height: 0, opacity: 0}}
-            transition={{duration: 0.2, ease: 'easeOut'}}
-            style={{overflow: 'hidden', width: '100%'}}
-          >
-            <Content width="100%">{children}</Content>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <ScmCollapsibleReveal open={expanded} id={contentId}>
+        <Content width="100%">{children}</Content>
+      </ScmCollapsibleReveal>
     </Stack>
   );
 }

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -115,8 +115,14 @@ describe('ScmProjectDetails', () => {
     });
 
     expect(await screen.findByText('High priority issues')).toBeInTheDocument();
-    expect(screen.getByText('Custom')).toBeInTheDocument();
-    expect(screen.getByText("I'll create my own alerts later")).toBeInTheDocument();
+    expect(
+      screen.getByText('Alert on new, regressed, and escalating issues')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Custom threshold')).toBeInTheDocument();
+    expect(screen.getByText("I'll set up alerts later")).toBeInTheDocument();
+    expect(
+      screen.getByText('You can always change alerts after project creation')
+    ).toBeInTheDocument();
   });
 
   it('re-derives the fields when the host clears the form', () => {

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -281,7 +281,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
             >
               <Layout.Title>{t('Create a new project')}</Layout.Title>
 
-              <MotionStack paddingBottom="lg" gap="md" layout="position">
+              <MotionStack gap="md" layout="position">
                 <Heading as="h1">{t('Create a project')}</Heading>
                 <Text variant="secondary" density="comfortable">
                   {tct(

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -744,12 +744,10 @@ class ScmOnboardingTest(AcceptanceTestCase):
             self.browser.click('[aria-label="Back"]')
             self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
 
-            # Switch alerts from "High priority issues" to "create later".
-            self.browser.click(
-                xpath='//button[@role="radio"][contains(., "create my own alerts later")]'
-            )
+            # Switch alerts from "High priority issues" to "set up later".
+            self.browser.click(xpath='//button[@role="radio"][contains(., "set up alerts later")]')
             self.browser.wait_until(
-                xpath='//button[@role="radio"][@aria-checked="true"][contains(., "create my own alerts later")]'
+                xpath='//button[@role="radio"][@aria-checked="true"][contains(., "set up alerts later")]'
             )
             self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
             self.browser.click(xpath='//button[contains(., "Create project")]')


### PR DESCRIPTION
## TLDR

Reworks the SCM project-creation alert-frequency component to match the updated design: bordered radio cards, the custom-threshold form expanding inside the selected card with an animated reveal, and a set of layout and accessibility fixes on top.

## Details

- Aligns the alert options with the new design: a description line under "High priority issues", equal-width threshold input and metric select, a footer note that alerts can be changed after project creation, and updated copy ("Custom threshold", "I'll set up alerts later").
- Moves the custom-threshold form inside the selected card and mounts it only when selected, animating its height with the same tween ScmCollapsibleSection uses so cards in scmCreateProject's layout="position" group reflow smoothly. That tween is extracted into a shared ScmCollapsibleReveal consumed by both components.
- Portals the threshold and interval select menus to the document body so they are not clipped or flipped by the card and animation overflow bounds.
- Fixes the card click target so the whole collapsed card is clickable, keeps input focus rings clear of the animation overflow bounds, and lays the radio, label, and description out in a 2x2 grid so the radio centers on the label row.
- Stacks the custom-threshold fields into a single column below the md breakpoint.
- Uses scraps md sizing across the component since the design's sizes do not map cleanly to scraps tokens.

## Stack

Continues the VDY-77 project-creation UI polish work. Base branch is jaygoss/vdy-77-project-creation-ui-polish-cont (#118193).
