### PR TITLE
fix(explore): Cap heat map unfurl grid to a fixed-density size

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -42,6 +42,34 @@ TOP_N = 5
 
 EXPLORE_CHART_SIZE: ChartSize = {"width": 1200, "height": 400}
 
+# Heat map unfurls always render to the fixed Chartcuterie canvas above, so we
+# target a fixed-density grid sized to it rather than bucketing by a time-range
+# ladder. A fine ladder interval emits tens of thousands of cells for long
+# ranges, which (a) trips ECharts' progressive-rendering threshold so the
+# server-side snapshot only captures the first columns and (b) looks nothing
+# like the live UI. 150 x 50 over 1200x400 gives ~8px square cells.
+HEATMAP_TARGET_X_BUCKETS = 150
+HEATMAP_TARGET_Y_BUCKETS = 50
+
+# Candidate x-axis intervals (finest to coarsest), in the same (timedelta, str)
+# format as `_DEFAULT_INTERVAL_LADDER` below. Note the timedelta here is the
+# interval itself, not a range threshold: `_heatmap_interval` picks the finest
+# one whose column count (`time_range / interval`) stays within
+# HEATMAP_TARGET_X_BUCKETS, capping cell density for the fixed canvas.
+_HEATMAP_INTERVAL_LADDER: tuple[tuple[timedelta, str], ...] = (
+    (timedelta(minutes=1), "1m"),
+    (timedelta(minutes=5), "5m"),
+    (timedelta(minutes=10), "10m"),
+    (timedelta(minutes=15), "15m"),
+    (timedelta(minutes=30), "30m"),
+    (timedelta(hours=1), "1h"),
+    (timedelta(hours=2), "2h"),
+    (timedelta(hours=3), "3h"),
+    (timedelta(hours=6), "6h"),
+    (timedelta(hours=12), "12h"),
+    (timedelta(days=1), "1d"),
+)
+
 # Mirrors the frontend's MINIMUM_INTERVAL ladder in
 # static/app/utils/useChartInterval.tsx. All Explore views call
 # `useChartInterval()` with the default `USE_SMALLEST` strategy, so the
@@ -83,6 +111,16 @@ def _interval_for_query(params: QueryDict) -> str:
         if diff >= threshold:
             return interval
     return "1m"
+
+
+def _heatmap_interval(time_range: timedelta) -> str:
+    """Pick the finest interval that keeps the heat map within
+    ``HEATMAP_TARGET_X_BUCKETS`` columns, so it renders a fixed-density grid
+    sized to the Chartcuterie canvas regardless of the selected time range."""
+    for interval_td, interval in _HEATMAP_INTERVAL_LADDER:
+        if time_range <= interval_td * HEATMAP_TARGET_X_BUCKETS:
+            return interval
+    return _HEATMAP_INTERVAL_LADDER[-1][1]
 
 
 def _clamp_interval(url_interval: str, minimum_interval: str) -> str:
@@ -150,8 +188,9 @@ def _parse_aggregate_field_entries(
 def _build_heatmap_query(raw_query: QueryDict) -> QueryDict:
     """Assemble the QueryDict sent to the events-heatmap API. Like
     ``_build_timeseries_query`` but adds the heatmap params (xAxis/yAxis/zAxis/
-    yBuckets). The interval is the per-range ladder value (the URL interval is
-    ignored); yBuckets is derived from it to keep cells ~square."""
+    yBuckets). The URL interval is ignored; instead we target a fixed-density
+    grid (`HEATMAP_TARGET_X_BUCKETS` x `HEATMAP_TARGET_Y_BUCKETS`) sized to the
+    Chartcuterie canvas."""
     out = QueryDict(mutable=True)
 
     for param in ("project", "statsPeriod", "start", "end", "environment"):
@@ -176,16 +215,12 @@ def _build_heatmap_query(raw_query: QueryDict) -> QueryDict:
     if not out.get("statsPeriod") and not out.get("start"):
         out["statsPeriod"] = DEFAULT_PERIOD
 
-    # Per-range ladder interval (fine end, for plenty of columns), then size
-    # yBuckets to keep cells roughly square: yBuckets ≈ xBuckets * (height / width).
-    interval = _interval_for_query(out)
-    out["interval"] = interval
-    interval_td = parse_stats_period(interval)
-    x_buckets = round(_query_time_range(out) / interval_td) if interval_td else 0
-    y_buckets = max(
-        1, round(x_buckets * EXPLORE_CHART_SIZE["height"] / EXPLORE_CHART_SIZE["width"])
-    )
-    out["yBuckets"] = str(y_buckets)
+    # Target a fixed-density grid sized to the Chartcuterie canvas: pick an
+    # interval that keeps the column count within HEATMAP_TARGET_X_BUCKETS and
+    # request HEATMAP_TARGET_Y_BUCKETS rows. (The endpoint honors `interval` and
+    # recomputes the column count from it.)
+    out["interval"] = _heatmap_interval(_query_time_range(out))
+    out["yBuckets"] = str(HEATMAP_TARGET_Y_BUCKETS)
 
     # Fixed axes — the endpoint currently only supports these values.
     out["xAxis"] = "time"

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -95,11 +95,11 @@ def _interval_for_query(params: QueryDict) -> str:
 
 
 def _heatmap_interval(time_range: timedelta) -> str:
-    """Pick the finest backend-supported granularity that keeps the heat map
+    """Pick the finest backend-supported granularity that keeps the Heat Map
     within ``HEATMAP_TARGET_X_BUCKETS`` columns, so it renders a fixed-density
     grid sized to the Chartcuterie canvas regardless of the selected time range.
-    Iterates the EAP-accepted ``VALID_GRANULARITIES`` (the events-heatmap dataset
-    is tracemetrics) so we can only ever pick an interval the backend honors."""
+    Iterates the EAP-accepted ``VALID_GRANULARITIES`` (the only dataset we
+    support for Heat Map widgets is trace metrics)."""
     seconds = time_range.total_seconds()
     for granularity in sorted(VALID_GRANULARITIES):
         if seconds / granularity <= HEATMAP_TARGET_X_BUCKETS:
@@ -199,10 +199,6 @@ def _build_heatmap_query(raw_query: QueryDict) -> QueryDict:
     if not out.get("statsPeriod") and not out.get("start"):
         out["statsPeriod"] = DEFAULT_PERIOD
 
-    # Target a fixed-density grid sized to the Chartcuterie canvas: pick an
-    # interval that keeps the column count within HEATMAP_TARGET_X_BUCKETS and
-    # request HEATMAP_TARGET_Y_BUCKETS rows. (The endpoint honors `interval` and
-    # recomputes the column count from it.)
     out["interval"] = _heatmap_interval(_query_time_range(out))
     out["yBuckets"] = str(HEATMAP_TARGET_Y_BUCKETS)
 

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -26,6 +26,7 @@ from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.unfurl.types import Handler, UnfurlableUrl, UnfurledUrl
 from sentry.models.apikey import ApiKey
 from sentry.models.organization import Organization
+from sentry.search.eap.constants import VALID_GRANULARITIES
 from sentry.search.eap.types import SupportedTraceItemType
 from sentry.search.events.constants import DURATION_UNITS, PERCENT_UNITS, SIZE_UNITS
 from sentry.search.events.fields import is_function, parse_arguments
@@ -42,34 +43,6 @@ TOP_N = 5
 
 EXPLORE_CHART_SIZE: ChartSize = {"width": 1200, "height": 400}
 
-# Heat map unfurls always render to the fixed Chartcuterie canvas above, so we
-# target a fixed-density grid sized to it rather than bucketing by a time-range
-# ladder. A fine ladder interval emits tens of thousands of cells for long
-# ranges, which (a) trips ECharts' progressive-rendering threshold so the
-# server-side snapshot only captures the first columns and (b) looks nothing
-# like the live UI. 150 x 50 over 1200x400 gives ~8px square cells.
-HEATMAP_TARGET_X_BUCKETS = 150
-HEATMAP_TARGET_Y_BUCKETS = 50
-
-# Candidate x-axis intervals (finest to coarsest), in the same (timedelta, str)
-# format as `_DEFAULT_INTERVAL_LADDER` below. Note the timedelta here is the
-# interval itself, not a range threshold: `_heatmap_interval` picks the finest
-# one whose column count (`time_range / interval`) stays within
-# HEATMAP_TARGET_X_BUCKETS, capping cell density for the fixed canvas.
-_HEATMAP_INTERVAL_LADDER: tuple[tuple[timedelta, str], ...] = (
-    (timedelta(minutes=1), "1m"),
-    (timedelta(minutes=5), "5m"),
-    (timedelta(minutes=10), "10m"),
-    (timedelta(minutes=15), "15m"),
-    (timedelta(minutes=30), "30m"),
-    (timedelta(hours=1), "1h"),
-    (timedelta(hours=2), "2h"),
-    (timedelta(hours=3), "3h"),
-    (timedelta(hours=6), "6h"),
-    (timedelta(hours=12), "12h"),
-    (timedelta(days=1), "1d"),
-)
-
 # Mirrors the frontend's MINIMUM_INTERVAL ladder in
 # static/app/utils/useChartInterval.tsx. All Explore views call
 # `useChartInterval()` with the default `USE_SMALLEST` strategy, so the
@@ -85,6 +58,14 @@ _DEFAULT_INTERVAL_LADDER: tuple[tuple[timedelta, str], ...] = (
     (timedelta(hours=12), "5m"),
     (timedelta(0), "1m"),
 )
+
+
+# Heat Map unfurls always render to a fixed Chartcuterie canvas, so we target a
+# fixed-density grid sized to those dimensions. 150 x 50 over 1200x400 gives
+# ~8px square cells. 150 is an approximation, since we're limited to a known set
+# of intervals.
+HEATMAP_TARGET_X_BUCKETS = 150
+HEATMAP_TARGET_Y_BUCKETS = 50
 
 
 def _query_time_range(params: QueryDict) -> timedelta:
@@ -114,13 +95,16 @@ def _interval_for_query(params: QueryDict) -> str:
 
 
 def _heatmap_interval(time_range: timedelta) -> str:
-    """Pick the finest interval that keeps the heat map within
-    ``HEATMAP_TARGET_X_BUCKETS`` columns, so it renders a fixed-density grid
-    sized to the Chartcuterie canvas regardless of the selected time range."""
-    for interval_td, interval in _HEATMAP_INTERVAL_LADDER:
-        if time_range <= interval_td * HEATMAP_TARGET_X_BUCKETS:
-            return interval
-    return _HEATMAP_INTERVAL_LADDER[-1][1]
+    """Pick the finest backend-supported granularity that keeps the heat map
+    within ``HEATMAP_TARGET_X_BUCKETS`` columns, so it renders a fixed-density
+    grid sized to the Chartcuterie canvas regardless of the selected time range.
+    Iterates the EAP-accepted ``VALID_GRANULARITIES`` (the events-heatmap dataset
+    is tracemetrics) so we can only ever pick an interval the backend honors."""
+    seconds = time_range.total_seconds()
+    for granularity in sorted(VALID_GRANULARITIES):
+        if seconds / granularity <= HEATMAP_TARGET_X_BUCKETS:
+            return f"{granularity}s"
+    return f"{max(VALID_GRANULARITIES)}s"
 
 
 def _clamp_interval(url_interval: str, minimum_interval: str) -> str:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1224,9 +1224,9 @@ class UnfurlTest(TestCase):
             "( metric.name:dashboards.widget.onEdit metric.type:distribution"
             " metric.unit:millisecond )"
         )
-        # 30d targets a fixed-density grid: 6h keeps columns (120) within
-        # HEATMAP_TARGET_X_BUCKETS (150).
-        assert api_params["interval"] == "6h"
+        # 30d targets a fixed-density grid: 21600s (6h) keeps columns (120)
+        # within HEATMAP_TARGET_X_BUCKETS (150).
+        assert api_params["interval"] == "21600s"
         assert api_params["yBuckets"] == "50"
 
         chart_data = mock_generate_chart.call_args[0][1]
@@ -1277,12 +1277,14 @@ class UnfurlTest(TestCase):
         # The heat map targets a fixed-density grid sized to the 1200x400
         # Chartcuterie canvas: the interval is the finest candidate keeping
         # columns within 150, and yBuckets is always 50 (URL intervals ignored).
+        # Intervals are the finest VALID_GRANULARITIES value (in seconds) that
+        # keeps columns within 150.
         base = "yAxis=sum(value,my.metric,counter,none)"
         cases = [
-            ("1h", "1m"),  # 60 columns
-            ("24h", "10m"),  # 144 columns (5m -> 288 would exceed 150)
-            ("7d", "2h"),  # 84 columns (1h -> 168 would exceed 150)
-            ("30d", "6h"),  # 120 columns (3h -> 240 would exceed 150)
+            ("1h", "30s"),  # 120 columns (15s -> 240 would exceed 150)
+            ("24h", "600s"),  # 144 columns (300s -> 288 would exceed 150)
+            ("7d", "7200s"),  # 84 columns (3600s -> 168 would exceed 150)
+            ("30d", "21600s"),  # 120 columns (14400s -> 180 would exceed 150)
         ]
         for stats_period, expected_interval in cases:
             # Inject a too-fine URL interval to prove it is ignored.

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1224,7 +1224,10 @@ class UnfurlTest(TestCase):
             "( metric.name:dashboards.widget.onEdit metric.type:distribution"
             " metric.unit:millisecond )"
         )
-        assert api_params["interval"] == "3h"
+        # 30d targets a fixed-density grid: 6h keeps columns (120) within
+        # HEATMAP_TARGET_X_BUCKETS (150).
+        assert api_params["interval"] == "6h"
+        assert api_params["yBuckets"] == "50"
 
         chart_data = mock_generate_chart.call_args[0][1]
         y_axis_meta = chart_data["heatmap"]["meta"]["yAxis"]
@@ -1271,15 +1274,22 @@ class UnfurlTest(TestCase):
         )
 
     def test_build_heatmap_query_interval_and_buckets(self) -> None:
-        # Per-range ladder interval (injected URL intervals ignored), with
-        # yBuckets ≈ xBuckets / 3 so cells stay ~square on the 1200x400 canvas.
+        # The heat map targets a fixed-density grid sized to the 1200x400
+        # Chartcuterie canvas: the interval is the finest candidate keeping
+        # columns within 150, and yBuckets is always 50 (URL intervals ignored).
         base = "yAxis=sum(value,my.metric,counter,none)"
-        # 30d / 3h -> 240 columns -> round(240/3) = 80 rows.
-        out = _build_heatmap_query(QueryDict(f"{base}&statsPeriod=30d&interval=12h"))
-        assert (out["interval"], out["yBuckets"]) == ("3h", "80")
-        # 24h / 5m -> 288 columns -> round(288/3) = 96 rows.
-        out = _build_heatmap_query(QueryDict(f"{base}&statsPeriod=24h"))
-        assert (out["interval"], out["yBuckets"]) == ("5m", "96")
+        cases = [
+            ("1h", "1m"),  # 60 columns
+            ("24h", "10m"),  # 144 columns (5m -> 288 would exceed 150)
+            ("7d", "2h"),  # 84 columns (1h -> 168 would exceed 150)
+            ("30d", "6h"),  # 120 columns (3h -> 240 would exceed 150)
+        ]
+        for stats_period, expected_interval in cases:
+            # Inject a too-fine URL interval to prove it is ignored.
+            out = _build_heatmap_query(QueryDict(f"{base}&statsPeriod={stats_period}&interval=1m"))
+            assert (out["interval"], out["yBuckets"]) == (expected_interval, "50"), (
+                f"statsPeriod={stats_period}"
+            )
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1224,8 +1224,6 @@ class UnfurlTest(TestCase):
             "( metric.name:dashboards.widget.onEdit metric.type:distribution"
             " metric.unit:millisecond )"
         )
-        # 30d targets a fixed-density grid: 21600s (6h) keeps columns (120)
-        # within HEATMAP_TARGET_X_BUCKETS (150).
         assert api_params["interval"] == "21600s"
         assert api_params["yBuckets"] == "50"
 
@@ -1274,11 +1272,6 @@ class UnfurlTest(TestCase):
         )
 
     def test_build_heatmap_query_interval_and_buckets(self) -> None:
-        # The heat map targets a fixed-density grid sized to the 1200x400
-        # Chartcuterie canvas: the interval is the finest candidate keeping
-        # columns within 150, and yBuckets is always 50 (URL intervals ignored).
-        # Intervals are the finest VALID_GRANULARITIES value (in seconds) that
-        # keeps columns within 150.
         base = "yAxis=sum(value,my.metric,counter,none)"
         cases = [
             ("1h", "30s"),  # 120 columns (15s -> 240 would exceed 150)
@@ -1287,7 +1280,6 @@ class UnfurlTest(TestCase):
             ("30d", "21600s"),  # 120 columns (14400s -> 180 would exceed 150)
         ]
         for stats_period, expected_interval in cases:
-            # Inject a too-fine URL interval to prove it is ignored.
             out = _build_heatmap_query(QueryDict(f"{base}&statsPeriod={stats_period}&interval=1m"))
             assert (out["interval"], out["yBuckets"]) == (expected_interval, "50"), (
                 f"statsPeriod={stats_period}"


### PR DESCRIPTION
We were seeing some broken Heat Map unfurls, turns out there were two causes:

- The Heat Map had way too many buckets, because of how aggressively we picked fine intervals (we borrowed the frontend logic that uses the size of the chart)
- Chartcuterie had some rendering problems

This PR fixes the first problem. On the backend side, the chart canvas dimensions are _fixed_, and we just care about having roughly the right amount of buckets. So, take the simple approach. Find an interval that produces roughly 150 buckets on the X-axis, and always render 50 buckets on the Y-axis. This should make it easy to compare charts in Slack unfurls, and keeps the code simple.

Fixes DAIN-1752, see also https://github.com/getsentry/chartcuterie/pull/234