### PR TITLE
feat(api-docs): publish group integration details endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -974,7 +974,6 @@ module = [
     "sentry.issues.endpoints.group_attachments",
     "sentry.issues.endpoints.group_current_release",
     "sentry.issues.endpoints.group_first_last_release",
-    "sentry.issues.endpoints.group_integration_details",
     "sentry.issues.endpoints.group_integrations",
     "sentry.issues.endpoints.group_reprocessing",
     "sentry.issues.endpoints.group_stats",

--- a/src/sentry/apidocs/examples/integration_examples.py
+++ b/src/sentry/apidocs/examples/integration_examples.py
@@ -794,6 +794,90 @@ class IntegrationExamples:
         )
     ]
 
+    GROUP_INTEGRATION_ISSUE_CONFIG = [
+        OpenApiExample(
+            "Config for creating a new external issue",
+            value={
+                "id": "123456",
+                "name": "Example Jira",
+                "icon": "https://example.atlassian.net/icon.png",
+                "domainName": "example.atlassian.net",
+                "accountType": None,
+                "scopes": None,
+                "status": "active",
+                "provider": {
+                    "key": "jira",
+                    "slug": "jira",
+                    "name": "Jira",
+                    "canAdd": False,
+                    "canDisable": False,
+                    "features": ["issue-basic", "issue-sync", "ticket-rules"],
+                    "aspects": {},
+                },
+                "createIssueConfig": [
+                    {
+                        "name": "title",
+                        "label": "Title",
+                        "default": 'TypeError: Cannot read property "foo" of undefined',
+                        "type": "string",
+                        "required": True,
+                    },
+                    {
+                        "name": "description",
+                        "label": "Description",
+                        "default": "Sentry Issue: PROJECT-1\nhttps://example.sentry.io/issues/1/",
+                        "type": "textarea",
+                        "autosize": True,
+                        "maxRows": 10,
+                    },
+                ],
+            },
+            status_codes=["200"],
+            response_only=True,
+        ),
+        OpenApiExample(
+            "Config for linking an existing external issue",
+            value={
+                "id": "123456",
+                "name": "Example Jira",
+                "icon": "https://example.atlassian.net/icon.png",
+                "domainName": "example.atlassian.net",
+                "accountType": None,
+                "scopes": None,
+                "status": "active",
+                "provider": {
+                    "key": "jira",
+                    "slug": "jira",
+                    "name": "Jira",
+                    "canAdd": False,
+                    "canDisable": False,
+                    "features": ["issue-basic", "issue-sync", "ticket-rules"],
+                    "aspects": {},
+                },
+                "linkIssueConfig": [
+                    {"name": "externalIssue", "label": "Issue", "default": "", "type": "string"}
+                ],
+            },
+            status_codes=["200"],
+            response_only=True,
+        ),
+    ]
+
+    EXTERNAL_ISSUE_LINK = [
+        OpenApiExample(
+            "Create or link an external issue",
+            value={
+                "id": 5,
+                "key": "PROJECT-123",
+                "url": "https://example.atlassian.net/browse/PROJECT-123",
+                "integrationId": 123456,
+                "displayName": "PROJECT-123",
+            },
+            status_codes=["201"],
+            response_only=True,
+        )
+    ]
+
     SINGLE_DATA_FORWARDER = [
         OpenApiExample(
             "A data forwarder for an organization",

--- a/src/sentry/issues/endpoints/group_integration_details.py
+++ b/src/sentry/issues/endpoints/group_integration_details.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, TypedDict
 
 from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError, router, transaction
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
+from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -13,7 +16,18 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.helpers.deprecation import deprecated
-from sentry.api.serializers import serialize
+from sentry.api.serializers import Serializer, serialize
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NO_CONTENT,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.examples.integration_examples import IntegrationExamples
+from sentry.apidocs.parameters import GlobalParams, IssueParams
+from sentry.apidocs.response_types import DetailResponse, ValidationErrorResponse
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.integrations.api.serializers.models.integration import (
     IntegrationSerializer,
@@ -42,6 +56,7 @@ from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
+from sentry.models.organization import Organization
 from sentry.shared_integrations.exceptions import (
     IntegrationConfigurationError,
     IntegrationError,
@@ -63,7 +78,15 @@ class IntegrationIssueConfigResponse(IntegrationSerializerResponse, total=False)
     createIssueConfig: list[dict[str, Any]]
 
 
-class IntegrationIssueConfigSerializer(IntegrationSerializer):
+class ExternalIssueLinkResponse(TypedDict):
+    id: int
+    key: str
+    url: str
+    integrationId: int
+    displayName: str
+
+
+class IntegrationIssueConfigSerializer(Serializer[IntegrationIssueConfigResponse]):
     def __init__(self, action: str, config: list[dict[str, Any]]) -> None:
         self.action = action
         self.config = config
@@ -75,26 +98,65 @@ class IntegrationIssueConfigSerializer(IntegrationSerializer):
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> IntegrationIssueConfigResponse:
-        base = super().serialize(obj, attrs, user)
+        base = IntegrationSerializer().serialize(obj, attrs, user)
         if self.action == "link":
             return {**base, "linkIssueConfig": self.config}
         return {**base, "createIssueConfig": self.config}
 
 
+ACTION_PARAM = OpenApiParameter(
+    name="action",
+    location=OpenApiParameter.QUERY,
+    type=OpenApiTypes.STR,
+    required=True,
+    enum=["link", "create"],
+    description=(
+        "Whether to fetch the config for linking an existing external issue (`link`) "
+        "or creating a new one (`create`)."
+    ),
+)
+
+
+@extend_schema(tags=["Integration"])
 @cell_silo_endpoint
 class GroupIntegrationDetailsEndpoint(GroupEndpoint):
     owner = ApiOwner.INTEGRATION_PLATFORM
     publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
-        "POST": ApiPublishStatus.PRIVATE,
-        "PUT": ApiPublishStatus.PRIVATE,
-        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PUBLIC,
+        "PUT": ApiPublishStatus.PUBLIC,
+        "DELETE": ApiPublishStatus.PUBLIC,
     }
 
+    @extend_schema(
+        operation_id="Retrieve an Integration's Issue Config for an Issue",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            IssueParams.ISSUES_OR_GROUPS,
+            IssueParams.ISSUE_ID,
+            GlobalParams.INTEGRATION_ID,
+            ACTION_PARAM,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "IntegrationIssueConfigResponse", IntegrationIssueConfigResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=IntegrationExamples.GROUP_INTEGRATION_ISSUE_CONFIG,
+    )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])
-    def get(self, request: Request, group, integration_id) -> Response:
+    def get(
+        self, request: Request, group: Group, integration_id: str
+    ) -> Response[IntegrationIssueConfigResponse] | Response[DetailResponse]:
         """
-        Retrieves the config needed to either link or create an external issue for a group.
+        Retrieve the form fields needed to either link an existing external issue
+        (such as a Jira ticket or GitHub issue) to a Sentry issue, or create a new
+        one. The returned `linkIssueConfig`/`createIssueConfig` describes the fields
+        to submit back to this endpoint via `PUT`/`POST` respectively.
         """
         if not request.user.is_authenticated:
             return Response(status=400)
@@ -146,10 +208,49 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             )
         )
 
+    @extend_schema(
+        operation_id="Create an External Issue and Link It to an Issue",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            IssueParams.ISSUES_OR_GROUPS,
+            IssueParams.ISSUE_ID,
+            GlobalParams.INTEGRATION_ID,
+        ],
+        request=inline_serializer(
+            "CreateExternalIssueRequest",
+            fields={
+                "title": serializers.CharField(
+                    help_text="The title of the external issue to create."
+                ),
+                "description": serializers.CharField(
+                    required=False,
+                    help_text="The description (body) of the external issue to create.",
+                ),
+            },
+        ),
+        responses={
+            201: inline_sentry_response_serializer(
+                "ExternalIssueLinkResponse", ExternalIssueLinkResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=IntegrationExamples.EXTERNAL_ISSUE_LINK,
+    )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])
-    def post(self, request: Request, group, integration_id) -> Response:
+    def post(
+        self, request: Request, group: Group, integration_id: str
+    ) -> (
+        Response[ExternalIssueLinkResponse]
+        | Response[DetailResponse]
+        | Response[ValidationErrorResponse]
+    ):
         """
-        Creates a new external issue and links it to a group.
+        Create a new issue in the external provider (such as a Jira ticket or GitHub
+        issue) and link it to the given Sentry issue. The accepted fields are
+        integration-specific; fetch them from the `createIssueConfig` returned by the
+        `GET` endpoint with `?action=create`.
         """
         if not request.user.is_authenticated:
             return Response(status=400)
@@ -190,7 +291,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
                 return Response({"non_field_errors": [str(exc)]}, status=400)
             except IntegrationFormError as exc:
                 lifecycle.record_halt(exc)
-                return Response(exc.field_errors, status=400)
+                return Response(dict(exc.field_errors or {}), status=400)
             except IntegrationError as e:
                 lifecycle.record_failure(e)
                 return Response({"non_field_errors": [str(e)]}, status=400)
@@ -260,10 +361,46 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         }
         return Response(context, status=201)
 
+    @extend_schema(
+        operation_id="Link an Existing External Issue to an Issue",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            IssueParams.ISSUES_OR_GROUPS,
+            IssueParams.ISSUE_ID,
+            GlobalParams.INTEGRATION_ID,
+        ],
+        request=inline_serializer(
+            "LinkExternalIssueRequest",
+            fields={
+                "externalIssue": serializers.CharField(
+                    help_text="The identifier of the existing external issue to link, "
+                    "as understood by the provider (such as a Jira issue key)."
+                ),
+            },
+        ),
+        responses={
+            201: inline_sentry_response_serializer(
+                "ExternalIssueLinkResponse", ExternalIssueLinkResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=IntegrationExamples.EXTERNAL_ISSUE_LINK,
+    )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])
-    def put(self, request: Request, group, integration_id) -> Response:
+    def put(
+        self, request: Request, group: Group, integration_id: str
+    ) -> (
+        Response[ExternalIssueLinkResponse]
+        | Response[DetailResponse]
+        | Response[ValidationErrorResponse]
+    ):
         """
-        Links an existing external issue to a group.
+        Link an issue that already exists in the external provider (such as a Jira
+        ticket or GitHub issue) to the given Sentry issue. Additional accepted fields
+        are integration-specific; fetch them from the `linkIssueConfig` returned by
+        the `GET` endpoint with `?action=link`.
         """
         if not request.user.is_authenticated:
             return Response(status=400)
@@ -298,7 +435,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
                 data = installation.get_issue(external_issue_id, data=request.data)
             except IntegrationFormError as exc:
                 lifecycle.record_halt(exc)
-                return Response(exc.field_errors, status=400)
+                return Response(dict(exc.field_errors or {}), status=400)
             except IntegrationError as e:
                 lifecycle.record_failure(e)
                 return Response({"non_field_errors": [str(e)]}, status=400)
@@ -332,7 +469,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
                 installation.after_link_issue(external_issue, data=request.data)
             except IntegrationFormError as exc:
                 lifecycle.record_halt(exc)
-                return Response(exc.field_errors, status=400)
+                return Response(dict(exc.field_errors or {}), status=400)
             except IntegrationError as e:
                 lifecycle.record_failure(e)
                 return Response({"non_field_errors": [str(e)]}, status=400)
@@ -375,10 +512,36 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         }
         return Response(context, status=201)
 
+    @extend_schema(
+        operation_id="Unlink an External Issue from an Issue",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            IssueParams.ISSUES_OR_GROUPS,
+            IssueParams.ISSUE_ID,
+            GlobalParams.INTEGRATION_ID,
+            OpenApiParameter(
+                name="externalIssue",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.INT,
+                required=True,
+                description="The ID of the `ExternalIssue` link to remove.",
+            ),
+        ],
+        responses={
+            204: RESPONSE_NO_CONTENT,
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
     @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])
-    def delete(self, request: Request, group, integration_id) -> Response:
+    def delete(
+        self, request: Request, group: Group, integration_id: str
+    ) -> Response[None] | Response[DetailResponse]:
         """
-        Deletes a link between a group and an external issue.
+        Remove the link between a Sentry issue and an external issue. If no other
+        Sentry issues reference the external issue, the link record is deleted
+        entirely. This does not delete the issue in the external provider.
         """
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
@@ -436,7 +599,9 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
 
         return Response(status=204)
 
-    def _has_issue_feature(self, organization, user) -> bool:
+    def _has_issue_feature(
+        self, organization: Organization, user: User | RpcUser | AnonymousUser
+    ) -> bool:
         has_issue_basic = features.has(
             "organizations:integrations-issue-basic", organization, actor=user
         )
@@ -467,7 +632,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         installation: IssueBasicIntegration,
         external_issue: ExternalIssue,
         new: bool,
-    ):
+    ) -> None:
         issue_information = {
             "title": external_issue.title,
             "provider": installation.model.get_provider().name,

--- a/tests/apidocs/endpoints/integration_platform/test_group_integration_details.py
+++ b/tests/apidocs/endpoints/integration_platform/test_group_integration_details.py
@@ -1,0 +1,77 @@
+from django.test.client import RequestFactory
+
+from fixtures.apidocs_test_case import APIDocsTestCase
+from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.models.grouplink import GroupLink
+from sentry.testutils.factories import EventType
+from sentry.testutils.helpers.datetime import before_now
+
+
+class GroupIntegrationDetailsDocs(APIDocsTestCase):
+    def setUp(self) -> None:
+        self.event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "timestamp": before_now(minutes=1).isoformat(),
+                "message": "message",
+            },
+            project_id=self.project.id,
+            default_event_type=EventType.DEFAULT,
+        )
+        self.group = self.event.group
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="example",
+            name="Example",
+            external_id="example:1",
+        )
+        self.base_url = (
+            f"/api/0/organizations/{self.organization.slug}/issues/"
+            f"{self.group.id}/integrations/{self.integration.id}/"
+        )
+
+        self.login_as(user=self.user)
+
+    def test_get(self) -> None:
+        url = f"{self.base_url}?action=create"
+        with self.feature("organizations:integrations-issue-basic"):
+            response = self.client.get(url)
+        request = RequestFactory().get(url)
+
+        self.validate_schema(request, response)
+
+    def test_post(self) -> None:
+        data = {"assignee": "foo@example.com"}
+        with self.feature("organizations:integrations-issue-basic"):
+            response = self.client.post(self.base_url, data=data)
+        request = RequestFactory().post(self.base_url, data=data)
+
+        self.validate_schema(request, response)
+
+    def test_put(self) -> None:
+        data = {"externalIssue": "APP-123"}
+        with self.feature("organizations:integrations-issue-basic"):
+            response = self.client.put(self.base_url, data=data)
+        request = RequestFactory().put(self.base_url, data=data)
+
+        self.validate_schema(request, response)
+
+    def test_delete(self) -> None:
+        external_issue = ExternalIssue.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            key="APP-123",
+        )
+        GroupLink.objects.create(
+            group_id=self.group.id,
+            project_id=self.group.project_id,
+            linked_type=GroupLink.LinkedType.issue,
+            linked_id=external_issue.id,
+            relationship=GroupLink.Relationship.references,
+        )
+        url = f"{self.base_url}?externalIssue={external_issue.id}"
+        with self.feature("organizations:integrations-issue-basic"):
+            response = self.client.delete(url)
+        request = RequestFactory().delete(url)
+
+        self.validate_schema(request, response)


### PR DESCRIPTION
Publish the group integration details API endpoint. This endpoint is a bit weird — calling it returns a config that renders out in the frontend, but regardless would be good to publish since its stable.

Resolves https://linear.app/getsentry/issue/RTC-1148/publish-groupintegrationdetailsendpoint-api