### PR TITLE
chore(cells) Remove connection pooling rollout option

### DIFF
--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -1,5 +1,5 @@
 from sentry.options import FLAG_AUTOMATOR_MODIFIABLE, register
-from sentry.utils.types import Bool, Dict, Float, Int, Sequence
+from sentry.utils.types import Bool, Dict, Int, Sequence
 
 register(
     "outbox_replication.sentry_organizationmember.replication_version",
@@ -207,11 +207,6 @@ register(
     type=Bool,
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "hybridcloud.rpc.use_pooling_rate",
-    type=Float,
-    default=1.0,
 )
 register(
     "apigateway.proxy.cell-rollout",

--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -32,7 +32,6 @@ from requests.adapters import HTTPAdapter, Retry
 from sentry import options
 from sentry.hybridcloud.rpc import ArgumentDict, DelegatedBySiloMode, RpcModel
 from sentry.hybridcloud.rpc.sig import SerializableFunctionSignature
-from sentry.options.rollout import in_random_rollout
 from sentry.silo.base import SiloMode, SingleProcessSiloModeState
 from sentry.types.cell import Cell, CellMappingNotFound
 from sentry.utils import json, metrics
@@ -524,14 +523,11 @@ def _get_connection(retry_count: int) -> requests.Session:
     if not hasattr(_connections, "lookup"):
         _connections.lookup = {}
 
-    if in_random_rollout("hybridcloud.rpc.use_pooling_rate"):
-        if not _connections.lookup.get(retry_count, None):
-            http = _create_request_session(retry_count)
-            _connections.lookup[retry_count] = http
+    if not _connections.lookup.get(retry_count, None):
+        http = _create_request_session(retry_count)
+        _connections.lookup[retry_count] = http
 
-        return _connections.lookup[retry_count]
-
-    return _create_request_session(retry_count)
+    return _connections.lookup[retry_count]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
We didn't end up using this as the problem wasn't with connection pooling, but in how loadbalancers were draining.

Refs INC-2198