### PR TITLE
feat(issues): add recommended-sort default and experimental flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -308,8 +308,12 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:issue-summary-experimental", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable new issue stream progress views
     manager.add("organizations:issue-stream-progress-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable the experimental "recommended" sort option in the issue stream
+    # Show the "recommended" sort as an option in the issue stream sort dropdown
     manager.add("organizations:issue-stream-recommended-sort", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Make the "recommended" sort the default sort in the issue stream
+    manager.add("organizations:issue-stream-recommended-sort-default", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Show the experimental "recommended" sort (recommended_v2) as an option in the issue stream sort dropdown
+    manager.add("organizations:issue-stream-recommended-sort-experimental", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the "progress" sort option (by issue fix-cycle progress) in the issue stream
     manager.add("organizations:issue-stream-progress-sort", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 


### PR DESCRIPTION
Splits the single `issue-stream-recommended-sort` flag's two responsibilities apart and adds a flag for the experimental sort, by registering two new FlagPole flags:

- `organizations:issue-stream-recommended-sort-default` — gates whether Recommended is the *default* issue-stream sort. The existing `issue-stream-recommended-sort` flag now only gates whether Recommended shows as a dropdown *option*.
- `organizations:issue-stream-recommended-sort-experimental` — gates whether the experimental `recommended_v2` sort shows as a dropdown option. 

