### PR TITLE
fix(explore): Validate spans group by selections

### DIFF
--- a/static/app/views/explore/spans/hooks/useValidateSpansTab.tsx
+++ b/static/app/views/explore/spans/hooks/useValidateSpansTab.tsx
@@ -26,7 +26,7 @@ export function useValidateSpansTab({enabled = true}: UseValidateSpansTabArgs = 
   const groupBys = useQueryParamsGroupBys();
   const visualizes = useQueryParamsVisualizes();
 
-  const {data, isLoading, isPlaceholderData} = useQuery({
+  const {data, isFetching, isLoading, isPlaceholderData} = useQuery({
     ...validateEventParamsOptions({
       organization,
       selection,
@@ -49,6 +49,7 @@ export function useValidateSpansTab({enabled = true}: UseValidateSpansTabArgs = 
 
   return {
     data,
+    isFetching,
     isPlaceholderData,
     isLoading,
   };

--- a/static/app/views/explore/spans/hooks/useValidateSpansTab.tsx
+++ b/static/app/views/explore/spans/hooks/useValidateSpansTab.tsx
@@ -26,7 +26,7 @@ export function useValidateSpansTab({enabled = true}: UseValidateSpansTabArgs = 
   const groupBys = useQueryParamsGroupBys();
   const visualizes = useQueryParamsVisualizes();
 
-  const {data, isLoading} = useQuery({
+  const {data, isLoading, isPlaceholderData} = useQuery({
     ...validateEventParamsOptions({
       organization,
       selection,
@@ -49,6 +49,7 @@ export function useValidateSpansTab({enabled = true}: UseValidateSpansTabArgs = 
 
   return {
     data,
+    isPlaceholderData,
     isLoading,
   };
 }

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -457,14 +457,17 @@ describe('ExploreToolbar', () => {
 
     const section = screen.getByTestId('section-group-by');
 
-    await waitFor(() => {
+    await waitFor(() =>
       expect(
         within(section).queryByRole('button', {name: 'invalid.attribute'})
-      ).not.toBeInTheDocument();
+      ).not.toBeInTheDocument()
+    );
+
+    await waitFor(() =>
       expect(within(section).getAllByRole('button', {name: '—'}).length).toBeGreaterThan(
         0
-      );
-    });
+      )
+    );
   });
 
   it('does not remove selected group bys using placeholder validation data', async () => {
@@ -1066,7 +1069,7 @@ describe('ExploreToolbar', () => {
 
     await userEvent.click(within(section).getByRole('button', {name: /save as/i}));
     await userEvent.click(within(section).getByText('Dashboard widget'));
-    await waitFor(() => {
+    await waitFor(() =>
       expect(openAddToDashboardModal).toHaveBeenCalledWith(
         expect.objectContaining({
           widgets: [
@@ -1087,8 +1090,8 @@ describe('ExploreToolbar', () => {
             },
           ],
         })
-      );
-    });
+      )
+    );
   });
 
   it('highlights save button when saved query is changed', async () => {
@@ -1154,9 +1157,7 @@ describe('ExploreToolbar', () => {
     );
 
     // After navigation, the save action should switch to the update state.
-    await waitFor(() => {
-      expect(screen.getByText(/^save$/i)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(/^save$/i)).toBeInTheDocument();
   });
 
   it('allows save as when cross events are present', async () => {

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useState, type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
@@ -27,7 +27,6 @@ import {
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {ExploreToolbar} from 'sentry/views/explore/toolbar';
-import {ToolbarGroupBy} from 'sentry/views/explore/toolbar/toolbarGroupBy';
 
 function Wrapper({children}: {children: ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
@@ -468,6 +467,102 @@ describe('ExploreToolbar', () => {
     });
   });
 
+  it('does not remove selected group bys using placeholder validation data', async () => {
+    const delayedValidateMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      asyncDelay: 100000,
+      body: {
+        dataset: [],
+        environment: [],
+        field: [
+          {
+            attrType: null,
+            error: 'Invalid attribute',
+            name: 'invalid.attribute',
+            valid: false,
+          },
+        ],
+        orderby: [],
+        projects: [],
+        query: {
+          error: null,
+          fields: [],
+          valid: true,
+        },
+        valid: false,
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      match: [
+        (_url, options) => JSON.stringify(options.query?.field).includes('valid.first'),
+      ],
+      body: {
+        dataset: [],
+        environment: [],
+        field: [
+          {
+            attrType: 'string',
+            error: null,
+            name: 'valid.first',
+            valid: true,
+          },
+          {
+            attrType: null,
+            error: 'Invalid attribute',
+            name: 'invalid.attribute',
+            valid: false,
+          },
+        ],
+        orderby: [],
+        projects: [],
+        query: {
+          error: null,
+          fields: [],
+          valid: true,
+        },
+        valid: false,
+      },
+    });
+
+    const {router} = render(<ExploreToolbar />, {
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/explore/traces/`,
+          query: {
+            aggregateField: [
+              JSON.stringify({groupBy: 'valid.first'}),
+              JSON.stringify({yAxes: ['count(span.duration)'], chartType: 0}),
+            ],
+          },
+        },
+      },
+    });
+
+    const section = screen.getByTestId('section-group-by');
+    await within(section).findAllByRole('button', {name: 'valid.first'});
+
+    const nextParams = new URLSearchParams();
+    nextParams.append('aggregateField', JSON.stringify({groupBy: 'invalid.attribute'}));
+    nextParams.append(
+      'aggregateField',
+      JSON.stringify({yAxes: ['count(span.duration)'], chartType: 0})
+    );
+
+    act(() => {
+      router.navigate(
+        `/organizations/${organization.slug}/explore/traces/?${nextParams}`
+      );
+    });
+
+    await waitFor(() => expect(delayedValidateMock).toHaveBeenCalled());
+    expect(router.location.query.aggregateField).toEqual([
+      JSON.stringify({groupBy: 'invalid.attribute'}),
+      JSON.stringify({yAxes: ['count(span.duration)'], chartType: 0}),
+    ]);
+  });
+
   it('removes invalid selected group bys and preserves empty values', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/validate/`,
@@ -541,57 +636,6 @@ describe('ExploreToolbar', () => {
     expect(
       screen.queryByRole('button', {name: 'invalid.attribute'})
     ).not.toBeInTheDocument();
-  });
-
-  it('removes invalid selected group bys when selection changes before cleanup applies', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/validate/`,
-      body: {
-        dataset: [],
-        environment: [],
-        field: [
-          {
-            attrType: null,
-            error: 'Invalid attribute',
-            name: 'invalid.attribute',
-            valid: false,
-          },
-          {
-            attrType: null,
-            error: 'Invalid attribute',
-            name: 'invalid.other',
-            valid: false,
-          },
-        ],
-        orderby: [],
-        projects: [],
-        query: {
-          error: null,
-          fields: [],
-          valid: true,
-        },
-        valid: false,
-      },
-    });
-
-    const setGroupBysMock = jest.fn();
-
-    function Component() {
-      const [localGroupBys, setLocalGroupBys] = useState(['invalid.attribute']);
-      const setGroupBys = useCallback((nextGroupBys: string[], mode?: Mode) => {
-        setGroupBysMock(nextGroupBys, mode);
-        setLocalGroupBys(currentGroupBys =>
-          currentGroupBys[0] === 'invalid.attribute' ? ['invalid.other'] : nextGroupBys
-        );
-      }, []);
-
-      return <ToolbarGroupBy groupBys={localGroupBys} setGroupBys={setGroupBys} />;
-    }
-
-    render(<Component />, {additionalWrapper: Wrapper});
-
-    await waitFor(() => expect(setGroupBysMock).toHaveBeenCalledTimes(2));
-    expect(setGroupBysMock).toHaveBeenLastCalledWith([], Mode.SAMPLES);
   });
 
   it('clears the last selected group by', async () => {

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -405,7 +405,7 @@ describe('ExploreToolbar', () => {
     const editorColumn = screen.getAllByTestId('editor-column')[0]!;
 
     await userEvent.click(
-      within(editorColumn).getByRole('button', {name: 'custom.measurement'})
+      await within(editorColumn).findByRole('button', {name: 'custom.measurement'})
     );
 
     const option = await within(section).findByRole('option', {

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -414,6 +414,134 @@ describe('ExploreToolbar', () => {
     await waitFor(() => expect(option).toHaveTextContent('number'));
   });
 
+  it('does not render unvalidated selected group bys while validation loads', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      asyncDelay: 100000,
+      body: {
+        dataset: [],
+        environment: [],
+        field: [
+          {
+            attrType: null,
+            error: 'Invalid attribute',
+            name: 'invalid.attribute',
+            valid: false,
+          },
+        ],
+        orderby: [],
+        projects: [],
+        query: {
+          error: null,
+          fields: [],
+          valid: true,
+        },
+        valid: false,
+      },
+    });
+
+    render(<ExploreToolbar />, {
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/explore/traces/`,
+          query: {
+            aggregateField: [
+              JSON.stringify({groupBy: 'invalid.attribute'}),
+              JSON.stringify({yAxes: ['count(span.duration)'], chartType: 0}),
+            ],
+          },
+        },
+      },
+    });
+
+    const section = screen.getByTestId('section-group-by');
+
+    await waitFor(() => {
+      expect(
+        within(section).queryByRole('button', {name: 'invalid.attribute'})
+      ).not.toBeInTheDocument();
+      expect(within(section).getAllByRole('button', {name: '—'}).length).toBeGreaterThan(
+        0
+      );
+    });
+  });
+
+  it('removes invalid selected group bys and preserves empty values', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      body: {
+        dataset: [],
+        environment: [],
+        field: [
+          {
+            attrType: null,
+            error: 'Invalid attribute',
+            name: 'invalid.attribute',
+            valid: false,
+          },
+          {
+            attrType: 'string',
+            error: null,
+            name: 'span.op',
+            valid: true,
+          },
+        ],
+        orderby: [],
+        projects: [],
+        query: {
+          error: null,
+          fields: [],
+          valid: true,
+        },
+        valid: false,
+      },
+    });
+
+    let groupBys: readonly string[] = [];
+
+    function Component() {
+      groupBys = useQueryParamsGroupBys();
+      return <ExploreToolbar />;
+    }
+
+    const {router} = render(<Component />, {
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/explore/traces/`,
+          query: {
+            aggregateField: [
+              JSON.stringify({groupBy: 'invalid.attribute'}),
+              JSON.stringify({groupBy: ''}),
+              JSON.stringify({groupBy: 'span.op'}),
+              JSON.stringify({yAxes: ['count(span.duration)'], chartType: 0}),
+            ],
+          },
+        },
+      },
+    });
+
+    await waitFor(() => expect(groupBys).toEqual(['', 'span.op']));
+
+    const aggregateFieldQuery = router.location.query.aggregateField;
+    const aggregateFields = (
+      Array.isArray(aggregateFieldQuery) ? aggregateFieldQuery : [aggregateFieldQuery]
+    )
+      .filter((field): field is string => typeof field === 'string')
+      .map(field => JSON.parse(field));
+
+    expect(aggregateFields).toEqual([
+      {groupBy: ''},
+      {groupBy: 'span.op'},
+      {yAxes: ['count(span.duration)'], chartType: 0},
+    ]);
+
+    expect(
+      screen.queryByRole('button', {name: 'invalid.attribute'})
+    ).not.toBeInTheDocument();
+  });
+
   it('clears the last selected group by', async () => {
     let groupBys: readonly string[] = [];
     let mode: Mode | undefined;

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -1,4 +1,4 @@
-import type {ReactNode} from 'react';
+import {useCallback, useState, type ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
@@ -27,6 +27,7 @@ import {
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {ExploreToolbar} from 'sentry/views/explore/toolbar';
+import {ToolbarGroupBy} from 'sentry/views/explore/toolbar/toolbarGroupBy';
 
 function Wrapper({children}: {children: ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
@@ -540,6 +541,57 @@ describe('ExploreToolbar', () => {
     expect(
       screen.queryByRole('button', {name: 'invalid.attribute'})
     ).not.toBeInTheDocument();
+  });
+
+  it('removes invalid selected group bys when selection changes before cleanup applies', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      body: {
+        dataset: [],
+        environment: [],
+        field: [
+          {
+            attrType: null,
+            error: 'Invalid attribute',
+            name: 'invalid.attribute',
+            valid: false,
+          },
+          {
+            attrType: null,
+            error: 'Invalid attribute',
+            name: 'invalid.other',
+            valid: false,
+          },
+        ],
+        orderby: [],
+        projects: [],
+        query: {
+          error: null,
+          fields: [],
+          valid: true,
+        },
+        valid: false,
+      },
+    });
+
+    const setGroupBysMock = jest.fn();
+
+    function Component() {
+      const [localGroupBys, setLocalGroupBys] = useState(['invalid.attribute']);
+      const setGroupBys = useCallback((nextGroupBys: string[], mode?: Mode) => {
+        setGroupBysMock(nextGroupBys, mode);
+        setLocalGroupBys(currentGroupBys =>
+          currentGroupBys[0] === 'invalid.attribute' ? ['invalid.other'] : nextGroupBys
+        );
+      }, []);
+
+      return <ToolbarGroupBy groupBys={localGroupBys} setGroupBys={setGroupBys} />;
+    }
+
+    render(<Component />, {additionalWrapper: Wrapper});
+
+    await waitFor(() => expect(setGroupBysMock).toHaveBeenCalledTimes(2));
+    expect(setGroupBysMock).toHaveBeenLastCalledWith([], Mode.SAMPLES);
   });
 
   it('clears the last selected group by', async () => {

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -84,6 +84,29 @@ describe('ExploreToolbar', () => {
         },
       ],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      body: {
+        dataset: [],
+        environment: [],
+        field: [
+          {
+            attrType: 'number',
+            error: null,
+            name: 'custom.measurement',
+            valid: true,
+          },
+        ],
+        orderby: [],
+        projects: [],
+        query: {
+          error: null,
+          fields: [],
+          valid: true,
+        },
+        valid: true,
+      },
+    });
   });
 
   it('disables changing visualize fields for count', async () => {
@@ -363,6 +386,32 @@ describe('ExploreToolbar', () => {
 
     // last one so remove column button is hidden
     expect(within(section).queryByLabelText('Remove Column')).not.toBeInTheDocument();
+  });
+
+  it('uses validated field type for the selected group by', async () => {
+    render(<ExploreToolbar />, {
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/explore/traces/`,
+          query: {
+            groupBy: 'custom.measurement',
+          },
+        },
+      },
+    });
+
+    const section = screen.getByTestId('section-group-by');
+    const editorColumn = screen.getAllByTestId('editor-column')[0]!;
+
+    await userEvent.click(
+      within(editorColumn).getByRole('button', {name: 'custom.measurement'})
+    );
+
+    const option = await within(section).findByRole('option', {
+      name: 'custom.measurement',
+    });
+    await waitFor(() => expect(option).toHaveTextContent('number'));
   });
 
   it('clears the last selected group by', async () => {

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
 
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKind} from 'sentry/utils/fields';
@@ -59,19 +59,7 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
     [groupBys, validatedSearchQueryData?.field, validationIsPending]
   );
 
-  useEffect(() => {
-    if (
-      validatedSearchQueryData &&
-      validationGroupBys.current?.data !== validatedSearchQueryData
-    ) {
-      validationGroupBys.current = {
-        data: validatedSearchQueryData,
-        groupBys,
-      };
-    }
-  }, [groupBys, validatedSearchQueryData]);
-
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (pendingValidatedGroupBys.current) {
       if (arraysAreEqual(groupBys, pendingValidatedGroupBys.current.to)) {
         pendingValidatedGroupBys.current = null;
@@ -83,11 +71,24 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
       }
     }
 
+    if (validationIsPending || !validatedSearchQueryData) {
+      return;
+    }
+
+    let validationGroupBySnapshot = validationGroupBys.current;
     if (
-      validationIsPending ||
-      !validatedSearchQueryData ||
-      validationGroupBys.current?.data !== validatedSearchQueryData ||
-      !arraysAreEqual(groupBys, validationGroupBys.current.groupBys) ||
+      !validationGroupBySnapshot?.data ||
+      validationGroupBySnapshot.data !== validatedSearchQueryData
+    ) {
+      validationGroupBySnapshot = {
+        data: validatedSearchQueryData,
+        groupBys,
+      };
+      validationGroupBys.current = validationGroupBySnapshot;
+    }
+
+    if (
+      !arraysAreEqual(groupBys, validationGroupBySnapshot.groupBys) ||
       arraysAreEqual(groupBys, validatedGroupBys)
     ) {
       return;

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import isEqual from 'lodash/isEqual';
 
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKind} from 'sentry/utils/fields';
@@ -61,11 +62,11 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
 
   useLayoutEffect(() => {
     if (pendingValidatedGroupBys.current) {
-      if (arraysAreEqual(groupBys, pendingValidatedGroupBys.current.to)) {
+      if (isEqual(groupBys, pendingValidatedGroupBys.current.to)) {
         pendingValidatedGroupBys.current = null;
       } else if (
-        arraysAreEqual(groupBys, pendingValidatedGroupBys.current.from) &&
-        arraysAreEqual(validatedGroupBys, pendingValidatedGroupBys.current.to)
+        isEqual(groupBys, pendingValidatedGroupBys.current.from) &&
+        isEqual(validatedGroupBys, pendingValidatedGroupBys.current.to)
       ) {
         return;
       }
@@ -88,8 +89,8 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
     }
 
     if (
-      !arraysAreEqual(groupBys, validationGroupBySnapshot.groupBys) ||
-      arraysAreEqual(groupBys, validatedGroupBys)
+      !isEqual(groupBys, validationGroupBySnapshot.groupBys) ||
+      isEqual(groupBys, validatedGroupBys)
     ) {
       return;
     }
@@ -282,10 +283,6 @@ function shouldHideGroupByForValidation(
   }
 
   return validationIsPending || field?.valid === false;
-}
-
-function arraysAreEqual(a: readonly string[], b: readonly string[]): boolean {
-  return a.length === b.length && a.every((value, index) => value === b[index]);
 }
 
 function mergeValidatedTags({

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -33,7 +33,10 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
     isLoading: validationLoading,
     isPlaceholderData: validationIsPlaceholderData,
   } = useValidateSpansTab();
-  const pendingValidatedGroupBys = useRef<string[] | null>(null);
+  const pendingValidatedGroupBys = useRef<{
+    from: readonly string[];
+    to: readonly string[];
+  } | null>(null);
   const validationIsPending = validationLoading || validationIsPlaceholderData;
 
   const validatedGroupBys = useMemo(
@@ -52,9 +55,12 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
 
   useEffect(() => {
     if (pendingValidatedGroupBys.current) {
-      if (arraysAreEqual(groupBys, pendingValidatedGroupBys.current)) {
+      if (arraysAreEqual(groupBys, pendingValidatedGroupBys.current.to)) {
         pendingValidatedGroupBys.current = null;
-      } else if (arraysAreEqual(validatedGroupBys, pendingValidatedGroupBys.current)) {
+      } else if (
+        arraysAreEqual(groupBys, pendingValidatedGroupBys.current.from) &&
+        arraysAreEqual(validatedGroupBys, pendingValidatedGroupBys.current.to)
+      ) {
         return;
       }
     }
@@ -63,7 +69,10 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
       return;
     }
 
-    pendingValidatedGroupBys.current = validatedGroupBys;
+    pendingValidatedGroupBys.current = {
+      from: groupBys,
+      to: validatedGroupBys,
+    };
 
     if (validatedGroupBys.some(Boolean)) {
       setGroupBys(validatedGroupBys);

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -1,5 +1,7 @@
-import {useCallback, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 
+import type {TagCollection} from 'sentry/types/group';
+import {FieldKind} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {
   ToolbarFooter,
@@ -10,12 +12,15 @@ import {
   ToolbarGroupByDropdown,
   ToolbarGroupByHeader,
 } from 'sentry/views/explore/components/toolbar/toolbarGroupBy';
+import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {useSpanItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
+import {useValidateSpansTab} from 'sentry/views/explore/spans/hooks/useValidateSpansTab';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import type {EventValidationData} from 'sentry/views/explore/utils/validateEventParamsOptions';
 
 interface ToolbarGroupByProps {
   groupBys: readonly string[];
@@ -97,12 +102,29 @@ function ToolbarGroupByItem({
     {search: debouncedSearch},
     'boolean'
   );
+  const {data: validatedSearchQueryData} = useValidateSpansTab();
+
+  const {validatedBooleanTags, validatedNumberTags, validatedStringTags} = useMemo(() => {
+    const validatedField = validatedSearchQueryData?.field.find(
+      field => field.valid && field.name === column.column
+    );
+
+    if (!validatedField) {
+      return {
+        validatedBooleanTags: booleanTags,
+        validatedNumberTags: numberTags,
+        validatedStringTags: stringTags,
+      };
+    }
+
+    return mergeValidatedTags({booleanTags, numberTags, stringTags, validatedField});
+  }, [booleanTags, column, numberTags, stringTags, validatedSearchQueryData?.field]);
 
   const options = useGroupByFields({
     groupBys,
-    numberTags,
-    stringTags,
-    booleanTags,
+    numberTags: validatedNumberTags,
+    stringTags: validatedStringTags,
+    booleanTags: validatedBooleanTags,
     traceItemType: TraceItemDataset.SPANS,
   });
 
@@ -120,4 +142,73 @@ function ToolbarGroupByItem({
       onColumnDelete={onColumnDelete}
     />
   );
+}
+
+function mergeValidatedTags({
+  booleanTags,
+  numberTags,
+  stringTags,
+  validatedField,
+}: {
+  booleanTags: TagCollection;
+  numberTags: TagCollection;
+  stringTags: TagCollection;
+  validatedField: EventValidationData['field'][number];
+}) {
+  switch (validatedField.attrType) {
+    case 'boolean': {
+      const validatedBooleanTags = {
+        ...booleanTags,
+        [validatedField.name]: {
+          key: validatedField.name,
+          name: prettifyAttributeName(validatedField.name),
+          kind: FieldKind.BOOLEAN,
+        },
+      };
+
+      return {
+        validatedBooleanTags,
+        validatedNumberTags: numberTags,
+        validatedStringTags: stringTags,
+      };
+    }
+    case 'number': {
+      const validatedNumberTags = {
+        ...numberTags,
+        [validatedField.name]: {
+          key: validatedField.name,
+          name: prettifyAttributeName(validatedField.name),
+          kind: FieldKind.MEASUREMENT,
+        },
+      };
+
+      return {
+        validatedBooleanTags: booleanTags,
+        validatedNumberTags,
+        validatedStringTags: stringTags,
+      };
+    }
+    case 'string': {
+      const validatedStringTags = {
+        ...stringTags,
+        [validatedField.name]: {
+          key: validatedField.name,
+          name: prettifyAttributeName(validatedField.name),
+          kind: FieldKind.TAG,
+        },
+      };
+
+      return {
+        validatedBooleanTags: booleanTags,
+        validatedNumberTags: numberTags,
+        validatedStringTags,
+      };
+    }
+    default:
+      return {
+        validatedBooleanTags: booleanTags,
+        validatedNumberTags: numberTags,
+        validatedStringTags: stringTags,
+      };
+  }
 }

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -30,6 +30,7 @@ interface ToolbarGroupByProps {
 export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
   const {
     data: validatedSearchQueryData,
+    isFetching: validationFetching,
     isLoading: validationLoading,
     isPlaceholderData: validationIsPlaceholderData,
   } = useValidateSpansTab();
@@ -37,7 +38,12 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
     from: readonly string[];
     to: readonly string[];
   } | null>(null);
-  const validationIsPending = validationLoading || validationIsPlaceholderData;
+  const validationGroupBys = useRef<{
+    data: EventValidationData;
+    groupBys: readonly string[];
+  } | null>(null);
+  const validationIsPending =
+    validationFetching || validationLoading || validationIsPlaceholderData;
 
   const validatedGroupBys = useMemo(
     () => filterInvalidGroupBys(groupBys, validatedSearchQueryData?.field),
@@ -54,6 +60,18 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
   );
 
   useEffect(() => {
+    if (
+      validatedSearchQueryData &&
+      validationGroupBys.current?.data !== validatedSearchQueryData
+    ) {
+      validationGroupBys.current = {
+        data: validatedSearchQueryData,
+        groupBys,
+      };
+    }
+  }, [groupBys, validatedSearchQueryData]);
+
+  useEffect(() => {
     if (pendingValidatedGroupBys.current) {
       if (arraysAreEqual(groupBys, pendingValidatedGroupBys.current.to)) {
         pendingValidatedGroupBys.current = null;
@@ -65,7 +83,13 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
       }
     }
 
-    if (!validatedSearchQueryData || arraysAreEqual(groupBys, validatedGroupBys)) {
+    if (
+      validationIsPending ||
+      !validatedSearchQueryData ||
+      validationGroupBys.current?.data !== validatedSearchQueryData ||
+      !arraysAreEqual(groupBys, validationGroupBys.current.groupBys) ||
+      arraysAreEqual(groupBys, validatedGroupBys)
+    ) {
       return;
     }
 
@@ -79,7 +103,13 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
     } else {
       setGroupBys(validatedGroupBys, Mode.SAMPLES);
     }
-  }, [groupBys, setGroupBys, validatedGroupBys, validatedSearchQueryData]);
+  }, [
+    groupBys,
+    setGroupBys,
+    validatedGroupBys,
+    validatedSearchQueryData,
+    validationIsPending,
+  ]);
 
   const setGroupBysWithOp = useCallback(
     (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => {

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKind} from 'sentry/utils/fields';
@@ -28,6 +28,50 @@ interface ToolbarGroupByProps {
 }
 
 export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
+  const {
+    data: validatedSearchQueryData,
+    isLoading: validationLoading,
+    isPlaceholderData: validationIsPlaceholderData,
+  } = useValidateSpansTab();
+  const pendingValidatedGroupBys = useRef<string[] | null>(null);
+  const validationIsPending = validationLoading || validationIsPlaceholderData;
+
+  const validatedGroupBys = useMemo(
+    () => filterInvalidGroupBys(groupBys, validatedSearchQueryData?.field),
+    [groupBys, validatedSearchQueryData?.field]
+  );
+  const visibleGroupBys = useMemo(
+    () =>
+      filterVisibleGroupBys(
+        groupBys,
+        validatedSearchQueryData?.field,
+        validationIsPending
+      ),
+    [groupBys, validatedSearchQueryData?.field, validationIsPending]
+  );
+
+  useEffect(() => {
+    if (pendingValidatedGroupBys.current) {
+      if (arraysAreEqual(groupBys, pendingValidatedGroupBys.current)) {
+        pendingValidatedGroupBys.current = null;
+      } else if (arraysAreEqual(validatedGroupBys, pendingValidatedGroupBys.current)) {
+        return;
+      }
+    }
+
+    if (!validatedSearchQueryData || arraysAreEqual(groupBys, validatedGroupBys)) {
+      return;
+    }
+
+    pendingValidatedGroupBys.current = validatedGroupBys;
+
+    if (validatedGroupBys.some(Boolean)) {
+      setGroupBys(validatedGroupBys);
+    } else {
+      setGroupBys(validatedGroupBys, Mode.SAMPLES);
+    }
+  }, [groupBys, setGroupBys, validatedGroupBys, validatedSearchQueryData]);
+
   const setGroupBysWithOp = useCallback(
     (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => {
       const hasValidGroupBy = columns.some(Boolean);
@@ -60,7 +104,9 @@ export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
               column={column}
               onColumnChange={c => updateColumnAtIndex(i, c)}
               onColumnDelete={() => deleteColumnAtIndex(i)}
-              groupBys={groupBys}
+              groupBys={visibleGroupBys}
+              validationIsPending={validationIsPending}
+              validatedSearchQueryData={validatedSearchQueryData}
             />
           ))}
           <ToolbarFooter>
@@ -78,6 +124,8 @@ interface ToolbarGroupByItemProps {
   groupBys: readonly string[];
   onColumnChange: (column: string) => void;
   onColumnDelete: () => void;
+  validationIsPending: boolean;
+  validatedSearchQueryData?: EventValidationData;
 }
 
 function ToolbarGroupByItem({
@@ -86,6 +134,8 @@ function ToolbarGroupByItem({
   column,
   onColumnChange,
   onColumnDelete,
+  validationIsPending,
+  validatedSearchQueryData,
 }: ToolbarGroupByItemProps) {
   const [search, setSearch] = useState<string | undefined>(undefined);
   const debouncedSearch = useDebouncedValue(search, 200);
@@ -102,7 +152,6 @@ function ToolbarGroupByItem({
     {search: debouncedSearch},
     'boolean'
   );
-  const {data: validatedSearchQueryData} = useValidateSpansTab();
 
   const {validatedBooleanTags, validatedNumberTags, validatedStringTags} = useMemo(() => {
     const validatedField = validatedSearchQueryData?.field.find(
@@ -128,11 +177,19 @@ function ToolbarGroupByItem({
     traceItemType: TraceItemDataset.SPANS,
   });
 
-  const loading = numberTagsLoading || stringTagsLoading || booleanTagsLoading;
+  const loading =
+    validationIsPending || numberTagsLoading || stringTagsLoading || booleanTagsLoading;
+  const displayColumn = shouldHideGroupByForValidation(
+    column.column,
+    validatedSearchQueryData?.field,
+    validationIsPending
+  )
+    ? {...column, column: ''}
+    : column;
 
   return (
     <ToolbarGroupByDropdown
-      column={column}
+      column={displayColumn}
       options={options}
       loading={loading}
       onClose={() => setSearch(undefined)}
@@ -142,6 +199,53 @@ function ToolbarGroupByItem({
       onColumnDelete={onColumnDelete}
     />
   );
+}
+
+function filterInvalidGroupBys(
+  groupBys: readonly string[],
+  fields: EventValidationData['field'] | undefined
+): string[] {
+  const invalidFields = new Set(
+    fields?.filter(field => !field.valid).map(field => field.name)
+  );
+
+  if (invalidFields.size === 0) {
+    return [...groupBys];
+  }
+
+  return groupBys.filter(groupBy => groupBy === '' || !invalidFields.has(groupBy));
+}
+
+function filterVisibleGroupBys(
+  groupBys: readonly string[],
+  fields: EventValidationData['field'] | undefined,
+  validationIsPending: boolean
+): string[] {
+  return groupBys.filter(
+    groupBy => !shouldHideGroupByForValidation(groupBy, fields, validationIsPending)
+  );
+}
+
+function shouldHideGroupByForValidation(
+  groupBy: string,
+  fields: EventValidationData['field'] | undefined,
+  validationIsPending: boolean
+): boolean {
+  if (groupBy === '') {
+    return false;
+  }
+
+  const field = fields?.find(({name}) => name === groupBy);
+
+  if (field?.valid) {
+    return false;
+  }
+
+  return validationIsPending || field?.valid === false;
+}
+
+function arraysAreEqual(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
 }
 
 function mergeValidatedTags({


### PR DESCRIPTION
The group by dropdowns  on the traces page now use the new validation endpoint when selected fields are not present in the attribute fetch results. As well, valid fields are inserted into the matching type bucket so their dropdown labels and field types render correctly.

Invalid URL-provided group-bys are hidden during validation and removed from aggregate query params once classified. Empty group-by rows remain intact so blank selections and clearing behavior keep working.

Closes EXP-1031