### PR TITLE
ref(project-creation): adjust create-project layout shift animations

### DIFF
--- a/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
+++ b/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
@@ -54,7 +54,7 @@ export function ScmProjectDetailsCore({
   }, [organization, analyticsFlow]);
 
   return (
-    <Grid width="100%" columns={{sm: '1fr', md: '1fr 1fr'}} gap="2xl">
+    <Grid width="100%" columns={{sm: '1fr', md: '1fr 1fr'}} gap="xl">
       <Stack gap="md">
         <Container>
           <Heading as="h4">{t('Project name')}</Heading>

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -268,19 +268,20 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
     <SentryDocumentTitle title={t('Create a new project')}>
       <Access access={canUserCreateProject ? ['project:read'] : ['project:admin']}>
         <Stack padding="3xl" gap="2xl" align="center">
-          <Stack
-            flexGrow={1}
-            gap="2xl"
-            padding="2xl"
-            maxWidth={CREATE_PROJECT_MAX_WIDTH}
-            width="100%"
-            border="primary"
-            radius="lg"
-          >
-            <LayoutGroup>
+          <LayoutGroup>
+            <MotionStack
+              flexGrow={1}
+              gap="2xl"
+              padding="2xl"
+              maxWidth={CREATE_PROJECT_MAX_WIDTH}
+              width="100%"
+              border="primary"
+              radius="lg"
+              layout="size"
+            >
               <Layout.Title>{t('Create a new project')}</Layout.Title>
 
-              <Stack paddingBottom="lg" gap="md">
+              <MotionStack paddingBottom="lg" gap="md" layout="position">
                 <Heading as="h1">{t('Create a project')}</Heading>
                 <Text variant="secondary" density="comfortable">
                   {tct(
@@ -292,7 +293,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                     }
                   )}
                 </Text>
-              </Stack>
+              </MotionStack>
 
               <MotionStack gap="md" layout="position">
                 <Flex justify="between" align="center">
@@ -370,26 +371,31 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                   onAlertChange={form.onAlertChange}
                 />
               </motion.div>
-            </LayoutGroup>
-          </Stack>
-          {/* Page-level CTA: disabled until a platform and project details are
+            </MotionStack>
+            {/* Page-level CTA: disabled until a platform and project details are
               ready. */}
-          <Stack gap="md" maxWidth={CREATE_PROJECT_MAX_WIDTH} width="100%">
-            <ProjectCreationErrorAlert error={form.error} />
-            <Flex justify="end">
-              <Tooltip title={submitTooltipText} disabled={!submitTooltipText}>
-                <Button
-                  variant="primary"
-                  onClick={form.submit}
-                  disabled={!form.canSubmit}
-                  busy={form.isBusy}
-                  icon={<IconProject />}
-                >
-                  {t('Create project')}
-                </Button>
-              </Tooltip>
-            </Flex>
-          </Stack>
+            <MotionStack
+              gap="md"
+              maxWidth={CREATE_PROJECT_MAX_WIDTH}
+              width="100%"
+              layout="position"
+            >
+              <ProjectCreationErrorAlert error={form.error} />
+              <Flex justify="end">
+                <Tooltip title={submitTooltipText} disabled={!submitTooltipText}>
+                  <Button
+                    variant="primary"
+                    onClick={form.submit}
+                    disabled={!form.canSubmit}
+                    busy={form.isBusy}
+                    icon={<IconProject />}
+                  >
+                    {t('Create project')}
+                  </Button>
+                </Tooltip>
+              </Flex>
+            </MotionStack>
+          </LayoutGroup>
         </Stack>
       </Access>
     </SentryDocumentTitle>


### PR DESCRIPTION
## TLDR

Animate the SCM create-project page so the card and the page-level CTA shift smoothly as sections appear or collapse, instead of snapping.

## Details

Extends the existing `LayoutGroup` to wrap both the create-project card and the page-level CTA, makes the card a `MotionStack` with `layout="size"`, and converts the inner section containers to `MotionStack` with `layout="position"`. As sections (platform, products, alert config) appear or collapse, the card resizing and the CTA repositioning below it now animate together rather than jumping.

Also tightens the project-details grid gap (project-name vs. team columns) from `2xl` to `xl` in `ScmProjectDetailsCore`.
