### PR TITLE
fix(explore): prevent grouping by the same attribute twice

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
@@ -45,6 +45,7 @@ interface ToolbarGroupByDropdownProps {
   onColumnDelete: () => void;
   options: Array<SelectOption<string>>;
   fieldDefinitionType?: GetFieldDefinitionType;
+  groupBys?: readonly string[];
   loading?: boolean;
   onClose?: () => void;
   onSearch?: (search: string) => void;
@@ -60,11 +61,31 @@ export function ToolbarGroupByDropdown({
   loading,
   onClose,
   fieldDefinitionType = 'span',
+  groupBys = [],
 }: ToolbarGroupByDropdownProps) {
   const {attributes, listeners, setNodeRef, transform} = useSortable({
     id: column.id,
     transition: null,
   });
+
+  const optionsWithDisabled = useMemo(() => {
+    const usedByOtherColumns = new Set(
+      groupBys.filter(groupBy => groupBy && groupBy !== column.column)
+    );
+    if (usedByOtherColumns.size === 0) {
+      return options;
+    }
+    return options.map(option =>
+      usedByOtherColumns.has(option.value)
+        ? {
+            ...option,
+            disabled: true,
+            tooltip: t('This attribute is already being grouped by.'),
+            tooltipOptions: {position: 'left' as const},
+          }
+        : option
+    );
+  }, [options, groupBys, column.column]);
 
   function handleColumnChange(option: SelectOption<SelectKey>) {
     if (typeof option.value === 'string') {
@@ -87,7 +108,7 @@ export function ToolbarGroupByDropdown({
       {canDelete ? <DragReorderButton iconSize="sm" {...listeners} /> : null}
       <StyledCompactSelect
         data-test-id="editor-column"
-        options={options}
+        options={optionsWithDisabled}
         value={column.column ?? ''}
         onChange={handleColumnChange}
         search={{

--- a/static/app/views/explore/logs/logsToolbar.spec.tsx
+++ b/static/app/views/explore/logs/logsToolbar.spec.tsx
@@ -290,6 +290,31 @@ describe('LogsToolbar', () => {
       );
     });
 
+    it('disables an attribute already selected in another group by', async () => {
+      render(<LogsToolbar />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
+
+      const firstColumn = screen.getAllByTestId('editor-column')[0]!;
+      await userEvent.click(within(firstColumn).getByRole('button', {name: '—'}));
+      await userEvent.click(screen.getByRole('option', {name: 'message'}));
+
+      await userEvent.click(screen.getByRole('button', {name: 'Add Group'}));
+
+      const secondColumn = screen.getAllByTestId('editor-column')[1]!;
+      await userEvent.click(within(secondColumn).getByRole('button', {name: '—'}));
+
+      expect(await screen.findByRole('option', {name: 'message'})).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+      expect(screen.getByRole('option', {name: 'severity'})).not.toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+    });
+
     it('can clear the last selected group by', async () => {
       let mode: Mode | undefined;
 

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -346,6 +346,7 @@ function ToolbarGroupBy() {
               onColumnChange={c => updateColumnAtIndex(i, c)}
               onColumnDelete={() => deleteColumnAtIndex(i)}
               options={options}
+              groupBys={groupBys}
               onSearch={onSearch}
               onClose={onClose}
               loading={numberTagsLoading || stringTagsLoading || booleanTagsLoading}

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -112,6 +112,7 @@ function ToolbarGroupByItem({
     <ToolbarGroupByDropdown
       column={column}
       options={options}
+      groupBys={groupBys}
       loading={loading}
       onClose={() => setSearch(undefined)}
       onSearch={setSearch}


### PR DESCRIPTION
The group by dropdowns in Explore offered every attribute regardless of what was already selected in other rows, so a user could add multiple group bys of the same attribute (e.g. group by `code.file.path` twice), which produces redundant, useless groupings.

Example from https://sentry-bx7s670ko.sentry.dev/explore/logs?aggregateField=%7B%22groupBy%22%3A%22code.file.path%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28message%29%22%5D%7D&logsFields=timestamp&logsFields=message&logsFields=code.file.path&logsSortBys=-timestamp&mode=aggregate:

<img width="848" height="310" alt="Screenshot 2026-06-25 at 12 00 27 PM" src="https://github.com/user-attachments/assets/43106cca-8d33-4ecf-abef-c7f7d1cf1724" />

Closes LOGS-896.
