### PR TITLE
feat(ourlogs): add specialized exports for aggregates

### DIFF
--- a/static/app/components/exports/dataExport.tsx
+++ b/static/app/components/exports/dataExport.tsx
@@ -8,11 +8,10 @@ import {
   type DataExportPayload,
 } from 'sentry/components/exports/useDataExport';
 import {t} from 'sentry/locale';
-import type {OurLogFieldKey} from 'sentry/views/explore/logs/types';
 
 export interface LogsQueryInfo {
   dataset: 'logs';
-  field: OurLogFieldKey[];
+  field: string[];
   project: number[];
   query: string;
   sort: string[];

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -15,6 +15,8 @@ export const LogAttributesHumanLabel: Partial<Record<OurLogFieldKey, string>> = 
 
 export const MAX_LOG_INGEST_DELAY = 40_000;
 export const QUERY_PAGE_LIMIT = 1000; // If this does not equal the limit with auto-refresh, the query keys will diverge and they will have separate caches. We may want to make this change in the future.
+/** Matches the OurLogs `max_per_page` cap on the events endpoint (organization_events.py). */
+export const AGGREGATE_EXPORT_MAX_ROWS = 9999;
 export const QUERY_PAGE_LIMIT_WITH_AUTO_REFRESH = 1000;
 export const LOG_ATTRIBUTE_LAZY_LOAD_HOVER_TIMEOUT = 150;
 export const DEFAULT_TRACE_ITEM_HOVER_TIMEOUT = 150;

--- a/static/app/views/explore/logs/exports/downloadLogs.ts
+++ b/static/app/views/explore/logs/exports/downloadLogs.ts
@@ -1,13 +1,18 @@
 import {downloadAsJsonl} from 'sentry/components/exports/downloadAsJsonl';
 import type {DataExportFormat} from 'sentry/components/exports/useDataExport';
 import {downloadLogsAsCsv} from 'sentry/views/explore/logs/exports/downloadLogsAsCsv';
-import type {OurLogFieldKey, OurLogsResponseItem} from 'sentry/views/explore/logs/types';
+import type {
+  OurLogsAggregateResponseItem,
+  OurLogsResponseItem,
+} from 'sentry/views/explore/logs/types';
+
+export type ExportableLogRow = OurLogsResponseItem | OurLogsAggregateResponseItem;
 
 interface DownloadLogsOptions {
-  fields: OurLogFieldKey[];
+  fields: string[];
   filename: string;
   format: DataExportFormat;
-  rows: OurLogsResponseItem[];
+  rows: ExportableLogRow[];
 }
 
 export function downloadLogs({fields, filename, format, rows}: DownloadLogsOptions) {

--- a/static/app/views/explore/logs/exports/downloadLogsAsCsv.ts
+++ b/static/app/views/explore/logs/exports/downloadLogsAsCsv.ts
@@ -2,7 +2,7 @@ import Papa from 'papaparse';
 
 import {createExportFilename} from 'sentry/components/exports/createExportFilename';
 import {downloadFromHref} from 'sentry/utils/downloadFromHref';
-import type {OurLogFieldKey, OurLogsResponseItem} from 'sentry/views/explore/logs/types';
+import type {ExportableLogRow} from 'sentry/views/explore/logs/exports/downloadLogs';
 
 function disableMacros(value: string | null | boolean | number | undefined) {
   if (
@@ -18,8 +18,8 @@ function disableMacros(value: string | null | boolean | number | undefined) {
 }
 
 export function downloadLogsAsCsv(
-  rows: OurLogsResponseItem[],
-  fields: OurLogFieldKey[],
+  rows: ExportableLogRow[],
+  fields: string[],
   filename: string
 ) {
   const headings = fields.map(field => field);
@@ -27,9 +27,9 @@ export function downloadLogsAsCsv(
 
   const csvContent = Papa.unparse({
     fields: headings,
-    data: rows.map((row: OurLogsResponseItem) =>
-      keys.map((key: OurLogFieldKey) => {
-        return disableMacros(row[key]);
+    data: rows.map(row =>
+      keys.map(key => {
+        return disableMacros((row as Record<string, string | number>)[key]);
       })
     ),
   });

--- a/static/app/views/explore/logs/exports/logsAggregateExportModalButton.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsAggregateExportModalButton.spec.tsx
@@ -1,0 +1,125 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import {
+  LOGS_AGGREGATE_FN_KEY,
+  LOGS_AGGREGATE_PARAM_KEY,
+  LOGS_FIELDS_KEY,
+  LOGS_GROUP_BY_KEY,
+  LOGS_QUERY_KEY,
+} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LOGS_AGGREGATE_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
+import {LogsAggregateExportModalButton} from 'sentry/views/explore/logs/exports/logsAggregateExportModalButton';
+import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
+import type {OurLogsAggregateResponseItem} from 'sentry/views/explore/logs/types';
+
+const mockDownloadFromHref = jest.fn();
+jest.mock('sentry/utils/downloadFromHref', () => ({
+  downloadFromHref: (...args: unknown[]) => mockDownloadFromHref(...args),
+}));
+
+const aggregateRow = (template: string, value: number) =>
+  ({
+    'message.template': template,
+    'p99(severity_number)': value,
+  }) as OurLogsAggregateResponseItem;
+
+describe('LogsAggregateExportModalButton', () => {
+  const {organization, project} = initializeOrg({
+    organization: {features: ['ourlogs-enabled']},
+  });
+
+  const tableData = [aggregateRow('one', 17), aggregateRow('two', 13)];
+
+  const nextPageLink =
+    '<https://sentry.io/api/0/?cursor=0:100:0>; rel="next"; results="true"; cursor="0:100:0"';
+
+  ProjectsStore.loadInitialData([project]);
+  PageFiltersStore.init();
+  PageFiltersStore.onInitializeUrlState({
+    projects: [parseInt(project.id, 10)],
+    environments: [],
+    datetime: {period: '14d', start: null, end: null, utc: null},
+  });
+
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/explore/logs/`,
+      query: {
+        project: project.id,
+        [LOGS_AGGREGATE_SORT_BYS_KEY]: '-p99(severity_number)',
+        [LOGS_QUERY_KEY]: '',
+        [LOGS_GROUP_BY_KEY]: 'message.template',
+        [LOGS_AGGREGATE_FN_KEY]: 'p99',
+        [LOGS_AGGREGATE_PARAM_KEY]: 'severity_number',
+        [LOGS_FIELDS_KEY]: ['timestamp', 'message'],
+      },
+    },
+    route: '/organizations/:orgId/explore/logs/',
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+  });
+
+  function renderButton(pageLinks?: string) {
+    render(
+      <LogsQueryParamsProvider
+        analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+        source="location"
+      >
+        <LogsAggregateExportModalButton
+          error={null}
+          isLoading={false}
+          pageLinks={pageLinks}
+          tableData={tableData}
+        />
+      </LogsQueryParamsProvider>,
+      {initialRouterConfig}
+    );
+    renderGlobalModal();
+  }
+
+  it('downloads locally without a server export when all rows are loaded', async () => {
+    const exportRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/data-export/`,
+      method: 'POST',
+      body: {},
+    });
+
+    renderButton();
+    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+
+    await waitFor(() => {
+      expect(mockDownloadFromHref).toHaveBeenCalled();
+    });
+    expect(exportRequest).not.toHaveBeenCalled();
+  });
+
+  it('routes through the server export when more rows remain on the next page', async () => {
+    const exportRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/data-export/`,
+      method: 'POST',
+      body: {},
+    });
+
+    renderButton(nextPageLink);
+    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+
+    await waitFor(() => {
+      expect(exportRequest).toHaveBeenCalled();
+    });
+  });
+});

--- a/static/app/views/explore/logs/exports/logsAggregateExportModalButton.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsAggregateExportModalButton.spec.tsx
@@ -43,6 +43,10 @@ describe('LogsAggregateExportModalButton', () => {
   const nextPageLink =
     '<https://sentry.io/api/0/?cursor=0:100:0>; rel="next"; results="true"; cursor="0:100:0"';
 
+  const lastPageLinks =
+    '<https://sentry.io/api/0/?cursor=0:0:1>; rel="previous"; results="true"; cursor="0:0:1", ' +
+    '<https://sentry.io/api/0/?cursor=0:200:0>; rel="next"; results="false"; cursor="0:200:0"';
+
   ProjectsStore.loadInitialData([project]);
   PageFiltersStore.init();
   PageFiltersStore.onInitializeUrlState({
@@ -115,6 +119,22 @@ describe('LogsAggregateExportModalButton', () => {
     });
 
     renderButton(nextPageLink);
+    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+
+    await waitFor(() => {
+      expect(exportRequest).toHaveBeenCalled();
+    });
+  });
+
+  it('routes through the server export on the last page of a paginated result', async () => {
+    const exportRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/data-export/`,
+      method: 'POST',
+      body: {},
+    });
+
+    renderButton(lastPageLinks);
     await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
     await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
 

--- a/static/app/views/explore/logs/exports/logsAggregateExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsAggregateExportModalButton.tsx
@@ -1,0 +1,46 @@
+import {t} from 'sentry/locale';
+import {AGGREGATE_EXPORT_MAX_ROWS} from 'sentry/views/explore/logs/constants';
+import {
+  formatExportSort,
+  LogsExportModalButton,
+  useLogsQueryInfo,
+} from 'sentry/views/explore/logs/exports/logsExportModalButton';
+import type {OurLogsAggregateResponseItem} from 'sentry/views/explore/logs/types';
+import {
+  useQueryParamsAggregateSortBys,
+  useQueryParamsGroupBys,
+  useQueryParamsVisualizes,
+} from 'sentry/views/explore/queryParams/context';
+
+type LogsAggregateExportModalButtonProps = {
+  isLoading: boolean;
+  tableData: OurLogsAggregateResponseItem[];
+  error?: Error | null;
+};
+
+export function LogsAggregateExportModalButton({
+  error,
+  isLoading,
+  tableData,
+}: LogsAggregateExportModalButtonProps) {
+  const groupBys = useQueryParamsGroupBys();
+  const visualizes = useQueryParamsVisualizes();
+  const aggregateSortBys = useQueryParamsAggregateSortBys();
+
+  const queryInfo = useLogsQueryInfo({
+    field: [...groupBys.filter(Boolean), ...visualizes.map(visualize => visualize.yAxis)],
+    sort: aggregateSortBys.map(formatExportSort),
+  });
+
+  return (
+    <LogsExportModalButton
+      error={error}
+      estimatedRowCount={AGGREGATE_EXPORT_MAX_ROWS}
+      isLoading={isLoading}
+      queryInfo={queryInfo}
+      supportsAllColumns={false}
+      tableData={tableData}
+      title={t('Log Aggregates Export')}
+    />
+  );
+}

--- a/static/app/views/explore/logs/exports/logsAggregateExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsAggregateExportModalButton.tsx
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
 import {AGGREGATE_EXPORT_MAX_ROWS} from 'sentry/views/explore/logs/constants';
 import {
   formatExportSort,
@@ -16,11 +17,13 @@ type LogsAggregateExportModalButtonProps = {
   isLoading: boolean;
   tableData: OurLogsAggregateResponseItem[];
   error?: Error | null;
+  pageLinks?: string | null;
 };
 
 export function LogsAggregateExportModalButton({
   error,
   isLoading,
+  pageLinks,
   tableData,
 }: LogsAggregateExportModalButtonProps) {
   const groupBys = useQueryParamsGroupBys();
@@ -32,10 +35,15 @@ export function LogsAggregateExportModalButton({
     sort: aggregateSortBys.map(formatExportSort),
   });
 
+  // When there's no further page, the loaded rows are the entire result set, so the
+  // export can run locally in the browser. Otherwise fall back to the server-side cap.
+  const hasNextPage = parseLinkHeader(pageLinks ?? null).next?.results === true;
+  const estimatedRowCount = hasNextPage ? AGGREGATE_EXPORT_MAX_ROWS : tableData.length;
+
   return (
     <LogsExportModalButton
       error={error}
-      estimatedRowCount={AGGREGATE_EXPORT_MAX_ROWS}
+      estimatedRowCount={estimatedRowCount}
       isLoading={isLoading}
       queryInfo={queryInfo}
       supportsAllColumns={false}

--- a/static/app/views/explore/logs/exports/logsAggregateExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsAggregateExportModalButton.tsx
@@ -35,10 +35,13 @@ export function LogsAggregateExportModalButton({
     sort: aggregateSortBys.map(formatExportSort),
   });
 
-  // When there's no further page, the loaded rows are the entire result set, so the
-  // export can run locally in the browser. Otherwise fall back to the server-side cap.
-  const hasNextPage = parseLinkHeader(pageLinks ?? null).next?.results === true;
-  const estimatedRowCount = hasNextPage ? AGGREGATE_EXPORT_MAX_ROWS : tableData.length;
+  // Only when there's neither a next nor a previous page are the loaded rows the entire
+  // result set, letting the export run locally in the browser. On any page of a paginated
+  // result (including the last) fall back to the server-side cap so the full export stays
+  // available.
+  const links = parseLinkHeader(pageLinks ?? null);
+  const isSinglePage = links.next?.results !== true && links.previous?.results !== true;
+  const estimatedRowCount = isSinglePage ? tableData.length : AGGREGATE_EXPORT_MAX_ROWS;
 
   return (
     <LogsExportModalButton

--- a/static/app/views/explore/logs/exports/logsAggregateExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsAggregateExportModalButton.tsx
@@ -7,6 +7,7 @@ import {
   useLogsQueryInfo,
 } from 'sentry/views/explore/logs/exports/logsExportModalButton';
 import type {OurLogsAggregateResponseItem} from 'sentry/views/explore/logs/types';
+import {getLogsAggregatesFields} from 'sentry/views/explore/logs/useLogsAggregatesTable';
 import {
   useQueryParamsAggregateSortBys,
   useQueryParamsGroupBys,
@@ -31,7 +32,7 @@ export function LogsAggregateExportModalButton({
   const aggregateSortBys = useQueryParamsAggregateSortBys();
 
   const queryInfo = useLogsQueryInfo({
-    field: [...groupBys.filter(Boolean), ...visualizes.map(visualize => visualize.yAxis)],
+    field: getLogsAggregatesFields(groupBys, visualizes),
     sort: aggregateSortBys.map(formatExportSort),
   });
 

--- a/static/app/views/explore/logs/exports/logsDirectExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsDirectExportModalButton.tsx
@@ -1,0 +1,45 @@
+import {t} from 'sentry/locale';
+import {
+  formatExportSort,
+  LogsExportModalButton,
+  useLogsQueryInfo,
+} from 'sentry/views/explore/logs/exports/logsExportModalButton';
+import {useLogsExportEstimatedRowCount} from 'sentry/views/explore/logs/exports/useLogsExportEstimatedRowCount';
+import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
+import {
+  useQueryParamsFields,
+  useQueryParamsSortBys,
+} from 'sentry/views/explore/queryParams/context';
+
+type LogsDirectExportModalButtonProps = {
+  isLoading: boolean;
+  tableData: OurLogsResponseItem[];
+  error?: Error | null;
+};
+
+export function LogsDirectExportModalButton({
+  error,
+  isLoading,
+  tableData,
+}: LogsDirectExportModalButtonProps) {
+  const fields = useQueryParamsFields();
+  const sortBys = useQueryParamsSortBys();
+
+  const queryInfo = useLogsQueryInfo({
+    field: [...fields],
+    sort: sortBys.map(formatExportSort),
+  });
+  const estimatedRowCount = useLogsExportEstimatedRowCount(tableData.length);
+
+  return (
+    <LogsExportModalButton
+      error={error}
+      estimatedRowCount={estimatedRowCount}
+      isLoading={isLoading}
+      queryInfo={queryInfo}
+      supportsAllColumns
+      tableData={tableData}
+      title={t('Logs Export')}
+    />
+  );
+}

--- a/static/app/views/explore/logs/exports/logsExportModalButton.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModalButton.spec.tsx
@@ -9,9 +9,8 @@ import {
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
-import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import type {LogsQueryInfo} from 'sentry/components/exports/dataExport';
 import {LogsExportModalButton} from 'sentry/views/explore/logs/exports/logsExportModalButton';
-import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 
 const mockTrackAnalytics = jest.fn();
@@ -31,25 +30,30 @@ describe('LogsExportModalButton', () => {
     }),
   ];
 
+  const queryInfo: LogsQueryInfo = {
+    dataset: 'logs',
+    field: ['message'],
+    project: [1],
+    query: '',
+    sort: ['-timestamp'],
+  };
+
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     jest.clearAllMocks();
-    // The export modal estimates row counts from a timeseries query.
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events-timeseries/`,
-      method: 'GET',
-      body: {timeSeries: []},
-    });
   });
 
   async function renderAndOpen() {
     render(
-      <LogsQueryParamsProvider
-        analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
-        source="location"
-      >
-        <LogsExportModalButton error={null} isLoading={false} tableData={tableData} />
-      </LogsQueryParamsProvider>,
+      <LogsExportModalButton
+        error={null}
+        estimatedRowCount={100}
+        isLoading={false}
+        queryInfo={queryInfo}
+        supportsAllColumns
+        tableData={tableData}
+        title="Logs Export"
+      />,
       {organization}
     );
     renderGlobalModal();

--- a/static/app/views/explore/logs/exports/logsExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModalButton.tsx
@@ -1,42 +1,51 @@
 import {type LogsQueryInfo} from 'sentry/components/exports/dataExport';
 import {ExportQueryType} from 'sentry/components/exports/useDataExport';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {ExploreExportModalButton} from 'sentry/views/explore/components/exports/exploreExportModalButton';
 import {trackExploreTableExported} from 'sentry/views/explore/components/exports/trackExploreTableExported';
 import type {ExploreExportConfig} from 'sentry/views/explore/components/exports/types';
 import {downloadLogs} from 'sentry/views/explore/logs/exports/downloadLogs';
-import {useLogsExportEstimatedRowCount} from 'sentry/views/explore/logs/exports/useLogsExportEstimatedRowCount';
-import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
-import {
-  useQueryParamsFields,
-  useQueryParamsSearch,
-  useQueryParamsSortBys,
-} from 'sentry/views/explore/queryParams/context';
+import type {
+  OurLogsAggregateResponseItem,
+  OurLogsResponseItem,
+} from 'sentry/views/explore/logs/types';
+import {useQueryParamsSearch} from 'sentry/views/explore/queryParams/context';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 type LogsExportModalButtonProps = {
+  estimatedRowCount: number;
   isLoading: boolean;
-  tableData: OurLogsResponseItem[];
+  queryInfo: LogsQueryInfo;
+  supportsAllColumns: boolean;
+  tableData: Array<OurLogsResponseItem | OurLogsAggregateResponseItem>;
+  title: string;
   error?: Error | null;
 };
 
-function useLogsQueryInfo(): LogsQueryInfo {
+export function formatExportSort(sort: {field: string; kind: 'asc' | 'desc'}) {
+  return `${sort.kind === 'desc' ? '-' : ''}${sort.field}`;
+}
+
+export function useLogsQueryInfo({
+  field,
+  sort,
+}: {
+  field: string[];
+  sort: string[];
+}): LogsQueryInfo {
   const {selection} = usePageFilters();
   const logsSearch = useQueryParamsSearch();
-  const fields = useQueryParamsFields();
-  const sortBys = useQueryParamsSortBys();
   const {start, end, period: statsPeriod} = selection.datetime;
   const {environments, projects} = selection;
 
   return {
     dataset: 'logs',
-    field: [...fields],
+    field,
     query: logsSearch.formatString(),
     project: projects,
-    sort: sortBys.map(sort => `${sort.kind === 'desc' ? '-' : ''}${sort.field}`),
+    sort,
     start: start ? new Date(start).toISOString() : undefined,
     end: end ? new Date(end).toISOString() : undefined,
     statsPeriod: statsPeriod || undefined,
@@ -46,21 +55,23 @@ function useLogsQueryInfo(): LogsQueryInfo {
 
 export function LogsExportModalButton({
   error,
+  estimatedRowCount,
   isLoading,
+  queryInfo,
+  supportsAllColumns,
   tableData,
+  title,
 }: LogsExportModalButtonProps) {
   const organization = useOrganization();
-  const queryInfo = useLogsQueryInfo();
-  const estimatedRowCount = useLogsExportEstimatedRowCount(tableData.length);
 
   const filenameBase = 'logs';
 
   const config: ExploreExportConfig = {
-    title: t('Logs Export'),
+    title,
     filenameBase,
     queryInfo: {...queryInfo, dataset: TraceItemDataset.LOGS},
     asyncQueryType: ExportQueryType.EXPLORE,
-    supportsAllColumns: true,
+    supportsAllColumns,
     availableFormats: ['csv', 'jsonl'],
     estimatedRowCount,
     localRowCount: tableData.length,

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -451,6 +451,7 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
                   isLoading={aggregatesTableResult.isPending}
                   tableData={aggregatesTableResult.data?.data ?? []}
                   error={aggregatesTableResult.error}
+                  pageLinks={aggregatesTableResult.pageLinks}
                 />
               ) : (
                 <LogsDirectExportModalButton

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -51,7 +51,8 @@ import {
   HiddenColumnEditorLogFields,
   HiddenLogSearchFields,
 } from 'sentry/views/explore/logs/constants';
-import {LogsExportModalButton} from 'sentry/views/explore/logs/exports/logsExportModalButton';
+import {LogsAggregateExportModalButton} from 'sentry/views/explore/logs/exports/logsAggregateExportModalButton';
+import {LogsDirectExportModalButton} from 'sentry/views/explore/logs/exports/logsDirectExportModalButton';
 import {AutorefreshToggle} from 'sentry/views/explore/logs/logsAutoRefresh';
 import {LogsDownSamplingAlert} from 'sentry/views/explore/logs/logsDownsamplingAlert';
 import {LogsGraph} from 'sentry/views/explore/logs/logsGraph';
@@ -445,11 +446,19 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
               >
                 {sidebarOpen ? null : t('Advanced')}
               </LogsSidebarCollapseButton>
-              <LogsExportModalButton
-                isLoading={tableData.isPending}
-                tableData={tableData.data}
-                error={tableData.error}
-              />
+              {mode === Mode.AGGREGATE ? (
+                <LogsAggregateExportModalButton
+                  isLoading={aggregatesTableResult.isPending}
+                  tableData={aggregatesTableResult.data?.data ?? []}
+                  error={aggregatesTableResult.error}
+                />
+              ) : (
+                <LogsDirectExportModalButton
+                  isLoading={tableData.isPending}
+                  tableData={tableData.data}
+                  error={tableData.error}
+                />
+              )}
             </OverChartButtonGroup>
             <QuotaExceededAlert referrer="logs-explore" traceItemDataset="logs" />
             <LogsDownSamplingAlert

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -119,7 +119,7 @@ export type OurLogsAggregate =
   | AggregationKey.MAX;
 
 type OurLogsAggregateKeys = `${OurLogsAggregate}(${OurLogFieldKey})`;
-type OurLogsAggregateResponseItem = Record<
+export type OurLogsAggregateResponseItem = Record<
   keyof OurLogsResponseItem | OurLogsAggregateKeys,
   string | number
 >;

--- a/static/app/views/explore/logs/useLogsAggregatesTable.tsx
+++ b/static/app/views/explore/logs/useLogsAggregatesTable.tsx
@@ -24,6 +24,7 @@ import {
   useQueryParamsSearch,
   useQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
+import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
 import {getEventView} from 'sentry/views/insights/common/queries/useDiscover';
 import {getStaleTimeForEventView} from 'sentry/views/insights/common/queries/useSpansQuery';
 
@@ -35,6 +36,13 @@ interface UseLogsAggregatesTableOptions {
 }
 
 export type LogsAggregatesTableResult = ReturnType<typeof useLogsAggregatesTable>;
+
+export function getLogsAggregatesFields(
+  groupBys: readonly string[],
+  visualizes: readonly Visualize[]
+): string[] {
+  return [...groupBys.filter(Boolean), ...visualizes.map(visualize => visualize.yAxis)];
+}
 
 export function useLogsAggregatesTable({
   enabled,
@@ -124,11 +132,7 @@ function useLogsAggregatesApiOptions({
   const aggregateSortBys = useQueryParamsAggregateSortBys();
   const aggregateCursor = useQueryParamsAggregateCursor();
   const [caseInsensitive] = useCaseInsensitivity();
-  const fields: string[] = [];
-  fields.push(
-    ...groupBys.filter(Boolean),
-    ...visualizes.map(visualize => visualize.yAxis)
-  );
+  const fields = getLogsAggregatesFields(groupBys, visualizes);
 
   const search = baseSearch ? _search.copy() : _search;
   if (baseSearch) {


### PR DESCRIPTION
Right now, asking to export logs always goes through the same standard logs exports flow. Even if you're viewing aggregates. Which is confusing to users who're trying to export aggregates, not the logs themselves (table mode).

This adds a specific export modal flow for log aggregates that's separate from the logs. The `LogsExportModalButton` component now takes in a few more props from two code paths:

* `LogsDirectExportModalButton` (table mode): the existing flow
* `LogsAggregateExportModalButton` (aggregate mode): builds `queryInfo` from group-bys + visualized y-axes and aggregate sorts, and cap rows at `AGGREGATE_EXPORT_MAX_ROWS` (9999) to match the events endpoint's `max_per_page`.

<img width="622" height="438" alt="image" src="https://github.com/user-attachments/assets/4fc724cf-65ca-4319-bf2a-3dc207d46cef" />

Previously stacked on #117949. ✅ 

Closes LOGS-900.