### PR TITLE
fix(issues): Use linked PR authors in sidebar

### DIFF
--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import {skipToken, useQuery} from '@tanstack/react-query';
 
-import {Avatar} from '@sentry/scraps/avatar';
+import {Avatar, UserAvatar} from '@sentry/scraps/avatar';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
@@ -16,8 +16,10 @@ import {GroupActivityType, type Group} from 'sentry/types/group';
 import type {
   LinkedPullRequest,
   LinkedPullRequestsResponse,
+  PullRequestAuthor,
   PullRequestAttribution,
 } from 'sentry/types/integrations';
+import type {User} from 'sentry/types/user';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getAnalyticsDataForGroup} from 'sentry/utils/events';
@@ -57,7 +59,7 @@ function LinkedPullRequestRow({
   const title = pullRequest.title ?? t('Pull request #%s', pullRequest.id);
   const statusLabel = getPullRequestStatusLabel(pullRequest.status);
   const pullRequestLabel = t('#%s', pullRequest.id);
-  const authorAvatar = getPullRequestAuthorAvatar(pullRequest);
+  const author = getPullRequestAuthor(pullRequest);
 
   return (
     <Tooltip
@@ -81,6 +83,7 @@ function LinkedPullRequestRow({
         onClick={() =>
           trackAnalytics('issue_details.external_issue_pull_request_clicked', {
             organization,
+            is_seer: pullRequest.attribution?.type === 'seer',
             pull_request_id: pullRequest.id,
             pull_request_status: pullRequest.status,
             repository_id: pullRequest.repository.id,
@@ -110,8 +113,8 @@ function LinkedPullRequestRow({
               <PullRequestStatusBadge status={pullRequest.status} />
               {pullRequest.attribution ? (
                 <PullRequestAttributionAvatar attribution={pullRequest.attribution} />
-              ) : authorAvatar ? (
-                <PullRequestAuthorAvatar author={authorAvatar} />
+              ) : author ? (
+                <PullRequestAuthorAvatar author={author} />
               ) : null}
               <Text as="span" size="sm" variant="muted">
                 <TimeSince
@@ -140,35 +143,41 @@ function PullRequestAttributionAvatar({
   }
 }
 
-function getPullRequestAuthorAvatar(pullRequest: LinkedPullRequest) {
+function getPullRequestAuthor(pullRequest: LinkedPullRequest): PullRequestAuthor | null {
   if (!pullRequest.author || pullRequest.author.email?.endsWith('@localhost')) {
     return null;
   }
 
-  const name = pullRequest.author.name || pullRequest.author.email;
-  const identifier = pullRequest.author.email || pullRequest.author.name;
-
-  return name && identifier ? {identifier, name} : null;
+  return pullRequest.author;
 }
 
-function PullRequestAuthorAvatar({
-  author,
-}: {
-  author: NonNullable<ReturnType<typeof getPullRequestAuthorAvatar>>;
-}) {
-  const label = t('Pull request author: %s', author.name);
+function isSentryUserAuthor(author: PullRequestAuthor): author is User {
+  return 'id' in author;
+}
+
+function PullRequestAuthorAvatar({author}: {author: PullRequestAuthor}) {
+  const name = author.name || author.email;
+  if (!name) {
+    return null;
+  }
+
+  const label = t('Pull request author: %s', name);
 
   return (
     <Flex as="span" aria-label={label} display="inline-flex" role="img" title={label}>
-      <Avatar
-        hasTooltip
-        identifier={author.identifier}
-        name={author.name}
-        round
-        size={18}
-        tooltip={label}
-        type="letter_avatar"
-      />
+      {isSentryUserAuthor(author) ? (
+        <UserAvatar hasTooltip size={18} tooltip={label} user={author} />
+      ) : (
+        <Avatar
+          hasTooltip
+          identifier={author.email || author.name || name}
+          name={name}
+          round
+          size={18}
+          tooltip={label}
+          type="letter_avatar"
+        />
+      )}
     </Flex>
   );
 }

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -83,7 +83,7 @@ function LinkedPullRequestRow({
         onClick={() =>
           trackAnalytics('issue_details.external_issue_pull_request_clicked', {
             organization,
-            is_seer: pullRequest.attribution?.type === 'seer',
+            attribution_type: pullRequest.attribution?.type,
             pull_request_id: pullRequest.id,
             pull_request_status: pullRequest.status,
             repository_id: pullRequest.repository.id,

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -132,6 +132,8 @@ export type CommitAuthor = {
   name?: string;
 };
 
+export type PullRequestAuthor = User | CommitAuthor;
+
 export type CommitFile = {
   author: CommitAuthor;
   commitMessage: string;
@@ -161,11 +163,12 @@ type SeerAttribution = {
 
 export type PullRequestAttribution = SeerAttribution;
 
-export interface LinkedPullRequest extends PullRequest {
+export type LinkedPullRequest = Omit<PullRequest, 'author'> & {
   attribution: PullRequestAttribution | null;
   dateLinked: string;
   status: PullRequestStatus;
-}
+  author?: PullRequestAuthor;
+};
 
 export interface LinkedPullRequestsResponse {
   pullRequests: LinkedPullRequest[];

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -163,12 +163,12 @@ type SeerAttribution = {
 
 export type PullRequestAttribution = SeerAttribution;
 
-export type LinkedPullRequest = Omit<PullRequest, 'author'> & {
+export interface LinkedPullRequest extends Omit<PullRequest, 'author'> {
   attribution: PullRequestAttribution | null;
   dateLinked: string;
   status: PullRequestStatus;
   author?: PullRequestAuthor;
-};
+}
 
 export interface LinkedPullRequestsResponse {
   pullRequests: LinkedPullRequest[];

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -1,6 +1,6 @@
 import type {FieldValue} from 'sentry/components/forms/model';
 import type {PriorityLevel} from 'sentry/types/group';
-import type {IntegrationType} from 'sentry/types/integrations';
+import type {IntegrationType, PullRequestAttribution} from 'sentry/types/integrations';
 import type {Broadcast} from 'sentry/types/system';
 import type {BaseEventAnalyticsParams} from 'sentry/utils/analytics/workflowAnalyticsEvents';
 import type {CommonGroupAnalyticsData} from 'sentry/utils/events';
@@ -37,11 +37,11 @@ interface ExternalIssueParams extends CommonGroupAnalyticsData {
 }
 
 interface ExternalIssuePullRequestParams extends CommonGroupAnalyticsData {
-  is_seer: boolean;
   pull_request_id: string;
   pull_request_status: string;
   repository_id: string;
   repository_provider: string;
+  attribution_type?: PullRequestAttribution['type'];
 }
 
 interface SetPriorityParams extends CommonGroupAnalyticsData {

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -37,6 +37,7 @@ interface ExternalIssueParams extends CommonGroupAnalyticsData {
 }
 
 interface ExternalIssuePullRequestParams extends CommonGroupAnalyticsData {
+  is_seer: boolean;
   pull_request_id: string;
   pull_request_status: string;
   repository_id: string;


### PR DESCRIPTION
Prefer mapped Sentry users for linked PR authors in the issue details sidebar, falling back to the lightweight author name/email when we do not have a user mapping.

Also adds `is_seer` to the linked PR click event so we can split Seer-attributed PR clicks without inferring it from the rest of the payload.