### PR TITLE
feat(seer): Surface convention attribute context in built_in_fields

### DIFF
--- a/src/sentry/seer/assisted_query/traces_tools.py
+++ b/src/sentry/seer/assisted_query/traces_tools.py
@@ -143,7 +143,9 @@ def get_attribute_names(
 
         Each built-in field's "context" is only populated when expand="context"
         is requested (and the attribute maps to a known convention); otherwise it
-        is None.
+        is None. Convention-backed attributes that aren't hardcoded built-ins
+        (e.g. http.route) are also appended to "built_in_fields" so their context
+        isn't lost.
     """
     organization = Organization.objects.get(id=org_id)
 
@@ -156,6 +158,9 @@ def get_attribute_names(
     # context comes from the sentry conventions, but custom attribute context is
     # planned, at which point user-defined attributes will be populated too.
     context_by_name: dict[str, dict[str, Any]] = {}
+    # Maps an attribute name to its type ("string"/"number"), so context-bearing
+    # attributes that aren't hardcoded built-ins can still be emitted as fields.
+    type_by_name: dict[str, str] = {}
 
     # Fetch both string and number attributes from the public API
     for attr_type in ["string", "number"]:
@@ -190,11 +195,23 @@ def get_attribute_names(
             # the built-in field's context stays None.
             if item.get("context"):
                 context_by_name[item["name"]] = item["context"]
+                type_by_name[item["name"]] = attr_type
 
+    hardcoded_fields = _get_built_in_fields(item_type)
     built_in_fields = [
-        BuiltInField(**f, context=context_by_name.get(f["key"]))
-        for f in _get_built_in_fields(item_type)
+        BuiltInField(**f, context=context_by_name.get(f["key"])) for f in hardcoded_fields
     ]
+
+    # Convention-backed attributes (e.g. http.route) aren't in the hardcoded
+    # list, so their context would otherwise be dropped. Surface them through
+    # built_in_fields too, since that's where Seer reads attribute context from.
+    # Only conventions are promoted (isConvention=True); user-authored custom
+    # context is intentionally left out.
+    hardcoded_keys = {f["key"] for f in hardcoded_fields}
+    for name, context in context_by_name.items():
+        if name in hardcoded_keys or not context.get("isConvention"):
+            continue
+        built_in_fields.append(BuiltInField(key=name, type=type_by_name[name], context=context))
 
     return AttributeNamesResponse(fields=fields, built_in_fields=built_in_fields)
 

--- a/tests/snuba/api/endpoints/test_seer_attributes.py
+++ b/tests/snuba/api/endpoints/test_seer_attributes.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 
 from sentry.seer.assisted_query.traces_tools import (
+    _get_built_in_fields,
     get_attribute_names,
     get_attribute_values_with_substring,
 )
@@ -111,6 +112,14 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         # Built-in fields that aren't returned by the public endpoint (e.g. no
         # data for them) carry no context.
         assert built_in_by_key["span.self_time"].context is None
+
+        # Convention-backed attributes that aren't hardcoded built-ins (e.g.
+        # device.class) are still surfaced in built_in_fields with their context.
+        assert "device.class" not in {f["key"] for f in _get_built_in_fields("spans")}
+        device_class_context = built_in_by_key["device.class"].context
+        assert device_class_context is not None
+        assert device_class_context["isConvention"] is True
+        assert device_class_context["brief"]
 
         # Context is either None or populated, never an empty dict (the endpoint
         # attaches an empty context to attributes without convention metadata).


### PR DESCRIPTION
`get_attribute_names` fetches per-attribute context (with `include_context=True`) but only attached it to the **hardcoded** built-in fields. Convention-backed attributes that aren't in those lists — e.g. `http.route`, `device.class`, `gen_ai.*` — had their context fetched and then silently dropped, so Seer never saw it.

This matters now that #118509 made the attributes endpoint return convention context regardless of `source_type` (so `http.route`, which resolves as `user` source, carries its convention context).

## Changes

- Track each context-bearing attribute's type alongside its context.
- After building the hardcoded `built_in_fields`, append any discovered attribute that has `isConvention=True` and **isn't already a hardcoded key** (deduped), as a `BuiltInField(key, type, context)`. `built_in_fields` is where Seer reads attribute context from, so this is the existing channel.
- Only conventions are promoted (`isConvention=True`); user-authored custom context (no `isConvention` flag) is intentionally left out for now.

## Notes

- The hardcoded built-in lists are **not** removed — they're the guaranteed baseline schema (always present, typed, regardless of data/RPC behavior), whereas this append only enriches attributes actually discovered in the data. Most built-ins (`span.op`, `span.duration`, `id`, `project`, `metric.name`, `value`, …) aren't conventions, so they can't come from convention metadata.
- The exact-match `test_get_attribute_names` (no context) is unaffected — without `include_context`, nothing is fetched or appended.

## Tests

- Extended `test_get_attribute_names_with_context` to assert `device.class` (a real convention not in the hardcoded list, present in the test data) is surfaced in `built_in_fields` with `isConvention: True` and a non-empty `brief`.

## Follow-up

Once the custom attribute context endpoint (#118498) serves user-authored context, those attributes can be surfaced through the same dedup path by relaxing the `isConvention` filter.
