### PR TITLE
feat(issues): show linked PR attribution avatars

### DIFF
--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -34,7 +34,9 @@ describe('LinkedPullRequests', () => {
               title: 'Fix widget crash on startup',
               repository,
               externalUrl: 'https://github.com/example/widget-app/pull/123',
+              author: {name: 'Ada Lovelace', email: 'ada@example.com'},
             }),
+            attribution: null,
             dateLinked: '2026-06-08T23:11:32.000000Z',
             status: 'merged',
           },
@@ -45,6 +47,10 @@ describe('LinkedPullRequests', () => {
               repository,
               externalUrl: 'https://github.com/example/widget-app/pull/124',
             }),
+            attribution: {
+              type: 'seer',
+              id: 'seer',
+            },
             dateLinked: '2026-06-08T23:10:32.000000Z',
             status: 'closed',
           },
@@ -74,9 +80,15 @@ describe('LinkedPullRequests', () => {
     expect(within(list).getByText('#123')).toBeInTheDocument();
     expect(within(list).getByText('#124')).toBeInTheDocument();
     expect(within(list).getAllByText(REPOSITORY_NAME)).toHaveLength(2);
-    expect(linkedPullRequest.querySelectorAll('svg')).toHaveLength(2);
     expect(within(list).getByText('Merged')).toBeInTheDocument();
     expect(within(list).getByText('Closed')).toBeInTheDocument();
+    expect(within(linkedPullRequest).getByText('AL')).toBeInTheDocument();
+    expect(
+      within(linkedPullRequest).getByLabelText('Pull request author: Ada Lovelace')
+    ).toHaveAttribute('title', 'Pull request author: Ada Lovelace');
+    expect(
+      within(list).getByLabelText('Pull request created by Seer')
+    ).toBeInTheDocument();
     const mergedStatus = within(list).getByLabelText('Pull request status: Merged');
     const closedStatus = within(list).getByLabelText('Pull request status: Closed');
     expect(mergedStatus).toBeInTheDocument();

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import {skipToken, useQuery} from '@tanstack/react-query';
 
+import {Avatar} from '@sentry/scraps/avatar';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
@@ -9,11 +10,13 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {Placeholder} from 'sentry/components/placeholder';
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
 import {TimeSince} from 'sentry/components/timeSince';
+import {IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {GroupActivityType, type Group} from 'sentry/types/group';
 import type {
   LinkedPullRequest,
   LinkedPullRequestsResponse,
+  PullRequestAttribution,
 } from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
@@ -54,6 +57,7 @@ function LinkedPullRequestRow({
   const title = pullRequest.title ?? t('Pull request #%s', pullRequest.id);
   const statusLabel = getPullRequestStatusLabel(pullRequest.status);
   const pullRequestLabel = t('#%s', pullRequest.id);
+  const authorAvatar = getPullRequestAuthorAvatar(pullRequest);
 
   return (
     <Tooltip
@@ -104,6 +108,11 @@ function LinkedPullRequestRow({
             </PullRequestTitle>
             <Flex align="center" gap="xs">
               <PullRequestStatusBadge status={pullRequest.status} />
+              {pullRequest.attribution ? (
+                <PullRequestAttributionAvatar attribution={pullRequest.attribution} />
+              ) : authorAvatar ? (
+                <PullRequestAuthorAvatar author={authorAvatar} />
+              ) : null}
               <Text as="span" size="sm" variant="muted">
                 <TimeSince
                   date={pullRequest.dateLinked}
@@ -116,6 +125,74 @@ function LinkedPullRequestRow({
           </Flex>
         </Grid>
       </PullRequestRow>
+    </Tooltip>
+  );
+}
+
+function PullRequestAttributionAvatar({
+  attribution,
+}: {
+  attribution: PullRequestAttribution;
+}) {
+  switch (attribution.type) {
+    case 'seer':
+      return <SeerAttributionAvatar />;
+  }
+}
+
+function getPullRequestAuthorAvatar(pullRequest: LinkedPullRequest) {
+  if (!pullRequest.author || pullRequest.author.email?.endsWith('@localhost')) {
+    return null;
+  }
+
+  const name = pullRequest.author.name || pullRequest.author.email;
+  const identifier = pullRequest.author.email || pullRequest.author.name;
+
+  return name && identifier ? {identifier, name} : null;
+}
+
+function PullRequestAuthorAvatar({
+  author,
+}: {
+  author: NonNullable<ReturnType<typeof getPullRequestAuthorAvatar>>;
+}) {
+  const label = t('Pull request author: %s', author.name);
+
+  return (
+    <Flex as="span" aria-label={label} display="inline-flex" role="img" title={label}>
+      <Avatar
+        hasTooltip
+        identifier={author.identifier}
+        name={author.name}
+        round
+        size={18}
+        tooltip={label}
+        type="letter_avatar"
+      />
+    </Flex>
+  );
+}
+
+function SeerAttributionAvatar() {
+  const label = t('Pull request created by Seer');
+
+  return (
+    <Tooltip title={label} skipWrapper>
+      <Flex
+        as="span"
+        align="center"
+        aria-label={label}
+        border="primary"
+        display="inline-flex"
+        height="18px"
+        justify="center"
+        radius="full"
+        role="img"
+        title={label}
+        width="18px"
+      >
+        <IconSeer aria-hidden size="xs" />
+      </Flex>
     </Tooltip>
   );
 }

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -154,7 +154,15 @@ export interface PullRequest {
 
 export type PullRequestStatus = 'merged' | 'open' | 'closed' | 'draft' | 'unknown';
 
+type SeerAttribution = {
+  id: 'seer';
+  type: 'seer';
+};
+
+export type PullRequestAttribution = SeerAttribution;
+
 export interface LinkedPullRequest extends PullRequest {
+  attribution: PullRequestAttribution | null;
   dateLinked: string;
   status: PullRequestStatus;
 }


### PR DESCRIPTION
shows linked PR authors as avatar-only UI and uses the attribution slot for Seer-created PRs.

depends on #118416 for the API response.

fixes https://linear.app/getsentry/issue/ID-1653/add-author-to-linked-pull-requests

seer attribution

<img width="307" height="71" alt="Screenshot 2026-06-24 at 3 50 01 PM" src="https://github.com/user-attachments/assets/50ea255d-861d-44e7-b649-8c1afb134ed7" />

with user avatar

<img width="313" height="69" alt="image" src="https://github.com/user-attachments/assets/ce6177f3-0fc9-4162-ba82-1d0af8cfb654" />

