### PR TITLE
fix(ourlogs): resolve release:latest and similar filters

### DIFF
--- a/src/sentry/search/eap/ourlogs/definitions.py
+++ b/src/sentry/search/eap/ourlogs/definitions.py
@@ -8,6 +8,7 @@ from sentry.search.eap.ourlogs.attributes import (
     ourlog_column_to_custom_alias,
     ourlog_custom_alias_to_column,
 )
+from sentry.search.eap.ourlogs.filter_aliases import OURLOG_FILTER_ALIAS_DEFINITIONS
 
 OURLOG_DEFINITIONS = ColumnDefinitions(
     aggregates=LOG_AGGREGATE_DEFINITIONS,
@@ -15,7 +16,7 @@ OURLOG_DEFINITIONS = ColumnDefinitions(
     columns=OURLOG_ATTRIBUTE_DEFINITIONS,
     contexts=OURLOG_VIRTUAL_CONTEXTS,
     trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
-    filter_aliases={},
+    filter_aliases=OURLOG_FILTER_ALIAS_DEFINITIONS,
     alias_to_column=ourlog_custom_alias_to_column,
     column_to_alias=ourlog_column_to_custom_alias,
 )

--- a/src/sentry/search/eap/ourlogs/filter_aliases.py
+++ b/src/sentry/search/eap/ourlogs/filter_aliases.py
@@ -1,0 +1,16 @@
+from sentry.search.eap.spans.filter_aliases import (
+    release_filter_converter,
+    release_stage_filter_converter,
+    semver_build_filter_converter,
+    semver_filter_converter,
+    semver_package_filter_converter,
+)
+from sentry.search.events import constants
+
+OURLOG_FILTER_ALIAS_DEFINITIONS = {
+    constants.RELEASE_ALIAS: release_filter_converter,
+    constants.RELEASE_STAGE_ALIAS: release_stage_filter_converter,
+    constants.SEMVER_ALIAS: semver_filter_converter,
+    constants.SEMVER_PACKAGE_ALIAS: semver_package_filter_converter,
+    constants.SEMVER_BUILD_ALIAS: semver_build_filter_converter,
+}

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -1009,6 +1009,50 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
         assert filtered.status_code == 200, filtered.content
         assert filtered.data["data"] == [{"message": "foo", "count(message)": 2}]
 
+    def test_resolves_latest_release_alias(self) -> None:
+        self.create_release(version="0.8")
+        self.store_eap_items([self.create_ourlog({"release": "0.8"}, timestamp=self.ten_mins_ago)])
+
+        request = {
+            "field": ["release"],
+            "query": "release:latest",
+            "project": self.project.id,
+            "dataset": self.dataset,
+        }
+
+        response = self.do_request(request)
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [{"release": "0.8"}]
+
+        self.create_release(version="0.9")
+        self.store_eap_items([self.create_ourlog({"release": "0.9"}, timestamp=self.ten_mins_ago)])
+
+        response = self.do_request(request)
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [{"release": "0.9"}]
+
+    def test_resolves_semver_release_filter(self) -> None:
+        self.create_release(version="test@1.2.3")
+        self.create_release(version="test@1.2.4")
+        self.store_eap_items(
+            [
+                self.create_ourlog({"release": "test@1.2.3"}, timestamp=self.ten_mins_ago),
+                self.create_ourlog({"release": "test@1.2.4"}, timestamp=self.ten_mins_ago),
+            ]
+        )
+
+        response = self.do_request(
+            {
+                "field": ["release"],
+                "query": "release.version:>1.2.3",
+                "orderby": "release",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [{"release": "test@1.2.4"}]
+
     @override_settings(SENTRY_MODE=SentryMode.SAAS)
     def test_no_project_sent_logs(self):
         project1 = self.create_project()

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -1011,7 +1011,9 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
 
     def test_resolves_latest_release_alias(self) -> None:
         self.create_release(version="0.8")
-        self.store_eap_items([self.create_ourlog({"release": "0.8"}, timestamp=self.ten_mins_ago)])
+        self.store_eap_items(
+            [self.create_ourlog(attributes={"sentry.release": "0.8"}, timestamp=self.ten_mins_ago)]
+        )
 
         request = {
             "field": ["release"],
@@ -1025,7 +1027,9 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
         assert response.data["data"] == [{"release": "0.8"}]
 
         self.create_release(version="0.9")
-        self.store_eap_items([self.create_ourlog({"release": "0.9"}, timestamp=self.ten_mins_ago)])
+        self.store_eap_items(
+            [self.create_ourlog(attributes={"sentry.release": "0.9"}, timestamp=self.ten_mins_ago)]
+        )
 
         response = self.do_request(request)
         assert response.status_code == 200, response.content
@@ -1036,8 +1040,12 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
         self.create_release(version="test@1.2.4")
         self.store_eap_items(
             [
-                self.create_ourlog({"release": "test@1.2.3"}, timestamp=self.ten_mins_ago),
-                self.create_ourlog({"release": "test@1.2.4"}, timestamp=self.ten_mins_ago),
+                self.create_ourlog(
+                    attributes={"sentry.release": "test@1.2.3"}, timestamp=self.ten_mins_ago
+                ),
+                self.create_ourlog(
+                    attributes={"sentry.release": "test@1.2.4"}, timestamp=self.ten_mins_ago
+                ),
             ]
         )
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
@@ -346,3 +346,39 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
             },
         )
         assert response.status_code == 200, response.content
+
+    def test_count_with_latest_release_filter(self) -> None:
+        self.create_release(version="0.8")
+        self.create_release(version="0.9")
+        event_counts = [6, 0, 6, 3, 0, 3]
+        logs = []
+        for hour, count in enumerate(event_counts):
+            logs.extend(
+                [
+                    self.create_ourlog(
+                        {"release": "0.9"},
+                        timestamp=self.start + timedelta(hours=hour, minutes=minute),
+                    )
+                    for minute in range(count)
+                ],
+            )
+        logs.append(
+            self.create_ourlog({"release": "0.8"}, timestamp=self.start + timedelta(minutes=1))
+        )
+        self.store_eap_items(logs)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "count()",
+                "query": "release:latest",
+                "project": self.project.id,
+                "dataset": "logs",
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert [attrs for time, attrs in response.data["data"]] == [
+            [{"count": count}] for count in event_counts
+        ]

--- a/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
@@ -356,14 +356,17 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
             logs.extend(
                 [
                     self.create_ourlog(
-                        {"release": "0.9"},
+                        attributes={"sentry.release": "0.9"},
                         timestamp=self.start + timedelta(hours=hour, minutes=minute),
                     )
                     for minute in range(count)
                 ],
             )
         logs.append(
-            self.create_ourlog({"release": "0.8"}, timestamp=self.start + timedelta(minutes=1))
+            self.create_ourlog(
+                attributes={"sentry.release": "0.8"},
+                timestamp=self.start + timedelta(minutes=1),
+            )
         )
         self.store_eap_items(logs)
 


### PR DESCRIPTION
Saving a Logs query with `release:latest` (or other release alias filters) as a dashboard widget returned an empty count. That's because `release:latest` is a special alias, where the literal string `latest` must be resolved at query time to the actual latest release version(s). Example on prod that shows 0 results: https://sentry.sentry.io/explore/logs?logsFields=timestamp&logsFields=message&logsQuery=release%3Alatest&logsSortBys=-timestamp&project=11276&statsPeriod=14d

The logs dataset previously registered `filter_aliases={}` (empty), so no resolution happened. Spans (Trace Explorer) already registers these converters and worked correctly. This PR registers release/semver filter alias family for logs, reusing the dataset-agnostic converters already used by spans.

Verified on my local dev box with seeded data:

<img width="950" height="409" alt="image" src="https://github.com/user-attachments/assets/737a8478-e0c2-4cd2-93eb-3dbf64d7257d" />

Closes LOGS-306