### PR TITLE
ref(pr-metrics): Add webhook name to webhook-triggered PR logs

### DIFF
--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -151,7 +151,13 @@ def handle_attribution(
     if not features.has("organizations:pr-metrics-attribution", organization):
         return
 
-    pr = _get_pull_request(organization, repo, pull_request, kwargs.get("github_delivery_id"))
+    pr = _get_pull_request(
+        organization,
+        repo,
+        pull_request,
+        kwargs.get("github_delivery_id"),
+        github_event=github_event,
+    )
     if pr is None:
         return
 
@@ -320,7 +326,11 @@ def handle_emission(
         return
 
     pr = _get_pull_request(
-        organization, repo, event.get("pull_request"), kwargs.get("github_delivery_id")
+        organization,
+        repo,
+        event.get("pull_request"),
+        kwargs.get("github_delivery_id"),
+        github_event=github_event,
     )
     if pr is None:
         return
@@ -370,7 +380,13 @@ def handle_metrics(
     if not features.has("organizations:pr-metrics-emit", organization):
         return
 
-    pr = _get_pull_request(organization, repo, pull_request, kwargs.get("github_delivery_id"))
+    pr = _get_pull_request(
+        organization,
+        repo,
+        pull_request,
+        kwargs.get("github_delivery_id"),
+        github_event=github_event,
+    )
     if pr is None:
         return
 
@@ -395,7 +411,13 @@ def handle_activity(
     if not action or action not in _ACTIVITY_ACTIONS:
         return
 
-    pr = _get_pull_request(organization, repo, pull_request_data, kwargs.get("github_delivery_id"))
+    pr = _get_pull_request(
+        organization,
+        repo,
+        pull_request_data,
+        kwargs.get("github_delivery_id"),
+        github_event=github_event,
+    )
     if pr is None:
         return
 
@@ -440,6 +462,7 @@ def handle_comment(
         opened_at=parse_datetime(issue_created_at) if issue_created_at else None,
         title=issue.get("title"),
         github_delivery_id=webhook_id,
+        github_event=github_event,
     )
     if pr is None:
         return
@@ -491,7 +514,11 @@ def handle_review(
         return
 
     pr = _get_pull_request(
-        organization, repo, event.get("pull_request"), kwargs.get("github_delivery_id")
+        organization,
+        repo,
+        event.get("pull_request"),
+        kwargs.get("github_delivery_id"),
+        github_event=github_event,
     )
     if pr is None:
         return
@@ -543,7 +570,11 @@ def handle_review_comment(
         return
 
     pr = _get_pull_request(
-        organization, repo, event.get("pull_request"), kwargs.get("github_delivery_id")
+        organization,
+        repo,
+        event.get("pull_request"),
+        kwargs.get("github_delivery_id"),
+        github_event=github_event,
     )
     if pr is None:
         return
@@ -594,7 +625,11 @@ def handle_review_thread(
         return
 
     pr = _get_pull_request(
-        organization, repo, event.get("pull_request"), kwargs.get("github_delivery_id")
+        organization,
+        repo,
+        event.get("pull_request"),
+        kwargs.get("github_delivery_id"),
+        github_event=github_event,
     )
     if pr is None:
         return
@@ -663,7 +698,7 @@ def handle_check_suite(
         )
     )
 
-    for pr in _prs_from_check_payload(organization, repo, check_suite, webhook_id):
+    for pr in _prs_from_check_payload(organization, repo, check_suite, webhook_id, github_event):
         _write_activity_row(pr, webhook_id, PullRequestActivityType.CHECK_SUITE_COMPLETED, payload)
 
 
@@ -706,7 +741,7 @@ def handle_check_run(
         )
     )
 
-    for pr in _prs_from_check_payload(organization, repo, check_run, webhook_id):
+    for pr in _prs_from_check_payload(organization, repo, check_run, webhook_id, github_event):
         _write_activity_row(pr, webhook_id, PullRequestActivityType.CHECK_RUN_COMPLETED, payload)
 
 
@@ -715,6 +750,7 @@ def _prs_from_check_payload(
     repo: Repository,
     container: Mapping[str, Any],
     webhook_id: str,
+    github_event: GithubWebhookType,
 ) -> list[PullRequest]:
     """Resolve the tracked PRs a check_suite/check_run payload references.
 
@@ -746,7 +782,9 @@ def _prs_from_check_payload(
             metrics.incr("pr_metrics.check.foreign_pull_request")
             continue
         seen.add(str(number))
-        pr = _get_pull_request(organization, repo, {"number": number}, webhook_id)
+        pr = _get_pull_request(
+            organization, repo, {"number": number}, webhook_id, github_event=github_event
+        )
         if pr is not None:
             prs.append(pr)
     return prs
@@ -770,6 +808,7 @@ def _resolve_or_stub_pull_request(
     opened_at: datetime | None,
     title: str | None,
     github_delivery_id: str | None,
+    github_event: GithubWebhookType,
 ) -> PullRequest | None:
     """Return the PullRequest row, creating a minimal stub for a recent miss.
 
@@ -791,6 +830,7 @@ def _resolve_or_stub_pull_request(
         pass
 
     log_extra = {
+        "github_event": github_event,
         "organization_id": organization.id,
         "repository_id": repo.id,
         "repo_name": repo.name,
@@ -822,6 +862,8 @@ def _get_pull_request(
     repo: Repository,
     pull_request: dict[str, Any] | None,
     github_delivery_id: str | None = None,
+    *,
+    github_event: GithubWebhookType,
 ) -> PullRequest | None:
     """Resolve the PullRequest row for a ``pull_request``-shaped payload.
 
@@ -840,6 +882,7 @@ def _get_pull_request(
         opened_at=parse_datetime(created_at) if created_at else None,
         title=pull_request.get("title"),
         github_delivery_id=github_delivery_id,
+        github_event=github_event,
     )
 
 

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -253,6 +253,7 @@ class HandleWebhookForPrMetricsTest(TestCase):
         mock_logger.info.assert_called_once_with(
             "pr_metrics.pull_request.unresolved",
             extra={
+                "github_event": GithubWebhookType.PULL_REQUEST,
                 "organization_id": self.organization.id,
                 "repository_id": self.repo.id,
                 "repo_name": self.repo.name,
@@ -453,6 +454,7 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
         mock_logger.info.assert_called_once_with(
             "pr_metrics.pull_request.unresolved",
             extra={
+                "github_event": GithubWebhookType.PULL_REQUEST,
                 "organization_id": self.organization.id,
                 "repository_id": self.repo.id,
                 "repo_name": self.repo.name,
@@ -1042,6 +1044,7 @@ class HandleCommentForPrMetricsTest(TestCase):
         mock_logger.info.assert_called_once_with(
             "pr_metrics.pull_request.unresolved",
             extra={
+                "github_event": GithubWebhookType.ISSUE_COMMENT,
                 "organization_id": self.organization.id,
                 "repository_id": self.repo.id,
                 "repo_name": self.repo.name,
@@ -1226,6 +1229,7 @@ class HandleReviewForPrMetricsTest(TestCase):
         mock_logger.info.assert_called_once_with(
             "pr_metrics.pull_request.unresolved",
             extra={
+                "github_event": GithubWebhookType.PULL_REQUEST_REVIEW,
                 "organization_id": self.organization.id,
                 "repository_id": self.repo.id,
                 "repo_name": self.repo.name,
@@ -1331,6 +1335,7 @@ class HandleReviewCommentForPrMetricsTest(TestCase):
         mock_logger.info.assert_called_once_with(
             "pr_metrics.pull_request.unresolved",
             extra={
+                "github_event": GithubWebhookType.PULL_REQUEST_REVIEW_COMMENT,
                 "organization_id": self.organization.id,
                 "repository_id": self.repo.id,
                 "repo_name": self.repo.name,
@@ -1429,6 +1434,7 @@ class HandleReviewThreadForPrMetricsTest(TestCase):
         mock_logger.info.assert_called_once_with(
             "pr_metrics.pull_request.unresolved",
             extra={
+                "github_event": GithubWebhookType.PULL_REQUEST_REVIEW_THREAD,
                 "organization_id": self.organization.id,
                 "repository_id": self.repo.id,
                 "repo_name": self.repo.name,


### PR DESCRIPTION
## Summary

Webhook-triggered `pr_metrics` logs now carry the GitHub webhook event name (`github_event`) in their context, but only where that value actually disambiguates the log.

The `pr_metrics.pull_request.unresolved` and `pr_metrics.pull_request.stub_created` logs are emitted from the shared resolve-or-stub helper, which is reached from **seven distinct webhook event types** — `pull_request`, `issue_comment`, the three `pull_request_review*` variants, `check_suite`, and `check_run`. These logs fire when a comment/review/check delivery races ahead of the `pull_request` (opened) delivery that writes the PR row; without the triggering event in context, you can't tell which delivery raced.

This threads `github_event` (already present on every webhook handler) down through `_get_pull_request` / `_resolve_or_stub_pull_request` / `_prs_from_check_payload` and into that shared log context.

## Scope

The webhook name is added **only where it varies**. Paths reached solely from the `pull_request` close webhook — `select_verdict` and the judge-forward logs (`pr_metrics.emit.needs_judge`, `pr_metrics.judge.enqueue_failed`) — would log a constant `pull_request`, so they were deliberately left unchanged. The log key already pins those to the close path.

Out of scope (not a GitHub webhook trigger, so no webhook name to capture): the Seer RPC callback path (`judge.py`, `update_pr_metrics`), the async forward task (`tasks.py`), and the attribution paths (Seer event / Cursor webhook / agent polling).

## Behavior change

Pure observability: the only functional effect is an added `github_event` field on the two PR-resolution logs. No change to pipeline logic, emission, or verdicts.
