### PR TITLE
chore(preprod): Remove preprod-enforce-size-quota feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -197,8 +197,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-artifact-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod PR comments for build distribution
     manager.add("organizations:preprod-build-distribution-pr-comments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable enforcement of preprod size quota checks (when disabled, size quota checks always return True)
-    manager.add("organizations:preprod-enforce-size-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)
     manager.add("organizations:preprod-enforce-distribution-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable preprod size monitors frontend

--- a/src/sentry/preprod/quotas.py
+++ b/src/sentry/preprod/quotas.py
@@ -46,12 +46,6 @@ DISTRIBUTION_ENABLED_QUERY_KEY = "sentry:preprod_distribution_enabled_query"
 
 
 def has_size_quota(organization: Organization, actor: User | AnonymousUser | None = None) -> bool:
-    if not features.has("organizations:preprod-enforce-size-quota", organization, actor=actor):
-        logger.info(
-            "has_size_quota",
-            extra={"organization_id": organization.id, "result": True, "reason": "not_enforced"},
-        )
-        return True
     result = quotas.backend.has_usage_quota(organization.id, DataCategory.SIZE_ANALYSIS)
     logger.info(
         "has_size_quota",

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -464,7 +464,6 @@ class CreatePreprodArtifactTest(TestCase):
 
         with self.feature(
             [
-                "organizations:preprod-enforce-size-quota",
                 "organizations:preprod-enforce-distribution-quota",
             ]
         ):
@@ -487,7 +486,6 @@ class CreatePreprodArtifactTest(TestCase):
 
         with self.feature(
             [
-                "organizations:preprod-enforce-size-quota",
                 "organizations:preprod-enforce-distribution-quota",
             ]
         ):
@@ -513,7 +511,6 @@ class CreatePreprodArtifactTest(TestCase):
 
         with self.feature(
             [
-                "organizations:preprod-enforce-size-quota",
                 "organizations:preprod-enforce-distribution-quota",
             ]
         ):
@@ -536,7 +533,6 @@ class CreatePreprodArtifactTest(TestCase):
 
         with self.feature(
             [
-                "organizations:preprod-enforce-size-quota",
                 "organizations:preprod-enforce-distribution-quota",
             ]
         ):


### PR DESCRIPTION
## Summary

Graduates preprod size quota enforcement to always-on by removing the `organizations:preprod-enforce-size-quota` feature flag.

Previously, `has_size_quota()` short-circuited with an early `return True` whenever the flag was disabled, so size quota was never enforced for orgs without the flag. The flag has served its rollout purpose; this bakes in the enforced behavior so the quota check always runs.

## Changes

- Remove the flag registration from `src/sentry/features/temporary.py`.
- Drop the flag gate in `has_size_quota()` (`src/sentry/preprod/quotas.py`); it now always calls `quotas.backend.has_usage_quota(..., SIZE_ANALYSIS)`.
- Remove the flag from the affected `self.feature([...])` blocks in `tests/sentry/preprod/test_tasks.py`.

The sibling `organizations:preprod-enforce-distribution-quota` flag is intentionally left untouched.