### PR TITLE
feat(seer): Restrict GitLab repos to Seer handoff in Autofix settings

### DIFF
--- a/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.spec.tsx
+++ b/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.spec.tsx
@@ -13,6 +13,7 @@ import {
 import {openModal} from 'sentry/actionCreators/modal';
 import {ProjectAddRepoModal} from 'sentry/components/seer/projectAddRepoModal/projectAddRepoModal';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {NON_GITHUB_HANDOFF_WARNING} from 'sentry/utils/seer/preferredAgent';
 
 describe('ProjectAddRepoModal', () => {
   const organization = OrganizationFixture();
@@ -85,9 +86,7 @@ describe('ProjectAddRepoModal', () => {
     await addRepository(/getsentry\/sentry/);
 
     expect(screen.getByRole('textbox', {name: 'Handoff to Agent'})).toBeEnabled();
-    expect(
-      screen.queryByText(/Non-GitHub repositories only support handing off to Seer/)
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(NON_GITHUB_HANDOFF_WARNING)).not.toBeInTheDocument();
   });
 
   it('disables the agent dropdown and warns when a GitLab repo is added', async () => {
@@ -98,9 +97,7 @@ describe('ProjectAddRepoModal', () => {
     await waitFor(() =>
       expect(screen.getByRole('textbox', {name: 'Handoff to Agent'})).toBeDisabled()
     );
-    expect(
-      screen.getByText(/Non-GitHub repositories only support handing off to Seer/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(NON_GITHUB_HANDOFF_WARNING)).toBeInTheDocument();
   });
 
   async function selectCodingAgent() {
@@ -134,9 +131,7 @@ describe('ProjectAddRepoModal', () => {
     );
     expect(screen.getByText('Seer')).toBeInTheDocument();
     expect(screen.queryByText('Cursor Cloud Agent')).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(/Non-GitHub repositories only support handing off to Seer/)
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(NON_GITHUB_HANDOFF_WARNING)).not.toBeInTheDocument();
   });
 
   it('saves Seer as the agent when a GitLab repo is attached', async () => {

--- a/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.spec.tsx
+++ b/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.spec.tsx
@@ -1,0 +1,178 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {RepositoryFixture} from 'sentry-fixture/repository';
+
+import {
+  act,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+
+import {openModal} from 'sentry/actionCreators/modal';
+import {ProjectAddRepoModal} from 'sentry/components/seer/projectAddRepoModal/projectAddRepoModal';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+
+describe('ProjectAddRepoModal', () => {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+
+  function mockEndpoints() {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      method: 'GET',
+      body: [
+        RepositoryFixture({
+          id: '1',
+          name: 'getsentry/sentry',
+          externalId: '101',
+          provider: {id: 'integrations:github', name: 'GitHub'},
+          integrationId: '201',
+        }),
+        RepositoryFixture({
+          id: '3',
+          name: 'getsentry/gitlab-repo',
+          externalId: '103',
+          provider: {id: 'integrations:gitlab', name: 'GitLab'},
+          integrationId: '203',
+        }),
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/projects/`,
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      method: 'GET',
+      body: {
+        integrations: [{id: '123', provider: 'cursor', name: 'Cursor Cloud Agent'}],
+      },
+    });
+  }
+
+  beforeEach(() => {
+    ProjectsStore.loadInitialData([project]);
+    mockEndpoints();
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    ProjectsStore.reset();
+  });
+
+  function openAddRepoModal(org = organization) {
+    renderGlobalModal({organization: org});
+    act(() => {
+      openModal(modalProps => (
+        <ProjectAddRepoModal {...modalProps} title="Add Project to Autofix" />
+      ));
+    });
+  }
+
+  async function addRepository(name: RegExp) {
+    await userEvent.click(await screen.findByRole('button', {name: 'Add Repository'}));
+    await userEvent.click(await screen.findByRole('option', {name}));
+  }
+
+  it('keeps the agent dropdown enabled for a GitHub repo', async () => {
+    openAddRepoModal();
+
+    expect(await screen.findByRole('textbox', {name: 'Handoff to Agent'})).toBeEnabled();
+
+    await addRepository(/getsentry\/sentry/);
+
+    expect(screen.getByRole('textbox', {name: 'Handoff to Agent'})).toBeEnabled();
+    expect(
+      screen.queryByText(/Non-GitHub repositories only support handing off to Seer/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables the agent dropdown and warns when a GitLab repo is added', async () => {
+    openAddRepoModal();
+
+    await addRepository(/gitlab-repo/);
+
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', {name: 'Handoff to Agent'})).toBeDisabled()
+    );
+    expect(
+      screen.getByText(/Non-GitHub repositories only support handing off to Seer/)
+    ).toBeInTheDocument();
+  });
+
+  async function selectCodingAgent() {
+    await userEvent.click(screen.getByRole('textbox', {name: 'Handoff to Agent'}));
+    await userEvent.click(
+      await screen.findByRole('menuitemradio', {name: 'Cursor Cloud Agent'})
+    );
+  }
+
+  it('hard-resets a chosen coding agent to Seer and keeps it on removal', async () => {
+    openAddRepoModal();
+
+    // The user picks a coding agent.
+    await screen.findByRole('textbox', {name: 'Handoff to Agent'});
+    await selectCodingAgent();
+    expect(screen.getByText('Cursor Cloud Agent')).toBeInTheDocument();
+
+    // Adding a GitLab repo forces the selection to Seer and disables it.
+    await addRepository(/gitlab-repo/);
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', {name: 'Handoff to Agent'})).toBeDisabled()
+    );
+    expect(screen.getByText('Seer')).toBeInTheDocument();
+    expect(screen.queryByText('Cursor Cloud Agent')).not.toBeInTheDocument();
+
+    // Removing the repo re-enables the dropdown, but the choice stays Seer — the
+    // prior coding-agent selection is not restored (hard reset).
+    await userEvent.click(screen.getByRole('button', {name: 'Remove repository'}));
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', {name: 'Handoff to Agent'})).toBeEnabled()
+    );
+    expect(screen.getByText('Seer')).toBeInTheDocument();
+    expect(screen.queryByText('Cursor Cloud Agent')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Non-GitHub repositories only support handing off to Seer/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('saves Seer as the agent when a GitLab repo is attached', async () => {
+    const reposPut = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/repos/`,
+      method: 'PUT',
+    });
+    const settingsPut = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/settings/`,
+      method: 'PUT',
+      body: {},
+    });
+
+    openAddRepoModal();
+
+    // Pick the project and a coding agent that the GitLab repo must override.
+    await userEvent.click(await screen.findByRole('button', {name: 'Select Project'}));
+    await userEvent.click(await screen.findByRole('option', {name: /project-slug/}));
+    await selectCodingAgent();
+
+    await addRepository(/gitlab-repo/);
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', {name: 'Handoff to Agent'})).toBeDisabled()
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Save Project'}));
+
+    await waitFor(() => expect(reposPut).toHaveBeenCalled());
+    expect(settingsPut).toHaveBeenCalledWith(
+      `/projects/${organization.slug}/${project.slug}/seer/settings/`,
+      expect.objectContaining({data: expect.objectContaining({agent: 'seer'})})
+    );
+    // The reset must not carry the coding-agent integration id either.
+    expect(settingsPut).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({data: expect.objectContaining({integrationId: '123'})})
+    );
+  });
+});

--- a/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
+++ b/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
@@ -372,7 +372,7 @@ export function ProjectAddRepoModal({
                     )}
                   >
                     <field.Select
-                      value={field.state.value}
+                      value={isOnlyGithubRepos ? field.state.value : 'seer'}
                       onChange={field.handleChange}
                       options={agentOptions}
                       disabled={!isOnlyGithubRepos}

--- a/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
+++ b/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
@@ -354,7 +354,7 @@ export function ProjectAddRepoModal({
 
             <Stack gap="md">
               {!isOnlyGithubRepos && (
-                <Alert variant="warning">{NON_GITHUB_HANDOFF_WARNING}</Alert>
+                <Alert variant="info">{NON_GITHUB_HANDOFF_WARNING}</Alert>
               )}
               <form.AppField name="agentOption">
                 {field => (

--- a/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
+++ b/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
@@ -1,11 +1,17 @@
-import {Fragment, useCallback} from 'react';
+import {Fragment, useCallback, useEffect} from 'react';
 import {useInfiniteQuery, useQuery, type InfiniteData} from '@tanstack/react-query';
 import {z} from 'zod';
 
+import {Alert} from '@sentry/scraps/alert';
 import {ProjectAvatar} from '@sentry/scraps/avatar';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
+import {
+  defaultFormOptions,
+  setFieldErrors,
+  useScrapsForm,
+  useStore,
+} from '@sentry/scraps/form';
 import {InputGroup} from '@sentry/scraps/input';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
@@ -27,6 +33,8 @@ import {useProjectsById} from 'sentry/utils/project/useProjectsById';
 import {useCompactSelectRepositoryOptions} from 'sentry/utils/repositories/useCompactSelectRepositoryOptions';
 import {useRepositoriesById} from 'sentry/utils/repositories/useRepositoriesById';
 import {
+  isGithubRepoProvider,
+  NON_GITHUB_HANDOFF_WARNING,
   orgDefaultAgentQueryOptions,
   seerAgentIntegrationsSelectQueryOptions,
 } from 'sentry/utils/seer/preferredAgent';
@@ -147,6 +155,23 @@ export function ProjectAddRepoModal({
         });
     },
   });
+
+  // Only GitHub repos can hand off to an external coding agent. When any other
+  // repo is attached, hard-reset the agent to Seer (rather than just overriding
+  // the display) so the user isn't left re-selecting an agent they can't use,
+  // and the saved value is correct. Unresolved repos (still loading) are ignored
+  // so the dropdown isn't disabled mid-fetch.
+  const repoEntries = useStore(form.store, state => state.values.repoEntries);
+  const isOnlyGithubRepos = repoEntries.every(entry => {
+    const providerId = repositoriesById.get(entry.repoId)?.provider.id;
+    // Ignore unresolved repos (still loading) so we don't disable mid-fetch.
+    return providerId === undefined || isGithubRepoProvider(providerId);
+  });
+  useEffect(() => {
+    if (!isOnlyGithubRepos && form.state.values.agentOption !== 'seer') {
+      form.setFieldValue('agentOption', 'seer');
+    }
+  }, [isOnlyGithubRepos, form]);
 
   return (
     <Fragment>
@@ -327,29 +352,35 @@ export function ProjectAddRepoModal({
 
             <Separator orientation="horizontal" />
 
-            <form.AppField name="agentOption">
-              {field => (
-                <field.Layout.Row
-                  label={t('Handoff to Agent')}
-                  hintText={tct(
-                    'Seer will always triage and perform Root Cause Analysis for you, but after that you can hand the results to an agent to create a plan, code a fix, and draft a PR. [manage:Manage Coding Agents]',
-                    {
-                      manage: (
-                        <ExternalLink
-                          href={`/settings/${organization.slug}/integrations/?category=coding+agent`}
-                        />
-                      ),
-                    }
-                  )}
-                >
-                  <field.Select
-                    value={field.state.value}
-                    onChange={field.handleChange}
-                    options={agentOptions}
-                  />
-                </field.Layout.Row>
+            <Stack gap="md">
+              {!isOnlyGithubRepos && (
+                <Alert variant="warning">{NON_GITHUB_HANDOFF_WARNING}</Alert>
               )}
-            </form.AppField>
+              <form.AppField name="agentOption">
+                {field => (
+                  <field.Layout.Row
+                    label={t('Handoff to Agent')}
+                    hintText={tct(
+                      'Seer will always triage and perform Root Cause Analysis for you, but after that you can hand the results to an agent to create a plan, code a fix, and draft a PR. [manage:Manage Coding Agents]',
+                      {
+                        manage: (
+                          <ExternalLink
+                            href={`/settings/${organization.slug}/integrations/?category=coding+agent`}
+                          />
+                        ),
+                      }
+                    )}
+                  >
+                    <field.Select
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      options={agentOptions}
+                      disabled={!isOnlyGithubRepos}
+                    />
+                  </field.Layout.Row>
+                )}
+              </form.AppField>
+            </Stack>
 
             <Separator orientation="horizontal" />
 

--- a/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
+++ b/static/app/components/seer/projectAddRepoModal/projectAddRepoModal.tsx
@@ -33,11 +33,11 @@ import {useProjectsById} from 'sentry/utils/project/useProjectsById';
 import {useCompactSelectRepositoryOptions} from 'sentry/utils/repositories/useCompactSelectRepositoryOptions';
 import {useRepositoriesById} from 'sentry/utils/repositories/useRepositoriesById';
 import {
-  isGithubRepoProvider,
   NON_GITHUB_HANDOFF_WARNING,
   orgDefaultAgentQueryOptions,
   seerAgentIntegrationsSelectQueryOptions,
 } from 'sentry/utils/seer/preferredAgent';
+import {isGitHubProvider} from 'sentry/utils/seer/seerProjectRepos';
 import {getInfiniteSeerProjectsSettingsQueryOptions} from 'sentry/utils/seer/seerProjectSettings';
 import {
   PROJECT_STOPPING_POINT_OPTIONS,
@@ -165,7 +165,7 @@ export function ProjectAddRepoModal({
   const isOnlyGithubRepos = repoEntries.every(entry => {
     const providerId = repositoriesById.get(entry.repoId)?.provider.id;
     // Ignore unresolved repos (still loading) so we don't disable mid-fetch.
-    return providerId === undefined || isGithubRepoProvider(providerId);
+    return providerId === undefined || isGitHubProvider(providerId);
   });
   useEffect(() => {
     if (!isOnlyGithubRepos && form.state.values.agentOption !== 'seer') {

--- a/static/app/components/seer/projectDetails/autofixAgent.spec.tsx
+++ b/static/app/components/seer/projectDetails/autofixAgent.spec.tsx
@@ -169,4 +169,45 @@ describe('AutofixAgent', () => {
     await waitFor(() => expect(select).toBeEnabled());
     expect(putMock).not.toHaveBeenCalled();
   });
+
+  // A read-only user must never trigger a write, even to coerce the agent.
+  it('does not persist Seer when the user cannot write', async () => {
+    const putMock = mockEndpoints({
+      repos: [seerRepo({provider: 'gitlab'})],
+      agent: 'cursor',
+      integrationId: '123',
+    });
+
+    render(<AutofixAgent canWrite={false} project={project} />, {organization});
+
+    const select = await screen.findByRole('textbox', {name: 'Handoff to Agent'});
+    await waitFor(() => expect(select).toBeDisabled());
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  // The coercion mutation rolls back its optimistic update on error, which would
+  // re-satisfy the condition and loop. The effect must fire exactly once.
+  it('does not retry the Seer coercion after a failed save', async () => {
+    mockEndpoints({
+      repos: [seerRepo({provider: 'gitlab'})],
+      agent: 'cursor',
+      integrationId: '123',
+    });
+    // Registered after mockEndpoints' PUT so this failing response wins.
+    const failingPut = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/settings/`,
+      method: 'PUT',
+      statusCode: 500,
+      body: {},
+    });
+
+    render(<AutofixAgent canWrite project={project} />, {organization});
+
+    await waitFor(() => expect(failingPut).toHaveBeenCalledTimes(1));
+    // Let the rollback + refetch settle; the effect must not re-fire.
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', {name: 'Handoff to Agent'})).toBeDisabled()
+    );
+    expect(failingPut).toHaveBeenCalledTimes(1);
+  });
 });

--- a/static/app/components/seer/projectDetails/autofixAgent.spec.tsx
+++ b/static/app/components/seer/projectDetails/autofixAgent.spec.tsx
@@ -5,6 +5,7 @@ import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {AutofixAgent} from 'sentry/components/seer/projectDetails/autofixAgent';
 import type {DetailedProject} from 'sentry/types/project';
+import {NON_GITHUB_HANDOFF_WARNING} from 'sentry/utils/seer/preferredAgent';
 
 describe('AutofixAgent', () => {
   let project: DetailedProject;
@@ -26,7 +27,17 @@ describe('AutofixAgent', () => {
     };
   }
 
-  function mockEndpoints({repos}: {repos: Array<ReturnType<typeof seerRepo>>}) {
+  function mockEndpoints({
+    repos,
+    agent = 'seer',
+    integrationId = null,
+    reposAsyncDelay,
+  }: {
+    repos: Array<ReturnType<typeof seerRepo>>;
+    agent?: string;
+    integrationId?: string | null;
+    reposAsyncDelay?: number;
+  }) {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/coding-agents/`,
       method: 'GET',
@@ -40,8 +51,8 @@ describe('AutofixAgent', () => {
       body: {
         projectId: project.id,
         projectSlug: project.slug,
-        agent: 'seer',
-        integrationId: null,
+        agent,
+        integrationId,
         stoppingPoint: 'root_cause',
         autoCreatePr: null,
         automationTuning: 'off',
@@ -53,6 +64,12 @@ describe('AutofixAgent', () => {
       url: `/projects/${organization.slug}/${project.slug}/seer/repos/`,
       method: 'GET',
       body: repos,
+      ...(reposAsyncDelay === undefined ? {} : {asyncDelay: reposAsyncDelay}),
+    });
+    return MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/settings/`,
+      method: 'PUT',
+      body: {},
     });
   }
 
@@ -70,10 +87,8 @@ describe('AutofixAgent', () => {
     render(<AutofixAgent canWrite project={project} />, {organization});
 
     const select = await screen.findByRole('textbox', {name: 'Handoff to Agent'});
-    expect(select).toBeEnabled();
-    expect(
-      screen.queryByText(/Non-GitHub repositories only support handing off to Seer/)
-    ).not.toBeInTheDocument();
+    await waitFor(() => expect(select).toBeEnabled());
+    expect(screen.queryByText(NON_GITHUB_HANDOFF_WARNING)).not.toBeInTheDocument();
   });
 
   it('disables the agent dropdown and warns when a GitLab repo is attached', async () => {
@@ -88,9 +103,7 @@ describe('AutofixAgent', () => {
 
     const select = await screen.findByRole('textbox', {name: 'Handoff to Agent'});
     await waitFor(() => expect(select).toBeDisabled());
-    expect(
-      screen.getByText(/Non-GitHub repositories only support handing off to Seer/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(NON_GITHUB_HANDOFF_WARNING)).toBeInTheDocument();
   });
 
   it('disables the agent dropdown for any non-GitHub provider', async () => {
@@ -100,8 +113,60 @@ describe('AutofixAgent', () => {
 
     const select = await screen.findByRole('textbox', {name: 'Handoff to Agent'});
     await waitFor(() => expect(select).toBeDisabled());
-    expect(
-      screen.getByText(/Non-GitHub repositories only support handing off to Seer/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(NON_GITHUB_HANDOFF_WARNING)).toBeInTheDocument();
+  });
+
+  // Regression test for the empty/partial repo list: `.every(isGithub)` on an
+  // unsettled list is `true`, which would briefly enable the dropdown (and hide
+  // the warning) before the repos query resolves. The dropdown must stay
+  // disabled until every page has loaded.
+  it('keeps the agent dropdown disabled while the repos query is still loading', async () => {
+    // Settings resolves immediately (so the form renders) but the repos query
+    // never resolves within the test, leaving it unsettled.
+    mockEndpoints({repos: [seerRepo({provider: 'github'})], reposAsyncDelay: 100_000});
+
+    render(<AutofixAgent canWrite project={project} />, {organization});
+
+    const select = await screen.findByRole('textbox', {name: 'Handoff to Agent'});
+    expect(select).toBeDisabled();
+  });
+
+  // Regression test for the display-only override: forcing the select's value to
+  // 'seer' without writing it back left the stored agent as a coding agent. When
+  // a non-GitHub repo is attached we must persist Seer, not just display it.
+  it('persists Seer when a non-GitHub repo is attached and the stored agent is a coding agent', async () => {
+    const putMock = mockEndpoints({
+      repos: [seerRepo({provider: 'gitlab'})],
+      agent: 'cursor',
+      integrationId: '123',
+    });
+
+    render(<AutofixAgent canWrite project={project} />, {organization});
+
+    await waitFor(() =>
+      expect(putMock).toHaveBeenCalledWith(
+        `/projects/${organization.slug}/${project.slug}/seer/settings/`,
+        expect.objectContaining({
+          method: 'PUT',
+          data: expect.objectContaining({agent: 'seer'}),
+        })
+      )
+    );
+  });
+
+  // The inverse of the above: a GitHub-only project must not trigger a coercion
+  // PUT for a stored coding agent.
+  it('does not persist Seer when only GitHub repos are attached', async () => {
+    const putMock = mockEndpoints({
+      repos: [seerRepo({provider: 'github'})],
+      agent: 'cursor',
+      integrationId: '123',
+    });
+
+    render(<AutofixAgent canWrite project={project} />, {organization});
+
+    const select = await screen.findByRole('textbox', {name: 'Handoff to Agent'});
+    await waitFor(() => expect(select).toBeEnabled());
+    expect(putMock).not.toHaveBeenCalled();
   });
 });

--- a/static/app/components/seer/projectDetails/autofixAgent.spec.tsx
+++ b/static/app/components/seer/projectDetails/autofixAgent.spec.tsx
@@ -1,0 +1,107 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {DetailedProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {AutofixAgent} from 'sentry/components/seer/projectDetails/autofixAgent';
+import type {DetailedProject} from 'sentry/types/project';
+
+describe('AutofixAgent', () => {
+  let project: DetailedProject;
+  const organization = OrganizationFixture();
+
+  function seerRepo(overrides: {provider: string} & Partial<{id: string}>) {
+    return {
+      id: overrides.id ?? '1',
+      repositoryId: overrides.id ?? '1',
+      branchName: '',
+      branchOverrides: [],
+      instructions: '',
+      externalId: '101',
+      integrationId: '201',
+      name: 'sentry',
+      organizationId: '',
+      owner: 'getsentry',
+      provider: overrides.provider,
+    };
+  }
+
+  function mockEndpoints({repos}: {repos: Array<ReturnType<typeof seerRepo>>}) {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      method: 'GET',
+      body: {
+        integrations: [{id: '123', provider: 'cursor', name: 'Cursor Cloud Agent'}],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/settings/`,
+      method: 'GET',
+      body: {
+        projectId: project.id,
+        projectSlug: project.slug,
+        agent: 'seer',
+        integrationId: null,
+        stoppingPoint: 'root_cause',
+        autoCreatePr: null,
+        automationTuning: 'off',
+        scannerAutomation: false,
+        reposCount: repos.length,
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/repos/`,
+      method: 'GET',
+      body: repos,
+    });
+  }
+
+  beforeEach(() => {
+    project = DetailedProjectFixture();
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('enables the agent dropdown when only GitHub repos are attached', async () => {
+    mockEndpoints({repos: [seerRepo({provider: 'github'})]});
+
+    render(<AutofixAgent canWrite project={project} />, {organization});
+
+    const select = await screen.findByRole('textbox', {name: 'Handoff to Agent'});
+    expect(select).toBeEnabled();
+    expect(
+      screen.queryByText(/Non-GitHub repositories only support handing off to Seer/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables the agent dropdown and warns when a GitLab repo is attached', async () => {
+    mockEndpoints({
+      repos: [
+        seerRepo({id: '1', provider: 'github'}),
+        seerRepo({id: '3', provider: 'gitlab'}),
+      ],
+    });
+
+    render(<AutofixAgent canWrite project={project} />, {organization});
+
+    const select = await screen.findByRole('textbox', {name: 'Handoff to Agent'});
+    await waitFor(() => expect(select).toBeDisabled());
+    expect(
+      screen.getByText(/Non-GitHub repositories only support handing off to Seer/)
+    ).toBeInTheDocument();
+  });
+
+  it('disables the agent dropdown for any non-GitHub provider', async () => {
+    mockEndpoints({repos: [seerRepo({provider: 'bitbucket'})]});
+
+    render(<AutofixAgent canWrite project={project} />, {organization});
+
+    const select = await screen.findByRole('textbox', {name: 'Handoff to Agent'});
+    await waitFor(() => expect(select).toBeDisabled());
+    expect(
+      screen.getByText(/Non-GitHub repositories only support handing off to Seer/)
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/components/seer/projectDetails/autofixAgent.tsx
+++ b/static/app/components/seer/projectDetails/autofixAgent.tsx
@@ -1,4 +1,10 @@
-import {useInfiniteQuery, useQuery, useQueryClient} from '@tanstack/react-query';
+import {useEffect} from 'react';
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
@@ -53,9 +59,25 @@ export function AutofixAgent({canWrite, project}: Props) {
     getSeerProjectReposInfiniteQueryOptions({organization, project: {slug: project.slug}})
   );
   useFetchAllPages({result: reposResult});
-  const isOnlyGithubRepos = (reposResult.data?.pages ?? [])
+  // An empty or partially-loaded page list would make `.every(isGithub)` true,
+  // so gate on the query being fully settled: until every page is in we can't
+  // know the project is GitHub-only, and must not enable the dropdown or hide
+  // the warning (a repos-fetch error keeps handoff restricted, which is safe).
+  const reposLoaded =
+    reposResult.isSuccess && !reposResult.hasNextPage && !reposResult.isFetchingNextPage;
+  const hasNonGithubRepo = (reposResult.data?.pages ?? [])
     .flatMap(page => page.json)
-    .every(repo => isGithubRepoProvider(repo.provider));
+    .some(repo => !isGithubRepoProvider(repo.provider));
+  const restrictToSeer = reposLoaded && hasNonGithubRepo;
+
+  const {mutate: persistAgentOption, isPending: isPersistingAgent} = useMutation(
+    getMutateSeerProjectSettingsOptions({
+      organization,
+      project: {slug: project.slug},
+      queryClient,
+      knownAgents,
+    })
+  );
 
   const {data, isPending, isError, error} = useQuery(
     getSeerProjectSettingsQueryOptions({
@@ -63,6 +85,24 @@ export function AutofixAgent({canWrite, project}: Props) {
       project: {slug: project.slug},
     })
   );
+
+  // A non-GitHub repo means the stored agent can no longer hand off, so persist
+  // Seer (rather than only overriding the dropdown's display value) to keep the
+  // saved setting consistent with what the user sees. The optimistic update in
+  // the mutation flips `storedAgent` to 'seer', so this fires at most once.
+  const storedAgent = data
+    ? coalesePreferredAgent(data.agent, data.integrationId)
+    : undefined;
+  useEffect(() => {
+    if (
+      restrictToSeer &&
+      storedAgent !== undefined &&
+      storedAgent !== 'seer' &&
+      !isPersistingAgent
+    ) {
+      persistAgentOption({agentOption: 'seer'});
+    }
+  }, [restrictToSeer, storedAgent, isPersistingAgent, persistAgentOption]);
 
   if (isPending) {
     return (
@@ -103,9 +143,7 @@ export function AutofixAgent({canWrite, project}: Props) {
       >
         {field => (
           <Stack gap="md">
-            {!isOnlyGithubRepos && (
-              <Alert variant="info">{NON_GITHUB_HANDOFF_WARNING}</Alert>
-            )}
+            {restrictToSeer && <Alert variant="info">{NON_GITHUB_HANDOFF_WARNING}</Alert>}
             <field.Layout.Row
               label={t('Handoff to Agent')}
               hintText={tct(
@@ -123,11 +161,11 @@ export function AutofixAgent({canWrite, project}: Props) {
               )}
             >
               <field.Select
-                disabled={!canWrite || !isOnlyGithubRepos}
+                disabled={!canWrite || !reposLoaded || hasNonGithubRepo}
                 multiple={false}
                 onChange={field.handleChange}
                 options={agentSelectOptions}
-                value={isOnlyGithubRepos ? field.state.value : 'seer'}
+                value={restrictToSeer ? 'seer' : field.state.value}
               />
             </field.Layout.Row>
           </Stack>

--- a/static/app/components/seer/projectDetails/autofixAgent.tsx
+++ b/static/app/components/seer/projectDetails/autofixAgent.tsx
@@ -17,13 +17,15 @@ import {t, tct} from 'sentry/locale';
 import type {DetailedProject} from 'sentry/types/project';
 import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
 import {
-  isGithubRepoProvider,
   NON_GITHUB_HANDOFF_WARNING,
   seerAgentIntegrationsSelectQueryOptions,
   knownAgentIntegrationsQueryOptions,
   coalesePreferredAgent,
 } from 'sentry/utils/seer/preferredAgent';
-import {getSeerProjectReposInfiniteQueryOptions} from 'sentry/utils/seer/seerProjectRepos';
+import {
+  getSeerProjectReposInfiniteQueryOptions,
+  isGitHubProvider,
+} from 'sentry/utils/seer/seerProjectRepos';
 import {
   getMutateSeerProjectSettingsOptions,
   getSeerProjectSettingsQueryOptions,
@@ -67,7 +69,7 @@ export function AutofixAgent({canWrite, project}: Props) {
     reposResult.isSuccess && !reposResult.hasNextPage && !reposResult.isFetchingNextPage;
   const hasNonGithubRepo = (reposResult.data?.pages ?? [])
     .flatMap(page => page.json)
-    .some(repo => !isGithubRepoProvider(repo.provider));
+    .some(repo => !isGitHubProvider(repo.provider));
   const restrictToSeer = reposLoaded && hasNonGithubRepo;
 
   // `isIdle` is true only until the first attempt settles, so the effect below

--- a/static/app/components/seer/projectDetails/autofixAgent.tsx
+++ b/static/app/components/seer/projectDetails/autofixAgent.tsx
@@ -1,18 +1,23 @@
-import {useQuery, useQueryClient} from '@tanstack/react-query';
+import {useInfiniteQuery, useQuery, useQueryClient} from '@tanstack/react-query';
 
+import {Alert} from '@sentry/scraps/alert';
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t, tct} from 'sentry/locale';
 import type {DetailedProject} from 'sentry/types/project';
+import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
 import {
+  isGithubRepoProvider,
+  NON_GITHUB_HANDOFF_WARNING,
   seerAgentIntegrationsSelectQueryOptions,
   knownAgentIntegrationsQueryOptions,
   coalesePreferredAgent,
 } from 'sentry/utils/seer/preferredAgent';
+import {getSeerProjectReposInfiniteQueryOptions} from 'sentry/utils/seer/seerProjectRepos';
 import {
   getMutateSeerProjectSettingsOptions,
   getSeerProjectSettingsQueryOptions,
@@ -41,6 +46,16 @@ export function AutofixAgent({canWrite, project}: Props) {
     seerAgentIntegrationsSelectQueryOptions({organization})
   );
   const stoppingPointOptions = useStoppingPointSelectOptions();
+
+  // Only GitHub repos can hand off to an external coding agent, so the agent
+  // dropdown is disabled when this project has any non-GitHub repo attached.
+  const reposResult = useInfiniteQuery(
+    getSeerProjectReposInfiniteQueryOptions({organization, project: {slug: project.slug}})
+  );
+  useFetchAllPages({result: reposResult});
+  const isOnlyGithubRepos = (reposResult.data?.pages ?? [])
+    .flatMap(page => page.json)
+    .every(repo => isGithubRepoProvider(repo.provider));
 
   const {data, isPending, isError, error} = useQuery(
     getSeerProjectSettingsQueryOptions({
@@ -87,30 +102,35 @@ export function AutofixAgent({canWrite, project}: Props) {
         })}
       >
         {field => (
-          <field.Layout.Row
-            label={t('Handoff to Agent')}
-            hintText={tct(
-              'Select your preferred agent to create a plan, and code up an issue fix. Seer Agent will always be used for the Root Cause Analysis step. [manageLink:Manage Coding Agents].',
-              {
-                manageLink: (
-                  <Link
-                    to={{
-                      pathname: `/settings/${organization.slug}/integrations/`,
-                      query: {category: 'coding agent'},
-                    }}
-                  />
-                ),
-              }
+          <Stack gap="md">
+            {!isOnlyGithubRepos && (
+              <Alert variant="warning">{NON_GITHUB_HANDOFF_WARNING}</Alert>
             )}
-          >
-            <field.Select
-              disabled={!canWrite}
-              multiple={false}
-              onChange={field.handleChange}
-              options={agentSelectOptions}
-              value={field.state.value}
-            />
-          </field.Layout.Row>
+            <field.Layout.Row
+              label={t('Handoff to Agent')}
+              hintText={tct(
+                'Select your preferred agent to create a plan, and code up an issue fix. Seer Agent will always be used for the Root Cause Analysis step. [manageLink:Manage Coding Agents].',
+                {
+                  manageLink: (
+                    <Link
+                      to={{
+                        pathname: `/settings/${organization.slug}/integrations/`,
+                        query: {category: 'coding agent'},
+                      }}
+                    />
+                  ),
+                }
+              )}
+            >
+              <field.Select
+                disabled={!canWrite || !isOnlyGithubRepos}
+                multiple={false}
+                onChange={field.handleChange}
+                options={agentSelectOptions}
+                value={isOnlyGithubRepos ? field.state.value : 'seer'}
+              />
+            </field.Layout.Row>
+          </Stack>
         )}
       </AutoSaveForm>
 

--- a/static/app/components/seer/projectDetails/autofixAgent.tsx
+++ b/static/app/components/seer/projectDetails/autofixAgent.tsx
@@ -70,7 +70,11 @@ export function AutofixAgent({canWrite, project}: Props) {
     .some(repo => !isGithubRepoProvider(repo.provider));
   const restrictToSeer = reposLoaded && hasNonGithubRepo;
 
-  const {mutate: persistAgentOption, isPending: isPersistingAgent} = useMutation(
+  // `isIdle` is true only until the first attempt settles, so the effect below
+  // fires at most once. This matters because the mutation rolls back its
+  // optimistic update on error; without a one-shot guard a failed persist would
+  // restore the coding agent, re-satisfy the condition, and loop indefinitely.
+  const {mutate: persistAgentOption, isIdle: agentPersistNotAttempted} = useMutation(
     getMutateSeerProjectSettingsOptions({
       organization,
       project: {slug: project.slug},
@@ -95,14 +99,21 @@ export function AutofixAgent({canWrite, project}: Props) {
     : undefined;
   useEffect(() => {
     if (
+      canWrite &&
       restrictToSeer &&
       storedAgent !== undefined &&
       storedAgent !== 'seer' &&
-      !isPersistingAgent
+      agentPersistNotAttempted
     ) {
       persistAgentOption({agentOption: 'seer'});
     }
-  }, [restrictToSeer, storedAgent, isPersistingAgent, persistAgentOption]);
+  }, [
+    canWrite,
+    restrictToSeer,
+    storedAgent,
+    agentPersistNotAttempted,
+    persistAgentOption,
+  ]);
 
   if (isPending) {
     return (

--- a/static/app/components/seer/projectDetails/autofixAgent.tsx
+++ b/static/app/components/seer/projectDetails/autofixAgent.tsx
@@ -104,7 +104,7 @@ export function AutofixAgent({canWrite, project}: Props) {
         {field => (
           <Stack gap="md">
             {!isOnlyGithubRepos && (
-              <Alert variant="warning">{NON_GITHUB_HANDOFF_WARNING}</Alert>
+              <Alert variant="info">{NON_GITHUB_HANDOFF_WARNING}</Alert>
             )}
             <field.Layout.Row
               label={t('Handoff to Agent')}

--- a/static/app/utils/seer/preferredAgent.ts
+++ b/static/app/utils/seer/preferredAgent.ts
@@ -27,6 +27,20 @@ export function coalesePreferredAgent(
   return `${agent}::${integrationId ?? ''}` as const;
 }
 
+// Only GitHub repositories can hand off to an external coding agent; everything
+// else (GitLab, Bitbucket, etc.) can only hand off to Seer. Provider identity
+// comes through in a few shapes — the repository `provider.id`
+// (`'integrations:github'`, `'github'`, `'integrations:github_enterprise'`, ...)
+// and the lowercased provider name persisted on Seer repos (`'github'`) — so
+// match on the substring rather than an exact list.
+export function isGithubRepoProvider(provider: string | undefined | null): boolean {
+  return Boolean(provider?.toLowerCase().includes('github'));
+}
+
+export const NON_GITHUB_HANDOFF_WARNING = t(
+  'Non-GitHub repositories only support handing off to Seer.'
+);
+
 export function isPreferredAgentProvider(
   provider: string | undefined
 ): provider is PreferredAgentProvider {

--- a/static/app/utils/seer/preferredAgent.ts
+++ b/static/app/utils/seer/preferredAgent.ts
@@ -38,7 +38,7 @@ export function isGithubRepoProvider(provider: string | undefined | null): boole
 }
 
 export const NON_GITHUB_HANDOFF_WARNING = t(
-  'Non-GitHub repositories only support handing off to Seer.'
+  'Only Seer can be used with non-GitHub repositories.'
 );
 
 export function isPreferredAgentProvider(

--- a/static/app/utils/seer/preferredAgent.ts
+++ b/static/app/utils/seer/preferredAgent.ts
@@ -38,7 +38,7 @@ export function isGithubRepoProvider(provider: string | undefined | null): boole
 }
 
 export const NON_GITHUB_HANDOFF_WARNING = t(
-  'Only Seer can be used with non-GitHub repositories.'
+  'Handoff to Agent is only supported for GitHub repositories.'
 );
 
 export function isPreferredAgentProvider(

--- a/static/app/utils/seer/preferredAgent.ts
+++ b/static/app/utils/seer/preferredAgent.ts
@@ -38,7 +38,7 @@ export function isGithubRepoProvider(provider: string | undefined | null): boole
 }
 
 export const NON_GITHUB_HANDOFF_WARNING = t(
-  'Handoff to Agent is only supported for GitHub repositories.'
+  'Only the Seer agent is supported for non-GitHub repositories.'
 );
 
 export function isPreferredAgentProvider(

--- a/static/app/utils/seer/preferredAgent.ts
+++ b/static/app/utils/seer/preferredAgent.ts
@@ -27,16 +27,6 @@ export function coalesePreferredAgent(
   return `${agent}::${integrationId ?? ''}` as const;
 }
 
-// Only GitHub repositories can hand off to an external coding agent; everything
-// else (GitLab, Bitbucket, etc.) can only hand off to Seer. Provider identity
-// comes through in a few shapes — the repository `provider.id`
-// (`'integrations:github'`, `'github'`, `'integrations:github_enterprise'`, ...)
-// and the lowercased provider name persisted on Seer repos (`'github'`) — so
-// match on the substring rather than an exact list.
-export function isGithubRepoProvider(provider: string | undefined | null): boolean {
-  return Boolean(provider?.toLowerCase().includes('github'));
-}
-
 export const NON_GITHUB_HANDOFF_WARNING = t(
   'Only the Seer agent is supported for non-GitHub repositories.'
 );


### PR DESCRIPTION
## Summary

GitLab (non Github) repositories can only hand off to **Seer** — external coding agents (Cursor, Claude Code, etc.) are not supported for GitLab. Previously the **Add Project to Autofix** modal and the per-project edit settings page let a user attach a GitLab repo and still pick a coding agent, which can't work.

When a GitLab repo is attached, this PR:
- **disables** the *Handoff to Agent* dropdown and pins it to **Seer**
- shows a **warning** explaining the limitation
- on the modal, **coerces** the saved agent to Seer on submit, so the persisted value is valid even when the org default is a coding agent


<img width="839" height="583" alt="image" src="https://github.com/user-attachments/assets/359d7839-4af7-44b0-881f-c781d84bc227" />

<img width="669" height="712" alt="image" src="https://github.com/user-attachments/assets/36f41b04-ffb1-4b08-ad16-2ffd611cc7f2" />


Related https://github.com/getsentry/sentry/pull/118465

🤖 Generated with [Claude Code](https://claude.com/claude-code)

