### PR TITLE
ref(seer-agent): dont count empty result as failed status, remove broken link icon

### DIFF
--- a/static/app/views/seerExplorer/components/chat/shared.tsx
+++ b/static/app/views/seerExplorer/components/chat/shared.tsx
@@ -58,9 +58,7 @@ export function getBlockStatus(block: Block): BlockStatus {
     return 'success';
   }
 
-  const failures = toolLinks.filter(
-    l => l.params?.is_error === true || l.params?.empty_results === true
-  ).length;
+  const failures = toolLinks.filter(l => l.params?.is_error === true).length;
 
   if (failures === 0) {
     return 'success';

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -8,13 +8,7 @@ import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {
-  IconCheckmark,
-  IconClose,
-  IconLink,
-  IconLinkBroken,
-  IconWarning,
-} from 'sentry/icons';
+import {IconCheckmark, IconClose, IconLink, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {unreachable} from 'sentry/utils/unreachable';
@@ -189,7 +183,6 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
 function ToolCallRow({
   toolString,
   blockStatus,
-  isLoading,
   toolUrl,
   failureTooltip,
   onLinkClick,
@@ -235,12 +228,7 @@ function ToolCallRow({
             </ToolCallLinkIconWrapper>
           </ToolCallLink>
         ) : (
-          <ToolCallPlainRow>
-            {toolCallText}
-            <ToolCallBrokenLinkIconWrapper isLoading={isLoading}>
-              <ToolCallBrokenLinkIcon size="xs" />
-            </ToolCallBrokenLinkIconWrapper>
-          </ToolCallPlainRow>
+          <ToolCallPlainRow>{toolCallText}</ToolCallPlainRow>
         )}
       </Flex>
       {todos && <TodoList todos={todos} />}
@@ -360,20 +348,4 @@ const ToolCallPlainRow = styled('span')`
   align-items: center;
   gap: ${p => p.theme.space.md};
   max-width: 100%;
-`;
-
-const ToolCallBrokenLinkIcon = styled(IconLinkBroken)`
-  color: ${p => p.theme.tokens.content.secondary};
-  flex-shrink: 0;
-  transform: translateY(2px);
-`;
-
-const ToolCallBrokenLinkIconWrapper = styled('span')<{isLoading?: boolean}>`
-  display: inline-flex;
-  flex-shrink: 0;
-  visibility: hidden;
-
-  ${ToolCallPlainRow}:hover & {
-    visibility: ${p => (p.isLoading ? 'hidden' : 'visible')};
-  }
 `;


### PR DESCRIPTION
interpreting empty result as a failure makes it look like our search tool is constantly breaking

**Before** (https://sentry.sentry.io/issues/?project=-1&statsPeriod=90d&explorerRunId=a129de61-005d-4d0f-991e-474d663c2841)
<img width="1044" height="364" alt="Screenshot 2026-06-26 at 4 46 50 PM" src="https://github.com/user-attachments/assets/8459a803-01a2-440c-82ee-b95995cfa489" />

**After**
<img width="1038" height="370" alt="Screenshot 2026-06-26 at 4 46 25 PM" src="https://github.com/user-attachments/assets/563395d4-0f15-4c0a-a8c0-3d60544e0a4d" />

**Kept**
<img width="650" height="72" alt="Screenshot 2026-06-26 at 4 46 59 PM" src="https://github.com/user-attachments/assets/41e9c20a-df75-43f1-9594-d250217e18e6" />


**Removed on hover icon** (used to show when there's no link, but this also looks like something broke)
<img width="262" height="41" alt="Screenshot 2026-06-26 at 4 47 08 PM" src="https://github.com/user-attachments/assets/c75543a5-e2db-4536-9b6d-2d25fa58d245" />
