### PR TITLE
ref(releases): replace SessionsRequest render-prop with useSessionsRequest hook

### DIFF
--- a/static/app/views/explore/releases/list/releasesAdoptionChart.tsx
+++ b/static/app/views/explore/releases/list/releasesAdoptionChart.tsx
@@ -176,13 +176,10 @@ export function ReleasesAdoptionChart({
     }
   }, [isError, error]);
 
-  const loading = isPending;
-  const reloading = isFetching && !isPending;
-
   const totalCount = getCount(response?.groups, field);
   const releasesSeries = getReleasesSeries(response);
 
-  if (loading) {
+  if (isPending) {
     return renderEmpty();
   }
 
@@ -202,8 +199,8 @@ export function ReleasesAdoptionChart({
         <ChartHeader>
           <Flex as="header">{t('Release Adoption')}</Flex>
         </ChartHeader>
-        <TransitionChart loading={loading} reloading={reloading}>
-          <TransparentLoadingMask visible={reloading} />
+        <TransitionChart loading={isPending} reloading={isFetching && !isPending}>
+          <TransparentLoadingMask visible={isFetching && !isPending} />
           <ChartZoom period={period} utc={utc} start={start} end={end}>
             {zoomRenderProps => (
               <LineChart

--- a/static/app/views/explore/releases/list/releasesAdoptionChart.tsx
+++ b/static/app/views/explore/releases/list/releasesAdoptionChart.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import type {LineSeriesOption} from 'echarts';
@@ -9,9 +9,9 @@ import moment from 'moment-timezone';
 
 import {Flex} from '@sentry/scraps/layout';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import ChartZoom from 'sentry/components/charts/chartZoom';
 import {LineChart} from 'sentry/components/charts/lineChart';
-import {SessionsRequest} from 'sentry/components/charts/sessionsRequest';
 import {
   HeaderTitleLegend,
   InlineContainer,
@@ -20,6 +20,7 @@ import {
 } from 'sentry/components/charts/styles';
 import {TransitionChart} from 'sentry/components/charts/transitionChart';
 import {TransparentLoadingMask} from 'sentry/components/charts/transparentLoadingMask';
+import {useSessionsRequest} from 'sentry/components/charts/useSessionsRequest';
 import {
   getDiffInMinutes,
   ONE_WEEK,
@@ -41,7 +42,6 @@ import type {EChartClickHandler} from 'sentry/types/echarts';
 import type {Organization, SessionApiResponse} from 'sentry/types/organization';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {getAdoptionSeries, getCount} from 'sentry/utils/sessions';
-import {useApi} from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {sessionDisplayToField} from 'sentry/views/explore/releases/list/releasesRequest';
@@ -62,7 +62,6 @@ export function ReleasesAdoptionChart({
   organization,
   location,
 }: Props) {
-  const api = useApi();
   const navigate = useNavigate();
 
   // needs to have different granularity, that's why we use custom getInterval instead of getSessionsInterval
@@ -156,155 +155,165 @@ export function ReleasesAdoptionChart({
   const {start, end, period, utc} = selection.datetime;
   const field = sessionDisplayToField(activeDisplay);
 
+  const {
+    data: response,
+    isPending,
+    isFetching,
+    isError,
+    error,
+  } = useSessionsRequest({
+    interval,
+    groupBy: ['release'],
+    field: [field],
+    ...normalizeDateTimeParams(pick(location.query, Object.values(URL_PARAM))),
+  });
+
+  useEffect(() => {
+    if (isError) {
+      addErrorMessage(
+        (error as any)?.responseJSON?.detail ?? t('Error loading health data')
+      );
+    }
+  }, [isError, error]);
+
+  const loading = isPending;
+  const reloading = isFetching && !isPending;
+
+  const totalCount = getCount(response?.groups, field);
+  const releasesSeries = getReleasesSeries(response);
+
+  if (loading) {
+    return renderEmpty();
+  }
+
+  if (!releasesSeries?.length) {
+    return null;
+  }
+
+  const numDataPoints = releasesSeries[0]!.data.length;
+  const xAxisData = releasesSeries[0]!.data.map(point => point.name);
+  const hideLastPoint = !releasesSeries.some(
+    series => series.data[numDataPoints - 1]!.value > 0
+  );
+
   return (
-    <SessionsRequest
-      api={api}
-      organization={organization}
-      interval={interval}
-      groupBy={['release']}
-      field={[field]}
-      {...normalizeDateTimeParams(pick(location.query, Object.values(URL_PARAM)))}
-    >
-      {({response, loading, reloading}) => {
-        const totalCount = getCount(response?.groups, field);
-        const releasesSeries = getReleasesSeries(response);
-        if (loading) {
-          return renderEmpty();
-        }
+    <Panel>
+      <PanelBody withPadding>
+        <ChartHeader>
+          <Flex as="header">{t('Release Adoption')}</Flex>
+        </ChartHeader>
+        <TransitionChart loading={loading} reloading={reloading}>
+          <TransparentLoadingMask visible={reloading} />
+          <ChartZoom period={period} utc={utc} start={start} end={end}>
+            {zoomRenderProps => (
+              <LineChart
+                {...zoomRenderProps}
+                grid={{left: '10px', right: '10px', top: '40px', bottom: '0px'}}
+                series={releasesSeries.map(series => ({
+                  ...series,
+                  data: hideLastPoint ? series.data.slice(0, -1) : series.data,
+                }))}
+                yAxis={{
+                  min: 0,
+                  max: 100,
+                  type: 'value',
+                  interval: 10,
+                  splitNumber: 10,
+                  axisLabel: {
+                    formatter: '{value}%',
+                  },
+                }}
+                xAxis={{
+                  show: true,
+                  min: xAxisData[0],
+                  max: xAxisData[numDataPoints - 1],
+                  type: 'time',
+                }}
+                tooltip={{
+                  formatter: seriesParams => {
+                    const series = Array.isArray(seriesParams)
+                      ? seriesParams
+                      : [seriesParams];
+                    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
+                    const timestamp = series[0].data[0];
+                    const [first, second, third, ...rest] = series
+                      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+                      .filter(s => s.data[1] > 0)
+                      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+                      .sort((a, b) => b.data[1] - a.data[1]);
 
-        if (!releasesSeries?.length) {
-          return null;
-        }
+                    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+                    const restSum = rest.reduce((acc, s) => acc + s.data[1], 0);
 
-        const numDataPoints = releasesSeries[0]!.data.length;
-        const xAxisData = releasesSeries[0]!.data.map(point => point.name);
-        const hideLastPoint = !releasesSeries.some(
-          series => series.data[numDataPoints - 1]!.value > 0
-        );
+                    const seriesToRender = compact([first, second, third]);
 
-        return (
-          <Panel>
-            <PanelBody withPadding>
-              <ChartHeader>
-                <Flex as="header">{t('Release Adoption')}</Flex>
-              </ChartHeader>
-              <TransitionChart loading={loading} reloading={reloading}>
-                <TransparentLoadingMask visible={reloading} />
-                <ChartZoom period={period} utc={utc} start={start} end={end}>
-                  {zoomRenderProps => (
-                    <LineChart
-                      {...zoomRenderProps}
-                      grid={{left: '10px', right: '10px', top: '40px', bottom: '0px'}}
-                      series={releasesSeries.map(series => ({
-                        ...series,
-                        data: hideLastPoint ? series.data.slice(0, -1) : series.data,
-                      }))}
-                      yAxis={{
-                        min: 0,
-                        max: 100,
-                        type: 'value',
-                        interval: 10,
-                        splitNumber: 10,
-                        axisLabel: {
-                          formatter: '{value}%',
-                        },
-                      }}
-                      xAxis={{
-                        show: true,
-                        min: xAxisData[0],
-                        max: xAxisData[numDataPoints - 1],
-                        type: 'time',
-                      }}
-                      tooltip={{
-                        formatter: seriesParams => {
-                          const series = Array.isArray(seriesParams)
-                            ? seriesParams
-                            : [seriesParams];
-                          // @ts-expect-error TS(2532): Object is possibly 'undefined'.
-                          const timestamp = series[0].data[0];
-                          const [first, second, third, ...rest] = series
-                            // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                            .filter(s => s.data[1] > 0)
-                            // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                            .sort((a, b) => b.data[1] - a.data[1]);
+                    if (rest.length) {
+                      // @ts-expect-error TS(2345): Argument of type '{ seriesName: string; data: any[... Remove this comment to see the full error message
+                      seriesToRender.push({
+                        seriesName: tn('%s Other', '%s Others', rest.length),
+                        data: [timestamp, restSum],
+                        marker:
+                          '<span style="display:inline-block;margin-right:5px;border-radius:10px;width:10px;height:10px;"></span>',
+                      });
+                    }
 
-                          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                          const restSum = rest.reduce((acc, s) => acc + s.data[1], 0);
+                    if (!seriesToRender.length) {
+                      return '<div/>';
+                    }
 
-                          const seriesToRender = compact([first, second, third]);
+                    const periodObj = parseStatsPeriod(interval) || {
+                      periodLength: 'd',
+                      period: '1',
+                    };
+                    const intervalStart = moment(timestamp).format('MMM D LT');
+                    const intervalEnd = (
+                      series[0]?.dataIndex === numDataPoints - 1
+                        ? moment(response?.end)
+                        : moment(timestamp).add(
+                            parseInt(periodObj.period!, 10),
+                            periodObj.periodLength
+                          )
+                    ).format('MMM D LT');
 
-                          if (rest.length) {
-                            // @ts-expect-error TS(2345): Argument of type '{ seriesName: string; data: any[... Remove this comment to see the full error message
-                            seriesToRender.push({
-                              seriesName: tn('%s Other', '%s Others', rest.length),
-                              data: [timestamp, restSum],
-                              marker:
-                                '<span style="display:inline-block;margin-right:5px;border-radius:10px;width:10px;height:10px;"></span>',
-                            });
-                          }
-
-                          if (!seriesToRender.length) {
-                            return '<div/>';
-                          }
-
-                          const periodObj = parseStatsPeriod(interval) || {
-                            periodLength: 'd',
-                            period: '1',
-                          };
-                          const intervalStart = moment(timestamp).format('MMM D LT');
-                          const intervalEnd = (
-                            series[0]?.dataIndex === numDataPoints - 1
-                              ? moment(response?.end)
-                              : moment(timestamp).add(
-                                  parseInt(periodObj.period!, 10),
-                                  periodObj.periodLength
-                                )
-                          ).format('MMM D LT');
-
-                          return [
-                            '<div class="tooltip-series">',
-                            seriesToRender
-                              .map(
-                                s =>
-                                  `<div><span class="tooltip-label">${
-                                    s.marker as string
-                                  }<strong>${
-                                    s.seriesName && truncationFormatter(s.seriesName, 32)
-                                    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                                  }</strong></span>${s.data[1].toFixed(2)}%</div>`
-                              )
-                              .join(''),
-                            '</div>',
-                            `<div class="tooltip-footer">${intervalStart} &mdash; ${intervalEnd}</div>`,
-                            '<div class="tooltip-arrow"></div>',
-                          ].join('');
-                        },
-                      }}
-                      onClick={handleClick}
-                    />
-                  )}
-                </ChartZoom>
-              </TransitionChart>
-            </PanelBody>
-            <ChartFooter>
-              <InlineContainer>
-                <SectionHeading>
-                  {tct('Total [display]', {
-                    display:
-                      activeDisplay === ReleasesDisplayOption.USERS
-                        ? 'Users'
-                        : 'Sessions',
-                  })}
-                </SectionHeading>
-                <SectionValue>
-                  <Count value={totalCount || 0} />
-                </SectionValue>
-              </InlineContainer>
-            </ChartFooter>
-          </Panel>
-        );
-      }}
-    </SessionsRequest>
+                    return [
+                      '<div class="tooltip-series">',
+                      seriesToRender
+                        .map(
+                          s =>
+                            `<div><span class="tooltip-label">${
+                              s.marker as string
+                            }<strong>${
+                              s.seriesName && truncationFormatter(s.seriesName, 32)
+                              // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+                            }</strong></span>${s.data[1].toFixed(2)}%</div>`
+                        )
+                        .join(''),
+                      '</div>',
+                      `<div class="tooltip-footer">${intervalStart} &mdash; ${intervalEnd}</div>`,
+                      '<div class="tooltip-arrow"></div>',
+                    ].join('');
+                  },
+                }}
+                onClick={handleClick}
+              />
+            )}
+          </ChartZoom>
+        </TransitionChart>
+      </PanelBody>
+      <ChartFooter>
+        <InlineContainer>
+          <SectionHeading>
+            {tct('Total [display]', {
+              display:
+                activeDisplay === ReleasesDisplayOption.USERS ? 'Users' : 'Sessions',
+            })}
+          </SectionHeading>
+          <SectionValue>
+            <Count value={totalCount || 0} />
+          </SectionValue>
+        </InlineContainer>
+      </ChartFooter>
+    </Panel>
   );
 }
 


### PR DESCRIPTION
Refactors `ReleasesAdoptionChart` to call `useSessionsRequest` directly instead of the class-based `<SessionsRequest>` render-prop component.

**What changed:**
- Replaced `<SessionsRequest>` (render-prop) with the `useSessionsRequest` hook
- Moved rendering logic out of the callback and into the component body, which lets us use early returns cleanly
- Added a `useEffect` to call `addErrorMessage` on error, replicating the old component's `catch` block behavior (`error.responseJSON?.detail ?? t('Error loading health data')`)
- Dropped `useApi` — the hook handles the API client internally via `useApiQuery`
- `loading` maps to `isPending`, `reloading` to `isFetching && !isPending`

**Verified:** diff-only change, no behavioural differences intended.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AD0AN20G5WMS%3A1782423421.734589%22)