### PR TITLE
fix(page-frame): standardize spacings

### DIFF
--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -29,9 +29,7 @@ export function Page(props: FlexProps<'main'>) {
  * Use `noActionWrap` to disable wrapping if there are minimal actions.
  */
 export const Header = styled((props: ContainerProps<'header'>) => {
-  return (
-    <Container as="header" padding={{sm: 'md lg 0 lg', md: 'lg xl 0 xl'}} {...props} />
-  );
+  return <Container padding={{sm: 'md lg 0 lg', md: 'lg xl 0 xl'}} {...props} />;
 })<{
   borderStyle?: 'dashed' | 'solid';
   noActionWrap?: boolean;

--- a/static/app/components/workflowEngine/layout/detail.tsx
+++ b/static/app/components/workflowEngine/layout/detail.tsx
@@ -51,14 +51,6 @@ function Sidebar({children}: RequiredChildren) {
   );
 }
 
-function Header({children}: RequiredChildren) {
-  return <Layout.Header>{children}</Layout.Header>;
-}
-
-function HeaderContent({children}: RequiredChildren) {
-  return <Layout.HeaderContent>{children}</Layout.HeaderContent>;
-}
-
 function Actions({children}: RequiredChildren) {
   return (
     <HeaderActions>
@@ -84,8 +76,6 @@ export const DetailLayout = Object.assign(DetailLayoutComponent, {
   Body: StyledBody,
   Main,
   Sidebar,
-  Header,
-  HeaderContent,
   Actions,
   Title,
 });

--- a/static/app/components/workflowEngine/layout/detail.tsx
+++ b/static/app/components/workflowEngine/layout/detail.tsx
@@ -5,7 +5,6 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {HeaderActions} from 'sentry/components/layouts/thirds';
 import type {AvatarProject} from 'sentry/types/project';
 
 interface WorkflowEngineDetailLayoutProps {
@@ -51,14 +50,6 @@ function Sidebar({children}: RequiredChildren) {
   );
 }
 
-function Actions({children}: RequiredChildren) {
-  return (
-    <HeaderActions>
-      <Flex gap="md">{children}</Flex>
-    </HeaderActions>
-  );
-}
-
 function Title({title, project}: {title: string; project?: AvatarProject}) {
   return (
     <Fragment>
@@ -76,6 +67,5 @@ export const DetailLayout = Object.assign(DetailLayoutComponent, {
   Body: StyledBody,
   Main,
   Sidebar,
-  Actions,
   Title,
 });

--- a/static/app/views/alerts/list/header.tsx
+++ b/static/app/views/alerts/list/header.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container} from '@sentry/scraps/layout';
 import {TabList} from '@sentry/scraps/tabs';
 
 import {navigateTo} from 'sentry/actionCreators/navigation';
@@ -77,8 +76,8 @@ export function AlertHeader({activeTab}: Props) {
           {null}
         </FeedbackButton>
       </TopBar.Slot>
-      <Layout.HeaderTabs value={activeTab}>
-        <Container padding={{sm: 'md lg 0 lg', md: 'lg xl 0 xl'}}>
+      <Layout.Header>
+        <Layout.HeaderTabs value={activeTab}>
           <TabList>
             {alertRulesLink}
             <TabList.Item
@@ -91,8 +90,8 @@ export function AlertHeader({activeTab}: Props) {
               {t('History')}
             </TabList.Item>
           </TabList>
-        </Container>
-      </Layout.HeaderTabs>
+        </Layout.HeaderTabs>
+      </Layout.Header>
     </Fragment>
   );
 }

--- a/static/app/views/alerts/list/header.tsx
+++ b/static/app/views/alerts/list/header.tsx
@@ -1,4 +1,7 @@
+import {Fragment} from 'react';
+
 import {LinkButton} from '@sentry/scraps/button';
+import {Container} from '@sentry/scraps/layout';
 import {TabList} from '@sentry/scraps/tabs';
 
 import {navigateTo} from 'sentry/actionCreators/navigation';
@@ -47,18 +50,16 @@ export function AlertHeader({activeTab}: Props) {
   );
 
   return (
-    <Layout.Header>
-      <Layout.HeaderContent>
-        <Layout.Title>
-          {t('Alerts')}
-          <PageHeadingQuestionTooltip
-            docsUrl="https://docs.sentry.io/product/alerts/"
-            title={t(
-              'Real-time visibility into problems with your code and the impact on your users, along with a view of your existing alert rules, their status, project, team, and creation date.'
-            )}
-          />
-        </Layout.Title>
-      </Layout.HeaderContent>
+    <Fragment>
+      <Layout.Title>
+        {t('Alerts')}
+        <PageHeadingQuestionTooltip
+          docsUrl="https://docs.sentry.io/product/alerts/"
+          title={t(
+            'Real-time visibility into problems with your code and the impact on your users, along with a view of your existing alert rules, their status, project, team, and creation date.'
+          )}
+        />
+      </Layout.Title>
       <TopBar.Slot name="actions">
         <LinkButton
           onClick={handleNavigateToSettings}
@@ -77,19 +78,21 @@ export function AlertHeader({activeTab}: Props) {
         </FeedbackButton>
       </TopBar.Slot>
       <Layout.HeaderTabs value={activeTab}>
-        <TabList>
-          {alertRulesLink}
-          <TabList.Item
-            key="stream"
-            to={makeAlertsPathname({
-              path: '/',
-              organization,
-            })}
-          >
-            {t('History')}
-          </TabList.Item>
-        </TabList>
+        <Container padding={{sm: 'md lg 0 lg', md: 'lg xl 0 xl'}}>
+          <TabList>
+            {alertRulesLink}
+            <TabList.Item
+              key="stream"
+              to={makeAlertsPathname({
+                path: '/',
+                organization,
+              })}
+            >
+              {t('History')}
+            </TabList.Item>
+          </TabList>
+        </Container>
       </Layout.HeaderTabs>
-    </Layout.Header>
+    </Fragment>
   );
 }

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1192,7 +1192,7 @@ class DashboardDetail extends Component<Props, State> {
           <MetricsResultsMetaProvider>
             <NoProjectMessage organization={organization}>
               {this.isEmbedded ? null : (
-                <Layout.Header unified>
+                <Fragment>
                   <TopBar.Slot name="title">
                     <Breadcrumbs
                       crumbs={[
@@ -1229,7 +1229,7 @@ class DashboardDetail extends Component<Props, State> {
                       isSaving={isCommittingChanges}
                     />
                   </TopBar.Slot>
-                </Layout.Header>
+                </Fragment>
               )}
               <Layout.Body>
                 <Layout.Main width="full">

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -582,50 +582,46 @@ function ManageDashboards() {
           ) : (
             <Stack flex={1}>
               <NoProjectMessage organization={organization}>
-                <Layout.Header unified>
-                  <Layout.HeaderContent unified>
-                    <Layout.Title>
-                      {pageTitle}
-                      <PageHeadingQuestionTooltip
-                        docsUrl="https://docs.sentry.io/product/dashboards/"
-                        title={
-                          isOnlyPrebuilt
-                            ? t(
-                                'Dashboards built by Sentry to help monitor your application out of the box.'
-                              )
-                            : t(
-                                "A broad overview of your application's health where you can navigate through error and performance data across multiple projects."
-                              )
-                        }
-                      />
-                    </Layout.Title>
-                  </Layout.HeaderContent>
-                  <TopBar.Slot name="actions">
-                    <Feature features="dashboards-import">
-                      <Button
-                        onClick={() => {
-                          openImportDashboardFromFileModal({
-                            organization,
-                            api,
-                            location,
-                          });
-                        }}
-                        variant="primary"
-                        icon={<IconAdd />}
-                      >
-                        {t('Import Dashboard from JSON')}
-                      </Button>
-                    </Feature>
-                  </TopBar.Slot>
-                  <TopBar.Slot name="feedback">
-                    <FeedbackButton
-                      aria-label={t('Give Feedback')}
-                      tooltipProps={{title: t('Give Feedback')}}
+                <Layout.Title>
+                  {pageTitle}
+                  <PageHeadingQuestionTooltip
+                    docsUrl="https://docs.sentry.io/product/dashboards/"
+                    title={
+                      isOnlyPrebuilt
+                        ? t(
+                            'Dashboards built by Sentry to help monitor your application out of the box.'
+                          )
+                        : t(
+                            "A broad overview of your application's health where you can navigate through error and performance data across multiple projects."
+                          )
+                    }
+                  />
+                </Layout.Title>
+                <TopBar.Slot name="actions">
+                  <Feature features="dashboards-import">
+                    <Button
+                      onClick={() => {
+                        openImportDashboardFromFileModal({
+                          organization,
+                          api,
+                          location,
+                        });
+                      }}
+                      variant="primary"
+                      icon={<IconAdd />}
                     >
-                      {null}
-                    </FeedbackButton>
-                  </TopBar.Slot>
-                </Layout.Header>
+                      {t('Import Dashboard from JSON')}
+                    </Button>
+                  </Feature>
+                </TopBar.Slot>
+                <TopBar.Slot name="feedback">
+                  <FeedbackButton
+                    aria-label={t('Give Feedback')}
+                    tooltipProps={{title: t('Give Feedback')}}
+                  >
+                    {null}
+                  </FeedbackButton>
+                </TopBar.Slot>
                 <Layout.Body>
                   <Layout.Main width="full">
                     {renderActions()}

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -72,11 +72,9 @@ export function EditDetectorLayout<
   return (
     <EditLayoutDeprecated formProps={formProps}>
       <EditLayoutDeprecated.Header maxWidth={maxWidth}>
-        <EditLayoutDeprecated.HeaderContent>
-          <TopBar.Slot name="title">
-            <DetectorFormBreadcrumbs />
-          </TopBar.Slot>
-        </EditLayoutDeprecated.HeaderContent>
+        <TopBar.Slot name="title">
+          <DetectorFormBreadcrumbs />
+        </TopBar.Slot>
 
         <div>
           <EditLayoutDeprecated.Actions>

--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -96,11 +96,9 @@ export function NewDetectorLayout<
   return (
     <EditLayoutDeprecated formProps={formProps}>
       <EditLayoutDeprecated.Header maxWidth={maxWidth}>
-        <EditLayoutDeprecated.HeaderContent>
-          <TopBar.Slot name="title">
-            <DetectorFormBreadcrumbs />
-          </TopBar.Slot>
-        </EditLayoutDeprecated.HeaderContent>
+        <TopBar.Slot name="title">
+          <DetectorFormBreadcrumbs />
+        </TopBar.Slot>
 
         <div>
           <MonitorFeedbackButton />

--- a/static/app/views/explore/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/explore/releases/detail/header/releaseHeader.tsx
@@ -152,26 +152,24 @@ export function ReleaseHeader({
 
   return (
     <Layout.Header>
-      <Layout.HeaderContent>
-        <TopBar.Slot name="title">
-          <Breadcrumbs
-            crumbs={[
-              {
-                to: makeReleasesPathname({organization, path: '/'}),
-                label: t('Releases'),
-                preservePageFilters: true,
-              },
-              {
-                label: (
-                  <Flex align="center" gap="md" minWidth={0} css={titleWrapperStyles}>
-                    {titleContent}
-                  </Flex>
-                ),
-              },
-            ]}
-          />
-        </TopBar.Slot>
-      </Layout.HeaderContent>
+      <TopBar.Slot name="title">
+        <Breadcrumbs
+          crumbs={[
+            {
+              to: makeReleasesPathname({organization, path: '/'}),
+              label: t('Releases'),
+              preservePageFilters: true,
+            },
+            {
+              label: (
+                <Flex align="center" gap="md" minWidth={0} css={titleWrapperStyles}>
+                  {titleContent}
+                </Flex>
+              ),
+            },
+          ]}
+        />
+      </TopBar.Slot>
       <TopBar.Slot name="actions">
         <ReleaseActions
           projectSlug={project.slug}

--- a/static/app/views/insights/crons/views/overview.tsx
+++ b/static/app/views/insights/crons/views/overview.tsx
@@ -87,44 +87,38 @@ function CronsOverview() {
   const page = (
     <Fragment>
       <CronsListPageHeader organization={organization} />
-      <Layout.Header unified>
-        <Layout.HeaderContent>
-          <Layout.Title>
-            {t('Cron Monitors')}
-            <PageHeadingQuestionTooltip
-              docsUrl={MODULE_DOC_LINK}
-              title={MODULE_DESCRIPTION}
-            />
-          </Layout.Title>
-        </Layout.HeaderContent>
-        <TopBar.Slot name="actions">
-          <Button
-            icon={<IconList />}
-            onClick={() =>
-              openBulkEditMonitorsModal({
-                onClose: () => refetch(),
-              })
-            }
-            analyticsEventKey="crons.bulk_edit_modal_button_clicked"
-            analyticsEventName="Crons: Bulk Edit Modal Button Clicked"
-          >
-            {t('Manage Monitors')}
-          </Button>
-          {!guideVisible && (
-            <NewMonitorButton icon={<IconAdd />}>
-              {t('Add Cron Monitor')}
-            </NewMonitorButton>
-          )}
-        </TopBar.Slot>
-        <TopBar.Slot name="feedback">
-          <FeedbackButton
-            aria-label={t('Give Feedback')}
-            tooltipProps={{title: t('Give Feedback')}}
-          >
-            {null}
-          </FeedbackButton>
-        </TopBar.Slot>
-      </Layout.Header>
+      <Layout.Title>
+        {t('Cron Monitors')}
+        <PageHeadingQuestionTooltip
+          docsUrl={MODULE_DOC_LINK}
+          title={MODULE_DESCRIPTION}
+        />
+      </Layout.Title>
+      <TopBar.Slot name="actions">
+        <Button
+          icon={<IconList />}
+          onClick={() =>
+            openBulkEditMonitorsModal({
+              onClose: () => refetch(),
+            })
+          }
+          analyticsEventKey="crons.bulk_edit_modal_button_clicked"
+          analyticsEventName="Crons: Bulk Edit Modal Button Clicked"
+        >
+          {t('Manage Monitors')}
+        </Button>
+        {!guideVisible && (
+          <NewMonitorButton icon={<IconAdd />}>{t('Add Cron Monitor')}</NewMonitorButton>
+        )}
+      </TopBar.Slot>
+      <TopBar.Slot name="feedback">
+        <FeedbackButton
+          aria-label={t('Give Feedback')}
+          tooltipProps={{title: t('Give Feedback')}}
+        >
+          {null}
+        </FeedbackButton>
+      </TopBar.Slot>
       <Layout.Body>
         <Layout.Main width="full">
           <Filters>

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -130,10 +130,12 @@ export function DomainViewHeader({
   return (
     <Fragment>
       <Layout.Header unified={unified}>
-        <Layout.HeaderContent>
-          {crumbs.length > 1 && <Breadcrumbs crumbs={crumbs} />}
-          <Layout.Title>{headerTitle || domainTitle}</Layout.Title>
-        </Layout.HeaderContent>
+        {crumbs.length > 1 && (
+          <Layout.HeaderContent>
+            <Breadcrumbs crumbs={crumbs} />
+          </Layout.HeaderContent>
+        )}
+        <Layout.Title>{headerTitle || domainTitle}</Layout.Title>
         {additonalHeaderActions && (
           <TopBar.Slot name="actions">{additonalHeaderActions}</TopBar.Slot>
         )}

--- a/static/app/views/insights/uptime/views/overview.tsx
+++ b/static/app/views/insights/uptime/views/overview.tsx
@@ -72,36 +72,32 @@ export default function UptimeOverview() {
 
   const page = (
     <Fragment>
-      <Layout.Header unified>
-        <Layout.HeaderContent>
-          <Layout.Title>
-            {t('Uptime Monitors')}
-            <PageHeadingQuestionTooltip
-              docsUrl={MODULE_DOC_LINK}
-              title={MODULE_DESCRIPTION}
-            />
-          </Layout.Title>
-        </Layout.HeaderContent>
-        <TopBar.Slot name="actions">
-          <LinkButton
-            variant="primary"
-            to={makeAlertsPathname({path: '/new/uptime/', organization})}
-            icon={<IconAdd />}
-            disabled={!canCreateAlert}
-            tooltipProps={{title: canCreateAlert ? undefined : permissionTooltipText}}
-          >
-            {t('Add Uptime Monitor')}
-          </LinkButton>
-        </TopBar.Slot>
-        <TopBar.Slot name="feedback">
-          <FeedbackButton
-            aria-label={t('Give Feedback')}
-            tooltipProps={{title: t('Give Feedback')}}
-          >
-            {null}
-          </FeedbackButton>
-        </TopBar.Slot>
-      </Layout.Header>
+      <Layout.Title>
+        {t('Uptime Monitors')}
+        <PageHeadingQuestionTooltip
+          docsUrl={MODULE_DOC_LINK}
+          title={MODULE_DESCRIPTION}
+        />
+      </Layout.Title>
+      <TopBar.Slot name="actions">
+        <LinkButton
+          variant="primary"
+          to={makeAlertsPathname({path: '/new/uptime/', organization})}
+          icon={<IconAdd />}
+          disabled={!canCreateAlert}
+          tooltipProps={{title: canCreateAlert ? undefined : permissionTooltipText}}
+        >
+          {t('Add Uptime Monitor')}
+        </LinkButton>
+      </TopBar.Slot>
+      <TopBar.Slot name="feedback">
+        <FeedbackButton
+          aria-label={t('Give Feedback')}
+          tooltipProps={{title: t('Give Feedback')}}
+        >
+          {null}
+        </FeedbackButton>
+      </TopBar.Slot>
       <Layout.Body>
         <Layout.Main width="full">
           <Filters>

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -376,21 +376,17 @@ export default function IssueViewsList() {
   return (
     <SentryDocumentTitle title={t('All Views')} orgSlug={organization.slug}>
       <Stack flex={1}>
-        <Layout.Header unified>
-          <Layout.HeaderContent>
-            <Layout.Title>{t('All Views')}</Layout.Title>
-          </Layout.HeaderContent>
-          <TopBar.Slot name="feedback">
-            <FeedbackButton
-              size="sm"
-              feedbackOptions={issueViewsFeedbackOptions}
-              aria-label={t('Give Feedback')}
-              tooltipProps={{title: t('Give Feedback')}}
-            >
-              {null}
-            </FeedbackButton>
-          </TopBar.Slot>
-        </Layout.Header>
+        <Layout.Title>{t('All Views')}</Layout.Title>
+        <TopBar.Slot name="feedback">
+          <FeedbackButton
+            size="sm"
+            feedbackOptions={issueViewsFeedbackOptions}
+            aria-label={t('Give Feedback')}
+            tooltipProps={{title: t('Give Feedback')}}
+          >
+            {null}
+          </FeedbackButton>
+        </TopBar.Slot>
         <Layout.Body>
           <MainTableLayout width="full">
             <FilterSortBar>

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -1,4 +1,4 @@
-import type {ReactNode} from 'react';
+import {Fragment, type ReactNode} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
@@ -226,16 +226,14 @@ export function IssueViewsHeader({
   );
 
   return (
-    <Layout.Header noActionWrap unified>
-      <Layout.HeaderContent unified>
-        <PageTitle title={title} description={description} />
-      </Layout.HeaderContent>
+    <Fragment>
+      <PageTitle title={title} description={description} />
       <TopBar.Slot name="actions">
         {headerActions}
         {realtimeButton}
         <IssueViewStarButton />
         <IssueViewEditMenu />
       </TopBar.Slot>
-    </Layout.Header>
+    </Fragment>
   );
 }

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -975,7 +975,7 @@ function IssueListOverviewInner({
           headerActions={headerActions}
         />
         <StyledBody>
-          <Grid area="content" padding={{sm: 'md lg', md: 'md xl'}}>
+          <Grid area="content" padding={{sm: 'md lg', md: 'lg xl'}}>
             <IssuesDataConsentBanner source="issues" />
             <IssueListFilters
               query={query}

--- a/static/app/views/navigation/topBar.tsx
+++ b/static/app/views/navigation/topBar.tsx
@@ -52,6 +52,7 @@ function TopBarContent() {
 
   return (
     <Flex
+      as="header"
       height={{
         sm: `${NAVIGATION_MOBILE_TOPBAR_HEIGHT_WITH_PAGE_FRAME}px`,
         md: `${PRIMARY_HEADER_HEIGHT}px`,

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -257,33 +257,31 @@ export function TransactionHeader({
 
   return (
     <Layout.Header>
-      <Layout.HeaderContent>
-        <TopBar.Slot name="title">
-          <Breadcrumbs
-            crumbs={getCrumbs({
-              organization,
-              location,
-              transaction: {project: projectId, name: transactionName},
-            }).concat({
-              label: (
-                <Flex align="center" gap="sm">
-                  {project && (
-                    <IdBadge
-                      project={project}
-                      avatarSize={16}
-                      hideName
-                      avatarProps={{hasTooltip: true, tooltip: project.slug}}
-                    />
-                  )}
-                  <Tooltip showOnlyOnOverflow skipWrapper title={transactionName}>
-                    <TransactionName>{transactionName}</TransactionName>
-                  </Tooltip>
-                </Flex>
-              ),
-            })}
-          />
-        </TopBar.Slot>
-      </Layout.HeaderContent>
+      <TopBar.Slot name="title">
+        <Breadcrumbs
+          crumbs={getCrumbs({
+            organization,
+            location,
+            transaction: {project: projectId, name: transactionName},
+          }).concat({
+            label: (
+              <Flex align="center" gap="sm">
+                {project && (
+                  <IdBadge
+                    project={project}
+                    avatarSize={16}
+                    hideName
+                    avatarProps={{hasTooltip: true, tooltip: project.slug}}
+                  />
+                )}
+                <Tooltip showOnlyOnOverflow skipWrapper title={transactionName}>
+                  <TransactionName>{transactionName}</TransactionName>
+                </Tooltip>
+              </Flex>
+            ),
+          })}
+        />
+      </TopBar.Slot>
       <TopBar.Slot name="actions">
         <Feature organization={organization} features="incidents">
           {({hasFeature}) =>

--- a/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
@@ -66,7 +66,7 @@ describe('BuildDetails', () => {
       initialRouterConfig,
     });
 
-    expect(screen.getByRole('banner')).toBeInTheDocument();
+    expect(screen.getByRole('complementary')).toBeInTheDocument();
 
     const loadingPlaceholders = screen.getAllByTestId('loading-placeholder');
     expect(loadingPlaceholders.length).toBeGreaterThan(0);

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderContent.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderContent.tsx
@@ -79,68 +79,66 @@ export function SnapshotHeaderContent({data}: SnapshotHeaderContentProps) {
   }
 
   return (
-    <Layout.HeaderContent unified>
-      <Layout.Title>
-        <Global styles={topBarShrinkOverride} />
+    <Layout.Title>
+      <Global styles={topBarShrinkOverride} />
+      <Flex
+        align="center"
+        gap="md"
+        minWidth={0}
+        overflow="hidden"
+        {...{[TITLE_MARKER_ATTR]: ''}}
+      >
+        {t('Snapshots')}
+        <Container display={{'2xs': 'none', xs: 'flex'}}>
+          <PageHeadingQuestionTooltip
+            docsUrl="https://docs.sentry.io/product/snapshots/"
+            title={t('Catch visual regressions before they reach users.')}
+          />
+        </Container>
+
+        {project && (
+          <Container display={{'2xs': 'none', lg: 'block'}}>
+            <Text as="div" size="sm">
+              <IdBadge project={project} avatarSize={16} />
+            </Text>
+          </Container>
+        )}
+
         <Flex
           align="center"
           gap="md"
+          flexShrink={1}
           minWidth={0}
           overflow="hidden"
-          {...{[TITLE_MARKER_ATTR]: ''}}
+          display={{'2xs': 'none', xs: 'none', sm: 'flex'}}
         >
-          {t('Snapshots')}
-          <Container display={{'2xs': 'none', xs: 'flex'}}>
-            <PageHeadingQuestionTooltip
-              docsUrl="https://docs.sentry.io/product/snapshots/"
-              title={t('Catch visual regressions before they reach users.')}
-            />
-          </Container>
-
-          {project && (
-            <Container display={{'2xs': 'none', lg: 'block'}}>
-              <Text as="div" size="sm">
-                <IdBadge project={project} avatarSize={16} />
-              </Text>
-            </Container>
+          {shortSha && shaUrl && (
+            <Flex align="center" gap="xs" flexShrink={0}>
+              <IconCommit size="xs" />
+              <ExternalLink href={shaUrl}>
+                <Text size="sm" variant="accent" monospace wrap="nowrap">
+                  {shortSha}
+                </Text>
+              </ExternalLink>
+            </Flex>
           )}
 
-          <Flex
-            align="center"
-            gap="md"
-            flexShrink={1}
-            minWidth={0}
-            overflow="hidden"
-            display={{'2xs': 'none', xs: 'none', sm: 'flex'}}
-          >
-            {shortSha && shaUrl && (
-              <Flex align="center" gap="xs" flexShrink={0}>
-                <IconCommit size="xs" />
-                <ExternalLink href={shaUrl}>
-                  <Text size="sm" variant="accent" monospace wrap="nowrap">
-                    {shortSha}
-                  </Text>
-                </ExternalLink>
-              </Flex>
-            )}
+          {renderVcsRef()}
 
-            {renderVcsRef()}
-
-            {appId && (
-              <Flex align="center" gap="xs" minWidth={0}>
-                <IconCode size="xs" style={{flexShrink: 0}} />
-                <Link
-                  to={`/organizations/${organization.slug}/explore/releases/?query=${encodeURIComponent(`app_id:${appId}`)}&tab=snapshots`}
-                >
-                  <Text size="sm" variant="accent" monospace ellipsis>
-                    {appId}
-                  </Text>
-                </Link>
-              </Flex>
-            )}
-          </Flex>
+          {appId && (
+            <Flex align="center" gap="xs" minWidth={0}>
+              <IconCode size="xs" style={{flexShrink: 0}} />
+              <Link
+                to={`/organizations/${organization.slug}/explore/releases/?query=${encodeURIComponent(`app_id:${appId}`)}&tab=snapshots`}
+              >
+                <Text size="sm" variant="accent" monospace ellipsis>
+                  {appId}
+                </Text>
+              </Link>
+            </Flex>
+          )}
         </Flex>
-      </Layout.Title>
-    </Layout.HeaderContent>
+      </Flex>
+    </Layout.Title>
   );
 }

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -155,37 +155,35 @@ export function ProjectDetail() {
         <Stack flex={1}>
           <NoProjectMessage organization={organization}>
             <Layout.Header unified>
-              <Layout.HeaderContent unified>
-                <TopBar.Slot name="title">
-                  <Breadcrumbs
-                    crumbs={[
-                      {
-                        to: makeProjectsPathname({path: '/', organization}),
-                        label: t('Projects'),
-                      },
-                      {
-                        label: (
-                          <Flex align="center" gap="xs">
-                            {project ? (
-                              <IdBadge
-                                project={project}
-                                avatarSize={16}
-                                hideOverflow="100%"
-                                disableLink
-                                hideName
-                              />
-                            ) : null}
-                            {project?.slug}
-                          </Flex>
-                        ),
-                      },
-                    ]}
-                  />
-                </TopBar.Slot>
-              </Layout.HeaderContent>
+              <TopBar.Slot name="title">
+                <Breadcrumbs
+                  crumbs={[
+                    {
+                      to: makeProjectsPathname({path: '/', organization}),
+                      label: t('Projects'),
+                    },
+                    {
+                      label: (
+                        <Flex align="center" gap="xs">
+                          {project ? (
+                            <IdBadge
+                              project={project}
+                              avatarSize={16}
+                              hideOverflow="100%"
+                              disableLink
+                              hideName
+                            />
+                          ) : null}
+                          {project?.slug}
+                        </Flex>
+                      ),
+                    },
+                  ]}
+                />
+              </TopBar.Slot>
 
               <Layout.HeaderActions>
-                <Grid flow="column" align="center" gap="md">
+                <Grid flow="column" align="center" justify="end" gap="md">
                   <TopBar.Slot name="feedback">
                     <FeedbackButton
                       aria-label={t('Give Feedback')}

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -197,51 +197,47 @@ function Dashboard() {
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Projects Dashboard')} orgSlug={organization.slug} />
-      <Layout.Header unified>
-        <Layout.HeaderContent unified>
-          <Layout.Title>
-            {t('All Projects')}
-            <PageHeadingQuestionTooltip
-              docsUrl="https://docs.sentry.io/product/projects/"
-              title={t(
-                "A high-level overview of errors, transactions, and deployments filtered by teams you're part of."
-              )}
-            />
-          </Layout.Title>
-        </Layout.HeaderContent>
-        <TopBar.Slot name="actions">
-          <LinkButton
-            icon={<IconUser />}
-            tooltipProps={{
-              title: canJoinTeam
-                ? undefined
-                : t('You do not have permission to join a team.'),
-            }}
-            disabled={!canJoinTeam}
-            to={`/settings/${organization.slug}/teams/`}
-            data-test-id="join-team"
-          >
-            {t('Join a Team')}
-          </LinkButton>
-          <LinkButton
-            variant="primary"
-            disabled={!canUserCreateProject}
-            tooltipProps={{
-              title: canUserCreateProject
-                ? undefined
-                : t('You do not have permission to create projects'),
-            }}
-            to={makeProjectsPathname({
-              path: '/new/',
-              organization,
-            })}
-            icon={<IconAdd />}
-            data-test-id="create-project"
-          >
-            {t('Create Project')}
-          </LinkButton>
-        </TopBar.Slot>
-      </Layout.Header>
+      <Layout.Title>
+        {t('All Projects')}
+        <PageHeadingQuestionTooltip
+          docsUrl="https://docs.sentry.io/product/projects/"
+          title={t(
+            "A high-level overview of errors, transactions, and deployments filtered by teams you're part of."
+          )}
+        />
+      </Layout.Title>
+      <TopBar.Slot name="actions">
+        <LinkButton
+          icon={<IconUser />}
+          tooltipProps={{
+            title: canJoinTeam
+              ? undefined
+              : t('You do not have permission to join a team.'),
+          }}
+          disabled={!canJoinTeam}
+          to={`/settings/${organization.slug}/teams/`}
+          data-test-id="join-team"
+        >
+          {t('Join a Team')}
+        </LinkButton>
+        <LinkButton
+          variant="primary"
+          disabled={!canUserCreateProject}
+          tooltipProps={{
+            title: canUserCreateProject
+              ? undefined
+              : t('You do not have permission to create projects'),
+          }}
+          to={makeProjectsPathname({
+            path: '/new/',
+            organization,
+          })}
+          icon={<IconAdd />}
+          data-test-id="create-project"
+        >
+          {t('Create Project')}
+        </LinkButton>
+      </TopBar.Slot>
       <Layout.Body>
         <Layout.Main width="full">
           <SearchAndSelectorWrapper>


### PR DESCRIPTION
remove Layout.Header and Layout.HeaderContent in places where only a TopBar.Slot was rendered, as TopBar.Slot doesn't render anything (it portals to the HeaderBar) and Header/HeaderContent left behind empty divs with spacing that stayed visible

The wrappers need to stay for cases where we still render something to the screen, like e.g. Tabs