### PR TITLE
fix(gsadmin): add CTA to reset stranded partner billing

### DIFF
--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -265,6 +265,86 @@ describe('CustomerOverview', () => {
     expect(screen.getByText('XX (migrated)')).toBeInTheDocument();
     expect(screen.getByText('ID: 123')).toBeInTheDocument();
     expect(screen.queryByText('Deactivate Partner')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Reset partner billing to self-serve')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders reset button for stranded managed partner still partner-billed', async () => {
+    const organization = OrganizationFixture();
+    const partnerSubscription = SubscriptionFixture({
+      organization,
+      plan: 'am2_business',
+      isPartner: true,
+      isManaged: true,
+      partner: {
+        externalId: '123',
+        name: 'test',
+        partnership: {
+          id: 'XX',
+          displayName: 'XX',
+          supportNote: '',
+        },
+        isActive: false,
+      },
+    });
+
+    const mockOnAction = jest.fn();
+
+    render(
+      <CustomerOverview
+        customer={partnerSubscription}
+        onAction={mockOnAction}
+        organization={organization}
+      />
+    );
+
+    expect(screen.getByText('XX (migrated)')).toBeInTheDocument();
+    expect(screen.getByText('ID: 123')).toBeInTheDocument();
+    expect(screen.queryByText('Deactivate Partner')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Reset partner billing to self-serve'));
+
+    expect(mockOnAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deactivatePartnerAccount: true,
+      })
+    );
+  });
+
+  it('hides reset button for stranded partner that is not managed', () => {
+    const organization = OrganizationFixture();
+    const partnerSubscription = SubscriptionFixture({
+      organization,
+      plan: 'am2_business',
+      isPartner: true,
+      isManaged: false,
+      partner: {
+        externalId: '123',
+        name: 'test',
+        partnership: {
+          id: 'XX',
+          displayName: 'XX',
+          supportNote: '',
+        },
+        isActive: false,
+      },
+    });
+
+    render(
+      <CustomerOverview
+        customer={partnerSubscription}
+        onAction={jest.fn()}
+        organization={organization}
+      />
+    );
+
+    expect(screen.getByText('XX (migrated)')).toBeInTheDocument();
+    expect(screen.getByText('ID: 123')).toBeInTheDocument();
+    expect(screen.queryByText('Deactivate Partner')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Reset partner billing to self-serve')
+    ).not.toBeInTheDocument();
   });
 
   it('deactivates partner account with right data', async () => {

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -772,7 +772,20 @@ export function CustomerOverview({customer, onAction, organization}: Props) {
                     </Button>
                   </Fragment>
                 ) : (
-                  <Fragment>(migrated)</Fragment>
+                  <Fragment>
+                    (migrated)
+                    {customer.isPartner && customer.isManaged && (
+                      <Fragment>
+                        <br />
+                        <Button
+                          variant="link"
+                          onClick={() => updateCustomerStatus('deactivatePartnerAccount')}
+                        >
+                          Reset partner billing to self-serve
+                        </Button>
+                      </Fragment>
+                    )}
+                  </Fragment>
                 )}
                 <br />
                 <small>ID: {customer.partner.externalId}</small>


### PR DESCRIPTION
This relates to https://github.com/getsentry/getsentry/pull/20825. See https://github.com/getsentry/getsentry/pull/20825 for more details.

What it looks like:

<img width="406" height="203" alt="Screenshot 2026-06-25 at 6 30 04 PM" src="https://github.com/user-attachments/assets/6b553105-cc7b-4902-9f85-69f4c48e343c" />


https://github.com/user-attachments/assets/eb3d4bf1-7566-4c35-94f3-6c9397aba6c5




------

**_Claude stuff below this line:_**

## Summary

Adds a `_admin` CTA to recover an organization stranded on partner billing.

## Why

When a partner account is inactive ("migrated") but the subscription is still partner-billed and `managed`, the org is stranded with no way to return it to self-serve. Previously the "Deactivate Partner" button only rendered for **active** partners, so a migrated-but-stranded org had no affordance at all — the partner row just showed "(migrated)".

## What changes

`customerOverview.tsx` now shows a distinct **"Reset partner billing to self-serve"** button for the migrated case, gated on `isPartner && isManaged` (hidden for config partners that clean up asynchronously). It triggers the same `deactivatePartnerAccount` action, which the backend now uses to reset the stranded subscription.

## Testing

`customerOverview.spec.tsx`:
- active partner → "Deactivate Partner" shown
- stranded managed partner → "(migrated)" + "Reset partner billing to self-serve" (click dispatches `deactivatePartnerAccount`)
- cleanly migrated, and `managed=false` → "(migrated)", no button

jest + eslint green.

## Companion PR

Backend recovery (handler + trial guard): getsentry/getsentry#20825
