### PR TITLE
feat(explore): Surface and apply Seer's cross-event queries

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -251,6 +251,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
             visualizations={item?.visualizations}
             expandedProjectIds={item?.expandedProjectIds}
             interval={item?.interval}
+            crossEvents={item?.crossEvents}
           />
         </Item>
       );

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -287,6 +287,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
             visualizations={item?.visualizations}
             expandedProjectIds={item?.expandedProjectIds}
             interval={item?.interval}
+            crossEvents={item?.crossEvents}
           />
         </Item>
       );

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -10,6 +10,7 @@ import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/forma
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {t} from 'sentry/locale';
 import {useProjects} from 'sentry/utils/useProjects';
+import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
 
 const MAX_PROJECT_CHIPS = 3;
 
@@ -161,12 +162,15 @@ export function QueryTokens({
   return (
     <Fragment>
       <TokenContainer>{tokens}</TokenContainer>
-      {crossEvents && crossEvents.length > 0 ? (
+      {crossEvents?.length ? (
         <CrossEventSection>
           {crossEvents.map((crossEvent, idx) => {
             const filterQuery =
               crossEvent.type === 'metrics'
-                ? [`metric.name:${crossEvent.metric.name}`, crossEvent.query]
+                ? [
+                    `${TraceMetricKnownFieldKey.METRIC_NAME}:${crossEvent.metric.name}`,
+                    crossEvent.query,
+                  ]
                     .filter(Boolean)
                     .join(' ')
                 : crossEvent.query;

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -43,6 +43,30 @@ export function QueryTokens({
     );
   }
 
+  if (crossEvents && crossEvents.length > 0) {
+    tokens.push(
+      <Flex
+        as="span"
+        align="center"
+        wrap="wrap"
+        gap="xs"
+        overflow="hidden"
+        key="crossEvents"
+      >
+        <ExploreParamTitle>{t('Cross-event filters')}</ExploreParamTitle>
+        {crossEvents.map((crossEvent, idx) => {
+          const label =
+            crossEvent.type === 'metrics'
+              ? `${crossEvent.type}: ${crossEvent.metric.name}${crossEvent.query ? ` ${crossEvent.query}` : ''}`
+              : `${crossEvent.type}: ${crossEvent.query}`;
+          return (
+            <ExploreGroupBys key={`${crossEvent.type}-${idx}`}>{label}</ExploreGroupBys>
+          );
+        })}
+      </Flex>
+    );
+  }
+
   if (visualizations && visualizations.length > 0) {
     tokens.push(
       <Flex
@@ -142,30 +166,6 @@ export function QueryTokens({
         {overflowCount > 0 ? (
           <ExploreGroupBys>{t('+%s more', overflowCount)}</ExploreGroupBys>
         ) : null}
-      </Flex>
-    );
-  }
-
-  if (crossEvents && crossEvents.length > 0) {
-    tokens.push(
-      <Flex
-        as="span"
-        align="center"
-        wrap="wrap"
-        gap="xs"
-        overflow="hidden"
-        key="crossEvents"
-      >
-        <ExploreParamTitle>{t('Cross-event')}</ExploreParamTitle>
-        {crossEvents.map((crossEvent, idx) => {
-          const label =
-            crossEvent.type === 'metrics'
-              ? `${crossEvent.type}: ${crossEvent.metric.name}${crossEvent.query ? ` ${crossEvent.query}` : ''}`
-              : `${crossEvent.type}: ${crossEvent.query}`;
-          return (
-            <ExploreGroupBys key={`${crossEvent.type}-${idx}`}>{label}</ExploreGroupBys>
-          );
-        })}
       </Flex>
     );
   }

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -22,6 +22,7 @@ export function QueryTokens({
   end,
   visualizations,
   expandedProjectIds,
+  crossEvents,
 }: QueryTokensProps) {
   const tokens = [];
   const {getFieldDefinition} = useSearchQueryBuilderConfig();
@@ -141,6 +142,30 @@ export function QueryTokens({
         {overflowCount > 0 ? (
           <ExploreGroupBys>{t('+%s more', overflowCount)}</ExploreGroupBys>
         ) : null}
+      </Flex>
+    );
+  }
+
+  if (crossEvents && crossEvents.length > 0) {
+    tokens.push(
+      <Flex
+        as="span"
+        align="center"
+        wrap="wrap"
+        gap="xs"
+        overflow="hidden"
+        key="crossEvents"
+      >
+        <ExploreParamTitle>{t('Cross-event')}</ExploreParamTitle>
+        {crossEvents.map((crossEvent, idx) => {
+          const label =
+            crossEvent.type === 'metrics'
+              ? `${crossEvent.type}: ${crossEvent.metric.name}${crossEvent.query ? ` ${crossEvent.query}` : ''}`
+              : `${crossEvent.type}: ${crossEvent.query}`;
+          return (
+            <ExploreGroupBys key={`${crossEvent.type}-${idx}`}>{label}</ExploreGroupBys>
+          );
+        })}
       </Flex>
     );
   }

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -39,30 +40,6 @@ export function QueryTokens({
               <ProvidedFormattedQuery query={text} />
             </FormattedQueryWrapper>
           ))}
-      </Flex>
-    );
-  }
-
-  if (crossEvents && crossEvents.length > 0) {
-    tokens.push(
-      <Flex
-        as="span"
-        align="center"
-        wrap="wrap"
-        gap="xs"
-        overflow="hidden"
-        key="crossEvents"
-      >
-        <ExploreParamTitle>{t('Cross-event filters')}</ExploreParamTitle>
-        {crossEvents.map((crossEvent, idx) => {
-          const label =
-            crossEvent.type === 'metrics'
-              ? `${crossEvent.type}: ${crossEvent.metric.name}${crossEvent.query ? ` ${crossEvent.query}` : ''}`
-              : `${crossEvent.type}: ${crossEvent.query}`;
-          return (
-            <ExploreGroupBys key={`${crossEvent.type}-${idx}`}>{label}</ExploreGroupBys>
-          );
-        })}
       </Flex>
     );
   }
@@ -181,13 +158,63 @@ export function QueryTokens({
     );
   }
 
-  return <TokenContainer>{tokens}</TokenContainer>;
+  return (
+    <Fragment>
+      <TokenContainer>{tokens}</TokenContainer>
+      {crossEvents && crossEvents.length > 0 ? (
+        <CrossEventSection>
+          {crossEvents.map((crossEvent, idx) => {
+            const filterQuery =
+              crossEvent.type === 'metrics'
+                ? [`metric.name:${crossEvent.metric.name}`, crossEvent.query]
+                    .filter(Boolean)
+                    .join(' ')
+                : crossEvent.query;
+            const parsedCrossEvent = filterQuery
+              ? parseQueryBuilderValue(filterQuery, getFieldDefinition)
+              : null;
+            return (
+              <Flex
+                as="span"
+                align="center"
+                wrap="wrap"
+                gap="xs"
+                overflow="hidden"
+                key={`${crossEvent.type}-${idx}`}
+              >
+                <ExploreParamTitle>{t('Cross Event Filter')}</ExploreParamTitle>
+                <ExploreParamTitle>{t('Dataset')}</ExploreParamTitle>
+                <ExploreGroupBys>{crossEvent.type}</ExploreGroupBys>
+                <ExploreParamTitle>{t('Filter')}</ExploreParamTitle>
+                {parsedCrossEvent
+                  ?.filter(({text}) => text.trim() !== '')
+                  .map(({text}) => (
+                    <FormattedQueryWrapper key={text}>
+                      <ProvidedFormattedQuery query={text} />
+                    </FormattedQueryWrapper>
+                  ))}
+              </Flex>
+            );
+          })}
+        </CrossEventSection>
+      ) : null}
+    </Fragment>
+  );
 }
 
 const TokenContainer = styled('div')`
   display: flex;
   gap: ${p => p.theme.space.md};
   padding: ${p => p.theme.space.md};
+`;
+
+// Cross-event filters render as their own block beneath the main query row,
+// one sibling per line, each labelled with its Dataset and Filter.
+const CrossEventSection = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.xs};
+  padding: 0 ${p => p.theme.space.md} ${p => p.theme.space.md};
 `;
 
 const ExploreParamTitle = styled('span')`

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/types.ts
@@ -1,3 +1,4 @@
+import type {CrossEvent} from 'sentry/views/explore/queryParams/crossEvent';
 import type {ChartType} from 'sentry/views/insights/common/components/chart';
 
 export interface SeerRawResponseItem {
@@ -8,6 +9,10 @@ export interface SeerRawResponseItem {
   sort: string;
   start: string | null;
   stats_period: string;
+  // Cross-event queries; null if absent. Only applicable for explore/traces
+  log_query?: string | null;
+  metric_query?: string | null;
+  span_query?: string | null;
   visualization?: Array<{
     chart_type?: number;
     interval?: string | null;
@@ -35,6 +40,12 @@ interface AskSeerSearchItem<S extends string> {
 export type AskSeerSearchItems<T> = (AskSeerSearchItem<string> & T) | NoneOfTheseItem;
 
 export interface QueryTokensProps {
+  /**
+   * Cross-event (same-trace) sibling filters the agent attached to the query.
+   * Drives the "Cross-event" chip and the `crossEvents` URL param applied when
+   * the suggestion is chosen. Traces tab only.
+   */
+  crossEvents?: CrossEvent[];
   end?: string | null;
   /**
    * Projects the agent broadened the query to, when it expanded scope beyond

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
@@ -278,6 +278,84 @@ describe('mapSeerResponseItem', () => {
       visualizations: [{yAxes: ['count()']}],
     });
   });
+
+  it('attaches span and log cross-events from Seer sibling queries', () => {
+    expect(
+      mapSeerResponseItem({
+        query: 'span.op:db',
+        sort: '',
+        group_by: [],
+        stats_period: '24h',
+        start: null,
+        end: null,
+        mode: 'samples',
+        span_query: 'span.description:*pool*',
+        log_query: 'severity:error',
+      })
+    ).toEqual(
+      expect.objectContaining({
+        crossEvents: [
+          {type: 'spans', query: 'span.description:*pool*'},
+          {type: 'logs', query: 'severity:error'},
+        ],
+      })
+    );
+  });
+
+  it('parses a metric cross-event from metric_query', () => {
+    expect(
+      mapSeerResponseItem({
+        query: 'span.op:db',
+        sort: '',
+        group_by: [],
+        stats_period: '24h',
+        start: null,
+        end: null,
+        mode: 'samples',
+        metric_query:
+          'metric.name:foo.duration metric.type:distribution metric.unit:millisecond value:>100',
+      })
+    ).toEqual(
+      expect.objectContaining({
+        crossEvents: [
+          {
+            type: 'metrics',
+            query: 'value:>100',
+            metric: {name: 'foo.duration', type: 'distribution', unit: 'millisecond'},
+          },
+        ],
+      })
+    );
+  });
+
+  it('drops an aggregate-mode metric cross-event with no parseable identity', () => {
+    expect(
+      mapSeerResponseItem({
+        query: 'span.op:db',
+        sort: '',
+        group_by: [],
+        stats_period: '24h',
+        start: null,
+        end: null,
+        mode: 'samples',
+        metric_query: 'value:>100',
+      })
+    ).not.toHaveProperty('crossEvents');
+  });
+
+  it('omits crossEvents when there are no sibling queries', () => {
+    expect(
+      mapSeerResponseItem({
+        query: 'span.op:db',
+        sort: '',
+        group_by: [],
+        stats_period: '24h',
+        start: null,
+        end: null,
+        mode: 'samples',
+      })
+    ).not.toHaveProperty('crossEvents');
+  });
 });
 
 describe('buildSeerDateTimeSelection', () => {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.spec.tsx
@@ -281,17 +281,20 @@ describe('mapSeerResponseItem', () => {
 
   it('attaches span and log cross-events from Seer sibling queries', () => {
     expect(
-      mapSeerResponseItem({
-        query: 'span.op:db',
-        sort: '',
-        group_by: [],
-        stats_period: '24h',
-        start: null,
-        end: null,
-        mode: 'samples',
-        span_query: 'span.description:*pool*',
-        log_query: 'severity:error',
-      })
+      mapSeerResponseItem(
+        {
+          query: 'span.op:db',
+          sort: '',
+          group_by: [],
+          stats_period: '24h',
+          start: null,
+          end: null,
+          mode: 'samples',
+          span_query: 'span.description:*pool*',
+          log_query: 'severity:error',
+        },
+        'spans'
+      )
     ).toEqual(
       expect.objectContaining({
         crossEvents: [
@@ -304,17 +307,20 @@ describe('mapSeerResponseItem', () => {
 
   it('parses a metric cross-event from metric_query', () => {
     expect(
-      mapSeerResponseItem({
-        query: 'span.op:db',
-        sort: '',
-        group_by: [],
-        stats_period: '24h',
-        start: null,
-        end: null,
-        mode: 'samples',
-        metric_query:
-          'metric.name:foo.duration metric.type:distribution metric.unit:millisecond value:>100',
-      })
+      mapSeerResponseItem(
+        {
+          query: 'span.op:db',
+          sort: '',
+          group_by: [],
+          stats_period: '24h',
+          start: null,
+          end: null,
+          mode: 'samples',
+          metric_query:
+            'metric.name:foo.duration metric.type:distribution metric.unit:millisecond value:>100',
+        },
+        'spans'
+      )
     ).toEqual(
       expect.objectContaining({
         crossEvents: [
@@ -330,29 +336,50 @@ describe('mapSeerResponseItem', () => {
 
   it('drops an aggregate-mode metric cross-event with no parseable identity', () => {
     expect(
-      mapSeerResponseItem({
-        query: 'span.op:db',
-        sort: '',
-        group_by: [],
-        stats_period: '24h',
-        start: null,
-        end: null,
-        mode: 'samples',
-        metric_query: 'value:>100',
-      })
+      mapSeerResponseItem(
+        {
+          query: 'span.op:db',
+          sort: '',
+          group_by: [],
+          stats_period: '24h',
+          start: null,
+          end: null,
+          mode: 'samples',
+          metric_query: 'value:>100',
+        },
+        'spans'
+      )
     ).not.toHaveProperty('crossEvents');
   });
 
   it('omits crossEvents when there are no sibling queries', () => {
     expect(
+      mapSeerResponseItem(
+        {
+          query: 'span.op:db',
+          sort: '',
+          group_by: [],
+          stats_period: '24h',
+          start: null,
+          end: null,
+          mode: 'samples',
+        },
+        'spans'
+      )
+    ).not.toHaveProperty('crossEvents');
+  });
+
+  it('does not build cross-events outside the spans tab', () => {
+    expect(
       mapSeerResponseItem({
-        query: 'span.op:db',
+        query: 'is:unresolved',
         sort: '',
         group_by: [],
         stats_period: '24h',
         start: null,
         end: null,
         mode: 'samples',
+        log_query: 'severity:error',
       })
     ).not.toHaveProperty('crossEvents');
   });

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -11,6 +11,9 @@ import type {DateString} from 'sentry/types/core';
 import type {PageFilters} from 'sentry/types/core';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {useProjects} from 'sentry/utils/useProjects';
+import {parseTraceMetricFromQuery} from 'sentry/views/explore/metrics/utils';
+import type {CrossEvent} from 'sentry/views/explore/queryParams/crossEvent';
+import {makeCrossEvent} from 'sentry/views/explore/spans/crossEvents/utils';
 import {isChartType} from 'sentry/views/insights/common/components/chart';
 
 import type {
@@ -147,11 +150,31 @@ export function buildSeerMutationResult<T extends QueryTokensProps>(
   };
 }
 
+function buildCrossEvents(item: SeerRawResponseItem): CrossEvent[] {
+  const crossEvents: CrossEvent[] = [];
+  if (item.span_query) {
+    crossEvents.push(makeCrossEvent('spans', item.span_query));
+  }
+  if (item.log_query) {
+    crossEvents.push(makeCrossEvent('logs', item.log_query));
+  }
+  if (item.metric_query) {
+    // cross event metric query can only be in samples mode. If aggregate-mode,
+    // cross-event query should be dropped.
+    const {metric, rest} = parseTraceMetricFromQuery(item.metric_query);
+    if (metric) {
+      crossEvents.push({type: 'metrics', query: rest, metric});
+    }
+  }
+  return crossEvents;
+}
+
 export function mapSeerResponseItem(
   item: SeerRawResponseItem,
   defaultMode = 'samples'
 ): AskSeerSearchQuery {
   const interval = getRawSeerInterval(item);
+  const crossEvents = buildCrossEvents(item);
   return {
     visualizations:
       item.visualization
@@ -170,6 +193,7 @@ export function mapSeerResponseItem(
     end: item.end ?? null,
     mode: item.mode || defaultMode,
     ...(interval ? {interval} : {}),
+    ...(crossEvents.length ? {crossEvents} : {}),
   };
 }
 

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -159,8 +159,10 @@ function buildCrossEvents(item: SeerRawResponseItem): CrossEvent[] {
     crossEvents.push(makeCrossEvent('logs', item.log_query));
   }
   if (item.metric_query) {
-    // cross event metric query can only be in samples mode. If aggregate-mode,
-    // cross-event query should be dropped.
+    // A metric cross-event needs a parseable metric identity (metric.name/type)
+    // in the query. parseTraceMetricFromQuery returns no metric when it's absent
+    // (e.g. an aggregate-mode sibling whose identity lives in the visualization),
+    // and we drop the cross-event in that case.
     const {metric, rest} = parseTraceMetricFromQuery(item.metric_query);
     if (metric) {
       crossEvents.push({type: 'metrics', query: rest, metric});

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -174,7 +174,7 @@ export function mapSeerResponseItem(
   defaultMode = 'samples'
 ): AskSeerSearchQuery {
   const interval = getRawSeerInterval(item);
-  const crossEvents = buildCrossEvents(item);
+  const crossEvents = defaultMode === 'spans' ? buildCrossEvents(item) : [];
   return {
     visualizations:
       item.visualization

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -246,5 +246,16 @@ export function generateQueryTokensString(args: QueryTokensProps): string {
     parts.push(`search expanded to ${count} ${count === 1 ? 'project' : 'projects'}`);
   }
 
+  if (args?.crossEvents && args.crossEvents.length > 0) {
+    const crossEventText = args.crossEvents
+      .map(crossEvent =>
+        crossEvent.type === 'metrics'
+          ? `${crossEvent.type} ${crossEvent.metric.name}`
+          : `${crossEvent.type} ${crossEvent.query}`
+      )
+      .join(', ');
+    parts.push(`cross-event filters are '${crossEventText}'`);
+  }
+
   return parts.length > 0 ? parts.join(', ') : 'No query parameters set';
 }

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -38,6 +38,7 @@ import {isTraceMetricTypeValue} from 'sentry/views/explore/metrics/types';
 import {
   makeMetricsAggregate,
   parseTraceMetricFromQuery,
+  stripTraceMetricTokens,
 } from 'sentry/views/explore/metrics/utils';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {useQueryParams} from 'sentry/views/explore/queryParams/context';
@@ -120,8 +121,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
           metric => metric.name && metric.type && isTraceMetricTypeValue(metric.type)
         );
 
-      const {metric: queryTraceMetric, rest: queryWithoutMetric} =
-        parseTraceMetricFromQuery(seerQuery.query);
+      const {metric: queryTraceMetric} = parseTraceMetricFromQuery(seerQuery.query);
 
       // Prefer the visualization metric (normalizing its unit to NONE_UNIT, since
       // parseMetricAggregate omits the unit arg), falling back to the query-filter
@@ -133,10 +133,13 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
 
       const nextMetric = resolvedMetric ?? traceMetric;
 
-      // Strip the metric tokens from the query only when we adopted a metric (it's
-      // then tracked on the panel, not the query); parseTraceMetricFromQuery
-      // returns that stripped query as `rest`.
-      const cleanedQuery = resolvedMetric ? queryWithoutMetric : seerQuery.query;
+      // Strip the metric identity tokens whenever we adopt a metric (it's tracked
+      // on the panel, not the query). Done unconditionally so stale/incomplete
+      // metric.* tokens don't linger when the metric came from the visualization
+      // aggregate rather than the query.
+      const cleanedQuery = resolvedMetric
+        ? stripTraceMetricTokens(seerQuery.query)
+        : seerQuery.query;
 
       const aggregateFields: AggregateField[] = [];
 

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -19,7 +19,6 @@ import {
   useSelectedProjectIdsForMutation,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
-import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {fetchMutation} from 'sentry/utils/queryClient';
@@ -35,11 +34,11 @@ import {
 } from 'sentry/views/explore/metrics/metricQuery';
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
+import {isTraceMetricTypeValue} from 'sentry/views/explore/metrics/types';
 import {
-  isTraceMetricTypeValue,
-  TraceMetricKnownFieldKey,
-} from 'sentry/views/explore/metrics/types';
-import {makeMetricsAggregate} from 'sentry/views/explore/metrics/utils';
+  makeMetricsAggregate,
+  parseTraceMetricFromQuery,
+} from 'sentry/views/explore/metrics/utils';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {useQueryParams} from 'sentry/views/explore/queryParams/context';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
@@ -109,13 +108,11 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         viz.yAxes.map(yAxis => new VisualizeFunction(yAxis, {chartType: viz.chartType}))
       );
 
-      // Keep the panel's TraceMetric in sync with what Seer queried. We parse
-      // the metric name/type/unit out of the visualize aggregate (e.g.
-      // p75(value, metric.name, distribution, millisecond)); if it's not there
-      // we read metric.name/type/unit filters from the query (typically only
-      // present in samples mode).
-      const search = new MutableSearch(seerQuery.query);
-
+      // Keep the panel's TraceMetric in sync with what Seer queried. We prefer
+      // the metric parsed out of the visualize aggregate (e.g.
+      // p75(value, metric.name, distribution, millisecond)); otherwise we fall
+      // back to the metric.name/type/unit filters in the query (samples mode),
+      // which parseTraceMetricFromQuery also strips back out for us.
       const visualizationTraceMetric = (result.visualizations ?? [])
         .flatMap(viz => viz.yAxes)
         .map(yAxis => parseMetricAggregate(yAxis).traceMetric)
@@ -123,54 +120,23 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
           metric => metric.name && metric.type && isTraceMetricTypeValue(metric.type)
         );
 
-      const queryMetricName = search.getFilterValues(
-        TraceMetricKnownFieldKey.METRIC_NAME
-      )[0];
-      const queryMetricType = search.getFilterValues(
-        TraceMetricKnownFieldKey.METRIC_TYPE
-      )[0];
-      const queryMetricUnit = search.getFilterValues(
-        TraceMetricKnownFieldKey.METRIC_UNIT
-      )[0];
+      const {metric: queryTraceMetric, rest: queryWithoutMetric} =
+        parseTraceMetricFromQuery(seerQuery.query);
 
-      // The metric Seer actually specified, if any. We require a valid metric
-      // type and prefer the visualization metric, falling back to the query
-      // filters. Left undefined when neither source yields a valid metric — in
-      // that case we keep the panel's existing metric untouched rather than
-      // guessing a default aggregate.
-      let resolvedMetric: TraceMetric | undefined;
-      if (visualizationTraceMetric) {
-        // parseMetricAggregate leaves unit undefined when the aggregate omits
-        // the unit arg; normalize to NONE_UNIT so downstream sample queries keep
-        // the same unit scoping as the query-filter path below.
-        resolvedMetric = {
-          ...visualizationTraceMetric,
-          unit: visualizationTraceMetric.unit ?? NONE_UNIT,
-        };
-      } else if (
-        queryMetricName &&
-        queryMetricType &&
-        isTraceMetricTypeValue(queryMetricType)
-      ) {
-        resolvedMetric = {
-          name: queryMetricName,
-          type: queryMetricType,
-          unit: queryMetricUnit ?? NONE_UNIT,
-        };
-      }
+      // Prefer the visualization metric (normalizing its unit to NONE_UNIT, since
+      // parseMetricAggregate omits the unit arg), falling back to the query-filter
+      // metric. Left undefined when neither yields a valid metric — we then keep
+      // the panel's existing metric and the query untouched.
+      const resolvedMetric = visualizationTraceMetric
+        ? {...visualizationTraceMetric, unit: visualizationTraceMetric.unit ?? NONE_UNIT}
+        : queryTraceMetric;
+
       const nextMetric = resolvedMetric ?? traceMetric;
 
-      // Only strip the metric filters from the query when we actually adopted a
-      // metric (it's then tracked on the panel, not the query). If we couldn't
-      // resolve one, leave the query untouched so it stays consistent with the
-      // unchanged panel metric.
-      let cleanedQuery = seerQuery.query;
-      if (resolvedMetric) {
-        search.removeFilter(TraceMetricKnownFieldKey.METRIC_NAME);
-        search.removeFilter(TraceMetricKnownFieldKey.METRIC_TYPE);
-        search.removeFilter(TraceMetricKnownFieldKey.METRIC_UNIT);
-        cleanedQuery = search.formatString();
-      }
+      // Strip the metric tokens from the query only when we adopted a metric (it's
+      // then tracked on the panel, not the query); parseTraceMetricFromQuery
+      // returns that stripped query as `rest`.
+      const cleanedQuery = resolvedMetric ? queryWithoutMetric : seerQuery.query;
 
       const aggregateFields: AggregateField[] = [];
 

--- a/static/app/views/explore/metrics/utils.spec.tsx
+++ b/static/app/views/explore/metrics/utils.spec.tsx
@@ -2,12 +2,14 @@ import qs from 'query-string';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {SavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {NONE_UNIT} from 'sentry/views/explore/metrics/constants';
 import {decodeMetricsQueryParams} from 'sentry/views/explore/metrics/metricQuery';
 import {
   createTraceMetricEventsFilter,
   getEquationMetricsTotalFilter,
   getMetricsUrlFromSavedQueryUrl,
   mapMetricUnitToFieldType,
+  parseTraceMetricFromQuery,
 } from 'sentry/views/explore/metrics/utils';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 
@@ -27,6 +29,36 @@ describe('mapMetricUnitToFieldType', () => {
     ['custom_unit', {fieldType: 'number', unit: undefined}],
   ])('maps %s to the correct field type', (unit, expected) => {
     expect(mapMetricUnitToFieldType(unit)).toEqual(expected);
+  });
+});
+
+describe('parseTraceMetricFromQuery', () => {
+  it('splits the metric identity from the remaining predicate', () => {
+    expect(
+      parseTraceMetricFromQuery(
+        'metric.name:foo.duration metric.type:distribution metric.unit:millisecond value:>100'
+      )
+    ).toEqual({
+      metric: {name: 'foo.duration', type: 'distribution', unit: 'millisecond'},
+      rest: 'value:>100',
+    });
+  });
+
+  it('defaults the unit to NONE_UNIT when absent', () => {
+    expect(
+      parseTraceMetricFromQuery('metric.name:foo.duration metric.type:counter')
+    ).toEqual({
+      metric: {name: 'foo.duration', type: 'counter', unit: NONE_UNIT},
+      rest: '',
+    });
+  });
+
+  it.each([
+    ['value:>100'],
+    ['metric.name:foo.duration value:>100'],
+    ['metric.name:foo.duration metric.type:bogus'],
+  ])('returns no metric and leaves %s untouched', query => {
+    expect(parseTraceMetricFromQuery(query)).toEqual({metric: undefined, rest: query});
   });
 });
 

--- a/static/app/views/explore/metrics/utils.spec.tsx
+++ b/static/app/views/explore/metrics/utils.spec.tsx
@@ -10,6 +10,7 @@ import {
   getMetricsUrlFromSavedQueryUrl,
   mapMetricUnitToFieldType,
   parseTraceMetricFromQuery,
+  stripTraceMetricTokens,
 } from 'sentry/views/explore/metrics/utils';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 
@@ -59,6 +60,19 @@ describe('parseTraceMetricFromQuery', () => {
     ['metric.name:foo.duration metric.type:bogus'],
   ])('returns no metric and leaves %s untouched', query => {
     expect(parseTraceMetricFromQuery(query)).toEqual({metric: undefined, rest: query});
+  });
+});
+
+describe('stripTraceMetricTokens', () => {
+  it.each([
+    ['metric.name:foo metric.type:distribution metric.unit:ms value:>100', 'value:>100'],
+    // Incomplete identity (missing metric.type) is still stripped — the case where
+    // the metric came from the visualization aggregate but a stale metric.name
+    // token lingered in the query.
+    ['metric.name:foo value:>100', 'value:>100'],
+    ['value:>100', 'value:>100'],
+  ])('strips metric tokens from %s', (query, expected) => {
+    expect(stripTraceMetricTokens(query)).toBe(expected);
   });
 });
 

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -106,6 +106,19 @@ export function createTraceMetricFilter(traceMetric: TraceMetric): string | unde
  * metrics query). Returns `metric: undefined` and the query untouched when the
  * identity isn't present, so callers can ignore it.
  */
+/**
+ * Removes any metric.name/metric.type/metric.unit identity tokens from a query,
+ * whether or not they form a complete metric. Use when the metric has been
+ * adopted onto the panel so no stale identity filters linger in the query.
+ */
+export function stripTraceMetricTokens(query: string): string {
+  const search = new MutableSearch(query);
+  search.removeFilter(TraceMetricKnownFieldKey.METRIC_NAME);
+  search.removeFilter(TraceMetricKnownFieldKey.METRIC_TYPE);
+  search.removeFilter(TraceMetricKnownFieldKey.METRIC_UNIT);
+  return search.formatString();
+}
+
 export function parseTraceMetricFromQuery(query: string): {
   metric: TraceMetric | undefined;
   rest: string;
@@ -117,10 +130,10 @@ export function parseTraceMetricFromQuery(query: string): {
   if (!name || !type || !isTraceMetricTypeValue(type)) {
     return {metric: undefined, rest: query};
   }
-  search.removeFilter(TraceMetricKnownFieldKey.METRIC_NAME);
-  search.removeFilter(TraceMetricKnownFieldKey.METRIC_TYPE);
-  search.removeFilter(TraceMetricKnownFieldKey.METRIC_UNIT);
-  return {metric: {name, type, unit: unit ?? NONE_UNIT}, rest: search.formatString()};
+  return {
+    metric: {name, type, unit: unit ?? NONE_UNIT},
+    rest: stripTraceMetricTokens(query),
+  };
 }
 
 export function hasDisplayMetricUnit(

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -32,6 +32,7 @@ import {
 import {normalizeFunctionToken} from 'sentry/views/explore/metrics/parseAggregateExpression';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
 import {
+  isTraceMetricTypeValue,
   TraceMetricKnownFieldKey,
   type SampleTableColumnKey,
 } from 'sentry/views/explore/metrics/types';
@@ -96,6 +97,30 @@ export function createTraceMetricFilter(traceMetric: TraceMetric): string | unde
         [`sentry._internal.cooccuring.type.${traceMetric.type}`]: ['true'],
       }).formatString()
     : undefined;
+}
+
+/**
+ * Splits a metrics query string into the structured metric identity and the
+ * remaining attribute predicate. The identity rides as metric.name/metric.type/
+ * metric.unit filter tokens (samples-mode form, e.g. what Ask Seer returns for a
+ * metrics query). Returns `metric: undefined` and the query untouched when the
+ * identity isn't present, so callers can ignore it.
+ */
+export function parseTraceMetricFromQuery(query: string): {
+  metric: TraceMetric | undefined;
+  rest: string;
+} {
+  const search = new MutableSearch(query);
+  const name = search.getFilterValues(TraceMetricKnownFieldKey.METRIC_NAME)[0];
+  const type = search.getFilterValues(TraceMetricKnownFieldKey.METRIC_TYPE)[0];
+  const unit = search.getFilterValues(TraceMetricKnownFieldKey.METRIC_UNIT)[0];
+  if (!name || !type || !isTraceMetricTypeValue(type)) {
+    return {metric: undefined, rest: query};
+  }
+  search.removeFilter(TraceMetricKnownFieldKey.METRIC_NAME);
+  search.removeFilter(TraceMetricKnownFieldKey.METRIC_TYPE);
+  search.removeFilter(TraceMetricKnownFieldKey.METRIC_UNIT);
+  return {metric: {name, type, unit: unit ?? NONE_UNIT}, rest: search.formatString()};
 }
 
 export function hasDisplayMetricUnit(

--- a/static/app/views/explore/spans/spansTabSeerComboBox.tsx
+++ b/static/app/views/explore/spans/spansTabSeerComboBox.tsx
@@ -136,6 +136,7 @@ export function SpansTabSeerComboBox() {
         sort: seerQuery.sort,
         mode: seerQuery.mode,
         interval: seerQuery.interval,
+        ...(result.crossEvents?.length ? {crossEvents: result.crossEvents} : {}),
       });
 
       askSeerSuggestedQueryRef.current = JSON.stringify({
@@ -146,6 +147,7 @@ export function SpansTabSeerComboBox() {
         sort: seerQuery.sort,
         mode: seerQuery.mode,
         interval: seerQuery.interval,
+        ...(result.crossEvents?.length ? {crossEvents: result.crossEvents} : {}),
       });
       trackAnalytics('ai_query.applied', {
         organization,


### PR DESCRIPTION
Ask Seer suggestions on the Traces tab now carry the agent's same-trace cross-event sibling filters (spans/logs/metrics). They render as a "Cross-event" chip in the suggestion row, and accepting a suggestion writes them to the `crossEvents` URL param so the query runs as a true same-trace join instead of collapsing to a single-dataset query.

Metric siblings reuse a shared `parseTraceMetricFromQuery` helper (also adopted by the metrics tab) to recover the structured metric identity from the query; aggregate-mode metric siblings, which carry no identity, are dropped.

Refs BROWSE-576

Views:
<img width="2363" height="286" alt="final_snapshot-a" src="https://github.com/user-attachments/assets/8722ffa6-a543-42fb-b91f-1f7803da53cd" />
<img width="1210" height="665" alt="final-snapshot-2" src="https://github.com/user-attachments/assets/4ef8d3e7-e143-4805-8abb-980fe00f77e8" />
<img width="1672" height="217" alt="final-snapshot-3" src="https://github.com/user-attachments/assets/c8de3a51-5fb8-4445-add1-4b6de91c41aa" />
