### PR TITLE
feat(slack): Also emit alert nudge metrics to the Sentry metrics product

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -38,6 +38,7 @@ from sentry.integrations.slack.utils.escape import (
     escape_slack_markdown_text,
     escape_slack_text,
 )
+from sentry.integrations.slack.utils.nudge import record_nudge_metric
 from sentry.integrations.time_utils import get_approx_start_time, time_since
 from sentry.integrations.types import ExternalProviders
 from sentry.issues.endpoints.group_details import get_group_global_count
@@ -543,12 +544,15 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         # new Slack app installations.
         if self.has_mentions_read_scope:
             nudge_text = "Mention or tag Sentry to investigate issues more deeply."
+            nudge_type = "mention_reminder"
         else:
             reinstall_url = org.absolute_url(
                 f"/settings/{org.slug}/integrations/slack/",
                 query="showInstallModal=1",
             )
             nudge_text = f"Ask Sentry questions and debug faster, <{reinstall_url}|reinstall Sentry Slack app>."
+            nudge_type = "reinstall"
+        record_nudge_metric("sent", nudge_type=nudge_type)
         return self.get_context_block(text=nudge_text)
 
     def build_description_block(self, description_text: str) -> SlackBlock | None:

--- a/src/sentry/integrations/slack/utils/nudge.py
+++ b/src/sentry/integrations/slack/utils/nudge.py
@@ -52,7 +52,5 @@ def should_send_nudge_block(
             # incr; incr raises ValueError on a missing key, so fall back to set.
             cache.set(cache_key, count + 1, timeout=7 * 24 * 60 * 60)
 
-    # The "sent" metric is emitted at render time in
-    # SlackIssuesMessageBuilder.get_slack_app_update_nudge_block, where we know
-    # which nudge variant (reinstall vs. @-mention reminder) is actually shown.
+    # The "sent" metric is emitted at render time
     return True

--- a/src/sentry/integrations/slack/utils/nudge.py
+++ b/src/sentry/integrations/slack/utils/nudge.py
@@ -1,12 +1,24 @@
 import random
 from datetime import datetime, timezone
 
+import sentry_sdk
+
 from sentry import features
 from sentry.models.organization import Organization
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 
 SLACK_NUDGE_METRIC = "slack.alert_nudge"
+
+
+def record_nudge_metric(result: str, nudge_type: str | None = None) -> None:
+    """Emit the nudge metric to Datadog (via ``metrics``) and the Sentry metrics
+    product (via the SDK) in one place, so both stay in sync."""
+    tags = {"result": result}
+    if nudge_type is not None:
+        tags["nudge_type"] = nudge_type
+    metrics.incr(SLACK_NUDGE_METRIC, sample_rate=1.0, tags=tags)
+    sentry_sdk.metrics.count(SLACK_NUDGE_METRIC, 1, attributes=tags)
 
 
 def should_send_nudge_block(
@@ -19,7 +31,7 @@ def should_send_nudge_block(
 
     # only 10% of the alerts should have the nudge blocks
     if random.random() >= 0.1:
-        metrics.incr(SLACK_NUDGE_METRIC, sample_rate=1.0, tags={"result": "skipped_random_check"})
+        record_nudge_metric("skipped_random_check")
         return False
 
     iso_year, iso_week, _ = datetime.now(timezone.utc).isocalendar()
@@ -27,7 +39,7 @@ def should_send_nudge_block(
 
     count = cache.get(cache_key, 0)
     if count >= 4:
-        metrics.incr(SLACK_NUDGE_METRIC, sample_rate=1.0, tags={"result": "skipped_weekly_limit"})
+        record_nudge_metric("skipped_weekly_limit")
         return False
 
     if count == 0:
@@ -40,5 +52,7 @@ def should_send_nudge_block(
             # incr; incr raises ValueError on a missing key, so fall back to set.
             cache.set(cache_key, count + 1, timeout=7 * 24 * 60 * 60)
 
-    metrics.incr(SLACK_NUDGE_METRIC, sample_rate=1.0, tags={"result": "sent"})
+    # The "sent" metric is emitted at render time in
+    # SlackIssuesMessageBuilder.get_slack_app_update_nudge_block, where we know
+    # which nudge variant (reinstall vs. @-mention reminder) is actually shown.
     return True


### PR DESCRIPTION
Instead of just sending the metrics to DD, let's also send it to Sentry.

Also, let's differentiate between sending a "Reinstall slack" vs. "oh, btw, you can use @ mentioning in sentry"