### PR TITLE
ref(pr-metrics): Extract reported-PR resolution to the model layer

### DIFF
--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -92,13 +92,14 @@ class ResolvedPullRequest(NamedTuple):
 
     ``pull_request`` is None when the reported ``(repo_name, provider)`` doesn't map to
     exactly one active ``Repository``; ``repo_resolution`` says why, and
-    ``provider_recognized`` flags a provider string we don't map. Callers decide how (and
+    ``provider_unmappable`` flags a *present* provider string we don't map (an empty or
+    ``"unknown"`` provider is treated as absent, not unmappable). Callers decide how (and
     whether) to log these under their own namespace.
     """
 
     pull_request: PullRequest | None
     repo_resolution: RepoResolution
-    provider_recognized: bool
+    provider_unmappable: bool
 
 
 def parse_pull_request_number(url: str) -> int | None:
@@ -183,8 +184,8 @@ class PullRequestManager(BaseManager["PullRequest"]):
         attribution).
         """
         normalized_provider = _normalize_scm_provider(provider)
-        provider_recognized = (
-            normalized_provider is None or normalized_provider in _KNOWN_SCM_PROVIDERS
+        provider_unmappable = (
+            normalized_provider is not None and normalized_provider not in _KNOWN_SCM_PROVIDERS
         )
 
         repository, resolution = self._resolve_repository(
@@ -193,7 +194,7 @@ class PullRequestManager(BaseManager["PullRequest"]):
             normalized_provider=normalized_provider,
         )
         if repository is None:
-            return ResolvedPullRequest(None, resolution, provider_recognized)
+            return ResolvedPullRequest(None, resolution, provider_unmappable)
 
         # get_or_create is race-safe via the unique constraint on (repository, key) —
         # Django retries the get on IntegrityError.
@@ -202,7 +203,7 @@ class PullRequestManager(BaseManager["PullRequest"]):
             repository_id=repository.id,
             key=str(key),
         )
-        return ResolvedPullRequest(pull_request, "resolved", provider_recognized)
+        return ResolvedPullRequest(pull_request, "resolved", provider_unmappable)
 
     def _resolve_repository(
         self, *, organization_id: int, repo_name: str, normalized_provider: str | None

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
@@ -12,7 +12,6 @@ from django.db.models.signals import post_save
 from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
-from sentry.constants import ObjectStatus
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -29,7 +28,7 @@ from sentry.models.group import Group
 from sentry.utils.groupreference import find_referenced_groups
 
 if TYPE_CHECKING:
-    from sentry.models.repository import Repository
+    from sentry.models.repository import RepoResolution
 
 
 class PullRequestLifecycleState(models.TextChoices):
@@ -67,8 +66,6 @@ class PullRequestVerdict(models.TextChoices):
     # Never a judge *result* — the callback rejects it coming back from Seer.
     JUDGE_IN_PROGRESS = "judge_in_progress"
 
-
-RepoResolution = Literal["resolved", "not_found", "ambiguous"]
 
 # SCM providers that can legitimately back a Repository. A reporting source (Seer, a
 # delegated coding agent, a future integration) normalizes its provider to one of these
@@ -172,8 +169,8 @@ class PullRequestManager(BaseManager["PullRequest"]):
     ) -> ResolvedPullRequest:
         """Resolve an externally-reported ``(repo_name, provider, key)`` to its canonical PR.
 
-        Resolves the org-scoped active ``Repository`` (see ``_resolve_repository``), then
-        find-or-creates the ``PullRequest`` keyed on ``key`` (the PR number). The
+        Resolves the org-scoped active ``Repository`` (via ``RepositoryManager.resolve_active``),
+        then find-or-creates the ``PullRequest`` keyed on ``key`` (the PR number). The
         find-or-create may run before the SCM ``opened`` webhook arrives, so the row can be
         a shell (no title/body) the webhook fills in later — we never overwrite it here.
 
@@ -183,14 +180,16 @@ class PullRequestManager(BaseManager["PullRequest"]):
         rather than through an SCM installation (e.g. Seer-created and delegated-agent
         attribution).
         """
+        from sentry.models.repository import Repository
+
         normalized_provider = _normalize_scm_provider(provider)
         provider_unmappable = (
             normalized_provider is not None and normalized_provider not in _KNOWN_SCM_PROVIDERS
         )
 
-        repository, resolution = self._resolve_repository(
+        repository, resolution = Repository.objects.resolve_active(
             organization_id=organization_id,
-            repo_name=repo_name,
+            name=repo_name,
             normalized_provider=normalized_provider,
         )
         if repository is None:
@@ -204,41 +203,6 @@ class PullRequestManager(BaseManager["PullRequest"]):
             key=str(key),
         )
         return ResolvedPullRequest(pull_request, "resolved", provider_unmappable)
-
-    def _resolve_repository(
-        self, *, organization_id: int, repo_name: str, normalized_provider: str | None
-    ) -> tuple[Repository | None, RepoResolution]:
-        """Resolve the org-scoped active repository for an externally-reported PR.
-
-        Sentry stores the ``integrations:``-prefixed provider while reporters send the bare
-        form, so we match both shapes — the same mapping ``filter_repo_by_provider`` uses.
-
-        Resolves only when exactly one repo matches. A known provider disambiguates
-        same-named repos across providers; an unknown provider refuses to guess between them
-        rather than risk mis-resolution.
-
-        Returns ``(repository, reason)`` where reason is ``"resolved"``, ``"not_found"``
-        (zero matches), or ``"ambiguous"`` (more than one).
-        """
-        from sentry.models.repository import Repository
-
-        candidates = Repository.objects.filter(
-            organization_id=organization_id,
-            name=repo_name,
-            status=ObjectStatus.ACTIVE,
-        )
-
-        if normalized_provider is not None:
-            candidates = candidates.filter(
-                Q(provider=normalized_provider) | Q(provider=f"integrations:{normalized_provider}")
-            )
-
-        # Fetch up to 2 to detect ambiguity — the same name can exist under multiple
-        # providers (e.g. github & gitlab) within one org.
-        matches = list(candidates.order_by("id")[:2])
-        if len(matches) == 1:
-            return matches[0], "resolved"
-        return None, "ambiguous" if matches else "not_found"
 
 
 @cell_silo_model

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
@@ -11,6 +12,7 @@ from django.db.models.signals import post_save
 from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
+from sentry.constants import ObjectStatus
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -22,8 +24,12 @@ from sentry.db.models import (
 )
 from sentry.db.models.fields.jsonfield import LegacyTextJSONField
 from sentry.db.models.manager.base import BaseManager
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
 from sentry.utils.groupreference import find_referenced_groups
+
+if TYPE_CHECKING:
+    from sentry.models.repository import Repository
 
 
 class PullRequestLifecycleState(models.TextChoices):
@@ -62,6 +68,67 @@ class PullRequestVerdict(models.TextChoices):
     JUDGE_IN_PROGRESS = "judge_in_progress"
 
 
+RepoResolution = Literal["resolved", "not_found", "ambiguous"]
+
+# SCM providers that can legitimately back a Repository. A reporting source (Seer, a
+# delegated coding agent, a future integration) normalizes its provider to one of these
+# (lowercased, no ``integrations:`` prefix); anything else is a value we don't understand
+# and should be fixed upstream.
+_KNOWN_SCM_PROVIDERS = frozenset(
+    {
+        IntegrationProviderSlug.GITHUB,
+        IntegrationProviderSlug.GITHUB_ENTERPRISE,
+        IntegrationProviderSlug.GITLAB,
+        IntegrationProviderSlug.BITBUCKET,
+        IntegrationProviderSlug.BITBUCKET_SERVER,
+        IntegrationProviderSlug.AZURE_DEVOPS,
+        IntegrationProviderSlug.PERFORCE,
+    }
+)
+
+
+class ResolvedPullRequest(NamedTuple):
+    """Result of resolving an externally-reported PR to its canonical ``PullRequest``.
+
+    ``pull_request`` is None when the reported ``(repo_name, provider)`` doesn't map to
+    exactly one active ``Repository``; ``repo_resolution`` says why, and
+    ``provider_recognized`` flags a provider string we don't map. Callers decide how (and
+    whether) to log these under their own namespace.
+    """
+
+    pull_request: PullRequest | None
+    repo_resolution: RepoResolution
+    provider_recognized: bool
+
+
+def parse_pull_request_number(url: str) -> int | None:
+    """Extract the PR/MR number from a pull-request URL, or None if there isn't one.
+
+    Matches the number after a ``/pull/`` (GitHub) or ``/merge_requests/`` (GitLab)
+    segment specifically — a source can report a branch/``tree`` URL as its result, and
+    we must not mistake a trailing branch-name segment for a PR number.
+    """
+    match = re.search(r"/(?:pull|pulls|merge_requests)/(\d+)", url)
+    return int(match.group(1)) if match else None
+
+
+def _normalize_scm_provider(provider: str | None) -> str | None:
+    """Normalize a reported SCM provider to Sentry's unprefixed form, or None if unusable.
+
+    Returns None for the ``"unknown"`` sentinel (the source couldn't resolve the repo) and
+    for empty values — neither can scope a provider filter. Lowercases before the sentinel
+    check so any casing (e.g. ``UNKNOWN``) is treated as unknown.
+    """
+    if not provider:
+        return None
+    provider = provider.lower()
+    if provider.startswith("integrations:"):
+        provider = provider.split(":", 1)[1]
+    if provider == "unknown":
+        return None
+    return provider
+
+
 class PullRequestManager(BaseManager["PullRequest"]):
     def update_or_create(
         self,
@@ -93,6 +160,84 @@ class PullRequestManager(BaseManager["PullRequest"]):
             )
             post_save.send(sender=self.__class__, instance=instance, created=created)
         return affected, created
+
+    def get_or_create_from_reference(
+        self,
+        *,
+        organization_id: int,
+        repo_name: str,
+        provider: str | None,
+        key: int | str,
+    ) -> ResolvedPullRequest:
+        """Resolve an externally-reported ``(repo_name, provider, key)`` to its canonical PR.
+
+        Resolves the org-scoped active ``Repository`` (see ``_resolve_repository``), then
+        find-or-creates the ``PullRequest`` keyed on ``key`` (the PR number). The
+        find-or-create may run before the SCM ``opened`` webhook arrives, so the row can be
+        a shell (no title/body) the webhook fills in later — we never overwrite it here.
+
+        Returns a ``ResolvedPullRequest``; ``pull_request`` is None when the repo can't be
+        uniquely resolved. Does not log or swallow errors — callers own observability and
+        error handling. Shared by every path that learns of a PR by repo name + provider
+        rather than through an SCM installation (e.g. Seer-created and delegated-agent
+        attribution).
+        """
+        normalized_provider = _normalize_scm_provider(provider)
+        provider_recognized = (
+            normalized_provider is None or normalized_provider in _KNOWN_SCM_PROVIDERS
+        )
+
+        repository, resolution = self._resolve_repository(
+            organization_id=organization_id,
+            repo_name=repo_name,
+            normalized_provider=normalized_provider,
+        )
+        if repository is None:
+            return ResolvedPullRequest(None, resolution, provider_recognized)
+
+        # get_or_create is race-safe via the unique constraint on (repository, key) —
+        # Django retries the get on IntegrityError.
+        pull_request, _ = self.get_or_create(
+            organization_id=organization_id,
+            repository_id=repository.id,
+            key=str(key),
+        )
+        return ResolvedPullRequest(pull_request, "resolved", provider_recognized)
+
+    def _resolve_repository(
+        self, *, organization_id: int, repo_name: str, normalized_provider: str | None
+    ) -> tuple[Repository | None, RepoResolution]:
+        """Resolve the org-scoped active repository for an externally-reported PR.
+
+        Sentry stores the ``integrations:``-prefixed provider while reporters send the bare
+        form, so we match both shapes — the same mapping ``filter_repo_by_provider`` uses.
+
+        Resolves only when exactly one repo matches. A known provider disambiguates
+        same-named repos across providers; an unknown provider refuses to guess between them
+        rather than risk mis-resolution.
+
+        Returns ``(repository, reason)`` where reason is ``"resolved"``, ``"not_found"``
+        (zero matches), or ``"ambiguous"`` (more than one).
+        """
+        from sentry.models.repository import Repository
+
+        candidates = Repository.objects.filter(
+            organization_id=organization_id,
+            name=repo_name,
+            status=ObjectStatus.ACTIVE,
+        )
+
+        if normalized_provider is not None:
+            candidates = candidates.filter(
+                Q(provider=normalized_provider) | Q(provider=f"integrations:{normalized_provider}")
+            )
+
+        # Fetch up to 2 to detect ambiguity — the same name can exist under multiple
+        # providers (e.g. github & gitlab) within one org.
+        matches = list(candidates.order_by("id")[:2])
+        if len(matches) == 1:
+            return matches[0], "resolved"
+        return None, "ambiguous" if matches else "not_found"
 
 
 @cell_silo_model

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar, Literal
 
 from django.contrib.postgres.fields.array import ArrayField
 from django.db import models, router, transaction
@@ -19,6 +19,7 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.db.models.fields.jsonfield import LegacyTextJSONField
+from sentry.db.models.manager.base import BaseManager
 from sentry.db.pending_deletion import (
     delete_pending_deletion_option,
     rename_on_pending_deletion,
@@ -33,6 +34,49 @@ from sentry.utils.email import MessageBuilder
 
 REPOSITORY_NAME_LENGTH = 500
 REPOSITORY_URL_LENGTH = 512
+
+
+RepoResolution = Literal["resolved", "not_found", "ambiguous"]
+
+
+class RepositoryManager(BaseManager["Repository"]):
+    def provider_match(self, provider: str) -> models.Q:
+        """Match a bare provider against both stored shapes.
+
+        Sentry stores the ``integrations:``-prefixed provider (e.g. ``integrations:github``)
+        while many callers carry the bare form (``github``). This is the single place that
+        owns the dual shape, so provider lookups stay consistent across SCM-reporting paths.
+        """
+        return models.Q(provider=provider) | models.Q(provider=f"integrations:{provider}")
+
+    def resolve_active(
+        self, *, organization_id: int, name: str, normalized_provider: str | None
+    ) -> tuple[Repository | None, RepoResolution]:
+        """Resolve the org-scoped active repository named ``name`` for a reported PR.
+
+        Resolves only when exactly one active repo matches. A provider disambiguates
+        same-named repos across providers (matching both stored shapes via
+        ``provider_match``); without one, refuse to guess between them rather than risk
+        mis-resolution.
+
+        ``normalized_provider`` is the bare, lowercased form (no ``integrations:`` prefix);
+        None skips provider filtering. Returns ``(repository, reason)`` where reason is
+        ``"resolved"``, ``"not_found"`` (zero matches), or ``"ambiguous"`` (more than one).
+        """
+        candidates = self.filter(
+            organization_id=organization_id,
+            name=name,
+            status=ObjectStatus.ACTIVE,
+        )
+        if normalized_provider is not None:
+            candidates = candidates.filter(self.provider_match(normalized_provider))
+
+        # Fetch up to 2 to detect ambiguity — the same name can exist under multiple
+        # providers (e.g. github & gitlab) within one org.
+        matches = list(candidates.order_by("id")[:2])
+        if len(matches) == 1:
+            return matches[0], "resolved"
+        return None, "ambiguous" if matches else "not_found"
 
 
 @cell_silo_model
@@ -52,6 +96,8 @@ class Repository(Model):
     date_added = models.DateTimeField(default=timezone.now)
     integration_id = BoundedPositiveIntegerField(db_index=True, null=True)
     languages = ArrayField(models.TextField(), default=list)
+
+    objects: ClassVar[RepositoryManager] = RepositoryManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -131,7 +131,7 @@ def _log_unresolved_reported_pull_request(
     """Emit the attribution warnings for a reported PR that didn't resolve to a unique repo."""
     # A present-but-unrecognized provider means the source sent something we don't map —
     # warn so it can be corrected upstream.
-    if not resolved.provider_recognized:
+    if resolved.provider_unmappable:
         logger.warning("pr_metrics.attribution.unrecognized_provider", extra=log_context)
 
     if resolved.pull_request is None:

--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -10,41 +10,24 @@ than collapsed into a single field.
 from __future__ import annotations
 
 import logging
-import re
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from django.db.models import Q
 from pydantic import BaseModel
 
 from sentry import features
 from sentry.constants import ObjectStatus
-from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.pullrequest import (
     PullRequest,
     PullRequestAttribution,
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
+    ResolvedPullRequest,
+    parse_pull_request_number,
 )
-from sentry.models.repository import Repository
 
 logger = logging.getLogger(__name__)
-
-# SCM providers that can legitimately back a Repository. Seer normalizes its
-# provider to one of these (lowercased, no ``integrations:`` prefix); anything
-# else in the event is a value we don't understand and should be fixed upstream.
-_KNOWN_SCM_PROVIDERS = frozenset(
-    {
-        IntegrationProviderSlug.GITHUB,
-        IntegrationProviderSlug.GITHUB_ENTERPRISE,
-        IntegrationProviderSlug.GITLAB,
-        IntegrationProviderSlug.BITBUCKET,
-        IntegrationProviderSlug.BITBUCKET_SERVER,
-        IntegrationProviderSlug.AZURE_DEVOPS,
-        IntegrationProviderSlug.PERFORCE,
-    }
-)
 
 # Precedence for picking a PR's primary attribution when more than one valid
 # signal is present (highest first): direct agent-authored signals rank above
@@ -142,6 +125,22 @@ def recompute_pull_request_attribution(pull_request: PullRequest) -> str | None:
     )
 
 
+def _log_unresolved_reported_pull_request(
+    resolved: ResolvedPullRequest, log_context: Mapping[str, Any]
+) -> None:
+    """Emit the attribution warnings for a reported PR that didn't resolve to a unique repo."""
+    # A present-but-unrecognized provider means the source sent something we don't map —
+    # warn so it can be corrected upstream.
+    if not resolved.provider_recognized:
+        logger.warning("pr_metrics.attribution.unrecognized_provider", extra=log_context)
+
+    if resolved.pull_request is None:
+        if resolved.repo_resolution == "ambiguous":
+            logger.warning("pr_metrics.attribution.repo_ambiguous", extra=log_context)
+        else:
+            logger.warning("pr_metrics.attribution.repo_not_found", extra=log_context)
+
+
 def _attribute_pull_request(
     *,
     organization_id: int,
@@ -153,48 +152,35 @@ def _attribute_pull_request(
     signal_details: Mapping[str, Any] | None,
     log_context: Mapping[str, Any],
 ) -> None:
-    """Resolve the org-scoped ``Repository`` for a reported PR, find-or-create the
-    canonical ``PullRequest`` row (keyed on PR number), and idempotently record one
-    attribution signal. Shared by the Seer-native and delegated-agent paths.
+    """Resolve a single reported PR to its canonical ``PullRequest`` and idempotently
+    record one attribution signal. Shared by the Seer-native and delegated-agent paths.
 
-    A find-or-create here may run before the SCM ``opened`` webhook arrives, so the
-    ``PullRequest`` row can be a shell (no title/body); the GitHub webhook fills
-    those in later. We never overwrite them from this path.
-
-    Failures are logged and swallowed rather than raised, so a batch caller's
-    remaining PRs are unaffected.
+    Resolution (repo lookup + find-or-create) lives on ``PullRequest.objects`` so every
+    PR-reporting path converges on the same row; here we add only the attribution write.
+    Failures are logged and swallowed rather than raised, so a batch caller's remaining
+    PRs are unaffected.
     """
-    normalized_provider = _normalize_provider(provider)
-    # A present-but-unrecognized provider means the source sent something we don't
-    # map — warn so it can be corrected upstream, but still attempt to resolve.
-    if normalized_provider is not None and normalized_provider not in _KNOWN_SCM_PROVIDERS:
-        logger.warning("pr_metrics.attribution.unrecognized_provider", extra=log_context)
+    try:
+        resolved = PullRequest.objects.get_or_create_from_reference(
+            organization_id=organization_id,
+            repo_name=repo_name,
+            provider=provider,
+            key=pr_number,
+        )
+    except Exception:
+        logger.exception("pr_metrics.attribution.record_failed", extra=log_context)
+        return
 
-    repository, resolution = _resolve_repository(
-        organization_id=organization_id,
-        repo_name=repo_name,
-        normalized_provider=normalized_provider,
-    )
-    if repository is None:
-        if resolution == "ambiguous":
-            logger.warning("pr_metrics.attribution.repo_ambiguous", extra=log_context)
-        else:
-            logger.warning("pr_metrics.attribution.repo_not_found", extra=log_context)
+    _log_unresolved_reported_pull_request(resolved, log_context)
+    if resolved.pull_request is None:
         return
 
     # The repo is resolved now, so its id sharpens every log from here on.
-    log_context = {**log_context, "repository_id": repository.id}
+    log_context = {**log_context, "repository_id": resolved.pull_request.repository_id}
 
-    # get_or_create is race-safe via the unique constraints — Django retries the
-    # get on IntegrityError.
     try:
-        pull_request, _ = PullRequest.objects.get_or_create(
-            organization_id=organization_id,
-            repository_id=repository.id,
-            key=str(pr_number),
-        )
         record_attribution_signal(
-            pull_request=pull_request,
+            pull_request=resolved.pull_request,
             signal_type=signal_type,
             source=source,
             signal_details=signal_details,
@@ -205,7 +191,7 @@ def _attribute_pull_request(
 
     logger.info(
         "pr_metrics.attribution.recorded",
-        extra={**log_context, "pull_request_id": pull_request.id},
+        extra={**log_context, "pull_request_id": resolved.pull_request.id},
     )
 
 
@@ -256,41 +242,6 @@ def attribute_seer_created_pull_requests(
         )
 
 
-def _resolve_repository(
-    *, organization_id: int, repo_name: str, normalized_provider: str | None
-) -> tuple[Repository | None, str]:
-    """Resolve the org-scoped active repository for a Seer-reported PR.
-
-    Sentry stores the ``integrations:``-prefixed provider while Seer sends the
-    bare form, so we match both shapes — the same mapping
-    ``filter_repo_by_provider`` uses.
-
-    Resolves only when exactly one repo matches. A known provider disambiguates
-    same-named repos across providers; an unknown provider (Seer couldn't match
-    the repo) refuses to guess between them rather than risk mis-attribution.
-
-    Returns ``(repository, reason)`` where reason is ``"resolved"``,
-    ``"not_found"`` (zero matches), or ``"ambiguous"`` (more than one).
-    """
-    candidates = Repository.objects.filter(
-        organization_id=organization_id,
-        name=repo_name,
-        status=ObjectStatus.ACTIVE,
-    )
-
-    if normalized_provider is not None:
-        candidates = candidates.filter(
-            Q(provider=normalized_provider) | Q(provider=f"integrations:{normalized_provider}")
-        )
-
-    # Fetch up to 2 to detect ambiguity — the same name can exist under
-    # multiple providers (e.g. github & gitlab) within one org.
-    matches = list(candidates.order_by("id")[:2])
-    if len(matches) == 1:
-        return matches[0], "resolved"
-    return None, "ambiguous" if matches else "not_found"
-
-
 def attribute_delegated_agent_pull_request(
     *,
     organization_id: int,
@@ -321,7 +272,7 @@ def attribute_delegated_agent_pull_request(
     if not features.has("organizations:pr-metrics-attribution", organization):
         return
 
-    pr_number = _parse_pr_number(pr_url)
+    pr_number = parse_pull_request_number(pr_url)
 
     log_context = {
         "organization_id": organization_id,
@@ -351,31 +302,3 @@ def attribute_delegated_agent_pull_request(
         ).dict(),
         log_context=log_context,
     )
-
-
-def _parse_pr_number(pr_url: str) -> int | None:
-    """Extract the PR/MR number from a pull-request URL, or None if there isn't one.
-
-    Matches the number after a ``/pull/`` (GitHub) or ``/merge_requests/`` (GitLab)
-    segment specifically — a delegated agent can report a branch/``tree`` URL as its
-    result, and we must not mistake a trailing branch-name segment for a PR number.
-    """
-    match = re.search(r"/(?:pull|pulls|merge_requests)/(\d+)", pr_url)
-    return int(match.group(1)) if match else None
-
-
-def _normalize_provider(provider: str | None) -> str | None:
-    """Normalize Seer's provider to Sentry's unprefixed form, or None if unusable.
-
-    Returns None for the ``"unknown"`` sentinel (Seer couldn't resolve the repo)
-    and for empty values — neither can scope a provider filter. Lowercases before
-    the sentinel check so any casing (e.g. ``UNKNOWN``) is treated as unknown.
-    """
-    if not provider:
-        return None
-    provider = provider.lower()
-    if provider.startswith("integrations:"):
-        provider = provider.split(":", 1)[1]
-    if provider == "unknown":
-        return None
-    return provider

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -10,7 +10,12 @@ from sentry.models.group import GroupStatus
 from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupresolution import GroupResolution
-from sentry.models.pullrequest import CommentType, PullRequest, PullRequestCommit
+from sentry.models.pullrequest import (
+    CommentType,
+    PullRequest,
+    PullRequestCommit,
+    parse_pull_request_number,
+)
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseheadcommit import ReleaseHeadCommit
 from sentry.models.repository import Repository
@@ -424,3 +429,151 @@ class PullRequestRetentionTest(TestCase):
             comment_type=CommentType.OPEN_PR,
         )
         assert not pr.is_unused(self.cutoff_date)
+
+
+class GetOrCreateFromReferenceTest(TestCase):
+    def setUp(self) -> None:
+        self.repo = self.create_repo(
+            self.project, name="getsentry/sentry", provider="integrations:github"
+        )
+
+    def _resolve(
+        self,
+        *,
+        repo_name: str = "getsentry/sentry",
+        provider: str | None = "github",
+        key: int | str = 42,
+    ):
+        return PullRequest.objects.get_or_create_from_reference(
+            organization_id=self.organization.id,
+            repo_name=repo_name,
+            provider=provider,
+            key=key,
+        )
+
+    def test_resolves_and_creates_pull_request(self) -> None:
+        resolved = self._resolve()
+
+        assert resolved.repo_resolution == "resolved"
+        assert resolved.provider_recognized is True
+        assert resolved.pull_request is not None
+        assert resolved.pull_request.repository_id == self.repo.id
+        assert resolved.pull_request.key == "42"
+
+    def test_coerces_integer_key_to_string(self) -> None:
+        resolved = self._resolve(key=7)
+
+        assert resolved.pull_request is not None
+        assert resolved.pull_request.key == "7"
+
+    def test_reuses_existing_pull_request_without_overwriting(self) -> None:
+        existing = self.create_pull_request(
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            key="42",
+            title="Real title",
+        )
+
+        resolved = self._resolve()
+
+        assert resolved.pull_request is not None
+        assert resolved.pull_request.id == existing.id
+        # The shell find-or-create must not clobber a title a webhook already filled in.
+        resolved.pull_request.refresh_from_db()
+        assert resolved.pull_request.title == "Real title"
+        assert PullRequest.objects.filter(repository_id=self.repo.id, key="42").count() == 1
+
+    def test_resolves_by_provider_when_name_collides(self) -> None:
+        gitlab_repo = self.create_repo(
+            self.project, name="getsentry/sentry", provider="integrations:gitlab"
+        )
+
+        resolved = self._resolve(provider="github")
+
+        assert resolved.pull_request is not None
+        assert resolved.pull_request.repository_id == self.repo.id
+        assert not PullRequest.objects.filter(repository_id=gitlab_repo.id).exists()
+
+    def test_not_found_when_no_repository_matches(self) -> None:
+        resolved = self._resolve(repo_name="getsentry/does-not-exist")
+
+        assert resolved.pull_request is None
+        assert resolved.repo_resolution == "not_found"
+        assert resolved.provider_recognized is True
+
+    def test_ambiguous_when_unknown_provider_matches_many(self) -> None:
+        self.create_repo(self.project, name="getsentry/sentry", provider="integrations:gitlab")
+
+        # Two same-named repos under different providers and no provider to disambiguate —
+        # refuse to guess rather than risk mis-resolution.
+        resolved = self._resolve(provider="unknown")
+
+        assert resolved.pull_request is None
+        assert resolved.repo_resolution == "ambiguous"
+        assert not PullRequest.objects.exists()
+
+    def test_resolves_unknown_provider_when_unambiguous(self) -> None:
+        resolved = self._resolve(provider="unknown")
+
+        assert resolved.pull_request is not None
+        assert resolved.provider_recognized is True
+
+    def test_flags_unrecognized_provider(self) -> None:
+        # An unmapped provider is surfaced via provider_recognized=False. Resolution still
+        # filters by it, so a repo stored under a recognized provider won't match.
+        resolved = self._resolve(provider="subversion")
+
+        assert resolved.provider_recognized is False
+        assert resolved.pull_request is None
+        assert resolved.repo_resolution == "not_found"
+
+    def test_unrecognized_provider_resolves_against_a_matching_repo(self) -> None:
+        svn_repo = self.create_repo(self.project, name="svn/project", provider="subversion")
+
+        resolved = self._resolve(repo_name="svn/project", provider="subversion")
+
+        # Still flagged, but resolution is attempted and succeeds when a repo actually
+        # carries that provider.
+        assert resolved.provider_recognized is False
+        assert resolved.pull_request is not None
+        assert resolved.pull_request.repository_id == svn_repo.id
+
+    def test_scopes_resolution_to_the_given_org(self) -> None:
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        other_repo = self.create_repo(
+            other_project, name="getsentry/sentry", provider="integrations:github"
+        )
+
+        resolved = PullRequest.objects.get_or_create_from_reference(
+            organization_id=other_org.id,
+            repo_name="getsentry/sentry",
+            provider="github",
+            key=42,
+        )
+
+        assert resolved.pull_request is not None
+        assert resolved.pull_request.repository_id == other_repo.id
+        assert not PullRequest.objects.filter(repository_id=self.repo.id).exists()
+
+
+class ParsePullRequestNumberTest(TestCase):
+    def test_extracts_number_from_supported_url_shapes(self) -> None:
+        # Each provider segment the regex recognizes must yield the trailing number.
+        cases = [
+            ("https://github.com/getsentry/sentry/pull/42", 42),
+            ("https://github.com/getsentry/sentry/pulls/7", 7),
+            ("https://gitlab.com/getsentry/sentry/merge_requests/13", 13),
+        ]
+        for url, expected in cases:
+            assert parse_pull_request_number(url) == expected
+
+    def test_returns_none_when_no_pr_segment(self) -> None:
+        # A branch/tree URL or a number-less path must not be mistaken for a PR.
+        cases = [
+            "https://github.com/getsentry/sentry/tree/123",
+            "https://github.com/getsentry/sentry/pulls",
+            "https://github.com/getsentry/sentry",
+        ]
+        for url in cases:
+            assert parse_pull_request_number(url) is None

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -455,7 +455,7 @@ class GetOrCreateFromReferenceTest(TestCase):
         resolved = self._resolve()
 
         assert resolved.repo_resolution == "resolved"
-        assert resolved.provider_recognized is True
+        assert resolved.provider_unmappable is False
         assert resolved.pull_request is not None
         assert resolved.pull_request.repository_id == self.repo.id
         assert resolved.pull_request.key == "42"
@@ -499,7 +499,7 @@ class GetOrCreateFromReferenceTest(TestCase):
 
         assert resolved.pull_request is None
         assert resolved.repo_resolution == "not_found"
-        assert resolved.provider_recognized is True
+        assert resolved.provider_unmappable is False
 
     def test_ambiguous_when_unknown_provider_matches_many(self) -> None:
         self.create_repo(self.project, name="getsentry/sentry", provider="integrations:gitlab")
@@ -516,25 +516,26 @@ class GetOrCreateFromReferenceTest(TestCase):
         resolved = self._resolve(provider="unknown")
 
         assert resolved.pull_request is not None
-        assert resolved.provider_recognized is True
+        # The "unknown" sentinel is treated as absent, not unmappable.
+        assert resolved.provider_unmappable is False
 
-    def test_flags_unrecognized_provider(self) -> None:
-        # An unmapped provider is surfaced via provider_recognized=False. Resolution still
+    def test_flags_unmappable_provider(self) -> None:
+        # An unmapped provider is surfaced via provider_unmappable=True. Resolution still
         # filters by it, so a repo stored under a recognized provider won't match.
         resolved = self._resolve(provider="subversion")
 
-        assert resolved.provider_recognized is False
+        assert resolved.provider_unmappable is True
         assert resolved.pull_request is None
         assert resolved.repo_resolution == "not_found"
 
-    def test_unrecognized_provider_resolves_against_a_matching_repo(self) -> None:
+    def test_unmappable_provider_resolves_against_a_matching_repo(self) -> None:
         svn_repo = self.create_repo(self.project, name="svn/project", provider="subversion")
 
         resolved = self._resolve(repo_name="svn/project", provider="subversion")
 
         # Still flagged, but resolution is attempted and succeeds when a repo actually
         # carries that provider.
-        assert resolved.provider_recognized is False
+        assert resolved.provider_unmappable is True
         assert resolved.pull_request is not None
         assert resolved.pull_request.repository_id == svn_repo.id
 

--- a/tests/sentry/models/test_repository.py
+++ b/tests/sentry/models/test_repository.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 from django.core import mail
 
-from sentry.constants import DEFAULT_CODE_REVIEW_TRIGGERS
+from sentry.constants import DEFAULT_CODE_REVIEW_TRIGGERS, ObjectStatus
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.repository import Repository
 from sentry.models.repositorysettings import RepositorySettings
@@ -267,3 +267,99 @@ class RepositoryCodeReviewSettingsTest(TestCase):
         # Verify the settings are correct
         settings = RepositorySettings.objects.get(repository=repo)
         assert settings.enabled_code_review is True
+
+
+class RepositoryManagerResolveActiveTest(TestCase):
+    def setUp(self) -> None:
+        self.repo = self.create_repo(
+            self.project, name="getsentry/sentry", provider="integrations:github"
+        )
+
+    def _resolve(
+        self, *, name: str = "getsentry/sentry", normalized_provider: str | None = "github"
+    ):
+        return Repository.objects.resolve_active(
+            organization_id=self.organization.id,
+            name=name,
+            normalized_provider=normalized_provider,
+        )
+
+    def test_resolves_single_active_match(self) -> None:
+        repo, reason = self._resolve()
+
+        assert reason == "resolved"
+        assert repo == self.repo
+
+    def test_matches_both_provider_shapes(self) -> None:
+        # Stored as ``integrations:github``; the bare ``github`` form must still match it.
+        repo, reason = self._resolve(normalized_provider="github")
+
+        assert reason == "resolved"
+        assert repo == self.repo
+
+    def test_resolves_without_provider_when_unambiguous(self) -> None:
+        repo, reason = self._resolve(normalized_provider=None)
+
+        assert reason == "resolved"
+        assert repo == self.repo
+
+    def test_not_found(self) -> None:
+        repo, reason = self._resolve(name="getsentry/missing")
+
+        assert repo is None
+        assert reason == "not_found"
+
+    def test_ambiguous_without_provider(self) -> None:
+        self.create_repo(self.project, name="getsentry/sentry", provider="integrations:gitlab")
+
+        repo, reason = self._resolve(normalized_provider=None)
+
+        assert repo is None
+        assert reason == "ambiguous"
+
+    def test_provider_disambiguates_same_name(self) -> None:
+        gitlab_repo = self.create_repo(
+            self.project, name="getsentry/sentry", provider="integrations:gitlab"
+        )
+
+        repo, reason = self._resolve(normalized_provider="gitlab")
+
+        assert reason == "resolved"
+        assert repo == gitlab_repo
+
+    def test_ignores_inactive_repositories(self) -> None:
+        self.repo.update(status=ObjectStatus.PENDING_DELETION)
+
+        repo, reason = self._resolve()
+
+        assert repo is None
+        assert reason == "not_found"
+
+    def test_scoped_to_organization(self) -> None:
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        self.create_repo(other_project, name="getsentry/sentry", provider="integrations:github")
+
+        repo, reason = Repository.objects.resolve_active(
+            organization_id=other_org.id, name="getsentry/sentry", normalized_provider="github"
+        )
+
+        assert reason == "resolved"
+        assert repo is not None
+        assert repo.organization_id == other_org.id
+
+
+class RepositoryManagerProviderMatchTest(TestCase):
+    def test_matches_bare_and_prefixed_only(self) -> None:
+        bare = self.create_repo(self.project, name="a/bare", provider="github")
+        prefixed = self.create_repo(self.project, name="a/prefixed", provider="integrations:github")
+        other = self.create_repo(self.project, name="a/other", provider="integrations:gitlab")
+
+        matched = set(
+            Repository.objects.filter(organization_id=self.organization.id).filter(
+                Repository.objects.provider_match("github")
+            )
+        )
+
+        assert matched == {bare, prefixed}
+        assert other not in matched

--- a/tests/sentry/pr_metrics/test_attribution.py
+++ b/tests/sentry/pr_metrics/test_attribution.py
@@ -9,7 +9,6 @@ from sentry.models.pullrequest import (
     PullRequestAttributionSource,
 )
 from sentry.pr_metrics.attribution import (
-    _parse_pr_number,
     attribute_delegated_agent_pull_request,
     attribute_seer_created_pull_requests,
     recompute_pull_request_attribution,
@@ -305,28 +304,6 @@ class AttributeDelegatedAgentPullRequestTest(TestCase):
         # Scoped to the given org's same-named repo — never this org's.
         assert not PullRequest.objects.filter(repository_id=self.repo.id).exists()
         assert PullRequest.objects.filter(repository_id=other_repo.id).exists()
-
-
-class ParsePrNumberTest(TestCase):
-    def test_extracts_number_from_supported_url_shapes(self) -> None:
-        # Each provider segment the regex recognizes must yield the trailing number.
-        cases = [
-            ("https://github.com/getsentry/sentry/pull/42", 42),
-            ("https://github.com/getsentry/sentry/pulls/7", 7),
-            ("https://gitlab.com/getsentry/sentry/merge_requests/13", 13),
-        ]
-        for url, expected in cases:
-            assert _parse_pr_number(url) == expected
-
-    def test_returns_none_when_no_pr_segment(self) -> None:
-        # A branch/tree URL or a number-less path must not be mistaken for a PR.
-        cases = [
-            "https://github.com/getsentry/sentry/tree/123",
-            "https://github.com/getsentry/sentry/pulls",
-            "https://github.com/getsentry/sentry",
-        ]
-        for url in cases:
-            assert _parse_pr_number(url) is None
 
 
 class RecordAttributionSignalTest(TestCase):


### PR DESCRIPTION
## Problem

Resolving an externally-reported PR — taking a `(repo_name, provider, PR number)` and finding the canonical `PullRequest` row for it — lived inside `pr_metrics/attribution.py`, welded to the attribution write in `_attribute_pull_request`.

That logic isn't attribution-specific (or even Seer-specific): it's general PR-domain reconciliation over `PullRequest`/`Repository`, and more than one path needs it — Seer-created attribution, delegated-agent attribution, and (soon) linking a Seer run to the PRs it opened. Leaving it in the attribution module overloads that module's purpose and forces unrelated callers to depend on `pr_metrics` for plain resolution.

## Change

Move the resolution primitives onto the model layer, where every PR-reporting path can reach them without cross-domain coupling:

- `Repository.objects.resolve_active(organization_id, name, normalized_provider)` resolves the org-scoped active `Repository` for a reported PR — matching both bare and `integrations:`-prefixed providers via `provider_match`, and refusing to guess when ambiguous. The repository-matching half is a `Repository` concern, so it lives on `RepositoryManager`; the `integrations:` storage convention now has a single home.
- `PullRequest.objects.get_or_create_from_reference(organization_id, repo_name, provider, key)` calls `resolve_active`, layers on the reporting-specific policy (provider normalization, the `unknown` sentinel, `_KNOWN_SCM_PROVIDERS`), and find-or-creates the canonical `PullRequest`. It returns a structured `ResolvedPullRequest(pull_request, repo_resolution, provider_unmappable)` and does **not** log or swallow errors — callers own observability.
- `parse_pull_request_number(url)` and provider normalization move alongside it.

`pr_metrics/attribution.py` now adds only the attribution write on top of the shared resolver. The `pr_metrics.attribution.*` log keys are unchanged and success-path behavior is identical. One intentional error-path difference: a DB error during repo resolution is now swallowed and logged as `record_failed` rather than propagating, so a single bad entry no longer aborts the rest of a batch — matching the module's documented "remaining PRs are unaffected" contract.

## Why it matters

Every path that learns of a PR by repo name + provider now converges on one resolver, so a link and an attribution for the same reported PR always reference the same row — instead of each path re-implementing resolution and risking divergence.

This is a standalone, behavior-preserving refactor. It also lays the groundwork for #118212 (linking Seer runs to the PRs they open): that PR can call `get_or_create_from_reference` from its own Seer-payload wrapper rather than expanding `attribution.py`.

## Tests

- New `PullRequestManager.get_or_create_from_reference` coverage in `tests/sentry/models/test_pullrequest.py` (resolution, provider disambiguation, ambiguity, not-found, org scoping, idempotent no-overwrite find-or-create, key coercion).
- New `RepositoryManager.resolve_active` / `provider_match` coverage in `tests/sentry/models/test_repository.py` (single match, both provider shapes, no-provider, not-found, ambiguity, disambiguation, inactive-ignored, org scoping).
- `parse_pull_request_number` tests moved with the function.
- Existing `pr_metrics` attribution tests pass unchanged.


