### PR TITLE
fix(conversations): Fix analytics event tracking

### DIFF
--- a/static/app/utils/analytics/conversationsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/conversationsAnalyticsEvents.tsx
@@ -1,14 +1,9 @@
-type ConversationOpenSource =
-  | 'table_conversation_id'
-  | 'table_input'
-  | 'table_output'
-  | 'table_row';
-
 export type ConversationsEventParameters = {
   'conversations.detail.click-errors-link': Record<string, unknown>;
   'conversations.detail.click-trace-link': Record<string, unknown>;
   'conversations.detail.copy-conversation': Record<string, unknown>;
   'conversations.detail.copy-conversation-id': Record<string, unknown>;
+  'conversations.detail.expand-thinking': {expanded: boolean};
   'conversations.detail.page-view': Record<string, unknown>;
   'conversations.detail.select-span': Record<string, unknown>;
   'conversations.detail.tab-switch': {
@@ -17,19 +12,20 @@ export type ConversationsEventParameters = {
   };
   'conversations.message.click': Record<string, unknown>;
   'conversations.message.click-tool-call': Record<string, unknown>;
+  'conversations.onboarding.page-view': Record<string, unknown>;
   'conversations.page-view': Record<string, unknown>;
-  'conversations.table.open': {
-    source: ConversationOpenSource;
-  };
+  'conversations.table.page-view': Record<string, unknown>;
   'conversations.table.paginate': {
     direction: 'next' | 'previous';
   };
 };
 
 export const conversationsEventMap: Record<keyof ConversationsEventParameters, string> = {
+  'conversations.onboarding.page-view': 'Conversations: Onboarding Page View',
   'conversations.page-view': 'Conversations: Page View',
-  'conversations.table.open': 'Conversations: Table Open',
+  'conversations.table.page-view': 'Conversations: Table Page View',
   'conversations.table.paginate': 'Conversations: Table Paginate',
+  'conversations.detail.expand-thinking': 'Conversations: Detail Expand Thinking',
   'conversations.detail.page-view': 'Conversations: Detail Page View',
   'conversations.detail.tab-switch': 'Conversations: Detail Tab Switch',
   'conversations.detail.select-span': 'Conversations: Detail Select Span',

--- a/static/app/views/explore/conversations/components/conversationView.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.tsx
@@ -1,4 +1,4 @@
-import {memo, useEffect, useMemo, useState} from 'react';
+import {memo, useCallback, useEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {Container, Flex} from '@sentry/scraps/layout';
@@ -99,6 +99,14 @@ function ConversationView({
     }
   }, [isLoading, error, nodes.length]);
 
+  const handleSpanTabSelectNode = useCallback(
+    (node: AITraceSpanNode) => {
+      trackAnalytics('conversations.detail.select-span', {organization});
+      onSelectNode(node);
+    },
+    [onSelectNode, organization]
+  );
+
   const handleTabChange = (newTab: ConversationTab) => {
     if (activeTab !== newTab) {
       trackAnalytics('conversations.detail.tab-switch', {
@@ -180,7 +188,7 @@ function ConversationView({
                   <AISpanList
                     nodes={nodes}
                     selectedNodeKey={selectedNode?.id ?? nodes[0]?.id ?? ''}
-                    onSelectNode={onSelectNode}
+                    onSelectNode={handleSpanTabSelectNode}
                     compressGaps
                   />
                 </Container>

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -262,23 +262,14 @@ const BodyCell = memo(function BodyCell({
     selection.projects
   );
 
-  const navigateToDetail = (source: 'table_input' | 'table_output') => {
-    trackAnalytics('conversations.table.open', {organization, source});
+  const navigateToDetail = () => {
     navigate(detailUrl);
   };
 
   switch (column.key) {
     case 'conversationId':
       return (
-        <ConversationIdLink
-          to={detailUrl}
-          onClick={() =>
-            trackAnalytics('conversations.table.open', {
-              organization,
-              source: 'table_conversation_id',
-            })
-          }
-        >
+        <ConversationIdLink to={detailUrl}>
           {isUUID(dataRow.conversationId) ? (
             dataRow.conversationId.slice(0, 8)
           ) : (
@@ -309,7 +300,7 @@ const BodyCell = memo(function BodyCell({
     case 'inputOutput': {
       return (
         <Stack width="100%">
-          <InputOutputRow type="button" onClick={() => navigateToDetail('table_input')}>
+          <InputOutputRow type="button" onClick={() => navigateToDetail()}>
             <InputOutputLabel variant="muted">{t('Input')}</InputOutputLabel>
             <Flex flex="1" minWidth="0">
               {dataRow.firstInput ? (
@@ -319,7 +310,7 @@ const BodyCell = memo(function BodyCell({
               )}
             </Flex>
           </InputOutputRow>
-          <InputOutputRow type="button" onClick={() => navigateToDetail('table_output')}>
+          <InputOutputRow type="button" onClick={() => navigateToDetail()}>
             <InputOutputLabel variant="muted">{t('Output')}</InputOutputLabel>
             <Flex flex="1" minWidth="0">
               {dataRow.lastOutput ? (

--- a/static/app/views/explore/conversations/components/conversationsTableNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableNew.tsx
@@ -159,10 +159,6 @@ export function ConversationsTableNew() {
 
   const handleRowClick = useCallback(
     (dataRow: Conversation) => {
-      trackAnalytics('conversations.table.open', {
-        organization,
-        source: 'table_row',
-      });
       navigate(getConversationDetailUrl(organization.slug, dataRow, selection.projects));
     },
     [navigate, organization, selection.projects]
@@ -221,10 +217,6 @@ const BodyCell = memo(function BodyCell({
           onClick={event => {
             // Let the link handle navigation; don't also trigger the row click.
             event.stopPropagation();
-            trackAnalytics('conversations.table.open', {
-              organization,
-              source: 'table_conversation_id',
-            });
           }}
         >
           {isUUID(dataRow.conversationId) ? (

--- a/static/app/views/explore/conversations/components/messagesPanel.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.tsx
@@ -60,6 +60,9 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
       trackAnalytics('conversations.message.click', {
         organization,
       });
+      trackAnalytics('conversations.detail.select-span', {
+        organization,
+      });
       setClickedMessageId(message.id);
       const node = nodeMap.get(message.nodeId);
       if (node) {
@@ -244,7 +247,17 @@ const MessageBubble = styled('div')<{
 `;
 
 function ReasoningSection({reasoning}: {reasoning: string}) {
+  const organization = useOrganization();
   const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleToggleExpanded = () => {
+    const newState = !isExpanded;
+    setIsExpanded(newState);
+    trackAnalytics('conversations.detail.expand-thinking', {
+      organization,
+      expanded: newState,
+    });
+  };
 
   return (
     <Fragment>
@@ -253,7 +266,7 @@ function ReasoningSection({reasoning}: {reasoning: string}) {
         variant="link"
         onClick={e => {
           e.stopPropagation();
-          setIsExpanded(prev => !prev);
+          handleToggleExpanded();
         }}
         aria-expanded={isExpanded}
       >

--- a/static/app/views/explore/conversations/conversationDetail.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.tsx
@@ -39,12 +39,9 @@ function ConversationDetailPage() {
 
   const handleSelectSpan = useCallback(
     (spanId: string) => {
-      trackAnalytics('conversations.detail.select-span', {
-        organization,
-      });
       setQueryState({spanId, focusedTool: null});
     },
-    [organization, setQueryState]
+    [setQueryState]
   );
 
   return (

--- a/static/app/views/explore/conversations/hooks/useConversationSelection.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationSelection.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo} from 'react';
+import {useCallback, useMemo, useEffect} from 'react';
 
 import {useFocusedToolSpan} from 'sentry/views/explore/conversations/hooks/useFocusedToolSpan';
 import {extractMessagesFromNodes} from 'sentry/views/explore/conversations/utils/conversationMessages';

--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -56,6 +56,20 @@ function ConversationsOverviewPage() {
     });
   }, [organization]);
 
+  useEffect(() => {
+    if (!isOnboardingLoading) {
+      if (showOnboarding) {
+        trackAnalytics('conversations.onboarding.page-view', {
+          organization,
+        });
+      } else {
+        trackAnalytics('conversations.table.page-view', {
+          organization,
+        });
+      }
+    }
+  }, [showOnboarding, isOnboardingLoading, organization]);
+
   const searchQueryBuilderProps: UseSpanSearchQueryBuilderProps = useMemo(
     () => ({
       initialQuery: searchQuery ?? '',


### PR DESCRIPTION
Fixes analytics tracking issues in the conversations feature.

**Changes:**

1. **Fix select-span analytics**: `conversations.detail.select-span` was firing on page load due to auto-selection of the default span. Moved the event to fire only on actual user clicks — message bubbles in the Chat tab and span rows in the Spans tab.

2. **Add thinking block expansion tracking**: Expand/collapse of thinking blocks now fires `conversations.detail.expand-thinking`.

3. **Add table and onboarding page-view events**: The overview page now fires:
   - `conversations.table.page-view` when users see the table
   - `conversations.onboarding.page-view` when users see the onboarding screen

4. **Remove `conversations.table.open`**: Removed the event that fired on row clicks to detail page — redundant since the detail page fires its own page-view on load.

5. **Register new events in `conversationsEventMap`**: All new events (`conversations.table.page-view`, `conversations.onboarding.page-view`, `conversations.detail.expand-thinking`) are now registered so they resolve to human-readable names in Amplitude.

**Event flow:**
- Landing on overview → `conversations.page-view`
- Seeing onboarding → `conversations.onboarding.page-view`
- Seeing the table → `conversations.table.page-view`
- Opening a conversation → `conversations.detail.page-view`
- Clicking a message or span → `conversations.detail.select-span`
- Expanding a thinking block → `conversations.detail.expand-thinking`

Closes TET-2580