### PR TITLE
feat(explore): Register gen_ai conversation and operation attributes as search keys

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -211,6 +211,21 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="currency",
         ),
         ResolvedAttribute(
+            public_alias="gen_ai.conversation.id",
+            internal_name="gen_ai.conversation.id",
+            search_type="string",
+        ),
+        ResolvedAttribute(
+            public_alias="gen_ai.operation.name",
+            internal_name="gen_ai.operation.name",
+            search_type="string",
+        ),
+        ResolvedAttribute(
+            public_alias="gen_ai.operation.type",
+            internal_name="gen_ai.operation.type",
+            search_type="string",
+        ),
+        ResolvedAttribute(
             public_alias="gen_ai.usage.input_tokens",
             internal_name="gen_ai.usage.input_tokens",
             search_type="integer",


### PR DESCRIPTION
Registers `gen_ai.conversation.id`, `gen_ai.operation.name`, and `gen_ai.operation.type` as hardcoded span attribute definitions so they're recognized as supported search keys even before any data carrying them is ingested.

Previously only the numeric gen_ai attributes (`gen_ai.usage.*`, `gen_ai.cost.*`) were hardcoded, so these string attributes only validated when an org happened to have AI spans in the selected time range. That caused the starred prebuilt "LLM Calls" query (`gen_ai.operation.type:ai_client`) to flag the key as unknown.

Follows the existing curated, one-line-per-attribute pattern rather than bulk-importing the whole `gen_ai.*` conventions namespace (which would also expose large free-text payload attributes as filterable keys).

Closes TET-2567