### PR TITLE
chore(seer-activity): Correct webhook `url` and `web_url` alert keys

### DIFF
--- a/src/sentry/notifications/notification_action/activity_registry/sentry_app.py
+++ b/src/sentry/notifications/notification_action/activity_registry/sentry_app.py
@@ -52,6 +52,7 @@ class WorkflowData(TypedDict):
     title: str
     sentry_app_id: int
     url: str
+    web_url: str
     settings: NotRequired[list[dict[str, Any]]]
 
 
@@ -147,7 +148,10 @@ def _build_workflow_data(
         id=workflow.id,
         title=workflow.name,
         sentry_app_id=install.sentry_app.id,
-        url=organization.absolute_url(
+        url=organization.absolute_api_url(
+            f"organizations/{organization.slug}/workflows/{workflow.id}/"
+        ),
+        web_url=organization.absolute_url(
             f"organizations/{organization.slug}/monitors/alerts/{workflow.id}/"
         ),
     )

--- a/src/sentry/notifications/notification_action/activity_registry/sentry_app.py
+++ b/src/sentry/notifications/notification_action/activity_registry/sentry_app.py
@@ -148,9 +148,7 @@ def _build_workflow_data(
         id=workflow.id,
         title=workflow.name,
         sentry_app_id=install.sentry_app.id,
-        url=organization.absolute_api_url(
-            f"organizations/{organization.slug}/workflows/{workflow.id}/"
-        ),
+        url=organization.absolute_api_url(f"workflows/{workflow.id}/"),
         web_url=organization.absolute_url(
             f"organizations/{organization.slug}/monitors/alerts/{workflow.id}/"
         ),

--- a/tests/sentry/notifications/notification_action/activity_registry/test_sentry_app.py
+++ b/tests/sentry/notifications/notification_action/activity_registry/test_sentry_app.py
@@ -160,7 +160,8 @@ class TestBuildWorkflowData(BaseWorkflowTest):
         assert result["id"] == self.workflow.id
         assert result["title"] == self.workflow.name
         assert result["sentry_app_id"] == self.sentry_app.id
-        assert f"alerts/{self.workflow.id}/" in result["url"]
+        assert f"workflows/{self.workflow.id}/" in result["url"]
+        assert f"alerts/{self.workflow.id}/" in result["web_url"]
         assert "settings" not in result
 
     def test_includes_settings_when_present(self) -> None:

--- a/tests/sentry/notifications/notification_action/activity_registry/test_sentry_app.py
+++ b/tests/sentry/notifications/notification_action/activity_registry/test_sentry_app.py
@@ -160,8 +160,10 @@ class TestBuildWorkflowData(BaseWorkflowTest):
         assert result["id"] == self.workflow.id
         assert result["title"] == self.workflow.name
         assert result["sentry_app_id"] == self.sentry_app.id
-        assert "api/0/" in result["url"]
-        assert f"workflows/{self.workflow.id}/" in result["url"]
+
+        assert result["url"].endswith(
+            f"/api/0/organizations/{self.organization.slug}/workflows/{self.workflow.id}/"
+        )
         assert f"alerts/{self.workflow.id}/" in result["web_url"]
         assert "settings" not in result
 

--- a/tests/sentry/notifications/notification_action/activity_registry/test_sentry_app.py
+++ b/tests/sentry/notifications/notification_action/activity_registry/test_sentry_app.py
@@ -160,6 +160,7 @@ class TestBuildWorkflowData(BaseWorkflowTest):
         assert result["id"] == self.workflow.id
         assert result["title"] == self.workflow.name
         assert result["sentry_app_id"] == self.sentry_app.id
+        assert "api/0/" in result["url"]
         assert f"workflows/{self.workflow.id}/" in result["url"]
         assert f"alerts/{self.workflow.id}/" in result["web_url"]
         assert "settings" not in result


### PR DESCRIPTION
Slight update to the webhook format I noticed while drafting https://github.com/getsentry/sentry-docs/pull/18588. For issues, the `url` is by default for the API, and we specify user facing urls as `web_url`.

Added `web_url` and corrected that for the `alert` section of the webhook.