### PR TITLE
fix(frontend): add agent discovery URLs to control silo pattern inventory

### DIFF
--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -251,4 +251,10 @@ export const controlsiloUrlPatterns: RegExp[] = [
   new RegExp('^extensions/discord/configure/$'),
   new RegExp('^extensions/discord/link-identity/[^/]+/$'),
   new RegExp('^extensions/discord/unlink-identity/[^/]+/$'),
+  new RegExp('^\\.well-known/mcp\\.json$'),
+  new RegExp('^\\.well-known/api-catalog$'),
+  new RegExp('^\\.well-known/oauth-authorization-server$'),
+  new RegExp('^\\.well-known/oauth-protected-resource$'),
+  new RegExp('^\\.well-known/mcp/server-card\\.json$'),
+  new RegExp('^\\.well-known/agent-skills/index\\.json$'),
 ];


### PR DESCRIPTION
## Summary
- Adds the 6 `.well-known` agent discovery URL patterns to `controlsiloUrlPatterns.ts` to match the backend change that scoped these views to `control_silo_view`.

## Test plan
- CI `test_generate_controlsilo_urls` passes with the new patterns present.
- Land after the backend PR on `feat/webmcp-agent-discovery`.