### PR TITLE
fix(quotas): Add repr for quota config

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -235,6 +235,9 @@ class QuotaConfig:
     def __str__(self) -> str:
         return str(self.to_json())
 
+    def __repr__(self) -> str:
+        return str(self.to_json())
+
 
 class RateLimit:
     """

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -110,6 +110,12 @@ def test_quotas_to_json(obj, json) -> None:
     assert obj.to_json() == json
 
 
+def test_quota_config_repr() -> None:
+    quota = QuotaConfig(id="o", limit=4711, window=42, reason_code="not_so_fast")
+
+    assert repr(quota) == str(quota.to_json())
+
+
 def test_seat_assignable_must_have_reason() -> None:
     with pytest.raises(ValueError):
         SeatAssignmentResult(assignable=False)


### PR DESCRIPTION
I'm stupid and don't know how to print stuff in python

QuotaConfig now defines __repr__ using the same JSON-shaped output as __str__, so quota lists and logging extras render useful quota details instead of object addresses.