### PR TITLE
feat(replays): Port ingest-replay-recordings to a taskbroker task

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1539,6 +1539,9 @@ SENTRY_POST_PROCESS_GROUP_APM_SAMPLING = 1 if DEBUG else 0
 # sample rate for all reprocessing tasks (except for the per-event ones)
 SENTRY_REPROCESSING_APM_SAMPLING = 1 if DEBUG else 0
 
+# sample rate for the ingest-replay-recordings processing (consumer and task)
+SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING = 0
+
 # ----
 # end APM config
 # ----

--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -95,9 +95,7 @@ def process_and_commit_message(message: Message[KafkaPayload], context: Processo
             name="replays.consumer.recording.process_and_commit_message",
             op="replays.consumer.recording.process_and_commit_message",
             custom_sampling_context={
-                "sample_rate": getattr(
-                    settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0
-                )
+                "sample_rate": settings.SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING
             },
             transaction=True,
         ):

--- a/src/sentry/replays/lib/eap/write.py
+++ b/src/sentry/replays/lib/eap/write.py
@@ -3,18 +3,13 @@ from datetime import datetime
 from typing import TypedDict
 
 import requests
-from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload
 from django.conf import settings
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue, KeyValue, KeyValueList
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem as EAPTraceItem
 
-from sentry.conf.types.kafka_definition import Topic
 from sentry.replays.lib.eap.snuba_transpiler import TRACE_ITEM_TYPE_MAP, TRACE_ITEM_TYPES
-from sentry.replays.lib.kafka import EAP_ITEMS_CODEC, eap_producer
 from sentry.utils.eap import EAP_ITEMS_INSERT_ENDPOINT
-from sentry.utils.kafka_config import get_topic_definition
 
 Value = bool | bytes | str | int | float | Sequence["Value"] | MutableMapping[str, "Value"]
 
@@ -93,11 +88,3 @@ def write_trace_items_test_suite(trace_items: list[EAPTraceItem]) -> None:
         },
     )
     assert response.status_code == 200
-
-
-def write_trace_items(trace_items: list[EAPTraceItem]) -> None:
-    """Publish trace-items to the EAP trace-items topic."""
-    topic = get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"]
-    for trace_item in trace_items:
-        payload = KafkaPayload(None, EAP_ITEMS_CODEC.encode(trace_item), [])
-        eap_producer.produce(ArroyoTopic(topic), payload)

--- a/src/sentry/replays/lib/kafka.py
+++ b/src/sentry/replays/lib/kafka.py
@@ -5,6 +5,7 @@ from arroyo.types import Topic as ArroyoTopic
 from django.conf import settings
 from sentry_kafka_schemas.codecs import Codec
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
+from taskbroker_client.state import current_task
 from taskbroker_client.worker.producer import TaskProducer
 
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
@@ -21,15 +22,39 @@ from sentry.utils.kafka_config import get_topic_definition
 EAP_ITEMS_CODEC: Codec[TraceItem] = get_topic_codec(Topic.SNUBA_ITEMS)
 
 
-def _get_eap_items_producer():
+def _get_eap_items_producer(name: str = "sentry.replays.lib.kafka.eap_items"):
     """Get a Kafka producer for EAP TraceItems."""
     return get_arroyo_producer(
-        name="sentry.replays.lib.kafka.eap_items",
+        name=name,
         topic=Topic.SNUBA_ITEMS,
     )
 
 
 eap_producer = SingletonProducer(_get_eap_items_producer)
+_eap_task_producer_name = "sentry.replays.lib.kafka.eap_items_taskproducer"
+eap_items_taskproducer = get_task_producer(
+    producer_name=_eap_task_producer_name,
+    producer_factory=partial(_get_eap_items_producer, name=_eap_task_producer_name),
+)
+
+
+def write_trace_items(trace_items: list[TraceItem]) -> None:
+    """Publish trace-items to the EAP trace-items topic.
+
+    When running inside a task we produce through the TaskProducer, which ties
+    delivery to task completion: the worker only acks an activation once all of
+    its producer futures succeed, otherwise the task is retried. Outside of a
+    task (e.g. the arroyo consumer) nobody collects those futures, so we use the
+    SingletonProducer which flushes on process shutdown.
+    """
+    if current_task() is not None:
+        producer: SingletonProducer | TaskProducer = eap_items_taskproducer
+    else:
+        producer = eap_producer
+    topic = ArroyoTopic(get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"])
+    for trace_item in trace_items:
+        payload = KafkaPayload(None, EAP_ITEMS_CODEC.encode(trace_item), [])
+        producer.produce(topic, payload)
 
 
 #

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -4,8 +4,10 @@ import logging
 from typing import Any
 
 from google.cloud.exceptions import NotFound
+from taskbroker_client.constants import CompressionType
 from taskbroker_client.retry import Retry
 
+from sentry.replays.consumers.recording import commit_message, process_message
 from sentry.replays.lib.kafka import publish_replay_event
 from sentry.replays.lib.storage import (
     RecordingSegmentStorageMeta,
@@ -21,10 +23,11 @@ from sentry.replays.usecases.delete import (
     fetch_rows_matching_pattern,
 )
 from sentry.replays.usecases.events import archive_event
+from sentry.replays.usecases.ingest.types import ProcessorContext
 from sentry.replays.usecases.reader import fetch_segments_metadata
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import replays_tasks
+from sentry.taskworker.namespaces import replays_raw_tasks, replays_tasks
 from sentry.utils import metrics
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
@@ -55,6 +58,41 @@ def delete_replay(
         delete_seer_replay_data(organization_id, project_id, [replay_id])
 
     metrics.incr("replays.delete_replay", amount=1, tags={"status": "finished"})
+
+
+@instrumented_task(
+    name="sentry.replays.tasks.process_replay_recording",
+    namespace=replays_raw_tasks,
+    processing_deadline_duration=90,
+    retry=Retry(times=3, delay=5),
+    compression_type=CompressionType.ZSTD,
+    silo_mode=SiloMode.CELL,
+    pass_headers=True,
+)
+def process_replay_recording(
+    message_bytes: bytes,
+    headers: dict[str, str],
+) -> None:
+    """Process a replay recording from raw Kafka message bytes.
+
+    This task is directly spawned from taskbroker in "raw mode". You won't find
+    any application code that calls apply_async or delay directly on it, instead
+    taskbroker itself is configured to consume the ingest-replay-recordings
+    topic (in infra templates) and spawns a task for each message.
+
+    As such, the task signature, name and namespace cannot be changed without
+    coordination. ``headers`` are currently unused but are passed by taskbroker.
+    """
+    processed_message = process_message(message_bytes)
+    if processed_message:
+        # The per-partition query caches that the consumer builds in
+        # create_with_partitions don't apply when each message is processed as an
+        # independent task, so we always use the uncached path here.
+        context: ProcessorContext = {
+            "has_sent_replays_cache": None,
+            "options_cache": None,
+        }
+        commit_message(processed_message, context)
 
 
 @instrumented_task(

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -67,12 +67,8 @@ def delete_replay(
     retry=Retry(times=3, delay=5),
     compression_type=CompressionType.ZSTD,
     silo_mode=SiloMode.CELL,
-    pass_headers=True,
 )
-def process_replay_recording(
-    message_bytes: bytes,
-    headers: dict[str, str],
-) -> None:
+def process_replay_recording(message_bytes: bytes) -> None:
     """Process a replay recording from raw Kafka message bytes.
 
     This task is directly spawned from taskbroker in "raw mode". You won't find
@@ -81,7 +77,7 @@ def process_replay_recording(
     topic (in infra templates) and spawns a task for each message.
 
     As such, the task signature, name and namespace cannot be changed without
-    coordination. ``headers`` are currently unused but are passed by taskbroker.
+    coordination.
     """
     processed_message = process_message(message_bytes)
     if processed_message:

--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -9,8 +9,7 @@ import sentry_sdk
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
 from sentry.models.options.project_option import ProjectOption
-from sentry.replays.lib.eap.write import write_trace_items
-from sentry.replays.lib.kafka import publish_replay_event
+from sentry.replays.lib.kafka import publish_replay_event, write_trace_items
 from sentry.replays.usecases.ingest.event_parser import ClickEvent, ParsedEventMeta, TapEvent
 from sentry.replays.usecases.ingest.issue_creation import (
     report_hydration_error_issue_with_replay_event,

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -217,6 +217,13 @@ replays_tasks = app.taskregistry.create_namespace(
     app_feature="replays",
 )
 
+# Dedicated namespace for the raw ingest-replay-recordings topic, consumed by
+# taskbroker in "raw mode" (one raw topic maps 1:1 to a namespace).
+replays_raw_tasks = app.taskregistry.create_namespace(
+    "replays.raw",
+    app_feature="replays",
+)
+
 reports_tasks = app.taskregistry.create_namespace(
     "reports",
     app_feature="shared",

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -72,6 +72,9 @@ SAMPLED_TASKS = {
     "sentry.tasks.process_buffer.process_incr": 0.1 * settings.SENTRY_BACKEND_APM_SAMPLING,
     "sentry.replays.tasks.delete_recording_segments": settings.SAMPLED_DEFAULT_RATE,
     "sentry.replays.tasks.delete_replay_recording_async": settings.SAMPLED_DEFAULT_RATE,
+    # Mirror the rate the ingest-replay-recordings consumer used for its
+    # per-message transaction, now that the work runs as a task.
+    "sentry.replays.tasks.process_replay_recording": settings.SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING,
     "sentry.tasks.summaries.weekly_reports.schedule_organizations": 1.0,
     "sentry.tasks.summaries.weekly_reports.prepare_organization_report": 0.1
     * settings.SENTRY_BACKEND_APM_SAMPLING,

--- a/tests/sentry/replays/consumers/test_recording.py
+++ b/tests/sentry/replays/consumers/test_recording.py
@@ -15,6 +15,7 @@ from sentry.analytics.events.first_replay_sent import FirstReplaySentEvent
 from sentry.models.organizationonboardingtask import OnboardingTask, OnboardingTaskStatus
 from sentry.replays.consumers.recording import ProcessReplayRecordingStrategyFactory
 from sentry.replays.lib.storage import _make_recording_filename, storage_kv
+from sentry.replays.tasks import process_replay_recording
 from sentry.replays.usecases.pack import unpack
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
@@ -275,3 +276,47 @@ class RecordingTestCase(TransactionTestCase):
             assert report_hydration_issue.called
             assert report_hydration_issue.call_count == 2
             assert set_project_flag_and_signal.call_count == 1
+
+    @patch("sentry.models.OrganizationOnboardingTask.objects.record")
+    @patch("sentry.analytics.record")
+    @patch("sentry.replays.usecases.ingest.track_outcome")
+    @patch("sentry.replays.usecases.ingest.report_hydration_error")
+    def test_process_replay_recording_task(
+        self,
+        report_hydration_issue: MagicMock,
+        track_outcome: MagicMock,
+        mock_record: MagicMock,
+        mock_onboarding_task: MagicMock,
+    ) -> None:
+        # The raw-mode taskbroker entrypoint: a single Kafka message is handed to
+        # the task as raw bytes (taskbroker also passes headers).
+        data = [{"hello": "world"}]
+        segment_id = 0
+        message = self.nonchunked_messages(
+            message=json.dumps(data).encode(),
+            segment_id=segment_id,
+            compressed=True,
+            replay_event=json.dumps(
+                {
+                    "type": "replay_event",
+                    "replay_id": self.replay_id,
+                    "timestamp": int(time.time()),
+                }
+            ).encode(),
+        )[0]
+
+        process_replay_recording(msgpack.packb(message), {})
+
+        dat = self.get_recording_data(segment_id)
+        assert json.loads(bytes(dat).decode("utf-8")) == data
+
+        self.project.refresh_from_db()
+        assert self.project.flags.has_replays
+
+        mock_onboarding_task.assert_called_with(
+            organization_id=self.project.organization_id,
+            task=OnboardingTask.SESSION_REPLAY,
+            status=OnboardingTaskStatus.COMPLETE,
+            date_completed=ANY,
+        )
+        assert track_outcome.called

--- a/tests/sentry/replays/consumers/test_recording.py
+++ b/tests/sentry/replays/consumers/test_recording.py
@@ -305,7 +305,7 @@ class RecordingTestCase(TransactionTestCase):
             ).encode(),
         )[0]
 
-        process_replay_recording(msgpack.packb(message), {})
+        process_replay_recording(msgpack.packb(message))
 
         dat = self.get_recording_data(segment_id)
         assert json.loads(bytes(dat).decode("utf-8")) == data


### PR DESCRIPTION
ref STREAM-1147

## Why

We're porting our legacy stateless Kafka consumers onto taskbroker so that ingestion workloads run as tasks instead of bespoke Arroyo consumers. The payoff is one execution model: shared retries/DLQ, monitoring, and autoscaling, and far less per-consumer boilerplate to maintain. This PR does the `ingest-replay-recordings` consumer.

## What

Exposes the existing replay recording processing logic as a taskbroker task, `process_replay_recording`, in a dedicated `replays.raw` namespace — mirroring `process_profile_from_kafka`. It's a thin wrapper over the same `process_message`/`commit_message` functions the Arroyo consumer already uses, so behavior is unchanged.

The task is spawned by taskbroker in "raw mode" (consuming the `ingest-replay-recordings` topic directly, since the data comes from relay); the topic→namespace wiring lives in infra templates, not this repo. The existing consumer stays in place until cutover.

## Notes

- `headers` is accepted (taskbroker passes it in raw mode) but currently unused — there is no replay killswitch.
- The per-partition query caches the consumer builds don't apply when each message is an independent task, so the task uses the uncached path.