### PR TITLE
feat(slack): Add metrics for slack reinstall nudge outcomes

### DIFF
--- a/src/sentry/integrations/slack/utils/nudge.py
+++ b/src/sentry/integrations/slack/utils/nudge.py
@@ -3,7 +3,10 @@ from datetime import datetime, timezone
 
 from sentry import features
 from sentry.models.organization import Organization
+from sentry.utils import metrics
 from sentry.utils.cache import cache
+
+SLACK_NUDGE_METRIC = "slack.alert_nudge"
 
 
 def should_send_nudge_block(
@@ -16,6 +19,7 @@ def should_send_nudge_block(
 
     # only 10% of the alerts should have the nudge blocks
     if random.random() >= 0.1:
+        metrics.incr(SLACK_NUDGE_METRIC, sample_rate=1.0, tags={"result": "skipped_random_check"})
         return False
 
     iso_year, iso_week, _ = datetime.now(timezone.utc).isocalendar()
@@ -23,6 +27,7 @@ def should_send_nudge_block(
 
     count = cache.get(cache_key, 0)
     if count >= 4:
+        metrics.incr(SLACK_NUDGE_METRIC, sample_rate=1.0, tags={"result": "skipped_weekly_limit"})
         return False
 
     if count == 0:
@@ -35,4 +40,5 @@ def should_send_nudge_block(
             # incr; incr raises ValueError on a missing key, so fall back to set.
             cache.set(cache_key, count + 1, timeout=7 * 24 * 60 * 60)
 
+    metrics.incr(SLACK_NUDGE_METRIC, sample_rate=1.0, tags={"result": "sent"})
     return True


### PR DESCRIPTION
we send "nudges" -- a short CTA after alert messages -- for a subset of alerts sent to Slack channels to either update their slack app installation, or to remind them they can @ mention sentry anywhere to start debugging their system.

Let's add some metrics for this nudge so we know when we send the nudge vs. when we do not.

also see:
#118288