### PR TITLE
ref(projectkey): Route DSN URLs through ProjectKeyEndpointUrls

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -670,6 +670,7 @@ class OrganizationSerializerResponse(_OrganizationSerializerResponseOptional):
     scrapeJavaScript: bool
     allowJoinRequests: bool
     relayPiiConfig: str | None
+    relayDsnEndpoint: str | None
     trustedRelays: list[TrustedRelaySerializerResponse]
     pendingAccessRequests: int
     hideAiFeatures: bool
@@ -827,6 +828,7 @@ class OrganizationSerializer(OrganizationSummarySerializer):
                 obj.get_option("sentry:join_requests", JOIN_REQUESTS_DEFAULT)
             ),
             "relayPiiConfig": str(obj.get_option("sentry:relay_pii_config") or "") or None,
+            "relayDsnEndpoint": obj.get_option("sentry:relay_dsn_endpoint") or None,
             "hideAiFeatures": bool(
                 obj.get_option("sentry:hide_ai_features", HIDE_AI_FEATURES_DEFAULT)
             ),

--- a/src/sentry/api/serializers/models/project_key.py
+++ b/src/sentry/api/serializers/models/project_key.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any, NotRequired, TypedDict
 
@@ -9,7 +9,10 @@ from sentry.loader.browsersdkversion import (
     get_selected_browser_sdk_version,
 )
 from sentry.loader.dynamic_sdk_options import DynamicSdkLoaderOption, get_dynamic_sdk_loader_option
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.projectkey import ProjectKey
+
+RELAY_DSN_ENDPOINT_OPTION = "sentry:relay_dsn_endpoint"
 
 
 class RateLimit(TypedDict):
@@ -68,6 +71,23 @@ class ProjectKeySerializerResponse(TypedDict):
 
 @register(ProjectKey)
 class ProjectKeySerializer(Serializer[ProjectKeySerializerResponse]):
+    def get_attrs(
+        self, item_list: Sequence[ProjectKey], user: Any, **kwargs: Any
+    ) -> dict[ProjectKey, dict[str, Any]]:
+        project_key_org_ids: dict[int, int] = dict(
+            ProjectKey.objects.filter(id__in=[item.id for item in item_list]).values_list(
+                "id", "project__organization_id"
+            )
+        )
+        relay_dsn_endpoints = OrganizationOption.objects.get_value_bulk_id(
+            list(project_key_org_ids.values()), RELAY_DSN_ENDPOINT_OPTION
+        )
+
+        return {
+            item: {"relay_dsn_endpoint": relay_dsn_endpoints.get(project_key_org_ids.get(item.id))}
+            for item in item_list
+        }
+
     def serialize(
         self, obj: ProjectKey, attrs: Mapping[str, Any], user: Any, **kwargs: Any
     ) -> ProjectKeySerializerResponse:
@@ -76,6 +96,10 @@ class ProjectKeySerializer(Serializer[ProjectKeySerializerResponse]):
         # must be Optional[str] instead of str. By setting else to "" we getaround this
         name = obj.label or (obj.public_key[:14] if obj.public_key else "")
         public_key = obj.public_key or ""
+        relay_dsn_endpoint = attrs.get("relay_dsn_endpoint")
+        endpoint_urls = obj.get_endpoint_urls(base_url=relay_dsn_endpoint)
+        # The JS SDK loader is served by Sentry, not by a customer Relay — keep that URL canonical.
+        canonical_endpoint_urls = obj.get_endpoint_urls() if relay_dsn_endpoint else endpoint_urls
         data: ProjectKeySerializerResponse = {
             "id": public_key,
             "name": name,
@@ -91,19 +115,19 @@ class ProjectKeySerializer(Serializer[ProjectKeySerializerResponse]):
                 else None
             ),
             "dsn": {
-                "secret": obj.dsn_private,
-                "public": obj.dsn_public,
-                "csp": obj.csp_endpoint,
-                "security": obj.security_endpoint,
-                "minidump": obj.minidump_endpoint,
-                "nel": obj.nel_endpoint,
-                "unreal": obj.unreal_endpoint,
-                "crons": obj.crons_endpoint,
-                "cdn": obj.js_sdk_loader_cdn_url,
-                "playstation": obj.playstation_endpoint,
-                "integration": obj.integration_endpoint,
-                "otlp_traces": obj.otlp_traces_endpoint,
-                "otlp_logs": obj.otlp_logs_endpoint,
+                "secret": endpoint_urls.dsn_private,
+                "public": endpoint_urls.dsn_public,
+                "csp": endpoint_urls.csp_endpoint,
+                "security": endpoint_urls.security_endpoint,
+                "minidump": endpoint_urls.minidump_endpoint,
+                "nel": endpoint_urls.nel_endpoint,
+                "unreal": endpoint_urls.unreal_endpoint,
+                "crons": endpoint_urls.crons_endpoint,
+                "cdn": canonical_endpoint_urls.js_sdk_loader_cdn_url,
+                "playstation": endpoint_urls.playstation_endpoint,
+                "integration": endpoint_urls.integration_endpoint,
+                "otlp_traces": endpoint_urls.otlp_traces_endpoint,
+                "otlp_logs": endpoint_urls.otlp_logs_endpoint,
             },
             "browserSdkVersion": get_selected_browser_sdk_version(obj),
             "browserSdk": {"choices": get_browser_sdk_version_choices(obj.project)},

--- a/src/sentry/api/serializers/models/project_key.py
+++ b/src/sentry/api/serializers/models/project_key.py
@@ -84,7 +84,13 @@ class ProjectKeySerializer(Serializer[ProjectKeySerializerResponse]):
         )
 
         return {
-            item: {"relay_dsn_endpoint": relay_dsn_endpoints.get(project_key_org_ids.get(item.id))}
+            item: {
+                "relay_dsn_endpoint": (
+                    relay_dsn_endpoints.get(org_id)
+                    if (org_id := project_key_org_ids.get(item.id)) is not None
+                    else None
+                )
+            }
             for item in item_list
         }
 

--- a/src/sentry/api/serializers/models/project_key.py
+++ b/src/sentry/api/serializers/models/project_key.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from datetime import datetime
 from typing import Any, NotRequired, TypedDict
 
@@ -9,10 +9,7 @@ from sentry.loader.browsersdkversion import (
     get_selected_browser_sdk_version,
 )
 from sentry.loader.dynamic_sdk_options import DynamicSdkLoaderOption, get_dynamic_sdk_loader_option
-from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.projectkey import ProjectKey
-
-RELAY_DSN_ENDPOINT_OPTION = "sentry:relay_dsn_endpoint"
 
 
 class RateLimit(TypedDict):
@@ -71,29 +68,6 @@ class ProjectKeySerializerResponse(TypedDict):
 
 @register(ProjectKey)
 class ProjectKeySerializer(Serializer[ProjectKeySerializerResponse]):
-    def get_attrs(
-        self, item_list: Sequence[ProjectKey], user: Any, **kwargs: Any
-    ) -> dict[ProjectKey, dict[str, Any]]:
-        project_key_org_ids: dict[int, int] = dict(
-            ProjectKey.objects.filter(id__in=[item.id for item in item_list]).values_list(
-                "id", "project__organization_id"
-            )
-        )
-        relay_dsn_endpoints = OrganizationOption.objects.get_value_bulk_id(
-            list(project_key_org_ids.values()), RELAY_DSN_ENDPOINT_OPTION
-        )
-
-        return {
-            item: {
-                "relay_dsn_endpoint": (
-                    relay_dsn_endpoints.get(org_id)
-                    if (org_id := project_key_org_ids.get(item.id)) is not None
-                    else None
-                )
-            }
-            for item in item_list
-        }
-
     def serialize(
         self, obj: ProjectKey, attrs: Mapping[str, Any], user: Any, **kwargs: Any
     ) -> ProjectKeySerializerResponse:
@@ -102,10 +76,7 @@ class ProjectKeySerializer(Serializer[ProjectKeySerializerResponse]):
         # must be Optional[str] instead of str. By setting else to "" we getaround this
         name = obj.label or (obj.public_key[:14] if obj.public_key else "")
         public_key = obj.public_key or ""
-        relay_dsn_endpoint = attrs.get("relay_dsn_endpoint")
-        endpoint_urls = obj.get_endpoint_urls(base_url=relay_dsn_endpoint)
-        # The JS SDK loader is served by Sentry, not by a customer Relay — keep that URL canonical.
-        canonical_endpoint_urls = obj.get_endpoint_urls() if relay_dsn_endpoint else endpoint_urls
+        endpoint_urls = obj.get_endpoint_urls()
         data: ProjectKeySerializerResponse = {
             "id": public_key,
             "name": name,
@@ -129,7 +100,7 @@ class ProjectKeySerializer(Serializer[ProjectKeySerializerResponse]):
                 "nel": endpoint_urls.nel_endpoint,
                 "unreal": endpoint_urls.unreal_endpoint,
                 "crons": endpoint_urls.crons_endpoint,
-                "cdn": canonical_endpoint_urls.js_sdk_loader_cdn_url,
+                "cdn": endpoint_urls.js_sdk_loader_cdn_url,
                 "playstation": endpoint_urls.playstation_endpoint,
                 "integration": endpoint_urls.integration_endpoint,
                 "otlp_traces": endpoint_urls.otlp_traces_endpoint,

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -288,6 +288,7 @@ class OrganizationExamples:
                 "scrapeJavaScript": True,
                 "allowJoinRequests": True,
                 "relayPiiConfig": None,
+                "relayDsnEndpoint": None,
                 "hideAiFeatures": False,
                 "aggregatedDataConsent": False,
                 "defaultAutofixAutomationTuning": AutofixAutomationTuningSettings.OFF,

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -4,6 +4,7 @@ import logging
 from copy import copy
 from datetime import datetime, timedelta, timezone
 from typing import TypedDict
+from urllib.parse import urlsplit
 
 from django.db import models, router, transaction
 from django.db.models.query_utils import DeferredAttribute
@@ -121,6 +122,10 @@ ERR_NO_USER = "This request requires an authenticated user."
 ERR_NO_2FA = "Cannot require two-factor authentication without personal two-factor enabled."
 ERR_SSO_ENABLED = "Cannot require two-factor authentication with SSO enabled"
 ERR_3RD_PARTY_PUBLISHED_APP = "Cannot delete an organization that owns a published integration. Contact support if you need assistance."
+RELAY_DSN_ENDPOINT_OPTION = "sentry:relay_dsn_endpoint"
+ERR_RELAY_DSN_ENDPOINT_INVALID = (
+    "Enter an absolute http(s) base URL with a host and no credentials, query, or fragment."
+)
 
 
 ORG_OPTIONS = (
@@ -261,6 +266,7 @@ ORG_OPTIONS = (
         str,
         INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
     ),
+    ("relayDsnEndpoint", RELAY_DSN_ENDPOINT_OPTION, str, None),
     (
         "enabledConsolePlatforms",
         "sentry:enabled_console_platforms",
@@ -330,6 +336,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     trustedRelays = serializers.ListField(child=TrustedRelaySerializer(), required=False)
     allowJoinRequests = serializers.BooleanField(required=False)
     relayPiiConfig = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    relayDsnEndpoint = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     apdexThreshold = serializers.IntegerField(min_value=1, required=False)
     targetSampleRate = serializers.FloatField(required=False, min_value=0, max_value=1)
     samplingMode = serializers.ChoiceField(choices=DynamicSamplingMode.choices, required=False)
@@ -456,6 +463,44 @@ class OrganizationSerializer(BaseOrganizationSerializer):
                 public_keys.add(key)
 
         return value
+
+    def validate_relayDsnEndpoint(self, value: str | None) -> str | None:
+        organization = self.context["organization"]
+        request = self.context["request"]
+
+        if not features.has(
+            "organizations:relay-dsn-endpoint-override", organization, actor=request.user
+        ):
+            raise serializers.ValidationError(
+                "Organization does not have the Relay DSN endpoint override feature enabled."
+            )
+
+        if value is None:
+            return None
+
+        value = value.strip()
+        if not value:
+            return None
+
+        try:
+            parts = urlsplit(value)
+            hostname = parts.hostname
+            # parts.port raises ValueError on a malformed port; urlsplit itself does not.
+            _ = parts.port
+        except ValueError:
+            raise serializers.ValidationError(ERR_RELAY_DSN_ENDPOINT_INVALID)
+
+        if (
+            parts.scheme not in {"http", "https"}
+            or not hostname
+            or parts.username is not None
+            or parts.password is not None
+            or parts.query
+            or parts.fragment
+        ):
+            raise serializers.ValidationError(ERR_RELAY_DSN_ENDPOINT_INVALID)
+
+        return value.rstrip("/")
 
     def validate_enabledConsolePlatforms(self, value):
         request = self.context["request"]
@@ -1035,6 +1080,12 @@ Below is an example of a payload for a set of advanced data scrubbing rules for 
                                           ```
                                           """,
         required=False,
+    )
+    relayDsnEndpoint = serializers.CharField(
+        help_text="A Relay base URL to use when displaying Client Key DSNs for this organization.",
+        required=False,
+        allow_blank=True,
+        allow_null=True,
     )
 
     # slack features

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -199,6 +199,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-enforce-distribution-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable preprod size monitors frontend
     manager.add("organizations:preprod-size-monitors-frontend", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enables configuring a Relay base URL for displayed Client Key DSNs
+    manager.add("organizations:relay-dsn-endpoint-override", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the playstation ingestion in relay
     manager.add("organizations:relay-playstation-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable the new apiFetch implementation that uses cell fetch.

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -4,6 +4,7 @@ import enum
 import re
 import secrets
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any, ClassVar
 from urllib.parse import urlparse
 
@@ -76,6 +77,110 @@ class UseCase(enum.Enum):
     TEMPEST = "tempest"
     """ An internal project key for demo mode."""
     DEMO = "demo"
+
+
+@dataclass(frozen=True)
+class ProjectKeyEndpointUrls:
+    project_key: ProjectKey
+    base_url: str
+
+    def get_dsn(self, public: bool = False) -> str:
+        urlparts = urlparse(self.base_url)
+
+        if not public:
+            key = f"{self.project_key.public_key}:{self.project_key.secret_key}"
+        else:
+            assert self.project_key.public_key is not None
+            key = self.project_key.public_key
+
+        if not urlparts.netloc or not urlparts.scheme:
+            return ""
+
+        return (
+            f"{urlparts.scheme}://{key}@"
+            f"{urlparts.netloc + urlparts.path}/{self.project_key.project_id}"
+        )
+
+    @property
+    def dsn_private(self):
+        return self.get_dsn(public=False)
+
+    @property
+    def dsn_public(self):
+        return self.get_dsn(public=True)
+
+    @property
+    def csp_endpoint(self):
+        return (
+            f"{self.base_url}/api/{self.project_key.project_id}/csp-report/"
+            f"?sentry_key={self.project_key.public_key}"
+        )
+
+    @property
+    def security_endpoint(self):
+        return (
+            f"{self.base_url}/api/{self.project_key.project_id}/security/"
+            f"?sentry_key={self.project_key.public_key}"
+        )
+
+    @property
+    def nel_endpoint(self):
+        return (
+            f"{self.base_url}/api/{self.project_key.project_id}/nel/"
+            f"?sentry_key={self.project_key.public_key}"
+        )
+
+    @property
+    def minidump_endpoint(self):
+        return (
+            f"{self.base_url}/api/{self.project_key.project_id}/minidump/"
+            f"?sentry_key={self.project_key.public_key}"
+        )
+
+    @property
+    def playstation_endpoint(self):
+        return (
+            f"{self.base_url}/api/{self.project_key.project_id}/playstation/"
+            f"?sentry_key={self.project_key.public_key}"
+        )
+
+    @property
+    def integration_endpoint(self):
+        return f"{self.base_url}/api/{self.project_key.project_id}/integration/"
+
+    def build_integration_endpoint(self, integration_name: str, postfix: str = "") -> str:
+        return f"{self.integration_endpoint}{integration_name}/{postfix}"
+
+    @property
+    def otlp_traces_endpoint(self):
+        return self.build_integration_endpoint("otlp", "v1/traces")
+
+    @property
+    def otlp_logs_endpoint(self):
+        return self.build_integration_endpoint("otlp", "v1/logs")
+
+    @property
+    def unreal_endpoint(self) -> str:
+        return (
+            f"{self.base_url}/api/{self.project_key.project_id}/unreal/"
+            f"{self.project_key.public_key}/"
+        )
+
+    @property
+    def crons_endpoint(self) -> str:
+        return (
+            f"{self.base_url}/api/{self.project_key.project_id}/cron/___MONITOR_SLUG___/"
+            f"{self.project_key.public_key}/"
+        )
+
+    @property
+    def js_sdk_loader_cdn_url(self) -> str:
+        if settings.JS_SDK_LOADER_CDN_URL:
+            return f"{settings.JS_SDK_LOADER_CDN_URL}{self.project_key.public_key}.min.js"
+        return "{}{}".format(
+            self.base_url,
+            reverse("sentry-js-sdk-loader", args=[self.project_key.public_key, ".min"]),
+        )
 
 
 @cell_silo_model
@@ -324,6 +429,9 @@ class ProjectKey(ReplicatedCellModel):
                 endpoint,
                 reverse("sentry-js-sdk-loader", args=[self.public_key, ".min"]),
             )
+
+    def get_endpoint_urls(self, base_url: str | None = None) -> ProjectKeyEndpointUrls:
+        return ProjectKeyEndpointUrls(self, base_url or self.get_endpoint())
 
     def get_endpoint(self) -> str:
         from sentry.api.utils import generate_locality_url

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -175,10 +175,12 @@ class ProjectKeyEndpointUrls:
 
     @property
     def js_sdk_loader_cdn_url(self) -> str:
+        # The loader is served by Sentry, not by a customer Relay, so this URL
+        # ignores `base_url` and always points at the canonical endpoint.
         if settings.JS_SDK_LOADER_CDN_URL:
             return f"{settings.JS_SDK_LOADER_CDN_URL}{self.project_key.public_key}.min.js"
         return "{}{}".format(
-            self.base_url,
+            self.project_key.get_endpoint(),
             reverse("sentry-js-sdk-loader", args=[self.project_key.public_key, ".min"]),
         )
 
@@ -335,19 +337,7 @@ class ProjectKey(ReplicatedCellModel):
         super().save(*args, **kwargs)
 
     def get_dsn(self, domain=None, secure=True, public=False):
-        urlparts = urlparse(self.get_endpoint())
-
-        if not public:
-            key = f"{self.public_key}:{self.secret_key}"
-        else:
-            assert self.public_key is not None
-            key = self.public_key
-
-        # If we do not have a scheme or domain/hostname, dsn is never valid
-        if not urlparts.netloc or not urlparts.scheme:
-            return ""
-
-        return f"{urlparts.scheme}://{key}@{urlparts.netloc + urlparts.path}/{self.project_id}"
+        return self.get_endpoint_urls().get_dsn(public=public)
 
     @property
     def organization_id(self):
@@ -359,79 +349,63 @@ class ProjectKey(ReplicatedCellModel):
 
     @property
     def dsn_private(self):
-        return self.get_dsn(public=False)
+        return self.get_endpoint_urls().dsn_private
 
     @property
     def dsn_public(self):
-        return self.get_dsn(public=True)
+        return self.get_endpoint_urls().dsn_public
 
     @property
     def csp_endpoint(self):
-        endpoint = self.get_endpoint()
-
-        return f"{endpoint}/api/{self.project_id}/csp-report/?sentry_key={self.public_key}"
+        return self.get_endpoint_urls().csp_endpoint
 
     @property
     def security_endpoint(self):
-        endpoint = self.get_endpoint()
-
-        return f"{endpoint}/api/{self.project_id}/security/?sentry_key={self.public_key}"
+        return self.get_endpoint_urls().security_endpoint
 
     @property
     def nel_endpoint(self):
-        endpoint = self.get_endpoint()
-
-        return f"{endpoint}/api/{self.project_id}/nel/?sentry_key={self.public_key}"
+        return self.get_endpoint_urls().nel_endpoint
 
     @property
     def minidump_endpoint(self):
-        endpoint = self.get_endpoint()
-
-        return f"{endpoint}/api/{self.project_id}/minidump/?sentry_key={self.public_key}"
+        return self.get_endpoint_urls().minidump_endpoint
 
     @property
     def playstation_endpoint(self):
-        endpoint = self.get_endpoint()
-
-        return f"{endpoint}/api/{self.project_id}/playstation/?sentry_key={self.public_key}"
+        return self.get_endpoint_urls().playstation_endpoint
 
     @property
     def integration_endpoint(self):
-        endpoint = self.get_endpoint()
-        return f"{endpoint}/api/{self.project_id}/integration/"
+        return self.get_endpoint_urls().integration_endpoint
 
     def build_integration_endpoint(self, integration_name: str, postfix: str = "") -> str:
-        return f"{self.integration_endpoint}{integration_name}/{postfix}"
+        return self.get_endpoint_urls().build_integration_endpoint(integration_name, postfix)
 
     @property
     def otlp_traces_endpoint(self):
-        return self.build_integration_endpoint("otlp", "v1/traces")
+        return self.get_endpoint_urls().otlp_traces_endpoint
 
     @property
     def otlp_logs_endpoint(self):
-        return self.build_integration_endpoint("otlp", "v1/logs")
+        return self.get_endpoint_urls().otlp_logs_endpoint
 
     @property
     def unreal_endpoint(self) -> str:
-        return f"{self.get_endpoint()}/api/{self.project_id}/unreal/{self.public_key}/"
+        return self.get_endpoint_urls().unreal_endpoint
 
     @property
     def crons_endpoint(self) -> str:
-        return f"{self.get_endpoint()}/api/{self.project_id}/cron/___MONITOR_SLUG___/{self.public_key}/"
+        return self.get_endpoint_urls().crons_endpoint
 
     @property
     def js_sdk_loader_cdn_url(self) -> str:
-        if settings.JS_SDK_LOADER_CDN_URL:
-            return f"{settings.JS_SDK_LOADER_CDN_URL}{self.public_key}.min.js"
-        else:
-            endpoint = self.get_endpoint()
-            return "{}{}".format(
-                endpoint,
-                reverse("sentry-js-sdk-loader", args=[self.public_key, ".min"]),
-            )
+        return self.get_endpoint_urls().js_sdk_loader_cdn_url
 
-    def get_endpoint_urls(self, base_url: str | None = None) -> ProjectKeyEndpointUrls:
-        return ProjectKeyEndpointUrls(self, base_url or self.get_endpoint())
+    def get_endpoint_urls(self) -> ProjectKeyEndpointUrls:
+        # Apply the org's relay-dsn-endpoint override when set; canonical otherwise.
+        base_url = self.organization.get_option("sentry:relay_dsn_endpoint") or self.get_endpoint()
+        return ProjectKeyEndpointUrls(self, base_url)
 
     def get_endpoint(self) -> str:
         from sentry.api.utils import generate_locality_url

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -336,9 +336,6 @@ class ProjectKey(ReplicatedCellModel):
             self.label = petname.generate(2, " ", letters=10).title()
         super().save(*args, **kwargs)
 
-    def get_dsn(self, domain=None, secure=True, public=False):
-        return self.get_endpoint_urls().get_dsn(public=public)
-
     @property
     def organization_id(self):
         return self.project.organization_id
@@ -346,61 +343,6 @@ class ProjectKey(ReplicatedCellModel):
     @property
     def organization(self):
         return self.project.organization
-
-    @property
-    def dsn_private(self):
-        return self.get_endpoint_urls().dsn_private
-
-    @property
-    def dsn_public(self):
-        return self.get_endpoint_urls().dsn_public
-
-    @property
-    def csp_endpoint(self):
-        return self.get_endpoint_urls().csp_endpoint
-
-    @property
-    def security_endpoint(self):
-        return self.get_endpoint_urls().security_endpoint
-
-    @property
-    def nel_endpoint(self):
-        return self.get_endpoint_urls().nel_endpoint
-
-    @property
-    def minidump_endpoint(self):
-        return self.get_endpoint_urls().minidump_endpoint
-
-    @property
-    def playstation_endpoint(self):
-        return self.get_endpoint_urls().playstation_endpoint
-
-    @property
-    def integration_endpoint(self):
-        return self.get_endpoint_urls().integration_endpoint
-
-    def build_integration_endpoint(self, integration_name: str, postfix: str = "") -> str:
-        return self.get_endpoint_urls().build_integration_endpoint(integration_name, postfix)
-
-    @property
-    def otlp_traces_endpoint(self):
-        return self.get_endpoint_urls().otlp_traces_endpoint
-
-    @property
-    def otlp_logs_endpoint(self):
-        return self.get_endpoint_urls().otlp_logs_endpoint
-
-    @property
-    def unreal_endpoint(self) -> str:
-        return self.get_endpoint_urls().unreal_endpoint
-
-    @property
-    def crons_endpoint(self) -> str:
-        return self.get_endpoint_urls().crons_endpoint
-
-    @property
-    def js_sdk_loader_cdn_url(self) -> str:
-        return self.get_endpoint_urls().js_sdk_loader_cdn_url
 
     def get_endpoint_urls(self) -> ProjectKeyEndpointUrls:
         # Apply the org's relay-dsn-endpoint override when set; canonical otherwise.

--- a/src/sentry/projects/services/project_key/serial.py
+++ b/src/sentry/projects/services/project_key/serial.py
@@ -3,10 +3,11 @@ from sentry.projects.services.project_key import RpcProjectKey
 
 
 def serialize_project_key(project_key: ProjectKey) -> RpcProjectKey:
+    endpoint_urls = project_key.get_endpoint_urls()
     return RpcProjectKey(
         project_id=project_key.project_id,
-        dsn_public=project_key.dsn_public,
+        dsn_public=endpoint_urls.dsn_public,
         status=project_key.status,
         public_key=project_key.public_key,
-        integration_endpoint=project_key.integration_endpoint,
+        integration_endpoint=endpoint_urls.integration_endpoint,
     )

--- a/src/sentry/runner/commands/createproject.py
+++ b/src/sentry/runner/commands/createproject.py
@@ -82,7 +82,7 @@ def createproject(
         )
 
     key = ProjectKey.get_default(project)
-    dsn = key.dsn_public if key else "(no DSN available)"
+    dsn = key.get_endpoint_urls().dsn_public if key else "(no DSN available)"
 
     click.echo("Created project:")
     click.echo(f"  ID: {project.id}")

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -2386,5 +2386,5 @@ def get_dsn(
     return GetDsnResponse(
         project_slug=project.slug,
         platform=project.platform,
-        dsn_public=key.dsn_public,
+        dsn_public=key.get_endpoint_urls().dsn_public,
     )

--- a/src/sentry/tempest/tasks.py
+++ b/src/sentry/tempest/tasks.py
@@ -299,7 +299,7 @@ def _poll_tempest_crashes_impl(credentials_id: int) -> None:
             project_key, created = ProjectKey.objects.get_or_create(
                 use_case=UseCase.TEMPEST, project=credentials.project
             )
-            dsn = project_key.get_dsn()
+            dsn = project_key.get_endpoint_urls().get_dsn()
             if created:
                 schedule_invalidate_project_config(
                     project_id=project_id, trigger="tempest:poll_tempest_crashes"

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -359,8 +359,10 @@ def configure_sdk():
         sentry_saas_transport = patch_transport_for_instrumentation(transport, "relay")
     elif settings.IS_DEV and not settings.SENTRY_USE_RELAY:
         sentry_saas_transport = None
-    elif internal_project_key and internal_project_key.dsn_private:
-        transport = make_transport(get_options(dsn=internal_project_key.dsn_private, **sdk_options))
+    elif internal_project_key and (
+        dsn_private := internal_project_key.get_endpoint_urls().dsn_private
+    ):
+        transport = make_transport(get_options(dsn=dsn_private, **sdk_options))
         sentry_saas_transport = patch_transport_for_instrumentation(transport, "relay")
     else:
         sentry_saas_transport = None

--- a/src/sentry/web/frontend/debug/debug_error_embed.py
+++ b/src/sentry/web/frontend/debug/debug_error_embed.py
@@ -18,7 +18,7 @@ class DebugErrorPageEmbedView(View):
         context = {
             "query_params": urlencode(
                 {
-                    "dsn": self._get_project_key().dsn_public,
+                    "dsn": self._get_project_key().get_endpoint_urls().dsn_public,
                     "eventId": "342a3d7f690a49f8bd7c4cf0e61a9ded",
                     **request.GET,
                 }

--- a/src/sentry/web/frontend/js_sdk_loader.py
+++ b/src/sentry/web/frontend/js_sdk_loader.py
@@ -243,7 +243,7 @@ class JavaScriptSdkLoader(View):
         except TypeError:
             sdk_url = ""  # It fails if it cannot inject the version in the string
 
-        config: SdkConfig = {"dsn": key.dsn_public}
+        config: SdkConfig = {"dsn": key.get_endpoint_urls().dsn_public}
 
         if loader_config["hasDebug"]:
             config["debug"] = True

--- a/tests/acceptance/test_error_page_embed.py
+++ b/tests/acceptance/test_error_page_embed.py
@@ -14,10 +14,11 @@ class ErrorPageEmbedTest(AcceptanceTestCase):
         self.project = self.create_project()
         self.key = self.create_project_key(project=self.project)
         self.event_id = uuid4().hex
+        dsn_public = self.key.get_endpoint_urls().dsn_public
         self.path = "{}?eventId={}&dsn={}".format(
             reverse("sentry-error-page-embed"),
             quote(self.event_id),
-            quote(self.key.dsn_public),
+            quote(dsn_public),
         )
 
     def wait_for_error_page_embed(self) -> None:

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -41,7 +41,7 @@ def post_event_with_sdk(settings, scope: Scope, relay_server, wait_for_ingest_co
     assert internal_project_key is not None
 
     client = sentry_sdk.Client(
-        dsn=internal_project_key.dsn_private,
+        dsn=internal_project_key.get_endpoint_urls().dsn_private,
     )
 
     wait_for_ingest_consumer = wait_for_ingest_consumer(settings)

--- a/tests/sentry/api/endpoints/test_dsn_lookup.py
+++ b/tests/sentry/api/endpoints/test_dsn_lookup.py
@@ -12,7 +12,7 @@ class DsnLookupEndpointTest(APITestCase):
         self.project = self.create_project(organization=self.org)
         self.key = self.project.key_set.first()
         assert self.key is not None
-        self.dsn = self.key.dsn_public
+        self.dsn = self.key.get_endpoint_urls().dsn_public
         self.login_as(self.user)
 
     def test_valid_dsn_returns_project_info(self) -> None:
@@ -37,7 +37,9 @@ class DsnLookupEndpointTest(APITestCase):
         other_key = other_project.key_set.first()
         assert other_key is not None
 
-        response = self.get_response(self.org.slug, qs_params={"dsn": other_key.dsn_public})
+        response = self.get_response(
+            self.org.slug, qs_params={"dsn": other_key.get_endpoint_urls().dsn_public}
+        )
         assert response.status_code == 404
 
     def test_user_without_project_access_returns_404(self) -> None:
@@ -54,5 +56,7 @@ class DsnLookupEndpointTest(APITestCase):
         self.create_member(user=user_without_access, organization=org, role="member", teams=[])
         self.login_as(user_without_access)
 
-        response = self.get_response(org.slug, qs_params={"dsn": key.dsn_public})
+        response = self.get_response(
+            org.slug, qs_params={"dsn": key.get_endpoint_urls().dsn_public}
+        )
         assert response.status_code == 404

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -250,7 +250,9 @@ class TestDSNAuthentication(TestCase):
 
     def test_authenticate(self) -> None:
         request = _drf_request()
-        request.META["HTTP_AUTHORIZATION"] = f"DSN {self.project_key.dsn_public}"
+        request.META["HTTP_AUTHORIZATION"] = (
+            f"DSN {self.project_key.get_endpoint_urls().dsn_public}"
+        )
 
         result = self.auth.authenticate(request)
         assert result is not None
@@ -262,7 +264,9 @@ class TestDSNAuthentication(TestCase):
     def test_inactive_key(self) -> None:
         self.project_key.update(status=ProjectKeyStatus.INACTIVE)
         request = _drf_request()
-        request.META["HTTP_AUTHORIZATION"] = f"DSN {self.project_key.dsn_public}"
+        request.META["HTTP_AUTHORIZATION"] = (
+            f"DSN {self.project_key.get_endpoint_urls().dsn_public}"
+        )
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -24,7 +24,11 @@ from sentry.constants import (
     SEER_DEFAULT_CODING_AGENT_DEFAULT,
     ObjectStatus,
 )
-from sentry.core.endpoints.organization_details import ERR_NO_2FA, ERR_SSO_ENABLED
+from sentry.core.endpoints.organization_details import (
+    ERR_NO_2FA,
+    ERR_RELAY_DSN_ENDPOINT_INVALID,
+    ERR_SSO_ENABLED,
+)
 from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.dynamic_sampling.types import DynamicSamplingMode
 from sentry.models.auditlogentry import AuditLogEntry
@@ -1250,6 +1254,82 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
     def test_get_ingest_through_trusted_relays_only_option(self) -> None:
         response = self.get_success_response(self.organization.slug)
         assert response.data["ingestThroughTrustedRelaysOnly"] == "disabled"
+
+    def test_relay_dsn_endpoint_returned_when_set(self) -> None:
+        self.organization.update_option(
+            "sentry:relay_dsn_endpoint", "https://relay.example.com/ingest"
+        )
+
+        response = self.get_success_response(self.organization.slug)
+
+        assert response.data["relayDsnEndpoint"] == "https://relay.example.com/ingest"
+
+    @with_feature("organizations:relay-dsn-endpoint-override")
+    def test_relay_dsn_endpoint_accepts_valid_write(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug,
+            relayDsnEndpoint="https://relay.example.com/ingest/",
+        )
+
+        assert self.organization.get_option("sentry:relay_dsn_endpoint") == (
+            "https://relay.example.com/ingest"
+        )
+        assert response.data["relayDsnEndpoint"] == "https://relay.example.com/ingest"
+
+    @with_feature("organizations:relay-dsn-endpoint-override")
+    def test_relay_dsn_endpoint_blank_clears_value(self) -> None:
+        self.organization.update_option(
+            "sentry:relay_dsn_endpoint", "https://relay.example.com/ingest"
+        )
+
+        response = self.get_success_response(self.organization.slug, relayDsnEndpoint="")
+
+        assert self.organization.get_option("sentry:relay_dsn_endpoint") is None
+        assert response.data["relayDsnEndpoint"] is None
+
+    @with_feature("organizations:relay-dsn-endpoint-override")
+    def test_relay_dsn_endpoint_null_clears_value(self) -> None:
+        self.organization.update_option(
+            "sentry:relay_dsn_endpoint", "https://relay.example.com/ingest"
+        )
+
+        response = self.get_success_response(self.organization.slug, relayDsnEndpoint=None)
+
+        assert self.organization.get_option("sentry:relay_dsn_endpoint") is None
+        assert response.data["relayDsnEndpoint"] is None
+
+    def test_relay_dsn_endpoint_rejects_write_without_feature(self) -> None:
+        response = self.get_error_response(
+            self.organization.slug,
+            status_code=400,
+            relayDsnEndpoint="https://relay.example.com/ingest",
+        )
+
+        assert response.data["relayDsnEndpoint"] == [
+            "Organization does not have the Relay DSN endpoint override feature enabled."
+        ]
+        assert self.organization.get_option("sentry:relay_dsn_endpoint") is None
+
+    def test_relay_dsn_endpoint_rejects_invalid_url(self) -> None:
+        relay_dsn_endpoints = [
+            "relay.example.com",
+            "https:///relay",
+            "ftp://relay.example.com",
+            "https://user:password@relay.example.com",
+            "https://relay.example.com?foo=bar",
+            "https://relay.example.com#fragment",
+        ]
+
+        with self.feature("organizations:relay-dsn-endpoint-override"):
+            for relay_dsn_endpoint in relay_dsn_endpoints:
+                with self.subTest(relay_dsn_endpoint=relay_dsn_endpoint):
+                    response = self.get_error_response(
+                        self.organization.slug,
+                        status_code=400,
+                        relayDsnEndpoint=relay_dsn_endpoint,
+                    )
+
+                    assert response.data["relayDsnEndpoint"] == [ERR_RELAY_DSN_ENDPOINT_INVALID]
 
     @with_feature("organizations:dynamic-sampling-custom")
     def test_target_sample_rate_range(self) -> None:

--- a/tests/sentry/core/endpoints/test_project_keys.py
+++ b/tests/sentry/core/endpoints/test_project_keys.py
@@ -40,6 +40,39 @@ class ListProjectKeysTest(APITestCase):
         assert response.status_code == 200
         assert response.data[0]["dsn"]["playstation"] == key.playstation_endpoint
 
+    def test_relay_dsn_endpoint_override(self) -> None:
+        project = self.create_project()
+        project.organization.update_option(
+            "sentry:relay_dsn_endpoint", "https://relay.example.com/ingest"
+        )
+        key = ProjectKey.objects.get_or_create(project=project)[0]
+        self.login_as(user=self.user)
+        url = reverse(
+            "sentry-api-0-project-keys",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.data[0]["dsn"] == {
+            "public": f"https://{key.public_key}@relay.example.com/ingest/{project.id}",
+            "secret": f"https://{key.public_key}:{key.secret_key}@relay.example.com/ingest/{project.id}",
+            "csp": f"https://relay.example.com/ingest/api/{project.id}/csp-report/?sentry_key={key.public_key}",
+            "security": f"https://relay.example.com/ingest/api/{project.id}/security/?sentry_key={key.public_key}",
+            "minidump": f"https://relay.example.com/ingest/api/{project.id}/minidump/?sentry_key={key.public_key}",
+            "nel": f"https://relay.example.com/ingest/api/{project.id}/nel/?sentry_key={key.public_key}",
+            "unreal": f"https://relay.example.com/ingest/api/{project.id}/unreal/{key.public_key}/",
+            "crons": f"https://relay.example.com/ingest/api/{project.id}/cron/___MONITOR_SLUG___/{key.public_key}/",
+            "cdn": key.js_sdk_loader_cdn_url,
+            "playstation": f"https://relay.example.com/ingest/api/{project.id}/playstation/?sentry_key={key.public_key}",
+            "integration": f"https://relay.example.com/ingest/api/{project.id}/integration/",
+            "otlp_traces": f"https://relay.example.com/ingest/api/{project.id}/integration/otlp/v1/traces",
+            "otlp_logs": f"https://relay.example.com/ingest/api/{project.id}/integration/otlp/v1/logs",
+        }
+
     def test_integration_endpoint(self) -> None:
         project = self.create_project()
         key = ProjectKey.objects.get_or_create(project=project)[0]

--- a/tests/sentry/core/endpoints/test_project_keys.py
+++ b/tests/sentry/core/endpoints/test_project_keys.py
@@ -38,7 +38,9 @@ class ListProjectKeysTest(APITestCase):
         )
         response = self.client.get(url)
         assert response.status_code == 200
-        assert response.data[0]["dsn"]["playstation"] == key.playstation_endpoint
+        assert (
+            response.data[0]["dsn"]["playstation"] == key.get_endpoint_urls().playstation_endpoint
+        )
 
     def test_relay_dsn_endpoint_override(self) -> None:
         project = self.create_project()
@@ -66,7 +68,7 @@ class ListProjectKeysTest(APITestCase):
             "nel": f"https://relay.example.com/ingest/api/{project.id}/nel/?sentry_key={key.public_key}",
             "unreal": f"https://relay.example.com/ingest/api/{project.id}/unreal/{key.public_key}/",
             "crons": f"https://relay.example.com/ingest/api/{project.id}/cron/___MONITOR_SLUG___/{key.public_key}/",
-            "cdn": key.js_sdk_loader_cdn_url,
+            "cdn": key.get_endpoint_urls().js_sdk_loader_cdn_url,
             "playstation": f"https://relay.example.com/ingest/api/{project.id}/playstation/?sentry_key={key.public_key}",
             "integration": f"https://relay.example.com/ingest/api/{project.id}/integration/",
             "otlp_traces": f"https://relay.example.com/ingest/api/{project.id}/integration/otlp/v1/traces",
@@ -86,7 +88,9 @@ class ListProjectKeysTest(APITestCase):
         )
         response = self.client.get(url)
         assert response.status_code == 200
-        assert response.data[0]["dsn"]["integration"] == key.integration_endpoint
+        assert (
+            response.data[0]["dsn"]["integration"] == key.get_endpoint_urls().integration_endpoint
+        )
 
     def test_otlp_traces_endpoint(self) -> None:
         project = self.create_project()
@@ -101,7 +105,9 @@ class ListProjectKeysTest(APITestCase):
         )
         response = self.client.get(url)
         assert response.status_code == 200
-        assert response.data[0]["dsn"]["otlp_traces"] == key.otlp_traces_endpoint
+        assert (
+            response.data[0]["dsn"]["otlp_traces"] == key.get_endpoint_urls().otlp_traces_endpoint
+        )
 
     def test_otlp_logs_endpoint(self) -> None:
         project = self.create_project()
@@ -116,7 +122,7 @@ class ListProjectKeysTest(APITestCase):
         )
         response = self.client.get(url)
         assert response.status_code == 200
-        assert response.data[0]["dsn"]["otlp_logs"] == key.otlp_logs_endpoint
+        assert response.data[0]["dsn"]["otlp_logs"] == key.get_endpoint_urls().otlp_logs_endpoint
         assert "integration/otlp/v1/logs" in response.data[0]["dsn"]["otlp_logs"]
 
     def test_use_case(self) -> None:

--- a/tests/sentry/feedback/endpoints/test_error_page_embed.py
+++ b/tests/sentry/feedback/endpoints/test_error_page_embed.py
@@ -37,10 +37,11 @@ class ErrorPageEmbedTest(TestCase):
         self.project = self.create_project()
         self.project.update_option("sentry:origins", ["example.com"])
         self.key = self.create_project_key(self.project)
+        self.dsn_public = self.key.get_endpoint_urls().dsn_public
         self.event_id = uuid4().hex
         self.path = reverse("sentry-error-page-embed")
         self.path_with_qs = (
-            f"{self.path}?eventId={quote(self.event_id)}&dsn={quote(self.key.dsn_public)}"
+            f"{self.path}?eventId={quote(self.event_id)}&dsn={quote(self.dsn_public)}"
         )
 
     def test_invalid_referer(self) -> None:
@@ -63,7 +64,7 @@ class ErrorPageEmbedTest(TestCase):
         assert resp["Content-Type"] == "text/javascript"
 
     def test_missing_eventId(self) -> None:
-        path = f"{self.path}?dsn={quote(self.key.dsn_public)}"
+        path = f"{self.path}?dsn={quote(self.dsn_public)}"
         resp = self.client.get(
             path, HTTP_REFERER="http://example.com", HTTP_ACCEPT="text/html, text/javascript"
         )
@@ -158,7 +159,7 @@ class ErrorPageEmbedTest(TestCase):
             user_feedback_options[key] = f"<img src=x onerror=alert({key})>XSS_{key}".encode()
 
         user_feedback_options_qs = urlencode(user_feedback_options)
-        path_with_qs = f"{self.path}?eventId={quote(self.event_id)}&dsn={quote(self.key.dsn_public)}&{user_feedback_options_qs}"
+        path_with_qs = f"{self.path}?eventId={quote(self.event_id)}&dsn={quote(self.dsn_public)}&{user_feedback_options_qs}"
         resp = self.client.get(
             path_with_qs,
             HTTP_REFERER="http://example.com",
@@ -205,7 +206,7 @@ class ErrorPageEmbedTest(TestCase):
 
     def test_submission_invalid_event_id(self) -> None:
         self.event_id = "x" * 100
-        path = f"{self.path}?eventId={quote(self.event_id)}&dsn={quote(self.key.dsn_public)}"
+        path = f"{self.path}?eventId={quote(self.event_id)}&dsn={quote(self.dsn_public)}"
 
         resp = self.client.post(
             path,
@@ -235,7 +236,7 @@ class ErrorPageEmbedEnvironmentTest(TestCase):
         self.path = "{}?eventId={}&dsn={}".format(
             reverse("sentry-error-page-embed"),
             quote(self.event_id),
-            quote(self.key.dsn_public),
+            quote(self.key.get_endpoint_urls().dsn_public),
         )
         self.environment = Environment.objects.create(
             organization_id=self.project.organization_id,

--- a/tests/sentry/feedback/endpoints/test_project_user_reports.py
+++ b/tests/sentry/feedback/endpoints/test_project_user_reports.py
@@ -123,7 +123,9 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
         url = _make_url(project)
 
-        response = self.client.get(url, HTTP_AUTHORIZATION=f"DSN {project_key.dsn_public}")
+        response = self.client.get(
+            url, HTTP_AUTHORIZATION=f"DSN {project_key.get_endpoint_urls().dsn_public}"
+        )
 
         assert response.status_code == 401, response.content
 
@@ -285,7 +287,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
 
         response = self.client.post(
             url,
-            HTTP_AUTHORIZATION=f"DSN {project_key.dsn_public}",
+            HTTP_AUTHORIZATION=f"DSN {project_key.get_endpoint_urls().dsn_public}",
             data={
                 "event_id": self.event.event_id,
                 "email": "foo@example.com",
@@ -306,7 +308,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
 
         response = self.client.post(
             url,
-            HTTP_AUTHORIZATION=f"DSN {project_key.dsn_public}",
+            HTTP_AUTHORIZATION=f"DSN {project_key.get_endpoint_urls().dsn_public}",
             data={
                 "event_id": uuid4().hex,
                 "email": "foo@example.com",

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_serverless_functions.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_serverless_functions.py
@@ -42,7 +42,7 @@ class AbstractServerlessTest(APITestCase):
 
     @property
     def sentry_dsn(self):
-        return ProjectKey.get_default(project=self.project).get_dsn(public=True)
+        return ProjectKey.get_default(project=self.project).get_endpoint_urls().get_dsn(public=True)
 
     def set_up_response_mocks(self, get_function_response, update_function_configuration_kwargs):
         responses.add(

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -200,7 +200,11 @@ class AwsLambdaApiPipelineTest(APITestCase):
         ]
 
         with assume_test_silo_mode(SiloMode.CELL):
-            sentry_project_dsn = ProjectKey.get_default(project=self.projectA).get_dsn(public=True)
+            sentry_project_dsn = (
+                ProjectKey.get_default(project=self.projectA)
+                .get_endpoint_urls()
+                .get_dsn(public=True)
+            )
 
         self._initialize_pipeline()
         self._advance_step({"projectId": self.projectA.id})

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -90,8 +90,9 @@ class VercelIntegrationTest(IntegrationTestCase):
         project_id = self.project.id
         with assume_test_silo_mode(SiloMode.CELL):
             project_key = ProjectKey.get_default(project=Project.objects.get(id=project_id))
-            enabled_dsn = project_key.get_dsn(public=True)
-            integration_endpoint = project_key.integration_endpoint
+            endpoint_urls = project_key.get_endpoint_urls()
+            enabled_dsn = endpoint_urls.get_dsn(public=True)
+            integration_endpoint = endpoint_urls.integration_endpoint
             public_key = project_key.public_key
         sentry_auth_token = SentryAppInstallationToken.objects.get_token(org.id, "vercel")
 
@@ -235,8 +236,9 @@ class VercelIntegrationTest(IntegrationTestCase):
         project_id = self.project.id
         with assume_test_silo_mode(SiloMode.CELL):
             project_key = ProjectKey.get_default(project=Project.objects.get(id=project_id))
-            enabled_dsn = project_key.get_dsn(public=True)
-            integration_endpoint = project_key.integration_endpoint
+            endpoint_urls = project_key.get_endpoint_urls()
+            enabled_dsn = endpoint_urls.get_dsn(public=True)
+            integration_endpoint = endpoint_urls.integration_endpoint
             public_key = project_key.public_key
 
         sentry_auth_token = SentryAppInstallationToken.objects.get_token(org.id, "vercel")
@@ -397,8 +399,9 @@ class VercelIntegrationTest(IntegrationTestCase):
         project_id = self.project.id
         with assume_test_silo_mode(SiloMode.CELL):
             project_key = ProjectKey.get_default(project=Project.objects.get(id=project_id))
-            enabled_dsn = project_key.get_dsn(public=True)
-            integration_endpoint = project_key.integration_endpoint
+            endpoint_urls = project_key.get_endpoint_urls()
+            enabled_dsn = endpoint_urls.get_dsn(public=True)
+            integration_endpoint = endpoint_urls.integration_endpoint
             public_key = project_key.public_key
 
         sentry_auth_token = SentryAppInstallationToken.objects.get_token(org.id, "vercel")

--- a/tests/sentry/models/test_projectkey.py
+++ b/tests/sentry/models/test_projectkey.py
@@ -24,7 +24,10 @@ class ProjectKeyTest(TestCase):
             self.options({"system.url-prefix": "http://example.com"}),
             override_settings(SENTRY_REGION_API_URL_TEMPLATE=""),
         ):
-            self.assertEqual(key.get_dsn(), f"http://public:secret@example.com/{self.project.id}")
+            self.assertEqual(
+                key.get_endpoint_urls().get_dsn(),
+                f"http://public:secret@example.com/{self.project.id}",
+            )
 
     def test_get_dsn_with_ssl(self) -> None:
         key = ProjectKey(project_id=self.project.id, public_key="public", secret_key="secret")
@@ -32,7 +35,10 @@ class ProjectKeyTest(TestCase):
             self.options({"system.url-prefix": "https://example.com"}),
             override_settings(SENTRY_REGION_API_URL_TEMPLATE=""),
         ):
-            self.assertEqual(key.get_dsn(), f"https://public:secret@example.com/{self.project.id}")
+            self.assertEqual(
+                key.get_endpoint_urls().get_dsn(),
+                f"https://public:secret@example.com/{self.project.id}",
+            )
 
     def test_get_dsn_with_port(self) -> None:
         key = ProjectKey(project_id=self.project.id, public_key="public", secret_key="secret")
@@ -41,20 +47,25 @@ class ProjectKeyTest(TestCase):
             override_settings(SENTRY_REGION_API_URL_TEMPLATE=""),
         ):
             self.assertEqual(
-                key.get_dsn(), f"http://public:secret@example.com:81/{self.project.id}"
+                key.get_endpoint_urls().get_dsn(),
+                f"http://public:secret@example.com:81/{self.project.id}",
             )
 
     def test_get_dsn_with_public_endpoint_setting(self) -> None:
         key = ProjectKey(project_id=self.project.id, public_key="public", secret_key="secret")
         with self.settings(SENTRY_ENDPOINT="http://endpoint.com"):
             self.assertEqual(
-                key.get_dsn(public=True), f"http://public@endpoint.com/{self.project.id}"
+                key.get_endpoint_urls().get_dsn(public=True),
+                f"http://public@endpoint.com/{self.project.id}",
             )
 
     def test_get_dsn_with_endpoint_setting(self) -> None:
         key = ProjectKey(project_id=self.project.id, public_key="public", secret_key="secret")
         with self.settings(SENTRY_ENDPOINT="http://endpoint.com"):
-            self.assertEqual(key.get_dsn(), f"http://public:secret@endpoint.com/{self.project.id}")
+            self.assertEqual(
+                key.get_endpoint_urls().get_dsn(),
+                f"http://public:secret@endpoint.com/{self.project.id}",
+            )
 
     def test_key_is_created_for_project(self) -> None:
         self.create_user("admin@example.com")
@@ -96,22 +107,29 @@ class ProjectKeyTest(TestCase):
     def test_get_dsn(self) -> None:
         with override_settings(SENTRY_REGION_API_URL_TEMPLATE=""):
             key = self.model(project_id=self.project.id, public_key="abc", secret_key="xyz")
-            assert key.dsn_private == f"http://abc:xyz@testserver/{self.project.id}"
-            assert key.dsn_public == f"http://abc@testserver/{self.project.id}"
+            endpoint_urls = key.get_endpoint_urls()
+
+            assert endpoint_urls.dsn_private == f"http://abc:xyz@testserver/{self.project.id}"
+            assert endpoint_urls.dsn_public == f"http://abc@testserver/{self.project.id}"
             assert (
-                key.csp_endpoint
+                endpoint_urls.csp_endpoint
                 == f"http://testserver/api/{self.project.id}/csp-report/?sentry_key=abc"
             )
             assert (
-                key.minidump_endpoint
+                endpoint_urls.minidump_endpoint
                 == f"http://testserver/api/{self.project.id}/minidump/?sentry_key=abc"
             )
-            assert key.unreal_endpoint == f"http://testserver/api/{self.project.id}/unreal/abc/"
             assert (
-                key.crons_endpoint
+                endpoint_urls.unreal_endpoint
+                == f"http://testserver/api/{self.project.id}/unreal/abc/"
+            )
+            assert (
+                endpoint_urls.crons_endpoint
                 == f"http://testserver/api/{self.project.id}/cron/___MONITOR_SLUG___/abc/"
             )
-            assert key.js_sdk_loader_cdn_url == "http://testserver/js-sdk-loader/abc.min.js"
+            assert (
+                endpoint_urls.js_sdk_loader_cdn_url == "http://testserver/js-sdk-loader/abc.min.js"
+            )
 
     def test_get_dsn_org_subdomain(self) -> None:
         with (
@@ -120,20 +138,23 @@ class ProjectKeyTest(TestCase):
         ):
             key = self.model(project_id=self.project.id, public_key="abc", secret_key="xyz")
             host = f"o{key.project.organization_id}.ingest.testserver"
+            endpoint_urls = key.get_endpoint_urls()
 
-            assert key.dsn_private == f"http://abc:xyz@{host}/{self.project.id}"
-            assert key.dsn_public == f"http://abc@{host}/{self.project.id}"
+            assert endpoint_urls.dsn_private == f"http://abc:xyz@{host}/{self.project.id}"
+            assert endpoint_urls.dsn_public == f"http://abc@{host}/{self.project.id}"
             assert (
-                key.csp_endpoint
+                endpoint_urls.csp_endpoint
                 == f"http://{host}/api/{self.project.id}/csp-report/?sentry_key=abc"
             )
             assert (
-                key.minidump_endpoint
+                endpoint_urls.minidump_endpoint
                 == f"http://{host}/api/{self.project.id}/minidump/?sentry_key=abc"
             )
-            assert key.unreal_endpoint == f"http://{host}/api/{self.project.id}/unreal/abc/"
             assert (
-                key.crons_endpoint
+                endpoint_urls.unreal_endpoint == f"http://{host}/api/{self.project.id}/unreal/abc/"
+            )
+            assert (
+                endpoint_urls.crons_endpoint
                 == f"http://{host}/api/{self.project.id}/cron/___MONITOR_SLUG___/abc/"
             )
 
@@ -141,16 +162,21 @@ class ProjectKeyTest(TestCase):
     def test_get_dsn_multiregion(self) -> None:
         key = self.model(project_id=self.project.id, public_key="abc", secret_key="xyz")
         host = "us.testserver" if SiloMode.get_current_mode() == SiloMode.CELL else "testserver"
+        endpoint_urls = key.get_endpoint_urls()
 
-        assert key.dsn_private == f"http://abc:xyz@{host}/{self.project.id}"
-        assert key.dsn_public == f"http://abc@{host}/{self.project.id}"
-        assert key.csp_endpoint == f"http://{host}/api/{self.project.id}/csp-report/?sentry_key=abc"
+        assert endpoint_urls.dsn_private == f"http://abc:xyz@{host}/{self.project.id}"
+        assert endpoint_urls.dsn_public == f"http://abc@{host}/{self.project.id}"
         assert (
-            key.minidump_endpoint == f"http://{host}/api/{self.project.id}/minidump/?sentry_key=abc"
+            endpoint_urls.csp_endpoint
+            == f"http://{host}/api/{self.project.id}/csp-report/?sentry_key=abc"
         )
-        assert key.unreal_endpoint == f"http://{host}/api/{self.project.id}/unreal/abc/"
         assert (
-            key.crons_endpoint
+            endpoint_urls.minidump_endpoint
+            == f"http://{host}/api/{self.project.id}/minidump/?sentry_key=abc"
+        )
+        assert endpoint_urls.unreal_endpoint == f"http://{host}/api/{self.project.id}/unreal/abc/"
+        assert (
+            endpoint_urls.crons_endpoint
             == f"http://{host}/api/{self.project.id}/cron/___MONITOR_SLUG___/abc/"
         )
 
@@ -161,20 +187,23 @@ class ProjectKeyTest(TestCase):
             host = f"o{key.project.organization_id}.ingest." + (
                 "us.testserver" if SiloMode.get_current_mode() == SiloMode.CELL else "testserver"
             )
+            endpoint_urls = key.get_endpoint_urls()
 
-            assert key.dsn_private == f"http://abc:xyz@{host}/{self.project.id}"
-            assert key.dsn_public == f"http://abc@{host}/{self.project.id}"
+            assert endpoint_urls.dsn_private == f"http://abc:xyz@{host}/{self.project.id}"
+            assert endpoint_urls.dsn_public == f"http://abc@{host}/{self.project.id}"
             assert (
-                key.csp_endpoint
+                endpoint_urls.csp_endpoint
                 == f"http://{host}/api/{self.project.id}/csp-report/?sentry_key=abc"
             )
             assert (
-                key.minidump_endpoint
+                endpoint_urls.minidump_endpoint
                 == f"http://{host}/api/{self.project.id}/minidump/?sentry_key=abc"
             )
-            assert key.unreal_endpoint == f"http://{host}/api/{self.project.id}/unreal/abc/"
             assert (
-                key.crons_endpoint
+                endpoint_urls.unreal_endpoint == f"http://{host}/api/{self.project.id}/unreal/abc/"
+            )
+            assert (
+                endpoint_urls.crons_endpoint
                 == f"http://{host}/api/{self.project.id}/cron/___MONITOR_SLUG___/abc/"
             )
 

--- a/tests/sentry/runner/commands/test_createproject.py
+++ b/tests/sentry/runner/commands/test_createproject.py
@@ -20,7 +20,7 @@ class CreateProjectTest(CliTestCase):
 
         key = ProjectKey.get_default(project)
         assert key is not None
-        assert f"DSN: {key.dsn_public}" in rv.output
+        assert f"DSN: {key.get_endpoint_urls().dsn_public}" in rv.output
 
     def test_basic_creation_with_org_id(self) -> None:
         org = self.create_organization(name="test-org")

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -242,7 +242,7 @@ class JavaScriptSdkLoaderTest(TestCase):
     def test_bundle_kind_modifiers(
         self, load_version_from_file: MagicMock, get_selected_browser_sdk_version: MagicMock
     ) -> None:
-        dsn = self.projectkey.get_dsn(public=True)
+        dsn = self.projectkey.get_endpoint_urls().get_dsn(public=True)
 
         for data, expected_bundle, expected_options in [
             (
@@ -459,12 +459,12 @@ class JavaScriptSdkLoaderTest(TestCase):
     def test_absolute_url(self) -> None:
         assert (
             reverse("sentry-js-sdk-loader", args=[self.projectkey.public_key, ".min"])
-            in self.projectkey.js_sdk_loader_cdn_url
+            in self.projectkey.get_endpoint_urls().js_sdk_loader_cdn_url
         )
         with self.settings(JS_SDK_LOADER_CDN_URL="https://js.sentry-cdn.com/"):
             assert (
                 "https://js.sentry-cdn.com/%s.min.js" % self.projectkey.public_key
-            ) == self.projectkey.js_sdk_loader_cdn_url
+            ) == self.projectkey.get_endpoint_urls().js_sdk_loader_cdn_url
 
     @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["10.0.0"])
     @mock.patch(
@@ -478,7 +478,7 @@ class JavaScriptSdkLoaderTest(TestCase):
         self, load_version_from_file: MagicMock, get_selected_browser_sdk_version: MagicMock
     ) -> None:
         """Test logs and metrics bundles which require SDK >= 10.0.0"""
-        dsn = self.projectkey.get_dsn(public=True)
+        dsn = self.projectkey.get_endpoint_urls().get_dsn(public=True)
 
         for data, expected_bundle, expected_options in [
             # Logs and metrics alone (no tracing required, bundle.logs.metrics exists)

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -414,10 +414,11 @@ def test_project_key_default() -> None:
     organization = Factories.create_organization(name="test-org")
     project = Factories.create_project(organization=organization)
     project_key = Factories.create_project_key(project)
-    assert project_key.dsn_public
+    dsn_public = project_key.get_endpoint_urls().dsn_public
+    assert dsn_public
 
     with override_settings(SENTRY_PROJECT=project.id):
-        assert get_client_config()["dsn"] == project_key.dsn_public
+        assert get_client_config()["dsn"] == dsn_public
 
 
 @no_silo_test


### PR DESCRIPTION
Follow-up cleanup on top of #118707. That PR introduced `ProjectKeyEndpointUrls` and made the existing `dsn_public`/`csp_endpoint`/… properties on `ProjectKey` delegate to it so the override applied everywhere without touching callers.

This PR routes the ~14 callers through `key.get_endpoint_urls().X` directly and deletes the now-trivial delegating properties. No behavior change.

`RpcProjectKey` has its own materialized fields and is unchanged; the only RPC-adjacent touch is `serialize_project_key` switching to the builder.