### PR TITLE
fix(metrics): stop stuck zoom selection bands

### DIFF
--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -212,7 +212,7 @@ function Graph({
               )}
             />
           ) : showChart ? (
-            <ChartVisualization chartInfo={chartInfo} />
+            <ChartVisualization chartInfo={chartInfo} notMerge={false} />
           ) : undefined
         }
         Footer={


### PR DESCRIPTION
A gray box appears when zooming the metrics chart in Explore > Metrics. The metrics chart rendered `ChartVisualization` without a `notMerge` prop, so it inherited `BaseChart`'s default of `true`. That re-inits echarts on every update and re-fires `onFinished`, which re-activates the dataZoom drag-to-select cursor into a stuck `lineX` selection band. Voila, a gray box. Same root cause as LOGS-901 -> #118688.

<img width="1323" height="621" alt="image" src="https://github.com/user-attachments/assets/1846abe0-662f-4169-946c-f60b03e7732b" />

This passes `notMerge={false}` so updates merge in place, matching the traces chart (`spans/charts`), which sets it explicitly and doesn't reproduce the issue.

Fixes LOGS-903
