### PR TITLE
fix(replays): restore gray border on timeline mouse-hover marker

### DIFF
--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -163,6 +163,7 @@ export const PlayerScrubber = styled(Scrubber)`
      */
     :after {
       background: ${p => p.theme.tokens.background.accent.vibrant};
+      border-color: ${p => p.theme.tokens.border.onVibrant.light};
     }
   }
 
@@ -179,6 +180,7 @@ export const PlayerScrubber = styled(Scrubber)`
      */
     :after {
       background: ${p => p.theme.tokens.graphics.neutral.muted};
+      border-color: ${p => p.theme.tokens.border.neutral.moderate};
     }
   }
 
@@ -193,7 +195,7 @@ export const PlayerScrubber = styled(Scrubber)`
     pointer-events: none;
     box-sizing: content-box;
     border-radius: var(--size);
-    border: solid ${p => p.theme.tokens.border.onVibrant.light};
+    border-style: solid;
     border-width: var(--borderWidth);
     position: absolute;
     top: 0;


### PR DESCRIPTION
The mouse-position marker on the replay scrubber shared a single `:after` rule with the current-time playhead. That rule hardcoded a white `border.onVibrant.light` border. This splits the border color out of the shared rule so each circle gets the appropriate one:

* Current-time playhead: keeps the white `onVibrant` ring on its purple fill
* Mouse-hover marker: gets a neutral gray ring (`border.neutral.moderate`)

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="542" height="134" alt="Screenshot 2026-06-25 at 12 14 29 PM" src="https://github.com/user-attachments/assets/25370b54-1a82-4d2a-968a-597c271fd826" />
</td>
<td>
<img width="542" height="134" alt="Screenshot 2026-06-25 at 12 14 46 PM" src="https://github.com/user-attachments/assets/d957ca40-5b80-4730-b3ad-0b6a62ccda8f" />
</td>
</tbody>
</table>

The screenshot from REPLAY-874 is actually worse than before/prod. But adding this border in is generally more clear either way.

Closes REPLAY-874.
