### PR TITLE
fix(dashboards): preserve page filters when opening an issue from a widget

### DIFF
--- a/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
@@ -257,13 +257,10 @@ describe('getIssueFieldRenderer', () => {
         }) as React.ReactElement
       );
 
-      const link = screen.getByRole('link', {name: '123'});
-      const href = link.getAttribute('href')!;
-      expect(href).toContain(`/organizations/${organization.slug}/issues/123/`);
-      expect(href).toContain('environment=production');
-      expect(href).toContain('statsPeriod=30d');
-      expect(href).toContain('project=2');
-      expect(href).not.toContain('widgetId');
+      expect(screen.getByRole('link', {name: '123'})).toHaveAttribute(
+        'href',
+        `/organizations/${organization.slug}/issues/123/?environment=production&project=2&statsPeriod=30d`
+      );
     });
   });
 

--- a/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
@@ -234,6 +234,37 @@ describe('getIssueFieldRenderer', () => {
       expect(screen.getByText('Matching search filters')).toBeInTheDocument();
       expect(screen.getByText('Since issue began')).toBeInTheDocument();
     });
+
+    it('forwards the dashboard page filters to the issue detail link', () => {
+      location.query = {
+        environment: 'production',
+        statsPeriod: '30d',
+        project: '2',
+        // Non page-filter params should not be forwarded.
+        widgetId: '5',
+      };
+      data['issue.id'] = '123';
+      data.issue = 'JS-456';
+
+      const renderer = getIssueFieldRenderer('issue', {});
+
+      render(
+        renderer(data, {
+          location,
+          navigate: jest.fn(),
+          organization,
+          theme,
+        }) as React.ReactElement
+      );
+
+      const link = screen.getByRole('link', {name: '123'});
+      const href = link.getAttribute('href')!;
+      expect(href).toContain(`/organizations/${organization.slug}/issues/123/`);
+      expect(href).toContain('environment=production');
+      expect(href).toContain('statsPeriod=30d');
+      expect(href).toContain('project=2');
+      expect(href).not.toContain('widgetId');
+    });
   });
 
   it('can render links', () => {

--- a/static/app/utils/dashboards/issueFieldRenderers.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.tsx
@@ -7,6 +7,7 @@ import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
+import {extractSelectionParameters} from 'sentry/components/pageFilters/parse';
 import {getRelativeSummary} from 'sentry/components/timeRangeSelector/utils';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t} from 'sentry/locale';
@@ -78,7 +79,7 @@ function getIssueRowMetadata(
 const SPECIAL_FIELDS: SpecialFields = {
   issue: {
     sortField: null,
-    renderFunc: (data, {organization}) => {
+    renderFunc: (data, {organization, location}) => {
       const issueID = data['issue.id'];
 
       if (!issueID) {
@@ -91,6 +92,7 @@ const SPECIAL_FIELDS: SpecialFields = {
 
       const target = {
         pathname: `/organizations/${organization.slug}/issues/${issueID}/`,
+        query: extractSelectionParameters(location.query),
       };
 
       return (


### PR DESCRIPTION
Fixes an issue where the dashboard's page filters (environment, date range, project) were not propagated to the Issue Details page when opening an issue from a widget. The issue link now forwards the active selection so the page inherits it instead of resetting to All Envs and the default period.

Fixes [DAIN-1720](https://linear.app/getsentry/issue/DAIN-1720/dashboard-environment-filter-not-preserved-when-opening-issue-detail)