### PR TITLE
feat(gitlab): Track merge request lifecycle state on PullRequest

### DIFF
--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -381,19 +381,13 @@ class IssuesEventWebhook(GitlabWebhook):
         return f"{integration.metadata['domain_name']}:{path_with_namespace}#{issue_iid}"
 
 
-def _merge_request_lifecycle_state(state: str | None) -> str | None:
-    """Map a GitLab merge request ``state`` to a ``PullRequestLifecycleState`` value.
-
-    GitLab reports the merge request state directly (e.g. "opened", "closed",
-    "merged", "locked"), unlike GitHub which folds "merged" into a separate flag.
-    Returns ``None`` for unrecognized states so we don't store a bogus value.
-    """
+def _map_gitlab_state_to_pullrequest_lifecycle(gitlab_state: str | None) -> str | None:
     return {
         "opened": PullRequestLifecycleState.OPEN,
         "closed": PullRequestLifecycleState.CLOSED,
         "merged": PullRequestLifecycleState.MERGED,
         "locked": PullRequestLifecycleState.LOCKED,
-    }.get(state or "")
+    }.get(gitlab_state or "")
 
 
 class MergeEventWebhook(GitlabWebhook):
@@ -466,11 +460,12 @@ class MergeEventWebhook(GitlabWebhook):
                 author_name = last_commit["author"]["name"]
                 head_commit_sha = last_commit.get("id")
 
-            # Lifecycle facts kept current for the PR metrics pipeline. GitLab
-            # only reports created_at/updated_at on the merge request, so we
-            # derive closed_at/merged_at from updated_at based on the state.
             updated_at = event["object_attributes"].get("updated_at")
-            state = _merge_request_lifecycle_state(event["object_attributes"].get("state"))
+            merged_at = event["object_attributes"].get("merged_at")
+            state = _map_gitlab_state_to_pullrequest_lifecycle(
+                event["object_attributes"].get("state")
+            )
+            action = event["object_attributes"].get("action")
             draft = event["object_attributes"].get("work_in_progress")
         except KeyError as e:
             logger.warning(
@@ -501,11 +496,30 @@ class MergeEventWebhook(GitlabWebhook):
 
         opened_at = parse_date(created_at).astimezone(timezone.utc)
         state_changed_at = parse_date(updated_at).astimezone(timezone.utc) if updated_at else None
-        # A merged merge request is also closed, so populate closed_at for both
-        # terminal states (matching the GitHub integration's convention).
-        is_terminal = state in (PullRequestLifecycleState.CLOSED, PullRequestLifecycleState.MERGED)
-        closed_at = state_changed_at if is_terminal else None
-        merged_at = state_changed_at if state == PullRequestLifecycleState.MERGED else None
+        merged_at_dt = parse_date(merged_at).astimezone(timezone.utc) if merged_at else None
+
+        defaults = {
+            "title": title,
+            "author": author,
+            "message": body,
+            "merge_commit_sha": merge_commit_sha,
+            "head_commit_sha": head_commit_sha,
+            "date_added": opened_at,
+            "opened_at": opened_at,
+            "merged_at": merged_at_dt,
+            "state": state,
+            "draft": draft,
+        }
+
+        # GitLab has no closed_at, so derive it from the lifecycle action. A
+        # merged merge request is also closed. Actions that don't change
+        # lifecycle state (e.g. "update") leave the stored closed_at untouched.
+        if action == "merge":
+            defaults["closed_at"] = merged_at_dt or state_changed_at
+        elif action == "close":
+            defaults["closed_at"] = state_changed_at
+        elif action in ("reopen", "open"):
+            defaults["closed_at"] = None
 
         author.preload_users()
         try:
@@ -513,19 +527,7 @@ class MergeEventWebhook(GitlabWebhook):
                 organization_id=organization.id,
                 repository_id=repo.id,
                 key=number,
-                defaults={
-                    "title": title,
-                    "author": author,
-                    "message": body,
-                    "merge_commit_sha": merge_commit_sha,
-                    "head_commit_sha": head_commit_sha,
-                    "date_added": opened_at,
-                    "opened_at": opened_at,
-                    "closed_at": closed_at,
-                    "merged_at": merged_at,
-                    "state": state,
-                    "draft": draft,
-                },
+                defaults=defaults,
             )
         except IntegrityError:
             pass

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -33,7 +33,7 @@ from sentry.integrations.utils.sync import sync_group_assignee_inbound_by_extern
 from sentry.integrations.utils.webhook_viewer_context import webhook_viewer_context
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
-from sentry.models.pullrequest import PullRequest
+from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
@@ -381,6 +381,21 @@ class IssuesEventWebhook(GitlabWebhook):
         return f"{integration.metadata['domain_name']}:{path_with_namespace}#{issue_iid}"
 
 
+def _merge_request_lifecycle_state(state: str | None) -> str | None:
+    """Map a GitLab merge request ``state`` to a ``PullRequestLifecycleState`` value.
+
+    GitLab reports the merge request state directly (e.g. "opened", "closed",
+    "merged", "locked"), unlike GitHub which folds "merged" into a separate flag.
+    Returns ``None`` for unrecognized states so we don't store a bogus value.
+    """
+    return {
+        "opened": PullRequestLifecycleState.OPEN,
+        "closed": PullRequestLifecycleState.CLOSED,
+        "merged": PullRequestLifecycleState.MERGED,
+        "locked": PullRequestLifecycleState.LOCKED,
+    }.get(state or "")
+
+
 class MergeEventWebhook(GitlabWebhook):
     """
     Handle Merge Request Hook
@@ -445,9 +460,18 @@ class MergeEventWebhook(GitlabWebhook):
             last_commit = event["object_attributes"]["last_commit"]
             author_email = None
             author_name = None
+            head_commit_sha = None
             if last_commit:
                 author_email = last_commit["author"]["email"]
                 author_name = last_commit["author"]["name"]
+                head_commit_sha = last_commit.get("id")
+
+            # Lifecycle facts kept current for the PR metrics pipeline. GitLab
+            # only reports created_at/updated_at on the merge request, so we
+            # derive closed_at/merged_at from updated_at based on the state.
+            updated_at = event["object_attributes"].get("updated_at")
+            state = _merge_request_lifecycle_state(event["object_attributes"].get("state"))
+            draft = event["object_attributes"].get("work_in_progress")
         except KeyError as e:
             logger.warning(
                 "gitlab.webhook.invalid-merge-data",
@@ -475,6 +499,14 @@ class MergeEventWebhook(GitlabWebhook):
             organization_id=organization.id, email=author_email, defaults={"name": author_name}
         )[0]
 
+        opened_at = parse_date(created_at).astimezone(timezone.utc)
+        state_changed_at = parse_date(updated_at).astimezone(timezone.utc) if updated_at else None
+        # A merged merge request is also closed, so populate closed_at for both
+        # terminal states (matching the GitHub integration's convention).
+        is_terminal = state in (PullRequestLifecycleState.CLOSED, PullRequestLifecycleState.MERGED)
+        closed_at = state_changed_at if is_terminal else None
+        merged_at = state_changed_at if state == PullRequestLifecycleState.MERGED else None
+
         author.preload_users()
         try:
             PullRequest.objects.update_or_create(
@@ -486,7 +518,13 @@ class MergeEventWebhook(GitlabWebhook):
                     "author": author,
                     "message": body,
                     "merge_commit_sha": merge_commit_sha,
-                    "date_added": parse_date(created_at).astimezone(timezone.utc),
+                    "head_commit_sha": head_commit_sha,
+                    "date_added": opened_at,
+                    "opened_at": opened_at,
+                    "closed_at": closed_at,
+                    "merged_at": merged_at,
+                    "state": state,
+                    "draft": draft,
                 },
             )
         except IntegrityError:

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import orjson
@@ -42,7 +43,6 @@ class WebhookTest(GitLabTestCase):
         assert pull.author == author
         assert pull.merge_commit_sha is None
         assert pull.organization_id == self.organization.id
-        # Lifecycle facts populated from the "opened" merge request event.
         assert pull.state == PullRequestLifecycleState.OPEN
         assert pull.opened_at is not None
         assert pull.closed_at is None
@@ -468,6 +468,7 @@ class WebhookTest(GitLabTestCase):
         payload["object_attributes"]["state"] = "merged"
         payload["object_attributes"]["action"] = "merge"
         payload["object_attributes"]["merge_commit_sha"] = "abc123"
+        payload["object_attributes"]["merged_at"] = "2017-09-28T12:23:42.365Z"
 
         response = self.client.post(
             self.url,
@@ -481,9 +482,58 @@ class WebhookTest(GitLabTestCase):
         pull = PullRequest.objects.get()
         assert pull.state == PullRequestLifecycleState.MERGED
         assert pull.merge_commit_sha == "abc123"
-        assert pull.merged_at is not None
+        # merged_at is taken directly from the webhook's object_attributes.
+        assert pull.merged_at == datetime(2017, 9, 28, 12, 23, 42, 365000, tzinfo=timezone.utc)
         # A merged merge request is also closed.
-        assert pull.closed_at is not None
+        assert pull.closed_at == pull.merged_at
+
+    def test_merge_event_edit_after_merge_preserves_terminal_timestamps(self) -> None:
+        self.create_gitlab_repo("getsentry/sentry")
+
+        # Merge the merge request, stamping merged_at from the reported
+        # merged_at and closed_at from the same value.
+        merge_payload = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+        merge_payload["object_attributes"]["state"] = "merged"
+        merge_payload["object_attributes"]["action"] = "merge"
+        merge_payload["object_attributes"]["merged_at"] = "2017-09-28T12:23:42.365Z"
+        self.client.post(
+            self.url,
+            data=orjson.dumps(merge_payload),
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Merge Request Hook",
+        )
+
+        pull = PullRequest.objects.get()
+        merged_at = pull.merged_at
+        closed_at = pull.closed_at
+        assert merged_at is not None
+        assert closed_at is not None
+
+        # GitLab fires the hook again for an edit (e.g. label change) with a
+        # later updated_at while the state is still "merged". The edit carries
+        # the same absolute merged_at, and an "update" action never touches
+        # closed_at, so the terminal timestamps must not drift to the edit time.
+        edit_payload = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+        edit_payload["object_attributes"]["state"] = "merged"
+        edit_payload["object_attributes"]["action"] = "update"
+        edit_payload["object_attributes"]["updated_at"] = "2018-01-01T00:00:00.000Z"
+        edit_payload["object_attributes"]["merged_at"] = "2017-09-28T12:23:42.365Z"
+        edit_payload["object_attributes"]["title"] = "Edited after merge"
+        response = self.client.post(
+            self.url,
+            data=orjson.dumps(edit_payload),
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Merge Request Hook",
+        )
+        assert response.status_code == 204
+
+        pull.refresh_from_db()
+        assert pull.title == "Edited after merge"
+        assert pull.state == PullRequestLifecycleState.MERGED
+        assert pull.merged_at == merged_at
+        assert pull.closed_at == closed_at
 
     def test_update_repo_path(self) -> None:
         repo_out_of_date_path = self.create_gitlab_repo(

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -20,7 +20,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.grouplink import GroupLink
-from sentry.models.pullrequest import PullRequest
+from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
 from sentry.seer.code_review.webhooks.merge_request import handle_merge_request_event
 from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_failure_metric, assert_success_metric
@@ -42,6 +42,13 @@ class WebhookTest(GitLabTestCase):
         assert pull.author == author
         assert pull.merge_commit_sha is None
         assert pull.organization_id == self.organization.id
+        # Lifecycle facts populated from the "opened" merge request event.
+        assert pull.state == PullRequestLifecycleState.OPEN
+        assert pull.opened_at is not None
+        assert pull.closed_at is None
+        assert pull.merged_at is None
+        assert pull.head_commit_sha == "ba3e0d8ff79c80d5b0bbb4f3e2e343e0aaa662b7"
+        assert pull.draft is False
 
     def assert_group_link(self, group, pull):
         link = GroupLink.objects.get()
@@ -452,6 +459,31 @@ class WebhookTest(GitLabTestCase):
 
         self.assert_pull_request(pull, author)
         self.assert_group_link(group, pull)
+
+    def test_merge_event_merged_pull_request_state(self) -> None:
+        self.create_gitlab_repo("getsentry/sentry")
+        self.create_group(project=self.project, short_id=9)
+
+        payload = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+        payload["object_attributes"]["state"] = "merged"
+        payload["object_attributes"]["action"] = "merge"
+        payload["object_attributes"]["merge_commit_sha"] = "abc123"
+
+        response = self.client.post(
+            self.url,
+            data=orjson.dumps(payload),
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Merge Request Hook",
+        )
+        assert response.status_code == 204
+
+        pull = PullRequest.objects.get()
+        assert pull.state == PullRequestLifecycleState.MERGED
+        assert pull.merge_commit_sha == "abc123"
+        assert pull.merged_at is not None
+        # A merged merge request is also closed.
+        assert pull.closed_at is not None
 
     def test_update_repo_path(self) -> None:
         repo_out_of_date_path = self.create_gitlab_repo(


### PR DESCRIPTION
I've noticed that the PullRequest model, for GitLab PRs, does not have the correct `state` like it does for the GitHub provider. You can see [this redash query ](https://redash.getsentry.net/queries/11557/source)which shows that it is always `null`.

All the information is available in the webhook already, so this creates and updates the PullRequest model with the same information that we give for github.

Motivation: We are relying more on the PullRequest model to display up-to-date PR statuses on the issue, which will not work as expected for gitlab without this change.