### PR TITLE
fix(autofix): consume queued PR iteration feedback after push

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -201,6 +201,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             _, is_synced = state.has_code_changes()
             if not is_synced and not cls._iteration_terminal_errored_repos(state):
                 return
+
             webhook_action_type = SeerActionType.ITERATION_COMPLETED
             iteration_index = get_latest_iteration_index(state)
             webhook_payload["pull_requests"] = cls._format_pull_requests_payload(state)
@@ -430,12 +431,17 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
         # update that PR. _push_changes is a no-op once the repos are synced, so
         # the hook re-fire after the push doesn't loop.
         if current_step == AutofixStep.PR_ITERATION:
-            cls._push_changes(group, run_id, state)
-            # Feedback may have been enqueued while this iteration was running.
-            # The consume task is a no-op while the run is still processing and
-            # only triggers a new iteration once the run settles, so it's safe
-            # to always kick it after handling an iteration completion.
-            cls._consume_queued_feedback(organization, run_id, group)
+            pushed = cls._push_changes(group, run_id, state)
+
+            if not pushed:
+                # we want to consume queued feedback _after_ we know changes have been pushed
+                # because some feedback in the queue could be filtered out
+                # since it's only applicable to a single revision of the code
+                # e.g.
+                # if we have CI failure feedback in the queue but our last iteration
+                # updated the code for that PR, we should filter it out and see if it
+                # fails again
+                cls._consume_queued_feedback(organization, run_id, group)
             return
 
         if stopping_point is None or reached_stopping_point:
@@ -555,8 +561,8 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
         return []
 
     @classmethod
-    def _push_changes(cls, group: Group, run_id: int, state: SeerRunState) -> None:
-        """Push code changes to create PRs."""
+    def _push_changes(cls, group: Group, run_id: int, state: SeerRunState) -> bool:
+        """Push code changes to create PRs. Returns True if changes were pushed."""
         # Check if there are code changes to push
         has_changes, is_synced = state.has_code_changes()
         if not has_changes or is_synced:
@@ -569,7 +575,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                     "is_synced": is_synced,
                 },
             )
-            return
+            return False
 
         # Errored repos are terminal — re-pushing would re-fire this hook in a loop.
         errored_repos = cls._iteration_terminal_errored_repos(state)
@@ -582,7 +588,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                     "errored_repos": errored_repos,
                 },
             )
-            return
+            return False
 
         logger.info(
             "autofix.on_completion_hook.pushing_changes",
@@ -601,6 +607,9 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                 "autofix.on_completion_hook.push_changes_failed",
                 extra={"run_id": run_id, "organization_id": group.organization.id},
             )
+            return False
+
+        return True
 
     @classmethod
     def _get_handoff_config_if_applicable(

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -307,6 +307,43 @@ class TestAutofixOnCompletionHookPipeline(TestCase):
             state=state,
         )
 
+    @patch("sentry.seer.autofix.on_completion_hook.AutofixOnCompletionHook._consume_queued_feedback")
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_push_changes")
+    def test_pr_iteration_does_not_consume_feedback_when_pushed(
+        self, mock_push_changes, mock_consume
+    ):
+        """When PR iteration pushes new changes, queued feedback is left for the next run."""
+        state = run_state(
+            blocks=[pr_iteration_memory_block()],
+            metadata={
+                "group_id": self.group.id,
+                "stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+            },
+        )
+        AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
+        mock_push_changes.assert_called_once()
+        mock_consume.assert_not_called()
+
+    @patch("sentry.seer.autofix.on_completion_hook.AutofixOnCompletionHook._consume_queued_feedback")
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_push_changes")
+    def test_pr_iteration_consumes_feedback_when_nothing_pushed(
+        self, mock_push_changes, mock_consume
+    ):
+        """When PR iteration has no new changes to push, queued feedback is consumed now."""
+        state = run_state(
+            blocks=[pr_iteration_memory_block(commit_sha="synced-sha")],
+            metadata={
+                "group_id": self.group.id,
+                "stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+            },
+        )
+        state.repo_pr_states = {
+            "test-repo": RepoPRState(repo_name="test-repo", commit_sha="synced-sha")
+        }
+        AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
+        mock_push_changes.assert_not_called()
+        mock_consume.assert_called_once_with(self.organization, 123, self.group)
+
     @patch("sentry.seer.autofix.on_completion_hook.trigger_push_changes")
     def test_push_changes_skips_when_all_unsynced_repos_errored(self, mock_push_changes):
         """Does not re-push when every un-synced repo is already in pr_creation_status='error'."""
@@ -328,7 +365,8 @@ class TestAutofixOnCompletionHookPipeline(TestCase):
                 pr_creation_error="No write access to repository test-repo",
             )
         }
-        AutofixOnCompletionHook._push_changes(self.group, 123, state)
+        pushed = AutofixOnCompletionHook._push_changes(self.group, 123, state)
+        assert pushed is False
         mock_push_changes.assert_not_called()
 
     @patch("sentry.seer.autofix.on_completion_hook.trigger_push_changes")
@@ -367,7 +405,8 @@ class TestAutofixOnCompletionHookPipeline(TestCase):
                 pr_creation_error="No write access to repository test-repo",
             )
         }
-        AutofixOnCompletionHook._push_changes(self.group, 123, state)
+        pushed = AutofixOnCompletionHook._push_changes(self.group, 123, state)
+        assert pushed is True
         mock_push_changes.assert_called_once()
 
 

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -307,7 +307,9 @@ class TestAutofixOnCompletionHookPipeline(TestCase):
             state=state,
         )
 
-    @patch("sentry.seer.autofix.on_completion_hook.AutofixOnCompletionHook._consume_queued_feedback")
+    @patch(
+        "sentry.seer.autofix.on_completion_hook.AutofixOnCompletionHook._consume_queued_feedback"
+    )
     @patch("sentry.seer.autofix.on_completion_hook.trigger_push_changes")
     def test_pr_iteration_does_not_consume_feedback_when_pushed(
         self, mock_push_changes, mock_consume
@@ -324,7 +326,9 @@ class TestAutofixOnCompletionHookPipeline(TestCase):
         mock_push_changes.assert_called_once()
         mock_consume.assert_not_called()
 
-    @patch("sentry.seer.autofix.on_completion_hook.AutofixOnCompletionHook._consume_queued_feedback")
+    @patch(
+        "sentry.seer.autofix.on_completion_hook.AutofixOnCompletionHook._consume_queued_feedback"
+    )
     @patch("sentry.seer.autofix.on_completion_hook.trigger_push_changes")
     def test_pr_iteration_consumes_feedback_when_nothing_pushed(
         self, mock_push_changes, mock_consume


### PR DESCRIPTION
because we're going to introduce a new type of feedback based on CI failures that's only valid for a given revision of the code, we'll want to filter out feedback that's no longer relevant

so we should wait to consume queued feedback until _after_ we know we've updated PRs

it looks weird in the code that we check the condition for not having pushed but we know if we haven't pushed that our PRs are in a steady-state:
- we have no changes to make
- we already made our changes in a previous completion hook

so now is the time to consume queued feedback