### PR TITLE
feat(seer): Add configurable CPU backend routing for grouping requests

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1129,6 +1129,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Fraction of grouping requests to route to the CPU (summarization) backend instead of GPU
+register(
+    "seer.similarity.cpu-backend-sample-rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 register(
     "embeddings-grouping.seer.delete-record-batch-size",

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Mapping
+from random import random
 
 import sentry_sdk
 from django.conf import settings
@@ -15,7 +16,11 @@ from sentry.conf.server import (
 )
 from sentry.models.grouphashmetadata import GroupHashMetadata
 from sentry.net.http import connection_from_url
-from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+from sentry.seer.signed_seer_api import (
+    SeerViewerContext,
+    make_signed_seer_api_request,
+    seer_summarization_default_connection_pool,
+)
 from sentry.seer.similarity.types import (
     IncompleteSeerDataError,
     SeerSimilarIssueData,
@@ -90,12 +95,27 @@ def get_similarity_data_from_seer(
         CountBasedTripStrategy.from_config(config),
     )
 
+    cpu_sample_rate = options.get("seer.similarity.cpu-backend-sample-rate")
+    if random() < cpu_sample_rate:
+        selected_pool = seer_summarization_default_connection_pool
+        seer_backend = "cpu"
+    else:
+        selected_pool = seer_grouping_connection_pool
+        seer_backend = "gpu"
+
+    metric_tags["seer_backend"] = seer_backend
+
+    request_metric_tags: dict[str, str | int | bool] = {"seer_backend": seer_backend}
+    if referrer:
+        request_metric_tags["referrer"] = referrer
+
     try:
         response = make_similar_issues_request(
             similar_issues_request,
+            connection_pool=selected_pool,
             retries=options.get("seer.similarity.grouping-ingest-retries"),
             timeout=options.get("seer.similarity.grouping-ingest-timeout"),
-            metric_tags={"referrer": referrer} if referrer else {},
+            metric_tags=request_metric_tags,
             viewer_context=viewer_context,
         )
     except (TimeoutError, MaxRetryError) as e:

--- a/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/issues/endpoints/test_group_similar_issues_embeddings.py
@@ -254,6 +254,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 "response_status": 200,
                 "outcome": "matching_group_found",
                 "referrer": "similar_issues",
+                "seer_backend": "gpu",
             },
         )
 
@@ -421,6 +422,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 "outcome": "error",
                 "error": "IncompleteSeerDataError",
                 "referrer": "similar_issues",
+                "seer_backend": "gpu",
             },
         )
 
@@ -473,6 +475,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 "outcome": "error",
                 "error": "SimilarHashNotFoundError",
                 "referrer": "similar_issues",
+                "seer_backend": "gpu",
             },
         )
         assert self.similar_event.group_id
@@ -531,6 +534,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 "outcome": "error",
                 "error": "SimilarHashMissingGroupError",
                 "referrer": "similar_issues",
+                "seer_backend": "gpu",
             },
         )
         assert response.data == []

--- a/tests/sentry/seer/similarity/test_similar_issues.py
+++ b/tests/sentry/seer/similarity/test_similar_issues.py
@@ -82,6 +82,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
                 tags={
                     "response_status": 200,
                     "outcome": expected_outcome,
+                    "seer_backend": "gpu",
                 },
             )
 
@@ -98,7 +99,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
         mock_metrics_incr.assert_any_call(
             "seer.similar_issues_request",
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"response_status": 200, "outcome": "no_similar_groups"},
+            tags={"response_status": 200, "outcome": "no_similar_groups", "seer_backend": "gpu"},
         )
 
     @mock.patch("sentry.grouping.ingest.seer.CircuitBreaker.record_error")
@@ -164,7 +165,12 @@ class GetSimilarityDataFromSeerTest(TestCase):
             mock_metrics_incr.assert_any_call(
                 "seer.similar_issues_request",
                 sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-                tags={"response_status": 200, "outcome": "error", "error": expected_error},
+                tags={
+                    "response_status": 200,
+                    "outcome": "error",
+                    "error": expected_error,
+                    "seer_backend": "gpu",
+                },
             )
             assert mock_record_circuit_breaker_error.call_count == 0
 
@@ -192,7 +198,12 @@ class GetSimilarityDataFromSeerTest(TestCase):
         mock_metrics_incr.assert_any_call(
             "seer.similar_issues_request",
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"response_status": 308, "outcome": "error", "error": "Redirect"},
+            tags={
+                "response_status": 308,
+                "outcome": "error",
+                "error": "Redirect",
+                "seer_backend": "gpu",
+            },
         )
         assert mock_record_circuit_breaker_error.call_count == 0
 
@@ -228,7 +239,7 @@ class GetSimilarityDataFromSeerTest(TestCase):
             mock_metrics_incr.assert_any_call(
                 "seer.similar_issues_request",
                 sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-                tags={"outcome": "error", "error": expected_error_tag},
+                tags={"outcome": "error", "error": expected_error_tag, "seer_backend": "gpu"},
             )
             assert mock_record_circuit_breaker_error.call_count == 1
 
@@ -261,7 +272,12 @@ class GetSimilarityDataFromSeerTest(TestCase):
             mock_metrics_incr.assert_any_call(
                 "seer.similar_issues_request",
                 sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-                tags={"response_status": status, "outcome": "error", "error": "RequestError"},
+                tags={
+                    "response_status": status,
+                    "outcome": "error",
+                    "error": "RequestError",
+                    "seer_backend": "gpu",
+                },
             )
             assert mock_record_circuit_breaker_error.call_count == (
                 1 if counts_for_circuit_breaker else 0
@@ -543,3 +559,36 @@ class GetSimilarityDataFromSeerTest(TestCase):
 
         assert model_used is None
         assert len(results) == 1
+
+    @mock.patch("sentry.seer.similarity.similar_issues.metrics.incr")
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_summarization_default_connection_pool")
+    @mock.patch("sentry.seer.similarity.similar_issues.random", return_value=0.5)
+    def test_cpu_backend_routing(
+        self, _rng: MagicMock, mock_cpu_pool: MagicMock, mock_metrics_incr: MagicMock
+    ) -> None:
+        with self.options({"seer.similarity.cpu-backend-sample-rate": 1.0}):
+            mock_cpu_pool.urlopen.return_value = self._make_response({"responses": []})
+            get_similarity_data_from_seer(self.request_params)
+
+        mock_cpu_pool.urlopen.assert_called_once()
+        mock_metrics_incr.assert_any_call(
+            "seer.similar_issues_request",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={"response_status": 200, "outcome": "no_similar_groups", "seer_backend": "cpu"},
+        )
+
+    @mock.patch("sentry.seer.similarity.similar_issues.metrics.incr")
+    @mock.patch("sentry.seer.similarity.similar_issues.seer_grouping_connection_pool")
+    @mock.patch("sentry.seer.similarity.similar_issues.random", return_value=0.5)
+    def test_gpu_backend_routing_default(
+        self, _rng: MagicMock, mock_gpu_pool: MagicMock, mock_metrics_incr: MagicMock
+    ) -> None:
+        mock_gpu_pool.urlopen.return_value = self._make_response({"responses": []})
+        get_similarity_data_from_seer(self.request_params)
+
+        mock_gpu_pool.urlopen.assert_called_once()
+        mock_metrics_incr.assert_any_call(
+            "seer.similar_issues_request",
+            sample_rate=options.get("seer.similarity.metrics_sample_rate"),
+            tags={"response_status": 200, "outcome": "no_similar_groups", "seer_backend": "gpu"},
+        )


### PR DESCRIPTION
+ Add a runtime option `seer.similarity.cpu-backend-sample-rate` (default 0.0) that controls what fraction of grouping requests route to the CPU summarization backend instead of the GPU backend. Each request independently selects the backend via random() and tags all grouping metrics with seer_backend:cpu or seer_backend:gpu for observability.
+ Trying out CPU pods since we are not able to get any GPU pods for STs in us-east4 region. Deploys have been failing for STs since a few days now. 
+ https://github.com/getsentry/ops/pull/21561 - this PR is mreged and deployed so LY CPU pods now have the grouping model loaded.