### PR TITLE
fix(ourlogs): remount chart on query change to stop stuck select bands

### DIFF
--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -175,11 +175,6 @@ function Graph({
 
   const plottables = useChartVisualizationPlottables(chartInfo);
 
-  const {period, start, end} = selection.datetime;
-  const chartRemountKey = autorefreshEnabled
-    ? 'logs-chart-streaming'
-    : `${period}|${start}|${end}|${userQuery}|${aggregate}|${visualize.chartType}|${interval}|${topEventsLimit}|${groupBys.join(',')}`;
-
   const Title = (
     <Widget.WidgetTitle
       summary={
@@ -258,6 +253,9 @@ function Graph({
       size="xs"
     />
   );
+
+  const {period, start, end} = selection.datetime;
+  const chartRemountKey = `${period}|${start}|${end}|${userQuery}|${aggregate}|${visualize.chartType}|${interval}|${topEventsLimit}|${groupBys.join(',')}`;
 
   return (
     <Widget

--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -44,6 +44,7 @@ import {ConfidenceFooter} from 'sentry/views/explore/logs/confidenceFooter';
 import {
   useQueryParamsAggregateFields,
   useQueryParamsAggregateSortBys,
+  useQueryParamsGroupBys,
   useQueryParamsMode,
   useQueryParamsQuery,
   useQueryParamsSearch,
@@ -133,6 +134,8 @@ function Graph({
   const aggregate = visualize.yAxis;
   const userQuery = useQueryParamsQuery();
   const topEventsLimit = useQueryParamsTopEventsLimit();
+  const {selection} = usePageFilters();
+  const groupBys = useQueryParamsGroupBys();
 
   const [interval, setInterval, intervalOptions] = useChartInterval();
 
@@ -171,6 +174,11 @@ function Graph({
   ]);
 
   const plottables = useChartVisualizationPlottables(chartInfo);
+
+  const {period, start, end} = selection.datetime;
+  const chartRemountKey = autorefreshEnabled
+    ? 'logs-chart-streaming'
+    : `${period}|${start}|${end}|${userQuery}|${aggregate}|${visualize.chartType}|${interval}|${topEventsLimit}|${groupBys.join(',')}`;
 
   const Title = (
     <Widget.WidgetTitle
@@ -257,7 +265,11 @@ function Graph({
       Actions={Actions}
       Visualization={
         visualize.visible && (
-          <ChartVisualization chartInfo={chartInfo} notMerge={!autorefreshEnabled} />
+          <ChartVisualization
+            key={chartRemountKey}
+            chartInfo={chartInfo}
+            notMerge={!autorefreshEnabled}
+          />
         )
       }
       Footer={


### PR DESCRIPTION
This was a fun little romp through rendering. The root cause of LOGS-901 is that dragged svg paths for time range selects never get cleaned up. They instead stay in sync with the dragged cursor. So although the first one looks fine, for the >=2nd on you get >=2 of them on top of each other - which looks opaque.

<img width="1323" height="621" alt="image" src="https://github.com/user-attachments/assets/917e27f7-003b-4d89-b046-25afe0f9febb" />

The bug started happening with my wack-a-mole changes in #117421. So to be super careful around weird cross-chart-selection state, this PR adds a React `key` based on a bunch of props for the chart (range, query, group-bys, aggregate, interval, chart type). This fixes the bug and generally keeps chart instances independent.

Sibling fix for metrics (same root cause, different branch in code): #118691

<img width="480" height="270" alt="giphy (3)" src="https://github.com/user-attachments/assets/955dbadf-97f4-4158-9941-0f9e46c88f00" />

Fixes LOGS-901
