### PR TITLE
fix(dashboards): fetch attributes while typing in the widget builder field dropdown

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -1464,6 +1464,90 @@ describe('Visualize', () => {
       expect(within(listbox).getByText('span.description')).toBeInTheDocument();
     });
 
+    it('fetches additional attributes from the server while typing in the column dropdown', async () => {
+      // Mock a search-aware attributes endpoint: the cold-start attribute is only
+      // returned when the dropdown forwards a matching search term, mirroring the
+      // capped initial `/attributes` response in production.
+      jest
+        .mocked(useTraceItemDatasetAttributes)
+        .mockImplementation((_traceItemType, options, type?) => {
+          if (type === 'number') {
+            const searched =
+              options?.enabled && options?.search?.includes('cold')
+                ? {
+                    'measurements.app_start_cold': {
+                      key: 'measurements.app_start_cold',
+                      name: 'measurements.app_start_cold',
+                      kind: 'measurement',
+                    },
+                  }
+                : {};
+            return {
+              attributes: {
+                'span.duration': {
+                  key: 'span.duration',
+                  name: 'span.duration',
+                  kind: 'measurement',
+                },
+                ...searched,
+              } as TagCollection,
+              secondaryAliases: {},
+              isLoading: false,
+            };
+          }
+
+          if (type === 'boolean') {
+            return {attributes: {}, secondaryAliases: {}, isLoading: false};
+          }
+
+          return {
+            attributes: {
+              'span.description': {
+                key: 'span.description',
+                name: 'span.description',
+                kind: 'tag',
+              },
+            } as TagCollection,
+            secondaryAliases: {},
+            isLoading: false,
+          };
+        });
+
+      render(
+        <WidgetBuilderProvider>
+          <Visualize />
+        </WidgetBuilderProvider>,
+        {
+          organization: OrganizationFixture({
+            features: ['performance-view', 'visibility-explore-view'],
+          }),
+          initialRouterConfig: {
+            location: {
+              pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+              query: {
+                dataset: WidgetType.SPANS,
+                displayType: DisplayType.TABLE,
+                field: ['span.duration'],
+              },
+            },
+            route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+          },
+        }
+      );
+
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'Column Selection'})
+      );
+
+      // The attribute is not part of the initial response.
+      expect(screen.queryByText('measurements.app_start_cold')).not.toBeInTheDocument();
+
+      // Typing forwards the search to the attributes endpoint and the newly
+      // fetched attribute shows up as an option.
+      await userEvent.type(screen.getByPlaceholderText('Search…'), 'cold');
+      expect(await screen.findByText('measurements.app_start_cold')).toBeInTheDocument();
+    });
+
     it('differentiates between function and column values in selection', async () => {
       jest
         .mocked(useTraceItemDatasetAttributes)

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -1551,8 +1551,94 @@ describe('Visualize', () => {
       // attribute should not linger in the options when there is no query.
       await userEvent.keyboard('{Escape}');
       await userEvent.click(screen.getByRole('button', {name: 'Column Selection'}));
-      expect(await screen.findByText('span.duration')).toBeInTheDocument();
-      expect(screen.queryByText('measurements.app_start_cold')).not.toBeInTheDocument();
+      const reopenedListbox = await screen.findByRole('listbox', {
+        name: 'Column Selection',
+      });
+      expect(within(reopenedListbox).getByText('span.duration')).toBeInTheDocument();
+      expect(
+        within(reopenedListbox).queryByText('measurements.app_start_cold')
+      ).not.toBeInTheDocument();
+    });
+
+    it('matches searched attributes by key even when the display label differs', async () => {
+      // The attribute's display label ("Cold Start") does not contain the
+      // queried substring, but its key does. The dropdown filter must score on
+      // the key so the server match is not dropped client-side.
+      jest
+        .mocked(useTraceItemDatasetAttributes)
+        .mockImplementation((_traceItemType, options, type?) => {
+          if (type === 'number') {
+            const searched =
+              options?.enabled && options?.search?.includes('app_start')
+                ? {
+                    'measurements.app_start_cold': {
+                      key: 'measurements.app_start_cold',
+                      name: 'Cold Start',
+                      kind: 'measurement',
+                    },
+                  }
+                : {};
+            return {
+              attributes: {
+                'span.duration': {
+                  key: 'span.duration',
+                  name: 'span.duration',
+                  kind: 'measurement',
+                },
+                ...searched,
+              } as TagCollection,
+              secondaryAliases: {},
+              isLoading: false,
+            };
+          }
+
+          if (type === 'boolean') {
+            return {attributes: {}, secondaryAliases: {}, isLoading: false};
+          }
+
+          return {
+            attributes: {
+              'span.description': {
+                key: 'span.description',
+                name: 'span.description',
+                kind: 'tag',
+              },
+            } as TagCollection,
+            secondaryAliases: {},
+            isLoading: false,
+          };
+        });
+
+      render(
+        <WidgetBuilderProvider>
+          <Visualize />
+        </WidgetBuilderProvider>,
+        {
+          organization: OrganizationFixture({
+            features: ['performance-view', 'visibility-explore-view'],
+          }),
+          initialRouterConfig: {
+            location: {
+              pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+              query: {
+                dataset: WidgetType.SPANS,
+                displayType: DisplayType.TABLE,
+                field: ['span.duration'],
+              },
+            },
+            route: DASHBOARD_WIDGET_BUILDER_ROUTE,
+          },
+        }
+      );
+
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'Column Selection'})
+      );
+
+      // Searching by the key surfaces the attribute even though its label is
+      // "Cold Start".
+      await userEvent.type(screen.getByPlaceholderText('Search…'), 'app_start');
+      expect(await screen.findByText('Cold Start')).toBeInTheDocument();
     });
 
     it('differentiates between function and column values in selection', async () => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -1546,6 +1546,13 @@ describe('Visualize', () => {
       // fetched attribute shows up as an option.
       await userEvent.type(screen.getByPlaceholderText('Search…'), 'cold');
       expect(await screen.findByText('measurements.app_start_cold')).toBeInTheDocument();
+
+      // Closing and reopening resets the search, so the previously fetched
+      // attribute should not linger in the options when there is no query.
+      await userEvent.keyboard('{Escape}');
+      await userEvent.click(screen.getByRole('button', {name: 'Column Selection'}));
+      expect(await screen.findByText('span.duration')).toBeInTheDocument();
+      expect(screen.queryByText('measurements.app_start_cold')).not.toBeInTheDocument();
     });
 
     it('differentiates between function and column values in selection', async () => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -27,12 +27,7 @@ import {
   type QueryFieldValue,
   type ValidateColumnTypes,
 } from 'sentry/utils/discover/fields';
-import {
-  classifyTagKey,
-  FieldKind,
-  FieldValueType,
-  prettifyTagKey,
-} from 'sentry/utils/fields';
+import {classifyTagKey, FieldValueType, prettifyTagKey} from 'sentry/utils/fields';
 import {useCustomMeasurements} from 'sentry/utils/useCustomMeasurements';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTags} from 'sentry/utils/useTags';
@@ -48,6 +43,7 @@ import {
   ColumnCompactSelect,
   SelectRow,
 } from 'sentry/views/dashboards/widgetBuilder/components/visualize/selectRow';
+import {buildTraceItemColumnOptions} from 'sentry/views/dashboards/widgetBuilder/components/visualize/traceItemColumnOptions';
 import {MetricSelectRow} from 'sentry/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow';
 import {MetricsEquationVisualize} from 'sentry/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize';
 import {VisualizeGhostField} from 'sentry/views/dashboards/widgetBuilder/components/visualize/visualizeGhostField';
@@ -375,26 +371,10 @@ export function Visualize({error, setError, traceMetricsVisualizeMode}: Visualiz
             trailingItems: () => <TypeBadge kind={classifyTagKey(column)} />,
           };
         }),
-      ...Object.values(booleanSpanTags).map(tag => {
-        return {
-          label: tag.name,
-          value: tag.key,
-          trailingItems: () => <TypeBadge kind={FieldKind.BOOLEAN} />,
-        };
-      }),
-      ...Object.values(stringSpanTags).map(tag => {
-        return {
-          label: tag.name,
-          value: tag.key,
-          trailingItems: () => <TypeBadge kind={FieldKind.TAG} />,
-        };
-      }),
-      ...Object.values(numericSpanTags).map(tag => {
-        return {
-          label: prettifyTagKey(tag.name),
-          value: tag.key,
-          trailingItems: () => <TypeBadge kind={FieldKind.MEASUREMENT} />,
-        };
+      ...buildTraceItemColumnOptions({
+        booleanTags: booleanSpanTags,
+        stringTags: stringSpanTags,
+        numberTags: numericSpanTags,
       }),
     ];
     options.sort(_sortFn);

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useRef} from 'react';
+import {useCallback, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -17,6 +17,7 @@ import {
   type QueryFieldValue,
 } from 'sentry/utils/discover/fields';
 import {AggregationKey, prettifyTagKey} from 'sentry/utils/fields';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -29,12 +30,17 @@ import {
   parseAggregateFromValueKey,
   PrimarySelectRow,
 } from 'sentry/views/dashboards/widgetBuilder/components/visualize';
+import {buildTraceItemColumnOptions} from 'sentry/views/dashboards/widgetBuilder/components/visualize/traceItemColumnOptions';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+import {useWidgetBuilderTraceItemConfig} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig';
 import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
 import type {FieldValue} from 'sentry/views/discover/table/types';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
+import {EXPLORE_FIVE_MIN_STALE_TIME} from 'sentry/views/explore/constants';
 import {DEFAULT_VISUALIZATION_FIELD} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import {useTraceItemDatasetAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
+import {sortSearchedAttributes} from 'sentry/views/explore/utils/sortSearchedAttributes';
 
 type AggregateFunction = [
   AggregationKeyWithAlias,
@@ -84,6 +90,28 @@ function validateParameter(
     return true;
   }
   return false;
+}
+
+type AttributeKind = 'string' | 'number' | 'boolean';
+
+const ALL_ATTRIBUTE_KINDS: readonly AttributeKind[] = ['string', 'number', 'boolean'];
+
+// Determines which attribute types are valid for the field's column selector so
+// we only fetch (and merge) those while searching. A plain column (FIELD)
+// accepts any type; an aggregate (FUNCTION) is constrained by its parameter —
+// count_unique accepts anything, while the numeric aggregates (p50, avg, sum,
+// ...) only accept numbers. Mirrors Explore's getSupportedAttributeKinds.
+function getSearchableAttributeKinds(
+  field: QueryFieldValue,
+  functionName: string | undefined
+): readonly AttributeKind[] {
+  if (field.kind !== FieldValueKind.FUNCTION) {
+    return ALL_ATTRIBUTE_KINDS;
+  }
+  if (functionName === AggregationKey.COUNT_UNIQUE) {
+    return ALL_ATTRIBUTE_KINDS;
+  }
+  return ['number'];
 }
 
 export function sortSelectedFirst(
@@ -192,22 +220,121 @@ export function SelectRow({
       ? (parsedFunction?.arguments[0] ?? '')
       : field.field;
 
+  // The column options for spans and logs are sourced from the `/attributes`
+  // endpoint, which only returns a capped initial page. Wire the dropdown's
+  // search input to a debounced server-side fetch (matching Explore) so
+  // attributes that weren't in the initial response can still be found by typing.
+  const isTraceItemColumnSelect =
+    (state.dataset === WidgetType.SPANS || state.dataset === WidgetType.LOGS) &&
+    !lockOptions;
+
+  const {
+    traceItemType,
+    enabled: traceItemEnabled,
+    ...traceItemOptions
+  } = useWidgetBuilderTraceItemConfig();
+
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebouncedValue(search, 250);
+  const hasSearch = debouncedSearch.length > 0;
+
+  const supportedKinds = useMemo(
+    () => getSearchableAttributeKinds(field, parsedFunction?.name),
+    [field, parsedFunction?.name]
+  );
+
+  const searchEnabled = traceItemEnabled && isTraceItemColumnSelect && hasSearch;
+
+  const {attributes: searchedStringTags, isLoading: stringLoading} =
+    useTraceItemDatasetAttributes(
+      traceItemType,
+      {
+        ...traceItemOptions,
+        search: debouncedSearch,
+        enabled: searchEnabled && supportedKinds.includes('string'),
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      },
+      'string'
+    );
+  const {attributes: searchedNumberTags, isLoading: numberLoading} =
+    useTraceItemDatasetAttributes(
+      traceItemType,
+      {
+        ...traceItemOptions,
+        search: debouncedSearch,
+        enabled: searchEnabled && supportedKinds.includes('number'),
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      },
+      'number'
+    );
+  const {attributes: searchedBooleanTags, isLoading: booleanLoading} =
+    useTraceItemDatasetAttributes(
+      traceItemType,
+      {
+        ...traceItemOptions,
+        search: debouncedSearch,
+        enabled: searchEnabled && supportedKinds.includes('boolean'),
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      },
+      'boolean'
+    );
+
+  const isSearchLoading =
+    searchEnabled &&
+    ((supportedKinds.includes('string') && stringLoading) ||
+      (supportedKinds.includes('number') && numberLoading) ||
+      (supportedKinds.includes('boolean') && booleanLoading));
+
+  // Always feed the base options to CompactSelect so its matcher can filter
+  // synchronously while typing. Once the debounced search returns, merge in any
+  // attributes the base list doesn't already cover. Only the kinds valid for
+  // this field are included so we never offer, e.g., a string column to p75().
+  const columnOptionsWithSearched = useMemo(() => {
+    if (!searchEnabled) {
+      return columnOptions;
+    }
+    const searched = buildTraceItemColumnOptions({
+      booleanTags: supportedKinds.includes('boolean') ? searchedBooleanTags : {},
+      stringTags: supportedKinds.includes('string') ? searchedStringTags : {},
+      numberTags: supportedKinds.includes('number') ? searchedNumberTags : {},
+    });
+    if (searched.length === 0) {
+      return columnOptions;
+    }
+    const baseValues = new Set(columnOptions.map(option => option.value));
+    const additions = searched.filter(option => !baseValues.has(option.value));
+    if (additions.length === 0) {
+      return columnOptions;
+    }
+    return [...columnOptions, ...additions];
+  }, [
+    searchEnabled,
+    columnOptions,
+    supportedKinds,
+    searchedBooleanTags,
+    searchedStringTags,
+    searchedNumberTags,
+  ]);
+
   // Ensure the currently selected column is always present in the options so the
   // dropdown reflects the saved state instead of showing "None" when the field is
   // missing from the fetched attributes (e.g. a saved field no longer returned by
   // the /attributes call).
   const columnOptionsWithSelected = useMemo(() => {
-    if (columnValue && !columnOptions.some(option => option.value === columnValue)) {
+    if (
+      columnValue &&
+      !columnOptionsWithSearched.some(option => option.value === columnValue)
+    ) {
       return [
-        ...columnOptions,
+        ...columnOptionsWithSearched,
         {
           label: prettifyTagKey(columnValue),
           value: columnValue,
         },
       ];
     }
-    return columnOptions;
-  }, [columnValue, columnOptions]);
+    return columnOptionsWithSearched;
+  }, [columnValue, columnOptionsWithSearched]);
 
   return (
     <PrimarySelectRow hasColumnParameter={hasColumnParameter}>
@@ -470,7 +597,27 @@ export function SelectRow({
       {hasColumnParameter && (
         <SelectWrapper ref={columnSelectRef}>
           <ColumnCompactSelect
-            search
+            search={
+              isTraceItemColumnSelect
+                ? {
+                    onChange: setSearch,
+                    filter: (option, searchText) =>
+                      sortSearchedAttributes({
+                        fieldDefinitionType: traceItemType,
+                        option,
+                        searchText,
+                      }),
+                  }
+                : true
+            }
+            loading={isSearchLoading}
+            emptyMessage={
+              isSearchLoading
+                ? t('Loading…')
+                : isTraceItemColumnSelect
+                  ? t('No matching attributes')
+                  : undefined
+            }
             options={sortSelectedFirst(columnValue, columnOptionsWithSelected)}
             value={columnValue}
             onChange={newField => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
@@ -610,6 +610,15 @@ export function SelectRow({
                   }
                 : true
             }
+            // CompactSelect clears its own search input on close but doesn't
+            // notify us, so reset our search state too. Otherwise the stale term
+            // keeps the previously fetched attributes merged into the options on
+            // reopen, even though the (cleared) input shows no query.
+            onOpenChange={isOpen => {
+              if (!isOpen) {
+                setSearch('');
+              }
+            }}
             loading={isSearchLoading}
             emptyMessage={
               isSearchLoading

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
@@ -236,7 +236,11 @@ export function SelectRow({
 
   const [search, setSearch] = useState('');
   const debouncedSearch = useDebouncedValue(search, 250);
-  const hasSearch = debouncedSearch.length > 0;
+  // Require both the immediate and debounced values: the debounced value gates
+  // fetching while typing, and the immediate value tears the merge down the
+  // moment the search is cleared (e.g. on close) instead of lingering for the
+  // debounce window.
+  const hasSearch = search.length > 0 && debouncedSearch.length > 0;
 
   const supportedKinds = useMemo(
     () => getSearchableAttributeKinds(field, parsedFunction?.name),

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceItemColumnOptions.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceItemColumnOptions.tsx
@@ -1,0 +1,46 @@
+import type {SelectValue} from '@sentry/scraps/select';
+
+import type {TagCollection} from 'sentry/types/group';
+import {FieldKind, prettifyTagKey} from 'sentry/utils/fields';
+import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
+
+export type TraceItemColumnOption = SelectValue<string> & {
+  label: string;
+  value: string;
+};
+
+interface BuildTraceItemColumnOptionsParams {
+  booleanTags: TagCollection;
+  numberTags: TagCollection;
+  stringTags: TagCollection;
+}
+
+/**
+ * Builds the column dropdown options for trace item datasets (spans, logs) from
+ * the typed attribute collections returned by the `/attributes` endpoint. Shared
+ * between the base option list and the search-while-typing merge so both render
+ * identically.
+ */
+export function buildTraceItemColumnOptions({
+  booleanTags,
+  stringTags,
+  numberTags,
+}: BuildTraceItemColumnOptionsParams): TraceItemColumnOption[] {
+  return [
+    ...Object.values(booleanTags).map(tag => ({
+      label: tag.name,
+      value: tag.key,
+      trailingItems: () => <TypeBadge kind={FieldKind.BOOLEAN} />,
+    })),
+    ...Object.values(stringTags).map(tag => ({
+      label: tag.name,
+      value: tag.key,
+      trailingItems: () => <TypeBadge kind={FieldKind.TAG} />,
+    })),
+    ...Object.values(numberTags).map(tag => ({
+      label: prettifyTagKey(tag.name),
+      value: tag.key,
+      trailingItems: () => <TypeBadge kind={FieldKind.MEASUREMENT} />,
+    })),
+  ];
+}

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceItemColumnOptions.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceItemColumnOptions.tsx
@@ -26,20 +26,27 @@ export function buildTraceItemColumnOptions({
   stringTags,
   numberTags,
 }: BuildTraceItemColumnOptionsParams): TraceItemColumnOption[] {
+  // `textValue` is set to the attribute key so the dropdown's search matcher
+  // (sortSearchedAttributes scores `textValue ?? label`) filters on the key
+  // rather than the prettified label. Otherwise a server match whose query hits
+  // the key but not the display label would be filtered out client-side.
   return [
     ...Object.values(booleanTags).map(tag => ({
       label: tag.name,
       value: tag.key,
+      textValue: tag.key,
       trailingItems: () => <TypeBadge kind={FieldKind.BOOLEAN} />,
     })),
     ...Object.values(stringTags).map(tag => ({
       label: tag.name,
       value: tag.key,
+      textValue: tag.key,
       trailingItems: () => <TypeBadge kind={FieldKind.TAG} />,
     })),
     ...Object.values(numberTags).map(tag => ({
       label: prettifyTagKey(tag.name),
       value: tag.key,
+      textValue: tag.key,
       trailingItems: () => <TypeBadge kind={FieldKind.MEASUREMENT} />,
     })),
   ];


### PR DESCRIPTION
The widget builder's field/column dropdown only filtered client-side over the single, capped initial `/attributes` response. Any attribute not in that first page could never be surfaced by typing. This pr makes it so the attributes endpoint is called on search, which exactly matches the behaviour of explore.

Before (no measurements.lcp option)
<img width="423" height="207" alt="image" src="https://github.com/user-attachments/assets/362d97f7-8e43-458d-9723-f97f49cc13c7" />

After
<img width="590" height="171" alt="image" src="https://github.com/user-attachments/assets/a73e1b1b-36bb-45c3-9d66-c9df9ef93b54" />


## Changes

- **`selectRow.tsx`** — Wire the column dropdown's search input to a debounced server-side `/attributes` fetch (via `useTraceItemDatasetAttributes`) for spans and logs, and merge the matches into the options. Only the attribute kinds valid for the field are fetched/merged — all types for a plain column, numbers for numeric aggregates (`p75`, `avg`, …), all types for `count_unique` — so we never offer an invalid column. Non-trace datasets keep their existing client-side search untouched.
- **`traceItemColumnOptions.tsx`** (new) — Extract the column-option builder so the base list and the searched-merge render identically and can't drift; `index.tsx` now uses it (behavior-identical).

This reuses Explore's existing data layer (`useTraceItemDatasetAttributes`, `sortSearchedAttributes`, `EXPLORE_FIVE_MIN_STALE_TIME`) and mirrors the column-editor pattern already used in Explore.

Fixes [DAIN-1748](https://linear.app/getsentry/issue/DAIN-1748/call-attributes-while-typing-in-widget-builder)
