### PR TITLE
fix(ourlogs): load out-of-range pinned logs via a narrow time window

### DIFF
--- a/static/app/views/explore/logs/pinning/PinnedLogs.spec.tsx
+++ b/static/app/views/explore/logs/pinning/PinnedLogs.spec.tsx
@@ -163,6 +163,97 @@ describe('PinnedLogs', () => {
     expect(screen.queryByTestId('pinned-row-missing-log')).not.toBeInTheDocument();
   });
 
+  it('renders an unavailable row when a pinned log cannot be resolved and the scan was partial', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: [], meta: {fields: {id: 'string'}, units: {}, dataScanned: 'partial'}},
+    });
+
+    renderPinnedLogs({
+      initialRouterConfig: {
+        location: {pathname: '/', query: {logsPinned: 'missing-log'}},
+      },
+    });
+
+    expect(
+      await screen.findByText('Pinned log unavailable in the selected time range')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Collapse 1 pinned'})).toBeInTheDocument();
+  });
+
+  it('keeps the pin in the url when a partial scan cannot resolve it', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: [], meta: {fields: {id: 'string'}, units: {}, dataScanned: 'partial'}},
+    });
+
+    const {router} = renderPinnedLogs({
+      initialRouterConfig: {
+        location: {pathname: '/', query: {logsPinned: 'missing-log'}},
+      },
+    });
+
+    expect(
+      await screen.findByText('Pinned log unavailable in the selected time range')
+    ).toBeInTheDocument();
+    expect(router.location.query.logsPinned).toBe('missing-log');
+  });
+
+  it('renders a count matching the rendered rows when some pins are unavailable', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: [], meta: {fields: {id: 'string'}, units: {}, dataScanned: 'partial'}},
+    });
+
+    renderPinnedLogs({
+      initialRouterConfig: {
+        location: {pathname: '/', query: {logsPinned: 'log-1,missing-log'}},
+      },
+    });
+
+    expect(
+      await screen.findByText('Pinned log unavailable in the selected time range')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('pinned-row-log-1')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Collapse 2 pinned'})).toBeInTheDocument();
+  });
+
+  it('renders a retry control and recovers when the pinned logs query errors', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      statusCode: 500,
+      body: {detail: 'Internal Error'},
+    });
+
+    renderPinnedLogs({
+      initialRouterConfig: {
+        location: {pathname: '/', query: {logsPinned: 'missing-log'}},
+      },
+    });
+
+    expect(await screen.findByText('Could not load pinned log')).toBeInTheDocument();
+
+    const fetchedRow = LogFixture({
+      [OurLogKnownFieldKey.ID]: 'missing-log',
+      [OurLogKnownFieldKey.PROJECT_ID]: '1',
+      [OurLogKnownFieldKey.ORGANIZATION_ID]: 1,
+      [OurLogKnownFieldKey.MESSAGE]: 'recovered pinned log',
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: [fetchedRow], meta: {fields: {id: 'string'}, units: {}}},
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Retry'}));
+
+    expect(await screen.findByTestId('pinned-row-missing-log')).toBeInTheDocument();
+  });
+
   it('shows the count of pinned rows in the collapse toggle label', () => {
     renderPinnedLogs({
       initialRouterConfig: {

--- a/static/app/views/explore/logs/pinning/PinnedLogs.tsx
+++ b/static/app/views/explore/logs/pinning/PinnedLogs.tsx
@@ -3,10 +3,11 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {Placeholder} from 'sentry/components/placeholder';
 import {GridRow} from 'sentry/components/tables/gridEditable/styles';
-import {IconChevron, IconClose} from 'sentry/icons';
+import {IconChevron, IconClose, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {TableBody} from 'sentry/views/explore/components/table';
 import type {LogsPinning} from 'sentry/views/explore/logs/pinning/useLogsPinning';
@@ -23,8 +24,12 @@ interface Props {
 }
 
 export function PinnedLogs({allRows, logsPinning, pinnedLogsQuery, renderRow}: Props) {
-  const {fetchedRows: fetchedPinnedRows, isPending: isFetchingPinnedRows} =
-    pinnedLogsQuery;
+  const {
+    fetchedRows: fetchedPinnedRows,
+    isPending: isFetchingPinnedRows,
+    isError: isErrorPinnedRows,
+    refetch: refetchPinnedRows,
+  } = pinnedLogsQuery;
   const [expanded, setExpanded] = useState(true);
   const pinnedRows = logsPinning.getPinnedRowIds();
 
@@ -63,7 +68,25 @@ export function PinnedLogs({allRows, logsPinning, pinnedLogsQuery, renderRow}: P
                 </GridRow>
               );
             }
-            return null;
+            return (
+              <GridRow key={rowId}>
+                <UnavailableGridBodyCell>
+                  <Flex align="center" gap="sm">
+                    <IconWarning size="xs" />
+                    <Text size="sm" variant="muted">
+                      {isErrorPinnedRows
+                        ? t('Could not load pinned log')
+                        : t('Pinned log unavailable in the selected time range')}
+                    </Text>
+                    {isErrorPinnedRows && (
+                      <Button size="xs" onClick={() => refetchPinnedRows()}>
+                        {t('Retry')}
+                      </Button>
+                    )}
+                  </Flex>
+                </UnavailableGridBodyCell>
+              </GridRow>
+            );
           }
 
           return <Fragment key={rowId}>{renderRow(dataRow)}</Fragment>;
@@ -112,5 +135,11 @@ const PinnedGridBodyCell = styled('td')`
 `;
 
 const LoadingGridBodyCell = styled(PinnedGridBodyCell)`
+  height: ${LOGS_GRID_BODY_ROW_HEIGHT}px;
+`;
+
+const UnavailableGridBodyCell = styled(PinnedGridBodyCell)`
+  display: flex;
+  align-items: center;
   height: ${LOGS_GRID_BODY_ROW_HEIGHT}px;
 `;

--- a/static/app/views/explore/logs/pinning/logItemId.spec.tsx
+++ b/static/app/views/explore/logs/pinning/logItemId.spec.tsx
@@ -1,0 +1,43 @@
+import {resetMockDate, setMockDate} from 'sentry-test/utils';
+
+import {logItemIdToTimestamp} from 'sentry/views/explore/logs/pinning/logItemId';
+
+describe('logItemIdToTimestamp', () => {
+  beforeEach(() => {
+    setMockDate(new Date('2026-06-19T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    resetMockDate();
+  });
+
+  it('decodes the epoch milliseconds from a v7 log id', () => {
+    const result = logItemIdToTimestamp('019ed8e2be157592b89c4bd51c7bd1e7');
+
+    expect(result).toBe(Date.parse('2026-06-18T03:59:58.997Z'));
+  });
+
+  it('returns null when the id is shorter than the timestamp prefix', () => {
+    const result = logItemIdToTimestamp('019ed8');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the prefix is not hexadecimal', () => {
+    const result = logItemIdToTimestamp('zzzzzzzzzzzz92b89c4bd51c7bd1e7');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the decoded time predates the plausible range', () => {
+    const result = logItemIdToTimestamp('000000000000b89c4bd51c7bd1e7abcd');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the decoded time is far in the future', () => {
+    const result = logItemIdToTimestamp('ffffffffffffb89c4bd51c7bd1e7abcd');
+
+    expect(result).toBeNull();
+  });
+});

--- a/static/app/views/explore/logs/pinning/logItemId.tsx
+++ b/static/app/views/explore/logs/pinning/logItemId.tsx
@@ -1,0 +1,30 @@
+const V7_TIMESTAMP_HEX_LENGTH = 12;
+
+const MIN_PLAUSIBLE_MS = Date.UTC(2020, 0, 1);
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Sentry log item ids are UUIDv7, whose first 48 bits (12 hex chars) are the
+ * creation time in epoch milliseconds. Decoding it lets us query a tight window
+ * around the log instead of scanning the org's full retention.
+ *
+ * Returns null when the id isn't a decodable v7 timestamp so callers can fall
+ * back to a wide query.
+ */
+export function logItemIdToTimestamp(id: string): number | null {
+  if (id.length < V7_TIMESTAMP_HEX_LENGTH) {
+    return null;
+  }
+
+  const hex = id.slice(0, V7_TIMESTAMP_HEX_LENGTH);
+  if (!/^[0-9a-f]+$/i.test(hex)) {
+    return null;
+  }
+
+  const ms = parseInt(hex, 16);
+  if (!Number.isFinite(ms) || ms < MIN_PLAUSIBLE_MS || ms > Date.now() + ONE_DAY_MS) {
+    return null;
+  }
+
+  return ms;
+}

--- a/static/app/views/explore/logs/pinning/usePinnedLogsQuery.spec.tsx
+++ b/static/app/views/explore/logs/pinning/usePinnedLogsQuery.spec.tsx
@@ -3,6 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
@@ -53,6 +54,10 @@ describe('usePinnedLogsQuery', () => {
         utc: null,
       },
     });
+  });
+
+  afterEach(() => {
+    resetMockDate();
   });
 
   it('returns empty fetchedRows when all pinned ids are in allRows', () => {
@@ -204,6 +209,81 @@ describe('usePinnedLogsQuery', () => {
     expect(logsPinning.removePinnedRows).not.toHaveBeenCalled();
   });
 
+  it('queries the wide window with a narrow range derived from the pin id when the id is a valid v7 timestamp', async () => {
+    setMockDate(new Date('2026-06-18T05:00:00Z'));
+    const v7Id = '019ed8e2be157592b89c4bd51c7bd1e7';
+    const outOfRangeLog = LogFixture({
+      [OurLogKnownFieldKey.ID]: v7Id,
+      [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
+      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: [], meta: {fields: {id: 'string'}, units: {}}},
+      match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
+    });
+    const wideRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: [outOfRangeLog], meta: {fields: {id: 'string'}, units: {}}},
+      match: [MockApiClient.matchQuery({start: '2026-06-18T03:54:58'})],
+    });
+
+    const logsPinning = makeLogsPinning([v7Id]);
+
+    const {result} = renderHookWithProviders(
+      () => usePinnedLogsQuery({allRows: [], logsPinning}),
+      {organization, additionalWrapper: AdditionalWrapper}
+    );
+
+    await waitFor(() => {
+      expect(result.current.fetchedRows).toHaveLength(1);
+    });
+
+    expect(wideRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          start: '2026-06-18T03:54:58',
+          end: '2026-06-18T04:04:58',
+        }),
+      })
+    );
+  });
+
+  it('falls back to the 9999d wide window when a missing pin id is not a decodable timestamp', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: [], meta: {fields: {id: 'string'}, units: {}}},
+      match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
+    });
+    const wideRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: [], meta: {fields: {id: 'string'}, units: {}, dataScanned: 'partial'}},
+      match: [MockApiClient.matchQuery({statsPeriod: '9999d'})],
+    });
+
+    const logsPinning = makeLogsPinning(['not-a-v7-id']);
+
+    renderHookWithProviders(() => usePinnedLogsQuery({allRows: [], logsPinning}), {
+      organization,
+      additionalWrapper: AdditionalWrapper,
+    });
+
+    await waitFor(() => {
+      expect(wideRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          query: expect.objectContaining({statsPeriod: '9999d'}),
+        })
+      );
+    });
+  });
+
   it('falls back to the wide window when the in-range query fails', async () => {
     const outOfRangeLog = LogFixture({
       [OurLogKnownFieldKey.ID]: 'log-out-of-range',
@@ -243,6 +323,26 @@ describe('usePinnedLogsQuery', () => {
       })
     );
     expect(logsPinning.removePinnedRows).not.toHaveBeenCalled();
+  });
+
+  it('reports isError when the pinned logs query fails', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      statusCode: 500,
+      body: {detail: 'Internal Error'},
+    });
+
+    const logsPinning = makeLogsPinning(['missing-log']);
+
+    const {result} = renderHookWithProviders(
+      () => usePinnedLogsQuery({allRows: [], logsPinning}),
+      {organization, additionalWrapper: AdditionalWrapper}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
   });
 
   it('does not unpin when both the in-range and wide queries fail', async () => {

--- a/static/app/views/explore/logs/pinning/usePinnedLogsQuery.tsx
+++ b/static/app/views/explore/logs/pinning/usePinnedLogsQuery.tsx
@@ -1,9 +1,11 @@
-import {useEffect, useMemo} from 'react';
+import {useCallback, useEffect, useMemo} from 'react';
 import {skipToken, useQuery} from '@tanstack/react-query';
+import moment from 'moment-timezone';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
+import {getUtcDateString} from 'sentry/utils/dates';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
@@ -11,6 +13,7 @@ import {
   type SamplingMode,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {AlwaysPresentLogFields} from 'sentry/views/explore/logs/constants';
+import {logItemIdToTimestamp} from 'sentry/views/explore/logs/pinning/logItemId';
 import type {LogsPinning} from 'sentry/views/explore/logs/pinning/useLogsPinning';
 import {
   OurLogKnownFieldKey,
@@ -27,8 +30,15 @@ interface PinnedLogsOptions {
 /**
  * Practically-infinite period so the wide step finds any log still in retention,
  * regardless of the selected range. The backend clamps it to the org's retention.
+ * Only used as a fallback when a pin's timestamp can't be derived from its id.
  */
 const WIDE_STATS_PERIOD = '9999d';
+
+/**
+ * Padding around the timestamps decoded from pin ids, to absorb clock skew
+ * between when the SDK minted the id and when the log was ingested.
+ */
+const WINDOW_BUFFER_MS = 5 * 60 * 1000;
 
 export function usePinnedLogsQuery({allRows, logsPinning}: PinnedLogsOptions) {
   const {selection, isReady: pageFiltersReady} = usePageFilters();
@@ -79,10 +89,26 @@ export function usePinnedLogsQuery({allRows, logsPinning}: PinnedLogsOptions) {
     return missingIds.filter(id => !foundIds.has(id));
   }, [inRangeQuery.isSuccess, inRangeQuery.isError, inRangeQuery.data?.json, missingIds]);
 
+  // Pin ids are UUIDv7, so we can derive a tight window from their timestamps and
+  // avoid scanning the org's full retention (which gets downsampled to a partial
+  // scan for high-volume orgs, missing the pinned log). Fall back to the wide
+  // period if any id isn't a decodable timestamp.
+  const wideDateParams = useMemo(() => {
+    const timestamps = stillMissingIds.map(logItemIdToTimestamp);
+    if (timestamps.length === 0 || timestamps.includes(null)) {
+      return {statsPeriod: WIDE_STATS_PERIOD};
+    }
+    const decoded = timestamps as number[];
+    return {
+      start: getUtcDateString(moment(Math.min(...decoded) - WINDOW_BUFFER_MS)),
+      end: getUtcDateString(moment(Math.max(...decoded) + WINDOW_BUFFER_MS)),
+    };
+  }, [stillMissingIds]);
+
   const wideQuery = useQuery({
     ...usePinnedLogsEventsQueryOptions({
       ids: stillMissingIds,
-      dateParams: {statsPeriod: WIDE_STATS_PERIOD},
+      dateParams: wideDateParams,
       baseQuery,
       canFetch,
       staleTime: Infinity,
@@ -116,11 +142,20 @@ export function usePinnedLogsQuery({allRows, logsPinning}: PinnedLogsOptions) {
     [inRangeQuery.data, wideQuery.data]
   );
 
+  const {refetch: refetchInRange} = inRangeQuery;
+  const {refetch: refetchWide} = wideQuery;
+  const refetch = useCallback(() => {
+    refetchInRange();
+    refetchWide();
+  }, [refetchInRange, refetchWide]);
+
   return {
     fetchedRows,
     isPending:
       missingIds.length > 0 &&
       (inRangeQuery.isPending || (stillMissingIds.length > 0 && wideQuery.isPending)),
+    isError: inRangeQuery.isError || wideQuery.isError,
+    refetch,
   };
 }
 


### PR DESCRIPTION
Pinned logs outside the selected time range were re-fetched with a `9999d` wide window. For high-volume orgs that scan gets downsampled to a partial result, so the specific pinned log was often missing — the row rendered nothing while the "N pinned" count still counted it, leaving the count higher than the visible rows.

Log item ids are UUIDv7, so we can derive each missing pin's creation timestamp from its id and query a tight window around it instead. A small, selective `id:[...]` lookup over a narrow window avoids downsampling and reliably returns the log. When an id isn't a decodable timestamp we fall back to the previous wide window.

As a backstop, any pin that still can't be resolved now renders an explicit row (instead of silently nothing) so the count always matches the rendered rows, with a Retry control shown when the fetch errored.

Closes LOGS-893