### PR TITLE
fix(ci): Fix failing `test-tools` action by updating hardcoded YAML

### DIFF
--- a/.github/codeowners-coverage-baseline.txt
+++ b/.github/codeowners-coverage-baseline.txt
@@ -2250,8 +2250,8 @@ tests/sentry/roles/__init__.py
 tests/sentry/roles/test_manager.py
 tests/sentry/runner/__init__.py
 tests/sentry/runner/commands/__init__.py
-tests/sentry/runner/commands/badpatch.yaml
-tests/sentry/runner/commands/badsync.yaml
+tests/sentry/runner/commands/badpatch.json
+tests/sentry/runner/commands/badsync.json
 tests/sentry/runner/commands/presenters/test_presenterdelegator.py
 tests/sentry/runner/commands/presenters/test_webhookpresenter.py
 tests/sentry/runner/commands/test_cleanup.py
@@ -2262,8 +2262,8 @@ tests/sentry/runner/commands/test_createuser.py
 tests/sentry/runner/commands/test_init.py
 tests/sentry/runner/commands/test_migrations.py
 tests/sentry/runner/commands/test_run.py
-tests/sentry/runner/commands/unsetsync.yaml
-tests/sentry/runner/commands/valid_patch.yaml
+tests/sentry/runner/commands/unsetsync.json
+tests/sentry/runner/commands/valid_patch.json
 tests/sentry/runner/test_initializer.py
 tests/sentry/security/__init__.py
 tests/sentry/security/test_csp.py

--- a/.github/workflows/scripts/compute-sentry-selected-tests.py
+++ b/.github/workflows/scripts/compute-sentry-selected-tests.py
@@ -109,17 +109,17 @@ EXTRA_FILE_TO_TEST_MAPPING: dict[str, list[str]] = {
     "fixtures/backup/user-with-minimum-privileges.json": ["tests/sentry/backup/test_rpc.py"],
     "fixtures/backup/single-integration.json": ["tests/sentry/backup/test_validate.py"],
     "fixtures/backup/single-option.json": ["tests/sentry/backup/test_validate.py"],
-    # YAML test-data files co-located with tests — only .py files are auto-selected
-    "tests/sentry/runner/commands/valid_patch.yaml": [
+    # JSON test-data files co-located with tests — only .py files are auto-selected
+    "tests/sentry/runner/commands/valid_patch.json": [
         "tests/sentry/runner/commands/test_configoptions.py"
     ],
-    "tests/sentry/runner/commands/badsync.yaml": [
+    "tests/sentry/runner/commands/badsync.json": [
         "tests/sentry/runner/commands/test_configoptions.py"
     ],
-    "tests/sentry/runner/commands/badpatch.yaml": [
+    "tests/sentry/runner/commands/badpatch.json": [
         "tests/sentry/runner/commands/test_configoptions.py"
     ],
-    "tests/sentry/runner/commands/unsetsync.yaml": [
+    "tests/sentry/runner/commands/unsetsync.json": [
         "tests/sentry/runner/commands/test_configoptions.py"
     ],
 }


### PR DESCRIPTION
`test-tools` (example here: https://github.com/getsentry/sentry/actions/runs/28364783465/job/84027847263?pr=117501) was failing because it was trying to find the old YAML path I removed. I updated it to be JSON.