### PR TITLE
fix(reprocessing): Check for stale reprocessing 

### DIFF
--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -595,8 +595,10 @@ def start_group_reprocessing(
             raise RuntimeError("Cannot reprocess group that is currently being reprocessed")
 
         # TODO: Replace this with a special group.status rather than using data.
-        # Check the marker to avoid reprocessing B if there is a reprocessing A -> B going on at the moment
-        if "_reprocessing_old_group_id" in (group.data or {}):
+        # Check the marker to avoid reprocessing B if there is a reprocessing A -> B going on at the moment.
+        # Since the marker can be stale check if the reprocessing is actually still active.
+        old_group_id = (group.data or {}).get("_reprocessing_old_group_id")
+        if old_group_id is not None and is_reprocessing_active(old_group_id):
             raise RuntimeError("Cannot reprocess group that is being reprocessed to")
 
         original_short_id = group.short_id
@@ -725,19 +727,37 @@ def get_progress(group_id: int, project_id: int | None = None) -> tuple[int, Any
         logger.error("reprocessing2.missing_info")
         return 0, None
 
-    # We expect reprocessing to make progress every now and then, by bumping the
-    # TTL of the "counter" key. If that TTL wasn't bumped in a while, we just
-    # assume that reprocessing is stuck, and will just call finish on it.
-    if project_id is not None and ttl is not None and ttl > 0:
-        default_ttl = settings.SENTRY_REPROCESSING_SYNC_TTL
-        age = default_ttl - ttl
-        if age > REPROCESSING_TIMEOUT:
-            from sentry.tasks.reprocessing2 import finish_reprocessing
+    if (
+        project_id is not None
+        and ttl is not None
+        and ttl > 0
+        and not _reprocessing_recently_active(ttl)
+    ):
+        # Reprocessing is likely stuck, so call finish on it.
+        from sentry.tasks.reprocessing2 import finish_reprocessing
 
-            finish_reprocessing.delay(project_id=project_id, group_id=group_id)
+        finish_reprocessing.delay(project_id=project_id, group_id=group_id)
 
     # Our internal sync counters are counting over *all* events, but the
     # progressbar in the frontend goes until max_events. Advance progressbar
     # proportionally.
     _pending = int(int(pending) * info["totalEvents"] / float(info.get("syncCount") or 1))
     return _pending, info
+
+
+def _reprocessing_recently_active(ttl: int | None) -> bool:
+    """
+    We expect reprocessing to make progress every now and then, by bumping the
+    TTL of the "counter" key. If that TTL wasn't bumped in a while, we just
+    assume that reprocessing is stuck.
+    """
+    if ttl is None or ttl <= 0:
+        return False
+    default_ttl = settings.SENTRY_REPROCESSING_SYNC_TTL
+    age = default_ttl - ttl
+    return age <= REPROCESSING_TIMEOUT
+
+
+def is_reprocessing_active(group_id: int) -> bool:
+    pending, ttl = reprocessing_store.get_pending(group_id)
+    return pending is not None and _reprocessing_recently_active(ttl)

--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -246,7 +246,9 @@ def finish_reprocessing(project_id: int, group_id: int) -> None:
         # to transfer manually.
         # Any activities created during reprocessing (e.g. user clicks "assign" in an old browser tab)
         # are ignored.
-        activities = Activity.objects.filter(group_id=group_id, type=ActivityType.REPROCESS.value)
+        activities = Activity.objects.filter(
+            group_id=group_id, type=ActivityType.REPROCESS.value
+        ).order_by("-datetime")
         activity = activities[0]
         new_group_id = activity.group_id = activity.data["newGroupId"]
         activity.save()

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -19,11 +19,15 @@ from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupredirect import GroupRedirect
 from sentry.models.userreport import UserReport
-from sentry.reprocessing2 import is_group_finished, reprocessing_store, start_group_reprocessing
+from sentry.reprocessing2 import is_group_finished, start_group_reprocessing
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event
 from sentry.services.eventstore.processing import event_processing_store
-from sentry.services.eventstore.reprocessing.redis import _get_sync_counter_key
+from sentry.services.eventstore.reprocessing import reprocessing_store
+from sentry.services.eventstore.reprocessing.redis import (
+    RedisReprocessingStore,
+    _get_sync_counter_key,
+)
 from sentry.tasks.reprocessing2 import finish_reprocessing, reprocess_group
 from sentry.tasks.store import preprocess_event
 from sentry.testutils.helpers.datetime import before_now
@@ -713,7 +717,9 @@ def test_reprocessing_allowed_when_previous_run_is_stale(default_project) -> Non
     new_group_id = start_group_reprocessing(default_project.id, old_group.id, "delete")
     assert "_reprocessing_old_group_id" in Group.objects.get(id=new_group_id).data
 
-    reprocessing_store.redis.expire(_get_sync_counter_key(old_group.id), 100)
+    reprocessing_store.test_only__downcast_to(RedisReprocessingStore).redis.expire(
+        _get_sync_counter_key(old_group.id), 100
+    )
 
     # This works since the reprocessing is stale
     start_group_reprocessing(default_project.id, new_group_id, "delete")
@@ -725,7 +731,7 @@ def test_reprocessing_blocked_when_previous_run_is_recent(default_project) -> No
     new_group_id = start_group_reprocessing(default_project.id, old_group.id, "delete")
     assert "_reprocessing_old_group_id" in Group.objects.get(id=new_group_id).data
 
-    reprocessing_store.redis.expire(
+    reprocessing_store.test_only__downcast_to(RedisReprocessingStore).redis.expire(
         _get_sync_counter_key(old_group.id), settings.SENTRY_REPROCESSING_SYNC_TTL
     )
 

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -686,7 +686,8 @@ def test_finish_reprocessing(default_project) -> None:
         )
     )
     assert len(redirects) == 1
-    assert redirects[0].group_id == new_group.id
+    # Should be most recently created activity.
+    assert redirects[0].group_id == new_group2.id
 
 
 @django_db_all

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest import mock
 
 import pytest
+from django.conf import settings
 
 from sentry.attachments import get_attachments_for_event
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG
@@ -18,10 +19,11 @@ from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupredirect import GroupRedirect
 from sentry.models.userreport import UserReport
-from sentry.reprocessing2 import is_group_finished, start_group_reprocessing
+from sentry.reprocessing2 import is_group_finished, reprocessing_store, start_group_reprocessing
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event
 from sentry.services.eventstore.processing import event_processing_store
+from sentry.services.eventstore.reprocessing.redis import _get_sync_counter_key
 from sentry.tasks.reprocessing2 import finish_reprocessing, reprocess_group
 from sentry.tasks.store import preprocess_event
 from sentry.testutils.helpers.datetime import before_now
@@ -702,3 +704,31 @@ def test_reprocessing_an_ongoing_reprocessing(default_project) -> None:
     assert Group.objects.get(id=new_group_id).data == {}
     # This should work now, i.e. not raise an exception like above
     start_group_reprocessing(default_project.id, new_group_id, "delete")
+
+
+@django_db_all
+def test_reprocessing_allowed_when_previous_run_is_stale(default_project) -> None:
+    old_group = Group.objects.create(project=default_project, data={})
+    new_group_id = start_group_reprocessing(default_project.id, old_group.id, "delete")
+    assert "_reprocessing_old_group_id" in Group.objects.get(id=new_group_id).data
+
+    reprocessing_store.redis.expire(_get_sync_counter_key(old_group.id), 100)
+
+    # This works since the reprocessing is stale
+    start_group_reprocessing(default_project.id, new_group_id, "delete")
+
+
+@django_db_all
+def test_reprocessing_blocked_when_previous_run_is_recent(default_project) -> None:
+    old_group = Group.objects.create(project=default_project, data={})
+    new_group_id = start_group_reprocessing(default_project.id, old_group.id, "delete")
+    assert "_reprocessing_old_group_id" in Group.objects.get(id=new_group_id).data
+
+    reprocessing_store.redis.expire(
+        _get_sync_counter_key(old_group.id), settings.SENTRY_REPROCESSING_SYNC_TTL
+    )
+
+    # This does not work since the reprocessing is 'active'.
+    with pytest.raises(RuntimeError) as e:
+        start_group_reprocessing(default_project.id, new_group_id, "delete")
+    assert "Cannot reprocess group that is being reprocessed to" in str(e)


### PR DESCRIPTION
Previously we had issues with a Group B having reprocessing triggered on it while there was an ongoing reprocessing A -> B.  To fix this we introduced a marker `_reprocessing_old_group_id` that guards against this.

Now however customers have gotten in a bad state where Group B  still has the marker even though there is no ongoing reprocessing A -> B. To avoid customers being stuck in this bad state (and effectively not being able to reprocess) we introduce a secondary check that ensures that reprocessing has been 'recently active' (this logic is taken from the existing logic that finishes reprocessing when it is stuck).