### PR TITLE
feat(pr-metrics): Emit CI failure signal on close/merge rows

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -59,6 +59,20 @@ class PrCloseMetricsEvent(analytics.Event):
     # free-string column; null off the judge path. BigQuery-only.
     diagnosis_labels: list[str] | None = None
 
+    # CI outcome reduced from the PR's completed check-suite activity rows (set
+    # only under pr-metrics-activity). Both null when Sentry saw no completed
+    # suite — flag off or no CI configured — which BigQuery reads as "unknown",
+    # distinct from False ("CI ran and was green"). Both span required and
+    # optional checks alike: GitHub's check webhooks don't mark which checks gate
+    # merge (that's branch-protection/ruleset config). BigQuery-only.
+    #
+    # Was CI red at the PR's terminal head — the latest suite per CI app at
+    # head_commit_sha, so a red run later re-run green at the same head reads green.
+    ci_failed_at_close: bool | None = None
+    # Did any suite go red over the PR's whole life — counts a since-fixed failure,
+    # answering "did this PR ever break the build".
+    ci_ever_failed: bool | None = None
+
     # --- Conversation judge (set only on a judged close/merge row) ---
     # One of several judges' outputs. Columns are prefixed ``conversation_`` so a
     # future judge's columns sit alongside without collision, and to disambiguate

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -161,9 +161,12 @@ def _ci_summary(pull_request: PullRequest) -> dict[str, Any]:
 
     ``ci_failed_at_close`` reduces to the latest suite per CI app at the PR's
     terminal ``head_commit_sha``, so a red run later re-run green at the same head
-    reads as green. ``ci_ever_failed`` is true if any suite went red over the PR's
-    whole life, counting a since-fixed failure. Both span required and optional
-    checks alike — the webhook doesn't say which gate merge.
+    reads as green. It stays null when no suite ran on the terminal head (CI only
+    on earlier commits, a fast merge, or still-pending CI), keeping "unknown at
+    close" distinct from ``False`` ("green at close") — even when earlier suites
+    make ``ci_ever_failed`` known. ``ci_ever_failed`` is true if any suite went
+    red over the PR's whole life, counting a since-fixed failure. Both span
+    required and optional checks alike — the webhook doesn't say which gate merge.
     """
     head = pull_request.head_commit_sha
     rows = (
@@ -191,7 +194,13 @@ def _ci_summary(pull_request: PullRequest) -> dict[str, Any]:
     if not saw_suite:
         return {}
     return {
-        "ci_failed_at_close": any(c in _CI_FAILURE_CONCLUSIONS for c in latest_at_head.values()),
+        # None (not False) when no suite ran on the terminal head: an empty
+        # any() would otherwise report "green at close" for an unknown state.
+        "ci_failed_at_close": (
+            any(c in _CI_FAILURE_CONCLUSIONS for c in latest_at_head.values())
+            if latest_at_head
+            else None
+        ),
         "ci_ever_failed": ever_failed,
     }
 

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -142,6 +142,60 @@ def _merge_commit_id(pull_request: PullRequest) -> int | None:
     )
 
 
+# GitHub check-suite conclusions that count as a red build. success/neutral/
+# skipped/stale aren't failures; cancelled is excluded (usually a superseded run,
+# not a real failure); action_required is a check requesting user action (e.g. app
+# authorization), not a CI failure.
+_CI_FAILURE_CONCLUSIONS = frozenset({"failure", "timed_out", "startup_failure"})
+
+
+def _ci_summary(pull_request: PullRequest) -> dict[str, Any]:
+    """The PR's CI outcome, reduced from its completed check-suite activity rows.
+
+    Reads ``CHECK_SUITE_COMPLETED`` rows — the aggregate outcome per CI app,
+    written under the same ``pr-metrics-activity`` flag as the rest of the
+    activity feed (so this is empty when that flag is off). No SCM fetch: the rows
+    are already persisted, so this works on the Seer judge callback path too.
+    Returns ``{}`` (every field keeps its ``None`` default) when Sentry saw no
+    completed suite, so BigQuery tells that "unknown" apart from ``False``.
+
+    ``ci_failed_at_close`` reduces to the latest suite per CI app at the PR's
+    terminal ``head_commit_sha``, so a red run later re-run green at the same head
+    reads as green. ``ci_ever_failed`` is true if any suite went red over the PR's
+    whole life, counting a since-fixed failure. Both span required and optional
+    checks alike — the webhook doesn't say which gate merge.
+    """
+    head = pull_request.head_commit_sha
+    rows = (
+        PullRequestActivity.objects.filter(
+            pull_request=pull_request,
+            event_type=PullRequestActivityType.CHECK_SUITE_COMPLETED,
+        )
+        .order_by("date_added", "id")
+        .values_list("payload", flat=True)
+    )
+
+    saw_suite = False
+    ever_failed = False
+    # app_slug -> its latest conclusion at the terminal head; ascending iteration
+    # means the last write wins, so a re-run supersedes its earlier run.
+    latest_at_head: dict[str, str] = {}
+    for payload in rows:
+        saw_suite = True
+        conclusion = payload.get("conclusion") or ""
+        if conclusion in _CI_FAILURE_CONCLUSIONS:
+            ever_failed = True
+        if head is not None and payload.get("head_sha") == head:
+            latest_at_head[payload.get("app_slug") or ""] = conclusion
+
+    if not saw_suite:
+        return {}
+    return {
+        "ci_failed_at_close": any(c in _CI_FAILURE_CONCLUSIONS for c in latest_at_head.values()),
+        "ci_ever_failed": ever_failed,
+    }
+
+
 def _conversation_analysis_fields(
     conversation_analysis: PrConversationAnalysis | None,
 ) -> dict[str, Any]:
@@ -225,6 +279,7 @@ def build_pr_metrics_row(
         attributions=json.dumps(attributions),
         verdict=metrics.verdict,
         diagnosis_labels=list(diagnosis_labels) if diagnosis_labels is not None else None,
+        **_ci_summary(pull_request),
         **_conversation_analysis_fields(conversation_analysis),
     )
 

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -175,7 +175,7 @@ def _ci_summary(pull_request: PullRequest) -> dict[str, Any]:
             event_type=PullRequestActivityType.CHECK_SUITE_COMPLETED,
         )
         .order_by("date_added", "id")
-        .values_list("payload", flat=True)
+        .values_list("id", "payload")
     )
 
     saw_suite = False
@@ -183,13 +183,18 @@ def _ci_summary(pull_request: PullRequest) -> dict[str, Any]:
     # app_slug -> its latest conclusion at the terminal head; ascending iteration
     # means the last write wins, so a re-run supersedes its earlier run.
     latest_at_head: dict[str, str] = {}
-    for payload in rows:
+    for row_id, payload in rows:
         saw_suite = True
         conclusion = payload.get("conclusion") or ""
         if conclusion in _CI_FAILURE_CONCLUSIONS:
             ever_failed = True
         if head is not None and payload.get("head_sha") == head:
-            latest_at_head[payload.get("app_slug") or ""] = conclusion
+            # Real check suites always carry an app slug, so re-runs of one app
+            # share a key and the latest wins. Fall back to the row id for a
+            # (malformed) slug-less suite, so distinct suites can't collide on ""
+            # and mask one another's failure.
+            key = payload.get("app_slug") or f"row:{row_id}"
+            latest_at_head[key] = conclusion
 
     if not saw_suite:
         return {}

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -596,6 +596,20 @@ class PrMetricsEmissionTest(TestCase):
         assert row.ci_failed_at_close is False
         assert row.ci_ever_failed is True
 
+    def test_build_row_ci_failed_at_close_null_when_no_suite_on_terminal_head(self) -> None:
+        # Suites ran on an earlier commit but none on the closing head (fast merge,
+        # still-pending CI): the at-close state is unknown (null), not green — even
+        # though we still know CI failed earlier in the PR's life.
+        self._check_suite(conclusion="failure", head_sha="c" * 40, webhook_id="cs-1")
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.ci_failed_at_close is None
+        assert row.ci_ever_failed is True
+
     def test_build_row_ci_rerun_green_supersedes_failure_at_head(self) -> None:
         # Same head, same CI app: a red suite re-run green. The latest suite per
         # app wins, so the terminal head reads green (but it did fail once).

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -137,6 +137,22 @@ class PrMetricsEmissionTest(TestCase):
             payload={},
         )
 
+    def _check_suite(
+        self,
+        *,
+        conclusion: str,
+        webhook_id: str,
+        head_sha: str = HEAD_SHA,
+        app_slug: str = "github-actions",
+    ) -> None:
+        # A completed check_suite — the aggregate CI outcome per app for a head.
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id=webhook_id,
+            event_type=PullRequestActivityType.CHECK_SUITE_COMPLETED,
+            payload={"conclusion": conclusion, "head_sha": head_sha, "app_slug": app_slug},
+        )
+
     def test_select_verdict_merged_without_later_commits_is_unchanged(self) -> None:
         # Merged with no SYNCHRONIZED activity: merge head == opened head.
         assert (
@@ -516,6 +532,97 @@ class PrMetricsEmissionTest(TestCase):
         emitted = emit_pr_metrics_row(pull_request=self.pull_request)
         assert emitted is False
         assert mock_record.call_count == 0
+
+    # --- CI summary (_ci_summary) ---
+
+    def test_build_row_ci_fields_null_when_no_check_suites(self) -> None:
+        # No completed check_suite activity leaves both fields null, so BigQuery
+        # tells "no CI seen" apart from "CI ran and was green".
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.ci_failed_at_close is None
+        assert row.ci_ever_failed is None
+
+    def test_build_row_ci_green(self) -> None:
+        self._check_suite(conclusion="success", webhook_id="cs-1")
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.ci_failed_at_close is False
+        assert row.ci_ever_failed is False
+
+    def test_build_row_ci_failed_at_close(self) -> None:
+        self._check_suite(conclusion="failure", webhook_id="cs-1")
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="closed",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.ci_failed_at_close is True
+        assert row.ci_ever_failed is True
+
+    def test_build_row_ci_cancelled_is_not_a_failure(self) -> None:
+        # cancelled is excluded from the failure set — typically a superseded run,
+        # not a red build.
+        self._check_suite(conclusion="cancelled", webhook_id="cs-1")
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.ci_failed_at_close is False
+        assert row.ci_ever_failed is False
+
+    def test_build_row_ci_ever_failed_but_green_at_close(self) -> None:
+        # An earlier head went red, a later push went green: the PR closed green,
+        # but it did break the build at some point.
+        self._check_suite(conclusion="failure", head_sha="c" * 40, webhook_id="cs-1")
+        self._check_suite(conclusion="success", webhook_id="cs-2")
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.ci_failed_at_close is False
+        assert row.ci_ever_failed is True
+
+    def test_build_row_ci_rerun_green_supersedes_failure_at_head(self) -> None:
+        # Same head, same CI app: a red suite re-run green. The latest suite per
+        # app wins, so the terminal head reads green (but it did fail once).
+        self._check_suite(conclusion="failure", webhook_id="cs-1")
+        self._check_suite(conclusion="success", webhook_id="cs-2")
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.ci_failed_at_close is False
+        assert row.ci_ever_failed is True
+
+    def test_build_row_ci_failed_at_close_when_any_app_red(self) -> None:
+        # Two CI apps on the terminal head, one green one red: a single red suite
+        # makes the close red.
+        self._check_suite(conclusion="success", app_slug="github-actions", webhook_id="cs-1")
+        self._check_suite(conclusion="failure", app_slug="codecov", webhook_id="cs-2")
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.ci_failed_at_close is True
+        assert row.ci_ever_failed is True
 
     # --- _commit_shas_from_activity ---
 

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -624,6 +624,21 @@ class PrMetricsEmissionTest(TestCase):
         assert row.ci_failed_at_close is False
         assert row.ci_ever_failed is True
 
+    def test_build_row_ci_slugless_suites_do_not_mask_each_other(self) -> None:
+        # Real check suites always carry an app slug; a (malformed) slug-less red
+        # then green pair at the same head must not collide on the "" key — a later
+        # success would otherwise overwrite and mask the earlier failure.
+        self._check_suite(conclusion="failure", app_slug="", webhook_id="cs-1")
+        self._check_suite(conclusion="success", app_slug="", webhook_id="cs-2")
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.ci_failed_at_close is True
+        assert row.ci_ever_failed is True
+
     def test_build_row_ci_failed_at_close_when_any_app_red(self) -> None:
         # Two CI apps on the terminal head, one green one red: a single red suite
         # makes the close red.


### PR DESCRIPTION
## Problem

We want to track how many tracked PRs (e.g. Seer PRs) have failing CI, as a metric. The CI conclusion is *already captured* on `CHECK_SUITE_COMPLETED` activity rows (`pr_metrics/webhooks.py`), but it was dropped at emit time — it never reached the `scm.pr.closed` BigQuery event, so the metric couldn't be built from existing data.

## Change

Add two columns to `PrCloseMetricsEvent`, derived from the persisted check-suite activity rows. No SCM fetch — the rows are already stored, so the Seer judge callback path (which has no webhook payload) populates them too.

- **`ci_failed_at_close`** — was CI red at the PR's terminal head? Reduced to the latest suite *per CI app* at `head_commit_sha`, so a red run later re-run green at the same head reads as green. Stays `null` when no suite ran on the terminal head (CI only on earlier commits, a fast merge, or still-pending CI) — "unknown at close", kept distinct from `False` ("green at close").
- **`ci_ever_failed`** — did any suite go red over the PR's whole life? Counts a since-fixed failure. This is the field that answers "how many of these PRs have failing CI".

Both are `null` when Sentry saw no completed suite at all (`pr-metrics-activity` off, or no CI configured), so BigQuery distinguishes "unknown" from `False` ("CI ran and was green").

### Notes / scope

- Failure set is `failure` / `timed_out` / `startup_failure`. `cancelled` (usually a superseded run) and `action_required` (an app prompt) are deliberately excluded.
- The per-app reduction keys on the suite's `app_slug`; a (malformed) slug-less suite falls back to its activity-row id so distinct suites can't collide on the empty key and mask one another's failure.
- Both fields span **required and optional checks alike** — GitHub's `check_suite`/`check_run` webhooks don't mark which checks gate merge (that's branch-protection / ruleset config, only resolvable via a GraphQL `isRequired` round-trip). Narrowing to required-only is intentionally left out of this v1 to preserve the module's no-SCM-fetch design.

## Tests

Nine cases in `test_emit.py`: no suites → null; green; failed-at-close; cancelled-not-a-failure; ever-failed-but-green-at-close; ever-failed-but-null-at-close (suite only on an earlier head); re-run-green-supersedes; slug-less suites don't mask each other; and any-app-red.

## Deploy note

Backend/analytics only — single PR, no frontend coupling. New optional `analytics.Event` fields should propagate to the BigQuery table automatically; worth a sanity check with the data owners since that schema lives outside this repo.
