### PR TITLE
feat(dashboards): Add per-display-type constraints framework

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -181,6 +181,31 @@ DATASET_CONFIG: dict[int, DatasetConfig] = {
 }
 
 
+class DisplayTypeConstraints(TypedDict, total=False):
+    """Declarative capabilities for a widget display type.
+
+    Mirrors the frontend's per-display-type capability predicates (e.g.
+    ``doesDisplayTypeSupportThresholds``). A capability that is omitted — and
+    every display type absent from ``DISPLAY_TYPE_CONSTRAINTS`` entirely — is
+    treated as supported, so adding an entry can only tighten validation, never
+    loosen it.
+    """
+
+    supports_thresholds: bool
+    supports_limit: bool
+    supports_grouping: bool
+    supports_field_aliases: bool
+    supports_sorting: bool
+    supports_multiple_queries: bool
+
+
+# Per-display-type constraints, enforced by
+# ``DashboardWidgetSerializer._validate_display_type_constraints``. Empty for
+# now: every display type keeps its current, unconstrained behavior. Individual
+# display types (e.g. heat map, categorical bar) are added in follow-up changes.
+DISPLAY_TYPE_CONSTRAINTS: dict[int, DisplayTypeConstraints] = {}
+
+
 class WidgetLayoutSerializer(CamelSnakeSerializer[Dashboard]):
     """Widget grid layout position and dimensions.
 
@@ -541,11 +566,51 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
 
         return data
 
+    def _validate_display_type_constraints(self, data) -> None:
+        """Enforce per-display-type capability constraints from
+        ``DISPLAY_TYPE_CONSTRAINTS``. A capability is enforced only when an
+        entry explicitly sets it to ``False``; anything else is permissive.
+        """
+        constraints = DISPLAY_TYPE_CONSTRAINTS.get(data.get("display_type"))
+        if not constraints:
+            return
+
+        if constraints.get("supports_thresholds") is False and data.get("thresholds"):
+            raise serializers.ValidationError(
+                {"thresholds": "This visualization does not support thresholds."}
+            )
+        if constraints.get("supports_limit") is False and data.get("limit") is not None:
+            raise serializers.ValidationError(
+                {"limit": "This visualization does not support a limit."}
+            )
+
+        queries = data.get("queries") or []
+        if constraints.get("supports_multiple_queries") is False and len(queries) > 1:
+            raise serializers.ValidationError(
+                {"queries": "This visualization supports only a single query."}
+            )
+
+        for query in queries:
+            if constraints.get("supports_grouping") is False and query.get("columns"):
+                raise serializers.ValidationError(
+                    {"queries": "This visualization does not support grouping."}
+                )
+            if constraints.get("supports_field_aliases") is False and query.get("field_aliases"):
+                raise serializers.ValidationError(
+                    {"queries": "This visualization does not support field aliases."}
+                )
+            if constraints.get("supports_sorting") is False and query.get("orderby"):
+                raise serializers.ValidationError(
+                    {"queries": "This visualization does not support ordering."}
+                )
+
     def validate(self, data):
         self.query_warnings = {"queries": [], "columns": {}}
 
         if data.get("display_type") == DashboardWidgetDisplayTypes.TEXT:
             return self._validate_text_widget(data)
+
+        self._validate_display_type_constraints(data)
 
         query_errors = []
         all_columns: set[str] = set()

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
@@ -200,6 +200,40 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert "displayType" in response.data, response.data
         assert "preprod-app-size" in str(response.data["displayType"])
 
+    def test_display_type_constraints_are_enforced(self) -> None:
+        # The shipped DISPLAY_TYPE_CONSTRAINTS table is empty, so inject a
+        # temporary entry to prove the framework enforces it end-to-end. Big
+        # number widgets support thresholds today; constraining them here lets
+        # us assert both the enforced and the default (permissive) behavior.
+        data = {
+            "title": "Big Number",
+            "displayType": "big_number",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "fields": ["count()"],
+                    "columns": [],
+                    "aggregates": ["count()"],
+                    "orderby": "",
+                }
+            ],
+            "thresholds": {"max_values": {"max1": 100, "max2": 200}},
+        }
+
+        # Default (empty table): thresholds are allowed, preserving behavior.
+        response = self.do_request("post", self.url(), data=data)
+        assert response.status_code == 200, response.data
+
+        # With a constraint injected, the same widget is rejected.
+        with mock.patch.dict(
+            "sentry.api.serializers.rest_framework.dashboard.DISPLAY_TYPE_CONSTRAINTS",
+            {DashboardWidgetDisplayTypes.BIG_NUMBER: {"supports_thresholds": False}},
+        ):
+            response = self.do_request("post", self.url(), data=data)
+        assert response.status_code == 400, response.data
+        assert "does not support thresholds" in str(response.data["thresholds"]), response.data
+
     def test_invalid_equation(self) -> None:
         data = {
             "title": "Invalid query",


### PR DESCRIPTION
Introduce a declarative `DISPLAY_TYPE_CONSTRAINTS` table (mirroring the existing `DATASET_CONFIG` table one axis over) that describes which capabilities each widget display type supports: thresholds, limit, grouping, field aliases, sorting, and multiple queries. A new `DashboardWidgetSerializer._validate_display_type_constraints` validator enforces any capability a display type explicitly opts out of.

This is groundwork for tightening validation on specific display types (e.g. heat map, categorical bar) without scattering per-type rules across the serializer. Expressing constraints as data means future restrictions are a one-line table edit rather than new validation code.

The table ships empty and capabilities are permissive by default (an omitted capability — and any display type absent from the table — is treated as supported), so this PR makes no behavior change: every display type remains unconstrained. Adding an entry can only tighten validation, never loosen it.

A follow-up PR will populate the heat map entry.