### PR TITLE
fix(auth): Avoid false no-org access on login

### DIFF
--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -351,6 +351,18 @@ class OrganizationMixin:
                 url_prefix = generate_organization_url(request.subdomain)
                 url = absolute_uri(url, url_prefix=url_prefix)
         elif not features.has("organizations:create"):
+            session = getattr(request, "session", None)
+            if session and (org_slug := session.get("activeorg")):
+                active_organization = determine_active_organization(request, org_slug)
+                if active_organization and active_organization.member:
+                    url = reverse(
+                        "sentry-organization-issue-list",
+                        args=[active_organization.organization.slug],
+                    )
+                    if is_using_customer_domain(request):
+                        url = absolute_uri(url, url_prefix=options.get("system.url-prefix"))
+                    return HttpResponseRedirect(url)
+                session.pop("activeorg", None)
             return self.respond("sentry/no-organization-access.html", status=403)
         else:
             url = reverse("sentry-organization-create")
@@ -428,7 +440,12 @@ class BaseView(View, OrganizationMixin):
 
         """
         organization_slug = kwargs.get("organization_slug", None)
-        if request and is_using_customer_domain(request) and not subdomain_is_locality(request):
+        if (
+            request
+            and is_using_customer_domain(request)
+            and not subdomain_is_locality(request)
+            and organization_slug is None
+        ):
             organization_slug = request.subdomain
         self.active_organization = determine_active_organization(request, organization_slug)
 

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -715,6 +715,51 @@ class AuthLoginCustomerDomainTest(TestCase):
             assert resp.status_code == 200
             self.assertTemplateUsed("sentry/login.html")
 
+    def test_authenticated_user_with_session_active_org_does_not_get_no_org_access(self) -> None:
+        visible_org = self.create_organization(owner=self.user)
+        self.create_organization(name="albertos-apples")
+        self.login_as(self.user)
+        self.session["activeorg"] = visible_org.slug
+        self.save_session()
+
+        with self.feature({"organizations:create": False}):
+            resp = self.client.get(
+                self.path,
+                HTTP_HOST="albertos-apples.testserver",
+                follow=True,
+            )
+
+            assert resp.status_code == 200
+            assert resp.redirect_chain == [
+                (f"http://testserver/organizations/{visible_org.slug}/issues/", 302)
+            ]
+
+    def test_authenticated_user_without_visible_org_still_gets_no_org_access(self) -> None:
+        user = self.create_user()
+        self.create_organization(name="albertos-apples")
+        self.login_as(user)
+
+        with self.feature({"organizations:create": False}):
+            resp = self.client.get(
+                self.path,
+                HTTP_HOST="albertos-apples.testserver",
+            )
+
+            assert resp.status_code == 403
+            self.assertTemplateUsed(resp, "sentry/no-organization-access.html")
+
+    def test_explicit_org_path_does_not_use_customer_domain_subdomain(self) -> None:
+        visible_org = self.create_organization(owner=self.user)
+        self.create_organization(name="albertos-apples")
+        self.login_as(self.user)
+
+        resp = self.client.get(
+            reverse("sentry-organization-issue-list", args=[visible_org.slug]),
+            HTTP_HOST="albertos-apples.testserver",
+        )
+
+        assert resp.status_code == 200
+
     def test_login_valid_credentials(self) -> None:
         # load it once for test cookie
         with self.disable_registration():


### PR DESCRIPTION
Authenticated users no longer get a false no-organization-access page when generic `/auth/login/` is reached after an explicit organization login on a customer-domain host. The no-access branch now passes the session `activeorg` back through `determine_active_organization()` before rendering the empty-org state, so the flow can continue to the organization the login path already established.

This keeps plain customer-domain non-member login host-scoped: if there is no valid session `activeorg`, the no-organization-access behavior is unchanged. The dispatch path also preserves explicit organization slugs from routed URLs while still using the host subdomain for generic customer-domain routes.

Validation:
- `.venv/bin/pytest -n3 -q --reuse-db tests/sentry/web/frontend/test_auth_login.py tests/sentry/web/frontend/test_auth_organization_login.py tests/sentry/web/frontend/test_home.py tests/sentry/web/frontend/test_react_page.py`
- `.venv/bin/prek run -q --files src/sentry/web/frontend/base.py tests/sentry/web/frontend/test_auth_login.py`