### PR TITLE
fix(project-creation): Preserve detected selection on back-to-recommended

### DIFF
--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {DetectedPlatformFixture} from 'sentry-fixture/detectedPlatform';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RepositoryFixture} from 'sentry-fixture/repository';
@@ -148,5 +149,103 @@ describe('ScmPlatformFeaturesCore', () => {
       screen.getByRole('button', {name: 'Back to recommended platforms'})
     ).toBeInTheDocument();
     expect(screen.queryByTestId('icon-close')).not.toBeInTheDocument();
+  });
+
+  it('keeps a non-default detected selection when returning to the recommended view', async () => {
+    const onFeaturesChange = jest.fn();
+    const onClearProjectDetailsForm = jest.fn();
+    const repository = RepositoryFixture({
+      id: '123',
+      provider: {id: 'integrations:github', name: 'GitHub'},
+    });
+    // python is the recommendation (first detected); javascript is the second.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/${repository.id}/platforms/`,
+      body: {
+        platforms: [
+          DetectedPlatformFixture({platform: 'python'}),
+          DetectedPlatformFixture({platform: 'javascript'}),
+        ],
+      },
+    });
+
+    // Controlled, so hold the selection in state for the manual-pick flow.
+    function Host() {
+      const [platform, setPlatform] = useState<OnboardingSelectedSDK | undefined>(
+        pythonPlatform
+      );
+      return (
+        <ScmPlatformFeaturesCore
+          analyticsFlow="onboarding"
+          selectedRepository={repository}
+          selectedPlatform={platform}
+          onPlatformChange={setPlatform}
+          onFeaturesChange={onFeaturesChange}
+          onClearProjectDetailsForm={onClearProjectDetailsForm}
+        />
+      );
+    }
+
+    render(<Host />, {organization});
+
+    // Select the second detected platform, then open the manual picker.
+    await userEvent.click(
+      await screen.findByRole('radio', {name: 'Browser JavaScript Language'})
+    );
+    await userEvent.click(
+      screen.getByRole('button', {name: "Doesn't look right? Change platform"})
+    );
+    onFeaturesChange.mockClear();
+    onClearProjectDetailsForm.mockClear();
+
+    // Returning keeps the chosen detected platform: it is already detected, so
+    // nothing is reset and the card stays selected.
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Back to recommended platforms'})
+    );
+
+    expect(
+      await screen.findByRole('radio', {name: 'Browser JavaScript Language'})
+    ).toBeChecked();
+    expect(onFeaturesChange).not.toHaveBeenCalled();
+    expect(onClearProjectDetailsForm).not.toHaveBeenCalled();
+  });
+
+  it('does not reset state when returning without a change', async () => {
+    const onFeaturesChange = jest.fn();
+    const onClearProjectDetailsForm = jest.fn();
+    const repository = RepositoryFixture({
+      id: '123',
+      provider: {id: 'integrations:github', name: 'GitHub'},
+    });
+    // python is both the recommendation and the already-selected platform.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/${repository.id}/platforms/`,
+      body: {platforms: [DetectedPlatformFixture({platform: 'python'})]},
+    });
+
+    render(
+      <ScmPlatformFeaturesCore
+        {...defaultProps({
+          selectedRepository: repository,
+          selectedPlatform: pythonPlatform,
+          onFeaturesChange,
+          onClearProjectDetailsForm,
+        })}
+      />,
+      {organization}
+    );
+
+    // Open the manual picker from the detected view, then return without
+    // choosing a different platform.
+    await userEvent.click(
+      await screen.findByRole('button', {name: "Doesn't look right? Change platform"})
+    );
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Back to recommended platforms'})
+    );
+
+    expect(onFeaturesChange).not.toHaveBeenCalled();
+    expect(onClearProjectDetailsForm).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -124,6 +124,13 @@ export function ScmPlatformFeaturesCore({
     isDetectionError,
   } = useScmResolvedPlatform({selectedPlatform, selectedRepository});
 
+  // Whether the active platform is one of the detected ones. Gates the
+  // detected-cards view below, and lets "Back to recommended" keep a detected
+  // selection (including a non-top one) rather than forcing the top detection.
+  const currentPlatformIsDetected = resolvedPlatforms.some(
+    p => p.platform === currentPlatformKey
+  );
+
   // Adopt the first detected platform once per repo when the user hasn't
   // explicitly chosen one: commit it to the host so flows without a Continue
   // boundary (single-view project creation) get a platform without an explicit
@@ -276,11 +283,18 @@ export function ScmPlatformFeaturesCore({
 
   function handleBackToRecommended() {
     setShowManualPicker(false);
-    if (detectedPlatformKey) {
-      setPlatform(detectedPlatformKey);
-      onFeaturesChange(DEFAULT_SCM_FEATURES);
-      onClearProjectDetailsForm();
+    // If the active platform is already a detected one, just reopen the cards
+    // view with it still selected. The user may have picked a non-top detection
+    // (or the auto-adopted default), so forcing the top detection here would
+    // clear a valid selection and wipe the derived features/form for no reason.
+    // Only a manual (non-detected) pick needs the fallback, since the cards view
+    // can't display it otherwise.
+    if (currentPlatformIsDetected || !detectedPlatformKey) {
+      return;
     }
+    setPlatform(detectedPlatformKey);
+    onFeaturesChange(DEFAULT_SCM_FEATURES);
+    onClearProjectDetailsForm();
   }
 
   // Shared by both manual-picker variants. A null option is the clear action,
@@ -316,11 +330,8 @@ export function ScmPlatformFeaturesCore({
     ];
   }, [currentPlatformKey]);
 
-  // If the user previously selected a platform manually (not in the detected
-  // list), show the manual picker so their selection is visible.
-  const currentPlatformIsDetected = resolvedPlatforms.some(
-    p => p.platform === currentPlatformKey
-  );
+  // When the active platform is a manual (non-detected) pick, show the manual
+  // picker so the selection stays visible (see showDetectedPlatforms below).
   const hasDetectedPlatforms = resolvedPlatforms.length > 0 || isDetecting;
   // Fall through to manual picker on detection error
   const showDetectedPlatforms =

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -283,13 +283,18 @@ export function ScmPlatformFeaturesCore({
 
   function handleBackToRecommended() {
     setShowManualPicker(false);
-    // If the active platform is already a detected one, just reopen the cards
-    // view with it still selected. The user may have picked a non-top detection
-    // (or the auto-adopted default), so forcing the top detection here would
-    // clear a valid selection and wipe the derived features/form for no reason.
-    // Only a manual (non-detected) pick needs the fallback, since the cards view
-    // can't display it otherwise.
-    if (currentPlatformIsDetected || !detectedPlatformKey) {
+    // If the host already has a detected platform committed, just reopen the
+    // cards view with it still selected. The user may have committed a non-top
+    // detection (or the auto-adopted default), so forcing the top detection here
+    // would clear a valid selection and wipe the derived features/form for no
+    // reason. Check selectedPlatform, not currentPlatformKey: the latter falls
+    // back to the top detection even when nothing is committed, so using it here
+    // would skip the commit below and strand Create behind an empty
+    // selectedPlatform while the cards still look selected.
+    const selectedIsDetected = resolvedPlatforms.some(
+      p => p.platform === selectedPlatform?.key
+    );
+    if (selectedIsDetected || !detectedPlatformKey) {
       return;
     }
     setPlatform(detectedPlatformKey);


### PR DESCRIPTION
## TLDR

Fix `handleBackToRecommended` so returning to the recommended view no longer clears a valid platform selection or wipes the derived features and project-details form.

## Details

"Back to recommended platforms" leaves the manual picker and returns to the auto-detected cards view. It reset the selected features and project-details form whenever a detected platform existed, even when the platform did not change. Two problems followed:

- Opening the manual picker and returning without choosing a different platform wiped customized features and the project name.
- Returning while a non-top detected platform was selected (for example the user picked the second detection) switched the selection to the top detection, clearing a valid choice.

`handleBackToRecommended` now returns early when the active platform is already one of the detected ones, mirroring `handleSelectDetectedPlatform`. Only a manual (non-detected) pick falls back to the top detection, since the cards view cannot display it otherwise. Specs cover the non-top detected selection and the unchanged-return path.
