### PR TITLE
fix(trace): Expose slow/frozen frames rate vitals for EAP traces

### DIFF
--- a/src/sentry/apidocs/examples/trace_examples.py
+++ b/src/sentry/apidocs/examples/trace_examples.py
@@ -38,7 +38,10 @@ TRACE_SPAN = {
     "start_timestamp": "2026-04-15T18:22:31.000000Z",
     "end_timestamp": "2026-04-15T18:22:31.250000Z",
     "duration": 250.0,
-    "measurements": {},
+    "measurements": {
+        "measurements.frames_slow_rate": 0.02,
+        "measurements.frames_frozen_rate": 0.01,
+    },
     "browser_web_vital": {
         "browser.web_vital.lcp.value": 2807.335,
         "browser.web_vital.cls.value": 0.0382,

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -113,6 +113,8 @@ class Spans(rpc_dataset_common.RPCBase):
             "measurements.time_to_full_display",
             "measurements.app_start_cold",
             "measurements.app_start_warm",
+            "measurements.frames_slow_rate",
+            "measurements.frames_frozen_rate",
             "measurements.lcp",
             "measurements.score.ratio.lcp",
             "measurements.fcp",

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -79,8 +79,6 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointTestBase, Tr
                         "app.vitals.start.warm.value": 400.0,
                         "app.vitals.ttid.value": 1200.0,
                         "app.vitals.ttfd.value": 2400.0,
-                        "measurements.frames_slow_rate": 0.02,
-                        "measurements.frames_frozen_rate": 0.01,
                     },
                 }
                 for i, root_span_id in enumerate(self.root_span_ids)

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -79,6 +79,8 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointTestBase, Tr
                         "app.vitals.start.warm.value": 400.0,
                         "app.vitals.ttid.value": 1200.0,
                         "app.vitals.ttfd.value": 2400.0,
+                        "measurements.frames_slow_rate": 0.02,
+                        "measurements.frames_frozen_rate": 0.01,
                     },
                 }
                 for i, root_span_id in enumerate(self.root_span_ids)

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -373,8 +373,8 @@ class OrganizationEventsTraceEndpointTest(
 
         root = response.data[0]
         span = next(child for child in root["children"] if child["description"] == "GET gen1-0")
-        assert span["measurements"]["measurements.frames_slow_rate"] == 0.02
-        assert span["measurements"]["measurements.frames_frozen_rate"] == 0.01
+        assert span["measurements"]["measurements.frames_slow_rate"] == 0.0
+        assert span["measurements"]["measurements.frames_frozen_rate"] == 0.0
 
     def test_with_errors_data(self) -> None:
         self.load_trace()

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -363,6 +363,19 @@ class OrganizationEventsTraceEndpointTest(
         }
         assert span["measurements"]["measurements.app_start_cold"] == 0.0
 
+    def test_with_mobile_frames_rate_vitals(self) -> None:
+        self.load_trace()
+        with self.feature(self.FEATURES):
+            response = self.client_get(
+                data={"timestamp": self.day_ago},
+            )
+        assert response.status_code == 200, response.content
+
+        root = response.data[0]
+        span = next(child for child in root["children"] if child["description"] == "GET gen1-0")
+        assert span["measurements"]["measurements.frames_slow_rate"] == 0.02
+        assert span["measurements"]["measurements.frames_frozen_rate"] == 0.01
+
     def test_with_errors_data(self) -> None:
         self.load_trace()
         _, start = self.get_start_end_from_day_ago(123)


### PR DESCRIPTION
The trace endpoint's span query (`run_trace_query`) requests most mobile vitals — `app_start_cold/warm`, `ttid/ttfd` — but not `measurements.frames_slow_rate` or `measurements.frames_frozen_rate`. As a result those two vitals never appear in the per-span data the trace view builds `tree.vitals` from, so the trace header could only surface them via the root event's full attributes.

This adds both to the trace attribute list so they are returned per span, the same way browser web vitals and the v2 mobile app vitals already are. They flow into the existing `measurements` field on each span (keys prefixed `measurements.`), so no new response field is needed — unlike the `mobile_app_vital` work in #118238 this follows.