### PR TITLE
feat(scm-multi-platform-detection): Conditional use of new multi dete…

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_repository_platforms.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_platforms.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import logging
-
+import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -11,14 +10,22 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.integrations.api.bases.organization_repository import OrganizationRepositoryEndpoint
 from sentry.integrations.github.client import GitHubApiClient
+from sentry.integrations.github.multi_platform_detection import detect_platforms_multi
 from sentry.integrations.github.platform_detection import detect_platforms
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
-from sentry.shared_integrations.exceptions import ApiError
+from sentry.shared_integrations.exceptions import ApiConflictError, ApiError
 
-logger = logging.getLogger(__name__)
+
+def _capture_detection_exception(type: str, is_multi: bool, repo_id: int, repo_name: str) -> None:
+    with sentry_sdk.new_scope() as scope:
+        scope.set_tag("scm_platform_detection", type)
+        scope.set_tag("is_multi", is_multi)
+        scope.set_tag("repo_id", repo_id)
+        scope.set_tag("repo_name", repo_name)
+        sentry_sdk.capture_exception()
 
 
 @cell_silo_endpoint
@@ -60,13 +67,22 @@ class OrganizationRepositoryPlatformsEndpoint(OrganizationRepositoryEndpoint):
 
         client = GitHubApiClient(integration=integration, org_integration_id=org_integration.id)
 
+        is_multi = features.has(
+            "organizations:integrations-github-multi-platform-detection",
+            organization,
+            actor=request.user,
+        )
         try:
-            platforms = detect_platforms(client=client, repo=repo.name)
+            if is_multi:
+                platforms = detect_platforms_multi(client, repo.name)["platforms"]
+            else:
+                platforms = detect_platforms(client=client, repo=repo.name)
+        except ApiConflictError:
+            # Empty / unprocessable repo (e.g. empty git tree) — multi path only.
+            _capture_detection_exception("empty_repo", is_multi, repo.id, repo.name)
+            return Response({"platforms": []})
         except (ApiError, ValueError):
-            logger.exception(
-                "integrations.github.platform_detection_failed",
-                extra={"repo_id": repo.id, "repo_name": repo.name},
-            )
+            _capture_detection_exception("failed", is_multi, repo.id, repo.name)
             return Response({"detail": "Failed to detect platforms from GitHub."}, status=502)
 
         return Response({"platforms": platforms})

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
@@ -11,6 +11,8 @@ from sentry.models.repository import Repository
 from sentry.testutils.cases import APITestCase
 
 FEATURE_FLAG = "organizations:integrations-github-platform-detection"
+MULTI_FLAG = "organizations:integrations-github-multi-platform-detection"
+ENDPOINT_MODULE = "sentry.integrations.api.endpoints.organization_repository_platforms"
 
 
 class OrganizationRepositoryPlatformsGetTest(APITestCase):
@@ -194,9 +196,12 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             response = self.get_response(self.organization.slug, other_repo.id)
         assert response.status_code == 404
 
+    @mock.patch(f"{ENDPOINT_MODULE}.sentry_sdk")
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
-    def test_github_api_error_returns_502(self, get_jwt: mock.MagicMock) -> None:
+    def test_github_api_error_returns_502(
+        self, get_jwt: mock.MagicMock, mock_sentry_sdk: mock.MagicMock
+    ) -> None:
         responses.add(
             method=responses.GET,
             url="https://api.github.com/repos/Test-Organization/foo/languages",
@@ -208,3 +213,125 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             response = self.get_response(self.organization.slug, self.repo.id)
         assert response.status_code == 502
         assert "Failed to detect" in response.data["detail"]
+        assert mock_sentry_sdk.capture_exception.called
+        scope = mock_sentry_sdk.new_scope.return_value.__enter__.return_value
+        scope.set_tag.assert_any_call("is_multi", False)
+        scope.set_tag.assert_any_call("repo_id", self.repo.id)
+        scope.set_tag.assert_any_call("repo_name", self.repo.name)
+
+
+class OrganizationRepositoryPlatformsMultiGetTest(APITestCase):
+    """Tests for the multi-platform detector path (both flags enabled)."""
+
+    endpoint = "sentry-api-0-organization-repository-platforms"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+
+        ten_days = timezone.now() + timedelta(days=10)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="Github Test Org",
+            external_id="1",
+            metadata={
+                "access_token": "12345token",
+                "expires_at": ten_days.strftime("%Y-%m-%dT%H:%M:%S"),
+            },
+        )
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="integrations:github",
+            external_id="123",
+            integration_id=self.integration.id,
+        )
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_multi_detects_framework_and_language(self, get_jwt: mock.MagicMock) -> None:
+        # manage.py is a pure existence rule for python-django — no content read needed.
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/languages",
+            json={"Python": 50000},
+            status=200,
+        )
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/git/trees/HEAD",
+            json={
+                "tree": [{"path": "manage.py", "type": "blob", "size": 100}],
+                "truncated": False,
+            },
+            status=200,
+        )
+
+        with self.feature({FEATURE_FLAG: True, MULTI_FLAG: True}):
+            response = self.get_success_response(
+                self.organization.slug, self.repo.id, status_code=200
+            )
+
+        platforms = {p["platform"]: p for p in response.data["platforms"]}
+        assert "python-django" in platforms
+        assert platforms["python-django"]["confidence"] == "high"
+        assert "python" in platforms
+        assert platforms["python"]["confidence"] == "medium"
+
+    @mock.patch(f"{ENDPOINT_MODULE}.sentry_sdk")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_multi_empty_repo_returns_empty_list(
+        self, get_jwt: mock.MagicMock, mock_sentry_sdk: mock.MagicMock
+    ) -> None:
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/languages",
+            json={"Python": 50000},
+            status=200,
+        )
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/git/trees/HEAD",
+            json={"message": "Git Repository is empty."},
+            status=409,
+        )
+
+        with self.feature({FEATURE_FLAG: True, MULTI_FLAG: True}):
+            response = self.get_success_response(
+                self.organization.slug, self.repo.id, status_code=200
+            )
+
+        assert response.data == {"platforms": []}
+        assert mock_sentry_sdk.capture_exception.called
+        scope = mock_sentry_sdk.new_scope.return_value.__enter__.return_value
+        scope.set_tag.assert_any_call("scm_platform_detection", "empty_repo")
+        scope.set_tag.assert_any_call("is_multi", True)
+        scope.set_tag.assert_any_call("repo_id", self.repo.id)
+        scope.set_tag.assert_any_call("repo_name", self.repo.name)
+
+    @mock.patch(f"{ENDPOINT_MODULE}.sentry_sdk")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_multi_github_api_error_returns_502(
+        self, get_jwt: mock.MagicMock, mock_sentry_sdk: mock.MagicMock
+    ) -> None:
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/languages",
+            json={"message": "Server Error"},
+            status=500,
+        )
+
+        with self.feature({FEATURE_FLAG: True, MULTI_FLAG: True}):
+            response = self.get_response(self.organization.slug, self.repo.id)
+
+        assert response.status_code == 502
+        assert "Failed to detect" in response.data["detail"]
+        assert mock_sentry_sdk.capture_exception.called
+        scope = mock_sentry_sdk.new_scope.return_value.__enter__.return_value
+        scope.set_tag.assert_any_call("is_multi", True)
+        scope.set_tag.assert_any_call("repo_id", self.repo.id)
+        scope.set_tag.assert_any_call("repo_name", self.repo.name)


### PR DESCRIPTION
- Easiest way to roll this out is to conditionally use the detector in the live endpoint
- If there are regressions we can just set the rollout on the feature flag to 0, faster deploy than frontend changes
- Note: I replaced the `logger` with sentry exception capture, with some helpful tags. Just way more comfortable with the sentry UI AND, metrics and issues will co-exist in sentry, making it easier to track

