### PR TITLE
feat(preprod): Show existing size comparisons on the compare page

### DIFF
--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -31,6 +31,7 @@ export type PreprodBuildEventParameters = {
   'preprod.builds.compare.go_to_build_details': BasePreprodBuildEvent & {
     slot?: 'head' | 'base';
   };
+  'preprod.builds.compare.open_existing_comparison': BasePreprodBuildEvent;
   'preprod.builds.compare.select_base_build': BasePreprodBuildEvent;
   'preprod.builds.compare.trigger_comparison': BasePreprodBuildEvent;
   'preprod.builds.details.compare_build_clicked': BasePreprodBuildEvent;
@@ -142,6 +143,8 @@ export const preprodBuildEventMap: Record<PreprodBuildAnalyticsKey, string | nul
   'preprod.builds.compare.download_csv': 'Preprod Build Comparison: Download CSV',
   'preprod.builds.compare.go_to_build_details':
     'Preprod Build Comparison: Go to Build Details',
+  'preprod.builds.compare.open_existing_comparison':
+    'Preprod Build Comparison: Existing Comparison Opened',
   'preprod.builds.compare.select_base_build': 'Preprod Build Comparison: Base Selected',
   'preprod.builds.compare.trigger_comparison':
     'Preprod Build Comparison: Compare Triggered',

--- a/static/app/views/preprod/buildComparison/main/buildItem.tsx
+++ b/static/app/views/preprod/buildComparison/main/buildItem.tsx
@@ -37,26 +37,26 @@ interface BuildItemProps {
   installSizeDelta?: number;
   /** Selection state, used by the base-build picker. */
   isSelected?: boolean;
+  /** When set, the card links to this path instead of being selectable. */
+  linkTo?: string;
   /** Click handler fired before navigation in link mode (e.g. analytics). */
   onClick?: () => void;
   /** Selection handler, used by the base-build picker. */
   onSelect?: () => void;
-  /** When provided, the card renders as a link to this path (no radio). */
-  to?: string;
 }
 
 export function BuildItem({
   build,
-  isSelected,
-  onSelect,
-  onClick,
-  to,
-  installSizeDelta,
   downloadSizeDelta,
+  installSizeDelta,
+  isSelected,
+  linkTo,
+  onClick,
+  onSelect,
 }: BuildItemProps) {
-  if (to) {
+  if (linkTo) {
     return (
-      <BuildItemLink to={to} onClick={onClick}>
+      <BuildItemLink to={linkTo} onClick={onClick}>
         <BuildItemDetails
           build={build}
           installSizeDelta={installSizeDelta}
@@ -85,8 +85,8 @@ export function BuildItem({
 
 function BuildItemDetails({
   build,
-  installSizeDelta,
   downloadSizeDelta,
+  installSizeDelta,
 }: {
   build: BuildDetailsApiResponse;
   downloadSizeDelta?: number;

--- a/static/app/views/preprod/buildComparison/main/buildItem.tsx
+++ b/static/app/views/preprod/buildComparison/main/buildItem.tsx
@@ -1,0 +1,237 @@
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Radio} from '@sentry/scraps/radio';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {TimeSince} from 'sentry/components/timeSince';
+import {
+  IconCalendar,
+  IconCode,
+  IconCommit,
+  IconDownload,
+  IconMobile,
+  IconTag,
+} from 'sentry/icons';
+import {IconBranch} from 'sentry/icons/iconBranch';
+import {t} from 'sentry/locale';
+import {
+  isSizeInfoCompleted,
+  type BuildDetailsApiResponse,
+} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {
+  formattedPrimaryMetricDownloadSize,
+  formattedPrimaryMetricInstallSize,
+  formattedSizeDiff,
+  getTrend,
+} from 'sentry/views/preprod/utils/labelUtils';
+
+interface BuildItemProps {
+  build: BuildDetailsApiResponse;
+  /** Download size change vs this build. */
+  downloadSizeDelta?: number;
+  /** Install size change vs this build. */
+  installSizeDelta?: number;
+  /** Selection state, used by the base-build picker. */
+  isSelected?: boolean;
+  /** Click handler fired before navigation in link mode (e.g. analytics). */
+  onClick?: () => void;
+  /** Selection handler, used by the base-build picker. */
+  onSelect?: () => void;
+  /** When provided, the card renders as a link to this path (no radio). */
+  to?: string;
+}
+
+export function BuildItem({
+  build,
+  isSelected,
+  onSelect,
+  onClick,
+  to,
+  installSizeDelta,
+  downloadSizeDelta,
+}: BuildItemProps) {
+  if (to) {
+    return (
+      <BuildItemLink to={to} onClick={onClick}>
+        <BuildItemDetails
+          build={build}
+          installSizeDelta={installSizeDelta}
+          downloadSizeDelta={downloadSizeDelta}
+        />
+      </BuildItemLink>
+    );
+  }
+
+  return (
+    <BuildItemContainer
+      onClick={onSelect}
+      isSelected={Boolean(isSelected)}
+      align="center"
+      gap="md"
+    >
+      <BuildItemDetails
+        build={build}
+        installSizeDelta={installSizeDelta}
+        downloadSizeDelta={downloadSizeDelta}
+      />
+      <Radio checked={Boolean(isSelected)} onChange={onSelect} />
+    </BuildItemContainer>
+  );
+}
+
+function BuildItemDetails({
+  build,
+  installSizeDelta,
+  downloadSizeDelta,
+}: {
+  build: BuildDetailsApiResponse;
+  downloadSizeDelta?: number;
+  installSizeDelta?: number;
+}) {
+  const prNumber = build.vcs_info?.pr_number;
+  const commitHash = build.vcs_info?.head_sha?.substring(0, 7);
+  const branchName = build.vcs_info?.head_ref;
+  const dateAdded = build.app_info?.date_added;
+  const sizeInfo = build.size_info;
+  const version = build.app_info?.version;
+  const buildNumber = build.app_info?.build_number;
+
+  const hasGitInfo = Boolean(prNumber || branchName || commitHash);
+  const versionInfo = formatVersionInfo(version, buildNumber);
+
+  return (
+    <Flex direction="column" gap="sm" flex={1}>
+      {(hasGitInfo || versionInfo) && (
+        <Flex align="center" gap="md">
+          {(prNumber || branchName) && <IconBranch size="xs" variant="muted" />}
+          {prNumber && (
+            <Flex align="center" gap="sm">
+              <Text>#{prNumber}</Text>
+            </Flex>
+          )}
+          {branchName && <BuildItemBranchTag>{branchName}</BuildItemBranchTag>}
+          {commitHash && (
+            <Flex align="center" gap="sm">
+              <IconCommit size="xs" variant="muted" />
+              <Text>{commitHash}</Text>
+            </Flex>
+          )}
+          {versionInfo && (
+            <Flex align="center" gap="sm">
+              <IconTag size="xs" variant="muted" />
+              <Text>{versionInfo}</Text>
+            </Flex>
+          )}
+        </Flex>
+      )}
+
+      <Flex align="center" gap="md">
+        {dateAdded && (
+          <Flex align="center" gap="sm">
+            <IconCalendar size="xs" variant="muted" />
+            <TimeSince date={dateAdded} />
+          </Flex>
+        )}
+        {build.app_info?.build_configuration && (
+          <Flex align="center" gap="sm">
+            <IconMobile size="xs" variant="muted" />
+            <Tooltip title={t('Build configuration')}>
+              <Text monospace>{build.app_info.build_configuration}</Text>
+            </Tooltip>
+          </Flex>
+        )}
+        {isSizeInfoCompleted(sizeInfo) && (
+          <Flex align="center" gap="sm">
+            <IconCode size="xs" variant="muted" />
+            <Text>{formattedPrimaryMetricInstallSize(sizeInfo)}</Text>
+            {installSizeDelta !== undefined && <SizeDelta diff={installSizeDelta} />}
+          </Flex>
+        )}
+        {isSizeInfoCompleted(sizeInfo) && (
+          <Flex align="center" gap="sm">
+            <IconDownload size="xs" variant="muted" />
+            <Text>{formattedPrimaryMetricDownloadSize(sizeInfo)}</Text>
+            {downloadSizeDelta !== undefined && <SizeDelta diff={downloadSizeDelta} />}
+          </Flex>
+        )}
+      </Flex>
+    </Flex>
+  );
+}
+
+// Signed size change (head - base) shown inline next to a size, colored by trend.
+function SizeDelta({diff}: {diff: number}) {
+  const trend = getTrend(diff);
+  return (
+    <Text variant={trend.variant} size="sm" tabular>
+      {formattedSizeDiff(diff) || '0 B'}
+    </Text>
+  );
+}
+
+// Combines version + build number into a display string, e.g. "v1.2.3 (456)".
+function formatVersionInfo(
+  version?: string | null,
+  buildNumber?: string | null
+): string | null {
+  if (!version && !buildNumber) {
+    return null;
+  }
+
+  if (version && buildNumber) {
+    return `v${version} (${buildNumber})`;
+  }
+
+  if (version) {
+    return `v${version}`;
+  }
+
+  return `(${buildNumber})`;
+}
+
+const BuildItemContainer = styled(Flex)<{isSelected: boolean}>`
+  border: 1px solid
+    ${p =>
+      p.isSelected
+        ? p.theme.tokens.border.accent.vibrant
+        : p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  padding: ${p => p.theme.space.md};
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${p => p.theme.colors.surface200};
+  }
+
+  ${p =>
+    p.isSelected &&
+    css`
+      background-color: ${p.theme.tokens.background.tertiary};
+    `}
+`;
+
+const BuildItemLink = styled(Link)`
+  display: block;
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  padding: ${p => p.theme.space.md};
+  color: inherit;
+
+  &:hover {
+    background-color: ${p => p.theme.colors.surface200};
+    color: inherit;
+  }
+`;
+
+const BuildItemBranchTag = styled('span')`
+  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.sm};
+  background-color: ${p => p.theme.colors.gray100};
+  border-radius: ${p => p.theme.radius.md};
+  color: ${p => p.theme.tokens.content.accent};
+  font-size: ${p => p.theme.font.size.sm};
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+`;

--- a/static/app/views/preprod/buildComparison/main/existingComparisons.spec.tsx
+++ b/static/app/views/preprod/buildComparison/main/existingComparisons.spec.tsx
@@ -1,0 +1,198 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PreprodBuildDetailsWithSizeInfoFixture} from 'sentry-fixture/preprod';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import * as analytics from 'sentry/utils/analytics';
+import {MetricsArtifactType} from 'sentry/views/preprod/types/appSizeTypes';
+import {
+  BuildDetailsSizeAnalysisState,
+  type BuildDetailsApiResponse,
+} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+import {ExistingComparisons} from './existingComparisons';
+
+const organization = OrganizationFixture();
+const HEAD_ID = 'head-1';
+const COMPARISONS_URL = `/organizations/${organization.slug}/preprodartifacts/${HEAD_ID}/size-analysis/comparisons/`;
+
+function makeBuild({
+  downloadBytes,
+  id,
+  installBytes,
+  version,
+}: {
+  downloadBytes: number;
+  id: string;
+  installBytes: number;
+  version: string;
+}): BuildDetailsApiResponse {
+  return PreprodBuildDetailsWithSizeInfoFixture(
+    {
+      state: BuildDetailsSizeAnalysisState.COMPLETED,
+      size_metrics: [
+        {
+          metrics_artifact_type: MetricsArtifactType.MAIN_ARTIFACT,
+          install_size_bytes: installBytes,
+          download_size_bytes: downloadBytes,
+        },
+      ],
+      base_size_metrics: [],
+    },
+    {id, app_info: {version}}
+  );
+}
+
+// The page's head build: 10 MB install / 5 MB download. Deltas below are head - base.
+const headBuild = makeBuild({
+  id: HEAD_ID,
+  version: '3.0.0',
+  installBytes: 10_000_000,
+  downloadBytes: 5_000_000,
+});
+
+describe('ExistingComparisons', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders a row per comparison with head-vs-base size deltas', async () => {
+    MockApiClient.addMockResponse({
+      url: COMPARISONS_URL,
+      method: 'GET',
+      body: {
+        comparisons: [
+          // Base smaller than head -> head grew (+).
+          makeBuild({
+            id: 'base-1',
+            version: '2.0.0',
+            installBytes: 8_000_000,
+            downloadBytes: 4_000_000,
+          }),
+          // Base larger than head -> head shrank (-).
+          makeBuild({
+            id: 'base-2',
+            version: '1.5.0',
+            installBytes: 13_000_000,
+            downloadBytes: 9_000_000,
+          }),
+        ],
+      },
+    });
+
+    render(<ExistingComparisons headBuildDetails={headBuild} />, {organization});
+
+    expect(await screen.findByText('v2.0.0')).toBeInTheDocument();
+    expect(screen.getByText('v1.5.0')).toBeInTheDocument();
+
+    // Deltas shown inline next to each base's install/download sizes.
+    expect(screen.getByText('+2 MB')).toBeInTheDocument(); // install: 10 - 8
+    expect(screen.getByText('+1 MB')).toBeInTheDocument(); // download: 5 - 4
+    expect(screen.getByText('-3 MB')).toBeInTheDocument(); // install: 10 - 13
+    expect(screen.getByText('-4 MB')).toBeInTheDocument(); // download: 5 - 9
+  });
+
+  it('links each comparison to its compare page', async () => {
+    MockApiClient.addMockResponse({
+      url: COMPARISONS_URL,
+      method: 'GET',
+      body: {
+        comparisons: [
+          makeBuild({
+            id: 'base-1',
+            version: '2.0.0',
+            installBytes: 8_000_000,
+            downloadBytes: 4_000_000,
+          }),
+        ],
+      },
+    });
+
+    render(<ExistingComparisons headBuildDetails={headBuild} />, {organization});
+
+    const link = await screen.findByRole('link', {name: /v2\.0\.0/});
+    expect(link).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/preprod/size/compare/${HEAD_ID}/base-1/`
+    );
+  });
+
+  it('renders nothing when there are no comparisons', async () => {
+    const mock = MockApiClient.addMockResponse({
+      url: COMPARISONS_URL,
+      method: 'GET',
+      body: {comparisons: []},
+    });
+
+    render(<ExistingComparisons headBuildDetails={headBuild} />, {organization});
+
+    await waitFor(() => expect(mock).toHaveBeenCalled());
+    expect(screen.queryByText('Existing Comparisons')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the request fails', async () => {
+    const mock = MockApiClient.addMockResponse({
+      url: COMPARISONS_URL,
+      method: 'GET',
+      statusCode: 500,
+      body: {detail: 'Internal Error'},
+    });
+
+    render(<ExistingComparisons headBuildDetails={headBuild} />, {organization});
+
+    await waitFor(() => expect(mock).toHaveBeenCalled());
+    expect(screen.queryByText('Existing Comparisons')).not.toBeInTheDocument();
+  });
+
+  it('applies the search query to the comparisons request', async () => {
+    MockApiClient.addMockResponse({
+      url: COMPARISONS_URL,
+      method: 'GET',
+      match: [MockApiClient.matchQuery({query: 'acme'})],
+      body: {
+        comparisons: [
+          makeBuild({
+            id: 'base-1',
+            version: '2.0.0',
+            installBytes: 8_000_000,
+            downloadBytes: 4_000_000,
+          }),
+        ],
+      },
+    });
+
+    render(<ExistingComparisons headBuildDetails={headBuild} searchQuery="acme" />, {
+      organization,
+    });
+
+    // The row only renders if the request carried query=acme and matched the mock.
+    expect(await screen.findByText('v2.0.0')).toBeInTheDocument();
+  });
+
+  it('tracks an analytics event when a comparison is opened', async () => {
+    const analyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    MockApiClient.addMockResponse({
+      url: COMPARISONS_URL,
+      method: 'GET',
+      body: {
+        comparisons: [
+          makeBuild({
+            id: 'base-1',
+            version: '2.0.0',
+            installBytes: 8_000_000,
+            downloadBytes: 4_000_000,
+          }),
+        ],
+      },
+    });
+
+    render(<ExistingComparisons headBuildDetails={headBuild} />, {organization});
+
+    await userEvent.click(await screen.findByRole('link', {name: /v2\.0\.0/}));
+
+    expect(analyticsSpy).toHaveBeenCalledWith(
+      'preprod.builds.compare.open_existing_comparison',
+      expect.objectContaining({build_id: 'base-1'})
+    );
+  });
+});

--- a/static/app/views/preprod/buildComparison/main/existingComparisons.tsx
+++ b/static/app/views/preprod/buildComparison/main/existingComparisons.tsx
@@ -1,0 +1,91 @@
+import {useQuery} from '@tanstack/react-query';
+
+import {Stack} from '@sentry/scraps/layout';
+import {Heading} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  getMainArtifactSizeMetric,
+  isSizeInfoCompleted,
+  type BuildDetailsApiResponse,
+} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getCompareBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {comparisonListApiOptions} from 'sentry/views/preprod/utils/comparisonListApiOptions';
+
+import {BuildItem} from './buildItem';
+
+interface ExistingComparisonsProps {
+  headBuildDetails: BuildDetailsApiResponse;
+  searchQuery?: string;
+}
+
+export function ExistingComparisons({
+  headBuildDetails,
+  searchQuery,
+}: ExistingComparisonsProps) {
+  const organization = useOrganization();
+
+  const comparisonsQuery = useQuery(
+    comparisonListApiOptions({
+      organization,
+      headArtifactId: headBuildDetails.id,
+      query: searchQuery,
+    })
+  );
+
+  const comparisons = comparisonsQuery.data?.comparisons ?? [];
+
+  // Hide the section until there are comparisons (also covers the loading/error states).
+  if (comparisons.length === 0) {
+    return null;
+  }
+
+  // The head build is fixed for this page, so resolve its primary metric once.
+  const headSizeInfo = headBuildDetails.size_info;
+  const headMetric = isSizeInfoCompleted(headSizeInfo)
+    ? getMainArtifactSizeMetric(headSizeInfo)
+    : undefined;
+
+  return (
+    <Stack gap="lg">
+      <Heading as="h2">{t('Existing Comparisons')}</Heading>
+
+      <Stack gap="md">
+        {comparisons.map(build => {
+          const baseSizeInfo = build.size_info;
+          const baseMetric = isSizeInfoCompleted(baseSizeInfo)
+            ? getMainArtifactSizeMetric(baseSizeInfo)
+            : undefined;
+          const sizeDelta = (key: 'install_size_bytes' | 'download_size_bytes') =>
+            headMetric && baseMetric ? headMetric[key] - baseMetric[key] : undefined;
+
+          return (
+            <BuildItem
+              key={build.id}
+              build={build}
+              to={getCompareBuildPath({
+                organizationSlug: organization.slug,
+                headArtifactId: headBuildDetails.id,
+                baseArtifactId: build.id,
+              })}
+              installSizeDelta={sizeDelta('install_size_bytes')}
+              downloadSizeDelta={sizeDelta('download_size_bytes')}
+              onClick={() =>
+                trackAnalytics('preprod.builds.compare.open_existing_comparison', {
+                  organization,
+                  build_id: build.id,
+                  platform:
+                    build.app_info?.platform ??
+                    headBuildDetails.app_info?.platform ??
+                    null,
+                })
+              }
+            />
+          );
+        })}
+      </Stack>
+    </Stack>
+  );
+}

--- a/static/app/views/preprod/buildComparison/main/existingComparisons.tsx
+++ b/static/app/views/preprod/buildComparison/main/existingComparisons.tsx
@@ -65,7 +65,7 @@ export function ExistingComparisons({
             <BuildItem
               key={build.id}
               build={build}
-              to={getCompareBuildPath({
+              linkTo={getCompareBuildPath({
                 organizationSlug: organization.slug,
                 headArtifactId: headBuildDetails.id,
                 baseArtifactId: build.id,

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -1,29 +1,15 @@
 import {useState} from 'react';
-import {css} from '@emotion/react';
-import styled from '@emotion/styled';
-import {useQuery, useMutation} from '@tanstack/react-query';
+import {useMutation, useQuery} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
 import {InputGroup} from '@sentry/scraps/input';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Pagination} from '@sentry/scraps/pagination';
-import {Radio} from '@sentry/scraps/radio';
-import {Text} from '@sentry/scraps/text';
-import {Tooltip} from '@sentry/scraps/tooltip';
+import {Heading} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {TimeSince} from 'sentry/components/timeSince';
-import {
-  IconCalendar,
-  IconCode,
-  IconCommit,
-  IconDownload,
-  IconMobile,
-  IconSearch,
-  IconTag,
-} from 'sentry/icons';
-import {IconBranch} from 'sentry/icons/iconBranch';
+import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
@@ -37,7 +23,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   BuildDetailsState,
-  isSizeInfoCompleted,
   type BuildDetailsApiResponse,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 import {buildDetailsApiOptions} from 'sentry/views/preprod/utils/buildDetailsApiOptions';
@@ -45,11 +30,9 @@ import {
   getCompareApiUrl,
   getCompareBuildPath,
 } from 'sentry/views/preprod/utils/buildLinkUtils';
-import {
-  formattedPrimaryMetricDownloadSize,
-  formattedPrimaryMetricInstallSize,
-} from 'sentry/views/preprod/utils/labelUtils';
 
+import {BuildItem} from './buildItem';
+import {ExistingComparisons} from './existingComparisons';
 import {SizeCompareSelectedBuilds} from './sizeCompareSelectedBuilds';
 
 interface SizeCompareSelectionContentProps {
@@ -142,7 +125,7 @@ export function SizeCompareSelectionContent({
   });
 
   return (
-    <Stack gap="xl">
+    <Stack gap="2xl">
       <SizeCompareSelectedBuilds
         isComparing={isComparing}
         headBuildDetails={headBuildDetails}
@@ -170,7 +153,8 @@ export function SizeCompareSelectionContent({
           value={searchQuery}
           onChange={e => {
             setSearchQuery(e.target.value);
-            // Clear cursor when search query changes to avoid pagination issues
+            // Clear the picker's cursor when the search changes to avoid
+            // landing on a now-empty page.
             if (cursor) {
               navigate(
                 getCompareBuildPath({
@@ -184,179 +168,49 @@ export function SizeCompareSelectionContent({
         />
       </InputGroup>
 
-      {buildsQuery.isLoading && <LoadingIndicator />}
-      {buildsQuery.isError && (
-        <Alert variant="danger">{buildsQuery.error?.message}</Alert>
-      )}
-      {buildsQuery.data?.json && (
-        <Stack gap="md">
-          {buildsQuery.data.json.map(build => {
-            if (build.id === headBuildDetails.id) {
-              return null;
-            }
+      <ExistingComparisons
+        headBuildDetails={headBuildDetails}
+        searchQuery={searchQuery}
+      />
 
-            return (
-              <BuildItem
-                key={build.id}
-                build={build}
-                isSelected={selectedBaseBuild === build}
-                onSelect={() => {
-                  setSelectedBaseBuild(build);
-                  trackAnalytics('preprod.builds.compare.select_base_build', {
-                    organization,
-                    build_id: build.id,
-                    platform:
-                      build.app_info?.platform ??
-                      headBuildDetails.app_info?.platform ??
-                      null,
-                  });
-                }}
-              />
-            );
-          })}
+      <Stack gap="lg">
+        <Heading as="h2">{t('Create New Comparison')}</Heading>
 
-          {hasPagination && <Pagination pageLinks={pageLinks} />}
-        </Stack>
-      )}
+        {buildsQuery.isLoading && <LoadingIndicator />}
+        {buildsQuery.isError && (
+          <Alert variant="danger">{buildsQuery.error?.message}</Alert>
+        )}
+        {buildsQuery.data?.json && (
+          <Stack gap="md">
+            {buildsQuery.data.json.map(build => {
+              if (build.id === headBuildDetails.id) {
+                return null;
+              }
+
+              return (
+                <BuildItem
+                  key={build.id}
+                  build={build}
+                  isSelected={selectedBaseBuild === build}
+                  onSelect={() => {
+                    setSelectedBaseBuild(build);
+                    trackAnalytics('preprod.builds.compare.select_base_build', {
+                      organization,
+                      build_id: build.id,
+                      platform:
+                        build.app_info?.platform ??
+                        headBuildDetails.app_info?.platform ??
+                        null,
+                    });
+                  }}
+                />
+              );
+            })}
+
+            {hasPagination && <Pagination pageLinks={pageLinks} />}
+          </Stack>
+        )}
+      </Stack>
     </Stack>
   );
 }
-
-/**
- * Formats version and build number into a combined string.
- * Examples: "v1.2.3 (456)", "v1.2.3", "(456)", or null
- */
-function formatVersionInfo(
-  version?: string | null,
-  buildNumber?: string | null
-): string | null {
-  if (!version && !buildNumber) {
-    return null;
-  }
-
-  if (version && buildNumber) {
-    return `v${version} (${buildNumber})`;
-  }
-
-  if (version) {
-    return `v${version}`;
-  }
-
-  return `(${buildNumber})`;
-}
-
-interface BuildItemProps {
-  build: BuildDetailsApiResponse;
-  isSelected: boolean;
-  onSelect: () => void;
-}
-
-function BuildItem({build, isSelected, onSelect}: BuildItemProps) {
-  const prNumber = build.vcs_info?.pr_number;
-  const commitHash = build.vcs_info?.head_sha?.substring(0, 7);
-  const branchName = build.vcs_info?.head_ref;
-  const dateAdded = build.app_info?.date_added;
-  const sizeInfo = build.size_info;
-  const version = build.app_info?.version;
-  const buildNumber = build.app_info?.build_number;
-
-  const hasGitInfo = Boolean(prNumber || branchName || commitHash);
-  const versionInfo = formatVersionInfo(version, buildNumber);
-
-  return (
-    <BuildItemContainer
-      onClick={onSelect}
-      isSelected={isSelected}
-      align="center"
-      gap="md"
-    >
-      <Flex direction="column" gap="sm" flex={1}>
-        {(hasGitInfo || versionInfo) && (
-          <Flex align="center" gap="md">
-            {(prNumber || branchName) && <IconBranch size="xs" variant="muted" />}
-            {prNumber && (
-              <Flex align="center" gap="sm">
-                <Text>#{prNumber}</Text>
-              </Flex>
-            )}
-            {branchName && (
-              <BuildItemBranchTag>{build.vcs_info?.head_ref}</BuildItemBranchTag>
-            )}
-            {commitHash && (
-              <Flex align="center" gap="sm">
-                <IconCommit size="xs" variant="muted" />
-                <Text>{commitHash}</Text>
-              </Flex>
-            )}
-            {versionInfo && (
-              <Flex align="center" gap="sm">
-                <IconTag size="xs" variant="muted" />
-                <Text>{versionInfo}</Text>
-              </Flex>
-            )}
-          </Flex>
-        )}
-
-        <Flex align="center" gap="md">
-          {dateAdded && (
-            <Flex align="center" gap="sm">
-              <IconCalendar size="xs" variant="muted" />
-              <TimeSince date={dateAdded} />
-            </Flex>
-          )}
-          {build.app_info?.build_configuration && (
-            <Flex align="center" gap="sm">
-              <IconMobile size="xs" variant="muted" />
-              <Tooltip title={t('Build configuration')}>
-                <Text monospace>{build.app_info.build_configuration}</Text>
-              </Tooltip>
-            </Flex>
-          )}
-          {isSizeInfoCompleted(sizeInfo) && (
-            <Flex align="center" gap="sm">
-              <IconCode size="xs" variant="muted" />
-              <Text>{formattedPrimaryMetricInstallSize(sizeInfo)}</Text>
-            </Flex>
-          )}
-          {isSizeInfoCompleted(sizeInfo) && (
-            <Flex align="center" gap="sm">
-              <IconDownload size="xs" variant="muted" />
-              <Text>{formattedPrimaryMetricDownloadSize(sizeInfo)}</Text>
-            </Flex>
-          )}
-        </Flex>
-      </Flex>
-      <Radio checked={isSelected} onChange={onSelect} />
-    </BuildItemContainer>
-  );
-}
-
-const BuildItemContainer = styled(Flex)<{isSelected: boolean}>`
-  border: 1px solid
-    ${p =>
-      p.isSelected
-        ? p.theme.tokens.border.accent.vibrant
-        : p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.md};
-  padding: ${p => p.theme.space.md};
-  cursor: pointer;
-
-  &:hover {
-    background-color: ${p => p.theme.colors.surface200};
-  }
-
-  ${p =>
-    p.isSelected &&
-    css`
-      background-color: ${p.theme.tokens.background.tertiary};
-    `}
-`;
-
-const BuildItemBranchTag = styled('span')`
-  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.sm};
-  background-color: ${p => p.theme.colors.gray100};
-  border-radius: ${p => p.theme.radius.md};
-  color: ${p => p.theme.tokens.content.accent};
-  font-size: ${p => p.theme.font.size.sm};
-  font-weight: ${p => p.theme.font.weight.sans.regular};
-`;

--- a/static/app/views/preprod/utils/comparisonListApiOptions.ts
+++ b/static/app/views/preprod/utils/comparisonListApiOptions.ts
@@ -1,0 +1,26 @@
+import type {Organization} from 'sentry/types/organization';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+interface SizeAnalysisComparisonsResponse {
+  comparisons: BuildDetailsApiResponse[];
+}
+
+export function comparisonListApiOptions({
+  organization,
+  headArtifactId,
+  query,
+}: {
+  headArtifactId: string;
+  organization: Organization;
+  query?: string;
+}) {
+  return apiOptions.as<SizeAnalysisComparisonsResponse>()(
+    '/organizations/$organizationIdOrSlug/preprodartifacts/$headArtifactId/size-analysis/comparisons/',
+    {
+      path: {organizationIdOrSlug: organization.slug, headArtifactId},
+      query: query ? {query} : {},
+      staleTime: 0,
+    }
+  );
+}


### PR DESCRIPTION
The size-compare selection page only offered the picker for creating a *new* comparison, so comparisons already run for a build were invisible. This adds an **Existing Comparisons** section listing the successful comparisons where the current build is the head — each row links straight to that comparison and shows the head-vs-base install/download size deltas.

- Consumes the comparisons list endpoint from #118526.
- No pagination; the section is only shown when existing comparisons are returned.
- Opening a comparison records an analytics event.
- Reuses the shared `BuildItem` row for both the base-build picker and the comparison links.

## Screenshots
<img width="80%" alt="looks-like" src="https://github.com/user-attachments/assets/2cc0d246-4308-479a-950b-5216b4e443b4" />

Refs EME-1025
