### PR TITLE
fix(auth): Preserve active org during auth redirects

### DIFF
--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -107,6 +107,9 @@ class CustomerDomainMiddleware:
             logger.info("customer_domain.redirect.logout", extra={"location": redirect_url})
             return HttpResponseRedirect(redirect_url)
 
+        if request.path_info.startswith(("/auth/", "/auth-v2/", "/saml/")):
+            return self.get_response(request)
+
         activeorg = _resolve_activeorg(request)
         if not activeorg:
             session = getattr(request, "session", None)

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -44,6 +44,19 @@ class CustomerDomainMiddlewareTest(TestCase):
         assert dict(request.session) == {"activeorg": "test"}
         assert response == mock.sentinel.response
 
+    @with_feature("system:multi-region")
+    def test_auth_path_preserves_session_active_org(self) -> None:
+        self.create_organization(name="albertos-apples")
+        self.create_organization(name="sentry")
+
+        request = RequestFactory().get("/auth/sentry/")
+        request.subdomain = "albertos-apples"
+        request.session = _session({"activeorg": "sentry"})
+        response = CustomerDomainMiddleware(lambda request: mock.sentinel.response)(request)
+
+        assert dict(request.session) == {"activeorg": "sentry"}
+        assert response == mock.sentinel.response
+
     def test_noop_if_customer_domain_is_off(self) -> None:
         with self.feature({"system:multi-region": False}):
             self.create_organization(name="test")


### PR DESCRIPTION
Follow-up to the generic-login no-org fix in https://github.com/getsentry/sentry/pull/118666. After SAML auth sets the session org, a customer-domain GET on `/auth/...` still ran `CustomerDomainMiddleware`, which resolved the host subdomain as the active org and overwrote `session["activeorg"]`. The follow-up `/auth/login/` then had no usable org from the auth flow and could render no-organization-access.

`CustomerDomainMiddleware` normally keeps the request session aligned with the customer-domain host: if a request comes in on an org subdomain, it treats that subdomain as the active org, writes it to `session["activeorg"]`, and redirects when the host and URL path point at different orgs. That is correct for product pages, but auth and SAML routes already have their own org state from the login flow.

Customer-domain middleware now leaves `/auth/`, `/auth-v2/`, and `/saml/` requests alone, so auth views and SSO helpers remain responsible for session org state. Product routes still resolve the active org from the customer domain as before.

The regression test covers the failing auth-path shape directly: a customer-domain host with a different session active org must preserve the session org and continue through the wrapped view without redirecting.
