### PR TITLE
feat(seer): Skip night-shift projects that can't open a PR

### DIFF
--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -397,8 +397,7 @@ def _get_eligible_orgs_from_batch(
     Check feature flags for a batch of orgs.
     Returns orgs that have all required feature flags enabled.
     """
-    # No code generation => night shift can't open PRs, so these orgs never get
-    # a task dispatched. Bulk-loaded to keep the batch a single query.
+    # No code generation => night shift can't open a PR for the org.
     enable_coding = OrganizationOption.objects.get_value_bulk(
         list(orgs), "sentry:enable_seer_coding", ENABLE_SEER_CODING_DEFAULT
     )

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -298,12 +298,6 @@ def run_night_shift_execution(
         _record_run_error(run, "No Seer quota available")
         return None
 
-    # No code generation => no PR can be opened. Guards the manual path (cron is
-    # already filtered in _get_eligible_orgs_from_batch).
-    if not organization.get_option("sentry:enable_seer_coding", ENABLE_SEER_CODING_DEFAULT):
-        logger.info("night_shift.code_generation_disabled", extra=log_extra)
-        return None
-
     try:
         eligible = _get_eligible_projects(
             organization, resolved_options["source"], project_ids=project_ids

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -11,6 +11,7 @@ import sentry_sdk
 
 from sentry import features, options, quotas
 from sentry.constants import (
+    ENABLE_SEER_CODING_DEFAULT,
     SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
     DataCategory,
     ObjectStatus,
@@ -480,7 +481,29 @@ def _get_eligible_projects(
     ]
     if source == "cron":
         eligible = [ep for ep in eligible if ep.tweaks.enabled]
-    return eligible
+
+    # A run only opens a PR when org-level code generation is on and the project
+    # stops at open_pr; anything short of that produces nothing night shift acts
+    # on. Drop those projects and log the decision inputs so we can spot
+    # misconfigured UX.
+    enable_seer_coding = organization.get_option(
+        "sentry:enable_seer_coding", ENABLE_SEER_CODING_DEFAULT
+    )
+    pr_producing: list[EligibleProject] = []
+    for ep in eligible:
+        if enable_seer_coding and ep.stopping_point == AutofixStoppingPoint.OPEN_PR:
+            pr_producing.append(ep)
+            continue
+        logger.info(
+            "night_shift.project_filtered.not_pr_producing",
+            extra={
+                "organization_id": organization.id,
+                "project_id": ep.project.id,
+                "stopping_point": ep.stopping_point.value,
+                "enable_seer_coding": enable_seer_coding,
+            },
+        )
+    return pr_producing
 
 
 def _build_triage_payload(

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -12,6 +12,7 @@ import sentry_sdk
 from sentry import features, options, quotas
 from sentry.constants import (
     ENABLE_SEER_CODING_DEFAULT,
+    HIDE_AI_FEATURES_DEFAULT,
     SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
     DataCategory,
     ObjectStatus,
@@ -397,13 +398,14 @@ def _get_eligible_orgs_from_batch(
     Check feature flags for a batch of orgs.
     Returns orgs that have all required feature flags enabled.
     """
-    # No code generation => night shift can't open a PR for the org.
+    # enable_seer_coding off => night shift can't open a PR for the org.
     enable_coding = OrganizationOption.objects.get_value_bulk(
-        list(orgs), "sentry:enable_seer_coding", ENABLE_SEER_CODING_DEFAULT
+        orgs, "sentry:enable_seer_coding", ENABLE_SEER_CODING_DEFAULT
     )
-    eligible = [
-        org for org in orgs if enable_coding[org] and not org.get_option("sentry:hide_ai_features")
-    ]
+    hide_ai = OrganizationOption.objects.get_value_bulk(
+        orgs, "sentry:hide_ai_features", HIDE_AI_FEATURES_DEFAULT
+    )
+    eligible = [org for org in orgs if enable_coding[org] and not hide_ai[org]]
 
     for feature_name in BATCH_FEATURE_NAMES:
         batch_result = features.batch_has_for_organizations(feature_name, eligible)

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -16,6 +16,7 @@ from sentry.constants import (
     DataCategory,
     ObjectStatus,
 )
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
 from sentry.seer.agent.client import SeerAgentClient
@@ -297,6 +298,12 @@ def run_night_shift_execution(
         _record_run_error(run, "No Seer quota available")
         return None
 
+    # No code generation => no PR can be opened. Guards the manual path (cron is
+    # already filtered in _get_eligible_orgs_from_batch).
+    if not organization.get_option("sentry:enable_seer_coding", ENABLE_SEER_CODING_DEFAULT):
+        logger.info("night_shift.code_generation_disabled", extra=log_extra)
+        return None
+
     try:
         eligible = _get_eligible_projects(
             organization, resolved_options["source"], project_ids=project_ids
@@ -396,7 +403,14 @@ def _get_eligible_orgs_from_batch(
     Check feature flags for a batch of orgs.
     Returns orgs that have all required feature flags enabled.
     """
-    eligible = [org for org in orgs if not org.get_option("sentry:hide_ai_features")]
+    # No code generation => night shift can't open PRs, so these orgs never get
+    # a task dispatched. Bulk-loaded to keep the batch a single query.
+    enable_coding = OrganizationOption.objects.get_value_bulk(
+        list(orgs), "sentry:enable_seer_coding", ENABLE_SEER_CODING_DEFAULT
+    )
+    eligible = [
+        org for org in orgs if enable_coding[org] and not org.get_option("sentry:hide_ai_features")
+    ]
 
     for feature_name in BATCH_FEATURE_NAMES:
         batch_result = features.batch_has_for_organizations(feature_name, eligible)
@@ -482,16 +496,11 @@ def _get_eligible_projects(
     if source == "cron":
         eligible = [ep for ep in eligible if ep.tweaks.enabled]
 
-    # A run only opens a PR when org-level code generation is on and the project
-    # stops at open_pr; anything short of that produces nothing night shift acts
-    # on. Drop those projects and log the decision inputs so we can spot
-    # misconfigured UX.
-    enable_seer_coding = organization.get_option(
-        "sentry:enable_seer_coding", ENABLE_SEER_CODING_DEFAULT
-    )
+    # Night shift's only output is a PR, so drop projects that don't stop at
+    # open_pr; log the stopping point to surface misconfigured UX.
     pr_producing: list[EligibleProject] = []
     for ep in eligible:
-        if enable_seer_coding and ep.stopping_point == AutofixStoppingPoint.OPEN_PR:
+        if ep.stopping_point == AutofixStoppingPoint.OPEN_PR:
             pr_producing.append(ep)
             continue
         logger.info(
@@ -500,7 +509,6 @@ def _get_eligible_projects(
                 "organization_id": organization.id,
                 "project_id": ep.project.id,
                 "stopping_point": ep.stopping_point.value,
-                "enable_seer_coding": enable_seer_coding,
             },
         )
     return pr_producing

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -328,25 +328,6 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
 
         assert [ep.project for ep in result] == [opens_pr]
 
-    def test_logs_decision_inputs_for_dropped_project(self) -> None:
-        org = self.create_organization()
-        project = self._make_eligible(
-            self.create_project(organization=org),
-            stopping_point=AutofixStoppingPoint.CODE_CHANGES.value,
-        )
-
-        with patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger:
-            _get_eligible_projects(org, "manual")
-
-        mock_logger.info.assert_called_once_with(
-            "night_shift.project_filtered.not_pr_producing",
-            extra={
-                "organization_id": org.id,
-                "project_id": project.id,
-                "stopping_point": "code_changes",
-            },
-        )
-
 
 @django_db_all
 class TestRunNightShiftForOrg(NightShiftFixtures, TestCase, SnubaTestCase):

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -24,6 +24,7 @@ from sentry.tasks.seer.night_shift.simple_triage import ScoredCandidate, fixabil
 from sentry.tasks.seer.night_shift.skip_cache import key as skip_cache_key
 from sentry.tasks.seer.night_shift.skip_cache import mark_skipped
 from sentry.testutils.cases import SnubaTestCase, TestCase
+from sentry.testutils.fixtures import Fixtures
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -40,7 +41,7 @@ def _dispatched_feature_body(organization):
     return seer_run, outbox.payload["body"]
 
 
-class NightShiftFixtures:
+class NightShiftFixtures(Fixtures):
     """Shared night-shift test setup. Mixed into the test cases below so the
     project-eligibility and event-seeding logic lives in one place."""
 
@@ -68,6 +69,7 @@ class NightShiftFixtures:
             },
             project_id=project.id,
         )
+        assert event.group_id is not None
         Group.objects.filter(id=event.group_id).update(**group_attrs)
         return Group.objects.get(id=event.group_id)
 

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -5,6 +5,7 @@ from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.models.group import Group
 from sentry.models.organization import OrganizationStatus
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
+from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
     SeerNightShiftRunResult,
@@ -37,6 +38,38 @@ def _dispatched_feature_body(organization):
     )
     assert outbox.payload is not None
     return seer_run, outbox.payload["body"]
+
+
+class NightShiftFixtures:
+    """Shared night-shift test setup. Mixed into the test cases below so the
+    project-eligibility and event-seeding logic lives in one place."""
+
+    def _make_eligible(
+        self, project, *, stopping_point=AutofixStoppingPoint.OPEN_PR.value, **tweak_overrides
+    ):
+        """Configure a project to pass every eligibility gate: automation on, a
+        connected repo, a PR-producing stopping point, and tweaks enabled.
+        Override stopping_point (or pass enabled=False) to exercise one gate."""
+        project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
+        )
+        project.update_option("sentry:seer_automated_run_stopping_point", stopping_point)
+        repo = self.create_repo(project=project, provider="github", name=f"owner/{project.slug}")
+        self.create_seer_project_repository(project=project, repository=repo)
+        project.update_option("sentry:seer_nightshift_tweaks", {"enabled": True, **tweak_overrides})
+        return project
+
+    def _store_event_and_update_group(self, project, fingerprint, **group_attrs):
+        event = self.store_event(
+            data={
+                "fingerprint": [fingerprint],
+                "timestamp": before_now(hours=1).isoformat(),
+                "environment": "production",
+            },
+            project_id=project.id,
+        )
+        Group.objects.filter(id=event.group_id).update(**group_attrs)
+        return Group.objects.get(id=event.group_id)
 
 
 @django_db_all
@@ -217,28 +250,21 @@ class TestScheduleNightShift(TestCase):
 
 
 @django_db_all
-class TestGetEligibleProjects(TestCase):
+class TestGetEligibleProjects(NightShiftFixtures, TestCase):
     def test_filters_by_automation_and_repos(self) -> None:
         org = self.create_organization()
 
-        # Eligible: automation on + connected repo
-        eligible = self.create_project(organization=org)
-        eligible.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
-        )
-        repo = self.create_repo(project=eligible, provider="github", name="owner/eligible-repo")
-        self.create_seer_project_repository(project=eligible, repository=repo)
+        # Eligible on every gate.
+        eligible = self._make_eligible(self.create_project(organization=org))
 
-        # Automation off (even with repo)
+        # Automation off (even with a connected repo).
         off = self.create_project(organization=org)
         off.update_option("sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF)
-        repo2 = self.create_repo(project=off, provider="github", name="owner/off-repo")
-        self.create_seer_project_repository(project=off, repository=repo2)
+        off_repo = self.create_repo(project=off, provider="github", name="owner/off-repo")
+        self.create_seer_project_repository(project=off, repository=off_repo)
 
-        # No connected repo
+        # No connected repo.
         self.create_project(organization=org)
-
-        eligible.update_option("sentry:seer_nightshift_tweaks", {"enabled": True})
 
         result = _get_eligible_projects(org, "manual")
 
@@ -247,20 +273,8 @@ class TestGetEligibleProjects(TestCase):
 
     def test_filters_by_project_id(self) -> None:
         org = self.create_organization()
-
-        target = self.create_project(organization=org)
-        target.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
-        )
-        target_repo = self.create_repo(project=target, provider="github", name="owner/target")
-        self.create_seer_project_repository(project=target, repository=target_repo)
-
-        other = self.create_project(organization=org)
-        other.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
-        )
-        other_repo = self.create_repo(project=other, provider="github", name="owner/other")
-        self.create_seer_project_repository(project=other, repository=other_repo)
+        target = self._make_eligible(self.create_project(organization=org))
+        self._make_eligible(self.create_project(organization=org))
 
         result = _get_eligible_projects(org, "manual", project_ids=[target.id])
 
@@ -268,15 +282,8 @@ class TestGetEligibleProjects(TestCase):
 
     def test_cron_filters_disabled_tweaks_manual_keeps_them(self) -> None:
         org = self.create_organization()
-
         for slug, enabled in (("on", True), ("off", False)):
-            project = self.create_project(organization=org, slug=slug)
-            project.update_option(
-                "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
-            )
-            repo = self.create_repo(project=project, provider="github", name=f"owner/{slug}")
-            self.create_seer_project_repository(project=project, repository=repo)
-            project.update_option("sentry:seer_nightshift_tweaks", {"enabled": enabled})
+            self._make_eligible(self.create_project(organization=org, slug=slug), enabled=enabled)
 
         cron_result = _get_eligible_projects(org, "cron")
         manual_result = _get_eligible_projects(org, "manual")
@@ -284,30 +291,56 @@ class TestGetEligibleProjects(TestCase):
         assert [ep.project.slug for ep in cron_result] == ["on"]
         assert sorted(ep.project.slug for ep in manual_result) == ["off", "on"]
 
+    def test_drops_projects_that_cannot_open_prs(self) -> None:
+        org = self.create_organization()
+        opens_pr = self._make_eligible(
+            self.create_project(organization=org),
+            stopping_point=AutofixStoppingPoint.OPEN_PR.value,
+        )
+        self._make_eligible(
+            self.create_project(organization=org),
+            stopping_point=AutofixStoppingPoint.CODE_CHANGES.value,
+        )
+        self._make_eligible(
+            self.create_project(organization=org),
+            stopping_point=AutofixStoppingPoint.ROOT_CAUSE.value,
+        )
+
+        result = _get_eligible_projects(org, "manual")
+
+        assert [ep.project for ep in result] == [opens_pr]
+
+    def test_drops_all_projects_when_code_generation_disabled(self) -> None:
+        org = self.create_organization()
+        org.update_option("sentry:enable_seer_coding", False)
+        self._make_eligible(self.create_project(organization=org))
+
+        assert _get_eligible_projects(org, "manual") == []
+
+    def test_logs_decision_inputs_for_dropped_project(self) -> None:
+        org = self.create_organization()
+        project = self._make_eligible(
+            self.create_project(organization=org),
+            stopping_point=AutofixStoppingPoint.CODE_CHANGES.value,
+        )
+
+        with patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger:
+            _get_eligible_projects(org, "manual")
+
+        mock_logger.info.assert_called_once_with(
+            "night_shift.project_filtered.not_pr_producing",
+            extra={
+                "organization_id": org.id,
+                "project_id": project.id,
+                "stopping_point": "code_changes",
+                "enable_seer_coding": True,
+            },
+        )
+
 
 @django_db_all
-class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
+class TestRunNightShiftForOrg(NightShiftFixtures, TestCase, SnubaTestCase):
     reset_snuba_data = False
-
-    def _make_eligible(self, project, **tweak_overrides):
-        project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
-        )
-        repo = self.create_repo(project=project, provider="github", name=f"owner/{project.slug}")
-        self.create_seer_project_repository(project=project, repository=repo)
-        project.update_option("sentry:seer_nightshift_tweaks", {"enabled": True, **tweak_overrides})
-
-    def _store_event_and_update_group(self, project, fingerprint, **group_attrs):
-        event = self.store_event(
-            data={
-                "fingerprint": [fingerprint],
-                "timestamp": before_now(hours=1).isoformat(),
-                "environment": "production",
-            },
-            project_id=project.id,
-        )
-        Group.objects.filter(id=event.group_id).update(**group_attrs)
-        return Group.objects.get(id=event.group_id)
 
     def test_nonexistent_org(self) -> None:
         with patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger:
@@ -470,31 +503,11 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
 
 
 @django_db_all
-class TestRunNightShiftFeatureDelivery(TestCase, SnubaTestCase):
+class TestRunNightShiftFeatureDelivery(NightShiftFixtures, TestCase, SnubaTestCase):
     """Coverage for the dispatch path, which hands triage off to Seer's
     feature-run endpoint. Seer pushes verdicts back via deliver_feature_result."""
 
     reset_snuba_data = False
-
-    def _make_eligible(self, project, **tweak_overrides):
-        project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
-        )
-        repo = self.create_repo(project=project, provider="github", name=f"owner/{project.slug}")
-        self.create_seer_project_repository(project=project, repository=repo)
-        project.update_option("sentry:seer_nightshift_tweaks", {"enabled": True, **tweak_overrides})
-
-    def _store_event_and_update_group(self, project, fingerprint, **group_attrs):
-        event = self.store_event(
-            data={
-                "fingerprint": [fingerprint],
-                "timestamp": before_now(hours=1).isoformat(),
-                "environment": "production",
-            },
-            project_id=project.id,
-        )
-        Group.objects.filter(id=event.group_id).update(**group_attrs)
-        return Group.objects.get(id=event.group_id)
 
     def _shard_group_ids(self, shard):
         outbox = CellOutbox.objects.get(
@@ -762,7 +775,7 @@ class TestRunNightShiftFeatureDelivery(TestCase, SnubaTestCase):
 
 
 @django_db_all
-class TestRunNightShiftForOrgManualPath(TestCase):
+class TestRunNightShiftForOrgManualPath(NightShiftFixtures, TestCase):
     """Manual-path coverage for run_night_shift_for_org — invoked from the
     project-settings "Run Now" endpoint with source="manual" and project_ids."""
 
@@ -847,13 +860,7 @@ class TestRunNightShiftForOrgManualPath(TestCase):
 
     def test_manual_runs_even_when_project_tweak_is_disabled(self) -> None:
         org = self.create_organization()
-        project = self.create_project(organization=org)
-        project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
-        )
-        repo = self.create_repo(project=project, provider="github", name=f"owner/{project.slug}")
-        self.create_seer_project_repository(project=project, repository=repo)
-        project.update_option("sentry:seer_nightshift_tweaks", {"enabled": False})
+        project = self._make_eligible(self.create_project(organization=org), enabled=False)
 
         with patch(
             "sentry.tasks.seer.night_shift.cron.fixability_score_strategy",
@@ -866,20 +873,8 @@ class TestRunNightShiftForOrgManualPath(TestCase):
 
 
 @django_db_all
-class TestFixabilityScoreStrategy(TestCase, SnubaTestCase):
+class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
     reset_snuba_data = False
-
-    def _store_event_and_update_group(self, project, fingerprint, **group_attrs):
-        event = self.store_event(
-            data={
-                "fingerprint": [fingerprint],
-                "timestamp": before_now(hours=1).isoformat(),
-                "environment": "production",
-            },
-            project_id=project.id,
-        )
-        Group.objects.filter(id=event.group_id).update(**group_attrs)
-        return Group.objects.get(id=event.group_id)
 
     def test_ranks_scored_above_threshold_first_then_preserves_recommended_order(self) -> None:
         project = self.create_project()

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -431,23 +431,6 @@ class TestRunNightShiftForOrg(NightShiftFixtures, TestCase, SnubaTestCase):
         assert not SeerRun.objects.filter(organization=org).exists()
         assert not SeerNightShiftRunResult.objects.filter(run=run).exists()
 
-    def test_skips_when_code_generation_disabled(self) -> None:
-        org = self.create_organization()
-        org.update_option("sentry:enable_seer_coding", False)
-        project = self.create_project(organization=org)
-        self._make_eligible(project)
-        self._store_event_and_update_group(
-            project, "fixable", seer_fixability_score=0.9, times_seen=5
-        )
-
-        with patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger:
-            run_night_shift_for_org(org.id)
-            info_events = [call.args[0] for call in mock_logger.info.call_args_list]
-            assert "night_shift.code_generation_disabled" in info_events
-
-        # Bailed before enumerating projects: no Seer dispatch.
-        assert not SeerRun.objects.filter(organization=org).exists()
-
     def test_max_candidates_defaults_to_global_option(self) -> None:
         org = self.create_organization()
         low = self.create_project(organization=org, slug="low")

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -225,6 +225,24 @@ class TestScheduleNightShift(TestCase):
             schedule_night_shift()
             mock_worker.apply_async.assert_not_called()
 
+    def test_skips_orgs_with_code_generation_disabled(self) -> None:
+        org = self.create_org_with_seer()
+        org.update_option("sentry:enable_seer_coding", False)
+
+        with (
+            self.options({"seer.night_shift.enable": True}),
+            self.feature(
+                {
+                    "organizations:seer-night-shift": [org.slug],
+                    "organizations:gen-ai-features": [org.slug],
+                    "organizations:seat-based-seer-enabled": [org.slug],
+                }
+            ),
+            patch("sentry.tasks.seer.night_shift.cron.run_night_shift_for_org") as mock_worker,
+        ):
+            schedule_night_shift()
+            mock_worker.apply_async.assert_not_called()
+
     def test_skips_orgs_without_seer_project_repository(self) -> None:
         # Orgs that have never connected a Seer repo are pre-filtered before
         # the feature flag fanout — even if they happen to have all the flags.
@@ -310,13 +328,6 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
 
         assert [ep.project for ep in result] == [opens_pr]
 
-    def test_drops_all_projects_when_code_generation_disabled(self) -> None:
-        org = self.create_organization()
-        org.update_option("sentry:enable_seer_coding", False)
-        self._make_eligible(self.create_project(organization=org))
-
-        assert _get_eligible_projects(org, "manual") == []
-
     def test_logs_decision_inputs_for_dropped_project(self) -> None:
         org = self.create_organization()
         project = self._make_eligible(
@@ -333,7 +344,6 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
                 "organization_id": org.id,
                 "project_id": project.id,
                 "stopping_point": "code_changes",
-                "enable_seer_coding": True,
             },
         )
 
@@ -420,6 +430,23 @@ class TestRunNightShiftForOrg(NightShiftFixtures, TestCase, SnubaTestCase):
         assert run.extras["error_message"] == "No Seer quota available"
         assert not SeerRun.objects.filter(organization=org).exists()
         assert not SeerNightShiftRunResult.objects.filter(run=run).exists()
+
+    def test_skips_when_code_generation_disabled(self) -> None:
+        org = self.create_organization()
+        org.update_option("sentry:enable_seer_coding", False)
+        project = self.create_project(organization=org)
+        self._make_eligible(project)
+        self._store_event_and_update_group(
+            project, "fixable", seer_fixability_score=0.9, times_seen=5
+        )
+
+        with patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger:
+            run_night_shift_for_org(org.id)
+            info_events = [call.args[0] for call in mock_logger.info.call_args_list]
+            assert "night_shift.code_generation_disabled" in info_events
+
+        # Bailed before enumerating projects: no Seer dispatch.
+        assert not SeerRun.objects.filter(organization=org).exists()
 
     def test_max_candidates_defaults_to_global_option(self) -> None:
         org = self.create_organization()


### PR DESCRIPTION
## Summary

Night shift now treats root-cause-only triage results as skips, so a Seer run's only actionable night-shift output is an opened PR. This tightens `_get_eligible_projects` so projects that can never reach that point are dropped before their issues enter triage — saving triage + autofix compute on work we'd discard.

A project is kept only when **both** hold:
- org-level code generation is on (`sentry:enable_seer_coding`) — the real runtime gate (the autofix pipeline halts before code changes, and `trigger_push_changes` raises, without it), and
- the project's stopping point is `open_pr`.

Every dropped project logs `night_shift.project_filtered.not_pr_producing` with `stopping_point` and `enable_seer_coding` as extras, so misconfigured projects are observable. The filter runs after the cron `tweaks.enabled` gate, so logs only cover projects that would otherwise have run.

## Notes

- Test cleanup: extracted a `NightShiftFixtures` mixin sharing project-eligibility and event-seeding setup, removing the duplicated `_make_eligible` / `_store_event_and_update_group` helpers across the night-shift test cases.