### PR TITLE
fix(tabs): Defer ResizeObserver recompute out of render phase

### DIFF
--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -214,11 +214,30 @@ function useOverflowTabs({
       return;
     }
 
-    const resizeObserver = new ResizeObserver(() => recompute());
+    // `recompute` is a `useEffectEvent`, which React forbids invoking while it
+    // is rendering. A ResizeObserver callback is scheduled by the browser and
+    // can fire while React is mid-render, tripping that guard (JAVASCRIPT-3AJN).
+    // Defer to an animation frame so the call always runs outside the render
+    // phase; this also coalesces bursts of resize notifications into one pass.
+    let frame: number | null = null;
+    const resizeObserver = new ResizeObserver(() => {
+      if (frame !== null) {
+        return;
+      }
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        recompute();
+      });
+    });
     resizeObserver.observe(outerWrap);
     resizeObserver.observe(tabList);
 
-    return () => resizeObserver.disconnect();
+    return () => {
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+      resizeObserver.disconnect();
+    };
   }, [disabled, outerWrapRef, tabListRef]);
 
   // Tabs with the `hidden` prop render with display: none; never surface them


### PR DESCRIPTION
## Summary

Fixes a production crash on the tab overflow logic: `A function wrapped in useEffectEvent can't be called during rendering.` (JAVASCRIPT-3AJN).

In `tabList.tsx`, the tab-overflow `ResizeObserver` called `recompute` — a `useEffectEvent` — **synchronously**:

```ts
const recompute = useEffectEvent(() => { ... });
// ...
const resizeObserver = new ResizeObserver(() => recompute());
```

React forbids invoking an effect event while it is rendering, and enforces it with a guard that throws this exact error. A `ResizeObserver` callback is scheduled by the browser, outside React's control, so it can fire at a moment that coincides with React doing render work — tripping the guard. This is the misuse the React docs warn about: effect events are meant to be called *from* Effects, not handed to external observer/subscription systems.

## Fix

Defer the observer's `recompute` to a `requestAnimationFrame` so it always runs outside the render phase.

```ts
let frame: number | null = null;
const resizeObserver = new ResizeObserver(() => {
  if (frame !== null) return;
  frame = requestAnimationFrame(() => {
    frame = null;
    recompute();
  });
});
// ...
return () => {
  if (frame !== null) cancelAnimationFrame(frame);
  resizeObserver.disconnect();
};
```

Bonus from the same change:
- **Coalescing** — both `outerWrap` and `tabList` are observed and tend to resize together; the `frame` guard collapses a burst of notifications into one recompute per frame.
- **Clean teardown** — a pending frame is cancelled on cleanup, so no stale `recompute` runs after the observer disconnects/unmounts.

The other `recompute()` call (the `useLayoutEffect` keyed on the tab set/order) is untouched — that one runs *inside* an effect, which is where effect events are allowed to be called, so the layout-driven path stays synchronous (no flicker on tab add/remove/reorder).

## Notes

- Behavior change is timing-only: a one-frame deferral of overflow recomputation on container resize, which is imperceptible in practice.
- No test added — the crash depends on a `ResizeObserver` callback coinciding with a React render, which jsdom (no real `ResizeObserver`) can't reproduce meaningfully.

Fixes JAVASCRIPT-3AJN
