### PR TITLE
fix(seer-infra-telemetry): Wrap monitoring provider disconnect logic with transaction

### DIFF
--- a/src/sentry/api/endpoints/organization_monitoring_provider_details.py
+++ b/src/sentry/api/endpoints/organization_monitoring_provider_details.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from django.db import IntegrityError
+from django.db import IntegrityError, router, transaction
 from django.http import HttpResponseRedirect
 from requests.exceptions import RequestException
 from rest_framework.request import Request
@@ -130,7 +130,7 @@ class OrganizationMonitoringProviderDetailsEndpoint(ControlSiloOrganizationEndpo
         if provider_key not in MONITORING_PROVIDERS:
             return Response({"detail": "Unknown monitoring provider."}, status=400)
 
-        org_identities = list(
+        org_identities: list[OrganizationIdentity] = list(
             OrganizationIdentity.objects.filter(
                 organization_id=organization.id,
                 identity__user_id=request.user.id,  # type: ignore[misc]
@@ -142,9 +142,10 @@ class OrganizationMonitoringProviderDetailsEndpoint(ControlSiloOrganizationEndpo
             return Response({"detail": "Not connected to this provider."}, status=404)
 
         for org_identity in org_identities:
-            identity = org_identity.identity
-            org_identity.delete()
-            if not OrganizationIdentity.objects.filter(identity=identity).exists():
-                identity.delete()
+            with transaction.atomic(router.db_for_write(OrganizationIdentity)):
+                identity: Identity = org_identity.identity
+                org_identity.delete()
+                if not OrganizationIdentity.objects.filter(identity=identity).exists():
+                    identity.delete()
 
         return Response(status=204)


### PR DESCRIPTION
Resolves [CW-1543](https://linear.app/getsentry/issue/CW-1543/wrap-delete-loop-in-transactionatomic-to-close-toctou-race-on-shared).

The `DELETE` endpoint for monitoring provider connections has a TOCTOU race: it deletes the `OrganizationIdentity`, checks if any other orgs still reference the underlying `Identity`, and conditionally deletes it - but these three operations weren't atomic. A crash or concurrent request between them could orphan an `Identity` or delete one still referenced by another org.

This PR wraps the loop body in `transaction.atomic()` so the delete + check + conditional delete commit or roll back together.