### PR TITLE
chore(weekly-report): Change color of resolved label

### DIFF
--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -478,7 +478,7 @@
   {% endif %}
   {% if past_issues|length > 0 and not enhanced_privacy %}
   <div id="past-resolved-issues">
-    <h4>Resolved this week</h4>
+    <h4>Resolved last week</h4>
     {% for a in past_issues %}
     <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
       <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
@@ -490,7 +490,7 @@
         <div title="{{a.message}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; width: auto; max-width: 100%; max-height: 38px; line-height: 1.2; font-size: 14px; color: #80708F; margin-bottom: 2px;">{{a.message}}</div>
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
-      <span style="background-color: #E7E1EC; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center;">Resolved</span>
+      <span style="background-color: #E3F7E3; color: #008900; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">Resolved</span>
     </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
Problem statement: Resolved label for "Resolved last week" section was gray instead of green (like the rest of the report)

To test:
- Start dev environment
- Go to `debug/mail/weekly-reports/`

How it's supposed to look:
<img width="1268" height="172" alt="image" src="https://github.com/user-attachments/assets/b6397365-a48b-4081-9938-8438d1efbad6" />

Before:
<img width="1262" height="514" alt="image" src="https://github.com/user-attachments/assets/9c7983f1-ac1d-4e7d-a213-447751d8ec39" />

After: 
<img width="1268" height="482" alt="image" src="https://github.com/user-attachments/assets/679cf96a-0c42-436f-9d29-15694862f7f9" />
