### PR TITLE
feat(trace-items): Match attribute context by convention, not source

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -427,10 +427,12 @@ def as_attribute_key(
         # When context is requested we always attach it. We match against the
         # sentry conventions by name and type regardless of source_type, because
         # `source_type` reflects who set the attribute (SDK vs user), not whether
-        # it maps to a convention -- e.g. `http.route` is a convention but isn't
-        # in `attributes.py`, so it resolves as a `user` source attribute.
-        # Anything without a matching convention gets an empty context for now;
-        # serving custom attribute context is planned.
+        # it maps to a convention. `attributes.py` only lists conventions that
+        # need an alias (a public name distinct from their internal name), so a
+        # convention whose name is already the same internally -- e.g.
+        # `http.route` -- is missing from it and resolves as a `user` source
+        # attribute. Anything without a matching convention gets an empty context
+        # for now; serving custom attribute context is planned.
         context = build_sentry_convention_context(public_name, name, attr_type) or {}
         attribute_key["context"] = context
 

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -298,8 +298,21 @@ def resolve_attribute_values_referrer(item_type: str) -> Referrer:
         raise ValueError(f"Invalid item type: {item_type}")
 
 
+# Maps sentry-convention attribute types to EAP search types. Array and "any"
+# convention types aren't representable as a single search type, so they're
+# omitted and treated as "no type constraint" when matching.
+_CONVENTION_TYPE_TO_SEARCH_TYPE: dict[str, str] = {
+    "string": "string",
+    "boolean": "boolean",
+    "integer": "number",
+    "double": "number",
+}
+
+
 def build_sentry_convention_context(
-    public_name: str, internal_name: str
+    public_name: str,
+    internal_name: str,
+    attribute_type: Literal["string", "number", "boolean"] | None = None,
 ) -> TraceItemAttributeContext | None:
     """
     Build the sentry conventions context for an attribute, if it maps to a known
@@ -310,16 +323,30 @@ def build_sentry_convention_context(
     alias or the internal name (see
     ``_update_attribute_definitions_with_deprecations`` in
     ``search/eap/spans/attributes.py``), so we try the public name first and
-    fall back to the internal name.
+    fall back to the internal name. The lookup is purely by name and does not
+    depend on the attribute's source, so conventions defined in
+    ``sentry_conventions`` but not in ``attributes.py`` (e.g. ``http.route``)
+    still resolve.
+
+    When ``attribute_type`` is provided, the convention only matches if its
+    expected type is compatible, so a custom attribute that merely shares a name
+    with a convention but has a different type isn't treated as that convention.
     """
     metadata = ATTRIBUTE_METADATA.get(public_name) or ATTRIBUTE_METADATA.get(internal_name)
     if metadata is None:
         return None
 
+    if attribute_type is not None:
+        expected_type = _CONVENTION_TYPE_TO_SEARCH_TYPE.get(metadata.type.value)
+        if expected_type is not None and expected_type != attribute_type:
+            return None
+
     deprecation = metadata.deprecation
 
-    # brief and isDeprecated are always present for a known convention.
+    # isConvention, brief and isDeprecated are always present for a known
+    # convention.
     context: TraceItemAttributeContext = {
+        "isConvention": True,
         "brief": metadata.brief,
         "isDeprecated": bool(
             deprecation is not None and (deprecation.status is not None or deprecation.replacement)
@@ -397,13 +424,14 @@ def as_attribute_key(
         attribute_key["secondaryAliases"] = sorted(secondary_aliases)
 
     if include_context:
-        # When context is requested we always attach it, even for custom
-        # (non-sentry-convention) attributes. Today only sentry-convention
-        # attributes have metadata to surface, so custom attributes get an empty
-        # context for now; serving custom attribute context is planned.
-        context: TraceItemAttributeContext = {}
-        if serialized_source["source_type"] == AttributeSourceType.SENTRY.value:
-            context = build_sentry_convention_context(public_name, name) or {}
+        # When context is requested we always attach it. We match against the
+        # sentry conventions by name and type regardless of source_type, because
+        # `source_type` reflects who set the attribute (SDK vs user), not whether
+        # it maps to a convention -- e.g. `http.route` is a convention but isn't
+        # in `attributes.py`, so it resolves as a `user` source attribute.
+        # Anything without a matching convention gets an empty context for now;
+        # serving custom attribute context is planned.
+        context = build_sentry_convention_context(public_name, name, attr_type) or {}
         attribute_key["context"] = context
 
     return attribute_key

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
@@ -12,14 +12,19 @@ class TraceItemAttributeContext(TypedDict):
 
     When ``expand=context`` is requested, context is attached to every
     attribute. Today the metadata is sourced from the sentry conventions
-    (``sentry_conventions.attributes.ATTRIBUTE_METADATA``), so attributes that
-    map to a known convention carry that metadata (only the fields actually
-    present are included) while custom attributes get an empty context. Serving
-    context for custom attributes is planned (gated behind the
+    (``sentry_conventions.attributes.ATTRIBUTE_METADATA``), matched by attribute
+    name (and type when known) regardless of the attribute's source, so any
+    attribute that maps to a known convention carries that metadata (only the
+    fields actually present are included) while the rest get an empty context.
+    Serving context for custom attributes is planned (gated behind the
     ``data-browsing-attribute-context`` feature), at which point the empty
     contexts will start to be populated.
     """
 
+    # Whether this context comes from a known sentry convention. Present (and
+    # True) for a known convention. Lets clients distinguish sentry-convention
+    # context from custom (user-authored) context once the latter is served.
+    isConvention: NotRequired[bool]
     # A short, human-readable description of the attribute. Present for a known
     # convention.
     brief: NotRequired[str]

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -43,6 +43,7 @@ class TestBuildAttributeContext:
         assert "span.op" not in ATTRIBUTE_METADATA
         context = build_sentry_convention_context("span.op", "sentry.op")
         assert context == {
+            "isConvention": True,
             "brief": "The operation of a span.",
             "examples": ["http.client"],
             "isDeprecated": False,
@@ -51,11 +52,30 @@ class TestBuildAttributeContext:
     def test_deprecated_attribute_includes_replacement(self) -> None:
         context = build_sentry_convention_context("transaction", "sentry.transaction")
         assert context is not None
+        assert context["isConvention"] is True
         assert context["isDeprecated"] is True
         assert context["replacementAttribute"] == "sentry.segment.name"
 
     def test_unknown_attribute_returns_none(self) -> None:
         assert build_sentry_convention_context("not.a.convention", "also.not.a.convention") is None
+
+    def test_matches_convention_not_in_attributes_py(self) -> None:
+        # `http.route` is defined in sentry-conventions but not in attributes.py,
+        # so it resolves as a `user` source attribute. It should still match.
+        context = build_sentry_convention_context("http.route", "http.route")
+        assert context is not None
+        assert context["isConvention"] is True
+        assert context["brief"]
+
+    def test_matching_type_is_required_when_provided(self) -> None:
+        # `http.route` is a string convention; a number attribute with the same
+        # name is not that convention.
+        assert build_sentry_convention_context("http.route", "http.route", "string") is not None
+        assert build_sentry_convention_context("http.route", "http.route", "number") is None
+        # Array / "any" convention types don't constrain the match (`ai.citations`
+        # is a `string[]` convention).
+        context = build_sentry_convention_context("ai.citations", "ai.citations", "number")
+        assert context is not None and context["isConvention"] is True
 
 
 class OrganizationTraceItemAttributesEndpointTestBase(APITestCase, SnubaTestCase):
@@ -499,10 +519,11 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             uuid4().hex,
             organization_id=self.organization.id,
             timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
-            # `gen_ai.request.model` is a sentry convention name, but as a
-            # user-supplied tag it resolves to a `user` source. It must not pick
-            # up convention metadata.
-            tags={"foo": "foo", "gen_ai.request.model": "gpt-4"},
+            # `gen_ai.request.model` is a sentry convention name supplied as a
+            # user tag, and `http.route` is a convention defined in
+            # sentry-conventions but not in attributes.py. Both stay `user`
+            # source but should still be matched to their convention's context.
+            tags={"foo": "foo", "gen_ai.request.model": "gpt-4", "http.route": "/users/:id"},
         )
 
     def test_expand_context(self) -> None:
@@ -517,6 +538,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
 
         # A non-deprecated sentry convention gets brief + examples + isDeprecated.
         assert attributes["device.class"]["context"] == {
+            "isConvention": True,
             "brief": (
                 "The classification of the device. For example, `low`, `medium`, or `high`. "
                 "Typically inferred by Relay - SDKs generally do not need to set this directly."
@@ -526,18 +548,38 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         }
         # A deprecated convention also surfaces the replacement attribute.
         assert attributes["transaction"]["context"] == {
+            "isConvention": True,
             "brief": "The sentry transaction (segment name).",
             "examples": ["GET /"],
             "isDeprecated": True,
             "replacementAttribute": "sentry.segment.name",
         }
-        # Custom attribute context isn't served yet, so user tags get an empty
-        # context for now.
+        # Custom (non-convention) attributes aren't served yet, so they get an
+        # empty context.
         assert attributes["foo"]["context"] == {}
-        # A user tag whose name collides with a sentry convention still gets an
-        # empty context, because only `sentry`-source attributes are expanded.
+        # A user tag whose name matches a sentry convention keeps its `user`
+        # source (it was user-set) but is still matched to the convention's
+        # context, since context is matched by name/type, not source.
         assert attributes["gen_ai.request.model"]["attributeSource"]["source_type"] == "user"
-        assert attributes["gen_ai.request.model"]["context"] == {}
+        assert attributes["gen_ai.request.model"]["context"] == {
+            "isConvention": True,
+            "brief": "The model identifier being used for the request.",
+            "examples": ["gpt-4-turbo-preview"],
+            "isDeprecated": False,
+        }
+        # `http.route` is a convention defined in sentry-conventions but not in
+        # attributes.py, so it resolves as a `user` source attribute but is still
+        # matched to its convention's context.
+        assert attributes["http.route"]["attributeSource"]["source_type"] == "user"
+        assert attributes["http.route"]["context"] == {
+            "isConvention": True,
+            "brief": (
+                "The matched route, that is, the path template in the format used "
+                "by the respective server framework."
+            ),
+            "examples": ["/users/:id"],
+            "isDeprecated": False,
+        }
 
     def test_expand_context_without_feature_flag(self) -> None:
         self._store_basic_segment()


### PR DESCRIPTION
On `/trace-items/attributes/` with `expand=context`, context was only populated for attributes with `source_type == sentry`. But `source_type` reflects **who set the attribute** (SDK/Sentry vs user-set tag), not whether it maps to a convention. Conventions defined in `sentry-conventions` but not in `attributes.py` — e.g. `http.route` — resolve as `user` source and so never got their context.

## Changes

- **Match by convention, not source.** `build_sentry_convention_context` is now called for every attribute regardless of `source_type`. It already returns `None` for non-conventions, so non-matches still get an empty `{}`.
- **Type-aware matching.** When the attribute type is known, the convention only matches if its expected type is compatible — so a custom attribute that merely shares a name with a convention (but has a different type) isn't mistaken for it. Array/`any` convention types don't constrain the match.
- **`isConvention` field** added to the context. It's `True` for convention-sourced context, letting clients distinguish convention context from custom (user-authored) context once the latter is served.

`source_type` semantics are unchanged — a user-set `gen_ai.request.model` or `http.route` stays `user` source but now carries the convention's context.

## Notes

- The `expand` param remains internal-only (`exclude=True` in the OpenAPI spec).
- The frontend parses `attributeSource` into a type but doesn't use it, so this has no UI impact; the behavioral change is purely which attributes get context.

BROWSE-586
