### PR TITLE
ref: Change Perf Monitoring to Tracing

### DIFF
--- a/static/app/views/settings/project/loaderScript.spec.tsx
+++ b/static/app/views/settings/project/loaderScript.spec.tsx
@@ -193,12 +193,12 @@ describe('LoaderScript', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
-    expect(screen.getByText('Enable Performance Monitoring')).toBeInTheDocument();
+    expect(screen.getByText('Enable Tracing')).toBeInTheDocument();
     expect(screen.getByText('Enable Session Replay')).toBeInTheDocument();
     expect(screen.getByText('Enable SDK debugging')).toBeInTheDocument();
 
     let performanceCheckbox = screen.getByRole('checkbox', {
-      name: 'Enable Performance Monitoring',
+      name: 'Enable Tracing',
     });
     expect(performanceCheckbox).toBeEnabled();
     expect(performanceCheckbox).not.toBeChecked();
@@ -218,12 +218,12 @@ describe('LoaderScript', () => {
     // Toggle performance option
     await userEvent.click(
       screen.getByRole('checkbox', {
-        name: 'Enable Performance Monitoring',
+        name: 'Enable Tracing',
       })
     );
 
     performanceCheckbox = await screen.findByRole('checkbox', {
-      name: 'Enable Performance Monitoring',
+      name: 'Enable Tracing',
       checked: true,
     });
     expect(performanceCheckbox).toBeEnabled();
@@ -311,7 +311,7 @@ describe('LoaderScript', () => {
 
     expect(
       screen.getAllByRole('checkbox', {
-        name: 'Enable Performance Monitoring',
+        name: 'Enable Tracing',
         checked: false,
       })
     ).toHaveLength(2);
@@ -331,20 +331,20 @@ describe('LoaderScript', () => {
     // Toggle performance option
     await userEvent.click(
       screen.getAllByRole('checkbox', {
-        name: 'Enable Performance Monitoring',
+        name: 'Enable Tracing',
       })[1]!
     );
 
     expect(
       await screen.findByRole('checkbox', {
-        name: 'Enable Performance Monitoring',
+        name: 'Enable Tracing',
         checked: true,
       })
     ).toBeInTheDocument();
 
     expect(
       screen.getByRole('checkbox', {
-        name: 'Enable Performance Monitoring',
+        name: 'Enable Tracing',
         checked: false,
       })
     ).toBeInTheDocument();

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
@@ -68,13 +68,13 @@ describe('Loader Script Settings', () => {
     // Panel title
     expect(screen.getByText('JavaScript Loader Script')).toBeInTheDocument();
 
-    expect(screen.getByText('Enable Performance Monitoring')).toBeInTheDocument();
+    expect(screen.getByText('Enable Tracing')).toBeInTheDocument();
     expect(screen.getByText('Enable Session Replay')).toBeInTheDocument();
     expect(screen.getByText('Enable User Feedback')).toBeInTheDocument();
     expect(screen.getByText('Enable SDK debugging')).toBeInTheDocument();
 
     const performanceCheckbox = screen.getByRole('checkbox', {
-      name: 'Enable Performance Monitoring',
+      name: 'Enable Tracing',
     });
     expect(performanceCheckbox).toBeEnabled();
     expect(performanceCheckbox).not.toBeChecked();
@@ -129,7 +129,7 @@ describe('Loader Script Settings', () => {
     // Toggle performance option
     await userEvent.click(
       screen.getByRole('checkbox', {
-        name: 'Enable Performance Monitoring',
+        name: 'Enable Tracing',
       })
     );
 
@@ -233,7 +233,7 @@ describe('Loader Script Settings', () => {
     );
 
     const performanceCheckbox = screen.getByRole('checkbox', {
-      name: 'Enable Performance Monitoring',
+      name: 'Enable Tracing',
     });
     expect(performanceCheckbox).not.toBeChecked();
 
@@ -461,9 +461,7 @@ describe('Loader Script Settings', () => {
     // with fresh data. Each request must carry ONLY its own changed field —
     // otherwise the slower-resolving request would overwrite the other's
     // change with a stale value (the backend merges partial options).
-    await userEvent.click(
-      screen.getByRole('checkbox', {name: 'Enable Performance Monitoring'})
-    );
+    await userEvent.click(screen.getByRole('checkbox', {name: 'Enable Tracing'}));
     await userEvent.click(screen.getByRole('checkbox', {name: 'Enable SDK debugging'}));
 
     await waitFor(() => {

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -166,7 +166,7 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
           >
             {field => (
               <field.Layout.Row
-                label={t('Enable Performance Monitoring')}
+                label={t('Enable Tracing')}
                 hintText={
                   supportsPerformance
                     ? data.dynamicSdkLoaderOptions.hasPerformance


### PR DESCRIPTION
closes #118632
closes [ENG-8054](https://linear.app/getsentry/issue/ENG-8054)

This only renames "Performance Monitoring" to "Tracing"

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
