### PR TITLE
feat(seer): Add get_organization_projects RPC method

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_rpc.py
+++ b/src/sentry/seer/endpoints/organization_seer_rpc.py
@@ -67,6 +67,7 @@ from sentry.seer.endpoints.seer_rpc import (
     get_github_enterprise_integration_config,
     get_organization_features,
     get_organization_project_ids,
+    get_organization_projects,
     get_organization_slug,
     has_repo_code_mappings,
     validate_repo,
@@ -103,6 +104,7 @@ logger = logging.getLogger(__name__)
 public_org_seer_method_registry: dict[str, SeerRpcMethod] = {
     # Common to Seer features
     "get_organization_project_ids": seer_rpc(map_org_id_param(get_organization_project_ids)),
+    "get_organization_projects": seer_rpc(map_org_id_param(get_organization_projects)),
     "get_organization_slug": seer_rpc(map_org_id_param(get_organization_slug)),
     "get_organization_features": seer_rpc(map_org_id_param(get_organization_features)),
     "validate_repo": seer_rpc(validate_repo),

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -77,6 +77,7 @@ from sentry.search.events.types import SnubaParams
 from sentry.seer.agent.client import (
     get_monitoring_provider_connections as fetch_monitoring_provider_connections,
 )
+from sentry.seer.agent.context_engine_utils import get_instrumentation_types
 from sentry.seer.agent.custom_tool_utils import call_custom_tool
 from sentry.seer.agent.feature_delivery import DELIVERY_HANDLERS, FeatureRunStatus
 from sentry.seer.agent.index_data import (
@@ -146,7 +147,9 @@ from sentry.seer.sentry_data_models import (
     OrganizationAutofixConsentResponse,
     OrganizationFeaturesResponse,
     OrganizationProject,
+    OrganizationProjectDetail,
     OrganizationProjectIdsResponse,
+    OrganizationProjectsResponse,
     OrganizationSlugResponse,
     PrAttributionResponse,
     RefreshMonitoringProviderTokenErrorResponse,
@@ -364,6 +367,25 @@ def get_organization_project_ids(*, org_id: int) -> OrganizationProjectIdsRespon
     ]
 
     return OrganizationProjectIdsResponse(projects=projects)
+
+
+def get_organization_projects(*, org_id: int) -> OrganizationProjectsResponse:
+    """Get all active projects with instrumentation types for an organization"""
+    try:
+        organization = Organization.objects.get(id=org_id)
+    except Organization.DoesNotExist:
+        return OrganizationProjectsResponse(projects=[])
+
+    projects = [
+        OrganizationProjectDetail(
+            id=project.id,
+            slug=project.slug,
+            instrumentation_types=get_instrumentation_types(project),
+        )
+        for project in Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
+    ]
+
+    return OrganizationProjectsResponse(projects=projects)
 
 
 _ORGANIZATION_SCOPE_PREFIX = "organizations:"

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -380,7 +380,7 @@ def get_organization_projects(*, org_id: int) -> OrganizationProjectsResponse:
         OrganizationProjectDetail(
             id=project.id,
             slug=project.slug,
-            instrumentation_types=get_instrumentation_types(project),
+            instrumentation=get_instrumentation_types(project),
         )
         for project in Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
     ]

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -125,6 +125,16 @@ class OrganizationProjectIdsResponse(BaseModel):
     projects: list[OrganizationProject]
 
 
+class OrganizationProjectDetail(BaseModel):
+    id: int
+    slug: str
+    instrumentation_types: list[str]
+
+
+class OrganizationProjectsResponse(BaseModel):
+    projects: list[OrganizationProjectDetail]
+
+
 class OrganizationFeaturesResponse(BaseModel):
     features: list[str]
 

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -128,7 +128,7 @@ class OrganizationProjectIdsResponse(BaseModel):
 class OrganizationProjectDetail(BaseModel):
     id: int
     slug: str
-    instrumentation_types: list[str]
+    instrumentation: list[str]
 
 
 class OrganizationProjectsResponse(BaseModel):

--- a/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 from django.urls import reverse
 
 from sentry.models.apitoken import ApiToken
+from sentry.models.project import Project
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
@@ -62,6 +63,27 @@ class TestOrganizationSeerRpcEndpoint(APITestCase):
         # Should include our project
         project_ids = [p["id"] for p in response.data["projects"]]
         assert self.project.id in project_ids
+
+    @with_feature("organizations:seer-public-rpc")
+    def test_get_organization_projects(self) -> None:
+        """instrumentation_types reflects project flags via get_instrumentation_types"""
+        path = self._get_path("get_organization_projects")
+
+        # No flags set — instrumentation_types should be empty
+        response = self.client.post(path, data={"args": {}}, format="json")
+        assert response.status_code == 200
+        project_data = next(p for p in response.data["projects"] if p["id"] == self.project.id)
+        assert project_data["instrumentation_types"] == []
+
+        # Set has_transactions and has_logs flags
+        self.project.update(
+            flags=Project.flags.has_transactions | Project.flags.has_logs,
+        )
+
+        response = self.client.post(path, data={"args": {}}, format="json")
+        assert response.status_code == 200
+        project_data = next(p for p in response.data["projects"] if p["id"] == self.project.id)
+        assert set(project_data["instrumentation_types"]) == {"transactions", "spans", "logs"}
 
     @with_feature("organizations:seer-public-rpc")
     def test_org_level_method_get_organization_features(self) -> None:

--- a/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
@@ -66,14 +66,14 @@ class TestOrganizationSeerRpcEndpoint(APITestCase):
 
     @with_feature("organizations:seer-public-rpc")
     def test_get_organization_projects(self) -> None:
-        """instrumentation_types reflects project flags via get_instrumentation_types"""
+        """instrumentation reflects project flags via get_instrumentation"""
         path = self._get_path("get_organization_projects")
 
-        # No flags set — instrumentation_types should be empty
+        # No flags set — instrumentation should be empty
         response = self.client.post(path, data={"args": {}}, format="json")
         assert response.status_code == 200
         project_data = next(p for p in response.data["projects"] if p["id"] == self.project.id)
-        assert project_data["instrumentation_types"] == []
+        assert project_data["instrumentation"] == []
 
         # Set has_transactions and has_logs flags
         self.project.update(
@@ -83,7 +83,7 @@ class TestOrganizationSeerRpcEndpoint(APITestCase):
         response = self.client.post(path, data={"args": {}}, format="json")
         assert response.status_code == 200
         project_data = next(p for p in response.data["projects"] if p["id"] == self.project.id)
-        assert set(project_data["instrumentation_types"]) == {"transactions", "spans", "logs"}
+        assert set(project_data["instrumentation"]) == {"transactions", "spans", "logs"}
 
     @with_feature("organizations:seer-public-rpc")
     def test_org_level_method_get_organization_features(self) -> None:


### PR DESCRIPTION
Add a new public Seer RPC method `get_organization_projects` that returns active project details. This response can be extended in the future, but for now it's only enriched with instrumentation types (derived from project flags via the existing `get_instrumentation_types` util).

The existing `get_organization_project_ids` is unchanged — it still returns only IDs and slugs via `.values()` for callers that don't need instrumentation context. The new method fetches full project objects to pass to `get_instrumentation_types`, which reads `project.flags` to determine which telemetry types (transactions, spans, profiles, replays, sessions, logs, trace_metrics) are active for each project.