### PR TITLE
fix(relocation) Avoid integrity errors on self-hosted import

### DIFF
--- a/src/sentry/users/models/user.py
+++ b/src/sentry/users/models/user.py
@@ -250,6 +250,10 @@ class User(Model, AbstractBaseUser):
                     if self.pk is None and not is_relocated_user:
                         # new users should set email_unique
                         self.email_unique = self.email
+                    elif self.pk is None and is_relocated_user and self.email_unique:
+                        # If the user is new, relocated and has email_unique blank email_unique
+                        # to dodge integrity errors.
+                        self.email_unique = None
                     else:
                         # existing users with shared email addresses + relocated users should be able to save without fail
                         self.email_unique = (
@@ -264,7 +268,7 @@ class User(Model, AbstractBaseUser):
         except IntegrityError:
             logger.info(
                 "Attempted to save user with non-unique primary email address",
-                extra={"email": self.email},
+                extra={"email": self.email, "is_relocated_user": is_relocated_user},
             )
             raise
 

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -2258,7 +2258,7 @@ class CollisionTests(ImportTestCase):
                 with assume_test_silo_mode(SiloMode.CONTROL):
                     colliding_owner.save()
 
-                org = self.create_organization("other-org", owner=owner)
+                org = self.create_organization("other-org", owner=colliding_owner)
 
                 import_in_organization_scope(
                     tmp_file,

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -2231,6 +2231,59 @@ class CollisionTests(ImportTestCase):
             with open(tmp_path, "rb") as tmp_file:
                 verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
 
+    @expect_models(COLLISION_TESTED, Organization, OrganizationMember, User, UserEmail)
+    def test_colliding_user_email_unique_with_merging_disabled_in_organization_scope(
+        self, expected_models: list[type[Model]]
+    ):
+        # Create an owner, and set email_unique as it isn't populated by factory methods.
+        owner = self.create_exhaustive_user(username="owner", email="importing@example.com")
+        owner.email_unique = owner.email
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            owner.save()
+
+        org = self.create_organization("some-org", owner=owner)
+        old_org_membership = OrganizationMember.objects.get(organization=org)
+        old_org_membership.regenerate_token()
+        old_org_membership.save()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path, "rb") as tmp_file:
+                # Create a user with a colliding username & email address,
+                # and set email_unique again.
+                colliding_owner = self.create_exhaustive_user(
+                    username="owner", email="importing@example.com"
+                )
+                colliding_owner.email_unique = colliding_owner.email
+                with assume_test_silo_mode(SiloMode.CONTROL):
+                    colliding_owner.save()
+
+                org = self.create_organization("other-org", owner=owner)
+
+                import_in_organization_scope(
+                    tmp_file,
+                    flags=ImportFlags(merge_users=False),
+                    printer=NOOP_PRINTER,
+                )
+
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                colliding_owner.refresh_from_db()
+                imported_user = User.objects.get(username__icontains="owner-")
+
+                # The colliding_owner should retain its original attributes.
+                assert colliding_owner.email == "importing@example.com"
+                assert colliding_owner.email_unique == "importing@example.com"
+
+                # The imported user should not have email_unique defined as it would conflict
+                assert imported_user.email == "importing@example.com"
+                assert imported_user.email_unique is None
+
+                assert User.objects.count() == 2
+                assert UserEmail.objects.count() == 2
+
+            with open(tmp_path, "rb") as tmp_file:
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
+
 
 CUSTOM_IMPORT_BEHAVIOR_TESTED: set[NormalizedModelName] = set()
 


### PR DESCRIPTION
When a self-hosted instance is imported, if that import data has users with `email_unique` defined, and that email address also has an account in saas, the import will fail because of an integrity error on `email_unique`.

We cannot trust data in self-hosted imports so we don't want to merge users (like we do with a saas to saas relocation). By blanking the incoming user's `email_unique` value we can create a duplicate user record that the customer will have to de-deduplicate on their own.

I briefly considered generating a random suffix for the email address but this could also conflict with existing data, or conflict with legitimate customer data in the future. This felt like the least disruptive and risky change to make.

Fixes SENTRY-5NJV