### PR TITLE
feat(admin): add Published Integrations admin page

### DIFF
--- a/static/gsAdmin/routes.tsx
+++ b/static/gsAdmin/routes.tsx
@@ -37,6 +37,7 @@ import {RelocationDetails} from 'admin/views/relocationDetails';
 import {Relocations} from 'admin/views/relocations';
 import {SeerAdminPage} from 'admin/views/seerAdminPage';
 import {SentryAppDetails} from 'admin/views/sentryAppDetails';
+import {PublishedIntegrations} from 'admin/views/publishedIntegrations';
 import {SentryApps} from 'admin/views/sentryApps';
 import {SentryEmployees} from 'admin/views/sentryEmployees';
 import {UserDetails} from 'admin/views/userDetails';
@@ -191,6 +192,15 @@ function buildRoutes() {
           {
             path: ':codeId/',
             component: PromoCodeDetails,
+          },
+        ],
+      },
+      {
+        path: 'published-integrations/',
+        children: [
+          {
+            index: true,
+            component: PublishedIntegrations,
           },
         ],
       },

--- a/static/gsAdmin/views/layout.tsx
+++ b/static/gsAdmin/views/layout.tsx
@@ -140,6 +140,7 @@ export function Layout() {
                 </NavLink>
                 <NavLink to="/_admin/customers/">Customers</NavLink>
                 <NavLink to="/_admin/users/">Users</NavLink>
+                <NavLink to="/_admin/published-integrations/">Published Integrations</NavLink>
                 <NavLink to="/_admin/sentry-apps/">Sentry Apps</NavLink>
                 <NavLink to="/_admin/doc-integrations/">Doc Integrations</NavLink>
                 <NavLink to="/_admin/broadcasts/">Broadcasts</NavLink>

--- a/static/gsAdmin/views/publishedIntegrations.tsx
+++ b/static/gsAdmin/views/publishedIntegrations.tsx
@@ -1,0 +1,107 @@
+import {SentryAppAvatar} from '@sentry/scraps/avatar';
+import {Tag} from '@sentry/scraps/badge';
+import {Flex} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+
+import {PageHeader} from 'admin/components/pageHeader';
+import {ResultGrid} from 'admin/components/resultGrid';
+
+type SentryAppRow = {
+  id: number;
+  installs: number;
+  name: string;
+  slug: string;
+  status: string;
+  uninstalls: number;
+  uuid: string;
+  avatars?: any[];
+  owner?: {id: number; slug: string} | null;
+};
+
+const STATUS_VARIANT: Record<string, 'danger' | 'warning' | 'success'> = {
+  unpublished: 'danger',
+  internal: 'warning',
+  publish_request_inprogress: 'warning',
+};
+
+function getRow(row: SentryAppRow) {
+  return [
+    <td key="name">
+      <Flex align="center" gap="md">
+        <SentryAppAvatar size={16} sentryApp={row} />
+        <strong>
+          <Link to={`/_admin/sentry-apps/${row.slug}/`}>{row.name}</Link>
+        </strong>
+      </Flex>
+    </td>,
+
+    <td key="owner" style={{textAlign: 'center'}}>
+      {row.owner ? (
+        <Link to={`/_admin/customers/${row.owner.slug}/`}>{row.owner.slug}</Link>
+      ) : (
+        '—'
+      )}
+    </td>,
+
+    <td key="status" style={{textAlign: 'center'}}>
+      <Tag variant={STATUS_VARIANT[row.status] ?? 'success'}>{row.status}</Tag>
+    </td>,
+
+    <td key="installs" style={{textAlign: 'right'}}>
+      {row.installs.toLocaleString()}
+    </td>,
+
+    <td key="uninstalls" style={{textAlign: 'right'}}>
+      {row.uninstalls.toLocaleString()}
+    </td>,
+  ];
+}
+
+export function PublishedIntegrations() {
+  return (
+    <div>
+      <PageHeader title="Published Integrations" />
+
+      <ResultGrid
+        inPanel
+        path="/_admin/published-integrations/"
+        endpoint="/sentry-apps-stats/"
+        method="GET"
+        defaultParams={{status: 'published', per_page: 50}}
+        columns={[
+          <th key="name">Name</th>,
+          <th key="owner" style={{width: 180, textAlign: 'center'}}>
+            Owner
+          </th>,
+          <th key="status" style={{width: 160, textAlign: 'center'}}>
+            Status
+          </th>,
+          <th key="installs" style={{width: 120, textAlign: 'right'}}>
+            Installs
+          </th>,
+          <th key="uninstalls" style={{width: 120, textAlign: 'right'}}>
+            Uninstalls
+          </th>,
+        ]}
+        columnsForRow={getRow}
+        hasSearch={false}
+        sortOptions={[
+          ['installs', 'Total Installs'],
+          ['uninstalls', 'Total Uninstalls'],
+        ]}
+        defaultSort="installs"
+        filters={{
+          period: {
+            name: 'Period',
+            options: [
+              ['all', 'All Time'],
+              ['7d', 'Last 7 Days'],
+              ['30d', 'Last 30 Days'],
+              ['90d', 'Last 90 Days'],
+            ],
+          },
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a new `/_admin/published-integrations/` page to the gsAdmin UI that shows a sortable, filterable table of published Sentry App integrations.

**Depends on** #118482 (backend endpoint changes).

## What it looks like

| Column | Notes |
|--------|-------|
| Name | App name + avatar, links to existing `/_admin/sentry-apps/{slug}/` detail view |
| Owner | Org slug, links to `/_admin/customers/{slug}/` |
| Status | Colored badge (published = success, others = warning/danger) |
| Installs | Count scoped to the selected period |
| Uninstalls | Count scoped to the selected period |

**Sorting** — dropdown to sort by Total Installs or Total Uninstalls (descending).

**Period filter** — All Time / Last 7 Days / Last 30 Days / Last 90 Days. Both install and uninstall counts update together.

## Files changed

- `static/gsAdmin/views/publishedIntegrations.tsx` — new page component
- `static/gsAdmin/routes.tsx` — register route at `published-integrations/`
- `static/gsAdmin/views/layout.tsx` — add nav link between Sentry Apps and Doc Integrations

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack:C0B7W7W517S:1782409238.572199%22)