### PR TITLE
ref(conversations): Persist table columns and widths together

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTableEditModal.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableEditModal.tsx
@@ -18,16 +18,15 @@ import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import {
   ALL_CONVERSATION_COLUMNS,
-  type ConversationColumnKey,
+  type ConversationColumn,
   CONVERSATION_COLUMNS,
   DEFAULT_CONVERSATION_COLUMNS,
-  parseConversationColumns,
 } from 'sentry/views/explore/conversations/utils/tableColumns';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 
 interface ConversationsTableEditModalProps extends ModalRenderProps {
-  columns: readonly ConversationColumnKey[];
-  onColumnsChange: (columns: ConversationColumnKey[]) => void;
+  columns: readonly ConversationColumn[];
+  onColumnsChange: (columns: ConversationColumn[]) => void;
 }
 
 export function ConversationsTableEditModal({
@@ -45,9 +44,12 @@ export function ConversationsTableEditModal({
       {({insertColumn, updateColumnAtIndex, deleteColumnAtIndex, editableColumns}) => {
         // Default the new row to the first column not already shown, falling back
         // to the first column so a duplicate is allowed once they're all in use.
-        const usedColumns = new Set(editableColumns.map(c => c.column));
-        const nextColumn: ConversationColumnKey =
-          ALL_CONVERSATION_COLUMNS.find(key => !usedColumns.has(key)) ?? 'conversationId';
+        const usedColumns = new Set(editableColumns.map(c => c.column.key));
+        const nextColumn: ConversationColumn = {
+          key:
+            ALL_CONVERSATION_COLUMNS.find(key => !usedColumns.has(key)) ??
+            'conversationId',
+        };
 
         return (
           <Fragment>
@@ -78,16 +80,17 @@ export function ConversationsTableEditModal({
             </Body>
             <Footer>
               <Grid flow="column" align="center" gap="md">
-                <Button onClick={() => setTempColumns([...DEFAULT_CONVERSATION_COLUMNS])}>
+                <Button
+                  onClick={() =>
+                    setTempColumns(DEFAULT_CONVERSATION_COLUMNS.map(key => ({key})))
+                  }
+                >
                   {t('Reset')}
                 </Button>
                 <Button
                   variant="primary"
                   onClick={() => {
-                    const parsedConversationColumns = parseConversationColumns(
-                      editableColumns.map(c => c.column)
-                    );
-                    onColumnsChange(parsedConversationColumns);
+                    onColumnsChange(editableColumns.map(c => c.column));
                     closeModal();
                   }}
                 >
@@ -104,8 +107,8 @@ export function ConversationsTableEditModal({
 
 interface ColumnEditorRowProps {
   canDelete: boolean;
-  column: Column<ConversationColumnKey>;
-  onColumnChange: (column: ConversationColumnKey) => void;
+  column: Column<ConversationColumn>;
+  onColumnChange: (column: ConversationColumn) => void;
   onColumnDelete: () => void;
 }
 
@@ -135,11 +138,13 @@ function ColumnEditorRow({
               label: CONVERSATION_COLUMNS[key].name,
               trailingItems: <TypeBadge valueType={CONVERSATION_COLUMNS[key].type} />,
             }))}
-            value={column.column}
-            onChange={option => onColumnChange(option.value)}
+            value={column.column.key}
+            onChange={option =>
+              onColumnChange({key: option.value, width: column.column.width})
+            }
             style={{flex: 1, minWidth: 0}}
             trigger={triggerProps => {
-              const definition = CONVERSATION_COLUMNS[column.column];
+              const definition = CONVERSATION_COLUMNS[column.column.key];
               return (
                 <OverlayTrigger.Button
                   {...triggerProps}

--- a/static/app/views/explore/conversations/components/conversationsTableNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableNew.tsx
@@ -50,31 +50,32 @@ export function ConversationsTableNew() {
   const navigate = useNavigate();
   const {selection} = usePageFilters();
   const {openModal} = useModal();
-  const {columns: columnKeys, setColumns} = useConversationsTableColumns();
+  const {columns, setColumns} = useConversationsTableColumns();
   const {data, isLoading, error, pageLinks, setCursor} = useConversations();
   const [highlightedRowKey, setHighlightedRowKey] = useState<number | undefined>();
 
-  // Session-only resized widths, keyed by column so they stick to the column
-  // through add/remove/reorder (not persisted; reset on refresh).
-  const [columnWidths, setColumnWidths] = useState<
-    Partial<Record<ConversationColumnKey, number>>
-  >({});
-
   const columnOrder = useMemo<Array<GridColumnOrder<ConversationColumnKey>>>(
     () =>
-      columnKeys.map(key => ({
+      columns.map(({key, width}) => ({
         key,
         name: CONVERSATION_COLUMNS[key].name,
-        width: columnWidths[key] ?? CONVERSATION_COLUMNS[key].width,
+        width: width ?? CONVERSATION_COLUMNS[key].width,
       })),
-    [columnKeys, columnWidths]
+    [columns]
   );
 
   const handleResizeColumn = useCallback(
-    (_columnIndex: number, nextColumn: GridColumnOrder<ConversationColumnKey>) => {
-      setColumnWidths(prev => ({...prev, [nextColumn.key]: nextColumn.width}));
+    (columnIndex: number, nextColumn: GridColumnOrder<ConversationColumnKey>) => {
+      const {width} = nextColumn;
+      if (typeof width === 'number' && width > 0) {
+        setColumns(
+          columns.map((c, i) =>
+            i === columnIndex ? {...c, width: Math.round(width)} : c
+          )
+        );
+      }
     },
-    []
+    [columns, setColumns]
   );
 
   const showMissingMessagesAlert =
@@ -96,7 +97,7 @@ export function ConversationsTableNew() {
       modalProps => (
         <ConversationsTableEditModal
           {...modalProps}
-          columns={columnKeys}
+          columns={columns}
           onColumnsChange={setColumns}
         />
       ),

--- a/static/app/views/explore/conversations/components/conversationsTableNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableNew.tsx
@@ -12,6 +12,7 @@ import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Count} from 'sentry/components/count';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {
+  COL_WIDTH_UNDEFINED,
   GridEditable,
   type GridColumnHeader,
   type GridColumnOrder,
@@ -67,13 +68,23 @@ export function ConversationsTableNew() {
   const handleResizeColumn = useCallback(
     (columnIndex: number, nextColumn: GridColumnOrder<ConversationColumnKey>) => {
       const {width} = nextColumn;
-      if (typeof width === 'number' && width > 0) {
-        setColumns(
-          columns.map((c, i) =>
-            i === columnIndex ? {...c, width: Math.round(width)} : c
-          )
-        );
-      }
+      // A double-click reset sends COL_WIDTH_UNDEFINED (-1); drop the persisted
+      // width so the column falls back to its default instead of keeping the old
+      // value. Any other non-positive width is ignored.
+      setColumns(
+        columns.map((c, i) => {
+          if (i !== columnIndex) {
+            return c;
+          }
+          if (typeof width === 'number' && width > 0) {
+            return {...c, width: Math.round(width)};
+          }
+          if (width === COL_WIDTH_UNDEFINED) {
+            return {key: c.key};
+          }
+          return c;
+        })
+      );
     },
     [columns, setColumns]
   );

--- a/static/app/views/explore/conversations/components/conversationsTableNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableNew.tsx
@@ -71,8 +71,10 @@ export function ConversationsTableNew() {
       // A double-click reset sends COL_WIDTH_UNDEFINED (-1); drop the persisted
       // width so the column falls back to its default instead of keeping the old
       // value. Any other non-positive width is ignored.
-      setColumns(
-        columns.map((c, i) => {
+      // Use the functional updater so back-to-back resizes compose off the
+      // latest columns rather than a stale closure value.
+      setColumns(prev =>
+        prev.map((c, i) => {
           if (i !== columnIndex) {
             return c;
           }
@@ -86,7 +88,7 @@ export function ConversationsTableNew() {
         })
       );
     },
-    [columns, setColumns]
+    [setColumns]
   );
 
   const showMissingMessagesAlert =

--- a/static/app/views/explore/conversations/components/conversationsTableNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableNew.tsx
@@ -71,10 +71,8 @@ export function ConversationsTableNew() {
       // A double-click reset sends COL_WIDTH_UNDEFINED (-1); drop the persisted
       // width so the column falls back to its default instead of keeping the old
       // value. Any other non-positive width is ignored.
-      // Use the functional updater so back-to-back resizes compose off the
-      // latest columns rather than a stale closure value.
-      setColumns(prev =>
-        prev.map((c, i) => {
+      setColumns(
+        columns.map((c, i) => {
           if (i !== columnIndex) {
             return c;
           }
@@ -88,7 +86,7 @@ export function ConversationsTableNew() {
         })
       );
     },
-    [setColumns]
+    [columns, setColumns]
   );
 
   const showMissingMessagesAlert =

--- a/static/app/views/explore/conversations/hooks/useConversationsTableColumns.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationsTableColumns.tsx
@@ -1,28 +1,48 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {parseAsArrayOf, parseAsString, useQueryState} from 'nuqs';
 
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {
-  type ConversationColumnKey,
+  type ConversationColumn,
   parseConversationColumns,
+  serializeConversationColumns,
 } from 'sentry/views/explore/conversations/utils/tableColumns';
 
-/**
- * Visible table columns, persisted in the URL so the view is shareable. When
- * the URL has no columns, the defaults are used.
- */
+const TABLE_COLUMNS_STORAGE_KEY = 'conversations:table-columns';
+
+const urlOptions = parseAsArrayOf(parseAsString).withOptions({history: 'replace'});
+
 export function useConversationsTableColumns() {
-  const [urlColumns, setUrlColumns] = useQueryState(
-    'tableColumns',
-    parseAsArrayOf(parseAsString).withOptions({history: 'replace'})
+  const [urlColumns, setUrlColumns] = useQueryState('tableColumns', urlOptions);
+  const [stored, setStored] = useLocalStorageState<string[]>(
+    TABLE_COLUMNS_STORAGE_KEY,
+    []
   );
 
-  const columns = useMemo(() => parseConversationColumns(urlColumns), [urlColumns]);
+  // Both URL and storage hold the same `key:width` entries; URL wins when present.
+  const source = useMemo(() => urlColumns ?? stored, [urlColumns, stored]);
+  const columns = useMemo(() => parseConversationColumns(source), [source]);
 
+  // Seed the URL from storage on first load so it reflects the saved layout.
+  const firstRender = useRef(true);
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      if (!urlColumns && stored.length) {
+        setUrlColumns(stored);
+      }
+    }
+  }, [urlColumns, stored, setUrlColumns]);
+
+  // Widths ride along on each column, so removing a column drops its width from
+  // both the URL and storage for free.
   const setColumns = useCallback(
-    (next: ConversationColumnKey[]) => {
-      setUrlColumns(next);
+    (next: ConversationColumn[]) => {
+      const entries = serializeConversationColumns(next);
+      setUrlColumns(entries);
+      setStored(entries);
     },
-    [setUrlColumns]
+    [setUrlColumns, setStored]
   );
 
   return {columns, setColumns};

--- a/static/app/views/explore/conversations/hooks/useConversationsTableColumns.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationsTableColumns.tsx
@@ -35,18 +35,12 @@ export function useConversationsTableColumns() {
   }, [urlColumns, stored, setUrlColumns]);
 
   // Widths ride along on each column, so removing a column drops its width from
-  // both the URL and storage for free. Accepts a functional updater so rapid
-  // resizes compose off the latest columns instead of a stale closure value.
+  // both the URL and storage for free.
   const setColumns = useCallback(
-    (
-      next: ConversationColumn[] | ((prev: ConversationColumn[]) => ConversationColumn[])
-    ) => {
-      const update = (prev: readonly string[] | null) =>
-        serializeConversationColumns(
-          typeof next === 'function' ? next(parseConversationColumns(prev)) : next
-        );
-      setUrlColumns(update);
-      setStored(update);
+    (next: ConversationColumn[]) => {
+      const entries = serializeConversationColumns(next);
+      setUrlColumns(entries);
+      setStored(entries);
     },
     [setUrlColumns, setStored]
   );

--- a/static/app/views/explore/conversations/hooks/useConversationsTableColumns.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationsTableColumns.tsx
@@ -35,12 +35,18 @@ export function useConversationsTableColumns() {
   }, [urlColumns, stored, setUrlColumns]);
 
   // Widths ride along on each column, so removing a column drops its width from
-  // both the URL and storage for free.
+  // both the URL and storage for free. Accepts a functional updater so rapid
+  // resizes compose off the latest columns instead of a stale closure value.
   const setColumns = useCallback(
-    (next: ConversationColumn[]) => {
-      const entries = serializeConversationColumns(next);
-      setUrlColumns(entries);
-      setStored(entries);
+    (
+      next: ConversationColumn[] | ((prev: ConversationColumn[]) => ConversationColumn[])
+    ) => {
+      const update = (prev: readonly string[] | null) =>
+        serializeConversationColumns(
+          typeof next === 'function' ? next(parseConversationColumns(prev)) : next
+        );
+      setUrlColumns(update);
+      setStored(update);
     },
     [setUrlColumns, setStored]
   );

--- a/static/app/views/explore/conversations/utils/tableColumns.tsx
+++ b/static/app/views/explore/conversations/utils/tableColumns.tsx
@@ -67,14 +67,39 @@ function isConversationColumnKey(value: string): value is ConversationColumnKey 
   return value in CONVERSATION_COLUMNS;
 }
 
+export interface ConversationColumn {
+  key: ConversationColumnKey;
+  width?: number;
+}
+
 /**
- * Keep only valid column keys, preserving order and duplicates so a column can
- * appear more than once. Falls back to the defaults when nothing usable remains
- * so the table never renders an empty column set.
+ * Serialize each column to a `key` or `key:width` entry, preserving order and
+ * duplicates, e.g. `['conversationId:80', 'user:203', 'errors']`.
+ */
+export function serializeConversationColumns(
+  columns: readonly ConversationColumn[]
+): string[] {
+  return columns.map(({key, width}) =>
+    typeof width === 'number' && width > 0 ? `${key}:${width}` : key
+  );
+}
+
+/**
+ * Parse `key` / `key:width` entries into columns, keeping order and duplicates so
+ * a column can appear more than once. Falls back to the defaults when nothing
+ * usable remains so the table never renders an empty column set.
  */
 export function parseConversationColumns(
   values: readonly string[] | null
-): ConversationColumnKey[] {
-  const parsed = (values ?? []).filter(isConversationColumnKey);
-  return parsed.length > 0 ? parsed : [...DEFAULT_CONVERSATION_COLUMNS];
+): ConversationColumn[] {
+  const parsed: ConversationColumn[] = [];
+  for (const entry of values ?? []) {
+    const [key, rawWidth] = entry.split(':');
+    if (!key || !isConversationColumnKey(key)) {
+      continue;
+    }
+    const width = Number(rawWidth);
+    parsed.push(width > 0 ? {key, width} : {key});
+  }
+  return parsed.length > 0 ? parsed : DEFAULT_CONVERSATION_COLUMNS.map(key => ({key}));
 }


### PR DESCRIPTION
Stores the conversations table's columns and widths as a single ordered list of `key:width` entries, kept identical in the URL (`tableColumns`) and localStorage (`conversations:table-columns`). 

- An array (not an object) because duplicate columns are allowed and order matters - each entry carries its own width.
- Removing a column drops its width from both stores for free; no orphaned entries.
- Widths survive reorders and type changes; duplicates keep independent widths. Reset restores default columns and widths.

**Preview**



https://github.com/user-attachments/assets/64c5b436-62b5-4ac1-916c-f58650e55d20


