### PR TITLE
feat: Support 'acks' kafka producer config

### DIFF
--- a/src/sentry/utils/kafka_config.py
+++ b/src/sentry/utils/kafka_config.py
@@ -32,6 +32,7 @@ SUPPORTED_KAFKA_CONFIGURATION = (
     "ssl.keystore.location",
     "ssl.keystore.password",
     "ssl.sigalgs.list",
+    "acks",
 )
 COMMON_SECTION = "common"
 PRODUCERS_SECTION = "producers"


### PR DESCRIPTION
Adds `acks` to the list of supported Kafka configuration keys in `kafka_config.py`, so it can be set on producers via the standard Kafka config plumbing.

ref inc-2272