### PR TITLE
feat(issue-details): Add pull request closed activity type

### DIFF
--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -12,7 +12,12 @@ import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon'
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {GroupActivityType, type Group} from 'sentry/types/group';
+import {
+  GroupActivityType,
+  type Group,
+  type GroupActivityPullRequestClosed,
+  type GroupActivitySetByResolvedInPullRequest,
+} from 'sentry/types/group';
 import type {
   LinkedPullRequest,
   LinkedPullRequestsResponse,
@@ -32,13 +37,25 @@ import {
 
 const LINKED_PULL_REQUESTS_FEATURE = 'issue-details-linked-pull-requests';
 
+const PULL_REQUEST_ACTIVITY_TYPES = new Set([
+  GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST,
+  GroupActivityType.PULL_REQUEST_CLOSED,
+]);
+
 export function getLinkedPullRequestActivityIds(group: Group) {
   return new Set(
     group.activity
       .filter(
-        activity => activity.type === GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST
+        (
+          activity
+        ): activity is
+          | GroupActivityPullRequestClosed
+          | GroupActivitySetByResolvedInPullRequest =>
+          PULL_REQUEST_ACTIVITY_TYPES.has(activity.type)
       )
-      .map(activity => activity.data.pullRequest?.id)
+      .map(activity => {
+        return activity.data.pullRequest?.id;
+      })
       .filter(id => id !== undefined)
   );
 }

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -609,6 +609,7 @@ export enum GroupActivityType {
   SEER_PR_CREATED = 'seer_pr_created',
   SEER_ITERATION_STARTED = 'seer_iteration_started',
   SEER_ITERATION_COMPLETED = 'seer_iteration_completed',
+  PULL_REQUEST_CLOSED = 'pull_request_closed',
 }
 
 export const SEER_ACTIVITY_TYPES = new Set<GroupActivityType>([
@@ -778,11 +779,18 @@ interface GroupActivityReferencedInCommit extends GroupActivityBase {
   type: GroupActivityType.REFERENCED_IN_COMMIT;
 }
 
-interface GroupActivitySetByResolvedInPullRequest extends GroupActivityBase {
+export interface GroupActivitySetByResolvedInPullRequest extends GroupActivityBase {
   data: {
     pullRequest?: PullRequest;
   };
   type: GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST;
+}
+
+export interface GroupActivityPullRequestClosed extends GroupActivityBase {
+  data: {
+    pullRequest?: PullRequest;
+  };
+  type: GroupActivityType.PULL_REQUEST_CLOSED;
 }
 
 export interface GroupActivitySetIgnored extends GroupActivityBase {
@@ -1024,7 +1032,8 @@ export type GroupActivity =
   | GroupActivitySeerCodingCompleted
   | GroupActivitySeerPrCreated
   | GroupActivitySeerIterationStarted
-  | GroupActivitySeerIterationCompleted;
+  | GroupActivitySeerIterationCompleted
+  | GroupActivityPullRequestClosed;
 
 export type Activity = GroupActivity;
 

--- a/static/app/views/issueDetails/activitySection/activityColorConfig.tsx
+++ b/static/app/views/issueDetails/activitySection/activityColorConfig.tsx
@@ -28,6 +28,7 @@ export function getActivityColorConfig(theme: Theme, type: GroupActivityType) {
       };
     case GroupActivityType.SET_UNRESOLVED:
     case GroupActivityType.SET_REGRESSION:
+    case GroupActivityType.PULL_REQUEST_CLOSED:
       return {
         ...defaultConfig,
         icon: theme.tokens.graphics.danger.vibrant,

--- a/static/app/views/issueDetails/activitySection/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityIcons.tsx
@@ -24,6 +24,7 @@ import {
   IconNext,
   IconPlay,
   IconPrevious,
+  IconPullRequestClosed,
   IconRefresh,
   IconSeer,
   IconUnsubscribed,
@@ -80,6 +81,10 @@ export const groupActivityTypeIconMapping: Record<
   },
   [GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST]: {
     Component: IconCommit,
+    defaultProps: {},
+  },
+  [GroupActivityType.PULL_REQUEST_CLOSED]: {
+    Component: IconPullRequestClosed,
     defaultProps: {},
   },
   [GroupActivityType.SET_UNRESOLVED]: {Component: IconClose, defaultProps: {}},

--- a/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
@@ -34,7 +34,8 @@ function getAuthorName(item: GroupActivity) {
     return item.user.name;
   }
   if (
-    item.type === GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST &&
+    (item.type === GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST ||
+      item.type === GroupActivityType.PULL_REQUEST_CLOSED) &&
     item.data.pullRequest?.author?.name &&
     !item.data.pullRequest.author.email?.endsWith('@localhost')
   ) {
@@ -488,6 +489,24 @@ export function getGroupActivityItem(
         const {pullRequest} = data;
         return {
           title: t('Pull Request Created'),
+          message: tct(' by [author]: [pullRequest]', {
+            author,
+            pullRequest: pullRequest ? (
+              <PullRequestLink
+                pullRequest={pullRequest}
+                repository={pullRequest.repository}
+              />
+            ) : (
+              t('PR not available')
+            ),
+          }),
+        };
+      }
+      case GroupActivityType.PULL_REQUEST_CLOSED: {
+        const {data} = activity;
+        const {pullRequest} = data;
+        return {
+          title: t('Pull Request Closed'),
           message: tct(' by [author]: [pullRequest]', {
             author,
             pullRequest: pullRequest ? (

--- a/static/app/views/issueList/progressActivityTooltip.tsx
+++ b/static/app/views/issueList/progressActivityTooltip.tsx
@@ -29,6 +29,7 @@ const PROGRESS_ACTIVITY_TYPES = new Set<GroupActivityType>([
   GroupActivityType.SEER_RCA_COMPLETED,
   GroupActivityType.SEER_PR_CREATED,
   GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST,
+  GroupActivityType.PULL_REQUEST_CLOSED,
   GroupActivityType.REFERENCED_IN_COMMIT,
   GroupActivityType.SET_RESOLVED_IN_COMMIT,
   GroupActivityType.SET_RESOLVED_IN_RELEASE,


### PR DESCRIPTION
The backend recently started emitting (internal orgs only) a `pull_request_closed` activity type when a linked PR is closed without merging (see #118524). This adds the frontend support to render that activity in the issue details timeline.

<img width="1400" height="432" alt="CleanShot 2026-06-26 at 13 09 35@2x" src="https://github.com/user-attachments/assets/f128f932-9091-4c05-bf8d-ecbf8a3a1e47" />
