### PR TITLE
ref(project-creation): SCM project-creation style polish

### DIFF
--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -4,7 +4,10 @@ import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedD
 import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
-import type {AlertRuleOptions} from 'sentry/views/projectInstall/issueAlertOptions';
+import type {
+  AlertRuleOptions,
+  RequestDataFragment,
+} from 'sentry/views/projectInstall/issueAlertOptions';
 
 /**
  * Persisted form state from the SCM project details step. Stored so the
@@ -14,6 +17,11 @@ import type {AlertRuleOptions} from 'sentry/views/projectInstall/issueAlertOptio
  */
 export interface ProjectDetailsFormState {
   alertRuleConfig?: AlertRuleOptions;
+  /**
+   * The chosen messaging-integration notification action, persisted so the
+   * selection survives navigation (the step remounts) and is re-seeded.
+   */
+  notificationActions?: RequestDataFragment['actions'];
   projectName?: string;
   teamSlug?: string;
 }

--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -4,10 +4,7 @@ import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedD
 import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
-import type {
-  AlertRuleOptions,
-  RequestDataFragment,
-} from 'sentry/views/projectInstall/issueAlertOptions';
+import type {AlertRuleOptions} from 'sentry/views/projectInstall/issueAlertOptions';
 
 /**
  * Persisted form state from the SCM project details step. Stored so the
@@ -17,11 +14,6 @@ import type {
  */
 export interface ProjectDetailsFormState {
   alertRuleConfig?: AlertRuleOptions;
-  /**
-   * The chosen messaging-integration notification action, persisted so the
-   * selection survives navigation (the step remounts) and is re-seeded.
-   */
-  notificationActions?: RequestDataFragment['actions'];
   projectName?: string;
   teamSlug?: string;
 }

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -1,9 +1,8 @@
 import {Input} from '@sentry/scraps/input';
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Grid, Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Text} from '@sentry/scraps/text';
 
-import {IconInfo} from 'sentry/icons/iconInfo';
 import {t} from 'sentry/locale';
 import {ScmAlertOptionCard} from 'sentry/views/onboarding/components/scmAlertOptionCard';
 import {
@@ -32,73 +31,64 @@ export function ScmAlertFrequency({
   const isLaterSelected = alertSetting === RuleAction.CREATE_ALERT_LATER;
 
   return (
-    <Stack gap="lg">
-      <Stack gap="md" role="radiogroup" aria-label={t('Alert frequency')}>
-        <ScmAlertOptionCard
-          label={t('High priority issues')}
-          description={t('Alert on new, regressed, and escalating issues')}
-          isSelected={isDefaultSelected}
-          onSelect={() => onFieldChange('alertSetting', RuleAction.DEFAULT_ALERT)}
-        />
+    <Stack gap="md" role="radiogroup" aria-label={t('Alert frequency')}>
+      <ScmAlertOptionCard
+        label={t('High priority issues')}
+        description={t('Alert on new, regressed, and escalating issues')}
+        isSelected={isDefaultSelected}
+        onSelect={() => onFieldChange('alertSetting', RuleAction.DEFAULT_ALERT)}
+      />
 
-        <ScmAlertOptionCard
-          label={t('Custom threshold')}
-          isSelected={isCustomSelected}
-          onSelect={() => onFieldChange('alertSetting', RuleAction.CUSTOMIZED_ALERTS)}
-        >
-          {isCustomSelected && (
-            <Stack gap="lg">
-              <Stack gap="xs">
-                <Text size="md" density="comfortable">
-                  {t('When there are more than')}
-                </Text>
-                <Grid gap="xl" columns={{sm: '1fr', md: '1fr 1fr'}}>
-                  <Input
-                    size="md"
-                    type="number"
-                    min="0"
-                    placeholder="10"
-                    value={threshold}
-                    onChange={e => onFieldChange('threshold', e.target.value)}
-                  />
-                  <Select
-                    size="md"
-                    value={metric}
-                    options={METRIC_CHOICES}
-                    onChange={option => onFieldChange('metric', option.value)}
-                    menuPortalTarget={document.body}
-                  />
-                </Grid>
-              </Stack>
-              <Stack gap="xs">
-                <Text size="md" density="comfortable">
-                  {t('a unique error in')}
-                </Text>
+      <ScmAlertOptionCard
+        label={t('Custom threshold')}
+        isSelected={isCustomSelected}
+        onSelect={() => onFieldChange('alertSetting', RuleAction.CUSTOMIZED_ALERTS)}
+      >
+        {isCustomSelected && (
+          <Stack gap="lg">
+            <Stack gap="xs">
+              <Text size="md" density="comfortable">
+                {t('When there are more than')}
+              </Text>
+              <Grid gap="xl" columns={{sm: '1fr', md: '1fr 1fr'}}>
+                <Input
+                  size="md"
+                  type="number"
+                  min="0"
+                  placeholder="10"
+                  value={threshold}
+                  onChange={e => onFieldChange('threshold', e.target.value)}
+                />
                 <Select
                   size="md"
-                  value={interval}
-                  options={INTERVAL_CHOICES}
-                  onChange={option => onFieldChange('interval', option.value)}
+                  value={metric}
+                  options={METRIC_CHOICES}
+                  onChange={option => onFieldChange('metric', option.value)}
                   menuPortalTarget={document.body}
                 />
-              </Stack>
+              </Grid>
             </Stack>
-          )}
-        </ScmAlertOptionCard>
+            <Stack gap="xs">
+              <Text size="md" density="comfortable">
+                {t('a unique error in')}
+              </Text>
+              <Select
+                size="md"
+                value={interval}
+                options={INTERVAL_CHOICES}
+                onChange={option => onFieldChange('interval', option.value)}
+                menuPortalTarget={document.body}
+              />
+            </Stack>
+          </Stack>
+        )}
+      </ScmAlertOptionCard>
 
-        <ScmAlertOptionCard
-          label={t("I'll set up alerts later")}
-          isSelected={isLaterSelected}
-          onSelect={() => onFieldChange('alertSetting', RuleAction.CREATE_ALERT_LATER)}
-        />
-      </Stack>
-
-      <Flex gap="sm" align="center">
-        <IconInfo size="md" variant="secondary" />
-        <Text variant="secondary" size="md" density="comfortable">
-          {t('You can always change alerts after project creation')}
-        </Text>
-      </Flex>
+      <ScmAlertOptionCard
+        label={t("I'll set up alerts later")}
+        isSelected={isLaterSelected}
+        onSelect={() => onFieldChange('alertSetting', RuleAction.CREATE_ALERT_LATER)}
+      />
     </Stack>
   );
 }

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -1,8 +1,9 @@
 import {Input} from '@sentry/scraps/input';
-import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Text} from '@sentry/scraps/text';
 
+import {IconInfo} from 'sentry/icons/iconInfo';
 import {t} from 'sentry/locale';
 import {ScmAlertOptionCard} from 'sentry/views/onboarding/components/scmAlertOptionCard';
 import {
@@ -31,72 +32,71 @@ export function ScmAlertFrequency({
   const isLaterSelected = alertSetting === RuleAction.CREATE_ALERT_LATER;
 
   return (
-    <Stack gap="xl" role="radiogroup" aria-label={t('Alert frequency')}>
-      <ScmAlertOptionCard
-        label={t('High priority issues')}
-        isSelected={isDefaultSelected}
-        onSelect={() => onFieldChange('alertSetting', RuleAction.DEFAULT_ALERT)}
-      />
+    <Stack gap="lg">
+      <Stack gap="md" role="radiogroup" aria-label={t('Alert frequency')}>
+        <ScmAlertOptionCard
+          label={t('High priority issues')}
+          description={t('Alert on new, regressed, and escalating issues')}
+          isSelected={isDefaultSelected}
+          onSelect={() => onFieldChange('alertSetting', RuleAction.DEFAULT_ALERT)}
+        />
 
-      <ScmAlertOptionCard
-        label={t('Custom')}
-        isSelected={isCustomSelected}
-        onSelect={() => onFieldChange('alertSetting', RuleAction.CUSTOMIZED_ALERTS)}
-      >
-        <Container paddingLeft="2xl">
-          <Stack
-            gap="lg"
-            padding="sm 0 0 2xl"
-            borderLeft={isCustomSelected ? 'accent' : 'secondary'}
-          >
-            <Stack gap="xs">
-              <Container>
+        <ScmAlertOptionCard
+          label={t('Custom threshold')}
+          isSelected={isCustomSelected}
+          onSelect={() => onFieldChange('alertSetting', RuleAction.CUSTOMIZED_ALERTS)}
+        >
+          {isCustomSelected && (
+            <Stack gap="lg">
+              <Stack gap="xs">
                 <Text size="md" density="comfortable">
                   {t('When there are more than')}
                 </Text>
-              </Container>
-              <Grid gap="md" columns=".35fr .65fr">
-                <Input
-                  size="sm"
-                  type="number"
-                  min="0"
-                  placeholder="10"
-                  value={threshold}
-                  onChange={e => onFieldChange('threshold', e.target.value)}
-                  disabled={!isCustomSelected}
-                />
-                <Select
-                  size="sm"
-                  value={metric}
-                  options={METRIC_CHOICES}
-                  onChange={option => onFieldChange('metric', option.value)}
-                  disabled={!isCustomSelected}
-                />
-              </Grid>
-            </Stack>
-            <Stack gap="xs">
-              <Container>
+                <Grid gap="xl" columns="1fr 1fr">
+                  <Input
+                    size="md"
+                    type="number"
+                    min="0"
+                    placeholder="10"
+                    value={threshold}
+                    onChange={e => onFieldChange('threshold', e.target.value)}
+                  />
+                  <Select
+                    size="md"
+                    value={metric}
+                    options={METRIC_CHOICES}
+                    onChange={option => onFieldChange('metric', option.value)}
+                  />
+                </Grid>
+              </Stack>
+              <Stack gap="xs">
                 <Text size="md" density="comfortable">
                   {t('a unique error in')}
                 </Text>
-              </Container>
-              <Select
-                size="sm"
-                value={interval}
-                options={INTERVAL_CHOICES}
-                onChange={option => onFieldChange('interval', option.value)}
-                disabled={!isCustomSelected}
-              />
+                <Select
+                  size="md"
+                  value={interval}
+                  options={INTERVAL_CHOICES}
+                  onChange={option => onFieldChange('interval', option.value)}
+                />
+              </Stack>
             </Stack>
-          </Stack>
-        </Container>
-      </ScmAlertOptionCard>
+          )}
+        </ScmAlertOptionCard>
 
-      <ScmAlertOptionCard
-        label={t("I'll create my own alerts later")}
-        isSelected={isLaterSelected}
-        onSelect={() => onFieldChange('alertSetting', RuleAction.CREATE_ALERT_LATER)}
-      />
+        <ScmAlertOptionCard
+          label={t("I'll set up alerts later")}
+          isSelected={isLaterSelected}
+          onSelect={() => onFieldChange('alertSetting', RuleAction.CREATE_ALERT_LATER)}
+        />
+      </Stack>
+
+      <Flex gap="sm" align="center">
+        <IconInfo size="sm" variant="secondary" />
+        <Text variant="secondary" size="sm" density="comfortable">
+          {t('You can always change alerts after project creation')}
+        </Text>
+      </Flex>
     </Stack>
   );
 }

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -66,6 +66,7 @@ export function ScmAlertFrequency({
                     value={metric}
                     options={METRIC_CHOICES}
                     onChange={option => onFieldChange('metric', option.value)}
+                    menuPortalTarget={document.body}
                   />
                 </Grid>
               </Stack>
@@ -78,6 +79,7 @@ export function ScmAlertFrequency({
                   value={interval}
                   options={INTERVAL_CHOICES}
                   onChange={option => onFieldChange('interval', option.value)}
+                  menuPortalTarget={document.body}
                 />
               </Stack>
             </Stack>

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -94,8 +94,8 @@ export function ScmAlertFrequency({
       </Stack>
 
       <Flex gap="sm" align="center">
-        <IconInfo size="sm" variant="secondary" />
-        <Text variant="secondary" size="sm" density="comfortable">
+        <IconInfo size="md" variant="secondary" />
+        <Text variant="secondary" size="md" density="comfortable">
           {t('You can always change alerts after project creation')}
         </Text>
       </Flex>

--- a/static/app/views/onboarding/components/scmAlertFrequency.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequency.tsx
@@ -52,7 +52,7 @@ export function ScmAlertFrequency({
                 <Text size="md" density="comfortable">
                   {t('When there are more than')}
                 </Text>
-                <Grid gap="xl" columns="1fr 1fr">
+                <Grid gap="xl" columns={{sm: '1fr', md: '1fr 1fr'}}>
                   <Input
                     size="md"
                     type="number"

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
@@ -2,16 +2,38 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {DEFAULT_ISSUE_ALERT_OPTIONS_VALUES} from 'sentry/views/projectInstall/issueAlertOptions';
+import {
+  type IssueAlertNotificationProps,
+  MultipleCheckboxOptions,
+} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import {
+  DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
+  RuleAction,
+} from 'sentry/views/projectInstall/issueAlertOptions';
 
 import {ScmAlertFrequencySection} from './scmAlertFrequencySection';
 
 type Props = React.ComponentProps<typeof ScmAlertFrequencySection>;
 
+const notificationProps: IssueAlertNotificationProps = {
+  actions: [MultipleCheckboxOptions.EMAIL],
+  provider: undefined,
+  integration: undefined,
+  channel: undefined,
+  providersToIntegrations: {},
+  querySuccess: true,
+  shouldRenderSetupButton: false,
+  setActions: jest.fn(),
+  setProvider: jest.fn(),
+  setIntegration: jest.fn(),
+  setChannel: jest.fn(),
+};
+
 function renderSection(overrides: Partial<Props> = {}) {
   const props: Props = {
     analyticsFlow: 'project-creation',
     alertRuleConfig: DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
+    notificationProps,
     onAlertChange: jest.fn(),
     ...overrides,
   };
@@ -42,5 +64,23 @@ describe('ScmAlertFrequencySection', () => {
     ).not.toBeInTheDocument();
     expect(screen.getByText('Alert frequency')).toBeInTheDocument();
     expect(screen.getByText('Get notified when things go wrong')).toBeInTheDocument();
+  });
+
+  it('shows the notification options when alerts are enabled', () => {
+    renderSection({analyticsFlow: 'onboarding'});
+
+    expect(screen.getByText('Notify via email')).toBeInTheDocument();
+  });
+
+  it('hides the notification options when alerts are turned off', () => {
+    renderSection({
+      analyticsFlow: 'onboarding',
+      alertRuleConfig: {
+        ...DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
+        alertSetting: RuleAction.CREATE_ALERT_LATER,
+      },
+    });
+
+    expect(screen.queryByText('Notify via email')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
@@ -69,7 +69,10 @@ describe('ScmAlertFrequencySection', () => {
   it('shows the notification options when alerts are enabled', () => {
     renderSection({analyticsFlow: 'onboarding'});
 
-    expect(screen.getByText('Notify via email')).toBeInTheDocument();
+    expect(screen.getByText('Notify via')).toBeInTheDocument();
+    expect(
+      screen.getByText('Integration (Slack, Discord, MS Teams, etc.)')
+    ).toBeInTheDocument();
   });
 
   it('hides the notification options when alerts are turned off', () => {
@@ -81,6 +84,6 @@ describe('ScmAlertFrequencySection', () => {
       },
     });
 
-    expect(screen.queryByText('Notify via email')).not.toBeInTheDocument();
+    expect(screen.queryByText('Notify via')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.spec.tsx
@@ -75,6 +75,27 @@ describe('ScmAlertFrequencySection', () => {
     ).toBeInTheDocument();
   });
 
+  it('adds the integration action when the Integration checkbox is clicked', async () => {
+    const setActions = jest.fn();
+    renderSection({
+      analyticsFlow: 'onboarding',
+      notificationProps: {...notificationProps, setActions},
+    });
+
+    // Querying the checkbox by the label text also asserts the label wraps the
+    // input, so clicking the text toggles it.
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'Integration (Slack, Discord, MS Teams, etc.)',
+      })
+    );
+
+    expect(setActions).toHaveBeenCalledWith([
+      MultipleCheckboxOptions.EMAIL,
+      MultipleCheckboxOptions.INTEGRATION,
+    ]);
+  });
+
   it('hides the notification options when alerts are turned off', () => {
     renderSection({
       analyticsFlow: 'onboarding',

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -51,7 +51,7 @@ export function ScmAlertFrequencySection({
   const footer = (
     <Flex gap="sm" align="center">
       <IconInfo size="md" variant="secondary" />
-      <Text variant="secondary" size="md" density="comfortable">
+      <Text variant="secondary" size="md" density="comfortable" ellipsis>
         {t('You can always change alerts after project creation')}
       </Text>
     </Flex>

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -5,6 +5,10 @@ import {Text} from '@sentry/scraps/text';
 import {t} from 'sentry/locale';
 import type {TagVariant} from 'sentry/utils/theme';
 import {
+  IssueAlertNotificationOptions,
+  type IssueAlertNotificationProps,
+} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import {
   type AlertRuleOptions,
   RuleAction,
 } from 'sentry/views/projectInstall/issueAlertOptions';
@@ -16,6 +20,7 @@ import {ScmCollapsibleSection} from './scmCollapsibleSection';
 interface ScmAlertFrequencySectionProps {
   alertRuleConfig: AlertRuleOptions;
   analyticsFlow: ScmAnalyticsFlow;
+  notificationProps: IssueAlertNotificationProps;
   onAlertChange: <K extends keyof AlertRuleOptions>(
     key: K,
     value: AlertRuleOptions[K]
@@ -32,9 +37,17 @@ interface ScmAlertFrequencySectionProps {
 export function ScmAlertFrequencySection({
   alertRuleConfig,
   analyticsFlow,
+  notificationProps,
   onAlertChange,
 }: ScmAlertFrequencySectionProps) {
   const collapsible = analyticsFlow === 'project-creation';
+
+  // Notification options are irrelevant when the user opts out of alerts, so
+  // hide them for "create alerts later" (mirrors issueAlertOptions).
+  const notificationOptions =
+    alertRuleConfig.alertSetting === RuleAction.CREATE_ALERT_LATER ? null : (
+      <IssueAlertNotificationOptions {...notificationProps} />
+    );
 
   if (collapsible) {
     // Summarize the current selection in the collapsed header.
@@ -64,6 +77,7 @@ export function ScmAlertFrequencySection({
         }
       >
         <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
+        {notificationOptions}
       </ScmCollapsibleSection>
     );
   }
@@ -83,6 +97,7 @@ export function ScmAlertFrequencySection({
         </Container>
       </Stack>
       <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
+      {notificationOptions}
     </Stack>
   );
 }

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -1,7 +1,8 @@
 import {Tag} from '@sentry/scraps/badge';
-import {Container, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
+import {IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {TagVariant} from 'sentry/utils/theme';
 import {
@@ -76,14 +77,22 @@ export function ScmAlertFrequencySection({
           </Tag>
         }
       >
-        <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
-        {notificationOptions}
+        <Stack gap="lg">
+          <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
+          {notificationOptions}
+          <Flex gap="sm" align="center">
+            <IconInfo size="md" variant="secondary" />
+            <Text variant="secondary" size="md" density="comfortable">
+              {t('You can always change alerts after project creation')}
+            </Text>
+          </Flex>
+        </Stack>
       </ScmCollapsibleSection>
     );
   }
 
   return (
-    <Stack gap="md">
+    <Stack gap="lg">
       <Stack gap="xs">
         <Container>
           <Text bold size="md" density="comfortable">
@@ -98,6 +107,12 @@ export function ScmAlertFrequencySection({
       </Stack>
       <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
       {notificationOptions}
+      <Flex gap="sm" align="center">
+        <IconInfo size="md" variant="secondary" />
+        <Text variant="secondary" size="md" density="comfortable">
+          {t('You can always change alerts after project creation')}
+        </Text>
+      </Flex>
     </Stack>
   );
 }

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -5,10 +5,7 @@ import {Text} from '@sentry/scraps/text';
 import {IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {TagVariant} from 'sentry/utils/theme';
-import {
-  IssueAlertNotificationOptions,
-  type IssueAlertNotificationProps,
-} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import {type IssueAlertNotificationProps} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
   type AlertRuleOptions,
   RuleAction,
@@ -17,6 +14,7 @@ import {
 import {ScmAlertFrequency} from './scmAlertFrequency';
 import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
 import {ScmCollapsibleSection} from './scmCollapsibleSection';
+import {ScmIssueAlertNotificationOptions} from './scmIssueAlertNotificationOptions';
 
 interface ScmAlertFrequencySectionProps {
   alertRuleConfig: AlertRuleOptions;
@@ -47,7 +45,7 @@ export function ScmAlertFrequencySection({
   // hide them for "create alerts later" (mirrors issueAlertOptions).
   const notificationOptions =
     alertRuleConfig.alertSetting === RuleAction.CREATE_ALERT_LATER ? null : (
-      <IssueAlertNotificationOptions {...notificationProps} />
+      <ScmIssueAlertNotificationOptions {...notificationProps} />
     );
 
   const footer = (

--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -50,6 +50,15 @@ export function ScmAlertFrequencySection({
       <IssueAlertNotificationOptions {...notificationProps} />
     );
 
+  const footer = (
+    <Flex gap="sm" align="center">
+      <IconInfo size="md" variant="secondary" />
+      <Text variant="secondary" size="md" density="comfortable">
+        {t('You can always change alerts after project creation')}
+      </Text>
+    </Flex>
+  );
+
   if (collapsible) {
     // Summarize the current selection in the collapsed header.
     const alertSettingLabel: Record<RuleAction, [string, TagVariant]> = {
@@ -80,12 +89,7 @@ export function ScmAlertFrequencySection({
         <Stack gap="lg">
           <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
           {notificationOptions}
-          <Flex gap="sm" align="center">
-            <IconInfo size="md" variant="secondary" />
-            <Text variant="secondary" size="md" density="comfortable">
-              {t('You can always change alerts after project creation')}
-            </Text>
-          </Flex>
+          {footer}
         </Stack>
       </ScmCollapsibleSection>
     );
@@ -107,12 +111,7 @@ export function ScmAlertFrequencySection({
       </Stack>
       <ScmAlertFrequency {...alertRuleConfig} onFieldChange={onAlertChange} />
       {notificationOptions}
-      <Flex gap="sm" align="center">
-        <IconInfo size="md" variant="secondary" />
-        <Text variant="secondary" size="md" density="comfortable">
-          {t('You can always change alerts after project creation')}
-        </Text>
-      </Flex>
+      {footer}
     </Stack>
   );
 }

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -1,4 +1,4 @@
-import {Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Grid, Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
 
@@ -10,27 +10,41 @@ interface ScmAlertOptionCardProps {
   label: string;
   onSelect: () => void;
   children?: React.ReactNode;
+  description?: string;
 }
 
 export function ScmAlertOptionCard({
   label,
+  description,
   isSelected,
   onSelect,
   children,
 }: ScmAlertOptionCardProps) {
   return (
-    <Stack gap="lg">
-      <ScmCardButton role="radio" aria-checked={isSelected} onClick={onSelect}>
-        <ScmSelectableContainer isSelected={isSelected} padding="lg">
-          <Grid gap="md" align="center" columns="min-content 1fr">
+    <ScmSelectableContainer isSelected={isSelected} padding="lg">
+      <Stack gap="md">
+        <ScmCardButton
+          role="radio"
+          aria-checked={isSelected}
+          onClick={onSelect}
+          style={{width: '100%'}}
+        >
+          <Grid gap="md" align="start" columns="min-content 1fr">
             <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
-            <Text bold={isSelected} size="md" density="comfortable">
-              {label}
-            </Text>
+            <Stack gap="xs">
+              <Text bold={isSelected} size="md" density="comfortable">
+                {label}
+              </Text>
+              {description && (
+                <Text variant="secondary" size="sm" density="comfortable">
+                  {description}
+                </Text>
+              )}
+            </Stack>
           </Grid>
-        </ScmSelectableContainer>
-      </ScmCardButton>
-      {children}
-    </Stack>
+        </ScmCardButton>
+        {children && <Container paddingLeft="2xl">{children}</Container>}
+      </Stack>
+    </ScmSelectableContainer>
   );
 }

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -1,3 +1,5 @@
+import {AnimatePresence, motion} from 'framer-motion';
+
 import {Container, Grid, Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
@@ -22,7 +24,7 @@ export function ScmAlertOptionCard({
 }: ScmAlertOptionCardProps) {
   return (
     <ScmSelectableContainer isSelected={isSelected} padding="lg">
-      <Stack gap="md">
+      <Stack gap="0">
         <ScmCardButton
           role="radio"
           aria-checked={isSelected}
@@ -43,7 +45,28 @@ export function ScmAlertOptionCard({
             </Stack>
           </Grid>
         </ScmCardButton>
-        {children && <Container paddingLeft="2xl">{children}</Container>}
+        {/* Selecting the card expands its body; the height tween mirrors
+            ScmCollapsibleSection so cards in scmCreateProject's
+            layout="position" group reflow smoothly. initial={false} keeps a
+            preselected card expanded without animating on mount. */}
+        <AnimatePresence initial={false}>
+          {children && (
+            <motion.div
+              key="content"
+              initial={{height: 0, opacity: 0}}
+              animate={{height: 'auto', opacity: 1}}
+              exit={{height: 0, opacity: 0}}
+              transition={{duration: 0.2, ease: 'easeOut'}}
+              style={{overflow: 'hidden', width: '100%'}}
+            >
+              {/* padding-top lives inside the animated body so the gap collapses
+                  with the height tween; padding-left aligns it under the label. */}
+              <Container paddingTop="md" paddingLeft="2xl">
+                {children}
+              </Container>
+            </motion.div>
+          )}
+        </AnimatePresence>
       </Stack>
     </ScmSelectableContainer>
   );

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -73,11 +73,11 @@ export function ScmAlertOptionCard({
   );
 }
 
-// The body indents to line up under the label (button padding + radio width +
-// grid column gap) and carries its own right/bottom padding so input focus
-// rings clear the animated overflow:hidden bounds. The top gap comes from the
-// header button's own bottom padding.
+// The body indents to line up under the label (button padding + the md radio's
+// 24px width + grid column gap) and carries its own right/bottom padding so
+// input focus rings clear the animated overflow:hidden bounds. The top gap
+// comes from the header button's own bottom padding.
 const ExpandedBody = styled('div')`
   padding: 0 ${p => p.theme.space.lg} ${p => p.theme.space.lg};
-  padding-left: calc(${p => p.theme.space.lg} + 20px + ${p => p.theme.space.md});
+  padding-left: calc(${p => p.theme.space.lg} + 24px + ${p => p.theme.space.md});
 `;

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -37,7 +37,7 @@ export function ScmAlertOptionCard({
           <Container padding="lg">
             <Grid
               columns="min-content 1fr"
-              gap="xs md"
+              gap="0 md"
               align="center"
               areas={`
                 "radio label"
@@ -45,16 +45,16 @@ export function ScmAlertOptionCard({
               `}
             >
               <Container area="radio">
-                <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
+                <Radio size="md" readOnly checked={isSelected} tabIndex={-1} />
               </Container>
               <Container area="label">
-                <Text bold size="sm" density="comfortable">
+                <Text bold size="md" density="comfortable">
                   {label}
                 </Text>
               </Container>
               {description && (
                 <Container area="description">
-                  <Text variant="secondary" size="sm" density="comfortable">
+                  <Text variant="secondary" size="md" density="comfortable">
                     {description}
                   </Text>
                 </Container>

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 
 import {Container, Grid, Stack} from '@sentry/scraps/layout';
@@ -23,27 +24,43 @@ export function ScmAlertOptionCard({
   children,
 }: ScmAlertOptionCardProps) {
   return (
-    <ScmSelectableContainer isSelected={isSelected} padding="lg">
+    <ScmSelectableContainer isSelected={isSelected}>
       <Stack gap="0">
+        {/* The padding lives on the button (not the card) so the whole header,
+            edge to edge, is part of the click target. */}
         <ScmCardButton
           role="radio"
           aria-checked={isSelected}
           onClick={onSelect}
           style={{width: '100%'}}
         >
-          <Grid gap="md" align="start" columns="min-content 1fr">
-            <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
-            <Stack gap="xs">
-              <Text bold={isSelected} size="md" density="comfortable">
-                {label}
-              </Text>
-              {description && (
-                <Text variant="secondary" size="sm" density="comfortable">
-                  {description}
+          <Container padding="lg">
+            <Grid
+              columns="min-content 1fr"
+              gap="xs md"
+              align="center"
+              areas={`
+                "radio label"
+                ".     description"
+              `}
+            >
+              <Container area="radio">
+                <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
+              </Container>
+              <Container area="label">
+                <Text bold={isSelected} size="md" density="comfortable">
+                  {label}
                 </Text>
+              </Container>
+              {description && (
+                <Container area="description">
+                  <Text variant="secondary" size="sm" density="comfortable">
+                    {description}
+                  </Text>
+                </Container>
               )}
-            </Stack>
-          </Grid>
+            </Grid>
+          </Container>
         </ScmCardButton>
         {/* Selecting the card expands its body; the height tween mirrors
             ScmCollapsibleSection so cards in scmCreateProject's
@@ -59,11 +76,7 @@ export function ScmAlertOptionCard({
               transition={{duration: 0.2, ease: 'easeOut'}}
               style={{overflow: 'hidden', width: '100%'}}
             >
-              {/* padding-top lives inside the animated body so the gap collapses
-                  with the height tween; padding-left aligns it under the label. */}
-              <Container paddingTop="md" paddingLeft="2xl">
-                {children}
-              </Container>
+              <ExpandedBody>{children}</ExpandedBody>
             </motion.div>
           )}
         </AnimatePresence>
@@ -71,3 +84,12 @@ export function ScmAlertOptionCard({
     </ScmSelectableContainer>
   );
 }
+
+// The body indents to line up under the label (button padding + radio width +
+// grid column gap) and carries its own right/bottom padding so input focus
+// rings clear the animated overflow:hidden bounds. The top gap comes from the
+// header button's own bottom padding.
+const ExpandedBody = styled('div')`
+  padding: 0 ${p => p.theme.space.lg} ${p => p.theme.space.lg};
+  padding-left: calc(${p => p.theme.space.lg} + 20px + ${p => p.theme.space.md});
+`;

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -72,10 +72,10 @@ export function ScmAlertOptionCard({
   );
 }
 
-// The body indents to line up under the label (button padding + the xs radio's
-// 12px width + grid column gap) and carries its own right/bottom padding so
-// input focus rings clear the animated overflow:hidden bounds. The top gap
-// comes from the header button's own bottom padding.
+// The body indents to line up under the label (header button padding + the xs
+// radio's 12px width + grid column gap) and insets its right/bottom to match
+// the header's padding, since the card itself carries none. The top gap comes
+// from the header button's own bottom padding.
 const ExpandedBody = styled('div')`
   padding: 0 ${p => p.theme.space.lg} ${p => p.theme.space.lg};
   padding-left: calc(${p => p.theme.space.lg} + 12px + ${p => p.theme.space.md});

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
 
@@ -38,23 +38,22 @@ export function ScmAlertOptionCard({
             <Grid
               columns="min-content 1fr"
               gap="0 md"
-              align="center"
               areas={`
                 "radio label"
                 ".     description"
               `}
             >
-              <Container area="radio">
-                <Radio size="md" readOnly checked={isSelected} tabIndex={-1} />
-              </Container>
+              <Flex area="radio" align="center">
+                <Radio size="xs" readOnly checked={isSelected} tabIndex={-1} />
+              </Flex>
               <Container area="label">
-                <Text bold size="md" density="comfortable">
+                <Text bold size="sm" density="comfortable">
                   {label}
                 </Text>
               </Container>
               {description && (
                 <Container area="description">
-                  <Text variant="secondary" size="md" density="comfortable">
+                  <Text variant="secondary" size="sm" density="comfortable">
                     {description}
                   </Text>
                 </Container>
@@ -73,11 +72,11 @@ export function ScmAlertOptionCard({
   );
 }
 
-// The body indents to line up under the label (button padding + the md radio's
-// 24px width + grid column gap) and carries its own right/bottom padding so
+// The body indents to line up under the label (button padding + the xs radio's
+// 12px width + grid column gap) and carries its own right/bottom padding so
 // input focus rings clear the animated overflow:hidden bounds. The top gap
 // comes from the header button's own bottom padding.
 const ExpandedBody = styled('div')`
   padding: 0 ${p => p.theme.space.lg} ${p => p.theme.space.lg};
-  padding-left: calc(${p => p.theme.space.lg} + 24px + ${p => p.theme.space.md});
+  padding-left: calc(${p => p.theme.space.lg} + 12px + ${p => p.theme.space.md});
 `;

--- a/static/app/views/onboarding/components/scmAlertOptionCard.tsx
+++ b/static/app/views/onboarding/components/scmAlertOptionCard.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
-import {AnimatePresence, motion} from 'framer-motion';
 
 import {Container, Grid, Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
 
 import {ScmCardButton} from 'sentry/views/onboarding/components/scmCardButton';
+import {ScmCollapsibleReveal} from 'sentry/views/onboarding/components/scmCollapsibleReveal';
 import {ScmSelectableContainer} from 'sentry/views/onboarding/components/scmSelectableContainer';
 
 interface ScmAlertOptionCardProps {
@@ -48,7 +48,7 @@ export function ScmAlertOptionCard({
                 <Radio size="sm" readOnly checked={isSelected} tabIndex={-1} />
               </Container>
               <Container area="label">
-                <Text bold={isSelected} size="md" density="comfortable">
+                <Text bold size="sm" density="comfortable">
                   {label}
                 </Text>
               </Container>
@@ -62,24 +62,12 @@ export function ScmAlertOptionCard({
             </Grid>
           </Container>
         </ScmCardButton>
-        {/* Selecting the card expands its body; the height tween mirrors
-            ScmCollapsibleSection so cards in scmCreateProject's
-            layout="position" group reflow smoothly. initial={false} keeps a
-            preselected card expanded without animating on mount. */}
-        <AnimatePresence initial={false}>
-          {children && (
-            <motion.div
-              key="content"
-              initial={{height: 0, opacity: 0}}
-              animate={{height: 'auto', opacity: 1}}
-              exit={{height: 0, opacity: 0}}
-              transition={{duration: 0.2, ease: 'easeOut'}}
-              style={{overflow: 'hidden', width: '100%'}}
-            >
-              <ExpandedBody>{children}</ExpandedBody>
-            </motion.div>
-          )}
-        </AnimatePresence>
+        {/* Selecting the card expands its body; ScmCollapsibleReveal's height
+            tween lets cards in scmCreateProject's layout="position" group
+            reflow smoothly. */}
+        <ScmCollapsibleReveal open={Boolean(children)}>
+          <ExpandedBody>{children}</ExpandedBody>
+        </ScmCollapsibleReveal>
       </Stack>
     </ScmSelectableContainer>
   );

--- a/static/app/views/onboarding/components/scmCollapsibleReveal.tsx
+++ b/static/app/views/onboarding/components/scmCollapsibleReveal.tsx
@@ -1,0 +1,36 @@
+import {AnimatePresence, motion} from 'framer-motion';
+
+interface ScmCollapsibleRevealProps {
+  children: React.ReactNode;
+  /** When true the content is shown; toggling tweens height and opacity. */
+  open: boolean;
+  /** Forwarded to the animated element, e.g. as an aria-controls target. */
+  id?: string;
+}
+
+/**
+ * Reveals or hides content with a height + fade tween. Shared by
+ * ScmCollapsibleSection and ScmAlertOptionCard so their expand/collapse timing
+ * stays in sync. Animating height (rather than display) lets sibling cards in a
+ * framer-motion layout="position" group reflow via normal document flow.
+ * initial={false} renders the open state without animating on mount.
+ */
+export function ScmCollapsibleReveal({open, id, children}: ScmCollapsibleRevealProps) {
+  return (
+    <AnimatePresence initial={false}>
+      {open && (
+        <motion.div
+          key="content"
+          id={id}
+          initial={{height: 0, opacity: 0}}
+          animate={{height: 'auto', opacity: 1}}
+          exit={{height: 0, opacity: 0}}
+          transition={{duration: 0.2, ease: 'easeOut'}}
+          style={{overflow: 'hidden', width: '100%'}}
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/static/app/views/onboarding/components/scmCollapsibleReveal.tsx
+++ b/static/app/views/onboarding/components/scmCollapsibleReveal.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {AnimatePresence, motion} from 'framer-motion';
 
 interface ScmCollapsibleRevealProps {
@@ -16,6 +17,14 @@ interface ScmCollapsibleRevealProps {
  * initial={false} renders the open state without animating on mount.
  */
 export function ScmCollapsibleReveal({open, id, children}: ScmCollapsibleRevealProps) {
+  // overflow:hidden is needed while the height tween runs so the content clips
+  // cleanly, but kept on it would also clip anything that extends past the
+  // settled bounds, e.g. a focus ring at the edge or an open select menu below.
+  // Switch to visible once open and settled, back to hidden whenever animating.
+  const [overflow, setOverflow] = useState<'hidden' | 'visible'>(
+    open ? 'visible' : 'hidden'
+  );
+
   return (
     <AnimatePresence initial={false}>
       {open && (
@@ -26,7 +35,13 @@ export function ScmCollapsibleReveal({open, id, children}: ScmCollapsibleRevealP
           animate={{height: 'auto', opacity: 1}}
           exit={{height: 0, opacity: 0}}
           transition={{duration: 0.2, ease: 'easeOut'}}
-          style={{overflow: 'hidden', width: '100%'}}
+          onAnimationStart={() => setOverflow('hidden')}
+          onAnimationComplete={() => {
+            if (open) {
+              setOverflow('visible');
+            }
+          }}
+          style={{overflow, width: '100%'}}
         >
           {children}
         </motion.div>

--- a/static/app/views/onboarding/components/scmCollapsibleSection.tsx
+++ b/static/app/views/onboarding/components/scmCollapsibleSection.tsx
@@ -1,12 +1,12 @@
 import {useId, useState} from 'react';
 import styled from '@emotion/styled';
-import {AnimatePresence, motion} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {IconChevron} from 'sentry/icons';
+import {ScmCollapsibleReveal} from 'sentry/views/onboarding/components/scmCollapsibleReveal';
 
 interface ScmCollapsibleSectionProps {
   children: React.ReactNode;
@@ -64,21 +64,9 @@ export function ScmCollapsibleSection({
         </ToggleButton>
         {trailing}
       </Flex>
-      <AnimatePresence initial={false}>
-        {expanded && (
-          <motion.div
-            id={contentId}
-            key="content"
-            initial={{height: 0, opacity: 0}}
-            animate={{height: 'auto', opacity: 1}}
-            exit={{height: 0, opacity: 0}}
-            transition={{duration: 0.2, ease: 'easeOut'}}
-            style={{overflow: 'hidden', width: '100%'}}
-          >
-            <Content width="100%">{children}</Content>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <ScmCollapsibleReveal open={expanded} id={contentId}>
+        <Content width="100%">{children}</Content>
+      </ScmCollapsibleReveal>
     </Stack>
   );
 }

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -13,6 +13,7 @@ import {
   MultipleCheckboxOptions,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
+import {ScmCollapsibleReveal} from './scmCollapsibleReveal';
 import {ScmMessagingIntegrationAlertRule} from './scmMessagingIntegrationAlertRule';
 
 /**
@@ -58,9 +59,11 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
               </MultipleCheckbox.Item>
             )}
           </Stack>
-          {!shouldRenderSetupButton && shouldRenderNotificationConfigs ? (
+          <ScmCollapsibleReveal
+            open={!shouldRenderSetupButton && shouldRenderNotificationConfigs}
+          >
             <ScmMessagingIntegrationAlertRule {...props} />
-          ) : null}
+          </ScmCollapsibleReveal>
         </Stack>
       </MultipleCheckbox>
       {shouldRenderSetupButton && (

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import {Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -62,7 +64,9 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
           <ScmCollapsibleReveal
             open={!shouldRenderSetupButton && shouldRenderNotificationConfigs}
           >
-            <ScmMessagingIntegrationAlertRule {...props} />
+            <IndentedRule>
+              <ScmMessagingIntegrationAlertRule {...props} />
+            </IndentedRule>
           </ScmCollapsibleReveal>
         </Stack>
       </MultipleCheckbox>
@@ -74,3 +78,10 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
     </Stack>
   );
 }
+
+// Indents the rule so its left edge lines up with the checkbox label text
+// rather than the checkbox itself: the sm Checkbox box (16px) plus the label's
+// left margin (space.md).
+const IndentedRule = styled('div')`
+  padding-left: calc(16px + ${p => p.theme.space.md});
+`;

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -79,11 +79,16 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
   );
 }
 
-// MultipleCheckbox.Item's label is fixed at 20% width with nowrap text, tuned
-// for the classic wrapping row layout. In this stacked layout the long
-// integration label overflows on narrow screens, so let each label fill its
-// row and truncate the text with an ellipsis instead.
+// MultipleCheckbox.Item wraps each label in a container that is only a fraction
+// of the row (down to 25% on wide screens), and the label itself is 20% with
+// nowrap text. Both are tuned for the classic side-by-side row layout, but here
+// they truncate the long integration label even when there is room. Widen the
+// container and label to fill the row so the text only ellipsis-truncates when
+// it genuinely overflows (narrow screens).
 const CheckboxStack = styled(Stack)`
+  > div {
+    width: 100%;
+  }
   label {
     width: 100%;
     min-width: 0;

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -1,0 +1,73 @@
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {MultipleCheckbox} from 'sentry/components/forms/controls/multipleCheckbox';
+import {t} from 'sentry/locale';
+import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import {
+  MessagingIntegrationAnalyticsView,
+  SetupMessagingIntegrationButton,
+} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
+import {
+  type IssueAlertNotificationProps,
+  MultipleCheckboxOptions,
+} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+
+import {ScmMessagingIntegrationAlertRule} from './scmMessagingIntegrationAlertRule';
+
+/**
+ * SCM-styled notification options for the alert-frequency section. Mirrors
+ * `IssueAlertNotificationOptions` but lifts the "Notify via" wording into a
+ * shared header (so the checkboxes read just "Email" / "Integration ..."), and
+ * renders the messaging rule stacked (`ScmMessagingIntegrationAlertRule`)
+ * instead of the classic inline card.
+ */
+export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationProps) {
+  const {actions, setActions, querySuccess, shouldRenderSetupButton} = props;
+
+  const shouldRenderNotificationConfigs = actions.some(
+    v => v !== MultipleCheckboxOptions.EMAIL
+  );
+
+  useRouteAnalyticsParams({
+    setup_message_integration_button_shown: shouldRenderSetupButton,
+  });
+
+  if (!querySuccess) {
+    return null;
+  }
+
+  return (
+    <Stack gap="lg" padding="lg 0">
+      <Text size="sm" bold variant="secondary" uppercase>
+        {t('Notify via')}
+      </Text>
+      <MultipleCheckbox
+        name="notification"
+        value={actions}
+        onChange={values => setActions(values)}
+      >
+        <Stack gap="md" width="100%">
+          <Stack>
+            <MultipleCheckbox.Item value={MultipleCheckboxOptions.EMAIL} disabled>
+              {t('Email')}
+            </MultipleCheckbox.Item>
+            {shouldRenderSetupButton ? null : (
+              <MultipleCheckbox.Item value={MultipleCheckboxOptions.INTEGRATION}>
+                {t('Integration (Slack, Discord, MS Teams, etc.)')}
+              </MultipleCheckbox.Item>
+            )}
+          </Stack>
+          {!shouldRenderSetupButton && shouldRenderNotificationConfigs ? (
+            <ScmMessagingIntegrationAlertRule {...props} />
+          ) : null}
+        </Stack>
+      </MultipleCheckbox>
+      {shouldRenderSetupButton && (
+        <SetupMessagingIntegrationButton
+          analyticsView={MessagingIntegrationAnalyticsView.PROJECT_CREATION}
+        />
+      )}
+    </Stack>
+  );
+}

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -49,7 +49,7 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
         <Stack gap="md">
           <Flex as="label" align="start" gap="md">
             <Checkbox checked disabled readOnly />
-            <Text>{t('Email')}</Text>
+            <Text bold={false}>{t('Email')}</Text>
           </Flex>
           {shouldRenderSetupButton ? null : (
             <Flex as="label" align="start" gap="md">
@@ -63,7 +63,9 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
                   )
                 }
               />
-              <Text>{t('Integration (Slack, Discord, MS Teams, etc.)')}</Text>
+              <Text bold={false} ellipsis>
+                {t('Integration (Slack, Discord, MS Teams, etc.)')}
+              </Text>
             </Flex>
           )}
         </Stack>

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -51,7 +51,7 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
         onChange={values => setActions(values)}
       >
         <Stack gap="md" width="100%">
-          <Stack>
+          <CheckboxStack>
             <MultipleCheckbox.Item value={MultipleCheckboxOptions.EMAIL} disabled>
               {t('Email')}
             </MultipleCheckbox.Item>
@@ -60,7 +60,7 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
                 {t('Integration (Slack, Discord, MS Teams, etc.)')}
               </MultipleCheckbox.Item>
             )}
-          </Stack>
+          </CheckboxStack>
           <ScmCollapsibleReveal
             open={!shouldRenderSetupButton && shouldRenderNotificationConfigs}
           >
@@ -78,6 +78,25 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
     </Stack>
   );
 }
+
+// MultipleCheckbox.Item's label is fixed at 20% width with nowrap text, tuned
+// for the classic wrapping row layout. In this stacked layout the long
+// integration label overflows on narrow screens, so let each label fill its
+// row and truncate the text with an ellipsis instead.
+const CheckboxStack = styled(Stack)`
+  label {
+    width: 100%;
+    min-width: 0;
+    /* The label's default right margin is for the side-by-side row layout; with
+       a full-width label it would push 10px past the container. */
+    margin-right: 0;
+  }
+  label > span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+`;
 
 // Indents the rule so its left edge lines up with the checkbox label text
 // rather than the checkbox itself: the sm Checkbox box (16px) plus the label's

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
-import {Stack} from '@sentry/scraps/layout';
+import {Checkbox} from '@sentry/scraps/checkbox';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {MultipleCheckbox} from 'sentry/components/forms/controls/multipleCheckbox';
 import {t} from 'sentry/locale';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {
@@ -45,31 +45,36 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
       <Text size="sm" bold variant="secondary" uppercase>
         {t('Notify via')}
       </Text>
-      <MultipleCheckbox
-        name="notification"
-        value={actions}
-        onChange={values => setActions(values)}
-      >
-        <Stack gap="md" width="100%">
-          <CheckboxStack>
-            <MultipleCheckbox.Item value={MultipleCheckboxOptions.EMAIL} disabled>
-              {t('Email')}
-            </MultipleCheckbox.Item>
-            {shouldRenderSetupButton ? null : (
-              <MultipleCheckbox.Item value={MultipleCheckboxOptions.INTEGRATION}>
-                {t('Integration (Slack, Discord, MS Teams, etc.)')}
-              </MultipleCheckbox.Item>
-            )}
-          </CheckboxStack>
-          <ScmCollapsibleReveal
-            open={!shouldRenderSetupButton && shouldRenderNotificationConfigs}
-          >
-            <IndentedRule>
-              <ScmMessagingIntegrationAlertRule {...props} />
-            </IndentedRule>
-          </ScmCollapsibleReveal>
+      <Stack gap="md" width="100%">
+        <Stack gap="md">
+          <Flex as="label" align="start" gap="md">
+            <Checkbox checked disabled readOnly />
+            <Text>{t('Email')}</Text>
+          </Flex>
+          {shouldRenderSetupButton ? null : (
+            <Flex as="label" align="start" gap="md">
+              <Checkbox
+                checked={actions.includes(MultipleCheckboxOptions.INTEGRATION)}
+                onChange={e =>
+                  setActions(
+                    e.target.checked
+                      ? [...actions, MultipleCheckboxOptions.INTEGRATION]
+                      : actions.filter(a => a !== MultipleCheckboxOptions.INTEGRATION)
+                  )
+                }
+              />
+              <Text>{t('Integration (Slack, Discord, MS Teams, etc.)')}</Text>
+            </Flex>
+          )}
         </Stack>
-      </MultipleCheckbox>
+        <ScmCollapsibleReveal
+          open={!shouldRenderSetupButton && shouldRenderNotificationConfigs}
+        >
+          <IndentedRule>
+            <ScmMessagingIntegrationAlertRule {...props} />
+          </IndentedRule>
+        </ScmCollapsibleReveal>
+      </Stack>
       {shouldRenderSetupButton && (
         <SetupMessagingIntegrationButton
           analyticsView={MessagingIntegrationAnalyticsView.PROJECT_CREATION}
@@ -79,33 +84,9 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
   );
 }
 
-// MultipleCheckbox.Item wraps each label in a container that is only a fraction
-// of the row (down to 25% on wide screens), and the label itself is 20% with
-// nowrap text. Both are tuned for the classic side-by-side row layout, but here
-// they truncate the long integration label even when there is room. Widen the
-// container and label to fill the row so the text only ellipsis-truncates when
-// it genuinely overflows (narrow screens).
-const CheckboxStack = styled(Stack)`
-  > div {
-    width: 100%;
-  }
-  label {
-    width: 100%;
-    min-width: 0;
-    /* The label's default right margin is for the side-by-side row layout; with
-       a full-width label it would push 10px past the container. */
-    margin-right: 0;
-  }
-  label > span {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-`;
-
 // Indents the rule so its left edge lines up with the checkbox label text
-// rather than the checkbox itself: the sm Checkbox box (16px) plus the label's
-// left margin (space.md).
+// rather than the checkbox itself: the sm Checkbox box (16px) plus the label
+// row's gap (space.md).
 const IndentedRule = styled('div')`
   padding-left: calc(16px + ${p => p.theme.space.md});
 `;

--- a/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/views/onboarding/components/scmIssueAlertNotificationOptions.tsx
@@ -5,7 +5,6 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
-import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {
   MessagingIntegrationAnalyticsView,
   SetupMessagingIntegrationButton,
@@ -13,6 +12,7 @@ import {
 import {
   type IssueAlertNotificationProps,
   MultipleCheckboxOptions,
+  useIssueAlertNotificationOptions,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
 import {ScmCollapsibleReveal} from './scmCollapsibleReveal';
@@ -26,15 +26,9 @@ import {ScmMessagingIntegrationAlertRule} from './scmMessagingIntegrationAlertRu
  * instead of the classic inline card.
  */
 export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationProps) {
-  const {actions, setActions, querySuccess, shouldRenderSetupButton} = props;
-
-  const shouldRenderNotificationConfigs = actions.some(
-    v => v !== MultipleCheckboxOptions.EMAIL
-  );
-
-  useRouteAnalyticsParams({
-    setup_message_integration_button_shown: shouldRenderSetupButton,
-  });
+  const {actions, setActions} = props;
+  const {querySuccess, shouldRenderNotificationConfigs, shouldRenderSetupButton} =
+    useIssueAlertNotificationOptions(props);
 
   if (!querySuccess) {
     return null;

--- a/static/app/views/onboarding/components/scmMessagingIntegrationAlertRule.spec.tsx
+++ b/static/app/views/onboarding/components/scmMessagingIntegrationAlertRule.spec.tsx
@@ -1,0 +1,50 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {IssueAlertNotificationProps} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+
+import {ScmMessagingIntegrationAlertRule} from './scmMessagingIntegrationAlertRule';
+
+describe('ScmMessagingIntegrationAlertRule', () => {
+  const organization = OrganizationFixture();
+  const slackIntegrations = [
+    OrganizationIntegrationsFixture({name: "Moo Deng's Workspace"}),
+  ];
+
+  const notificationProps: IssueAlertNotificationProps = {
+    actions: [],
+    channel: {label: 'channel', value: 'channel'},
+    integration: slackIntegrations[0],
+    provider: 'slack',
+    providersToIntegrations: {slack: slackIntegrations},
+    querySuccess: true,
+    shouldRenderSetupButton: false,
+    setActions: jest.fn(),
+    setChannel: jest.fn(),
+    setIntegration: jest.fn(),
+    setProvider: jest.fn(),
+  };
+
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${slackIntegrations[0]!.id}/channels/`,
+      body: {results: []},
+    });
+  });
+
+  it('renders the reused provider sentence with its three controls', () => {
+    render(<ScmMessagingIntegrationAlertRule {...notificationProps} />, {organization});
+
+    // The same three controls as the classic rule render.
+    expect(screen.getByLabelText('provider')).toBeInTheDocument();
+    expect(screen.getByLabelText('integration')).toBeInTheDocument();
+    expect(screen.getByLabelText('channel')).toBeInTheDocument();
+
+    // The provider sentence text is reused verbatim. The fragments are the
+    // column's direct text nodes, so they read as one normalized string
+    // ("Send [provider] notification to the [integration] workspace to [channel]").
+    expect(screen.getByText('Send notification to the workspace to')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/onboarding/components/scmMessagingIntegrationAlertRule.tsx
+++ b/static/app/views/onboarding/components/scmMessagingIntegrationAlertRule.tsx
@@ -1,0 +1,107 @@
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+import {Select} from '@sentry/scraps/select';
+
+import {t} from 'sentry/locale';
+import {
+  type IssueAlertNotificationProps,
+  providerDetails,
+} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import {
+  ChannelField,
+  ChannelSelect,
+  useMessagingIntegrationAlertRule,
+} from 'sentry/views/projectInstall/messagingIntegrationAlertRule';
+
+/**
+ * SCM-styled variant of `MessagingIntegrationAlertRule`. Instead of the classic
+ * inline sentence inside a grey card, the provider sentence is rendered into a
+ * flex column: each input is its own flex item and each contiguous run of text
+ * becomes an anonymous flex item, so every text block and input lands on its
+ * own full-width row in `makeSentence`'s order. Letting the column do the
+ * splitting (rather than parsing the sentence) keeps it correct no matter how a
+ * translation reorders the placeholders.
+ *
+ * Reuses `useMessagingIntegrationAlertRule` (the channel query, validation, and
+ * option lists) and the same provider sentence as the classic layout, so copy
+ * and behavior stay in lockstep; only the presentation differs.
+ */
+export function ScmMessagingIntegrationAlertRule(props: IssueAlertNotificationProps) {
+  const {
+    provider,
+    integration,
+    channel,
+    providerOptions,
+    integrationOptions,
+    channelOptions,
+    isChannelLoading,
+    channelError,
+    providerDisabled,
+    integrationDisabled,
+    onProviderChange,
+    onIntegrationChange,
+    onChannelChange,
+    onCreateChannel,
+  } = useMessagingIntegrationAlertRule(props);
+
+  if (!provider) {
+    return null;
+  }
+
+  return (
+    <Flex direction="column" gap="md">
+      {providerDetails[provider as keyof typeof providerDetails]?.makeSentence({
+        providerName: (
+          <FullWidthSelect
+            aria-label={t('provider')}
+            disabled={providerDisabled}
+            value={provider}
+            options={providerOptions}
+            onChange={onProviderChange}
+          />
+        ),
+        integrationName: (
+          <FullWidthSelect
+            aria-label={t('integration')}
+            disabled={integrationDisabled}
+            value={integration}
+            options={integrationOptions}
+            onChange={onIntegrationChange}
+          />
+        ),
+        target: (
+          // flexibleControlStateSize collapses the (empty) control-state column
+          // that otherwise reserves a fixed 24px, so the full-width select can
+          // fill the row.
+          <ChannelField
+            name="channel"
+            error={channelError}
+            inline={false}
+            flexibleControlStateSize
+          >
+            {() => (
+              <FullWidthChannelSelect
+                provider={provider}
+                options={channelOptions}
+                value={channel}
+                isLoading={isChannelLoading}
+                disabled={!integration}
+                onChange={onChannelChange}
+                onCreateOption={onCreateChannel}
+              />
+            )}
+          </ChannelField>
+        ),
+      })}
+    </Flex>
+  );
+}
+
+const FullWidthSelect = styled(Select)`
+  width: 100%;
+`;
+
+const FullWidthChannelSelect = styled(ChannelSelect)`
+  width: 100%;
+`;

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {DetectedPlatformFixture} from 'sentry-fixture/detectedPlatform';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RepositoryFixture} from 'sentry-fixture/repository';
@@ -148,5 +149,103 @@ describe('ScmPlatformFeaturesCore', () => {
       screen.getByRole('button', {name: 'Back to recommended platforms'})
     ).toBeInTheDocument();
     expect(screen.queryByTestId('icon-close')).not.toBeInTheDocument();
+  });
+
+  it('keeps a non-default detected selection when returning to the recommended view', async () => {
+    const onFeaturesChange = jest.fn();
+    const onClearProjectDetailsForm = jest.fn();
+    const repository = RepositoryFixture({
+      id: '123',
+      provider: {id: 'integrations:github', name: 'GitHub'},
+    });
+    // python is the recommendation (first detected); javascript is the second.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/${repository.id}/platforms/`,
+      body: {
+        platforms: [
+          DetectedPlatformFixture({platform: 'python'}),
+          DetectedPlatformFixture({platform: 'javascript'}),
+        ],
+      },
+    });
+
+    // Controlled, so hold the selection in state for the manual-pick flow.
+    function Host() {
+      const [platform, setPlatform] = useState<OnboardingSelectedSDK | undefined>(
+        pythonPlatform
+      );
+      return (
+        <ScmPlatformFeaturesCore
+          analyticsFlow="onboarding"
+          selectedRepository={repository}
+          selectedPlatform={platform}
+          onPlatformChange={setPlatform}
+          onFeaturesChange={onFeaturesChange}
+          onClearProjectDetailsForm={onClearProjectDetailsForm}
+        />
+      );
+    }
+
+    render(<Host />, {organization});
+
+    // Select the second detected platform, then open the manual picker.
+    await userEvent.click(
+      await screen.findByRole('radio', {name: 'Browser JavaScript Language'})
+    );
+    await userEvent.click(
+      screen.getByRole('button', {name: "Doesn't look right? Change platform"})
+    );
+    onFeaturesChange.mockClear();
+    onClearProjectDetailsForm.mockClear();
+
+    // Returning keeps the chosen detected platform: it is already detected, so
+    // nothing is reset and the card stays selected.
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Back to recommended platforms'})
+    );
+
+    expect(
+      await screen.findByRole('radio', {name: 'Browser JavaScript Language'})
+    ).toBeChecked();
+    expect(onFeaturesChange).not.toHaveBeenCalled();
+    expect(onClearProjectDetailsForm).not.toHaveBeenCalled();
+  });
+
+  it('does not reset state when returning without a change', async () => {
+    const onFeaturesChange = jest.fn();
+    const onClearProjectDetailsForm = jest.fn();
+    const repository = RepositoryFixture({
+      id: '123',
+      provider: {id: 'integrations:github', name: 'GitHub'},
+    });
+    // python is both the recommendation and the already-selected platform.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/${repository.id}/platforms/`,
+      body: {platforms: [DetectedPlatformFixture({platform: 'python'})]},
+    });
+
+    render(
+      <ScmPlatformFeaturesCore
+        {...defaultProps({
+          selectedRepository: repository,
+          selectedPlatform: pythonPlatform,
+          onFeaturesChange,
+          onClearProjectDetailsForm,
+        })}
+      />,
+      {organization}
+    );
+
+    // Open the manual picker from the detected view, then return without
+    // choosing a different platform.
+    await userEvent.click(
+      await screen.findByRole('button', {name: "Doesn't look right? Change platform"})
+    );
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Back to recommended platforms'})
+    );
+
+    expect(onFeaturesChange).not.toHaveBeenCalled();
+    expect(onClearProjectDetailsForm).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.spec.tsx
@@ -3,7 +3,7 @@ import {DetectedPlatformFixture} from 'sentry-fixture/detectedPlatform';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import * as analytics from 'sentry/utils/analytics';
@@ -45,6 +45,15 @@ const pythonPlatform: OnboardingSelectedSDK = {
   language: 'python',
   type: 'language',
   link: 'https://docs.sentry.io/platforms/python/',
+  category: 'popular',
+};
+
+const javascriptPlatform: OnboardingSelectedSDK = {
+  key: 'javascript',
+  name: 'Browser JavaScript',
+  language: 'javascript',
+  type: 'language',
+  link: 'https://docs.sentry.io/platforms/javascript/',
   category: 'popular',
 };
 
@@ -247,5 +256,54 @@ describe('ScmPlatformFeaturesCore', () => {
 
     expect(onFeaturesChange).not.toHaveBeenCalled();
     expect(onClearProjectDetailsForm).not.toHaveBeenCalled();
+  });
+
+  it('reverts a manual pick to the detected platform on return, recording it', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    const onPlatformChange = jest.fn();
+    const onFeaturesChange = jest.fn();
+    const onClearProjectDetailsForm = jest.fn();
+    const repository = RepositoryFixture({
+      id: '123',
+      provider: {id: 'integrations:github', name: 'GitHub'},
+    });
+    const detectionRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/${repository.id}/platforms/`,
+      body: {platforms: [DetectedPlatformFixture({platform: 'python'})]},
+    });
+
+    // The active platform is a manual pick that is not among the detected
+    // platforms, so the manual picker shows with a route back to recommended.
+    render(
+      <ScmPlatformFeaturesCore
+        {...defaultProps({
+          selectedRepository: repository,
+          selectedPlatform: javascriptPlatform,
+          onPlatformChange,
+          onFeaturesChange,
+          onClearProjectDetailsForm,
+        })}
+      />,
+      {organization}
+    );
+
+    // Wait for detection so the detected fallback (python) is available.
+    await waitFor(() => expect(detectionRequest).toHaveBeenCalled());
+
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Back to recommended platforms'})
+    );
+
+    // Leaving the manual pick reverts to the detected platform and records the
+    // selection with the detected source.
+    await waitFor(() =>
+      expect(onPlatformChange).toHaveBeenCalledWith(
+        expect.objectContaining({key: 'python'})
+      )
+    );
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'onboarding.scm_platform_selected',
+      expect.objectContaining({platform: 'python', source: 'detected'})
+    );
   });
 });

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -124,6 +124,13 @@ export function ScmPlatformFeaturesCore({
     isDetectionError,
   } = useScmResolvedPlatform({selectedPlatform, selectedRepository});
 
+  // Whether the active platform is one of the detected ones. Gates the
+  // detected-cards view below, and lets "Back to recommended" keep a detected
+  // selection (including a non-top one) rather than forcing the top detection.
+  const currentPlatformIsDetected = resolvedPlatforms.some(
+    p => p.platform === currentPlatformKey
+  );
+
   // Adopt the first detected platform once per repo when the user hasn't
   // explicitly chosen one: commit it to the host so flows without a Continue
   // boundary (single-view project creation) get a platform without an explicit
@@ -276,11 +283,18 @@ export function ScmPlatformFeaturesCore({
 
   function handleBackToRecommended() {
     setShowManualPicker(false);
-    if (detectedPlatformKey) {
-      setPlatform(detectedPlatformKey);
-      onFeaturesChange(DEFAULT_SCM_FEATURES);
-      onClearProjectDetailsForm();
+    // If the active platform is already a detected one, just reopen the cards
+    // view with it still selected. The user may have picked a non-top detection
+    // (or the auto-adopted default), so forcing the top detection here would
+    // clear a valid selection and wipe the derived features/form for no reason.
+    // Only a manual (non-detected) pick needs the fallback, since the cards view
+    // can't display it otherwise.
+    if (currentPlatformIsDetected || !detectedPlatformKey) {
+      return;
     }
+    setPlatform(detectedPlatformKey);
+    onFeaturesChange(DEFAULT_SCM_FEATURES);
+    onClearProjectDetailsForm();
   }
 
   // Shared by both manual-picker variants. A null option is the clear action,
@@ -316,11 +330,8 @@ export function ScmPlatformFeaturesCore({
     ];
   }, [currentPlatformKey]);
 
-  // If the user previously selected a platform manually (not in the detected
-  // list), show the manual picker so their selection is visible.
-  const currentPlatformIsDetected = resolvedPlatforms.some(
-    p => p.platform === currentPlatformKey
-  );
+  // When the active platform is a manual (non-detected) pick, show the manual
+  // picker so the selection stays visible (see showDetectedPlatforms below).
   const hasDetectedPlatforms = resolvedPlatforms.length > 0 || isDetecting;
   // Fall through to manual picker on detection error
   const showDetectedPlatforms =

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -295,6 +295,15 @@ export function ScmPlatformFeaturesCore({
     setPlatform(detectedPlatformKey);
     onFeaturesChange(DEFAULT_SCM_FEATURES);
     onClearProjectDetailsForm();
+    // Leaving a manual pick for the detected platform is itself a platform
+    // selection, so record it as the detected source (mirrors the auto-adopt
+    // path and handleSelectDetectedPlatform, which were the only detected-source
+    // emitters before).
+    trackAnalytics(PLATFORM_SELECTED_EVENT[analyticsFlow], {
+      organization,
+      platform: detectedPlatformKey,
+      source: 'detected',
+    });
   }
 
   // Shared by both manual-picker variants. A null option is the clear action,

--- a/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
+++ b/static/app/views/onboarding/components/scmProjectDetailsCore.tsx
@@ -54,7 +54,7 @@ export function ScmProjectDetailsCore({
   }, [organization, analyticsFlow]);
 
   return (
-    <Grid width="100%" columns={{sm: '1fr', md: '1fr 1fr'}} gap="2xl">
+    <Grid width="100%" columns={{sm: '1fr', md: '1fr 1fr'}} gap="xl">
       <Stack gap="md">
         <Container>
           <Heading as="h4">{t('Project name')}</Heading>

--- a/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
@@ -1,11 +1,12 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {TeamFixture} from 'sentry-fixture/team';
 
-import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import {MultipleCheckboxOptions} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
 import {useScmProjectDetails} from './useScmProjectDetails';
 
@@ -53,6 +54,32 @@ describe('useScmProjectDetails', () => {
   afterEach(() => {
     TeamStore.reset();
     MockApiClient.clearMockResponses();
+  });
+
+  it('requires an integration channel when notifying via integration', () => {
+    TeamStore.loadInitialData([adminTeam]);
+    ProjectsStore.loadInitialData([]);
+
+    const {result} = renderDetails();
+
+    // Default actions are email-only, so no channel is required.
+    expect(result.current.missingFields.notificationChannel).toBe(false);
+
+    // Selecting the integration action with no channel blocks submission.
+    act(() => {
+      result.current.notificationProps.setActions([
+        MultipleCheckboxOptions.EMAIL,
+        MultipleCheckboxOptions.INTEGRATION,
+      ]);
+    });
+    expect(result.current.missingFields.notificationChannel).toBe(true);
+    expect(result.current.canSubmit).toBe(false);
+
+    // Picking a channel clears the requirement.
+    act(() => {
+      result.current.notificationProps.setChannel({label: '#general', value: '#general'});
+    });
+    expect(result.current.missingFields.notificationChannel).toBe(false);
   });
 
   it('does not report the team as missing while teams are still loading', () => {

--- a/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
@@ -5,6 +5,7 @@ import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
+import {IssueAlertActionType} from 'sentry/types/alerts';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {MultipleCheckboxOptions} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
@@ -80,6 +81,52 @@ describe('useScmProjectDetails', () => {
       result.current.notificationProps.setChannel({label: '#general', value: '#general'});
     });
     expect(result.current.missingFields.notificationChannel).toBe(false);
+  });
+
+  it('persists the messaging-integration selection to the form', () => {
+    TeamStore.loadInitialData([adminTeam]);
+    ProjectsStore.loadInitialData([]);
+    const onProjectDetailsFormChange = jest.fn();
+
+    const {result} = renderDetails({onProjectDetailsFormChange});
+
+    act(() => {
+      result.current.notificationProps.setProvider('slack');
+    });
+    act(() => {
+      result.current.notificationProps.setActions([
+        MultipleCheckboxOptions.EMAIL,
+        MultipleCheckboxOptions.INTEGRATION,
+      ]);
+    });
+    act(() => {
+      result.current.notificationProps.setChannel({label: '#general', value: '#general'});
+    });
+
+    expect(onProjectDetailsFormChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        notificationActions: [
+          expect.objectContaining({id: IssueAlertActionType.SLACK, channel: '#general'}),
+        ],
+      })
+    );
+  });
+
+  it('restores the messaging-integration selection from the persisted form', () => {
+    TeamStore.loadInitialData([adminTeam]);
+    ProjectsStore.loadInitialData([]);
+
+    const {result} = renderDetails({
+      projectDetailsForm: {
+        projectName: 'my-project',
+        notificationActions: [{id: IssueAlertActionType.SLACK, channel: '#general'}],
+      },
+    });
+
+    expect(result.current.notificationProps.actions).toContain(
+      MultipleCheckboxOptions.INTEGRATION
+    );
+    expect(result.current.notificationProps.channel?.value).toBe('#general');
   });
 
   it('does not report the team as missing while teams are still loading', () => {

--- a/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
@@ -5,7 +5,6 @@ import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
-import {IssueAlertActionType} from 'sentry/types/alerts';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {MultipleCheckboxOptions} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
@@ -81,52 +80,6 @@ describe('useScmProjectDetails', () => {
       result.current.notificationProps.setChannel({label: '#general', value: '#general'});
     });
     expect(result.current.missingFields.notificationChannel).toBe(false);
-  });
-
-  it('persists the messaging-integration selection to the form', () => {
-    TeamStore.loadInitialData([adminTeam]);
-    ProjectsStore.loadInitialData([]);
-    const onProjectDetailsFormChange = jest.fn();
-
-    const {result} = renderDetails({onProjectDetailsFormChange});
-
-    act(() => {
-      result.current.notificationProps.setProvider('slack');
-    });
-    act(() => {
-      result.current.notificationProps.setActions([
-        MultipleCheckboxOptions.EMAIL,
-        MultipleCheckboxOptions.INTEGRATION,
-      ]);
-    });
-    act(() => {
-      result.current.notificationProps.setChannel({label: '#general', value: '#general'});
-    });
-
-    expect(onProjectDetailsFormChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        notificationActions: [
-          expect.objectContaining({id: IssueAlertActionType.SLACK, channel: '#general'}),
-        ],
-      })
-    );
-  });
-
-  it('restores the messaging-integration selection from the persisted form', () => {
-    TeamStore.loadInitialData([adminTeam]);
-    ProjectsStore.loadInitialData([]);
-
-    const {result} = renderDetails({
-      projectDetailsForm: {
-        projectName: 'my-project',
-        notificationActions: [{id: IssueAlertActionType.SLACK, channel: '#general'}],
-      },
-    });
-
-    expect(result.current.notificationProps.actions).toContain(
-      MultipleCheckboxOptions.INTEGRATION
-    );
-    expect(result.current.notificationProps.channel?.value).toBe('#general');
   });
 
   it('does not report the team as missing while teams are still loading', () => {

--- a/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
@@ -41,8 +41,18 @@ describe('useScmProjectDetails', () => {
     );
   }
 
+  beforeEach(() => {
+    // useCreateNotificationAction queries messaging integrations on mount.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body: [],
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+    });
+  });
+
   afterEach(() => {
     TeamStore.reset();
+    MockApiClient.clearMockResponses();
   });
 
   it('does not report the team as missing while teams are still loading', () => {

--- a/static/app/views/onboarding/components/useScmProjectDetails.ts
+++ b/static/app/views/onboarding/components/useScmProjectDetails.ts
@@ -18,7 +18,6 @@ import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
 import type {ScmAnalyticsFlow} from 'sentry/views/onboarding/components/scmAnalyticsFlow';
 import {
-  getMessagingIntegrationAction,
   type IssueAlertNotificationProps,
   MultipleCheckboxOptions,
   useCreateNotificationAction,
@@ -153,66 +152,8 @@ export function useScmProjectDetails({
   const createProjectAndRules = useCreateProjectAndRules();
   // Provides the messaging-integration notification picker (notificationProps,
   // rendered in ScmAlertFrequencySection) and the side-effect that creates the
-  // chosen notification rule at project creation. Seeded from the persisted
-  // selection so it survives navigation (the onboarding step remounts; the SCM
-  // create-project return restores the form).
-  const {createNotificationAction, notificationProps: baseNotificationProps} =
-    useCreateNotificationAction(
-      projectDetailsForm?.notificationActions
-        ? {actions: projectDetailsForm.notificationActions}
-        : undefined
-    );
-
-  // Persist the selection on each user change (not via an effect on derived
-  // state), so re-seeding from the persisted action can't loop. Limitation:
-  // when several messaging providers are connected, the hook re-selects the
-  // first available on load, so a non-first provider is not faithfully
-  // restored (the channel is).
-  const persistNotificationSelection = useCallback(
-    (next: {
-      actions?: IssueAlertNotificationProps['actions'];
-      channel?: IssueAlertNotificationProps['channel'];
-      integration?: IssueAlertNotificationProps['integration'];
-      provider?: IssueAlertNotificationProps['provider'];
-    }) => {
-      const actions = next.actions ?? baseNotificationProps.actions;
-      const action = actions.includes(MultipleCheckboxOptions.INTEGRATION)
-        ? getMessagingIntegrationAction({
-            provider: 'provider' in next ? next.provider : baseNotificationProps.provider,
-            integration:
-              'integration' in next
-                ? next.integration
-                : baseNotificationProps.integration,
-            channel: 'channel' in next ? next.channel : baseNotificationProps.channel,
-          })
-        : undefined;
-      onProjectDetailsFormChange({
-        ...projectDetailsForm,
-        notificationActions: action ? [action] : undefined,
-      });
-    },
-    [baseNotificationProps, projectDetailsForm, onProjectDetailsFormChange]
-  );
-
-  const notificationProps: IssueAlertNotificationProps = {
-    ...baseNotificationProps,
-    setActions: actions => {
-      baseNotificationProps.setActions(actions);
-      persistNotificationSelection({actions});
-    },
-    setProvider: provider => {
-      baseNotificationProps.setProvider(provider);
-      persistNotificationSelection({provider});
-    },
-    setIntegration: integration => {
-      baseNotificationProps.setIntegration(integration);
-      persistNotificationSelection({integration});
-    },
-    setChannel: channel => {
-      baseNotificationProps.setChannel(channel);
-      persistNotificationSelection({channel});
-    },
-  };
+  // chosen notification rule at project creation.
+  const {createNotificationAction, notificationProps} = useCreateNotificationAction();
 
   const accessTeams = teams.filter((team: Team) => team.access.includes('team:admin'));
   const firstAdminTeam = accessTeams[0];
@@ -362,10 +303,6 @@ export function useScmProjectDetails({
       projectName: projectNameResolved,
       teamSlug: teamSlugResolved,
       alertRuleConfig,
-      // Carry the notification selection into the persisted form so it survives
-      // a back-nav restore (onboarding context / createProject session), not
-      // just live edits on the mounted step.
-      notificationActions: projectDetailsForm?.notificationActions,
     };
 
     try {
@@ -426,7 +363,6 @@ export function useScmProjectDetails({
     nothingChanged,
     onComplete,
     organization,
-    projectDetailsForm,
     projectNameResolved,
     selectedPlatform,
     selectedRepository,

--- a/static/app/views/onboarding/components/useScmProjectDetails.ts
+++ b/static/app/views/onboarding/components/useScmProjectDetails.ts
@@ -19,6 +19,7 @@ import {useTeams} from 'sentry/utils/useTeams';
 import type {ScmAnalyticsFlow} from 'sentry/views/onboarding/components/scmAnalyticsFlow';
 import {
   type IssueAlertNotificationProps,
+  MultipleCheckboxOptions,
   useCreateNotificationAction,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
@@ -103,7 +104,12 @@ interface ScmProjectDetailsForm {
   /** Whether the team selector should be hidden (no-access member). */
   isOrgMemberWithNoAccess: boolean;
   /** Required fields still missing, for disabled-submit messaging. */
-  missingFields: {platform: boolean; projectName: boolean; team: boolean};
+  missingFields: {
+    notificationChannel: boolean;
+    platform: boolean;
+    projectName: boolean;
+    team: boolean;
+  };
   /** Messaging-integration notification picker props for the alert section. */
   notificationProps: IssueAlertNotificationProps;
   onAlertChange: <K extends keyof AlertRuleOptions>(
@@ -223,7 +229,17 @@ export function useScmProjectDetails({
     ]
   );
 
+  // When notifying via a messaging integration, a channel must be picked before
+  // the project can be created. Mirrors the classic flow's active gate (its
+  // useValidateChannel is wired with enabled:false, so live validation is off
+  // there too; this is the real check). Irrelevant when alerts are turned off.
+  const isMissingNotificationChannel =
+    alertRuleConfig.alertSetting !== RuleAction.CREATE_ALERT_LATER &&
+    notificationProps.actions.includes(MultipleCheckboxOptions.INTEGRATION) &&
+    !notificationProps.channel;
+
   const missingFields = {
+    notificationChannel: isMissingNotificationChannel,
     platform: !selectedPlatform,
     projectName: projectNameResolved.length === 0,
     // While teams load, teamSlugResolved is empty only because firstAdminTeam
@@ -249,6 +265,7 @@ export function useScmProjectDetails({
     !missingFields.projectName &&
     !missingFields.team &&
     !missingFields.platform &&
+    !missingFields.notificationChannel &&
     !isCompleting &&
     !isLoadingTeams &&
     projectsLoaded;

--- a/static/app/views/onboarding/components/useScmProjectDetails.ts
+++ b/static/app/views/onboarding/components/useScmProjectDetails.ts
@@ -18,6 +18,10 @@ import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
 import type {ScmAnalyticsFlow} from 'sentry/views/onboarding/components/scmAnalyticsFlow';
 import {
+  type IssueAlertNotificationProps,
+  useCreateNotificationAction,
+} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import {
   DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
   getRequestDataFragment,
   type AlertRuleOptions,
@@ -100,6 +104,8 @@ interface ScmProjectDetailsForm {
   isOrgMemberWithNoAccess: boolean;
   /** Required fields still missing, for disabled-submit messaging. */
   missingFields: {platform: boolean; projectName: boolean; team: boolean};
+  /** Messaging-integration notification picker props for the alert section. */
+  notificationProps: IssueAlertNotificationProps;
   onAlertChange: <K extends keyof AlertRuleOptions>(
     key: K,
     value: AlertRuleOptions[K]
@@ -138,6 +144,10 @@ export function useScmProjectDetails({
   const {teams, fetching: isLoadingTeams} = useTeams();
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const createProjectAndRules = useCreateProjectAndRules();
+  // Provides the messaging-integration notification picker (notificationProps,
+  // rendered in ScmAlertFrequencySection) and the side-effect that creates the
+  // chosen notification rule at project creation.
+  const {createNotificationAction, notificationProps} = useCreateNotificationAction();
 
   const accessTeams = teams.filter((team: Team) => team.access.includes('team:admin'));
   const firstAdminTeam = accessTeams[0];
@@ -296,7 +306,7 @@ export function useScmProjectDetails({
         platform: selectedPlatform,
         team: isOrgMemberWithNoAccess ? undefined : teamSlugResolved,
         alertRuleConfig: getRequestDataFragment(alertRuleConfig),
-        createNotificationAction: () => {},
+        createNotificationAction,
       });
 
       if (selectedRepository?.id) {
@@ -329,6 +339,7 @@ export function useScmProjectDetails({
     analyticsFlow,
     alertRuleConfig,
     canSubmit,
+    createNotificationAction,
     createProjectAndRules,
     existingProject,
     isOrgMemberWithNoAccess,
@@ -349,6 +360,7 @@ export function useScmProjectDetails({
     onTeamChange,
     alertRuleConfig,
     onAlertChange,
+    notificationProps,
     isOrgMemberWithNoAccess,
     missingFields,
     canSubmit,

--- a/static/app/views/onboarding/components/useScmProjectDetails.ts
+++ b/static/app/views/onboarding/components/useScmProjectDetails.ts
@@ -18,6 +18,7 @@ import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
 import type {ScmAnalyticsFlow} from 'sentry/views/onboarding/components/scmAnalyticsFlow';
 import {
+  getMessagingIntegrationAction,
   type IssueAlertNotificationProps,
   MultipleCheckboxOptions,
   useCreateNotificationAction,
@@ -152,8 +153,66 @@ export function useScmProjectDetails({
   const createProjectAndRules = useCreateProjectAndRules();
   // Provides the messaging-integration notification picker (notificationProps,
   // rendered in ScmAlertFrequencySection) and the side-effect that creates the
-  // chosen notification rule at project creation.
-  const {createNotificationAction, notificationProps} = useCreateNotificationAction();
+  // chosen notification rule at project creation. Seeded from the persisted
+  // selection so it survives navigation (the onboarding step remounts; the SCM
+  // create-project return restores the form).
+  const {createNotificationAction, notificationProps: baseNotificationProps} =
+    useCreateNotificationAction(
+      projectDetailsForm?.notificationActions
+        ? {actions: projectDetailsForm.notificationActions}
+        : undefined
+    );
+
+  // Persist the selection on each user change (not via an effect on derived
+  // state), so re-seeding from the persisted action can't loop. Limitation:
+  // when several messaging providers are connected, the hook re-selects the
+  // first available on load, so a non-first provider is not faithfully
+  // restored (the channel is).
+  const persistNotificationSelection = useCallback(
+    (next: {
+      actions?: IssueAlertNotificationProps['actions'];
+      channel?: IssueAlertNotificationProps['channel'];
+      integration?: IssueAlertNotificationProps['integration'];
+      provider?: IssueAlertNotificationProps['provider'];
+    }) => {
+      const actions = next.actions ?? baseNotificationProps.actions;
+      const action = actions.includes(MultipleCheckboxOptions.INTEGRATION)
+        ? getMessagingIntegrationAction({
+            provider: 'provider' in next ? next.provider : baseNotificationProps.provider,
+            integration:
+              'integration' in next
+                ? next.integration
+                : baseNotificationProps.integration,
+            channel: 'channel' in next ? next.channel : baseNotificationProps.channel,
+          })
+        : undefined;
+      onProjectDetailsFormChange({
+        ...projectDetailsForm,
+        notificationActions: action ? [action] : undefined,
+      });
+    },
+    [baseNotificationProps, projectDetailsForm, onProjectDetailsFormChange]
+  );
+
+  const notificationProps: IssueAlertNotificationProps = {
+    ...baseNotificationProps,
+    setActions: actions => {
+      baseNotificationProps.setActions(actions);
+      persistNotificationSelection({actions});
+    },
+    setProvider: provider => {
+      baseNotificationProps.setProvider(provider);
+      persistNotificationSelection({provider});
+    },
+    setIntegration: integration => {
+      baseNotificationProps.setIntegration(integration);
+      persistNotificationSelection({integration});
+    },
+    setChannel: channel => {
+      baseNotificationProps.setChannel(channel);
+      persistNotificationSelection({channel});
+    },
+  };
 
   const accessTeams = teams.filter((team: Team) => team.access.includes('team:admin'));
   const firstAdminTeam = accessTeams[0];
@@ -303,6 +362,10 @@ export function useScmProjectDetails({
       projectName: projectNameResolved,
       teamSlug: teamSlugResolved,
       alertRuleConfig,
+      // Carry the notification selection into the persisted form so it survives
+      // a back-nav restore (onboarding context / createProject session), not
+      // just live edits on the mounted step.
+      notificationActions: projectDetailsForm?.notificationActions,
     };
 
     try {
@@ -363,6 +426,7 @@ export function useScmProjectDetails({
     nothingChanged,
     onComplete,
     organization,
+    projectDetailsForm,
     projectNameResolved,
     selectedPlatform,
     selectedRepository,

--- a/static/app/views/onboarding/components/useScmProjectDetails.ts
+++ b/static/app/views/onboarding/components/useScmProjectDetails.ts
@@ -288,7 +288,13 @@ export function useScmProjectDetails({
     alertRuleConfig.alertSetting === savedAlert?.alertSetting &&
     alertRuleConfig.interval === savedAlert?.interval &&
     alertRuleConfig.metric === savedAlert?.metric &&
-    alertRuleConfig.threshold === savedAlert?.threshold;
+    alertRuleConfig.threshold === savedAlert?.threshold &&
+    // A configured messaging-integration notification would create a rule the
+    // reused project lacks: the selection isn't persisted across nav, so the
+    // baseline is always "no integration". Treat it as a change so the reuse
+    // shortcut can't silently drop the notification rule. Persisting the
+    // selection (and comparing it precisely) is tracked as follow-up work.
+    !notificationProps.actions.includes(MultipleCheckboxOptions.INTEGRATION);
 
   const submit = useCallback(async () => {
     if (!selectedPlatform || !canSubmit || isCompletingRef.current) {

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -115,8 +115,14 @@ describe('ScmProjectDetails', () => {
     });
 
     expect(await screen.findByText('High priority issues')).toBeInTheDocument();
-    expect(screen.getByText('Custom')).toBeInTheDocument();
-    expect(screen.getByText("I'll create my own alerts later")).toBeInTheDocument();
+    expect(
+      screen.getByText('Alert on new, regressed, and escalating issues')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Custom threshold')).toBeInTheDocument();
+    expect(screen.getByText("I'll set up alerts later")).toBeInTheDocument();
+    expect(
+      screen.getByText('You can always change alerts after project creation')
+    ).toBeInTheDocument();
   });
 
   it('re-derives the fields when the host clears the form', () => {

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -95,6 +95,7 @@ export function ScmProjectDetails({
         <ScmAlertFrequencySection
           analyticsFlow="onboarding"
           alertRuleConfig={form.alertRuleConfig}
+          notificationProps={form.notificationProps}
           onAlertChange={form.onAlertChange}
         />
       </Stack>

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -249,11 +249,19 @@ export function useCreateNotificationAction({
   };
 }
 
-export function IssueAlertNotificationOptions(
-  notificationProps: IssueAlertNotificationProps
-) {
-  const {actions, setActions, querySuccess, shouldRenderSetupButton} = notificationProps;
-
+/**
+ * Shared shell for the project-creation notification options: derives which
+ * sub-controls to show and reports the setup-button impression. The classic
+ * (`IssueAlertNotificationOptions`) and SCM (`ScmIssueAlertNotificationOptions`)
+ * layouts reuse this and differ only in presentation.
+ *
+ * @public Consumed by the SCM layout in a downstream PR.
+ */
+export function useIssueAlertNotificationOptions({
+  actions,
+  querySuccess,
+  shouldRenderSetupButton,
+}: IssueAlertNotificationProps) {
   const shouldRenderNotificationConfigs = actions.some(
     v => v !== MultipleCheckboxOptions.EMAIL
   );
@@ -261,6 +269,20 @@ export function IssueAlertNotificationOptions(
   useRouteAnalyticsParams({
     setup_message_integration_button_shown: shouldRenderSetupButton,
   });
+
+  return {
+    querySuccess,
+    shouldRenderNotificationConfigs,
+    shouldRenderSetupButton,
+  };
+}
+
+export function IssueAlertNotificationOptions(
+  notificationProps: IssueAlertNotificationProps
+) {
+  const {actions, setActions} = notificationProps;
+  const {querySuccess, shouldRenderNotificationConfigs, shouldRenderSetupButton} =
+    useIssueAlertNotificationOptions(notificationProps);
 
   if (!querySuccess) {
     return null;

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -85,6 +85,45 @@ export type IssueAlertNotificationProps = {
   channel?: IntegrationChannel;
 };
 
+/**
+ * Builds the alert-rule action for the selected messaging integration, or
+ * undefined when there is no integration selection. Shared by
+ * createNotificationAction (to create the rule) and the SCM flow (to persist
+ * the selection across navigation, then re-seed it).
+ */
+export function getMessagingIntegrationAction({
+  provider,
+  integration,
+  channel,
+}: {
+  channel?: IntegrationChannel;
+  integration?: OrganizationIntegration;
+  provider?: string;
+}): IntegrationAction | undefined {
+  switch (provider) {
+    case 'slack':
+      return {
+        id: IssueAlertActionType.SLACK,
+        workspace: integration?.id,
+        channel: channel?.value,
+      };
+    case 'discord':
+      return {
+        id: IssueAlertActionType.DISCORD,
+        server: integration?.id,
+        channel_id: channel?.value,
+      };
+    case 'msteams':
+      return {
+        id: IssueAlertActionType.MS_TEAMS,
+        team: integration?.id,
+        channel: channel?.value,
+      };
+    default:
+      return undefined;
+  }
+}
+
 export function useCreateNotificationAction({
   actions: defaultActions,
 }: Partial<Pick<RequestDataFragment, 'actions'>> = {}) {
@@ -186,37 +225,13 @@ export function useCreateNotificationAction({
       const isCreatingIntegrationNotification = actions.find(
         action => action === MultipleCheckboxOptions.INTEGRATION
       );
-      if (!shouldCreateRule || !isCreatingIntegrationNotification) {
+      const integrationAction = getMessagingIntegrationAction({
+        provider,
+        integration,
+        channel,
+      });
+      if (!shouldCreateRule || !isCreatingIntegrationNotification || !integrationAction) {
         return;
-      }
-
-      let integrationAction: IntegrationAction;
-      switch (provider) {
-        case 'slack':
-          integrationAction = {
-            id: IssueAlertActionType.SLACK,
-            workspace: integration?.id,
-            channel: channel?.value,
-          };
-
-          break;
-        case 'discord':
-          integrationAction = {
-            id: IssueAlertActionType.DISCORD,
-            server: integration?.id,
-            channel_id: channel?.value,
-          };
-
-          break;
-        case 'msteams':
-          integrationAction = {
-            id: IssueAlertActionType.MS_TEAMS,
-            team: integration?.id,
-            channel: channel?.value,
-          };
-          break;
-        default:
-          return;
       }
 
       return createProjectRules.mutateAsync({

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -85,45 +85,6 @@ export type IssueAlertNotificationProps = {
   channel?: IntegrationChannel;
 };
 
-/**
- * Builds the alert-rule action for the selected messaging integration, or
- * undefined when there is no integration selection. Shared by
- * createNotificationAction (to create the rule) and the SCM flow (to persist
- * the selection across navigation, then re-seed it).
- */
-export function getMessagingIntegrationAction({
-  provider,
-  integration,
-  channel,
-}: {
-  channel?: IntegrationChannel;
-  integration?: OrganizationIntegration;
-  provider?: string;
-}): IntegrationAction | undefined {
-  switch (provider) {
-    case 'slack':
-      return {
-        id: IssueAlertActionType.SLACK,
-        workspace: integration?.id,
-        channel: channel?.value,
-      };
-    case 'discord':
-      return {
-        id: IssueAlertActionType.DISCORD,
-        server: integration?.id,
-        channel_id: channel?.value,
-      };
-    case 'msteams':
-      return {
-        id: IssueAlertActionType.MS_TEAMS,
-        team: integration?.id,
-        channel: channel?.value,
-      };
-    default:
-      return undefined;
-  }
-}
-
 export function useCreateNotificationAction({
   actions: defaultActions,
 }: Partial<Pick<RequestDataFragment, 'actions'>> = {}) {
@@ -225,13 +186,37 @@ export function useCreateNotificationAction({
       const isCreatingIntegrationNotification = actions.find(
         action => action === MultipleCheckboxOptions.INTEGRATION
       );
-      const integrationAction = getMessagingIntegrationAction({
-        provider,
-        integration,
-        channel,
-      });
-      if (!shouldCreateRule || !isCreatingIntegrationNotification || !integrationAction) {
+      if (!shouldCreateRule || !isCreatingIntegrationNotification) {
         return;
+      }
+
+      let integrationAction: IntegrationAction;
+      switch (provider) {
+        case 'slack':
+          integrationAction = {
+            id: IssueAlertActionType.SLACK,
+            workspace: integration?.id,
+            channel: channel?.value,
+          };
+
+          break;
+        case 'discord':
+          integrationAction = {
+            id: IssueAlertActionType.DISCORD,
+            server: integration?.id,
+            channel_id: channel?.value,
+          };
+
+          break;
+        case 'msteams':
+          integrationAction = {
+            id: IssueAlertActionType.MS_TEAMS,
+            team: integration?.id,
+            channel: channel?.value,
+          };
+          break;
+        default:
+          return;
       }
 
       return createProjectRules.mutateAsync({

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
@@ -9,8 +9,9 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
-  providerDetails,
+  type IntegrationChannel,
   type IssueAlertNotificationProps,
+  providerDetails,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {useValidateChannel} from 'sentry/views/projectInstall/useValidateChannel';
 
@@ -25,7 +26,15 @@ type ChannelListResponse = {
   results: Channel[];
 };
 
-export function MessagingIntegrationAlertRule({
+/**
+ * Shared data + handlers for the messaging-integration alert rule. Owns the
+ * channels query, channel validation, and the provider/integration/channel
+ * option lists and change handlers, so the classic inline layout
+ * (`MessagingIntegrationAlertRule`) and the SCM stacked layout
+ * (`ScmMessagingIntegrationAlertRule`) build identical controls and feed them
+ * to the same provider sentence, differing only in presentation.
+ */
+export function useMessagingIntegrationAlertRule({
   channel,
   integration,
   provider,
@@ -79,6 +88,126 @@ export function MessagingIntegrationAlertRule({
     [providersToIntegrations, provider]
   );
 
+  const channelOptions = useMemo(
+    () =>
+      channels?.results.map(ch =>
+        provider === 'slack'
+          ? {label: ch.display, value: ch.display}
+          : {label: `${ch.display} (${ch.id})`, value: ch.id}
+      ),
+    [channels, provider]
+  );
+
+  return {
+    provider,
+    integration,
+    channel,
+    providerOptions,
+    integrationOptions,
+    channelOptions,
+    isChannelLoading: isPending || validateChannel.isFetching,
+    channelError: validateChannel.error,
+    providerDisabled: Object.keys(providersToIntegrations).length === 1,
+    integrationDisabled: integrationOptions.length === 1,
+    onProviderChange: (option: any) => {
+      setProvider(option.value);
+      setIntegration(providersToIntegrations[option.value]![0]);
+      setChannel(undefined);
+      validateChannel.clear();
+    },
+    onIntegrationChange: (option: any) => {
+      setIntegration(option.value);
+      setChannel(undefined);
+      validateChannel.clear();
+    },
+    onChannelChange: (option: {label: React.ReactNode; value: string} | null) => {
+      setChannel(
+        option ? {value: option.value, label: option.label, new: false} : undefined
+      );
+      validateChannel.clear();
+    },
+    onCreateChannel: (newOption: string) => {
+      setChannel({value: newOption, label: newOption, new: true});
+    },
+  };
+}
+
+type ChannelSelectProps = {
+  disabled: boolean;
+  isLoading: boolean;
+  onChange: (option: {label: React.ReactNode; value: string} | null) => void;
+  onCreateOption: (value: string) => void;
+  options: Array<{label: React.ReactNode; value: string}> | undefined;
+  provider: string;
+  value: IntegrationChannel | undefined;
+  className?: string;
+};
+
+/**
+ * The creatable channel picker, shared by both layouts. The Slack API returns
+ * at most 1000 channels, so it stays creatable to let users enter one that is
+ * not in the results.
+ */
+export function ChannelSelect({
+  className,
+  provider,
+  options,
+  value,
+  isLoading,
+  disabled,
+  onChange,
+  onCreateOption,
+}: ChannelSelectProps) {
+  return (
+    <Select
+      className={className}
+      aria-label={t('channel')}
+      placeholder={providerDetails[provider as keyof typeof providerDetails]?.placeholder}
+      isSearchable
+      options={options}
+      isLoading={isLoading}
+      disabled={disabled}
+      value={value ? {label: value.label, value: value.value} : undefined}
+      onChange={onChange}
+      onCreateOption={onCreateOption}
+      clearable
+      creatable
+      formatCreateLabel={(inputValue: string) => inputValue}
+      components={{
+        Option: optionProps => (
+          <SelectOption
+            {...(optionProps as any)}
+            data={{
+              ...optionProps.data,
+              // Hide IconAdd for new channel options by setting __isNew__ to false.
+              // We do that to not give the impression that the user can create a new channel.
+              __isNew__: false,
+            }}
+          />
+        ),
+      }}
+    />
+  );
+}
+
+export function MessagingIntegrationAlertRule(props: IssueAlertNotificationProps) {
+  const {
+    provider,
+    integration,
+    channel,
+    providerOptions,
+    integrationOptions,
+    channelOptions,
+    isChannelLoading,
+    channelError,
+    providerDisabled,
+    integrationDisabled,
+    onProviderChange,
+    onIntegrationChange,
+    onChannelChange,
+    onCreateChannel,
+  } = useMessagingIntegrationAlertRule(props);
+
   if (!provider) {
     return null;
   }
@@ -89,84 +218,32 @@ export function MessagingIntegrationAlertRule({
         providerName: (
           <InlineSelectControl
             aria-label={t('provider')}
-            disabled={Object.keys(providersToIntegrations).length === 1}
+            disabled={providerDisabled}
             value={provider}
             options={providerOptions}
-            onChange={(p: any) => {
-              setProvider(p.value);
-              setIntegration(providersToIntegrations[p.value]![0]);
-              setChannel(undefined);
-              validateChannel.clear();
-            }}
+            onChange={onProviderChange}
           />
         ),
         integrationName: (
           <InlineSelectControl
             aria-label={t('integration')}
-            disabled={integrationOptions.length === 1}
+            disabled={integrationDisabled}
             value={integration}
             options={integrationOptions}
-            onChange={(i: any) => {
-              setIntegration(i.value);
-              setChannel(undefined);
-              validateChannel.clear();
-            }}
+            onChange={onIntegrationChange}
           />
         ),
         target: (
-          <ChannelField name="channel" error={validateChannel.error} inline={false}>
+          <ChannelField name="channel" error={channelError} inline={false}>
             {() => (
-              <InlineSelect
-                aria-label={t('channel')}
-                placeholder={
-                  providerDetails[provider as keyof typeof providerDetails]?.placeholder
-                }
-                isSearchable
-                options={channels?.results.map(ch =>
-                  provider === 'slack'
-                    ? {
-                        label: ch.display,
-                        value: ch.display,
-                      }
-                    : {
-                        label: `${ch.display} (${ch.id})`,
-                        value: ch.id,
-                      }
-                )}
-                isLoading={isPending || validateChannel.isFetching}
+              <InlineChannelSelect
+                provider={provider}
+                options={channelOptions}
+                value={channel}
+                isLoading={isChannelLoading}
                 disabled={!integration}
-                value={channel ? {label: channel.label, value: channel.value} : undefined}
-                onChange={option => {
-                  if (option) {
-                    setChannel({value: option.value, label: option.label, new: false});
-                  } else {
-                    setChannel(undefined);
-                  }
-                  validateChannel.clear();
-                }}
-                onCreateOption={(newOption: string) => {
-                  setChannel({value: newOption, label: newOption, new: true});
-                }}
-                clearable
-                // The Slack API returns the maximum of channels, and users might not find the channel they want in the first 1000.
-                // This allows them to add a channel that is not present in the results.
-                creatable
-                formatCreateLabel={(inputValue: string) => inputValue}
-                components={{
-                  Option: optionProps => {
-                    return (
-                      <SelectOption
-                        {...(optionProps as any)}
-                        data={{
-                          ...optionProps.data,
-                          // Hide IconAdd for new channel options by setting __isNew__ to false
-                          // We are doing that to don't give the impression that the user can create a new channel.
-                          __isNew__: false,
-                        }}
-                      />
-                    );
-                  },
-                }}
+                onChange={onChannelChange}
+                onCreateOption={onCreateChannel}
               />
             )}
           </ChannelField>
@@ -190,10 +267,11 @@ const InlineSelectControl = styled(Select)`
   width: 180px;
 `;
 
-const InlineSelect = styled(Select)`
+// Preserves the classic inline channel-select width.
+const InlineChannelSelect = styled(ChannelSelect)`
   min-width: 220px;
 `;
 
-const ChannelField = styled(FormField)`
+export const ChannelField = styled(FormField)`
   padding: 0;
 `;

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
@@ -33,6 +33,8 @@ type ChannelListResponse = {
  * (`MessagingIntegrationAlertRule`) and the SCM stacked layout
  * (`ScmMessagingIntegrationAlertRule`) build identical controls and feed them
  * to the same provider sentence, differing only in presentation.
+ *
+ * @public Consumed by the SCM layout in a downstream PR.
  */
 export function useMessagingIntegrationAlertRule({
   channel,
@@ -147,6 +149,8 @@ type ChannelSelectProps = {
  * The creatable channel picker, shared by both layouts. The Slack API returns
  * at most 1000 channels, so it stays creatable to let users enter one that is
  * not in the results.
+ *
+ * @public Consumed by the SCM layout in a downstream PR.
  */
 export function ChannelSelect({
   className,
@@ -272,6 +276,7 @@ const InlineChannelSelect = styled(ChannelSelect)`
   min-width: 220px;
 `;
 
+/** @public Consumed by the SCM layout in a downstream PR. */
 export const ChannelField = styled(FormField)`
   padding: 0;
 `;

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -281,7 +281,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
             >
               <Layout.Title>{t('Create a new project')}</Layout.Title>
 
-              <MotionStack paddingBottom="lg" gap="md" layout="position">
+              <MotionStack gap="md" layout="position">
                 <Heading as="h1">{t('Create a project')}</Heading>
                 <Text variant="secondary" density="comfortable">
                   {tct(

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -73,7 +73,9 @@ function getSubmitTooltipText({
   platform,
   projectName,
   team,
+  notificationChannel,
 }: {
+  notificationChannel: boolean;
   platform: boolean;
   projectName: boolean;
   team: boolean;
@@ -90,6 +92,9 @@ function getSubmitTooltipText({
   }
   if (team) {
     return t('Please select a team');
+  }
+  if (notificationChannel) {
+    return t('Please provide an integration channel for alert notifications');
   }
   return undefined;
 }

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -368,6 +368,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                 <ScmAlertFrequencySection
                   analyticsFlow="project-creation"
                   alertRuleConfig={form.alertRuleConfig}
+                  notificationProps={form.notificationProps}
                   onAlertChange={form.onAlertChange}
                 />
               </motion.div>

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -80,7 +80,9 @@ function getSubmitTooltipText({
   projectName: boolean;
   team: boolean;
 }): string | undefined {
-  const missingCount = [platform, projectName, team].filter(Boolean).length;
+  const missingCount = [platform, projectName, team, notificationChannel].filter(
+    Boolean
+  ).length;
   if (missingCount > 1) {
     return t('Please fill out all the required fields');
   }

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -744,12 +744,10 @@ class ScmOnboardingTest(AcceptanceTestCase):
             self.browser.click('[aria-label="Back"]')
             self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
 
-            # Switch alerts from "High priority issues" to "create later".
-            self.browser.click(
-                xpath='//button[@role="radio"][contains(., "create my own alerts later")]'
-            )
+            # Switch alerts from "High priority issues" to "set up later".
+            self.browser.click(xpath='//button[@role="radio"][contains(., "set up alerts later")]')
             self.browser.wait_until(
-                xpath='//button[@role="radio"][@aria-checked="true"][contains(., "create my own alerts later")]'
+                xpath='//button[@role="radio"][@aria-checked="true"][contains(., "set up alerts later")]'
             )
             self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
             self.browser.click(xpath='//button[contains(., "Create project")]')


### PR DESCRIPTION
## TLDR

Small visual polish for the SCM project-creation page. A catch-all for minor style tweaks that don't warrant their own PR.

## Details

- Tighten the project-details grid gap between the project-name and team columns from `2xl` to `xl` (`ScmProjectDetailsCore`).
