### PR TITLE
feat(snuba): Register over-usage shadow referrer

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -695,6 +695,7 @@ class Referrer(StrEnum):
 
     METRIC_EXTRACTION_CARDINALITY_CHECK = "metric_extraction.cardinality_check"
     BILLING_USAGE_SERVICE_CLICKHOUSE = "billing.usage_service.clickhouse"
+    QUOTAS_OVER_USAGE_SHADOW = "getsentry.quotas.over_usage_shadow"
     OUTCOMES_TIMESERIES = "outcomes.timeseries"
     OUTCOMES_TOTALS = "outcomes.totals"
     PREVIEW_GET_EVENTS = "preview.get_events"


### PR DESCRIPTION
Registers the `getsentry.quotas.over_usage_shadow` referrer for the cross-org outcomes discovery query used by the billing-platform over-usage shadow scan. Referrer-only addition; the matching snuba-side `cross_org_referrer_limits` registration ships with the dedicated org-level outcomes storage in a separate snuba PR.

Made with [Cursor](https://cursor.com)