### PR TITLE
fix(conversations): Show single (no value) for redacted multi-part messages

### DIFF
--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.spec.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.spec.ts
@@ -139,6 +139,22 @@ describe('normalizeToMessages', () => {
       expect(messages?.[0]?.content).toBe(EMPTY_TEXT_CONTENT);
     });
 
+    it('renders a single placeholder when multiple text parts all have no usable text', () => {
+      const input = JSON.stringify([
+        {
+          role: 'assistant',
+          content: [
+            {type: 'text', chars: 56},
+            {type: 'text', chars: 100},
+          ],
+        },
+      ]);
+
+      const {messages} = normalizeToMessages(input, {defaultRole: 'assistant'});
+
+      expect(messages?.[0]?.content).toBe(EMPTY_TEXT_CONTENT);
+    });
+
     it('keeps tool role content as-is (not re-rendered)', () => {
       const input = JSON.stringify([
         {role: 'tool', content: [{type: 'text', text: 'result'}]},
@@ -404,6 +420,32 @@ describe('extractAssistantOutput', () => {
 
     it('returns the placeholder for empty text parts in parts-format output', () => {
       const input = JSON.stringify([{role: 'assistant', parts: [{type: 'text'}]}]);
+
+      const {responseText} = extractAssistantOutput(input, {defaultRole: 'assistant'});
+
+      expect(responseText).toBe(EMPTY_TEXT_CONTENT);
+    });
+
+    it('returns a single placeholder when multiple parts-format text parts are all empty', () => {
+      const input = JSON.stringify([
+        {role: 'assistant', parts: [{type: 'text'}, {type: 'text'}, {type: 'text'}]},
+      ]);
+
+      const {responseText} = extractAssistantOutput(input, {defaultRole: 'assistant'});
+
+      expect(responseText).toBe(EMPTY_TEXT_CONTENT);
+    });
+
+    it('returns a single placeholder when multiple content-format text parts are all empty', () => {
+      const input = JSON.stringify([
+        {
+          role: 'assistant',
+          content: [
+            {type: 'text', chars: 56},
+            {type: 'text', chars: 100},
+          ],
+        },
+      ]);
 
       const {responseText} = extractAssistantOutput(input, {defaultRole: 'assistant'});
 

--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
@@ -326,7 +326,9 @@ function collapseParts(parts: unknown[]): unknown {
   const buckets = bucketParts(parts);
 
   if (buckets.hasRenderableTextPart) {
-    return buckets.textParts.join('\n');
+    return buckets.textParts.length > 0
+      ? buckets.textParts.join('\n')
+      : EMPTY_TEXT_CONTENT;
   }
   if (buckets.objectParts.length > 0) {
     return buckets.objectParts.length === 1
@@ -366,7 +368,9 @@ function bucketParts(parts: unknown[]): PartBuckets {
     if (partType === 'text') {
       buckets.hasRenderableTextPart = true;
       const text = getTextPartContent(part, {trim: true});
-      buckets.textParts.push(text || EMPTY_TEXT_CONTENT);
+      if (text) {
+        buckets.textParts.push(text);
+      }
       continue;
     }
     if (partType === 'reasoning') {
@@ -449,11 +453,17 @@ function appendOutputFromParts(
   }
 ): void {
   const {textParts, reasoningParts, toolCallParts, objectParts} = buckets;
+  let hasEmptyTextPart = false;
+  const textPartsLengthBefore = textParts.length;
   for (const part of parts) {
     const partType = getPartType(part);
     if (partType === 'text' && isRecord(part)) {
       const text = getStringField(part, 'content') ?? getStringField(part, 'text');
-      textParts.push(text ?? EMPTY_TEXT_CONTENT);
+      if (text) {
+        textParts.push(text);
+      } else {
+        hasEmptyTextPart = true;
+      }
       continue;
     }
     if (partType === 'reasoning' && isRecord(part)) {
@@ -474,6 +484,11 @@ function appendOutputFromParts(
     if (isFileContentPartType(partType) && isRecord(part)) {
       textParts.push(redactedFileContent(part));
     }
+  }
+  // If there were empty text parts but no real text was added for this message's
+  // parts, emit exactly one placeholder so the message still renders.
+  if (hasEmptyTextPart && textParts.length === textPartsLengthBefore) {
+    textParts.push(EMPTY_TEXT_CONTENT);
   }
 }
 
@@ -509,7 +524,11 @@ function looksLikeJson(raw: string): boolean {
 }
 
 function extractTextFromContentParts(parts: unknown[]): string {
-  return bucketParts(parts).textParts.join('\n');
+  const buckets = bucketParts(parts);
+  if (buckets.textParts.length > 0) {
+    return buckets.textParts.join('\n');
+  }
+  return buckets.hasRenderableTextPart ? EMPTY_TEXT_CONTENT : '';
 }
 
 function isRecord(value: unknown): value is UnknownRecord {


### PR DESCRIPTION
When a conversation message had multiple text parts that all lacked usable text (e.g. `parts: [{type: 'text'}, {type: 'text'}]`), each empty part independently pushed `EMPTY_TEXT_CONTENT` into the text buffer. Joining them produced `(no value)\n(no value)` instead of a single marker — which also broke the `=== EMPTY_TEXT_CONTENT` identity check in `turnsToMessages` that gates deduplication.

Three paths in `aiMessageNormalizer.ts` shared the same root cause:
- `bucketParts` pushed `EMPTY_TEXT_CONTENT` once per empty text part
- `extractTextFromContentParts` joined them all verbatim
- `appendOutputFromParts` did the same for assistant output in parts format

`bucketParts` now only appends real text; `collapseParts` and `extractTextFromContentParts` fall back to exactly one `EMPTY_TEXT_CONTENT` when no real text was collected but renderable text parts were present. `appendOutputFromParts` tracks whether any empty text part was seen and appends at most one placeholder after the loop, only if no real text was added for that message's parts.

Closes TET-2560
