### PR TITLE
feat(seer): Send connected repos to night-shift triage

### DIFF
--- a/src/sentry/seer/night_shift/models.py
+++ b/src/sentry/seer/night_shift/models.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from sentry.tasks.seer.night_shift.models import TriageAction
 
@@ -27,6 +27,7 @@ class TriageCandidate(_Base):
     times_seen: int
     first_seen: str  # ISO 8601; Seer parses it back to a datetime.
     priority: str | None = None
+    connected_repos: list[str] = Field(default_factory=list)
 
 
 class TriageTweaks(_Base):

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -446,6 +446,7 @@ class EligibleProject:
     project: Project
     tweaks: NightShiftTweaks
     stopping_point: AutofixStoppingPoint
+    connected_repos: list[str]
 
 
 def _get_eligible_projects(
@@ -485,6 +486,9 @@ def _get_eligible_projects(
                 preferences[p.id].automated_run_stopping_point
                 or SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
             ),
+            connected_repos=[
+                f"{repo.owner}/{repo.name}" for repo in preferences[p.id].repositories
+            ],
         )
         for p in with_automation
     ]
@@ -512,6 +516,7 @@ def _get_eligible_projects(
 def _build_triage_payload(
     candidates: Sequence[ScoredCandidate],
     resolved_options: SeerNightShiftRunOptions,
+    repos_by_project: dict[int, list[str]],
 ) -> NightShiftPayload:
     return NightShiftPayload(
         candidates=[
@@ -523,6 +528,7 @@ def _build_triage_payload(
                 times_seen=c.group.times_seen,
                 first_seen=c.group.first_seen.isoformat(),
                 priority=priority_label(c.group.priority),
+                connected_repos=repos_by_project.get(c.group.project_id, []),
             )
             for c in candidates
         ],
@@ -547,6 +553,7 @@ def _dispatch_to_seer_feature(
     SeerNightShiftRunShard. Seer pushes verdicts back per shard via
     deliver_feature_result."""
     eligible_projects = [ep.project for ep in eligible]
+    repos_by_project = {ep.project.id: ep.connected_repos for ep in eligible}
     scored = fixability_score_strategy(eligible_projects, resolved_options["max_candidates"])
     if not scored:
         logger.info("night_shift.no_candidates", extra=log_extra)
@@ -566,7 +573,7 @@ def _dispatch_to_seer_feature(
     shards = list(chunked(scored, shard_size))
     dispatched = 0
     for shard_index, chunk in enumerate(shards):
-        payload = _build_triage_payload(chunk, resolved_options)
+        payload = _build_triage_payload(chunk, resolved_options, repos_by_project)
         try:
             client.start_feature_run(
                 feature_id="night_shift",

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -291,6 +291,19 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
         assert [ep.project for ep in result] == [eligible]
         assert result[0].tweaks.enabled is True
 
+    def test_carries_each_projects_connected_repos(self) -> None:
+        org = self.create_organization()
+        a = self._make_eligible(self.create_project(organization=org, slug="a"))
+        b = self._make_eligible(self.create_project(organization=org, slug="b"))
+        extra = self.create_repo(project=b, provider="github", name="owner/b-extra")
+        self.create_seer_project_repository(project=b, repository=extra)
+
+        result = _get_eligible_projects(org, "manual")
+
+        repos_by_slug = {ep.project.slug: sorted(ep.connected_repos) for ep in result}
+        assert repos_by_slug[a.slug] == ["owner/a"]
+        assert repos_by_slug[b.slug] == ["owner/b", "owner/b-extra"]
+
     def test_filters_by_project_id(self) -> None:
         org = self.create_organization()
         target = self._make_eligible(self.create_project(organization=org))
@@ -604,6 +617,7 @@ class TestRunNightShiftFeatureDelivery(NightShiftFixtures, TestCase, SnubaTestCa
         assert body["feature_id"] == "night_shift"
         assert [c["group_id"] for c in body["payload"]["candidates"]] == [group.id]
         assert body["payload"]["candidates"][0]["priority"] == "high"
+        assert body["payload"]["candidates"][0]["connected_repos"] == [f"owner/{project.slug}"]
 
         outbox = CellOutbox.objects.get(
             category=OutboxCategory.SEER_RUN_CREATE, object_identifier=seer_run.id


### PR DESCRIPTION
Attaches each issue's project's connected repos (`owner/name`) to the night-shift triage candidates sent to Seer, so the triage agent grounds `code_search` on the real repo instead of relying on the context engine's volume-gated org index or trying to guess.

`EligibleProject` now carries the connected repos (already read from prefs during eligibility), threaded through `_build_triage_payload` and mapped per-candidate by `group.project_id`. The wire field is optional for rolling-deploy compatibility.

Pairs with Seer getsentry/seer#7103 (renders `connected_repos` into the prompt) and follows getsentry/seer#7101 (disable context engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)