### PR TITLE
ref(devtools): move TanStack devtools position to bottom-right

### DIFF
--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -48,7 +48,7 @@ export function Main() {
             </NuqsAdapter>
             {USE_TANSTACK_DEVTOOL && (
               <TanStackDevtools
-                config={{position: 'bottom-left'}}
+                config={{position: 'bottom-right'}}
                 plugins={[
                   {
                     name: 'TanStack Query',


### PR DESCRIPTION
because bottom-left completely overlaps with the user menu in the new sidebar layout
