### PR TITLE
feat(conversations): Move LLM Calls column next to Tool Calls

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTableNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableNew.tsx
@@ -48,8 +48,8 @@ type ColumnKey =
 
 const DEFAULT_COLUMNS: Array<GridColumnOrder<ColumnKey>> = [
   {key: 'conversationId', name: t('Conv. ID'), width: 150},
-  {key: 'llmCalls', name: t('LLM Calls'), width: 100},
   {key: 'user', name: t('User'), width: COL_WIDTH_UNDEFINED},
+  {key: 'llmCalls', name: t('LLM Calls'), width: 100},
   {key: 'toolCalls', name: t('Tool Calls'), width: 120},
   {key: 'errors', name: t('Errors'), width: 100},
   {key: 'cost', name: t('Cost'), width: 110},


### PR DESCRIPTION
Moves the **LLM Calls** column in the redesigned conversations table so it sits immediately before **Tool Calls**, grouping the two call-count metrics together.

### Before
`Conv. ID` · `LLM Calls` · `User` · `Tool Calls` · `Errors` · `Cost` · `Last Message`

### After
`Conv. ID` · `User` · `LLM Calls` · `Tool Calls` · `Errors` · `Cost` · `Last Message`

This only affects the redesigned table gated behind the `gen-ai-conversations-redesign` feature flag.
