### PR TITLE
chore(notif-platform): Support italics and blockquote sections

### DIFF
--- a/src/sentry/notifications/platform/discord/provider.py
+++ b/src/sentry/notifications/platform/discord/provider.py
@@ -107,6 +107,8 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
                 description.append(f"\n{cls.render_text_blocks(block.blocks)}")
             elif block.type == NotificationSectionType.CODE_BLOCK:
                 description.append(f"\n```{cls.render_text_blocks(block.blocks)}```")
+            elif block.type == NotificationSectionType.BLOCK_QUOTE:
+                description.append(f"\n> {cls.render_text_blocks(block.blocks)}")
         return "".join(description)
 
     @classmethod
@@ -123,6 +125,8 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
                 texts.append(block.text)
             elif block.type == NotificationTextBlockType.BOLD_TEXT:
                 texts.append(f"**{block.text}**")
+            elif block.type == NotificationTextBlockType.ITALIC_TEXT:
+                texts.append(f"*{block.text}*")
             elif block.type == NotificationTextBlockType.CODE:
                 texts.append(f"`{block.text}`")
             elif block.type == NotificationTextBlockType.LINK and isinstance(block, LinkTextBlock):

--- a/src/sentry/notifications/platform/discord/provider.py
+++ b/src/sentry/notifications/platform/discord/provider.py
@@ -108,7 +108,7 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
             elif block.type == NotificationSectionType.CODE_BLOCK:
                 description.append(f"\n```{cls.render_text_blocks(block.blocks)}```")
             elif block.type == NotificationSectionType.BLOCK_QUOTE:
-                description.append(f"\n> {cls.render_text_blocks(block.blocks)}")
+                description.append(f"\n>>> {cls.render_text_blocks(block.blocks)}")
         return "".join(description)
 
     @classmethod

--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -101,6 +101,9 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
             elif block.type == NotificationSectionType.CODE_BLOCK:
                 safe_content = cls.render_text_blocks_to_html_string(block.blocks)
                 body_blocks.append(f"<pre><code>{safe_content}</code></pre>")
+            elif block.type == NotificationSectionType.BLOCK_QUOTE:
+                safe_content = cls.render_text_blocks_to_html_string(block.blocks)
+                body_blocks.append(f"<blockquote>{safe_content}</blockquote>")
 
         return mark_safe("".join(body_blocks))
 
@@ -115,6 +118,8 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
                 texts.append(escaped_text)
             elif block.type == NotificationTextBlockType.BOLD_TEXT:
                 texts.append(f"<strong>{escaped_text}</strong>")
+            elif block.type == NotificationTextBlockType.ITALIC_TEXT:
+                texts.append(f"<em>{escaped_text}</em>")
             elif block.type == NotificationTextBlockType.CODE:
                 texts.append(f"<code>{escaped_text}</code>")
             elif block.type == NotificationTextBlockType.LINK and isinstance(block, LinkTextBlock):
@@ -131,6 +136,8 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
                 body_blocks.append(f"\n{cls.render_text_blocks_to_txt_string(block.blocks)}")
             elif block.type == NotificationSectionType.CODE_BLOCK:
                 body_blocks.append(f"\n```{cls.render_text_blocks_to_txt_string(block.blocks)}```")
+            elif block.type == NotificationSectionType.BLOCK_QUOTE:
+                body_blocks.append(f"\n> {cls.render_text_blocks_to_txt_string(block.blocks)}")
         return " ".join(body_blocks)
 
     @classmethod
@@ -141,6 +148,8 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
                 texts.append(block.text)
             elif block.type == NotificationTextBlockType.BOLD_TEXT:
                 texts.append(f"**{block.text}**")
+            elif block.type == NotificationTextBlockType.ITALIC_TEXT:
+                texts.append(f"_{block.text}_")
             elif block.type == NotificationTextBlockType.CODE:
                 texts.append(f"`{block.text}`")
             elif block.type == NotificationTextBlockType.LINK and isinstance(block, LinkTextBlock):

--- a/src/sentry/notifications/platform/msteams/provider.py
+++ b/src/sentry/notifications/platform/msteams/provider.py
@@ -54,13 +54,16 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
             OpenUrlAction,
             TextSize,
             TextWeight,
-            create_text_block,
         )
 
         subject_text = cls.render_text_blocks(rendered_template.subject_blocks)
-        title_text = create_text_block(
-            text=subject_text, size=TextSize.LARGE, weight=TextWeight.BOLDER
-        )
+        title_text: Block = {
+            "type": "TextBlock",
+            "text": subject_text,
+            "size": TextSize.LARGE,
+            "weight": TextWeight.BOLDER,
+            "wrap": True,
+        }
         body_text = cls.render_body_blocks(rendered_template.body)
         body_blocks: list[Block] = [title_text, *body_text]
 
@@ -84,7 +87,9 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
 
         if rendered_template.footer is not None:
             footer_str = cls.render_text_blocks(rendered_template.footer_blocks)
-            body_blocks.append(create_text_block(text=footer_str, size=TextSize.SMALL))
+            body_blocks.append(
+                {"type": "TextBlock", "text": footer_str, "size": TextSize.SMALL, "wrap": True}
+            )
 
         card: AdaptiveCard = {
             "type": "AdaptiveCard",
@@ -101,7 +106,6 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
         from sentry.integrations.msteams.card_builder.block import (
             TextSize,
             create_code_block,
-            create_text_block,
         )
 
         if size is None:
@@ -111,13 +115,23 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
         for block in body:
             if block.type == NotificationSectionType.PARAGRAPH:
                 body_blocks.append(
-                    create_text_block(text=cls.render_text_blocks(block.blocks), size=size)
+                    {
+                        "type": "TextBlock",
+                        "text": cls.render_text_blocks(block.blocks),
+                        "size": size,
+                        "wrap": True,
+                    }
                 )
             elif block.type == NotificationSectionType.CODE_BLOCK:
                 body_blocks.append(create_code_block(text=cls.render_text_blocks(block.blocks)))
             elif block.type == NotificationSectionType.BLOCK_QUOTE:
                 body_blocks.append(
-                    create_text_block(text=f"> {cls.render_text_blocks(block.blocks)}", size=size)
+                    {
+                        "type": "TextBlock",
+                        "text": f"> {cls.render_text_blocks(block.blocks)}",
+                        "size": size,
+                        "wrap": True,
+                    }
                 )
         return body_blocks
 
@@ -130,7 +144,7 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
             elif block.type == NotificationTextBlockType.BOLD_TEXT:
                 texts.append(f"**{block.text}**")
             elif block.type == NotificationTextBlockType.ITALIC_TEXT:
-                texts.append(f"*{block.text}*")
+                texts.append(f"_{block.text}_")
             elif block.type == NotificationTextBlockType.CODE:
                 texts.append(f"`{block.text}`")
             elif block.type == NotificationTextBlockType.LINK and isinstance(block, LinkTextBlock):

--- a/src/sentry/notifications/platform/msteams/provider.py
+++ b/src/sentry/notifications/platform/msteams/provider.py
@@ -115,6 +115,10 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
                 )
             elif block.type == NotificationSectionType.CODE_BLOCK:
                 body_blocks.append(create_code_block(text=cls.render_text_blocks(block.blocks)))
+            elif block.type == NotificationSectionType.BLOCK_QUOTE:
+                body_blocks.append(
+                    create_text_block(text=f"> {cls.render_text_blocks(block.blocks)}", size=size)
+                )
         return body_blocks
 
     @classmethod
@@ -125,6 +129,8 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
                 texts.append(block.text)
             elif block.type == NotificationTextBlockType.BOLD_TEXT:
                 texts.append(f"**{block.text}**")
+            elif block.type == NotificationTextBlockType.ITALIC_TEXT:
+                texts.append(f"*{block.text}*")
             elif block.type == NotificationTextBlockType.CODE:
                 texts.append(f"`{block.text}`")
             elif block.type == NotificationTextBlockType.LINK and isinstance(block, LinkTextBlock):

--- a/src/sentry/notifications/platform/slack/provider.py
+++ b/src/sentry/notifications/platform/slack/provider.py
@@ -105,6 +105,9 @@ class SlackRenderer(NotificationRenderer[SlackRenderable]):
             elif block.type == NotificationSectionType.CODE_BLOCK:
                 text = cls._render_text_blocks(block.blocks)
                 blocks.append(SectionBlock(text=MarkdownTextObject(text=f"```{text}```")))
+            elif block.type == NotificationSectionType.BLOCK_QUOTE:
+                text = cls._render_text_blocks(block.blocks)
+                blocks.append(SectionBlock(text=MarkdownTextObject(text=f">{text}")))
         return blocks
 
     @classmethod
@@ -115,6 +118,8 @@ class SlackRenderer(NotificationRenderer[SlackRenderable]):
                 texts.append(block.text)
             elif block.type == NotificationTextBlockType.BOLD_TEXT:
                 texts.append(f"*{block.text}*")
+            elif block.type == NotificationTextBlockType.ITALIC_TEXT:
+                texts.append(f"_{block.text}_")
             elif block.type == NotificationTextBlockType.CODE:
                 texts.append(f"`{block.text}`")
             elif block.type == NotificationTextBlockType.LINK and isinstance(block, LinkTextBlock):

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -320,6 +320,10 @@ class NotificationTextBlockType(StrEnum):
     """
     A bolded section of text.
     """
+    ITALIC_TEXT = "italic_text"
+    """
+    An italicized section of text.
+    """
     CODE = "code"
     """
     Inline block of code.
@@ -342,6 +346,10 @@ class NotificationSectionType(StrEnum):
     CODE_BLOCK = "code_block"
     """
     A new section of code with a line break before.
+    """
+    BLOCK_QUOTE = "block_quote"
+    """
+    A quoted block of text, rendered as a blockquote.
     """
 
 
@@ -388,9 +396,21 @@ class CodeBlock(NotificationSection):
 
 
 @dataclass
+class BlockQuoteSection(NotificationSection):
+    blocks: list[NotificationTextBlock]
+    type: Literal[NotificationSectionType.BLOCK_QUOTE] = NotificationSectionType.BLOCK_QUOTE
+
+
+@dataclass
 class BoldTextBlock(NotificationTextBlock):
     text: str
     type: Literal[NotificationTextBlockType.BOLD_TEXT] = NotificationTextBlockType.BOLD_TEXT
+
+
+@dataclass
+class ItalicTextBlock(NotificationTextBlock):
+    text: str
+    type: Literal[NotificationTextBlockType.ITALIC_TEXT] = NotificationTextBlockType.ITALIC_TEXT
 
 
 @dataclass

--- a/src/sentry/testutils/notifications/platform.py
+++ b/src/sentry/testutils/notifications/platform.py
@@ -1,5 +1,11 @@
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.types import (
+    BlockQuoteSection,
+    BoldTextBlock,
+    CodeBlock,
+    CodeTextBlock,
+    ItalicTextBlock,
+    LinkTextBlock,
     NotificationCategory,
     NotificationData,
     NotificationRenderedAction,
@@ -26,8 +32,22 @@ class MockNotificationTemplate(NotificationTemplate[MockNotification]):
 
     def render(self, data: MockNotification) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
-            subject="Mock Notification",
-            body=[ParagraphBlock(blocks=[PlainTextBlock(text=data.message)])],
+            subject=[
+                PlainTextBlock(text="Alert:"),
+                ItalicTextBlock(text="Mock Notification"),
+            ],
+            body=[
+                ParagraphBlock(
+                    blocks=[
+                        PlainTextBlock(text=data.message),
+                        BoldTextBlock(text="important"),
+                        ItalicTextBlock(text="urgent"),
+                        LinkTextBlock(text="View Issue", url="https://sentry.io/issue/1"),
+                    ]
+                ),
+                CodeBlock(blocks=[PlainTextBlock(text="raise Exception('test')")]),
+                BlockQuoteSection(blocks=[PlainTextBlock(text="This is a quoted message")]),
+            ],
             actions=[
                 NotificationRenderedAction(label="Visit Sentry", link="https://www.sentry.io")
             ],
@@ -35,7 +55,10 @@ class MockNotificationTemplate(NotificationTemplate[MockNotification]):
                 url="https://raw.githubusercontent.com/knobiknows/all-the-bufo/main/all-the-bufo/bufo-pog.png",
                 alt_text="Bufo Pog",
             ),
-            footer="This is a mock footer",
+            footer=[
+                PlainTextBlock(text="Sent via"),
+                CodeTextBlock(text="sentry-alerts"),
+            ],
         )
 
 

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -328,7 +328,7 @@ class SlackIntegrationNotificationPlatformTest(TestCase):
         mock_chat_post.assert_called_once_with(
             channel="C1234567890",
             blocks=self.slack_renderable.get("blocks", []),
-            text="Mock Notification",
+            text="Alert: Mock Notification",
             attachments=None,
             unfurl_links=False,
             unfurl_media=False,

--- a/tests/sentry/notifications/platform/api/endpoints/test_internal_registered_templates.py
+++ b/tests/sentry/notifications/platform/api/endpoints/test_internal_registered_templates.py
@@ -142,10 +142,13 @@ class SerializeSlackPreviewTest(TestCase):
         assert len(blocks) >= 4  # header, body, actions, footer, image
 
         # Check header block
-        assert_header_block(blocks[0], "Mock Notification")
+        assert_header_block(blocks[0], "Alert: Mock Notification")
 
         # Check body block
-        assert_section_block(blocks[1], "This is a mock notification")
+        assert_section_block(
+            blocks[1],
+            "This is a mock notification *important* _urgent_ <https://sentry.io/issue/1|View Issue>",
+        )
 
         # Check actions block exists
         actions_block = find_block_by_type(blocks, "actions")

--- a/tests/sentry/notifications/platform/discord/test_provider.py
+++ b/tests/sentry/notifications/platform/discord/test_provider.py
@@ -75,7 +75,7 @@ class DiscordRendererTest(TestCase):
             embed["description"]
             == "\ntest **important** *urgent* [View Issue](https://sentry.io/issue/1)"
             "\n```raise Exception('test')```"
-            "\n> This is a quoted message"
+            "\n>>> This is a quoted message"
         )
         assert embed["footer"]["text"] == "Sent via sentry-alerts"
         assert (

--- a/tests/sentry/notifications/platform/discord/test_provider.py
+++ b/tests/sentry/notifications/platform/discord/test_provider.py
@@ -75,7 +75,7 @@ class DiscordRendererTest(TestCase):
             embed["description"]
             == "\ntest **important** *urgent* [View Issue](https://sentry.io/issue/1)"
             "\n```raise Exception('test')```"
-            "\n>>> This is a quoted message"
+            "\n> This is a quoted message"
         )
         assert embed["footer"]["text"] == "Sent via sentry-alerts"
         assert (

--- a/tests/sentry/notifications/platform/discord/test_provider.py
+++ b/tests/sentry/notifications/platform/discord/test_provider.py
@@ -15,13 +15,9 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.platform.discord.provider import (
     DiscordNotificationProvider,
     DiscordRenderable,
-    DiscordRenderer,
 )
 from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.types import (
-    BlockQuoteSection,
-    ItalicTextBlock,
-    LinkTextBlock,
     NotificationCategory,
     NotificationProviderKey,
     NotificationRenderedAction,
@@ -55,68 +51,6 @@ def assert_button_properties(
 
 
 class DiscordRendererTest(TestCase):
-    def test_link_text_block_rendering(self) -> None:
-        rendered_template = NotificationRenderedTemplate(
-            subject="Test Link",
-            body=[
-                ParagraphBlock(
-                    blocks=[
-                        PlainTextBlock(text="PR:"),
-                        LinkTextBlock(
-                            text="getsentry/sentry (#1234)",
-                            url="https://github.com/getsentry/sentry/pull/1234",
-                        ),
-                    ],
-                )
-            ],
-        )
-
-        data = MockNotification(message="test")
-        renderable = DiscordRenderer.render(data=data, rendered_template=rendered_template)
-
-        embed = renderable["embeds"][0]
-        assert (
-            "[getsentry/sentry (#1234)](https://github.com/getsentry/sentry/pull/1234)"
-            in embed["description"]
-        )
-
-    def test_italic_text_block_rendering(self) -> None:
-        rendered_template = NotificationRenderedTemplate(
-            subject="Test Italic",
-            body=[
-                ParagraphBlock(
-                    blocks=[
-                        PlainTextBlock(text="This is"),
-                        ItalicTextBlock(text="important"),
-                    ],
-                )
-            ],
-        )
-
-        data = MockNotification(message="test")
-        renderable = DiscordRenderer.render(data=data, rendered_template=rendered_template)
-
-        embed = renderable["embeds"][0]
-        assert "*important*" in embed["description"]
-
-    def test_block_quote_section_rendering(self) -> None:
-        rendered_template = NotificationRenderedTemplate(
-            subject="Test Quote",
-            body=[
-                BlockQuoteSection(
-                    blocks=[
-                        PlainTextBlock(text="This is a quoted message"),
-                    ],
-                )
-            ],
-        )
-
-        data = MockNotification(message="test")
-        renderable = DiscordRenderer.render(data=data, rendered_template=rendered_template)
-
-        embed = renderable["embeds"][0]
-        assert "> This is a quoted message" in embed["description"]
-
     def test_default_renderer(self) -> None:
         data = MockNotification(message="test")
         template = MockNotificationTemplate()
@@ -136,10 +70,14 @@ class DiscordRendererTest(TestCase):
         embeds = renderable["embeds"]
         assert len(embeds) == 1
         embed = embeds[0]
-        description = embed["description"]
-        assert description == "\ntest"
-        assert embed["title"] == "Mock Notification"
-        assert embed["footer"]["text"] == "This is a mock footer"
+        assert embed["title"] == "Alert: *Mock Notification*"
+        assert (
+            embed["description"]
+            == "\ntest **important** *urgent* [View Issue](https://sentry.io/issue/1)"
+            "\n```raise Exception('test')```"
+            "\n> This is a quoted message"
+        )
+        assert embed["footer"]["text"] == "Sent via sentry-alerts"
         assert (
             embed["image"]["url"]
             == "https://raw.githubusercontent.com/knobiknows/all-the-bufo/main/all-the-bufo/bufo-pog.png"

--- a/tests/sentry/notifications/platform/discord/test_provider.py
+++ b/tests/sentry/notifications/platform/discord/test_provider.py
@@ -19,6 +19,8 @@ from sentry.notifications.platform.discord.provider import (
 )
 from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.types import (
+    BlockQuoteSection,
+    ItalicTextBlock,
     LinkTextBlock,
     NotificationCategory,
     NotificationProviderKey,
@@ -77,6 +79,43 @@ class DiscordRendererTest(TestCase):
             "[getsentry/sentry (#1234)](https://github.com/getsentry/sentry/pull/1234)"
             in embed["description"]
         )
+
+    def test_italic_text_block_rendering(self) -> None:
+        rendered_template = NotificationRenderedTemplate(
+            subject="Test Italic",
+            body=[
+                ParagraphBlock(
+                    blocks=[
+                        PlainTextBlock(text="This is"),
+                        ItalicTextBlock(text="important"),
+                    ],
+                )
+            ],
+        )
+
+        data = MockNotification(message="test")
+        renderable = DiscordRenderer.render(data=data, rendered_template=rendered_template)
+
+        embed = renderable["embeds"][0]
+        assert "*important*" in embed["description"]
+
+    def test_block_quote_section_rendering(self) -> None:
+        rendered_template = NotificationRenderedTemplate(
+            subject="Test Quote",
+            body=[
+                BlockQuoteSection(
+                    blocks=[
+                        PlainTextBlock(text="This is a quoted message"),
+                    ],
+                )
+            ],
+        )
+
+        data = MockNotification(message="test")
+        renderable = DiscordRenderer.render(data=data, rendered_template=rendered_template)
+
+        embed = renderable["embeds"][0]
+        assert "> This is a quoted message" in embed["description"]
 
     def test_default_renderer(self) -> None:
         data = MockNotification(message="test")

--- a/tests/sentry/notifications/platform/email/test_provider.py
+++ b/tests/sentry/notifications/platform/email/test_provider.py
@@ -6,9 +6,7 @@ from sentry import options
 from sentry.notifications.platform.email.provider import EmailNotificationProvider, EmailRenderer
 from sentry.notifications.platform.target import GenericNotificationTarget
 from sentry.notifications.platform.types import (
-    BlockQuoteSection,
     BoldTextBlock,
-    ItalicTextBlock,
     LinkTextBlock,
     NotificationProviderKey,
     NotificationRenderedTemplate,
@@ -28,12 +26,17 @@ def validate_text_block(
     text_block: NotificationTextBlock, text_content: str, html_content: str
 ) -> None:
     if text_block.type == NotificationTextBlockType.PLAIN_TEXT:
-        assert text_block.text in text_content
         assert text_block.text in html_content
     elif text_block.type == NotificationTextBlockType.BOLD_TEXT:
-        assert f"<strong>{text_block.text}</strong>" in html_content
+        assert "<strong" in html_content
+        assert f"{text_block.text}</strong>" in html_content
     elif text_block.type == NotificationTextBlockType.CODE:
-        assert f"<code>{text_block.text}</code>" in html_content
+        assert "<code" in html_content
+        assert f"{text_block.text}</code>" in html_content
+    elif text_block.type == NotificationTextBlockType.ITALIC_TEXT:
+        assert text_block.text in html_content
+    elif text_block.type == NotificationTextBlockType.LINK:
+        assert text_block.text in html_content
 
 
 def validate_formatting_block(
@@ -49,6 +52,8 @@ def validate_formatting_block(
         assert "</pre>" in html_content
         assert "<code" in html_content
         assert "</code>" in html_content
+    elif formatting_block.type == NotificationSectionType.BLOCK_QUOTE:
+        assert "<blockquote" in html_content
 
 
 class EmailRendererTest(TestCase):
@@ -61,7 +66,7 @@ class EmailRendererTest(TestCase):
         email = EmailRenderer.render(data=self.data, rendered_template=self.rendered_template)
 
         assert isinstance(email, EmailMultiAlternatives)
-        assert email.subject == self.rendered_template.subject
+        assert email.subject == self.rendered_template.subject_text
         assert email.from_email == options.get("mail.from")
         assert len(email.to) == 0
         assert "Message-Id" in email.extra_headers
@@ -83,87 +88,21 @@ class EmailRendererTest(TestCase):
             self.rendered_template.actions[0].link,
             self.rendered_template.chart.url,
             self.rendered_template.chart.alt_text,
-            self.rendered_template.footer_text,
         ]:
             assert element in str(text_content)
             assert element in str(html_content)
+
+        # validate footer blocks individually (footer_text won't match verbatim
+        # because the renderer applies formatting like backticks for code blocks)
+        for footer_block in self.rendered_template.footer_blocks:
+            assert footer_block.text in str(text_content)
+            assert footer_block.text in str(html_content)
 
         # validate body blocks
         for block in self.rendered_template.body:
             validate_formatting_block(block, str(text_content), str(html_content))
             for text_block in block.blocks:
                 validate_text_block(text_block, str(text_content), str(html_content))
-
-    def test_link_text_block_rendering(self) -> None:
-        rendered_template = NotificationRenderedTemplate(
-            subject="Test Link",
-            body=[
-                ParagraphBlock(
-                    blocks=[
-                        PlainTextBlock(text="Check out"),
-                        LinkTextBlock(
-                            text="getsentry/sentry (#1234)",
-                            url="https://github.com/getsentry/sentry/pull/1234",
-                        ),
-                    ],
-                )
-            ],
-        )
-
-        email = EmailRenderer.render(data=self.data, rendered_template=rendered_template)
-        [html_content, _] = email.alternatives[0]
-        text_content = email.body
-
-        html_str = str(html_content)
-        assert 'href="https://github.com/getsentry/sentry/pull/1234"' in html_str
-        assert "getsentry/sentry (#1234)" in html_str
-        assert (
-            "getsentry/sentry (#1234) (https://github.com/getsentry/sentry/pull/1234)"
-            in text_content
-        )
-
-    def test_italic_text_block_rendering(self) -> None:
-        rendered_template = NotificationRenderedTemplate(
-            subject="Test Italic",
-            body=[
-                ParagraphBlock(
-                    blocks=[
-                        PlainTextBlock(text="This is"),
-                        ItalicTextBlock(text="important"),
-                    ],
-                )
-            ],
-        )
-
-        email = EmailRenderer.render(data=self.data, rendered_template=rendered_template)
-        [html_content, _] = email.alternatives[0]
-        text_content = email.body
-
-        html_str = str(html_content)
-        assert "<em" in html_str
-        assert "important</em>" in html_str
-        assert "_important_" in text_content
-
-    def test_block_quote_section_rendering(self) -> None:
-        rendered_template = NotificationRenderedTemplate(
-            subject="Test Quote",
-            body=[
-                BlockQuoteSection(
-                    blocks=[
-                        PlainTextBlock(text="This is a quoted message"),
-                    ],
-                )
-            ],
-        )
-
-        email = EmailRenderer.render(data=self.data, rendered_template=rendered_template)
-        [html_content, _] = email.alternatives[0]
-        text_content = email.body
-
-        html_str = str(html_content)
-        assert "<blockquote" in html_str
-        assert "This is a quoted message</blockquote>" in html_str
-        assert "This is a quoted message" in text_content
 
     def test_xss_protection(self) -> None:
         xss_template = NotificationRenderedTemplate(

--- a/tests/sentry/notifications/platform/email/test_provider.py
+++ b/tests/sentry/notifications/platform/email/test_provider.py
@@ -6,7 +6,9 @@ from sentry import options
 from sentry.notifications.platform.email.provider import EmailNotificationProvider, EmailRenderer
 from sentry.notifications.platform.target import GenericNotificationTarget
 from sentry.notifications.platform.types import (
+    BlockQuoteSection,
     BoldTextBlock,
+    ItalicTextBlock,
     LinkTextBlock,
     NotificationProviderKey,
     NotificationRenderedTemplate,
@@ -119,6 +121,49 @@ class EmailRendererTest(TestCase):
             "getsentry/sentry (#1234) (https://github.com/getsentry/sentry/pull/1234)"
             in text_content
         )
+
+    def test_italic_text_block_rendering(self) -> None:
+        rendered_template = NotificationRenderedTemplate(
+            subject="Test Italic",
+            body=[
+                ParagraphBlock(
+                    blocks=[
+                        PlainTextBlock(text="This is"),
+                        ItalicTextBlock(text="important"),
+                    ],
+                )
+            ],
+        )
+
+        email = EmailRenderer.render(data=self.data, rendered_template=rendered_template)
+        [html_content, _] = email.alternatives[0]
+        text_content = email.body
+
+        html_str = str(html_content)
+        assert "<em" in html_str
+        assert "important</em>" in html_str
+        assert "_important_" in text_content
+
+    def test_block_quote_section_rendering(self) -> None:
+        rendered_template = NotificationRenderedTemplate(
+            subject="Test Quote",
+            body=[
+                BlockQuoteSection(
+                    blocks=[
+                        PlainTextBlock(text="This is a quoted message"),
+                    ],
+                )
+            ],
+        )
+
+        email = EmailRenderer.render(data=self.data, rendered_template=rendered_template)
+        [html_content, _] = email.alternatives[0]
+        text_content = email.body
+
+        html_str = str(html_content)
+        assert "<blockquote" in html_str
+        assert "This is a quoted message</blockquote>" in html_str
+        assert "This is a quoted message" in text_content
 
     def test_xss_protection(self) -> None:
         xss_template = NotificationRenderedTemplate(

--- a/tests/sentry/notifications/platform/msteams/test_provider.py
+++ b/tests/sentry/notifications/platform/msteams/test_provider.py
@@ -48,7 +48,7 @@ class MSTeamsRendererTest(TestCase):
         # Verify title block
         title_block = body_blocks[0]
         assert title_block["type"] == "TextBlock"
-        assert title_block["text"] == "Alert: *Mock Notification*"
+        assert title_block["text"] == "Alert: _Mock Notification_"
         assert title_block["size"] == TextSize.LARGE
         assert title_block["weight"] == TextWeight.BOLDER
 
@@ -57,7 +57,7 @@ class MSTeamsRendererTest(TestCase):
         assert body_block_1["type"] == "TextBlock"
         assert (
             body_block_1["text"]
-            == "test **important** *urgent* [View Issue](https://sentry.io/issue/1)"
+            == "test **important** _urgent_ [View Issue](https://sentry.io/issue/1)"
         )
 
         # Verify body block 2 (CodeBlock)

--- a/tests/sentry/notifications/platform/msteams/test_provider.py
+++ b/tests/sentry/notifications/platform/msteams/test_provider.py
@@ -15,6 +15,8 @@ from sentry.notifications.platform.msteams.provider import (
 )
 from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.types import (
+    BlockQuoteSection,
+    ItalicTextBlock,
     LinkTextBlock,
     NotificationCategory,
     NotificationProviderKey,
@@ -56,6 +58,47 @@ class MSTeamsRendererTest(TestCase):
             "[getsentry/sentry (#1234)](https://github.com/getsentry/sentry/pull/1234)"
             in body_text_block["text"]
         )
+
+    def test_italic_text_block_rendering(self) -> None:
+        rendered_template = NotificationRenderedTemplate(
+            subject="Test Italic",
+            body=[
+                ParagraphBlock(
+                    blocks=[
+                        PlainTextBlock(text="This is"),
+                        ItalicTextBlock(text="important"),
+                    ],
+                )
+            ],
+        )
+
+        data = MockNotification(message="test")
+        renderable = MSTeamsRenderer.render(data=data, rendered_template=rendered_template)
+
+        body_blocks = renderable["body"]
+        body_text_block = body_blocks[1]
+        assert body_text_block["type"] == "TextBlock"
+        assert "*important*" in body_text_block["text"]
+
+    def test_block_quote_section_rendering(self) -> None:
+        rendered_template = NotificationRenderedTemplate(
+            subject="Test Quote",
+            body=[
+                BlockQuoteSection(
+                    blocks=[
+                        PlainTextBlock(text="This is a quoted message"),
+                    ],
+                )
+            ],
+        )
+
+        data = MockNotification(message="test")
+        renderable = MSTeamsRenderer.render(data=data, rendered_template=rendered_template)
+
+        body_blocks = renderable["body"]
+        body_text_block = body_blocks[1]
+        assert body_text_block["type"] == "TextBlock"
+        assert "This is a quoted message" in body_text_block["text"]
 
     def test_default_renderer(self) -> None:
         data = MockNotification(message="test")

--- a/tests/sentry/notifications/platform/msteams/test_provider.py
+++ b/tests/sentry/notifications/platform/msteams/test_provider.py
@@ -11,20 +11,14 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.platform.msteams.provider import (
     MSTeamsNotificationProvider,
     MSTeamsRenderable,
-    MSTeamsRenderer,
 )
 from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.types import (
-    BlockQuoteSection,
-    ItalicTextBlock,
-    LinkTextBlock,
     NotificationCategory,
     NotificationProviderKey,
     NotificationRenderedAction,
     NotificationRenderedTemplate,
     NotificationTargetResourceType,
-    ParagraphBlock,
-    PlainTextBlock,
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
@@ -32,74 +26,6 @@ from tests.sentry.integrations.msteams.test_message_builder import _is_open_url_
 
 
 class MSTeamsRendererTest(TestCase):
-    def test_link_text_block_rendering(self) -> None:
-        rendered_template = NotificationRenderedTemplate(
-            subject="Test Link",
-            body=[
-                ParagraphBlock(
-                    blocks=[
-                        PlainTextBlock(text="PR:"),
-                        LinkTextBlock(
-                            text="getsentry/sentry (#1234)",
-                            url="https://github.com/getsentry/sentry/pull/1234",
-                        ),
-                    ],
-                )
-            ],
-        )
-
-        data = MockNotification(message="test")
-        renderable = MSTeamsRenderer.render(data=data, rendered_template=rendered_template)
-
-        body_blocks = renderable["body"]
-        body_text_block = body_blocks[1]
-        assert body_text_block["type"] == "TextBlock"
-        assert (
-            "[getsentry/sentry (#1234)](https://github.com/getsentry/sentry/pull/1234)"
-            in body_text_block["text"]
-        )
-
-    def test_italic_text_block_rendering(self) -> None:
-        rendered_template = NotificationRenderedTemplate(
-            subject="Test Italic",
-            body=[
-                ParagraphBlock(
-                    blocks=[
-                        PlainTextBlock(text="This is"),
-                        ItalicTextBlock(text="important"),
-                    ],
-                )
-            ],
-        )
-
-        data = MockNotification(message="test")
-        renderable = MSTeamsRenderer.render(data=data, rendered_template=rendered_template)
-
-        body_blocks = renderable["body"]
-        body_text_block = body_blocks[1]
-        assert body_text_block["type"] == "TextBlock"
-        assert "*important*" in body_text_block["text"]
-
-    def test_block_quote_section_rendering(self) -> None:
-        rendered_template = NotificationRenderedTemplate(
-            subject="Test Quote",
-            body=[
-                BlockQuoteSection(
-                    blocks=[
-                        PlainTextBlock(text="This is a quoted message"),
-                    ],
-                )
-            ],
-        )
-
-        data = MockNotification(message="test")
-        renderable = MSTeamsRenderer.render(data=data, rendered_template=rendered_template)
-
-        body_blocks = renderable["body"]
-        body_text_block = body_blocks[1]
-        assert body_text_block["type"] == "TextBlock"
-        assert "This is a quoted message" in body_text_block["text"]
-
     def test_default_renderer(self) -> None:
         data = MockNotification(message="test")
         template = MockNotificationTemplate()
@@ -117,22 +43,35 @@ class MSTeamsRendererTest(TestCase):
         assert "body" in renderable
 
         body_blocks = renderable["body"]
-        assert len(body_blocks) == 5  # title, body, actions, chart, footer
+        assert len(body_blocks) == 7  # title, 3 body blocks, actions, chart, footer
 
         # Verify title block
         title_block = body_blocks[0]
         assert title_block["type"] == "TextBlock"
-        assert title_block["text"] == "Mock Notification"
+        assert title_block["text"] == "Alert: *Mock Notification*"
         assert title_block["size"] == TextSize.LARGE
         assert title_block["weight"] == TextWeight.BOLDER
 
-        # Verify body block
-        body_block = body_blocks[1]
-        assert body_block["type"] == "TextBlock"
-        assert body_block["text"] == "test"
+        # Verify body block 1 (ParagraphBlock)
+        body_block_1 = body_blocks[1]
+        assert body_block_1["type"] == "TextBlock"
+        assert (
+            body_block_1["text"]
+            == "test **important** *urgent* [View Issue](https://sentry.io/issue/1)"
+        )
+
+        # Verify body block 2 (CodeBlock)
+        body_block_2 = body_blocks[2]
+        assert body_block_2["type"] == "CodeBlock"
+        assert body_block_2["codeSnippet"] == "raise Exception('test')"
+
+        # Verify body block 3 (BlockQuoteSection)
+        body_block_3 = body_blocks[3]
+        assert body_block_3["type"] == "TextBlock"
+        assert "This is a quoted message" in body_block_3["text"]
 
         # Verify actions block
-        actions_block = body_blocks[2]
+        actions_block = body_blocks[4]
         assert actions_block["type"] == "ActionSet"
         assert len(actions_block["actions"]) == 1
         action = actions_block["actions"][0]
@@ -141,7 +80,7 @@ class MSTeamsRendererTest(TestCase):
         assert action["url"] == "https://www.sentry.io"
 
         # Verify chart image block
-        chart_block = body_blocks[3]
+        chart_block = body_blocks[5]
         assert chart_block["type"] == "Image"
         assert (
             chart_block["url"]
@@ -150,9 +89,9 @@ class MSTeamsRendererTest(TestCase):
         assert chart_block["altText"] == "Bufo Pog"
 
         # Verify footer block
-        footer_block = body_blocks[4]
+        footer_block = body_blocks[6]
         assert footer_block["type"] == "TextBlock"
-        assert footer_block["text"] == "This is a mock footer"
+        assert footer_block["text"] == "Sent via `sentry-alerts`"
         assert footer_block["size"] == TextSize.SMALL
 
     def test_renderer_without_chart(self) -> None:
@@ -174,7 +113,7 @@ class MSTeamsRendererTest(TestCase):
         renderable = renderer.render(data=data, rendered_template=rendered_template)
 
         body_blocks = renderable["body"]
-        assert len(body_blocks) == 4  # title, body, actions, footer (no chart)
+        assert len(body_blocks) == 6  # title, 3 body blocks, actions, footer (no chart)
 
         # Verify no chart block is present
         block_types = [block["type"] for block in body_blocks]
@@ -199,7 +138,7 @@ class MSTeamsRendererTest(TestCase):
         renderable = renderer.render(data=data, rendered_template=rendered_template)
 
         body_blocks = renderable["body"]
-        assert len(body_blocks) == 4  # title, body, actions, chart (no footer)
+        assert len(body_blocks) == 6  # title, 3 body blocks, actions, chart (no footer)
 
         # Verify no footer block with size="small" is present
         small_text_blocks = [
@@ -228,7 +167,7 @@ class MSTeamsRendererTest(TestCase):
         renderable = renderer.render(data=data, rendered_template=rendered_template)
 
         body_blocks = renderable["body"]
-        assert len(body_blocks) == 4  # title, body,  chart, footer
+        assert len(body_blocks) == 6  # title, 3 body blocks, chart, footer (no actions)
 
         # Verify no footer block with size="small" is present
         action_blocks = [block for block in body_blocks if block.get("type") == "ActionSet"]
@@ -266,7 +205,7 @@ class MSTeamsRendererTest(TestCase):
         renderable = renderer.render(data=data, rendered_template=rendered_template)
 
         body_blocks = renderable["body"]
-        actions_block = body_blocks[2]
+        actions_block = body_blocks[4]
         assert actions_block["type"] == "ActionSet"
         assert len(actions_block["actions"]) == 3
 

--- a/tests/sentry/notifications/platform/slack/test_provider.py
+++ b/tests/sentry/notifications/platform/slack/test_provider.py
@@ -21,7 +21,6 @@ from sentry.notifications.platform.provider import (
 from sentry.notifications.platform.slack.provider import (
     SlackNotificationProvider,
     SlackRenderable,
-    SlackRenderer,
 )
 from sentry.notifications.platform.target import (
     GenericNotificationTarget,
@@ -29,90 +28,16 @@ from sentry.notifications.platform.target import (
 )
 from sentry.notifications.platform.threading import ThreadContext, ThreadKey
 from sentry.notifications.platform.types import (
-    BlockQuoteSection,
-    ItalicTextBlock,
-    LinkTextBlock,
     NotificationCategory,
     NotificationProviderKey,
-    NotificationRenderedTemplate,
     NotificationSource,
     NotificationTargetResourceType,
-    ParagraphBlock,
-    PlainTextBlock,
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
 
 
 class SlackRendererTest(TestCase):
-    def test_link_text_block_rendering(self) -> None:
-        rendered_template = NotificationRenderedTemplate(
-            subject="Test Link",
-            body=[
-                ParagraphBlock(
-                    blocks=[
-                        PlainTextBlock(text="PR:"),
-                        LinkTextBlock(
-                            text="getsentry/sentry (#1234)",
-                            url="https://github.com/getsentry/sentry/pull/1234",
-                        ),
-                    ],
-                )
-            ],
-        )
-
-        renderable = SlackRenderer.render(
-            data=MockNotification(message="test"), rendered_template=rendered_template
-        )
-        body_block = renderable["blocks"][1]
-        assert isinstance(body_block, SectionBlock)
-        assert body_block.text is not None
-        assert (
-            "<https://github.com/getsentry/sentry/pull/1234|getsentry/sentry (#1234)>"
-            in body_block.text.text
-        )
-
-    def test_italic_text_block_rendering(self) -> None:
-        rendered_template = NotificationRenderedTemplate(
-            subject="Test Italic",
-            body=[
-                ParagraphBlock(
-                    blocks=[
-                        PlainTextBlock(text="This is"),
-                        ItalicTextBlock(text="important"),
-                    ],
-                )
-            ],
-        )
-
-        renderable = SlackRenderer.render(
-            data=MockNotification(message="test"), rendered_template=rendered_template
-        )
-        body_block = renderable["blocks"][1]
-        assert isinstance(body_block, SectionBlock)
-        assert body_block.text is not None
-        assert "_important_" in body_block.text.text
-
-    def test_block_quote_section_rendering(self) -> None:
-        rendered_template = NotificationRenderedTemplate(
-            subject="Test Quote",
-            body=[
-                BlockQuoteSection(
-                    blocks=[
-                        PlainTextBlock(text="This is a quoted message"),
-                    ],
-                )
-            ],
-        )
-
-        renderable = SlackRenderer.render(
-            data=MockNotification(message="test"), rendered_template=rendered_template
-        )
-        body_block = renderable["blocks"][1]
-        assert isinstance(body_block, SectionBlock)
-        assert body_block.text is not None
-        assert ">This is a quoted message" in body_block.text.text
-
     def test_default_renderer(self) -> None:
         data = MockNotification(message="test")
         template = MockNotificationTemplate()
@@ -125,8 +50,22 @@ class SlackRendererTest(TestCase):
         rendererable_dict = [block.to_dict() for block in rendererable.get("blocks", [])]
 
         assert rendererable_dict == [
-            {"text": {"text": "Mock Notification", "type": "plain_text"}, "type": "header"},
-            {"text": {"text": "test", "type": "mrkdwn"}, "type": "section"},
+            {"text": {"text": "Alert: Mock Notification", "type": "plain_text"}, "type": "header"},
+            {
+                "text": {
+                    "text": "test *important* _urgent_ <https://sentry.io/issue/1|View Issue>",
+                    "type": "mrkdwn",
+                },
+                "type": "section",
+            },
+            {
+                "text": {"text": "```raise Exception('test')```", "type": "mrkdwn"},
+                "type": "section",
+            },
+            {
+                "text": {"text": ">This is a quoted message", "type": "mrkdwn"},
+                "type": "section",
+            },
             {
                 "elements": [
                     {
@@ -144,7 +83,7 @@ class SlackRendererTest(TestCase):
                 "type": "image",
             },
             {
-                "elements": [{"text": "This is a mock footer", "type": "mrkdwn"}],
+                "elements": [{"text": "Sent via `sentry-alerts`", "type": "mrkdwn"}],
                 "type": "context",
             },
         ]

--- a/tests/sentry/notifications/platform/slack/test_provider.py
+++ b/tests/sentry/notifications/platform/slack/test_provider.py
@@ -29,6 +29,8 @@ from sentry.notifications.platform.target import (
 )
 from sentry.notifications.platform.threading import ThreadContext, ThreadKey
 from sentry.notifications.platform.types import (
+    BlockQuoteSection,
+    ItalicTextBlock,
     LinkTextBlock,
     NotificationCategory,
     NotificationProviderKey,
@@ -69,6 +71,47 @@ class SlackRendererTest(TestCase):
             "<https://github.com/getsentry/sentry/pull/1234|getsentry/sentry (#1234)>"
             in body_block.text.text
         )
+
+    def test_italic_text_block_rendering(self) -> None:
+        rendered_template = NotificationRenderedTemplate(
+            subject="Test Italic",
+            body=[
+                ParagraphBlock(
+                    blocks=[
+                        PlainTextBlock(text="This is"),
+                        ItalicTextBlock(text="important"),
+                    ],
+                )
+            ],
+        )
+
+        renderable = SlackRenderer.render(
+            data=MockNotification(message="test"), rendered_template=rendered_template
+        )
+        body_block = renderable["blocks"][1]
+        assert isinstance(body_block, SectionBlock)
+        assert body_block.text is not None
+        assert "_important_" in body_block.text.text
+
+    def test_block_quote_section_rendering(self) -> None:
+        rendered_template = NotificationRenderedTemplate(
+            subject="Test Quote",
+            body=[
+                BlockQuoteSection(
+                    blocks=[
+                        PlainTextBlock(text="This is a quoted message"),
+                    ],
+                )
+            ],
+        )
+
+        renderable = SlackRenderer.render(
+            data=MockNotification(message="test"), rendered_template=rendered_template
+        )
+        body_block = renderable["blocks"][1]
+        assert isinstance(body_block, SectionBlock)
+        assert body_block.text is not None
+        assert ">This is a quoted message" in body_block.text.text
 
     def test_default_renderer(self) -> None:
         data = MockNotification(message="test")


### PR DESCRIPTION
 Allows block quotes and italics. Italics feel like they'd be nice to have, but I really wanted the block quotes for showing what Seer RCA and Plans have in their contents. Using the codeblock didn't look exactly right.

There's no formatting for blockquote in email, but it does appear in the HTML:
<img width="558" height="86" alt="image" src="https://github.com/user-attachments/assets/eed01f13-03b1-4600-a683-5015f051ba62" />


For Discord and Slack, they appear as expected
<img width="620" height="149" alt="image" src="https://github.com/user-attachments/assets/6b47ab67-0152-4391-b37d-9cacba58d36c" />
<img width="555" height="156" alt="image" src="https://github.com/user-attachments/assets/761bb26b-2385-4066-b227-40d4eac92cd8" />
