### PR TITLE
ref(explore): Remove empty group by option

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
@@ -73,8 +73,11 @@ export function ToolbarGroupByDropdown({
   }
 
   const label = useMemo(() => {
-    const tag = options.find(option => option.value === column.column);
-    return <TriggerLabel>{tag?.label ?? column.column}</TriggerLabel>;
+    const tag = column.column
+      ? options.find(option => option.value === column.column)
+      : undefined;
+    const labelText = tag?.label ?? (column.column || t('—'));
+    return <TriggerLabel>{labelText}</TriggerLabel>;
   }, [column.column, options]);
 
   return (

--- a/static/app/views/explore/logs/logsToolbar.spec.tsx
+++ b/static/app/views/explore/logs/logsToolbar.spec.tsx
@@ -311,6 +311,10 @@ describe('LogsToolbar', () => {
       expect(mode).toEqual(Mode.AGGREGATE);
       expect(within(section).queryByLabelText('Remove Column')).not.toBeInTheDocument();
 
+      await userEvent.click(within(editorColumn).getByRole('button', {name: 'message'}));
+      expect(within(section).queryByRole('option', {name: '—'})).not.toBeInTheDocument();
+      await userEvent.keyboard('{Escape}');
+
       await userEvent.click(within(section).getByLabelText('Clear Group By'));
       expect(router.location.query.aggregateField).toEqual(
         [{groupBy: ''}, {yAxes: ['count(message)'], visible: false}].map(aggregateField =>

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -311,6 +311,7 @@ function ToolbarGroupBy() {
     booleanTags: booleanTags ?? {},
     groupBys,
     traceItemType: TraceItemDataset.LOGS,
+    hideEmptyOption: true,
   });
 
   const setGroupBysWithOp = useCallback(

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -339,6 +339,7 @@ describe('ExploreToolbar', () => {
     await userEvent.click(within(spanOpColumn).getByRole('button', {name: 'span.op'}));
     options = await within(section).findAllByRole('option');
     expect(options.length).toBeGreaterThan(0);
+    expect(within(section).queryByRole('option', {name: '—'})).not.toBeInTheDocument();
     await userEvent.click(within(section).getByRole('option', {name: 'project'}));
     expect(groupBys).toEqual(['project']);
 

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -104,6 +104,7 @@ function ToolbarGroupByItem({
     stringTags,
     booleanTags,
     traceItemType: TraceItemDataset.SPANS,
+    hideEmptyOption: true,
   });
 
   const loading = numberTagsLoading || stringTagsLoading || booleanTagsLoading;


### PR DESCRIPTION
Since we added a way to "clear" by hitting the delete button on the group by selector, we can remove the "empty" state value `-` from the dropdown, as this was the only way to previously clear all group bys.