### PR TITLE
feat(seer): Write SeerRunPullRequest links for Seer-created PRs

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1122,6 +1122,14 @@ register(
     default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Killswitch for writing SeerRunPullRequest links (records the PRs Seer directly
+# creates). Default off -> writes happen; flip on to stop writes without a deploy.
+register(
+    "seer.pull-request-linking.killswitch.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
 register(
     "seer.explorer.context-engine-rollout",
     type=Float,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1122,8 +1122,6 @@ register(
     default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Killswitch for writing SeerRunPullRequest links (records the PRs Seer directly
-# creates). Default off -> writes happen; flip on to stop writes without a deploy.
 register(
     "seer.pull-request-linking.killswitch.enabled",
     type=Bool,

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -686,8 +686,6 @@ def process_autofix_updates(
                         extra={"group_id": group_id, "run_id": run_id},
                     )
 
-            # Record the product-facing run<->PR link. Decoupled from metrics:
-            # its own killswitch, its own best-effort failure handling.
             try:
                 link_seer_run_pull_requests(
                     organization=organization,

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -29,6 +29,7 @@ from sentry.seer.entrypoints.types import (
     SeerEntrypointKey,
 )
 from sentry.seer.models import SeerPermissionError
+from sentry.seer.pull_requests import link_seer_run_pull_requests
 from sentry.seer.seer_setup import has_seer_access
 from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.tasks.base import instrumented_task
@@ -668,19 +669,34 @@ def process_autofix_updates(
                 },
             )
 
-        if event_type == SentryAppEventType.SEER_PR_CREATED and features.has(
-            "organizations:pr-metrics-attribution", organization
-        ):
+        if event_type == SentryAppEventType.SEER_PR_CREATED:
+            pull_requests = event_payload.get("pull_requests", [])
+
+            if features.has("organizations:pr-metrics-attribution", organization):
+                try:
+                    attribute_seer_created_pull_requests(
+                        organization=organization,
+                        pull_requests=pull_requests,
+                        run_id=run_id,
+                        group_id=group_id,
+                    )
+                except Exception:
+                    logger.exception(
+                        "seer.pr_attribution.failed",
+                        extra={"group_id": group_id, "run_id": run_id},
+                    )
+
+            # Record the product-facing run<->PR link. Decoupled from metrics:
+            # its own killswitch, its own best-effort failure handling.
             try:
-                attribute_seer_created_pull_requests(
+                link_seer_run_pull_requests(
                     organization=organization,
-                    pull_requests=event_payload.get("pull_requests", []),
-                    run_id=run_id,
-                    group_id=group_id,
+                    seer_run_state_id=run_id,
+                    pull_requests=pull_requests,
                 )
             except Exception:
                 logger.exception(
-                    "seer.pr_attribution.failed",
+                    "seer.pr_link.failed",
                     extra={"group_id": group_id, "run_id": run_id},
                 )
 

--- a/src/sentry/seer/pull_requests.py
+++ b/src/sentry/seer/pull_requests.py
@@ -23,18 +23,10 @@ def link_seer_run_pull_requests(
     seer_run_state_id: int | str | None,
     pull_requests: Sequence[Mapping[str, Any]],
 ) -> None:
-    """Record a :class:`SeerRunPullRequest` link for each PR Seer reports it opened.
+    """Link each PR in a ``seer.pr_created`` event to its run's :class:`SeerRun`.
 
-    ``pull_requests`` is the ``seer.pr_created`` event's PR list (the same shape
-    consumed by ``attribute_seer_created_pull_requests``). Each entry is resolved
-    to its canonical ``PullRequest`` via the shared
-    ``get_or_create_from_reference`` query, then linked to the run's
-    :class:`SeerRun` mirror.
-
-    Idempotent: the unique constraint on ``pull_request`` means redelivery is a
-    no-op and the first run to claim a PR keeps it. Best-effort — every failure
-    (a not-yet-mirrored run, an unresolvable repo, a single bad entry) is logged
-    and swallowed so it never interrupts the caller's flow.
+    Idempotent (first run to claim a PR keeps it) and best-effort: every failure
+    is logged and swallowed.
     """
     if options.get(PULL_REQUEST_LINKING_KILLSWITCH):
         return
@@ -51,8 +43,7 @@ def link_seer_run_pull_requests(
         )
         return
 
-    # The mirror row may not exist yet (create outbox not drained) or for legacy
-    # runs predating SeerRun mirroring — nothing to link to in either case.
+    # No mirror row yet (outbox not drained) or legacy run — nothing to link to.
     seer_run = get_seer_run(seer_run_state_id, organization)
     if seer_run is None:
         logger.info(

--- a/src/sentry/seer/pull_requests.py
+++ b/src/sentry/seer/pull_requests.py
@@ -1,20 +1,4 @@
-"""Product-facing record of the pull requests Seer directly creates.
-
-This module owns the write side of :class:`SeerRunPullRequest` — the link
-between a Seer run and the pull request(s) it opened. Its purpose is to give us
-a durable, product-focused record of Seer's PR output that can be queried
-straight from the ORM (``seer_run.pull_requests``).
-
-It is intentionally kept separate from the PR Merge Live Metrics pipeline
-(``sentry.pr_metrics``): metrics judges PR *outcomes* (was it merged, did it get
-iterated on), while this records PR *authorship* (which run opened it). They
-share only the PR-resolution query (``PullRequest.objects.get_or_create_from_reference``)
-and the run lookup (``get_seer_run``) — never each other's logic, flags, or
-failure modes.
-
-Writes are best-effort and guarded by a killswitch so they can be turned off
-without a deploy if anything goes wrong.
-"""
+"""Records the pull requests Seer directly creates via :class:`SeerRunPullRequest`."""
 
 from __future__ import annotations
 
@@ -30,9 +14,6 @@ from sentry.seer.models.run import SeerRunPullRequest
 
 logger = logging.getLogger(__name__)
 
-# Killswitch for SeerRunPullRequest writes. Follows the Seer killswitch
-# convention: default off (``False`` -> writes happen); flip to ``True`` to stop
-# all writes without a deploy.
 PULL_REQUEST_LINKING_KILLSWITCH = "seer.pull-request-linking.killswitch.enabled"
 
 
@@ -70,9 +51,8 @@ def link_seer_run_pull_requests(
         )
         return
 
-    # The run id in the event equals SeerRun.seer_run_state_id; the mirror row may
-    # still be absent if its create outbox hasn't drained yet, or for legacy runs
-    # predating SeerRun mirroring. Either way there is nothing to link to.
+    # The mirror row may not exist yet (create outbox not drained) or for legacy
+    # runs predating SeerRun mirroring — nothing to link to in either case.
     seer_run = get_seer_run(seer_run_state_id, organization)
     if seer_run is None:
         logger.info(
@@ -111,9 +91,6 @@ def link_seer_run_pull_requests(
             continue
 
         if resolved.pull_request is None:
-            # Repo couldn't be uniquely resolved (not found / ambiguous). The
-            # metrics path logs the precise reason under its own namespace; here
-            # we only need to know we couldn't link.
             logger.warning("seer.pull_request_link.repo_unresolved", extra=log_context)
             continue
 

--- a/src/sentry/seer/pull_requests.py
+++ b/src/sentry/seer/pull_requests.py
@@ -14,8 +14,6 @@ from sentry.seer.models.run import SeerRunPullRequest
 
 logger = logging.getLogger(__name__)
 
-PULL_REQUEST_LINKING_KILLSWITCH = "seer.pull-request-linking.killswitch.enabled"
-
 
 def link_seer_run_pull_requests(
     *,
@@ -28,7 +26,7 @@ def link_seer_run_pull_requests(
     Idempotent (first run to claim a PR keeps it) and best-effort: every failure
     is logged and swallowed.
     """
-    if options.get(PULL_REQUEST_LINKING_KILLSWITCH):
+    if options.get("seer.pull-request-linking.killswitch.enabled"):
         return
 
     if seer_run_state_id is None:

--- a/src/sentry/seer/pull_requests.py
+++ b/src/sentry/seer/pull_requests.py
@@ -43,7 +43,6 @@ def link_seer_run_pull_requests(
         )
         return
 
-    # No mirror row yet (outbox not drained) or legacy run — nothing to link to.
     seer_run = get_seer_run(seer_run_state_id, organization)
     if seer_run is None:
         logger.info(

--- a/src/sentry/seer/pull_requests.py
+++ b/src/sentry/seer/pull_requests.py
@@ -20,7 +20,7 @@ PULL_REQUEST_LINKING_KILLSWITCH = "seer.pull-request-linking.killswitch.enabled"
 def link_seer_run_pull_requests(
     *,
     organization: Organization,
-    seer_run_state_id: int | str | None,
+    seer_run_state_id: int | None,
     pull_requests: Sequence[Mapping[str, Any]],
 ) -> None:
     """Link each PR in a ``seer.pr_created`` event to its run's :class:`SeerRun`.
@@ -32,15 +32,6 @@ def link_seer_run_pull_requests(
         return
 
     if seer_run_state_id is None:
-        return
-
-    try:
-        seer_run_state_id = int(seer_run_state_id)
-    except (TypeError, ValueError):
-        logger.warning(
-            "seer.pull_request_link.invalid_run_id",
-            extra={"organization_id": organization.id, "seer_run_state_id": seer_run_state_id},
-        )
         return
 
     seer_run = get_seer_run(seer_run_state_id, organization)

--- a/src/sentry/seer/pull_requests.py
+++ b/src/sentry/seer/pull_requests.py
@@ -35,7 +35,7 @@ def link_seer_run_pull_requests(
     seer_run = get_seer_run(seer_run_state_id, organization)
     if seer_run is None:
         logger.info(
-            "seer.pull_request_link.run_not_found",
+            "seer.pr_link.run_not_found",
             extra={"organization_id": organization.id, "seer_run_state_id": seer_run_state_id},
         )
         return
@@ -55,7 +55,7 @@ def link_seer_run_pull_requests(
         }
 
         if not repo_name or pr_number is None:
-            logger.warning("seer.pull_request_link.missing_fields", extra=log_context)
+            logger.warning("seer.pr_link.missing_fields", extra=log_context)
             continue
 
         try:
@@ -66,11 +66,11 @@ def link_seer_run_pull_requests(
                 key=pr_number,
             )
         except Exception:
-            logger.exception("seer.pull_request_link.resolve_failed", extra=log_context)
+            logger.exception("seer.pr_link.resolve_failed", extra=log_context)
             continue
 
         if resolved.pull_request is None:
-            logger.warning("seer.pull_request_link.repo_unresolved", extra=log_context)
+            logger.warning("seer.pr_link.repo_unresolved", extra=log_context)
             continue
 
         try:
@@ -80,13 +80,13 @@ def link_seer_run_pull_requests(
             )
         except Exception:
             logger.exception(
-                "seer.pull_request_link.write_failed",
+                "seer.pr_link.write_failed",
                 extra={**log_context, "pull_request_id": resolved.pull_request.id},
             )
             continue
 
         if created:
             logger.info(
-                "seer.pull_request_link.created",
+                "seer.pr_link.created",
                 extra={**log_context, "pull_request_id": resolved.pull_request.id},
             )

--- a/src/sentry/seer/pull_requests.py
+++ b/src/sentry/seer/pull_requests.py
@@ -1,0 +1,136 @@
+"""Product-facing record of the pull requests Seer directly creates.
+
+This module owns the write side of :class:`SeerRunPullRequest` — the link
+between a Seer run and the pull request(s) it opened. Its purpose is to give us
+a durable, product-focused record of Seer's PR output that can be queried
+straight from the ORM (``seer_run.pull_requests``).
+
+It is intentionally kept separate from the PR Merge Live Metrics pipeline
+(``sentry.pr_metrics``): metrics judges PR *outcomes* (was it merged, did it get
+iterated on), while this records PR *authorship* (which run opened it). They
+share only the PR-resolution query (``PullRequest.objects.get_or_create_from_reference``)
+and the run lookup (``get_seer_run``) — never each other's logic, flags, or
+failure modes.
+
+Writes are best-effort and guarded by a killswitch so they can be turned off
+without a deploy if anything goes wrong.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from sentry import options
+from sentry.models.organization import Organization
+from sentry.models.pullrequest import PullRequest
+from sentry.seer.endpoints.utils import get_seer_run
+from sentry.seer.models.run import SeerRunPullRequest
+
+logger = logging.getLogger(__name__)
+
+# Killswitch for SeerRunPullRequest writes. Follows the Seer killswitch
+# convention: default off (``False`` -> writes happen); flip to ``True`` to stop
+# all writes without a deploy.
+PULL_REQUEST_LINKING_KILLSWITCH = "seer.pull-request-linking.killswitch.enabled"
+
+
+def link_seer_run_pull_requests(
+    *,
+    organization: Organization,
+    seer_run_state_id: int | str | None,
+    pull_requests: Sequence[Mapping[str, Any]],
+) -> None:
+    """Record a :class:`SeerRunPullRequest` link for each PR Seer reports it opened.
+
+    ``pull_requests`` is the ``seer.pr_created`` event's PR list (the same shape
+    consumed by ``attribute_seer_created_pull_requests``). Each entry is resolved
+    to its canonical ``PullRequest`` via the shared
+    ``get_or_create_from_reference`` query, then linked to the run's
+    :class:`SeerRun` mirror.
+
+    Idempotent: the unique constraint on ``pull_request`` means redelivery is a
+    no-op and the first run to claim a PR keeps it. Best-effort — every failure
+    (a not-yet-mirrored run, an unresolvable repo, a single bad entry) is logged
+    and swallowed so it never interrupts the caller's flow.
+    """
+    if options.get(PULL_REQUEST_LINKING_KILLSWITCH):
+        return
+
+    if seer_run_state_id is None:
+        return
+
+    try:
+        seer_run_state_id = int(seer_run_state_id)
+    except (TypeError, ValueError):
+        logger.warning(
+            "seer.pull_request_link.invalid_run_id",
+            extra={"organization_id": organization.id, "seer_run_state_id": seer_run_state_id},
+        )
+        return
+
+    # The run id in the event equals SeerRun.seer_run_state_id; the mirror row may
+    # still be absent if its create outbox hasn't drained yet, or for legacy runs
+    # predating SeerRun mirroring. Either way there is nothing to link to.
+    seer_run = get_seer_run(seer_run_state_id, organization)
+    if seer_run is None:
+        logger.info(
+            "seer.pull_request_link.run_not_found",
+            extra={"organization_id": organization.id, "seer_run_state_id": seer_run_state_id},
+        )
+        return
+
+    for entry in pull_requests:
+        repo_name = entry.get("repo_name")
+        provider = entry.get("provider")
+        pr_payload = entry.get("pull_request") or {}
+        pr_number = pr_payload.get("pr_number")
+
+        log_context = {
+            "organization_id": organization.id,
+            "seer_run_state_id": seer_run_state_id,
+            "repo_name": repo_name,
+            "provider": provider,
+            "pr_number": pr_number,
+        }
+
+        if not repo_name or pr_number is None:
+            logger.warning("seer.pull_request_link.missing_fields", extra=log_context)
+            continue
+
+        try:
+            resolved = PullRequest.objects.get_or_create_from_reference(
+                organization_id=organization.id,
+                repo_name=repo_name,
+                provider=provider,
+                key=pr_number,
+            )
+        except Exception:
+            logger.exception("seer.pull_request_link.resolve_failed", extra=log_context)
+            continue
+
+        if resolved.pull_request is None:
+            # Repo couldn't be uniquely resolved (not found / ambiguous). The
+            # metrics path logs the precise reason under its own namespace; here
+            # we only need to know we couldn't link.
+            logger.warning("seer.pull_request_link.repo_unresolved", extra=log_context)
+            continue
+
+        try:
+            _, created = SeerRunPullRequest.objects.get_or_create(
+                pull_request=resolved.pull_request,
+                defaults={"seer_run": seer_run},
+            )
+        except Exception:
+            logger.exception(
+                "seer.pull_request_link.write_failed",
+                extra={**log_context, "pull_request_id": resolved.pull_request.id},
+            )
+            continue
+
+        if created:
+            logger.info(
+                "seer.pull_request_link.created",
+                extra={**log_context, "pull_request_id": resolved.pull_request.id},
+            )

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -417,8 +417,6 @@ class SeerOperatorTest(TestCase):
             self.organization, type=SeerRunType.FEATURE_RUN, seer_run_state_id=MOCK_RUN_ID
         )
 
-        # Metrics attribution flag intentionally off — linking is decoupled and
-        # must still record the run<->PR link.
         with (
             override_options({"issues.record-seer-actions-as-activities": False}),
             patch.dict(
@@ -436,7 +434,6 @@ class SeerOperatorTest(TestCase):
         pull_request = PullRequest.objects.get(repository_id=repo.id, key="99")
         link = SeerRunPullRequest.objects.get(pull_request=pull_request)
         assert link.seer_run_id == seer_run.id
-        # Attribution did not run (flag off), confirming the paths are independent.
         assert not PullRequestAttribution.objects.exists()
 
     @patch.object(SeerAutofixOperator, "has_access", return_value=True)

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -39,6 +39,7 @@ from sentry.seer.entrypoints.types import (
     SeerEntrypointKey,
     SeerOperatorCacheResult,
 )
+from sentry.seer.models.run import SeerRunPullRequest, SeerRunType
 from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.testutils.asserts import assert_failure_metric
 from sentry.testutils.cases import TestCase
@@ -408,6 +409,64 @@ class SeerOperatorTest(TestCase):
 
         assert not PullRequest.objects.filter(repository_id=repo.id).exists()
         assert not PullRequestAttribution.objects.exists()
+
+    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
+    def test_process_autofix_updates_links_pull_requests(self, _mock_has_access):
+        repo = self.create_repo(self.project, name="getsentry/sentry")
+        seer_run = self.create_seer_run(
+            self.organization, type=SeerRunType.FEATURE_RUN, seer_run_state_id=MOCK_RUN_ID
+        )
+
+        # Metrics attribution flag intentionally off — linking is decoupled and
+        # must still record the run<->PR link.
+        with (
+            override_options({"issues.record-seer-actions-as-activities": False}),
+            patch.dict(
+                "sentry.seer.entrypoints.operator.autofix_entrypoint_registry.registrations",
+                {},
+                clear=True,
+            ),
+        ):
+            process_autofix_updates(
+                event_type=SentryAppEventType.SEER_PR_CREATED,
+                event_payload=self._pr_created_event_payload(),
+                organization_id=self.organization.id,
+            )
+
+        pull_request = PullRequest.objects.get(repository_id=repo.id, key="99")
+        link = SeerRunPullRequest.objects.get(pull_request=pull_request)
+        assert link.seer_run_id == seer_run.id
+        # Attribution did not run (flag off), confirming the paths are independent.
+        assert not PullRequestAttribution.objects.exists()
+
+    @patch.object(SeerAutofixOperator, "has_access", return_value=True)
+    def test_process_autofix_updates_link_killswitch(self, _mock_has_access):
+        repo = self.create_repo(self.project, name="getsentry/sentry")
+        self.create_seer_run(
+            self.organization, type=SeerRunType.FEATURE_RUN, seer_run_state_id=MOCK_RUN_ID
+        )
+
+        with (
+            override_options(
+                {
+                    "issues.record-seer-actions-as-activities": False,
+                    "seer.pull-request-linking.killswitch.enabled": True,
+                }
+            ),
+            patch.dict(
+                "sentry.seer.entrypoints.operator.autofix_entrypoint_registry.registrations",
+                {},
+                clear=True,
+            ),
+        ):
+            process_autofix_updates(
+                event_type=SentryAppEventType.SEER_PR_CREATED,
+                event_payload=self._pr_created_event_payload(),
+                organization_id=self.organization.id,
+            )
+
+        assert not SeerRunPullRequest.objects.exists()
+        assert not PullRequest.objects.filter(repository_id=repo.id).exists()
 
     def test_process_autofix_updates_no_operator_access(self) -> None:
         mock_entrypoint_cls = Mock(spec=SeerAutofixEntrypoint)

--- a/tests/sentry/seer/test_pull_requests.py
+++ b/tests/sentry/seer/test_pull_requests.py
@@ -55,24 +55,6 @@ class LinkSeerRunPullRequestsTest(TestCase):
         assert link.seer_run_id == self.seer_run.id
         assert list(self.seer_run.pull_requests) == [pull_request]
 
-    def test_reuses_existing_pull_request(self) -> None:
-        existing = self.create_pull_request(
-            organization_id=self.organization.id, repository_id=self.repo.id, key="42"
-        )
-
-        self._link(self._payload())
-
-        assert PullRequest.objects.filter(repository_id=self.repo.id, key="42").count() == 1
-        link = SeerRunPullRequest.objects.get(pull_request=existing)
-        assert link.seer_run_id == self.seer_run.id
-
-    def test_is_idempotent_on_redelivery(self) -> None:
-        self._link(self._payload())
-        self._link(self._payload())
-
-        pull_request = PullRequest.objects.get(repository_id=self.repo.id, key="42")
-        assert SeerRunPullRequest.objects.filter(pull_request=pull_request).count() == 1
-
     def test_first_run_keeps_pull_request(self) -> None:
         self._link(self._payload())
 
@@ -94,14 +76,6 @@ class LinkSeerRunPullRequestsTest(TestCase):
         self._link(self._payload() + self._payload(pr_number=43))
 
         assert SeerRunPullRequest.objects.filter(seer_run=self.seer_run).count() == 2
-
-    @patch("sentry.seer.pull_requests.logger")
-    def test_no_link_when_run_not_mirrored(self, mock_logger: Mock) -> None:
-        self._link(self._payload(), seer_run_state_id=999999)
-
-        assert not SeerRunPullRequest.objects.exists()
-        assert not PullRequest.objects.filter(repository_id=self.repo.id, key="42").exists()
-        assert mock_logger.info.call_args.args[0] == "seer.pull_request_link.run_not_found"
 
     def test_noop_when_run_id_missing(self) -> None:
         self._link(self._payload(), seer_run_state_id=None)

--- a/tests/sentry/seer/test_pull_requests.py
+++ b/tests/sentry/seer/test_pull_requests.py
@@ -39,7 +39,7 @@ class LinkSeerRunPullRequestsTest(TestCase):
         self,
         pull_requests: list[dict[str, Any]],
         *,
-        seer_run_state_id: int | str | None = RUN_STATE_ID,
+        seer_run_state_id: int | None = RUN_STATE_ID,
     ) -> None:
         link_seer_run_pull_requests(
             organization=self.organization,
@@ -106,13 +106,6 @@ class LinkSeerRunPullRequestsTest(TestCase):
     def test_noop_when_run_id_missing(self) -> None:
         self._link(self._payload(), seer_run_state_id=None)
         assert not SeerRunPullRequest.objects.exists()
-
-    @patch("sentry.seer.pull_requests.logger")
-    def test_invalid_run_id_logged(self, mock_logger: Mock) -> None:
-        self._link(self._payload(), seer_run_state_id="not-an-int")
-
-        assert not SeerRunPullRequest.objects.exists()
-        assert "seer.pull_request_link.invalid_run_id" in _warning_events(mock_logger)
 
     @patch("sentry.seer.pull_requests.logger")
     def test_missing_fields_skipped(self, mock_logger: Mock) -> None:

--- a/tests/sentry/seer/test_pull_requests.py
+++ b/tests/sentry/seer/test_pull_requests.py
@@ -86,7 +86,7 @@ class LinkSeerRunPullRequestsTest(TestCase):
         self._link([{"provider": "github", "pull_request": {"pr_number": None}}])
 
         assert not SeerRunPullRequest.objects.exists()
-        assert "seer.pull_request_link.missing_fields" in _warning_events(mock_logger)
+        assert "seer.pr_link.missing_fields" in _warning_events(mock_logger)
 
     @patch("sentry.seer.pull_requests.logger")
     def test_unresolvable_repo_skipped(self, mock_logger: Mock) -> None:
@@ -101,7 +101,7 @@ class LinkSeerRunPullRequestsTest(TestCase):
         )
 
         assert not SeerRunPullRequest.objects.exists()
-        assert "seer.pull_request_link.repo_unresolved" in _warning_events(mock_logger)
+        assert "seer.pr_link.repo_unresolved" in _warning_events(mock_logger)
 
     @patch("sentry.seer.pull_requests.options.get", return_value=True)
     def test_killswitch_disables_writes(self, mock_option: Mock) -> None:

--- a/tests/sentry/seer/test_pull_requests.py
+++ b/tests/sentry/seer/test_pull_requests.py
@@ -1,0 +1,157 @@
+from typing import Any
+from unittest.mock import Mock, patch
+
+from sentry.models.pullrequest import PullRequest
+from sentry.seer.models.run import SeerRun, SeerRunPullRequest, SeerRunType
+from sentry.seer.pull_requests import link_seer_run_pull_requests
+from sentry.testutils.cases import TestCase
+
+REPO_NAME = "getsentry/sentry"
+RUN_STATE_ID = 123
+
+
+def _warning_events(mock_logger: Mock) -> list[str]:
+    return [call.args[0] for call in mock_logger.warning.call_args_list]
+
+
+class LinkSeerRunPullRequestsTest(TestCase):
+    def setUp(self) -> None:
+        self.repo = self.create_repo(self.project, name=REPO_NAME, provider="integrations:github")
+        self.seer_run = self.create_seer_run(
+            self.organization, type=SeerRunType.FEATURE_RUN, seer_run_state_id=RUN_STATE_ID
+        )
+
+    def _payload(
+        self,
+        pr_number: int = 42,
+        pr_url: str = "https://github.com/getsentry/sentry/pull/42",
+        provider: str = "github",
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "provider": provider,
+                "repo_name": REPO_NAME,
+                "pull_request": {"pr_id": 999, "pr_number": pr_number, "pr_url": pr_url},
+            }
+        ]
+
+    def _link(
+        self,
+        pull_requests: list[dict[str, Any]],
+        *,
+        seer_run_state_id: int | str | None = RUN_STATE_ID,
+    ) -> None:
+        link_seer_run_pull_requests(
+            organization=self.organization,
+            seer_run_state_id=seer_run_state_id,
+            pull_requests=pull_requests,
+        )
+
+    def test_creates_link_and_resolves_pull_request(self) -> None:
+        self._link(self._payload())
+
+        pull_request = PullRequest.objects.get(repository_id=self.repo.id, key="42")
+        link = SeerRunPullRequest.objects.get(pull_request=pull_request)
+        assert link.seer_run_id == self.seer_run.id
+        # The run convenience accessor surfaces the linked PR.
+        assert list(self.seer_run.pull_requests) == [pull_request]
+
+    def test_reuses_existing_pull_request(self) -> None:
+        existing = self.create_pull_request(
+            organization_id=self.organization.id, repository_id=self.repo.id, key="42"
+        )
+
+        self._link(self._payload())
+
+        assert PullRequest.objects.filter(repository_id=self.repo.id, key="42").count() == 1
+        link = SeerRunPullRequest.objects.get(pull_request=existing)
+        assert link.seer_run_id == self.seer_run.id
+
+    def test_is_idempotent_on_redelivery(self) -> None:
+        self._link(self._payload())
+        self._link(self._payload())
+
+        pull_request = PullRequest.objects.get(repository_id=self.repo.id, key="42")
+        assert SeerRunPullRequest.objects.filter(pull_request=pull_request).count() == 1
+
+    def test_first_run_keeps_pull_request(self) -> None:
+        """A PR belongs to exactly one run; a later run reporting it is a no-op."""
+        self._link(self._payload())
+
+        other_run = self.create_seer_run(
+            self.organization, type=SeerRunType.FEATURE_RUN, seer_run_state_id=456
+        )
+        link_seer_run_pull_requests(
+            organization=self.organization,
+            seer_run_state_id=456,
+            pull_requests=self._payload(),
+        )
+
+        pull_request = PullRequest.objects.get(repository_id=self.repo.id, key="42")
+        link = SeerRunPullRequest.objects.get(pull_request=pull_request)
+        assert link.seer_run_id == self.seer_run.id
+        assert link.seer_run_id != other_run.id
+
+    def test_links_multiple_pull_requests(self) -> None:
+        self._link(self._payload() + self._payload(pr_number=43))
+
+        assert SeerRunPullRequest.objects.filter(seer_run=self.seer_run).count() == 2
+
+    @patch("sentry.seer.pull_requests.logger")
+    def test_no_link_when_run_not_mirrored(self, mock_logger: Mock) -> None:
+        self._link(self._payload(), seer_run_state_id=999999)
+
+        assert not SeerRunPullRequest.objects.exists()
+        # Resolution is skipped entirely when the run can't be found.
+        assert not PullRequest.objects.filter(repository_id=self.repo.id, key="42").exists()
+        assert mock_logger.info.call_args.args[0] == "seer.pull_request_link.run_not_found"
+
+    def test_noop_when_run_id_missing(self) -> None:
+        self._link(self._payload(), seer_run_state_id=None)
+        assert not SeerRunPullRequest.objects.exists()
+
+    @patch("sentry.seer.pull_requests.logger")
+    def test_invalid_run_id_logged(self, mock_logger: Mock) -> None:
+        self._link(self._payload(), seer_run_state_id="not-an-int")
+
+        assert not SeerRunPullRequest.objects.exists()
+        assert "seer.pull_request_link.invalid_run_id" in _warning_events(mock_logger)
+
+    @patch("sentry.seer.pull_requests.logger")
+    def test_missing_fields_skipped(self, mock_logger: Mock) -> None:
+        self._link([{"provider": "github", "pull_request": {"pr_number": None}}])
+
+        assert not SeerRunPullRequest.objects.exists()
+        assert "seer.pull_request_link.missing_fields" in _warning_events(mock_logger)
+
+    @patch("sentry.seer.pull_requests.logger")
+    def test_unresolvable_repo_skipped(self, mock_logger: Mock) -> None:
+        self._link(
+            [
+                {
+                    "provider": "github",
+                    "repo_name": "getsentry/does-not-exist",
+                    "pull_request": {"pr_number": 42},
+                }
+            ]
+        )
+
+        assert not SeerRunPullRequest.objects.exists()
+        assert "seer.pull_request_link.repo_unresolved" in _warning_events(mock_logger)
+
+    @patch("sentry.seer.pull_requests.options.get", return_value=True)
+    def test_killswitch_disables_writes(self, mock_option: Mock) -> None:
+        self._link(self._payload())
+
+        mock_option.assert_called_once_with("seer.pull-request-linking.killswitch.enabled")
+        assert not SeerRunPullRequest.objects.exists()
+        assert not PullRequest.objects.filter(repository_id=self.repo.id, key="42").exists()
+
+    def test_run_lookup_is_org_scoped(self) -> None:
+        """A run id that exists only in another org must not link here."""
+        other_org = self.create_organization()
+        SeerRun.objects.filter(id=self.seer_run.id).update(organization=other_org)
+
+        self._link(self._payload())
+
+        assert not SeerRunPullRequest.objects.exists()

--- a/tests/sentry/seer/test_pull_requests.py
+++ b/tests/sentry/seer/test_pull_requests.py
@@ -53,7 +53,6 @@ class LinkSeerRunPullRequestsTest(TestCase):
         pull_request = PullRequest.objects.get(repository_id=self.repo.id, key="42")
         link = SeerRunPullRequest.objects.get(pull_request=pull_request)
         assert link.seer_run_id == self.seer_run.id
-        # The run convenience accessor surfaces the linked PR.
         assert list(self.seer_run.pull_requests) == [pull_request]
 
     def test_reuses_existing_pull_request(self) -> None:
@@ -75,7 +74,6 @@ class LinkSeerRunPullRequestsTest(TestCase):
         assert SeerRunPullRequest.objects.filter(pull_request=pull_request).count() == 1
 
     def test_first_run_keeps_pull_request(self) -> None:
-        """A PR belongs to exactly one run; a later run reporting it is a no-op."""
         self._link(self._payload())
 
         other_run = self.create_seer_run(
@@ -102,7 +100,6 @@ class LinkSeerRunPullRequestsTest(TestCase):
         self._link(self._payload(), seer_run_state_id=999999)
 
         assert not SeerRunPullRequest.objects.exists()
-        # Resolution is skipped entirely when the run can't be found.
         assert not PullRequest.objects.filter(repository_id=self.repo.id, key="42").exists()
         assert mock_logger.info.call_args.args[0] == "seer.pull_request_link.run_not_found"
 


### PR DESCRIPTION
Hooks up writes to the `SeerRunPullRequest` model (#118572): every PR Seer directly opens now gets a record linking it to its run, queryable via `SeerRun.pull_requests`.

New `sentry/seer/pull_requests.py` resolves each reported PR (reusing the metrics PR-resolution query) and links it to the run. Idempotent, best-effort, and guarded by the `seer.pull-request-linking.killswitch.enabled` killswitch. Kept decoupled from PR metrics — own module, own killswitch, not gated behind the metrics flag.

Scoped to the Seer-native `SEER_PR_CREATED` path; delegated-agent PRs left out for now.