### PR TITLE
feat(seer-infra-telemetry): Add Datadog PAT connect flow to monitoring providers UI

### DIFF
--- a/static/gsApp/views/seerAutomation/components/datadogPatConnectModal.tsx
+++ b/static/gsApp/views/seerAutomation/components/datadogPatConnectModal.tsx
@@ -1,0 +1,144 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+import {useMutation} from '@tanstack/react-query';
+
+import {Button} from '@sentry/scraps/button';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Input} from '@sentry/scraps/input';
+import {Flex} from '@sentry/scraps/layout';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Text} from '@sentry/scraps/text';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {t} from 'sentry/locale';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+
+const DATADOG_SITES = [
+  {value: 'datadoghq.com', label: 'datadoghq.com (US1)'},
+  {value: 'us3.datadoghq.com', label: 'us3.datadoghq.com (US3)'},
+  {value: 'us5.datadoghq.com', label: 'us5.datadoghq.com (US5)'},
+  {value: 'datadoghq.eu', label: 'datadoghq.eu (EU)'},
+  {value: 'ddog-gov.com', label: 'ddog-gov.com (US1-FED)'},
+  {value: 'us2.ddog-gov.com', label: 'us2.ddog-gov.com (US2-FED)'},
+  {value: 'ap1.datadoghq.com', label: 'ap1.datadoghq.com (AP1)'},
+  {value: 'ap2.datadoghq.com', label: 'ap2.datadoghq.com (AP2)'},
+];
+
+interface DatadogPatConnectModalProps extends ModalRenderProps {
+  onSuccess: () => void;
+  orgSlug: string;
+}
+
+export function DatadogPatConnectModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  onSuccess,
+  orgSlug,
+}: DatadogPatConnectModalProps) {
+  const [accessToken, setAccessToken] = useState('');
+  const [site, setSite] = useState('datadoghq.com');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const connectMutation = useMutation({
+    mutationFn: () =>
+      fetchMutation<void>({
+        method: 'POST',
+        url: getApiUrl(
+          '/organizations/$organizationIdOrSlug/monitoring-providers/$providerKey/',
+          {
+            path: {
+              organizationIdOrSlug: orgSlug,
+              providerKey: 'datadog_pat',
+            },
+          }
+        ),
+        data: {access_token: accessToken, site},
+      }),
+    onSuccess: () => {
+      closeModal();
+      onSuccess();
+    },
+    onError: (error: Error) => {
+      if (error instanceof RequestError && error.responseJSON?.detail) {
+        const detail = error.responseJSON.detail;
+        setFormError(typeof detail === 'string' ? detail : (detail.message ?? ''));
+      } else {
+        addErrorMessage(t('Failed to connect provider.'));
+      }
+    },
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFormError(null);
+    connectMutation.mutate();
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Header>
+        <h4>{t('Connect Datadog (Personal Access Token)')}</h4>
+      </Header>
+      <Body>
+        <Flex direction="column" gap="md">
+          <Flex direction="column" gap="xs">
+            <Text as="label" htmlFor="datadog-pat-token">
+              {t('Access Token')}
+            </Text>
+            <Input
+              id="datadog-pat-token"
+              type="password"
+              value={accessToken}
+              onChange={e => setAccessToken(e.target.value)}
+              placeholder={t('Enter your Datadog personal access token')}
+              aria-label={t('Access Token')}
+            />
+          </Flex>
+          <Flex direction="column" gap="xs">
+            <Text as="label">{t('Datadog Site')}</Text>
+            <StyledCompactSelect
+              value={site}
+              options={DATADOG_SITES}
+              onChange={option => setSite(String(option.value))}
+              trigger={triggerProps => (
+                <OverlayTrigger.Button {...triggerProps} aria-label={t('Datadog Site')} />
+              )}
+            />
+          </Flex>
+          {formError ? <ErrorText role="alert">{formError}</ErrorText> : null}
+        </Flex>
+      </Body>
+      <Footer>
+        <Flex gap="sm" align="center" justify="end">
+          <Button onClick={closeModal}>{t('Cancel')}</Button>
+          <Button
+            type="submit"
+            variant="primary"
+            busy={connectMutation.isPending}
+            disabled={!accessToken.trim()}
+          >
+            {t('Connect')}
+          </Button>
+        </Flex>
+      </Footer>
+    </form>
+  );
+}
+
+const StyledCompactSelect = styled(CompactSelect)`
+  width: 100%;
+
+  > button {
+    width: 100%;
+  }
+`;
+
+const ErrorText = styled('div')`
+  color: ${p => p.theme.tokens.content.danger};
+  margin-top: ${p => p.theme.space.sm};
+`;

--- a/static/gsApp/views/seerAutomation/components/monitoringProviders.spec.tsx
+++ b/static/gsApp/views/seerAutomation/components/monitoringProviders.spec.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
@@ -144,5 +145,253 @@ describe('MonitoringProvidersSection', () => {
     expect(
       await screen.findByText('There was an error loading data.')
     ).toBeInTheDocument();
+  });
+});
+
+describe('Datadog PAT flow', () => {
+  const organization = OrganizationFixture({
+    features: ['seer-infra-telemetry'],
+  });
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders PAT provider in list', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/`,
+      body: {
+        providers: [
+          {
+            provider: 'datadog_pat',
+            name: 'Datadog (Personal Access Token)',
+            connected: false,
+          },
+        ],
+      },
+    });
+
+    render(<MonitoringProvidersSection />, {organization});
+
+    expect(
+      await screen.findByText('Datadog (Personal Access Token)')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Not connected')).toBeInTheDocument();
+  });
+
+  it('connect on PAT provider opens modal instead of redirecting', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/`,
+      body: {
+        providers: [
+          {
+            provider: 'datadog_pat',
+            name: 'Datadog (Personal Access Token)',
+            connected: false,
+          },
+        ],
+      },
+    });
+
+    render(<MonitoringProvidersSection />, {organization});
+    renderGlobalModal();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Connect'}));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(
+      within(dialog).getByText('Connect Datadog (Personal Access Token)')
+    ).toBeInTheDocument();
+    expect(within(dialog).getByLabelText('Access Token')).toBeInTheDocument();
+    expect(within(dialog).getByText('Datadog Site')).toBeInTheDocument();
+    expect(testableWindowLocation.assign).not.toHaveBeenCalled();
+  });
+
+  it('PAT modal submits token and shows success', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/`,
+      body: {
+        providers: [
+          {
+            provider: 'datadog_pat',
+            name: 'Datadog (Personal Access Token)',
+            connected: false,
+          },
+        ],
+      },
+    });
+
+    const connectMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/datadog_pat/`,
+      method: 'POST',
+      statusCode: 204,
+      match: [
+        MockApiClient.matchData({access_token: 'my-pat-token', site: 'datadoghq.com'}),
+      ],
+    });
+
+    render(<MonitoringProvidersSection />, {organization});
+    renderGlobalModal();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Connect'}));
+
+    const dialog = await screen.findByRole('dialog');
+    await userEvent.type(within(dialog).getByLabelText('Access Token'), 'my-pat-token');
+
+    // Override GET mock before submit so refetch returns updated state
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/`,
+      body: {
+        providers: [
+          {
+            provider: 'datadog_pat',
+            name: 'Datadog (Personal Access Token)',
+            connected: true,
+          },
+        ],
+      },
+    });
+
+    await userEvent.click(within(dialog).getByRole('button', {name: 'Connect'}));
+
+    await waitFor(() => expect(connectMock).toHaveBeenCalled());
+    expect(await screen.findByText('Connected')).toBeInTheDocument();
+  });
+
+  it('PAT modal shows validation error', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/`,
+      body: {
+        providers: [
+          {
+            provider: 'datadog_pat',
+            name: 'Datadog (Personal Access Token)',
+            connected: false,
+          },
+        ],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/datadog_pat/`,
+      method: 'POST',
+      statusCode: 400,
+      body: {detail: 'Failed to verify token with provider.'},
+    });
+
+    render(<MonitoringProvidersSection />, {organization});
+    renderGlobalModal();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Connect'}));
+
+    const dialog = await screen.findByRole('dialog');
+    await userEvent.type(within(dialog).getByLabelText('Access Token'), 'bad-token');
+    await userEvent.click(within(dialog).getByRole('button', {name: 'Connect'}));
+
+    expect(
+      await screen.findByText('Failed to verify token with provider.')
+    ).toBeInTheDocument();
+  });
+
+  it('PAT modal shows conflict error', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/`,
+      body: {
+        providers: [
+          {
+            provider: 'datadog_pat',
+            name: 'Datadog (Personal Access Token)',
+            connected: false,
+          },
+        ],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/datadog_pat/`,
+      method: 'POST',
+      statusCode: 409,
+      body: {detail: 'This account is already connected.'},
+    });
+
+    render(<MonitoringProvidersSection />, {organization});
+    renderGlobalModal();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Connect'}));
+
+    const dialog = await screen.findByRole('dialog');
+    await userEvent.type(within(dialog).getByLabelText('Access Token'), 'my-token');
+    await userEvent.click(within(dialog).getByRole('button', {name: 'Connect'}));
+
+    expect(
+      await screen.findByText('This account is already connected.')
+    ).toBeInTheDocument();
+  });
+
+  it('disconnect works for PAT provider', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/`,
+      body: {
+        providers: [
+          {
+            provider: 'datadog_pat',
+            name: 'Datadog (Personal Access Token)',
+            connected: true,
+          },
+        ],
+      },
+    });
+
+    const deleteMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/datadog_pat/`,
+      method: 'DELETE',
+      statusCode: 204,
+    });
+
+    render(<MonitoringProvidersSection />, {organization});
+    renderGlobalModal();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Disconnect'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Confirm'}));
+
+    await waitFor(() => expect(deleteMock).toHaveBeenCalled());
+  });
+
+  it('cancel closes modal without submitting', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/`,
+      body: {
+        providers: [
+          {
+            provider: 'datadog_pat',
+            name: 'Datadog (Personal Access Token)',
+            connected: false,
+          },
+        ],
+      },
+    });
+
+    const connectMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/datadog_pat/`,
+      method: 'POST',
+      statusCode: 204,
+    });
+
+    render(<MonitoringProvidersSection />, {organization});
+    renderGlobalModal();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Connect'}));
+    expect(
+      await screen.findByText('Connect Datadog (Personal Access Token)')
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Connect Datadog (Personal Access Token)')
+      ).not.toBeInTheDocument();
+    });
+    expect(connectMock).not.toHaveBeenCalled();
   });
 });

--- a/static/gsApp/views/seerAutomation/components/monitoringProviders.tsx
+++ b/static/gsApp/views/seerAutomation/components/monitoringProviders.tsx
@@ -5,6 +5,7 @@ import {Container, Flex} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {openModal} from 'sentry/actionCreators/modal';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -15,6 +16,8 @@ import {fetchMutation} from 'sentry/utils/queryClient';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
+import {DatadogPatConnectModal} from 'getsentry/views/seerAutomation/components/datadogPatConnectModal';
+
 type MonitoringProvider = {
   connected: boolean;
   name: string;
@@ -24,6 +27,8 @@ type MonitoringProvider = {
 type MonitoringProvidersResponse = {
   providers: MonitoringProvider[];
 };
+
+const PAT_PROVIDERS = new Set(['datadog_pat']);
 
 function monitoringProvidersQueryOptions(orgSlug: string) {
   return apiOptions.as<MonitoringProvidersResponse>()(
@@ -92,6 +97,22 @@ export function MonitoringProvidersSection() {
   });
 
   function handleConnect(provider: MonitoringProvider) {
+    if (PAT_PROVIDERS.has(provider.provider)) {
+      openModal(modalProps => (
+        <DatadogPatConnectModal
+          {...modalProps}
+          orgSlug={organization.slug}
+          onSuccess={() => {
+            queryClient.invalidateQueries({
+              queryKey: monitoringProvidersQueryOptions(organization.slug).queryKey,
+            });
+            addSuccessMessage(t('Provider connected.'));
+          }}
+        />
+      ));
+      return;
+    }
+
     const params: {provider: string; site?: string} = {provider: provider.provider};
     if (provider.provider === 'datadog') {
       // TODO(CW-1501): v0 only supports datadoghq.com; add site selection when per-site connections are supported


### PR DESCRIPTION
Resolves [CW-1542](https://linear.app/getsentry/issue/CW-1542/frontend-add-datadog-pat-connect-flow-to-monitoring-providers-ui).

See the [Seer Advanced Settings page](https://sentry-87a34xlrs.sentry.dev/settings/seer/advanced/) for more.

Adds a modal to the monitoring providers UI for connecting Datadog via Personal Access Token (PAT), as an alternative to OAuth. The PAT modal collects the access token (password-masked) and the Datadog site (via a selection from the list of valid/possible sites). On connection creation, it `POST`s `{access_token, site}` to the existing backend endpoint, which returns 204. The disconnect flow works identically for both OAuth providers and PAT providers.

Gated behind the organization `seer-infra-telemetry` feature flag.

**Main page**

<img width="4466" height="540" alt="image" src="https://github.com/user-attachments/assets/57099eb9-c433-43ee-9370-680aa30ff6ca" />

**After attempting to connect with an invalid token or incorrect site**

<img width="1260" height="768" alt="image" src="https://github.com/user-attachments/assets/1dc6aa8a-b836-41d0-be9f-c3633bcc0d82" />

**Main page after successful provider connection**

<img width="4454" height="520" alt="image" src="https://github.com/user-attachments/assets/20c2c1ae-80d9-442f-a68c-a813432e2453" />

**Confirmation modal for disconnecting a provider**

<img width="1258" height="368" alt="image" src="https://github.com/user-attachments/assets/b333d37c-27b3-4f22-a797-f1ad4459597f" />