### PR TITLE
experiment(derived data): Add decorator for merged groups

### DIFF
--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -135,13 +135,14 @@ def _track_progress_impl(state: StateView, entry: GroupActionLogEntry) -> Aggreg
 
 
 def _track_progress_merged(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
-    # ASSIGN advances progress the same way regardless of which group it came
+    # ASSIGN advance progress the same way regardless of which group it came
     # from, so merged-in assignments fall through to the default behavior.
-    if entry.type == GroupActionType.ASSIGN:
+    if entry.type in (GroupActionType.ASSIGN):
         return _track_progress_impl(state, entry)
-    # Other merged-in actions (e.g. SET_PRIORITY) don't advance the canonical
-    # issue's progress; the non-merged group's contribution stands even if the
-    # merged-in entry is more recent.
+
+    # XXX: ignore every other type of action from merged in groups so that we prioritize the destination group's actions
+    # e.g. for mark reviewed, if the destination group is not reviewed but the merged in group is, we do not
+    # progress towards assigned issue progress state
     return None
 
 

--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -13,6 +13,7 @@ from sentry.issues.derived.framework import (
     aggregator,
     emit,
 )
+from sentry.issues.derived.merge import merge_aware
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.progress_state import IssueProgressState
 
@@ -20,6 +21,12 @@ from sentry.issues.progress_state import IssueProgressState
 @aggregator((VIEW_COUNT,), scope=(GroupActionType.VIEW,))
 def track_views(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
     return emit(VIEW_COUNT.value(state[VIEW_COUNT] + 1))
+
+
+def _track_status_merged(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
+    # Status transitions inherited from a group that was merged away don't drive
+    # the canonical issue's status; that's owned by the surviving group's actions.
+    return None
 
 
 @aggregator(
@@ -32,6 +39,7 @@ def track_views(state: StateView, entry: GroupActionLogEntry) -> AggregatorResul
         GroupActionType.SET_REGRESSED,
     ),
 )
+@merge_aware(_track_status_merged)
 def track_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
     current = state[STATUS]
     resolves = (
@@ -99,11 +107,7 @@ _ACTION_TO_MIN_PROGRESS: dict[int, IssueProgressState] = {
 }
 
 
-@aggregator(
-    (PROGRESS, LAST_PROGRESSED_AT),
-    deps=(STATUS,),
-)
-def track_progress(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
+def _track_progress_impl(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
     current = state[PROGRESS]
     ts = entry.date_added
 
@@ -128,6 +132,26 @@ def track_progress(state: StateView, entry: GroupActionLogEntry) -> AggregatorRe
         return emit(PROGRESS.value(min_progress), LAST_PROGRESSED_AT.value(ts))
 
     return None
+
+
+def _track_progress_merged(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
+    # ASSIGN advances progress the same way regardless of which group it came
+    # from, so merged-in assignments fall through to the default behavior.
+    if entry.type == GroupActionType.ASSIGN:
+        return _track_progress_impl(state, entry)
+    # Other merged-in actions (e.g. SET_PRIORITY) don't advance the canonical
+    # issue's progress; the non-merged group's contribution stands even if the
+    # merged-in entry is more recent.
+    return None
+
+
+@aggregator(
+    (PROGRESS, LAST_PROGRESSED_AT),
+    deps=(STATUS,),
+)
+@merge_aware(_track_progress_merged)
+def track_progress(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
+    return _track_progress_impl(state, entry)
 
 
 AGGREGATORS: list[Aggregator[GroupActionLogEntry]] = [

--- a/src/sentry/issues/derived/merge.py
+++ b/src/sentry/issues/derived/merge.py
@@ -1,0 +1,59 @@
+"""
+Helpers for writing merge-aware aggregators.
+
+When groups are merged, the canonical group's action log absorbs entries that
+originally belonged to other groups. Such entries carry an original_group_id
+that differs from their (post-merge) group_id. Some aggregators want to fold
+those entries differently from native ones; merge_aware packages that
+dispatch so each aggregator doesn't have to repeat it.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+
+from sentry.issues.derived.framework import AggregatorResult, StateView
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+
+type EntryFn = Callable[[StateView, GroupActionLogEntry], AggregatorResult]
+
+
+def is_merged_entry(entry: GroupActionLogEntry) -> bool:
+    """
+    True when this entry came from a group merged into the canonical one.
+    """
+    return entry.original_group_id is not None and entry.original_group_id != entry.group_id
+
+
+def merge_aware(
+    merged_fn: EntryFn,
+    *,
+    predicate: Callable[[GroupActionLogEntry], bool] = is_merged_entry,
+) -> Callable[[EntryFn], EntryFn]:
+    """
+    Dispatch to merged_fn for merged-in entries, else the default fn.
+
+    Apply *below* ``@aggregator`` so the wrapped value is still a plain
+    ``AggregatorFn``::
+
+        @aggregator((VIEW_COUNT,), scope=(GroupActionType.VIEW,))
+        @merge_aware(_track_views_merged)
+        def track_views(state, entry):
+            return emit(VIEW_COUNT.value(state[VIEW_COUNT] + 1))
+
+    Both branches share the aggregator's declared deps/outputs, so
+    merged_fn may only read and write features the aggregator already
+    declares — the ``StateView`` rejects anything else.
+    """
+
+    def decorator(default_fn: EntryFn) -> EntryFn:
+        @functools.wraps(default_fn)  # preserves __name__ -> Aggregator.name
+        def wrapper(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
+            if predicate(entry):
+                return merged_fn(state, entry)
+            return default_fn(state, entry)
+
+        return wrapper
+
+    return decorator

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -528,8 +528,13 @@ def _merged(type: int, **kwargs: Any) -> FakeEntry:
     return FakeEntry(type=type, group_id=1, original_group_id=2, **kwargs)
 
 
+########################## STATUS ##########################
+
+
 def test_merged_resolve_does_not_close() -> None:
-    # track_status ignores transitions inherited from a merged-away group.
+    """
+    Test that track_status ignores a resolution action from a merged in group
+    """
     assert (
         _run_for_feature(
             STATUS,
@@ -542,6 +547,10 @@ def test_merged_resolve_does_not_close() -> None:
 
 
 def test_merged_unresolve_does_not_reopen() -> None:
+    """
+    Test that an unresolve action from a merged in group doesn't result in the destination group's
+    issue status reverting to open
+    """
     assert (
         _run_for_feature(
             STATUS,
@@ -554,8 +563,13 @@ def test_merged_unresolve_does_not_reopen() -> None:
     )
 
 
+########################## PROGRESS ##########################
+
+
 def test_merged_assign_advances_progress() -> None:
-    # ASSIGN advances progress regardless of which group it came from.
+    """
+    Test that an assignment advances progress regardless of which group it came from
+    """
     assert (
         _run_for_feature(
             PROGRESS,
@@ -568,7 +582,10 @@ def test_merged_assign_advances_progress() -> None:
 
 
 def test_merged_set_priority_does_not_advance_progress() -> None:
-    # Merged-in SET_PRIORITY doesn't advance the canonical issue's progress.
+    """
+    Test that a merged group's set priority action doesn't advance the destination group's progress
+    (assuming the destination group does NOT have a priority set)
+    """
     assert (
         _run_for_feature(
             PROGRESS,
@@ -581,8 +598,10 @@ def test_merged_set_priority_does_not_advance_progress() -> None:
 
 
 def test_merged_set_priority_does_not_override_native() -> None:
-    # The non-merged group's contribution stands even if the merged-in
-    # SET_PRIORITY is more recent.
+    """
+    Test that the destination group's RCA action stands even if the merged in
+    group's set priority action is more recent
+    """
     assert (
         _run_for_feature(
             PROGRESS,
@@ -596,7 +615,9 @@ def test_merged_set_priority_does_not_override_native() -> None:
 
 
 def test_merged_root_cause_does_not_advance_progress() -> None:
-    # Only ASSIGN falls through; other merged-in actions stay a no-op.
+    """
+    Test that only an assignment action from a merged in group falls through; other merged in actions stay a no-op
+    """
     assert (
         _run_for_feature(
             PROGRESS,

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -57,6 +57,8 @@ class FakeEntry:
     actor_type: int = GroupActorType.SYSTEM
     actor_id: int = 0
     data: dict[str, object] = field(default_factory=dict)
+    group_id: int = 1
+    original_group_id: int | None = None
 
 
 def _ts(year: int = 2025, month: int = 1, day: int = 1, hour: int = 0) -> datetime:
@@ -514,6 +516,96 @@ def test_last_progressed_at_set_on_reopen() -> None:
             FakeEntry(type=GroupActionType.UNRESOLVE, date_added=_ts(hour=2)),
         ],
     ) == _ts(hour=2)
+
+
+# ---------------------------------------------------------------------------
+# Merge-aware behavior
+# ---------------------------------------------------------------------------
+
+
+def _merged(type: int, **kwargs: Any) -> FakeEntry:
+    """An entry inherited from a group that was merged into the canonical one."""
+    return FakeEntry(type=type, group_id=1, original_group_id=2, **kwargs)
+
+
+def test_merged_resolve_does_not_close() -> None:
+    # track_status ignores transitions inherited from a merged-away group.
+    assert (
+        _run_for_feature(
+            STATUS,
+            [
+                _merged(GroupActionType.RESOLVE),
+            ],
+        )
+        == IssueStatus.OPEN
+    )
+
+
+def test_merged_unresolve_does_not_reopen() -> None:
+    assert (
+        _run_for_feature(
+            STATUS,
+            [
+                FakeEntry(type=GroupActionType.RESOLVE),
+                _merged(GroupActionType.UNRESOLVE),
+            ],
+        )
+        == IssueStatus.CLOSED
+    )
+
+
+def test_merged_assign_advances_progress() -> None:
+    # ASSIGN advances progress regardless of which group it came from.
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [
+                _merged(GroupActionType.ASSIGN),
+            ],
+        )
+        == IssueProgressState.ASSIGNED
+    )
+
+
+def test_merged_set_priority_does_not_advance_progress() -> None:
+    # Merged-in SET_PRIORITY doesn't advance the canonical issue's progress.
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [
+                _merged(GroupActionType.SET_PRIORITY),
+            ],
+        )
+        == IssueProgressState.IDENTIFIED
+    )
+
+
+def test_merged_set_priority_does_not_override_native() -> None:
+    # The non-merged group's contribution stands even if the merged-in
+    # SET_PRIORITY is more recent.
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [
+                FakeEntry(type=GroupActionType.ROOT_CAUSE_IDENTIFIED, date_added=_ts(hour=1)),
+                _merged(GroupActionType.SET_PRIORITY, date_added=_ts(hour=2)),
+            ],
+        )
+        == IssueProgressState.DIAGNOSED
+    )
+
+
+def test_merged_root_cause_does_not_advance_progress() -> None:
+    # Only ASSIGN falls through; other merged-in actions stay a no-op.
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [
+                _merged(GroupActionType.ROOT_CAUSE_IDENTIFIED),
+            ],
+        )
+        == IssueProgressState.IDENTIFIED
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sentry/issues/derived/test_merge.py
+++ b/tests/sentry/issues/derived/test_merge.py
@@ -1,0 +1,115 @@
+"""
+Pure-Python tests for merge-aware aggregators. No database, no Django TestCase.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from sentry.issues.action_log.types import GroupActionType
+from sentry.issues.derived.framework import (
+    AggregatorResult,
+    Feature,
+    Pipeline,
+    StateView,
+    aggregator,
+    emit,
+)
+from sentry.issues.derived.merge import is_merged_entry, merge_aware
+
+VIEWS = Feature[int]("views", default=0)
+
+
+@dataclass(frozen=True)
+class FakeEntry:
+    type: int
+    group_id: int = 1
+    original_group_id: int | None = None
+    date_added: datetime = datetime(2025, 1, 1, tzinfo=UTC)
+
+
+def _pipeline(*aggregators: Any) -> Pipeline[Any]:
+    return Pipeline(aggregators, version=1, check_mutations=True)
+
+
+# ---------------------------------------------------------------------------
+# is_merged_entry
+# ---------------------------------------------------------------------------
+
+
+def test_native_entry_is_not_merged() -> None:
+    assert not is_merged_entry(FakeEntry(type=GroupActionType.VIEW))
+
+
+def test_entry_with_matching_original_is_not_merged() -> None:
+    assert not is_merged_entry(
+        FakeEntry(type=GroupActionType.VIEW, group_id=7, original_group_id=7)
+    )
+
+
+def test_entry_from_other_group_is_merged() -> None:
+    assert is_merged_entry(FakeEntry(type=GroupActionType.VIEW, group_id=7, original_group_id=99))
+
+
+# ---------------------------------------------------------------------------
+# merge_aware
+# ---------------------------------------------------------------------------
+
+
+def _views_merged(state: StateView, entry: FakeEntry) -> AggregatorResult:
+    # Merged-in views are worth half as much (rounded down).
+    return emit(VIEWS.value(state[VIEWS]))
+
+
+@aggregator((VIEWS,), scope=(GroupActionType.VIEW,))
+@merge_aware(_views_merged)
+def track_views(state: StateView, entry: FakeEntry) -> AggregatorResult:
+    return emit(VIEWS.value(state[VIEWS] + 1))
+
+
+def test_native_entries_use_default_branch() -> None:
+    state = _pipeline(track_views).run(
+        [
+            FakeEntry(type=GroupActionType.VIEW),
+            FakeEntry(type=GroupActionType.VIEW),
+        ]
+    )
+    assert state[VIEWS] == 2
+
+
+def test_merged_entries_use_merged_branch() -> None:
+    state = _pipeline(track_views).run(
+        [
+            FakeEntry(type=GroupActionType.VIEW, group_id=1, original_group_id=2),
+            FakeEntry(type=GroupActionType.VIEW, group_id=1, original_group_id=2),
+        ]
+    )
+    assert state[VIEWS] == 0
+
+
+def test_mixed_entries_dispatch_per_entry() -> None:
+    state = _pipeline(track_views).run(
+        [
+            FakeEntry(type=GroupActionType.VIEW),  # native -> +1
+            FakeEntry(type=GroupActionType.VIEW, group_id=1, original_group_id=2),  # merged -> noop
+            FakeEntry(type=GroupActionType.VIEW),  # native -> +1
+        ]
+    )
+    assert state[VIEWS] == 2
+
+
+def test_preserves_aggregator_name() -> None:
+    # @functools.wraps keeps the name so the Pipeline sees `track_views`, not `wrapper`.
+    assert track_views.name == "track_views"
+
+
+def test_custom_predicate() -> None:
+    @aggregator((VIEWS,), scope=(GroupActionType.VIEW,))
+    @merge_aware(_views_merged, predicate=lambda entry: True)
+    def always_merged(state: StateView, entry: FakeEntry) -> AggregatorResult:
+        return emit(VIEWS.value(state[VIEWS] + 1))
+
+    state = _pipeline(always_merged).run([FakeEntry(type=GroupActionType.VIEW)])
+    assert state[VIEWS] == 0


### PR DESCRIPTION
Add a decorator to indicate that we want to have different behavior for merged groups - in some cases we want the default behavior (use whatever is most recent) and in some cases we may want to prioritize the non-merged group's log over the merged in ones. This tries out a way of accomplishing that for the case where each group is assigned to a different user/team and the case where each group has set a different priority.