### PR TITLE
feat(dashboards): Improve heat map axis tick placement

### DIFF
--- a/static/app/chartcuterie/heatmaps.tsx
+++ b/static/app/chartcuterie/heatmaps.tsx
@@ -2,11 +2,14 @@ import type {Theme} from '@emotion/react';
 
 import {Grid} from 'sentry/components/charts/components/grid';
 import type {HeatMapSeries} from 'sentry/views/dashboards/widgets/common/types';
-import {formatYAxisValue} from 'sentry/views/dashboards/widgets/heatMapWidget/formatters/formatYAxisValue';
 import {visualMapOptions} from 'sentry/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization';
 import {HeatMap} from 'sentry/views/dashboards/widgets/heatMapWidget/plottables/heatMap';
 import {HEATMAP_COLORS} from 'sentry/views/dashboards/widgets/heatMapWidget/settings';
-import {formatXAxisTimestamp} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp';
+import {
+  HIDDEN_CATEGORY_AXIS,
+  heatMapTimeAxis,
+  heatMapValueAxis,
+} from 'sentry/views/dashboards/widgets/heatMapWidget/utils/heatMapAxes';
 
 import {DEFAULT_FONT_FAMILY} from './slack';
 import {CHART_SIZE, FONT_SIZE} from './timeseries';
@@ -25,139 +28,31 @@ export function buildHeatmapChartOption({
   theme: Theme;
 }) {
   const heatMapPlottable = new HeatMap(heatMapSeries);
+  const {xAxis: xAxisMeta, yAxis: yAxisMeta} = heatMapSeries.meta;
 
-  const yAxisDataType = heatMapPlottable.yAxisValueType;
-  const yAxisDataUnit = heatMapPlottable.yAxisValueUnit;
-
-  // The full value range of the buckets. `start` is the first bucket's lower
-  // bound and `end` is the last bucket's upper bound. We pin an overlaid value
-  // axis to this range so ECharts can place round ticks on it (see `yAxis`).
-  const yAxisMin = heatMapPlottable.heatMapSeries.meta.yAxis.start;
-  const yAxisMax = heatMapPlottable.heatMapSeries.meta.yAxis.end;
-
-  // The full time range of the X-axis buckets, in milliseconds. We overlay a
-  // `time` axis on this range so ECharts can place ticks on natural time
-  // boundaries (day/hour starts) instead of on every bucket edge (see `xAxis`).
-  const xAxisMin = heatMapPlottable.heatMapSeries.meta.xAxis.start;
-  const xAxisMax = heatMapPlottable.heatMapSeries.meta.xAxis.end;
-
-  const series = heatMapPlottable.toSeries({theme});
+  // Chartcuterie renders without BaseChart's axis wrappers, so we set the label
+  // font on the overlay (visible) axes ourselves.
+  const labelFont = {fontSize: FONT_SIZE, fontFamily: DEFAULT_FONT_FAMILY};
+  const timeAxis = heatMapTimeAxis({min: xAxisMeta.start, max: xAxisMeta.end, utc: true});
+  const valueAxis = heatMapValueAxis({
+    min: yAxisMeta.start,
+    max: yAxisMeta.end,
+    valueType: heatMapPlottable.yAxisValueType,
+    valueUnit: heatMapPlottable.yAxisValueUnit ?? undefined,
+  });
 
   return {
     grid: Grid({left: 10, right: 10, bottom: 10, top: 10}),
     backgroundColor: theme.tokens.background.primary,
     xAxis: [
-      // Category axis: positions the heat map cells (ECharts requires a category
-      // axis for heat map series). Its categories are the bucket boundaries
-      // (timestamps), so we hide its labels and let the overlaid time axis
-      // render readable ticks instead. As with the Y axis, we don't set `data`
-      // so ECharts matches cells to categories by value.
-      {
-        type: 'category',
-        axisLabel: {
-          show: false,
-        },
-        axisLine: {
-          show: false,
-        },
-        axisTick: {
-          show: false,
-        },
-        axisPointer: {
-          show: false,
-        },
-        splitArea: {
-          show: false,
-        },
-      },
-      // Time axis (overlay): spans the full time range of the buckets and lets
-      // ECharts place ticks on natural time boundaries. A second x-axis defaults
-      // to the top, so we pin it to the bottom explicitly.
-      {
-        type: 'time',
-        position: 'bottom',
-        min: xAxisMin,
-        max: xAxisMax,
-        axisLabel: {
-          hideOverlap: true,
-          formatter: (value: number) => formatXAxisTimestamp(value, {utc: true}),
-          fontSize: FONT_SIZE,
-          fontFamily: DEFAULT_FONT_FAMILY,
-        },
-        axisLine: {
-          show: false,
-        },
-        axisPointer: {
-          show: false,
-        },
-        splitArea: {
-          show: false,
-        },
-        splitLine: {
-          show: false,
-        },
-      },
+      HIDDEN_CATEGORY_AXIS,
+      {...timeAxis, axisLabel: {...timeAxis.axisLabel, ...labelFont}},
     ],
     yAxis: [
-      // Category axis: positions the heat map cells (ECharts requires a
-      // category axis for heat map series). Its categories are the bucket
-      // boundaries, which are rarely round, so we hide its labels and let the
-      // overlaid value axis render readable ticks instead.
-      //
-      // We deliberately don't set `data` here: ECharts collects the categories
-      // from the series' Y values and matches cells to them by value. Supplying
-      // our own category list would make ECharts treat those same Y values as
-      // category *indices* instead, dropping every cell whose value isn't a
-      // valid index.
-      {
-        type: 'category',
-        animation: false,
-        axisLabel: {
-          show: false,
-        },
-        axisLine: {
-          show: false,
-        },
-        axisTick: {
-          show: false,
-        },
-        axisPointer: {
-          show: false,
-        },
-        splitArea: {
-          show: false,
-        },
-      },
-      // Value axis (overlay): spans the full value range of the buckets and
-      // lets ECharts place round ticks on it. These don't line up with the
-      // bucket boundaries, they just read cleanly. A second y-axis defaults to
-      // the right, so we pin it to the left explicitly. The min/max labels are
-      // hidden because `start`/`end` are themselves bucket boundaries and
-      // rarely round.
-      {
-        type: 'value',
-        position: 'left',
-        min: yAxisMin,
-        max: yAxisMax,
-        animation: false,
-        axisLabel: {
-          hideOverlap: true,
-          showMinLabel: false,
-          showMaxLabel: false,
-          formatter: (value: number) =>
-            formatYAxisValue(value, yAxisDataType, yAxisDataUnit ?? undefined),
-          fontSize: FONT_SIZE,
-          fontFamily: DEFAULT_FONT_FAMILY,
-        },
-        axisLine: {
-          show: false,
-        },
-        splitLine: {
-          show: false,
-        },
-      },
+      HIDDEN_CATEGORY_AXIS,
+      {...valueAxis, axisLabel: {...valueAxis.axisLabel, ...labelFont}},
     ],
-    series,
+    series: heatMapPlottable.toSeries({theme}),
     visualMap: visualMapOptions(HEATMAP_COLORS),
     useUTC: true,
   };

--- a/static/app/chartcuterie/heatmaps.tsx
+++ b/static/app/chartcuterie/heatmaps.tsx
@@ -35,33 +35,69 @@ export function buildHeatmapChartOption({
   const yAxisMin = heatMapPlottable.heatMapSeries.meta.yAxis.start;
   const yAxisMax = heatMapPlottable.heatMapSeries.meta.yAxis.end;
 
+  // The full time range of the X-axis buckets, in milliseconds. We overlay a
+  // `time` axis on this range so ECharts can place ticks on natural time
+  // boundaries (day/hour starts) instead of on every bucket edge (see `xAxis`).
+  const xAxisMin = heatMapPlottable.heatMapSeries.meta.xAxis.start;
+  const xAxisMax = heatMapPlottable.heatMapSeries.meta.xAxis.end;
+
   const series = heatMapPlottable.toSeries({theme});
 
   return {
     grid: Grid({left: 10, right: 10, bottom: 10, top: 10}),
     backgroundColor: theme.tokens.background.primary,
-    xAxis: {
-      type: 'category',
-      axisLabel: {
-        formatter: (value: string) => {
-          // NOTE: ECharts requires a `"category"` X-axis for heat maps, but we _know_ that we only support time as the X-axis. We need to parse the value here.
-          return formatXAxisTimestamp(parseFloat(value), {
-            utc: true,
-          });
+    xAxis: [
+      // Category axis: positions the heat map cells (ECharts requires a category
+      // axis for heat map series). Its categories are the bucket boundaries
+      // (timestamps), so we hide its labels and let the overlaid time axis
+      // render readable ticks instead. As with the Y axis, we don't set `data`
+      // so ECharts matches cells to categories by value.
+      {
+        type: 'category',
+        axisLabel: {
+          show: false,
         },
-        fontSize: FONT_SIZE,
-        fontFamily: DEFAULT_FONT_FAMILY,
+        axisLine: {
+          show: false,
+        },
+        axisTick: {
+          show: false,
+        },
+        axisPointer: {
+          show: false,
+        },
+        splitArea: {
+          show: false,
+        },
       },
-      axisLine: {
-        show: false,
+      // Time axis (overlay): spans the full time range of the buckets and lets
+      // ECharts place ticks on natural time boundaries. A second x-axis defaults
+      // to the top, so we pin it to the bottom explicitly.
+      {
+        type: 'time',
+        position: 'bottom',
+        min: xAxisMin,
+        max: xAxisMax,
+        axisLabel: {
+          hideOverlap: true,
+          formatter: (value: number) => formatXAxisTimestamp(value, {utc: true}),
+          fontSize: FONT_SIZE,
+          fontFamily: DEFAULT_FONT_FAMILY,
+        },
+        axisLine: {
+          show: false,
+        },
+        axisPointer: {
+          show: false,
+        },
+        splitArea: {
+          show: false,
+        },
+        splitLine: {
+          show: false,
+        },
       },
-      axisPointer: {
-        show: false,
-      },
-      splitArea: {
-        show: false,
-      },
-    },
+    ],
     yAxis: [
       // Category axis: positions the heat map cells (ECharts requires a
       // category axis for heat map series). Its categories are the bucket

--- a/static/app/chartcuterie/heatmaps.tsx
+++ b/static/app/chartcuterie/heatmaps.tsx
@@ -29,6 +29,12 @@ export function buildHeatmapChartOption({
   const yAxisDataType = heatMapPlottable.yAxisValueType;
   const yAxisDataUnit = heatMapPlottable.yAxisValueUnit;
 
+  // The full value range of the buckets. `start` is the first bucket's lower
+  // bound and `end` is the last bucket's upper bound. We pin an overlaid value
+  // axis to this range so ECharts can place round ticks on it (see `yAxis`).
+  const yAxisMin = heatMapPlottable.heatMapSeries.meta.yAxis.start;
+  const yAxisMax = heatMapPlottable.heatMapSeries.meta.yAxis.end;
+
   const series = heatMapPlottable.toSeries({theme});
 
   return {
@@ -56,28 +62,65 @@ export function buildHeatmapChartOption({
         show: false,
       },
     },
-    yAxis: {
-      type: 'category',
-      animation: false,
-      axisLabel: {
-        hideOverlap: true,
-        showMinLabel: true,
-        showMaxLabel: true,
-        formatter: (value: string) => {
-          // NOTE: ECharts requires a `"category"` Y-axis for heat maps, but we _know_ that we only support continuous values for the Y-axis. We need to parse the value here.
-          return formatYAxisValue(
-            parseFloat(value),
-            yAxisDataType,
-            yAxisDataUnit ?? undefined
-          );
+    yAxis: [
+      // Category axis: positions the heat map cells (ECharts requires a
+      // category axis for heat map series). Its categories are the bucket
+      // boundaries, which are rarely round, so we hide its labels and let the
+      // overlaid value axis render readable ticks instead.
+      //
+      // We deliberately don't set `data` here: ECharts collects the categories
+      // from the series' Y values and matches cells to them by value. Supplying
+      // our own category list would make ECharts treat those same Y values as
+      // category *indices* instead, dropping every cell whose value isn't a
+      // valid index.
+      {
+        type: 'category',
+        animation: false,
+        axisLabel: {
+          show: false,
         },
-        fontSize: FONT_SIZE,
-        fontFamily: DEFAULT_FONT_FAMILY,
+        axisLine: {
+          show: false,
+        },
+        axisTick: {
+          show: false,
+        },
+        axisPointer: {
+          show: false,
+        },
+        splitArea: {
+          show: false,
+        },
       },
-      axisLine: {
-        show: false,
+      // Value axis (overlay): spans the full value range of the buckets and
+      // lets ECharts place round ticks on it. These don't line up with the
+      // bucket boundaries, they just read cleanly. A second y-axis defaults to
+      // the right, so we pin it to the left explicitly. The min/max labels are
+      // hidden because `start`/`end` are themselves bucket boundaries and
+      // rarely round.
+      {
+        type: 'value',
+        position: 'left',
+        min: yAxisMin,
+        max: yAxisMax,
+        animation: false,
+        axisLabel: {
+          hideOverlap: true,
+          showMinLabel: false,
+          showMaxLabel: false,
+          formatter: (value: number) =>
+            formatYAxisValue(value, yAxisDataType, yAxisDataUnit ?? undefined),
+          fontSize: FONT_SIZE,
+          fontFamily: DEFAULT_FONT_FAMILY,
+        },
+        axisLine: {
+          show: false,
+        },
+        splitLine: {
+          show: false,
+        },
       },
-    },
+    ],
     series,
     visualMap: visualMapOptions(HEATMAP_COLORS),
     useUTC: true,

--- a/static/app/chartcuterie/heatmaps.tsx
+++ b/static/app/chartcuterie/heatmaps.tsx
@@ -30,9 +30,11 @@ export function buildHeatmapChartOption({
   const heatMapPlottable = new HeatMap(heatMapSeries);
   const {xAxis: xAxisMeta, yAxis: yAxisMeta} = heatMapSeries.meta;
 
-  // Chartcuterie renders without BaseChart's axis wrappers, so we set the label
-  // font on the overlay (visible) axes ourselves.
+  // Chartcuterie is more limited in rendering, so it sets its own font
+  // properties. Also we're not using the `YAxis` and `XAxis` base helpers here,
+  // so we have a bit more control
   const labelFont = {fontSize: FONT_SIZE, fontFamily: DEFAULT_FONT_FAMILY};
+
   const timeAxis = heatMapTimeAxis({min: xAxisMeta.start, max: xAxisMeta.end, utc: true});
   const valueAxis = heatMapValueAxis({
     min: yAxisMeta.start,

--- a/static/app/components/charts/useChartXRangeSelection.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.tsx
@@ -12,7 +12,7 @@ import type {BrushComponentOption, EChartsOption, ToolboxComponentOption} from '
 // entry calls `use()` on *every* feature — including `LegacyGridContainLabel`.
 // ECharts' feature registry is a process-wide singleton shared with
 // `echarts/core`, so this flips every `grid.containLabel` chart in the app
-// (e.g. anything built on `BaseChart`) onto the legacy grid layout, which
+// (e.g., anything built on `BaseChart`) onto the legacy grid layout, which
 // reserves space differently than ECharts 6's default `outerBounds` layout.
 // If you switch this to `echarts/core`, audit `containLabel` charts for shifted
 // axis padding. See heatMapWidget/utils/heatMapAxes.tsx for one place this bit us.

--- a/static/app/components/charts/useChartXRangeSelection.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.tsx
@@ -8,6 +8,14 @@ import {
 } from 'react';
 import {createPortal} from 'react-dom';
 import type {BrushComponentOption, EChartsOption, ToolboxComponentOption} from 'echarts';
+// FOOTGUN: this imports the full `echarts` bundle (not `echarts/core`), whose
+// entry calls `use()` on *every* feature — including `LegacyGridContainLabel`.
+// ECharts' feature registry is a process-wide singleton shared with
+// `echarts/core`, so this flips every `grid.containLabel` chart in the app
+// (e.g. anything built on `BaseChart`) onto the legacy grid layout, which
+// reserves space differently than ECharts 6's default `outerBounds` layout.
+// If you switch this to `echarts/core`, audit `containLabel` charts for shifted
+// axis padding. See heatMapWidget/utils/heatMapAxes.tsx for one place this bit us.
 import * as echarts from 'echarts';
 import type EChartsReact from 'echarts-for-react';
 import type {EChartsInstance} from 'echarts-for-react';

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -21,10 +21,13 @@ import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {ECHARTS_MISSING_DATA_VALUE} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {NO_PLOTTABLE_VALUES} from 'sentry/views/dashboards/widgets/common/settings';
-import {formatYAxisValue} from 'sentry/views/dashboards/widgets/heatMapWidget/formatters/formatYAxisValue';
+import {
+  HIDDEN_CATEGORY_AXIS,
+  heatMapTimeAxis,
+  heatMapValueAxis,
+} from 'sentry/views/dashboards/widgets/heatMapWidget/utils/heatMapAxes';
 import {plottablesCanBeVisualized} from 'sentry/views/dashboards/widgets/plottablesCanBeVisualized';
 import {formatTooltipValue} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue';
-import {formatXAxisTimestamp} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp';
 import {FALLBACK_TYPE} from 'sentry/views/dashboards/widgets/timeSeriesWidget/settings';
 
 import {HeatMap} from './plottables/heatMap';
@@ -142,19 +145,8 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
     return typeof value === 'number' ? value : null;
   }
 
-  const yAxisBucketSize = heatMapPlottable.heatMapSeries.meta.yAxis.bucketSize;
-
-  // The full value range of the buckets. `start` is the first bucket's lower
-  // bound and `end` is the last bucket's upper bound. We pin an overlaid value
-  // axis to this range so ECharts can place round ticks on it (see `yAxes`).
-  const yAxisMin = heatMapPlottable.heatMapSeries.meta.yAxis.start;
-  const yAxisMax = heatMapPlottable.heatMapSeries.meta.yAxis.end;
-
-  // The full time range of the X-axis buckets, in milliseconds. We overlay a
-  // `time` axis on this range so ECharts can place ticks on natural time
-  // boundaries (day/hour starts) instead of on every bucket edge (see `xAxes`).
-  const xAxisMin = heatMapPlottable.heatMapSeries.meta.xAxis.start;
-  const xAxisMax = heatMapPlottable.heatMapSeries.meta.xAxis.end;
+  const {meta} = heatMapPlottable.heatMapSeries;
+  const yAxisBucketSize = meta.yAxis.bucketSize;
 
   // Create tooltip formatter
   const formatTooltip: TooltipFormatterCallback<TopLevelFormatterParams> = params => {
@@ -293,115 +285,21 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
         }}
         series={series}
         xAxes={[
-          // Category axis: positions the heat map cells (ECharts requires a
-          // category axis for heat map series). Its categories are the bucket
-          // boundaries (timestamps), so we hide its labels and let the overlaid
-          // time axis render readable ticks instead. As with the Y axis, we
-          // don't set `data` so ECharts matches cells to categories by value.
-          {
-            type: 'category',
-            animation: false,
-            axisLabel: {
-              show: false,
-            },
-            axisTick: {
-              show: false,
-            },
-            axisLine: {
-              show: false,
-            },
-            axisPointer: {
-              show: false,
-            },
-            splitArea: {
-              show: false,
-            },
-          },
-          // Time axis (overlay): spans the full time range of the buckets and
-          // lets ECharts place ticks on natural time boundaries. A second
-          // x-axis defaults to the top, so we pin it to the bottom explicitly.
-          {
-            type: 'time',
-            position: 'bottom',
-            min: xAxisMin,
-            max: xAxisMax,
-            animation: false,
-            axisLabel: {
-              hideOverlap: true,
-              formatter: value =>
-                formatXAxisTimestamp(Number(value), {utc: utc ?? undefined}),
-            },
-            axisPointer: {
-              show: false,
-            },
-            splitArea: {
-              show: false,
-            },
-            splitLine: {
-              show: false,
-            },
-          },
+          HIDDEN_CATEGORY_AXIS,
+          heatMapTimeAxis({
+            min: meta.xAxis.start,
+            max: meta.xAxis.end,
+            utc: utc ?? undefined,
+          }),
         ]}
         yAxes={[
-          // Category axis: positions the heat map cells (ECharts requires a
-          // category axis for heat map series). Its categories are the bucket
-          // boundaries, which are rarely round, so we hide its labels and let
-          // the overlaid value axis render readable ticks instead.
-          //
-          // We deliberately don't set `data` here: ECharts collects the
-          // categories from the series' Y values and matches cells to them by
-          // value. Supplying our own category list would make ECharts treat
-          // those same Y values as category *indices* instead, dropping every
-          // cell whose value isn't a valid index.
-          {
-            type: 'category',
-            animation: false,
-            axisLabel: {
-              show: false,
-            },
-            axisTick: {
-              show: false,
-            },
-            axisPointer: {
-              show: false,
-            },
-            splitArea: {
-              show: false,
-            },
-          },
-          // Value axis (overlay): spans the full value range of the buckets and
-          // lets ECharts place round ticks on it. These don't line up with the
-          // bucket boundaries, they just read cleanly. A second y-axis defaults
-          // to the right, so we pin it to the left explicitly. The min/max
-          // labels are hidden because `start`/`end` are themselves bucket
-          // boundaries and rarely round.
-          {
-            type: 'value',
-            position: 'left',
-            min: yAxisMin,
-            max: yAxisMax,
-            animation: false,
-            axisLabel: {
-              hideOverlap: true,
-              showMinLabel: false,
-              showMaxLabel: false,
-              formatter: value =>
-                formatYAxisValue(
-                  Number(value),
-                  yAxisDataType,
-                  yAxisDataUnit ?? undefined
-                ),
-            },
-            axisPointer: {
-              show: false,
-            },
-            splitArea: {
-              show: false,
-            },
-            splitLine: {
-              show: false,
-            },
-          },
+          HIDDEN_CATEGORY_AXIS,
+          heatMapValueAxis({
+            min: meta.yAxis.start,
+            max: meta.yAxis.end,
+            valueType: yAxisDataType,
+            valueUnit: yAxisDataUnit ?? undefined,
+          }),
         ]}
         visualMap={visualMapOptions(HEATMAP_COLORS)}
         start={start ? new Date(start) : undefined}

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -31,10 +31,6 @@ import {HeatMap} from './plottables/heatMap';
 import type {HeatMapPlottable} from './plottables/heatMapPlottable';
 import {HEATMAP_COLORS} from './settings';
 
-// This is the ECharts default font size for axis labels. We need to use this number to do axis label frequency calculations
-// Source: https://echarts.apache.org/en/option.html#yAxis.axisLabel.fontSize
-const Y_AXIS_LABEL_FONT_SIZE = 12;
-
 interface HeatMapWidgetVisualizationProps {
   /**
    * An single `HeatMap` object to render on the chart, and any number of other compatible Heat Map plottables.
@@ -157,7 +153,12 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
   }
 
   const yAxisBucketSize = heatMapPlottable.heatMapSeries.meta.yAxis.bucketSize;
-  const yAxisBucketCount = heatMapPlottable.heatMapSeries.meta.yAxis.bucketCount;
+
+  // The full value range of the buckets. `start` is the first bucket's lower
+  // bound and `end` is the last bucket's upper bound. We pin an overlaid value
+  // axis to this range so ECharts can place round ticks on it (see `yAxes`).
+  const yAxisMin = heatMapPlottable.heatMapSeries.meta.yAxis.start;
+  const yAxisMax = heatMapPlottable.heatMapSeries.meta.yAxis.end;
 
   // Create tooltip formatter
   const formatTooltip: TooltipFormatterCallback<TopLevelFormatterParams> = params => {
@@ -314,57 +315,67 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
             show: false,
           },
         }}
-        yAxis={{
-          type: 'category',
-          animation: false,
-          axisLabel: {
-            hideOverlap: true,
-            interval: (index, _value) => {
-              // show the first and last label
-              if (index === 0 || index === yAxisBucketCount - 1) {
-                return true;
-              }
-              // we want to make sure that there's going to be ample amount of space between each label:
-              // chart height / label size = number of labels that will fix with no space between
-              // chart height / (label size * 3) = number of labels that will fit with space between (label shown every 3 label placements)
-              // NOTE: this may change as we start putting heat widgets in dashboards with different chart heights
-              const numFittingLabels = Math.floor(
-                (chartRef.current?.ele.clientHeight ?? 0) / (Y_AXIS_LABEL_FONT_SIZE * 3)
-              );
-              // show all labels if we can't find the client height
-              if (numFittingLabels === 0) {
-                return true;
-              }
-              const nthBucketToShow = Math.ceil(yAxisBucketCount / numFittingLabels);
-              // don't show the third last and second last labels; we want to make sure the last label
-              // isn't smushed up against another label
-              if (
-                index % nthBucketToShow === 0 &&
-                (nthBucketToShow === 1 ||
-                  (index !== yAxisBucketCount - 3 && index !== yAxisBucketCount - 2))
-              ) {
-                return true;
-              }
-              return false;
+        yAxes={[
+          // Category axis: positions the heat map cells (ECharts requires a
+          // category axis for heat map series). Its categories are the bucket
+          // boundaries, which are rarely round, so we hide its labels and let
+          // the overlaid value axis render readable ticks instead.
+          //
+          // We deliberately don't set `data` here: ECharts collects the
+          // categories from the series' Y values and matches cells to them by
+          // value. Supplying our own category list would make ECharts treat
+          // those same Y values as category *indices* instead, dropping every
+          // cell whose value isn't a valid index.
+          {
+            type: 'category',
+            animation: false,
+            axisLabel: {
+              show: false,
             },
-            showMinLabel: true,
-            showMaxLabel: true,
-            formatter: value => {
-              // NOTE: ECharts requires a `"category"` Y-axis for heat maps, but we _know_ that we only support continuous values for the Y-axis. We need to parse the value here.
-              return formatYAxisValue(
-                parseFloat(value),
-                yAxisDataType,
-                yAxisDataUnit ?? undefined
-              );
+            axisTick: {
+              show: false,
+            },
+            axisPointer: {
+              show: false,
+            },
+            splitArea: {
+              show: false,
             },
           },
-          axisPointer: {
-            show: false,
+          // Value axis (overlay): spans the full value range of the buckets and
+          // lets ECharts place round ticks on it. These don't line up with the
+          // bucket boundaries, they just read cleanly. A second y-axis defaults
+          // to the right, so we pin it to the left explicitly. The min/max
+          // labels are hidden because `start`/`end` are themselves bucket
+          // boundaries and rarely round.
+          {
+            type: 'value',
+            position: 'left',
+            min: yAxisMin,
+            max: yAxisMax,
+            animation: false,
+            axisLabel: {
+              hideOverlap: true,
+              showMinLabel: false,
+              showMaxLabel: false,
+              formatter: value =>
+                formatYAxisValue(
+                  Number(value),
+                  yAxisDataType,
+                  yAxisDataUnit ?? undefined
+                ),
+            },
+            axisPointer: {
+              show: false,
+            },
+            splitArea: {
+              show: false,
+            },
+            splitLine: {
+              show: false,
+            },
           },
-          splitArea: {
-            show: false,
-          },
-        }}
+        ]}
         visualMap={visualMapOptions(Zmax)}
         start={start ? new Date(start) : undefined}
         end={end ? new Date(end) : undefined}

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -150,6 +150,12 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
   const yAxisMin = heatMapPlottable.heatMapSeries.meta.yAxis.start;
   const yAxisMax = heatMapPlottable.heatMapSeries.meta.yAxis.end;
 
+  // The full time range of the X-axis buckets, in milliseconds. We overlay a
+  // `time` axis on this range so ECharts can place ticks on natural time
+  // boundaries (day/hour starts) instead of on every bucket edge (see `xAxes`).
+  const xAxisMin = heatMapPlottable.heatMapSeries.meta.xAxis.start;
+  const xAxisMax = heatMapPlottable.heatMapSeries.meta.xAxis.end;
+
   // Create tooltip formatter
   const formatTooltip: TooltipFormatterCallback<TopLevelFormatterParams> = params => {
     // Only show the tooltip of the current chart. Otherwise, all tooltips
@@ -286,24 +292,56 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
           formatter: formatTooltip,
         }}
         series={series}
-        xAxis={{
-          type: 'category',
-          animation: false,
-          axisLabel: {
-            formatter: value => {
-              // NOTE: ECharts requires a `"category"` X-axis for heat maps, but we _know_ that we only support time as the X-axis. We need to parse the value here.
-              return formatXAxisTimestamp(parseFloat(value), {
-                utc: utc ?? undefined,
-              });
+        xAxes={[
+          // Category axis: positions the heat map cells (ECharts requires a
+          // category axis for heat map series). Its categories are the bucket
+          // boundaries (timestamps), so we hide its labels and let the overlaid
+          // time axis render readable ticks instead. As with the Y axis, we
+          // don't set `data` so ECharts matches cells to categories by value.
+          {
+            type: 'category',
+            animation: false,
+            axisLabel: {
+              show: false,
+            },
+            axisTick: {
+              show: false,
+            },
+            axisLine: {
+              show: false,
+            },
+            axisPointer: {
+              show: false,
+            },
+            splitArea: {
+              show: false,
             },
           },
-          axisPointer: {
-            show: false,
+          // Time axis (overlay): spans the full time range of the buckets and
+          // lets ECharts place ticks on natural time boundaries. A second
+          // x-axis defaults to the top, so we pin it to the bottom explicitly.
+          {
+            type: 'time',
+            position: 'bottom',
+            min: xAxisMin,
+            max: xAxisMax,
+            animation: false,
+            axisLabel: {
+              hideOverlap: true,
+              formatter: value =>
+                formatXAxisTimestamp(Number(value), {utc: utc ?? undefined}),
+            },
+            axisPointer: {
+              show: false,
+            },
+            splitArea: {
+              show: false,
+            },
+            splitLine: {
+              show: false,
+            },
           },
-          splitArea: {
-            show: false,
-          },
-        }}
+        ]}
         yAxes={[
           // Category axis: positions the heat map cells (ECharts requires a
           // category axis for heat map series). Its categories are the bucket

--- a/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapAxes.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapAxes.tsx
@@ -16,16 +16,25 @@ import {formatXAxisTimestamp} from 'sentry/views/dashboards/widgets/timeSeriesWi
  */
 
 /**
- * Positions the heat map cells. `show: false` hides the whole axis while
- * keeping it in the coordinate system. We deliberately don't set `data`:
- * ECharts collects the categories from the series' values and matches cells to
- * them by value. Supplying our own list would make ECharts treat those same
- * values as category *indices* instead, dropping every cell whose value isn't a
- * valid index.
+ * Positions the heat map cells. `show: false` hides the axis while keeping it
+ * in the coordinate system to place the cells.
+ *
+ * `axisLabel: {show: false}` looks redundant with `show: false`, but it isn't:
+ * the app also loads the full `echarts` bundle (via `useChartXRangeSelection`),
+ * which registers the legacy `containLabel` layout. That layout reserves grid
+ * space for an axis's labels based on `axisLabel.show` alone — it ignores the
+ * axis-level `show` — so without this the hidden category axis pads the chart
+ * with room for its (never-rendered) bucket-boundary labels.
+ *
+ * We also deliberately don't set `data`: ECharts collects the categories from
+ * the series' values and matches cells to them by value. Supplying our own list
+ * would make ECharts treat those same values as category *indices* instead,
+ * dropping every cell whose value isn't a valid index.
  */
 export const HIDDEN_CATEGORY_AXIS = {
   type: 'category',
   show: false,
+  axisLabel: {show: false},
 } as const;
 
 export function heatMapValueAxis({

--- a/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapAxes.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapAxes.tsx
@@ -1,0 +1,86 @@
+import type {XAXisComponentOption, YAXisComponentOption} from 'echarts';
+
+import {formatYAxisValue} from 'sentry/views/dashboards/widgets/heatMapWidget/formatters/formatYAxisValue';
+import {formatXAxisTimestamp} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp';
+
+/**
+ * Pieces of the heat map cartesian axes, shared between the in-app
+ * visualization and the Chartcuterie (server-side render) config.
+ *
+ * ECharts requires category axes for heat map series, but a category axis can
+ * only put ticks on the bucket boundaries, which rarely fall on readable
+ * values. So on each dimension we pair the hidden category axis below (which
+ * positions the cells) with an overlay axis — `heatMapValueAxis` on Y,
+ * `heatMapTimeAxis` on X — that ECharts can put clean ticks on. Callers compose
+ * the pair themselves so they can tweak either axis (e.g. label fonts).
+ */
+
+/**
+ * Positions the heat map cells. `show: false` hides the whole axis while
+ * keeping it in the coordinate system. We deliberately don't set `data`:
+ * ECharts collects the categories from the series' values and matches cells to
+ * them by value. Supplying our own list would make ECharts treat those same
+ * values as category *indices* instead, dropping every cell whose value isn't a
+ * valid index.
+ */
+export const HIDDEN_CATEGORY_AXIS = {
+  type: 'category',
+  show: false,
+} as const;
+
+export function heatMapValueAxis({
+  min,
+  max,
+  valueType,
+  valueUnit,
+}: {
+  max: number;
+  min: number;
+  valueType: string;
+  valueUnit?: string;
+}): YAXisComponentOption {
+  return {
+    type: 'value',
+    // A second y-axis defaults to the right, so we pin it to the left.
+    position: 'left',
+    min,
+    max,
+    animation: false,
+    axisLabel: {
+      hideOverlap: true,
+      // `min`/`max` are bucket boundaries and rarely round, so hide them.
+      showMinLabel: false,
+      showMaxLabel: false,
+      formatter: (value: number) => formatYAxisValue(value, valueType, valueUnit),
+    },
+    axisLine: {show: false},
+    splitArea: {show: false},
+    splitLine: {show: false},
+  };
+}
+
+export function heatMapTimeAxis({
+  min,
+  max,
+  utc,
+}: {
+  max: number;
+  min: number;
+  utc?: boolean;
+}): XAXisComponentOption {
+  return {
+    type: 'time',
+    // A second x-axis defaults to the top, so we pin it to the bottom.
+    position: 'bottom',
+    min,
+    max,
+    animation: false,
+    axisLabel: {
+      hideOverlap: true,
+      formatter: (value: number) => formatXAxisTimestamp(value, {utc}),
+    },
+    axisPointer: {show: false},
+    splitArea: {show: false},
+    splitLine: {show: false},
+  };
+}

--- a/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapAxes.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapAxes.tsx
@@ -10,9 +10,8 @@ import {formatXAxisTimestamp} from 'sentry/views/dashboards/widgets/timeSeriesWi
  * ECharts requires category axes for heat map series, but a category axis can
  * only put ticks on the bucket boundaries, which rarely fall on readable
  * values. So on each dimension we pair the hidden category axis below (which
- * positions the cells) with an overlay axis — `heatMapValueAxis` on Y,
- * `heatMapTimeAxis` on X — that ECharts can put clean ticks on. Callers compose
- * the pair themselves so they can tweak either axis (e.g. label fonts).
+ * positions the cells) with an overlay axis (`heatMapValueAxis` on Y,
+ * `heatMapTimeAxis` on X) that ECharts can put clean ticks on.
  */
 
 /**
@@ -25,11 +24,6 @@ import {formatXAxisTimestamp} from 'sentry/views/dashboards/widgets/timeSeriesWi
  * space for an axis's labels based on `axisLabel.show` alone — it ignores the
  * axis-level `show` — so without this the hidden category axis pads the chart
  * with room for its (never-rendered) bucket-boundary labels.
- *
- * We also deliberately don't set `data`: ECharts collects the categories from
- * the series' values and matches cells to them by value. Supplying our own list
- * would make ECharts treat those same values as category *indices* instead,
- * dropping every cell whose value isn't a valid index.
  */
 export const HIDDEN_CATEGORY_AXIS = {
   type: 'category',
@@ -54,7 +48,6 @@ export function heatMapValueAxis({
 }): YAXisComponentOption {
   return {
     type: 'value',
-    // A second y-axis defaults to the right, so we pin it to the left.
     position: 'left',
     min,
     max,
@@ -83,7 +76,6 @@ export function heatMapTimeAxis({
 }): XAXisComponentOption {
   return {
     type: 'time',
-    // A second x-axis defaults to the top, so we pin it to the bottom.
     position: 'bottom',
     min,
     max,

--- a/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapAxes.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/utils/heatMapAxes.tsx
@@ -35,6 +35,10 @@ export const HIDDEN_CATEGORY_AXIS = {
   type: 'category',
   show: false,
   axisLabel: {show: false},
+  // `BaseChart`'s `XAxis` wrapper turns the axis pointer on by default. Left
+  // enabled it highlights the whole hovered column, which (combined with the
+  // series' emphasis border) outlines every cell in it — so disable it.
+  axisPointer: {show: false},
 } as const;
 
 export function heatMapValueAxis({


### PR DESCRIPTION
**Before:**
<img width="677" height="292" alt="Screenshot 2026-06-24 at 6 50 27 PM" src="https://github.com/user-attachments/assets/e26f7bc7-8566-4299-88a1-93e028c252b8" />

**After:**
<img width="676" height="304" alt="Screenshot 2026-06-24 at 6 50 39 PM" src="https://github.com/user-attachments/assets/e4858f43-f8d9-4440-8db5-b07c5c1f0319" />

In ECharts, a heat map _must_ have `"category"` axes. This is bad for us, because it means that tick placement on both axes is bad. On the Y-axis, the ticks are placed _at the bucket boundaries_ which is gross. On the X-axis the ticks are placed using an overflow algorithm, instead of according to round time boundaries.

We _know_ that our Heat Maps use a continuous value on both the X and Y axis. So, we trick ECharts by _hiding_ the category axis, and creating `"value"` and `"time"` axes which gets the nicer ticks!

There's some _major_ trickery in ECharts with regards to the layout engine that we have to work around, but there you have it.

Closes DAIN-1722
