### PR TITLE
feat(outcomes): begin porting track_outcomes to TaskProducer

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3742,6 +3742,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Rolls out the new TaskProducer to track_outcome in tasks
+register(
+    "tasks.producer.track_outcome.rollout",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # If False, TaskWorkers will wait for a task's producer futures to complete
 # before marking a task as complete
 register(

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -6,13 +6,18 @@ import time
 from collections import namedtuple
 from datetime import datetime, timedelta
 from enum import IntEnum
+from functools import partial
 from threading import Lock
 
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from arroyo.types import Topic as ArroyoTopic
+from django.conf import settings
+from taskbroker_client.worker.producer import TaskProducer
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.constants import DataCategory
+from sentry.options.rollout import in_random_rollout
+from sentry.taskworker.producer import get_task_producer
 from sentry.utils import json, kafka_config, metrics
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.dates import to_datetime
@@ -159,22 +164,30 @@ class Outcome(IntEnum):
         return self in (Outcome.ACCEPTED, Outcome.RATE_LIMITED)
 
 
-def _get_outcomes_producer() -> KafkaProducer:
+def _get_outcomes_producer(name: str = "sentry.utils.outcomes") -> KafkaProducer:
     return get_arroyo_producer(
-        "sentry.utils.outcomes",
+        name,
         Topic.OUTCOMES,
     )
 
 
-def _get_billing_producer() -> KafkaProducer:
+def _get_billing_producer(name: str = "sentry.utils.outcomes.billing") -> KafkaProducer:
     return get_arroyo_producer(
-        "sentry.utils.outcomes.billing",
+        name,
         Topic.OUTCOMES_BILLING,
     )
 
 
 outcomes_producer = SingletonProducer(_get_outcomes_producer)
+outcomes_tp_name = "sentry.utils.outcomes.taskproducer"
+outcomes_task_producer = get_task_producer(
+    outcomes_tp_name, partial(_get_outcomes_producer, outcomes_tp_name)
+)
 billing_producer = SingletonProducer(_get_billing_producer)
+billing_tp_name = "sentry.utils.outcomes.billing.taskproducer"
+billing_task_producer = get_task_producer(
+    billing_tp_name, partial(_get_billing_producer, billing_tp_name)
+)
 
 LATE_OUTCOME_THRESHOLD = timedelta(days=1)
 
@@ -219,9 +232,19 @@ def track_outcome(
     # Create a second producer instance only if the cluster differs. Otherwise,
     # reuse the same producer and just send to the other topic.
     if use_billing and billing_config["cluster"] != outcomes_config["cluster"]:
-        producer = billing_producer
+        if settings.TASKWORKER_USE_TASK_PRODUCER and in_random_rollout(
+            "tasks.producer.track_outcome.rollout"
+        ):
+            producer: SingletonProducer | TaskProducer = billing_task_producer
+        else:
+            producer = billing_producer
     else:
-        producer = outcomes_producer
+        if settings.TASKWORKER_USE_TASK_PRODUCER and in_random_rollout(
+            "tasks.producer.track_outcome.rollout"
+        ):
+            producer = outcomes_task_producer
+        else:
+            producer = outcomes_producer
 
     now = to_datetime(time.time())
     timestamp = timestamp or now


### PR DESCRIPTION
Followup to https://github.com/getsentry/sentry/pull/117741

This PR updates `track_outcome` to use TaskProducer as its producer backend from inside tasks.

The reason for this change is that SingletonProducer doesn't guarantee at-least-once delivery when used inside a task. TaskProducer keeps track of any producer futures generated as a part of task execution, and only marks a task as successful if all producer futures succeed.

To ensure a safe rollout, workers will instantiate an instance of the old and new producers, and cut over to the new producers based on a rollout option. This means that task futures won't be properly tracked while the rollout option is <1.0, but since our base state is to just ignore producer futures that's acceptable.