### PR TITLE
feat(api): Add response schemas to private events and notes endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from typing import TypedDict
 
 import sentry_sdk
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -11,6 +12,7 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors, update_snuba_params_with_timestamp
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.search.utils import DEVICE_CLASS
 
@@ -32,6 +34,13 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsEndpointBase):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
+    @extend_schema(
+        responses={
+            200: inline_sentry_response_serializer(
+                "OrganizationEventsFacetsResponse", list[_KeyTopValues]
+            )
+        },
+    )
     def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -1,6 +1,8 @@
 import re
+from typing import TypedDict
 
 import sentry_sdk
+from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -15,6 +17,7 @@ from sentry.api.helpers.group_index import build_query_params_from_request
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializer
 from sentry.api.utils import handle_query_errors
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.search.eap.types import EAPResponse, SearchResolverConfig
 from sentry.search.events.types import EventsResponse, SnubaParams
@@ -23,13 +26,26 @@ from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.utils import RPC_DATASETS
 
 
+class OrganizationEventsMetaResponse(TypedDict):
+    count: int
+
+
 @cell_silo_endpoint
 class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get(self, request: Request, organization: Organization) -> Response:
+    @extend_schema(
+        responses={
+            200: inline_sentry_response_serializer(
+                "OrganizationEventsMetaResponse", OrganizationEventsMetaResponse
+            )
+        },
+    )
+    def get(
+        self, request: Request, organization: Organization
+    ) -> Response[OrganizationEventsMetaResponse]:
         try:
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from typing import Any
 
 import sentry_sdk
+from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -16,6 +17,8 @@ from sentry.api.helpers.error_upsampling import (
     is_errors_query_for_error_upsampled_projects,
     transform_query_columns_for_error_upsampling,
 )
+from sentry.api.serializers.snuba import StatsTimeSeriesResult
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import MAX_TOP_EVENTS
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
 from sentry.models.organization import Organization
@@ -110,6 +113,14 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
         )
         return has_data
 
+    @extend_schema(
+        responses={
+            200: inline_sentry_response_serializer(
+                "OrganizationEventsStatsResponse",
+                StatsTimeSeriesResult | dict[str, StatsTimeSeriesResult],
+            )
+        },
+    )
     def get(self, request: Request, organization: Organization) -> Response:
         query_source = self.get_request_source(request)
         logger.info(

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -1,4 +1,5 @@
-from typing import TypedDict
+from datetime import datetime
+from typing import Any, TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.commit import CommitWithReleaseSerializer
@@ -22,6 +23,21 @@ class _ActivitySentryAppEmbed(TypedDict):
     name: str
     slug: str
     avatars: list[SentryAppAvatarSerializerResponse]
+
+
+class ActivitySerializerResponse(TypedDict):
+    # Byte-identical envelope of ActivitySerializer.serialize() — always these six keys.
+    id: str
+    # The serialized acting user (a user serializer response), or null for
+    # system/integration activity. Left loose: the full user shape is out of scope.
+    user: dict[str, Any] | None
+    sentry_app: _ActivitySentryAppEmbed | None
+    type: str
+    # Polymorphic by activity type (note text, commit, pull request, unmerge
+    # fingerprints + source/destination, ...). Loose by design — describing every
+    # variant is out of scope.
+    data: dict[str, Any]
+    dateCreated: datetime
 
 
 COMMIT_ACTIVITY_TYPES = {

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -1,4 +1,29 @@
 import itertools
+from typing import Any, NotRequired, TypedDict
+
+
+class StatsTimeSeriesResult(TypedDict):
+    """Permissive, byte-faithful shape of a single serialized timeseries as
+    emitted by ``SnubaTSResultSerializer.serialize()`` and
+    ``OrganizationEventsEndpointBase.get_event_stats_data()``.
+
+    Only ``data`` is always present; every other key appears conditionally
+    (axis/top-N/comparison/on-demand/metrics paths), so all are ``NotRequired``.
+    Inner structures (``data`` buckets, ``meta``) are heterogeneous and left
+    loose on purpose — documenting every variant is out of scope. This describes
+    the existing payload; it does not constrain or change it.
+    """
+
+    data: list[Any]
+    meta: NotRequired[dict[str, Any]]
+    order: NotRequired[float]
+    isMetricsData: NotRequired[bool]
+    isMetricsExtractedData: NotRequired[bool]
+    confidence: NotRequired[list[Any]]
+    totals: NotRequired[dict[str, Any]]
+    comparisonCount: NotRequired[float]
+    start: NotRequired[int]
+    end: NotRequired[int]
 
 
 def value_from_row(row, tagkey):

--- a/src/sentry/apidocs/utils.py
+++ b/src/sentry/apidocs/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import types
 import typing
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -11,6 +12,16 @@ from drf_spectacular.plumbing import UnableToProceedError
 
 from sentry.api.serializers import Serializer
 
+# A response shape expressed as a type hint, as accepted by drf-spectacular's
+# (untyped) ``resolve_type_hint``: a class/TypedDict or generic alias such as
+# ``list[Foo]`` / ``dict[str, Foo]`` (all of which are ``type`` at the type level),
+# or a PEP-604 union of those such as ``Foo | dict[str, Foo]`` (``types.UnionType``)
+# for endpoints whose success response is one of several shapes. This is the most
+# specific annotation possible — the type system has no name for "a wire-describable
+# shape", so the real per-endpoint contract lives in the argument passed here and the
+# OpenAPI schema it generates, not in this alias.
+ResponseTypeHint: typing.TypeAlias = type | types.UnionType
+
 
 class _RawSchema:
     """
@@ -18,11 +29,11 @@ class _RawSchema:
     Used by `utils.inline_sentry_response_serializer`
     """
 
-    def __init__(self, t: type) -> None:
+    def __init__(self, t: ResponseTypeHint) -> None:
         self.typeSchema = t
 
 
-def inline_sentry_response_serializer(name: str, t: type) -> type:
+def inline_sentry_response_serializer(name: str, t: ResponseTypeHint) -> type:
     """
     Function for documenting an API response with python types.
     You may use existing types, and likely serializer response types.
@@ -35,7 +46,9 @@ def inline_sentry_response_serializer(name: str, t: type) -> type:
         )
 
     :param name: the name of the component, used in the OpenAPIJson
-    :param t: the type of the response
+    :param t: the response shape as a type hint (see ``ResponseTypeHint``): a
+        class/TypedDict, a generic alias (``list[Foo]`` / ``dict[str, Foo]``), or
+        a union (``Foo | dict[str, Foo]``).
     """
 
     if isinstance(t, Serializer):

--- a/src/sentry/issues/endpoints/group_notes.py
+++ b/src/sentry/issues/endpoints/group_notes.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.utils import timezone
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
@@ -11,7 +12,9 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.helpers.deprecation import deprecated
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.activity import ActivitySerializerResponse
 from sentry.api.serializers.rest_framework.group_notes import NoteSerializer
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.action_log import (
     GroupActionActor,
@@ -35,6 +38,13 @@ class GroupNotesEndpoint(GroupEndpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
 
+    @extend_schema(
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListGroupNotes", list[ActivitySerializerResponse]
+            )
+        },
+    )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-notes"])
     def get(self, request: Request, group: Group) -> Response:
         notes = Activity.objects.filter(group=group, type=ActivityType.NOTE.value)
@@ -47,6 +57,12 @@ class GroupNotesEndpoint(GroupEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
+    @extend_schema(
+        request=NoteSerializer,
+        responses={
+            201: inline_sentry_response_serializer("CreateGroupNote", ActivitySerializerResponse)
+        },
+    )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-notes"])
     def post(self, request: Request, group: Group) -> Response:
         if not request.user.is_authenticated:

--- a/src/sentry/issues/endpoints/group_notes_details.py
+++ b/src/sentry/issues/endpoints/group_notes_details.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
@@ -8,8 +9,11 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.activity import ActivitySerializerResponse
 from sentry.api.serializers.rest_framework.group_notes import NoteSerializer
 from sentry.api.utils import to_valid_int_id
+from sentry.apidocs.constants import RESPONSE_NO_CONTENT
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.action_log import (
     GroupActionActor,
@@ -37,6 +41,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
     # since an ApiKey is bound to the Organization, not
     # an individual. Not sure if we'd want to allow an ApiKey
     # to delete/update other users' comments
+    @extend_schema(responses={204: RESPONSE_NO_CONTENT})
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-note-details"])
     def delete(self, request: Request, group: Group, note_id: str) -> Response:
         if not request.user.is_authenticated:
@@ -90,6 +95,12 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
 
         return Response(status=204)
 
+    @extend_schema(
+        request=NoteSerializer,
+        responses={
+            200: inline_sentry_response_serializer("UpdateGroupNote", ActivitySerializerResponse)
+        },
+    )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-note-details"])
     def put(self, request: Request, group: Group, note_id: str) -> Response:
         if not request.user.is_authenticated:


### PR DESCRIPTION
Adds drf-spectacular response schemas (and request bodies for the note writes)
to five PRIVATE/EXPERIMENTAL endpoints — organization `events-meta`,
`events-facets`, and `events-stats`, plus the group notes list/create and
update/delete endpoints — so typed OpenAPI consumers (e.g. Seer's generated API
client) can represent them. They previously resolved to no response schema.

This is documentation only: no response/request bytes, endpoint behavior, or
`publish_status` change. Each new TypedDict (`ActivitySerializerResponse`,
`StatsTimeSeriesResult`) transcribes the serializer's existing output, reusing
`NoteSerializer` and the in-file events-facets TypedDicts where they already
exist; genuinely polymorphic fields (note `data`, the timeseries buckets) stay
loose on purpose rather than being reshaped.

The one non-mechanical bit: `events-stats` returns either a single series or a
map of series, so its response is a union — which required widening
`inline_sentry_response_serializer`'s parameter from `type` to
`type | types.UnionType` (it has always accepted arbitrary type hints at
runtime; the annotation was simply too narrow).
