### PR TITLE
fix(ai-conversations): Widen AI conversations filter to include tool spans

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -236,11 +236,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
         user_query: str,
         sampling_mode: SAMPLING_MODES = "NORMAL",
     ) -> list[dict]:
-        base_filter = (
-            "has:gen_ai.conversation.id"
-            " (has:gen_ai.input.messages OR has:gen_ai.request.messages)"
-            " (has:gen_ai.output.messages OR has:gen_ai.response.text)"
-        )
+        base_filter = "has:gen_ai.conversation.id has:gen_ai.operation.type"
         query_string = _build_conversation_query(base_filter, user_query)
 
         conversation_ids_results = self._fetch_conversation_ids(

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -468,6 +468,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
                 conversation_id=conversation_id,
                 timestamp=now - timedelta(seconds=i),
                 op="gen_ai.chat",
+                operation_type="ai_client",
                 status=span_status,
                 trace_id=trace_id,
                 **extra_kwargs,
@@ -647,17 +648,18 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert conversation["firstInput"] == first_user_content
         assert conversation["lastOutput"] == last_response_text
 
-    def test_no_ai_client_spans_filtered_out(self) -> None:
-        """Test conversations without input/output are filtered out"""
+    def test_conversation_without_ai_client_spans_included(self) -> None:
+        """Conversations are surfaced based on gen_ai.operation.type, even without LLM I/O"""
         now = before_now(days=12).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
-        # Only invoke_agent spans, no ai_client spans with input/output
+        # Only invoke_agent and tool spans, no ai_client spans with input/output
         self.store_ai_span(
             conversation_id=conversation_id,
             timestamp=now - timedelta(seconds=2),
             op="gen_ai.invoke_agent",
+            operation_type="invoke_agent",
             agent_name="Test Agent",
             trace_id=trace_id,
         )
@@ -667,6 +669,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
             timestamp=now - timedelta(seconds=1),
             op="gen_ai.execute_tool",
             operation_type="tool",
+            tool_name="weather",
             trace_id=trace_id,
         )
 
@@ -678,7 +681,57 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert len(response.data) == 0
+        assert len(response.data) == 1
+        conversation = response.data[0]
+        assert conversation["conversationId"] == conversation_id
+        assert conversation["toolNames"] == ["weather"]
+        assert conversation["firstInput"] is None
+        assert conversation["lastOutput"] is None
+
+    def test_query_filter_by_tool_name(self) -> None:
+        """Test that a tool-name query filters conversations by the tools they used"""
+        now = before_now(days=24).replace(microsecond=0)
+        conversation_with_tool = uuid4().hex
+        conversation_without_tool = uuid4().hex
+
+        # Conversation that uses the weather tool
+        self.store_ai_span(
+            conversation_id=conversation_with_tool,
+            timestamp=now - timedelta(seconds=3),
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            messages=[{"role": "user", "content": "What is the weather?"}],
+            response_text="Let me check",
+        )
+        self.store_ai_span(
+            conversation_id=conversation_with_tool,
+            timestamp=now - timedelta(seconds=2),
+            op="gen_ai.execute_tool",
+            operation_type="tool",
+            tool_name="weather",
+        )
+
+        # Conversation that does not use the weather tool
+        self.store_ai_span(
+            conversation_id=conversation_without_tool,
+            timestamp=now - timedelta(seconds=1),
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            messages=[{"role": "user", "content": "Tell me a joke"}],
+            response_text="Here is one",
+        )
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+            "query": "gen_ai.tool.name:weather",
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["conversationId"] == conversation_with_tool
 
     def test_query_filter(self) -> None:
         """Test that query parameter filters conversations"""


### PR DESCRIPTION
Filtering conversations by tool (e.g. `gen_ai.tool.name:weather`) returned no results. The listing query required input/output messages, which only exist on `ai_client` spans, while the tool name lives on `tool` spans — so the tool condition ANDed against the message requirement and matched no span.

The base filter now uses `has:gen_ai.conversation.id has:gen_ai.operation.type`, an attribute every gen_ai span carries, so tool-scoped queries resolve their conversations. A side effect is that conversations made up only of agent/tool spans (no LLM I/O) now surface; this matches how the endpoint already derives its metrics from `gen_ai.operation.type`.

Regression coverage: a tool-name filter test, plus an updated test asserting operation-typed conversations without LLM I/O are included.

Negation ("conversations that did not use a given tool") is not yet correct with a span-level filter — `!gen_ai.tool.name:x` matches per span, not per conversation. That needs a per-conversation aggregate pre-query as a follow-up.

Closes TET-2450