### PR TITLE
fix(seer): trim whitespace from Datadog PAT access token before submission

### DIFF
--- a/static/gsApp/views/seerAutomation/components/datadogPatConnectModal.tsx
+++ b/static/gsApp/views/seerAutomation/components/datadogPatConnectModal.tsx
@@ -57,7 +57,7 @@ export function DatadogPatConnectModal({
             },
           }
         ),
-        data: {access_token: accessToken, site},
+        data: {access_token: accessToken.trim(), site},
       }),
     onSuccess: () => {
       closeModal();


### PR DESCRIPTION
When a user pastes a Datadog personal access token with leading/trailing whitespace into the connect modal, the raw value (including whitespace) was sent to the API, causing a validation error.

The button's `disabled` logic already used `accessToken.trim()` to check for emptiness, so this aligns the submission path to match.

**Change:** `.trim()` the `access_token` value before POSTing to `/monitoring-providers/datadog_pat/`.

Refs https://sentry.sentry.io/issues/7575749973/

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0B8X2W4TB2%3A1782420329.021649%22)