### PR TITLE
fix(seer): Unstick Copilot handoff status when global_id is empty

### DIFF
--- a/src/sentry/integrations/github_copilot/client.py
+++ b/src/sentry/integrations/github_copilot/client.py
@@ -8,7 +8,7 @@ from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
 from sentry.integrations.github_copilot.models import (
     GithubCopilotTask,
     GithubCopilotTaskRequest,
-    GithubPRFromGraphQL,
+    GithubPullRequest,
 )
 from sentry.seer.autofix.utils import CodingAgentProviderType, CodingAgentState, CodingAgentStatus
 
@@ -138,7 +138,7 @@ class GithubCopilotAgentClient(CodingAgentClient):
 
         return GithubCopilotTask.validate(api_response.json)
 
-    def get_pr_from_graphql(self, global_id: str) -> GithubPRFromGraphQL | None:
+    def get_pr_from_graphql(self, global_id: str) -> GithubPullRequest | None:
         query = """
             query($id: ID!) {
                 node(id: $id) {
@@ -174,8 +174,47 @@ class GithubCopilotAgentClient(CodingAgentClient):
         if not node or "number" not in node:
             return None
 
-        return GithubPRFromGraphQL(
+        return GithubPullRequest(
             number=node["number"],
             title=node["title"],
             url=node["url"],
+        )
+
+    def get_pr_from_branch(self, owner: str, repo: str, head_ref: str) -> GithubPullRequest | None:
+        """Resolve a PR from its head branch via the GitHub REST API.
+
+        Fallback for when the Copilot task artifact's ``global_id`` is empty
+        (which the Copilot API returns intermittently even for completed tasks).
+        Relies only on the reliably-populated branch artifact and public PR
+        fields, so it sidesteps ``global_id`` entirely.
+        """
+        api_response = self.get(
+            f"https://api.github.com/repos/{owner}/{repo}/pulls",
+            headers=self._get_auth_headers(),
+            params={"head": f"{owner}:{head_ref}", "state": "all"},
+            timeout=30,
+        )
+
+        prs = api_response.json or []
+
+        logger.info(
+            "coding_agent.github_copilot.get_pr_from_branch",
+            extra={
+                "owner": owner,
+                "repo": repo,
+                "head_ref": head_ref,
+                "status_code": api_response.status_code,
+                "pr_count": len(prs),
+            },
+        )
+
+        if not prs:
+            return None
+
+        # The head filter is unique per branch; take the most recent if several.
+        pr = prs[0]
+        return GithubPullRequest(
+            number=pr["number"],
+            title=pr["title"],
+            url=pr["html_url"],
         )

--- a/src/sentry/integrations/github_copilot/models.py
+++ b/src/sentry/integrations/github_copilot/models.py
@@ -102,8 +102,9 @@ class GithubCopilotTask(BaseModel):
     url: str | None = None
 
 
-class GithubPRFromGraphQL(BaseModel):
-    """PR info fetched from GitHub GraphQL API"""
+class GithubPullRequest(BaseModel):
+    """Minimal PR info, resolved either from the GitHub GraphQL API (via the
+    task artifact's ``global_id``) or from the REST API (via the head branch)."""
 
     number: int
     title: str

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -208,8 +208,12 @@ def poll_github_copilot_agents(
                 branch_artifact.data.head_ref if branch_artifact and branch_artifact.data else None
             )
 
-            # The Copilot API uses `state` (not `status`) for task lifecycle.
+            # Map the Copilot task lifecycle to our status. The Copilot API uses
+            # `state` (not `status`). Derive this purely from `state` so a
+            # terminal task is never left on RUNNING just because a (possibly
+            # draft) PR exists on its head branch.
             is_task_done = task_status.state == "completed"
+            is_task_failed = task_status.state in ("failed", "timed_out")
 
             # Resolve PR details. The documented path is the PR artifact's
             # `global_id` -> GraphQL node lookup, but the Copilot API
@@ -223,10 +227,17 @@ def poll_github_copilot_agents(
             if pr_info is None and branch_name:
                 pr_info = client.get_pr_from_branch(owner, repo, branch_name)
 
-            # Update state whenever the task is done (so it never gets stuck on
-            # RUNNING just because we couldn't resolve a PR) or whenever we have
-            # PR details to surface.
-            if is_task_done or pr_info is not None:
+            if is_task_done:
+                new_status = CodingAgentStatus.COMPLETED
+            elif is_task_failed:
+                new_status = CodingAgentStatus.FAILED
+            else:
+                new_status = CodingAgentStatus.RUNNING
+
+            # Push an update when the task reached a terminal state (so the
+            # status never gets stuck) or when we have PR details to surface
+            # while it is still running.
+            if is_task_done or is_task_failed or pr_info is not None:
                 pr_url = None
                 result = None
                 if pr_info:
@@ -238,10 +249,6 @@ def poll_github_copilot_agents(
                         pr_url=pr_url,
                         branch_name=branch_name,
                     )
-
-                new_status = (
-                    CodingAgentStatus.COMPLETED if is_task_done else CodingAgentStatus.RUNNING
-                )
 
                 update_coding_agent_state(
                     agent_id=agent_id,
@@ -273,17 +280,8 @@ def poll_github_copilot_agents(
                         "pr_url": pr_url,
                         "task_state": task_status.state,
                         "is_task_done": is_task_done,
+                        "is_task_failed": is_task_failed,
                     },
-                )
-
-            elif task_status.state in ("failed", "timed_out"):
-                update_coding_agent_state(
-                    agent_id=agent_id,
-                    status=CodingAgentStatus.FAILED,
-                )
-                logger.info(
-                    "coding_agent.github_copilot.task_failed",
-                    extra={"agent_id": agent_id, "task_state": task_status.state},
                 )
 
         except Exception:

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -208,59 +208,73 @@ def poll_github_copilot_agents(
                 branch_artifact.data.head_ref if branch_artifact and branch_artifact.data else None
             )
 
+            # The Copilot API uses `state` (not `status`) for task lifecycle.
+            is_task_done = task_status.state == "completed"
+
+            # Resolve PR details. The documented path is the PR artifact's
+            # `global_id` -> GraphQL node lookup, but the Copilot API
+            # intermittently returns an empty `global_id` even for completed
+            # tasks whose PR exists. Fall back to resolving the PR from the head
+            # branch, which relies only on the reliably-populated branch artifact
+            # and public PR fields.
+            pr_info = None
             if pr_artifact and pr_artifact.data and pr_artifact.data.global_id:
-                # Get PR info from GraphQL using the global_id
                 pr_info = client.get_pr_from_graphql(pr_artifact.data.global_id)
+            if pr_info is None and branch_name:
+                pr_info = client.get_pr_from_branch(owner, repo, branch_name)
+
+            # Update state whenever the task is done (so it never gets stuck on
+            # RUNNING just because we couldn't resolve a PR) or whenever we have
+            # PR details to surface.
+            if is_task_done or pr_info is not None:
+                pr_url = None
+                result = None
                 if pr_info:
                     pr_url = pr_info.url
-                    description = pr_info.title
-
                     result = CodingAgentResult(
-                        description=description,
+                        description=pr_info.title,
                         repo_provider="github",
                         repo_full_name=f"{owner}/{repo}",
                         pr_url=pr_url,
                         branch_name=branch_name,
                     )
 
-                    # The Copilot API uses `state` (not `status`) for task lifecycle.
-                    is_task_done = task_status.state == "completed"
-                    new_status = (
-                        CodingAgentStatus.COMPLETED if is_task_done else CodingAgentStatus.RUNNING
-                    )
+                new_status = (
+                    CodingAgentStatus.COMPLETED if is_task_done else CodingAgentStatus.RUNNING
+                )
 
-                    update_coding_agent_state(
-                        agent_id=agent_id,
-                        status=new_status,
-                        result=result,
-                    )
+                update_coding_agent_state(
+                    agent_id=agent_id,
+                    status=new_status,
+                    result=result,
+                )
 
-                    if is_task_done and pr_url:
-                        try:
-                            attribute_delegated_agent_pull_request(
-                                organization_id=organization_id,
-                                signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_GITHUB_COPILOT,
-                                repo_full_name=f"{owner}/{repo}",
-                                repo_provider="github",
-                                pr_url=pr_url,
-                                agent_id=agent_id,
-                                run_id=run_id,
-                            )
-                        except Exception:
-                            logger.exception(
-                                "coding_agent.github_copilot.pr_attribution_failed",
-                                extra={"agent_id": agent_id, "pr_url": pr_url},
-                            )
+                if is_task_done and pr_url:
+                    try:
+                        attribute_delegated_agent_pull_request(
+                            organization_id=organization_id,
+                            signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_GITHUB_COPILOT,
+                            repo_full_name=f"{owner}/{repo}",
+                            repo_provider="github",
+                            pr_url=pr_url,
+                            agent_id=agent_id,
+                            run_id=run_id,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "coding_agent.github_copilot.pr_attribution_failed",
+                            extra={"agent_id": agent_id, "pr_url": pr_url},
+                        )
 
-                    logger.info(
-                        "coding_agent.github_copilot.pr_update",
-                        extra={
-                            "agent_id": agent_id,
-                            "pr_url": pr_url,
-                            "task_state": task_status.state,
-                            "is_task_done": is_task_done,
-                        },
-                    )
+                logger.info(
+                    "coding_agent.github_copilot.pr_update",
+                    extra={
+                        "agent_id": agent_id,
+                        "pr_url": pr_url,
+                        "task_state": task_status.state,
+                        "is_task_done": is_task_done,
+                    },
+                )
 
             elif task_status.state in ("failed", "timed_out"):
                 update_coding_agent_state(

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -221,11 +221,26 @@ def poll_github_copilot_agents(
             # tasks whose PR exists. Fall back to resolving the PR from the head
             # branch, which relies only on the reliably-populated branch artifact
             # and public PR fields.
+            #
+            # PR resolution is enrichment only: isolate its failures so a GitHub
+            # API error (these clients raise on HTTP errors) can never block the
+            # terminal status update below and leave the agent stuck on RUNNING.
             pr_info = None
-            if pr_artifact and pr_artifact.data and pr_artifact.data.global_id:
-                pr_info = client.get_pr_from_graphql(pr_artifact.data.global_id)
-            if pr_info is None and branch_name:
-                pr_info = client.get_pr_from_branch(owner, repo, branch_name)
+            try:
+                if pr_artifact and pr_artifact.data and pr_artifact.data.global_id:
+                    pr_info = client.get_pr_from_graphql(pr_artifact.data.global_id)
+                if pr_info is None and branch_name:
+                    pr_info = client.get_pr_from_branch(owner, repo, branch_name)
+            except Exception:
+                logger.exception(
+                    "coding_agent.github_copilot.pr_resolution_failed",
+                    extra={
+                        "agent_id": agent_id,
+                        "owner": owner,
+                        "repo": repo,
+                        "task_id": task_id,
+                    },
+                )
 
             if is_task_done:
                 new_status = CodingAgentStatus.COMPLETED

--- a/tests/sentry/integrations/github_copilot/test_client.py
+++ b/tests/sentry/integrations/github_copilot/test_client.py
@@ -210,6 +210,51 @@ class GithubCopilotAgentClientTest(TestCase):
 
         assert result is None
 
+    @patch.object(GithubCopilotAgentClient, "get")
+    def test_get_pr_from_branch_success(self, mock_get: Mock) -> None:
+        """get_pr_from_branch resolves a PR from the head branch via the REST API"""
+        mock_response = Mock()
+        mock_response.json = [
+            {
+                "number": 46,
+                "title": "Fix the bug",
+                "html_url": "https://github.com/getsentry/sentry/pull/46",
+                "node_id": "PR_abc123",
+            }
+        ]
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        result = self.copilot_client.get_pr_from_branch(
+            owner="getsentry", repo="sentry", head_ref="copilot/fix-bug"
+        )
+
+        assert result is not None
+        assert result.number == 46
+        assert result.title == "Fix the bug"
+        assert result.url == "https://github.com/getsentry/sentry/pull/46"
+
+        mock_get.assert_called_once_with(
+            "https://api.github.com/repos/getsentry/sentry/pulls",
+            headers={"Authorization": "Bearer test_access_token", "User-Agent": "sentry"},
+            params={"head": "getsentry:copilot/fix-bug", "state": "all"},
+            timeout=30,
+        )
+
+    @patch.object(GithubCopilotAgentClient, "get")
+    def test_get_pr_from_branch_no_pr(self, mock_get: Mock) -> None:
+        """get_pr_from_branch returns None when no PR exists for the branch"""
+        mock_response = Mock()
+        mock_response.json = []
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        result = self.copilot_client.get_pr_from_branch(
+            owner="getsentry", repo="sentry", head_ref="no-pr-branch"
+        )
+
+        assert result is None
+
     @patch.object(GithubCopilotAgentClient, "post")
     def test_launch_truncates_long_prompt(self, mock_post: Mock) -> None:
         """Prompts exceeding 25,000 chars are truncated"""

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -175,6 +175,118 @@ class TestPollGithubCopilotAgents(TestCase):
         assert call_kwargs["result"].description == "Fix the bug"
         assert call_kwargs["result"].repo_full_name == "getsentry/sentry"
 
+    @patch("sentry.seer.autofix.coding_agent.update_coding_agent_state")
+    @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")
+    def test_poll_falls_back_to_branch_when_global_id_empty(
+        self, mock_identity_service, mock_update_state
+    ):
+        """When the Copilot API returns an empty global_id, resolve the PR via the head branch."""
+        mock_identity_service.get_access_token_for_user.return_value = "test_token"
+
+        mock_get_task_status = MagicMock(
+            return_value=GithubCopilotTask(
+                id="task-123",
+                state="completed",
+                artifacts=[
+                    GithubCopilotArtifact(
+                        provider="github",
+                        type="github_resource",
+                        data=GithubCopilotArtifactData(id=456, type="pull", global_id=""),
+                    ),
+                    GithubCopilotArtifact(
+                        provider="github",
+                        type="branch",
+                        data=GithubCopilotArtifactData(head_ref="copilot/fix-bug", base_ref="main"),
+                    ),
+                ],
+            )
+        )
+
+        mock_pr_info = MagicMock()
+        mock_pr_info.url = "https://github.com/getsentry/sentry/pull/46"
+        mock_pr_info.title = "Fix the bug"
+        mock_get_pr_from_graphql = MagicMock()
+        mock_get_pr_from_branch = MagicMock(return_value=mock_pr_info)
+
+        agents = {
+            "getsentry:sentry:task-123": CodingAgentState(
+                id="getsentry:sentry:task-123",
+                status=CodingAgentStatus.RUNNING,
+                provider=CodingAgentProviderType.GITHUB_COPILOT_AGENT,
+                name="GitHub Copilot",
+                started_at=datetime.now(UTC),
+            )
+        }
+        autofix_state = self._create_autofix_state_with_agents(agents)
+
+        with patch.object(GithubCopilotAgentClient, "__init__", return_value=None):
+            with patch.object(GithubCopilotAgentClient, "get_task_status", mock_get_task_status):
+                with patch.object(
+                    GithubCopilotAgentClient, "get_pr_from_graphql", mock_get_pr_from_graphql
+                ):
+                    with patch.object(
+                        GithubCopilotAgentClient, "get_pr_from_branch", mock_get_pr_from_branch
+                    ):
+                        poll_github_copilot_agents(autofix_state, user_id=self.user.id)
+
+        # Empty global_id -> GraphQL path skipped, branch fallback used.
+        mock_get_pr_from_graphql.assert_not_called()
+        mock_get_pr_from_branch.assert_called_once_with("getsentry", "sentry", "copilot/fix-bug")
+
+        mock_update_state.assert_called_once()
+        call_kwargs = mock_update_state.call_args[1]
+        assert call_kwargs["status"] == CodingAgentStatus.COMPLETED
+        assert call_kwargs["result"].pr_url == "https://github.com/getsentry/sentry/pull/46"
+        assert call_kwargs["result"].description == "Fix the bug"
+
+    @patch("sentry.seer.autofix.coding_agent.update_coding_agent_state")
+    @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")
+    def test_poll_marks_completed_without_pr_when_unresolved(
+        self, mock_identity_service, mock_update_state
+    ):
+        """A completed task flips to COMPLETED even when no PR can be resolved."""
+        mock_identity_service.get_access_token_for_user.return_value = "test_token"
+
+        mock_get_task_status = MagicMock(
+            return_value=GithubCopilotTask(
+                id="task-123",
+                state="completed",
+                artifacts=[
+                    GithubCopilotArtifact(
+                        provider="github",
+                        type="branch",
+                        data=GithubCopilotArtifactData(head_ref="copilot/fix-bug", base_ref="main"),
+                    ),
+                ],
+            )
+        )
+
+        mock_get_pr_from_branch = MagicMock(return_value=None)
+
+        agents = {
+            "getsentry:sentry:task-123": CodingAgentState(
+                id="getsentry:sentry:task-123",
+                status=CodingAgentStatus.RUNNING,
+                provider=CodingAgentProviderType.GITHUB_COPILOT_AGENT,
+                name="GitHub Copilot",
+                started_at=datetime.now(UTC),
+            )
+        }
+        autofix_state = self._create_autofix_state_with_agents(agents)
+
+        with patch.object(GithubCopilotAgentClient, "__init__", return_value=None):
+            with patch.object(GithubCopilotAgentClient, "get_task_status", mock_get_task_status):
+                with patch.object(
+                    GithubCopilotAgentClient, "get_pr_from_branch", mock_get_pr_from_branch
+                ):
+                    poll_github_copilot_agents(autofix_state, user_id=self.user.id)
+
+        mock_get_pr_from_branch.assert_called_once_with("getsentry", "sentry", "copilot/fix-bug")
+        mock_update_state.assert_called_once()
+        call_kwargs = mock_update_state.call_args[1]
+        assert call_kwargs["status"] == CodingAgentStatus.COMPLETED
+        assert call_kwargs["result"] is None
+
     @patch("sentry.seer.autofix.coding_agent.attribute_delegated_agent_pull_request")
     @patch("sentry.seer.autofix.coding_agent.update_coding_agent_state")
     @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -439,6 +439,53 @@ class TestPollGithubCopilotAgents(TestCase):
 
     @patch("sentry.seer.autofix.coding_agent.update_coding_agent_state")
     @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")
+    def test_poll_marks_completed_when_pr_resolution_errors(
+        self, mock_identity_service, mock_update_state
+    ):
+        """A GitHub API error during PR resolution must not block the terminal status update."""
+        mock_identity_service.get_access_token_for_user.return_value = "test_token"
+
+        mock_get_task_status = MagicMock(
+            return_value=GithubCopilotTask(
+                id="task-123",
+                state="completed",
+                artifacts=[
+                    GithubCopilotArtifact(
+                        provider="github",
+                        type="branch",
+                        data=GithubCopilotArtifactData(head_ref="copilot/fix-bug", base_ref="main"),
+                    ),
+                ],
+            )
+        )
+        mock_get_pr_from_branch = MagicMock(side_effect=Exception("GitHub 502"))
+
+        agents = {
+            "getsentry:sentry:task-123": CodingAgentState(
+                id="getsentry:sentry:task-123",
+                status=CodingAgentStatus.RUNNING,
+                provider=CodingAgentProviderType.GITHUB_COPILOT_AGENT,
+                name="GitHub Copilot",
+                started_at=datetime.now(UTC),
+            )
+        }
+        autofix_state = self._create_autofix_state_with_agents(agents)
+
+        with patch.object(GithubCopilotAgentClient, "__init__", return_value=None):
+            with patch.object(GithubCopilotAgentClient, "get_task_status", mock_get_task_status):
+                with patch.object(
+                    GithubCopilotAgentClient, "get_pr_from_branch", mock_get_pr_from_branch
+                ):
+                    poll_github_copilot_agents(autofix_state, user_id=self.user.id)
+
+        mock_get_pr_from_branch.assert_called_once()
+        mock_update_state.assert_called_once()
+        call_kwargs = mock_update_state.call_args[1]
+        assert call_kwargs["status"] == CodingAgentStatus.COMPLETED
+        assert call_kwargs["result"] is None
+
+    @patch("sentry.seer.autofix.coding_agent.update_coding_agent_state")
+    @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")
     def test_poll_marks_failed_even_when_branch_has_pr(
         self, mock_identity_service, mock_update_state
     ):

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -434,7 +434,58 @@ class TestPollGithubCopilotAgents(TestCase):
         mock_update_state.assert_called_once_with(
             agent_id="getsentry:sentry:task-123",
             status=CodingAgentStatus.FAILED,
+            result=None,
         )
+
+    @patch("sentry.seer.autofix.coding_agent.update_coding_agent_state")
+    @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")
+    def test_poll_marks_failed_even_when_branch_has_pr(
+        self, mock_identity_service, mock_update_state
+    ):
+        """A failed/timed_out task is marked FAILED even if a PR exists on the head branch."""
+        mock_identity_service.get_access_token_for_user.return_value = "test_token"
+
+        mock_get_task_status = MagicMock(
+            return_value=GithubCopilotTask(
+                id="task-123",
+                state="failed",
+                artifacts=[
+                    GithubCopilotArtifact(
+                        provider="github",
+                        type="branch",
+                        data=GithubCopilotArtifactData(head_ref="copilot/fix-bug", base_ref="main"),
+                    ),
+                ],
+            )
+        )
+
+        # A draft PR may already exist on the head branch even though the task failed.
+        mock_pr_info = MagicMock()
+        mock_pr_info.url = "https://github.com/getsentry/sentry/pull/46"
+        mock_pr_info.title = "WIP"
+        mock_get_pr_from_branch = MagicMock(return_value=mock_pr_info)
+
+        agents = {
+            "getsentry:sentry:task-123": CodingAgentState(
+                id="getsentry:sentry:task-123",
+                status=CodingAgentStatus.RUNNING,
+                provider=CodingAgentProviderType.GITHUB_COPILOT_AGENT,
+                name="GitHub Copilot",
+                started_at=datetime.now(UTC),
+            )
+        }
+        autofix_state = self._create_autofix_state_with_agents(agents)
+
+        with patch.object(GithubCopilotAgentClient, "__init__", return_value=None):
+            with patch.object(GithubCopilotAgentClient, "get_task_status", mock_get_task_status):
+                with patch.object(
+                    GithubCopilotAgentClient, "get_pr_from_branch", mock_get_pr_from_branch
+                ):
+                    poll_github_copilot_agents(autofix_state, user_id=self.user.id)
+
+        mock_update_state.assert_called_once()
+        call_kwargs = mock_update_state.call_args[1]
+        assert call_kwargs["status"] == CodingAgentStatus.FAILED
 
     @patch("sentry.seer.autofix.coding_agent.update_coding_agent_state")
     @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")


### PR DESCRIPTION
## Summary

When Seer hands off a fix to the **GitHub Copilot coding agent**, the issue page polls the Copilot task API and shows the agent's status. The status was getting **stuck on "running" forever** even after Copilot finished and opened the PR.

### Root cause

In `poll_github_copilot_agents`, the only code path that flips the agent status to `COMPLETED` lived **inside** the branch guarded by the PR artifact's `global_id`:

```python
if pr_artifact and pr_artifact.data and pr_artifact.data.global_id:   # "" is falsy → skipped
    ...
    update_coding_agent_state(agent_id, status=COMPLETED, ...)        # only place it completes
elif task_status.state in ("failed", "timed_out"):                   # state == "completed" → skipped
    ...
```

The Copilot task API **intermittently returns an empty `global_id`** for the PR artifact even on `state: "completed"` tasks whose PR exists (confirmed live: PR's real node id existed, but the artifact's `global_id` and the session's `resource_global_id` both came back `""`). With an empty `global_id`, neither the `if` nor the `elif` runs, so the status never leaves `RUNNING`. It can't self-heal either — the poller only re-checks `RUNNING` agents, and every poll hits the same empty value.

### Fix

Decouple the status transition from `global_id`:

- Derive completion from the task `state`, not from PR resolution.
- Resolve PR details via GraphQL when a `global_id` is present (unchanged, documented path); otherwise fall back to the GitHub REST API `GET /repos/{owner}/{repo}/pulls?head={owner}:{head_ref}&state=all`, which relies only on the reliably-populated branch artifact + public PR fields and returns the PR's `node_id`/`number`/`html_url`.
- A completed task now always leaves `RUNNING` — even if no PR can be resolved at all (status flips to `COMPLETED` with no result rather than hanging).

The REST fallback was suggested by the GitHub Copilot team while they investigate why `global_id` comes back empty.

## Verification

- Verified the fallback endpoint against the live API: the PR's branch returns `{number, title, html_url}` as parsed; a branch with no PR returns `[]` → `None`.
- `tests/sentry/integrations/github_copilot/test_client.py` — new `get_pr_from_branch` success/no-PR tests.
- `tests/sentry/seer/autofix/test_coding_agent.py` — new tests for the empty-`global_id` branch fallback and for completing without a resolvable PR.
- Full suite for both files: 54 passing. `prek` (ruff + mypy) clean.

## Notes

Backend-only change (`src/` + `tests/`). A separate bug report has been sent to the GitHub Copilot team about the upstream empty-`global_id` behavior.



Agent transcript: https://claudescope.sentry.dev/share/XBQNsF7uNO8Int8DiFiIOEiQA0cPmpVsruFRavlnb0g