### PR TITLE
feat(sentry-apps): Allow anthropic-version and anthropic-beta webhook headers

### DIFF
--- a/src/sentry/sentry_apps/api/parsers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/parsers/sentry_app.py
@@ -16,9 +16,15 @@ from sentry.sentry_apps.models.sentry_app import REQUIRED_EVENT_PERMISSIONS, UUI
 from sentry.sentry_apps.utils.webhooks import VALID_EVENT_RESOURCES
 from sentry.utils.display_name_filter import is_spam_display_name
 
-# Custom webhook headers are intentionally limited to Authorization and X-*
+# Custom webhook headers are intentionally limited to the below list and "X-*"
 # custom headers. Names are compared case-insensitively.
-ALLOWED_WEBHOOK_HEADERS = frozenset({"authorization"})
+ALLOWED_WEBHOOK_HEADERS = frozenset(
+    {
+        "authorization",
+        "anthropic-version",
+        "anthropic-beta",
+    }
+)
 
 # RFC 7230 §3.2.6 — header field names are "tokens": letters, digits, and
 # the limited punctuation set below. Excludes separators and control chars.

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
@@ -798,6 +798,26 @@ class PostSentryAppsTest(SentryAppsTest):
             f"Authorization: {MASKED_VALUE}",
         ]
 
+    def test_create_integration_with_anthropic_webhook_headers(self) -> None:
+        response = self.get_success_response(
+            **self.get_data(
+                webhookHeaders=[
+                    "Anthropic-Version: 2023-06-01",
+                    "Anthropic-Beta: messages-2023-12-15",
+                ]
+            ),
+            status_code=201,
+        )
+        sentry_app = SentryApp.objects.get(slug=response.data["slug"])
+        assert sentry_app.webhook_headers == [
+            "Anthropic-Version: 2023-06-01",
+            "Anthropic-Beta: messages-2023-12-15",
+        ]
+        assert response.data["webhookHeaders"] == [
+            f"Anthropic-Version: {MASKED_VALUE}",
+            f"Anthropic-Beta: {MASKED_VALUE}",
+        ]
+
     def test_create_integration_strips_webhook_header_whitespace(self) -> None:
         # CharField children are whitespace-trimmed during validation, so a
         # leading/trailing CR/LF passes the newline check. The endpoint must


### PR DESCRIPTION
Widens the Sentry apps custom-webhook-header allowlist to accept `anthropic-version` and `anthropic-beta`, alongside the existing `Authorization` and `X-*` headers.


