### PR TITLE
feat(autofix): add Alpha badge to PR iteration feedback form

### DIFF
--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
@@ -1,5 +1,6 @@
 import {useRef, useState} from 'react';
 
+import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {InputGroup} from '@sentry/scraps/input';
 import {Flex} from '@sentry/scraps/layout';
@@ -68,7 +69,10 @@ export function PrIterationFeedbackForm({
 
   return (
     <Flex direction="column" gap="lg">
-      <Text>{prompt}</Text>
+      <Flex gap="xs" align="center">
+        <Text>{prompt}</Text>
+        <FeatureBadge type="alpha" />
+      </Flex>
       <InputGroup>
         <InputGroup.TextArea
           autosize

--- a/static/app/components/events/autofix/v3/pullRequestsCard.tsx
+++ b/static/app/components/events/autofix/v3/pullRequestsCard.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 
+import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
@@ -17,6 +18,7 @@ import {IconPullRequest} from 'sentry/icons/iconPullRequest';
 import {IconRefresh} from 'sentry/icons/iconRefresh';
 import {t} from 'sentry/locale';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface PullRequestsCardProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
@@ -24,6 +26,8 @@ interface PullRequestsCardProps {
 }
 
 export function PullRequestsCard({autofix, section}: PullRequestsCardProps) {
+  const organization = useOrganization();
+  const hasPrIterationFeature = organization.features.includes('autofix-pr-iteration');
   const runId = autofix.runState?.run_id;
   const {createPR} = autofix;
   const artifact = useMemo(() => {
@@ -43,7 +47,16 @@ export function PullRequestsCard({autofix, section}: PullRequestsCardProps) {
   return (
     <ArtifactCard
       icon={<IconPullRequest />}
-      title={t('Pull Requests')}
+      title={
+        hasPrIterationFeature ? (
+          <Flex gap="xs" align="center">
+            {t('Pull Requests')}
+            <FeatureBadge type="alpha" />
+          </Flex>
+        ) : (
+          t('Pull Requests')
+        )
+      }
       onCopy={
         markdown
           ? () => copy(markdown, {successMessage: t('Copied to clipboard.')})

--- a/static/app/components/events/autofix/v3/pullRequestsCard.tsx
+++ b/static/app/components/events/autofix/v3/pullRequestsCard.tsx
@@ -1,6 +1,5 @@
 import {useMemo} from 'react';
 
-import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
@@ -18,7 +17,6 @@ import {IconPullRequest} from 'sentry/icons/iconPullRequest';
 import {IconRefresh} from 'sentry/icons/iconRefresh';
 import {t} from 'sentry/locale';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
-import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface PullRequestsCardProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
@@ -26,8 +24,6 @@ interface PullRequestsCardProps {
 }
 
 export function PullRequestsCard({autofix, section}: PullRequestsCardProps) {
-  const organization = useOrganization();
-  const hasPrIterationFeature = organization.features.includes('autofix-pr-iteration');
   const runId = autofix.runState?.run_id;
   const {createPR} = autofix;
   const artifact = useMemo(() => {
@@ -47,16 +43,7 @@ export function PullRequestsCard({autofix, section}: PullRequestsCardProps) {
   return (
     <ArtifactCard
       icon={<IconPullRequest />}
-      title={
-        hasPrIterationFeature ? (
-          <Flex gap="xs" align="center">
-            {t('Pull Requests')}
-            <FeatureBadge type="alpha" />
-          </Flex>
-        ) : (
-          t('Pull Requests')
-        )
-      }
+      title={t('Pull Requests')}
       onCopy={
         markdown
           ? () => copy(markdown, {successMessage: t('Copied to clipboard.')})


### PR DESCRIPTION
## What

Adds a `FeatureBadge type="alpha"` inline next to the prompt in `PrIterationFeedbackForm` — the component that only renders when the `autofix-pr-iteration` flag is on.

## Where

- **`PrIterationFeedbackForm`** — badge appears next to "Anything else you want to see on your PR?". Since this component is only rendered when `isRunValidForPrIteration` returns true, the badge is inherently scoped to flag holders. It covers both render sites: the next-step view after PR creation, and the inline code-changes reset flow.

## Why

Feedback from an internal user made clear the feature's alpha status wasn't obvious. The `FeatureBadge` follows the same pattern already used in `autofixAgent.tsx` (Night Shift) and shows a tooltip: "This feature is internal and available for QA purposes".

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0B3BC328DU%3A1782476746.903839%22)