### PR TITLE
feat(preprod): Re-emit preprod.snapshots.diff.duration_s metric

### DIFF
--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -4,6 +4,7 @@ import logging
 import threading
 import time
 from collections.abc import Callable
+from datetime import datetime
 from difflib import SequenceMatcher
 from typing import NamedTuple
 
@@ -728,6 +729,7 @@ def compare_snapshots(
     head_artifact_id: int,
     base_artifact_id: int,
 ) -> None:
+    task_start_time = timezone.now()
     logger.info(
         "Snapshot comparison kicked off for artifacts",
         extra={
@@ -998,8 +1000,12 @@ def compare_snapshots(
                 }
             )
 
+        comparison.extras = {
+            **(comparison.extras or {}),
+            "diff_processing_started_at": task_start_time.isoformat(),
+        }
         comparison.chunks_total = len(plan.chunks)
-        comparison.save(update_fields=["chunks_total", "date_updated"])
+        comparison.save(update_fields=["chunks_total", "extras", "date_updated"])
 
         logger.info(
             "compare_snapshots: orchestration dispatched",
@@ -1242,6 +1248,25 @@ def finalize_snapshot_comparison(
             sample_rate=1.0,
             tags=metric_tags,
         )
+
+        started_raw = (comparison.extras or {}).get("diff_processing_started_at")
+        if started_raw:
+            try:
+                diff_duration_s = (
+                    timezone.now() - datetime.fromisoformat(started_raw)
+                ).total_seconds()
+            except (ValueError, TypeError):
+                logger.warning(
+                    "finalize: unparseable diff_processing_started_at, skipping metric",
+                    extra={"comparison_id": comparison.id},
+                )
+            else:
+                metrics.distribution(
+                    "preprod.snapshots.diff.duration_s",
+                    diff_duration_s,
+                    sample_rate=1.0,
+                    tags=metric_tags,
+                )
 
         if (
             counts["changed"] == 0

--- a/tests/sentry/preprod/snapshots/test_compare_snapshots.py
+++ b/tests/sentry/preprod/snapshots/test_compare_snapshots.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import orjson
 import pytest
@@ -534,6 +534,43 @@ class FinalizeSnapshotComparisonTest(TestCase):
         from sentry.preprod.snapshots.manifest import ChunkResult, ComparisonImageResult
 
         return ChunkResult(chunk_index=0, images={"a.png": ComparisonImageResult(status="changed")})
+
+    def _finalize_with_extras(self, extras):
+        from sentry.preprod.snapshots.tasks import finalize_snapshot_comparison
+
+        comparison, h, b = self._comparison(1, done_indices=[0])
+        comparison.extras = extras
+        comparison.save()
+        prefix = f"{self.organization.id}/{self.project.id}/{h.id}/{b.id}"
+        stored = {
+            f"{prefix}/plan.json": orjson.dumps(self._single_chunk_plan(h, b).dict()),
+            f"{prefix}/chunks/0.json": orjson.dumps(self._changed_chunk_result().dict()),
+        }
+        session = _dict_backed_session(stored)
+        with (
+            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks._try_auto_approve_snapshot"),
+            patch("sentry.preprod.snapshots.tasks.metrics") as mock_metrics,
+        ):
+            finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
+        comparison.refresh_from_db()
+        diff_calls = [
+            c
+            for c in mock_metrics.distribution.call_args_list
+            if c.args and c.args[0] == "preprod.snapshots.diff.duration_s"
+        ]
+        return comparison, diff_calls
+
+    def test_finalize_skips_diff_duration_metric_on_missing_or_invalid_timestamp(self):
+        missing, missing_calls = self._finalize_with_extras({})
+        assert missing.state == PreprodSnapshotComparison.State.SUCCESS
+        assert missing_calls == []
+
+        invalid, invalid_calls = self._finalize_with_extras(
+            {"diff_processing_started_at": "not-a-date"}
+        )
+        assert invalid.state == PreprodSnapshotComparison.State.SUCCESS
+        assert invalid_calls == []
 
     def test_terminal_state_skips_finalize(self):
         from sentry.preprod.snapshots.tasks import finalize_snapshot_comparison
@@ -1586,6 +1623,8 @@ class EndToEndFanoutTest(TestCase):
         return {h: b"img" for h in hashes}, set()
 
     def test_full_flow_reaches_success(self):
+        from datetime import datetime
+
         from sentry.preprod.snapshots.tasks import (
             compare_snapshots,
             finalize_snapshot_comparison,
@@ -1626,6 +1665,7 @@ class EndToEndFanoutTest(TestCase):
                 side_effect=lambda kwargs, **_: dispatched.append(kwargs),
             ),
             patch("sentry.preprod.snapshots.tasks.finalize_snapshot_comparison.apply_async"),
+            patch("sentry.preprod.snapshots.tasks.metrics") as mock_metrics,
         ):
             compare_snapshots(**kwargs)
 
@@ -1664,3 +1704,13 @@ class EndToEndFanoutTest(TestCase):
         manifest = orjson.loads(stored[f"{prefix}/comparison.json"])
         assert manifest["summary"]["changed"] == 3
         assert manifest["summary"]["added"] == 1
+
+        # The orchestrator stamps the processing-start timestamp at fan-out, and
+        # finalize reads it to emit the diff-duration metric — assert the full round-trip.
+        assert datetime.fromisoformat(comparison.extras["diff_processing_started_at"])
+        mock_metrics.distribution.assert_any_call(
+            "preprod.snapshots.diff.duration_s",
+            ANY,
+            sample_rate=1.0,
+            tags={"app_id_temp": head_artifact.app_id or ""},
+        )

--- a/tests/sentry/preprod/snapshots/test_compare_snapshots.py
+++ b/tests/sentry/preprod/snapshots/test_compare_snapshots.py
@@ -1707,7 +1707,9 @@ class EndToEndFanoutTest(TestCase):
 
         # The orchestrator stamps the processing-start timestamp at fan-out, and
         # finalize reads it to emit the diff-duration metric — assert the full round-trip.
-        assert datetime.fromisoformat(comparison.extras["diff_processing_started_at"])
+        extras = comparison.extras
+        assert extras is not None
+        assert datetime.fromisoformat(extras["diff_processing_started_at"])
         mock_metrics.distribution.assert_any_call(
             "preprod.snapshots.diff.duration_s",
             ANY,


### PR DESCRIPTION
## Summary

Restores the `preprod.snapshots.diff.duration_s` distribution metric used to track snapshot-comparison processing speed on our dashboards. The metric was inadvertently dropped in the `compare_snapshots` fan-out refactor (#116813): the old metric measured a single task's wall-clock (`now - task_start_time`), and once the work was split across an orchestrator + parallel chunk tasks + finalize, that single-task measurement became meaningless and was removed with no replacement. There is currently no metric capturing how fast we process comparisons (`e2e_duration_s` measures upload→finalize latency, which includes queueing/upload, not processing).

## Changes

- **Orchestrator (`compare_snapshots`)** captures a start timestamp at entry and persists it into `PreprodSnapshotComparison.extras["diff_processing_started_at"]` (ISO-8601) **only at the fan-out commit point**. Because deferred runs (base chain not ready) and failed runs return before fan-out, only the run that actually does the work anchors the clock — a deferred re-run resets to its own start, so deferral/queue waiting is excluded.
- **`finalize_snapshot_comparison`** reads that timestamp and emits `metrics.distribution("preprod.snapshots.diff.duration_s", ...)` beside the existing `e2e_duration_s` emission, reusing the same `app_id_temp` tag and `sample_rate=1.0`.
- The parse is **guarded**: a missing or unparseable timestamp logs and skips the metric instead of raising. Finalize runs after the comparison row is already `SUCCESS`, so the metric is strictly best-effort and can never break finalization. Comparisons created before this change simply have no stamp and skip the metric.

## Notes

- **No DB migration** — the start time piggybacks on the existing `extras` JSON field.
- The metric is **aggregate-only**. It intentionally cannot be sliced by org: metric tag keys ending in `_id` are stripped by the metrics middleware denylist, and org id is unbounded cardinality. It is usable in both Datadog and Sentry's "Application Metrics" dashboard (e.g. p95), grouped only by the low-cardinality `app_id_temp` tag.