### PR TITLE
ref: Document taskbroker raw-mode kafka tasks

### DIFF
--- a/src/sentry/ingest/consumer/simple_event.py
+++ b/src/sentry/ingest/consumer/simple_event.py
@@ -91,7 +91,16 @@ def process_simple_event_message(
     silo_mode=SiloMode.CELL,
 )
 def process_event_from_kafka(message_bytes: bytes) -> None:
-    """Process an event from raw Kafka message bytes (taskbroker raw mode)."""
+    """Process an event from raw Kafka message bytes.
+
+    This task is directly spawned from taskbroker in "raw mode". You won't find
+    any application code that calls apply_async or delay directly on it,
+    instead taskbroker itself is configured to consume a topic (in infra
+    templates) and spawns tasks for each message.
+
+    As such, the task signature, name and namespace cannot be changed without
+    coordination.
+    """
     metrics.distribution(
         "ingest_consumer.payload_size",
         len(message_bytes),

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -168,7 +168,16 @@ def process_profile_from_kafka(
     message_bytes: bytes,
     headers: dict[str, str],
 ) -> None:
-    """Process a profile from raw Kafka message bytes (taskbroker passthrough mode)."""
+    """Process a profile from raw Kafka message bytes.
+
+    This task is directly spawned from taskbroker in "raw mode". You won't find
+    any application code that calls apply_async or delay directly on it,
+    instead taskbroker itself is configured to consume a topic (in infra
+    templates) and spawns tasks for each message.
+
+    As such, the task signature, name and namespace cannot be changed without
+    coordination.
+    """
     if _should_drop(headers):
         return
 

--- a/src/sentry/snuba/query_subscriptions/run.py
+++ b/src/sentry/snuba/query_subscriptions/run.py
@@ -182,6 +182,16 @@ def _register_subscription_tasks() -> None:
             silo_mode=SiloMode.CELL,
         )
         def task_fn(message_bytes: bytes, _d: Dataset = dataset) -> None:
+            """Process a subscription message from raw Kafka message bytes.
+
+            This task is directly spawned from taskbroker in "raw mode". You won't find
+            any application code that calls apply_async or delay directly on it,
+            instead taskbroker itself is configured to consume a topic (in infra
+            templates) and spawns tasks for each message.
+
+            As such, the task signature, name and namespace cannot be changed without
+            coordination.
+            """
             _process_subscription_message(message_bytes, _d)
 
 


### PR DESCRIPTION
Adds explanatory comments to the three tasks that taskbroker spawns directly from Kafka in "raw mode": `process_profile_from_kafka`, `process_event_from_kafka`, and the subscription `task_fn`. These tasks have no in-app callers and their signature/name/namespace are pinned by infra config, which isn't obvious from the code.

We add these disclaimers everywhere because we can't think of a decent way to have real guardrails here.