### PR TITLE
fix(alerts): Return fallthrough type

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -713,11 +713,6 @@ class WorkflowEngineRuleSerializer(Serializer):
                     action.type == Action.Type.EMAIL.value
                     and "fallthroughType" not in action_data
                     and action_data.get("targetType")
-                    in (
-                        ActionTargetType.MEMBER.value,
-                        ActionTargetType.TEAM.value,
-                        ActionTargetType.ISSUE_OWNERS.value,
-                    )
                 ):
                     action_data["fallthroughType"] = FallthroughChoiceType.ACTIVE_MEMBERS.value
 

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -671,6 +671,15 @@ class WorkflowEngineRuleSerializer(Serializer):
                 if not action_data:
                     continue
 
+                # XXX: default an empty/missing fallthrough_type before rendering the
+                # label so the label and the fallthroughType we return below agree
+                if (
+                    action.type == Action.Type.EMAIL.value
+                    and action_data.get("targetType")
+                    and not action_data.get("fallthrough_type")
+                ):
+                    action_data["fallthrough_type"] = FallthroughChoiceType.ACTIVE_MEMBERS.value
+
                 action_data["name"] = action_to_handler[action].render_label(
                     workflow.organization_id, action_data, integration_cache=integration_cache
                 )
@@ -707,14 +716,6 @@ class WorkflowEngineRuleSerializer(Serializer):
                     fallthrough_type = action_data.pop("fallthrough_type")
                     if fallthrough_type:
                         action_data["fallthroughType"] = fallthrough_type
-
-                # XXX: add default fallthroughType for email Team/Member/IssueOwners actions
-                if (
-                    action.type == Action.Type.EMAIL.value
-                    and "fallthroughType" not in action_data
-                    and action_data.get("targetType")
-                ):
-                    action_data["fallthroughType"] = FallthroughChoiceType.ACTIVE_MEMBERS.value
 
                 # XXX: add a targetIdentifier empty string for email only
                 if (

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -305,6 +305,14 @@ class RuleSerializer(Serializer[RuleSerializerResponse]):
                         action_data["targetIdentifier"] = str(action_data["targetIdentifier"])
                     if "fallthroughType" not in action_data:
                         action_data["fallthroughType"] = FallthroughChoiceType.ACTIVE_MEMBERS.value
+                # IssueOwners email actions also emit a default fallthroughType to match
+                # WorkflowEngineRuleSerializer output
+                elif (
+                    action_data.get("id") == EMAIL_ACTION
+                    and action_data.get("targetType") == ActionTargetType.ISSUE_OWNERS.value
+                    and "fallthroughType" not in action_data
+                ):
+                    action_data["fallthroughType"] = FallthroughChoiceType.ACTIVE_MEMBERS.value
                 actions.append(action_data)
             except serializers.ValidationError:
                 # Integrations can be deleted and we don't want to fail to load the rule
@@ -695,16 +703,21 @@ class WorkflowEngineRuleSerializer(Serializer):
                 # HACKs below - we don't want to change the underlying data we render for ACI but we need to return it in the expected issue alert format
 
                 # XXX: convert fallthrough_type to fallthroughType
-                if action_data.get("fallthrough_type"):
-                    action_data["fallthroughType"] = action_data.get("fallthrough_type")
-                    del action_data["fallthrough_type"]
+                if "fallthrough_type" in action_data:
+                    fallthrough_type = action_data.pop("fallthrough_type")
+                    if fallthrough_type:
+                        action_data["fallthroughType"] = fallthrough_type
 
-                # XXX: add default fallthroughType for email Team/Member actions
+                # XXX: add default fallthroughType for email Team/Member/IssueOwners actions
                 if (
                     action.type == Action.Type.EMAIL.value
                     and "fallthroughType" not in action_data
                     and action_data.get("targetType")
-                    in (ActionTargetType.MEMBER.value, ActionTargetType.TEAM.value)
+                    in (
+                        ActionTargetType.MEMBER.value,
+                        ActionTargetType.TEAM.value,
+                        ActionTargetType.ISSUE_OWNERS.value,
+                    )
                 ):
                     action_data["fallthroughType"] = FallthroughChoiceType.ACTIVE_MEMBERS.value
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -263,6 +263,38 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
         )
         assert response.data["lastTriggered"] == datetime.now(UTC)
 
+    def test_issue_owners_action_returns_fallthrough_type(self) -> None:
+        # An IssueOwners email action whose stored data is missing a fallthrough_type
+        # should still return the default fallthroughType when serialized.
+        rule = self.create_project_rule(
+            project=self.project,
+            action_data=[
+                {
+                    "targetType": "IssueOwners",
+                    "id": "sentry.mail.actions.NotifyEmailAction",
+                    "targetIdentifier": "",
+                }
+            ],
+        )
+        workflow = AlertRuleWorkflow.objects.get(rule_id=rule.id).workflow
+        action = Action.objects.get(
+            dataconditiongroupaction__condition_group__workflowdataconditiongroup__workflow=workflow,
+            type=Action.Type.EMAIL,
+        )
+        action.data.pop("fallthrough_type", None)
+        action.save()
+
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, rule.id, status_code=200
+        )
+        email_actions = [
+            action
+            for action in response.data["actions"]
+            if action["id"] == "sentry.mail.actions.NotifyEmailAction"
+        ]
+        assert len(email_actions) == 1
+        assert email_actions[0]["fallthroughType"] == "ActiveMembers"
+
 
 class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
     method = "PUT"
@@ -322,6 +354,50 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                 **payload,
             )
         assert_serializer_results_match(response.data, workflow_response.data)
+
+    def test_issue_owners_action_returns_fallthrough_type(self) -> None:
+        # An IssueOwners email action sent without a fallthroughType should still
+        # return the default fallthroughType in the response, for both the legacy
+        # and workflow engine serializers.
+        payload = {
+            "name": "hello world",
+            "actionMatch": "any",
+            "filterMatch": "any",
+            "actions": [
+                {
+                    "targetType": "IssueOwners",
+                    "id": "sentry.mail.actions.NotifyEmailAction",
+                    "targetIdentifier": "",
+                }
+            ],
+            "conditions": [
+                {"id": "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"}
+            ],
+        }
+
+        def assert_fallthrough_type(response_data):
+            email_actions = [
+                action
+                for action in response_data["actions"]
+                if action["id"] == "sentry.mail.actions.NotifyEmailAction"
+            ]
+            assert len(email_actions) == 1
+            assert email_actions[0]["fallthroughType"] == "ActiveMembers"
+
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
+        )
+        assert_fallthrough_type(response.data)
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            workflow_response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.rule.id,
+                status_code=200,
+                **payload,
+            )
+        assert_fallthrough_type(workflow_response.data)
 
     def test_no_owner(self) -> None:
         conditions = [{"id": "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"}]


### PR DESCRIPTION
Update the workflow engine rule serializer response to have the fallthrough type for issue owners to address point 1 in "Affected Fields" of https://github.com/getsentry/sentry/issues/115160