### PR TITLE
ref(auth): Refactor signup email verification into an abstract base class

### DIFF
--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -23,6 +23,7 @@ DEFAULT_MAX_AGE_MINUTES = 120
 
 def send_signup_verification_email(
     email: str,
+    url_name: str,
     max_age_minutes: int = DEFAULT_MAX_AGE_MINUTES,
 ) -> None:
     """
@@ -31,6 +32,9 @@ def send_signup_verification_email(
     Signs {email, expires_at} into a URL-safe blob and emails the link.
     Pure send function — callers are responsible for session state
     (setting request.session[PENDING_VERIFICATION_SESSION_KEY])
+
+    url_name controls which verification endpoint the link points to,
+    allowing different signup methods to have their own completion logic.
     """
     payload = {
         "email": email,
@@ -38,7 +42,7 @@ def send_signup_verification_email(
     }
     signed_data = sign(salt=settings.SIGNUP_VERIFICATION_EMAIL_SALT, **payload)
 
-    url = absolute_uri(reverse("sentry-signup-verify-email", args=[signed_data]))
+    url = absolute_uri(reverse(url_name, args=[signed_data]))
 
     context = {
         "confirm_email": email,

--- a/src/sentry/web/frontend/signup_email_verification.py
+++ b/src/sentry/web/frontend/signup_email_verification.py
@@ -12,7 +12,7 @@ from django.views.decorators.cache import never_cache
 from sentry import ratelimits as ratelimiter
 from sentry.auth.email_verification import verify_signup_link
 from sentry.utils.hashlib import sha256_text
-from sentry.web.frontend.base import BaseView, control_silo_view
+from sentry.web.frontend.base import BaseView
 
 PENDING_VERIFICATION_SESSION_KEY = "pending_signup_verification_email"
 VERIFIED_SESSION_KEY = "verified_email"
@@ -24,8 +24,15 @@ def _get_signup_url() -> str:
     return settings.SENTRY_SIGNUP_URL or "/auth/login/"
 
 
-@control_silo_view
-class SignupEmailVerificationView(BaseView):
+class BaseSignupVerificationView(BaseView):
+    """
+    Base class for signup email verification endpoints.
+
+    Handles rate limiting, signed blob validation, and same-browser session
+    enforcement. Subclasses implement handle_verified_email() for
+    method-specific completion logic.
+    """
+
     auth_required = False
 
     def _render_error(self, title: str, message: str) -> HttpResponseBase:
@@ -82,6 +89,11 @@ class SignupEmailVerificationView(BaseView):
             extra={"email_hash": sha256_text(email.lower()).hexdigest()},
         )
 
-        # TODO: redirect based on data in session. Different methods for sso, social auth, and email+pword
+        return self.handle_verified_email(request, email)
 
-        return self.redirect(_get_signup_url())
+    def handle_verified_email(self, request: HttpRequest, email: str) -> HttpResponseBase:
+        """
+        Called after the email has been successfully verified.
+        Subclasses implement method-specific completion logic.
+        """
+        raise NotImplementedError

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -52,7 +52,6 @@ from sentry.web.frontend.reactivate_account import ReactivateAccountView
 from sentry.web.frontend.release_webhook import ReleaseWebhookView
 from sentry.web.frontend.setup_wizard import SetupWizardView
 from sentry.web.frontend.shared_group_details import SharedGroupDetailsView
-from sentry.web.frontend.signup_email_verification import SignupEmailVerificationView
 from sentry.web.frontend.sudo import SudoView
 from sentry.web.frontend.team_avatar import TeamAvatarPhotoView
 from sentry.web.frontend.twofactor import TwoFactorAuthView, u2f_appid
@@ -307,11 +306,6 @@ urlpatterns += [
                     r"^register/$",
                     AuthLoginView.as_view(),
                     name="sentry-register",
-                ),
-                re_path(
-                    r"^signup/verify-email/(?P<signed_data>[-A-Za-z0-9_]+)/$",
-                    SignupEmailVerificationView.as_view(),
-                    name="sentry-signup-verify-email",
                 ),
                 re_path(
                     r"^close/$",

--- a/tests/sentry/auth/test_email_verification.py
+++ b/tests/sentry/auth/test_email_verification.py
@@ -29,7 +29,9 @@ class SendSignupVerificationEmailTest(TestCase):
         mock_msg = mock.MagicMock()
         mock_builder.return_value = mock_msg
 
-        send_signup_verification_email("test@example.com", max_age_minutes=10)
+        send_signup_verification_email(
+            "test@example.com", url_name="sentry-signup-verify-email", max_age_minutes=10
+        )
 
         context = mock_builder.call_args[1]["context"]
         assert context["confirm_email"] == "test@example.com"
@@ -47,7 +49,7 @@ class SendSignupVerificationEmailTest(TestCase):
     ) -> None:
         mock_builder.return_value = mock.MagicMock()
 
-        send_signup_verification_email("user@example.com")
+        send_signup_verification_email("user@example.com", url_name="sentry-signup-verify-email")
 
         signed_blob = mock_reverse.call_args[1]["args"][0]
         payload = verify_signup_link(signed_blob)

--- a/tests/sentry/web/frontend/test_signup_email_verification.py
+++ b/tests/sentry/web/frontend/test_signup_email_verification.py
@@ -4,15 +4,37 @@ import time
 from typing import Any
 
 from django.conf import settings
+from django.http import HttpRequest
+from django.http.response import HttpResponseBase
 from django.test import override_settings
-from django.urls import reverse
+from django.urls import path, reverse
 
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.signing import sign
-from sentry.web.frontend.signup_email_verification import VERIFIED_SESSION_KEY
+from sentry.web.frontend.base import control_silo_view
+from sentry.web.frontend.signup_email_verification import (
+    VERIFIED_SESSION_KEY,
+    BaseSignupVerificationView,
+)
 
 SIGNUP_URL = "https://test.sentry.io/signup/"
+
+
+@control_silo_view
+class _TestVerificationView(BaseSignupVerificationView):
+    def handle_verified_email(self, request: HttpRequest, email: str) -> HttpResponseBase:
+        return self.redirect(SIGNUP_URL)
+
+
+# Wire up a test URL so we can exercise the base class
+urlpatterns = [
+    path(
+        "auth/signup/verify-email/test/<signed_data>/",
+        _TestVerificationView.as_view(),
+        name="test-signup-verify-email",
+    ),
+]
 
 
 def _make_signed_blob(email: str = "test@example.com", expires_at: float | None = None) -> str:
@@ -22,10 +44,13 @@ def _make_signed_blob(email: str = "test@example.com", expires_at: float | None 
 
 
 @control_silo_test
-@override_settings(SENTRY_SIGNUP_URL=SIGNUP_URL)
-class SignupEmailVerificationViewTest(TestCase):
+@override_settings(
+    SENTRY_SIGNUP_URL=SIGNUP_URL,
+    ROOT_URLCONF="tests.sentry.web.frontend.test_signup_email_verification",
+)
+class BaseSignupVerificationViewTest(TestCase):
     def _get_path(self, signed_data: str) -> str:
-        return reverse("sentry-signup-verify-email", args=[signed_data])
+        return reverse("test-signup-verify-email", args=[signed_data])
 
     def _get_with_session(self, email: str = "test@example.com", **blob_kwargs: Any) -> Any:
         session = self.client.session


### PR DESCRIPTION
## Summary

Refactors `SignupEmailVerificationView` into `BaseSignupVerificationView` — an abstract base class that handles all shared verification concerns and removes the concrete view + URL route.

**Why:** We're adding email verification to multiple signup flows (SSO, email+password on SaaS, email+password on self-hosted, social auth). The original plan was a single endpoint that redirects to method-specific completion logic, but since the saas email+password and social auth completion logic lives in getsentry (billing, org provisioning), this would require a redirect just to cross the repo boundary. Per-method endpoints that each inherit from the shared base avoid that round-trip entirely.

**What changed:**
- `SignupEmailVerificationView` → `BaseSignupVerificationView` with abstract `handle_verified_email(request, email)` hook
- Removed the generic `sentry-signup-verify-email` URL route (each method registers its own)
- `send_signup_verification_email()` now requires a `url_name` parameter so the email link points at the correct method-specific endpoint

**Next steps (subsequent PRs):**
- getsentry: SaaS email+password verification endpoint inheriting from base