### PR TITLE
chore(traces): Add meta remark to default-trace-ids

### DIFF
--- a/src/sentry/issues/event.schema.json
+++ b/src/sentry/issues/event.schema.json
@@ -328,6 +328,18 @@
           "description": " Version",
           "default": null,
           "type": ["string", "null"]
+        },
+        "_meta": {
+          "description": " Meta-information about the event processing pipleline.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/_Meta"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": ["event_id", "platform", "project_id", "timestamp"],
@@ -3033,6 +3045,15 @@
               "type": ["string", "null"]
             }
           },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "_Meta": {
+      "description": " Meta-information about the event processing pipleline.",
+      "anyOf": [
+        {
+          "type": "object",
           "additionalProperties": true
         }
       ]

--- a/src/sentry/issues/json_schemas.py
+++ b/src/sentry/issues/json_schemas.py
@@ -150,6 +150,9 @@ LEGACY_EVENT_PAYLOAD_SCHEMA: Mapping[str, Any] = {
             },
             "additionalProperties": True,
         },
+        "_meta": {
+            "type": ["object", "null"],
+        },
     },
     "required": [
         "event_id",

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -280,6 +280,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                     "trace_id",
                     "transaction",
                     "user",
+                    "_meta",
                 ]
                 for optional_param in optional_params:
                     if optional_param in event_payload:
@@ -294,6 +295,16 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                             "trace_id": uuid4().hex,
                             "span_id": None,
                         },
+                    )
+                    set_path(
+                        event_data,
+                        "_meta",
+                        "contexts",
+                        "trace",
+                        "trace_id",
+                        "",
+                        "err",
+                        value=["trace_id.missing"],
                     )
 
                 try:

--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -129,6 +129,17 @@ def _prepare_occurrence_message(
                 },
             )
 
+            set_path(
+                event_data,
+                "_meta",
+                "contexts",
+                "trace",
+                "trace_id",
+                "",
+                "err",
+                value=["trace_id.missing"],
+            )
+
         payload_data["event"] = event_data
 
     if is_buffered_spans:

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -137,6 +137,17 @@ class SDKCrashDetection:
                 },
             )
 
+            set_path(
+                sdk_crash_event_data,
+                "_meta",
+                "contexts",
+                "trace",
+                "trace_id",
+                "",
+                "err",
+                value=["trace_id.missing"],
+            )
+
             sdk_version = get_path(sdk_crash_event_data, "sdk", "version")
             set_path(sdk_crash_event_data, "release", value=sdk_version)
 


### PR DESCRIPTION
We need trace IDs on all occurrences for the purpose of enabling EAP ingestion. For this reason, we've begun adding "dummy" / "default" trace IDs to events that don't already pass ones in. (e.g. performance events, errors from old SDKs.)

This PR adds a `_meta` remark to these default cases so that they can be hidden from the UI when appropriate.