### PR TITLE
feat(activity): Emit group activity when a linked PR is closed

### DIFF
--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -45,6 +45,11 @@ COMMIT_ACTIVITY_TYPES = {
     ActivityType.REFERENCED_IN_COMMIT.value,
 }
 
+PULL_REQUEST_ACTIVITY_TYPES = {
+    ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value,
+    ActivityType.PULL_REQUEST_CLOSED.value,
+}
+
 
 @register(Activity)
 class ActivitySerializer(Serializer):
@@ -98,9 +103,7 @@ class ActivitySerializer(Serializer):
             commits = {}
 
         pull_request_ids = {
-            i.data["pull_request"]
-            for i in item_list
-            if i.type == ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value
+            i.data["pull_request"] for i in item_list if i.type in PULL_REQUEST_ACTIVITY_TYPES
         }
         if pull_request_ids:
             pull_request_list = list(PullRequest.objects.filter(id__in=pull_request_ids))
@@ -110,7 +113,7 @@ class ActivitySerializer(Serializer):
             pull_requests = {
                 i: pull_requests_by_id.get(i.data["pull_request"])
                 for i in item_list
-                if i.type == ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value
+                if i.type in PULL_REQUEST_ACTIVITY_TYPES
             }
         else:
             pull_requests = {}
@@ -154,7 +157,7 @@ class ActivitySerializer(Serializer):
     def serialize(self, obj: Activity, attrs, user, **kwargs):
         if obj.type in COMMIT_ACTIVITY_TYPES:
             data = {"commit": attrs["commit"]}
-        elif obj.type == ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value:
+        elif obj.type in PULL_REQUEST_ACTIVITY_TYPES:
             data = {"pullRequest": attrs["pull_request"]}
         elif obj.type == ActivityType.UNMERGE_DESTINATION.value:
             data = {"fingerprints": obj.data["fingerprints"], "source": attrs["source"]}

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -189,6 +189,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-web-vitals-seer-suggestions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the warning banner to inform users of pending deprecation of the transactions dataset
     manager.add("organizations:performance-transaction-deprecation-banner", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Emit group activity when a linked pull request is closed
+    manager.add("organizations:pr-group-activity", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Write PullRequestActivity rows from GitHub PR lifecycle webhooks
     manager.add("organizations:pr-metrics-activity", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Record PullRequestAttribution from webhook and seer.pr_created events

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -85,6 +85,7 @@ class GroupActionType(IntEnum):
     ROOT_CAUSE_IDENTIFIED = 26
     AUTOFIX_CODING_COMPLETE = 27
     SET_REGRESSED = 28
+    PULL_REQUEST_CLOSED = 29
 
 
 class GroupAction(BaseModel, abc.ABC):
@@ -317,3 +318,11 @@ class SetRegressedAction(GroupAction):
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.SET_REGRESSED
+
+
+class PullRequestClosedAction(GroupAction):
+    pull_request: int  # PullRequest model ID
+
+    @classmethod
+    def get_type(cls) -> GroupActionType:
+        return GroupActionType.PULL_REQUEST_CLOSED

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -1,9 +1,11 @@
+import logging
+
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, router, transaction
 from django.db.models import F
 from django.db.models.signals import post_save, pre_save
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.integrations.analytics import IntegrationResolveCommitEvent, IntegrationResolvePREvent
 from sentry.issues.action_log import (
@@ -21,9 +23,10 @@ from sentry.models.grouphistory import (
 )
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupsubscription import GroupSubscription
+from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
-from sentry.models.pullrequest import PullRequest
+from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.repository import Repository
@@ -34,6 +37,8 @@ from sentry.types.activity import ActivityType
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.users.services.user_option import get_option_from_list, user_option_service
+
+logger = logging.getLogger(__name__)
 
 
 def validate_release_empty_version(instance: Release, **kwargs):
@@ -265,6 +270,51 @@ def resolved_in_pull_request(instance: PullRequest, created, **kwargs):
                 )
 
 
+def pull_request_closing(instance: PullRequest, **kwargs: object) -> None:
+    """
+    Emit PULL_REQUEST_CLOSED group activity when a PR transitions to closed.
+    """
+    try:
+        if instance.state != PullRequestLifecycleState.CLOSED:
+            return
+
+        try:
+            organization = Organization.objects.get_from_cache(id=instance.organization_id)
+        except Organization.DoesNotExist:
+            return
+        if not features.has("organizations:pr-group-activity", organization):
+            return
+
+        if instance.pk is not None:
+            old = PullRequest.objects.filter(pk=instance.pk).first()
+            if old is None or old.state == PullRequestLifecycleState.CLOSED:
+                return
+
+        group_ids = list(
+            GroupLink.objects.filter(
+                linked_type=GroupLink.LinkedType.pull_request,
+                linked_id=instance.id,
+            ).values_list("group_id", flat=True)
+        )
+        if not group_ids:
+            return
+
+        def create_activities():
+            for group in Group.objects.filter(id__in=group_ids):
+                Activity.objects.create(
+                    project_id=group.project_id,
+                    group=group,
+                    type=ActivityType.PULL_REQUEST_CLOSED.value,
+                    ident=str(instance.id),
+                    data={"pull_request": instance.id},
+                )
+
+        transaction.on_commit(create_activities, router.db_for_write(PullRequest))
+    except Exception:
+        # If something fails we don't want to block the model from saving.
+        logger.exception("Failed to create pull request closed activity")
+
+
 pre_save.connect(
     validate_release_empty_version,
     sender=Release,
@@ -277,6 +327,14 @@ post_save.connect(
 )
 
 post_save.connect(resolved_in_commit, sender=Commit, dispatch_uid="resolved_in_commit", weak=False)
+
+
+pre_save.connect(
+    pull_request_closing,
+    sender=PullRequest,
+    dispatch_uid="pull_request_closing",
+    weak=False,
+)
 
 post_save.connect(
     resolved_in_pull_request,

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -12,7 +12,9 @@ from sentry.issues.action_log import (
     ActionSource,
     GroupActionActor,
     action_context_scope,
+    publish_action,
 )
+from sentry.issues.action_log.types import PullRequestClosedAction
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
@@ -308,6 +310,12 @@ def pull_request_closing(instance: PullRequest, **kwargs: object) -> None:
                     type=ActivityType.PULL_REQUEST_CLOSED.value,
                     ident=str(instance.id),
                     data={"pull_request": instance.id},
+                )
+                publish_action(
+                    PullRequestClosedAction(pull_request=instance.id),
+                    source=ActionSource.SYSTEM,
+                    group_id=group.id,
+                    project=group.project,
                 )
 
         transaction.on_commit(create_activities, router.db_for_write(PullRequest))

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -303,20 +303,25 @@ def pull_request_closing(instance: PullRequest, **kwargs: object) -> None:
             return
 
         def create_activities():
-            for group in Group.objects.filter(id__in=group_ids):
-                Activity.objects.create(
-                    project_id=group.project_id,
-                    group=group,
-                    type=ActivityType.PULL_REQUEST_CLOSED.value,
-                    ident=str(instance.id),
-                    data={"pull_request": instance.id},
-                )
-                publish_action(
-                    PullRequestClosedAction(pull_request=instance.id),
-                    source=ActionSource.SYSTEM,
-                    group_id=group.id,
-                    project=group.project,
-                )
+            # This runs after the transaction commits, outside the try/except below,
+            # so it needs its own error handling to avoid propagating failures.
+            try:
+                for group in Group.objects.filter(id__in=group_ids).select_related("project"):
+                    Activity.objects.create(
+                        project_id=group.project_id,
+                        group=group,
+                        type=ActivityType.PULL_REQUEST_CLOSED.value,
+                        ident=str(instance.id),
+                        data={"pull_request": instance.id},
+                    )
+                    publish_action(
+                        PullRequestClosedAction(pull_request=instance.id),
+                        source=ActionSource.SYSTEM,
+                        group_id=group.id,
+                        project=group.project,
+                    )
+            except Exception:
+                logger.exception("Failed to create pull request closed activity")
 
         transaction.on_commit(create_activities, router.db_for_write(PullRequest))
     except Exception:

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -16,6 +16,7 @@ from sentry.issues.action_log import (
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
+from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.grouphistory import (
     GroupHistoryStatus,

--- a/src/sentry/types/activity.py
+++ b/src/sentry/types/activity.py
@@ -44,6 +44,9 @@ class ActivityType(Enum):
     SEER_ITERATION_STARTED = 36
     SEER_ITERATION_COMPLETED = 37
 
+    # A pull request linked to the group was closed without merging
+    PULL_REQUEST_CLOSED = 38
+
 
 # Warning: This must remain in this EXACT order.
 CHOICES = tuple(
@@ -86,6 +89,7 @@ CHOICES = tuple(
         ActivityType.SEER_PR_CREATED,  # 35
         ActivityType.SEER_ITERATION_STARTED,  # 36
         ActivityType.SEER_ITERATION_COMPLETED,  # 37
+        ActivityType.PULL_REQUEST_CLOSED,  # 38
     ]
 )
 

--- a/tests/sentry/api/serializers/test_activity.py
+++ b/tests/sentry/api/serializers/test_activity.py
@@ -38,6 +38,33 @@ class GroupActivityTestCase(TestCase):
         assert pull_request["repository"]["name"] == "organization-bar"
         assert pull_request["message"] == "kartoffel"
 
+    def test_pull_request_closed_activity(self) -> None:
+        self.org = self.create_organization(name="Rowdy Tiger")
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+        repo = self.create_repo(self.project, name="organization-bar")
+        pr = PullRequest.objects.create(
+            organization_id=self.org.id,
+            repository_id=repo.id,
+            key=5,
+            title="aaaa",
+            message="kartoffel",
+        )
+
+        activity = Activity.objects.create(
+            project_id=group.project_id,
+            group=group,
+            type=ActivityType.PULL_REQUEST_CLOSED.value,
+            ident=str(pr.id),
+            data={"pull_request": pr.id},
+        )
+
+        result = serialize([activity], user)[0]
+        assert result["type"] == "pull_request_closed"
+        pull_request = result["data"]["pullRequest"]
+        assert pull_request["repository"]["name"] == "organization-bar"
+        assert pull_request["message"] == "kartoffel"
+
     def test_commit_activity(self) -> None:
         self.org = self.create_organization(name="Rowdy Tiger")
         user = self.create_user()

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -14,7 +14,7 @@ from sentry.models.groupinbox import GroupInbox, GroupInboxReason, add_group_to_
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.organizationmember import OrganizationMember
-from sentry.models.pullrequest import PullRequest
+from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.repository import Repository
@@ -403,3 +403,58 @@ class ProjectHasReleasesReceiverTest(TestCase):
             filters={"release_id": -1, "project_id": -2},
             sender=ReleaseProject,
         )
+
+
+class PullRequestClosedSignalTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.repo = self.create_repo(project=self.project, name="example/repo")
+        self.group = self.create_group(project=self.project)
+        self.pull_request = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id, key="1"
+        )
+        GroupLink.objects.create(
+            group_id=self.group.id,
+            project_id=self.group.project_id,
+            linked_type=GroupLink.LinkedType.pull_request,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id=self.pull_request.id,
+        )
+
+    def _save_with_state(self, state: str) -> None:
+        self.pull_request.state = state
+        self.pull_request.save()
+
+    def test_closed_emits_activity_when_flag_enabled(self) -> None:
+        with self.feature("organizations:pr-group-activity"):
+            self._save_with_state(PullRequestLifecycleState.CLOSED)
+
+        activity = Activity.objects.get(
+            group=self.group, type=ActivityType.PULL_REQUEST_CLOSED.value
+        )
+        assert activity.ident == str(self.pull_request.id)
+        assert activity.data == {"pull_request": self.pull_request.id}
+
+    def test_merged_does_not_emit_activity(self) -> None:
+        with self.feature("organizations:pr-group-activity"):
+            self._save_with_state(PullRequestLifecycleState.MERGED)
+
+        assert not Activity.objects.filter(type=ActivityType.PULL_REQUEST_CLOSED.value).exists()
+
+    def test_open_does_not_emit_activity(self) -> None:
+        with self.feature("organizations:pr-group-activity"):
+            self._save_with_state(PullRequestLifecycleState.OPEN)
+
+        assert not Activity.objects.filter(type=ActivityType.PULL_REQUEST_CLOSED.value).exists()
+
+    def test_closed_skips_activity_when_flag_disabled(self) -> None:
+        self._save_with_state(PullRequestLifecycleState.CLOSED)
+
+        assert not Activity.objects.filter(type=ActivityType.PULL_REQUEST_CLOSED.value).exists()
+
+    def test_resaving_closed_pr_does_not_duplicate(self) -> None:
+        with self.feature("organizations:pr-group-activity"):
+            self._save_with_state(PullRequestLifecycleState.CLOSED)
+            self._save_with_state(PullRequestLifecycleState.CLOSED)
+
+        assert Activity.objects.filter(type=ActivityType.PULL_REQUEST_CLOSED.value).count() == 1


### PR DESCRIPTION
This adds a new group activity entry for when a pull request that's linked to an issue gets closed without being merged: PULL_REQUEST_CLOSED`.

Right now, you get an activity entry created when you open the PR (confusingly called `SET_RESOLVED_IN_PULL_REQUEST`, and a `SET_RESOLVED_IN_RELEASE` when you merge it. But there is nothing when you close without merging.

This PR adds a pre_save signal to the `PullRequest` model which checks to see if the status has changed to `closed`. If it has, a group activity entry is created for any issues which are linked to it. 

This is flagged under `organizations:pr-group-activity` which will be turned on internally for testing before rolling out to more orgs.