### PR TITLE
ref(spans): Restrict span-first detector comparison to real results

### DIFF
--- a/src/sentry/issue_detection/detectors/span_first/run_detectors.py
+++ b/src/sentry/issue_detection/detectors/span_first/run_detectors.py
@@ -15,6 +15,7 @@ from sentry.issue_detection.performance_detection import get_detection_settings
 from sentry.issue_detection.performance_problem import PerformanceProblem
 from sentry.issue_detection.types import StandaloneSpan
 from sentry.models.project import Project
+from sentry.utils import metrics
 from sentry.utils.rollout import SourceOfTruth
 
 logger = logging.getLogger(__name__)
@@ -136,10 +137,23 @@ def compare_span_first_problems_to_control_data(
         control_fingerprints = {problem.fingerprint for problem in control_problems}
         span_first_fingerprints = {problem.fingerprint for problem in span_first_problems}
 
+        # The vast majority of the time, a given detector isn't going to detect anything, and while
+        # it's good to know that the new and legacy detectors agree on not having found anything,
+        # those trivial cases can end up overwhelming the more interesting cases. Splitting them off
+        # into their own metric lets us continue to track them (at the standard 10% sample rate)
+        # while at the same time reducing the hits to the main comparison metric sufficiently that
+        # we can afford to ramp its sample rate up to 100%.
+        if not control_fingerprints and not span_first_fingerprints:
+            metrics.incr(
+                "span_first_detectors.empty_result_comparison_skipped", tags={"callsite": grouptype}
+            )
+            continue  # Skip running the comparison for this grouptype
+
         SpanFirstDetectorsRolloutController.compare(
             callsite=grouptype,
             control_data=control_fingerprints,
             experimental_data=span_first_fingerprints,
             is_experimental_data_nullish=not bool(span_first_fingerprints),
             source_of_truth=get_source_of_truth(grouptype),
+            metric_sample_rate=1.0,
         )

--- a/tests/sentry/issue_detection/span_first/test_run_detectors.py
+++ b/tests/sentry/issue_detection/span_first/test_run_detectors.py
@@ -158,6 +158,7 @@ class CompareSpanFirstProblemsToControlDataTest(TestCase):
                 experimental_data={"slow-db-fingerprint", "span-first-slow-db-fingerprint"},
                 is_experimental_data_nullish=False,
                 source_of_truth="neither",
+                metric_sample_rate=1.0,
             )
             mock_compare.assert_any_call(
                 callsite=N_PLUS_ONE_SLUG,
@@ -165,4 +166,31 @@ class CompareSpanFirstProblemsToControlDataTest(TestCase):
                 experimental_data={"n-plus-one-fingerprint", "span-first-n-plus-one-fingerprint"},
                 is_experimental_data_nullish=False,
                 source_of_truth="neither",
+                metric_sample_rate=1.0,
+            )
+
+    def test_skips_comparison_for_null_results(self) -> None:
+        span_first_problems_by_grouptype = {
+            SLOW_DB_SLUG: [make_problem("slow-db-fingerprint", SLOW_DB_GROUPTYPE)],
+            N_PLUS_ONE_SLUG: [],
+        }
+        control_problems = [make_problem("slow-db-fingerprint", SLOW_DB_GROUPTYPE)]
+
+        with patch.object(SpanFirstDetectorsRolloutController, "compare") as mock_compare:
+            compare_span_first_problems_to_control_data(
+                span_first_problems_by_grouptype,
+                control_problems,
+                get_source_of_truth=lambda _: "neither",
+            )
+
+            # Comparison was run only for the slow DB detector results, not for the n+1 results,
+            # since they were null
+            assert mock_compare.call_count == 1
+            mock_compare.assert_any_call(
+                callsite=SLOW_DB_SLUG,
+                control_data={"slow-db-fingerprint"},
+                experimental_data={"slow-db-fingerprint"},
+                is_experimental_data_nullish=False,
+                source_of_truth="neither",
+                metric_sample_rate=1.0,
             )


### PR DESCRIPTION
In the roughly 24 hours since we enabled running the span-first vs. legacy slow DB detection results comparison, we've seen ~108K cases in which neither detector found anything, and 54 cases in which both detectors have detected the same problems. While it's great that so far it seems like the new detector works the same way the old detector does, it'd be nice to collect the comparison results for all of the comparisons, rather than just the standard 10% at which our metrics send data. That said, the cases where neither detector finds anything (clearly the vast majority of cases) aren't that interesting, so collecting 100% of those cases doesn't gain us much.

This PR therefore splits the trivial cases off into their own metric, `span_first_detectors.empty_result_comparison_skipped`, (running at the normal 10% rate) and skips running the comparison for them, since if both new and old detector results are null, we already know they match. Cutting out so many cases then lets us ramp the sample rate of the cases we do care about up to 100%.