### PR TITLE
chore(integrations): track when auto-open integration modal is used

### DIFF
--- a/static/app/utils/analytics/integrations/index.ts
+++ b/static/app/utils/analytics/integrations/index.ts
@@ -86,6 +86,7 @@ export type IntegrationEventParameters = {
   'integrations.disabled': SingleIntegrationEventParams;
   'integrations.enabled': SingleIntegrationEventParams;
   'integrations.index_viewed': MultipleIntegrationsEventParams;
+  'integrations.install_modal_auto_opened': SingleIntegrationEventParams;
   'integrations.install_modal_opened': SingleIntegrationEventParams;
   'integrations.installation_complete': IntegrationInstallEventParams;
   'integrations.installation_input_value_changed': IntegrationInstallationInputValueChangeEventParams;
@@ -111,6 +112,7 @@ type IntegrationAnalyticsKey = keyof IntegrationEventParameters;
 export const integrationEventMap: Record<IntegrationAnalyticsKey, string> = {
   'integrations.upgrade_plan_modal_opened': 'Integrations: Upgrade Plan Modal Opened',
   'integrations.install_modal_opened': 'Integrations: Install Modal Opened',
+  'integrations.install_modal_auto_opened': 'Integrations: Install Modal Auto Opened',
   'integrations.integration_viewed': 'Integrations: Integration Viewed',
   'integrations.installation_start': 'Integrations: Installation Start',
   'integrations.installation_complete': 'Integrations: Installation Complete',

--- a/static/app/utils/integrations/useAutoOpenInstallModal.tsx
+++ b/static/app/utils/integrations/useAutoOpenInstallModal.tsx
@@ -4,6 +4,7 @@ import {useQueryState} from 'nuqs';
 import {t} from 'sentry/locale';
 import type {IntegrationProvider} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import type {AddIntegrationParams} from 'sentry/utils/integrations/useAddIntegration';
 import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
 
@@ -54,6 +55,12 @@ export function useAutoOpenInstallModal({
     }
 
     autoOpenedForRef.current = provider.key;
+
+    trackAnalytics('integrations.install_modal_auto_opened', {
+      organization,
+      integration: provider.key,
+      integration_type: 'first_party',
+    });
 
     // NOTE: The `?showInstallModal=1` entry point is currently only used by the
     // Slack reinstall/upgrade nudge, so we override the generic install modal


### PR DESCRIPTION
in #118288 we added nudges to Slack alerts and created a URL query param which can be used to auto-open integration installation modals (#118285 and #118286).

Let's add analytics for when the auto-open integration is triggered. This will allow us to see how many people are actually clicking these links from Slack notifications.