### PR TITLE
fix(eap): Skip validation for empty-string sentinel in has: queries

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -716,9 +716,7 @@ class SearchResolver:
                             comparison_filter=ComparisonFilter(
                                 key=resolved_column.proto_definition,
                                 op=operator,
-                                value=self._resolve_search_value(
-                                    resolved_column, term.operator, value
-                                ),
+                                value=AttributeValue(val_str=value),
                             )
                         )
                     )
@@ -734,9 +732,7 @@ class SearchResolver:
                             comparison_filter=ComparisonFilter(
                                 key=resolved_column.proto_definition,
                                 op=operator,
-                                value=self._resolve_search_value(
-                                    resolved_column, term.operator, value
-                                ),
+                                value=AttributeValue(val_str=value),
                             )
                         )
                     )

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -802,13 +802,6 @@ class SearchResolverQueryTest(TestCase):
             group2.qualified_short_id in resolver.qualified_short_id_to_group_id_cache[project_id]
         )
 
-
-class HasTraceTest(TestCase):
-    def setUp(self) -> None:
-        self.resolver = SearchResolver(
-            params=SnubaParams(), config=SearchResolverConfig(), definitions=SPAN_DEFINITIONS
-        )
-
     def test_has_trace(self) -> None:
         where, having, _ = self.resolver.resolve_query("has:trace")
         trace_key = AttributeKey(name="sentry.trace_id", type=AttributeKey.Type.TYPE_STRING)

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -803,6 +803,61 @@ class SearchResolverQueryTest(TestCase):
         )
 
 
+class HasTraceTest(TestCase):
+    def setUp(self) -> None:
+        self.resolver = SearchResolver(
+            params=SnubaParams(), config=SearchResolverConfig(), definitions=SPAN_DEFINITIONS
+        )
+
+    def test_has_trace(self) -> None:
+        where, having, _ = self.resolver.resolve_query("has:trace")
+        trace_key = AttributeKey(name="sentry.trace_id", type=AttributeKey.Type.TYPE_STRING)
+        assert where == TraceItemFilter(
+            and_filter=AndFilter(
+                filters=[
+                    TraceItemFilter(
+                        exists_filter=ExistsFilter(key=trace_key),
+                    ),
+                    TraceItemFilter(
+                        comparison_filter=ComparisonFilter(
+                            key=trace_key,
+                            op=ComparisonFilter.OP_NOT_EQUALS,
+                            value=AttributeValue(val_str=""),
+                        )
+                    ),
+                ]
+            )
+        )
+        assert having is None
+
+    def test_not_has_trace(self) -> None:
+        where, having, _ = self.resolver.resolve_query("!has:trace")
+        trace_key = AttributeKey(name="sentry.trace_id", type=AttributeKey.Type.TYPE_STRING)
+        assert where == TraceItemFilter(
+            or_filter=OrFilter(
+                filters=[
+                    TraceItemFilter(
+                        not_filter=NotFilter(
+                            filters=[
+                                TraceItemFilter(
+                                    exists_filter=ExistsFilter(key=trace_key),
+                                )
+                            ]
+                        )
+                    ),
+                    TraceItemFilter(
+                        comparison_filter=ComparisonFilter(
+                            key=trace_key,
+                            op=ComparisonFilter.OP_EQUALS,
+                            value=AttributeValue(val_str=""),
+                        )
+                    ),
+                ]
+            )
+        )
+        assert having is None
+
+
 class SearchResolverColumnTest(TestCase):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
Checking whether the empty string constructed as a sentinel for has queries is well-formed seems unnecessary and causes otherwise reasonable queries to fail.

See SENTRY-5QZN for an example.

