### PR TITLE
fix(project-creation): Forward the SCM product selection to setup docs

### DIFF
--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -239,6 +239,46 @@ describe('ScmCreateProject', () => {
     });
   });
 
+  it('forwards the selected products to getting-started as the product query', async () => {
+    persistWizardSession({
+      selectedFeatures: ['performance-monitoring', 'session-replay'],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      method: 'POST',
+      body: ProjectFixture({slug: 'python', name: 'python'}),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [adminTeam],
+    });
+
+    const {router} = render(<ScmCreateProject />, {
+      organization,
+      initialRouterConfig: returningRouterConfig,
+    });
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
+
+    await waitFor(() => {
+      expect(router.location.pathname).toContain('/python/getting-started/');
+    });
+    // The upfront product selection seeds the setup docs via the product query.
+    expect(router.location.query.product).toEqual([
+      'performance-monitoring',
+      'session-replay',
+    ]);
+  });
+
   it('reuses the existing project on an unchanged return instead of duplicating', async () => {
     ProjectsStore.loadInitialData([
       ProjectFixture({slug: 'python', name: 'python', platform: 'python'}),

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -232,12 +232,21 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
         createdProjectSlug: project.slug,
         projectDetailsForm: submittedForm,
       });
-      navigate(
-        makeProjectsPathname({
+      navigate({
+        pathname: makeProjectsPathname({
           path: `/${project.slug}/getting-started/`,
           organization,
-        })
-      );
+        }),
+        // Carry the upfront product selection into the setup docs so the
+        // instructions match what was chosen here; the getting-started page
+        // seeds its selection from the `product` query. Mirrors the SCM
+        // onboarding flow (ScmProjectDetails -> goNextStep). Classic
+        // createProject selects products on that page instead, so it forwards
+        // nothing.
+        query: wizardState.selectedFeatures
+          ? {product: wizardState.selectedFeatures}
+          : undefined,
+      });
     },
     [wizardState, navigate, organization]
   );


### PR DESCRIPTION
## TLDR

The SCM create-project flow lets you pick products upfront, but the selection was dropped when navigating to the getting-started setup docs. This forwards it as the `product` query so the instructions match what was chosen.

## Details

- `handleComplete` now navigates to getting-started with `query: {product: selectedFeatures}` instead of dropping the selection. The getting-started page (ProjectInstallPlatform) seeds its product selection from `location.query.product`, so the setup docs now reflect the upfront choice.
- Mirrors the SCM onboarding flow, which already forwards the selection the same way (ScmProjectDetails -> goNextStep). The classic createProject flow selects products on the getting-started page itself, so it has nothing to forward.
- Adds a test asserting the product query is forwarded on creation.

## Stack

Based on jaygoss/vdy-77-project-creation-ui-polish-cont (#118193), where the SCM create-project flow lives.
