### PR TITLE
feat(conversations): Make thinking blocks searchable and copyable

### DIFF
--- a/static/app/views/explore/conversations/components/messagesPanel.spec.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.spec.tsx
@@ -501,6 +501,49 @@ describe('MessagesPanel', () => {
     expect(screen.getByText('weather_api')).toBeInTheDocument();
   });
 
+  it('keeps reasoning text in the DOM and hidden until found while collapsed', async () => {
+    const requestMessages = JSON.stringify([{role: 'user', content: 'User message'}]);
+    const outputMessages = JSON.stringify([
+      {
+        role: 'assistant',
+        parts: [
+          {type: 'reasoning', content: 'My secret thinking text'},
+          {type: 'text', text: 'The final answer'},
+        ],
+      },
+    ]);
+
+    const node = createMockNode({
+      id: 'span-1',
+      attributes: {
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+        [SpanFields.GEN_AI_OUTPUT_MESSAGES]: outputMessages,
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    // Reasoning text is rendered in the DOM even though the disclosure is
+    // collapsed, so the browser's find-in-page (Ctrl-F) can locate it.
+    const reasoning = screen.getByText('My secret thinking text');
+    expect(reasoning).toBeInTheDocument();
+
+    // While collapsed, its container carries `hidden="until-found"` so it stays
+    // visually hidden but findable.
+    const collapsedContainer = reasoning.closest('[hidden]');
+    expect(collapsedContainer).toHaveAttribute('hidden', 'until-found');
+
+    // Expanding via the toggle reveals it (removes the hidden attribute).
+    await userEvent.click(screen.getByRole('button', {name: /Thinking/}));
+    expect(reasoning.closest('[hidden]')).toBeNull();
+  });
+
   it('handles output messages as a JSON object with content key', () => {
     const requestMessages = JSON.stringify([{role: 'user', content: 'User message'}]);
     const outputObj = JSON.stringify({content: 'Response from object format'});

--- a/static/app/views/explore/conversations/components/messagesPanel.spec.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.spec.tsx
@@ -501,7 +501,7 @@ describe('MessagesPanel', () => {
     expect(screen.getByText('weather_api')).toBeInTheDocument();
   });
 
-  it('keeps reasoning text in the DOM and hidden until found while collapsed', async () => {
+  it('keeps reasoning text in the DOM inside a collapsed details element', () => {
     const requestMessages = JSON.stringify([{role: 'user', content: 'User message'}]);
     const outputMessages = JSON.stringify([
       {
@@ -529,19 +529,14 @@ describe('MessagesPanel', () => {
       />
     );
 
-    // Reasoning text is rendered in the DOM even though the disclosure is
-    // collapsed, so the browser's find-in-page (Ctrl-F) can locate it.
+    // Reasoning text is rendered in the DOM even though the <details> is
+    // collapsed, so the browser's find-in-page (Ctrl-F) can locate it and
+    // natively open the section.
     const reasoning = screen.getByText('My secret thinking text');
     expect(reasoning).toBeInTheDocument();
-
-    // While collapsed, its container carries `hidden="until-found"` so it stays
-    // visually hidden but findable.
-    const collapsedContainer = reasoning.closest('[hidden]');
-    expect(collapsedContainer).toHaveAttribute('hidden', 'until-found');
-
-    // Expanding via the toggle reveals it (removes the hidden attribute).
-    await userEvent.click(screen.getByRole('button', {name: /Thinking/}));
-    expect(reasoning.closest('[hidden]')).toBeNull();
+    const details = reasoning.closest('details');
+    expect(details).not.toBeNull();
+    expect(details).not.toHaveAttribute('open');
   });
 
   it('handles output messages as a JSON object with content key', () => {

--- a/static/app/views/explore/conversations/components/messagesPanel.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.tsx
@@ -259,10 +259,8 @@ function ReasoningSection({reasoning}: {reasoning: string}) {
   const [isExpanded, setIsExpanded] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
-  // Keep the reasoning text in the DOM while collapsed, using the native
-  // `hidden="until-found"` attribute. The content stays collapsed/invisible but
-  // remains exposed to the browser's find-in-page (Ctrl-F), which auto-reveals
-  // the matching section instead of skipping it.
+  // Collapse via `hidden="until-found"` so the text stays in the DOM and
+  // find-in-page (Ctrl-F) can locate it.
   useLayoutEffect(() => {
     const el = contentRef.current;
     if (!el) {
@@ -275,9 +273,7 @@ function ReasoningSection({reasoning}: {reasoning: string}) {
     }
   }, [isExpanded]);
 
-  // When find-in-page reveals a `hidden="until-found"` element, the browser
-  // removes the attribute and fires `beforematch`. Sync our state so the
-  // section stays expanded and the chevron points down.
+  // Find-in-page fires `beforematch` when it reveals the section; keep state in sync.
   useEffect(() => {
     const el = contentRef.current;
     if (!el) {
@@ -319,14 +315,27 @@ function ReasoningSection({reasoning}: {reasoning: string}) {
           />
         </Flex>
       </Button>
-      <Container ref={contentRef} padding="md">
+      <ReasoningContent ref={contentRef}>
         <MessageText size="sm" align="left" variant="muted" monospace italic>
           <AIContentRenderer text={reasoning} inline autoCollapseLimit={10} />
         </MessageText>
-      </Container>
+      </ReasoningContent>
     </Fragment>
   );
 }
+
+// Override the global `[hidden] { display: none }` reset so the collapsed
+// `hidden="until-found"` state keeps `content-visibility: hidden`, which
+// find-in-page can reveal.
+const ReasoningContent = styled('div')`
+  padding: ${p => p.theme.space.md};
+
+  &[hidden='until-found'] {
+    display: block;
+    content-visibility: hidden;
+    padding: 0;
+  }
+`;
 
 const StyledClippedBox = styled(ClippedBox)`
   padding: 0;

--- a/static/app/views/explore/conversations/components/messagesPanel.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.tsx
@@ -1,4 +1,12 @@
-import {Fragment, useCallback, useMemo, useState} from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -249,6 +257,36 @@ const MessageBubble = styled('div')<{
 function ReasoningSection({reasoning}: {reasoning: string}) {
   const organization = useOrganization();
   const [isExpanded, setIsExpanded] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  // Keep the reasoning text in the DOM while collapsed, using the native
+  // `hidden="until-found"` attribute. The content stays collapsed/invisible but
+  // remains exposed to the browser's find-in-page (Ctrl-F), which auto-reveals
+  // the matching section instead of skipping it.
+  useLayoutEffect(() => {
+    const el = contentRef.current;
+    if (!el) {
+      return;
+    }
+    if (isExpanded) {
+      el.removeAttribute('hidden');
+    } else {
+      el.setAttribute('hidden', 'until-found');
+    }
+  }, [isExpanded]);
+
+  // When find-in-page reveals a `hidden="until-found"` element, the browser
+  // removes the attribute and fires `beforematch`. Sync our state so the
+  // section stays expanded and the chevron points down.
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) {
+      return () => {};
+    }
+    const handleBeforeMatch = () => setIsExpanded(true);
+    el.addEventListener('beforematch', handleBeforeMatch);
+    return () => el.removeEventListener('beforematch', handleBeforeMatch);
+  }, []);
 
   const handleToggleExpanded = () => {
     const newState = !isExpanded;
@@ -281,13 +319,11 @@ function ReasoningSection({reasoning}: {reasoning: string}) {
           />
         </Flex>
       </Button>
-      {isExpanded && (
-        <Container padding="md">
-          <MessageText size="sm" align="left" variant="muted" monospace italic>
-            <AIContentRenderer text={reasoning} inline autoCollapseLimit={10} />
-          </MessageText>
-        </Container>
-      )}
+      <Container ref={contentRef} padding="md">
+        <MessageText size="sm" align="left" variant="muted" monospace italic>
+          <AIContentRenderer text={reasoning} inline autoCollapseLimit={10} />
+        </MessageText>
+      </Container>
     </Fragment>
   );
 }

--- a/static/app/views/explore/conversations/components/messagesPanel.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.tsx
@@ -1,16 +1,7 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -256,84 +247,46 @@ const MessageBubble = styled('div')<{
 
 function ReasoningSection({reasoning}: {reasoning: string}) {
   const organization = useOrganization();
-  const [isExpanded, setIsExpanded] = useState(false);
-  const contentRef = useRef<HTMLDivElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
 
-  // Collapse via `hidden="until-found"` so the text stays in the DOM and
-  // find-in-page (Ctrl-F) can locate it.
-  useLayoutEffect(() => {
-    const el = contentRef.current;
-    if (!el) {
-      return;
-    }
-    if (isExpanded) {
-      el.removeAttribute('hidden');
-    } else {
-      el.setAttribute('hidden', 'until-found');
-    }
-  }, [isExpanded]);
-
-  // Find-in-page fires `beforematch` when it reveals the section; keep state in sync.
-  useEffect(() => {
-    const el = contentRef.current;
-    if (!el) {
-      return () => {};
-    }
-    const handleBeforeMatch = () => setIsExpanded(true);
-    el.addEventListener('beforematch', handleBeforeMatch);
-    return () => el.removeEventListener('beforematch', handleBeforeMatch);
-  }, []);
-
-  const handleToggleExpanded = () => {
-    const newState = !isExpanded;
-    setIsExpanded(newState);
+  const handleToggle = (open: boolean) => {
+    setIsOpen(open);
     trackAnalytics('conversations.detail.expand-thinking', {
       organization,
-      expanded: newState,
+      expanded: open,
     });
   };
 
+  // A collapsed <details> keeps its text in the DOM so find-in-page can reveal it.
   return (
-    <Fragment>
-      <Button
-        size="zero"
-        variant="link"
-        onClick={e => {
-          e.stopPropagation();
-          handleToggleExpanded();
-        }}
-        aria-expanded={isExpanded}
-      >
+    <ReasoningDetails onToggle={e => handleToggle(e.currentTarget.open)}>
+      <ReasoningSummary onClick={e => e.stopPropagation()}>
         <Flex align="center" gap="xs" padding="sm md 0" width="100%" justify="start">
           <Text size="xs" variant="muted" monospace italic>
             {t('Thinking...')}
           </Text>
-          <IconChevron
-            direction={isExpanded ? 'down' : 'right'}
-            size="xs"
-            variant="muted"
-          />
+          <IconChevron direction={isOpen ? 'down' : 'right'} size="xs" variant="muted" />
         </Flex>
-      </Button>
-      <ReasoningContent ref={contentRef}>
+      </ReasoningSummary>
+      <Container padding="md">
         <MessageText size="sm" align="left" variant="muted" monospace italic>
           <AIContentRenderer text={reasoning} inline autoCollapseLimit={10} />
         </MessageText>
-      </ReasoningContent>
-    </Fragment>
+      </Container>
+    </ReasoningDetails>
   );
 }
 
-// Override the global `[hidden] { display: none }` reset so the collapsed
-// `hidden="until-found"` state keeps `content-visibility: hidden`, which
-// find-in-page can reveal.
-const ReasoningContent = styled('div')`
-  padding: ${p => p.theme.space.md};
+const ReasoningDetails = styled('details')`
+  width: 100%;
+`;
 
-  &[hidden='until-found'] {
-    display: block;
-    content-visibility: hidden;
-    padding: 0;
+const ReasoningSummary = styled('summary')`
+  cursor: pointer;
+  list-style: none;
+
+  &::-webkit-details-marker {
+    display: none;
   }
 `;
 

--- a/static/app/views/explore/conversations/components/messagesPanel.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.tsx
@@ -260,14 +260,21 @@ function ReasoningSection({reasoning}: {reasoning: string}) {
   // A collapsed <details> keeps its text in the DOM so find-in-page can reveal it.
   return (
     <ReasoningDetails onToggle={e => handleToggle(e.currentTarget.open)}>
-      <ReasoningSummary onClick={e => e.stopPropagation()}>
-        <Flex align="center" gap="xs" padding="sm md 0" width="100%" justify="start">
-          <Text size="xs" variant="muted" monospace italic>
-            {t('Thinking...')}
-          </Text>
-          <IconChevron direction={isOpen ? 'down' : 'right'} size="xs" variant="muted" />
-        </Flex>
-      </ReasoningSummary>
+      <Flex
+        as="summary"
+        align="center"
+        gap="xs"
+        padding="sm md 0"
+        width="100%"
+        justify="start"
+        cursor="pointer"
+        onClick={e => e.stopPropagation()}
+      >
+        <Text size="xs" variant="muted" monospace italic>
+          {t('Thinking...')}
+        </Text>
+        <IconChevron direction={isOpen ? 'down' : 'right'} size="xs" variant="muted" />
+      </Flex>
       <Container padding="md">
         <MessageText size="sm" align="left" variant="muted" monospace italic>
           <AIContentRenderer text={reasoning} inline autoCollapseLimit={10} />
@@ -279,13 +286,11 @@ function ReasoningSection({reasoning}: {reasoning: string}) {
 
 const ReasoningDetails = styled('details')`
   width: 100%;
-`;
 
-const ReasoningSummary = styled('summary')`
-  cursor: pointer;
-  list-style: none;
-
-  &::-webkit-details-marker {
+  summary {
+    list-style: none;
+  }
+  summary::-webkit-details-marker {
     display: none;
   }
 `;

--- a/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
@@ -1252,7 +1252,7 @@ describe('conversationMessages utilities', () => {
       expect(messagesToMarkdown([])).toBe('');
     });
 
-    it('excludes reasoning from markdown output', () => {
+    it('includes reasoning as a Thinking blockquote', () => {
       const result = messagesToMarkdown([
         {
           id: 'assistant-1',
@@ -1263,8 +1263,38 @@ describe('conversationMessages utilities', () => {
           reasoning: 'Let me think step by step...',
         },
       ]);
-      expect(result).not.toContain('step by step');
+      expect(result).toContain('> Thinking:');
+      expect(result).toContain('> Let me think step by step...');
       expect(result).toContain('The answer is 42');
+    });
+
+    it('prefixes every line of multi-line reasoning with a blockquote marker', () => {
+      const result = messagesToMarkdown([
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          content: 'Done',
+          timestamp: 1000,
+          nodeId: 'n1',
+          reasoning: 'First I check the input.\nThen I compute the result.',
+        },
+      ]);
+      expect(result).toContain(
+        '> Thinking:\n> First I check the input.\n> Then I compute the result.'
+      );
+    });
+
+    it('omits the Thinking blockquote when there is no reasoning', () => {
+      const result = messagesToMarkdown([
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          content: 'The answer is 42',
+          timestamp: 1000,
+          nodeId: 'n1',
+        },
+      ]);
+      expect(result).not.toContain('Thinking:');
     });
   });
 });

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -359,6 +359,17 @@ function getGenAiOpType(node: AITraceSpanNode): string | undefined {
   return getStringAttr(node, SpanFields.GEN_AI_OPERATION_TYPE);
 }
 
+/**
+ * Formats text as a Markdown blockquote, prefixing every line with `> ` so
+ * multi-line content (e.g. reasoning) stays inside the quote.
+ */
+function toBlockquote(text: string): string {
+  return text
+    .split('\n')
+    .map(line => `> ${line}`)
+    .join('\n');
+}
+
 export function messagesToMarkdown(messages: ConversationMessage[]): string {
   const blocks: string[] = [];
 
@@ -379,6 +390,10 @@ export function messagesToMarkdown(messages: ConversationMessage[]): string {
       if (message.toolCalls && message.toolCalls.length > 0) {
         const toolNames = message.toolCalls.map(tc => `\`${tc.name}\``).join(', ');
         lines.push(`> Called tools: ${toolNames}`);
+      }
+
+      if (message.reasoning) {
+        lines.push(toBlockquote(`Thinking:\n${message.reasoning}`));
       }
     }
 

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -359,10 +359,7 @@ function getGenAiOpType(node: AITraceSpanNode): string | undefined {
   return getStringAttr(node, SpanFields.GEN_AI_OPERATION_TYPE);
 }
 
-/**
- * Formats text as a Markdown blockquote, prefixing every line with `> ` so
- * multi-line content (e.g. reasoning) stays inside the quote.
- */
+// Prefix every line with `> ` so multi-line content forms one blockquote.
 function toBlockquote(text: string): string {
   return text
     .split('\n')


### PR DESCRIPTION
Text inside the `Thinking...` disclosure widgets in the Conversations view is now findable with the browser's `Ctrl-F` and included when you copy a conversation as markdown. Previously the reasoning was only mounted in the DOM after manually expanding each widget, so find-in-page skipped it, and `Copy as markdown` dropped it entirely.

The reasoning content now stays mounted while collapsed via the native `hidden="until-found"` attribute, so find-in-page locates and auto-reveals the matching section. The revealed state is synced back to React via the `beforematch` event so the chevron and toggle stay consistent. `messagesToMarkdown` also emits the reasoning as a `> Thinking:` blockquote per assistant message.

Note: `hidden="until-found"` find-in-page reveal is supported in Chromium browsers; elsewhere the widget degrades to its previous collapsed behavior. The markdown change works everywhere.

Closes TET-2563
