### PR TITLE
chore(notif-platform): Allow headers + footers to support rich text

### DIFF
--- a/src/sentry/integrations/discord/message_builder/base/embed/base.py
+++ b/src/sentry/integrations/discord/message_builder/base/embed/base.py
@@ -35,7 +35,7 @@ class DiscordMessageEmbed:
 
     Some fields are not implemented, add to this as needed.
 
-    https://discord.com/developers/docs/resources/channel#embed-object
+    https://docs.discord.com/developers/resources/message#embed-object
     """
 
     def __init__(

--- a/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
+++ b/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
@@ -39,9 +39,25 @@ class InternalRegisteredTemplatesEndpoint(Endpoint):
         return Response(response)
 
 
+def _serialize_blocks(blocks: list) -> list[dict[str, Any]]:
+    return [
+        {
+            "type": block.type,
+            "blocks": [
+                {"type": text_block.type, "text": text_block.text} for text_block in block.blocks
+            ],
+        }
+        for block in blocks
+    ]
+
+
 def serialize_rendered_example(rendered_template: NotificationRenderedTemplate) -> dict[str, Any]:
     response: dict[str, Any] = {
-        "subject": rendered_template.subject,
+        "subject": (
+            _serialize_blocks(rendered_template.subject)
+            if isinstance(rendered_template.subject, list)
+            else rendered_template.subject
+        ),
         "body": [
             {
                 "type": block.type,
@@ -63,16 +79,7 @@ def serialize_rendered_example(rendered_template: NotificationRenderedTemplate) 
         }
     if rendered_template.footer:
         if isinstance(rendered_template.footer, list):
-            response["footer"] = [
-                {
-                    "type": block.type,
-                    "blocks": [
-                        {"type": text_block.type, "text": text_block.text}
-                        for text_block in block.blocks
-                    ],
-                }
-                for block in rendered_template.footer
-            ]
+            response["footer"] = _serialize_blocks(rendered_template.footer)
         else:
             response["footer"] = rendered_template.footer
     return response

--- a/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
+++ b/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
@@ -62,7 +62,19 @@ def serialize_rendered_example(rendered_template: NotificationRenderedTemplate) 
             "alt_text": rendered_template.chart.alt_text,
         }
     if rendered_template.footer:
-        response["footer"] = rendered_template.footer
+        if isinstance(rendered_template.footer, list):
+            response["footer"] = [
+                {
+                    "type": block.type,
+                    "blocks": [
+                        {"type": text_block.type, "text": text_block.text}
+                        for text_block in block.blocks
+                    ],
+                }
+                for block in rendered_template.footer
+            ]
+        else:
+            response["footer"] = rendered_template.footer
     return response
 
 

--- a/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
+++ b/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
@@ -14,6 +14,7 @@ from sentry.notifications.platform.msteams.provider import MSTeamsRenderable, MS
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.slack.provider import SlackNotificationProvider
 from sentry.notifications.platform.types import (
+    LinkTextBlock,
     NotificationData,
     NotificationProviderKey,
     NotificationRenderedTemplate,
@@ -50,7 +51,13 @@ def _serialize_sections(
 
 
 def _serialize_blocks(blocks: list[NotificationTextBlock]) -> list[dict[str, Any]]:
-    return [{"type": block.type, "text": block.text} for block in blocks]
+    serialized_blocks = []
+    for block in blocks:
+        serialized_block = {"type": block.type, "text": block.text}
+        if isinstance(block, LinkTextBlock):
+            serialized_block["url"] = block.url
+        serialized_blocks.append(serialized_block)
+    return serialized_blocks
 
 
 def serialize_rendered_example(rendered_template: NotificationRenderedTemplate) -> dict[str, Any]:

--- a/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
+++ b/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
@@ -14,6 +14,8 @@ from sentry.notifications.platform.msteams.provider import MSTeamsRenderable, MS
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.slack.provider import SlackNotificationProvider
 from sentry.notifications.platform.types import (
+    NotificationBodyFormattingBlock,
+    NotificationBodyTextBlock,
     NotificationData,
     NotificationProviderKey,
     NotificationRenderedTemplate,
@@ -39,35 +41,23 @@ class InternalRegisteredTemplatesEndpoint(Endpoint):
         return Response(response)
 
 
-def _serialize_blocks(blocks: list) -> list[dict[str, Any]]:
+def _serialize_sections(
+    sections: list[NotificationBodyFormattingBlock],
+) -> list[dict[str, Any]]:
     return [
-        {
-            "type": block.type,
-            "blocks": [
-                {"type": text_block.type, "text": text_block.text} for text_block in block.blocks
-            ],
-        }
-        for block in blocks
+        {"type": section.type, "blocks": [_serialize_blocks(block) for block in section.blocks]}
+        for section in sections
     ]
+
+
+def _serialize_blocks(blocks: list[NotificationBodyTextBlock]) -> list[dict[str, Any]]:
+    return [{"type": block.type, "text": block.text} for block in blocks]
 
 
 def serialize_rendered_example(rendered_template: NotificationRenderedTemplate) -> dict[str, Any]:
     response: dict[str, Any] = {
-        "subject": (
-            _serialize_blocks(rendered_template.subject)
-            if isinstance(rendered_template.subject, list)
-            else rendered_template.subject
-        ),
-        "body": [
-            {
-                "type": block.type,
-                "blocks": [
-                    {"type": text_block.type, "text": text_block.text}
-                    for text_block in block.blocks
-                ],
-            }
-            for block in rendered_template.body
-        ],
+        "subject": _serialize_blocks(rendered_template.subject_blocks),
+        "body": _serialize_sections(rendered_template.body),
         "actions": [
             {"label": action.label, "link": action.link} for action in rendered_template.actions
         ],
@@ -78,10 +68,7 @@ def serialize_rendered_example(rendered_template: NotificationRenderedTemplate) 
             "alt_text": rendered_template.chart.alt_text,
         }
     if rendered_template.footer:
-        if isinstance(rendered_template.footer, list):
-            response["footer"] = _serialize_blocks(rendered_template.footer)
-        else:
-            response["footer"] = rendered_template.footer
+        response["footer"] = _serialize_blocks(rendered_template.footer_blocks)
     return response
 
 

--- a/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
+++ b/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
@@ -45,8 +45,7 @@ def _serialize_sections(
     sections: list[NotificationSection],
 ) -> list[dict[str, Any]]:
     return [
-        {"type": section.type, "blocks": [_serialize_blocks(block) for block in section.blocks]}
-        for section in sections
+        {"type": section.type, "blocks": _serialize_blocks(section.blocks)} for section in sections
     ]
 
 

--- a/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
+++ b/src/sentry/notifications/platform/api/endpoints/internal_registered_templates.py
@@ -14,12 +14,12 @@ from sentry.notifications.platform.msteams.provider import MSTeamsRenderable, MS
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.slack.provider import SlackNotificationProvider
 from sentry.notifications.platform.types import (
-    NotificationBodyFormattingBlock,
-    NotificationBodyTextBlock,
     NotificationData,
     NotificationProviderKey,
     NotificationRenderedTemplate,
+    NotificationSection,
     NotificationTemplate,
+    NotificationTextBlock,
 )
 
 
@@ -42,7 +42,7 @@ class InternalRegisteredTemplatesEndpoint(Endpoint):
 
 
 def _serialize_sections(
-    sections: list[NotificationBodyFormattingBlock],
+    sections: list[NotificationSection],
 ) -> list[dict[str, Any]]:
     return [
         {"type": section.type, "blocks": [_serialize_blocks(block) for block in section.blocks]}
@@ -50,7 +50,7 @@ def _serialize_sections(
     ]
 
 
-def _serialize_blocks(blocks: list[NotificationBodyTextBlock]) -> list[dict[str, Any]]:
+def _serialize_blocks(blocks: list[NotificationTextBlock]) -> list[dict[str, Any]]:
     return [{"type": block.type, "text": block.text} for block in blocks]
 
 

--- a/src/sentry/notifications/platform/discord/provider.py
+++ b/src/sentry/notifications/platform/discord/provider.py
@@ -68,11 +68,12 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
         embeds = []
 
         body_blocks = cls.render_body_blocks(rendered_template.body)
-        subject = (
-            cls.render_body_blocks(rendered_template.subject)
-            if isinstance(rendered_template.subject, list)
-            else rendered_template.subject
-        )
+        subject = cls.render_text_blocks(rendered_template.subject_blocks, include_links=False)
+
+        footer: DiscordMessageEmbedFooter | None = None
+        if rendered_template.footer:
+            # Discord does not support rich footers
+            footer = DiscordMessageEmbedFooter(text=rendered_template.footer_text)
 
         embeds.append(
             DiscordMessageEmbed(
@@ -83,26 +84,13 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
                     if rendered_template.chart
                     else None
                 ),
-                footer=(
-                    DiscordMessageEmbedFooter(
-                        text=(
-                            cls.render_body_blocks(rendered_template.footer)
-                            if isinstance(rendered_template.footer, list)
-                            else rendered_template.footer
-                        )
-                    )
-                    if rendered_template.footer
-                    else None
-                ),
+                footer=footer,
             )
         )
 
         if len(rendered_template.actions) > 0:
             buttons = [
-                DiscordLinkButton(
-                    label=action.label,
-                    url=action.link,
-                )
+                DiscordLinkButton(label=action.label, url=action.link)
                 for action in rendered_template.actions
             ]
             components.append(DiscordActionRow(components=buttons))
@@ -122,7 +110,13 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
         return "".join(description)
 
     @classmethod
-    def render_text_blocks(cls, blocks: list[NotificationBodyTextBlock]) -> str:
+    def render_text_blocks(
+        cls, blocks: list[NotificationBodyTextBlock], include_links: bool = True
+    ) -> str:
+        """
+        For Discord, in some cases links will not be supported even though other rich text is.
+        If include_links is False, the text will be rendered as plain text with the URL in parentheses.
+        """
         texts = []
         for block in blocks:
             if block.type == NotificationBodyTextBlockType.PLAIN_TEXT:
@@ -134,7 +128,10 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
             elif block.type == NotificationBodyTextBlockType.LINK and isinstance(
                 block, LinkTextBlock
             ):
-                texts.append(f"[{block.text}]({block.url})")
+                if include_links:
+                    texts.append(f"[{block.text}]({block.url})")
+                else:
+                    texts.append(f"{block.text} ({block.url})")
         return " ".join(texts)
 
 

--- a/src/sentry/notifications/platform/discord/provider.py
+++ b/src/sentry/notifications/platform/discord/provider.py
@@ -79,7 +79,13 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
                     else None
                 ),
                 footer=(
-                    DiscordMessageEmbedFooter(text=rendered_template.footer)
+                    DiscordMessageEmbedFooter(
+                        text=(
+                            cls.render_body_blocks(rendered_template.footer)
+                            if isinstance(rendered_template.footer, list)
+                            else rendered_template.footer
+                        )
+                    )
                     if rendered_template.footer
                     else None
                 ),

--- a/src/sentry/notifications/platform/discord/provider.py
+++ b/src/sentry/notifications/platform/discord/provider.py
@@ -68,10 +68,15 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
         embeds = []
 
         body_blocks = cls.render_body_blocks(rendered_template.body)
+        subject = (
+            cls.render_body_blocks(rendered_template.subject)
+            if isinstance(rendered_template.subject, list)
+            else rendered_template.subject
+        )
 
         embeds.append(
             DiscordMessageEmbed(
-                title=rendered_template.subject,
+                title=subject,
                 description=body_blocks,
                 image=(
                     DiscordMessageEmbedImage(url=rendered_template.chart.url)

--- a/src/sentry/notifications/platform/discord/provider.py
+++ b/src/sentry/notifications/platform/discord/provider.py
@@ -18,16 +18,16 @@ from sentry.notifications.platform.target import (
 from sentry.notifications.platform.threading import ThreadContext
 from sentry.notifications.platform.types import (
     LinkTextBlock,
-    NotificationBodyFormattingBlock,
-    NotificationBodyFormattingBlockType,
-    NotificationBodyTextBlock,
-    NotificationBodyTextBlockType,
     NotificationCategory,
     NotificationData,
     NotificationProviderKey,
     NotificationRenderedTemplate,
+    NotificationSection,
+    NotificationSectionType,
     NotificationTarget,
     NotificationTargetResourceType,
+    NotificationTextBlock,
+    NotificationTextBlockType,
 )
 from sentry.organizations.services.organization.model import RpcOrganizationSummary
 from sentry.shared_integrations.exceptions import IntegrationError
@@ -100,18 +100,18 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
         return builder.build()
 
     @classmethod
-    def render_body_blocks(cls, body: list[NotificationBodyFormattingBlock]) -> str:
+    def render_body_blocks(cls, body: list[NotificationSection]) -> str:
         description = []
         for block in body:
-            if block.type == NotificationBodyFormattingBlockType.PARAGRAPH:
+            if block.type == NotificationSectionType.PARAGRAPH:
                 description.append(f"\n{cls.render_text_blocks(block.blocks)}")
-            elif block.type == NotificationBodyFormattingBlockType.CODE_BLOCK:
+            elif block.type == NotificationSectionType.CODE_BLOCK:
                 description.append(f"\n```{cls.render_text_blocks(block.blocks)}```")
         return "".join(description)
 
     @classmethod
     def render_text_blocks(
-        cls, blocks: list[NotificationBodyTextBlock], include_links: bool = True
+        cls, blocks: list[NotificationTextBlock], include_links: bool = True
     ) -> str:
         """
         For Discord, in some cases links will not be supported even though other rich text is.
@@ -119,15 +119,13 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
         """
         texts = []
         for block in blocks:
-            if block.type == NotificationBodyTextBlockType.PLAIN_TEXT:
+            if block.type == NotificationTextBlockType.PLAIN_TEXT:
                 texts.append(block.text)
-            elif block.type == NotificationBodyTextBlockType.BOLD_TEXT:
+            elif block.type == NotificationTextBlockType.BOLD_TEXT:
                 texts.append(f"**{block.text}**")
-            elif block.type == NotificationBodyTextBlockType.CODE:
+            elif block.type == NotificationTextBlockType.CODE:
                 texts.append(f"`{block.text}`")
-            elif block.type == NotificationBodyTextBlockType.LINK and isinstance(
-                block, LinkTextBlock
-            ):
+            elif block.type == NotificationTextBlockType.LINK and isinstance(block, LinkTextBlock):
                 if include_links:
                     texts.append(f"[{block.text}]({block.url})")
                 else:

--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -47,16 +47,25 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
         html_body_blocks = cls.render_body_blocks_to_html_string(rendered_template.body)
         txt_body_blocks = cls.render_body_blocks_to_txt_string(rendered_template.body)
 
+        footer_html = (
+            cls.render_body_blocks_to_html_string(rendered_template.footer)
+            if isinstance(rendered_template.footer, list)
+            else rendered_template.footer
+        )
+        footer_txt = (
+            cls.render_body_blocks_to_txt_string(rendered_template.footer)
+            if isinstance(rendered_template.footer, list)
+            else rendered_template.footer
+        )
         email_context = {
             "subject": rendered_template.subject,
             "actions": [(action.label, action.link) for action in rendered_template.actions],
             "chart_url": rendered_template.chart.url if rendered_template.chart else None,
             "chart_alt_text": rendered_template.chart.alt_text if rendered_template.chart else None,
-            "footer": rendered_template.footer,
         }
 
-        html_email_context = {**email_context, "body": html_body_blocks}
-        txt_email_context = {**email_context, "body": txt_body_blocks}
+        html_email_context = {**email_context, "body": html_body_blocks, "footer": footer_html}
+        txt_email_context = {**email_context, "body": txt_body_blocks, "footer": footer_txt}
 
         html_body = inline_css(
             render_to_string(

--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -10,7 +10,7 @@ from sentry.notifications.platform.provider import (
     SendSuccessResult,
 )
 from sentry.notifications.platform.registry import provider_registry
-from sentry.notifications.platform.renderer import NotificationRenderer, blocks_to_plain_text
+from sentry.notifications.platform.renderer import NotificationRenderer
 from sentry.notifications.platform.target import GenericNotificationTarget
 from sentry.notifications.platform.threading import ThreadContext
 from sentry.notifications.platform.types import (
@@ -47,21 +47,12 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
         html_body_blocks = cls.render_body_blocks_to_html_string(rendered_template.body)
         txt_body_blocks = cls.render_body_blocks_to_txt_string(rendered_template.body)
 
-        subject = (
-            blocks_to_plain_text(rendered_template.subject)
-            if isinstance(rendered_template.subject, list)
-            else rendered_template.subject
-        )
-        footer_html = (
-            cls.render_body_blocks_to_html_string(rendered_template.footer)
-            if isinstance(rendered_template.footer, list)
-            else rendered_template.footer
-        )
-        footer_txt = (
-            cls.render_body_blocks_to_txt_string(rendered_template.footer)
-            if isinstance(rendered_template.footer, list)
-            else rendered_template.footer
-        )
+        # Email doesn't support rich text in subjects (obviously, lol)
+        subject = rendered_template.subject_text
+        footer_html = cls.render_text_blocks_to_html_string(rendered_template.footer_blocks)
+
+        footer_txt = cls.render_text_blocks_to_txt_string(rendered_template.footer_blocks)
+
         email_context = {
             "subject": subject,
             "actions": [(action.label, action.link) for action in rendered_template.actions],

--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -49,8 +49,9 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
 
         # Email doesn't support rich text in subjects (obviously, lol)
         subject = rendered_template.subject_text
-        footer_html = cls.render_text_blocks_to_html_string(rendered_template.footer_blocks)
-
+        footer_html = mark_safe(
+            cls.render_text_blocks_to_html_string(rendered_template.footer_blocks)
+        )
         footer_txt = cls.render_text_blocks_to_txt_string(rendered_template.footer_blocks)
 
         email_context = {

--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -15,15 +15,15 @@ from sentry.notifications.platform.target import GenericNotificationTarget
 from sentry.notifications.platform.threading import ThreadContext
 from sentry.notifications.platform.types import (
     LinkTextBlock,
-    NotificationBodyFormattingBlock,
-    NotificationBodyFormattingBlockType,
-    NotificationBodyTextBlock,
-    NotificationBodyTextBlockType,
     NotificationData,
     NotificationProviderKey,
     NotificationRenderedTemplate,
+    NotificationSection,
+    NotificationSectionType,
     NotificationTarget,
     NotificationTargetResourceType,
+    NotificationTextBlock,
+    NotificationTextBlockType,
 )
 from sentry.organizations.services.organization.model import RpcOrganizationSummary
 from sentry.utils.email.address import get_from_email_domain
@@ -91,62 +91,58 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
         return email
 
     @classmethod
-    def render_body_blocks_to_html_string(cls, body: list[NotificationBodyFormattingBlock]) -> str:
+    def render_body_blocks_to_html_string(cls, body: list[NotificationSection]) -> str:
         body_blocks = []
         for block in body:
-            if block.type == NotificationBodyFormattingBlockType.PARAGRAPH:
+            if block.type == NotificationSectionType.PARAGRAPH:
                 safe_content = cls.render_text_blocks_to_html_string(block.blocks)
                 body_blocks.append(f"<p>{safe_content}</p>")
-            elif block.type == NotificationBodyFormattingBlockType.CODE_BLOCK:
+            elif block.type == NotificationSectionType.CODE_BLOCK:
                 safe_content = cls.render_text_blocks_to_html_string(block.blocks)
                 body_blocks.append(f"<pre><code>{safe_content}</code></pre>")
 
         return mark_safe("".join(body_blocks))
 
     @classmethod
-    def render_text_blocks_to_html_string(cls, blocks: list[NotificationBodyTextBlock]) -> str:
+    def render_text_blocks_to_html_string(cls, blocks: list[NotificationTextBlock]) -> str:
         texts: list[str] = []
         for block in blocks:
             # Escape user content to prevent XSS
             escaped_text = escape(block.text)
 
-            if block.type == NotificationBodyTextBlockType.PLAIN_TEXT:
+            if block.type == NotificationTextBlockType.PLAIN_TEXT:
                 texts.append(escaped_text)
-            elif block.type == NotificationBodyTextBlockType.BOLD_TEXT:
+            elif block.type == NotificationTextBlockType.BOLD_TEXT:
                 texts.append(f"<strong>{escaped_text}</strong>")
-            elif block.type == NotificationBodyTextBlockType.CODE:
+            elif block.type == NotificationTextBlockType.CODE:
                 texts.append(f"<code>{escaped_text}</code>")
-            elif block.type == NotificationBodyTextBlockType.LINK and isinstance(
-                block, LinkTextBlock
-            ):
+            elif block.type == NotificationTextBlockType.LINK and isinstance(block, LinkTextBlock):
                 escaped_url = escape(block.url)
                 texts.append(f'<a href="{escaped_url}">{escaped_text}</a>')
 
         return " ".join(texts)
 
     @classmethod
-    def render_body_blocks_to_txt_string(cls, blocks: list[NotificationBodyFormattingBlock]) -> str:
+    def render_body_blocks_to_txt_string(cls, blocks: list[NotificationSection]) -> str:
         body_blocks = []
         for block in blocks:
-            if block.type == NotificationBodyFormattingBlockType.PARAGRAPH:
+            if block.type == NotificationSectionType.PARAGRAPH:
                 body_blocks.append(f"\n{cls.render_text_blocks_to_txt_string(block.blocks)}")
-            elif block.type == NotificationBodyFormattingBlockType.CODE_BLOCK:
+            elif block.type == NotificationSectionType.CODE_BLOCK:
                 body_blocks.append(f"\n```{cls.render_text_blocks_to_txt_string(block.blocks)}```")
         return " ".join(body_blocks)
 
     @classmethod
-    def render_text_blocks_to_txt_string(cls, blocks: list[NotificationBodyTextBlock]) -> str:
+    def render_text_blocks_to_txt_string(cls, blocks: list[NotificationTextBlock]) -> str:
         texts = []
         for block in blocks:
-            if block.type == NotificationBodyTextBlockType.PLAIN_TEXT:
+            if block.type == NotificationTextBlockType.PLAIN_TEXT:
                 texts.append(block.text)
-            elif block.type == NotificationBodyTextBlockType.BOLD_TEXT:
+            elif block.type == NotificationTextBlockType.BOLD_TEXT:
                 texts.append(f"**{block.text}**")
-            elif block.type == NotificationBodyTextBlockType.CODE:
+            elif block.type == NotificationTextBlockType.CODE:
                 texts.append(f"`{block.text}`")
-            elif block.type == NotificationBodyTextBlockType.LINK and isinstance(
-                block, LinkTextBlock
-            ):
+            elif block.type == NotificationTextBlockType.LINK and isinstance(block, LinkTextBlock):
                 texts.append(f"{block.text} ({block.url})")
         return " ".join(texts)
 

--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -10,7 +10,7 @@ from sentry.notifications.platform.provider import (
     SendSuccessResult,
 )
 from sentry.notifications.platform.registry import provider_registry
-from sentry.notifications.platform.renderer import NotificationRenderer
+from sentry.notifications.platform.renderer import NotificationRenderer, blocks_to_plain_text
 from sentry.notifications.platform.target import GenericNotificationTarget
 from sentry.notifications.platform.threading import ThreadContext
 from sentry.notifications.platform.types import (
@@ -47,6 +47,11 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
         html_body_blocks = cls.render_body_blocks_to_html_string(rendered_template.body)
         txt_body_blocks = cls.render_body_blocks_to_txt_string(rendered_template.body)
 
+        subject = (
+            blocks_to_plain_text(rendered_template.subject)
+            if isinstance(rendered_template.subject, list)
+            else rendered_template.subject
+        )
         footer_html = (
             cls.render_body_blocks_to_html_string(rendered_template.footer)
             if isinstance(rendered_template.footer, list)
@@ -58,7 +63,7 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
             else rendered_template.footer
         )
         email_context = {
-            "subject": rendered_template.subject,
+            "subject": subject,
             "actions": [(action.label, action.link) for action in rendered_template.actions],
             "chart_url": rendered_template.chart.url if rendered_template.chart else None,
             "chart_alt_text": rendered_template.chart.alt_text if rendered_template.chart else None,
@@ -80,7 +85,7 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
         # Required by RFC 2822 (https://www.rfc-editor.org/rfc/rfc2822.html)
         headers = {"Message-Id": make_msgid(domain=get_from_email_domain())}
         email = EmailMultiAlternatives(
-            subject=rendered_template.subject,
+            subject=subject,
             body=txt_body,
             # TODO(ecosystem): Potentially allow templates to configure more attributes of emails
             from_email=options.get("mail.from"),

--- a/src/sentry/notifications/platform/msteams/provider.py
+++ b/src/sentry/notifications/platform/msteams/provider.py
@@ -18,15 +18,15 @@ from sentry.notifications.platform.target import (
 from sentry.notifications.platform.threading import ThreadContext
 from sentry.notifications.platform.types import (
     LinkTextBlock,
-    NotificationBodyFormattingBlock,
-    NotificationBodyFormattingBlockType,
-    NotificationBodyTextBlock,
-    NotificationBodyTextBlockType,
     NotificationData,
     NotificationProviderKey,
     NotificationRenderedTemplate,
+    NotificationSection,
+    NotificationSectionType,
     NotificationTarget,
     NotificationTargetResourceType,
+    NotificationTextBlock,
+    NotificationTextBlockType,
 )
 from sentry.organizations.services.organization.model import RpcOrganizationSummary
 from sentry.shared_integrations.exceptions import IntegrationError
@@ -96,7 +96,7 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
 
     @classmethod
     def render_body_blocks(
-        cls, body: list[NotificationBodyFormattingBlock], size: TextSize | None = None
+        cls, body: list[NotificationSection], size: TextSize | None = None
     ) -> list[Block]:
         from sentry.integrations.msteams.card_builder.block import (
             TextSize,
@@ -109,27 +109,25 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
 
         body_blocks: list[Block] = []
         for block in body:
-            if block.type == NotificationBodyFormattingBlockType.PARAGRAPH:
+            if block.type == NotificationSectionType.PARAGRAPH:
                 body_blocks.append(
                     create_text_block(text=cls.render_text_blocks(block.blocks), size=size)
                 )
-            elif block.type == NotificationBodyFormattingBlockType.CODE_BLOCK:
+            elif block.type == NotificationSectionType.CODE_BLOCK:
                 body_blocks.append(create_code_block(text=cls.render_text_blocks(block.blocks)))
         return body_blocks
 
     @classmethod
-    def render_text_blocks(cls, blocks: list[NotificationBodyTextBlock]) -> str:
+    def render_text_blocks(cls, blocks: list[NotificationTextBlock]) -> str:
         texts = []
         for block in blocks:
-            if block.type == NotificationBodyTextBlockType.PLAIN_TEXT:
+            if block.type == NotificationTextBlockType.PLAIN_TEXT:
                 texts.append(block.text)
-            elif block.type == NotificationBodyTextBlockType.BOLD_TEXT:
+            elif block.type == NotificationTextBlockType.BOLD_TEXT:
                 texts.append(f"**{block.text}**")
-            elif block.type == NotificationBodyTextBlockType.CODE:
+            elif block.type == NotificationTextBlockType.CODE:
                 texts.append(f"`{block.text}`")
-            elif block.type == NotificationBodyTextBlockType.LINK and isinstance(
-                block, LinkTextBlock
-            ):
+            elif block.type == NotificationTextBlockType.LINK and isinstance(block, LinkTextBlock):
                 texts.append(f"[{block.text}]({block.url})")
         return " ".join(texts)
 

--- a/src/sentry/notifications/platform/msteams/provider.py
+++ b/src/sentry/notifications/platform/msteams/provider.py
@@ -57,13 +57,7 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
             create_text_block,
         )
 
-        subject_text = (
-            cls.render_text_blocks(
-                [tb for block in rendered_template.subject for tb in block.blocks]
-            )
-            if isinstance(rendered_template.subject, list)
-            else rendered_template.subject
-        )
+        subject_text = cls.render_text_blocks(rendered_template.subject_blocks)
         title_text = create_text_block(
             text=subject_text, size=TextSize.LARGE, weight=TextWeight.BOLDER
         )
@@ -89,13 +83,8 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
             body_blocks.append(chart_image)
 
         if rendered_template.footer is not None:
-            if isinstance(rendered_template.footer, list):
-                body_blocks.extend(
-                    cls.render_body_blocks(rendered_template.footer, size=TextSize.SMALL)
-                )
-            else:
-                footer_text = create_text_block(text=rendered_template.footer, size=TextSize.SMALL)
-                body_blocks.append(footer_text)
+            footer_str = cls.render_text_blocks(rendered_template.footer_blocks)
+            body_blocks.append(create_text_block(text=footer_str, size=TextSize.SMALL))
 
         card: AdaptiveCard = {
             "type": "AdaptiveCard",

--- a/src/sentry/notifications/platform/msteams/provider.py
+++ b/src/sentry/notifications/platform/msteams/provider.py
@@ -57,8 +57,15 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
             create_text_block,
         )
 
+        subject_text = (
+            cls.render_text_blocks(
+                [tb for block in rendered_template.subject for tb in block.blocks]
+            )
+            if isinstance(rendered_template.subject, list)
+            else rendered_template.subject
+        )
         title_text = create_text_block(
-            text=rendered_template.subject, size=TextSize.LARGE, weight=TextWeight.BOLDER
+            text=subject_text, size=TextSize.LARGE, weight=TextWeight.BOLDER
         )
         body_text = cls.render_body_blocks(rendered_template.body)
         body_blocks: list[Block] = [title_text, *body_text]
@@ -81,12 +88,13 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
             )
             body_blocks.append(chart_image)
 
-        if footer := rendered_template.footer is not None:
-            if isinstance(footer, list):
-                footer_blocks = cls.render_body_blocks(footer, size=TextSize.SMALL)
-                body_blocks.extend(footer_blocks)
+        if rendered_template.footer is not None:
+            if isinstance(rendered_template.footer, list):
+                body_blocks.extend(
+                    cls.render_body_blocks(rendered_template.footer, size=TextSize.SMALL)
+                )
             else:
-                footer_text = create_text_block(text=footer, size=TextSize.SMALL)
+                footer_text = create_text_block(text=rendered_template.footer, size=TextSize.SMALL)
                 body_blocks.append(footer_text)
 
         card: AdaptiveCard = {
@@ -99,12 +107,16 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
 
     @classmethod
     def render_body_blocks(
-        cls, body: list[NotificationBodyFormattingBlock], size: TextSize = TextSize.MEDIUM
+        cls, body: list[NotificationBodyFormattingBlock], size: TextSize | None = None
     ) -> list[Block]:
         from sentry.integrations.msteams.card_builder.block import (
+            TextSize,
             create_code_block,
             create_text_block,
         )
+
+        if size is None:
+            size = TextSize.MEDIUM
 
         body_blocks: list[Block] = []
         for block in body:
@@ -113,9 +125,7 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
                     create_text_block(text=cls.render_text_blocks(block.blocks), size=size)
                 )
             elif block.type == NotificationBodyFormattingBlockType.CODE_BLOCK:
-                body_blocks.append(
-                    create_code_block(text=cls.render_text_blocks(block.blocks), size=size)
-                )
+                body_blocks.append(create_code_block(text=cls.render_text_blocks(block.blocks)))
         return body_blocks
 
     @classmethod

--- a/src/sentry/notifications/platform/msteams/provider.py
+++ b/src/sentry/notifications/platform/msteams/provider.py
@@ -32,7 +32,7 @@ from sentry.organizations.services.organization.model import RpcOrganizationSumm
 from sentry.shared_integrations.exceptions import IntegrationError
 
 if TYPE_CHECKING:
-    from sentry.integrations.msteams.card_builder.block import AdaptiveCard, Block
+    from sentry.integrations.msteams.card_builder.block import AdaptiveCard, Block, TextSize
 
 type MSTeamsRenderable = AdaptiveCard
 
@@ -81,9 +81,13 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
             )
             body_blocks.append(chart_image)
 
-        if rendered_template.footer is not None:
-            footer_text = create_text_block(text=rendered_template.footer, size=TextSize.SMALL)
-            body_blocks.append(footer_text)
+        if footer := rendered_template.footer is not None:
+            if isinstance(footer, list):
+                footer_blocks = cls.render_body_blocks(footer, size=TextSize.SMALL)
+                body_blocks.extend(footer_blocks)
+            else:
+                footer_text = create_text_block(text=footer, size=TextSize.SMALL)
+                body_blocks.append(footer_text)
 
         card: AdaptiveCard = {
             "type": "AdaptiveCard",
@@ -94,7 +98,9 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
         return card
 
     @classmethod
-    def render_body_blocks(cls, body: list[NotificationBodyFormattingBlock]) -> list[Block]:
+    def render_body_blocks(
+        cls, body: list[NotificationBodyFormattingBlock], size: TextSize = TextSize.MEDIUM
+    ) -> list[Block]:
         from sentry.integrations.msteams.card_builder.block import (
             create_code_block,
             create_text_block,
@@ -103,9 +109,13 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
         body_blocks: list[Block] = []
         for block in body:
             if block.type == NotificationBodyFormattingBlockType.PARAGRAPH:
-                body_blocks.append(create_text_block(text=cls.render_text_blocks(block.blocks)))
+                body_blocks.append(
+                    create_text_block(text=cls.render_text_blocks(block.blocks), size=size)
+                )
             elif block.type == NotificationBodyFormattingBlockType.CODE_BLOCK:
-                body_blocks.append(create_code_block(text=cls.render_text_blocks(block.blocks)))
+                body_blocks.append(
+                    create_code_block(text=cls.render_text_blocks(block.blocks), size=size)
+                )
         return body_blocks
 
     @classmethod

--- a/src/sentry/notifications/platform/renderer.py
+++ b/src/sentry/notifications/platform/renderer.py
@@ -1,19 +1,10 @@
 from typing import Protocol
 
 from sentry.notifications.platform.types import (
-    NotificationBodyFormattingBlock,
     NotificationData,
     NotificationProviderKey,
     NotificationRenderedTemplate,
 )
-
-
-def blocks_to_plain_text(blocks: list[NotificationBodyFormattingBlock]) -> str:
-    """Extract plain text content from formatting blocks, stripping all formatting."""
-    parts = []
-    for block in blocks:
-        parts.append(" ".join(tb.text for tb in block.blocks))
-    return " ".join(parts)
 
 
 # TODO(ecosystem): Evaluate whether or not this even makes sense as a protocol, or we can just use a typed Callable.

--- a/src/sentry/notifications/platform/renderer.py
+++ b/src/sentry/notifications/platform/renderer.py
@@ -1,10 +1,19 @@
 from typing import Protocol
 
 from sentry.notifications.platform.types import (
+    NotificationBodyFormattingBlock,
     NotificationData,
     NotificationProviderKey,
     NotificationRenderedTemplate,
 )
+
+
+def blocks_to_plain_text(blocks: list[NotificationBodyFormattingBlock]) -> str:
+    """Extract plain text content from formatting blocks, stripping all formatting."""
+    parts = []
+    for block in blocks:
+        parts.append(" ".join(tb.text for tb in block.blocks))
+    return " ".join(parts)
 
 
 # TODO(ecosystem): Evaluate whether or not this even makes sense as a protocol, or we can just use a typed Callable.

--- a/src/sentry/notifications/platform/slack/provider.py
+++ b/src/sentry/notifications/platform/slack/provider.py
@@ -89,8 +89,12 @@ class SlackRenderer(NotificationRenderer[SlackRenderable]):
             )
             blocks.append(chart)
         if rendered_template.footer:
-            footer = ContextBlock(elements=[MarkdownTextObject(text=rendered_template.footer)])
-            blocks.append(footer)
+            if isinstance(rendered_template.footer, list):
+                footer_blocks = cls._render_body(rendered_template.footer)
+                blocks.extend(footer_blocks)
+            else:
+                footer = ContextBlock(elements=[MarkdownTextObject(text=rendered_template.footer)])
+                blocks.append(footer)
 
         return SlackRenderable(blocks=blocks, text=rendered_template.subject)
 

--- a/src/sentry/notifications/platform/slack/provider.py
+++ b/src/sentry/notifications/platform/slack/provider.py
@@ -32,16 +32,16 @@ from sentry.notifications.platform.target import (
 from sentry.notifications.platform.threading import ThreadContext
 from sentry.notifications.platform.types import (
     LinkTextBlock,
-    NotificationBodyFormattingBlock,
-    NotificationBodyFormattingBlockType,
-    NotificationBodyTextBlock,
-    NotificationBodyTextBlockType,
     NotificationCategory,
     NotificationData,
     NotificationProviderKey,
     NotificationRenderedTemplate,
+    NotificationSection,
+    NotificationSectionType,
     NotificationTarget,
     NotificationTargetResourceType,
+    NotificationTextBlock,
+    NotificationTextBlockType,
 )
 from sentry.organizations.services.organization.model import RpcOrganizationSummary
 from sentry.shared_integrations.exceptions import IntegrationError
@@ -96,30 +96,28 @@ class SlackRenderer(NotificationRenderer[SlackRenderable]):
         return SlackRenderable(blocks=blocks, text=rendered_template.subject_text)
 
     @classmethod
-    def _render_body(cls, body: list[NotificationBodyFormattingBlock]) -> list[Block]:
+    def _render_body(cls, body: list[NotificationSection]) -> list[Block]:
         blocks: list[Block] = []
         for block in body:
-            if block.type == NotificationBodyFormattingBlockType.PARAGRAPH:
+            if block.type == NotificationSectionType.PARAGRAPH:
                 text = cls._render_text_blocks(block.blocks)
                 blocks.append(SectionBlock(text=MarkdownTextObject(text=text)))
-            elif block.type == NotificationBodyFormattingBlockType.CODE_BLOCK:
+            elif block.type == NotificationSectionType.CODE_BLOCK:
                 text = cls._render_text_blocks(block.blocks)
                 blocks.append(SectionBlock(text=MarkdownTextObject(text=f"```{text}```")))
         return blocks
 
     @classmethod
-    def _render_text_blocks(cls, blocks: list[NotificationBodyTextBlock]) -> str:
+    def _render_text_blocks(cls, blocks: list[NotificationTextBlock]) -> str:
         texts = []
         for block in blocks:
-            if block.type == NotificationBodyTextBlockType.PLAIN_TEXT:
+            if block.type == NotificationTextBlockType.PLAIN_TEXT:
                 texts.append(block.text)
-            elif block.type == NotificationBodyTextBlockType.BOLD_TEXT:
+            elif block.type == NotificationTextBlockType.BOLD_TEXT:
                 texts.append(f"*{block.text}*")
-            elif block.type == NotificationBodyTextBlockType.CODE:
+            elif block.type == NotificationTextBlockType.CODE:
                 texts.append(f"`{block.text}`")
-            elif block.type == NotificationBodyTextBlockType.LINK and isinstance(
-                block, LinkTextBlock
-            ):
+            elif block.type == NotificationTextBlockType.LINK and isinstance(block, LinkTextBlock):
                 texts.append(f"<{block.url}|{block.text}>")
         return " ".join(texts)
 

--- a/src/sentry/notifications/platform/slack/provider.py
+++ b/src/sentry/notifications/platform/slack/provider.py
@@ -24,7 +24,7 @@ from sentry.notifications.platform.provider import (
     integration_error_result,
 )
 from sentry.notifications.platform.registry import provider_registry
-from sentry.notifications.platform.renderer import NotificationRenderer, blocks_to_plain_text
+from sentry.notifications.platform.renderer import NotificationRenderer
 from sentry.notifications.platform.target import (
     IntegrationNotificationTarget,
     PreparedIntegrationNotificationTarget,
@@ -70,13 +70,11 @@ class SlackRenderer(NotificationRenderer[SlackRenderable]):
     def render[DataT: NotificationData](
         cls, *, data: DataT, rendered_template: NotificationRenderedTemplate
     ) -> SlackRenderable:
-        if isinstance(rendered_template.subject, list):
-            subject_blocks = cls._render_body(rendered_template.subject)
-        else:
-            subject_blocks = [HeaderBlock(text=PlainTextObject(text=rendered_template.subject))]
+        # Slack does not support rich text in the subject
+        subject_block = HeaderBlock(text=PlainTextObject(text=rendered_template.subject_text))
         body_blocks: list[Block] = cls._render_body(rendered_template.body)
 
-        blocks = [*subject_blocks, *body_blocks]
+        blocks: list[Block] = [subject_block, *body_blocks]
 
         if len(rendered_template.actions) > 0:
             actions_block = ActionsBlock(elements=[])
@@ -92,19 +90,10 @@ class SlackRenderer(NotificationRenderer[SlackRenderable]):
             )
             blocks.append(chart)
         if rendered_template.footer:
-            if isinstance(rendered_template.footer, list):
-                footer_blocks = cls._render_body(rendered_template.footer)
-                blocks.extend(footer_blocks)
-            else:
-                footer = ContextBlock(elements=[MarkdownTextObject(text=rendered_template.footer)])
-                blocks.append(footer)
+            footer_text = cls._render_text_blocks(rendered_template.footer_blocks)
+            blocks.append(ContextBlock(elements=[MarkdownTextObject(text=footer_text)]))
 
-        subject_text = (
-            blocks_to_plain_text(rendered_template.subject)
-            if isinstance(rendered_template.subject, list)
-            else rendered_template.subject
-        )
-        return SlackRenderable(blocks=blocks, text=subject_text)
+        return SlackRenderable(blocks=blocks, text=rendered_template.subject_text)
 
     @classmethod
     def _render_body(cls, body: list[NotificationBodyFormattingBlock]) -> list[Block]:

--- a/src/sentry/notifications/platform/slack/provider.py
+++ b/src/sentry/notifications/platform/slack/provider.py
@@ -24,7 +24,7 @@ from sentry.notifications.platform.provider import (
     integration_error_result,
 )
 from sentry.notifications.platform.registry import provider_registry
-from sentry.notifications.platform.renderer import NotificationRenderer
+from sentry.notifications.platform.renderer import NotificationRenderer, blocks_to_plain_text
 from sentry.notifications.platform.target import (
     IntegrationNotificationTarget,
     PreparedIntegrationNotificationTarget,
@@ -70,10 +70,13 @@ class SlackRenderer(NotificationRenderer[SlackRenderable]):
     def render[DataT: NotificationData](
         cls, *, data: DataT, rendered_template: NotificationRenderedTemplate
     ) -> SlackRenderable:
-        subject = HeaderBlock(text=PlainTextObject(text=rendered_template.subject))
+        if isinstance(rendered_template.subject, list):
+            subject_blocks = cls._render_body(rendered_template.subject)
+        else:
+            subject_blocks = [HeaderBlock(text=PlainTextObject(text=rendered_template.subject))]
         body_blocks: list[Block] = cls._render_body(rendered_template.body)
 
-        blocks = [subject, *body_blocks]
+        blocks = [*subject_blocks, *body_blocks]
 
         if len(rendered_template.actions) > 0:
             actions_block = ActionsBlock(elements=[])
@@ -96,7 +99,12 @@ class SlackRenderer(NotificationRenderer[SlackRenderable]):
                 footer = ContextBlock(elements=[MarkdownTextObject(text=rendered_template.footer)])
                 blocks.append(footer)
 
-        return SlackRenderable(blocks=blocks, text=rendered_template.subject)
+        subject_text = (
+            blocks_to_plain_text(rendered_template.subject)
+            if isinstance(rendered_template.subject, list)
+            else rendered_template.subject
+        )
+        return SlackRenderable(blocks=blocks, text=subject_text)
 
     @classmethod
     def _render_body(cls, body: list[NotificationBodyFormattingBlock]) -> list[Block]:

--- a/src/sentry/notifications/platform/templates/sample.py
+++ b/src/sentry/notifications/platform/templates/sample.py
@@ -6,8 +6,6 @@ from sentry.notifications.platform.types import (
     CodeBlock,
     CodeTextBlock,
     LinkTextBlock,
-    NotificationBodyFormattingBlockType,
-    NotificationBodyTextBlockType,
     NotificationCategory,
     NotificationData,
     NotificationRenderedAction,
@@ -57,50 +55,20 @@ class ErrorAlertNotificationTemplate(NotificationTemplate[ErrorAlertData]):
             ],
             body=[
                 ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
                     blocks=[
+                        PlainTextBlock(text="A new"),
+                        CodeTextBlock(text=data.error_type),
                         PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
-                            text="A new",
-                        ),
-                        CodeTextBlock(
-                            type=NotificationBodyTextBlockType.CODE,
-                            text=data.error_type,
-                        ),
-                        PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
                             text=f"error has been detected in {data.project_name} with",
                         ),
-                        BoldTextBlock(
-                            type=NotificationBodyTextBlockType.BOLD_TEXT,
-                            text=f"{data.error_count} occurrences.",
-                        ),
-                        LinkTextBlock(text="View Issue", url="https://example.com/issues"),
+                        BoldTextBlock(text=f"{data.error_count} occurrences."),
                     ],
                 ),
+                ParagraphBlock(blocks=[PlainTextBlock(text="The error message is:")]),
+                CodeBlock(blocks=[PlainTextBlock(text=data.error_message)]),
                 ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
                     blocks=[
                         PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
-                            text="The error message is:",
-                        )
-                    ],
-                ),
-                CodeBlock(
-                    type=NotificationBodyFormattingBlockType.CODE_BLOCK,
-                    blocks=[
-                        PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
-                            text=data.error_message,
-                        ),
-                    ],
-                ),
-                ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
-                    blocks=[
-                        PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
                             text=f"This error was first seen at {data.first_seen} and requires immediate attention.",
                         )
                     ],
@@ -114,11 +82,9 @@ class ErrorAlertNotificationTemplate(NotificationTemplate[ErrorAlertData]):
                 url="https://github.com/knobiknows/all-the-bufo/blob/main/all-the-bufo/all-the-bufo.png?raw=true",
                 alt_text="Error occurrence chart",
             ),
-            # footer="This alert was triggered by your error monitoring rules.",
             footer=[
                 PlainTextBlock(text="This alert was triggered by your error monitoring rules."),
-                CodeTextBlock(text=data.error_type),
-                LinkTextBlock(text="View Issue", url="https://example.com/issues"),
+                LinkTextBlock(text="View Alert", url="https://example.com/issues"),
             ],
         )
 
@@ -155,28 +121,22 @@ class DeploymentNotificationTemplate(NotificationTemplate[DeploymentData]):
             subject=f"Deployment to {data.environment}: {data.version}",
             body=[
                 ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
                     blocks=[
                         PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
                             text=f"Version {data.version} has been successfully deployed to {data.environment} for project {data.project_name}. ",
                         )
                     ],
                 ),
                 ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
                     blocks=[
                         PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
                             text=f"The deployment was initiated by {data.deployer} with commit {data.commit_sha[:8]}: {data.commit_message}. ",
                         )
                     ],
                 ),
                 ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
                     blocks=[
                         PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
                             text="Monitor the deployment status and be ready to rollback if any issues are detected.",
                         )
                     ],
@@ -227,19 +187,10 @@ class SlowLoadMetricAlertNotificationTemplate(NotificationTemplate[SlowLoadMetri
             subject=f"{data.severity.upper()}: {data.alert_type} in {data.project_name}",
             body=[
                 ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
-                    blocks=[
-                        PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
-                            text=f"{data.measurement} since {data.start_time}",
-                        )
-                    ],
+                    blocks=[PlainTextBlock(text=f"{data.measurement} since {data.start_time}")],
                 ),
             ],
-            chart=NotificationRenderedImage(
-                url=data.chart_url,
-                alt_text="Metric alert chart",
-            ),
+            chart=NotificationRenderedImage(url=data.chart_url, alt_text="Metric alert chart"),
             actions=[
                 NotificationRenderedAction(
                     label="Acknowledge", link="https://example.com/acknowledge"
@@ -277,28 +228,22 @@ class PerformanceAlertNotificationTemplate(NotificationTemplate[PerformanceAlert
             subject=f"Performance Alert: {data.metric_name} threshold exceeded",
             body=[
                 ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
                     blocks=[
                         PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
                             text=f"Performance alert triggered for {data.metric_name} in project {data.project_name}. ",
                         )
                     ],
                 ),
                 ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
                     blocks=[
                         PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
                             text=f"The current value of {data.current_value} exceeds the threshold of {data.threshold}. ",
                         )
                     ],
                 ),
                 ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
                     blocks=[
                         PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
                             text="Immediate investigation is recommended to identify and resolve the performance degradation.",
                         )
                     ],
@@ -341,31 +286,15 @@ class TeamUpdateNotificationTemplate(NotificationTemplate[TeamUpdateData]):
             subject=f"Team Update: {data.update_type}",
             body=[
                 ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
                     blocks=[
                         PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
                             text=f"Team {data.team_name} has posted a {data.update_type} update. ",
                         )
                     ],
                 ),
+                ParagraphBlock(blocks=[PlainTextBlock(text=f"Message: {data.message} ")]),
                 ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
-                    blocks=[
-                        PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
-                            text=f"Message: {data.message} ",
-                        )
-                    ],
-                ),
-                ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
-                    blocks=[
-                        PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
-                            text=f"Posted by {data.author} at {data.timestamp}.",
-                        )
-                    ],
+                    blocks=[PlainTextBlock(text=f"Posted by {data.author} at {data.timestamp}.")],
                 ),
             ],
             footer="This is an informational update from your team.",

--- a/src/sentry/notifications/platform/templates/sample.py
+++ b/src/sentry/notifications/platform/templates/sample.py
@@ -5,6 +5,7 @@ from sentry.notifications.platform.types import (
     BoldTextBlock,
     CodeBlock,
     CodeTextBlock,
+    LinkTextBlock,
     NotificationBodyFormattingBlockType,
     NotificationBodyTextBlockType,
     NotificationCategory,
@@ -49,7 +50,11 @@ class ErrorAlertNotificationTemplate(NotificationTemplate[ErrorAlertData]):
 
     def render(self, data: ErrorAlertData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
-            subject=f"{data.error_count} new {data.error_type} errors in {data.project_name}",
+            subject=[
+                CodeTextBlock(text=f"{data.error_count}"),
+                PlainTextBlock(text=f"new {data.error_type} errors in"),
+                LinkTextBlock(text=data.project_name, url="https://example.com/project"),
+            ],
             body=[
                 ParagraphBlock(
                     type=NotificationBodyFormattingBlockType.PARAGRAPH,
@@ -70,6 +75,7 @@ class ErrorAlertNotificationTemplate(NotificationTemplate[ErrorAlertData]):
                             type=NotificationBodyTextBlockType.BOLD_TEXT,
                             text=f"{data.error_count} occurrences.",
                         ),
+                        LinkTextBlock(text="View Issue", url="https://example.com/issues"),
                     ],
                 ),
                 ParagraphBlock(
@@ -108,7 +114,12 @@ class ErrorAlertNotificationTemplate(NotificationTemplate[ErrorAlertData]):
                 url="https://github.com/knobiknows/all-the-bufo/blob/main/all-the-bufo/all-the-bufo.png?raw=true",
                 alt_text="Error occurrence chart",
             ),
-            footer="This alert was triggered by your error monitoring rules.",
+            # footer="This alert was triggered by your error monitoring rules.",
+            footer=[
+                PlainTextBlock(text="This alert was triggered by your error monitoring rules."),
+                CodeTextBlock(text=data.error_type),
+                LinkTextBlock(text="View Issue", url="https://example.com/issues"),
+            ],
         )
 
 

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_base.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_base.py
@@ -3,12 +3,12 @@ from django.conf import settings
 from sentry.models.group import Group
 from sentry.notifications.platform.types import (
     CodeTextBlock,
-    NotificationBodyFormattingBlock,
-    NotificationBodyTextBlock,
     NotificationData,
     NotificationRenderedAction,
     NotificationRenderedTemplate,
+    NotificationSection,
     NotificationSource,
+    NotificationTextBlock,
     ParagraphBlock,
     PlainTextBlock,
 )
@@ -41,10 +41,10 @@ class WorkflowEngineActivityAction(NotificationData):
     detector_id: int
 
 
-def get_issue_description(group: Group) -> list[NotificationBodyFormattingBlock]:
+def get_issue_description(group: Group) -> list[NotificationSection]:
     from sentry.integrations.messaging.message_builder import build_attachment_title
 
-    blocks: list[NotificationBodyTextBlock] = []
+    blocks: list[NotificationTextBlock] = []
     title = build_attachment_title(group)
     if title:
         blocks.append(PlainTextBlock(text=title))
@@ -69,7 +69,7 @@ def get_view_in_sentry_button(group: Group) -> NotificationRenderedAction:
 def build_template(
     data: WorkflowEngineActivityAction,
     subject: str,
-    body: list[NotificationBodyFormattingBlock],
+    body: list[NotificationSection],
     extra_actions: list[NotificationRenderedAction],
 ) -> NotificationRenderedTemplate:
     from sentry.notifications.notification_action.activity_registry.base import (
@@ -97,7 +97,7 @@ def build_template(
     )
 
 
-def get_example_issue_description() -> list[NotificationBodyFormattingBlock]:
+def get_example_issue_description() -> list[NotificationSection]:
     return [
         ParagraphBlock(
             blocks=[
@@ -118,7 +118,7 @@ def get_example_actions() -> list[NotificationRenderedAction]:
 
 def get_example_template(
     subject: str,
-    body: list[NotificationBodyFormattingBlock] | None = None,
+    body: list[NotificationSection] | None = None,
     actions: list[NotificationRenderedAction] | None = None,
 ) -> NotificationRenderedTemplate:
     return NotificationRenderedTemplate(

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_iteration_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_iteration_completed.py
@@ -10,12 +10,12 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
 )
 from sentry.notifications.platform.types import (
     LinkTextBlock,
-    NotificationBodyFormattingBlock,
-    NotificationBodyTextBlock,
     NotificationCategory,
     NotificationRenderedTemplate,
+    NotificationSection,
     NotificationSource,
     NotificationTemplate,
+    NotificationTextBlock,
     ParagraphBlock,
     PlainTextBlock,
 )
@@ -60,10 +60,10 @@ class SeerIterationCompletedActivityTemplate(NotificationTemplate[WorkflowEngine
             activity_id=data.activity_id
         )
 
-        body: list[NotificationBodyFormattingBlock] = [*get_issue_description(group)]
+        body: list[NotificationSection] = [*get_issue_description(group)]
 
         if activity.data:
-            detail_blocks: list[NotificationBodyTextBlock] = []
+            detail_blocks: list[NotificationTextBlock] = []
 
             iteration_index = activity.data.get("iteration_index")
             if iteration_index is not None:

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_pr_created.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_pr_created.py
@@ -10,12 +10,12 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
 )
 from sentry.notifications.platform.types import (
     LinkTextBlock,
-    NotificationBodyFormattingBlock,
-    NotificationBodyTextBlock,
     NotificationCategory,
     NotificationRenderedTemplate,
+    NotificationSection,
     NotificationSource,
     NotificationTemplate,
+    NotificationTextBlock,
     ParagraphBlock,
 )
 from sentry.types.activity import ActivityType
@@ -58,7 +58,7 @@ class SeerPrCreatedActivityTemplate(NotificationTemplate[WorkflowEngineActivityA
             activity_id=data.activity_id
         )
 
-        pr_links: list[NotificationBodyTextBlock] = []
+        pr_links: list[NotificationTextBlock] = []
         if activity.data:
             for pull_request in activity.data.get("pull_requests", []):
                 repo_name = pull_request.get("repo_name", "")
@@ -68,7 +68,7 @@ class SeerPrCreatedActivityTemplate(NotificationTemplate[WorkflowEngineActivityA
                     label = f"{repo_name} (#{pr_number})" if pr_number else repo_name
                     pr_links.append(LinkTextBlock(text=label, url=pr_url))
 
-        body: list[NotificationBodyFormattingBlock] = [*get_issue_description(group)]
+        body: list[NotificationSection] = [*get_issue_description(group)]
         if pr_links:
             body.append(ParagraphBlock(blocks=pr_links))
 

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_completed.py
@@ -10,9 +10,9 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
 )
 from sentry.notifications.platform.types import (
     CodeBlock,
-    NotificationBodyFormattingBlock,
     NotificationCategory,
     NotificationRenderedTemplate,
+    NotificationSection,
     NotificationSource,
     NotificationTemplate,
     PlainTextBlock,
@@ -56,9 +56,7 @@ class SeerRcaCompletedActivityTemplate(NotificationTemplate[WorkflowEngineActivi
             activity_id=data.activity_id
         )
         fallback = "View the details in Sentry."
-        body: list[NotificationBodyFormattingBlock] = [
-            *get_issue_description(group),
-        ]
+        body: list[NotificationSection] = [*get_issue_description(group)]
         if activity.data:
             summary_block = PlainTextBlock(text=activity.data.get("summary", fallback))
             body.append(CodeBlock(blocks=[summary_block]))

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_completed.py
@@ -10,9 +10,9 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
 )
 from sentry.notifications.platform.types import (
     CodeBlock,
-    NotificationBodyFormattingBlock,
     NotificationCategory,
     NotificationRenderedTemplate,
+    NotificationSection,
     NotificationSource,
     NotificationTemplate,
     PlainTextBlock,
@@ -56,9 +56,7 @@ class SeerSolutionCompletedActivityTemplate(NotificationTemplate[WorkflowEngineA
             activity_id=data.activity_id
         )
         fallback = "View the details in Sentry."
-        body: list[NotificationBodyFormattingBlock] = [
-            *get_issue_description(group),
-        ]
+        body: list[NotificationSection] = [*get_issue_description(group)]
         if activity.data:
             summary_block = PlainTextBlock(text=activity.data.get("summary", fallback))
             body.append(CodeBlock(blocks=[summary_block]))

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -231,11 +231,13 @@ class NotificationRenderedImage:
 
 @dataclass(frozen=True)
 class NotificationRenderedTemplate:
-    subject: str
+    subject: str | list[NotificationBodyFormattingBlock]
     """
     The subject or title of the notification. It's expected that the receiver understand the
     expected content of the notification based on this alone, and it will be the first thing
-    they see. This string should not contain any formatting, and will be displayed as is.
+    they see. Accepts a plain string for simple text, or a list of NotificationBodyFormattingBlock
+    for rich formatting (links, bold, code, etc.). For providers that don't support rich subjects
+    (e.g. email subject lines), block content is rendered as plain text.
     """
     body: list[NotificationBodyFormattingBlock]
     """

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -231,7 +231,7 @@ class NotificationRenderedImage:
 
 @dataclass(frozen=True)
 class NotificationRenderedTemplate:
-    subject: str | list[NotificationBodyTextBlock]
+    subject: str | list[NotificationTextBlock]
     """
     The subject or title of the notification. It's expected that the receiver understand the
     expected content of the notification based on this alone, and it will be the first thing
@@ -239,17 +239,17 @@ class NotificationRenderedTemplate:
     """
 
     @staticmethod
-    def render_text_blocks(blocks: list[NotificationBodyTextBlock]) -> str:
+    def render_text_blocks(blocks: list[NotificationTextBlock]) -> str:
         text = []
         for block in blocks:
-            if block.type == NotificationBodyTextBlockType.LINK:
+            if block.type == NotificationTextBlockType.LINK:
                 text.append(f"{block.text} ({block.url})")
             else:
                 text.append(block.text)
         return " ".join(text)
 
     @property
-    def subject_blocks(self) -> list[NotificationBodyTextBlock]:
+    def subject_blocks(self) -> list[NotificationTextBlock]:
         if isinstance(self.subject, list):
             return self.subject
         return [PlainTextBlock(text=self.subject)]
@@ -258,7 +258,7 @@ class NotificationRenderedTemplate:
     def subject_text(self) -> str:
         return self.render_text_blocks(self.subject_blocks)
 
-    body: list[NotificationBodyFormattingBlock]
+    body: list[NotificationSection]
     """
     The full contents of the notification. Put the details of the notification here, but consider
     keeping it concise and useful to the receiver.
@@ -271,14 +271,14 @@ class NotificationRenderedTemplate:
     """
     The image that will be displayed in the notification.
     """
-    footer: str | list[NotificationBodyTextBlock] | None = None
+    footer: str | list[NotificationTextBlock] | None = None
     """
     Extra notification content that will appear after any actions, separate from the body. Optional,
     and consider omitting if the extra data is not necessary for your notification to be useful.
     """
 
     @property
-    def footer_blocks(self) -> list[NotificationBodyTextBlock]:
+    def footer_blocks(self) -> list[NotificationTextBlock]:
         if self.footer is None:
             return []
         if isinstance(self.footer, list):
@@ -307,7 +307,7 @@ class NotificationRenderedTemplate:
     """
 
 
-class NotificationBodyTextBlockType(StrEnum):
+class NotificationTextBlockType(StrEnum):
     """
     Represents a block of text to be rendered in the notification body.
     """
@@ -330,7 +330,7 @@ class NotificationBodyTextBlockType(StrEnum):
     """
 
 
-class NotificationBodyFormattingBlockType(StrEnum):
+class NotificationSectionType(StrEnum):
     """
     The type of formatting to be applied to the encapsulated blocks.
     """
@@ -345,27 +345,27 @@ class NotificationBodyFormattingBlockType(StrEnum):
     """
 
 
-class NotificationBodyFormattingBlock(Protocol):
+class NotificationSection(Protocol):
     """
     A block that applies formatting such as a newline and encapsulates other text.
     """
 
-    type: NotificationBodyFormattingBlockType
+    type: NotificationSectionType
     """
     The type of the block, such as ParagraphBlock, BoldTextBlock, etc.
     """
-    blocks: list[NotificationBodyTextBlock]
+    blocks: list[NotificationTextBlock]
     """
     Some blocks may want to contain other blocks, such as a ParagraphBlock containing a BoldTextBlock.
     """
 
 
-class NotificationBodyTextBlock(Protocol):
+class NotificationTextBlock(Protocol):
     """
     Represents a block of text to be rendered in the notification body.
     """
 
-    type: NotificationBodyTextBlockType
+    type: NotificationTextBlockType
     """
     The type of the block, such as BoldTextBlock, CodeBlock, etc.
     """
@@ -376,46 +376,40 @@ class NotificationBodyTextBlock(Protocol):
 
 
 @dataclass
-class ParagraphBlock(NotificationBodyFormattingBlock):
-    blocks: list[NotificationBodyTextBlock]
-    type: Literal[NotificationBodyFormattingBlockType.PARAGRAPH] = (
-        NotificationBodyFormattingBlockType.PARAGRAPH
-    )
+class ParagraphBlock(NotificationSection):
+    blocks: list[NotificationTextBlock]
+    type: Literal[NotificationSectionType.PARAGRAPH] = NotificationSectionType.PARAGRAPH
 
 
 @dataclass
-class CodeBlock(NotificationBodyFormattingBlock):
-    blocks: list[NotificationBodyTextBlock]
-    type: Literal[NotificationBodyFormattingBlockType.CODE_BLOCK] = (
-        NotificationBodyFormattingBlockType.CODE_BLOCK
-    )
+class CodeBlock(NotificationSection):
+    blocks: list[NotificationTextBlock]
+    type: Literal[NotificationSectionType.CODE_BLOCK] = NotificationSectionType.CODE_BLOCK
 
 
 @dataclass
-class BoldTextBlock(NotificationBodyTextBlock):
+class BoldTextBlock(NotificationTextBlock):
     text: str
-    type: Literal[NotificationBodyTextBlockType.BOLD_TEXT] = NotificationBodyTextBlockType.BOLD_TEXT
+    type: Literal[NotificationTextBlockType.BOLD_TEXT] = NotificationTextBlockType.BOLD_TEXT
 
 
 @dataclass
-class CodeTextBlock(NotificationBodyTextBlock):
+class CodeTextBlock(NotificationTextBlock):
     text: str
-    type: Literal[NotificationBodyTextBlockType.CODE] = NotificationBodyTextBlockType.CODE
+    type: Literal[NotificationTextBlockType.CODE] = NotificationTextBlockType.CODE
 
 
 @dataclass
-class PlainTextBlock(NotificationBodyTextBlock):
+class PlainTextBlock(NotificationTextBlock):
     text: str
-    type: Literal[NotificationBodyTextBlockType.PLAIN_TEXT] = (
-        NotificationBodyTextBlockType.PLAIN_TEXT
-    )
+    type: Literal[NotificationTextBlockType.PLAIN_TEXT] = NotificationTextBlockType.PLAIN_TEXT
 
 
 @dataclass
-class LinkTextBlock(NotificationBodyTextBlock):
+class LinkTextBlock(NotificationTextBlock):
     text: str
     url: str
-    type: Literal[NotificationBodyTextBlockType.LINK] = NotificationBodyTextBlockType.LINK
+    type: Literal[NotificationTextBlockType.LINK] = NotificationTextBlockType.LINK
 
 
 class NotificationTemplate[T: NotificationData](abc.ABC):

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -250,11 +250,12 @@ class NotificationRenderedTemplate:
     """
     The image that will be displayed in the notification.
     """
-    footer: str | None = None
+    footer: str | list[NotificationBodyFormattingBlock] | None = None
     """
     Extra notification content that will appear after any actions, separate from the body. Optional,
     and consider omitting if the extra data is not necessary for your notification to be useful.
-    This string should not contain any formatting, and will be displayed as is.
+    Accepts a plain string for simple text, or a list of NotificationBodyFormattingBlock for rich
+    formatting (links, bold, code, etc.).
     """
 
     # The following are optional, as omitting them will use a default email template which expects

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -231,14 +231,33 @@ class NotificationRenderedImage:
 
 @dataclass(frozen=True)
 class NotificationRenderedTemplate:
-    subject: str | list[NotificationBodyFormattingBlock]
+    subject: str | list[NotificationBodyTextBlock]
     """
     The subject or title of the notification. It's expected that the receiver understand the
     expected content of the notification based on this alone, and it will be the first thing
-    they see. Accepts a plain string for simple text, or a list of NotificationBodyFormattingBlock
-    for rich formatting (links, bold, code, etc.). For providers that don't support rich subjects
-    (e.g. email subject lines), block content is rendered as plain text.
+    they see.
     """
+
+    @staticmethod
+    def render_text_blocks(blocks: list[NotificationBodyTextBlock]) -> str:
+        text = []
+        for block in blocks:
+            if block.type == NotificationBodyTextBlockType.LINK:
+                text.append(f"{block.text} ({block.url})")
+            else:
+                text.append(block.text)
+        return " ".join(text)
+
+    @property
+    def subject_blocks(self) -> list[NotificationBodyTextBlock]:
+        if isinstance(self.subject, list):
+            return self.subject
+        return [PlainTextBlock(text=self.subject)]
+
+    @property
+    def subject_text(self) -> str:
+        return self.render_text_blocks(self.subject_blocks)
+
     body: list[NotificationBodyFormattingBlock]
     """
     The full contents of the notification. Put the details of the notification here, but consider
@@ -252,13 +271,23 @@ class NotificationRenderedTemplate:
     """
     The image that will be displayed in the notification.
     """
-    footer: str | list[NotificationBodyFormattingBlock] | None = None
+    footer: str | list[NotificationBodyTextBlock] | None = None
     """
     Extra notification content that will appear after any actions, separate from the body. Optional,
     and consider omitting if the extra data is not necessary for your notification to be useful.
-    Accepts a plain string for simple text, or a list of NotificationBodyFormattingBlock for rich
-    formatting (links, bold, code, etc.).
     """
+
+    @property
+    def footer_blocks(self) -> list[NotificationBodyTextBlock]:
+        if self.footer is None:
+            return []
+        if isinstance(self.footer, list):
+            return self.footer
+        return [PlainTextBlock(text=self.footer)]
+
+    @property
+    def footer_text(self) -> str:
+        return self.render_text_blocks(self.footer_blocks)
 
     # The following are optional, as omitting them will use a default email template which expects
     # the required fields above to be present instead.

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -242,7 +242,7 @@ class NotificationRenderedTemplate:
     def render_text_blocks(blocks: list[NotificationTextBlock]) -> str:
         text = []
         for block in blocks:
-            if block.type == NotificationTextBlockType.LINK:
+            if isinstance(block, LinkTextBlock):
                 text.append(f"{block.text} ({block.url})")
             else:
                 text.append(block.text)

--- a/src/sentry/testutils/notifications/platform.py
+++ b/src/sentry/testutils/notifications/platform.py
@@ -1,7 +1,5 @@
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.types import (
-    NotificationBodyFormattingBlockType,
-    NotificationBodyTextBlockType,
     NotificationCategory,
     NotificationData,
     NotificationRenderedAction,
@@ -29,16 +27,7 @@ class MockNotificationTemplate(NotificationTemplate[MockNotification]):
     def render(self, data: MockNotification) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
             subject="Mock Notification",
-            body=[
-                ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
-                    blocks=[
-                        PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT, text=data.message
-                        )
-                    ],
-                )
-            ],
+            body=[ParagraphBlock(blocks=[PlainTextBlock(text=data.message)])],
             actions=[
                 NotificationRenderedAction(label="Visit Sentry", link="https://www.sentry.io")
             ],

--- a/static/app/debug/notifications/components/debugNotificationsExample.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsExample.tsx
@@ -118,13 +118,9 @@ export function DebugNotificationsExample({
             <Text variant="success" bold>
               Footer
             </Text>
-            {displayFormat === ExampleDataFormat.FORMATTED ? (
-              <Text>{registration.example.footer}</Text>
-            ) : (
-              <CodeBlock language="javascript">
-                {JSON.stringify(registration.example.footer)}
-              </CodeBlock>
-            )}
+            <CodeBlock language="json">
+              {JSON.stringify(registration.example.footer, null, 2)}
+            </CodeBlock>
           </Fragment>
         )}
       </ExampleGrid>

--- a/static/app/debug/notifications/components/debugNotificationsExample.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsExample.tsx
@@ -46,11 +46,7 @@ export function DebugNotificationsExample({
           Subject
         </Text>
         {displayFormat === ExampleDataFormat.FORMATTED ? (
-          <Text>
-            {typeof registration.example.subject === 'string'
-              ? registration.example.subject
-              : JSON.stringify(registration.example.subject)}
-          </Text>
+          <Text>{registration.example.subject.map(block => block.text).join(' ')}</Text>
         ) : (
           <CodeBlock language="json">
             {JSON.stringify(registration.example.subject, null, 2)}

--- a/static/app/debug/notifications/components/debugNotificationsExample.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsExample.tsx
@@ -46,10 +46,14 @@ export function DebugNotificationsExample({
           Subject
         </Text>
         {displayFormat === ExampleDataFormat.FORMATTED ? (
-          <Text>{registration.example.subject}</Text>
+          <Text>
+            {typeof registration.example.subject === 'string'
+              ? registration.example.subject
+              : JSON.stringify(registration.example.subject)}
+          </Text>
         ) : (
-          <CodeBlock language="javascript">
-            {JSON.stringify(registration.example.subject)}
+          <CodeBlock language="json">
+            {JSON.stringify(registration.example.subject, null, 2)}
           </CodeBlock>
         )}
         <Text variant="success" bold>

--- a/static/app/debug/notifications/components/notificationBodyRenderer.tsx
+++ b/static/app/debug/notifications/components/notificationBodyRenderer.tsx
@@ -13,7 +13,7 @@ enum NotificationBodyTextBlockType {
   CODE = 'code',
 }
 
-interface NotificationBodyTextBlock {
+export interface NotificationBodyTextBlock {
   text: string;
   type: NotificationBodyTextBlockType;
 }

--- a/static/app/debug/notifications/previews/discordPreview.tsx
+++ b/static/app/debug/notifications/previews/discordPreview.tsx
@@ -45,16 +45,7 @@ export function DiscordPreview({
             gap="md"
           >
             <DiscordWhiteText size="md" bold>
-              {typeof subject === 'string' ? (
-                subject
-              ) : (
-                <NotificationBodyRenderer
-                  body={subject}
-                  codeBlockBackground="#2f3136"
-                  codeBlockBorder="#202225"
-                  codeBlockTextColor="#dcddde"
-                />
-              )}
+              {subject.map(block => block.text).join(' ')}
             </DiscordWhiteText>
             <DiscordWhiteText size="sm">
               <NotificationBodyRenderer
@@ -75,16 +66,7 @@ export function DiscordPreview({
             )}
             {footer && (
               <DiscordWhiteText size="xs">
-                {typeof footer === 'string' ? (
-                  footer
-                ) : (
-                  <NotificationBodyRenderer
-                    body={footer}
-                    codeBlockBackground="#2f3136"
-                    codeBlockBorder="#202225"
-                    codeBlockTextColor="#dcddde"
-                  />
-                )}
+                {footer.map(block => block.text).join(' ')}
               </DiscordWhiteText>
             )}
           </DiscordEmbedContainer>

--- a/static/app/debug/notifications/previews/discordPreview.tsx
+++ b/static/app/debug/notifications/previews/discordPreview.tsx
@@ -45,7 +45,16 @@ export function DiscordPreview({
             gap="md"
           >
             <DiscordWhiteText size="md" bold>
-              {subject}
+              {typeof subject === 'string' ? (
+                subject
+              ) : (
+                <NotificationBodyRenderer
+                  body={subject}
+                  codeBlockBackground="#2f3136"
+                  codeBlockBorder="#202225"
+                  codeBlockTextColor="#dcddde"
+                />
+              )}
             </DiscordWhiteText>
             <DiscordWhiteText size="sm">
               <NotificationBodyRenderer

--- a/static/app/debug/notifications/previews/discordPreview.tsx
+++ b/static/app/debug/notifications/previews/discordPreview.tsx
@@ -64,7 +64,20 @@ export function DiscordPreview({
                 objectFit="contain"
               />
             )}
-            {footer && <DiscordWhiteText size="xs">{footer}</DiscordWhiteText>}
+            {footer && (
+              <DiscordWhiteText size="xs">
+                {typeof footer === 'string' ? (
+                  footer
+                ) : (
+                  <NotificationBodyRenderer
+                    body={footer}
+                    codeBlockBackground="#2f3136"
+                    codeBlockBorder="#202225"
+                    codeBlockTextColor="#dcddde"
+                  />
+                )}
+              </DiscordWhiteText>
+            )}
           </DiscordEmbedContainer>
           <Flex gap="xs">
             {actions.map(action => (

--- a/static/app/debug/notifications/previews/slackPreview.tsx
+++ b/static/app/debug/notifications/previews/slackPreview.tsx
@@ -88,7 +88,15 @@ export function SlackPreview({
             )}
             {footer && (
               <SlackBlackText size="xs" variant="muted">
-                {footer}
+                {typeof footer === 'string' ? (
+                  footer
+                ) : (
+                  <NotificationBodyRenderer
+                    body={footer}
+                    codeBlockBackground="#f8f8f8"
+                    codeBlockBorder="#e0e0e0"
+                  />
+                )}
               </SlackBlackText>
             )}
           </Flex>

--- a/static/app/debug/notifications/previews/slackPreview.tsx
+++ b/static/app/debug/notifications/previews/slackPreview.tsx
@@ -53,7 +53,15 @@ export function SlackPreview({
           </Flex>
           <Flex direction="column" align="start" padding="sm 0" gap="md">
             <SlackBlackText size="xl" bold>
-              {subject}
+              {typeof subject === 'string' ? (
+                subject
+              ) : (
+                <NotificationBodyRenderer
+                  body={subject}
+                  codeBlockBackground="#f8f8f8"
+                  codeBlockBorder="#e0e0e0"
+                />
+              )}
             </SlackBlackText>
             <SlackBodyText>
               <NotificationBodyRenderer

--- a/static/app/debug/notifications/previews/slackPreview.tsx
+++ b/static/app/debug/notifications/previews/slackPreview.tsx
@@ -53,15 +53,7 @@ export function SlackPreview({
           </Flex>
           <Flex direction="column" align="start" padding="sm 0" gap="md">
             <SlackBlackText size="xl" bold>
-              {typeof subject === 'string' ? (
-                subject
-              ) : (
-                <NotificationBodyRenderer
-                  body={subject}
-                  codeBlockBackground="#f8f8f8"
-                  codeBlockBorder="#e0e0e0"
-                />
-              )}
+              {subject.map(block => block.text).join(' ')}
             </SlackBlackText>
             <SlackBodyText>
               <NotificationBodyRenderer
@@ -96,15 +88,7 @@ export function SlackPreview({
             )}
             {footer && (
               <SlackBlackText size="xs" variant="muted">
-                {typeof footer === 'string' ? (
-                  footer
-                ) : (
-                  <NotificationBodyRenderer
-                    body={footer}
-                    codeBlockBackground="#f8f8f8"
-                    codeBlockBorder="#e0e0e0"
-                  />
-                )}
+                {footer.map(block => block.text).join(' ')}
               </SlackBlackText>
             )}
           </Flex>

--- a/static/app/debug/notifications/previews/teamsPreview.tsx
+++ b/static/app/debug/notifications/previews/teamsPreview.tsx
@@ -72,7 +72,15 @@ export function TeamsPreview({
             </Flex>
             <TeamsCard direction="column" align="start" padding="xl" gap="md">
               <TeamsBlackText size="xl" bold>
-                {subject}
+                {typeof subject === 'string' ? (
+                  subject
+                ) : (
+                  <NotificationBodyRenderer
+                    body={subject}
+                    codeBlockBackground="#f3f2f1"
+                    codeBlockBorder="#e1dfdd"
+                  />
+                )}
               </TeamsBlackText>
               <TeamsBlackText>
                 <NotificationBodyRenderer

--- a/static/app/debug/notifications/previews/teamsPreview.tsx
+++ b/static/app/debug/notifications/previews/teamsPreview.tsx
@@ -99,7 +99,19 @@ export function TeamsPreview({
                   />
                 </Flex>
               )}
-              {footer && <TeamsBlackText size="sm">{footer}</TeamsBlackText>}
+              {footer && (
+                <TeamsBlackText size="sm">
+                  {typeof footer === 'string' ? (
+                    footer
+                  ) : (
+                    <NotificationBodyRenderer
+                      body={footer}
+                      codeBlockBackground="#f3f2f1"
+                      codeBlockBorder="#e1dfdd"
+                    />
+                  )}
+                </TeamsBlackText>
+              )}
             </TeamsCard>
           </TeamsMessage>
         </TeamsPreviewContainer>

--- a/static/app/debug/notifications/previews/teamsPreview.tsx
+++ b/static/app/debug/notifications/previews/teamsPreview.tsx
@@ -72,15 +72,7 @@ export function TeamsPreview({
             </Flex>
             <TeamsCard direction="column" align="start" padding="xl" gap="md">
               <TeamsBlackText size="xl" bold>
-                {typeof subject === 'string' ? (
-                  subject
-                ) : (
-                  <NotificationBodyRenderer
-                    body={subject}
-                    codeBlockBackground="#f3f2f1"
-                    codeBlockBorder="#e1dfdd"
-                  />
-                )}
+                {subject.map(block => block.text).join(' ')}
               </TeamsBlackText>
               <TeamsBlackText>
                 <NotificationBodyRenderer
@@ -109,15 +101,7 @@ export function TeamsPreview({
               )}
               {footer && (
                 <TeamsBlackText size="sm">
-                  {typeof footer === 'string' ? (
-                    footer
-                  ) : (
-                    <NotificationBodyRenderer
-                      body={footer}
-                      codeBlockBackground="#f3f2f1"
-                      codeBlockBorder="#e1dfdd"
-                    />
-                  )}
+                  {footer.map(block => block.text).join(' ')}
                 </TeamsBlackText>
               )}
             </TeamsCard>

--- a/static/app/debug/notifications/types.ts
+++ b/static/app/debug/notifications/types.ts
@@ -12,7 +12,7 @@ export interface NotificationTemplateRegistration {
   example: {
     actions: Array<{label: string; link: string}>;
     body: NotificationBodyFormattingBlock[];
-    subject: string;
+    subject: string | NotificationBodyFormattingBlock[];
     chart?: {alt_text: string; url: string};
     footer?: string | NotificationBodyFormattingBlock[];
   };

--- a/static/app/debug/notifications/types.ts
+++ b/static/app/debug/notifications/types.ts
@@ -1,4 +1,7 @@
-import type {NotificationBodyFormattingBlock} from 'sentry/debug/notifications/components/notificationBodyRenderer';
+import type {
+  NotificationBodyFormattingBlock,
+  NotificationBodyTextBlock,
+} from 'sentry/debug/notifications/components/notificationBodyRenderer';
 
 export enum NotificationProviderKey {
   EMAIL = 'email',
@@ -12,9 +15,9 @@ export interface NotificationTemplateRegistration {
   example: {
     actions: Array<{label: string; link: string}>;
     body: NotificationBodyFormattingBlock[];
-    subject: string | NotificationBodyFormattingBlock[];
+    subject: NotificationBodyTextBlock[];
     chart?: {alt_text: string; url: string};
-    footer?: string | NotificationBodyFormattingBlock[];
+    footer?: NotificationBodyTextBlock[];
   };
   previews: {
     [NotificationProviderKey.EMAIL]: {

--- a/static/app/debug/notifications/types.ts
+++ b/static/app/debug/notifications/types.ts
@@ -14,7 +14,7 @@ export interface NotificationTemplateRegistration {
     body: NotificationBodyFormattingBlock[];
     subject: string;
     chart?: {alt_text: string; url: string};
-    footer?: string;
+    footer?: string | NotificationBodyFormattingBlock[];
   };
   previews: {
     [NotificationProviderKey.EMAIL]: {

--- a/tests/sentry/notifications/platform/discord/test_provider.py
+++ b/tests/sentry/notifications/platform/discord/test_provider.py
@@ -20,8 +20,6 @@ from sentry.notifications.platform.discord.provider import (
 from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.types import (
     LinkTextBlock,
-    NotificationBodyFormattingBlockType,
-    NotificationBodyTextBlockType,
     NotificationCategory,
     NotificationProviderKey,
     NotificationRenderedAction,
@@ -122,17 +120,7 @@ class DiscordRendererTest(TestCase):
     def test_renderer_without_chart(self) -> None:
         rendered_template = NotificationRenderedTemplate(
             subject="Test Without Chart",
-            body=[
-                ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
-                    blocks=[
-                        PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
-                            text="test without chart",
-                        )
-                    ],
-                )
-            ],
+            body=[ParagraphBlock(blocks=[PlainTextBlock(text="test without chart")])],
             actions=[
                 NotificationRenderedAction(label="Visit Sentry", link="https://www.sentry.io")
             ],
@@ -153,17 +141,7 @@ class DiscordRendererTest(TestCase):
     def test_renderer_without_footer(self) -> None:
         rendered_template = NotificationRenderedTemplate(
             subject="Test Without Footer",
-            body=[
-                ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
-                    blocks=[
-                        PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
-                            text="test without footer",
-                        )
-                    ],
-                )
-            ],
+            body=[ParagraphBlock(blocks=[PlainTextBlock(text="test without footer")])],
             actions=[
                 NotificationRenderedAction(label="Visit Sentry", link="https://www.sentry.io")
             ],
@@ -187,17 +165,7 @@ class DiscordRendererTest(TestCase):
     def test_renderer_without_actions(self) -> None:
         rendered_template = NotificationRenderedTemplate(
             subject="Test Without Actions",
-            body=[
-                ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
-                    blocks=[
-                        PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
-                            text="test without actions",
-                        )
-                    ],
-                )
-            ],
+            body=[ParagraphBlock(blocks=[PlainTextBlock(text="test without actions")])],
             actions=[],  # No actions
             footer="Test footer",
             chart=NotificationRenderedImage(
@@ -227,17 +195,7 @@ class DiscordRendererTest(TestCase):
         # Create a custom rendered template with multiple actions
         rendered_template = NotificationRenderedTemplate(
             subject="Test Multiple Actions",
-            body=[
-                ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
-                    blocks=[
-                        PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
-                            text="test with multiple actions",
-                        )
-                    ],
-                )
-            ],
+            body=[ParagraphBlock(blocks=[PlainTextBlock(text="test with multiple actions")])],
             actions=actions,
             footer="Test footer",
             chart=NotificationRenderedImage(

--- a/tests/sentry/notifications/platform/email/test_provider.py
+++ b/tests/sentry/notifications/platform/email/test_provider.py
@@ -8,13 +8,13 @@ from sentry.notifications.platform.target import GenericNotificationTarget
 from sentry.notifications.platform.types import (
     BoldTextBlock,
     LinkTextBlock,
-    NotificationBodyFormattingBlock,
-    NotificationBodyFormattingBlockType,
-    NotificationBodyTextBlock,
-    NotificationBodyTextBlockType,
     NotificationProviderKey,
     NotificationRenderedTemplate,
+    NotificationSection,
+    NotificationSectionType,
     NotificationTargetResourceType,
+    NotificationTextBlock,
+    NotificationTextBlockType,
     ParagraphBlock,
     PlainTextBlock,
 )
@@ -23,25 +23,25 @@ from sentry.testutils.notifications.platform import MockNotification, MockNotifi
 
 
 def validate_text_block(
-    text_block: NotificationBodyTextBlock, text_content: str, html_content: str
+    text_block: NotificationTextBlock, text_content: str, html_content: str
 ) -> None:
-    if text_block.type == NotificationBodyTextBlockType.PLAIN_TEXT:
+    if text_block.type == NotificationTextBlockType.PLAIN_TEXT:
         assert text_block.text in text_content
         assert text_block.text in html_content
-    elif text_block.type == NotificationBodyTextBlockType.BOLD_TEXT:
+    elif text_block.type == NotificationTextBlockType.BOLD_TEXT:
         assert f"<strong>{text_block.text}</strong>" in html_content
-    elif text_block.type == NotificationBodyTextBlockType.CODE:
+    elif text_block.type == NotificationTextBlockType.CODE:
         assert f"<code>{text_block.text}</code>" in html_content
 
 
 def validate_formatting_block(
-    formatting_block: NotificationBodyFormattingBlock, text_content: str, html_content: str
+    formatting_block: NotificationSection, text_content: str, html_content: str
 ) -> None:
-    if formatting_block.type == NotificationBodyFormattingBlockType.PARAGRAPH:
+    if formatting_block.type == NotificationSectionType.PARAGRAPH:
         assert "\n" in text_content
         assert "<p" in html_content
         assert "</p>" in html_content
-    elif formatting_block.type == NotificationBodyFormattingBlockType.CODE_BLOCK:
+    elif formatting_block.type == NotificationSectionType.CODE_BLOCK:
         assert "\n" in text_content
         assert "<pre" in html_content
         assert "</pre>" in html_content
@@ -125,16 +125,9 @@ class EmailRendererTest(TestCase):
             subject="Test XSS",
             body=[
                 ParagraphBlock(
-                    type=NotificationBodyFormattingBlockType.PARAGRAPH,
                     blocks=[
-                        PlainTextBlock(
-                            type=NotificationBodyTextBlockType.PLAIN_TEXT,
-                            text="<script>alert('xss')</script>",
-                        ),
-                        BoldTextBlock(
-                            type=NotificationBodyTextBlockType.BOLD_TEXT,
-                            text="<img src=x onerror=alert('xss')>",
-                        ),
+                        PlainTextBlock(text="<script>alert('xss')</script>"),
+                        BoldTextBlock(text="<img src=x onerror=alert('xss')>"),
                     ],
                 )
             ],

--- a/tests/sentry/notifications/platform/email/test_provider.py
+++ b/tests/sentry/notifications/platform/email/test_provider.py
@@ -70,7 +70,10 @@ class EmailRendererTest(TestCase):
         text_content = email.body
 
         assert self.rendered_template.chart is not None
-        assert self.rendered_template.footer is not None
+        assert isinstance(self.rendered_template.subject_blocks, list)
+        assert isinstance(self.rendered_template.subject_text, str)
+        assert isinstance(self.rendered_template.footer_blocks, list)
+        assert isinstance(self.rendered_template.footer_text, str)
 
         for element in [
             self.rendered_template.subject,

--- a/tests/sentry/notifications/platform/email/test_provider.py
+++ b/tests/sentry/notifications/platform/email/test_provider.py
@@ -76,12 +76,12 @@ class EmailRendererTest(TestCase):
         assert isinstance(self.rendered_template.footer_text, str)
 
         for element in [
-            self.rendered_template.subject,
+            self.rendered_template.subject_text,
             self.rendered_template.actions[0].label,
             self.rendered_template.actions[0].link,
             self.rendered_template.chart.url,
             self.rendered_template.chart.alt_text,
-            self.rendered_template.footer,
+            self.rendered_template.footer_text,
         ]:
             assert element in str(text_content)
             assert element in str(html_content)


### PR DESCRIPTION
The type has been changed from `str` to `str | list[FormattingBlock]`, and added pathways for parsing and interpreting both. It seemed to work fine for all providers except I couldn't test MS Teams.

The only caveat is email subjects which obviously can't support rich text.

This approach is kinda ugly but would avoid custom renderers for small adjustments.