### PR TITLE
chore(unmerge): Stop sending analytics events from `unmerge` task

### DIFF
--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -10,8 +10,7 @@ from typing import Any
 from django.db import router, transaction
 from django.db.models.base import Model
 
-from sentry import analytics, similarity, tsdb
-from sentry.analytics.events.eventuser_endpoint_request import EventUserEndpointRequest
+from sentry import similarity, tsdb
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS_MAP
 from sentry.culprit import generate_culprit
 from sentry.models.activity import Activity
@@ -359,12 +358,6 @@ def repair_group_release_data(
 
 
 def get_event_user_from_interface(value: dict[str, Any], project: Project) -> EventUser:
-    analytics.record(
-        EventUserEndpointRequest(
-            project_id=project.id,
-            endpoint="sentry.tasks.unmerge.get_event_user_from_interface",
-        )
-    )
     return EventUser(
         user_ident=value.get("id"),
         email=value.get("email"),

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -12,7 +12,6 @@ from unittest.mock import patch
 from django.utils import timezone
 
 from sentry import eventstream, tsdb
-from sentry.analytics.events.eventuser_endpoint_request import EventUserEndpointRequest
 from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.groupenvironment import GroupEnvironment
@@ -33,7 +32,6 @@ from sentry.tasks.unmerge import (
     unmerge,
 )
 from sentry.testutils.cases import SnubaTestCase, TestCase
-from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.tsdb.base import TSDBModel
@@ -175,8 +173,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         }
 
     @with_feature("projects:similarity-indexing")
-    @mock.patch("sentry.analytics.record")
-    def test_unmerge(self, mock_record) -> None:
+    def test_unmerge(self) -> None:
         # Replace second=0 to ensure all 17 events (now+0s to now+17s)
         # stay within the same hour bucket. Without this, if now is within
         # 17 seconds of an hour boundary, events can cross into the next
@@ -465,13 +462,6 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
             aggregate = aggregate if aggregate is not None else set()
             aggregate.add(
                 get_event_user_from_interface(event.data["user"], event.group.project).tag_value
-            )
-            assert_last_analytics_event(
-                mock_record,
-                EventUserEndpointRequest(
-                    project_id=event.group.project.id,
-                    endpoint="sentry.tasks.unmerge.get_event_user_from_interface",
-                ),
             )
             return aggregate
 


### PR DESCRIPTION
Seeing high load in the analytics pipeline for this event, so removing it from the `unmerge` task.

[Slack thread for context](https://sentry.slack.com/archives/C08LXCVPH0B/p1782347566621879)