### PR TITLE
feat(seer-explorer): Dock auto sidebar right in landscape mobile

### DIFF
--- a/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.spec.tsx
+++ b/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.spec.tsx
@@ -46,10 +46,11 @@ const defaultHookReturn: ReturnType<typeof useSeerExplorerModule.useSeerExplorer
 // Non-zero size so the SplitPanel isn't gated out (jsdom reports 0×0).
 const CONTAINER_SIZE = {width: 1200, height: 800};
 
-// Orientation is driven by a media query (the `xl` breakpoint).
-function mockWideScreen(matches: boolean) {
+// Drive matchMedia per-query so the wide-screen and short-landscape checks can
+// resolve independently.
+function mockMatchMedia(matches: (query: string) => boolean) {
   window.matchMedia = jest.fn().mockImplementation((query: string) => ({
-    matches,
+    matches: matches(query),
     media: query,
     onchange: null,
     addListener: jest.fn(),
@@ -58,6 +59,12 @@ function mockWideScreen(matches: boolean) {
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
   }));
+}
+
+// Orientation is driven by media queries (the `xl` width breakpoint and a
+// short-landscape check); match every query uniformly.
+function mockWideScreen(matches: boolean) {
+  mockMatchMedia(() => matches);
 }
 
 function OpenSeerControl({options}: {options?: OpenSeerExplorerDrawerOptions}) {
@@ -201,6 +208,18 @@ describe('SeerExplorerSidebarLayout', () => {
 
   it('docks Seer to the right on a wide viewport (auto)', async () => {
     mockWideScreen(true);
+    renderSidebar(orgWithSidebar);
+
+    await userEvent.click(screen.getByText('open-seer'));
+
+    expect(await screen.findByTestId('seer-explorer-input')).toBeInTheDocument();
+    expect(splitOrientation()).toBe('horizontal');
+  });
+
+  it('docks Seer to the right on a short landscape viewport (auto)', async () => {
+    // Not wide (min-width: xl is false), but landscape and short — e.g. a phone
+    // held sideways, where a bottom dock has no room. Auto docks right instead.
+    mockMatchMedia(query => query.includes('orientation: landscape'));
     renderSidebar(orgWithSidebar);
 
     await userEvent.click(screen.getByText('open-seer'));

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -1173,17 +1173,20 @@ type SeerExplorerSidebarOrientation = 'right' | 'bottom';
 
 /**
  * Resolves the dock preference to a concrete orientation. `auto` docks right on
- * wide viewports (≥ `xl`) and bottom otherwise. Shared by the layout (to lay
- * out the split) and the provider (to persist the popped-out window's size to
- * the right key).
+ * wide viewports (≥ `xl`) and on short landscape viewports (e.g. phones in
+ * landscape), and bottom otherwise. Shared by the layout (to lay out the split)
+ * and the provider (to persist the popped-out window's size to the right key).
  */
 export function useSeerExplorerSidebarOrientation(
   sidebarPosition: SeerExplorerSidebarPosition
 ): SeerExplorerSidebarOrientation {
   const theme = useTheme();
   const isWideScreen = useMedia(`(min-width: ${theme.breakpoints.xl})`);
+  const isShortLandscape = useMedia(
+    `(orientation: landscape) and (max-height: ${theme.breakpoints.xs})`
+  );
   if (sidebarPosition === 'auto') {
-    return isWideScreen ? 'right' : 'bottom';
+    return isWideScreen || isShortLandscape ? 'right' : 'bottom';
   }
   return sidebarPosition;
 }


### PR DESCRIPTION
## Summary

In `auto` mode, Seer Explorer's persistent sidebar docked to the **bottom** on any viewport below the `xl` breakpoint. On a **landscape phone** the viewport is too short to fit the app-content and Seer height minimums (`MIN_CONTENT 200 + MIN_SEER 240 + chrome` ≈ 500px), so the bottom dock collapsed Seer to roughly the input box, with the divider's `[min, max]` range degenerating to a point (unresizable).

This resolves `auto` to the **right** dock when the viewport is **landscape and ≤ `xs` (500px) tall**, where horizontal room is ample. Portrait phones still dock to the bottom; wide screens (≥ `xl`) still dock right.

| Viewport | `auto` orientation |
|---|---|
| ≥ `xl` (1440px) wide | right |
| Landscape **and** ≤ 500px tall (phone sideways) | **right** (new) |
| Portrait phone (tall) | bottom |
| Other (tablet / narrow desktop) | bottom |

Implemented purely with media queries in `useSeerExplorerSidebarOrientation` (a second `useMedia` for `(orientation: landscape) and (max-height: xs)`), reusing the `xs` breakpoint token as the height cutoff.

> Note: this sidesteps the short-viewport bottom-dock squish by switching orientation rather than fixing the bottom-dock sizing math itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)