### PR TITLE
feat(seer-infra-telemetry): Add GCP support to `McpIdentityProvider` for MCP tool calls

### DIFF
--- a/src/sentry/identity/datadog/provider.py
+++ b/src/sentry/identity/datadog/provider.py
@@ -304,11 +304,9 @@ class DatadogIdentityProvider(McpIdentityProvider, OAuth2Provider):
             raise ValueError(f"Invalid Datadog site: {site}")
         return base
 
-    def build_mcp_url(self, identity_data: dict[str, Any]) -> str | None:
-        """Full MCP endpoint URL for a stored Datadog identity.
-        Returns None when the site is missing or invalid."""
+    def build_mcp_urls(self, identity_data: dict[str, Any]) -> list[str]:
         base = _mcp_base_url_for_site(identity_data.get("site"))
-        return f"{base}{MCP_ENDPOINT_PATH}" if base else None
+        return [f"{base}{MCP_ENDPOINT_PATH}"] if base else []
 
     def get_oauth_authorize_url(self) -> str:
         return self._build_mcp_base_url() + MCP_AUTHORIZE_PATH
@@ -425,11 +423,9 @@ class DatadogPatIdentityProvider(McpIdentityProvider, Provider):
     def get_pipeline_views(self) -> list[PipelineView[IdentityPipeline]]:
         return []
 
-    def build_mcp_url(self, identity_data: dict[str, Any]) -> str | None:
-        """Full MCP endpoint URL for a stored Datadog identity.
-        Returns None when the site is missing or invalid."""
+    def build_mcp_urls(self, identity_data: dict[str, Any]) -> list[str]:
         base = _mcp_base_url_for_site(identity_data.get("site"))
-        return f"{base}{MCP_ENDPOINT_PATH}" if base else None
+        return [f"{base}{MCP_ENDPOINT_PATH}"] if base else []
 
     def build_identity(self, data: dict[str, Any]) -> dict[str, Any]:
         access_token = (data.get("access_token") or "").strip()

--- a/src/sentry/identity/gcp/provider.py
+++ b/src/sentry/identity/gcp/provider.py
@@ -6,6 +6,7 @@ import orjson
 
 from sentry import options
 from sentry.auth.exceptions import IdentityNotValid
+from sentry.identity.mcp import McpIdentityProvider
 from sentry.identity.oauth2 import (
     OAuth2ApiStep,
     OAuth2CallbackView,
@@ -32,7 +33,14 @@ class GCPOAuth2LoginView(OAuth2LoginView):
         return params
 
 
-class GCPIdentityProvider(OAuth2Provider):
+GCP_MCP_URLS: tuple[str, ...] = (
+    "https://logging.googleapis.com/mcp",
+    "https://monitoring.googleapis.com/mcp",
+    "https://cloudtrace.googleapis.com/mcp",
+)
+
+
+class GCPIdentityProvider(McpIdentityProvider, OAuth2Provider):
     key = IntegrationProviderSlug.GCP
     name = "Google Cloud Platform"
     create_organization_identity = True
@@ -104,6 +112,9 @@ class GCPIdentityProvider(OAuth2Provider):
             "scopes": sorted(self.get_oauth_scopes()),
             "data": self.get_oauth_data(data),
         }
+
+    def build_mcp_urls(self, identity_data: dict[str, Any]) -> list[str]:
+        return list(GCP_MCP_URLS)
 
     def get_refresh_token_url(self) -> str:
         return self.oauth_access_token_url

--- a/src/sentry/identity/mcp.py
+++ b/src/sentry/identity/mcp.py
@@ -6,9 +6,11 @@ from typing import Any
 class McpIdentityProvider:
     """Mixin for identity providers that back an MCP server."""
 
-    def build_mcp_url(self, identity_data: dict[str, Any]) -> str | None:
-        """Build the MCP server URL from the identity's stored ``data`` dict.
+    def build_mcp_urls(self, identity_data: dict[str, Any]) -> list[str]:
+        """Build MCP server URLs from the identity's stored ``data`` dict.
 
-        Returns ``None`` when URL cannot be built.
+        Returns a list of URLs. Providers with a single MCP endpoint return
+        a one-element list; providers with multiple endpoints (e.g. GCP)
+        return several.
         """
         raise NotImplementedError

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -147,21 +147,23 @@ def get_monitoring_provider_connections(
             access_token = identity.data.get("access_token")
             if not access_token:
                 continue
-            url = provider.build_mcp_url(identity.data)
-            if not url:
+            urls = provider.build_mcp_urls(identity.data)
+            if not urls:
                 continue
             encrypted_access_token = encrypt_access_token_for_seer(access_token)
             if not encrypted_access_token:
                 continue
-            connections.append(
-                {
-                    "provider_key": provider_type,
-                    "url": url,
-                    "encrypted_access_token": encrypted_access_token,
-                    "identity_id": identity.id,
-                    "auth_method": "oauth" if is_oauth_provider else "pat",
-                }
-            )
+            auth_method = "oauth" if is_oauth_provider else "pat"
+            for url in urls:
+                connections.append(
+                    {
+                        "provider_key": provider_type,
+                        "url": url,
+                        "encrypted_access_token": encrypted_access_token,
+                        "identity_id": identity.id,
+                        "auth_method": auth_method,
+                    }
+                )
 
     return connections
 

--- a/tests/sentry/identity/datadog/test_provider.py
+++ b/tests/sentry/identity/datadog/test_provider.py
@@ -674,22 +674,20 @@ class DatadogIdentityProviderTest(TestCase):
         with pytest.raises(ValueError, match="Invalid Datadog site"):
             self.provider._build_mcp_base_url()
 
-    def test_build_mcp_url(self) -> None:
-        assert (
-            self.provider.build_mcp_url({"site": "datadoghq.com"})
-            == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
-        )
+    def test_build_mcp_urls(self) -> None:
+        assert self.provider.build_mcp_urls({"site": "datadoghq.com"}) == [
+            "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+        ]
 
-        assert (
-            self.provider.build_mcp_url({"site": "datadoghq.eu"})
-            == "https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp"
-        )
+        assert self.provider.build_mcp_urls({"site": "datadoghq.eu"}) == [
+            "https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp"
+        ]
 
-    def test_build_mcp_url_missing_site(self) -> None:
-        assert self.provider.build_mcp_url({}) is None
+    def test_build_mcp_urls_missing_site(self) -> None:
+        assert self.provider.build_mcp_urls({}) == []
 
-    def test_build_mcp_url_invalid_site(self) -> None:
-        assert self.provider.build_mcp_url({"site": "evil.example.com"}) is None
+    def test_build_mcp_urls_invalid_site(self) -> None:
+        assert self.provider.build_mcp_urls({"site": "evil.example.com"}) == []
 
 
 @control_silo_test
@@ -778,14 +776,13 @@ class DatadogPatIdentityProviderTest(TestCase):
         with pytest.raises(IdentityNotValid, match="missing required fields"):
             self.provider.build_identity({"access_token": "pat-abc", "site": "datadoghq.com"})
 
-    def test_build_mcp_url(self) -> None:
-        assert (
-            self.provider.build_mcp_url({"site": "datadoghq.com"})
-            == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
-        )
+    def test_build_mcp_urls(self) -> None:
+        assert self.provider.build_mcp_urls({"site": "datadoghq.com"}) == [
+            "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+        ]
 
-    def test_build_mcp_url_missing_site(self) -> None:
-        assert self.provider.build_mcp_url({}) is None
+    def test_build_mcp_urls_missing_site(self) -> None:
+        assert self.provider.build_mcp_urls({}) == []
 
-    def test_build_mcp_url_invalid_site(self) -> None:
-        assert self.provider.build_mcp_url({"site": "evil.example.com"}) is None
+    def test_build_mcp_urls_invalid_site(self) -> None:
+        assert self.provider.build_mcp_urls({"site": "evil.example.com"}) == []

--- a/tests/sentry/identity/gcp/test_provider.py
+++ b/tests/sentry/identity/gcp/test_provider.py
@@ -15,6 +15,7 @@ from django.test import Client, RequestFactory
 import sentry.identity
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.identity.gcp.provider import (
+    GCP_MCP_URLS,
     GCPIdentityProvider,
     GCPOAuth2LoginView,
 )
@@ -90,7 +91,7 @@ class GCPOAuth2LoginViewTest(TestCase):
 
 
 @control_silo_test
-class GCPIdentityProviderBuildIdentityTest(TestCase):
+class GCPIdentityProviderTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.provider = GCPIdentityProvider()
@@ -148,13 +149,6 @@ class GCPIdentityProviderBuildIdentityTest(TestCase):
         with pytest.raises(IdentityNotValid, match="Unable to decode id_token payload"):
             self.provider.build_identity({"data": {"id_token": bad_token}})
 
-
-@control_silo_test
-class GCPIdentityProviderRefreshTest(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.provider = GCPIdentityProvider()
-
     def test_get_refresh_token_url(self) -> None:
         assert self.provider.get_refresh_token_url() == TOKEN_URL
 
@@ -174,6 +168,17 @@ class GCPIdentityProviderRefreshTest(TestCase):
             "client_id": "my-client-id",
             "client_secret": "my-client-secret",
         }
+
+    def test_build_mcp_urls(self) -> None:
+        urls = self.provider.build_mcp_urls({})
+        assert urls == list(GCP_MCP_URLS)
+        assert len(urls) == 3
+        assert "https://logging.googleapis.com/mcp" in urls
+        assert "https://monitoring.googleapis.com/mcp" in urls
+        assert "https://cloudtrace.googleapis.com/mcp" in urls
+
+    def test_build_mcp_urls_ignores_identity_data(self) -> None:
+        assert self.provider.build_mcp_urls({"some_key": "some_value"}) == list(GCP_MCP_URLS)
 
 
 class GCPTestProvider(DummyProvider):

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -1510,3 +1510,107 @@ class TestGetMonitoringProviderConnections(TestCase):
     def test_degrades_when_identity_service_errors(self, mock_get: MagicMock) -> None:
         # A control-silo RPC failure must not propagate (it would stall the outbox shard).
         assert get_monitoring_provider_connections(self.organization, self.user.id) == []
+
+    def test_returns_gcp_connections(self) -> None:
+        idp = self.create_identity_provider(type="gcp", external_id="")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="gcp-user-1",
+            data={
+                "access_token": "gcp-access-token",
+                "refresh_token": "gcp-refresh-token",
+            },
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=identity,
+        )
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 3
+        urls = {c["url"] for c in result}
+        assert urls == {
+            "https://logging.googleapis.com/mcp",
+            "https://monitoring.googleapis.com/mcp",
+            "https://cloudtrace.googleapis.com/mcp",
+        }
+        for connection in result:
+            assert connection["provider_key"] == "gcp"
+            assert connection["identity_id"] == identity.id
+            assert connection["auth_method"] == "oauth"
+            fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
+            decrypted = fernet.decrypt(connection["encrypted_access_token"].encode("utf-8")).decode(
+                "utf-8"
+            )
+            assert decrypted == "gcp-access-token"
+
+    def test_gcp_and_datadog_connections_together(self) -> None:
+        gcp_idp = self.create_identity_provider(type="gcp", external_id="")
+        gcp_identity = self.create_identity(
+            user=self.user,
+            identity_provider=gcp_idp,
+            external_id="gcp-user-1",
+            data={"access_token": "gcp-token"},
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=gcp_identity,
+        )
+
+        dd_idp = self.create_identity_provider(type="datadog", external_id="dd-org-1")
+        dd_identity = self.create_identity(
+            user=self.user,
+            identity_provider=dd_idp,
+            external_id="dd-user-1",
+            data={"access_token": "dd-token", "site": "datadoghq.com"},
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=dd_identity,
+        )
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 4
+        gcp_connections = [c for c in result if c["provider_key"] == "gcp"]
+        dd_connections = [c for c in result if c["provider_key"] == "datadog"]
+        assert len(gcp_connections) == 3
+        assert len(dd_connections) == 1
+
+    def test_gcp_skips_identity_missing_access_token(self) -> None:
+        idp = self.create_identity_provider(type="gcp", external_id="")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="gcp-user-1",
+            data={"refresh_token": "refresh-only"},
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=identity,
+        )
+
+        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
+
+    @patch("sentry.seer.agent.client.encrypt_access_token_for_seer")
+    def test_gcp_token_encrypted_once(self, mock_encrypt: MagicMock) -> None:
+        mock_encrypt.return_value = "encrypted-token"
+
+        idp = self.create_identity_provider(type="gcp", external_id="")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="gcp-user-1",
+            data={"access_token": "gcp-token"},
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=identity,
+        )
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 3
+        mock_encrypt.assert_called_once_with("gcp-token")


### PR DESCRIPTION
Resolves [CW-1530](https://linear.app/getsentry/issue/CW-1530/add-gcp-support-to-mcpidentityprovider-monitoring-provider-connections).

Replaces `McpIdentityProvider.build_mcp_url()` with `build_mcp_urls()` returning `list[str]` in order to support providers with multiple MCP servers. GCP has one MCP server deployed for each service, e.g. logging, monitoring, and cloud trace.

Monitoring provider connection calculation is updated to iterate over (potentially) multiple URLs per identity.