### PR TITLE
fix(autofix): fix autofix drawer UI bugs

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -17,6 +17,7 @@ import {
   type CodingAgentIntegration,
 } from 'sentry/components/events/autofix/useAutofix';
 import type {Organization} from 'sentry/types/organization';
+import type {User} from 'sentry/types/user';
 import {isArrayOf, isString} from 'sentry/types/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
@@ -124,6 +125,16 @@ export function isCodingAgentsArtifact(
  * State returned from the Explorer autofix endpoint.
  * This extends the SeerExplorer types with autofix-specific data.
  */
+export interface QueuedFeedbackItem {
+  source?: {
+    comment?: {html_url?: string; user?: {login: string}};
+    type?: string;
+    user?: User;
+  };
+  text: string;
+  timestamp?: string;
+}
+
 export interface ExplorerAutofixState {
   blocks: Block[];
   run_id: number;
@@ -135,6 +146,7 @@ export interface ExplorerAutofixState {
     id: string;
     input_type: 'file_change_approval' | 'ask_user_question';
   } | null;
+  queued_feedback?: QueuedFeedbackItem[];
   repo_pr_states?: Record<string, RepoPRState>;
 }
 
@@ -203,11 +215,14 @@ const isActivelyProcessing = (
       codingAgent.status === CodingAgentStatus.RUNNING
   );
 
+  const hasQueuedFeedback = (autofixState.queued_feedback ?? []).length > 0;
+
   return (
     autofixState.status === 'processing' ||
     autofixState.blocks.some(block => block.loading) ||
     anyPRCreating ||
-    anyCodingAgentsRunning
+    anyCodingAgentsRunning ||
+    hasQueuedFeedback
   );
 };
 
@@ -755,7 +770,6 @@ export function useExplorerAutofix(
     ]
   );
 
-  // Clear waiting state when we get a response
   if (waitingForResponse && runState) {
     const hasLoadingBlock = runState.blocks.some(block => block.loading);
     if (!hasLoadingBlock && runState.status !== 'processing') {

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -126,12 +126,12 @@ export function isCodingAgentsArtifact(
  * This extends the SeerExplorer types with autofix-specific data.
  */
 export interface QueuedFeedbackItem {
+  text: string;
   source?: {
     comment?: {html_url?: string; user?: {login: string}};
     type?: string;
     user?: User;
   };
-  text: string;
   timestamp?: string;
 }
 

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -763,6 +763,86 @@ describe('ArtifactCard', () => {
       expect(screen.getByText('"Add a test for this"')).toBeInTheDocument();
     });
 
+    it('shows the iterating loader when feedback is queued', () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: 'Make the button blue', source: {type: 'user-ui'}}],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByText('Iterating on PR…')).toBeInTheDocument();
+      expect(screen.queryByTestId('file-diff-viewer')).not.toBeInTheDocument();
+    });
+
+    it('renders queued feedback as a feedback item', () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: 'Make the button blue', source: {type: 'user-ui'}}],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByText('Feedback')).toBeInTheDocument();
+      expect(screen.getByText('"Make the button blue"')).toBeInTheDocument();
+    });
+
+    it('shows generic processing copy for queued feedback without the feature flag', () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: 'Make the button blue', source: {type: 'user-ui'}}],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />
+      );
+
+      expect(screen.getByText('Implementing changes…')).toBeInTheDocument();
+      expect(screen.queryByText('Iterating on PR…')).not.toBeInTheDocument();
+    });
+
     it('does not render iteration feedback without the feature flag', () => {
       render(
         <CodeChangesCard

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -96,9 +96,9 @@ function parseQueuedFeedback(
   }
 }
 
-function parseFeedback(
-  raw: string
-): DistributiveOmit<IterationFeedback, 'iterationIndex'> | null {
+type FeedbackVariant = DistributiveOmit<IterationFeedback, 'iterationIndex'>;
+
+function parseFeedback(raw: string): FeedbackVariant[] {
   type ParsedFeedback = {
     text: string;
     source?: {
@@ -109,24 +109,28 @@ function parseFeedback(
     timestamp?: string;
   };
   const rawParsed: ParsedFeedback | ParsedFeedback[] = JSON.parse(raw);
-  const parsed: ParsedFeedback = Array.isArray(rawParsed) ? rawParsed[0] : rawParsed;
-  if (!parsed) {
-    return null;
-  }
-  const base = {text: parsed.text, timestamp: parsed.timestamp};
-  switch (parsed.source?.type) {
-    case 'user-ui':
-      return {...base, sourceType: 'user-ui', user: parsed.source?.user};
-    case 'github-pr-comment':
-      return {
-        ...base,
-        sourceType: 'github-pr-comment',
-        githubUsername: parsed.source?.comment?.user?.login,
-        commentUrl: parsed.source?.comment?.html_url,
-      };
-    default:
-      return null;
-  }
+  const items = Array.isArray(rawParsed) ? rawParsed : [rawParsed];
+  return items.flatMap((parsed): FeedbackVariant[] => {
+    if (!parsed) {
+      return [];
+    }
+    const base = {text: parsed.text, timestamp: parsed.timestamp};
+    switch (parsed.source?.type) {
+      case 'user-ui':
+        return [{...base, sourceType: 'user-ui', user: parsed.source?.user}];
+      case 'github-pr-comment':
+        return [
+          {
+            ...base,
+            sourceType: 'github-pr-comment',
+            githubUsername: parsed.source?.comment?.user?.login,
+            commentUrl: parsed.source?.comment?.html_url,
+          },
+        ];
+      default:
+        return [];
+    }
+  });
 }
 
 /**
@@ -170,11 +174,10 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
       if (!value || iterationIndex === undefined) {
         return [];
       }
-      const parsed = parseFeedback(value);
-      if (!parsed) {
-        return [];
-      }
-      return [{...parsed, iterationIndex: Number(iterationIndex)}];
+      return parseFeedback(value).map(parsed => ({
+        ...parsed,
+        iterationIndex: Number(iterationIndex),
+      }));
     });
     const maxIndex = processed.reduce((m, f) => Math.max(m, f.iterationIndex), -1);
     const queued = (autofix.runState?.queued_feedback ?? []).flatMap((item, i) => {
@@ -289,8 +292,8 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
       {feedback.length > 0 && (
         <ArtifactDetails>
           <Text bold>{t('Feedback')}</Text>
-          {feedback.map(item => (
-            <FeedbackItem key={item.iterationIndex} item={item} />
+          {feedback.map((item, index) => (
+            <FeedbackItem key={index} item={item} />
           ))}
         </ArtifactDetails>
       )}

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -15,6 +15,7 @@ import {
   isCodeChangesArtifact,
   isPrIterationBlock,
   type AutofixSection,
+  type QueuedFeedbackItem,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {ArtifactCard} from 'sentry/components/events/autofix/v3/artifactCard';
@@ -75,9 +76,30 @@ type DistributiveOmit<T, K extends keyof any> = T extends unknown ? Omit<T, K> :
  * we don't recognize return `null` so a backend change can roll out ahead of the
  * frontend without rendering anything unexpected.
  */
+function parseQueuedFeedback(
+  item: QueuedFeedbackItem,
+  iterationIndex: number
+): IterationFeedback | null {
+  const base = {text: item.text, timestamp: item.timestamp, iterationIndex};
+  switch (item.source?.type) {
+    case 'user-ui':
+      return {...base, sourceType: 'user-ui', user: item.source.user ?? null};
+    case 'github-pr-comment':
+      return {
+        ...base,
+        sourceType: 'github-pr-comment',
+        githubUsername: item.source.comment?.user?.login,
+        commentUrl: item.source.comment?.html_url,
+      };
+    default:
+      return null;
+  }
+}
+
 function parseFeedback(
   raw: string
 ): DistributiveOmit<IterationFeedback, 'iterationIndex'> | null {
+  const rawParsed = JSON.parse(raw);
   const parsed: {
     text: string;
     source?: {
@@ -86,7 +108,10 @@ function parseFeedback(
       user?: User;
     };
     timestamp?: string;
-  } = JSON.parse(raw);
+  } = Array.isArray(rawParsed) ? rawParsed[0] : rawParsed;
+  if (!parsed) {
+    return null;
+  }
   const base = {text: parsed.text, timestamp: parsed.timestamp};
   switch (parsed.source?.type) {
     case 'user-ui':
@@ -133,25 +158,30 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
   // section's code-change artifact by getOrderedAutofixSections. Gated behind
   // the PR iteration feature; when it's off we render the card as if no
   // iterations exist.
-  const feedback = useMemo<IterationFeedback[]>(
-    () =>
-      hasPrIterationFeature
-        ? section.blocks.filter(isPrIterationBlock).flatMap(block => {
-            const metadata = block.message.metadata;
-            const value = metadata?.feedback;
-            const iterationIndex = metadata?.iteration_index;
-            if (!value || iterationIndex === undefined) {
-              return [];
-            }
-            const parsed = parseFeedback(value);
-            if (!parsed) {
-              return [];
-            }
-            return [{...parsed, iterationIndex: Number(iterationIndex)}];
-          })
-        : [],
-    [section.blocks, hasPrIterationFeature]
-  );
+  const feedback = useMemo<IterationFeedback[]>(() => {
+    if (!hasPrIterationFeature) {
+      return [];
+    }
+    const processed = section.blocks.filter(isPrIterationBlock).flatMap(block => {
+      const metadata = block.message.metadata;
+      const value = metadata?.feedback;
+      const iterationIndex = metadata?.iteration_index;
+      if (!value || iterationIndex === undefined) {
+        return [];
+      }
+      const parsed = parseFeedback(value);
+      if (!parsed) {
+        return [];
+      }
+      return [{...parsed, iterationIndex: Number(iterationIndex)}];
+    });
+    const maxIndex = processed.reduce<number>((m, f) => Math.max(m, f.iterationIndex), -1);
+    const queued = (autofix.runState?.queued_feedback ?? []).flatMap((item, i) => {
+      const parsed = parseQueuedFeedback(item, maxIndex + 1 + i);
+      return parsed ? [parsed] : [];
+    });
+    return [...processed, ...queued];
+  }, [section.blocks, hasPrIterationFeature, autofix.runState?.queued_feedback]);
 
   const latestIterationIndex = useMemo(
     () =>
@@ -163,10 +193,12 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     [feedback]
   );
 
+  const hasQueuedFeedback = (autofix.runState?.queued_feedback ?? []).length > 0;
+
   const isIterating =
     hasPrIterationFeature &&
-    section.status === 'processing' &&
-    section.blocks.some(isPrIterationBlock);
+    (hasQueuedFeedback ||
+      (section.status === 'processing' && section.blocks.some(isPrIterationBlock)));
 
   // While processing, only replay the assistant output from the current
   // in-progress step. Steps (the original coding step plus each PR iteration)
@@ -229,7 +261,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     return t('%s files changed in %s repos', filesChanged.size, reposChanged);
   }, [patchesByRepo]);
 
-  const isProcessing = section.status === 'processing';
+  const isProcessing = section.status === 'processing' || hasQueuedFeedback;
 
   return (
     <ArtifactCard

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -175,7 +175,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
       }
       return [{...parsed, iterationIndex: Number(iterationIndex)}];
     });
-    const maxIndex = processed.reduce<number>((m, f) => Math.max(m, f.iterationIndex), -1);
+    const maxIndex = processed.reduce((m, f) => Math.max(m, f.iterationIndex), -1);
     const queued = (autofix.runState?.queued_feedback ?? []).flatMap((item, i) => {
       const parsed = parseQueuedFeedback(item, maxIndex + 1 + i);
       return parsed ? [parsed] : [];

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -99,8 +99,7 @@ function parseQueuedFeedback(
 function parseFeedback(
   raw: string
 ): DistributiveOmit<IterationFeedback, 'iterationIndex'> | null {
-  const rawParsed = JSON.parse(raw);
-  const parsed: {
+  type ParsedFeedback = {
     text: string;
     source?: {
       type: string;
@@ -108,7 +107,9 @@ function parseFeedback(
       user?: User;
     };
     timestamp?: string;
-  } = Array.isArray(rawParsed) ? rawParsed[0] : rawParsed;
+  };
+  const rawParsed: ParsedFeedback | ParsedFeedback[] = JSON.parse(raw);
+  const parsed: ParsedFeedback = Array.isArray(rawParsed) ? rawParsed[0] : rawParsed;
   if (!parsed) {
     return null;
   }

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
@@ -77,6 +77,7 @@ export function PrIterationFeedbackForm({
             'Give Seer additional context to improve your pull request and make changes to your code. Hit ENTER to submit.'
           )}
           value={feedback}
+          disabled={isSubmitting}
           onChange={event => setFeedback(event.target.value)}
           onKeyDown={event => {
             if (event.nativeEvent.isComposing) {
@@ -100,12 +101,11 @@ export function PrIterationFeedbackForm({
         )}
         <Button
           ref={submitButtonRef}
-          icon={<IconArrow size="md" direction="right" />}
-          busy={isSubmitting}
-          disabled={isPolling || !feedback.trim()}
+          icon={isSubmitting ? undefined : <IconArrow size="md" direction="right" />}
+          disabled={isSubmitting || isPolling || !feedback.trim()}
           onClick={handleSubmit}
         >
-          {t('Submit')}
+          {isSubmitting ? t('Submitting feedback') : t('Submit')}
         </Button>
       </Flex>
     </Flex>


### PR DESCRIPTION
there were some issues:
- weren't showing any feedback items because of a schema mismatch
- weren't disabling the textarea after submitting
- the polling was broken due to a timing issues

this is all fixed by:
- receiving queued feedback from the backend
- treating queued feedback existing like we're processing an iteration
- disabling the textarea in the pull request next step after submitting and updating how the button displays
- updating the parsing of feedback to support both formats

you can run `pnpm run dev-ui` and go to the issue in the slack thread to test this out
slack thread: https://sentry.slack.com/archives/C0B3BC328DU/p1782429580508719