### PR TITLE
feat(relay): Add DSN endpoint override input to org Relay settings

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -122,6 +122,7 @@ export interface Organization extends OrganizationSummary {
   ingestThroughTrustedRelaysOnly?: 'enabled' | 'disabled';
   orgRole?: string;
   planSampleRate?: number | null;
+  relayDsnEndpoint?: string | null;
   trustedRelays?: Relay[];
 }
 

--- a/static/app/views/settings/organizationRelay/relayWrapper.spec.tsx
+++ b/static/app/views/settings/organizationRelay/relayWrapper.spec.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {GlobalModal} from '@sentry/scraps/modal';
 
@@ -190,6 +190,118 @@ describe('RelayWrapper', () => {
           name: 'Ingest Through Trusted Relays Only',
         })
       ).toBeDisabled();
+    });
+  });
+
+  describe('relayDsnEndpoint input', () => {
+    it('is hidden without the feature flag', () => {
+      renderComponent();
+
+      expect(
+        screen.queryByRole('textbox', {name: 'DSN Endpoint Override'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the persisted value when the feature flag is on', () => {
+      renderComponent({
+        features: ['relay-dsn-endpoint-override'],
+        relayDsnEndpoint: 'https://relay.example.com',
+      });
+
+      expect(screen.getByRole('textbox', {name: 'DSN Endpoint Override'})).toHaveValue(
+        'https://relay.example.com'
+      );
+    });
+
+    it('submits relayDsnEndpoint when edited', async () => {
+      const mock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        method: 'PUT',
+        body: OrganizationFixture({relayDsnEndpoint: 'https://relay.example.com'}),
+      });
+
+      renderComponent({
+        features: ['relay-dsn-endpoint-override'],
+        relayDsnEndpoint: 'https://old-relay.example.com',
+      });
+
+      const input = screen.getByRole('textbox', {name: 'DSN Endpoint Override'});
+      await userEvent.clear(input);
+      await userEvent.type(input, 'https://relay.example.com');
+      await userEvent.tab();
+
+      await waitFor(() =>
+        expect(mock).toHaveBeenCalledWith(
+          '/organizations/org-slug/',
+          expect.objectContaining({
+            method: 'PUT',
+            data: {relayDsnEndpoint: 'https://relay.example.com'},
+          })
+        )
+      );
+    });
+
+    it('submits an empty relayDsnEndpoint when cleared', async () => {
+      const mock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        method: 'PUT',
+        body: OrganizationFixture({relayDsnEndpoint: null}),
+      });
+
+      renderComponent({
+        features: ['relay-dsn-endpoint-override'],
+        relayDsnEndpoint: 'https://relay.example.com',
+      });
+
+      const input = screen.getByRole('textbox', {name: 'DSN Endpoint Override'});
+      await userEvent.clear(input);
+      await userEvent.tab();
+
+      await waitFor(() =>
+        expect(mock).toHaveBeenCalledWith(
+          '/organizations/org-slug/',
+          expect.objectContaining({
+            method: 'PUT',
+            data: {relayDsnEndpoint: ''},
+          })
+        )
+      );
+    });
+
+    it('is disabled when user lacks org:write permission', () => {
+      renderComponent({
+        features: ['relay-dsn-endpoint-override'],
+        access: [],
+      });
+
+      expect(screen.getByRole('textbox', {name: 'DSN Endpoint Override'})).toBeDisabled();
+    });
+
+    it.each([
+      'relay.example.com',
+      'ftp://relay.example.com',
+      'https://user:password@relay.example.com',
+      'https://relay.example.com?foo=bar',
+      'https://relay.example.com#fragment',
+    ])('rejects %s locally without calling the API', async invalidValue => {
+      const mock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        method: 'PUT',
+      });
+
+      renderComponent({features: ['relay-dsn-endpoint-override']});
+
+      const input = screen.getByRole('textbox', {name: 'DSN Endpoint Override'});
+      await userEvent.clear(input);
+      await userEvent.type(input, invalidValue);
+      await userEvent.tab();
+
+      expect(
+        await screen.findByText(
+          'Enter an absolute http(s) base URL with a host and no credentials, query, or fragment.'
+        )
+      ).toBeInTheDocument();
+      expect(mock).not.toHaveBeenCalled();
     });
   });
 });

--- a/static/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/static/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -34,6 +34,38 @@ const relaySchema = z.object({
   ingestThroughTrustedRelaysOnly: z.boolean(),
 });
 
+const relayDsnEndpointSchema = z.object({
+  relayDsnEndpoint: z
+    .string()
+    .trim()
+    .refine(
+      value => {
+        if (value === '') {
+          return true;
+        }
+        let parts: URL;
+        try {
+          parts = new URL(value);
+        } catch {
+          return false;
+        }
+        return (
+          (parts.protocol === 'http:' || parts.protocol === 'https:') &&
+          parts.hostname !== '' &&
+          parts.username === '' &&
+          parts.password === '' &&
+          parts.search === '' &&
+          parts.hash === ''
+        );
+      },
+      {
+        message: t(
+          'Enter an absolute http(s) base URL with a host and no credentials, query, or fragment.'
+        ),
+      }
+    ),
+});
+
 export function RelayWrapper() {
   const {openModal} = useModal();
 
@@ -42,6 +74,9 @@ export function RelayWrapper() {
   const [relays, setRelays] = useState(organization.trustedRelays ?? []);
 
   const disabled = !organization.access.includes('org:write');
+  const hasRelayDsnEndpointOverrideFeature = organization.features.includes(
+    'relay-dsn-endpoint-override'
+  );
 
   const handleOpenAddDialog = () => {
     openModal(modalProps => (
@@ -127,6 +162,39 @@ export function RelayWrapper() {
             </field.Layout.Row>
           )}
         </AutoSaveForm>
+        {hasRelayDsnEndpointOverrideFeature && (
+          <AutoSaveForm
+            name="relayDsnEndpoint"
+            schema={relayDsnEndpointSchema}
+            initialValue={organization.relayDsnEndpoint ?? ''}
+            mutationOptions={{
+              mutationFn: data =>
+                fetchMutation<Organization>({
+                  url: `/organizations/${organization.slug}/`,
+                  method: 'PUT',
+                  data: {relayDsnEndpoint: data.relayDsnEndpoint},
+                }),
+              onSuccess: updatedOrg => {
+                OrganizationStore.onUpdate(updatedOrg);
+              },
+            }}
+          >
+            {field => (
+              <field.Layout.Row
+                label={t('DSN Endpoint Override')}
+                hintText={t(
+                  "Use a Relay base URL when displaying Client Key DSNs. Leave blank to use Sentry's default ingest endpoint."
+                )}
+              >
+                <field.Input
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                  disabled={disabled}
+                />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
+        )}
       </FieldGroup>
       {relays.length === 0 ? (
         <EmptyState />

--- a/tests/js/fixtures/organization.ts
+++ b/tests/js/fixtures/organization.ts
@@ -76,6 +76,7 @@ export function OrganizationFixture(params: Partial<Organization> = {}): Organiz
       maxRateInterval: null,
       projectLimit: null,
     },
+    relayDsnEndpoint: null,
     relayPiiConfig: null,
     require2FA: false,
     requiresSso: false,


### PR DESCRIPTION
Adds a *DSN Endpoint Override* text input to the org Relay settings page, gated on the new `organizations:relay-dsn-endpoint-override` feature flag. Reads and writes the `relayDsnEndpoint` field on the Organization via `AutoSaveForm`; empty or whitespace clears the override.

Client-side zod validation mirrors the server: must be an absolute http(s) URL with a host and no credentials, query, or fragment. Empty is accepted. The server stays authoritative — anything that slips through is surfaced via the existing `setFieldErrors` path.

<img width="644" height="185" alt="Screenshot 2026-06-30 at 16 19 18" src="https://github.com/user-attachments/assets/322db5cc-e7fe-45bb-abd3-03e4fc718089" />


Depends on #118707 (BE serializer + validator).
Part of TET-2529