### PR TITLE
fix(tab): observe the root tabs component when calculating overflowMenu

### DIFF
--- a/static/app/components/core/tabs/tabList.snapshots.tsx
+++ b/static/app/components/core/tabs/tabList.snapshots.tsx
@@ -1,0 +1,125 @@
+import {MemoryRouter} from 'react-router-dom';
+import {ThemeProvider} from '@emotion/react';
+
+import {TabList, Tabs} from '@sentry/scraps/tabs';
+
+// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
+import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
+
+const themes = {light: lightTheme, dark: darkTheme};
+
+const TABS = [
+  {key: 'details', label: 'Details'},
+  {key: 'activity', label: 'Activity'},
+  {key: 'user-feedback', label: 'User Feedback'},
+  {key: 'attachments', label: 'Attachments'},
+] as const;
+
+const allVariants = ['flat', 'floating'] as const;
+const allSizes = ['md', 'sm', 'xs'] as const;
+
+describe('TabList', () => {
+  describe.each(['light', 'dark'] as const)('%s', themeName => {
+    function Wrapper({children}: {children: React.ReactNode}) {
+      return (
+        // TabList renders tab links and calls useNavigate(), which needs a
+        // router in context even under SSR.
+        <MemoryRouter>
+          <ThemeProvider theme={themes[themeName]}>
+            {/* Padding so selection indicators / focus rings aren't clipped by
+              rootElement.screenshot()'s border-box crop. */}
+            <div style={{padding: 8}}>{children}</div>
+          </ThemeProvider>
+        </MemoryRouter>
+      );
+    }
+
+    describe.each(allVariants)('variant %s', variant => {
+      describe.each(allSizes)('size %s', size => {
+        it.snapshot(
+          'horizontal',
+          () => (
+            <Wrapper>
+              <Tabs size={size} defaultValue="activity">
+                <TabList variant={variant}>
+                  {TABS.map(tab => (
+                    <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
+                  ))}
+                </TabList>
+              </Tabs>
+            </Wrapper>
+          ),
+          {
+            group: `${themeName} – horizontal`,
+            display_name: `${themeName} / ${variant} / ${size} / horizontal`,
+            tags: {variant: String(variant), size: String(size), area: 'core'},
+          }
+        );
+      });
+    });
+
+    describe.each(allVariants)('vertical variant %s', variant => {
+      it.snapshot(
+        'vertical',
+        () => (
+          <Wrapper>
+            <Tabs orientation="vertical" defaultValue="activity">
+              <TabList variant={variant}>
+                {TABS.map(tab => (
+                  <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
+                ))}
+              </TabList>
+            </Tabs>
+          </Wrapper>
+        ),
+        {
+          group: `${themeName} – vertical`,
+          display_name: `${themeName} / ${variant} / vertical`,
+          tags: {variant: String(variant), orientation: 'vertical', area: 'core'},
+        }
+      );
+    });
+
+    it.snapshot(
+      'disabled',
+      () => (
+        <Wrapper>
+          <Tabs disabled defaultValue="activity">
+            <TabList>
+              {TABS.map(tab => (
+                <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
+              ))}
+            </TabList>
+          </Tabs>
+        </Wrapper>
+      ),
+      {
+        group: `${themeName} – disabled`,
+        display_name: `${themeName} / disabled`,
+        tags: {state: 'disabled', area: 'core'},
+      }
+    );
+
+    it.snapshot(
+      'single disabled tab',
+      () => (
+        <Wrapper>
+          <Tabs defaultValue="details">
+            <TabList>
+              {TABS.map(tab => (
+                <TabList.Item key={tab.key} disabled={tab.key === 'user-feedback'}>
+                  {tab.label}
+                </TabList.Item>
+              ))}
+            </TabList>
+          </Tabs>
+        </Wrapper>
+      ),
+      {
+        group: `${themeName} – disabled`,
+        display_name: `${themeName} / single disabled tab`,
+        tags: {state: 'single-disabled', area: 'core'},
+      }
+    );
+  });
+});

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -93,14 +93,12 @@ function useOverflowTabs({
   tabListRef,
   tabItemsRef,
   tabItems,
-  orientation,
   disabled,
 }: {
   /**
    * Prevent tabs from being put in the overflow menu.
    */
   disabled: boolean | undefined;
-  orientation: Orientation;
   /**
    * The relatively-positioned wrapper around the list. Its width is the space
    * available to the tabs and is unaffected by the list overflowing.
@@ -118,6 +116,11 @@ function useOverflowTabs({
 
   // Measures the list against the available space and updates the overflow set.
   const recompute = useEffectEvent(() => {
+    if (disabled) {
+      setOverflowTabs(prev => (prev.length === 0 ? prev : []));
+      return;
+    }
+
     const outerWrap = outerWrapRef.current;
     const tabList = tabListRef.current;
     if (!outerWrap || !tabList) {
@@ -185,9 +188,23 @@ function useOverflowTabs({
     );
   });
 
+  // Recompute whenever an input that affects the overflow result changes: the
+  // disabled state, or the set/order/hidden-state of the tabs. Width changes are
+  // handled by the ResizeObserver below; a reorder can leave the total width
+  // unchanged, so the observer alone wouldn't catch it.
+  const recomputeSignature = [
+    disabled ? 'disabled' : 'enabled',
+    ...tabItems.map(item => `${item.key}:${item.hidden ? 1 : 0}`),
+  ].join('|');
+
   useLayoutEffect(() => {
-    if (disabled || orientation !== 'horizontal') {
-      setOverflowTabs(prev => (prev.length === 0 ? prev : []));
+    recompute();
+  }, [recomputeSignature]);
+
+  // Recompute on container resize (available space changes) and on list resize
+  // (tabs added/removed/relabeled change its intrinsic width). Keyed only on the
+  useEffect(() => {
+    if (disabled) {
       return;
     }
 
@@ -197,15 +214,12 @@ function useOverflowTabs({
       return;
     }
 
-    // Recompute on container resize (available space changes) and on list
-    // resize (tabs added/removed/relabeled change its intrinsic width).
     const resizeObserver = new ResizeObserver(() => recompute());
     resizeObserver.observe(outerWrap);
     resizeObserver.observe(tabList);
-    recompute();
 
     return () => resizeObserver.disconnect();
-  }, [disabled, orientation, outerWrapRef, tabListRef]);
+  }, [disabled, outerWrapRef, tabListRef]);
 
   // Tabs with the `hidden` prop render with display: none; never surface them
   // in the overflow menu.
@@ -305,8 +319,8 @@ function BaseTabList({outerWrapStyles, variant = 'flat', ...props}: BaseTabListP
     tabListRef,
     tabItemsRef,
     tabItems: props.items,
-    orientation,
-    disabled: disableOverflow,
+    // Overflow only applies to horizontal tab lists.
+    disabled: disableOverflow || orientation !== 'horizontal',
   });
 
   const overflowMenuItems = useMemo(() => {

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -1,5 +1,5 @@
-import {useContext, useEffect, useMemo, useRef, useState} from 'react';
-import {css, useTheme} from '@emotion/react';
+import {useContext, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {AriaTabListOptions} from '@react-aria/tabs';
 import {useTabList} from '@react-aria/tabs';
@@ -62,96 +62,159 @@ const StyledTabListOverflowWrap = styled('div')`
 `;
 
 /**
- * Uses IntersectionObserver API to detect overflowing tabs. Returns an array
- * containing of keys of overflowing tabs.
+ * Width (px) reserved on the right edge for the overflow menu trigger button.
+ * Kept slightly larger than the actual button so the trigger never overlaps
+ * the last visible tab.
+ */
+const RESERVED_OVERFLOW_TRIGGER_WIDTH = 48;
+
+/**
+ * Measures the tab list against the space available in its container and
+ * returns the keys of the tabs that don't fit, as a contiguous suffix. Those
+ * tabs are visually hidden (see `Tab`) and surfaced through an overflow menu.
+ *
+ * This uses direct measurement rather than an IntersectionObserver on purpose:
+ * the result is deterministic, so for a given container width the same set of
+ * tabs always overflows. That avoids the inconsistent states the observer-based
+ * approach could settle into while resizing — tabs from the middle of the list
+ * disappearing, the trigger overlapping a tab, or no overflow being detected at
+ * all when the list was momentarily allowed to grow to its content width.
  */
 function useOverflowTabs({
+  outerWrapRef,
   tabListRef,
   tabItemsRef,
   tabItems,
+  orientation,
   disabled,
 }: {
   /**
    * Prevent tabs from being put in the overflow menu.
    */
   disabled: boolean | undefined;
+  orientation: Orientation;
+  /**
+   * The relatively-positioned wrapper around the list. Its width is the space
+   * available to the tabs and is unaffected by the list overflowing.
+   */
+  outerWrapRef: React.RefObject<HTMLDivElement | null>;
   tabItems: TabListItemProps[];
   tabItemsRef: React.RefObject<Record<string | number, HTMLLIElement | null>>;
   tabListRef: React.RefObject<HTMLUListElement | null>;
 }) {
   const [overflowTabs, setOverflowTabs] = useState<Array<string | number>>([]);
-  const theme = useTheme();
+  // Mirrors `overflowTabs` so the measuring callback can read the latest value
+  // synchronously without having to re-subscribe the ResizeObserver each time.
+  const overflowTabsRef = useRef(overflowTabs);
+  // Cached intrinsic widths per tab key. Hidden tabs measure 0, so we remember
+  // their last measured width to know when they fit again as space grows.
+  const tabWidthsRef = useRef(new Map<string | number, number>());
 
-  useEffect(() => {
-    if (disabled) {
-      return () => {};
+  // Keys of tabs that participate in the layout, in render order. Tabs with the
+  // `hidden` prop render with `display: none` and take up no space. The string
+  // signature is used as the effect dependency so the observer re-subscribes
+  // (recapturing these keys) whenever the set of tabs changes.
+  const layoutKeys = tabItems.filter(item => !item.hidden).map(item => item.key);
+  const layoutKeysSignature = layoutKeys.join(' ');
+
+  useLayoutEffect(() => {
+    if (disabled || orientation !== 'horizontal') {
+      overflowTabsRef.current = [];
+      setOverflowTabs([]);
+      return;
     }
 
-    const options = {
-      root: tabListRef.current,
-      // Negative right margin to account for overflow menu's trigger button
-      rootMargin: `0px -42px 1px ${theme.space.md}`,
-      // Use 0.95 rather than 1 because of a bug in Edge (Windows) where the intersection
-      // ratio may unexpectedly drop to slightly below 1 (0.999…) on page scroll.
-      threshold: 0.95,
-    };
+    const outerWrap = outerWrapRef.current;
+    const tabList = tabListRef.current;
+    if (!outerWrap || !tabList) {
+      return;
+    }
 
-    const callback: IntersectionObserverCallback = entries => {
-      entries.forEach(entry => {
-        const {target} = entry;
-        const {key} = (target as HTMLElement).dataset;
-        if (!key) {
-          return;
+    const keys = layoutKeys;
+
+    const recompute = () => {
+      const elements = tabItemsRef.current ?? {};
+      const previousOverflow = overflowTabsRef.current;
+      const previousOverflowSet = new Set(previousOverflow);
+      const gap = parseFloat(getComputedStyle(tabList).columnGap) || 0;
+
+      // Refresh cached widths for every currently visible (measurable) tab.
+      for (const key of keys) {
+        if (previousOverflowSet.has(key)) {
+          continue;
         }
-
-        if (!entry.isIntersecting) {
-          setOverflowTabs(prev => prev.concat([key]));
-          return;
+        const width = elements[key]?.getBoundingClientRect().width ?? 0;
+        if (width > 0) {
+          tabWidthsRef.current.set(key, width);
         }
-
-        setOverflowTabs(prev => prev.filter(k => k !== key));
-      });
-    };
-
-    const observer = new IntersectionObserver(callback, options);
-    Object.values(tabItemsRef.current ?? {}).forEach(
-      element => element && observer.observe(element)
-    );
-
-    // When tabs are hidden via `display: none`, IntersectionObserver can no
-    // longer detect them. If the container grows, those tabs would remain
-    // permanently hidden. Resetting overflow state when the container grows
-    // removes `display: none`, allowing the IO to re-evaluate all tabs.
-    let previousWidth = tabListRef.current?.getBoundingClientRect().width ?? 0;
-    const resizeObserver = new ResizeObserver(entries => {
-      const newWidth = entries[0]?.contentRect.width ?? 0;
-      if (newWidth > previousWidth) {
-        setOverflowTabs([]);
       }
-      previousWidth = newWidth;
-    });
-    if (tabListRef.current) {
-      resizeObserver.observe(tabListRef.current);
-    }
+
+      const available = outerWrap.clientWidth;
+
+      // Width required to render every tab, without reserving the trigger.
+      const fullWidth = keys.reduce((sum: number, key, index) => {
+        const width = tabWidthsRef.current.get(key) ?? 0;
+        return sum + width + (index === 0 ? 0 : gap);
+      }, 0);
+
+      let nextOverflow: Array<string | number>;
+      if (fullWidth <= available) {
+        nextOverflow = [];
+      } else {
+        // Overflow is needed, so leave room for the trigger button.
+        const budget = available - RESERVED_OVERFLOW_TRIGGER_WIDTH;
+        const overflow: Array<string | number> = [];
+        let used = 0;
+        let isOverflowing = false;
+        keys.forEach((key, index) => {
+          if (isOverflowing) {
+            overflow.push(key);
+            return;
+          }
+          const width = tabWidthsRef.current.get(key) ?? 0;
+          const nextUsed = used + width + (index === 0 ? 0 : gap);
+          // Always keep the first tab to avoid an empty tab bar.
+          if (index === 0 || nextUsed <= budget) {
+            used = nextUsed;
+          } else {
+            isOverflowing = true;
+            overflow.push(key);
+          }
+        });
+        nextOverflow = overflow;
+      }
+
+      const unchanged =
+        nextOverflow.length === previousOverflow.length &&
+        nextOverflow.every((key, index) => key === previousOverflow[index]);
+      if (unchanged) {
+        return;
+      }
+
+      overflowTabsRef.current = nextOverflow;
+      setOverflowTabs(nextOverflow);
+    };
+
+    recompute();
+
+    // Observe the wrapper (available space) and the list (intrinsic size, e.g.
+    // when labels or fonts change). `recompute` is deterministic, so the
+    // self-induced resize from hiding/showing tabs just re-runs and bails out.
+    const resizeObserver = new ResizeObserver(() => recompute());
+    resizeObserver.observe(outerWrap);
+    resizeObserver.observe(tabList);
 
     return () => {
-      observer.disconnect();
       resizeObserver.disconnect();
-      setOverflowTabs([]);
     };
-  }, [tabListRef, tabItemsRef, disabled, theme]);
+    // `layoutKeys` is intentionally tracked via its primitive `layoutKeysSignature`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [outerWrapRef, tabListRef, tabItemsRef, disabled, orientation, layoutKeysSignature]);
 
-  const tabItemKeyToHiddenMap = tabItems.reduce<Record<string | number, boolean>>(
-    (acc, next) => ({
-      ...acc,
-      [next.key]: !!next.hidden,
-    }),
-    {}
-  );
-
-  // Tabs that are hidden will be rendered with display: none so won't intersect,
-  // but we don't want to show them in the overflow menu
-  return overflowTabs.filter(tabKey => !tabItemKeyToHiddenMap[tabKey]);
+  // Tabs with the `hidden` prop render with display: none; never surface them
+  // in the overflow menu.
+  const hiddenKeys = new Set(tabItems.filter(item => item.hidden).map(item => item.key));
+  return overflowTabs.filter(key => !hiddenKeys.has(key));
 }
 
 interface OverflowMenuProps {
@@ -197,6 +260,7 @@ interface BaseTabListProps extends AriaTabListOptions<TabListItemProps>, TabList
 
 function BaseTabList({outerWrapStyles, variant = 'flat', ...props}: BaseTabListProps) {
   const navigate = useNavigate();
+  const outerWrapRef = useRef<HTMLDivElement>(null);
   const tabListRef = useRef<HTMLUListElement>(null);
   const {rootProps, setTabListState} = useContext(TabsContext);
   const {
@@ -241,16 +305,18 @@ function BaseTabList({outerWrapStyles, variant = 'flat', ...props}: BaseTabListP
   // Detect tabs that overflow from the wrapper and put them in an overflow menu
   const tabItemsRef = useRef<Record<string | number, HTMLLIElement | null>>({});
   const overflowTabs = useOverflowTabs({
+    outerWrapRef,
     tabListRef,
     tabItemsRef,
     tabItems: props.items,
+    orientation,
     disabled: disableOverflow,
   });
 
   const overflowMenuItems = useMemo(() => {
     // Sort overflow items in the order that they appear in TabList
     const sortedKeys = [...state.collection].map(item => item.key);
-    const sortedOverflowTabs = overflowTabs.sort(
+    const sortedOverflowTabs = overflowTabs.toSorted(
       (a, b) => sortedKeys.indexOf(a) - sortedKeys.indexOf(b)
     );
 
@@ -275,7 +341,7 @@ function BaseTabList({outerWrapStyles, variant = 'flat', ...props}: BaseTabListP
   }, [state.collection, overflowTabs]);
 
   return (
-    <Container position="relative" style={outerWrapStyles}>
+    <Container position="relative" style={outerWrapStyles} ref={outerWrapRef}>
       <TabListWrap
         {...tabListProps}
         orientation={orientation}

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -1,4 +1,12 @@
-import {useContext, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {
+  useContext,
+  useEffect,
+  useEffectEvent,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {AriaTabListOptions} from '@react-aria/tabs';
@@ -103,24 +111,83 @@ function useOverflowTabs({
   tabListRef: React.RefObject<HTMLUListElement | null>;
 }) {
   const [overflowTabs, setOverflowTabs] = useState<Array<string | number>>([]);
-  // Mirrors `overflowTabs` so the measuring callback can read the latest value
-  // synchronously without having to re-subscribe the ResizeObserver each time.
-  const overflowTabsRef = useRef(overflowTabs);
-  // Cached intrinsic widths per tab key. Hidden tabs measure 0, so we remember
-  // their last measured width to know when they fit again as space grows.
+  // Cached intrinsic widths per tab key. Overflowing tabs render with
+  // `display: none` and measure 0, so we remember their last measured width to
+  // know when they would fit again as space grows.
   const tabWidthsRef = useRef(new Map<string | number, number>());
 
-  // Keys of tabs that participate in the layout, in render order. Tabs with the
-  // `hidden` prop render with `display: none` and take up no space. The string
-  // signature is used as the effect dependency so the observer re-subscribes
-  // (recapturing these keys) whenever the set of tabs changes.
-  const layoutKeys = tabItems.filter(item => !item.hidden).map(item => item.key);
-  const layoutKeysSignature = layoutKeys.join(' ');
+  // Measures the list against the available space and updates the overflow set.
+  const recompute = useEffectEvent(() => {
+    const outerWrap = outerWrapRef.current;
+    const tabList = tabListRef.current;
+    if (!outerWrap || !tabList) {
+      return;
+    }
+
+    const elements = tabItemsRef.current ?? {};
+    const gap = parseFloat(getComputedStyle(tabList).columnGap) || 0;
+
+    // Tabs that participate in the layout, in render (visual) order. Tabs with
+    // the `hidden` prop render with `display: none` and take up no space.
+    const keys = tabItems.filter(item => !item.hidden).map(item => item.key);
+
+    // Refresh the cached width of every measurable (currently visible) tab.
+    // Overflowing tabs measure 0; their last known width is kept.
+    for (const key of keys) {
+      const measured = elements[key]?.getBoundingClientRect().width ?? 0;
+      if (measured > 0) {
+        tabWidthsRef.current.set(key, measured);
+      }
+    }
+
+    const available = outerWrap.clientWidth;
+
+    // Width required to render every tab, without reserving the trigger.
+    const fullWidth = keys.reduce(
+      (sum: number, key, index) =>
+        sum + (tabWidthsRef.current.get(key) ?? 0) + (index === 0 ? 0 : gap),
+      0
+    );
+
+    let nextOverflow: Array<string | number>;
+    if (fullWidth <= available) {
+      nextOverflow = [];
+    } else {
+      // Overflow is needed, so leave room for the trigger button.
+      const budget = available - RESERVED_OVERFLOW_TRIGGER_WIDTH;
+      nextOverflow = [];
+      let used = 0;
+      let isOverflowing = false;
+      keys.forEach((key, index) => {
+        if (isOverflowing) {
+          nextOverflow.push(key);
+          return;
+        }
+        const nextUsed =
+          used + (tabWidthsRef.current.get(key) ?? 0) + (index === 0 ? 0 : gap);
+        // Always keep the first tab to avoid an empty tab bar.
+        if (index === 0 || nextUsed <= budget) {
+          used = nextUsed;
+        } else {
+          isOverflowing = true;
+          nextOverflow.push(key);
+        }
+      });
+    }
+
+    // Bail out when the result is unchanged to avoid re-render churn (and any
+    // observer feedback from hiding/showing tabs).
+    setOverflowTabs(prev =>
+      prev.length === nextOverflow.length &&
+      prev.every((key, index) => key === nextOverflow[index])
+        ? prev
+        : nextOverflow
+    );
+  });
 
   useLayoutEffect(() => {
     if (disabled || orientation !== 'horizontal') {
-      overflowTabsRef.current = [];
-      setOverflowTabs([]);
+      setOverflowTabs(prev => (prev.length === 0 ? prev : []));
       return;
     }
 
@@ -130,86 +197,15 @@ function useOverflowTabs({
       return;
     }
 
-    const keys = layoutKeys;
-
-    const recompute = () => {
-      const elements = tabItemsRef.current ?? {};
-      const previousOverflow = overflowTabsRef.current;
-      const previousOverflowSet = new Set(previousOverflow);
-      const gap = parseFloat(getComputedStyle(tabList).columnGap) || 0;
-
-      // Refresh cached widths for every currently visible (measurable) tab.
-      for (const key of keys) {
-        if (previousOverflowSet.has(key)) {
-          continue;
-        }
-        const width = elements[key]?.getBoundingClientRect().width ?? 0;
-        if (width > 0) {
-          tabWidthsRef.current.set(key, width);
-        }
-      }
-
-      const available = outerWrap.clientWidth;
-
-      // Width required to render every tab, without reserving the trigger.
-      const fullWidth = keys.reduce((sum: number, key, index) => {
-        const width = tabWidthsRef.current.get(key) ?? 0;
-        return sum + width + (index === 0 ? 0 : gap);
-      }, 0);
-
-      let nextOverflow: Array<string | number>;
-      if (fullWidth <= available) {
-        nextOverflow = [];
-      } else {
-        // Overflow is needed, so leave room for the trigger button.
-        const budget = available - RESERVED_OVERFLOW_TRIGGER_WIDTH;
-        const overflow: Array<string | number> = [];
-        let used = 0;
-        let isOverflowing = false;
-        keys.forEach((key, index) => {
-          if (isOverflowing) {
-            overflow.push(key);
-            return;
-          }
-          const width = tabWidthsRef.current.get(key) ?? 0;
-          const nextUsed = used + width + (index === 0 ? 0 : gap);
-          // Always keep the first tab to avoid an empty tab bar.
-          if (index === 0 || nextUsed <= budget) {
-            used = nextUsed;
-          } else {
-            isOverflowing = true;
-            overflow.push(key);
-          }
-        });
-        nextOverflow = overflow;
-      }
-
-      const unchanged =
-        nextOverflow.length === previousOverflow.length &&
-        nextOverflow.every((key, index) => key === previousOverflow[index]);
-      if (unchanged) {
-        return;
-      }
-
-      overflowTabsRef.current = nextOverflow;
-      setOverflowTabs(nextOverflow);
-    };
-
-    recompute();
-
-    // Observe the wrapper (available space) and the list (intrinsic size, e.g.
-    // when labels or fonts change). `recompute` is deterministic, so the
-    // self-induced resize from hiding/showing tabs just re-runs and bails out.
+    // Recompute on container resize (available space changes) and on list
+    // resize (tabs added/removed/relabeled change its intrinsic width).
     const resizeObserver = new ResizeObserver(() => recompute());
     resizeObserver.observe(outerWrap);
     resizeObserver.observe(tabList);
+    recompute();
 
-    return () => {
-      resizeObserver.disconnect();
-    };
-    // `layoutKeys` is intentionally tracked via its primitive `layoutKeysSignature`.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [outerWrapRef, tabListRef, tabItemsRef, disabled, orientation, layoutKeysSignature]);
+    return () => resizeObserver.disconnect();
+  }, [disabled, orientation, outerWrapRef, tabListRef]);
 
   // Tabs with the `hidden` prop render with display: none; never surface them
   // in the overflow menu.

--- a/static/app/components/core/tabs/tabs.spec.tsx
+++ b/static/app/components/core/tabs/tabs.spec.tsx
@@ -419,4 +419,51 @@ describe('Tabs overflow', () => {
 
     expect(screen.queryByRole('button', {name: 'More tabs'})).not.toBeInTheDocument();
   });
+
+  it('recomputes overflow when tabs are reordered without a resize', async () => {
+    // Fits the first three tabs (budget = 380 - 48 = 332 >= 3 * 100).
+    containerWidth = 380;
+
+    function TabsWithItems({
+      items,
+    }: {
+      items: ReadonlyArray<{key: string; label: string}>;
+    }) {
+      return (
+        <Tabs>
+          <TabList>
+            {items.map(tab => (
+              <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
+            ))}
+          </TabList>
+        </Tabs>
+      );
+    }
+
+    const {rerender} = render(<TabsWithItems items={TABS} />);
+
+    // Initially the trailing tab (Attachments) is the one that overflows.
+    expect(screen.getByRole('button', {name: 'More tabs'})).toBeInTheDocument();
+
+    // Reorder so Activity becomes the trailing tab. The total width is
+    // unchanged, so the ResizeObserver never fires – overflow must still be
+    // recomputed from the new order.
+    rerender(
+      <TabsWithItems
+        items={[
+          {key: 'details', label: 'Details'},
+          {key: 'user-feedback', label: 'User Feedback'},
+          {key: 'attachments', label: 'Attachments'},
+          {key: 'activity', label: 'Activity'},
+        ]}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More tabs'}));
+
+    // The new trailing tab overflows; the previously-overflowing one is now
+    // visible (not stuck in the menu based on the old order).
+    expect(screen.getByRole('option', {name: 'Activity'})).toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Attachments'})).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/core/tabs/tabs.spec.tsx
+++ b/static/app/components/core/tabs/tabs.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {TabList, TabPanels, Tabs} from '.';
 
@@ -275,5 +275,148 @@ describe('Tabs', () => {
       const tabEl = screen.getByRole('tab', {name: tab.label});
       expect(within(tabEl).queryByRole('link', {hidden: true})).not.toBeInTheDocument();
     });
+  });
+});
+
+describe('Tabs overflow', () => {
+  // Every tab measures this wide; the container width is varied per test to
+  // control how many tabs fit. The component reserves 48px for the trigger.
+  const TAB_WIDTH = 100;
+
+  // Available width reported by the tab list wrapper, mutable so resizes can be
+  // simulated. jsdom has no layout engine, so all measurement is mocked.
+  let containerWidth = 1000;
+  let resizeCallbacks: ResizeObserverCallback[] = [];
+  let originalResizeObserver: typeof ResizeObserver;
+
+  beforeEach(() => {
+    containerWidth = 1000;
+    resizeCallbacks = [];
+
+    // Each tab (<li role="tab">) measures TAB_WIDTH; everything else is 0.
+    jest
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        const width = this.getAttribute('role') === 'tab' ? TAB_WIDTH : 0;
+        return {
+          width,
+          height: 0,
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: width,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        } as DOMRect;
+      });
+
+    // Only the tab list wrapper (whose direct child is the tablist) reports the
+    // configured available width; everything else reports 0 (jsdom default).
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.querySelector(':scope > [role="tablist"]') ? containerWidth : 0;
+      },
+    });
+
+    // Controllable ResizeObserver so resizes can be triggered on demand (the
+    // global mock is a no-op).
+    originalResizeObserver = window.ResizeObserver;
+    window.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallbacks.push(callback);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    // Remove the prototype override so the jsdom default is restored.
+    delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientWidth;
+    window.ResizeObserver = originalResizeObserver;
+  });
+
+  function resizeContainerTo(width: number) {
+    containerWidth = width;
+    act(() => {
+      resizeCallbacks.forEach(callback => callback([], {} as ResizeObserver));
+    });
+  }
+
+  function renderTabs(orientation?: 'horizontal' | 'vertical') {
+    return render(
+      <Tabs orientation={orientation}>
+        <TabList>
+          {TABS.map(tab => (
+            <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
+          ))}
+        </TabList>
+        <TabPanels>
+          {TABS.map(tab => (
+            <TabPanels.Item key={tab.key}>{tab.content}</TabPanels.Item>
+          ))}
+        </TabPanels>
+      </Tabs>
+    );
+  }
+
+  it('does not render an overflow menu when all tabs fit', () => {
+    containerWidth = 1000;
+    renderTabs();
+
+    expect(screen.queryByRole('button', {name: 'More tabs'})).not.toBeInTheDocument();
+  });
+
+  it('moves tabs that do not fit into an overflow menu', async () => {
+    // Fits the first two tabs (budget = 260 - 48 = 212 => 2 * 100).
+    containerWidth = 260;
+    renderTabs();
+
+    await userEvent.click(screen.getByRole('button', {name: 'More tabs'}));
+
+    expect(screen.getByRole('option', {name: 'User Feedback'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Attachments'})).toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Details'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Activity'})).not.toBeInTheDocument();
+  });
+
+  it('recomputes overflow when the container is resized', async () => {
+    containerWidth = 1000;
+    renderTabs();
+
+    expect(screen.queryByRole('button', {name: 'More tabs'})).not.toBeInTheDocument();
+
+    resizeContainerTo(260);
+    await userEvent.click(await screen.findByRole('button', {name: 'More tabs'}));
+    expect(screen.getByRole('option', {name: 'User Feedback'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Attachments'})).toBeInTheDocument();
+
+    resizeContainerTo(1000);
+    expect(screen.queryByRole('button', {name: 'More tabs'})).not.toBeInTheDocument();
+  });
+
+  it('activates an overflowing tab when selected from the menu', async () => {
+    containerWidth = 260;
+    renderTabs();
+
+    await userEvent.click(screen.getByRole('button', {name: 'More tabs'}));
+    await userEvent.click(screen.getByRole('option', {name: 'Attachments'}));
+
+    expect(screen.getByRole('tab', {name: 'Attachments'})).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(screen.getByText(TABS[3].content)).toBeInTheDocument();
+  });
+
+  it('never overflows tabs in vertical orientation', () => {
+    containerWidth = 260;
+    renderTabs('vertical');
+
+    expect(screen.queryByRole('button', {name: 'More tabs'})).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
before: tabs and the `...` were sometimes overlapping, sometimes no `...` were shown and sometimes tabs were even missing.

https://github.com/user-attachments/assets/5163170e-b035-486d-9577-c205feb75555

after: buttery smooth tabs

https://github.com/user-attachments/assets/97486802-5f67-4e9e-a3fe-6d8d0447faea

