### PR TITLE
ref(autofix): Always check write access in autofix setup check

### DIFF
--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -133,14 +133,12 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
                 organization=org, project=group.project
             )
 
-        write_integration_check = None
-        if request.query_params.get("check_write_access", False):
-            repos = get_repos_and_access(group.project, group.id)
-            write_access_ok = len(repos) > 0 and all(repo["ok"] for repo in repos)
-            write_integration_check = {
-                "ok": write_access_ok,
-                "repos": repos,
-            }
+        repos = get_repos_and_access(group.project, group.id)
+        write_access_ok = len(repos) > 0 and all(repo["ok"] for repo in repos)
+        write_integration_check = {
+            "ok": write_access_ok,
+            "repos": repos,
+        }
 
         has_autofix_quota: bool = quotas.backend.check_seer_quota(
             org_id=org.id, data_category=DataCategory.SEER_AUTOFIX

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -141,7 +141,10 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
                 "ok": True,
                 "reason": None,
             },
-            "githubWriteIntegration": None,
+            "githubWriteIntegration": {
+                "ok": False,
+                "repos": [],
+            },
             "setupAcknowledgement": {
                 "orgHasAcknowledged": True,
                 "userHasAcknowledged": True,
@@ -178,7 +181,7 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
 
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/?check_write_access=true"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -363,7 +366,7 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
 
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/?check_write_access=true"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -402,7 +405,7 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
 
         group = self.create_group()
         self.login_as(user=self.user)
-        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/?check_write_access=true"
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200


### PR DESCRIPTION
## Summary

The autofix setup check endpoint (`GET /organizations/{org}/issues/{issue}/autofix/setup/`) previously ran the SCM write-access check only when the `check_write_access` query param was passed, otherwise returning `githubWriteIntegration: null`.

This makes the write-access check non-optional: it always runs and `githubWriteIntegration` is always populated. Callers no longer need to opt in via the query param.

## Changes

- Remove the `check_write_access` query-param gate in `GroupAutofixSetupCheck.get` so `get_repos_and_access` always runs.
- Update tests accordingly and drop the now-unused `?check_write_access=true` query param from the test URLs.

## Notes

Backend-only change. The frontend `useAutofixSetup` hook still sends `check_write_access` when `checkWriteAccess` is set, which is now a harmless no-op; the response type already allows a non-null `githubWriteIntegration`. A follow-up frontend cleanup can drop the param.

## Test plan

- `pytest tests/sentry/seer/endpoints/test_group_autofix_setup_check.py` — 19 passed



Agent transcript: https://claudescope.sentry.dev/share/IwAryq8fw27imCEaj4borhkLJieShNTo8aRauyDuDPI