### PR TITLE
fix(pr-metrics): Match check PRs on their own repo, not the check's

### DIFF
--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -635,8 +635,9 @@ def handle_check_suite(
     """Record the aggregate CI outcome from a completed check_suite event.
 
     Only ``completed`` carries a conclusion; ``requested``/``rerequested`` are
-    ignored. The suite's ``pull_requests`` array lists the same-repo PRs the run
-    pertains to (empty for fork PRs) — one activity row is written per PR.
+    ignored. One activity row is written per referenced PR that belongs to this
+    repo (``pull_requests`` can also carry other repos' PRs — see
+    ``_prs_from_check_payload``).
     """
     if event.get("action") != "completed":
         return
@@ -678,7 +679,8 @@ def handle_check_run(
     """Record an individual CI check outcome from a completed check_run event.
 
     Per-check granularity beneath ``check_suite``; only ``completed`` carries a
-    conclusion. ``check_run.pull_requests`` resolves the affected same-repo PRs.
+    conclusion. ``check_run.pull_requests`` is resolved like ``check_suite`` —
+    entries from other repos are filtered in ``_prs_from_check_payload``.
     """
     if event.get("action") != "completed":
         return
@@ -716,15 +718,31 @@ def _prs_from_check_payload(
 ) -> list[PullRequest]:
     """Resolve the tracked PRs a check_suite/check_run payload references.
 
-    Both events carry a ``pull_requests`` array of same-repo PR refs (empty for
-    fork PRs, and a suite can span more than one PR). Numbers are deduped before
-    resolving each to its stored row; unknown PRs are dropped by ``_get_pull_request``.
+    GitHub lists a PR on a check when they share ``head_sha`` + ``head_branch``,
+    so ``pull_requests`` can include PRs that live in *other* repositories. The
+    common case: a PR opened to merge this repo's default branch into another
+    repo (e.g. a fork syncing from upstream) has its head in this repo, so it
+    matches every default-branch check here — but the PR belongs to that other
+    repo and its ``number`` is scoped to it. Each entry carries its own
+    ``base.repo``, so an entry is only ours to resolve when its base repo is the
+    one this webhook is for. Resolving a foreign entry's number against ``repo``
+    would miss, or — on a number collision — attribute another repo's PR activity
+    to ours, so it is skipped.
+
+    Numbers are deduped before resolving each to its stored row; unknown PRs are
+    dropped by ``_get_pull_request``.
     """
     seen: set[str] = set()
     prs: list[PullRequest] = []
     for ref in container.get("pull_requests") or ():
         number = ref.get("number")
         if number is None or str(number) in seen:
+            continue
+        # A PR's number is scoped to its own base repo; resolve it against
+        # ``repo`` only when the PR lives here. Entries whose base is another repo
+        # (a PR merging this repo's branch elsewhere) are not ours to record.
+        base_repo_id = ((ref.get("base") or {}).get("repo") or {}).get("id")
+        if base_repo_id is None or str(base_repo_id) != repo.external_id:
             continue
         seen.add(str(number))
         pr = _get_pull_request(organization, repo, {"number": number}, webhook_id)

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -743,6 +743,7 @@ def _prs_from_check_payload(
         # (a PR merging this repo's branch elsewhere) are not ours to record.
         base_repo_id = ((ref.get("base") or {}).get("repo") or {}).get("id")
         if base_repo_id is None or str(base_repo_id) != repo.external_id:
+            metrics.incr("pr_metrics.check.foreign_pull_request")
             continue
         seen.add(str(number))
         pr = _get_pull_request(organization, repo, {"number": number}, webhook_id)

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -1457,6 +1457,24 @@ class HandleCheckEventsForPrMetricsTest(TestCase):
             key="42",
         )
 
+    def _pull_request_refs(
+        self,
+        pr_numbers: tuple[int, ...],
+        foreign_pr_numbers: tuple[int, ...] = (),
+    ) -> list[dict[str, Any]]:
+        """Build a check payload's ``pull_requests`` array.
+
+        Same-repo entries carry this repo's id as ``base.repo.id``. Foreign
+        entries (a PR that lives in another repo but merges this repo's branch —
+        e.g. a fork syncing from upstream) carry a different ``base.repo.id`` and
+        must be skipped by the handler.
+        """
+        same = [
+            {"number": n, "base": {"repo": {"id": int(self.repo.external_id)}}} for n in pr_numbers
+        ]
+        foreign = [{"number": n, "base": {"repo": {"id": 999999}}} for n in foreign_pr_numbers]
+        return same + foreign
+
     def _call_suite(
         self,
         action: str = "completed",
@@ -1465,6 +1483,7 @@ class HandleCheckEventsForPrMetricsTest(TestCase):
         app_slug: str = "github-actions",
         check_runs_count: int = 4,
         pr_numbers: tuple[int, ...] = (42,),
+        foreign_pr_numbers: tuple[int, ...] = (),
         webhook_id: str | None = "delivery-1",
     ) -> None:
         event: dict[str, Any] = {
@@ -1475,7 +1494,7 @@ class HandleCheckEventsForPrMetricsTest(TestCase):
                 "conclusion": conclusion,
                 "app": {"slug": app_slug},
                 "latest_check_runs_count": check_runs_count,
-                "pull_requests": [{"number": n} for n in pr_numbers],
+                "pull_requests": self._pull_request_refs(pr_numbers, foreign_pr_numbers),
             },
             "sender": {"id": 5, "login": "ci-bot", "type": "Bot"},
         }
@@ -1495,6 +1514,7 @@ class HandleCheckEventsForPrMetricsTest(TestCase):
         head_sha: str = "headsha1",
         app_slug: str = "github-actions",
         pr_numbers: tuple[int, ...] = (42,),
+        foreign_pr_numbers: tuple[int, ...] = (),
         webhook_id: str | None = "delivery-1",
     ) -> None:
         event: dict[str, Any] = {
@@ -1505,7 +1525,7 @@ class HandleCheckEventsForPrMetricsTest(TestCase):
                 "status": "completed",
                 "conclusion": conclusion,
                 "app": {"slug": app_slug},
-                "pull_requests": [{"number": n} for n in pr_numbers],
+                "pull_requests": self._pull_request_refs(pr_numbers, foreign_pr_numbers),
             },
             "sender": {"id": 5, "login": "ci-bot", "type": "Bot"},
         }
@@ -1563,6 +1583,23 @@ class HandleCheckEventsForPrMetricsTest(TestCase):
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
+    def test_check_suite_skips_pull_request_from_other_repo(self) -> None:
+        # GitHub lists a PR on our check when their heads match (head_sha +
+        # head_branch). A PR that merges this repo's default branch into another
+        # repo (head here, base elsewhere — e.g. a fork syncing from upstream)
+        # rides along on every default-branch check, but its number belongs to the
+        # other repo. It must not resolve against ours, even when the number
+        # collides with one of our PRs (here, key "42").
+        self._call_suite(pr_numbers=(), foreign_pr_numbers=(42,))
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_check_suite_resolves_only_same_repo_pull_requests(self) -> None:
+        self._call_suite(pr_numbers=(42,), foreign_pr_numbers=(77,))
+
+        assert PullRequestActivity.objects.filter(pull_request=self.pr).count() == 1
+        assert not PullRequest.objects.filter(repository_id=self.repo.id, key="77").exists()
+
     def test_check_suite_no_activity_without_webhook_id(self) -> None:
         self._call_suite(webhook_id=None)
 
@@ -1606,6 +1643,11 @@ class HandleCheckEventsForPrMetricsTest(TestCase):
 
     def test_check_run_without_prs_writes_nothing(self) -> None:
         self._call_run(pr_numbers=())
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_check_run_skips_pull_request_from_other_repo(self) -> None:
+        self._call_run(pr_numbers=(), foreign_pr_numbers=(42,))
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 


### PR DESCRIPTION
## Problem

`check_suite` / `check_run` webhooks carry a `pull_requests` array. GitHub populates it by matching a PR's `head_sha` + `head_branch` to the check — and that match can include PRs that live in **other repositories**. The common case is a PR opened to merge this repo's default branch into another repo (e.g. a fork syncing from upstream): its head is our branch, so it shows up on *every* default-branch check here, even though the PR itself belongs to the other repo and its `number` is scoped to that repo.

`_prs_from_check_payload` resolved each entry's `number` against the repo the webhook was for, ignoring each entry's own `base.repo`. For these cross-repo PRs that is:

- a **guaranteed miss** every time CI runs on the default branch — the dominant source of `pr_metrics.pull_request.unresolved` noise during the rollout; and
- a latent **mis-attribution** bug: if such a foreign PR number ever collides with one of our tracked PR numbers, the other repo's CI activity would be recorded against our PR.

## Approach

Resolve an entry only when its `base.repo.id` matches the webhook repo (`repo.external_id`). The PR's `number` is scoped to its base repo, so this is the correct identity to match on — not the repo the check happened to run in.

- Real PRs targeting this repo (including incoming fork contributions, whose `base` is us) keep working.
- PRs that merely merge our branch elsewhere (`base` is another repo) are skipped before they hit the resolve path.

## Tests

- `test_check_suite_skips_pull_request_from_other_repo` — a foreign PR whose number collides with one of ours is **not** attributed to ours.
- `test_check_suite_resolves_only_same_repo_pull_requests` — mixed payload: only the same-repo PR is recorded.
- `test_check_run_skips_pull_request_from_other_repo` — same guard on the `check_run` path.

Existing check tests updated to send realistic refs carrying `base.repo`.

Refs CORE-247
