### PR TITLE
refactor(claude-code): Consolidate client construction through integration

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -487,4 +487,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:workflow-engine-performance-detectors", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     manager.add("organizations:relay-generate-billing-outcome", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+
+    manager.add("organizations:claude-code-vault-reuse", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # fmt: on

--- a/src/sentry/integrations/claude_code/integration.py
+++ b/src/sentry/integrations/claude_code/integration.py
@@ -319,7 +319,10 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
         return ClaudeCodeIntegrationMetadata.parse_obj(fresh.metadata or {})
 
     def get_vault_id_for_installation(self, installation_id: int) -> str | None:
-        return self._get_metadata().installation_vault_ids.get(str(installation_id))
+        metadata = self._read_fresh_metadata()
+        if metadata is None:
+            return None
+        return metadata.installation_vault_ids.get(str(installation_id))
 
     def set_vault_id_for_installation(self, installation_id: int, vault_id: str) -> None:
         with self._vault_metadata_lock().acquire():
@@ -340,15 +343,18 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
             return vault_id
 
     def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
-        metadata = self._get_metadata()
+        with self._vault_metadata_lock().acquire():
+            metadata = self._read_fresh_metadata()
+            if metadata is None:
+                return
 
-        if "environment_id" in data:
-            metadata.environment_id = data["environment_id"] or None
+            if "environment_id" in data:
+                metadata.environment_id = data["environment_id"] or None
 
-        if "workspace_is_default" in data:
-            metadata.workspace_name = "default" if data["workspace_is_default"] else None
+            if "workspace_is_default" in data:
+                metadata.workspace_name = "default" if data["workspace_is_default"] else None
 
-        self._persist_metadata(metadata)
+            self._persist_metadata(metadata)
         super().update_organization_config({})
 
     def get_config_data(self) -> Mapping[str, Any]:
@@ -399,20 +405,23 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
         state = client.launch(webhook_url=webhook_url, request=request)
         state.integration_id = self.model.id
 
-        metadata = self._get_metadata()
-        metadata_changed = False
+        with self._vault_metadata_lock().acquire():
+            metadata = self._read_fresh_metadata()
+            if metadata is None:
+                return state
+            metadata_changed = False
 
-        if client.environment_id and client.environment_id != metadata.environment_id:
-            metadata.environment_id = client.environment_id
-            metadata_changed = True
+            if client.environment_id and client.environment_id != metadata.environment_id:
+                metadata.environment_id = client.environment_id
+                metadata_changed = True
 
-        if client.agent_id and client.agent_id != metadata.agent_id:
-            metadata.agent_id = client.agent_id
-            metadata.agent_version = client.agent_version
-            metadata_changed = True
+            if client.agent_id and client.agent_id != metadata.agent_id:
+                metadata.agent_id = client.agent_id
+                metadata.agent_version = client.agent_version
+                metadata_changed = True
 
-        if metadata_changed:
-            self._persist_metadata(metadata)
+            if metadata_changed:
+                self._persist_metadata(metadata)
 
         return state
 

--- a/src/sentry/integrations/claude_code/integration.py
+++ b/src/sentry/integrations/claude_code/integration.py
@@ -373,12 +373,16 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
         )
 
     def uninstall(self) -> None:
-        metadata = self._get_metadata()
-        if not metadata.installation_vault_ids:
-            return
+        with self._vault_metadata_lock().acquire():
+            fresh = self._read_fresh_metadata()
+            if fresh is None or not fresh.installation_vault_ids:
+                return
+            vault_ids = list(fresh.installation_vault_ids.values())
+            fresh.installation_vault_ids = {}
+            self._persist_metadata(fresh)
 
         client = self.get_client()
-        for vault_id in list(metadata.installation_vault_ids.values()):
+        for vault_id in vault_ids:
             try:
                 client.archive_vault(vault_id)
             except Exception:
@@ -386,13 +390,6 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
                     "claude_code.uninstall.archive_vault_failed",
                     extra={"vault_id": vault_id, "integration_id": self.model.id},
                 )
-
-        with self._vault_metadata_lock().acquire():
-            fresh = self._read_fresh_metadata()
-            if fresh is None:
-                return
-            fresh.installation_vault_ids = {}
-            self._persist_metadata(fresh)
 
     def launch(self, request: CodingAgentLaunchRequest) -> CodingAgentState:
         """Launch coding agent and persist resolved environment/agent IDs."""

--- a/src/sentry/integrations/claude_code/integration.py
+++ b/src/sentry/integrations/claude_code/integration.py
@@ -320,10 +320,11 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
         return ClaudeCodeIntegrationMetadata.parse_obj(fresh.metadata or {})
 
     def get_vault_id_for_installation(self, installation_id: int) -> str | None:
-        metadata = self._read_fresh_metadata()
-        if metadata is None:
-            return None
-        return metadata.installation_vault_ids.get(str(installation_id))
+        with self._vault_metadata_lock().acquire():
+            metadata = self._read_fresh_metadata()
+            if metadata is None:
+                return None
+            return metadata.installation_vault_ids.get(str(installation_id))
 
     def set_vault_id_for_installation(self, installation_id: int, vault_id: str) -> None:
         with self._vault_metadata_lock().acquire():
@@ -333,29 +334,17 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
             metadata.installation_vault_ids[str(installation_id)] = vault_id
             self._persist_metadata(metadata)
 
-    def pop_vault_id_for_installation(self, installation_id: int) -> str | None:
-        with self._vault_metadata_lock().acquire():
-            metadata = self._read_fresh_metadata()
-            if metadata is None:
-                return None
-            vault_id = metadata.installation_vault_ids.pop(str(installation_id), None)
-            if vault_id is not None:
-                self._persist_metadata(metadata)
-            return vault_id
-
     def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
         with self._vault_metadata_lock().acquire():
             metadata = self._read_fresh_metadata()
-            if metadata is None:
-                return
+            if metadata is not None:
+                if "environment_id" in data:
+                    metadata.environment_id = data["environment_id"] or None
 
-            if "environment_id" in data:
-                metadata.environment_id = data["environment_id"] or None
+                if "workspace_is_default" in data:
+                    metadata.workspace_name = "default" if data["workspace_is_default"] else None
 
-            if "workspace_is_default" in data:
-                metadata.workspace_name = "default" if data["workspace_is_default"] else None
-
-            self._persist_metadata(metadata)
+                self._persist_metadata(metadata)
         super().update_organization_config({})
 
     def get_config_data(self) -> Mapping[str, Any]:
@@ -371,7 +360,7 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
 
         vault_reuse = features.has(
             "organizations:claude-code-vault-reuse",
-            self.organization_id,
+            self.organization,
         )
 
         return client_class(
@@ -394,7 +383,14 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
             fresh.installation_vault_ids = {}
             self._persist_metadata(fresh)
 
-        client = self.get_client()
+        metadata = self._get_metadata()
+        client_class = _get_client_class()
+        client = client_class(
+            api_key=metadata.api_key,
+            environment_id=metadata.environment_id,
+            workspace_name=metadata.workspace_name,
+        )
+
         for vault_id in vault_ids:
             try:
                 client.archive_vault(vault_id)

--- a/src/sentry/integrations/claude_code/integration.py
+++ b/src/sentry/integrations/claude_code/integration.py
@@ -18,6 +18,7 @@ from django.utils.translation import gettext_lazy as _
 from pydantic import BaseModel, validator
 from rest_framework.fields import CharField
 
+from sentry import features
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.integrations.base import (
     FeatureDescription,
@@ -367,6 +368,12 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
     def get_client(self) -> Any:
         metadata = self._get_metadata()
         client_class = _get_client_class()
+
+        vault_reuse = features.has(
+            "organizations:claude-code-vault-reuse",
+            self.organization_id,
+        )
+
         return client_class(
             api_key=metadata.api_key,
             environment_id=metadata.environment_id,
@@ -374,8 +381,8 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
             agent_id=metadata.agent_id,
             agent_version=metadata.agent_version,
             model=metadata.model,
-            installation_vault_lookup=self.get_vault_id_for_installation,
-            installation_vault_writer=self.set_vault_id_for_installation,
+            installation_vault_lookup=self.get_vault_id_for_installation if vault_reuse else None,
+            installation_vault_writer=self.set_vault_id_for_installation if vault_reuse else None,
         )
 
     def uninstall(self) -> None:

--- a/src/sentry/integrations/claude_code/integration.py
+++ b/src/sentry/integrations/claude_code/integration.py
@@ -33,7 +33,9 @@ from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.locks import locks
 from sentry.pipeline.types import PipelineStepResult
 from sentry.pipeline.views.base import ApiPipelineSteps
 from sentry.seer.autofix.utils import CodingAgentState
@@ -46,6 +48,7 @@ PROVIDER_KEY = "claude_code"
 PROVIDER_NAME = "Claude Agent"
 DESCRIPTION = "Connect your Sentry organization with Claude Agent."
 DEFAULT_ENVIRONMENT_NAME = "sentry-autofix-agents"
+VAULT_METADATA_LOCK_DURATION_S = 10
 
 
 def _get_client_class() -> type[Any]:
@@ -82,6 +85,8 @@ class ClaudeCodeIntegrationMetadata(BaseModel):
     agent_id: str | None = None
     agent_version: int | None = None
     model: str | None = None
+    # One vault per github installation so concurrent launches don't clobber each other's credentials.
+    installation_vault_ids: dict[str, str] = {}
 
     @validator("agent_version", pre=True)
     def coerce_agent_version(cls, v: object) -> int | None:
@@ -300,6 +305,40 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
         """Parse and return the integration metadata."""
         return ClaudeCodeIntegrationMetadata.parse_obj(self.model.metadata or {})
 
+    def _vault_metadata_lock(self):
+        return locks.get(
+            f"claude_code:vault:{self.model.id}",
+            duration=VAULT_METADATA_LOCK_DURATION_S,
+            name="claude_code_vault_metadata",
+        )
+
+    def _read_fresh_metadata(self) -> ClaudeCodeIntegrationMetadata | None:
+        fresh = integration_service.get_integration(integration_id=self.model.id)
+        if fresh is None:
+            return None
+        return ClaudeCodeIntegrationMetadata.parse_obj(fresh.metadata or {})
+
+    def get_vault_id_for_installation(self, installation_id: int) -> str | None:
+        return self._get_metadata().installation_vault_ids.get(str(installation_id))
+
+    def set_vault_id_for_installation(self, installation_id: int, vault_id: str) -> None:
+        with self._vault_metadata_lock().acquire():
+            metadata = self._read_fresh_metadata()
+            if metadata is None:
+                return
+            metadata.installation_vault_ids[str(installation_id)] = vault_id
+            self._persist_metadata(metadata)
+
+    def pop_vault_id_for_installation(self, installation_id: int) -> str | None:
+        with self._vault_metadata_lock().acquire():
+            metadata = self._read_fresh_metadata()
+            if metadata is None:
+                return None
+            vault_id = metadata.installation_vault_ids.pop(str(installation_id), None)
+            if vault_id is not None:
+                self._persist_metadata(metadata)
+            return vault_id
+
     def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
         metadata = self._get_metadata()
 
@@ -329,7 +368,31 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
             agent_id=metadata.agent_id,
             agent_version=metadata.agent_version,
             model=metadata.model,
+            installation_vault_lookup=self.get_vault_id_for_installation,
+            installation_vault_writer=self.set_vault_id_for_installation,
         )
+
+    def uninstall(self) -> None:
+        metadata = self._get_metadata()
+        if not metadata.installation_vault_ids:
+            return
+
+        client = self.get_client()
+        for vault_id in list(metadata.installation_vault_ids.values()):
+            try:
+                client.archive_vault(vault_id)
+            except Exception:
+                logger.exception(
+                    "claude_code.uninstall.archive_vault_failed",
+                    extra={"vault_id": vault_id, "integration_id": self.model.id},
+                )
+
+        with self._vault_metadata_lock().acquire():
+            fresh = self._read_fresh_metadata()
+            if fresh is None:
+                return
+            fresh.installation_vault_ids = {}
+            self._persist_metadata(fresh)
 
     def launch(self, request: CodingAgentLaunchRequest) -> CodingAgentState:
         """Launch coding agent and persist resolved environment/agent IDs."""

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -6,7 +6,6 @@ import secrets
 import string
 from typing import Any
 
-from django.conf import settings as django_settings
 from rest_framework.exceptions import NotFound, ValidationError
 
 
@@ -15,9 +14,7 @@ class IntegrationNotFound(NotFound):
 
 
 from sentry.constants import ObjectStatus
-from sentry.integrations.claude_code.integration import (
-    ClaudeCodeIntegrationMetadata,
-)
+from sentry.integrations.claude_code.integration import ClaudeCodeAgentIntegrationProvider
 from sentry.integrations.claude_code.utils import ClaudeSessionEvent, ClaudeSessionEventStatus
 from sentry.integrations.coding_agent.integration import CodingAgentIntegration
 from sentry.integrations.coding_agent.utils import get_coding_agent_providers
@@ -38,7 +35,6 @@ from sentry.seer.autofix.utils import (
 )
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import SeerViewerContext
-from sentry.utils.imports import import_string
 
 logger = logging.getLogger(__name__)
 
@@ -307,10 +303,6 @@ def poll_claude_code_agents(
 
     clients: dict[int, Any] = {}
 
-    if not django_settings.CLAUDE_CODE_CLIENT_CLASS:
-        logger.warning("coding_agent.claude_code.no_client_class_configured")
-        return
-
     run_id = run_id if run_id is not None else (autofix_state.run_id if autofix_state else None)
 
     for agent_id, agent_state in agents.items():
@@ -394,7 +386,6 @@ def poll_claude_agent(
 
 
 def get_claude_code_client(clients, agent_id, org_id, integration_id: int | None) -> Any | None:
-    # Get or create client for this agent's integration
     if integration_id is None:
         logger.warning(
             "coding_agent.claude_code.missing_integration_id",
@@ -402,38 +393,26 @@ def get_claude_code_client(clients, agent_id, org_id, integration_id: int | None
         )
         return None
     if integration_id in clients:
-        client = clients[integration_id]
-    else:
-        org_integration = integration_service.get_organization_integration(
-            organization_id=org_id,
-            integration_id=integration_id,
-        )
-        if not org_integration:
-            logger.warning(
-                "coding_agent.claude_code.integration_not_found",
-                extra={"organization_id": org_id, "integration_id": integration_id},
-            )
-            return None
-        integration = integration_service.get_integration(
-            organization_integration_id=org_integration.id,
-        )
-        if not integration:
-            logger.warning(
-                "coding_agent.claude_code.integration_not_found",
-                extra={"organization_id": org_id, "integration_id": integration_id},
-            )
-            return None
-        metadata = ClaudeCodeIntegrationMetadata.parse_obj(integration.metadata or {})
+        return clients[integration_id]
 
-        if not django_settings.CLAUDE_CODE_CLIENT_CLASS:
-            return None
-        client_class = import_string(django_settings.CLAUDE_CODE_CLIENT_CLASS)
-        client = client_class(
-            api_key=metadata.api_key,
-            environment_id=metadata.environment_id,
-            workspace_name=metadata.workspace_name,
+    integration = integration_service.get_integration(integration_id=integration_id)
+    if not integration:
+        logger.warning(
+            "coding_agent.claude_code.integration_not_found",
+            extra={"organization_id": org_id, "integration_id": integration_id},
         )
-        clients[integration_id] = client
+        return None
+
+    installation = ClaudeCodeAgentIntegrationProvider.get_installation(integration, org_id)
+    try:
+        client = installation.get_client()
+    except Exception:
+        logger.exception(
+            "coding_agent.claude_code.get_client_failed",
+            extra={"organization_id": org_id, "integration_id": integration_id},
+        )
+        return None
+    clients[integration_id] = client
     return client
 
 

--- a/tests/sentry/integrations/claude_code/test_integration.py
+++ b/tests/sentry/integrations/claude_code/test_integration.py
@@ -529,6 +529,25 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             integration = Integration.objects.get(id=installation.model.id)
         assert integration.metadata["installation_vault_ids"] == {}
 
+    def test_uninstall_concurrent_vault_write_during_archive_is_preserved(self) -> None:
+        """A vault written by a concurrent session while archive_vault() runs must not be lost."""
+        installation = self._create_installation(
+            installation_vault_ids={"42": "vault_a"},
+        )
+        mock_cls, mock_client = _mock_client_class()
+
+        def archive_with_concurrent_write(vault_id):
+            installation.set_vault_id_for_installation(99, "vault_new")
+
+        mock_client.archive_vault.side_effect = archive_with_concurrent_write
+
+        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+            installation.uninstall()
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(id=installation.model.id)
+        assert integration.metadata["installation_vault_ids"] == {"99": "vault_new"}
+
     # ── launch ───────────────────────────────────────────────────────
 
     def _setup_launch(

--- a/tests/sentry/integrations/claude_code/test_integration.py
+++ b/tests/sentry/integrations/claude_code/test_integration.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Mapping
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from django.urls import reverse
@@ -233,7 +233,12 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             agent_id=None,
             agent_version=None,
             model=None,
+            installation_vault_lookup=ANY,
+            installation_vault_writer=ANY,
         )
+        passed = mock_cls.call_args.kwargs
+        assert passed["installation_vault_lookup"] == installation.get_vault_id_for_installation
+        assert passed["installation_vault_writer"] == installation.set_vault_id_for_installation
 
     def test_get_client_with_environment_and_workspace(self) -> None:
         mock_cls, mock_client = _mock_client_class()
@@ -261,6 +266,8 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             agent_id="agent-123",
             agent_version=1,
             model=None,
+            installation_vault_lookup=ANY,
+            installation_vault_writer=ANY,
         )
 
     def test_get_client_passes_model_from_metadata(self) -> None:
@@ -283,6 +290,8 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             agent_id=None,
             agent_version=None,
             model="claude-sonnet-4-6",
+            installation_vault_lookup=ANY,
+            installation_vault_writer=ANY,
         )
 
     def test_get_client_passes_none_model_when_metadata_has_none(self) -> None:
@@ -305,6 +314,8 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             agent_id=None,
             agent_version=None,
             model=None,
+            installation_vault_lookup=ANY,
+            installation_vault_writer=ANY,
         )
 
     def test_get_client_class_not_configured(self) -> None:
@@ -411,6 +422,112 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
         assert "workspace_is_default" in fields
         assert fields["workspace_is_default"]["type"] == "boolean"
         assert "workspace_name" not in fields
+
+    # ── installation_vault_ids helpers ───────────────────────────────
+
+    def test_installation_vault_ids_default_empty(self) -> None:
+        installation = self._create_installation()
+        assert installation.get_vault_id_for_installation(42) is None
+
+    def test_installation_vault_ids_round_trip(self) -> None:
+        installation = self._create_installation(
+            installation_vault_ids={"42": "vault_pre"},
+        )
+        assert installation.get_vault_id_for_installation(42) == "vault_pre"
+
+    def test_set_vault_id_for_installation_writes_metadata(self) -> None:
+        installation = self._create_installation()
+
+        installation.set_vault_id_for_installation(42, "vault_abc")
+
+        assert installation.get_vault_id_for_installation(42) == "vault_abc"
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(id=installation.model.id)
+        assert integration.metadata["installation_vault_ids"] == {"42": "vault_abc"}
+
+    def test_set_vault_id_for_installation_merges_concurrent_writer(self) -> None:
+        installation = self._create_installation()
+
+        original_read = installation._read_fresh_metadata
+
+        def read_with_concurrent_writer():
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                Integration.objects.filter(id=installation.model.id).update(
+                    metadata={
+                        **installation.model.metadata,
+                        "installation_vault_ids": {"99": "vault_other"},
+                    }
+                )
+            return original_read()
+
+        with patch.object(
+            installation, "_read_fresh_metadata", side_effect=read_with_concurrent_writer
+        ):
+            installation.set_vault_id_for_installation(42, "vault_mine")
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(id=installation.model.id)
+        assert integration.metadata["installation_vault_ids"] == {
+            "99": "vault_other",
+            "42": "vault_mine",
+        }
+
+    def test_pop_vault_id_for_installation_removes_and_returns(self) -> None:
+        installation = self._create_installation(
+            installation_vault_ids={"42": "vault_abc", "7": "vault_xyz"},
+        )
+
+        popped = installation.pop_vault_id_for_installation(42)
+
+        assert popped == "vault_abc"
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(id=installation.model.id)
+        assert integration.metadata["installation_vault_ids"] == {"7": "vault_xyz"}
+
+    def test_pop_vault_id_for_installation_missing_returns_none(self) -> None:
+        installation = self._create_installation()
+
+        assert installation.pop_vault_id_for_installation(42) is None
+
+    # ── uninstall ────────────────────────────────────────────────────
+
+    def test_uninstall_archives_each_vault_and_clears_metadata(self) -> None:
+        installation = self._create_installation(
+            installation_vault_ids={"42": "vault_a", "7": "vault_b"},
+        )
+        mock_cls, mock_client = _mock_client_class()
+
+        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+            installation.uninstall()
+
+        archive_calls = [c.args[0] for c in mock_client.archive_vault.call_args_list]
+        assert sorted(archive_calls) == ["vault_a", "vault_b"]
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(id=installation.model.id)
+        assert integration.metadata["installation_vault_ids"] == {}
+
+    def test_uninstall_no_vaults_is_a_noop(self) -> None:
+        installation = self._create_installation()
+        mock_cls, mock_client = _mock_client_class()
+
+        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+            installation.uninstall()
+
+        mock_client.archive_vault.assert_not_called()
+
+    def test_uninstall_clears_metadata_even_when_archive_fails(self) -> None:
+        installation = self._create_installation(
+            installation_vault_ids={"42": "vault_a"},
+        )
+        mock_cls, mock_client = _mock_client_class()
+        mock_client.archive_vault.side_effect = RuntimeError("anthropic api blew up")
+
+        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+            installation.uninstall()
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(id=installation.model.id)
+        assert integration.metadata["installation_vault_ids"] == {}
 
     # ── launch ───────────────────────────────────────────────────────
 

--- a/tests/sentry/integrations/claude_code/test_integration.py
+++ b/tests/sentry/integrations/claude_code/test_integration.py
@@ -221,9 +221,11 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             metadata=self._make_metadata(),
         )
         installation = integration.get_installation(organization_id=self.organization.id)
+        assert isinstance(installation, ClaudeCodeAgentIntegration)
 
-        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
-            client = installation.get_client()
+        with self.feature("organizations:claude-code-vault-reuse"):
+            with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+                client = installation.get_client()
 
         assert client is mock_client
         mock_cls.assert_called_once_with(
@@ -266,8 +268,8 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             agent_id="agent-123",
             agent_version=1,
             model=None,
-            installation_vault_lookup=ANY,
-            installation_vault_writer=ANY,
+            installation_vault_lookup=None,
+            installation_vault_writer=None,
         )
 
     def test_get_client_passes_model_from_metadata(self) -> None:
@@ -290,8 +292,8 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             agent_id=None,
             agent_version=None,
             model="claude-sonnet-4-6",
-            installation_vault_lookup=ANY,
-            installation_vault_writer=ANY,
+            installation_vault_lookup=None,
+            installation_vault_writer=None,
         )
 
     def test_get_client_passes_none_model_when_metadata_has_none(self) -> None:
@@ -314,8 +316,8 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             agent_id=None,
             agent_version=None,
             model=None,
-            installation_vault_lookup=ANY,
-            installation_vault_writer=ANY,
+            installation_vault_lookup=None,
+            installation_vault_writer=None,
         )
 
     def test_get_client_class_not_configured(self) -> None:
@@ -471,23 +473,6 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             "99": "vault_other",
             "42": "vault_mine",
         }
-
-    def test_pop_vault_id_for_installation_removes_and_returns(self) -> None:
-        installation = self._create_installation(
-            installation_vault_ids={"42": "vault_abc", "7": "vault_xyz"},
-        )
-
-        popped = installation.pop_vault_id_for_installation(42)
-
-        assert popped == "vault_abc"
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.get(id=installation.model.id)
-        assert integration.metadata["installation_vault_ids"] == {"7": "vault_xyz"}
-
-    def test_pop_vault_id_for_installation_missing_returns_none(self) -> None:
-        installation = self._create_installation()
-
-        assert installation.pop_vault_id_for_installation(42) is None
 
     # ── uninstall ────────────────────────────────────────────────────
 

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -421,10 +421,9 @@ class TestPollGithubCopilotAgents(TestCase):
         poll_github_copilot_agents(autofix_state, user_id=self.user.id)
 
 
-MOCK_CLIENT_CLASS_PATH = "sentry.seer.autofix.coding_agent.import_string"
+MOCK_CLIENT_CLASS_PATH = "sentry.integrations.claude_code.integration._get_client_class"
 MOCK_INTEGRATION_SERVICE_PATH = "sentry.seer.autofix.coding_agent.integration_service"
 MOCK_UPDATE_STATE_PATH = "sentry.seer.autofix.coding_agent.update_coding_agent_state"
-MOCK_DJANGO_SETTINGS_PATH = "sentry.seer.autofix.coding_agent.django_settings"
 
 
 def _make_agent_event(text: str) -> ClaudeSessionEvent:
@@ -526,11 +525,6 @@ class TestPollClaudeCodeAgents(TestCase):
         self.project = self.create_project(organization=self.organization)
         self.run_id = 12345
         self.integration_id = 99
-
-        patcher = patch(MOCK_DJANGO_SETTINGS_PATH)
-        self.mock_settings = patcher.start()
-        self.mock_settings.CLAUDE_CODE_CLIENT_CLASS = "test.MockClaudeCodeClient"
-        self.addCleanup(patcher.stop)
 
     def _create_autofix_state_with_agents(
         self, agents: dict[str, CodingAgentState]
@@ -817,7 +811,7 @@ class TestPollClaudeCodeAgents(TestCase):
     @patch(MOCK_CLIENT_CLASS_PATH)
     @patch(MOCK_INTEGRATION_SERVICE_PATH)
     def test_uses_correct_integration_per_agent(
-        self, mock_integration_service, mock_import_string, mock_update_state
+        self, mock_integration_service, mock_get_client_class, mock_update_state
     ):
         integration_a = MagicMock()
         integration_a.metadata = {
@@ -831,20 +825,10 @@ class TestPollClaudeCodeAgents(TestCase):
             "environment_id": "env-b",
             "workspace_name": "ws-b",
         }
-        org_integration_a = MagicMock()
-        org_integration_a.id = 1001
-        org_integration_b = MagicMock()
-        org_integration_b.id = 1002
-        mock_integration_service.get_organization_integration.side_effect = (
-            lambda organization_id, integration_id: {
-                100: org_integration_a,
-                200: org_integration_b,
-            }[integration_id]
-        )
-        mock_integration_service.get_integration.side_effect = lambda organization_integration_id: {
-            1001: integration_a,
-            1002: integration_b,
-        }[organization_integration_id]
+        mock_integration_service.get_integration.side_effect = lambda integration_id: {
+            100: integration_a,
+            200: integration_b,
+        }[integration_id]
 
         clients = {}
 
@@ -854,7 +838,7 @@ class TestPollClaudeCodeAgents(TestCase):
             clients[kwargs["api_key"]] = client
             return client
 
-        mock_import_string.return_value = make_client
+        mock_get_client_class.return_value = make_client
 
         agent_a = CodingAgentState(
             id="session-a",


### PR DESCRIPTION
## Summary
- Replace manual client construction in `get_claude_code_client()` with `ClaudeCodeAgentIntegrationProvider.get_installation().get_client()`
- Eliminates a diverging second construction site in the polling path that was missing `agent_id`, `agent_version`, `model`, and vault callbacks
- Depends on #118271

## Test plan
- [x] `pytest tests/sentry/seer/autofix/test_coding_agent.py::TestPollClaudeCodeAgents` — all 14 tests pass
- [x] `pytest tests/sentry/integrations/claude_code/test_integration.py` — all 46 tests pass
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)