### PR TITLE
ref(taskworker): Replace TASKWORKER_USE_TASK_PRODUCER with current_task()

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -864,11 +864,6 @@ TASKWORKER_ROUTER: str = "sentry.taskworker.adapters.SentryRouter"
 # Expected to be a JSON encoded dictionary of namespace:topic
 TASKWORKER_ROUTES = os.getenv("TASKWORKER_ROUTES")
 
-# If true, taskbroker-client's TaskProducer will be used to produce messages to Kafka
-# from within tasks.
-# Set to True in the worker child entrypoint in taskworker/bootstrap.py.
-TASKWORKER_USE_TASK_PRODUCER: bool = False
-
 # The list of modules that workers will import after starting up
 # Taskworkers need to import task modules to make tasks
 # accessible to the worker.

--- a/src/sentry/issues/attributes.py
+++ b/src/sentry/issues/attributes.py
@@ -14,6 +14,7 @@ from django.db.models.functions import Rank
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from sentry_kafka_schemas.schema_types.group_attributes_v1 import GroupAttributesSnapshot
+from taskbroker_client.state import current_task
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.models.group import Group
@@ -131,9 +132,7 @@ def produce_snapshot_to_kafka(snapshot: GroupAttributesSnapshot) -> None:
             raise snuba.SnubaError(err)
     else:
         payload = KafkaPayload(None, json.dumps(snapshot).encode("utf-8"), [])
-        if settings.TASKWORKER_USE_TASK_PRODUCER and in_random_rollout(
-            "tasks.producer.snapshots.rollout"
-        ):
+        if current_task() is not None and in_random_rollout("tasks.producer.snapshots.rollout"):
             _attribute_snapshot_task_producer.produce(
                 ArroyoTopic(get_topic_definition(Topic.GROUP_ATTRIBUTES)["real_topic_name"]),
                 payload,

--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -11,6 +11,7 @@ from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from arroyo.types import Message, Value
 from confluent_kafka import KafkaException
 from django.conf import settings
+from taskbroker_client.state import current_task
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.hybridcloud.rpc import ValueEqualityEnum
@@ -88,9 +89,7 @@ def produce_occurrence_to_kafka(
 
     try:
         topic = get_topic_definition(Topic.INGEST_OCCURRENCES)["real_topic_name"]
-        if settings.TASKWORKER_USE_TASK_PRODUCER and in_random_rollout(
-            "tasks.producer.occurrences.rollout"
-        ):
+        if current_task() is not None and in_random_rollout("tasks.producer.occurrences.rollout"):
             _occurrence_task_producer.produce(ArroyoTopic(topic), payload)
         else:
             _occurrence_producer.produce(ArroyoTopic(topic), payload)

--- a/src/sentry/preprod/eap/write.py
+++ b/src/sentry/preprod/eap/write.py
@@ -7,13 +7,13 @@ from typing import Any
 
 from arroyo import Topic as ArroyoTopic
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer
-from django.conf import settings
 from django.db.models import Sum
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_kafka_schemas.codecs import Codec
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem as EAPTraceItem
+from taskbroker_client.state import current_task
 
 from sentry import quotas
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
@@ -142,9 +142,7 @@ def produce_preprod_size_metric_to_eap(
 
     topic = get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"]
     payload = KafkaPayload(None, EAP_ITEMS_CODEC.encode(trace_item), [])
-    if settings.TASKWORKER_USE_TASK_PRODUCER and in_random_rollout(
-        "tasks.producer.preprod.rollout"
-    ):
+    if current_task() is not None and in_random_rollout("tasks.producer.preprod.rollout"):
         _eap_task_producer.produce(ArroyoTopic(topic), payload)
     else:
         _eap_producer.produce(ArroyoTopic(topic), payload)
@@ -262,9 +260,7 @@ def produce_preprod_build_distribution_to_eap(
 
     topic = get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"]
     payload = KafkaPayload(None, EAP_ITEMS_CODEC.encode(trace_item), [])
-    if settings.TASKWORKER_USE_TASK_PRODUCER and in_random_rollout(
-        "tasks.producer.preprod.rollout"
-    ):
+    if current_task() is not None and in_random_rollout("tasks.producer.preprod.rollout"):
         _eap_task_producer.produce(ArroyoTopic(topic), payload)
     else:
         _eap_producer.produce(ArroyoTopic(topic), payload)

--- a/src/sentry/replays/lib/kafka.py
+++ b/src/sentry/replays/lib/kafka.py
@@ -2,7 +2,6 @@ from functools import partial
 
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import Topic as ArroyoTopic
-from django.conf import settings
 from sentry_kafka_schemas.codecs import Codec
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 from taskbroker_client.state import current_task
@@ -93,8 +92,7 @@ def publish_replay_event(message: str) -> None:
     # delivery is tied to the task succeeding. Every other caller keeps the
     # existing rollout-gated behavior.
     if _in_process_replay_recording_task() or (
-        settings.TASKWORKER_USE_TASK_PRODUCER
-        and in_random_rollout("tasks.producer.replays.rollout")
+        current_task() is not None and in_random_rollout("tasks.producer.replays.rollout")
     ):
         producer: SingletonProducer | TaskProducer = ingest_replay_events_taskproducer
     else:

--- a/src/sentry/taskworker/bootstrap.py
+++ b/src/sentry/taskworker/bootstrap.py
@@ -8,10 +8,6 @@ from sentry.runner import configure
 
 configure()
 
-from django.conf import settings
-
 from sentry.taskworker.runtime import app
-
-settings.TASKWORKER_USE_TASK_PRODUCER = True
 
 __all__ = ("app",)

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -11,7 +11,7 @@ from threading import Lock
 
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from arroyo.types import Topic as ArroyoTopic
-from django.conf import settings
+from taskbroker_client.state import current_task
 from taskbroker_client.worker.producer import TaskProducer
 
 from sentry.conf.types.kafka_definition import Topic
@@ -232,16 +232,12 @@ def track_outcome(
     # Create a second producer instance only if the cluster differs. Otherwise,
     # reuse the same producer and just send to the other topic.
     if use_billing and billing_config["cluster"] != outcomes_config["cluster"]:
-        if settings.TASKWORKER_USE_TASK_PRODUCER and in_random_rollout(
-            "tasks.producer.track_outcome.rollout"
-        ):
+        if current_task() is not None and in_random_rollout("tasks.producer.track_outcome.rollout"):
             producer: SingletonProducer | TaskProducer = billing_task_producer
         else:
             producer = billing_producer
     else:
-        if settings.TASKWORKER_USE_TASK_PRODUCER and in_random_rollout(
-            "tasks.producer.track_outcome.rollout"
-        ):
+        if current_task() is not None and in_random_rollout("tasks.producer.track_outcome.rollout"):
             producer = outcomes_task_producer
         else:
             producer = outcomes_producer


### PR DESCRIPTION
`TASKWORKER_USE_TASK_PRODUCER` was only ever set to `True` in the taskworker child entrypoint (`taskworker/bootstrap.py`), defaulting to `False` everywhere else, with no overrides in tests, getsentry, or options. So it exists only to answer "am I running in a taskworker process," as a stand-in for "am I in a task."

`current_task()` answers that directly: in `workerchild.py` it's set right before executing an activation and cleared right after, so it's non-None exactly while a worker is running a task. This swaps the process-wide proxy for the direct signal and deletes the setting.

This is behavior-preserving for every place these producers are called:
- In consumer / request processes neither is set, so both resolve to the `SingletonProducer` (rollout-gated) — including the two `OutcomeAggregator` singletons, which live in consumer code, not tasks.
- In a taskworker these producers only fire while a task is executing, where the old setting was `True` and `current_task()` is non-None — both pick the rollout-gated `TaskProducer`.

The two would only differ for a produce that happens in a taskworker *outside* an activation (e.g. an atexit flush, or off the main task thread — `current_task()` is thread-local). None of these call sites do the former, and the latter resolves to the `SingletonProducer`, which is the right choice there anyway.

Swapped at every call site (outcomes, issue occurrences, group attributes, preprod EAP, replay events); the rollout flags are untouched.

ref STREAM-1147