### PR TITLE
fix(spans): Write span `status` field as trace item attribute

### DIFF
--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -32,6 +32,13 @@ FIELD_TO_ATTRIBUTE = {
     "start_timestamp": "sentry.start_timestamp_precise",
 }
 
+# Like FIELD_TO_ATTRIBUTE, but does not overwrite existing attribute values.
+FIELD_TO_MISSING_ATTRIBUTE = {
+    # Keep backwards compatibility for v1 spans, which write their own
+    # sentry.status values upstream.
+    "status": "sentry.status",
+}
+
 RENAME_ATTRIBUTES = {
     ATTRIBUTE_NAMES.SENTRY_DESCRIPTION: "sentry.raw_description",
     ATTRIBUTE_NAMES.SENTRY_SEGMENT_ID: "sentry.segment_id",
@@ -74,6 +81,12 @@ def convert_span_to_item(span: CompatibleSpan) -> TraceItem:
         attribute = span.get(field_name)  # type:ignore[assignment]
         if attribute is not None:
             attributes[attribute_name] = _anyvalue(attribute)
+
+    for field_name, attribute_name in FIELD_TO_MISSING_ATTRIBUTE.items():
+        if attribute_name not in attributes:
+            attribute = span.get(field_name)  # type:ignore[assignment]
+            if attribute is not None:
+                attributes[attribute_name] = _anyvalue(attribute)
 
     # Rename some attributes from their sentry-conventions name to what the product currently expects.
     # Eventually this should all be handled by deprecation policies in sentry-conventions.

--- a/tests/sentry/spans/consumers/process_segments/test_convert.py
+++ b/tests/sentry/spans/consumers/process_segments/test_convert.py
@@ -299,3 +299,23 @@ def test_convert_outcomes_missing_key_id() -> None:
             ),
         ],
     )
+
+
+def test_field_to_missing_attribute_writes_if_missing() -> None:
+    message: SpanEvent = copy.deepcopy(SPAN_KAFKA_MESSAGE)
+    message["status"] = "error"
+    del message["attributes"]["sentry.status"]  # type: ignore[union-attr]
+
+    item = convert_span_to_item(cast(CompatibleSpan, message))
+
+    assert item.attributes.get("sentry.status") == AnyValue(string_value="error")
+
+
+def test_field_to_missing_attribute_keeps_existing_value() -> None:
+    message: SpanEvent = copy.deepcopy(SPAN_KAFKA_MESSAGE)
+    message["status"] = "error"
+    message["attributes"]["sentry.status"] = {"value": "ok", "type": "string"}  # type: ignore[index]
+
+    item = convert_span_to_item(cast(CompatibleSpan, message))
+
+    assert item.attributes.get("sentry.status") == AnyValue(string_value="ok")


### PR DESCRIPTION
Spans' `status` field is not currently being written to an attribute when converted to an EAP trace item. As a result, we don't actually save the status value.

The expected attribute for status is `sentry.status` and is used in various places in the product (as `span.status`). `sentry.status` is always already populated for incoming v1 (transaction-based) spans, but never for v2 (span streaming) or OTel spans. Conditionally write the value of the `status` field into the `sentry.status` attribute if it's missing.

Not overwriting v1 span `sentry.status` is important for backwards compatibility, since v1 spans support different values for this field than v2 spans (v1 supports the `status` list [here](https://develop.sentry.dev/sdk/foundations/envelopes/event-payloads/contexts/#trace-context), while v2 only supports `ok` and `error`).