### PR TITLE
feat(billing-platform): Register getsentry over-usage shadow referrer

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -666,6 +666,7 @@ class Referrer(StrEnum):
     GETSENTRY_API_PENDO_DETAILS = "getsentry.api.pendo-details"
     GETSENTRY_EXPORT_SPANS_GET_TRACES = "getsentry.export.spans.get_traces"
     GETSENTRY_EXPORT_SPANS_GET_ITEM_DETAILS = "getsentry.export.spans.get_item_details"
+    GETSENTRY_QUOTAS_OVER_USAGE_SHADOW = "getsentry.quotas.over_usage_shadow"
     GITHUB_PR_COMMENT_BOT = "tasks.github_comment"
     GITLAB_PR_COMMENT_BOT = "tasks.gitlab_comment"
     GROUP_FILTER_BY_EVENT_ID = "group.filter_by_event_id"


### PR DESCRIPTION
Registers `getsentry.quotas.over_usage_shadow` in the `Referrer` enum. The getsentry billing-platform over-usage shadow scan issues a cross-org outcomes query under this referrer; without an enum entry, `validate_referrer` logs a warning and emits `snql.sdk.api.new_referrers` on every scan tick once the scan is enabled.

This is observability cleanup only — unregistered referrers still run, so this is non-blocking for the getsentry feature and can land independently. The referrer's actual concurrency limit lives in the snuba `CrossOrgQueryAllocationPolicy` config, not here.

Made with [Cursor](https://cursor.com)