### PR TITLE
feat(outbox) Enable selective outbox backfills from control

### DIFF
--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -157,6 +157,13 @@ register(
 )
 
 register(
+    "outbox_replication.sentry_apitoken.target_cells",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "hybrid_cloud.authentication.disabled_organization_shards",
     type=Sequence,
     default=[],

--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -157,7 +157,7 @@ register(
 )
 
 register(
-    "outbox_replication.sentry_apitoken.target_cells",
+    "outbox_replication.sentry_apitoken.backfill.target_cells",
     type=Sequence,
     default=[],
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -162,7 +162,7 @@ def process_outbox_backfill_batch(
                 target_cells: list[str] | None = None
                 try:
                     target_cells = options.get(
-                        f"outbox_replication.{inst._meta.db_table}.target-cells"
+                        f"outbox_replication.{inst._meta.db_table}.backfill.target_cells"
                     )
                 except options.UnknownOption:
                     pass

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -159,7 +159,16 @@ def process_outbox_backfill_batch(
             if isinstance(inst, CellOutboxProducingModel):
                 inst.outbox_for_update().save()
             if isinstance(inst, ControlOutboxProducingModel) or isinstance(inst, User):
+                target_cells: list[str] | None = None
+                try:
+                    target_cells = options.get(
+                        f"outbox_replication.{inst._meta.db_table}.target-cells"
+                    )
+                except options.UnknownOption:
+                    pass
                 for outbox in inst.outboxes_for_update():
+                    if target_cells and outbox.cell_name not in target_cells:
+                        continue
                     outbox.save()
 
     if not processing_state.has_more:

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -175,7 +175,7 @@ def test_control_processing_auth(task_runner: Callable[..., Any]) -> None:
 
 @django_db_all
 @control_silo_test(cells=create_test_cells("us", "de"))
-@override_options({"outbox_replication.sentry_apitoken.target-cells": ["us"]})
+@override_options({"outbox_replication.sentry_apitoken.backfill.target_cells": ["us"]})
 def test_control_processing_target_cells(task_runner: Callable[..., Any]) -> None:
     reset_processing_state()
 

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -3,9 +3,11 @@ from typing import Any
 from unittest.mock import patch
 
 from django.apps import apps
+from django.db import router, transaction
 from django.test.utils import override_settings
 
 from sentry.db.models import BaseModel
+from sentry.hybridcloud.models.apitokenreplica import ApiTokenReplica
 from sentry.hybridcloud.models.outbox import CellOutbox, ControlOutbox, outbox_context
 from sentry.hybridcloud.outbox.base import run_outbox_replications_for_self_hosted
 from sentry.hybridcloud.tasks.backfill_outboxes import (
@@ -14,6 +16,7 @@ from sentry.hybridcloud.tasks.backfill_outboxes import (
     get_processing_state,
     process_outbox_backfill_batch,
 )
+from sentry.models.apitoken import ApiToken
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authidentityreplica import AuthIdentityReplica
 from sentry.models.authprovider import AuthProvider
@@ -25,7 +28,12 @@ from sentry.testutils.factories import Factories
 from sentry.testutils.helpers import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, no_silo_test
+from sentry.testutils.silo import (
+    assume_test_silo_mode,
+    control_silo_test,
+    create_test_cells,
+    no_silo_test,
+)
 from sentry.utils import redis
 
 
@@ -80,7 +88,7 @@ def test_cell_processing(task_runner: Callable[..., Any]) -> None:
 
 @django_db_all
 @control_silo_test
-def test_control_processing(task_runner: Callable[..., Any]) -> None:
+def test_control_processing_auth(task_runner: Callable[..., Any]) -> None:
     reset_processing_state()
 
     org = Factories.create_organization()
@@ -163,6 +171,52 @@ def test_control_processing(task_runner: Callable[..., Any]) -> None:
             assert AuthIdentityReplica.objects.filter(auth_provider_id=ap.id).count() == 5
 
         assert get_processing_state(AuthIdentity._meta.db_table)[1] == 10001
+
+
+@django_db_all
+@control_silo_test(cells=create_test_cells("us", "de"))
+@override_options({"outbox_replication.sentry_apitoken.target-cells": ["us"]})
+def test_control_processing_target_cells(task_runner: Callable[..., Any]) -> None:
+    reset_processing_state()
+
+    user = Factories.create_user()
+
+    # Monkeypatch ApiToken.default_flush because it is a option driven attribute
+    with (
+        patch.object(ApiToken, "default_flush", False),
+        outbox_context(transaction.atomic(using=router.db_for_write(ApiToken)), flush=False),
+    ):
+        first_token = Factories.create_user_auth_token(user)
+        second_token = Factories.create_user_auth_token(user)
+
+    # Clear existing outboxes, force replication by hand
+    ControlOutbox.objects.all().delete()
+
+    assert not ControlOutbox.objects.all().exists()
+    with assume_test_silo_mode(SiloMode.CELL):
+        assert not ApiTokenReplica.objects.filter(user_id=user.id).exists()
+
+    def run_for_model(model: type[BaseModel]) -> None:
+        while True:
+            if process_outbox_backfill_batch(model, 1, force_synchronous=True) is None:
+                break
+
+    with task_runner():
+        run_for_model(ApiToken)
+
+    assert get_processing_state(ApiToken._meta.db_table)[1] == ApiToken.replication_version + 1
+
+    with outbox_runner():
+        assert ControlOutbox.objects.all().count() == 2
+        assert ControlOutbox.objects.filter(cell_name="us").count() == 2
+        assert ControlOutbox.objects.filter(cell_name="de").count() == 0
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert not ApiTokenReplica.objects.filter(user_id=user.id).exists()
+
+    with assume_test_silo_mode(SiloMode.CELL):
+        # After outbox_runner() is complete replication should complete.
+        assert ApiTokenReplica.objects.filter(apitoken_id=first_token.id).exists()
+        assert ApiTokenReplica.objects.filter(apitoken_id=second_token.id).exists()
 
 
 @django_db_all


### PR DESCRIPTION
When a new cell is added we need a way to replicate existing data into the new cell. These changes let us use options to select which cells get outboxes generated for them during an outbox backfill.

The process for using this would be:

- Set the target-cell option value to the list of cells we want to do backfills in.
- Increment the `replication_version` on the model class.
- Increment the replication version in options to begin the backfill.

Changing the replication version will also trigger backfills in self-hosted/single-tenant on their next deploy/upgrade.

Refs PRODENG-1653