### PR TITLE
fix(autofix): always check write access in useAiConfig

### DIFF
--- a/static/app/views/issueDetails/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/hooks/useAiConfig.tsx
@@ -7,6 +7,7 @@ import {useIsSampleEvent} from 'sentry/views/issueDetails/utils';
 
 interface AiConfigResult {
   areAiFeaturesAllowed: boolean;
+  canCreatePullRequests: boolean;
   hasAutofix: boolean;
   hasAutofixQuota: boolean;
   hasGithubIntegration: boolean;
@@ -26,8 +27,10 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
     hasAutofixQuota,
     refetch: refetchAutofixSetup,
     seerReposLinked,
+    canCreatePullRequests,
   } = useAutofixSetup({
     groupId: group.id,
+    checkWriteAccess: true,
   });
 
   const isSampleError = useIsSampleEvent();
@@ -52,6 +55,7 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
     hasResources,
     isAutofixSetupLoading,
     areAiFeaturesAllowed,
+    canCreatePullRequests,
     hasGithubIntegration,
     hasAutofixQuota,
     refetchAutofixSetup,


### PR DESCRIPTION
## What

`useAiConfig` calls `useAutofixSetup` without `checkWriteAccess: true`, so:

- The `check_write_access=true` query param was never sent to the Sentry autofix setup endpoint
- The Sentry → Seer `/v1/automation/codebase/repo/check-access` call was never triggered
- `githubWriteIntegration` was absent from every response, so `canCreatePullRequests` was always `false`
- The Seer endpoint saw **zero** traffic over 14 days despite the full code path existing

## Change

- Add `checkWriteAccess: true` to the `useAutofixSetup` call in `useAiConfig`
- Destructure and surface `canCreatePullRequests` through `AiConfigResult` so callers can gate PR-creation flows on real write-access data

## Why not make it optional

Write access is required for autofix to create PRs. Checking it should not be opt-in — it belongs in the primary setup check that runs on every issue detail load.