### PR TITLE
feat(explore): Forbid selecting a heat map for non-distribution metrics

### DIFF
--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -347,6 +347,15 @@ export const DEFAULT_YAXIS_BY_TYPE: Record<string, string> = {
   gauge: 'avg',
 };
 
+/**
+ * Heat maps plot the distribution of a measurement's values over time, so they
+ * only make sense for `distribution` metrics. Counters (always `1`) and gauges
+ * have no meaningful value distribution to visualize.
+ */
+export function isHeatmapSupportedMetricType(metricType: string | undefined): boolean {
+  return metricType === 'distribution';
+}
+
 export const RATE_AGGREGATES = new Set(['per_second', 'per_minute']);
 
 /**

--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -7,6 +7,7 @@ import {
   SENTRY_TRACEMETRIC_NUMBER_TAGS,
   SENTRY_TRACEMETRIC_STRING_TAGS,
 } from 'sentry/views/explore/constants';
+import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {
   TraceMetricKnownFieldKey,
   VirtualTableSampleColumnKey,
@@ -352,8 +353,8 @@ export const DEFAULT_YAXIS_BY_TYPE: Record<string, string> = {
  * only make sense for `distribution` metrics. Counters (always `1`) and gauges
  * have no meaningful value distribution to visualize.
  */
-export function isHeatmapSupportedMetricType(metricType: string | undefined): boolean {
-  return metricType === 'distribution';
+export function doesMetricSupportHeatMapVisualization(metric: TraceMetric): boolean {
+  return metric.type === 'distribution';
 }
 
 export const RATE_AGGREGATES = new Set(['per_second', 'per_minute']);

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -12,6 +12,7 @@ import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesW
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {ChartVisualization} from 'sentry/views/explore/components/chart/chartVisualization';
 import {ConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
+import {isHeatmapSupportedMetricType} from 'sentry/views/explore/metrics/constants';
 import {canUseMetricsHeatMap} from 'sentry/views/explore/metrics/metricsFlags';
 import {
   useMetricLabel,
@@ -52,12 +53,19 @@ import {WidgetWrapper} from './styles';
 
 export function getMetricsChartTypeOptions(
   organization: Organization,
-  isEquation: boolean
+  isEquation: boolean,
+  metricType?: string
 ) {
   if (canUseMetricsHeatMap(organization)) {
     return [
       ...EXPLORE_CHART_TYPE_OPTIONS,
-      {value: ChartType.HEATMAP, label: t('Heat Map'), disabled: isEquation},
+      {
+        value: ChartType.HEATMAP,
+        label: t('Heat Map'),
+        // Heat maps can only render distributions; equations and
+        // non-distribution metrics (counters, gauges) are not supported.
+        disabled: isEquation || !isHeatmapSupportedMetricType(metricType),
+      },
     ];
   }
   return EXPLORE_CHART_TYPE_OPTIONS;

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -12,7 +12,8 @@ import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesW
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {ChartVisualization} from 'sentry/views/explore/components/chart/chartVisualization';
 import {ConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
-import {isHeatmapSupportedMetricType} from 'sentry/views/explore/metrics/constants';
+import {doesMetricSupportHeatMapVisualization} from 'sentry/views/explore/metrics/constants';
+import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {canUseMetricsHeatMap} from 'sentry/views/explore/metrics/metricsFlags';
 import {
   useMetricLabel,
@@ -54,7 +55,7 @@ import {WidgetWrapper} from './styles';
 export function getMetricsChartTypeOptions(
   organization: Organization,
   isEquation: boolean,
-  metricType?: string
+  metric?: TraceMetric
 ) {
   if (canUseMetricsHeatMap(organization)) {
     return [
@@ -62,9 +63,8 @@ export function getMetricsChartTypeOptions(
       {
         value: ChartType.HEATMAP,
         label: t('Heat Map'),
-        // Heat maps can only render distributions; equations and
-        // non-distribution metrics (counters, gauges) are not supported.
-        disabled: isEquation || !isHeatmapSupportedMetricType(metricType),
+        disabled:
+          isEquation || !metric || !doesMetricSupportHeatMapVisualization(metric),
       },
     ];
   }

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -63,8 +63,7 @@ export function getMetricsChartTypeOptions(
       {
         value: ChartType.HEATMAP,
         label: t('Heat Map'),
-        disabled:
-          isEquation || !metric || !doesMetricSupportHeatMapVisualization(metric),
+        disabled: isEquation || !metric || !doesMetricSupportHeatMapVisualization(metric),
       },
     ];
   }

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -277,6 +277,42 @@ describe('MetricPanel', () => {
     expect(heatMapOption).toHaveAttribute('aria-disabled', 'true');
   });
 
+  it('disables heat map visualization for non-distribution metrics', async () => {
+    const counterTraceMetric: TraceMetric = {name: 'bar', type: 'counter'};
+    const counterQueryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [new VisualizeFunction('sum(value)', {chartType: ChartType.LINE})],
+      aggregateSortBys: [{field: 'sum(value)', kind: 'desc'}],
+    });
+
+    const heatMapOrg = {
+      ...organization,
+      features: [...organization.features, 'data-browsing-heat-map-widget'],
+    };
+
+    render(
+      <MetricPanel traceMetric={counterTraceMetric} queryIndex={0} queryLabel="A" />,
+      {
+        organization: heatMapOrg,
+        additionalWrapper: createWrapper({
+          queryParams: counterQueryParams,
+          traceMetric: counterTraceMetric,
+        }),
+      }
+    );
+
+    const chartTypeSelect = await screen.findByTestId('metric-panel-chart-type-select');
+    await userEvent.click(chartTypeSelect);
+    const heatMapOption = await screen.findByRole('option', {name: 'Heat Map'});
+    expect(heatMapOption).toHaveAttribute('aria-disabled', 'true');
+  });
+
   it('renders the samples column order', async () => {
     const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
 

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -256,7 +256,11 @@ export function MetricPanel({
         )}
         value={visualize.chartType}
         menuTitle="Type"
-        options={getMetricsChartTypeOptions(organization, isVisualizeEquation(visualize))}
+        options={getMetricsChartTypeOptions(
+          organization,
+          isVisualizeEquation(visualize),
+          traceMetric.type
+        )}
         onChange={option => handleChartTypeChange(option.value)}
       />
       <CompactSelect

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -259,7 +259,7 @@ export function MetricPanel({
         options={getMetricsChartTypeOptions(
           organization,
           isVisualizeEquation(visualize),
-          traceMetric.type
+          traceMetric
         )}
         onChange={option => handleChartTypeChange(option.value)}
       />

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
@@ -18,6 +18,7 @@ import {
   VisualizeEquation,
   VisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 function TestableMetricComponent() {
   const metricQueries = useMultiMetricsQueryParams();
@@ -191,6 +192,42 @@ describe('MultiMetricsQueryParamsProvider', () => {
         }),
       }),
     ]);
+  });
+
+  it('falls back from heat map when changing to a non-distribution metric', () => {
+    const metricQuery = JSON.stringify({
+      metric: {name: 'test_metric', type: 'distribution'},
+      query: '',
+      aggregateFields: [
+        {
+          yAxes: ['count(value,test_metric,distribution,none)'],
+          chartType: ChartType.HEATMAP,
+        },
+      ],
+      aggregateSortBys: [],
+      mode: 'samples',
+    });
+
+    const {result} = renderHookWithProviders(useMultiMetricsQueryParams, {
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/metrics/',
+          query: {metric: [metricQuery]},
+        },
+      },
+    });
+
+    expect(result.current[0]!.queryParams.aggregateFields[0]).toEqual(
+      expect.objectContaining({chartType: ChartType.HEATMAP})
+    );
+
+    act(() => result.current[0]!.setTraceMetric({name: 'foo', type: 'counter'}));
+
+    // The counter can't be a heat map, so the chart type falls back.
+    const counterVisualize = result.current[0]!.queryParams
+      .aggregateFields[0] as VisualizeFunction;
+    expect(counterVisualize.chartType).not.toBe(ChartType.HEATMAP);
   });
 
   it('parses multiple visualizes from URL params', () => {

--- a/static/app/views/explore/metrics/useMetricQueriesController.tsx
+++ b/static/app/views/explore/metrics/useMetricQueriesController.tsx
@@ -3,7 +3,7 @@ import {useMemo} from 'react';
 import {determineDefaultChartType} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {
   DEFAULT_YAXIS_BY_TYPE,
-  isHeatmapSupportedMetricType,
+  doesMetricSupportHeatMapVisualization,
   OPTIONS_BY_TYPE,
 } from 'sentry/views/explore/metrics/constants';
 import {syncEquationMetricQueries} from 'sentry/views/explore/metrics/equationBuilder/utils';
@@ -131,7 +131,7 @@ export function useMetricQueriesController({
 
               if (
                 visualize.chartType === ChartType.HEATMAP &&
-                !isHeatmapSupportedMetricType(newTraceMetric.type)
+                !doesMetricSupportHeatMapVisualization(newTraceMetric)
               ) {
                 updatedVisualize = updatedVisualize.replace({
                   chartType: determineDefaultChartType([updatedVisualize.yAxis]),

--- a/static/app/views/explore/metrics/useMetricQueriesController.tsx
+++ b/static/app/views/explore/metrics/useMetricQueriesController.tsx
@@ -1,7 +1,9 @@
 import {useMemo} from 'react';
 
+import {determineDefaultChartType} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {
   DEFAULT_YAXIS_BY_TYPE,
+  isHeatmapSupportedMetricType,
   OPTIONS_BY_TYPE,
 } from 'sentry/views/explore/metrics/constants';
 import {syncEquationMetricQueries} from 'sentry/views/explore/metrics/equationBuilder/utils';
@@ -24,6 +26,7 @@ import {
   isVisualizeFunction,
   VisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 function syncUpdatedMetricQueries(
   previousMetricQueries: BaseMetricQuery[],
@@ -114,23 +117,31 @@ export function useMetricQueriesController({
             if (visualize && isVisualizeFunction(visualize)) {
               const selectedAggregation = visualize.parsedFunction?.name;
               const allowedAggregations = OPTIONS_BY_TYPE[newTraceMetric.type];
-
-              if (
+              const aggregation =
                 selectedAggregation &&
                 allowedAggregations?.find(option => option.value === selectedAggregation)
+                  ? selectedAggregation
+                  : DEFAULT_YAXIS_BY_TYPE[newTraceMetric.type] || 'sum';
+
+              let updatedVisualize = updateVisualizeYAxis(
+                visualize,
+                aggregation,
+                newTraceMetric
+              );
+
+              if (
+                visualize.chartType === ChartType.HEATMAP &&
+                !isHeatmapSupportedMetricType(newTraceMetric.type)
               ) {
-                aggregateFields = [
-                  updateVisualizeYAxis(visualize, selectedAggregation, newTraceMetric),
-                  ...metricQuery.queryParams.aggregateFields.filter(isGroupBy),
-                ];
-              } else {
-                const defaultAggregation =
-                  DEFAULT_YAXIS_BY_TYPE[newTraceMetric.type] || 'sum';
-                aggregateFields = [
-                  updateVisualizeYAxis(visualize, defaultAggregation, newTraceMetric),
-                  ...metricQuery.queryParams.aggregateFields.filter(isGroupBy),
-                ];
+                updatedVisualize = updatedVisualize.replace({
+                  chartType: determineDefaultChartType([updatedVisualize.yAxis]),
+                });
               }
+
+              aggregateFields = [
+                updatedVisualize,
+                ...metricQuery.queryParams.aggregateFields.filter(isGroupBy),
+              ];
             }
 
             return {


### PR DESCRIPTION
Forbid selecting a Heat Map visualization in Explore when the selected metric isn't a distribution. Heat Maps only makes sense if the `value` of the metric has a range of possible values at any given time. Neither counters not gauges have this quality, they produce nonsensical heat maps.

**e.g.,**

<img width="1140" height="295" alt="Screenshot 2026-06-25 at 3 56 46 PM" src="https://github.com/user-attachments/assets/756fda5e-8567-4310-9605-638016f819c7" />

In Explore, users choose the metric first, and we don't have to have a weird down-to-up dependency, so we'll just disable the "Heat Map" option (or change away from it) if the current metric isn't eligible.

Closes DAIN-1755
