### PR TITLE
chore(tasks) Switch to un-prefixed taskworker metrics

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -108,14 +108,11 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
     from django.conf import settings
     from taskbroker_client.scheduler import RunStorage, ScheduleRunner
 
-    from sentry.taskworker.adapters import SentryMetricsBackend
     from sentry.taskworker.runtime import app
     from sentry.utils.redis import redis_clusters
 
     app.load_modules()
-    run_storage = RunStorage(
-        metrics=SentryMetricsBackend(), redis=redis_clusters.get(redis_cluster)
-    )
+    run_storage = RunStorage(metrics=app.metrics, redis=redis_clusters.get(redis_cluster))
 
     with managed_bgtasks(role="taskworker-scheduler"):
         runner = ScheduleRunner(app, run_storage)

--- a/src/sentry/taskworker/adapters.py
+++ b/src/sentry/taskworker/adapters.py
@@ -18,6 +18,7 @@ from arroyo.backends.kafka import KafkaProducer
 from django.conf import settings
 from django.core.cache.backends.base import BaseCache
 from sentry_sdk import capture_exception
+from taskbroker_client.metrics import DatadogMetrics, MetricsBackend, NoOpMetricsBackend
 from taskbroker_client.router import TaskRouter as LibraryRouter
 from taskbroker_client.types import AtMostOnceStore
 
@@ -159,3 +160,41 @@ def make_producer(topic: str) -> SingletonProducer:
             factory, max_futures=options.get("taskworker.producer.max_futures")
         )
     return _producer_local.producers[topic]
+
+
+def _extract_metrics_config() -> tuple[str | None, int | None]:
+    host, port = None, None
+    metric_options = settings.SENTRY_METRICS_OPTIONS
+    try:
+        if settings.SENTRY_METRICS_BACKEND == "sentry.metrics.dummy.DummyMetricsBackend":
+            return host, port
+
+        # For non-dummy implementations
+        # Use the metrics settings options to infer the host/port.
+        # The metrics options have different structures depending on which backend is used.
+        if settings.SENTRY_METRICS_BACKEND == "sentry.metrics.dualwrite.DualWriteMetricsBackend":
+            metric_options = settings.SENTRY_METRICS_OPTIONS["primary_backend_args"]
+
+        # statsd backend uses `host` while datadog use `statsd_host`
+        host = metric_options.get("statsd_host", None) or metric_options.get("host", None)
+        raw_port = metric_options.get("statsd_port", None) or metric_options.get("port", None)
+        if isinstance(raw_port, (str, int)):
+            port = int(raw_port)
+    except Exception as e:
+        logger.warning("Could not extract metrics settings", extra={"error": str(e)})
+    return host, port
+
+
+def make_metrics() -> MetricsBackend:
+    host, port = _extract_metrics_config()
+    if host and port:
+        # Metrics created by this interface will not
+        # have `sentry.` prefix, and will not have
+        # K8S_LABEL applied.
+        return DatadogMetrics(
+            application="sentry",
+            statsd_host=host,
+            statsd_port=port,
+            sample_rate=settings.SENTRY_METRICS_SAMPLE_RATE,
+        )
+    return NoOpMetricsBackend()

--- a/src/sentry/taskworker/adapters.py
+++ b/src/sentry/taskworker/adapters.py
@@ -11,15 +11,13 @@ import contextlib
 import logging
 import threading
 from collections.abc import MutableMapping
-from contextlib import contextmanager
-from typing import Any, Generator
+from typing import Any
 
 import orjson
 from arroyo.backends.kafka import KafkaProducer
 from django.conf import settings
 from django.core.cache.backends.base import BaseCache
 from sentry_sdk import capture_exception
-from taskbroker_client.metrics import MetricsBackend, Tags
 from taskbroker_client.router import TaskRouter as LibraryRouter
 from taskbroker_client.types import AtMostOnceStore
 
@@ -27,9 +25,7 @@ from sentry import options
 from sentry.conf.types.kafka_definition import Topic
 from sentry.silo.base import SiloMode
 from sentry.utils import json
-from sentry.utils import metrics as sentry_metrics
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
-from sentry.utils.memory import track_memory_usage as sentry_track_memory_usage
 from sentry.viewer_context import (
     ViewerContext,
     get_viewer_context,
@@ -66,82 +62,6 @@ class DjangoCacheAtMostOnceStore(AtMostOnceStore):
 
     def add(self, key: str, value: str, timeout: int) -> bool:
         return self._cache.add(key, value, timeout)
-
-
-class SentryMetricsBackend(MetricsBackend):
-    """
-    MetricsBackend implementation that delegates to sentry.utils.metrics.
-    """
-
-    def incr(
-        self,
-        name: str,
-        value: int | float = 1,
-        tags: Tags | None = None,
-        sample_rate: float | None = None,
-    ) -> None:
-        if sample_rate is None:
-            sample_rate = settings.SENTRY_METRICS_SAMPLE_RATE
-        sentry_metrics.incr(name, amount=int(value), tags=tags, sample_rate=sample_rate)
-
-    def gauge(
-        self,
-        key: str,
-        value: float,
-        instance: str | None = None,
-        tags: Tags | None = None,
-        sample_rate: float | None = None,
-        unit: str | None = None,
-        stacklevel: int = 0,
-    ) -> None:
-        if sample_rate is None:
-            sample_rate = settings.SENTRY_METRICS_SAMPLE_RATE
-
-        return sentry_metrics.gauge(
-            key,
-            value,
-            instance=instance,
-            tags=tags,
-            sample_rate=sample_rate,
-            unit=unit,
-            stacklevel=stacklevel,
-        )
-
-    def distribution(
-        self,
-        name: str,
-        value: int | float,
-        tags: Tags | None = None,
-        unit: str | None = None,
-        sample_rate: float | None = None,
-    ) -> None:
-        if sample_rate is None:
-            sample_rate = settings.SENTRY_METRICS_SAMPLE_RATE
-        sentry_metrics.distribution(
-            name, value=value, tags=tags, unit=unit, sample_rate=sample_rate
-        )
-
-    @contextmanager
-    def timer(
-        self,
-        key: str,
-        tags: Tags | None = None,
-        sample_rate: float | None = None,
-        stacklevel: int = 0,
-    ) -> Generator[None]:
-        if sample_rate is None:
-            sample_rate = settings.SENTRY_METRICS_SAMPLE_RATE
-        with sentry_metrics.timer(key, tags=tags, sample_rate=sample_rate):
-            yield
-
-    @contextmanager
-    def track_memory_usage(
-        self,
-        key: str,
-        tags: Tags | None = None,
-    ) -> Generator[None]:
-        with sentry_track_memory_usage(key, tags=tags):
-            yield
 
 
 class SentryRouter(LibraryRouter):

--- a/src/sentry/taskworker/producer.py
+++ b/src/sentry/taskworker/producer.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 from taskbroker_client.types import CloseableProducerProtocol
 from taskbroker_client.worker.producer import TaskProducer
 
-from sentry.taskworker.adapters import SentryMetricsBackend
+from sentry.taskworker.runtime import create_metrics
 
 
 def get_task_producer(
@@ -16,5 +16,5 @@ def get_task_producer(
     return TaskProducer(
         name=producer_name,
         producer_factory=producer_factory,
-        metrics_backend=SentryMetricsBackend(),
+        metrics_backend=create_metrics(),
     )

--- a/src/sentry/taskworker/producer.py
+++ b/src/sentry/taskworker/producer.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 from taskbroker_client.types import CloseableProducerProtocol
 from taskbroker_client.worker.producer import TaskProducer
 
-from sentry.taskworker.runtime import create_metrics
+from sentry.taskworker.adapters import make_metrics
 
 
 def get_task_producer(
@@ -16,5 +16,5 @@ def get_task_producer(
     return TaskProducer(
         name=producer_name,
         producer_factory=producer_factory,
-        metrics_backend=create_metrics(),
+        metrics_backend=make_metrics(),
     )

--- a/src/sentry/taskworker/runtime.py
+++ b/src/sentry/taskworker/runtime.py
@@ -1,14 +1,12 @@
 import logging
-import os
 
 from django.conf import settings
 from django.core.cache import cache
 from taskbroker_client.app import TaskbrokerApp
-from taskbroker_client.metrics import DatadogMetrics, MetricsBackend
+from taskbroker_client.metrics import DatadogMetrics, MetricsBackend, NoOpMetricsBackend
 
 from sentry.taskworker.adapters import (
     DjangoCacheAtMostOnceStore,
-    SentryMetricsBackend,
     SentryRouter,
     ViewerContextHook,
     make_producer,
@@ -21,12 +19,16 @@ def _extract_metrics_config() -> tuple[str | None, int | None]:
     host, port = None, None
     metric_options = settings.SENTRY_METRICS_OPTIONS
     try:
+        if settings.SENTRY_METRICS_BACKEND == "sentry.metrics.dummy.DummyMetricsBackend":
+            return host, port
+
+        # For non-dummy implementations
         # Use the metrics settings options to infer the host/port.
         # The metrics options have different structures depending on which backend is used.
         if settings.SENTRY_METRICS_BACKEND == "sentry.metrics.dualwrite.DualWriteMetricsBackend":
             metric_options = settings.SENTRY_METRICS_OPTIONS["primary_backend_args"]
 
-        # Some backends use `host` and others use `statsd_host`
+        # statsd backend uses `host` while datadog use `statsd_host`
         host = metric_options.get("statsd_host", None) or metric_options.get("host", None)
         raw_port = metric_options.get("statsd_port", None) or metric_options.get("port", None)
         if isinstance(raw_port, (str, int)):
@@ -36,26 +38,25 @@ def _extract_metrics_config() -> tuple[str | None, int | None]:
     return host, port
 
 
-metrics_class: MetricsBackend = SentryMetricsBackend()
-
-if os.getenv("USE_TASKWORKER_METRICS", None) == "1":
+def create_metrics() -> MetricsBackend:
     host, port = _extract_metrics_config()
     if host and port:
         # Metrics created by this interface will not
         # have `sentry.` prefix, and will not have
         # K8S_LABEL applied.
-        metrics_class = DatadogMetrics(
+        return DatadogMetrics(
             application="sentry",
             statsd_host=host,
             statsd_port=port,
             sample_rate=settings.SENTRY_METRICS_SAMPLE_RATE,
-            enable_prefixed_metrics=True,
         )
+    return NoOpMetricsBackend()
+
 
 app = TaskbrokerApp(
     name="sentry",
     producer_factory=make_producer,
-    metrics_class=metrics_class,
+    metrics_class=create_metrics(),
     router_class=SentryRouter(),
     at_most_once_store=DjangoCacheAtMostOnceStore(cache),
     context_hooks=[ViewerContextHook()],

--- a/src/sentry/taskworker/runtime.py
+++ b/src/sentry/taskworker/runtime.py
@@ -1,62 +1,19 @@
-import logging
-
 from django.conf import settings
 from django.core.cache import cache
 from taskbroker_client.app import TaskbrokerApp
-from taskbroker_client.metrics import DatadogMetrics, MetricsBackend, NoOpMetricsBackend
 
 from sentry.taskworker.adapters import (
     DjangoCacheAtMostOnceStore,
     SentryRouter,
     ViewerContextHook,
+    make_metrics,
     make_producer,
 )
-
-logger = logging.getLogger(__name__)
-
-
-def _extract_metrics_config() -> tuple[str | None, int | None]:
-    host, port = None, None
-    metric_options = settings.SENTRY_METRICS_OPTIONS
-    try:
-        if settings.SENTRY_METRICS_BACKEND == "sentry.metrics.dummy.DummyMetricsBackend":
-            return host, port
-
-        # For non-dummy implementations
-        # Use the metrics settings options to infer the host/port.
-        # The metrics options have different structures depending on which backend is used.
-        if settings.SENTRY_METRICS_BACKEND == "sentry.metrics.dualwrite.DualWriteMetricsBackend":
-            metric_options = settings.SENTRY_METRICS_OPTIONS["primary_backend_args"]
-
-        # statsd backend uses `host` while datadog use `statsd_host`
-        host = metric_options.get("statsd_host", None) or metric_options.get("host", None)
-        raw_port = metric_options.get("statsd_port", None) or metric_options.get("port", None)
-        if isinstance(raw_port, (str, int)):
-            port = int(raw_port)
-    except Exception as e:
-        logger.warning("Could not extract metrics settings", extra={"error": str(e)})
-    return host, port
-
-
-def create_metrics() -> MetricsBackend:
-    host, port = _extract_metrics_config()
-    if host and port:
-        # Metrics created by this interface will not
-        # have `sentry.` prefix, and will not have
-        # K8S_LABEL applied.
-        return DatadogMetrics(
-            application="sentry",
-            statsd_host=host,
-            statsd_port=port,
-            sample_rate=settings.SENTRY_METRICS_SAMPLE_RATE,
-        )
-    return NoOpMetricsBackend()
-
 
 app = TaskbrokerApp(
     name="sentry",
     producer_factory=make_producer,
-    metrics_class=create_metrics(),
+    metrics_class=make_metrics(),
     router_class=SentryRouter(),
     at_most_once_store=DjangoCacheAtMostOnceStore(cache),
     context_hooks=[ViewerContextHook()],

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -6,7 +6,7 @@ from taskbroker_client.retry import Retry
 
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.adapters import SentryMetricsBackend, SentryRouter, make_producer
+from sentry.taskworker.adapters import SentryRouter, make_metrics, make_producer
 from sentry.taskworker.namespaces import exampletasks, test_tasks
 
 
@@ -107,7 +107,7 @@ def test_instrumented_task_parameters() -> None:
         application="sentry",
         producer_factory=make_producer,
         router=SentryRouter(),
-        metrics=SentryMetricsBackend(),
+        metrics=make_metrics(),
     )
     namespace = registry.create_namespace("registertest")
 

--- a/tests/sentry/taskworker/test_adapters.py
+++ b/tests/sentry/taskworker/test_adapters.py
@@ -3,12 +3,12 @@ import contextlib
 import orjson
 import pytest
 from django.test.utils import override_settings
+from taskbroker_client.metrics import NoOpMetricsBackend
 from taskbroker_client.registry import TaskRegistry
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.silo.base import SiloMode
 from sentry.taskworker.adapters import (
-    SentryMetricsBackend,
     SentryRouter,
     ViewerContextHook,
     make_producer,
@@ -23,7 +23,7 @@ def test_registry_create_namespace_route_setting() -> None:
             application="sentry",
             producer_factory=make_producer,
             router=SentryRouter(),
-            metrics=SentryMetricsBackend(),
+            metrics=NoOpMetricsBackend(),
         )
 
         # namespaces without routes resolve to the default topic.


### PR DESCRIPTION
After I've finished validating metrics continunity, these changes will remove the custom metrics backend and rely entirely on the metrics backend from taskbroker-client, and stop emitting both prefixed metrics.

Refs STREAM-1174