### PR TITLE
feat(slack): Nudge per-workspace to update outdated Slack app installs

### DIFF
--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -282,18 +282,27 @@ export function getCodeOwnerIcon(
       return <IconSentry size={iconSize} />;
   }
 }
+const isIntegrationUpToDate = (integration: Integration): boolean =>
+  integration.provider.key !== 'slack' ||
+  (integration.scopes?.includes('app_mentions:read') ?? false);
+
 const isSlackIntegrationUpToDate = (integrations: Integration[]): boolean => {
-  return integrations.every(
-    integration =>
-      integration.provider.key !== 'slack' || integration.scopes?.includes('commands')
-  );
+  return integrations.every(isIntegrationUpToDate);
 };
+
+/**
+ * Whether a single integration installation is running an outdated app and
+ * should surface an "Update Now" prompt. Checked per-workspace so that, e.g.,
+ * an outdated Slack workspace doesn't flag a sibling workspace that is current.
+ */
+export const integrationRequiresUpgrade = (integration: Integration): boolean =>
+  !isIntegrationUpToDate(integration);
 
 export const getAlertText = (integrations?: Integration[]): string | undefined => {
   return isSlackIntegrationUpToDate(integrations || [])
     ? undefined
     : t(
-        'Update to the latest version of our Slack app to get access to personal and team notifications.'
+        'Update to the latest version of our Slack app to tag Sentry and ask it to triage and debug issues'
       );
 };
 

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -165,6 +165,53 @@ describe('IntegrationDetailedView', () => {
     expect(screen.getByRole('button', {name: 'Configure'})).toBeEnabled();
   });
 
+  it('shows Update Now only for the outdated Slack workspace', async () => {
+    const slackProvider = {
+      aspects: {},
+      canAdd: true,
+      canDisable: false,
+      features: ['alert-rule', 'chat-unfurl'],
+      key: 'slack',
+      name: 'Slack',
+      slug: 'slack',
+    };
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      match: [MockApiClient.matchQuery({provider_key: 'slack', includeConfig: 0})],
+      body: [
+        {
+          id: '10',
+          name: 'Outdated Workspace',
+          domainName: 'outdated.slack.com',
+          provider: slackProvider,
+          status: 'active',
+          // Missing app_mentions:read -> outdated install.
+          scopes: ['commands', 'chat:write'],
+        },
+        {
+          id: '11',
+          name: 'Current Workspace',
+          domainName: 'current.slack.com',
+          provider: slackProvider,
+          status: 'active',
+          scopes: ['commands', 'chat:write', 'app_mentions:read'],
+        },
+      ],
+    });
+
+    render(<IntegrationDetailedView />, {
+      initialRouterConfig: createRouterConfig('slack', {tab: 'configurations'}),
+      organization,
+    });
+
+    expect(await screen.findByText('Outdated Workspace')).toBeInTheDocument();
+    expect(screen.getByText('Current Workspace')).toBeInTheDocument();
+
+    // Only the outdated workspace surfaces an Update Now button, not every row.
+    expect(screen.getByTestId('integration-upgrade-button')).toBeInTheDocument();
+    expect(screen.getAllByTestId('integration-upgrade-button')).toHaveLength(1);
+  });
+
   it('disables configure for members without access', async () => {
     const lowerAccessOrg = OrganizationFixture({access: ['org:read']});
     render(<IntegrationDetailedView />, {

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -25,6 +25,7 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {
   getAlertText,
   getIntegrationStatus,
+  integrationRequiresUpgrade,
   isScmProvider,
   trackIntegrationAnalytics,
 } from 'sentry/utils/integrationUtil';
@@ -406,7 +407,7 @@ export default function IntegrationDetailedView() {
                     organization,
                   });
                 }}
-                requiresUpgrade={!!alertText}
+                requiresUpgrade={integrationRequiresUpgrade(integration)}
               />
             </PanelItem>
           ))}

--- a/static/app/views/settings/organizationIntegrations/integrationRow.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRow.spec.tsx
@@ -109,4 +109,50 @@ describe('IntegrationRow', () => {
       );
     });
   });
+
+  describe('Update Now alert', () => {
+    it('auto-opens the install modal for a single outdated workspace', () => {
+      render(
+        <IntegrationRow
+          organization={org}
+          type="firstParty"
+          slug="slack"
+          displayName="Slack"
+          status="Installed"
+          publishStatus="published"
+          configurations={1}
+          categories={[]}
+          alertText="Update to the latest version of our Slack app"
+          resolveText="Update Now"
+        />
+      );
+      expect(screen.getByRole('button', {name: 'Update Now'})).toHaveAttribute(
+        'href',
+        `/settings/${org.slug}/integrations/slack/?tab=configurations&referrer=directory_resolve_now&showInstallModal=1`
+      );
+    });
+
+    it('sends users to the config page when multiple workspaces exist', () => {
+      render(
+        <IntegrationRow
+          organization={org}
+          type="firstParty"
+          slug="slack"
+          displayName="Slack"
+          status="Installed"
+          publishStatus="published"
+          configurations={2}
+          categories={[]}
+          alertText="Update to the latest version of our Slack app"
+          resolveText="Update Now"
+        />
+      );
+      const button = screen.getByRole('button', {name: 'Update Now'});
+      expect(button).toHaveAttribute(
+        'href',
+        `/settings/${org.slug}/integrations/slack/?tab=configurations&referrer=directory_resolve_now`
+      );
+      expect(button.getAttribute('href')).not.toContain('showInstallModal');
+    });
+  });
 });

--- a/static/app/views/settings/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRow.tsx
@@ -118,8 +118,9 @@ export function IntegrationRow(props: Props) {
             <Alert
               variant="warning"
               trailingItems={
-                <ResolveNowButton
+                <LinkButton
                   href={`${baseUrl}?tab=configurations&referrer=directory_resolve_now`}
+                  variant="primary"
                   size="xs"
                   onClick={() =>
                     trackIntegrationAnalytics('integrations.resolve_now_clicked', {
@@ -130,7 +131,7 @@ export function IntegrationRow(props: Props) {
                   }
                 >
                   {resolveText || t('Resolve Now')}
-                </ResolveNowButton>
+                </LinkButton>
               }
             >
               {alertText}
@@ -194,9 +195,4 @@ const PublishStatus = styled(({status, ...props}: PublishStatusProps) => (
     margin-right: ${p => p.theme.space.sm};
     font-weight: ${p => p.theme.font.weight.sans.regular};
   }
-`;
-
-const ResolveNowButton = styled(LinkButton)`
-  color: ${p => p.theme.tokens.content.secondary};
-  float: right;
 `;

--- a/static/app/views/settings/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRow.tsx
@@ -73,6 +73,15 @@ export function IntegrationRow(props: Props) {
       ? `/settings/${organization.slug}/developer-settings/${slug}/`
       : `/settings/${organization.slug}/${urlMap[type]}/${slug}/`;
 
+  // When there's exactly one installed workspace there's nothing to
+  // disambiguate, so auto-open the install/upgrade modal (via
+  // `useAutoOpenInstallModal`) instead of making the user pick on the config
+  // page. With multiple workspaces we still send them to the config tab to
+  // choose which one to update.
+  const resolveNowHref =
+    `${baseUrl}?tab=configurations&referrer=directory_resolve_now` +
+    (configurations === 1 ? '&showInstallModal=1' : '');
+
   const renderDetails = () => {
     if (type === 'sentryApp') {
       return publishStatus !== 'published' && <PublishStatus status={publishStatus} />;
@@ -119,7 +128,7 @@ export function IntegrationRow(props: Props) {
               variant="warning"
               trailingItems={
                 <LinkButton
-                  href={`${baseUrl}?tab=configurations&referrer=directory_resolve_now`}
+                  href={resolveNowHref}
                   variant="primary"
                   size="xs"
                   onClick={() =>


### PR DESCRIPTION
In our last Slack app update (back in 2021 💀), we would notify the user when the user's slack integrations are outdated.

With the release of Seer Agent in Slack, we also want to let users know their Slack app is outdated. 

This is what users would see in `settings/integrations` page:

<img width="762" height="135" alt="image" src="https://github.com/user-attachments/assets/26d6110c-dcf4-42d0-a013-9c3506fdb2fa" />

And if the user only has one configuration (i.e. Slack workspace) for their Slack integration, we'll just immediately open the modal to update the app using the `showInstallModal` we introduced with Slack nudge:

<img width="1399" height="402" alt="image" src="https://github.com/user-attachments/assets/e170e79b-cc17-4930-a0cf-f48e5aec8a73" />

If there are multiple workspaces though, we want the user to know which workspace has out-of-date Slack app. So we show them exactly which workspace needs update. This feature was broken previously, it showed every workspace needed an update before but this PR fixes it too.

<img width="1402" height="353" alt="image" src="https://github.com/user-attachments/assets/74f7c950-2136-4669-8734-69d7d6ba0098" />

