### PR TITLE
fix(integrations): re-register github project management feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -130,6 +130,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # API-driven integration setup pipeline (per-provider rollout)
     # ...
     # Project Management Integrations Feature Parity Flags
+    manager.add("organizations:integrations-github-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-github_enterprise-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-gitlab-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable recent linked pull requests on issue details


### PR DESCRIPTION
Fixes SENTRY-5KBA

This flag is dynamically registered in `github/issue_sync.py` and we keep removing it since it looks unused. Exclude it from staleness detection here: https://github.com/getsentry/getsentry/pull/20848