### PR TITLE
fix(conversations): Treat "None" user fields as missing

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -166,8 +166,20 @@ function ConversationsTableInner() {
   );
 }
 
+function normalizeUserField(value: string | null): string | null {
+  if (!value || value.toLowerCase() === 'none') {
+    return null;
+  }
+  return value;
+}
+
 export function getUserDisplayName(user: ConversationUser): string | null {
-  return user.email || user.username || user.ip_address || null;
+  return (
+    normalizeUserField(user.email) ||
+    normalizeUserField(user.username) ||
+    normalizeUserField(user.ip_address) ||
+    null
+  );
 }
 
 const TOOLTIP_MAX_CHARS = 2048;


### PR DESCRIPTION
User fields in the conversations table sometimes arrive as the literal string `"None"` instead of being absent, causing `"None"` to render as the display name. `getUserDisplayName` now normalizes those values to `null` so each table falls back to its placeholder (`—` in the redesign, `Unknown` in the old table).