### PR TITLE
docs(scraps): [StatusIndicator] add non-animated usage subsection

### DIFF
--- a/static/app/components/core/statusIndicator/statusIndicator.mdx
+++ b/static/app/components/core/statusIndicator/statusIndicator.mdx
@@ -74,6 +74,21 @@ The background pulse repeats continuously by default. Pass `animationIterationCo
 
 When the user prefers reduced motion, the indicator renders in its settled static state.
 
+### Static
+
+Pass `animationIterationCount={0}` to render a static dot with no pulse. Reach for this when the indicator reflects a known, persistent value — such as a fixed `level` or `severity` from query parameters — rather than a change worth drawing attention to.
+
+<Storybook.Demo>
+  <Grid columns="8px 1fr" flow="row" gap="md" align="center">
+    <StatusIndicator variant="danger" aria-label="Error" animationIterationCount={0} />
+    <Text>error</Text>
+  </Grid>
+</Storybook.Demo>
+
+```jsx
+<StatusIndicator variant="error" animationIterationCount={0} />
+```
+
 ## Accessibility
 
 The component handles three patterns based on the props provided:

--- a/static/app/components/core/statusIndicator/statusIndicator.mdx
+++ b/static/app/components/core/statusIndicator/statusIndicator.mdx
@@ -86,7 +86,7 @@ Pass `animationIterationCount={0}` to render a static dot with no pulse. Reach f
 </Storybook.Demo>
 
 ```jsx
-<StatusIndicator variant="error" animationIterationCount={0} />
+<StatusIndicator variant="danger" animationIterationCount={0} />
 ```
 
 ## Accessibility


### PR DESCRIPTION
Adds a **Static** subsection to the `StatusIndicator` Animation docs covering `animationIterationCount={0}` for rendering a dot with no background pulse.

Quick link: https://sentry-l5ukyzmnx.sentry.dev/stories/core/statusindicator/#static

Closes DE-1336.