### PR TITLE
feat(conversations): Show "All" instead of "None" in Agent filter

### DIFF
--- a/static/app/views/insights/common/components/agentSelector.tsx
+++ b/static/app/views/insights/common/components/agentSelector.tsx
@@ -10,6 +10,7 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {hasGenAiConversationsRedesignFeature} from 'sentry/views/explore/conversations/utils/features';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/useCompactSelectOptionsCache';
 import {useWasSearchSpaceExhausted} from 'sentry/views/insights/common/utils/useWasSearchSpaceExhausted';
@@ -161,7 +162,12 @@ export function AgentSelector({storageKeyPrefix, referrer}: AgentSelectorProps) 
       menuTitle={t('Agent')}
       data-test-id="agent-selector"
       trigger={triggerProps => (
-        <OverlayTrigger.Button {...triggerProps} prefix={t('Agent')} />
+        <OverlayTrigger.Button {...triggerProps} prefix={t('Agent')}>
+          {selectedAgents.length === 0 &&
+          hasGenAiConversationsRedesignFeature(organization)
+            ? t('All')
+            : triggerProps.children}
+        </OverlayTrigger.Button>
       )}
       onChange={newValue => {
         const values = newValue.map(v => v.value).filter(Boolean);


### PR DESCRIPTION
In the redesigned conversations view, the Agent dropdown now displays "All" instead of "None" when no agent is selected, since an empty selection means results aren't filtered by agent. The change is gated behind the `gen-ai-conversations-redesign` feature flag.