### PR TITLE
feat(seer): Restrict night shift to an org's allowed project slugs

### DIFF
--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -458,10 +458,15 @@ def _get_eligible_projects(
 
     When project_ids is provided, the org's projects are restricted to that set.
     Manual triggers bypass the tweaks.enabled gate — the user explicitly asked
-    for this run. Scheduler runs respect it."""
+    for this run. Scheduler runs respect it, and are additionally restricted to
+    the org's allowed_project_slugs when that override is set."""
     project_qs = Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
     if project_ids is not None:
         project_qs = project_qs.filter(id__in=project_ids)
+    if source == "cron":
+        org_tweaks = get_night_shift_org_tweaks(organization.id)
+        if org_tweaks is not None and org_tweaks.allowed_project_slugs is not None:
+            project_qs = project_qs.filter(slug__in=org_tweaks.allowed_project_slugs)
     project_map = {p.id: p for p in project_qs}
     if not project_map:
         return []

--- a/src/sentry/tasks/seer/night_shift/tweaks.py
+++ b/src/sentry/tasks/seer/night_shift/tweaks.py
@@ -34,6 +34,7 @@ class NightShiftTweaks(pydantic.BaseModel):
     extra_triage_instructions: str = DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS
     intelligence_level: IntelligenceLevel = DEFAULT_INTELLIGENCE_LEVEL
     reasoning_effort: ReasoningEffort = DEFAULT_REASONING_EFFORT
+    allowed_project_slugs: list[str] | None = None
 
     class Config:
         alias_generator = snake_to_camel_case

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -330,6 +330,20 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
 
         assert [ep.project for ep in result] == [opens_pr]
 
+    def test_cron_respects_org_allowed_project_slugs_manual_ignores(self) -> None:
+        org = self.create_organization()
+        for slug in ("keep", "drop"):
+            self._make_eligible(self.create_project(organization=org, slug=slug))
+
+        with self.options(
+            {"seer.night_shift.org_tweaks": {str(org.id): {"allowed_project_slugs": ["keep"]}}}
+        ):
+            cron_result = _get_eligible_projects(org, "cron")
+            manual_result = _get_eligible_projects(org, "manual")
+
+        assert [ep.project.slug for ep in cron_result] == ["keep"]
+        assert sorted(ep.project.slug for ep in manual_result) == ["drop", "keep"]
+
 
 @django_db_all
 class TestRunNightShiftForOrg(NightShiftFixtures, TestCase, SnubaTestCase):


### PR DESCRIPTION
Adds an `allowed_project_slugs` override to `NightShiftTweaks`. When set on an org's `seer.night_shift.org_tweaks` entry, scheduled night shift runs are restricted to projects with those slugs (cron only; manual triggers unaffected).

Config that uses this is in a separate options-automator PR — land this first.