### PR TITLE
fix(explore): Reduce time window in trace item details

### DIFF
--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 from sentry_protos.snuba.v1.endpoint_trace_item_details_pb2 import TraceItemDetailsRequest
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
 
-from sentry import features
+from sentry import features, options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -360,9 +360,9 @@ class ProjectTraceItemDetailsEndpoint(ProjectEndpoint):
                 example_timestamp = parse_datetime_string(request.GET["timestamp"])
             except InvalidQuery:
                 return Response("timestamp parameter invalid", status=400)
-            time_buffer = 1.5
-            example_start = example_timestamp - timedelta(days=time_buffer)
-            example_end = example_timestamp + timedelta(days=time_buffer)
+            time_buffer = options.get("performance.traces.trace-item-details-timebuffer-minutes")
+            example_start = example_timestamp - timedelta(minutes=time_buffer)
+            example_end = example_timestamp + timedelta(minutes=time_buffer)
             if start is not None:
                 start = max(start, example_start)
             else:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1958,6 +1958,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )  # hours
 register(
+    "performance.traces.trace-item-details-timebuffer-minutes",
+    type=Float,
+    default=5.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)  # minutes
+register(
     "performance.traces.query_timestamp_projects",
     type=Bool,
     default=False,

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -14,6 +14,7 @@ from sentry.testutils.cases import (
     TraceAttachmentTestCase,
 )
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.options import override_options
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 
 
@@ -706,6 +707,30 @@ class ProjectTraceItemDetailsEndpointTest(
             trace_details_response = self.do_request("logs", item_id, extra_data=extra_data)
 
             assert trace_details_response.status_code == 404, trace_details_response.content
+
+    @override_options({"performance.traces.trace-item-details-timebuffer-minutes": 1.0})
+    def test_timestamp_respects_timebuffer_option(self) -> None:
+        log = self.create_ourlog(
+            {
+                "body": "foo",
+                "trace_id": self.trace_uuid,
+            },
+            attributes={
+                "str_attr": {
+                    "string_value": "1",
+                },
+            },
+            timestamp=self.one_min_ago,
+        )
+        self.store_eap_items([log])
+        item_id = log.item_id.hex()
+
+        trace_details_response = self.do_request(
+            "logs",
+            item_id,
+            extra_data={"timestamp": (self.one_min_ago - timedelta(minutes=2)).isoformat()},
+        )
+        assert trace_details_response.status_code == 404, trace_details_response.content
 
     def test_with_invalid_timestamp(self) -> None:
         log = self.create_ourlog(


### PR DESCRIPTION
Adds an option for the trace item details endpoint time buffer. Item details are used for a particular item which happens in a fixed point in time (unlike a trace, which doesn't strictly have a start and end), so we don't need a large time window. We can potentially make this way lower, but this should speed it up significantly for now.

Original source for this bug was that +/- 3 day was causing timeouts on large orgs.

Fixes LOGS-897

