### PR TITLE
ref(seer-infra-telemetry): Extract `link_provider_identity` helper function

### DIFF
--- a/src/sentry/api/endpoints/organization_monitoring_provider_details.py
+++ b/src/sentry/api/endpoints/organization_monitoring_provider_details.py
@@ -23,7 +23,12 @@ from sentry.identity.base import Provider
 from sentry.identity.oauth2 import OAuth2Provider
 from sentry.identity.pipeline import IdentityPipeline
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.users.models.identity import Identity, IdentityProvider, OrganizationIdentity
+from sentry.users.models.identity import (
+    Identity,
+    IdentityProvider,
+    OrganizationIdentity,
+    link_provider_identity,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -87,37 +92,20 @@ class OrganizationMonitoringProviderDetailsEndpoint(ControlSiloOrganizationEndpo
     ) -> Response:
         """Verify a user-submitted token and link the identity (no OAuth flow)."""
         try:
-            identity = provider_type.build_identity(request.data)
+            identity_data = provider_type.build_identity(request.data)
         except (ValueError, IdentityNotValid) as e:
             return Response({"detail": str(e)}, status=400)
         except RequestException:
             return Response({"detail": "Failed to verify token with provider."}, status=400)
 
-        idp, _ = IdentityProvider.objects.get_or_create(
-            type=identity["type"],
-            external_id=identity["idp_external_id"],
-            defaults={"config": identity.get("idp_config", {})},
-        )
-
         try:
-            linked_identity = Identity.objects.link_identity(
+            link_provider_identity(
                 user=request.user,  # type: ignore[arg-type]
-                idp=idp,
-                external_id=identity["id"],
-                should_reattach=False,
-                defaults={
-                    "scopes": identity.get("scopes", []),
-                    "data": identity.get("data", {}),
-                },
+                identity_data=identity_data,
+                organization_id=organization.id,
             )
         except IntegrityError:
             return Response({"detail": "This account is already connected."}, status=409)
-
-        if linked_identity:
-            OrganizationIdentity.objects.get_or_create(
-                organization_id=organization.id,
-                identity=linked_identity,
-            )
 
         return Response(status=204)
 

--- a/src/sentry/identity/datadog/provider.py
+++ b/src/sentry/identity/datadog/provider.py
@@ -31,18 +31,16 @@ from sentry.pipeline.views.base import PipelineView
 from sentry.users.models.identity import Identity
 from sentry.utils.http import absolute_uri
 
-DATADOG_VALID_SITES = frozenset(
-    {
-        "datadoghq.com",
-        "us3.datadoghq.com",
-        "us5.datadoghq.com",
-        "datadoghq.eu",
-        "ddog-gov.com",
-        "us2.ddog-gov.com",
-        "ap1.datadoghq.com",
-        "ap2.datadoghq.com",
-    }
-)
+DATADOG_VALID_SITES: dict[str, str] = {
+    "datadoghq.com": "US1",
+    "us3.datadoghq.com": "US3",
+    "us5.datadoghq.com": "US5",
+    "datadoghq.eu": "EU",
+    "ap1.datadoghq.com": "AP1",
+    "ap2.datadoghq.com": "AP2",
+    "ddog-gov.com": "US1-FED",
+    "us2.ddog-gov.com": "US2-FED",
+}
 
 MCP_REGISTER_PATH = "/api/unstable/mcp-server/register"
 MCP_AUTHORIZE_PATH = "/api/unstable/mcp-server/authorize"

--- a/src/sentry/users/models/identity.py
+++ b/src/sentry/users/models/identity.py
@@ -257,3 +257,41 @@ class OrganizationIdentity(DefaultFieldsModel):
         app_label = "sentry"
         db_table = "sentry_organizationidentity"
         unique_together = (("organization_id", "identity_id"),)
+
+
+def link_provider_identity(
+    user: User | RpcUser,
+    identity_data: dict[str, Any],
+    organization_id: int,
+) -> Identity | None:
+    """Create/get an IdentityProvider, link an Identity, and create an
+    OrganizationIdentity.
+
+    ``identity_data`` is the dict returned by ``Provider.build_identity()``.
+    Propagates ``IntegrityError`` from ``link_identity`` when the identity is
+    already linked to another user.
+    """
+    idp, _ = IdentityProvider.objects.get_or_create(
+        type=identity_data["type"],
+        external_id=identity_data["idp_external_id"],
+        defaults={"config": identity_data.get("idp_config", {})},
+    )
+
+    linked_identity = Identity.objects.link_identity(
+        user=user,
+        idp=idp,
+        external_id=identity_data["id"],
+        should_reattach=False,
+        defaults={
+            "scopes": identity_data.get("scopes", []),
+            "data": identity_data.get("data", {}),
+        },
+    )
+
+    if linked_identity:
+        OrganizationIdentity.objects.get_or_create(
+            organization_id=organization_id,
+            identity=linked_identity,
+        )
+
+    return linked_identity

--- a/src/sentry/users/models/identity.py
+++ b/src/sentry/users/models/identity.py
@@ -264,34 +264,28 @@ def link_provider_identity(
     identity_data: dict[str, Any],
     organization_id: int,
 ) -> Identity | None:
-    """Create/get an IdentityProvider, link an Identity, and create an
-    OrganizationIdentity.
-
-    ``identity_data`` is the dict returned by ``Provider.build_identity()``.
-    Propagates ``IntegrityError`` from ``link_identity`` when the identity is
-    already linked to another user.
-    """
-    idp, _ = IdentityProvider.objects.get_or_create(
-        type=identity_data["type"],
-        external_id=identity_data["idp_external_id"],
-        defaults={"config": identity_data.get("idp_config", {})},
-    )
-
-    linked_identity = Identity.objects.link_identity(
-        user=user,
-        idp=idp,
-        external_id=identity_data["id"],
-        should_reattach=False,
-        defaults={
-            "scopes": identity_data.get("scopes", []),
-            "data": identity_data.get("data", {}),
-        },
-    )
-
-    if linked_identity:
-        OrganizationIdentity.objects.get_or_create(
-            organization_id=organization_id,
-            identity=linked_identity,
+    with transaction.atomic(router.db_for_write(Identity)):
+        idp, _ = IdentityProvider.objects.get_or_create(
+            type=identity_data["type"],
+            external_id=identity_data["idp_external_id"],
+            defaults={"config": identity_data.get("idp_config", {})},
         )
+
+        linked_identity = Identity.objects.link_identity(
+            user=user,
+            idp=idp,
+            external_id=identity_data["id"],
+            should_reattach=False,
+            defaults={
+                "scopes": identity_data.get("scopes", []),
+                "data": identity_data.get("data", {}),
+            },
+        )
+
+        if linked_identity:
+            OrganizationIdentity.objects.get_or_create(
+                organization_id=organization_id,
+                identity=linked_identity,
+            )
 
     return linked_identity


### PR DESCRIPTION
[CW-1549](https://linear.app/getsentry/issue/CW-1549/pat-modal-builder-submission-handler)

Extracts the 3-step identity linking pattern (get/create `IdentityProvider` -> link `Identity` -> get/create `OrganizationIdentity`) into a reusable `link_provider_identity()` helper to be reused for other flows triggering monitoring provider connections.

Converts `DATADOG_VALID_SITES` into a dict so that we have both the site values and the regions.