### PR TITLE
fix(jira): Prevent algorithm-confusion attack

### DIFF
--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -1,6 +1,12 @@
 import sentry_sdk
 from django.db import router, transaction
-from jwt import DecodeError, ExpiredSignatureError, InvalidKeyError, InvalidSignatureError
+from jwt import (
+    DecodeError,
+    ExpiredSignatureError,
+    InvalidAlgorithmError,
+    InvalidKeyError,
+    InvalidSignatureError,
+)
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -83,6 +89,11 @@ class JiraSentryInstalledWebhook(JiraWebhookBase):
                 lifecycle.record_halt(halt_reason="JWT contained invalid signature")
                 return self.respond(
                     {"detail": "Invalid signature"}, status=status.HTTP_400_BAD_REQUEST
+                )
+            except InvalidAlgorithmError:
+                lifecycle.record_halt(halt_reason="JWT signed with unexpected algorithm")
+                return self.respond(
+                    {"detail": "Invalid algorithm"}, status=status.HTTP_400_BAD_REQUEST
                 )
             except DecodeError:
                 lifecycle.record_halt(halt_reason="Could not decode JWT token")

--- a/src/sentry/integrations/utils/atlassian_connect.py
+++ b/src/sentry/integrations/utils/atlassian_connect.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping, Sequence
 
 import requests
 from django.http import HttpRequest
-from jwt import ExpiredSignatureError, InvalidSignatureError
+from jwt import ExpiredSignatureError, InvalidAlgorithmError, InvalidSignatureError
 
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
@@ -108,6 +108,8 @@ def get_integration_from_jwt(
         raise AtlassianConnectValidationError("Signature is invalid") from e
     except ExpiredSignatureError as e:
         raise AtlassianConnectValidationError("Signature is expired") from e
+    except InvalidAlgorithmError as e:
+        raise AtlassianConnectValidationError("Algorithm is invalid") from e
 
     verify_claims(decoded_claims, path, query_params, method)
 

--- a/src/sentry/integrations/utils/atlassian_connect.py
+++ b/src/sentry/integrations/utils/atlassian_connect.py
@@ -95,7 +95,15 @@ def get_integration_from_jwt(
         raise AtlassianConnectValidationError("Invalid algorithm in JWT header")
 
     try:
-        decoded_claims = jwt.decode(token, integration.metadata["shared_secret"], audience=False)
+        # We only authenticate asymmetrically (through the CDN) if the event provides a key ID
+        # in its JWT headers. This should only appear for install/uninstall events.
+        # authenticate_asymmetric_jwt hardcodes algorithms=["RS256"], so the algorithm-confusion
+        # attack (forcing an asymmetric public key to be used as an HMAC secret) is not possible.
+        decoded_claims = (
+            authenticate_asymmetric_jwt(token, key_id)
+            if key_id
+            else jwt.decode(token, integration.metadata["shared_secret"], audience=False)
+        )
     except InvalidSignatureError as e:
         raise AtlassianConnectValidationError("Signature is invalid") from e
     except ExpiredSignatureError as e:

--- a/src/sentry/integrations/utils/atlassian_connect.py
+++ b/src/sentry/integrations/utils/atlassian_connect.py
@@ -95,14 +95,7 @@ def get_integration_from_jwt(
         raise AtlassianConnectValidationError("Invalid algorithm in JWT header")
 
     try:
-        # We only authenticate asymmetrically (through the CDN) if the event provides a key ID
-        # in its JWT headers. This should only appear for install/uninstall events.
-
-        decoded_claims = (
-            authenticate_asymmetric_jwt(token, key_id)
-            if key_id
-            else jwt.decode(token, integration.metadata["shared_secret"], audience=False)
-        )
+        decoded_claims = jwt.decode(token, integration.metadata["shared_secret"], audience=False)
     except InvalidSignatureError as e:
         raise AtlassianConnectValidationError("Signature is invalid") from e
     except ExpiredSignatureError as e:
@@ -133,12 +126,9 @@ def authenticate_asymmetric_jwt(token: str | None, key_id: str) -> dict[str, str
     """
     if token is None:
         raise AtlassianConnectValidationError("No token parameter")
-    headers = jwt.peek_header(token)
     key_response = requests.get(f"https://connect-install-keys.atlassian.com/{key_id}")
     public_key = key_response.content.decode("utf-8").strip()
-    decoded_claims = jwt.decode(
-        token, public_key, audience=absolute_uri(), algorithms=[headers.get("alg")]
-    )
+    decoded_claims = jwt.decode(token, public_key, audience=absolute_uri(), algorithms=["RS256"])
     if not decoded_claims:
         raise AtlassianConnectValidationError("Unable to verify asymmetric installation JWT")
     return decoded_claims

--- a/tests/sentry/integrations/jira/test_installed.py
+++ b/tests/sentry/integrations/jira/test_installed.py
@@ -186,6 +186,36 @@ class JiraInstalledTest(APITestCase):
             "Could not decode JWT token",
         )
 
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @responses.activate
+    def test_rejects_non_rs256_algorithm(self, mock_record_event: MagicMock) -> None:
+        """
+        Test an algorithm-confusion attack: the token carries a valid key id (kid) but is
+        signed with a symmetric algorithm (HS256) rather than RS256. since authenticate_asymmetric_jwt
+        only allows RS256 the token is rejected with a clean 400 halt rather than a 500
+        """
+        self.add_response()
+
+        token = self._jwt_token("HS256", "attacker-secret", headers={"kid": self.kid})
+        self.get_error_response(
+            **self.body(),
+            extra_headers=dict(HTTP_AUTHORIZATION="JWT " + token),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+        assert not Integration.objects.filter(
+            provider="jira", external_id=self.external_id
+        ).exists()
+        # SLO metric asserts
+        # ENSURE_CONTROL_SILO (success) -> VERIFY_INSTALLATION (halt) -> GET_CONTROL_RESPONSE (success)
+        assert_count_of_metric(mock_record_event, EventLifecycleOutcome.STARTED, 3)
+        assert_count_of_metric(mock_record_event, EventLifecycleOutcome.HALTED, 1)
+        assert_count_of_metric(mock_record_event, EventLifecycleOutcome.SUCCESS, 2)
+        assert_halt_metric(
+            mock_record_event,
+            "JWT signed with unexpected algorithm",
+        )
+
     @patch("sentry_sdk.set_tag")
     @responses.activate
     def test_with_key_id(self, mock_set_tag: MagicMock) -> None:

--- a/tests/sentry/integrations/utils/test_atlassian_connect.py
+++ b/tests/sentry/integrations/utils/test_atlassian_connect.py
@@ -1,8 +1,14 @@
+from unittest import mock
+
 import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from django.test import RequestFactory, override_settings
+from jwt import InvalidAlgorithmError
 
 from sentry.integrations.utils.atlassian_connect import (
     AtlassianConnectValidationError,
+    authenticate_asymmetric_jwt,
     get_integration_from_jwt,
     get_query_hash,
     get_token,
@@ -10,6 +16,8 @@ from sentry.integrations.utils.atlassian_connect import (
 )
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.utils import jwt
+from sentry.utils.http import absolute_uri
 
 
 class AtlassianConnectTest(TestCase):
@@ -145,3 +153,28 @@ class AtlassianConnectTest(TestCase):
         )
         integration = parse_integration_from_request(request=request, provider=self.provider)
         assert integration == self.integration
+
+
+class AuthenticateAsymmetricJwtTest(TestCase):
+    def setUp(self) -> None:
+        self.key_id = "key-123"
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self.public_pem = (
+            private_key.public_key()
+            .public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
+            .decode("utf-8")
+        )
+        self.payload = {"aud": absolute_uri(), "iss": "connect:123"}
+
+    def test_rejects_non_rs256_algorithm(self) -> None:
+        """
+        Test for an algorithm-confusion attack - the attacker presents a token whose header
+        claims a symmetric algorithm (HS256) instead of RS256. since we hardcode algorithm to RS256,
+        pyjwt rejects it on the algorithm mismatch before ever checking the signature against the public key
+        """
+        forged_token = jwt.encode(self.payload, "attacker-secret", algorithm="HS256")
+
+        with mock.patch("sentry.integrations.utils.atlassian_connect.requests.get") as mock_get:
+            mock_get.return_value.content = self.public_pem.encode("utf-8")
+            with pytest.raises(InvalidAlgorithmError):
+                authenticate_asymmetric_jwt(forged_token, self.key_id)


### PR DESCRIPTION
Hard code RS256 algorithm instead of reading a potentially attacky HS256 one for Jira JWT

Fixes ISWF-2904 which links to an extremely detailed explanation of the vulnerability