### PR TITLE
ref(api): type group response fields as literals

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Protocol, TypedDict, TypeGuard
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict, TypeGuard
 
 import sentry_sdk
 from django.conf import settings
@@ -49,7 +49,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.tagstore.snuba.backend import fix_tag_value_data
 from sentry.tagstore.types import GroupTagValue
 from sentry.tsdb.snuba import SnubaTSDB
-from sentry.types.group import SUBSTATUS_TO_STR, PriorityLevel
+from sentry.types.group import SUBSTATUS_TO_STR, GroupPriorityStr, GroupSubStatusStr, PriorityLevel
 from sentry.users.api.serializers.user import UserSerializerResponse
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
@@ -124,12 +124,12 @@ class BaseGroupSerializerResponse(BaseGroupResponseOptional):
     permalink: str
     logger: str | None
     level: str
-    status: str
+    status: GroupStatusStr
     statusDetails: GroupStatusDetailsResponseOptional
-    substatus: str | None
+    substatus: GroupSubStatusStr | None
     isPublic: bool
     platform: str | None
-    priority: str | None
+    priority: GroupPriorityStr | None
     priorityLockedAt: datetime | None
     seerFixabilityScore: float | None
     seerAutofixLastTriggered: datetime | None
@@ -198,26 +198,34 @@ def _make_group_project_response(project: Project) -> GroupProjectResponse:
     }
 
 
-def _get_status_label(group: Group):
+GroupStatusStr = Literal[
+    "resolved",
+    "ignored",
+    "pending_deletion",
+    "pending_merge",
+    "reprocessing",
+    "unresolved",
+]
+
+
+def _get_status_label(group: Group) -> GroupStatusStr:
     status = group.get_status()
 
     if status == GroupStatus.RESOLVED:
-        status_label = "resolved"
+        return "resolved"
     elif status == GroupStatus.IGNORED:
-        status_label = "ignored"
+        return "ignored"
     elif status in [GroupStatus.PENDING_DELETION, GroupStatus.DELETION_IN_PROGRESS]:
-        status_label = "pending_deletion"
+        return "pending_deletion"
     elif status == GroupStatus.PENDING_MERGE:
-        status_label = "pending_merge"
+        return "pending_merge"
     elif status == GroupStatus.REPROCESSING:
-        status_label = "reprocessing"
+        return "reprocessing"
     else:
-        status_label = "unresolved"
-
-    return status_label
+        return "unresolved"
 
 
-def _get_substatus_label(group: Group):
+def _get_substatus_label(group: Group) -> GroupSubStatusStr | None:
     return SUBSTATUS_TO_STR[group.substatus] if group.substatus else None
 
 
@@ -495,6 +503,8 @@ class GroupSerializerBase(Serializer, ABC):
             if obj.issue_type.enable_auto_resolve:
                 status = GroupStatus.RESOLVED
                 status_details["autoResolved"] = True
+
+        status_label: GroupStatusStr
         if status == GroupStatus.RESOLVED:
             status_label = "resolved"
             if attrs["resolution_type"] == "release":
@@ -1173,8 +1183,8 @@ class SimpleGroupSerializerResponse(TypedDict):
     culprit: str | None
     shortId: str | None
     level: str
-    status: str
-    substatus: str | None
+    status: GroupStatusStr
+    substatus: GroupSubStatusStr | None
     platform: str | None
     project: GroupProjectResponse
     type: str

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -19,6 +19,7 @@ from sentry.api.serializers.models.group import (
     GroupSerializer,
     GroupSerializerSnuba,
     GroupStatusDetailsResponseOptional,
+    GroupStatusStr,
     SeenStats,
     is_seen_stats,
     snuba_tsdb,
@@ -40,6 +41,7 @@ from sentry.sentry_apps.api.serializers.platform_external_issue import (
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.snuba.dataset import Dataset
 from sentry.tsdb.base import TSDBModel
+from sentry.types.group import GroupPriorityStr, GroupSubStatusStr
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.utils import metrics
@@ -251,12 +253,12 @@ class StreamGroupSerializerSnubaResponse(TypedDict):
     permalink: NotRequired[str]
     logger: NotRequired[str | None]
     level: NotRequired[str]
-    status: NotRequired[str]
+    status: NotRequired[GroupStatusStr]
     statusDetails: NotRequired[GroupStatusDetailsResponseOptional]
-    substatus: NotRequired[str | None]
+    substatus: NotRequired[GroupSubStatusStr | None]
     isPublic: NotRequired[bool]
     platform: NotRequired[str | None]
-    priority: NotRequired[str | None]
+    priority: NotRequired[GroupPriorityStr | None]
     priorityLockedAt: NotRequired[datetime | None]
     seerFixabilityScore: NotRequired[float | None]
     seerAutofixLastTriggered: NotRequired[datetime | None]

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -228,6 +228,7 @@ def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> An
                 method_info["servers"] = servers
 
     _fix_issue_paths(result)
+    _fix_nullable_enums(result)
 
     # Fetch schema component references
     schema_components = result["components"]["schemas"]
@@ -300,6 +301,23 @@ def _check_tag(method_info: Mapping[str, Any], endpoint_name: str) -> None:
 def _check_description(json_body: Mapping[str, Any], err_str: str) -> None:
     if json_body.get("description") is None:
         raise SentryApiBuildError(err_str)
+
+
+def _fix_nullable_enums(node: Any) -> None:
+    """Add null to the values of any nullable enum schema.
+
+    A nullable enum must list null among its enum values; otherwise strict validators
+    reject a null value even when "nullable: true" is set, because in OpenAPI 3.0 the
+    enum membership constraint is evaluated independently of nullability.
+    """
+    if isinstance(node, dict):
+        if node.get("nullable") and isinstance(node.get("enum"), list) and None not in node["enum"]:
+            node["enum"].append(None)
+        for value in node.values():
+            _fix_nullable_enums(value)
+    elif isinstance(node, list):
+        for item in node:
+            _fix_nullable_enums(item)
 
 
 def _fix_issue_paths(result: Any) -> Any:

--- a/src/sentry/types/group.py
+++ b/src/sentry/types/group.py
@@ -1,5 +1,6 @@
 from collections.abc import Mapping
 from enum import IntEnum
+from typing import Literal
 
 
 class GroupSubStatus:
@@ -40,7 +41,17 @@ SUBSTATUS_UPDATE_CHOICES: Mapping[str, int] = {
     "new": GroupSubStatus.NEW,
 }
 
-SUBSTATUS_TO_STR: Mapping[int, str] = {
+GroupSubStatusStr = Literal[
+    "archived_until_escalating",
+    "archived_until_condition_met",
+    "archived_forever",
+    "escalating",
+    "ongoing",
+    "regressed",
+    "new",
+]
+
+SUBSTATUS_TO_STR: Mapping[int, GroupSubStatusStr] = {
     GroupSubStatus.UNTIL_ESCALATING: "archived_until_escalating",
     GroupSubStatus.UNTIL_CONDITION_MET: "archived_until_condition_met",
     GroupSubStatus.FOREVER: "archived_forever",
@@ -60,16 +71,23 @@ GROUP_SUBSTATUS_TO_GROUP_HISTORY_STATUS = {
 }
 
 
+GroupPriorityStr = Literal["low", "medium", "high"]
+
+
 class PriorityLevel(IntEnum):
     LOW = 25
     MEDIUM = 50
     HIGH = 75
 
-    def to_str(self) -> str:
+    def to_str(self) -> GroupPriorityStr:
         """
         Return the string representation of the priority level.
         """
-        return self.name.lower()
+        if self == PriorityLevel.LOW:
+            return "low"
+        if self == PriorityLevel.MEDIUM:
+            return "medium"
+        return "high"
 
     @classmethod
     def from_str(self, name: str) -> "PriorityLevel | None":

--- a/tests/apidocs/test_hooks.py
+++ b/tests/apidocs/test_hooks.py
@@ -3,7 +3,11 @@ from unittest import TestCase
 
 import pytest
 
-from sentry.apidocs.hooks import _ENDPOINT_SERVERS, custom_postprocessing_hook
+from sentry.apidocs.hooks import (
+    _ENDPOINT_SERVERS,
+    _fix_nullable_enums,
+    custom_postprocessing_hook,
+)
 from sentry.apidocs.utils import SentryApiBuildError
 
 
@@ -163,3 +167,77 @@ class FixIssueRoutesTest(TestCase):
             "components": {"schemas": {}},
         }
         assert custom_postprocessing_hook(BEFORE, None) == AFTER
+
+
+class FixNullableEnumsTest(TestCase):
+    def test_adds_null_to_nullable_enum(self) -> None:
+        schema = {"enum": ["a", "b"], "type": "string", "nullable": True}
+        _fix_nullable_enums(schema)
+        assert schema["enum"] == ["a", "b", None]
+
+    def test_does_not_duplicate_null(self) -> None:
+        schema = {"enum": ["a", None], "type": "string", "nullable": True}
+        _fix_nullable_enums(schema)
+        assert schema["enum"] == ["a", None]
+
+    def test_ignores_non_nullable_enum(self) -> None:
+        schema = {"enum": ["a", "b"], "type": "string"}
+        _fix_nullable_enums(schema)
+        assert schema["enum"] == ["a", "b"]
+
+    def test_ignores_nullable_without_enum(self) -> None:
+        schema = {"type": "string", "nullable": True}
+        _fix_nullable_enums(schema)
+        assert schema == {"type": "string", "nullable": True}
+
+    def test_recurses_into_nested_dicts_and_lists(self) -> None:
+        result = {
+            "components": {
+                "schemas": {
+                    "Group": {
+                        "properties": {
+                            "substatus": {
+                                "enum": ["ongoing", "new"],
+                                "type": "string",
+                                "nullable": True,
+                            },
+                            "status": {
+                                "enum": ["resolved", "unresolved"],
+                                "type": "string",
+                            },
+                        }
+                    }
+                }
+            },
+            "anyOfExample": [
+                {"enum": ["x"], "nullable": True},
+                {"type": "object", "nullable": True},
+            ],
+        }
+        _fix_nullable_enums(result)
+        # Nullable enums gain null wherever they are nested (deep in dicts and inside
+        # lists); the non-nullable enum and the nullable-but-enumless schema are left
+        # untouched.
+        assert result == {
+            "components": {
+                "schemas": {
+                    "Group": {
+                        "properties": {
+                            "substatus": {
+                                "enum": ["ongoing", "new", None],
+                                "type": "string",
+                                "nullable": True,
+                            },
+                            "status": {
+                                "enum": ["resolved", "unresolved"],
+                                "type": "string",
+                            },
+                        }
+                    }
+                }
+            },
+            "anyOfExample": [
+                {"enum": ["x", None], "nullable": True},
+                {"type": "object", "nullable": True},
+            ],
+        }


### PR DESCRIPTION
Add `GroupStatusStr, SubstatusStr, PriorityStr` types so these flow into the API docs.
