### PR TITLE
ref(replays): Force task producer for events from raw-mode task

### DIFF
--- a/src/sentry/replays/lib/kafka.py
+++ b/src/sentry/replays/lib/kafka.py
@@ -21,6 +21,23 @@ from sentry.utils.kafka_config import get_topic_definition
 
 EAP_ITEMS_CODEC: Codec[TraceItem] = get_topic_codec(Topic.SNUBA_ITEMS)
 
+# The raw-mode taskbroker task that processes ingest-replay-recordings. tasks.py
+# references this constant as the task's name so the two can't drift.
+PROCESS_REPLAY_RECORDING_TASK_NAME = "sentry.replays.tasks.process_replay_recording"
+
+
+def _in_process_replay_recording_task() -> bool:
+    """Whether we're running inside the ingest-replay-recordings task.
+
+    That task hands its delivery guarantee to the TaskProducer: the worker only
+    acks an activation once all of its producer futures succeed, otherwise the
+    task is retried. We scope this to the one task by name so we don't change
+    delivery behavior for anyone else sharing these producers (the arroyo
+    consumer, or any other task that happens to publish).
+    """
+    task = current_task()
+    return task is not None and task.taskname == PROCESS_REPLAY_RECORDING_TASK_NAME
+
 
 def _get_eap_items_producer(name: str = "sentry.replays.lib.kafka.eap_items"):
     """Get a Kafka producer for EAP TraceItems."""
@@ -39,15 +56,8 @@ eap_items_taskproducer = get_task_producer(
 
 
 def write_trace_items(trace_items: list[TraceItem]) -> None:
-    """Publish trace-items to the EAP trace-items topic.
-
-    When running inside a task we produce through the TaskProducer, which ties
-    delivery to task completion: the worker only acks an activation once all of
-    its producer futures succeed, otherwise the task is retried. Outside of a
-    task (e.g. the arroyo consumer) nobody collects those futures, so we use the
-    SingletonProducer which flushes on process shutdown.
-    """
-    if current_task() is not None:
+    """Publish trace-items to the EAP trace-items topic."""
+    if _in_process_replay_recording_task():
         producer: SingletonProducer | TaskProducer = eap_items_taskproducer
     else:
         producer = eap_producer
@@ -79,8 +89,12 @@ ingest_replay_events_taskproducer = get_task_producer(
 
 def publish_replay_event(message: str) -> None:
     """Publishes messages to the ingest-replay-events topic."""
-    if settings.TASKWORKER_USE_TASK_PRODUCER and in_random_rollout(
-        "tasks.producer.replays.rollout"
+    # Inside the ingest-replay-recordings task we always use the TaskProducer so
+    # delivery is tied to the task succeeding. Every other caller keeps the
+    # existing rollout-gated behavior.
+    if _in_process_replay_recording_task() or (
+        settings.TASKWORKER_USE_TASK_PRODUCER
+        and in_random_rollout("tasks.producer.replays.rollout")
     ):
         producer: SingletonProducer | TaskProducer = ingest_replay_events_taskproducer
     else:

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -8,7 +8,7 @@ from taskbroker_client.constants import CompressionType
 from taskbroker_client.retry import Retry
 
 from sentry.replays.consumers.recording import commit_message, process_message
-from sentry.replays.lib.kafka import publish_replay_event
+from sentry.replays.lib.kafka import PROCESS_REPLAY_RECORDING_TASK_NAME, publish_replay_event
 from sentry.replays.lib.storage import (
     RecordingSegmentStorageMeta,
     filestore,
@@ -61,7 +61,7 @@ def delete_replay(
 
 
 @instrumented_task(
-    name="sentry.replays.tasks.process_replay_recording",
+    name=PROCESS_REPLAY_RECORDING_TASK_NAME,
     namespace=replays_raw_tasks,
     processing_deadline_duration=90,
     retry=Retry(times=3, delay=5),


### PR DESCRIPTION
The new raw-mode `process_replay_recording` task should publish every replay event and EAP trace-item it produces through the `TaskProducer`, so delivery is tied to the task succeeding (the worker only acks an activation once all of its producer futures succeed, otherwise the task is retried).

This opts in **all** replay events published from the new task to the new producer, so we can roll the task and its producer out together rather than gating the producer behind a separate rollout.

We scope this to the one task by name (`_in_process_replay_recording_task`), so we don't change delivery behavior for anyone else sharing these producers — the arroyo consumer, or any other task that happens to publish, keep the existing rollout-gated behavior.

- `publish_replay_event`: forces the `TaskProducer` inside the task; every other caller keeps the existing `TASKWORKER_USE_TASK_PRODUCER` + rollout-flag path.
- `write_trace_items`: same helper, replacing the previous broad `current_task() is not None` check.
- `tasks.py` references `PROCESS_REPLAY_RECORDING_TASK_NAME` as the task's `name=`, so the task name and the producer-selection check can't drift apart silently.

ref STREAM-1147