### PR TITLE
ref(ai-search): Gate issue list AI search on gen-ai-issues-search flag

### DIFF
--- a/static/app/views/issueList/issueSearch.tsx
+++ b/static/app/views/issueList/issueSearch.tsx
@@ -42,7 +42,9 @@ export function IssueSearch({query, onSearch, className}: IssueSearchProps) {
     useIssueListSearchBarDataProvider({pageFilters});
 
   const organization = useOrganization();
-  const hasTranslateEndpoint = organization.features.includes('gen-ai-issues-search');
+  const hasTranslateEndpoint =
+    organization.features.includes('gen-ai-search-agent-translate') &&
+    organization.features.includes('gen-ai-issues-search');
 
   return (
     <SearchQueryBuilderProvider

--- a/static/app/views/issueList/issueSearch.tsx
+++ b/static/app/views/issueList/issueSearch.tsx
@@ -42,9 +42,7 @@ export function IssueSearch({query, onSearch, className}: IssueSearchProps) {
     useIssueListSearchBarDataProvider({pageFilters});
 
   const organization = useOrganization();
-  const hasTranslateEndpoint = organization.features.includes(
-    'gen-ai-search-agent-translate'
-  );
+  const hasTranslateEndpoint = organization.features.includes('gen-ai-issues-search');
 
   return (
     <SearchQueryBuilderProvider


### PR DESCRIPTION
## Changes

Switches the AI search enablement check in `IssueSearch` from the generic `gen-ai-search-agent-translate` flag to the new issues-specific `gen-ai-issues-search` flag. This allows the issues page AI search to be rolled out independently from other surfaces (Explore traces, logs, etc.) that use the translate flag.

Depends on backend flag registration: https://github.com/getsentry/sentry/pull/118424