### PR TITLE
feat(weekly-report): Use recommended sort v1 to find top issues

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -383,6 +383,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:weekly-report-batched-key-errors", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Show combined resolved "past issues" section instead of separate key errors / performance issues
     manager.add("organizations:weekly-report-past-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use recommended sort algorithm to select top issues for weekly email reports
+    manager.add("organizations:weekly-report-recommended-sort", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable week-over-week percentage change metric in weekly email reports
     manager.add("organizations:weekly-report-week-over-week-metric", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable logging to debug workflow engine process workflows

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -863,6 +863,29 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Weekly report recommended sort weights. Same factors as the issue stream recommended
+# sort but tuned for a weekly digest: heavier on volume and severity, lighter on recency.
+register(
+    "weekly-report.recommended.recency-weight",
+    default=0.10,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "weekly-report.recommended.severity-weight",
+    default=0.30,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "weekly-report.recommended.user-impact-weight",
+    default=0.20,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "weekly-report.recommended.event-volume-weight",
+    default=0.40,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # The percentage of tagkeys that we want to cache. Set to 1.0 in order to cache everything, <=0.0 to stop caching
 register(
     "snuba.tagstore.cache-tagkeys-rate",

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -800,23 +800,30 @@ def trends_aggregation_impl(
 
 
 def _recommended_aggregation(
-    timestamp_column: str, type_column: str | None = None
+    timestamp_column: str,
+    type_column: str | None = None,
+    weight_overrides: dict[str, float] | None = None,
 ) -> Sequence[str]:
     hour = 3600
 
+    def _weight(key: str, option_suffix: str) -> float:
+        if weight_overrides and key in weight_overrides:
+            return weight_overrides[key]
+        return options.get(f"snuba.search.recommended.{option_suffix}")
+
     # Recency: exponential decay based on time since last event (24hr halflife)
-    recency_weight = options.get("snuba.search.recommended.recency-weight")
+    recency_weight = _weight("recency", "recency-weight")
     age_hours = f"divide(minus(now(), max({timestamp_column})), {hour})"
     recency = f"divide(1, pow(2, divide({age_hours}, 24)))"
 
     # Spike: ratio of recent 6hr events to total 3d events
-    spike_weight = options.get("snuba.search.recommended.spike-weight")
+    spike_weight = _weight("spike", "spike-weight")
     recent_6h = f"countIf(lessOrEquals(minus(now(), {timestamp_column}), {6 * hour}))"
     total_3d = f"countIf(lessOrEquals(minus(now(), {timestamp_column}), {3 * 24 * hour}))"
     spike = f"least(1.0, divide({recent_6h}, plus({total_3d}, 1)))"
 
     # Severity: max log level - maps fatal=1.0, error=0.75, warning=0.5, info=0.25, debug=0.0
-    severity_weight = options.get("snuba.search.recommended.severity-weight")
+    severity_weight = _weight("severity", "severity-weight")
     severity = (
         "max(multiIf("
         "equals(level, 'fatal'), 1.0, "
@@ -827,11 +834,11 @@ def _recommended_aggregation(
     )
 
     # User impact: ln(uniq(tags[sentry:user]) + 1)/ln(1001) - maps 1→~0, 10→0.33, 100→0.67, 1000→1.0
-    user_impact_weight = options.get("snuba.search.recommended.user-impact-weight")
+    user_impact_weight = _weight("user_impact", "user-impact-weight")
     user_impact = "least(1.0, divide(log(plus(uniq(tags[sentry:user]), 1)), log(1001)))"
 
     # Event volume: ln(count() + 1)/ln(10001) - maps 1→~0, 10→0.25, 100→0.50, 1000→0.75, 10000+→1.0
-    event_volume_weight = options.get("snuba.search.recommended.event-volume-weight")
+    event_volume_weight = _weight("event_volume", "event-volume-weight")
     event_volume = "least(1.0, divide(log(plus(count(), 1)), log(10001)))"
 
     # Group type boost: additive signal per issue type

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -790,6 +790,7 @@ class Referrer(StrEnum):
     REPORTS_KEY_ERRORS_BATCHED = "reports.key_errors.batched"
     REPORTS_KEY_PERFORMANCE_ISSUES = "reports.key_performance_issues"
     REPORTS_PAST_RESOLVED_ISSUES = "reports.past_resolved_issues"
+    REPORTS_RECOMMENDED_ISSUES = "reports.recommended_issues"
     REPORTS_OUTCOME_SERIES = "reports.outcome_series"
     REPORTS_OUTCOMES = "reports.outcomes"
     REPROCESSING2_REPROCESS_GROUP = "reprocessing2.reprocess_group"

--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -13,6 +13,7 @@ from sentry.tasks.summaries.utils import (
     fetch_key_performance_issue_groups,
     fetch_past_resolved_issue_links,
     org_key_errors,
+    org_recommended_issues,
     organization_project_issue_substatus_summaries,
     project_event_counts_for_organization,
     project_key_errors,
@@ -227,6 +228,21 @@ class OrganizationReportContextFactory:
 
             fetch_past_resolved_issue_links(ctx)
 
+    @metrics.wraps("weekly_report.create_context.recommended_issues")
+    def _append_recommended_issues(self, ctx: OrganizationReportContext) -> None:
+        with sentry_sdk.start_span(op="weekly_reports.recommended_issues"):
+            eligible_project_ids = [
+                p.id
+                for p in ctx.organization.project_set.all()
+                if p.id in ctx.projects_context_map and p.first_event
+            ]
+            if eligible_project_ids:
+                ctx.recommended_issue_candidates = org_recommended_issues(
+                    ctx,
+                    project_ids=eligible_project_ids,
+                    referrer=Referrer.REPORTS_RECOMMENDED_ISSUES.value,
+                )
+
     def create_context(self) -> OrganizationReportContext:
         ctx = OrganizationReportContext(self.timestamp, self.duration, self.organization)
 
@@ -249,5 +265,7 @@ class OrganizationReportContextFactory:
                 self._hydrate_key_performance_issue_groups(ctx)
                 if features.has("organizations:weekly-report-past-issues", self.organization):
                     self._append_project_past_resolved_issues(ctx)
+                if features.has("organizations:weekly-report-recommended-sort", self.organization):
+                    self._append_recommended_issues(ctx)
 
         return ctx

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
+import sentry_sdk
 from django.db.models import Count
 from snuba_sdk import Request
 from snuba_sdk.column import Column
@@ -894,9 +895,7 @@ def _org_recommended_issues_snuba(
         "user_impact": options.get("weekly-report.recommended.user-impact-weight"),
         "event_volume": options.get("weekly-report.recommended.event-volume-weight"),
     }
-    agg = _recommended_aggregation(
-        timestamp_column="timestamp", weight_overrides=weight_overrides
-    )
+    agg = _recommended_aggregation(timestamp_column="timestamp", weight_overrides=weight_overrides)
     aggregations = [
         [agg[0], agg[1], "recommended"],
         ["count()", "", "count"],

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
@@ -31,16 +32,26 @@ from sentry.search.eap.occurrences.query_utils import keyed_counts_subset_match
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
+from sentry.search.snuba.executors import _recommended_aggregation
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.occurrences_rpc import OccurrenceCategory, Occurrences
 from sentry.types.group import GroupSubStatus
 from sentry.utils.dates import to_datetime
 from sentry.utils.outcomes import Outcome
-from sentry.utils.snuba import raw_snql_query
+from sentry.utils.snuba import raw_query, raw_snql_query
 from sentry.utils.tracing import start_span
 
 ONE_DAY = int(timedelta(days=1).total_seconds())
+RECOMMENDED_CANDIDATE_LIMIT = 50
+RECOMMENDED_DISPLAY_LIMIT = 5
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RecommendedIssueCandidate:
+    group: Group
+    base_score: float
+    event_count: int
 
 
 class OrganizationReportContext:
@@ -55,6 +66,7 @@ class OrganizationReportContext:
         self.projects_context_map: dict[int, ProjectContext] = {}  # { project_id: ProjectContext }
 
         self.project_ownership: dict[int, set[int]] = {}  # { user_id: set<project_id> }
+        self.recommended_issue_candidates: list[RecommendedIssueCandidate] = []
         for project in organization.project_set.all():
             self.projects_context_map[project.id] = ProjectContext(project)
 
@@ -861,3 +873,99 @@ def fetch_past_resolved_issue_links(ctx: OrganizationReportContext) -> None:
             reverse=True,
         )
         project_ctx.past_resolved_issues = project_ctx.past_resolved_issues[:3]
+
+
+def _org_recommended_issues_snuba(
+    ctx: OrganizationReportContext,
+    project_ids: Sequence[int],
+    group_ids: list[int],
+    referrer: str,
+) -> list[dict[str, Any]]:
+    """Fetch candidate issues scored by the recommended aggregation in ClickHouse."""
+    if not group_ids:
+        return []
+
+    from sentry import options
+
+    weight_overrides = {
+        "recency": options.get("weekly-report.recommended.recency-weight"),
+        "spike": 0.0,
+        "severity": options.get("weekly-report.recommended.severity-weight"),
+        "user_impact": options.get("weekly-report.recommended.user-impact-weight"),
+        "event_volume": options.get("weekly-report.recommended.event-volume-weight"),
+    }
+    agg = _recommended_aggregation(
+        timestamp_column="timestamp", weight_overrides=weight_overrides
+    )
+    aggregations = [
+        [agg[0], agg[1], "recommended"],
+        ["count()", "", "count"],
+    ]
+
+    result = raw_query(
+        dataset=Dataset.Events,
+        start=ctx.start,
+        end=ctx.end + timedelta(days=1),
+        groupby=["group_id", "project_id"],
+        filter_keys={
+            "group_id": group_ids,
+            "project_id": list(project_ids),
+        },
+        aggregations=aggregations,
+        orderby=["-recommended"],
+        limit=RECOMMENDED_CANDIDATE_LIMIT,
+        referrer=referrer,
+        tenant_ids={"organization_id": ctx.organization.id},
+    )
+
+    return result["data"]
+
+
+def org_recommended_issues(
+    ctx: OrganizationReportContext,
+    project_ids: Sequence[int],
+    referrer: str,
+) -> list[RecommendedIssueCandidate]:
+    """Fetch and score recommended issue candidates for the organization."""
+    if not project_ids:
+        return []
+
+    with sentry_sdk.start_span(op="weekly_reports.org_recommended_issues"):
+        candidate_groups = list(
+            Group.objects.filter(
+                project_id__in=project_ids,
+                status=GroupStatus.UNRESOLVED,
+                last_seen__gte=ctx.start,
+            ).order_by("-times_seen")[: RECOMMENDED_CANDIDATE_LIMIT * 2]
+        )
+
+        if not candidate_groups:
+            return []
+
+        group_id_to_group = {g.id: g for g in candidate_groups}
+
+        rows = _org_recommended_issues_snuba(
+            ctx=ctx,
+            project_ids=project_ids,
+            group_ids=list(group_id_to_group.keys()),
+            referrer=referrer,
+        )
+
+        if not rows:
+            return []
+
+        candidates = []
+        for row in rows:
+            group = group_id_to_group.get(row["group_id"])
+            if group is None:
+                continue
+
+            candidates.append(
+                RecommendedIssueCandidate(
+                    group=group,
+                    base_score=row["recommended"],
+                    event_count=row["count"],
+                )
+            )
+
+        return candidates

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -36,7 +36,12 @@ from sentry.tasks.summaries.metrics import (
 from sentry.tasks.summaries.organization_report_context_factory import (
     OrganizationReportContextFactory,
 )
-from sentry.tasks.summaries.utils import ONE_DAY, PAST_ISSUES_LINK_BOOST, OrganizationReportContext
+from sentry.tasks.summaries.utils import (
+    ONE_DAY,
+    PAST_ISSUES_LINK_BOOST,
+    RECOMMENDED_DISPLAY_LIMIT,
+    OrganizationReportContext,
+)
 from sentry.tasks.summaries.weekly_report_cache import cache_project_metrics
 from sentry.taskworker.namespaces import reports_tasks
 from sentry.types.group import GroupSubStatus
@@ -807,7 +812,42 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
             "total_substatus_count": total_substatus_count,
         }
 
+    def recommended_issues():
+        user_project_ids = {p.project.id for p in user_projects}
+        user_candidates = [
+            c for c in ctx.recommended_issue_candidates if c.group.project_id in user_project_ids
+        ]
+
+        if not user_candidates:
+            return []
+
+        scored = []
+        for candidate in user_candidates:
+            display = get_group_display(candidate.group)
+            substatus, substatus_color, substatus_text_color = get_group_status_badge(
+                candidate.group
+            )
+            scored.append(
+                {
+                    "count": candidate.event_count,
+                    "group": candidate.group,
+                    "title": display["title"],
+                    "message": display["message"],
+                    "status": "Unresolved",
+                    "status_color": group_status_to_color[GroupHistoryStatus.NEW],
+                    "group_substatus": substatus,
+                    "group_substatus_color": substatus_color,
+                    "group_substatus_text_color": substatus_text_color,
+                    "_score": candidate.base_score,
+                }
+            )
+
+        return heapq.nlargest(RECOMMENDED_DISPLAY_LIMIT, scored, key=lambda d: d["_score"])
+
     show_past_issues = features.has("organizations:weekly-report-past-issues", ctx.organization)
+    use_recommended_sort = features.has(
+        "organizations:weekly-report-recommended-sort", ctx.organization
+    )
 
     return {
         "organization": ctx.organization,
@@ -815,6 +855,7 @@ def render_template_context(ctx, user_id: int | None) -> dict[str, Any] | None:
         "end": date_format(local_end),
         "trends": trends(),
         "key_errors": key_errors(),
+        "recommended_issues": recommended_issues() if use_recommended_sort else [],
         "key_performance_issues": key_performance_issues(),
         "past_issues": past_issues() if show_past_issues else [],
         "show_past_issues": show_past_issues,

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -408,7 +408,7 @@
 
   {% if key_errors|length > 0 and not enhanced_privacy %}
   <div id="key-errors">
-    <h4>Issues with the most errors</h4>
+    <h4>{% if recommended_sort %}Top issues for you{% else %}Issues with the most errors{% endif %}</h4>
     {% for a in key_errors %}
     <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
       <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -408,7 +408,7 @@
 
   {% if key_errors|length > 0 and not enhanced_privacy %}
   <div id="key-errors">
-    <h4>{% if recommended_sort %}Top issues for you{% else %}Issues with the most errors{% endif %}</h4>
+    <h4>Issues with the most errors</h4>
     {% for a in key_errors %}
     <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
       <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
@@ -426,6 +426,29 @@
       <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">{{a.status}}</span>
       {% endif %}
       </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+  {% if recommended_issues|length > 0 and not enhanced_privacy %}
+  <div id="recommended-issues">
+    <h4>Top issues for you</h4>
+    {% for a in recommended_issues %}
+    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
+      <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
+      <div style="width: 65%; min-width: 0; overflow: hidden;">
+        {% url 'sentry-organization-issue-detail' issue_id=a.group.id organization_slug=organization.slug as issue_detail %}
+        {% querystring referrer="weekly_report" notification_uuid=notification_uuid as query %}
+        <a title="{{a.title}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; max-height: 21px; font-size: 17px; line-height: 1.2; margin-bottom: 2px;"
+           href="{% org_url organization issue_detail query=query %}">{{a.title}}</a>
+        <div title="{{a.message}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; max-height: 17px; line-height: 1.2; font-size: 14px; color: #80708F; margin-bottom: 2px;">{{a.message}}</div>
+        <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
+      </div>
+      {% if a.group_substatus and a.group_substatus_color %}
+      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">{{a.group_substatus}}</span>
+      {% else %}
+      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">{{a.status}}</span>
+      {% endif %}
+    </div>
     {% endfor %}
   </div>
   {% endif %}

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -16,7 +16,12 @@ from sentry.issues.grouptype import (
 from sentry.models.group import Group, GroupStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.tasks.summaries.utils import ONE_DAY, OrganizationReportContext, ProjectContext
+from sentry.tasks.summaries.utils import (
+    ONE_DAY,
+    OrganizationReportContext,
+    ProjectContext,
+    RecommendedIssueCandidate,
+)
 from sentry.tasks.summaries.weekly_reports import get_group_display, render_template_context
 from sentry.types.group import GroupSubStatus
 from sentry.utils import loremipsum
@@ -205,6 +210,34 @@ class DebugWeeklyReportView(MailPreviewView):
             ]
 
             ctx.projects_context_map[project.id] = project_context
+
+        projects_list = [ctx.projects_context_map[pid].project for pid in ctx.projects_context_map]
+        substatuses_for_rec = [
+            GroupSubStatus.NEW,
+            GroupSubStatus.ESCALATING,
+            GroupSubStatus.REGRESSED,
+            GroupSubStatus.ONGOING,
+            GroupSubStatus.ONGOING,
+        ]
+        ctx.recommended_issue_candidates = [
+            RecommendedIssueCandidate(
+                group=make_debug_group(
+                    group_id=40000 + i,
+                    project=random.choice(projects_list),
+                    title=make_debug_issue_title(
+                        random,
+                        random.choice(["TypeError", "ValueError", "RuntimeError", "KeyError"]),
+                    ),
+                    message=make_debug_issue_message(random),
+                    group_type=ErrorGroupType,
+                    event_type="error",
+                    substatus=substatuses_for_rec[i],
+                ),
+                base_score=round(random.uniform(0.3, 1.0), 3),
+                event_count=random.randint(50, 5000),
+            )
+            for i in range(5)
+        ]
 
         user_id = request.user.id
         ctx.project_ownership[user_id] = {pid for pid in ctx.projects_context_map}

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -32,6 +32,7 @@ from sentry.tasks.summaries.utils import (
     ONE_DAY,
     OrganizationReportContext,
     ProjectContext,
+    RecommendedIssueCandidate,
     _project_key_errors_eap,
     _project_key_errors_snuba,
     _project_key_performance_issues_eap,
@@ -2046,3 +2047,135 @@ class WeeklyReportsTest(
             assert context["show_past_issues"] is False
             assert len(context["past_issues"]) == 0
             assert len(context["key_errors"]) == 1
+
+    def test_recommended_sort_populates_candidates(self) -> None:
+        """When the feature flag is off, recommended_issue_candidates stays empty."""
+        user = self.create_user()
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+
+        self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ONGOING,
+            data={"type": "error", "metadata": {"type": "TypeError", "value": "oops"}},
+        )
+
+        ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
+        assert ctx.recommended_issue_candidates == []
+
+    @with_feature("organizations:weekly-report-recommended-sort")
+    def test_recommended_sort_render_template_uses_candidates(self) -> None:
+        """When recommended candidates exist and flag is on, render_template_context
+        returns them as key_errors with recommended_sort=True."""
+        user = self.create_user()
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+
+        group1 = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ONGOING,
+            data={"type": "error", "metadata": {"type": "TypeError", "value": "error 1"}},
+        )
+        group2 = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ESCALATING,
+            data={"type": "error", "metadata": {"type": "ValueError", "value": "error 2"}},
+        )
+
+        ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
+        project_context = ProjectContext(self.project)
+        project_context.accepted_error_count = 100
+        ctx.projects_context_map = {self.project.id: project_context}
+        ctx.project_ownership[user.id] = {self.project.id}
+
+        ctx.recommended_issue_candidates = [
+            RecommendedIssueCandidate(
+                group=group1,
+                base_score=0.5,
+                event_count=50,
+            ),
+            RecommendedIssueCandidate(
+                group=group2,
+                base_score=0.8,
+                event_count=30,
+            ),
+        ]
+
+        rendered = render_template_context(ctx, user.id)
+        assert rendered is not None
+        assert rendered["recommended_sort"] is True
+        assert len(rendered["key_errors"]) == 2
+        # group2 has higher base_score so it comes first
+        assert rendered["key_errors"][0]["group"] == group2
+        assert rendered["key_errors"][1]["group"] == group1
+
+    def test_recommended_sort_flag_off_uses_key_errors(self) -> None:
+        """When flag is off, render_template_context uses traditional key_errors."""
+        user = self.create_user()
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+
+        group = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ONGOING,
+            data={"type": "error", "metadata": {"type": "TypeError", "value": "error"}},
+        )
+
+        ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
+        project_context = ProjectContext(self.project)
+        project_context.key_errors_by_group = [(group, 10)]
+        project_context.accepted_error_count = 100
+        ctx.projects_context_map = {self.project.id: project_context}
+        ctx.project_ownership[user.id] = {self.project.id}
+
+        rendered = render_template_context(ctx, user.id)
+        assert rendered is not None
+        assert rendered["recommended_sort"] is False
+        assert len(rendered["key_errors"]) == 1
+        assert rendered["key_errors"][0]["count"] == 10
+
+    @with_feature("organizations:weekly-report-recommended-sort")
+    def test_recommended_sort_regressed_boosts_score(self) -> None:
+        """A regressed issue should rank higher than an otherwise-identical non-regressed one."""
+        user = self.create_user()
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+
+        group_normal = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ONGOING,
+            data={"type": "error", "metadata": {"type": "TypeError", "value": "normal"}},
+        )
+        group_regressed = self.create_group(
+            project=self.project,
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.REGRESSED,
+            data={"type": "error", "metadata": {"type": "TypeError", "value": "regressed"}},
+        )
+
+        ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
+        project_context = ProjectContext(self.project)
+        project_context.accepted_error_count = 100
+        ctx.projects_context_map = {self.project.id: project_context}
+        ctx.project_ownership[user.id] = {self.project.id}
+
+        # Same base scores, but one group has REGRESSED substatus
+        ctx.recommended_issue_candidates = [
+            RecommendedIssueCandidate(
+                group=group_normal,
+                base_score=0.5,
+                event_count=50,
+            ),
+            RecommendedIssueCandidate(
+                group=group_regressed,
+                base_score=0.5,
+                event_count=50,
+            ),
+        ]
+
+        rendered = render_template_context(ctx, user.id)
+        assert rendered is not None
+        # Regressed issue should come first due to regressed_weight boost
+        assert rendered["key_errors"][0]["group"] == group_regressed
+        assert rendered["key_errors"][1]["group"] == group_normal

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -2136,22 +2136,22 @@ class WeeklyReportsTest(
         assert rendered["key_errors"][0]["count"] == 10
 
     @with_feature("organizations:weekly-report-recommended-sort")
-    def test_recommended_sort_regressed_boosts_score(self) -> None:
-        """A regressed issue should rank higher than an otherwise-identical non-regressed one."""
+    def test_recommended_sort_orders_by_base_score(self) -> None:
+        """Issues are ordered by base_score from ClickHouse (v1 scoring, no Postgres boosts)."""
         user = self.create_user()
         self.create_member(teams=[self.team], user=user, organization=self.organization)
 
-        group_normal = self.create_group(
+        group_low = self.create_group(
             project=self.project,
             status=GroupStatus.UNRESOLVED,
             substatus=GroupSubStatus.ONGOING,
-            data={"type": "error", "metadata": {"type": "TypeError", "value": "normal"}},
+            data={"type": "error", "metadata": {"type": "TypeError", "value": "low score"}},
         )
-        group_regressed = self.create_group(
+        group_high = self.create_group(
             project=self.project,
             status=GroupStatus.UNRESOLVED,
-            substatus=GroupSubStatus.REGRESSED,
-            data={"type": "error", "metadata": {"type": "TypeError", "value": "regressed"}},
+            substatus=GroupSubStatus.ONGOING,
+            data={"type": "error", "metadata": {"type": "ValueError", "value": "high score"}},
         )
 
         ctx = OrganizationReportContext(self.now.timestamp(), ONE_DAY * 7, self.organization)
@@ -2160,22 +2160,20 @@ class WeeklyReportsTest(
         ctx.projects_context_map = {self.project.id: project_context}
         ctx.project_ownership[user.id] = {self.project.id}
 
-        # Same base scores, but one group has REGRESSED substatus
         ctx.recommended_issue_candidates = [
             RecommendedIssueCandidate(
-                group=group_normal,
-                base_score=0.5,
-                event_count=50,
+                group=group_low,
+                base_score=0.3,
+                event_count=20,
             ),
             RecommendedIssueCandidate(
-                group=group_regressed,
-                base_score=0.5,
-                event_count=50,
+                group=group_high,
+                base_score=0.9,
+                event_count=80,
             ),
         ]
 
         rendered = render_template_context(ctx, user.id)
         assert rendered is not None
-        # Regressed issue should come first due to regressed_weight boost
-        assert rendered["key_errors"][0]["group"] == group_regressed
-        assert rendered["key_errors"][1]["group"] == group_normal
+        assert rendered["key_errors"][0]["group"] == group_high
+        assert rendered["key_errors"][1]["group"] == group_low

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -2104,11 +2104,10 @@ class WeeklyReportsTest(
 
         rendered = render_template_context(ctx, user.id)
         assert rendered is not None
-        assert rendered["recommended_sort"] is True
-        assert len(rendered["key_errors"]) == 2
+        assert len(rendered["recommended_issues"]) == 2
         # group2 has higher base_score so it comes first
-        assert rendered["key_errors"][0]["group"] == group2
-        assert rendered["key_errors"][1]["group"] == group1
+        assert rendered["recommended_issues"][0]["group"] == group2
+        assert rendered["recommended_issues"][1]["group"] == group1
 
     def test_recommended_sort_flag_off_uses_key_errors(self) -> None:
         """When flag is off, render_template_context uses traditional key_errors."""
@@ -2131,7 +2130,7 @@ class WeeklyReportsTest(
 
         rendered = render_template_context(ctx, user.id)
         assert rendered is not None
-        assert rendered["recommended_sort"] is False
+        assert rendered["recommended_issues"] == []
         assert len(rendered["key_errors"]) == 1
         assert rendered["key_errors"][0]["count"] == 10
 
@@ -2175,5 +2174,5 @@ class WeeklyReportsTest(
 
         rendered = render_template_context(ctx, user.id)
         assert rendered is not None
-        assert rendered["key_errors"][0]["group"] == group_high
-        assert rendered["key_errors"][1]["group"] == group_low
+        assert rendered["recommended_issues"][0]["group"] == group_high
+        assert rendered["recommended_issues"][1]["group"] == group_low


### PR DESCRIPTION
Resolves  -----

**Summary**
- Replace the "top 3 issues by event count" approach with the recommended sort v1 algorithm (pure ClickHouse scoring) to find the top 5 issues for the weekly email report
- Use custom weights tuned for a weekly digest: heavier on event volume (0.40) and severity (0.30), lighter on recency (0.10), with spike zeroed out (not meaningful for a 7-day window — it measures a 6h/3d ratio at query time)
- Weights are registered as `weekly-report.recommended.*` options so they can be tuned via automator independently of the issue stream weights
- Add `weight_overrides` parameter to `_recommended_aggregation()` so the weekly report can pass its own weights without duplicating the ClickHouse expression logic
- Gated behind `organizations:weekly-report-recommended-sort` feature flag

**Changes**

- `src/sentry/options/defaults.py` — register 4 weekly report weight options
- `src/sentry/search/snuba/executors.py` — add `weight_overrides` param to `_recommended_aggregation()`
- `src/sentry/tasks/summaries/utils.py` — build candidates using `_recommended_aggregation` with weekly report weights
- `src/sentry/tasks/summaries/organization_report_context_factory.py` — populate candidates behind feature flag
- `src/sentry/tasks/summaries/weekly_reports.py` — simplify render path: use ClickHouse base_score directly, drop v2 reranking
- `src/sentry/templates/sentry/emails/reports/body.html` — conditional header: "Top issues for you" vs "Issues with the most errors"
- `src/sentry/features/temporary.py` — register feature flag
- `src/sentry/snuba/referrer.py` — add `REPORTS_RECOMMENDED_ISSUES` referrer
- `tests/sentry/tasks/test_weekly_reports.py` — 4 tests covering flag on/off, candidate ordering, template rendering

## Test plan

- [x] `pytest -k recommended_sort tests/sentry/tasks/test_weekly_reports.py` — 4 pass
- [ ] Enable flag for a test org, trigger weekly report, verify top 5 issues appear with "Top issues for you" header
- [ ] Verify flag-off path still shows "Issues with the most errors" with event-count ordering