### PR TITLE
ref(seer-infra-telemetry): Replace `MonitoringIdentityPipeline` with provider flag

### DIFF
--- a/src/sentry/api/endpoints/organization_monitoring_provider_details.py
+++ b/src/sentry/api/endpoints/organization_monitoring_provider_details.py
@@ -21,7 +21,7 @@ from sentry.auth.exceptions import IdentityNotValid
 from sentry.identity import default_manager as identity_manager
 from sentry.identity.base import Provider
 from sentry.identity.oauth2 import OAuth2Provider
-from sentry.identity.pipeline import MonitoringIdentityPipeline
+from sentry.identity.pipeline import IdentityPipeline
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.users.models.identity import Identity, IdentityProvider, OrganizationIdentity
 
@@ -62,7 +62,7 @@ class OrganizationMonitoringProviderDetailsEndpoint(ControlSiloOrganizationEndpo
         if not provider_type.auto_create_provider_model:
             idp, _ = IdentityProvider.objects.get_or_create(type=provider_key, external_id="")
 
-        pipeline = MonitoringIdentityPipeline(
+        pipeline = IdentityPipeline(
             request=request._request,
             provider_key=provider_key,
             organization=organization,

--- a/src/sentry/identity/base.py
+++ b/src/sentry/identity/base.py
@@ -18,6 +18,7 @@ class Provider(PipelineProvider["IdentityPipeline"], abc.ABC):
     """
 
     auto_create_provider_model = False
+    create_organization_identity = False
 
     def __init__(self, **config):
         super().__init__()

--- a/src/sentry/identity/datadog/provider.py
+++ b/src/sentry/identity/datadog/provider.py
@@ -274,6 +274,7 @@ class DatadogIdentityProvider(McpIdentityProvider, OAuth2Provider):
     key = IntegrationProviderSlug.DATADOG
     name = "Datadog"
     auto_create_provider_model = True
+    create_organization_identity = True
 
     oauth_scopes: tuple[str, ...] = (
         "mcp_read",
@@ -419,6 +420,7 @@ class DatadogPatIdentityProvider(McpIdentityProvider, Provider):
 
     key = IntegrationProviderSlug.DATADOG_PAT
     name = "Datadog (Personal Access Token)"
+    create_organization_identity = True
 
     def get_pipeline_views(self) -> list[PipelineView[IdentityPipeline]]:
         return []

--- a/src/sentry/identity/gcp/provider.py
+++ b/src/sentry/identity/gcp/provider.py
@@ -35,6 +35,7 @@ class GCPOAuth2LoginView(OAuth2LoginView):
 class GCPIdentityProvider(OAuth2Provider):
     key = IntegrationProviderSlug.GCP
     name = "Google Cloud Platform"
+    create_organization_identity = True
 
     oauth_access_token_url = "https://oauth2.googleapis.com/token"
     oauth_authorize_url = "https://accounts.google.com/o/oauth2/v2/auth"

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -73,7 +73,7 @@ class IdentityPipeline(Pipeline[IdentityProvider, PipelineSessionStore]):
 
             assert self.provider_model is not None
 
-            Identity.objects.link_identity(
+            self._linked_identity = Identity.objects.link_identity(
                 user=self.request.user,
                 idp=self.provider_model,
                 external_id=identity["id"],
@@ -121,16 +121,10 @@ class MonitoringIdentityPipeline(IdentityPipeline):
     def finish_pipeline(self) -> HttpResponseBase:
         response = super().finish_pipeline()
 
-        user = self.request.user
-        if self.organization and self.provider_model is not None and user.is_authenticated:
-            identity = Identity.objects.filter(
-                idp=self.provider_model,
-                user_id=user.id,
-            ).first()
-            if identity:
-                OrganizationIdentity.objects.get_or_create(
-                    organization_id=self.organization.id,
-                    identity=identity,
-                )
+        if self.organization and self._linked_identity is not None:
+            OrganizationIdentity.objects.get_or_create(
+                organization_id=self.organization.id,
+                identity=self._linked_identity,
+            )
 
         return response

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -84,6 +84,16 @@ class IdentityPipeline(Pipeline[IdentityProvider, PipelineSessionStore]):
                 },
             )
 
+            if (
+                self.provider.create_organization_identity
+                and self.organization
+                and self._linked_identity is not None
+            ):
+                OrganizationIdentity.objects.get_or_create(
+                    organization_id=self.organization.id,
+                    identity=self._linked_identity,
+                )
+
             # Let providers react to a freshly linked identity (e.g. backfilling
             # derived mappings). Best-effort: never let it break the link flow.
             try:
@@ -113,18 +123,3 @@ class IdentityPipeline(Pipeline[IdentityProvider, PipelineSessionStore]):
             # identity management page that supports these new identities (not
             # social-auth ones), redirect to the identities page.
             return HttpResponseRedirect(reverse("sentry-account-settings"))
-
-
-class MonitoringIdentityPipeline(IdentityPipeline):
-    pipeline_name = "monitoring_identity_provider"
-
-    def finish_pipeline(self) -> HttpResponseBase:
-        response = super().finish_pipeline()
-
-        if self.organization and self._linked_identity is not None:
-            OrganizationIdentity.objects.get_or_create(
-                organization_id=self.organization.id,
-                identity=self._linked_identity,
-            )
-
-        return response

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -75,7 +75,7 @@ class IdentityPipeline(Pipeline[IdentityProvider, PipelineSessionStore]):
 
                 assert self.provider_model is not None
 
-                self._linked_identity = Identity.objects.link_identity(
+                linked_identity = Identity.objects.link_identity(
                     user=self.request.user,
                     idp=self.provider_model,
                     external_id=identity["id"],
@@ -89,11 +89,11 @@ class IdentityPipeline(Pipeline[IdentityProvider, PipelineSessionStore]):
                 if (
                     self.provider.create_organization_identity
                     and self.organization
-                    and self._linked_identity is not None
+                    and linked_identity is not None
                 ):
                     OrganizationIdentity.objects.get_or_create(
                         organization_id=self.organization.id,
-                        identity=self._linked_identity,
+                        identity=linked_identity,
                     )
 
             # Let providers react to a freshly linked identity (e.g. backfilling

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Sequence
 from functools import cached_property
 
 from django.contrib import messages
+from django.db import router, transaction
 from django.http.response import HttpResponseBase, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -64,35 +65,36 @@ class IdentityPipeline(Pipeline[IdentityProvider, PipelineSessionStore]):
 
             assert self.request.user.is_authenticated
 
-            if self.provider_model is None and self.provider.auto_create_provider_model:
-                self.provider_model, _ = IdentityProvider.objects.get_or_create(
-                    type=identity["type"],
-                    external_id=identity["idp_external_id"],
-                    defaults={"config": identity.get("idp_config", {})},
+            with transaction.atomic(router.db_for_write(Identity)):
+                if self.provider_model is None and self.provider.auto_create_provider_model:
+                    self.provider_model, _ = IdentityProvider.objects.get_or_create(
+                        type=identity["type"],
+                        external_id=identity["idp_external_id"],
+                        defaults={"config": identity.get("idp_config", {})},
+                    )
+
+                assert self.provider_model is not None
+
+                self._linked_identity = Identity.objects.link_identity(
+                    user=self.request.user,
+                    idp=self.provider_model,
+                    external_id=identity["id"],
+                    should_reattach=False,
+                    defaults={
+                        "scopes": identity.get("scopes", []),
+                        "data": identity.get("data", {}),
+                    },
                 )
 
-            assert self.provider_model is not None
-
-            self._linked_identity = Identity.objects.link_identity(
-                user=self.request.user,
-                idp=self.provider_model,
-                external_id=identity["id"],
-                should_reattach=False,
-                defaults={
-                    "scopes": identity.get("scopes", []),
-                    "data": identity.get("data", {}),
-                },
-            )
-
-            if (
-                self.provider.create_organization_identity
-                and self.organization
-                and self._linked_identity is not None
-            ):
-                OrganizationIdentity.objects.get_or_create(
-                    organization_id=self.organization.id,
-                    identity=self._linked_identity,
-                )
+                if (
+                    self.provider.create_organization_identity
+                    and self.organization
+                    and self._linked_identity is not None
+                ):
+                    OrganizationIdentity.objects.get_or_create(
+                        organization_id=self.organization.id,
+                        identity=self._linked_identity,
+                    )
 
             # Let providers react to a freshly linked identity (e.g. backfilling
             # derived mappings). Best-effort: never let it break the link flow.

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from sentry import features
-from sentry.identity.pipeline import IdentityPipeline, MonitoringIdentityPipeline
+from sentry.identity.pipeline import IdentityPipeline
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.absolute_url import generate_organization_url
@@ -19,7 +19,7 @@ from sentry.web.frontend.base import BaseView, all_silo_view
 # The request doesn't contain the pipeline type (pipeline information is stored
 # in redis keyed by the pipeline name), so we try to construct multiple pipelines
 # and use whichever one works.
-PIPELINE_CLASSES = (IntegrationPipeline, IdentityPipeline, MonitoringIdentityPipeline)
+PIPELINE_CLASSES = (IntegrationPipeline, IdentityPipeline)
 
 TRAMPOLINE_HTML = """\
 <!DOCTYPE html>

--- a/tests/sentry/api/endpoints/test_organization_monitoring_provider_details.py
+++ b/tests/sentry/api/endpoints/test_organization_monitoring_provider_details.py
@@ -24,10 +24,10 @@ class OrganizationMonitoringProviderDetailsConnectTest(APITestCase):
         assert response.status_code == 404
 
     @patch(
-        "sentry.api.endpoints.organization_monitoring_provider_details.MonitoringIdentityPipeline.current_step"
+        "sentry.api.endpoints.organization_monitoring_provider_details.IdentityPipeline.current_step"
     )
     @patch(
-        "sentry.api.endpoints.organization_monitoring_provider_details.MonitoringIdentityPipeline.initialize"
+        "sentry.api.endpoints.organization_monitoring_provider_details.IdentityPipeline.initialize"
     )
     def test_connect_returns_redirect_url(
         self, mock_initialize: MagicMock, mock_current_step: MagicMock
@@ -44,10 +44,10 @@ class OrganizationMonitoringProviderDetailsConnectTest(APITestCase):
         mock_initialize.assert_called_once()
 
     @patch(
-        "sentry.api.endpoints.organization_monitoring_provider_details.MonitoringIdentityPipeline.current_step"
+        "sentry.api.endpoints.organization_monitoring_provider_details.IdentityPipeline.current_step"
     )
     @patch(
-        "sentry.api.endpoints.organization_monitoring_provider_details.MonitoringIdentityPipeline.initialize"
+        "sentry.api.endpoints.organization_monitoring_provider_details.IdentityPipeline.initialize"
     )
     def test_connect_gcp_creates_identity_provider(
         self, mock_initialize: MagicMock, mock_current_step: MagicMock
@@ -62,13 +62,13 @@ class OrganizationMonitoringProviderDetailsConnectTest(APITestCase):
         assert IdentityProvider.objects.filter(type="gcp").exists()
 
     @patch(
-        "sentry.api.endpoints.organization_monitoring_provider_details.MonitoringIdentityPipeline.current_step"
+        "sentry.api.endpoints.organization_monitoring_provider_details.IdentityPipeline.current_step"
     )
     @patch(
-        "sentry.api.endpoints.organization_monitoring_provider_details.MonitoringIdentityPipeline.initialize"
+        "sentry.api.endpoints.organization_monitoring_provider_details.IdentityPipeline.initialize"
     )
     @patch(
-        "sentry.api.endpoints.organization_monitoring_provider_details.MonitoringIdentityPipeline.__init__",
+        "sentry.api.endpoints.organization_monitoring_provider_details.IdentityPipeline.__init__",
         return_value=None,
     )
     def test_connect_datadog_does_not_create_identity_provider(
@@ -108,13 +108,13 @@ class OrganizationMonitoringProviderDetailsConnectTest(APITestCase):
         assert "Unknown monitoring provider" in response.data["detail"]
 
     @patch(
-        "sentry.api.endpoints.organization_monitoring_provider_details.MonitoringIdentityPipeline.current_step"
+        "sentry.api.endpoints.organization_monitoring_provider_details.IdentityPipeline.current_step"
     )
     @patch(
-        "sentry.api.endpoints.organization_monitoring_provider_details.MonitoringIdentityPipeline.initialize"
+        "sentry.api.endpoints.organization_monitoring_provider_details.IdentityPipeline.initialize"
     )
     @patch(
-        "sentry.api.endpoints.organization_monitoring_provider_details.MonitoringIdentityPipeline.__init__",
+        "sentry.api.endpoints.organization_monitoring_provider_details.IdentityPipeline.__init__",
         return_value=None,
     )
     def test_connect_allowed_for_org_read_member(

--- a/tests/sentry/identity/test_pipeline.py
+++ b/tests/sentry/identity/test_pipeline.py
@@ -9,7 +9,7 @@ from django.contrib.sessions.backends.base import SessionBase
 from django.test import RequestFactory
 
 import sentry.identity
-from sentry.identity.pipeline import IdentityPipeline, MonitoringIdentityPipeline
+from sentry.identity.pipeline import IdentityPipeline
 from sentry.identity.providers.dummy import DummyProvider
 from sentry.organizations.services.organization.serial import serialize_rpc_organization
 from sentry.silo.base import SiloMode
@@ -126,7 +126,7 @@ class IdentityPipelineFinishTest(TestCase):
 
 @control_silo_test
 @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-class MonitoringIdentityPipelineFinishTest(TestCase):
+class IdentityPipelineOrganizationIdentityTest(TestCase):
     def setUp(self) -> None:
         sentry.identity.register(DummyProvider)
         super().setUp()
@@ -144,6 +144,7 @@ class MonitoringIdentityPipelineFinishTest(TestCase):
         setattr(request, "_messages", FallbackStorage(request))
         return request
 
+    @patch.object(DummyProvider, "create_organization_identity", True)
     @patch.object(DummyProvider, "build_identity", return_value=DUMMY_IDENTITY_DATA)
     def test_creates_organization_identity(
         self, mock_build: MagicMock, mock_record: MagicMock
@@ -155,7 +156,7 @@ class MonitoringIdentityPipelineFinishTest(TestCase):
             type="dummy", external_id="org-456", config={"site": "example.com"}
         )
 
-        pipeline = MonitoringIdentityPipeline(
+        pipeline = IdentityPipeline(
             request=self.request,
             provider_key="dummy",
             organization=rpc_org,
@@ -171,6 +172,7 @@ class MonitoringIdentityPipelineFinishTest(TestCase):
             identity=identity,
         ).exists()
 
+    @patch.object(DummyProvider, "create_organization_identity", True)
     @patch.object(DummyProvider, "build_identity", return_value=DUMMY_IDENTITY_DATA)
     def test_no_organization_skips_organization_identity(
         self, mock_build: MagicMock, mock_record: MagicMock
@@ -179,10 +181,34 @@ class MonitoringIdentityPipelineFinishTest(TestCase):
             type="dummy", external_id="org-456", config={"site": "example.com"}
         )
 
-        pipeline = MonitoringIdentityPipeline(
+        pipeline = IdentityPipeline(
             request=self.request,
             provider_key="dummy",
             organization=None,
+            provider_model=idp,
+        )
+        pipeline.initialize()
+
+        pipeline.finish_pipeline()
+
+        identity = Identity.objects.get(idp=idp, user=self.user)
+        assert not OrganizationIdentity.objects.filter(identity=identity).exists()
+
+    @patch.object(DummyProvider, "build_identity", return_value=DUMMY_IDENTITY_DATA)
+    def test_flag_defaults_to_false_skips_organization_identity(
+        self, mock_build: MagicMock, mock_record: MagicMock
+    ) -> None:
+        with assume_test_silo_mode(SiloMode.CELL):
+            rpc_org = serialize_rpc_organization(self.organization)
+
+        idp = IdentityProvider.objects.create(
+            type="dummy", external_id="org-456", config={"site": "example.com"}
+        )
+
+        pipeline = IdentityPipeline(
+            request=self.request,
+            provider_key="dummy",
+            organization=rpc_org,
             provider_model=idp,
         )
         pipeline.initialize()


### PR DESCRIPTION
Resolves [CW-1544](https://linear.app/getsentry/issue/CW-1544/eliminate-monitoringidentitypipeline-via-provider-flag-on).

Eliminates `MonitoringIdentityPipeline` by adding a `create_organization_identity` flag on the `Provider` base class (follows the existing `auto_create_provider_model` pattern). `OrganizationIdentity` creation now happens in `IdentityPipeline.finish_pipeline()`, gated by the flag, so only providers that opt in (Datadog, Datadog PAT, GCP) get this behavior.

Wraps the DB-mutating block in `finish_pipeline` (`IdentityProvider` get-or-create, `Identity` link, `OrganizationIdentity` creation) in a transaction.