### PR TITLE
feat(issues): Restrict merge/unmerge for large groups

### DIFF
--- a/src/sentry/issues/endpoints/group_hashes.py
+++ b/src/sentry/issues/endpoints/group_hashes.py
@@ -8,6 +8,7 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -124,6 +125,13 @@ class GroupHashesEndpoint(GroupEndpoint):
         grouphash_ids = request.GET.getlist("id")
         if not grouphash_ids:
             return Response()
+
+        max_times_seen = options.get("issues.merge-unmerge.max-group-times-seen")
+        if max_times_seen and group.times_seen > max_times_seen:
+            return Response(
+                {"detail": "Large merges and unmerges are temporarily restricted at this time."},
+                status=400,
+            )
 
         grouphashes = list(
             GroupHash.objects.filter(

--- a/src/sentry/issues/merge.py
+++ b/src/sentry/issues/merge.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 import rest_framework
 
-from sentry import eventstream
+from sentry import eventstream, options
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
@@ -34,6 +34,12 @@ def handle_merge(
     """
     if any(group.issue_category != GroupCategory.ERROR for group in group_list):
         raise rest_framework.exceptions.ValidationError(detail="Only error issues can be merged.")
+
+    max_times_seen = options.get("issues.merge-unmerge.max-group-times-seen")
+    if max_times_seen and any(group.times_seen > max_times_seen for group in group_list):
+        raise rest_framework.exceptions.ValidationError(
+            detail="Large merges and unmerges are temporarily restricted at this time."
+        )
 
     # Sort by:
     # 1) Earliest first-seen time.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -326,6 +326,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "issues.merge-unmerge.max-group-times-seen",
+    default=10000,
+    type=Int,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 register(
     "cleanup.abort_execution",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -335,7 +335,7 @@ register(
 
 register(
     "issues.merge-unmerge.max-group-times-seen",
-    default=10000,
+    default=0,
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/tests/sentry/issues/endpoints/test_group_hashes.py
+++ b/tests/sentry/issues/endpoints/test_group_hashes.py
@@ -278,7 +278,8 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
             ]
         )
 
-        response = self.client.put(url, format="json")
+        with self.options({"issues.merge-unmerge.max-group-times-seen": 10000}):
+            response = self.client.put(url, format="json")
 
         assert response.status_code == 400
         assert "temporarily restricted" in response.data["detail"]
@@ -300,6 +301,7 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
             ]
         )
 
-        response = self.client.put(url, format="json")
+        with self.options({"issues.merge-unmerge.max-group-times-seen": 10000}):
+            response = self.client.put(url, format="json")
 
         assert response.status_code == 202

--- a/tests/sentry/issues/endpoints/test_group_hashes.py
+++ b/tests/sentry/issues/endpoints/test_group_hashes.py
@@ -260,3 +260,46 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 409
         assert response.data["detail"] == "Already being unmerged"
+
+    def test_unmerge_rejects_large_group(self) -> None:
+        self.login_as(user=self.user)
+
+        group = self.create_group(platform="javascript", times_seen=10001)
+
+        hashes = [
+            GroupHash.objects.create(project=group.project, group=group, hash=hash)
+            for hash in ["a" * 32, "b" * 32]
+        ]
+
+        url = "?".join(
+            [
+                f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/hashes/",
+                urlencode({"id": [h.hash for h in hashes]}, True),
+            ]
+        )
+
+        response = self.client.put(url, format="json")
+
+        assert response.status_code == 400
+        assert "temporarily restricted" in response.data["detail"]
+
+    def test_unmerge_allows_group_at_threshold(self) -> None:
+        self.login_as(user=self.user)
+
+        group = self.create_group(platform="javascript", times_seen=10000)
+
+        hashes = [
+            GroupHash.objects.create(project=group.project, group=group, hash=hash)
+            for hash in ["a" * 32, "b" * 32]
+        ]
+
+        url = "?".join(
+            [
+                f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/hashes/",
+                urlencode({"id": [h.hash for h in hashes]}, True),
+            ]
+        )
+
+        response = self.client.put(url, format="json")
+
+        assert response.status_code == 202

--- a/tests/sentry/issues/test_merge.py
+++ b/tests/sentry/issues/test_merge.py
@@ -55,8 +55,9 @@ class HandleIssueMergeTest(TestCase):
         self.groups[0].update(times_seen=10001)
         self.groups[0].refresh_from_db()
 
-        with pytest.raises(rest_framework.exceptions.ValidationError) as exc_info:
-            handle_merge(self.groups, self.project_lookup, self.user)
+        with self.options({"issues.merge-unmerge.max-group-times-seen": 10000}):
+            with pytest.raises(rest_framework.exceptions.ValidationError) as exc_info:
+                handle_merge(self.groups, self.project_lookup, self.user)
 
         assert "temporarily restricted" in str(exc_info.value.detail)
         assert not merge_groups.called
@@ -67,7 +68,8 @@ class HandleIssueMergeTest(TestCase):
             group.update(times_seen=10000)
             group.refresh_from_db()
 
-        handle_merge(self.groups, self.project_lookup, self.user)
+        with self.options({"issues.merge-unmerge.max-group-times-seen": 10000}):
+            handle_merge(self.groups, self.project_lookup, self.user)
         assert merge_groups.called
 
     @patch("sentry.tasks.merge.merge_groups.delay")

--- a/tests/sentry/issues/test_merge.py
+++ b/tests/sentry/issues/test_merge.py
@@ -50,6 +50,47 @@ class HandleIssueMergeTest(TestCase):
         assert primary_group.status == GroupStatus.UNRESOLVED
         assert primary_group.substatus == GroupSubStatus.ONGOING
 
+    @patch("sentry.tasks.merge.merge_groups.delay")
+    def test_handle_merge_rejects_large_groups(self, merge_groups: MagicMock) -> None:
+        self.groups[0].update(times_seen=10001)
+        self.groups[0].refresh_from_db()
+
+        with pytest.raises(rest_framework.exceptions.ValidationError) as exc_info:
+            handle_merge(self.groups, self.project_lookup, self.user)
+
+        assert "temporarily restricted" in str(exc_info.value.detail)
+        assert not merge_groups.called
+
+    @patch("sentry.tasks.merge.merge_groups.delay")
+    def test_handle_merge_allows_groups_at_threshold(self, merge_groups: MagicMock) -> None:
+        for group in self.groups:
+            group.update(times_seen=10000)
+            group.refresh_from_db()
+
+        handle_merge(self.groups, self.project_lookup, self.user)
+        assert merge_groups.called
+
+    @patch("sentry.tasks.merge.merge_groups.delay")
+    def test_handle_merge_respects_custom_threshold(self, merge_groups: MagicMock) -> None:
+        self.groups[0].update(times_seen=500)
+        self.groups[0].refresh_from_db()
+
+        with self.options({"issues.merge-unmerge.max-group-times-seen": 100}):
+            with pytest.raises(rest_framework.exceptions.ValidationError):
+                handle_merge(self.groups, self.project_lookup, self.user)
+
+        assert not merge_groups.called
+
+    @patch("sentry.tasks.merge.merge_groups.delay")
+    def test_handle_merge_disabled_with_zero_threshold(self, merge_groups: MagicMock) -> None:
+        self.groups[0].update(times_seen=999999)
+        self.groups[0].refresh_from_db()
+
+        with self.options({"issues.merge-unmerge.max-group-times-seen": 0}):
+            handle_merge(self.groups, self.project_lookup, self.user)
+
+        assert merge_groups.called
+
     def test_handle_merge_performance_issues(self) -> None:
         group = Group.objects.create(
             project=self.project, type=PerformanceNPlusOneGroupType.type_id


### PR DESCRIPTION
- Adds a configurable `times_seen` threshold (`issues.merge-unmerge.max-group-times-seen`, default 10,000) that rejects merge and unmerge requests at the API layer when any involved group exceeds it
- Guard applied in `handle_merge()` for merges and `GroupHashesEndpoint.put()` for unmerges
- Returns `{"detail": "Large merges and unmerges are temporarily restricted at this time."}` with HTTP 400
- Setting the option to `0` disables the check