### PR TITLE
ci(snapshots): re-run when PR base branch changes

### DIFF
--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -16,6 +17,9 @@ env:
 jobs:
   snapshots:
     name: snapshot tests
+    # Skip 'edited' events that aren't a base branch change (e.g. title/body edits).
+    # When the base branch changes, the diff target changes so we need a fresh run.
+    if: github.event.action != 'edited' || github.event.changes.base != ''
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## What

The `frontend-snapshots` workflow only triggered on `pull_request` events with types `opened`, `synchronize`, and `reopened` (GitHub's defaults). It didn't handle the `edited` event type, which fires when a PR's base branch is changed via the UI.

When the base branch changes, the diffing runs against a different base — so snapshots need to re-run to produce a meaningful comparison against the new target.

## Changes

- Add `edited` to `pull_request` trigger types so GitHub fires the workflow when the base branch is changed.
- Add a job-level `if` condition to skip `edited` events that are NOT a base branch change (e.g. title or body edits), to avoid spurious extra runs. This uses `github.event.changes.base`, which is only set in the payload when the base ref was changed.

## Verification

Logic summary:
- `push` to master → `github.event.action` is `''`, condition is true ✓
- PR `opened`/`synchronize`/`reopened` → action `!= 'edited'`, condition is true ✓
- PR `edited` + base branch changed → `github.event.changes.base` is an object (`!= ''`), condition is true ✓
- PR `edited` + title/body changed → `github.event.changes.base` is undefined (evaluates to `''` in GHA expressions), condition is false → job skipped ✓

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0APJV7CSHM%3A1782385666.721949%22)