### PR TITLE
fix(seer): Register get_organization_projects on internal RPC

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -1129,6 +1129,7 @@ seer_method_registry: dict[str, SeerRpcMethod] = {  # return type must be serial
     # Common to Seer features
     "get_github_enterprise_integration_config": seer_rpc(get_github_enterprise_integration_config),
     "get_organization_project_ids": seer_rpc(get_organization_project_ids),
+    "get_organization_projects": seer_rpc(get_organization_projects),
     "get_organization_features": seer_rpc(get_organization_features),
     "check_repository_integrations_status": seer_rpc(check_repository_integrations_status),
     "validate_repo": seer_rpc(validate_repo),

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -92,6 +92,18 @@ class TestSeerRpc(APITestCase):
         assert "features" in response.data
         assert isinstance(response.data["features"], list)
 
+    def test_get_organization_projects_registered_on_internal_rpc(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        path = self._get_path("get_organization_projects")
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(
+            path, data=data, HTTP_AUTHORIZATION=self.auth_header(path, data)
+        )
+        assert response.status_code == 200
+        assert "projects" in response.data
+        assert project.id in [p["id"] for p in response.data["projects"]]
+
     def test_validate_llm_proxy_key(self) -> None:
         path = self._get_path("validate_llm_proxy_key")
         data: dict[str, Any] = {"args": {"api_key": "test-key"}}


### PR DESCRIPTION
## Summary

`get_organization_projects` was returning `RpcResolutionException: Unknown method get_organization_projects` on the internal seer-rpc endpoint (`/api/0/internal/seer-rpc/{method_name}/`), the path Seer's Explorer calls.

PR #118427 added the `get_organization_projects` handler and registered it on the **public org** RPC endpoint (`public_org_seer_method_registry` in `organization_seer_rpc.py`), with a test covering that endpoint. It never added the method to `seer_method_registry` in `seer_rpc.py`, which backs the **internal** seer-rpc endpoint that Seer actually calls. So the handler existed but was unreachable, and every call raised at the `method_name not in seer_method_registry` guard.

This adds the missing registry entry, next to its sibling `get_organization_project_ids`, plus a regression test asserting the method is reachable on the internal endpoint (mirroring the existing `get_organization_features` internal-registration test).

## Test plan

- New `test_get_organization_projects_registered_on_internal_rpc` passes.
- Existing internal-registration test still passes.
- `prek` clean on both changed files.

Fixes SENTRY-5QZB
