### PR TITLE
feat(ai-conversations): Link issues in AI conversation span details

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import replace
 from datetime import datetime, timedelta
 
@@ -19,7 +20,10 @@ from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
+from sentry.snuba.trace import SpanIssueMeta, get_issues_by_span_for_traces
 from sentry.utils.dates import parse_stats_period
+
+logger = logging.getLogger(__name__)
 
 MAX_RETENTION_DAYS = 30
 
@@ -103,7 +107,9 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                 )
 
             def data_fn(offset: int, limit: int) -> list:
-                return self._fetch_spans(resolved_params, conversation_id, offset, limit)
+                spans = self._fetch_spans(resolved_params, conversation_id, offset, limit)
+                self._annotate_issues(spans, resolved_params, organization)
+                return spans
 
             return self.paginate(
                 request=request,
@@ -142,6 +148,65 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                 steps.append(step)
 
         return [replace(base_params, start=now - delta, end=now) for delta in steps]
+
+    @sentry_sdk.trace
+    def _annotate_issues(
+        self,
+        spans: list[dict],
+        snuba_params: SnubaParams,
+        organization: Organization,
+    ) -> None:
+        """Attach linked error/occurrence issues to each span, keyed by span id.
+
+        Best-effort: a failure to resolve issues must not break listing the conversation
+        spans, so each span always ends up with ``errors``/``occurrences`` arrays.
+        """
+        for span in spans:
+            span.setdefault("errors", [])
+            span.setdefault("occurrences", [])
+
+        if not spans:
+            return
+
+        span_meta_by_id: dict[str, SpanIssueMeta] = {}
+        trace_ids: list[str] = []
+        for span in spans:
+            span_id = span.get("span_id")
+            if not span_id:
+                continue
+            span_meta_by_id[span_id] = SpanIssueMeta(
+                start_timestamp=span.get("precise.start_ts", 0.0),
+                end_timestamp=span.get("precise.finish_ts", 0.0),
+                project_slug=span.get("project", ""),
+                transaction=span.get("transaction", ""),
+            )
+            trace = span.get("trace")
+            if trace:
+                trace_ids.append(trace)
+
+        if not trace_ids:
+            return
+
+        try:
+            issues_by_span = get_issues_by_span_for_traces(
+                snuba_params=snuba_params,
+                trace_ids=trace_ids,
+                organization=organization,
+                referrer=Referrer.API_AI_CONVERSATION_DETAILS_ISSUES.value,
+                span_meta_by_id=span_meta_by_id,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to resolve issues for AI conversation spans",
+                extra={"organization_id": organization.id},
+            )
+            return
+
+        for span in spans:
+            bucket = issues_by_span.get(span.get("span_id", ""))
+            if bucket:
+                span["errors"] = bucket["errors"]
+                span["occurrences"] = bucket["occurrences"]
 
     @sentry_sdk.trace
     def _fetch_spans(

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -501,6 +501,7 @@ class Referrer(StrEnum):
     API_AI_CONVERSATIONS_ENRICHMENT = "api.ai-conversations.enrichment"
     API_AI_CONVERSATIONS_FIRST_LAST_IO = "api.ai-conversations.first-last-io"
     API_AI_CONVERSATION_DETAILS = "api.ai-conversation-details"
+    API_AI_CONVERSATION_DETAILS_ISSUES = "api.ai-conversation-details.issues"
     API_AI_PIPELINES_VIEW = "api.ai-pipelines.view"
     API_AI_PIPELINES_DETAILS_VIEW = "api.ai-pipelines.details.view"
     API_PROFILING_ONBOARDING = "profiling-onboarding"

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any, Literal, NotRequired, TypedDict
 
@@ -120,6 +120,15 @@ class TraceOccurrenceEvent(TypedDict):
     event_type: Literal["occurrence"]
     event_data: TraceOccurrenceEventData
     issue_data: TraceIssueOccurrenceData
+
+
+class SpanIssueMeta(TypedDict):
+    """Span fields needed to serialize an occurrence issue attached to that span."""
+
+    start_timestamp: float
+    end_timestamp: float
+    project_slug: str
+    transaction: str
 
 
 def _serialize_rpc_issue(
@@ -290,9 +299,9 @@ def _serialize_rpc_event(
 
 
 def _errors_query(
-    snuba_params: SnubaParams, trace_id: str, error_id: str | None
+    snuba_params: SnubaParams, trace_ids: Sequence[str], error_id: str | None
 ) -> DiscoverQueryBuilder:
-    """Run an error query, getting all the errors for a given trace id"""
+    """Run an error query, getting all the errors for the given trace ids"""
     # TODO: replace this with EAP calls, this query is copied from the old trace view
     columns = [
         "id",
@@ -317,7 +326,7 @@ def _errors_query(
         Dataset.Events,
         params={},
         snuba_params=snuba_params,
-        query=f"trace:{trace_id}",
+        query=f"trace:[{','.join(trace_ids)}]",
         selected_columns=columns,
         # Don't add timestamp to this orderby as snuba will have to split the time range up and make multiple queries
         orderby=orderby,
@@ -426,15 +435,15 @@ def _run_errors_query_eap(
 
 def _perf_issues_query(
     snuba_params: SnubaParams,
-    trace_id: str,
+    trace_ids: Sequence[str],
     organization: Organization | None = None,
 ) -> DiscoverQueryBuilder:
-    query = f"trace:{trace_id}"
+    query = f"trace:[{','.join(trace_ids)}]"
 
     if organization:
         visible_type_ids = [gt.type_id for gt in grouptype_registry.get_visible(organization)]
         if visible_type_ids:
-            query = f"trace:{trace_id} occurrence_type_id:[{','.join(map(str, visible_type_ids))}]"
+            query = f"{query} occurrence_type_id:[{','.join(map(str, visible_type_ids))}]"
 
     occurrence_query = DiscoverQueryBuilder(
         Dataset.IssuePlatform,
@@ -488,6 +497,76 @@ def _run_perf_issues_query(
                 result.append({"occurrence": issue, "issue_id": issue_id})
 
     return result
+
+
+@sentry_sdk.tracing.trace
+def get_issues_by_span_for_traces(
+    snuba_params: SnubaParams,
+    trace_ids: Sequence[str],
+    organization: Organization,
+    referrer: str,
+    span_meta_by_id: Mapping[str, SpanIssueMeta],
+) -> dict[str, dict[str, list[SerializedIssue]]]:
+    """Map span ids to their linked error and occurrence issues for the given traces.
+
+    Reuses the same error/occurrence association the trace view uses (errors keyed by
+    ``trace.span``, occurrences keyed by ``offender_span_ids``) so spans can be annotated
+    with their issues outside of the full trace view (e.g. AI conversation span details).
+
+    ``span_meta_by_id`` provides the span fields required to serialize occurrence issues
+    and also acts as the allow-list of spans we attach issues to.
+
+    Returns a mapping of ``span_id -> {"errors": [...], "occurrences": [...]}``.
+    """
+    unique_trace_ids = list({trace_id for trace_id in trace_ids if trace_id})
+    if not unique_trace_ids:
+        return {}
+
+    errors_data = _run_errors_query(
+        _errors_query(snuba_params, unique_trace_ids, None), referrer=referrer
+    )
+    occurrence_data = _run_perf_issues_query(
+        _perf_issues_query(snuba_params, unique_trace_ids, organization), referrer=referrer
+    )
+
+    group_cache: dict[int, Group] = {}
+    issues_by_span: dict[str, dict[str, list[SerializedIssue]]] = {}
+
+    def _bucket(span_id: str) -> dict[str, list[SerializedIssue]]:
+        return issues_by_span.setdefault(span_id, {"errors": [], "occurrences": []})
+
+    for error in errors_data:
+        span_id = error.get("trace.span")
+        if not span_id or span_id not in span_meta_by_id:
+            continue
+        serialized = _serialize_rpc_issue(error, group_cache)
+        if serialized is not None:
+            _bucket(span_id)["errors"].append(serialized)
+
+    for occurrence_event in occurrence_data:
+        occurrence = occurrence_event["occurrence"]
+        issue_id = occurrence_event["issue_id"]
+        for span_id in occurrence.evidence_data.get("offender_span_ids", []):
+            meta = span_meta_by_id.get(span_id)
+            if meta is None:
+                continue
+            serialized = _serialize_rpc_issue(
+                {
+                    "event_type": "occurrence",
+                    "event_data": {
+                        "start_timestamp": meta["start_timestamp"],
+                        "end_timestamp": meta["end_timestamp"],
+                        "project_slug": meta["project_slug"],
+                        "transaction": meta["transaction"],
+                    },
+                    "issue_data": {"occurrence": occurrence, "issue_id": issue_id},
+                },
+                group_cache,
+            )
+            if serialized is not None:
+                _bucket(span_id)["occurrences"].append(serialized)
+
+    return issues_by_span
 
 
 def _uptime_results_query(
@@ -656,8 +735,8 @@ def query_trace_data(
     if referrer is None or referrer == "" or not is_valid_referrer(referrer):
         referrer = Referrer.API_TRACE_VIEW_GET_EVENTS.value
 
-    errors_query = _errors_query(snuba_params, trace_id, error_id)
-    occurrence_query = _perf_issues_query(snuba_params, trace_id, organization)
+    errors_query = _errors_query(snuba_params, [trace_id], error_id)
+    occurrence_query = _perf_issues_query(snuba_params, [trace_id], organization)
     uptime_query = _uptime_results_query(snuba_params, trace_id) if include_uptime else None
 
     # 1 worker each for spans, errors, performance issues, and optionally uptime

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -6,8 +6,12 @@ from uuid import uuid4
 from django.urls import reverse
 from urllib3.exceptions import ReadTimeoutError
 
+from sentry.issues.grouptype import PerformanceFileIOMainThreadGroupType
+from sentry.issues.ingest import save_issue_occurrence
+from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now
+from sentry.utils.samples import load_data
 from sentry.utils.snuba_rpc import SnubaRPCTimeout
 
 from .test_organization_ai_conversations_base import BaseAIConversationsTestCase
@@ -476,3 +480,209 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             response = self.do_request(conversation_id, {"project": [self.project.id]})
 
         assert response.status_code == 504
+
+    def _store_error_on_span(self, trace_id, span_id, timestamp, project=None):
+        project = project or self.project
+        error_data = load_data("javascript", timestamp=timestamp)
+        error_data["contexts"]["trace"] = {
+            "type": "trace",
+            "trace_id": trace_id,
+            "span_id": span_id,
+        }
+        return self.store_event(error_data, project_id=project.id)
+
+    def test_spans_without_issues_have_empty_arrays(self) -> None:
+        now = before_now(days=10).replace(microsecond=0)
+        trace_id = uuid4().hex
+        conversation_id = uuid4().hex
+
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now,
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            trace_id=trace_id,
+        )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["errors"] == []
+        assert response.data[0]["occurrences"] == []
+
+    def test_links_error_issue_to_span(self) -> None:
+        now = before_now(days=10).replace(microsecond=0)
+        trace_id = uuid4().hex
+        conversation_id = uuid4().hex
+
+        span = self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=1),
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            status="error",
+            trace_id=trace_id,
+        )
+        span_id = span["span_id"]
+
+        error = self._store_error_on_span(trace_id, span_id, now)
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert len(response.data) == 1
+
+        span_data = response.data[0]
+        assert span_data["span_id"] == span_id
+        assert span_data["occurrences"] == []
+        assert len(span_data["errors"]) == 1
+
+        error_issue = span_data["errors"][0]
+        assert error_issue["event_id"] == error.event_id
+        assert error_issue["issue_id"] == error.group_id
+        assert error_issue["level"] == "error"
+        assert error_issue["event_type"] == "error"
+
+    def test_error_only_attached_to_matching_span(self) -> None:
+        now = before_now(days=10).replace(microsecond=0)
+        trace_id = uuid4().hex
+        conversation_id = uuid4().hex
+
+        failing_span = self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=2),
+            op="gen_ai.execute_tool",
+            operation_type="tool",
+            status="error",
+            trace_id=trace_id,
+        )
+        healthy_span = self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=1),
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            trace_id=trace_id,
+        )
+
+        self._store_error_on_span(trace_id, failing_span["span_id"], now)
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert len(response.data) == 2
+
+        by_span = {span["span_id"]: span for span in response.data}
+        assert len(by_span[failing_span["span_id"]]["errors"]) == 1
+        assert by_span[healthy_span["span_id"]]["errors"] == []
+
+    def test_links_errors_across_multiple_traces(self) -> None:
+        now = before_now(days=10).replace(microsecond=0)
+        conversation_id = uuid4().hex
+        trace_id_1 = uuid4().hex
+        trace_id_2 = uuid4().hex
+
+        span_1 = self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=2),
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            status="error",
+            trace_id=trace_id_1,
+        )
+        span_2 = self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=1),
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            status="error",
+            trace_id=trace_id_2,
+        )
+
+        self._store_error_on_span(trace_id_1, span_1["span_id"], now)
+        self._store_error_on_span(trace_id_2, span_2["span_id"], now)
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert len(response.data) == 2
+
+        by_span = {span["span_id"]: span for span in response.data}
+        assert len(by_span[span_1["span_id"]]["errors"]) == 1
+        assert len(by_span[span_2["span_id"]]["errors"]) == 1
+
+    def test_links_occurrence_issue_to_span(self) -> None:
+        now = before_now(days=10).replace(microsecond=0)
+        trace_id = uuid4().hex
+        conversation_id = uuid4().hex
+
+        span = self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=1),
+            op="gen_ai.execute_tool",
+            operation_type="tool",
+            trace_id=trace_id,
+        )
+        span_id = span["span_id"]
+
+        event_data = load_data("transaction", timestamp=now)
+        event_data["contexts"]["trace"]["trace_id"] = trace_id
+        event_data["contexts"]["trace"]["span_id"] = span_id
+        event = self.store_event(event_data, project_id=self.project.id)
+
+        occurrence = IssueOccurrence(
+            id=uuid4().hex,
+            resource_id=None,
+            project_id=self.project.id,
+            event_id=event.event_id,
+            fingerprint=[uuid4().hex],
+            type=PerformanceFileIOMainThreadGroupType,
+            issue_title="File IO on Main Thread",
+            subtitle="",
+            evidence_display=[],
+            evidence_data={"offender_span_ids": [span_id]},
+            culprit="",
+            detection_time=now,
+            level="info",
+        )
+        with patch("sentry.issues.ingest.should_create_group", return_value=True):
+            _, group_info = save_issue_occurrence(occurrence.to_dict(), event)
+        assert group_info is not None
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(conversation_id, query)
+        assert response.status_code == 200
+        assert len(response.data) == 1
+
+        span_data = response.data[0]
+        assert span_data["span_id"] == span_id
+        assert len(span_data["occurrences"]) == 1
+        occurrence_issue = span_data["occurrences"][0]
+        assert occurrence_issue["event_type"] == "occurrence"
+        assert occurrence_issue["issue_id"] == group_info.group.id
+        assert occurrence_issue["description"] == "File IO on Main Thread"


### PR DESCRIPTION
Selecting a span in the Conversations Span tab doesn't show its linked error/issue, even though the same span does in the trace waterfall.

Both views use the same detail component, which only renders issues when the span node has them. Trace nodes are built from the full trace so they're populated; Conversations spans come from the `ai-conversations/{id}` endpoint, which returns no issue data.

This adds `errors` and `occurrences` to each span in that endpoint's response, in the same shape the trace endpoint returns. A new `get_issues_by_span_for_traces` helper groups issues by span, reusing the trace view's association (errors by `trace.span`, occurrences by `offender_span_ids`) and serialization. `_errors_query`/`_perf_issues_query` now take multiple trace ids so a conversation resolves in one batched query per issue type. Resolution is best-effort and falls back to empty arrays.

Refs TET-2565
