### PR TITLE
fix(issues): show logs under hydration error and rage-click replays

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
@@ -13,6 +13,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {OurlogsSection} from 'sentry/components/events/ourlogs/ourlogsSection';
+import {IssueType} from 'sentry/types/group';
 
 jest.mock('sentry/components/lazyRender', () => ({
   LazyRender: ({children}: {children: React.ReactNode}) => children,
@@ -22,6 +23,8 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 
 const TRACE_ID = '00000000000000000000000000000000';
+const REPLAY_ID = '22222222222222222222222222222222';
+const REPLAY_TRACE_ID = '33333333333333333333333333333333';
 
 jest.mock('@tanstack/react-virtual', () => {
   return {
@@ -256,6 +259,154 @@ describe('OurlogsSection', () => {
 
     expect(within(aside).getByTestId('tree-key-severity')).toBeInTheDocument();
     expect(within(aside).getByTestId('tree-key-severity')).toHaveTextContent('severity');
+  });
+
+  const rageClickGroup = GroupFixture({issueType: IssueType.REPLAY_RAGE_CLICK});
+
+  function mockReplayRecord(traceIds: string[]) {
+    return MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays/${REPLAY_ID}/`,
+      body: {
+        data: {
+          id: REPLAY_ID,
+          started_at: '2019-03-20T00:00:00.000Z',
+          finished_at: '2019-03-20T01:00:00.000Z',
+          duration: 3600,
+          trace_ids: traceIds,
+        },
+      },
+    });
+  }
+
+  const replayEvent = EventFixture({
+    contexts: {
+      replay: {type: 'default', replay_id: REPLAY_ID},
+    },
+  });
+
+  it('renders logs for a rage-click issue when there is no trace context', async () => {
+    mockReplayRecord([REPLAY_TRACE_ID]);
+
+    render(
+      <OurlogsSection event={replayEvent} project={project} group={rageClickGroup} />,
+      {organization}
+    );
+
+    expect(await screen.findByText(/i am a log/)).toBeInTheDocument();
+    expect(mockRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/trace-logs/`,
+      expect.objectContaining({
+        query: expect.objectContaining({
+          replayId: REPLAY_ID,
+          traceId: [REPLAY_TRACE_ID],
+        }),
+      })
+    );
+  });
+
+  it('queries by both the replay id and the replay trace ids when both are available', async () => {
+    mockReplayRecord([REPLAY_TRACE_ID]);
+    const replayAndTraceEvent = EventFixture({
+      contexts: {
+        replay: {type: 'default', replay_id: REPLAY_ID},
+        trace: {type: 'trace', trace_id: TRACE_ID, span_id: 'b0e6f15b45c36b12'},
+      },
+    });
+
+    render(
+      <OurlogsSection
+        event={replayAndTraceEvent}
+        project={project}
+        group={rageClickGroup}
+      />,
+      {organization}
+    );
+
+    expect(await screen.findByText(/i am a log/)).toBeInTheDocument();
+    expect(mockRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/trace-logs/`,
+      expect.objectContaining({
+        query: expect.objectContaining({
+          replayId: REPLAY_ID,
+          traceId: expect.arrayContaining([REPLAY_TRACE_ID, TRACE_ID]),
+        }),
+      })
+    );
+  });
+
+  it('falls back to trace-only logs when the replay record fails to load', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays/${REPLAY_ID}/`,
+      statusCode: 404,
+      body: {detail: 'Not found'},
+    });
+    const replayAndTraceEvent = EventFixture({
+      contexts: {
+        replay: {type: 'default', replay_id: REPLAY_ID},
+        trace: {type: 'trace', trace_id: TRACE_ID, span_id: 'b0e6f15b45c36b12'},
+      },
+    });
+
+    render(
+      <OurlogsSection
+        event={replayAndTraceEvent}
+        project={project}
+        group={rageClickGroup}
+      />,
+      {organization}
+    );
+
+    expect(await screen.findByText(/i am a log/)).toBeInTheDocument();
+    const [, options] = mockRequest.mock.calls[0];
+    expect(options.query.traceId).toEqual([TRACE_ID]);
+    expect(options.query.replayId).toBeUndefined();
+  });
+
+  it('does not fetch the replay record for non-replay-generated issues', async () => {
+    const replayRecordRequest = mockReplayRecord([REPLAY_TRACE_ID]);
+    const errorEventWithReplay = EventFixture({
+      contexts: {
+        replay: {type: 'default', replay_id: REPLAY_ID},
+        trace: {type: 'trace', trace_id: TRACE_ID, span_id: 'b0e6f15b45c36b12'},
+      },
+    });
+
+    render(
+      <OurlogsSection event={errorEventWithReplay} project={project} group={group} />,
+      {organization}
+    );
+
+    expect(await screen.findByText(/i am a log/)).toBeInTheDocument();
+    expect(replayRecordRequest).not.toHaveBeenCalled();
+    const [, options] = mockRequest.mock.calls[0];
+    expect(options.query.traceId).toEqual([TRACE_ID]);
+    expect(options.query.replayId).toBeUndefined();
+  });
+
+  it('omits an empty query param when freezing on replay + traces', async () => {
+    mockReplayRecord([REPLAY_TRACE_ID]);
+
+    render(
+      <OurlogsSection event={replayEvent} project={project} group={rageClickGroup} />,
+      {organization}
+    );
+
+    expect(await screen.findByText(/i am a log/)).toBeInTheDocument();
+    const [, options] = mockRequest.mock.calls[0];
+    expect(options.query.query).toBeUndefined();
+  });
+
+  it('renders nothing when the event has neither a trace id nor a replay id', async () => {
+    const bareEvent = EventFixture({contexts: {}});
+
+    render(<OurlogsSection event={bareEvent} project={project} group={group} />, {
+      organization,
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Logs/)).not.toBeInTheDocument();
+    });
+    expect(mockRequest).not.toHaveBeenCalled();
   });
 
   it('renders Open in explore button with correct URL when trace_id exists', async () => {

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -1,5 +1,6 @@
-import {useCallback, useEffect, useRef} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
+import {useQuery} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
 import {useDrawer} from '@sentry/scraps/drawer';
@@ -12,9 +13,13 @@ import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
+import {IssueType} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
+import {replayRecordApiOptions} from 'sentry/utils/replays/hooks/useReplayData';
+import {mapResponseToReplayRecord} from 'sentry/utils/replays/replayDataUtils';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -25,6 +30,7 @@ import {
   useLogsPageDataQueryResult,
 } from 'sentry/views/explore/contexts/logs/logsPageData';
 import {LOGS_DRAWER_QUERY_PARAM} from 'sentry/views/explore/logs/constants';
+import type {LogsFrozenContextProviderProps} from 'sentry/views/explore/logs/logsFrozenContext';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {LogRowContent} from 'sentry/views/explore/logs/tables/logsTableRow';
 import {useQueryParamsSearch} from 'sentry/views/explore/queryParams/context';
@@ -41,10 +47,56 @@ export function OurlogsSection({
   project: Project;
 }) {
   const location = useLocation();
+  const organization = useOrganization();
   const traceId = event.contexts?.trace?.trace_id;
-  if (!traceId) {
+
+  // Replay-generated issues (eg. rage clicks) may not carry a usable trace context,
+  // and even when they do it's only the first of the replay's traces. For these issue
+  // types we correlate logs by the replay and its full set of trace ids. Other issue
+  // types keep the trace-only behavior so we don't add a replay fetch to their path.
+  const isReplayGeneratedIssue =
+    group.issueType === IssueType.REPLAY_RAGE_CLICK ||
+    group.issueType === IssueType.REPLAY_HYDRATION_ERROR;
+  const replayId = isReplayGeneratedIssue ? getReplayIdFromEvent(event) : undefined;
+
+  const {data: replayData, isLoading: isReplayLoading} = useQuery({
+    ...replayRecordApiOptions({organizationIdOrSlug: organization.slug, replayId}),
+    retry: false,
+  });
+
+  const replayRecord = useMemo(
+    () => (replayData?.data ? mapResponseToReplayRecord(replayData.data) : undefined),
+    [replayData?.data]
+  );
+
+  const freeze = useMemo<LogsFrozenContextProviderProps | undefined>(() => {
+    if (replayId && replayRecord?.started_at) {
+      const traceIds = Array.from(
+        new Set([...replayRecord.trace_ids, ...(traceId ? [traceId] : [])])
+      );
+      return {
+        replayId,
+        replayStartedAt: replayRecord.started_at,
+        replayEndedAt: replayRecord.finished_at ?? undefined,
+        ...(traceIds.length ? {traceIds} : {}),
+      };
+    }
+    if (traceId) {
+      return {traceId};
+    }
+    return;
+  }, [replayId, replayRecord, traceId]);
+
+  if (replayId && isReplayLoading) {
     return null;
   }
+
+  if (!freeze) {
+    // No trace or replay to scope logs to (eg. profiling issues), so there's nothing
+    // to show since logs are trace/replay specific.
+    return null;
+  }
+
   return (
     <LazyRender
       disabled={
@@ -57,10 +109,15 @@ export function OurlogsSection({
       <LogsQueryParamsProvider
         analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
         source="state"
-        freeze={{traceId}}
+        freeze={freeze}
       >
         <LogsPageDataProvider disabled={false} staleTime={EXPLORE_FIVE_MIN_STALE_TIME}>
-          <OurlogsSectionContent event={event} group={group} project={project} />
+          <OurlogsSectionContent
+            event={event}
+            group={group}
+            project={project}
+            freeze={freeze}
+          />
         </LogsPageDataProvider>
       </LogsQueryParamsProvider>
     </LazyRender>
@@ -71,8 +128,10 @@ function OurlogsSectionContent({
   event,
   project,
   group,
+  freeze,
 }: {
   event: Event;
+  freeze: LogsFrozenContextProviderProps;
   group: Group;
   project: Project;
 }) {
@@ -87,7 +146,6 @@ function OurlogsSectionContent({
   const viewAllButtonRef = useRef<HTMLButtonElement>(null);
   const sharedHoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const traceId = event.contexts?.trace?.trace_id;
   const onOpenLogsDrawer = useCallback(
     (e: React.MouseEvent, expandedLogId?: string) => {
       e.stopPropagation();
@@ -119,7 +177,7 @@ function OurlogsSectionContent({
 
   useEffect(() => {
     const shouldOpenDrawer = location.query[LOGS_DRAWER_QUERY_PARAM] === 'true';
-    if (shouldOpenDrawer && traceId) {
+    if (shouldOpenDrawer) {
       const expandedLogId = location.query.expandedLogId as string | undefined;
 
       openDrawer(
@@ -127,10 +185,10 @@ function OurlogsSectionContent({
           <LogsQueryParamsProvider
             analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
             source="state"
-            freeze={traceId ? {traceId} : undefined}
+            freeze={freeze}
           >
             <LogsPageDataProvider
-              disabled={!traceId}
+              disabled={false}
               staleTime={EXPLORE_FIVE_MIN_STALE_TIME}
             >
               <OurlogsDrawer
@@ -171,13 +229,8 @@ function OurlogsSectionContent({
         }
       );
     }
-  }, [location.query, traceId, group, event, project, openDrawer, navigate, location]);
+  }, [location.query, freeze, group, event, project, openDrawer, navigate, location]);
   if (!feature) {
-    return null;
-  }
-  if (!traceId) {
-    // If there isn't a traceId (eg. profiling issue), we shouldn't show logs since they are trace specific.
-    // We may change this in the future if we have a trace-group or we generate trace sids for these issue types.
     return null;
   }
   if (!tableData?.data || (tableData.data.length === 0 && logsSearch.isEmpty())) {

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -64,12 +64,10 @@ export function OurlogsSection({
     retry: false,
   });
 
-  const replayRecord = useMemo(
-    () => (replayData?.data ? mapResponseToReplayRecord(replayData.data) : undefined),
-    [replayData?.data]
-  );
-
   const freeze = useMemo<LogsFrozenContextProviderProps | undefined>(() => {
+    const replayRecord = replayData?.data
+      ? mapResponseToReplayRecord(replayData.data)
+      : undefined;
     if (replayId && replayRecord?.started_at) {
       const traceIds = Array.from(
         new Set([...replayRecord.trace_ids, ...(traceId ? [traceId] : [])])
@@ -85,7 +83,7 @@ export function OurlogsSection({
       return {traceId};
     }
     return;
-  }, [replayId, replayRecord, traceId]);
+  }, [replayId, replayData?.data, traceId]);
 
   if (replayId && isReplayLoading) {
     return null;

--- a/static/app/views/explore/logs/logsFrozenContext.tsx
+++ b/static/app/views/explore/logs/logsFrozenContext.tsx
@@ -38,6 +38,7 @@ interface LogsFrozenForReplayProviderProps {
   replayId: string;
   replayStartedAt: Date;
   replayEndedAt?: Date;
+  traceIds?: string[];
 }
 
 type LogsNotFrozenProviderProps = Record<keyof any, never>;
@@ -96,6 +97,35 @@ export function LogsFrozenContextProvider(
   props: LogsFrozenContextProviderWithChildrenProps
 ) {
   const value: LogsFrozenContextValue = useMemo(() => {
+    // Checked before the trace variants because a combined replay + trace freeze
+    // carries both `replayId` and `traceIds`.
+    if (isLogsFrozenForReplayProviderWithChildrenProps(props)) {
+      if (props.traceIds?.length) {
+        // Combined replay + trace freeze. We rely on the trace-logs endpoint to
+        // OR `replayId` and `traceId` natively (via the params built in
+        // useLogsApiOptions), so we deliberately leave `search` unset to avoid
+        // ANDing a constraint onto that union.
+        return {
+          frozen: true,
+          replayId: props.replayId,
+          traceIds: props.traceIds,
+          projectIds: [ALL_ACCESS_PROJECTS],
+          replayStartedAt: props.replayStartedAt,
+          replayEndedAt: props.replayEndedAt,
+        };
+      }
+      const search = new MutableSearch('');
+      search.addFilterValue(OurLogKnownFieldKey.REPLAY_ID, props.replayId);
+      return {
+        frozen: true,
+        search,
+        replayId: props.replayId,
+        projectIds: [ALL_ACCESS_PROJECTS],
+        replayStartedAt: props.replayStartedAt,
+        replayEndedAt: props.replayEndedAt,
+      };
+    }
+
     if (isLogsFrozenForTracesProviderWithChildrenProps(props) && props.traceIds.length) {
       const search = new MutableSearch('');
       const traceIds = `[${props.traceIds.join(',')}]`;
@@ -128,19 +158,6 @@ export function LogsFrozenContextProvider(
         search,
         traceIds: [props.span.traceId],
         projectIds: props.span.projectIds ?? [ALL_ACCESS_PROJECTS],
-      };
-    }
-
-    if (isLogsFrozenForReplayProviderWithChildrenProps(props)) {
-      const search = new MutableSearch('');
-      search.addFilterValue(OurLogKnownFieldKey.REPLAY_ID, props.replayId);
-      return {
-        frozen: true,
-        search,
-        replayId: props.replayId,
-        projectIds: [ALL_ACCESS_PROJECTS],
-        replayStartedAt: props.replayStartedAt,
-        replayEndedAt: props.replayEndedAt,
       };
     }
 

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -133,7 +133,7 @@ function useLogsApiOptions({
 
   const orderby = eventViewPayload.sort;
 
-  const query = {
+  const baseQuery = {
     ...eventViewPayload,
     ...(frozenTraceIds ? {traceId: frozenTraceIds} : {}),
     ...(frozenReplayInfo.replayId ? {replayId: frozenReplayInfo.replayId} : {}),
@@ -145,6 +145,16 @@ function useLogsApiOptions({
     caseInsensitive: caseInsensitive ? '1' : undefined,
     truncate,
   };
+
+  const usesTraceLogsEndpoint = Boolean(frozenTraceIds || frozenReplayInfo.replayId);
+
+  // The trace-logs endpoint treats an empty `query` as a real (non-null) additional
+  // filter and would build a malformed `(...) and ` query. When there's no search to
+  // apply (e.g. a combined replay + trace freeze relies on the endpoint's native OR of
+  // the traceId/replayId params), omit the param entirely.
+  const {query: searchQuery, ...baseQueryWithoutSearch} = baseQuery;
+  const query =
+    usesTraceLogsEndpoint && !searchQuery ? baseQueryWithoutSearch : baseQuery;
 
   const path = {organizationIdOrSlug: organization.slug};
   const data = {highFidelity};


### PR DESCRIPTION
The issue-details Logs section (`OurlogsSection`) required `event.contexts.trace.trace_id` and rendered nothing otherwise. Replay-generated issues are built during replay ingest and only get a trace context when the replay reported `trace_ids` - and even then only the *first* one is stored. So these issues frequently had no usable `traceId`, and the Logs section was hidden entirely.

To fix that for replay-generated issue types only (`replay_click_rage`, `replay_hydration_error`), this PR has us resolve the replay id from the event, fetch the replay record for its time window + full `trace_ids`, and freeze the logs query on both the _replay id_ and the _merged set of trace ids_ (the replay's traces + the event's own).

I'm not super familiar with these endpoint nuances, so I left the AI-y explanation comments in there. Definitely don't trust I've gotten this right! 👼 

Closes LOGS-453.
