### PR TITLE
feat(GALE): Invalidate derived data on merge

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -304,6 +304,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:issue-activity-feed-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new stack trace component for issue details
     manager.add("organizations:issue-details-new-stack-trace", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable invalidating group derived data when groups are merged
+    manager.add("organizations:hard-delete-derived-data-invalidation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable double-reading from EAP for issue feed search queries
     manager.add("organizations:issue-feed.eap-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Remove trace and breadcrumbs from issue summary input

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -84,7 +84,7 @@ def merge_groups(
         )
 
     try:
-        group = Group.objects.select_related("project").get(id=from_object_id)
+        group = Group.objects.select_related("project__organization").get(id=from_object_id)
     except Group.DoesNotExist:
         from_object_ids.remove(from_object_id)
 
@@ -200,7 +200,7 @@ def merge_groups(
             # hard delete derived data on the new group - it will be rebuilt when the next action is processed
             if features.has(
                 "organizations:hard-delete-derived-data-invalidation",
-                new_group.project.organization,
+                group.project.organization,
             ):
                 invalidate_group_derived_data(new_group.id)
 

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -210,7 +210,7 @@ def merge_groups(
     else:
         if features.has(
             "organizations:hard-delete-derived-data-invalidation",
-            new_group.project.organization,
+            group.project.organization,
         ):
             # hard delete derived data on the new group - it will be rebuilt when the next action is processed
             invalidate_group_derived_data(new_group.id)

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -8,8 +8,9 @@ from django.db.models import F
 from django.db.models.functions import Coalesce
 from taskbroker_client.retry import Retry
 
-from sentry import eventstream, similarity, tsdb
+from sentry import eventstream, features, similarity, tsdb
 from sentry.db.models.base import Model
+from sentry.issues.derived.processing import invalidate_group_derived_data
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.group import Group
 from sentry.silo.base import SiloMode
@@ -195,6 +196,13 @@ def merge_groups(
                     scope.set_extra("new_group_id", new_group.id)
                     scope.set_extra("old_group_id", group.id)
                     sentry_sdk.capture_exception(e, level="warning")
+
+            # hard delete derived data on the new group - it will be rebuilt when the next action is processed
+            if features.has(
+                "organizations:hard-delete-derived-data-invalidation",
+                new_group.project.organization,
+            ):
+                invalidate_group_derived_data(new_group.id)
 
     if from_object_ids:
         # This task is recursed until `from_object_ids` is empty and all

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -197,13 +197,6 @@ def merge_groups(
                     scope.set_extra("old_group_id", group.id)
                     sentry_sdk.capture_exception(e, level="warning")
 
-            # hard delete derived data on the new group - it will be rebuilt when the next action is processed
-            if features.has(
-                "organizations:hard-delete-derived-data-invalidation",
-                group.project.organization,
-            ):
-                invalidate_group_derived_data(new_group.id)
-
     if from_object_ids:
         # This task is recursed until `from_object_ids` is empty and all
         # "from" groups have merged into the `to_group_id`.
@@ -214,9 +207,17 @@ def merge_groups(
             recursed=True,
             eventstream_state=eventstream_state,
         )
-    elif eventstream_state:
-        # All `from_object_ids` have been merged!
-        eventstream.backend.end_merge(eventstream_state)
+    else:
+        if features.has(
+            "organizations:hard-delete-derived-data-invalidation",
+            new_group.project.organization,
+        ):
+            # hard delete derived data on the new group - it will be rebuilt when the next action is processed
+            invalidate_group_derived_data(new_group.id)
+
+        if eventstream_state:
+            # All `from_object_ids` have been merged!
+            eventstream.backend.end_merge(eventstream_state)
 
     return True
 

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -60,7 +60,10 @@ def merge_groups(
     from_object_id = from_object_ids[0]
 
     try:
-        new_group, _ = get_group_with_redirect(to_object_id)
+        new_group, _ = get_group_with_redirect(
+            to_object_id,
+            queryset=Group.objects.select_related("project__organization"),
+        )
     except Group.DoesNotExist:
         logger.warning(
             "group.malformed.invalid_id",
@@ -84,7 +87,7 @@ def merge_groups(
         )
 
     try:
-        group = Group.objects.select_related("project__organization").get(id=from_object_id)
+        group = Group.objects.select_related("project").get(id=from_object_id)
     except Group.DoesNotExist:
         from_object_ids.remove(from_object_id)
 
@@ -210,7 +213,7 @@ def merge_groups(
     else:
         if features.has(
             "organizations:hard-delete-derived-data-invalidation",
-            group.project.organization,
+            new_group.project.organization,
         ):
             # hard delete derived data on the new group - it will be rebuilt when the next action is processed
             invalidate_group_derived_data(new_group.id)

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest.mock import patch
 
 from sentry import buffer, eventstream
+from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.group import Group
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.groupmeta import GroupMeta
@@ -13,6 +14,7 @@ from sentry.tasks.merge import merge_groups
 from sentry.tasks.post_process import fetch_buffered_group_stats
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.utils import redis
 
@@ -221,6 +223,20 @@ class MergeGroupTest(TestCase, SnubaTestCase):
         fetch_buffered_group_stats(new_group)
         assert new_group.times_seen_pending == 3
         assert new_group.times_seen_with_pending == 168
+
+    @with_feature("organizations:hard-delete-derived-data-invalidation")
+    def test_merge_invalidates_derived_data(self) -> None:
+        project = self.create_project()
+        old_group = self.create_group(project)
+        new_group = self.create_group(project)
+
+        GroupDerivedData.objects.create(group=new_group)
+
+        with self.tasks():
+            merge_groups([old_group.id], new_group.id)
+
+        assert Group.objects.filter(id=old_group.id).exists() is False
+        assert GroupDerivedData.objects.filter(group_id=new_group.id).exists() is False
 
     @mock_redis_buffer()
     def test_merge_original_group_id(self) -> None:


### PR DESCRIPTION
Experimental option for handling derived data after groups have been merged - hard delete the derived data so that when the next `GroupActionLogEntry` (GALE) is processed, derived data will replay all of the GALE entries from epoch and regenerate the result to include the merged actions as well (as opposed to continuing from the current cursor and not considering the merged in group's actions). 

We may not go with this long term but it's not hooked up to anything yet and is the easiest option to implement.