### PR TITLE
fix(explore): Allow max/min aggregations on timestamp column

### DIFF
--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -644,6 +644,9 @@ SPAN_AGGREGATE_DEFINITIONS = {
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
+                # timestamp has search_type="string" for display purposes but its
+                # internal_type is DOUBLE, so max/min on it is valid.
+                field_allowlist={"timestamp"},
                 default_arg="span.duration",
             )
         ],
@@ -662,6 +665,9 @@ SPAN_AGGREGATE_DEFINITIONS = {
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
+                # timestamp has search_type="string" for display purposes but its
+                # internal_type is DOUBLE, so max/min on it is valid.
+                field_allowlist={"timestamp"},
                 default_arg="span.duration",
             )
         ],

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -1013,6 +1013,30 @@ class SearchResolverColumnTest(TestCase):
         )
         assert virtual_context is None
 
+    def test_max_timestamp(self) -> None:
+        resolved_column, virtual_context = self.resolver.resolve_column("max(timestamp)")
+        assert resolved_column.proto_definition == AttributeAggregation(
+            aggregate=Function.FUNCTION_MAX,
+            key=AttributeKey(name="sentry.timestamp", type=AttributeKey.Type.TYPE_DOUBLE),
+            label="max(timestamp)",
+            extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
+        )
+        assert virtual_context is None
+
+    def test_min_timestamp(self) -> None:
+        resolved_column, virtual_context = self.resolver.resolve_column("min(timestamp)")
+        assert resolved_column.proto_definition == AttributeAggregation(
+            aggregate=Function.FUNCTION_MIN,
+            key=AttributeKey(name="sentry.timestamp", type=AttributeKey.Type.TYPE_DOUBLE),
+            label="min(timestamp)",
+            extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
+        )
+        assert virtual_context is None
+
+    def test_max_string_field_raises(self) -> None:
+        with pytest.raises(InvalidSearchQuery):
+            self.resolver.resolve_column("max(span.description)")
+
     def test_resolver_cache_attribute(self) -> None:
         self.resolver.resolve_columns(["span.op"])
         assert "span.op" in self.resolver._resolved_attribute_cache


### PR DESCRIPTION
`max(timestamp)` and `min(timestamp)` raised `InvalidSearchQuery` even though the operation is semantically valid. The argument validator for `max` and `min` checks that the column's `search_type` is in the allowed set (`duration`, `number`, `integer`, etc.), but `timestamp` uses `search_type="string"` — a presentation detail so the datetime processor can return ISO strings in responses. Its actual `internal_type` is `DOUBLE`, which is what gets sent to Snuba.

Added `field_allowlist={"timestamp"}` to the `AttributeArgumentDefinition` for both `max` and `min`. The resolver already supports this escape hatch: when `search_type` fails the type check but the column's public alias is in the allowlist, the query is allowed through. 
