### PR TITLE
fix(auth): Keep login redirect in browser history

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -131,7 +131,7 @@ export const initApiClientErrorHandling = () =>
     }
 
     if (EXPERIMENTAL_SPA) {
-      apiNavigate?.('/auth/login/', {replace: true});
+      apiNavigate?.('/auth/login/');
     } else {
       window.location.reload();
     }


### PR DESCRIPTION
in SPA mode (mostly local dev) do not replace history with /auth/login/ and allow users to get back to where they were