### PR TITLE
fix(pr-metrics): Stub PullRequest on check-event race

### DIFF
--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -782,21 +782,33 @@ def _prs_from_check_payload(
             metrics.incr("pr_metrics.check.foreign_pull_request")
             continue
         seen.add(str(number))
-        pr = _get_pull_request(
-            organization, repo, {"number": number}, webhook_id, github_event=github_event
+        # Check payloads carry no PR timestamp, only a number. A missing row is the
+        # open→check race the stub exists for, so use ``now`` as the opened_at proxy
+        # to clear the recency gate; the ``pull_request`` event overwrites it with
+        # the true opened_at when it lands.
+        pr = _resolve_or_stub_pull_request(
+            organization,
+            repo,
+            pr_number=number,
+            opened_at=timezone.now(),
+            title=None,
+            github_delivery_id=webhook_id,
+            github_event=github_event,
         )
         if pr is not None:
             prs.append(pr)
     return prs
 
 
-# A comment or review webhook can be delivered before the ``pull_request``
+# A comment, review, or check webhook can be delivered before the ``pull_request``
 # (opened) webhook that writes the PullRequest row — they are separate GitHub
 # deliveries with no ordering guarantee. When the PR was opened within this
 # window we treat a miss as that race and create a minimal stub the opened/sync
 # event later enriches; an older miss predates our ingestion (no opened event
 # will re-fire to fill the stub), so we skip it. Sized well above the observed
-# seconds-to-minutes race to absorb webhook backlog.
+# seconds-to-minutes race to absorb webhook backlog. (Check payloads carry no PR
+# timestamp, so that path passes ``now`` and always clears this window — see
+# ``_prs_from_check_payload``.)
 _PULL_REQUEST_STUB_MAX_AGE = timedelta(hours=1)
 
 
@@ -813,13 +825,19 @@ def _resolve_or_stub_pull_request(
     """Return the PullRequest row, creating a minimal stub for a recent miss.
 
     pr_metrics piggybacks on rows written by ``PullRequestEventWebhook`` from
-    ``pull_request`` events. Comment and review events are separate deliveries
-    that can arrive before that row exists. Rather than drop the activity, create
-    a minimal stub the ``pull_request`` event enriches via its own
-    ``update_or_create`` — but only for a PR opened recently, since an older miss
-    predates ingestion and has no opened event coming to fill the stub.
+    ``pull_request`` events. Comment, review, and check events are separate
+    deliveries that can arrive before that row exists. Rather than drop the
+    activity, create a minimal stub the ``pull_request`` event enriches via its
+    own ``update_or_create`` — but only for a PR opened recently, since an older
+    miss predates ingestion and has no opened event coming to fill the stub.
     ``get_or_create`` is race-safe on the ``(repository_id, key)`` unique
     constraint.
+
+    Callers whose payload carries no PR timestamp (the check_suite/check_run path,
+    whose PR refs hold only a number) pass ``opened_at`` as ``timezone.now()``: a
+    missing row on a check is the out-of-order race the stub exists for (CI fired
+    before the ``opened`` delivery landed), and the ``opened`` event overwrites the
+    proxy with the true ``opened_at`` when it lands.
     """
     key = str(pr_number)
     try:
@@ -838,11 +856,21 @@ def _resolve_or_stub_pull_request(
         "github_delivery_id": github_delivery_id,
     }
 
-    if opened_at is None or opened_at < timezone.now() - _PULL_REQUEST_STUB_MAX_AGE:
-        # Expected miss: the PR predates our ingestion (or its age is unknown), so
-        # no opened event will arrive to enrich a stub. Skip it — not an error.
-        metrics.incr("pr_metrics.pull_request.unresolved", tags={"reason": "predates_ingestion"})
-        logger.info("pr_metrics.pull_request.unresolved", extra=log_extra)
+    # Two distinct misses, kept apart so rollout dashboards can tell them by
+    # `reason`: a payload that carried no parseable timestamp (`missing_opened_at`)
+    # vs. a PR known to predate our ingestion window (`predates_ingestion`).
+    # Neither can be stubbed — no `opened` event will arrive to enrich it — so both
+    # skip; only the reason differs. (Expected, not errors.)
+    if opened_at is None:
+        reason = "missing_opened_at"
+    elif opened_at < timezone.now() - _PULL_REQUEST_STUB_MAX_AGE:
+        reason = "predates_ingestion"
+    else:
+        reason = None
+
+    if reason is not None:
+        metrics.incr("pr_metrics.pull_request.unresolved", tags={"reason": reason})
+        logger.info("pr_metrics.pull_request.unresolved", extra={**log_extra, "reason": reason})
         return None
 
     pull_request, created = PullRequest.objects.get_or_create(

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -259,6 +259,7 @@ class HandleWebhookForPrMetricsTest(TestCase):
                 "repo_name": self.repo.name,
                 "pr_number": 9999,
                 "github_delivery_id": None,
+                "reason": "missing_opened_at",
             },
         )
         assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
@@ -460,6 +461,7 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
                 "repo_name": self.repo.name,
                 "pr_number": 9999,
                 "github_delivery_id": None,
+                "reason": "missing_opened_at",
             },
         )
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
@@ -1050,6 +1052,7 @@ class HandleCommentForPrMetricsTest(TestCase):
                 "repo_name": self.repo.name,
                 "pr_number": 9999,
                 "github_delivery_id": "delivery-unknown",
+                "reason": "missing_opened_at",
             },
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
@@ -1110,6 +1113,8 @@ class HandleCommentForPrMetricsTest(TestCase):
     def test_old_missing_pr_is_not_stubbed(self) -> None:
         # A comment on a PR opened before our ingestion window: no `opened` event
         # will arrive to enrich a stub, so we skip it rather than track a partial.
+        # Reported as `predates_ingestion` — a known-but-old timestamp, distinct from
+        # the `missing_opened_at` miss of a payload with no parseable timestamp.
         event: dict[str, Any] = {
             "action": "created",
             "issue": {
@@ -1121,15 +1126,17 @@ class HandleCommentForPrMetricsTest(TestCase):
             "sender": {"id": 123, "login": "testuser", "type": "User"},
             "comment": {"id": 1, "author_association": "NONE"},
         }
-        handle_comment(
-            github_event=GithubWebhookType.ISSUE_COMMENT,
-            event=event,
-            organization=self.organization,
-            repo=self.repo,
-            github_delivery_id="delivery-old",
-        )
+        with patch(f"{MODULE}.logger") as mock_logger:
+            handle_comment(
+                github_event=GithubWebhookType.ISSUE_COMMENT,
+                event=event,
+                organization=self.organization,
+                repo=self.repo,
+                github_delivery_id="delivery-old",
+            )
 
         assert not PullRequest.objects.filter(repository_id=self.repo.id, key="9999").exists()
+        assert mock_logger.info.call_args.kwargs["extra"]["reason"] == "predates_ingestion"
 
 
 @with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
@@ -1235,6 +1242,7 @@ class HandleReviewForPrMetricsTest(TestCase):
                 "repo_name": self.repo.name,
                 "pr_number": 9999,
                 "github_delivery_id": "delivery-x",
+                "reason": "missing_opened_at",
             },
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
@@ -1341,6 +1349,7 @@ class HandleReviewCommentForPrMetricsTest(TestCase):
                 "repo_name": self.repo.name,
                 "pr_number": 9999,
                 "github_delivery_id": "delivery-x",
+                "reason": "missing_opened_at",
             },
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
@@ -1440,6 +1449,7 @@ class HandleReviewThreadForPrMetricsTest(TestCase):
                 "repo_name": self.repo.name,
                 "pr_number": 9999,
                 "github_delivery_id": "delivery-x",
+                "reason": "missing_opened_at",
             },
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
@@ -1584,10 +1594,16 @@ class HandleCheckEventsForPrMetricsTest(TestCase):
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
-    def test_check_suite_unknown_pr_skipped(self) -> None:
+    def test_check_suite_missing_pr_creates_stub_and_writes_activity(self) -> None:
+        # A check can be delivered before the PR's `opened` event writes the row.
+        # Check payloads carry no PR timestamp, so we stub on a `now` proxy (rather
+        # than drop the CI status) — the same out-of-order race the stub exists for.
         self._call_suite(pr_numbers=(9999,))
 
-        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+        pr = PullRequest.objects.get(repository_id=self.repo.id, key="9999")
+        assert pr.opened_at is not None
+        activity = PullRequestActivity.objects.get(pull_request=pr)
+        assert activity.event_type == PullRequestActivityType.CHECK_SUITE_COMPLETED
 
     def test_check_suite_skips_pull_request_from_other_repo(self) -> None:
         # GitHub lists a PR on our check when their heads match (head_sha +


### PR DESCRIPTION
## Problem

`check_suite`/`check_run` webhook payloads list their PRs as bare `{number, head, base}` refs — no `created_at`. So when the `PullRequest` row didn't exist yet, the check path resolved through `_resolve_or_stub_pull_request` with `opened_at=None`, fell into the undated skip, and logged `pr_metrics.pull_request.unresolved` / `reason: predates_ingestion` — **even for brand-new PRs** whose `pull_request` (opened) delivery was still in flight. That out-of-order delivery is exactly the race the stub mechanism exists for, so we dropped the CI status instead of recording it.

Surfaced during the CORE-247 rollout sanity checks (new PRs logging `predates_ingestion`).

## Changes

- **Stub on check events.** `_prs_from_check_payload` now resolves through `_resolve_or_stub_pull_request` with `timezone.now()` as the `opened_at` proxy. A new PR's CI fires within seconds of opening, so `now` clears the 1h recency gate and a minimal stub is created; the real `pull_request` event later overwrites `opened_at`/`title` via its own `update_or_create` (same PK, so attached activity rows stay valid). A rare CI re-run on a long-closed PR also stubs here, but such a stub never gains attribution and so is never tracked — inert.
- **Split the skip reason.** The single `predates_ingestion` reason is split into `missing_opened_at` (payload carried no parseable timestamp) vs `predates_ingestion` (timestamp present but older than the window), and the reason is now on the log `extra`, not just the metric tag — so rollout dashboards can tell a no-timestamp miss from a genuinely-old PR.

Backend-only; no API or schema changes.

Refs CORE-247