### PR TITLE
chore(dynamic-sampling): Add finer smallest-transaction factor buckets

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -155,7 +155,8 @@ def _factor_bucket(factor: float) -> str:
     # (inclusive lower bound, label), ordered high -> low; the first bound the factor clears wins.
     factor_buckets: tuple[tuple[float, str], ...] = (
         (0.1, "1-0.1"),
-        (0.001, "0.1-0.001"),
+        (0.01, "0.1-0.01"),
+        (0.001, "0.01-0.001"),
         (0.0001, "0.001-0.0001"),
         (0.00001, "0.0001-0.00001"),
     )


### PR DESCRIPTION
- Split the 0.1-0.001 smallest-transaction factor bucket into 0.1-0.01 and 0.01-0.001 for finer-grained visibility into the sampling factor assigned to the lowest-volume transaction of a project.