### PR TITLE
fix(seer): Resolve UUID run_id in OrganizationSeerAgentUpdateEndpoint

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_agent_update.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_update.py
@@ -84,7 +84,7 @@ class OrganizationSeerAgentUpdateEndpoint(OrganizationEndpoint):
                     data={"detail": "Code generation is disabled for this organization"},
                 )
 
-        resolved = resolve_seer_run(run_id, organization)
+        resolved = resolve_seer_run(run_id, organization, for_continue=True)
         if isinstance(resolved, Response):
             return resolved
 

--- a/src/sentry/seer/endpoints/organization_seer_agent_update.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_update.py
@@ -21,6 +21,7 @@ from sentry.seer.agent.client_utils import (
     has_seer_agent_access_with_detail,
 )
 from sentry.seer.autofix.constants import CODING_PAYLOAD_TYPES
+from sentry.seer.endpoints.utils import resolve_seer_run
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 
@@ -61,7 +62,7 @@ class OrganizationSeerAgentUpdateEndpoint(OrganizationEndpoint):
     owner = ApiOwner.ML_AI
     permission_classes = (OrganizationSeerAgentUpdatePermission,)
 
-    def post(self, request: Request, organization: Organization, run_id: int) -> Response:
+    def post(self, request: Request, organization: Organization, run_id: str) -> Response:
         """
         Send an update event to the agent for a given run.
         """
@@ -83,12 +84,16 @@ class OrganizationSeerAgentUpdateEndpoint(OrganizationEndpoint):
                     data={"detail": "Code generation is disabled for this organization"},
                 )
 
+        resolved = resolve_seer_run(run_id, organization)
+        if isinstance(resolved, Response):
+            return resolved
+
         path = "/v1/automation/explorer/update"
 
         body = orjson.dumps(
             {
                 **request.data,
-                "run_id": run_id,
+                "run_id": resolved.seer_run_state_id,
                 "organization_id": organization.id,
             }
         )

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_update.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_update.py
@@ -91,6 +91,54 @@ class TestOrganizationSeerAgentUpdate(APITestCase):
 
     @patch("sentry.seer.endpoints.organization_seer_agent_update.has_seer_agent_access_with_detail")
     @patch("sentry.seer.endpoints.organization_seer_agent_update.make_signed_seer_api_request")
+    def test_explorer_update_uuid_run_still_mirroring_returns_409(
+        self, mock_request: MagicMock, mock_has_access: MagicMock
+    ) -> None:
+        """A UUID run whose seer_run_state_id is not yet populated should return 409."""
+        mock_has_access.return_value = (True, None)
+
+        run_uuid = uuid.uuid4()
+        SeerRun.objects.create(
+            organization=self.organization,
+            uuid=run_uuid,
+            seer_run_state_id=None,  # not yet mirrored
+            type=SeerRunType.EXPLORER,
+            mirror_status=SeerRunMirrorStatus.PENDING,
+            last_triggered_at=datetime.now(tz=timezone.utc),
+        )
+
+        url = f"/api/0/organizations/{self.organization.slug}/seer/explorer-update/{run_uuid}/"
+        response = self.client.post(url, data={"payload": {"type": "interrupt"}}, format="json")
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        mock_request.assert_not_called()
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_update.has_seer_agent_access_with_detail")
+    @patch("sentry.seer.endpoints.organization_seer_agent_update.make_signed_seer_api_request")
+    def test_explorer_update_uuid_run_mirror_failed_returns_422(
+        self, mock_request: MagicMock, mock_has_access: MagicMock
+    ) -> None:
+        """A UUID run whose mirror failed should return 422."""
+        mock_has_access.return_value = (True, None)
+
+        run_uuid = uuid.uuid4()
+        SeerRun.objects.create(
+            organization=self.organization,
+            uuid=run_uuid,
+            seer_run_state_id=None,
+            type=SeerRunType.EXPLORER,
+            mirror_status=SeerRunMirrorStatus.FAILED,
+            last_triggered_at=datetime.now(tz=timezone.utc),
+        )
+
+        url = f"/api/0/organizations/{self.organization.slug}/seer/explorer-update/{run_uuid}/"
+        response = self.client.post(url, data={"payload": {"type": "interrupt"}}, format="json")
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        mock_request.assert_not_called()
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_update.has_seer_agent_access_with_detail")
+    @patch("sentry.seer.endpoints.organization_seer_agent_update.make_signed_seer_api_request")
     def test_explorer_update_missing_payload(
         self, mock_request: MagicMock, mock_has_access: MagicMock
     ) -> None:

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_update.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_update.py
@@ -1,8 +1,11 @@
+import uuid
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import orjson
 from rest_framework import status
 
+from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus, SeerRunType
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 
@@ -48,9 +51,43 @@ class TestOrganizationSeerAgentUpdate(APITestCase):
 
         # Verify the payload
         sent_data = orjson.loads(call_args[0][2])
-        assert sent_data["run_id"] == "123"
+        assert sent_data["run_id"] == 123
         assert sent_data["organization_id"] == self.organization.id
         assert sent_data["payload"]["type"] == "interrupt"
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_update.has_seer_agent_access_with_detail")
+    @patch("sentry.seer.endpoints.organization_seer_agent_update.make_signed_seer_api_request")
+    def test_explorer_update_with_uuid_run_id(
+        self, mock_request: MagicMock, mock_has_access: MagicMock
+    ) -> None:
+        """UUID run_id should be resolved to the numeric seer_run_state_id before forwarding to Seer."""
+        mock_has_access.return_value = (True, None)
+        mock_request.return_value.status = 200
+        mock_request.return_value.json.return_value = {"run_id": 456}
+
+        run_uuid = uuid.uuid4()
+        SeerRun.objects.create(
+            organization=self.organization,
+            uuid=run_uuid,
+            seer_run_state_id=456,
+            type=SeerRunType.EXPLORER,
+            mirror_status=SeerRunMirrorStatus.LIVE,
+            last_triggered_at=datetime.now(tz=timezone.utc),
+        )
+
+        url = f"/api/0/organizations/{self.organization.slug}/seer/explorer-update/{run_uuid}/"
+        response = self.client.post(
+            url,
+            data={"payload": {"type": "interrupt"}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        mock_request.assert_called_once()
+        sent_data = orjson.loads(mock_request.call_args[0][2])
+        # UUID must be translated to the numeric seer_run_state_id before Seer sees it
+        assert sent_data["run_id"] == 456
+        assert sent_data["organization_id"] == self.organization.id
 
     @patch("sentry.seer.endpoints.organization_seer_agent_update.has_seer_agent_access_with_detail")
     @patch("sentry.seer.endpoints.organization_seer_agent_update.make_signed_seer_api_request")


### PR DESCRIPTION
## What

After #117265 and #117780, the Seer Explorer frontend started sending `sentry_run_id` (a UUID) instead of the numeric `seer_run_state_id` for run identification. The chat endpoint's GET (poll) and POST (continue) paths were updated to resolve either form via `resolve_seer_run()`. The update endpoint (`/seer/explorer-update/{run_id}/`) was missed, so Seer's Pydantic model rejects UUID run IDs with:

```
{"detail":[{"type":"int_parsing","loc":["body","run_id"],"msg":"Input should be a valid integer, unable to parse string as an integer","input":"cac2b2c1-4fd7-4003-acc2-e0f1ca0a5640"}]}
```

## Fix

Apply `resolve_seer_run()` to `OrganizationSeerAgentUpdateEndpoint.post()`, translating UUIDs (or numeric IDs) to `seer_run_state_id` before forwarding to Seer's `/v1/automation/explorer/update`. Mirrors the fix already applied to the chat endpoint.

- `run_id` type hint widened to `str` (the URL pattern already captured it as `[^/]+`)
- `resolved.seer_run_state_id` (int) used in the Seer request body
- Added `test_explorer_update_with_uuid_run_id` covering the UUID path end-to-end
- Updated existing `run_id` assertion from `"123"` → `123` (now correctly an int after resolution)

Reported by Sofia Rest. Refs #117265, #117780.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0B0PFS5069%3A1782524325.765739%22)