### PR TITLE
ui(seer-activity): Update the copy/appearance of activity alerts

### DIFF
--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_base.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_base.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from sentry.models.group import Group
 from sentry.notifications.platform.types import (
     CodeTextBlock,
+    LinkTextBlock,
     NotificationData,
     NotificationRenderedAction,
     NotificationRenderedTemplate,
@@ -29,7 +30,6 @@ ACTIVITY_TYPE_TO_SOURCE: dict[int, NotificationSource] = {
 
 EXAMPLE_SEER_URL = "https://sentry.io/organizations/example/issues/1/?seerDrawer=true"
 EXAMPLE_ALERT_URL = "https://sentry.io/organizations/example/monitors/alerts/1/"
-EXAMPLE_FOOTER = "This notification was sent as part of an alert."
 
 
 class WorkflowEngineActivityAction(NotificationData):
@@ -56,21 +56,21 @@ def get_issue_description(group: Group) -> list[NotificationSection]:
     return [ParagraphBlock(blocks=blocks)]
 
 
-def get_subject(label: str, group: Group) -> str:
+def get_subject(label: str, group: Group) -> list[NotificationTextBlock]:
     short_id = group.qualified_short_id or "unknown"
-    return f"{label} for {short_id}"
+    group_link = absolute_uri(group.get_absolute_url())
+    return [PlainTextBlock(text=f"{label} for"), LinkTextBlock(text=short_id, url=group_link)]
 
 
-def get_view_in_sentry_button(group: Group) -> NotificationRenderedAction:
+def get_view_autofix_button(group: Group) -> NotificationRenderedAction:
     link = f"{absolute_uri(group.get_absolute_url())}?seerDrawer=true"
-    return NotificationRenderedAction(label="View in Sentry", link=link)
+    return NotificationRenderedAction(label="View Autofix", link=link)
 
 
 def build_template(
     data: WorkflowEngineActivityAction,
-    subject: str,
+    subject: list[NotificationTextBlock],
     body: list[NotificationSection],
-    extra_actions: list[NotificationRenderedAction],
 ) -> NotificationRenderedTemplate:
     from sentry.notifications.notification_action.activity_registry.base import (
         extract_notification_models_by_activity,
@@ -82,18 +82,15 @@ def build_template(
     configuration_url = organization.absolute_url(
         f"organizations/{organization.slug}/monitors/alerts/{data.workflow_id}/"
     )
-    footer = EXAMPLE_FOOTER
+    footer = [
+        PlainTextBlock(text="This notification was sent as part of"),
+        LinkTextBlock(text="an alert", url=configuration_url),
+    ]
     if settings.DEBUG and activity.data:
-        footer += f" Run ID: {activity.data.get('run_id')}"
+        footer.append(PlainTextBlock(text=f"Run ID: {activity.data.get('run_id')}"))
 
     return NotificationRenderedTemplate(
-        subject=subject,
-        body=body,
-        actions=[
-            NotificationRenderedAction(label="View Alert", link=configuration_url),
-            *extra_actions,
-        ],
-        footer=footer,
+        subject=subject, body=body, actions=[get_view_autofix_button(group)], footer=footer
     )
 
 
@@ -110,10 +107,7 @@ def get_example_issue_description() -> list[NotificationSection]:
 
 
 def get_example_actions() -> list[NotificationRenderedAction]:
-    return [
-        NotificationRenderedAction(label="View Alert", link=EXAMPLE_ALERT_URL),
-        NotificationRenderedAction(label="View in Sentry", link=EXAMPLE_SEER_URL),
-    ]
+    return [NotificationRenderedAction(label="View Autofix", link=EXAMPLE_SEER_URL)]
 
 
 def get_example_template(
@@ -125,5 +119,8 @@ def get_example_template(
         subject=subject,
         body=body if body is not None else get_example_issue_description(),
         actions=actions if actions is not None else get_example_actions(),
-        footer=EXAMPLE_FOOTER,
+        footer=[
+            PlainTextBlock(text="This notification was sent as part of"),
+            LinkTextBlock(text="an alert", url=EXAMPLE_ALERT_URL),
+        ],
     )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_base.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_base.py
@@ -47,7 +47,8 @@ def get_issue_description(group: Group) -> list[NotificationSection]:
     blocks: list[NotificationTextBlock] = []
     title = build_attachment_title(group)
     if title:
-        blocks.append(PlainTextBlock(text=title))
+        group_link = absolute_uri(group.get_absolute_url())
+        blocks.append(LinkTextBlock(text=title, url=group_link))
     culprit = group.culprit
     if culprit:
         if blocks:
@@ -57,9 +58,10 @@ def get_issue_description(group: Group) -> list[NotificationSection]:
 
 
 def get_subject(label: str, group: Group) -> list[NotificationTextBlock]:
-    short_id = group.qualified_short_id or "unknown"
-    group_link = absolute_uri(group.get_absolute_url())
-    return [PlainTextBlock(text=f"{label} for"), LinkTextBlock(text=short_id, url=group_link)]
+    if group.qualified_short_id:
+        return [PlainTextBlock(text=f"{label} for"), CodeTextBlock(text=group.qualified_short_id)]
+    else:
+        return [PlainTextBlock(text=f"{label} for a Sentry Issue")]
 
 
 def get_view_autofix_button(group: Group) -> NotificationRenderedAction:
@@ -87,7 +89,7 @@ def build_template(
         LinkTextBlock(text="an alert", url=configuration_url),
     ]
     if settings.DEBUG and activity.data:
-        footer.append(PlainTextBlock(text=f"Run ID: {activity.data.get('run_id')}"))
+        footer.append(PlainTextBlock(text=f"· Run ID: {activity.data.get('run_id')}"))
 
     return NotificationRenderedTemplate(
         subject=subject, body=body, actions=[get_view_autofix_button(group)], footer=footer

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_completed.py
@@ -41,7 +41,7 @@ class SeerCodingCompletedActivityTemplate(NotificationTemplate[WorkflowEngineAct
         )
         return build_template(
             data=data,
-            subject=get_subject("Seer Coding Completed", group),
+            subject=get_subject("Coding Completed", group),
             body=get_issue_description(group),
             extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_completed.py
@@ -5,7 +5,6 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_subject,
-    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
@@ -43,5 +42,4 @@ class SeerCodingCompletedActivityTemplate(NotificationTemplate[WorkflowEngineAct
             data=data,
             subject=get_subject("Coding Completed", group),
             body=get_issue_description(group),
-            extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_started.py
@@ -5,7 +5,6 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_subject,
-    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
@@ -43,5 +42,4 @@ class SeerCodingStartedActivityTemplate(NotificationTemplate[WorkflowEngineActiv
             data=data,
             subject=get_subject("Coding Started", group),
             body=get_issue_description(group),
-            extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_coding_started.py
@@ -41,7 +41,7 @@ class SeerCodingStartedActivityTemplate(NotificationTemplate[WorkflowEngineActiv
         )
         return build_template(
             data=data,
-            subject=get_subject("Seer Coding Started", group),
+            subject=get_subject("Coding Started", group),
             body=get_issue_description(group),
             extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_iteration_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_iteration_completed.py
@@ -89,7 +89,7 @@ class SeerIterationCompletedActivityTemplate(NotificationTemplate[WorkflowEngine
 
         return build_template(
             data=data,
-            subject=get_subject("Seer PR Iteration Completed", group),
+            subject=get_subject("PR Iteration Completed", group),
             body=body,
             extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_iteration_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_iteration_completed.py
@@ -6,7 +6,6 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_subject,
-    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     LinkTextBlock,
@@ -91,5 +90,4 @@ class SeerIterationCompletedActivityTemplate(NotificationTemplate[WorkflowEngine
             data=data,
             subject=get_subject("PR Iteration Completed", group),
             body=body,
-            extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_iteration_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_iteration_started.py
@@ -5,7 +5,6 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_subject,
-    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
@@ -43,5 +42,4 @@ class SeerIterationStartedActivityTemplate(NotificationTemplate[WorkflowEngineAc
             data=data,
             subject=get_subject("PR Iteration Started", group),
             body=get_issue_description(group),
-            extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_iteration_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_iteration_started.py
@@ -41,7 +41,7 @@ class SeerIterationStartedActivityTemplate(NotificationTemplate[WorkflowEngineAc
         )
         return build_template(
             data=data,
-            subject=get_subject("Seer PR Iteration Started", group),
+            subject=get_subject("PR Iteration Started", group),
             body=get_issue_description(group),
             extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_pr_created.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_pr_created.py
@@ -6,7 +6,6 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_subject,
-    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     LinkTextBlock,
@@ -73,8 +72,5 @@ class SeerPrCreatedActivityTemplate(NotificationTemplate[WorkflowEngineActivityA
             body.append(ParagraphBlock(blocks=pr_links))
 
         return build_template(
-            data=data,
-            subject=get_subject("Pull Request Created", group),
-            body=body,
-            extra_actions=[get_view_in_sentry_button(group)],
+            data=data, subject=get_subject("Pull Request Created", group), body=body
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_pr_created.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_pr_created.py
@@ -74,7 +74,7 @@ class SeerPrCreatedActivityTemplate(NotificationTemplate[WorkflowEngineActivityA
 
         return build_template(
             data=data,
-            subject=get_subject("Seer PR Created", group),
+            subject=get_subject("Pull Request Created", group),
             body=body,
             extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_completed.py
@@ -6,7 +6,6 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_subject,
-    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     CodeBlock,
@@ -61,8 +60,5 @@ class SeerRcaCompletedActivityTemplate(NotificationTemplate[WorkflowEngineActivi
             summary_block = PlainTextBlock(text=activity.data.get("summary", fallback))
             body.append(CodeBlock(blocks=[summary_block]))
         return build_template(
-            data=data,
-            subject=get_subject("Root Cause Analysis Completed", group),
-            body=body,
-            extra_actions=[get_view_in_sentry_button(group)],
+            data=data, subject=get_subject("Root Cause Analysis Completed", group), body=body
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_completed.py
@@ -62,7 +62,7 @@ class SeerRcaCompletedActivityTemplate(NotificationTemplate[WorkflowEngineActivi
             body.append(CodeBlock(blocks=[summary_block]))
         return build_template(
             data=data,
-            subject=get_subject("Seer RCA Completed", group),
+            subject=get_subject("Root Cause Analysis Completed", group),
             body=body,
             extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_started.py
@@ -41,7 +41,7 @@ class SeerRcaStartedActivityTemplate(NotificationTemplate[WorkflowEngineActivity
         )
         return build_template(
             data=data,
-            subject=get_subject("Seer RCA Started", group),
+            subject=get_subject("Root Cause Analysis Started", group),
             body=get_issue_description(group),
             extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_rca_started.py
@@ -5,7 +5,6 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_subject,
-    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
@@ -43,5 +42,4 @@ class SeerRcaStartedActivityTemplate(NotificationTemplate[WorkflowEngineActivity
             data=data,
             subject=get_subject("Root Cause Analysis Started", group),
             body=get_issue_description(group),
-            extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_completed.py
@@ -62,7 +62,7 @@ class SeerSolutionCompletedActivityTemplate(NotificationTemplate[WorkflowEngineA
             body.append(CodeBlock(blocks=[summary_block]))
         return build_template(
             data=data,
-            subject=get_subject("Seer Solution Completed", group),
+            subject=get_subject("Planning Completed", group),
             body=body,
             extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_completed.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_completed.py
@@ -6,7 +6,6 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_subject,
-    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     CodeBlock,
@@ -61,8 +60,5 @@ class SeerSolutionCompletedActivityTemplate(NotificationTemplate[WorkflowEngineA
             summary_block = PlainTextBlock(text=activity.data.get("summary", fallback))
             body.append(CodeBlock(blocks=[summary_block]))
         return build_template(
-            data=data,
-            subject=get_subject("Planning Completed", group),
-            body=body,
-            extra_actions=[get_view_in_sentry_button(group)],
+            data=data, subject=get_subject("Planning Completed", group), body=body
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_started.py
@@ -5,7 +5,6 @@ from sentry.notifications.platform.templates.workflow_engine.activity.seer_base 
     get_example_template,
     get_issue_description,
     get_subject,
-    get_view_in_sentry_button,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
@@ -43,5 +42,4 @@ class SeerSolutionStartedActivityTemplate(NotificationTemplate[WorkflowEngineAct
             data=data,
             subject=get_subject("Planning Started", group),
             body=get_issue_description(group),
-            extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_started.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/seer_solution_started.py
@@ -41,7 +41,7 @@ class SeerSolutionStartedActivityTemplate(NotificationTemplate[WorkflowEngineAct
         )
         return build_template(
             data=data,
-            subject=get_subject("Seer Solution Started", group),
+            subject=get_subject("Planning Started", group),
             body=get_issue_description(group),
             extra_actions=[get_view_in_sentry_button(group)],
         )

--- a/static/app/views/automations/components/actionFilters/seerActivityTrigger.tsx
+++ b/static/app/views/automations/components/actionFilters/seerActivityTrigger.tsx
@@ -13,8 +13,8 @@ import {useDataConditionNodeContext} from 'sentry/views/automations/components/d
 const SEER_ACTIVITY_STAGE_CHOICES: Array<{label: string; value: string}> = [
   {value: 'rca_started', label: t('Root cause analysis started')},
   {value: 'rca_completed', label: t('Root cause analysis completed')},
-  {value: 'solution_started', label: t('Solution search started')},
-  {value: 'solution_completed', label: t('Solution search completed')},
+  {value: 'solution_started', label: t('Planning started')},
+  {value: 'solution_completed', label: t('Planning completed')},
   {value: 'coding_started', label: t('Coding started')},
   {value: 'coding_completed', label: t('Coding completed')},
   {value: 'pr_created', label: t('Pull request created')},


### PR DESCRIPTION
Update the appearance of seer activity notifications from alerts:

<img width="685" height="291" alt="image" src="https://github.com/user-attachments/assets/e717faa1-b2fd-403a-9db1-b9e1d0689c53" />

 - the titles now omit 'Seer', and anything displaying `solution` has been replaced with `plan` to match the UI. 
 - the footers now have links to the alert, and the issue title is clickable