### PR TITLE
chore(codeowners): add dashboards as owner of static/app/utils/dashboards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -364,6 +364,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/views/insights/                                               @getsentry/dashboards
 
 /static/app/views/dashboards/                                             @getsentry/dashboards
+/static/app/utils/dashboards/                                             @getsentry/dashboards
 /static/app/components/modals/widgetViewerModal*                          @getsentry/dashboards
 
 /static/app/views/discover/                                               @getsentry/explore


### PR DESCRIPTION
`static/app/utils/dashboards/` (issue widget field renderers, dashboards API options, etc.) was falling under the broad `/static/app/utils/ @getsentry/app-frontend` rule rather than being owned by @getsentry/dashboards. This adds an explicit entry so the team owns its own utils directory.