### PR TITLE
ref(grouping): Add broken random id parameterization test cases

### DIFF
--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -379,6 +379,42 @@ incorrect_cases = [
         "{'dogs are great': <bool>, 'dog_id': '<id>'}",
         "{'dogs are great': true, 'dog_id': 'greatdog1231'}",
     ),
+    (
+        "random id - leading underscore",
+        "img_k9Mtd2gDcgG.jpg",
+        "img_<random_id>.jpg",
+        "img_k9Mtd2gDcgG.jpg",
+    ),
+    (
+        "random id - trailing underscore",
+        "k9Mtd2gDcgG_thumbnail.jpg",
+        "<random_id>_thumbnail.jpg",
+        "k9Mtd2gDcgG_thumbnail.jpg",
+    ),
+    (
+        "random id - no capitals",
+        "k9m2gd",
+        "<random_id>",
+        "k9m2gd",
+    ),
+    (
+        "random id - no lowercase",
+        "K9M2GD",
+        "<random_id>",
+        "K9M2GD",
+    ),
+    (
+        "random id - dash-separated",
+        "k9Mt-d2vg-DcgG",
+        "<random_id>",
+        "k9Mt-d2vg-DcgG",
+    ),
+    (
+        "random id - dot-separated",
+        "k9Mt.d2vg.DcgG",
+        "<random_id>",
+        "k9Mt.d2vg.DcgG",
+    ),
 ]
 
 


### PR DESCRIPTION
This adds a number of new test cases to our list of things we should parameterize correctly, but don't. In this case, it's a number of different variations of random alphanumeric ids, all seen in the wild in cases where we're not grouping well. They will be fixed in an upcoming PR, but I'm adding them here first to document exactly what problems those future changes fix.