### PR TITLE
fix(agent-insights): Stop trace.rendered analytics from firing twice

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
@@ -34,12 +34,6 @@ function useAiSpanSelection(nodes: AITraceSpanNode[]) {
     const lastSpan = path?.findLast(item => item.startsWith('span-'));
     return lastSpan?.replace('span-', '') ?? null;
   });
-
-  useEffect(() => {
-    trackAnalytics('agent-monitoring.trace.rendered', {
-      organization,
-    });
-  }, [organization]);
 
   const selectedNode = useMemo(() => {
     return (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiTab.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiTab.spec.tsx
@@ -1,0 +1,59 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {hasGenAiConversationsFeature} from 'sentry/views/explore/conversations/utils/features';
+import {useAITrace} from 'sentry/views/insights/pages/agents/hooks/useAITrace';
+import {getStringAttr} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
+import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
+import {TraceAiTab} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceAiTab';
+
+jest.mock('sentry/utils/analytics');
+jest.mock('sentry/views/insights/pages/agents/hooks/useAITrace');
+jest.mock('sentry/views/insights/pages/agents/utils/aiTraceNodes');
+jest.mock('sentry/views/explore/conversations/utils/features');
+jest.mock(
+  'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans',
+  () => ({TraceAiSpans: () => <div>ai-spans</div>})
+);
+jest.mock(
+  'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations',
+  () => ({TraceAiConversations: () => <div>ai-conversations</div>})
+);
+
+const mockUseAITrace = jest.mocked(useAITrace);
+const mockGetStringAttr = jest.mocked(getStringAttr);
+const mockHasConversations = jest.mocked(hasGenAiConversationsFeature);
+const mockTrackAnalytics = jest.mocked(trackAnalytics);
+
+describe('TraceAiTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasConversations.mockReturnValue(false);
+    mockGetStringAttr.mockReturnValue(undefined);
+  });
+
+  it('fires trace.rendered exactly once across the loading -> conversations swap', () => {
+    mockUseAITrace.mockReturnValue({nodes: [], isLoading: true, error: false});
+    const {rerender} = render(<TraceAiTab traceSlug="trace-slug" />);
+    expect(mockTrackAnalytics).not.toHaveBeenCalled();
+
+    mockHasConversations.mockReturnValue(true);
+    mockGetStringAttr.mockReturnValue('conversation-1');
+    mockUseAITrace.mockReturnValue({
+      nodes: [{} as AITraceSpanNode],
+      isLoading: false,
+      error: false,
+    });
+    rerender(<TraceAiTab traceSlug="trace-slug" />);
+
+    expect(screen.getByText('ai-conversations')).toBeInTheDocument();
+    expect(mockTrackAnalytics).toHaveBeenCalledTimes(1);
+    expect(mockTrackAnalytics).toHaveBeenCalledWith(
+      'agent-monitoring.trace.rendered',
+      expect.anything()
+    );
+
+    rerender(<TraceAiTab traceSlug="trace-slug" />);
+    expect(mockTrackAnalytics).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiTab.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiTab.tsx
@@ -1,5 +1,6 @@
-import {useMemo} from 'react';
+import {useEffect, useMemo, useRef} from 'react';
 
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {hasGenAiConversationsFeature} from 'sentry/views/explore/conversations/utils/features';
 import {useAITrace} from 'sentry/views/insights/pages/agents/hooks/useAITrace';
@@ -25,6 +26,19 @@ export function TraceAiTab({traceSlug}: {traceSlug: string}) {
   const {nodes, isLoading, error} = useAITrace(traceSlug);
 
   const conversationIds = useMemo(() => getConversationIds(nodes), [nodes]);
+
+  // Fire once per trace after load, regardless of which child tab renders.
+  const renderedTrackedFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (isLoading || error || nodes.length === 0) {
+      return;
+    }
+    if (renderedTrackedFor.current === traceSlug) {
+      return;
+    }
+    renderedTrackedFor.current = traceSlug;
+    trackAnalytics('agent-monitoring.trace.rendered', {organization});
+  }, [isLoading, error, nodes.length, traceSlug, organization]);
 
   const hasConversations =
     hasGenAiConversationsFeature(organization) && conversationIds.length > 0;


### PR DESCRIPTION
The `agent-monitoring.trace.rendered` event was firing twice per trace view. The tracking effect lived in the shared `useAiSpanSelection` hook used by both `TraceAiSpans` and `AiSpansSplitView`. `TraceAiTab` renders `TraceAiSpans` while loading (empty nodes), then swaps to `TraceAiConversations` → `AiSpansSplitView` once a trace with conversations loads, and that remount fired the effect again. It also fired during the loading spinner, before the trace had rendered.

This regressed in #112907, which extracted the shared hook and introduced the loading→loaded component swap. Before that, `TraceAiSpans` rendered directly and stayed mounted, firing once.

The fix moves tracking to the stable owner `TraceAiTab`, gated on loaded data and deduped per `traceSlug`, so it fires exactly once after the trace renders. Frontend-only.