### PR TITLE
fix(theme): Strip stale body theme class on cmd-k theme switch

### DIFF
--- a/static/app/utils/useMutateUserOptions.tsx
+++ b/static/app/utils/useMutateUserOptions.tsx
@@ -4,6 +4,7 @@ import merge from 'lodash/merge';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {User} from 'sentry/types/user';
+import {removeBodyTheme} from 'sentry/utils/removeBodyTheme';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useApi} from 'sentry/utils/useApi';
 import {useUser} from 'sentry/utils/useUser';
@@ -31,6 +32,7 @@ export function useMutateUserOptions({onSuccess, onError}: Props = {}) {
         options.theme !== 'system'
       ) {
         ConfigStore.set('theme', options.theme);
+        removeBodyTheme();
       }
       ConfigStore.set('user', merge({}, user, {options}));
       return onSuccess?.();


### PR DESCRIPTION
Switching the theme via the Command+K palette left some inherited text colors
stale (e.g. `RadioLineText`), while switching via Settings > Preferences worked
correctly. The cmd-k path updates `ConfigStore` but never removed the `theme-*`
class added to `<body>` in `base-react.html`, whose CSS overrode the color
inherited from the body for elements without an explicit color.

**The fix**

`useMutateUserOptions` now calls `removeBodyTheme()` when the theme changes, so
the cmd-k path behaves the same as the Settings path. The Settings path already
did this in its mutation's `onSuccess`.