### PR TITLE
fix(cmd-k): Make settings field helpText searchable in command palette

### DIFF
--- a/static/app/views/settings/settingsCommandPaletteActions.tsx
+++ b/static/app/views/settings/settingsCommandPaletteActions.tsx
@@ -64,7 +64,7 @@ function isSettingsRoute(route: string): boolean {
 }
 
 type SettingsFieldEntry = {
-  display: {label: string};
+  display: {label: string; details?: string};
   key: string;
   keywords: string[];
   to: {hash: string; pathname: string};
@@ -119,17 +119,23 @@ function getSettingsFieldSections(orgSlug: string): SettingsFieldSection[] {
             (f): f is FormSearchField & {title: string} =>
               typeof f.title === 'string' && f.title.length > 0
           )
-          .map(f => ({
-            key: `${route}#${f.field.name}`,
-            display: {
-              label: f.title,
-            },
-            keywords: ['settings', title, f.field.name],
-            to: {
-              pathname: resolvedPath,
-              hash: `#${encodeURIComponent(f.field.name)}`,
-            },
-          }))
+          .map(f => {
+            const helpText =
+              typeof f.description === 'string' ? f.description : undefined;
+
+            return {
+              key: `${route}#${f.field.name}`,
+              display: {
+                label: f.title,
+                details: helpText,
+              },
+              keywords: ['settings', title, f.field.name],
+              to: {
+                pathname: resolvedPath,
+                hash: `#${encodeURIComponent(f.field.name)}`,
+              },
+            };
+          })
           .sort((a, b) => a.display.label.localeCompare(b.display.label)),
       };
     })


### PR DESCRIPTION
Settings search moved into cmd-k but lost the ability to match on a field's helpText. Searching for a field label like "User ID" surfaced a pointer to *Account Details → User ID*, but searching for the helpText "The unique identifier" matched nothing. This restores that and renders the hint in the result.

**Root cause**

Each settings field was registered with only a label and `['settings', title, fieldName]` as keywords, dropping the `FormSearchField` `description` (the field's `help`/`hintText`, still present in the generated field registry).

**Fix**

The cmd-k scorer matches against `[label, details, ...keywords]` and the renderer displays `display.details`. Threading the field description into `display.details` makes the helpText both searchable and visible as the muted detail line under each result — fixing both halves in one change.

before:

<img width="662" height="232" alt="Screenshot 2026-06-26 at 14 02 07" src="https://github.com/user-attachments/assets/d3c650df-1226-49a6-a1a6-70bef3cc5acf" />

after:

<img width="654" height="360" alt="Screenshot 2026-06-26 at 14 02 17" src="https://github.com/user-attachments/assets/6f926e9c-f73b-4480-8dc0-b9cdc2f3ac0a" />
