### PR TITLE
fix(producer): Register SingletonProducer shutdown eagerly

### DIFF
--- a/src/sentry/utils/arroyo_producer.py
+++ b/src/sentry/utils/arroyo_producer.py
@@ -32,6 +32,16 @@ class SingletonProducer:
         self._futures: deque[_ProducerFuture] = deque()
         self.max_futures = max_futures
 
+        # This fixes a shutdown-ordering bug with OutcomeAggregator, which
+        # flushes buffered outcomes into a producer from its own atexit handler.
+        # atexit runs handlers in reverse registration order. When we registered
+        # our shutdown lazily (on the first produce), it ran after the
+        # aggregator's, so the producer was closed before that flush could run
+        # and the flush failed with "producer has been closed". Registering here,
+        # at construction (import time), makes our close run after the flush.
+        # _shutdown is a no-op when the producer was never created.
+        atexit.register(self._shutdown)
+
     def produce(
         self, destination: ArroyoTopic | Partition, payload: KafkaPayload
     ) -> _ProducerFuture:
@@ -42,7 +52,6 @@ class SingletonProducer:
     def _get(self) -> KafkaProducer:
         if self._producer is None:
             self._producer = self._factory()
-            atexit.register(self._shutdown)
 
         return self._producer
 

--- a/tests/sentry/utils/test_arroyo_producer.py
+++ b/tests/sentry/utils/test_arroyo_producer.py
@@ -1,8 +1,29 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from arroyo.backends.kafka import KafkaProducer
 
 from sentry.utils.arroyo_producer import SingletonProducer
+
+
+def test_registers_shutdown_at_construction() -> None:
+    # The shutdown must be registered eagerly (not on first produce) so atexit's
+    # LIFO ordering runs it after anything that flushes into the producer at exit.
+    def dummy_producer() -> KafkaProducer:
+        raise AssertionError("no producer")
+
+    with patch("sentry.utils.arroyo_producer.atexit.register") as register:
+        producer = SingletonProducer(dummy_producer)
+
+    register.assert_called_once_with(producer._shutdown)
+
+
+def test_shutdown_is_noop_without_producer() -> None:
+    # A producer that is never used must shut down cleanly.
+    def dummy_producer() -> KafkaProducer:
+        raise AssertionError("no producer")
+
+    producer = SingletonProducer(dummy_producer)
+    producer._shutdown()
 
 
 def test_track_futures() -> None:


### PR DESCRIPTION
`OutcomeAggregator` flushes buffered outcomes from an atexit handler, producing
into a module-level outcomes `SingletonProducer`. But `SingletonProducer`
registered its own flush+close lazily, on the first `produce()`. Since atexit
runs handlers in reverse registration order, the producer's close ran before the
aggregator's flush, so the flush hit a closed producer and dropped those outcomes
at shutdown.

We saw this during test execution, as atexit teardown noise:

```
File "sentry/utils/outcomes.py", line 141, in _atexit_flush
File "sentry/utils/outcomes.py", line 84, in flush
File "sentry/utils/outcomes.py", line 257, in track_outcome
File "sentry/utils/arroyo_producer.py", line 38, in produce
RuntimeError: producer has been closed
```

Fix: register the shutdown in `__init__` instead, so it runs after the
aggregator's flush.