### PR TITLE
fix(issue-details): avoid leaking issue filters into trace links

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -174,6 +174,7 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
       ...location,
       query: {
         groupId: event.groupID,
+        referrer: location.query.referrer,
       },
     },
     TraceViewSources.ISSUE_DETAILS

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -173,7 +173,6 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
     {
       ...location,
       query: {
-        ...location.query,
         groupId: event.groupID,
       },
     },

--- a/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
@@ -96,10 +96,10 @@ describe('TraceLink', () => {
 
     expect(url.pathname).toBe(`/organizations/${organization.slug}/issues/trace/123/`);
     expect(url.searchParams.get('groupId')).toBe(event.groupID);
+    expect(url.searchParams.get('referrer')).toBe('issue-stream');
     expect(url.searchParams.get('source')).toBe('issue_details');
     expect(url.searchParams.has('project')).toBe(false);
     expect(url.searchParams.has('query')).toBe(false);
-    expect(url.searchParams.has('referrer')).toBe(false);
   });
 
   it('renders no trace available', async () => {

--- a/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
@@ -11,9 +11,6 @@ import type {TraceEventResponse} from './useTraceTimelineEvents';
 
 describe('TraceLink', () => {
   const organization = OrganizationFixture();
-  const performanceViewOrganization = OrganizationFixture({
-    features: ['performance-view'],
-  });
   const event = EventFixture({
     contexts: {
       trace: {
@@ -81,7 +78,7 @@ describe('TraceLink', () => {
 
   it('does not carry issue list filters into the trace target', async () => {
     render(<TraceLink event={event} />, {
-      organization: performanceViewOrganization,
+      organization: {...organization, features: ['performance-view']},
       initialRouterConfig: {
         location: {
           pathname: `/organizations/${organization.slug}/issues/${event.groupID}/`,

--- a/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
@@ -11,6 +11,9 @@ import type {TraceEventResponse} from './useTraceTimelineEvents';
 
 describe('TraceLink', () => {
   const organization = OrganizationFixture();
+  const performanceViewOrganization = OrganizationFixture({
+    features: ['performance-view'],
+  });
   const event = EventFixture({
     contexts: {
       trace: {
@@ -74,6 +77,32 @@ describe('TraceLink', () => {
     });
     render(<TraceLink event={event} />, {organization});
     expect(await screen.findByText('View Full Trace')).toBeInTheDocument();
+  });
+
+  it('does not carry issue list filters into the trace target', async () => {
+    render(<TraceLink event={event} />, {
+      organization: performanceViewOrganization,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/issues/${event.groupID}/`,
+          query: {
+            project: project.id,
+            query: 'is:unresolved issue.category:[error,outage]',
+            referrer: 'issue-stream',
+          },
+        },
+      },
+    });
+
+    const link = await screen.findByRole('link', {name: 'View Full Trace'});
+    const url = new URL(link.getAttribute('href')!, 'https://example.com');
+
+    expect(url.pathname).toBe(`/organizations/${organization.slug}/issues/trace/123/`);
+    expect(url.searchParams.get('groupId')).toBe(event.groupID);
+    expect(url.searchParams.get('source')).toBe('issue_details');
+    expect(url.searchParams.has('project')).toBe(false);
+    expect(url.searchParams.has('query')).toBe(false);
+    expect(url.searchParams.has('referrer')).toBe(false);
   });
 
   it('renders no trace available', async () => {

--- a/static/app/views/issueDetails/traceTimeline/traceLink.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceLink.tsx
@@ -27,7 +27,6 @@ export function TraceLink({event}: TraceLinkProps) {
     {
       ...location,
       query: {
-        ...location.query,
         groupId: event.groupID,
       },
     },

--- a/static/app/views/issueDetails/traceTimeline/traceLink.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceLink.tsx
@@ -28,6 +28,7 @@ export function TraceLink({event}: TraceLinkProps) {
       ...location,
       query: {
         groupId: event.groupID,
+        referrer: location.query.referrer,
       },
     },
     area.startsWith('feedback')

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
@@ -35,6 +35,14 @@ export function TraceTimelineTooltip({event, timelineEvents}: TraceTimelineToolt
   );
   const displayYouAreHere = filteredTimelineEvents.length !== timelineEvents.length;
   const hasTitle = filteredTimelineEvents.length > 1 || displayYouAreHere;
+  const traceTargetLocation = area.startsWith('issue_details')
+    ? {
+        ...location,
+        query: {
+          groupId: event.groupID,
+        },
+      }
+    : location;
 
   return (
     <UnstyledUnorderedList>
@@ -54,7 +62,7 @@ export function TraceTimelineTooltip({event, timelineEvents}: TraceTimelineToolt
       {filteredTimelineEvents.length > 3 && (
         <TraceItem>
           <Link
-            to={generateTraceTarget(event, organization, location)}
+            to={generateTraceTarget(event, organization, traceTargetLocation)}
             onClick={() => {
               if (area.startsWith('issue_details')) {
                 // Track this event for backwards compatibility. TODO: remove after issues team dashboards/queries are migrated

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
@@ -40,6 +40,7 @@ export function TraceTimelineTooltip({event, timelineEvents}: TraceTimelineToolt
         ...location,
         query: {
           groupId: event.groupID,
+          referrer: location.query.referrer,
         },
       }
     : location;

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.spec.tsx
@@ -1,0 +1,62 @@
+import {createRef} from 'react';
+import {EventFixture} from 'sentry-fixture/event';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {IssuesTraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/issuesTraceTree';
+
+import type {VirtualizedViewManager} from './traceRenderers/virtualizedViewManager';
+import {IssueTraceWaterfallOverlay} from './issuesTraceWaterfallOverlay';
+
+describe('IssueTraceWaterfallOverlay', () => {
+  it('does not carry issue list filters into the trace target', () => {
+    const event = EventFixture({
+      contexts: {
+        trace: {
+          trace_id: '123',
+        },
+      },
+    });
+    const organization = OrganizationFixture({features: ['performance-view']});
+    const viewManager = {
+      row_measurer: {
+        off: jest.fn(),
+        on: jest.fn(),
+      },
+    } as unknown as VirtualizedViewManager;
+
+    render(
+      <IssueTraceWaterfallOverlay
+        containerRef={createRef<HTMLDivElement>()}
+        event={event}
+        groupId={event.groupID}
+        tree={{list: []} as unknown as IssuesTraceTree}
+        viewManager={viewManager}
+      />,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/issues/${event.groupID}/`,
+            query: {
+              project: '1',
+              query: 'is:unresolved issue.category:[error,outage]',
+              referrer: 'issue-stream',
+            },
+          },
+        },
+      }
+    );
+
+    const link = screen.getByRole('link');
+    const url = new URL(link.getAttribute('href')!, 'https://example.com');
+
+    expect(url.pathname).toBe(`/organizations/${organization.slug}/issues/trace/123/`);
+    expect(url.searchParams.get('groupId')).toBe(event.groupID);
+    expect(url.searchParams.get('source')).toBe('issue_details');
+    expect(url.searchParams.has('project')).toBe(false);
+    expect(url.searchParams.has('query')).toBe(false);
+    expect(url.searchParams.has('referrer')).toBe(false);
+  });
+});

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.spec.tsx
@@ -54,9 +54,9 @@ describe('IssueTraceWaterfallOverlay', () => {
 
     expect(url.pathname).toBe(`/organizations/${organization.slug}/issues/trace/123/`);
     expect(url.searchParams.get('groupId')).toBe(event.groupID);
+    expect(url.searchParams.get('referrer')).toBe('issue-stream');
     expect(url.searchParams.get('source')).toBe('issue_details');
     expect(url.searchParams.has('project')).toBe(false);
     expect(url.searchParams.has('query')).toBe(false);
-    expect(url.searchParams.has('referrer')).toBe(false);
   });
 });

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.tsx
@@ -58,10 +58,7 @@ export function IssueTraceWaterfallOverlay({
         organization,
         {
           ...location,
-          query: {
-            ...location.query,
-            ...(groupId ? {groupId} : {}),
-          },
+          query: groupId ? {groupId} : {},
         },
         TraceViewSources.ISSUE_DETAILS
       ),

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfallOverlay.tsx
@@ -58,7 +58,10 @@ export function IssueTraceWaterfallOverlay({
         organization,
         {
           ...location,
-          query: groupId ? {groupId} : {},
+          query: {
+            ...(groupId ? {groupId} : {}),
+            referrer: location.query.referrer,
+          },
         },
         TraceViewSources.ISSUE_DETAILS
       ),


### PR DESCRIPTION
The goal of this PR is to remove some query params from being passed along to the trace view, which was causing some spans to not be shown.

Closes EXP-970