### PR TITLE
ref(ai-search): Add gen-ai-issues-search feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -105,6 +105,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:gen-ai-search-agent-translate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable AI search bar on the explore > metrics tab
     manager.add("organizations:gen-ai-explore-metrics-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable AI search bar on the issues page
+    manager.add("organizations:gen-ai-issues-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GenAI consent
     manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable LLM-generated title and description for external issue details

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -146,6 +146,12 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
                 organization,
                 actor=request.user,
             )
+        if strategy == "Issues":
+            has_feature = has_feature and features.has(
+                "organizations:gen-ai-issues-search",
+                organization,
+                actor=request.user,
+            )
         if not has_feature:
             return Response(
                 {"detail": "Feature flag not enabled"},

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -84,8 +84,6 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
         """
         has_feature = features.has(
             "organizations:gen-ai-search-agent-translate", organization, actor=request.user
-        ) or features.has(
-            "organizations:gen-ai-explore-metrics-search", organization, actor=request.user
         )
         if not has_feature:
             return Response(


### PR DESCRIPTION
## Changes

- Registers a new `organizations:gen-ai-issues-search` FlagPole feature flag (`api_expose=True`) to gate the Seer AI search bar on the issues page.
- In the search agent **start** endpoint, requires `gen-ai-issues-search` (in addition to `gen-ai-search-agent-translate`) when `strategy == "Issues"`, mirroring the existing `Metrics` pattern with `gen-ai-explore-metrics-search`.
- Simplifies the search agent **state** endpoint to use only `gen-ai-search-agent-translate` as its gate — the state endpoint has no `strategy` param, so the previously-added `gen-ai-explore-metrics-search` OR condition was unnecessary.