### PR TITLE
feat(agent-monitoring): drop redundant streamGenAiSpans from JS onboarding

### DIFF
--- a/static/app/gettingStartedDocs/deno/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/deno/agentMonitoring.tsx
@@ -12,7 +12,7 @@ import {ManualInstrumentationNote} from 'sentry/views/insights/pages/agents/llmO
 import {AgentIntegration} from 'sentry/views/insights/pages/agents/utils/agentIntegrations';
 
 const PACKAGE_NAME = '@sentry/deno';
-const MIN_VERSION = '10.53.0';
+const MIN_VERSION = '10.61.0';
 
 const sentryImport = `import * as Sentry from "npm:${PACKAGE_NAME}";`;
 

--- a/static/app/gettingStartedDocs/deno/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/deno/agentMonitoring.tsx
@@ -86,7 +86,6 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   dataCollection: {
     // Control data collection of LLMs and tools.
     // For more info visit: https://docs.sentry.io/platforms/javascript/data-management/data-collected/

--- a/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
@@ -80,7 +80,6 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   dataCollection: {
     // Control data collection of LLMs and tools.
     // For more info visit: https://docs.sentry.io/platforms/javascript/data-management/data-collected/

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -177,7 +177,6 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   dataCollection: {
     // Control data collection of LLMs and tools.
     // For more info visit: https://docs.sentry.io/platforms/javascript/data-management/data-collected/
@@ -349,7 +348,6 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   dataCollection: {
     // Control data collection of LLMs and tools.
     // For more info visit: https://docs.sentry.io/platforms/javascript/data-management/data-collected/

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -16,7 +16,7 @@ import {
   AgentIntegration,
 } from 'sentry/views/insights/pages/agents/utils/agentIntegrations';
 
-export const MIN_REQUIRED_VERSION = '10.53.0';
+export const MIN_REQUIRED_VERSION = '10.61.0';
 
 export function getAgentIntegration(params: DocsParams): AgentIntegration {
   return (params.platformOptions?.integration ??


### PR DESCRIPTION
The agent monitoring onboarding for Node, JavaScript, and Deno drops the explicit `streamGenAiSpans: true` and raises the minimum SDK shown to users to 10.61.0. The option has defaulted to `true` since 10.61.0, so the opt-in only added noise — but the displayed minimum has to move up with it, otherwise users on 10.53.x–10.60.x following the examples would silently stop streaming Gen AI spans. Python onboarding keeps `stream_gen_ai_spans` because that option still defaults to off.

Paired with getsentry/sentry-for-ai#230, which makes the same change in the AI setup skills. The JS docs already document the new default (getsentry/sentry-docs#18535), so no docs change is needed here.

Refs TET-2553