### PR TITLE
chore(scm): upgrade sentry-scm to 0.30.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dependencies = [
   "sentry-protos>=0.33.1",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
-  "sentry-scm==0.22.0",
+  "sentry-scm==0.30.0",
   "sentry-sdk[http2]>=2.63.0",
   "sentry-usage-accountant>=0.0.10",
   # remove once there are no unmarked transitive dependencies on setuptools

--- a/uv.lock
+++ b/uv.lock
@@ -2415,7 +2415,7 @@ requires-dist = [
     { name = "sentry-protos", specifier = ">=0.33.1" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
-    { name = "sentry-scm", specifier = "==0.22.0" },
+    { name = "sentry-scm", specifier = "==0.30.0" },
     { name = "sentry-sdk", extras = ["http2"], specifier = ">=2.63.0" },
     { name = "sentry-usage-accountant", specifier = ">=0.0.10" },
     { name = "setuptools", specifier = ">=70.0.0" },
@@ -2633,14 +2633,14 @@ wheels = [
 
 [[package]]
 name = "sentry-scm"
-version = "0.22.0"
+version = "0.30.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "msgspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_scm-0.22.0-py3-none-any.whl", hash = "sha256:e6eb96e85a7f0d1b3cfd9a348843aba2b8f1668869a9e63365c5fa1a26da44f8" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_scm-0.30.0-py3-none-any.whl", hash = "sha256:dd0ee3f8551b6c2ee315184716af8a848da4a1613b5cfa35d61a14d2e6f0fc83" },
 ]
 
 [[package]]


### PR DESCRIPTION
no breaking changes since we're not using any of the APIs that were changed in this version of the library