### PR TITLE
ref(project-creation): Add SCM-styled notification options

### DIFF
--- a/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
@@ -69,7 +69,10 @@ describe('ScmAlertFrequencySection', () => {
   it('shows the notification options when alerts are enabled', () => {
     renderSection({analyticsFlow: 'onboarding'});
 
-    expect(screen.getByText('Notify via email')).toBeInTheDocument();
+    expect(screen.getByText('Notify via')).toBeInTheDocument();
+    expect(
+      screen.getByText('Integration (Slack, Discord, MS Teams, etc.)')
+    ).toBeInTheDocument();
   });
 
   it('hides the notification options when alerts are turned off', () => {
@@ -81,6 +84,6 @@ describe('ScmAlertFrequencySection', () => {
       },
     });
 
-    expect(screen.queryByText('Notify via email')).not.toBeInTheDocument();
+    expect(screen.queryByText('Notify via')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
@@ -75,6 +75,27 @@ describe('ScmAlertFrequencySection', () => {
     ).toBeInTheDocument();
   });
 
+  it('adds the integration action when the Integration checkbox is clicked', async () => {
+    const setActions = jest.fn();
+    renderSection({
+      analyticsFlow: 'onboarding',
+      notificationProps: {...notificationProps, setActions},
+    });
+
+    // Querying the checkbox by the label text also asserts the label wraps the
+    // input, so clicking the text toggles it.
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'Integration (Slack, Discord, MS Teams, etc.)',
+      })
+    );
+
+    expect(setActions).toHaveBeenCalledWith([
+      MultipleCheckboxOptions.EMAIL,
+      MultipleCheckboxOptions.INTEGRATION,
+    ]);
+  });
+
   it('hides the notification options when alerts are turned off', () => {
     renderSection({
       analyticsFlow: 'onboarding',

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -51,7 +51,7 @@ export function ScmAlertFrequencySection({
   const footer = (
     <Flex gap="sm" align="center">
       <IconInfo size="md" variant="secondary" />
-      <Text variant="secondary" size="md" density="comfortable">
+      <Text variant="secondary" size="md" density="comfortable" ellipsis>
         {t('You can always change alerts after project creation')}
       </Text>
     </Flex>

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -5,10 +5,7 @@ import {Text} from '@sentry/scraps/text';
 import {IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {TagVariant} from 'sentry/utils/theme';
-import {
-  IssueAlertNotificationOptions,
-  type IssueAlertNotificationProps,
-} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import {type IssueAlertNotificationProps} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
   type AlertRuleOptions,
   RuleAction,
@@ -17,6 +14,7 @@ import {
 import {ScmAlertFrequency} from './scmAlertFrequency';
 import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
 import {ScmCollapsibleSection} from './scmCollapsibleSection';
+import {ScmIssueAlertNotificationOptions} from './scmIssueAlertNotificationOptions';
 
 interface ScmAlertFrequencySectionProps {
   alertRuleConfig: AlertRuleOptions;
@@ -47,7 +45,7 @@ export function ScmAlertFrequencySection({
   // hide them for "create alerts later" (mirrors issueAlertOptions).
   const notificationOptions =
     alertRuleConfig.alertSetting === RuleAction.CREATE_ALERT_LATER ? null : (
-      <IssueAlertNotificationOptions {...notificationProps} />
+      <ScmIssueAlertNotificationOptions {...notificationProps} />
     );
 
   const footer = (

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -13,6 +13,7 @@ import {
   MultipleCheckboxOptions,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
+import {ScmCollapsibleReveal} from './scmCollapsibleReveal';
 import {ScmMessagingIntegrationAlertRule} from './scmMessagingIntegrationAlertRule';
 
 /**
@@ -58,9 +59,11 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
               </MultipleCheckbox.Item>
             )}
           </Stack>
-          {!shouldRenderSetupButton && shouldRenderNotificationConfigs ? (
+          <ScmCollapsibleReveal
+            open={!shouldRenderSetupButton && shouldRenderNotificationConfigs}
+          >
             <ScmMessagingIntegrationAlertRule {...props} />
-          ) : null}
+          </ScmCollapsibleReveal>
         </Stack>
       </MultipleCheckbox>
       {shouldRenderSetupButton && (

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import {Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -62,7 +64,9 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
           <ScmCollapsibleReveal
             open={!shouldRenderSetupButton && shouldRenderNotificationConfigs}
           >
-            <ScmMessagingIntegrationAlertRule {...props} />
+            <IndentedRule>
+              <ScmMessagingIntegrationAlertRule {...props} />
+            </IndentedRule>
           </ScmCollapsibleReveal>
         </Stack>
       </MultipleCheckbox>
@@ -74,3 +78,10 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
     </Stack>
   );
 }
+
+// Indents the rule so its left edge lines up with the checkbox label text
+// rather than the checkbox itself: the sm Checkbox box (16px) plus the label's
+// left margin (space.md).
+const IndentedRule = styled('div')`
+  padding-left: calc(16px + ${p => p.theme.space.md});
+`;

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -79,11 +79,16 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
   );
 }
 
-// MultipleCheckbox.Item's label is fixed at 20% width with nowrap text, tuned
-// for the classic wrapping row layout. In this stacked layout the long
-// integration label overflows on narrow screens, so let each label fill its
-// row and truncate the text with an ellipsis instead.
+// MultipleCheckbox.Item wraps each label in a container that is only a fraction
+// of the row (down to 25% on wide screens), and the label itself is 20% with
+// nowrap text. Both are tuned for the classic side-by-side row layout, but here
+// they truncate the long integration label even when there is room. Widen the
+// container and label to fill the row so the text only ellipsis-truncates when
+// it genuinely overflows (narrow screens).
 const CheckboxStack = styled(Stack)`
+  > div {
+    width: 100%;
+  }
   label {
     width: 100%;
     min-width: 0;

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -1,0 +1,73 @@
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {MultipleCheckbox} from 'sentry/components/forms/controls/multipleCheckbox';
+import {t} from 'sentry/locale';
+import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import {
+  MessagingIntegrationAnalyticsView,
+  SetupMessagingIntegrationButton,
+} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
+import {
+  type IssueAlertNotificationProps,
+  MultipleCheckboxOptions,
+} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+
+import {ScmMessagingIntegrationAlertRule} from './scmMessagingIntegrationAlertRule';
+
+/**
+ * SCM-styled notification options for the alert-frequency section. Mirrors
+ * `IssueAlertNotificationOptions` but lifts the "Notify via" wording into a
+ * shared header (so the checkboxes read just "Email" / "Integration ..."), and
+ * renders the messaging rule stacked (`ScmMessagingIntegrationAlertRule`)
+ * instead of the classic inline card.
+ */
+export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationProps) {
+  const {actions, setActions, querySuccess, shouldRenderSetupButton} = props;
+
+  const shouldRenderNotificationConfigs = actions.some(
+    v => v !== MultipleCheckboxOptions.EMAIL
+  );
+
+  useRouteAnalyticsParams({
+    setup_message_integration_button_shown: shouldRenderSetupButton,
+  });
+
+  if (!querySuccess) {
+    return null;
+  }
+
+  return (
+    <Stack gap="lg" padding="lg 0">
+      <Text size="sm" bold variant="secondary" uppercase>
+        {t('Notify via')}
+      </Text>
+      <MultipleCheckbox
+        name="notification"
+        value={actions}
+        onChange={values => setActions(values)}
+      >
+        <Stack gap="md" width="100%">
+          <Stack>
+            <MultipleCheckbox.Item value={MultipleCheckboxOptions.EMAIL} disabled>
+              {t('Email')}
+            </MultipleCheckbox.Item>
+            {shouldRenderSetupButton ? null : (
+              <MultipleCheckbox.Item value={MultipleCheckboxOptions.INTEGRATION}>
+                {t('Integration (Slack, Discord, MS Teams, etc.)')}
+              </MultipleCheckbox.Item>
+            )}
+          </Stack>
+          {!shouldRenderSetupButton && shouldRenderNotificationConfigs ? (
+            <ScmMessagingIntegrationAlertRule {...props} />
+          ) : null}
+        </Stack>
+      </MultipleCheckbox>
+      {shouldRenderSetupButton && (
+        <SetupMessagingIntegrationButton
+          analyticsView={MessagingIntegrationAnalyticsView.PROJECT_CREATION}
+        />
+      )}
+    </Stack>
+  );
+}

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -49,7 +49,7 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
         <Stack gap="md">
           <Flex as="label" align="start" gap="md">
             <Checkbox checked disabled readOnly />
-            <Text>{t('Email')}</Text>
+            <Text bold={false}>{t('Email')}</Text>
           </Flex>
           {shouldRenderSetupButton ? null : (
             <Flex as="label" align="start" gap="md">
@@ -63,7 +63,9 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
                   )
                 }
               />
-              <Text>{t('Integration (Slack, Discord, MS Teams, etc.)')}</Text>
+              <Text bold={false} ellipsis>
+                {t('Integration (Slack, Discord, MS Teams, etc.)')}
+              </Text>
             </Flex>
           )}
         </Stack>

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -51,7 +51,7 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
         onChange={values => setActions(values)}
       >
         <Stack gap="md" width="100%">
-          <Stack>
+          <CheckboxStack>
             <MultipleCheckbox.Item value={MultipleCheckboxOptions.EMAIL} disabled>
               {t('Email')}
             </MultipleCheckbox.Item>
@@ -60,7 +60,7 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
                 {t('Integration (Slack, Discord, MS Teams, etc.)')}
               </MultipleCheckbox.Item>
             )}
-          </Stack>
+          </CheckboxStack>
           <ScmCollapsibleReveal
             open={!shouldRenderSetupButton && shouldRenderNotificationConfigs}
           >
@@ -78,6 +78,25 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
     </Stack>
   );
 }
+
+// MultipleCheckbox.Item's label is fixed at 20% width with nowrap text, tuned
+// for the classic wrapping row layout. In this stacked layout the long
+// integration label overflows on narrow screens, so let each label fill its
+// row and truncate the text with an ellipsis instead.
+const CheckboxStack = styled(Stack)`
+  label {
+    width: 100%;
+    min-width: 0;
+    /* The label's default right margin is for the side-by-side row layout; with
+       a full-width label it would push 10px past the container. */
+    margin-right: 0;
+  }
+  label > span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+`;
 
 // Indents the rule so its left edge lines up with the checkbox label text
 // rather than the checkbox itself: the sm Checkbox box (16px) plus the label's

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
-import {Stack} from '@sentry/scraps/layout';
+import {Checkbox} from '@sentry/scraps/checkbox';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {MultipleCheckbox} from 'sentry/components/forms/controls/multipleCheckbox';
 import {t} from 'sentry/locale';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {
@@ -45,31 +45,36 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
       <Text size="sm" bold variant="secondary" uppercase>
         {t('Notify via')}
       </Text>
-      <MultipleCheckbox
-        name="notification"
-        value={actions}
-        onChange={values => setActions(values)}
-      >
-        <Stack gap="md" width="100%">
-          <CheckboxStack>
-            <MultipleCheckbox.Item value={MultipleCheckboxOptions.EMAIL} disabled>
-              {t('Email')}
-            </MultipleCheckbox.Item>
-            {shouldRenderSetupButton ? null : (
-              <MultipleCheckbox.Item value={MultipleCheckboxOptions.INTEGRATION}>
-                {t('Integration (Slack, Discord, MS Teams, etc.)')}
-              </MultipleCheckbox.Item>
-            )}
-          </CheckboxStack>
-          <ScmCollapsibleReveal
-            open={!shouldRenderSetupButton && shouldRenderNotificationConfigs}
-          >
-            <IndentedRule>
-              <ScmMessagingIntegrationAlertRule {...props} />
-            </IndentedRule>
-          </ScmCollapsibleReveal>
+      <Stack gap="md" width="100%">
+        <Stack gap="md">
+          <Flex as="label" align="start" gap="md">
+            <Checkbox checked disabled readOnly />
+            <Text>{t('Email')}</Text>
+          </Flex>
+          {shouldRenderSetupButton ? null : (
+            <Flex as="label" align="start" gap="md">
+              <Checkbox
+                checked={actions.includes(MultipleCheckboxOptions.INTEGRATION)}
+                onChange={e =>
+                  setActions(
+                    e.target.checked
+                      ? [...actions, MultipleCheckboxOptions.INTEGRATION]
+                      : actions.filter(a => a !== MultipleCheckboxOptions.INTEGRATION)
+                  )
+                }
+              />
+              <Text>{t('Integration (Slack, Discord, MS Teams, etc.)')}</Text>
+            </Flex>
+          )}
         </Stack>
-      </MultipleCheckbox>
+        <ScmCollapsibleReveal
+          open={!shouldRenderSetupButton && shouldRenderNotificationConfigs}
+        >
+          <IndentedRule>
+            <ScmMessagingIntegrationAlertRule {...props} />
+          </IndentedRule>
+        </ScmCollapsibleReveal>
+      </Stack>
       {shouldRenderSetupButton && (
         <SetupMessagingIntegrationButton
           analyticsView={MessagingIntegrationAnalyticsView.PROJECT_CREATION}
@@ -79,33 +84,9 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
   );
 }
 
-// MultipleCheckbox.Item wraps each label in a container that is only a fraction
-// of the row (down to 25% on wide screens), and the label itself is 20% with
-// nowrap text. Both are tuned for the classic side-by-side row layout, but here
-// they truncate the long integration label even when there is room. Widen the
-// container and label to fill the row so the text only ellipsis-truncates when
-// it genuinely overflows (narrow screens).
-const CheckboxStack = styled(Stack)`
-  > div {
-    width: 100%;
-  }
-  label {
-    width: 100%;
-    min-width: 0;
-    /* The label's default right margin is for the side-by-side row layout; with
-       a full-width label it would push 10px past the container. */
-    margin-right: 0;
-  }
-  label > span {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-`;
-
 // Indents the rule so its left edge lines up with the checkbox label text
-// rather than the checkbox itself: the sm Checkbox box (16px) plus the label's
-// left margin (space.md).
+// rather than the checkbox itself: the sm Checkbox box (16px) plus the label
+// row's gap (space.md).
 const IndentedRule = styled('div')`
   padding-left: calc(16px + ${p => p.theme.space.md});
 `;

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -5,7 +5,6 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
-import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {
   MessagingIntegrationAnalyticsView,
   SetupMessagingIntegrationButton,
@@ -13,6 +12,7 @@ import {
 import {
   type IssueAlertNotificationProps,
   MultipleCheckboxOptions,
+  useIssueAlertNotificationOptions,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
 import {ScmCollapsibleReveal} from './scmCollapsibleReveal';
@@ -26,15 +26,9 @@ import {ScmMessagingIntegrationAlertRule} from './scmMessagingIntegrationAlertRu
  * instead of the classic inline card.
  */
 export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationProps) {
-  const {actions, setActions, querySuccess, shouldRenderSetupButton} = props;
-
-  const shouldRenderNotificationConfigs = actions.some(
-    v => v !== MultipleCheckboxOptions.EMAIL
-  );
-
-  useRouteAnalyticsParams({
-    setup_message_integration_button_shown: shouldRenderSetupButton,
-  });
+  const {actions, setActions} = props;
+  const {querySuccess, shouldRenderNotificationConfigs, shouldRenderSetupButton} =
+    useIssueAlertNotificationOptions(props);
 
   if (!querySuccess) {
     return null;

--- a/static/app/views/onboarding/components/scmMessagingIntegrationAlertRule.spec.tsx
+++ b/static/app/views/onboarding/components/scmMessagingIntegrationAlertRule.spec.tsx
@@ -1,0 +1,50 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {IssueAlertNotificationProps} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+
+import {ScmMessagingIntegrationAlertRule} from './scmMessagingIntegrationAlertRule';
+
+describe('ScmMessagingIntegrationAlertRule', () => {
+  const organization = OrganizationFixture();
+  const slackIntegrations = [
+    OrganizationIntegrationsFixture({name: "Moo Deng's Workspace"}),
+  ];
+
+  const notificationProps: IssueAlertNotificationProps = {
+    actions: [],
+    channel: {label: 'channel', value: 'channel'},
+    integration: slackIntegrations[0],
+    provider: 'slack',
+    providersToIntegrations: {slack: slackIntegrations},
+    querySuccess: true,
+    shouldRenderSetupButton: false,
+    setActions: jest.fn(),
+    setChannel: jest.fn(),
+    setIntegration: jest.fn(),
+    setProvider: jest.fn(),
+  };
+
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${slackIntegrations[0]!.id}/channels/`,
+      body: {results: []},
+    });
+  });
+
+  it('renders the reused provider sentence with its three controls', () => {
+    render(<ScmMessagingIntegrationAlertRule {...notificationProps} />, {organization});
+
+    // The same three controls as the classic rule render.
+    expect(screen.getByLabelText('provider')).toBeInTheDocument();
+    expect(screen.getByLabelText('integration')).toBeInTheDocument();
+    expect(screen.getByLabelText('channel')).toBeInTheDocument();
+
+    // The provider sentence text is reused verbatim. The fragments are the
+    // column's direct text nodes, so they read as one normalized string
+    // ("Send [provider] notification to the [integration] workspace to [channel]").
+    expect(screen.getByText('Send notification to the workspace to')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/onboarding/components/scmMessagingIntegrationAlertRule.tsx
+++ b/static/app/views/onboarding/components/scmMessagingIntegrationAlertRule.tsx
@@ -1,0 +1,107 @@
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+import {Select} from '@sentry/scraps/select';
+
+import {t} from 'sentry/locale';
+import {
+  type IssueAlertNotificationProps,
+  providerDetails,
+} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import {
+  ChannelField,
+  ChannelSelect,
+  useMessagingIntegrationAlertRule,
+} from 'sentry/views/projectInstall/messagingIntegrationAlertRule';
+
+/**
+ * SCM-styled variant of `MessagingIntegrationAlertRule`. Instead of the classic
+ * inline sentence inside a grey card, the provider sentence is rendered into a
+ * flex column: each input is its own flex item and each contiguous run of text
+ * becomes an anonymous flex item, so every text block and input lands on its
+ * own full-width row in `makeSentence`'s order. Letting the column do the
+ * splitting (rather than parsing the sentence) keeps it correct no matter how a
+ * translation reorders the placeholders.
+ *
+ * Reuses `useMessagingIntegrationAlertRule` (the channel query, validation, and
+ * option lists) and the same provider sentence as the classic layout, so copy
+ * and behavior stay in lockstep; only the presentation differs.
+ */
+export function ScmMessagingIntegrationAlertRule(props: IssueAlertNotificationProps) {
+  const {
+    provider,
+    integration,
+    channel,
+    providerOptions,
+    integrationOptions,
+    channelOptions,
+    isChannelLoading,
+    channelError,
+    providerDisabled,
+    integrationDisabled,
+    onProviderChange,
+    onIntegrationChange,
+    onChannelChange,
+    onCreateChannel,
+  } = useMessagingIntegrationAlertRule(props);
+
+  if (!provider) {
+    return null;
+  }
+
+  return (
+    <Flex direction="column" gap="md">
+      {providerDetails[provider as keyof typeof providerDetails]?.makeSentence({
+        providerName: (
+          <FullWidthSelect
+            aria-label={t('provider')}
+            disabled={providerDisabled}
+            value={provider}
+            options={providerOptions}
+            onChange={onProviderChange}
+          />
+        ),
+        integrationName: (
+          <FullWidthSelect
+            aria-label={t('integration')}
+            disabled={integrationDisabled}
+            value={integration}
+            options={integrationOptions}
+            onChange={onIntegrationChange}
+          />
+        ),
+        target: (
+          // flexibleControlStateSize collapses the (empty) control-state column
+          // that otherwise reserves a fixed 24px, so the full-width select can
+          // fill the row.
+          <ChannelField
+            name="channel"
+            error={channelError}
+            inline={false}
+            flexibleControlStateSize
+          >
+            {() => (
+              <FullWidthChannelSelect
+                provider={provider}
+                options={channelOptions}
+                value={channel}
+                isLoading={isChannelLoading}
+                disabled={!integration}
+                onChange={onChannelChange}
+                onCreateOption={onCreateChannel}
+              />
+            )}
+          </ChannelField>
+        ),
+      })}
+    </Flex>
+  );
+}
+
+const FullWidthSelect = styled(Select)`
+  width: 100%;
+`;
+
+const FullWidthChannelSelect = styled(ChannelSelect)`
+  width: 100%;
+`;


### PR DESCRIPTION
## TLDR

Add an SCM-styled version of the notification options for the alert-frequency section. The messaging-integration rule lays out one sentence fragment per row with full-width inputs and no grey card background, and reveals with the shared collapse animation. Builds on #118581.

## Details

- Add `ScmMessagingIntegrationAlertRule`, which reuses the `useMessagingIntegrationAlertRule` hook (from #118581) and renders `makeSentence` in a flat `Flex` column, so each fragment ("Send", the provider select, "notification to the", and so on) sits on its own full-width row, without the `background.secondary` card styling.
- Add `ScmIssueAlertNotificationOptions`: a "Notify via" header above "Email" and "Integration (Slack, Discord, MS Teams, etc.)" checkboxes that renders the stacked rule, replacing the direct use of the shared picker in `ScmAlertFrequencySection`. The checkboxes are composed directly from the scraps `Checkbox` (not `MultipleCheckbox`) so they stack full width.
- The rule reveals with `ScmCollapsibleReveal` (height and fade) when Integration is checked and indents under its checkbox label. The long Integration label and the section footer truncate with an ellipsis on narrow screens.
