### PR TITLE
feat(relay): Allow a custom Relay endpoint to override DSNs

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -670,6 +670,7 @@ class OrganizationSerializerResponse(_OrganizationSerializerResponseOptional):
     scrapeJavaScript: bool
     allowJoinRequests: bool
     relayPiiConfig: str | None
+    relayDsnEndpoint: str | None
     trustedRelays: list[TrustedRelaySerializerResponse]
     pendingAccessRequests: int
     hideAiFeatures: bool
@@ -827,6 +828,7 @@ class OrganizationSerializer(OrganizationSummarySerializer):
                 obj.get_option("sentry:join_requests", JOIN_REQUESTS_DEFAULT)
             ),
             "relayPiiConfig": str(obj.get_option("sentry:relay_pii_config") or "") or None,
+            "relayDsnEndpoint": obj.get_option("sentry:relay_dsn_endpoint") or None,
             "hideAiFeatures": bool(
                 obj.get_option("sentry:hide_ai_features", HIDE_AI_FEATURES_DEFAULT)
             ),

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -288,6 +288,7 @@ class OrganizationExamples:
                 "scrapeJavaScript": True,
                 "allowJoinRequests": True,
                 "relayPiiConfig": None,
+                "relayDsnEndpoint": None,
                 "hideAiFeatures": False,
                 "aggregatedDataConsent": False,
                 "defaultAutofixAutomationTuning": AutofixAutomationTuningSettings.OFF,

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -4,6 +4,7 @@ import logging
 from copy import copy
 from datetime import datetime, timedelta, timezone
 from typing import TypedDict
+from urllib.parse import urlsplit
 
 from django.db import models, router, transaction
 from django.db.models.query_utils import DeferredAttribute
@@ -121,6 +122,10 @@ ERR_NO_USER = "This request requires an authenticated user."
 ERR_NO_2FA = "Cannot require two-factor authentication without personal two-factor enabled."
 ERR_SSO_ENABLED = "Cannot require two-factor authentication with SSO enabled"
 ERR_3RD_PARTY_PUBLISHED_APP = "Cannot delete an organization that owns a published integration. Contact support if you need assistance."
+RELAY_DSN_ENDPOINT_OPTION = "sentry:relay_dsn_endpoint"
+ERR_RELAY_DSN_ENDPOINT_INVALID = (
+    "Enter an absolute http(s) base URL with a host and no credentials, query, or fragment."
+)
 
 
 ORG_OPTIONS = (
@@ -261,6 +266,7 @@ ORG_OPTIONS = (
         str,
         INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
     ),
+    ("relayDsnEndpoint", RELAY_DSN_ENDPOINT_OPTION, str, None),
     (
         "enabledConsolePlatforms",
         "sentry:enabled_console_platforms",
@@ -330,6 +336,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     trustedRelays = serializers.ListField(child=TrustedRelaySerializer(), required=False)
     allowJoinRequests = serializers.BooleanField(required=False)
     relayPiiConfig = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    relayDsnEndpoint = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     apdexThreshold = serializers.IntegerField(min_value=1, required=False)
     targetSampleRate = serializers.FloatField(required=False, min_value=0, max_value=1)
     samplingMode = serializers.ChoiceField(choices=DynamicSamplingMode.choices, required=False)
@@ -456,6 +463,44 @@ class OrganizationSerializer(BaseOrganizationSerializer):
                 public_keys.add(key)
 
         return value
+
+    def validate_relayDsnEndpoint(self, value: str | None) -> str | None:
+        organization = self.context["organization"]
+        request = self.context["request"]
+
+        if not features.has(
+            "organizations:relay-dsn-endpoint-override", organization, actor=request.user
+        ):
+            raise serializers.ValidationError(
+                "Organization does not have the Relay DSN endpoint override feature enabled."
+            )
+
+        if value is None:
+            return None
+
+        value = value.strip()
+        if not value:
+            return None
+
+        try:
+            parts = urlsplit(value)
+            hostname = parts.hostname
+            # parts.port raises ValueError on a malformed port; urlsplit itself does not.
+            _ = parts.port
+        except ValueError:
+            raise serializers.ValidationError(ERR_RELAY_DSN_ENDPOINT_INVALID)
+
+        if (
+            parts.scheme not in {"http", "https"}
+            or not hostname
+            or parts.username is not None
+            or parts.password is not None
+            or parts.query
+            or parts.fragment
+        ):
+            raise serializers.ValidationError(ERR_RELAY_DSN_ENDPOINT_INVALID)
+
+        return value.rstrip("/")
 
     def validate_enabledConsolePlatforms(self, value):
         request = self.context["request"]
@@ -1035,6 +1080,12 @@ Below is an example of a payload for a set of advanced data scrubbing rules for 
                                           ```
                                           """,
         required=False,
+    )
+    relayDsnEndpoint = serializers.CharField(
+        help_text="A Relay base URL to use when displaying Client Key DSNs for this organization.",
+        required=False,
+        allow_blank=True,
+        allow_null=True,
     )
 
     # slack features

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -208,6 +208,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-enforce-distribution-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable preprod size monitors frontend
     manager.add("organizations:preprod-size-monitors-frontend", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enables configuring a Relay base URL for displayed Client Key DSNs
+    manager.add("organizations:relay-dsn-endpoint-override", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the playstation ingestion in relay
     manager.add("organizations:relay-playstation-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable the new apiFetch implementation that uses cell fetch.

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -328,6 +328,11 @@ class ProjectKey(ReplicatedCellModel):
     def get_endpoint(self) -> str:
         from sentry.api.utils import generate_locality_url
 
+        # Apply the org's relay-dsn-endpoint override when set.
+        override = self.organization.get_option("sentry:relay_dsn_endpoint")
+        if override:
+            return override
+
         endpoint = settings.SENTRY_ENDPOINT
         if not endpoint:
             if SiloMode.get_current_mode() == SiloMode.CELL:

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -24,7 +24,11 @@ from sentry.constants import (
     SEER_DEFAULT_CODING_AGENT_DEFAULT,
     ObjectStatus,
 )
-from sentry.core.endpoints.organization_details import ERR_NO_2FA, ERR_SSO_ENABLED
+from sentry.core.endpoints.organization_details import (
+    ERR_NO_2FA,
+    ERR_RELAY_DSN_ENDPOINT_INVALID,
+    ERR_SSO_ENABLED,
+)
 from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.dynamic_sampling.types import DynamicSamplingMode
 from sentry.models.auditlogentry import AuditLogEntry
@@ -1250,6 +1254,82 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
     def test_get_ingest_through_trusted_relays_only_option(self) -> None:
         response = self.get_success_response(self.organization.slug)
         assert response.data["ingestThroughTrustedRelaysOnly"] == "disabled"
+
+    def test_relay_dsn_endpoint_returned_when_set(self) -> None:
+        self.organization.update_option(
+            "sentry:relay_dsn_endpoint", "https://relay.example.com/ingest"
+        )
+
+        response = self.get_success_response(self.organization.slug)
+
+        assert response.data["relayDsnEndpoint"] == "https://relay.example.com/ingest"
+
+    @with_feature("organizations:relay-dsn-endpoint-override")
+    def test_relay_dsn_endpoint_accepts_valid_write(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug,
+            relayDsnEndpoint="https://relay.example.com/ingest/",
+        )
+
+        assert self.organization.get_option("sentry:relay_dsn_endpoint") == (
+            "https://relay.example.com/ingest"
+        )
+        assert response.data["relayDsnEndpoint"] == "https://relay.example.com/ingest"
+
+    @with_feature("organizations:relay-dsn-endpoint-override")
+    def test_relay_dsn_endpoint_blank_clears_value(self) -> None:
+        self.organization.update_option(
+            "sentry:relay_dsn_endpoint", "https://relay.example.com/ingest"
+        )
+
+        response = self.get_success_response(self.organization.slug, relayDsnEndpoint="")
+
+        assert self.organization.get_option("sentry:relay_dsn_endpoint") is None
+        assert response.data["relayDsnEndpoint"] is None
+
+    @with_feature("organizations:relay-dsn-endpoint-override")
+    def test_relay_dsn_endpoint_null_clears_value(self) -> None:
+        self.organization.update_option(
+            "sentry:relay_dsn_endpoint", "https://relay.example.com/ingest"
+        )
+
+        response = self.get_success_response(self.organization.slug, relayDsnEndpoint=None)
+
+        assert self.organization.get_option("sentry:relay_dsn_endpoint") is None
+        assert response.data["relayDsnEndpoint"] is None
+
+    def test_relay_dsn_endpoint_rejects_write_without_feature(self) -> None:
+        response = self.get_error_response(
+            self.organization.slug,
+            status_code=400,
+            relayDsnEndpoint="https://relay.example.com/ingest",
+        )
+
+        assert response.data["relayDsnEndpoint"] == [
+            "Organization does not have the Relay DSN endpoint override feature enabled."
+        ]
+        assert self.organization.get_option("sentry:relay_dsn_endpoint") is None
+
+    def test_relay_dsn_endpoint_rejects_invalid_url(self) -> None:
+        relay_dsn_endpoints = [
+            "relay.example.com",
+            "https:///relay",
+            "ftp://relay.example.com",
+            "https://user:password@relay.example.com",
+            "https://relay.example.com?foo=bar",
+            "https://relay.example.com#fragment",
+        ]
+
+        with self.feature("organizations:relay-dsn-endpoint-override"):
+            for relay_dsn_endpoint in relay_dsn_endpoints:
+                with self.subTest(relay_dsn_endpoint=relay_dsn_endpoint):
+                    response = self.get_error_response(
+                        self.organization.slug,
+                        status_code=400,
+                        relayDsnEndpoint=relay_dsn_endpoint,
+                    )
+
+                    assert response.data["relayDsnEndpoint"] == [ERR_RELAY_DSN_ENDPOINT_INVALID]
 
     @with_feature("organizations:dynamic-sampling-custom")
     def test_target_sample_rate_range(self) -> None:

--- a/tests/sentry/core/endpoints/test_project_keys.py
+++ b/tests/sentry/core/endpoints/test_project_keys.py
@@ -40,6 +40,39 @@ class ListProjectKeysTest(APITestCase):
         assert response.status_code == 200
         assert response.data[0]["dsn"]["playstation"] == key.playstation_endpoint
 
+    def test_relay_dsn_endpoint_override(self) -> None:
+        project = self.create_project()
+        project.organization.update_option(
+            "sentry:relay_dsn_endpoint", "https://relay.example.com/ingest"
+        )
+        key = ProjectKey.objects.get_or_create(project=project)[0]
+        self.login_as(user=self.user)
+        url = reverse(
+            "sentry-api-0-project-keys",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.data[0]["dsn"] == {
+            "public": f"https://{key.public_key}@relay.example.com/ingest/{project.id}",
+            "secret": f"https://{key.public_key}:{key.secret_key}@relay.example.com/ingest/{project.id}",
+            "csp": f"https://relay.example.com/ingest/api/{project.id}/csp-report/?sentry_key={key.public_key}",
+            "security": f"https://relay.example.com/ingest/api/{project.id}/security/?sentry_key={key.public_key}",
+            "minidump": f"https://relay.example.com/ingest/api/{project.id}/minidump/?sentry_key={key.public_key}",
+            "nel": f"https://relay.example.com/ingest/api/{project.id}/nel/?sentry_key={key.public_key}",
+            "unreal": f"https://relay.example.com/ingest/api/{project.id}/unreal/{key.public_key}/",
+            "crons": f"https://relay.example.com/ingest/api/{project.id}/cron/___MONITOR_SLUG___/{key.public_key}/",
+            "cdn": key.js_sdk_loader_cdn_url,
+            "playstation": f"https://relay.example.com/ingest/api/{project.id}/playstation/?sentry_key={key.public_key}",
+            "integration": f"https://relay.example.com/ingest/api/{project.id}/integration/",
+            "otlp_traces": f"https://relay.example.com/ingest/api/{project.id}/integration/otlp/v1/traces",
+            "otlp_logs": f"https://relay.example.com/ingest/api/{project.id}/integration/otlp/v1/logs",
+        }
+
     def test_integration_endpoint(self) -> None:
         project = self.create_project()
         key = ProjectKey.objects.get_or_create(project=project)[0]


### PR DESCRIPTION
Adds an org-level option that overrides the base URL used for every DSN-derived URL Sentry displays. Customers running their own Relay can hand their developers DSNs pointed at it instead of `ingest.sentry.io`, and the same override flows into the Vercel/Lambda integration env vars, the JS SDK loader script, the debug embed, the createproject CLI, etc.

Gated by the new `organizations:relay-dsn-endpoint-override` flag (FLAGPOLE, api_expose). The PUT validator rejects writes when the flag is off and rejects URLs that aren't absolute http(s), have no host, or carry credentials, a query, or a fragment. Blank or null clears the option. Audit logging is handled by the existing `ORG_OPTIONS` flow.

The mechanism is a short-circuit at the top of `ProjectKey.get_endpoint()`: when the org option is set, return it directly. Every existing URL property derived from `get_endpoint()` picks up the override transparently.

Refs getsentry/sentry#117935