### PR TITLE
feat(preprod): Record client attribution on snapshot archive download

### DIFF
--- a/src/sentry/preprod/analytics.py
+++ b/src/sentry/preprod/analytics.py
@@ -61,6 +61,15 @@ class PreprodArtifactApiGetLatestBaseSnapshotEvent(analytics.Event):
     client: str
 
 
+@analytics.eventclass("preprod_artifact.api.snapshot_archive_download")
+class PreprodArtifactApiSnapshotArchiveDownloadEvent(analytics.Event):
+    organization_id: int
+    project_id: int
+    user_id: int | None = None
+    artifact_id: str
+    client: str
+
+
 @analytics.eventclass("preprod_artifact.api.install_details")
 class PreprodArtifactApiInstallDetailsEvent(analytics.Event):
     organization_id: int
@@ -195,6 +204,7 @@ analytics.register(PreprodArtifactApiGetBuildDetailsEvent)
 analytics.register(PreprodArtifactApiGetSnapshotDetailsEvent)
 analytics.register(PreprodArtifactApiGetSnapshotImageEvent)
 analytics.register(PreprodArtifactApiGetLatestBaseSnapshotEvent)
+analytics.register(PreprodArtifactApiSnapshotArchiveDownloadEvent)
 analytics.register(PreprodArtifactApiInstallDetailsEvent)
 analytics.register(PreprodArtifactApiRerunAnalysisEvent)
 analytics.register(PreprodArtifactApiRerunStatusChecksEvent)

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -10,13 +10,16 @@ from objectstore_client import RequestError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
 from sentry.auth.staff import is_active_staff
+from sentry.issues.action_log import resolve_action_source
 from sentry.models.organization import Organization
 from sentry.objectstore import get_preprod_session
+from sentry.preprod.analytics import PreprodArtifactApiSnapshotArchiveDownloadEvent
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.preprod.snapshots.zip_builder import archive_exists, archive_object_key
@@ -119,6 +122,17 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
         artifact, _metrics = resolved
 
         if request.GET.get("download") is not None:
+            analytics.record(
+                PreprodArtifactApiSnapshotArchiveDownloadEvent(
+                    organization_id=organization.id,
+                    project_id=artifact.project_id,
+                    user_id=(
+                        request.user.id if request.user and request.user.is_authenticated else None
+                    ),
+                    artifact_id=str(artifact.id),
+                    client=resolve_action_source(request),
+                )
+            )
             return self._download(artifact)
 
         # Readiness probe (no side effect): lets the UI download a ready archive

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -6,12 +6,14 @@ from unittest.mock import MagicMock, patch
 from django.urls import reverse
 from objectstore_client import RequestError
 
+from sentry.preprod.analytics import PreprodArtifactApiSnapshotArchiveDownloadEvent
 from sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_archive import (
     OrganizationPreprodSnapshotArchiveEndpoint,
 )
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.types.ratelimit import RateLimitCategory
 
 ENQUEUE_TARGET = (
@@ -132,3 +134,81 @@ class SnapshotArchiveDownloadTest(BaseSnapshotArchiveTest):
         mock_session.return_value = session
         response = self.client.get(self._url(artifact.id, download=True))
         assert response.status_code == 409
+
+    def _ready_session(self, mock_session):
+        result = MagicMock()
+        result.payload.read.side_effect = [b"ZIPBYTES", b""]
+        result.metadata = MagicMock()
+        session = MagicMock()
+        session.get.return_value = result
+        mock_session.return_value = session
+
+    @patch("sentry.analytics.record")
+    @patch(SESSION_TARGET)
+    def test_download_records_web_client_analytics(self, mock_session, mock_record):
+        artifact = self._artifact()
+        self._ready_session(mock_session)
+        # setUp logged the user in via session cookies and sent no token, so the
+        # request classifies as a frontend (web) download.
+        response = self.client.get(self._url(artifact.id, download=True))
+        assert response.status_code == 200
+        assert_last_analytics_event(
+            mock_record,
+            PreprodArtifactApiSnapshotArchiveDownloadEvent(
+                organization_id=self.org.id,
+                project_id=self.project.id,
+                user_id=self.user.id,
+                artifact_id=str(artifact.id),
+                client="web",
+            ),
+        )
+
+    @patch("sentry.analytics.record")
+    @patch(SESSION_TARGET)
+    def test_download_records_sentry_cli_client_analytics(self, mock_session, mock_record):
+        artifact = self._artifact()
+        self._ready_session(mock_session)
+        token = self.create_user_auth_token(user=self.user, scope_list=["project:read"])
+        # Bearer auth sets request.auth, so the request is not a frontend request and
+        # the sentry-cli User-Agent drives classification — mirroring the real CLI.
+        response = self.client.get(
+            self._url(artifact.id, download=True),
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            HTTP_USER_AGENT="sentry-cli/2.30.0",
+        )
+        assert response.status_code == 200
+        assert_last_analytics_event(
+            mock_record,
+            PreprodArtifactApiSnapshotArchiveDownloadEvent(
+                organization_id=self.org.id,
+                project_id=self.project.id,
+                user_id=self.user.id,
+                artifact_id=str(artifact.id),
+                client="sentry-cli",
+            ),
+        )
+
+    @patch("sentry.analytics.record")
+    @patch(SESSION_TARGET)
+    def test_readiness_probe_records_no_download_event(self, mock_session, mock_record):
+        artifact = self._artifact()
+        session = MagicMock()
+        session.get.return_value = MagicMock()
+        mock_session.return_value = session
+        response = self.client.get(self._url(artifact.id))
+        assert response.status_code == 200
+        assert not any(
+            isinstance(call.args[0], PreprodArtifactApiSnapshotArchiveDownloadEvent)
+            for call in mock_record.call_args_list
+        )
+
+    @patch("sentry.analytics.record")
+    @patch(ENQUEUE_TARGET)
+    def test_post_build_trigger_records_no_download_event(self, mock_task, mock_record):
+        artifact = self._artifact()
+        response = self.client.post(self._url(artifact.id))
+        assert response.status_code == 202
+        assert not any(
+            isinstance(call.args[0], PreprodArtifactApiSnapshotArchiveDownloadEvent)
+            for call in mock_record.call_args_list
+        )


### PR DESCRIPTION
The snapshot archive download endpoint now records a `client` field
(`web` / `sentry-cli` / `mcp:<family>`) so we can see how much download traffic
comes from sentry-cli versus the web UI. This completes the CLI-download half of
client attribution that was deferred from #118387, which covered the MCP read
endpoints (`get_snapshot`, `get_snapshot_image`, `get_latest_base_snapshot`).

The event fires only on the `GET .../snapshots/{id}/archive/?download` branch —
the same path the web UI and `sentry-cli snapshots download` both use. The
readiness probe (`GET archive/`, which the CLI polls up to ~150× per download)
and the `POST archive/` build trigger are intentionally left uninstrumented so
download counts are not inflated. Classification reuses the existing
`resolve_action_source()` helper, so values match the scheme #118387 introduced.

Refs EME-1215