### PR TITLE
feat(ourlogs): prefer message template for cell action filters if available

### DIFF
--- a/static/app/views/explore/logs/pinning/PinnedLogs.spec.tsx
+++ b/static/app/views/explore/logs/pinning/PinnedLogs.spec.tsx
@@ -15,14 +15,16 @@ import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParams
 import {PinnedLogs} from 'sentry/views/explore/logs/pinning/PinnedLogs';
 import {useLogsPinning} from 'sentry/views/explore/logs/pinning/useLogsPinning';
 import {usePinnedLogsQuery} from 'sentry/views/explore/logs/pinning/usePinnedLogsQuery';
-import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
-import type {LogTableRowItem} from 'sentry/views/explore/logs/utils';
+import {
+  OurLogKnownFieldKey,
+  type OurLogsResponseItem,
+} from 'sentry/views/explore/logs/types';
 
 const organization = OrganizationFixture({
   features: ['ourlogs-enabled', 'ourlogs-pinning'],
 });
 
-const allRows: LogTableRowItem[] = [
+const allRows: OurLogsResponseItem[] = [
   LogFixture({
     [OurLogKnownFieldKey.ID]: 'log-1',
     [OurLogKnownFieldKey.PROJECT_ID]: '1',
@@ -37,7 +39,7 @@ const allRows: LogTableRowItem[] = [
   }),
 ];
 
-const renderRow = (dataRow: LogTableRowItem) => (
+const renderRow = (dataRow: OurLogsResponseItem) => (
   <tr data-test-id={`pinned-row-${dataRow[OurLogKnownFieldKey.ID]}`}>
     <td>{dataRow[OurLogKnownFieldKey.MESSAGE]}</td>
   </tr>

--- a/static/app/views/explore/logs/pinning/PinnedLogs.tsx
+++ b/static/app/views/explore/logs/pinning/PinnedLogs.tsx
@@ -13,14 +13,16 @@ import {TableBody} from 'sentry/views/explore/components/table';
 import type {LogsPinning} from 'sentry/views/explore/logs/pinning/useLogsPinning';
 import type {usePinnedLogsQuery} from 'sentry/views/explore/logs/pinning/usePinnedLogsQuery';
 import {LOGS_GRID_BODY_ROW_HEIGHT} from 'sentry/views/explore/logs/styles';
-import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
-import type {LogTableRowItem} from 'sentry/views/explore/logs/utils';
+import {
+  OurLogKnownFieldKey,
+  type OurLogsResponseItem,
+} from 'sentry/views/explore/logs/types';
 
 interface Props {
-  allRows: LogTableRowItem[];
+  allRows: OurLogsResponseItem[];
   logsPinning: LogsPinning;
   pinnedLogsQuery: ReturnType<typeof usePinnedLogsQuery>;
-  renderRow: (dataRow: LogTableRowItem) => React.ReactNode;
+  renderRow: (dataRow: OurLogsResponseItem) => React.ReactNode;
 }
 
 export function PinnedLogs({allRows, logsPinning, pinnedLogsQuery, renderRow}: Props) {
@@ -38,7 +40,7 @@ export function PinnedLogs({allRows, logsPinning, pinnedLogsQuery, renderRow}: P
   }, []);
 
   const rowById = useMemo(() => {
-    const map = new Map<string, LogTableRowItem>();
+    const map = new Map<string, OurLogsResponseItem>();
     for (const row of fetchedPinnedRows) {
       map.set(row[OurLogKnownFieldKey.ID], row);
     }

--- a/static/app/views/explore/logs/tables/getMessageFilter.spec.tsx
+++ b/static/app/views/explore/logs/tables/getMessageFilter.spec.tsx
@@ -1,0 +1,63 @@
+import {LogFixture} from 'sentry-fixture/log';
+
+import {getMessageFilter} from 'sentry/views/explore/logs/tables/getMessageFilter';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+
+describe('getMessageFilter', () => {
+  const baseRow = LogFixture({
+    [OurLogKnownFieldKey.ID]: '1',
+    [OurLogKnownFieldKey.PROJECT_ID]: '1',
+    [OurLogKnownFieldKey.ORGANIZATION_ID]: 1,
+  });
+
+  it('uses the message template when filtering on the message field and a template is available', () => {
+    const row = {
+      ...baseRow,
+      [OurLogKnownFieldKey.MESSAGE]: 'User 123 logged in',
+      [OurLogKnownFieldKey.TEMPLATE]: 'User {id} logged in',
+    };
+
+    const filter = getMessageFilter(
+      OurLogKnownFieldKey.MESSAGE,
+      row,
+      'User 123 logged in'
+    );
+
+    expect(filter).toEqual({
+      key: OurLogKnownFieldKey.TEMPLATE,
+      value: 'User {id} logged in',
+    });
+  });
+
+  it('uses the message value when filtering on the message field and no template is available', () => {
+    const row = {
+      ...baseRow,
+      [OurLogKnownFieldKey.MESSAGE]: 'User 123 logged in',
+    };
+
+    const filter = getMessageFilter(
+      OurLogKnownFieldKey.MESSAGE,
+      row,
+      'User 123 logged in'
+    );
+
+    expect(filter).toEqual({
+      key: OurLogKnownFieldKey.MESSAGE,
+      value: 'User 123 logged in',
+    });
+  });
+
+  it('uses the field and cell value when filtering on a non-message field', () => {
+    const row = {
+      ...baseRow,
+      [OurLogKnownFieldKey.TEMPLATE]: 'User {id} logged in',
+    };
+
+    const filter = getMessageFilter(OurLogKnownFieldKey.SEVERITY, row, 'error');
+
+    expect(filter).toEqual({
+      key: OurLogKnownFieldKey.SEVERITY,
+      value: 'error',
+    });
+  });
+});

--- a/static/app/views/explore/logs/tables/getMessageFilter.tsx
+++ b/static/app/views/explore/logs/tables/getMessageFilter.tsx
@@ -1,0 +1,24 @@
+import {
+  OurLogKnownFieldKey,
+  type OurLogsResponseItem,
+} from 'sentry/views/explore/logs/types';
+
+export interface MessageFilter {
+  key: string;
+  value: string | number | boolean;
+}
+
+export function getMessageFilter(
+  field: string,
+  dataRow: OurLogsResponseItem,
+  cellValue: string | number | boolean
+): MessageFilter {
+  if (field === OurLogKnownFieldKey.MESSAGE) {
+    const template = dataRow[OurLogKnownFieldKey.TEMPLATE];
+    if (template !== undefined) {
+      return {key: OurLogKnownFieldKey.TEMPLATE, value: template};
+    }
+  }
+
+  return {key: field, value: cellValue};
+}

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -463,7 +463,7 @@ export function LogsInfiniteTable({
   );
 
   const renderRow = useCallback(
-    (dataRow: LogTableRowItem) => {
+    (dataRow: OurLogsResponseItem) => {
       const rowId = dataRow[OurLogKnownFieldKey.ID];
       const pinnedExpandKey = `pinned-${rowId}`;
       return (
@@ -551,7 +551,7 @@ export function LogsInfiniteTable({
         )}
         {!isPending && logsPinning && (
           <PinnedLogs
-            allRows={data}
+            allRows={data as OurLogsResponseItem[]}
             logsPinning={logsPinning}
             pinnedLogsQuery={pinnedLogsQuery}
             renderRow={renderRow}
@@ -608,7 +608,7 @@ export function LogsInfiniteTable({
             return (
               <Fragment key={virtualRow.key}>
                 <LogRowContent
-                  dataRow={dataRow}
+                  dataRow={dataRow as OurLogsResponseItem}
                   meta={meta}
                   highlightTerms={highlightTerms}
                   embedded={embedded}

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -20,6 +20,7 @@ import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent
 import {
   LOGS_FIELDS_KEY,
   LOGS_GROUP_BY_KEY,
+  LOGS_QUERY_KEY,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {type TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
@@ -419,6 +420,64 @@ describe('logsTableRow', () => {
         query: 'message:"test \\"quoted\\" log body"',
       },
     ]);
+  });
+
+  it('uses the message template for the message cell action filter when available', async () => {
+    const rowDataWithTemplate = LogFixture({
+      [OurLogKnownFieldKey.ID]: '1',
+      [OurLogKnownFieldKey.PROJECT_ID]: project.id,
+      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
+      [OurLogKnownFieldKey.MESSAGE]: 'User 123 logged in',
+      [OurLogKnownFieldKey.TEMPLATE]: 'User {id} logged in',
+    });
+
+    const {router} = render(
+      <LogRowContent
+        dataRow={rowDataWithTemplate}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowDataWithTemplate)}
+        sharedHoverTimeoutRef={{current: null}}
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.hover(logTableRow);
+    const messageCell = await screen.findByTestId('log-table-cell-message');
+    await userEvent.click(within(messageCell).getByRole('button', {name: 'Actions'}));
+    await userEvent.click(
+      await screen.findByRole('menuitemradio', {name: 'Add to filter'})
+    );
+
+    await waitFor(() => {
+      expect(router.location.query[LOGS_QUERY_KEY]).toBe(
+        'message.template:"User {id} logged in"'
+      );
+    });
+  });
+
+  it('uses the message value for the message cell action filter when no template is available', async () => {
+    const {router} = render(
+      <LogRowContent
+        dataRow={rowData}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowData)}
+        sharedHoverTimeoutRef={{current: null}}
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.hover(logTableRow);
+    const messageCell = await screen.findByTestId('log-table-cell-message');
+    await userEvent.click(within(messageCell).getByRole('button', {name: 'Actions'}));
+    await userEvent.click(
+      await screen.findByRole('menuitemradio', {name: 'Add to filter'})
+    );
+
+    await waitFor(() => {
+      expect(router.location.query[LOGS_QUERY_KEY]).toBe('message:"test log body"');
+    });
   });
 
   it.isKnownFlake(

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -31,7 +31,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {normalizeTimestampToSeconds} from 'sentry/utils/dates';
 import {defined} from 'sentry/utils/defined';
-import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {FieldValueType} from 'sentry/utils/fields';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
@@ -92,6 +91,10 @@ import {
   TraceIconStyleWrapper,
 } from 'sentry/views/explore/logs/styles';
 import {
+  getMessageFilter,
+  type MessageFilter,
+} from 'sentry/views/explore/logs/tables/getMessageFilter';
+import {
   OurLogKnownFieldKey,
   type OurLogsResponseItem,
 } from 'sentry/views/explore/logs/types';
@@ -104,7 +107,6 @@ import {
   getLogSeverityLevel,
   isPseudoLogResponseItem,
   isRegularLogResponseItem,
-  type LogTableRowItem,
   ourlogToJson,
 } from 'sentry/views/explore/logs/utils';
 import type {ReplayEmbeddedTableOptions} from 'sentry/views/explore/logs/utils/logsReplayUtils';
@@ -117,7 +119,7 @@ import {getExploreUrl} from 'sentry/views/explore/utils';
 import {TraceIcons} from 'sentry/views/performance/newTraceDetails/traceIcons';
 
 type LogsRowProps = {
-  dataRow: LogTableRowItem;
+  dataRow: OurLogsResponseItem;
   highlightTerms: string[];
   meta: EventsMetaType | undefined;
   sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
@@ -496,7 +498,7 @@ export const LogRowContent = memo(function LogRowContent({
           const shouldRenderActions =
             (showCellActions ?? !embedded) && shouldRenderHoverElements;
 
-          const value = (dataRow as OurLogsResponseItem)[field];
+          const value = dataRow[field];
 
           const extraMenuItems =
             field === OurLogKnownFieldKey.MESSAGE
@@ -522,7 +524,7 @@ export const LogRowContent = memo(function LogRowContent({
 
           const renderedField = (
             <LogFieldRenderer
-              item={getLogRowItem(field, dataRow as unknown as OurLogsResponseItem, meta)}
+              item={getLogRowItem(field, dataRow, meta)}
               meta={meta}
               extra={{
                 ...rendererExtra,
@@ -532,7 +534,7 @@ export const LogRowContent = memo(function LogRowContent({
             />
           );
 
-          const discoverColumn: TableColumn<keyof TableDataRow> = {
+          const discoverColumn: TableColumn<keyof OurLogsResponseItem> = {
             column: {
               field,
               kind: 'field',
@@ -552,19 +554,20 @@ export const LogRowContent = memo(function LogRowContent({
               {shouldRenderActions ? (
                 <CellAction
                   column={discoverColumn}
-                  dataRow={dataRow as unknown as TableDataRow}
+                  dataRow={dataRow}
                   handleCellAction={(actions, cellValue) => {
+                    const filter = getMessageFilter(field, dataRow, cellValue);
                     switch (actions) {
                       case Actions.ADD:
                         addSearchFilter({
-                          key: field,
-                          value: cellValue,
+                          key: filter.key,
+                          value: filter.value,
                         });
                         break;
                       case Actions.EXCLUDE:
                         addSearchFilter({
-                          key: field,
-                          value: cellValue,
+                          key: filter.key,
+                          value: filter.value,
                           negated: true,
                         });
                         break;
@@ -626,7 +629,7 @@ function LogRowDetails({
   meta,
   ref,
 }: {
-  dataRow: LogTableRowItem;
+  dataRow: OurLogsResponseItem;
   embedded: boolean;
   highlightTerms: string[];
   meta: EventsMetaType | undefined;
@@ -783,7 +786,7 @@ function LogRowDetails({
   );
 }
 
-function LogRowDetailsFilterActions({message}: {message: string}) {
+function LogRowDetailsFilterActions({filter}: {filter: MessageFilter}) {
   const addSearchFilter = useAddSearchFilter();
   return (
     <LogDetailTableActionsButtonBar>
@@ -793,8 +796,8 @@ function LogRowDetailsFilterActions({message}: {message: string}) {
         icon={<IconAdd />}
         onClick={() => {
           addSearchFilter({
-            key: OurLogKnownFieldKey.MESSAGE,
-            value: message,
+            key: filter.key,
+            value: filter.value,
           });
         }}
       >
@@ -806,8 +809,8 @@ function LogRowDetailsFilterActions({message}: {message: string}) {
         icon={<IconSubtract />}
         onClick={() => {
           addSearchFilter({
-            key: OurLogKnownFieldKey.MESSAGE,
-            value: message,
+            key: filter.key,
+            value: filter.value,
             negated: true,
           });
         }}
@@ -825,7 +828,7 @@ function LogRowDetailsActions({
 }: {
   fullLogDataResult: UseQueryResult<TraceItemDetailsResponse>;
   projectSlug: string;
-  tableDataRow: LogTableRowItem;
+  tableDataRow: OurLogsResponseItem;
 }) {
   const {data, isPending, isError} = fullLogDataResult;
   const isFrozen = useLogsFrozenIsFrozen();
@@ -836,6 +839,11 @@ function LogRowDetailsActions({
     data?.attributes?.find(attr => attr.name === OurLogKnownFieldKey.MESSAGE)?.value ??
       tableDataRow[OurLogKnownFieldKey.MESSAGE] ??
       ''
+  );
+  const messageFilter = getMessageFilter(
+    OurLogKnownFieldKey.MESSAGE,
+    tableDataRow,
+    message
   );
 
   const {copy} = useCopyToClipboard();
@@ -888,7 +896,11 @@ function LogRowDetailsActions({
 
   return (
     <Fragment>
-      {showFilterButtons ? <LogRowDetailsFilterActions message={message} /> : <span />}
+      {showFilterButtons ? (
+        <LogRowDetailsFilterActions filter={messageFilter} />
+      ) : (
+        <span />
+      )}
       <LogDetailTableActionsButtonBar>
         <Button
           variant="transparent"


### PR DESCRIPTION
Adding a log's message to the search filter now prefers the message template (e.g. `message.template:"User {id} logged in"`) over the interpolated message (`message:"User 123 logged in"`) whenever a template is available on the row. This applies both to:

* the table cell action
* the expanded-row "Add to filter" / "Exclude from filter" buttons 

The template-resolution logic lives in a small standalone `getMessageFilter` helper so both the cell action and detail-view buttons share it. In making that I was inconvenienced by all the `as OurLogsResponseItem` assertions in `logsTableRow.tsx‎`, so I moved those up to `logsInfiniteTable.tsx`.

Closes LOGS-195