### PR TITLE
ref(trace-waterfall): Squeeze out all of the pixels

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -278,7 +278,10 @@ function TraceInnerLayout(props: FlexProps) {
       background="primary"
       direction="column"
       gap="md"
-      padding="xl"
+      paddingLeft="xl"
+      paddingRight="xl"
+      paddingTop="lg"
+      paddingBottom="lg"
       flex="1"
       overflowY="auto"
     />

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -1,4 +1,4 @@
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
@@ -92,32 +92,29 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
 
   return (
     <TraceHeaderComponents.HeaderLayout>
-      <TraceHeaderComponents.HeaderContent>
-        <TraceHeaderComponents.HeaderRow>
-          <TopBar.Slot name="title">
-            <Breadcrumbs
-              crumbs={getTraceViewBreadcrumbs({
-                organization: props.organization,
-                location,
-                moduleURLBuilder,
-                traceSlug: props.traceSlug,
-                project,
-                view,
-              })}
-            />
-          </TopBar.Slot>
-          <Grid flow="column" align="center" gap="md">
-            <TopBar.Slot name="feedback">
-              <FeedbackButton
-                feedbackOptions={traceViewFeedbackOptions}
-                aria-label={t('Give Feedback')}
-                tooltipProps={{title: t('Give Feedback')}}
-              >
-                {null}
-              </FeedbackButton>
-            </TopBar.Slot>
-          </Grid>
-        </TraceHeaderComponents.HeaderRow>
+      <TraceHeaderComponents.HeaderContent gap="xs">
+        <TopBar.Slot name="title">
+          <Breadcrumbs
+            crumbs={getTraceViewBreadcrumbs({
+              organization: props.organization,
+              location,
+              moduleURLBuilder,
+              traceSlug: props.traceSlug,
+              project,
+              view,
+            })}
+          />
+        </TopBar.Slot>
+        <TopBar.Slot name="feedback">
+          <FeedbackButton
+            feedbackOptions={traceViewFeedbackOptions}
+            aria-label={t('Give Feedback')}
+            tooltipProps={{title: t('Give Feedback')}}
+          >
+            {null}
+          </FeedbackButton>
+        </TopBar.Slot>
+
         <TraceHeaderComponents.HeaderRow>
           <Title representativeEvent={rep} rootEventResults={props.rootEventResults} />
           <Meta
@@ -131,7 +128,6 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
             metricsEnabled={metricsEnabled}
           />
         </TraceHeaderComponents.HeaderRow>
-        <TraceHeaderComponents.StyledBreak />
         <TraceHeaderComponents.HeaderRow>
           <Highlights
             rootEventResults={props.rootEventResults}

--- a/static/app/views/performance/newTraceDetails/traceHeader/placeholder.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/placeholder.tsx
@@ -72,7 +72,6 @@ export function PlaceHolder({
             <TraceHeaderComponents.StyledPlaceholder _width={300} _height={24} />
           </Stack>
         </TraceHeaderComponents.HeaderRow>
-        <TraceHeaderComponents.StyledBreak />
         <TraceHeaderComponents.HeaderRow>
           <Flex align="center" gap="md">
             <TraceHeaderComponents.StyledPlaceholder _width={150} _height={20} />

--- a/static/app/views/performance/newTraceDetails/traceHeader/projects.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/projects.tsx
@@ -58,7 +58,7 @@ export function Projects({projects, logs, tree}: Props) {
         disableLink
         onProjectClick={onProjectClick}
         projectSlugs={projectSlugs}
-        visibleAvatarSize={24}
+        visibleAvatarSize={20}
         maxVisibleProjects={3}
       />
     </ProjectsRendererWrapper>

--- a/static/app/views/performance/newTraceDetails/traceHeader/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/styles.tsx
@@ -16,7 +16,6 @@ const HeaderLayout = styled((props: ContainerProps) => {
       padding="lg xl"
       borderBottom="primary"
       flexShrink={0}
-      minHeight="150px"
       {...props}
     />
   );
@@ -38,11 +37,6 @@ function HeaderContent(props: StackProps) {
   return <Stack {...props} />;
 }
 
-const StyledBreak = styled('hr')`
-  margin: ${p => p.theme.space.md} 0;
-  border-color: ${p => p.theme.tokens.border.primary};
-`;
-
 const StyledPlaceholder = styled(Placeholder)<{_height: number; _width: number}>`
   border-radius: ${p => p.theme.radius.md};
   height: ${p => p._height}px;
@@ -53,7 +47,6 @@ const TraceHeaderComponents = {
   HeaderLayout,
   HeaderRow,
   HeaderContent,
-  StyledBreak,
   StyledPlaceholder,
 };
 


### PR DESCRIPTION
This PR makes some styling tweaks to the trace waterfall page to squeeze out as many pixels as we can to get some extra vertical height.

**Before**
<img width="1249" height="869" alt="Screenshot 2026-06-25 at 15 24 04" src="https://github.com/user-attachments/assets/a41f592f-15db-49b5-9d5e-6b72810386cd" />

**After**
<img width="1250" height="869" alt="Screenshot 2026-06-25 at 15 24 09" src="https://github.com/user-attachments/assets/ba1b0e4d-227d-43c4-9642-c41242aae9b7" />