### PR TITLE
feat(startup): Add SENTRY_TRACE_STARTUP instrumentation for initialize_app

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -4,6 +4,7 @@ import importlib.metadata
 import logging
 import os
 import sys
+import time
 from typing import IO, Any
 
 import click
@@ -309,6 +310,22 @@ def show_big_error(message: str | list[str]) -> None:
 def initialize_app(config: dict[str, Any], skip_service_validation: bool = False) -> None:
     settings = config["settings"]
 
+    # Instrumentation to diagnose slow/hanging startup (e.g. the process-spans
+    # flusher subprocess timing out during configure()). Opt-in via the
+    # SENTRY_TRACE_STARTUP env var. Logging isn't configured until
+    # configure_structlog() runs partway through this function, so emit
+    # breadcrumbs straight to stderr with cumulative timing.
+    _trace_startup = bool(os.environ.get("SENTRY_TRACE_STARTUP"))
+    _init_start = time.monotonic()
+
+    def _trace(step: str) -> None:
+        if not _trace_startup:
+            return
+        sys.stderr.write(f"[initialize_app] +{time.monotonic() - _init_start:6.1f}s {step}\n")
+        sys.stderr.flush()
+
+    _trace("start")
+
     # Just reuse the integration app for Single Org / Self-Hosted as
     # it doesn't make much sense to use 2 separate apps for SSO and
     # integration.
@@ -320,6 +337,7 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
             }
         )
 
+    _trace("bootstrap_options")
     bootstrap_options(settings, config["options"])
 
     # The SENTRY_LOG_FORMAT env var (e.g. the `--logformat` CLI flag) overrides
@@ -330,6 +348,7 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
 
     logging.raiseExceptions = settings.DEBUG
 
+    _trace("configure_structlog")
     configure_structlog()
 
     # Commonly setups don't correctly configure themselves for production envs
@@ -369,38 +388,54 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
 
     import django
 
+    _trace("django.setup")
     django.setup()
 
+    _trace("validate_regions")
     validate_regions(settings)
 
+    _trace("validate_outbox_config")
     validate_outbox_config()
 
+    _trace("monkeypatch_django_migrations")
     monkeypatch_django_migrations()
 
+    _trace("patch_silo_aware_atomic")
     patch_silo_aware_atomic()
 
+    _trace("apply_legacy_settings")
     apply_legacy_settings(settings)
 
+    _trace("bind_cache_to_option_store")
     bind_cache_to_option_store()
 
+    _trace("register_plugins")
     register_plugins(settings)
 
+    _trace("initialize_receivers")
     initialize_receivers()
 
+    _trace("validate_options")
     validate_options(settings)
 
+    _trace("validate_snuba")
     validate_snuba()
 
+    _trace("configure_sdk")
     configure_sdk()
 
+    _trace("setup_services")
     setup_services(validate=not skip_service_validation)
 
+    _trace("import_grouptype")
     import_grouptype()
 
+    _trace("initialize_arroyo_main")
     initialize_arroyo_main()
 
     # Encryption keys should be initialized before any
     # database queries that use encrypted fields are made
+    _trace("initialize_encrypted_field_key_store")
     initialize_encrypted_field_key_store()
 
     # Hacky workaround to dynamically set the CSRF_TRUSTED_ORIGINS for self hosted
@@ -413,6 +448,8 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
         else:
             # For first time users that have not yet set system url prefix, let's default to localhost url
             settings.CSRF_TRUSTED_ORIGINS = ["http://localhost:9000", "http://127.0.0.1:9000"]
+
+    _trace("done")
 
 
 def setup_services(validate: bool = True) -> None:


### PR DESCRIPTION
## Why

process-spans `SpanFlusher` spawns a subprocess that blocks until healthy. On cold start it hangs inside `sentry.runner.configure()` (~127s) and the parent's 120s health window expires:

```
RuntimeError: process 0 (shards [0]) didn't start up in 120 seconds
```

It's a hang, not a crash, but logging isn't configured until partway through `initialize_app`, so there's a multi-minute silent gap with no clue where it's stuck. Was prod-only and non-blocking; now also fails self-hosted integration tests.

Failing run: https://github.com/getsentry/self-hosted/actions/runs/28161998690/job/83404536373

## What

Add `SENTRY_TRACE_STARTUP`-gated, per-step cumulative-timed breadcrumbs to `initialize_app`, written to stderr (logging isn't up yet for the early steps). No-op when the env var is unset. Each breadcrumb prints *before* its step, so the last line emitted is the step it's stuck in (suspect: `validate_snuba`).

```
[initialize_app] +  0.0s start
[initialize_app] +  2.1s django.setup
[initialize_app] + 12.0s validate_snuba
```

Rollout: set `SENTRY_TRACE_STARTUP=1` on process-spans to capture the hang next time it times out.

ref STREAM-1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)