### PR TITLE
feat(dynamic-sampling): Floor transaction sample rate to bound extrapolation

### DIFF
--- a/src/sentry/dynamic_sampling/models/full_rebalancing.py
+++ b/src/sentry/dynamic_sampling/models/full_rebalancing.py
@@ -10,11 +10,13 @@ class FullRebalancingInput(ModelInput):
     sample_rate: float
     intensity: float
     min_budget: float | None = None
+    min_sample_rate: float = 0.0
 
     def validate(self) -> bool:
         return (
             0.0 <= self.sample_rate <= 1.0
             and 0.0 <= self.intensity <= 1.0
+            and 0.0 <= self.min_sample_rate <= 1.0
             and len(self.classes) > 0
         )
 
@@ -31,6 +33,9 @@ class FullRebalancingModel(Model[FullRebalancingInput, tuple[list[RebalancedItem
         necessary :param model_input.intensity: How close to the ideal should we go from our current position (0=do
         not change, 1 go to ideal) :param model_input.min_budget: Ensure that we use at least min_budget (in order to
         keep the overall rate)
+        :param model_input.min_sample_rate: Absolute floor applied to every class's resulting rate. Bounds the
+        extrapolation factor (1 / rate) so high-volume classes can't be pushed to a near-zero rate when many classes
+        compete for the budget. The caller is responsible for keeping this at or below the overall sample rate.
 
         :return: A mapping with the frequency for all items + the amount of items used (it should allways be at least
         minimum_consumption if passed).
@@ -39,6 +44,7 @@ class FullRebalancingModel(Model[FullRebalancingInput, tuple[list[RebalancedItem
         sample_rate = model_input.sample_rate
         intensity = model_input.intensity
         min_budget = model_input.min_budget
+        min_sample_rate = model_input.min_sample_rate
 
         total = sum_classes_counts(classes)
         num_classes = len(classes)
@@ -64,6 +70,10 @@ class FullRebalancingModel(Model[FullRebalancingInput, tuple[list[RebalancedItem
             delta = ideal - sampled
             correction = delta * intensity
             desired_count = sampled + correction
+
+            # floor the rate so the extrapolation factor stays bounded; reclaiming the extra
+            # budget is left to the caller (it lowers the implicit/tail rate accordingly)
+            desired_count = max(desired_count, count * min_sample_rate)
 
             if desired_count > count:
                 # we need more than we have, the best we can do is give all, i.e. rate = 1.0

--- a/src/sentry/dynamic_sampling/models/transactions_rebalancing.py
+++ b/src/sentry/dynamic_sampling/models/transactions_rebalancing.py
@@ -15,11 +15,13 @@ class TransactionsRebalancingInput(ModelInput):
     total_num_classes: int | None
     total: float | None
     intensity: float
+    min_sample_rate: float = 0.0
 
     def validate(self) -> bool:
         return (
             0.0 <= self.sample_rate <= 1.0
             and 0.0 <= self.intensity <= 1.0
+            and 0.0 <= self.min_sample_rate <= 1.0
             and len(self.classes) > 0
         )
 
@@ -40,6 +42,12 @@ class TransactionsRebalancingModel(
         :param model_input.total_num_classes: total number of classes (including the explicitly specified in classes)
         :param model_input.intensity: the adjustment strength 0: no adjustment, 1: try to bring everything to mean
         :param model_input.total: total number of samples in all classes (including the explicitly specified classes)
+        :param model_input.min_sample_rate: lower bound applied to every explicit class rate. With many low-volume
+            classes the per-class ideal collapses to a near-zero rate, which sends the highest-volume classes to a
+            huge extrapolation factor (1 / rate) and makes their extrapolated volume spiky. Flooring the explicit
+            rates caps that factor at 1 / min_sample_rate; the budget this costs is reclaimed by lowering the
+            implicit (tail) rate. The floor is clamped to the overall sample rate so it never samples a class above
+            the project rate.
 
         :return: a list of items with calculated sample_rates and a rate for all other (unspecified) classes.
         """
@@ -48,6 +56,9 @@ class TransactionsRebalancingModel(
         total_num_classes = model_input.total_num_classes
         total = model_input.total
         intensity = model_input.intensity
+        # never floor a class above the project's overall rate (keeps very low-rate projects sane and
+        # bounds how much budget the floor can reclaim from the tail)
+        min_sample_rate = min(model_input.min_sample_rate, sample_rate)
 
         classes = sorted(classes, key=lambda x: (x.count, x.id), reverse=True)
 
@@ -81,7 +92,12 @@ class TransactionsRebalancingModel(
         if num_explicit_classes == total_num_classes:
             # we have specified all classes
             explicit_rates, _used = full_rebalancing.run(
-                FullRebalancingInput(classes=classes, sample_rate=sample_rate, intensity=intensity)
+                FullRebalancingInput(
+                    classes=classes,
+                    sample_rate=sample_rate,
+                    intensity=intensity,
+                    min_sample_rate=min_sample_rate,
+                )
             )
             implicit_rate = sample_rate  # doesn't really matter since everything is explicit
         elif total_implicit < implicit_budget:
@@ -97,7 +113,10 @@ class TransactionsRebalancingModel(
             explicit_rate = explicit_budget / total_explicit
             explicit_rates, _used = full_rebalancing.run(
                 FullRebalancingInput(
-                    classes=classes, sample_rate=explicit_rate, intensity=intensity
+                    classes=classes,
+                    sample_rate=explicit_rate,
+                    intensity=intensity,
+                    min_sample_rate=min_sample_rate,
                 )
             )
         elif total_explicit < explicit_budget:
@@ -130,10 +149,13 @@ class TransactionsRebalancingModel(
                     sample_rate=explicit_rate,
                     intensity=intensity,
                     min_budget=minimum_explicit_budget,
+                    min_sample_rate=min_sample_rate,
                 )
             )
-            # recalculate implicit_budget based on used
-            implicit_budget = total_budget - used
+            # recalculate implicit_budget based on used. Flooring the explicit rates can push `used`
+            # above what the un-floored split spent, so reclaim the difference from the implicit tail.
+            # If the floor consumes the whole budget there is nothing left for the tail (max(0, ...)).
+            implicit_budget = max(0.0, total_budget - used)
             implicit_rate = implicit_budget / total_implicit
 
         return explicit_rates, implicit_rate

--- a/src/sentry/dynamic_sampling/models/transactions_rebalancing.py
+++ b/src/sentry/dynamic_sampling/models/transactions_rebalancing.py
@@ -154,8 +154,13 @@ class TransactionsRebalancingModel(
             )
             # recalculate implicit_budget based on used. Flooring the explicit rates can push `used`
             # above what the un-floored split spent, so reclaim the difference from the implicit tail.
-            # If the floor consumes the whole budget there is nothing left for the tail (max(0, ...)).
-            implicit_budget = max(0.0, total_budget - used)
+            # The tail's extrapolation factor must stay bounded too, so it gets the same floor
+            # (a 0.0 rate would also be rewritten to 1.0 by the relay bias). This can overshoot the
+            # overall budget; accepted for now. Guarded so min_sample_rate == 0.0 stays bit-identical
+            # to the un-floored model.
+            implicit_budget = total_budget - used
+            if min_sample_rate > 0.0:
+                implicit_budget = max(implicit_budget, min_sample_rate * total_implicit)
             implicit_rate = implicit_budget / total_implicit
 
         return explicit_rates, implicit_rate

--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, cast
 import orjson
 import sentry_sdk
 
+from sentry import options
 from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.models.full_rebalancing import (
     FullRebalancingInput,
@@ -312,6 +313,7 @@ def run_transaction_balancing(
     transaction_volumes: list[ProjectTransactionCounts],
 ) -> dict[int, tuple[list[RebalancedItem], float]]:
     sample_rates = config.get_project_sample_rates()
+    min_sample_rate = options.get("dynamic-sampling.prioritise_transactions.min_sample_rate")
     result: dict[int, tuple[list[RebalancedItem], float]] = {}
     project_volume_by_id = {
         project_volume.project_id: project_volume for project_volume in project_volumes
@@ -342,6 +344,7 @@ def run_transaction_balancing(
                 total_num_classes=project_volume.num_distinct_transactions,
                 total=project_volume.total,
                 intensity=REBALANCE_INTENSITY,
+                min_sample_rate=min_sample_rate,
             )
         )
 
@@ -351,6 +354,7 @@ def run_transaction_balancing(
                 implicit_sample_rate=implicit_rate,
                 floor_sample_rate=sample_rate,
                 total_volume=project_volume.total,
+                min_sample_rate=min_sample_rate,
             )
 
         result[project_id] = (named_rates, implicit_rate)
@@ -362,6 +366,7 @@ def _apply_implicit_sample_rate_floor(
     implicit_sample_rate: float,
     floor_sample_rate: float,
     total_volume: int,
+    min_sample_rate: float = 0.0,
 ) -> tuple[list[RebalancedItem], float]:
     total_explicit_volume = sum(item.count for item in named_rates)
     total_implicit_volume = total_volume - total_explicit_volume
@@ -381,6 +386,9 @@ def _apply_implicit_sample_rate_floor(
             classes=[RebalancedItem(id=item.id, count=item.count) for item in named_rates],
             sample_rate=new_explicit_sample_rate,
             intensity=REBALANCE_INTENSITY,
+            # keep the head floor here too, so reclaiming budget for the implicit tail can't push the
+            # explicit rates back below the floor. Clamp to the floor rate (the overall rate here).
+            min_sample_rate=min(min_sample_rate, floor_sample_rate),
         )
     )
     return new_rates, floor_sample_rate

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -247,6 +247,7 @@ def boost_low_volume_transactions_of_project(project_transactions: ProjectTransa
         return
 
     intensity = options.get("dynamic-sampling.prioritise_transactions.rebalance_intensity", 1.0)
+    min_sample_rate = options.get("dynamic-sampling.prioritise_transactions.min_sample_rate")
 
     model = TransactionsRebalancingModel()
     rebalanced_transactions = guarded_run(
@@ -257,6 +258,7 @@ def boost_low_volume_transactions_of_project(project_transactions: ProjectTransa
             total_num_classes=total_num_classes,
             total=total_num_transactions,
             intensity=intensity,
+            min_sample_rate=min_sample_rate,
         ),
     )
     # In case the result of the model is None, it means that an error occurred, thus we want to early return.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2049,6 +2049,18 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Lower bound on the per-transaction sample rate produced by transaction rebalancing. When a project
+# has many low-volume transaction classes, the per-class ideal collapses to a near-zero rate and the
+# highest-volume transactions are pushed to a huge extrapolation factor (1 / rate), making their
+# extrapolated volume spiky and the sampling distribution non-ergodic. Flooring the explicit rates at
+# this value caps that factor at 1 / min_sample_rate and reclaims the cost from the implicit (tail)
+# rate. The floor is clamped to the project's overall rate, so it never raises a class above it.
+# 0.0 disables the floor (default), preserving the previous behaviour until rolled out via automator.
+register(
+    "dynamic-sampling.prioritise_transactions.min_sample_rate",
+    default=0.0,
+    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Stops dynamic sampling rules from being emitted in relay config.
 # This is required for ST instances that have flakey flags as we want to be able kill DS ruining customer data if necessary.

--- a/tests/sentry/dynamic_sampling/models/test_transactions_rebalancing.py
+++ b/tests/sentry/dynamic_sampling/models/test_transactions_rebalancing.py
@@ -284,11 +284,22 @@ def test_min_sample_rate_clamped_to_overall_rate(transactions_rebalancing_model)
 def test_min_sample_rate_inert_when_rates_healthy(transactions_rebalancing_model) -> None:
     """When the natural rates already sit above the floor, enabling it changes nothing."""
     classes = [RebalancedItem(id=f"big{i}", count=1000) for i in range(3)]
-    kwargs = dict(classes=classes, sample_rate=0.5, total_num_classes=20, total=10_000)
 
-    base_rates, base_implicit = _run(transactions_rebalancing_model, **kwargs, min_sample_rate=0.0)
+    base_rates, base_implicit = _run(
+        transactions_rebalancing_model,
+        classes=classes,
+        sample_rate=0.5,
+        total_num_classes=20,
+        total=10_000,
+        min_sample_rate=0.0,
+    )
     floored_rates, floored_implicit = _run(
-        transactions_rebalancing_model, **kwargs, min_sample_rate=1e-6
+        transactions_rebalancing_model,
+        classes=classes,
+        sample_rate=0.5,
+        total_num_classes=20,
+        total=10_000,
+        min_sample_rate=1e-6,
     )
 
     assert {item.id: item.new_sample_rate for item in floored_rates} == {

--- a/tests/sentry/dynamic_sampling/models/test_transactions_rebalancing.py
+++ b/tests/sentry/dynamic_sampling/models/test_transactions_rebalancing.py
@@ -1,7 +1,8 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 
 import pytest
 
+from sentry.dynamic_sampling.models.base import InvalidModelInputError
 from sentry.dynamic_sampling.models.common import RebalancedItem, sum_classes_counts
 from sentry.dynamic_sampling.models.transactions_rebalancing import (
     TransactionsRebalancingInput,
@@ -129,6 +130,183 @@ def test_explicit_elements_ideal_rate(
                 actual_rate * count == pytest.approx(ideal_number_of_elements_per_class)
                 or actual_rate * count >= ideal_number_of_elements_per_class
             )
+
+
+def _run(
+    model: TransactionsRebalancingModel,
+    *,
+    classes: list[RebalancedItem],
+    sample_rate: float,
+    total_num_classes: int,
+    total: float,
+    intensity: float = 1.0,
+    min_sample_rate: float = 0.0,
+) -> tuple[list[RebalancedItem], float]:
+    return model.run(
+        TransactionsRebalancingInput(
+            classes=classes,
+            sample_rate=sample_rate,
+            total_num_classes=total_num_classes,
+            total=total,
+            intensity=intensity,
+            min_sample_rate=min_sample_rate,
+        )
+    )
+
+
+def _overall_kept(
+    explicit_rates: Sequence[RebalancedItem], implicit_rate: float, total: float
+) -> float:
+    """Expected number of kept samples across explicit classes and the implicit (tail) classes."""
+    explicit_kept = sum(item.new_sample_rate * item.count for item in explicit_rates)
+    total_implicit = total - sum_classes_counts(list(explicit_rates))
+    return explicit_kept + implicit_rate * total_implicit
+
+
+def test_high_class_count_crushes_dominant_transaction_without_floor(
+    transactions_rebalancing_model,
+) -> None:
+    """
+    Reproduces TET-2535: one transaction carrying half the project volume while competing against a
+    very large number of low-volume classes. With no floor the per-class ideal collapses, the
+    dominant transaction is driven to a ~1e-6 rate (a ~1,000,000x extrapolation factor) and is
+    expected to keep only ~1 raw sample - the spiky "lottery" behaviour we want to remove.
+    """
+    big = RebalancedItem(id="big", count=1_000_000)
+
+    explicit_rates, implicit_rate = _run(
+        transactions_rebalancing_model,
+        classes=[big],
+        sample_rate=0.05,
+        total_num_classes=100_000,
+        total=2_000_000,
+        min_sample_rate=0.0,
+    )
+
+    (big_rate,) = explicit_rates
+    assert big_rate.new_sample_rate == pytest.approx(1e-6)
+    # the dominant transaction expects to keep ~1 raw sample, yet the tail is sampled ~100,000x denser
+    assert big_rate.new_sample_rate * big_rate.count == pytest.approx(1.0)
+    assert implicit_rate == pytest.approx(0.099999)
+    assert implicit_rate / big_rate.new_sample_rate == pytest.approx(99999.0)
+
+
+def test_min_sample_rate_floors_dominant_transaction(transactions_rebalancing_model) -> None:
+    """
+    Same scenario as above, but with the floor enabled: the dominant transaction's rate is floored
+    so its extrapolation factor is capped at 1 / min_sample_rate, the cost is reclaimed from the
+    implicit tail, and the overall sampling rate is still maintained exactly.
+    """
+    big = RebalancedItem(id="big", count=1_000_000)
+
+    explicit_rates, implicit_rate = _run(
+        transactions_rebalancing_model,
+        classes=[big],
+        sample_rate=0.05,
+        total_num_classes=100_000,
+        total=2_000_000,
+        min_sample_rate=0.001,
+    )
+
+    (big_rate,) = explicit_rates
+    # rate floored to 0.001 => extrapolation factor capped at 1000 (was 1,000,000)
+    assert big_rate.new_sample_rate == pytest.approx(0.001)
+    # expected kept samples jump from ~1 to ~1000, killing the shot noise
+    assert big_rate.new_sample_rate * big_rate.count == pytest.approx(1000.0)
+    # the budget is reclaimed by lowering the tail rate, not by exceeding the overall budget
+    assert implicit_rate == pytest.approx(0.099)
+    assert _overall_kept(explicit_rates, implicit_rate, total=2_000_000) == pytest.approx(
+        0.05 * 2_000_000
+    )
+
+
+def test_min_sample_rate_with_many_explicit_transactions(transactions_rebalancing_model) -> None:
+    """
+    Production-shaped case: 30 high-volume explicit transactions (60% of volume) competing with a
+    ~50k-class tail. Without the floor every head transaction collapses to a 5e-5 rate (20,000x
+    factor); with the floor they are lifted to the floor and the tail rate barely moves.
+    """
+    classes = [RebalancedItem(id=f"big{i}", count=20_000) for i in range(30)]
+
+    no_floor_rates, no_floor_implicit = _run(
+        transactions_rebalancing_model,
+        classes=classes,
+        sample_rate=0.05,
+        total_num_classes=50_000,
+        total=1_000_000,
+        min_sample_rate=0.0,
+    )
+    assert all(item.new_sample_rate == pytest.approx(5e-5) for item in no_floor_rates)
+
+    floored_rates, floored_implicit = _run(
+        transactions_rebalancing_model,
+        classes=classes,
+        sample_rate=0.05,
+        total_num_classes=50_000,
+        total=1_000_000,
+        min_sample_rate=0.001,
+    )
+
+    assert all(item.new_sample_rate == pytest.approx(0.001) for item in floored_rates)
+    # reclaimed from the tail; the implicit rate drops but stays well above zero
+    assert floored_implicit < no_floor_implicit
+    assert floored_implicit == pytest.approx(0.1235)
+    assert _overall_kept(floored_rates, floored_implicit, total=1_000_000) == pytest.approx(
+        0.05 * 1_000_000
+    )
+
+
+def test_min_sample_rate_clamped_to_overall_rate(transactions_rebalancing_model) -> None:
+    """
+    For a project whose overall rate is already below the configured floor, the floor is clamped to
+    the overall rate, so a class is never sampled above the project rate and the budget cannot be
+    overshot.
+    """
+    big = RebalancedItem(id="big", count=1_000_000)
+
+    explicit_rates, implicit_rate = _run(
+        transactions_rebalancing_model,
+        classes=[big],
+        sample_rate=0.0005,
+        total_num_classes=100_000,
+        total=2_000_000,
+        min_sample_rate=0.001,
+    )
+
+    (big_rate,) = explicit_rates
+    assert big_rate.new_sample_rate == pytest.approx(0.0005)
+    assert big_rate.new_sample_rate <= 0.0005
+    assert _overall_kept(explicit_rates, implicit_rate, total=2_000_000) == pytest.approx(
+        0.0005 * 2_000_000
+    )
+
+
+def test_min_sample_rate_inert_when_rates_healthy(transactions_rebalancing_model) -> None:
+    """When the natural rates already sit above the floor, enabling it changes nothing."""
+    classes = [RebalancedItem(id=f"big{i}", count=1000) for i in range(3)]
+    kwargs = dict(classes=classes, sample_rate=0.5, total_num_classes=20, total=10_000)
+
+    base_rates, base_implicit = _run(transactions_rebalancing_model, **kwargs, min_sample_rate=0.0)
+    floored_rates, floored_implicit = _run(
+        transactions_rebalancing_model, **kwargs, min_sample_rate=1e-6
+    )
+
+    assert {item.id: item.new_sample_rate for item in floored_rates} == {
+        item.id: item.new_sample_rate for item in base_rates
+    }
+    assert floored_implicit == pytest.approx(base_implicit)
+
+
+def test_min_sample_rate_out_of_range_is_invalid(transactions_rebalancing_model) -> None:
+    with pytest.raises(InvalidModelInputError):
+        _run(
+            transactions_rebalancing_model,
+            classes=[RebalancedItem(id="big", count=1000)],
+            sample_rate=0.5,
+            total_num_classes=10,
+            total=10_000,
+            min_sample_rate=1.5,
+        )
 
 
 def test_total_num_classes_mismatch(transactions_rebalancing_model) -> None:

--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -424,6 +424,51 @@ class TransactionBalancingCalculationsTest(TestCase):
         assert model_run.call_count == 1
         assert set(result.keys()) == {project_a.id}
 
+    def test_run_transaction_balancing_passes_min_sample_rate_option(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        config = Mock()
+        config.organization = org
+        config.get_project_sample_rates.return_value = {project.id: 0.5}
+
+        with override_options({"dynamic-sampling.prioritise_transactions.min_sample_rate": 0.002}):
+            with patch(
+                "sentry.dynamic_sampling.per_org.calculations.TransactionsRebalancingModel.run",
+                side_effect=lambda model_input: ([], model_input.sample_rate),
+            ) as model_run:
+                run_transaction_balancing(
+                    config,
+                    [_project_volume(project.id)],
+                    [_project_transactions(org.id, project.id, [("/a", 1.0)])],
+                )
+
+        assert model_run.call_args.args[-1].min_sample_rate == 0.002
+
+    def test_run_transaction_balancing_floors_dominant_transaction(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        config = Mock()
+        config.organization = org
+        config.get_project_sample_rates.return_value = {project.id: 0.05}
+
+        project_volume = ProjectVolume(
+            project_id=project.id,
+            total=2_000_000,
+            keep=100_000,
+            drop=1_900_000,
+            num_distinct_transactions=100_000,
+        )
+        project_transactions = _project_transactions(org.id, project.id, [("/big", 1_000_000.0)])
+
+        with override_options({"dynamic-sampling.prioritise_transactions.min_sample_rate": 0.001}):
+            result = run_transaction_balancing(config, [project_volume], [project_transactions])
+
+        named_rates, implicit_rate = result[project.id]
+        (big_rate,) = named_rates
+        # without the floor this rate collapses to 1e-6 (a 1,000,000x extrapolation factor)
+        assert big_rate.new_sample_rate == pytest.approx(0.001)
+        assert implicit_rate == pytest.approx(0.099)
+
     def test_get_cached_rebalanced_transaction_sample_rates(self) -> None:
         org = self.create_organization()
         project_hit = self.create_project(organization=org)


### PR DESCRIPTION
- With many low-volume transaction classes, the rebalancing model's per-class ideal (`total · rate / N`) collapses toward zero. Because the highest-volume transactions have the largest counts, they get the *smallest* rate — their extrapolation factor (`1 / rate`) grows with the number of classes.
- The biggest transactions (the majority of real traffic) end up sampled most sparsely, with expected kept counts near 1 → shot-noise in extrapolated EAP volume
- Add an optional per-class sample-rate floor. Flooring the explicit (head) rates caps the extrapolation factor at `1 / min_sample_rate` and reclaims the cost by lowering the implicit (tail) rate, so the overall sampling rate is preserved
- The floor is clamped to the project's overall rate, so a class is never sampled above it (graceful for very-low-rate projects).
- New tests reproduce the bug (one transaction = 50% of volume vs. ~100k small classes → head rate `1e-6`, a 1,000,000× factor) and verify the fix (floored to `0.001` → 1,000× factor, ~1000 expected kept, overall rate maintained)

Contributes to TET-2535
