### PR TITLE
feat(preprod): Add URL route resolving to latest base snapshot

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2365,6 +2365,12 @@ function buildRoutes(): RouteObject[] {
       path: 'snapshots/:snapshotId/',
       component: make(() => import('sentry/views/preprod/snapshots/snapshots')),
     },
+    {
+      path: 'snapshots/:projectId/:appId/',
+      component: make(
+        () => import('sentry/views/preprod/snapshots/latestBaseSnapshotResolver')
+      ),
+    },
     // TODO(EME-735): Remove old routes after backend deployment
     {
       path: ':projectId/:artifactId/',

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2366,7 +2366,7 @@ function buildRoutes(): RouteObject[] {
       component: make(() => import('sentry/views/preprod/snapshots/snapshots')),
     },
     {
-      path: 'snapshots/:projectId/:appId/',
+      path: 'snapshots/latest-base/:projectId/:appId/',
       component: make(
         () => import('sentry/views/preprod/snapshots/latestBaseSnapshotResolver')
       ),

--- a/static/app/views/preprod/snapshots/latestBaseSnapshotResolver.spec.tsx
+++ b/static/app/views/preprod/snapshots/latestBaseSnapshotResolver.spec.tsx
@@ -12,9 +12,9 @@ describe('LatestBaseSnapshotResolver', () => {
 
   const initialRouterConfig = {
     location: {
-      pathname: `/organizations/${organization.slug}/preprod/snapshots/my-project/com.acme.app/`,
+      pathname: `/organizations/${organization.slug}/preprod/snapshots/latest-base/my-project/com.acme.app/`,
     },
-    route: '/organizations/:orgId/preprod/snapshots/:projectId/:appId/',
+    route: '/organizations/:orgId/preprod/snapshots/latest-base/:projectId/:appId/',
   };
 
   beforeEach(() => {
@@ -57,7 +57,7 @@ describe('LatestBaseSnapshotResolver', () => {
 
     expect(await screen.findByText('No base snapshot found')).toBeInTheDocument();
     expect(router.location.pathname).toBe(
-      '/organizations/org-slug/preprod/snapshots/my-project/com.acme.app/'
+      '/organizations/org-slug/preprod/snapshots/latest-base/my-project/com.acme.app/'
     );
   });
 });

--- a/static/app/views/preprod/snapshots/latestBaseSnapshotResolver.spec.tsx
+++ b/static/app/views/preprod/snapshots/latestBaseSnapshotResolver.spec.tsx
@@ -1,0 +1,63 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import LatestBaseSnapshotResolver from './latestBaseSnapshotResolver';
+
+describe('LatestBaseSnapshotResolver', () => {
+  const organization = OrganizationFixture();
+
+  const LATEST_BASE_URL =
+    '/organizations/org-slug/preprodartifacts/snapshots/latest-base/';
+
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/preprod/snapshots/my-project/com.acme.app/`,
+    },
+    route: '/organizations/:orgId/preprod/snapshots/:projectId/:appId/',
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('redirects to the snapshot viewer for the resolved head artifact', async () => {
+    const latestBaseMock = MockApiClient.addMockResponse({
+      url: LATEST_BASE_URL,
+      method: 'GET',
+      body: {head_artifact_id: 'abc123'},
+      match: [MockApiClient.matchQuery({app_id: 'com.acme.app', project: 'my-project'})],
+    });
+
+    const {router} = render(<LatestBaseSnapshotResolver />, {
+      organization,
+      initialRouterConfig,
+    });
+
+    await waitFor(() => {
+      expect(router.location.pathname).toBe(
+        '/organizations/org-slug/preprod/snapshots/abc123/'
+      );
+    });
+    expect(latestBaseMock).toHaveBeenCalled();
+  });
+
+  it('shows an error when no base snapshot is found', async () => {
+    MockApiClient.addMockResponse({
+      url: LATEST_BASE_URL,
+      method: 'GET',
+      statusCode: 404,
+      body: {detail: 'No snapshot found'},
+    });
+
+    const {router} = render(<LatestBaseSnapshotResolver />, {
+      organization,
+      initialRouterConfig,
+    });
+
+    expect(await screen.findByText('No base snapshot found')).toBeInTheDocument();
+    expect(router.location.pathname).toBe(
+      '/organizations/org-slug/preprod/snapshots/my-project/com.acme.app/'
+    );
+  });
+});

--- a/static/app/views/preprod/snapshots/latestBaseSnapshotResolver.tsx
+++ b/static/app/views/preprod/snapshots/latestBaseSnapshotResolver.tsx
@@ -1,0 +1,72 @@
+import {useEffect} from 'react';
+import {useQuery} from '@tanstack/react-query';
+
+import {Flex, Stack} from '@sentry/scraps/layout';
+
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import {ConfigStore} from 'sentry/stores/configStore';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import {BuildError} from 'sentry/views/preprod/components/buildError';
+
+type LatestBaseSnapshotResponse = {
+  head_artifact_id: string;
+};
+
+export default function LatestBaseSnapshotResolver() {
+  const organization = useOrganization();
+  const navigate = useNavigate();
+  const {projectId, appId} = useParams<{appId: string; projectId: string}>();
+
+  const {data, isError} = useQuery({
+    ...apiOptions.as<LatestBaseSnapshotResponse>()(
+      '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/latest-base/',
+      {
+        path: {organizationIdOrSlug: organization.slug},
+        query: {app_id: appId, project: projectId},
+        staleTime: 0,
+      }
+    ),
+    retry: (count, err) =>
+      count < 3 && (!(err instanceof RequestError) || (err.status ?? 0) >= 500),
+  });
+
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+    const {customerDomain} = ConfigStore.getState();
+    const orgPrefix = customerDomain ? '' : `/organizations/${organization.slug}`;
+    navigate(`${orgPrefix}/preprod/snapshots/${data.head_artifact_id}/`, {replace: true});
+  }, [data, navigate, organization.slug]);
+
+  if (isError) {
+    return (
+      <SentryDocumentTitle title={t('Snapshot')}>
+        <Stack flex={1}>
+          <BuildError
+            title={t('No base snapshot found')}
+            message={t(
+              'We could not find a base snapshot for this app. It may not have been uploaded yet, or you may not have access to it.'
+            )}
+          />
+        </Stack>
+      </SentryDocumentTitle>
+    );
+  }
+
+  return (
+    <SentryDocumentTitle title={t('Snapshot')}>
+      <Stack flex={1}>
+        <Flex align="center" justify="center" padding="3xl">
+          <LoadingIndicator />
+        </Flex>
+      </Stack>
+    </SentryDocumentTitle>
+  );
+}


### PR DESCRIPTION
Adds a stable, shareable URL that lands the user on the latest base snapshot for an app without needing the snapshot's ID:

- `/preprod/snapshots/:projectId/:appId/` — `:projectId` is a project slug

A new resolver component reads the slug and app-id, calls the existing latest-base endpoint (`GET /organizations/{org}/preprodartifacts/snapshots/latest-base/`), and redirects to the existing snapshot viewer. The endpoint's returned `head_artifact_id` is exactly the `snapshotId` the viewer expects, so the viewer is reused unchanged. The project slug is forwarded straight to the endpoint's `project` query param, so there's no slug→id resolution, and no `?project=` is needed on the redirect target since the viewer derives project from its own API response.

While resolving it shows a loading indicator; a 404 (no base snapshot) renders the same `BuildError` surface the viewer already uses.

The optional `:branch` segment from the ticket is deferred — the endpoint already supports a `branch` filter, so a `snapshots/:projectId/:appId/:branch/` route is a straightforward follow-up.

Refs EME-1220