### PR TITLE
fix(mobile-vitals): include app.start in cold/warm start transaction.op conditions

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/constants.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/constants.ts
@@ -21,7 +21,13 @@ export const WARM_START_CONDITION = `(${ROOT_APP_START_TRANSACTION_CONDITION} ha
 export const TTID_CONDITION = `(${ROOT_TRANSACTION_CONDITION} has:${SpanFields.APP_VITALS_TTID_VALUE} OR ${SpanFields.SPAN_OP}:ui.load.initial_display has:${SpanFields.APP_VITALS_TTID_VALUE})`;
 export const TTFD_CONDITION = `(${ROOT_TRANSACTION_CONDITION} has:${SpanFields.APP_VITALS_TTFD_VALUE} OR ${SpanFields.SPAN_OP}:ui.load.full_display has:${SpanFields.APP_VITALS_TTFD_VALUE})`;
 
-const APP_START_CONDITION = `(${COLD_START_CONDITION} OR ${WARM_START_CONDITION})`;
+// The App Starts table groups rows by screen (transaction), so it keeps the
+// narrower ROOT_TRANSACTION_CONDITION op list. app.start root transactions are
+// not per-screen rows and would otherwise show up as spurious table entries —
+// only the cold/warm start metric widgets should pull them in.
+const COLD_START_TABLE_VALUE_CONDITION = `(${ROOT_TRANSACTION_CONDITION} has:${SpanFields.APP_VITALS_START_COLD_VALUE} OR ${SpanFields.SPAN_OP}:app.start.cold has:${SpanFields.APP_VITALS_START_COLD_VALUE})`;
+const WARM_START_TABLE_VALUE_CONDITION = `(${ROOT_TRANSACTION_CONDITION} has:${SpanFields.APP_VITALS_START_WARM_VALUE} OR ${SpanFields.SPAN_OP}:app.start.warm has:${SpanFields.APP_VITALS_START_WARM_VALUE})`;
+const APP_START_CONDITION = `(${COLD_START_TABLE_VALUE_CONDITION} OR ${WARM_START_TABLE_VALUE_CONDITION})`;
 export const APP_START_TABLE_CONDITION = `${APP_START_CONDITION} has:${SpanFields.TRANSACTION}`;
 
 // TTFD can be absent while TTID is present because reportFullyDrawn() is opt-in.

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/constants.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/constants.ts
@@ -9,8 +9,15 @@ export const TRANSACTION_COUNT = `count_unique(${SpanFields.TRANSACTION_SPAN_ID}
 // coalesces those old measurement keys into the app.vitals.* attributes below.
 // In the newer span shape, the same vital can arrive as a standalone span with a
 // specific span.op. Query both shapes so mixed SDK versions appear in one dashboard.
-export const COLD_START_CONDITION = `(${ROOT_TRANSACTION_CONDITION} has:${SpanFields.APP_VITALS_START_COLD_VALUE} OR ${SpanFields.SPAN_OP}:app.start.cold has:${SpanFields.APP_VITALS_START_COLD_VALUE})`;
-export const WARM_START_CONDITION = `(${ROOT_TRANSACTION_CONDITION} has:${SpanFields.APP_VITALS_START_WARM_VALUE} OR ${SpanFields.SPAN_OP}:app.start.warm has:${SpanFields.APP_VITALS_START_WARM_VALUE})`;
+//
+// App start vitals also appear on root transactions with transaction.op:app.start,
+// so use a broader op list for the cold/warm start conditions only. Screen load and
+// other conditions continue to use the narrower TRANSACTION_OP_CONDITION to avoid
+// pulling app.start transactions into unrelated queries.
+const APP_START_TRANSACTION_OP_CONDITION = `${SpanFields.TRANSACTION_OP}:[ui.load,navigation,app.start]`;
+const ROOT_APP_START_TRANSACTION_CONDITION = `${SpanFields.IS_TRANSACTION}:true ${APP_START_TRANSACTION_OP_CONDITION}`;
+export const COLD_START_CONDITION = `(${ROOT_APP_START_TRANSACTION_CONDITION} has:${SpanFields.APP_VITALS_START_COLD_VALUE} OR ${SpanFields.SPAN_OP}:app.start.cold has:${SpanFields.APP_VITALS_START_COLD_VALUE})`;
+export const WARM_START_CONDITION = `(${ROOT_APP_START_TRANSACTION_CONDITION} has:${SpanFields.APP_VITALS_START_WARM_VALUE} OR ${SpanFields.SPAN_OP}:app.start.warm has:${SpanFields.APP_VITALS_START_WARM_VALUE})`;
 export const TTID_CONDITION = `(${ROOT_TRANSACTION_CONDITION} has:${SpanFields.APP_VITALS_TTID_VALUE} OR ${SpanFields.SPAN_OP}:ui.load.initial_display has:${SpanFields.APP_VITALS_TTID_VALUE})`;
 export const TTFD_CONDITION = `(${ROOT_TRANSACTION_CONDITION} has:${SpanFields.APP_VITALS_TTFD_VALUE} OR ${SpanFields.SPAN_OP}:ui.load.full_display has:${SpanFields.APP_VITALS_TTFD_VALUE})`;
 


### PR DESCRIPTION
## Summary

The avg cold/warm start big number widgets on the mobile vitals pre-built dashboard were missing data from root transactions with `transaction.op:app.start`.

Previously, `COLD_START_CONDITION` and `WARM_START_CONDITION` used `ROOT_TRANSACTION_CONDITION`, which scoped the root-transaction branch to `transaction.op:[ui.load,navigation]`. This excluded root transactions that arrive with `transaction.op:app.start`.

## Change

Introduces two new local constants scoped to the app-start conditions only:

- `APP_START_TRANSACTION_OP_CONDITION` — extends the op list to `[ui.load,navigation,app.start]`
- `ROOT_APP_START_TRANSACTION_CONDITION` — root transaction filter using the broader op list

`COLD_START_CONDITION` and `WARM_START_CONDITION` now use these instead of `ROOT_TRANSACTION_CONDITION`. The original `TRANSACTION_OP_CONDITION` / `ROOT_TRANSACTION_CONDITION` remain unchanged so screen load, screen rendering, and operations table conditions are unaffected.

### Expected conditions after fix

**Warm start:**
```
(is_transaction:true transaction.op:[ui.load,navigation,app.start] has:app.vitals.start.warm.value OR span.op:app.start.warm has:app.vitals.start.warm.value)
```

**Cold start:**
```
(is_transaction:true transaction.op:[ui.load,navigation,app.start] has:app.vitals.start.cold.value OR span.op:app.start.cold has:app.vitals.start.cold.value)
```

## Files changed

- `static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/constants.ts`

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AD0AND00ESR2%3A1782377344.463959%22)