### PR TITLE
feat(taskworkers): add option to set skip_await_futures

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3742,6 +3742,15 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# If False, TaskWorkers will wait for a task's producer futures to complete
+# before marking a task as complete
+register(
+    "taskworker.skip.awaiting.futures",
+    type=Bool,
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 register(
     "github-enterprise.disallow-domain-mismatch",
     type=Bool,

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -10,6 +10,7 @@ from typing import Any
 import click
 import taskbroker_client.constants as taskworker_constants
 
+from sentry import options as sentry_options
 from sentry.bgtasks.api import managed_bgtasks
 from sentry.runner.decorators import configuration, log_options
 from sentry.utils.kafka import run_processor_with_signals
@@ -246,6 +247,7 @@ def run_taskworker(
     from taskbroker_client.worker import BatchPushTaskWorker, PushTaskWorker, TaskWorker
     from taskbroker_client.worker.client import make_broker_hosts
 
+    skip_awaiting_futures = sentry_options.get("taskworker.skip.awaiting.futures")
     with managed_bgtasks(role="taskworker"):
         if push_mode:
             worker: PushTaskWorker | TaskWorker = PushTaskWorker(
@@ -263,6 +265,7 @@ def run_taskworker(
                 health_check_sec_per_touch=health_check_sec_per_touch,
                 grpc_port=worker_rpc_port,
                 push_task_timeout=push_timeout_sec,
+                skip_awaiting_futures=skip_awaiting_futures,
             )
         elif batch_push_mode:
             worker = BatchPushTaskWorker(
@@ -280,6 +283,7 @@ def run_taskworker(
                 health_check_sec_per_touch=health_check_sec_per_touch,
                 grpc_port=worker_rpc_port,
                 update_in_batches=True,
+                skip_awaiting_futures=skip_awaiting_futures,
             )
         else:
             worker = TaskWorker(
@@ -296,6 +300,7 @@ def run_taskworker(
                 processing_pool_name=processing_pool_name,
                 health_check_file_path=health_check_file_path,
                 health_check_sec_per_touch=health_check_sec_per_touch,
+                skip_awaiting_futures=skip_awaiting_futures,
             )
         exitcode = worker.start()
         raise SystemExit(exitcode)


### PR DESCRIPTION
This PR sets up a sentry option which can be used to set `skip_awaiting_futures` on/off for taskworkers in a region, which configures whether they wait for a task's producer futures to complete before marking the task as complete.