### PR TITLE
fix(seer-infra-telemetry): strip whitespace from Datadog PAT access_token in build_identity

### DIFF
--- a/src/sentry/identity/datadog/provider.py
+++ b/src/sentry/identity/datadog/provider.py
@@ -432,7 +432,7 @@ class DatadogPatIdentityProvider(McpIdentityProvider, Provider):
         return f"{base}{MCP_ENDPOINT_PATH}" if base else None
 
     def build_identity(self, data: dict[str, Any]) -> dict[str, Any]:
-        access_token = data.get("access_token")
+        access_token = (data.get("access_token") or "").strip()
         if not access_token:
             raise ValueError("Datadog requires an 'access_token' parameter.")
 

--- a/tests/sentry/identity/datadog/test_provider.py
+++ b/tests/sentry/identity/datadog/test_provider.py
@@ -727,6 +727,7 @@ class DatadogPatIdentityProviderTest(TestCase):
         with pytest.raises(ValueError, match="requires an 'access_token'"):
             self.provider.build_identity({"site": "datadoghq.com"})
         mock_get_user_info.assert_not_called()
+
     @patch("sentry.identity.datadog.provider.get_user_info")
     def test_build_identity_strips_whitespace_from_access_token(
         self, mock_get_user_info: MagicMock

--- a/tests/sentry/identity/datadog/test_provider.py
+++ b/tests/sentry/identity/datadog/test_provider.py
@@ -727,6 +727,29 @@ class DatadogPatIdentityProviderTest(TestCase):
         with pytest.raises(ValueError, match="requires an 'access_token'"):
             self.provider.build_identity({"site": "datadoghq.com"})
         mock_get_user_info.assert_not_called()
+    @patch("sentry.identity.datadog.provider.get_user_info")
+    def test_build_identity_strips_whitespace_from_access_token(
+        self, mock_get_user_info: MagicMock
+    ) -> None:
+        mock_get_user_info.return_value = {
+            "user_uuid": "dd-user-123",
+            "org_uuid": "dd-org-456",
+        }
+
+        result = self.provider.build_identity(
+            {"access_token": "  pat-abc  ", "site": "datadoghq.com"}
+        )
+
+        assert result["data"]["access_token"] == "pat-abc"
+        mock_get_user_info.assert_called_once_with("pat-abc", "https://mcp.datadoghq.com")
+
+    @patch("sentry.identity.datadog.provider.get_user_info")
+    def test_build_identity_whitespace_only_access_token(
+        self, mock_get_user_info: MagicMock
+    ) -> None:
+        with pytest.raises(ValueError, match="requires an 'access_token'"):
+            self.provider.build_identity({"access_token": "   ", "site": "datadoghq.com"})
+        mock_get_user_info.assert_not_called()
 
     @patch("sentry.identity.datadog.provider.get_user_info")
     def test_build_identity_missing_site(self, mock_get_user_info: MagicMock) -> None:


### PR DESCRIPTION
When a user pastes a Datadog PAT with leading/trailing whitespace, the raw value was forwarded to the MCP `get_user_info` call and stored in the identity, causing an auth failure.

**Fix:** `.strip()` the token at the top of `DatadogPatIdentityProvider.build_identity` before validation or use. This also correctly rejects whitespace-only tokens (previously they could slip past the `if not access_token` guard as truthy strings).

**Tests added:**
- `test_build_identity_strips_whitespace_from_access_token` — confirms the stripped token is passed to `get_user_info` and stored
- `test_build_identity_whitespace_only_access_token` — confirms a whitespace-only token raises `ValueError`

Refs https://sentry.sentry.io/issues/7575749973/

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0B8X2W4TB2%3A1782420329.021649%22)