### PR TITLE
fix(test): freeze time in deprecation url_names test to avoid noon-UTC flake

### DIFF
--- a/tests/sentry/api/helpers/test_deprecation.py
+++ b/tests/sentry/api/helpers/test_deprecation.py
@@ -218,7 +218,7 @@ class TestDeprecationDecorator(APITestCase):
                 self.assert_denied_request("GET")
 
     def test_with_url_names(self) -> None:
-        with self.settings(SENTRY_SELF_HOSTED=False):
+        with self.settings(SENTRY_SELF_HOSTED=False), freeze_time(test_date - timedelta(minutes=1)):
             # Resolver url_name doesn't match
             request = self.make_request(method="DELETE")
             request.resolver_match = ResolverMatch(


### PR DESCRIPTION
`test_with_url_names` is the only test in `TestDeprecationDecorator` that doesn't freeze time, so it flakes whenever it runs during the daily noon-UTC minute. The endpoint is decorated with `@deprecated(test_date=2020-01-01)`, so the date is always past and the only thing holding the response at `200` instead of `410 Gone` is the brownout window, checked against the real clock (default cron `"0 12 * * *"`, 60s). A master backend run hit exactly this: the test got `410` near 12:00 UTC and all 5 reruns landed in the same 60s window (https://github.com/getsentry/sentry/actions/runs/28370131840/job/84048168633, `backend test (21)`).

We wrap the body in `freeze_time(test_date - timedelta(minutes=1))`, matching the sibling `test_with_url_names_brownout`.