### PR TITLE
experiment(GALE): Favor merged in status

### DIFF
--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -35,8 +35,8 @@ def track_views(state: StateView, entry: GroupActionLogEntry) -> AggregatorResul
 )
 def track_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
     from_merged = entry.original_group_id is not None
-    merged_status_locked = state[STATUS_FROM_MERGED]
-    if merged_status_locked and not from_merged:
+    has_merged_status = state[STATUS_FROM_MERGED]
+    if has_merged_status and not from_merged:
         return None
 
     current = state[STATUS]
@@ -55,10 +55,10 @@ def track_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResu
     elif entry.type in reopens and current == IssueStatus.CLOSED:
         new_status = IssueStatus.OPEN
 
-    if new_status == current and not (from_merged and not merged_status_locked):
+    if new_status == current and not (from_merged and not has_merged_status):
         return None
     return emit(
-        STATUS.value(new_status), STATUS_FROM_MERGED.value(merged_status_locked or from_merged)
+        STATUS.value(new_status), STATUS_FROM_MERGED.value(has_merged_status or from_merged)
     )
 
 

--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -3,6 +3,7 @@ from sentry.issues.derived.features import (
     LAST_PROGRESSED_AT,
     PROGRESS,
     STATUS,
+    STATUS_FROM_MERGED,
     VIEW_COUNT,
     IssueStatus,
 )
@@ -23,7 +24,7 @@ def track_views(state: StateView, entry: GroupActionLogEntry) -> AggregatorResul
 
 
 @aggregator(
-    (STATUS,),
+    (STATUS, STATUS_FROM_MERGED),
     scope=(
         GroupActionType.RESOLVE,
         GroupActionType.UNRESOLVE,
@@ -33,6 +34,11 @@ def track_views(state: StateView, entry: GroupActionLogEntry) -> AggregatorResul
     ),
 )
 def track_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
+    from_merged = entry.original_group_id is not None
+    merged_status_locked = state[STATUS_FROM_MERGED]
+    if merged_status_locked and not from_merged:
+        return None
+
     current = state[STATUS]
     resolves = (
         GroupActionType.RESOLVE.value,
@@ -43,11 +49,17 @@ def track_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResu
         GroupActionType.UNRESOLVE.value,
         GroupActionType.SET_REGRESSED.value,
     )
+    new_status = current
     if entry.type in resolves and current == IssueStatus.OPEN:
-        return emit(STATUS.value(IssueStatus.CLOSED))
-    if entry.type in reopens and current == IssueStatus.CLOSED:
-        return emit(STATUS.value(IssueStatus.OPEN))
-    return None
+        new_status = IssueStatus.CLOSED
+    elif entry.type in reopens and current == IssueStatus.CLOSED:
+        new_status = IssueStatus.OPEN
+
+    if new_status == current and not (from_merged and not merged_status_locked):
+        return None
+    return emit(
+        STATUS.value(new_status), STATUS_FROM_MERGED.value(merged_status_locked or from_merged)
+    )
 
 
 # Progress state machine for open issues (None when closed).

--- a/src/sentry/issues/derived/features.py
+++ b/src/sentry/issues/derived/features.py
@@ -16,6 +16,9 @@ VIEW_COUNT = Feature[int]("view_count", default=0)
 # Status of the issue based on the log.
 STATUS = Feature[IssueStatus]("status", default=IssueStatus.OPEN, codec=EnumCodec(IssueStatus))
 
+# Status may differ if groups have been merged in
+STATUS_FROM_MERGED = Feature[bool]("status_from_merged", default=False)
+
 # The current Progress of the issue.
 PROGRESS = Feature[IssueProgressState | None](
     "progress",

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -240,6 +240,20 @@ def test_resolved_in_pr_when_already_closed_is_noop() -> None:
     )
 
 
+def test_archive_unresolve() -> None:
+    assert (
+        _run_for_feature(
+            STATUS,
+            [
+                FakeEntry(type=GroupActionType.ARCHIVE, date_added=_ts(hour=1)),
+                FakeEntry(type=GroupActionType.UNRESOLVE, date_added=_ts(hour=2)),
+                FakeEntry(type=GroupActionType.ARCHIVE, date_added=_ts(hour=3)),
+            ],
+        )
+        == IssueStatus.CLOSED
+    )
+
+
 def test_merged_archive_unresolve() -> None:
     assert (
         _run_for_feature(

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -57,6 +57,7 @@ class FakeEntry:
     actor_type: int = GroupActorType.SYSTEM
     actor_id: int = 0
     data: dict[str, object] = field(default_factory=dict)
+    original_group_id: int | None = None
 
 
 def _ts(year: int = 2025, month: int = 1, day: int = 1, hour: int = 0) -> datetime:
@@ -236,6 +237,26 @@ def test_resolved_in_pr_when_already_closed_is_noop() -> None:
             ],
         )
         == IssueStatus.CLOSED
+    )
+
+
+def test_merged_archive_unresolve() -> None:
+    assert (
+        _run_for_feature(
+            STATUS,
+            [
+                # group B is archived and then unresolved, b is merged into a
+                FakeEntry(
+                    type=GroupActionType.ARCHIVE, date_added=_ts(hour=1), original_group_id=1
+                ),
+                FakeEntry(
+                    type=GroupActionType.UNRESOLVE, date_added=_ts(hour=2), original_group_id=1
+                ),
+                # group A is archived later, but the merged group's status wins
+                FakeEntry(type=GroupActionType.ARCHIVE, date_added=_ts(hour=3)),
+            ],
+        )
+        == IssueStatus.OPEN
     )
 
 


### PR DESCRIPTION
A possible way we could deal with one specific instance of merged issues' activities not making sense - we haven't necessarily made a product decision about whether this is the direction we want to go for archived vs. unresolved, I just wanted to poke around at it and see how we might accomplish it. 