### PR TITLE
ref(forms): Make FieldGroup transparent to direct child forms

### DIFF
--- a/static/app/components/core/form/layout/fieldGroup.tsx
+++ b/static/app/components/core/form/layout/fieldGroup.tsx
@@ -26,9 +26,34 @@ const PanelBody = styled(Container)`
   > * {
     padding: ${p => p.theme.space.xl};
     border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  }
 
-    &:last-child {
-      border-bottom: none;
-    }
+  > *:last-child {
+    border-bottom: none;
+  }
+
+  /*
+   * A direct child <form> (AutoSaveForm / useScrapsForm) is transparent for
+   * layout: unstyle the form element itself and apply the row styles to its
+   * first-level children instead, so every field row gets its own padding and
+   * divider. This only reaches one level deep.
+   *
+   * The base "> *" selector above is intentionally left untouched (rather than
+   * "> *:not(form)") so its specificity stays equal to a directly-nested
+   * component's own styles — e.g. an <Alert> rendered straight inside a
+   * FieldGroup still overrides the row padding as it did before.
+   */
+  > form {
+    padding: 0;
+    border-bottom: none;
+  }
+
+  > form > * {
+    padding: ${p => p.theme.space.xl};
+    border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  }
+
+  > form:last-child > *:last-child {
+    border-bottom: none;
   }
 `;


### PR DESCRIPTION
## Summary

`FieldGroup`'s `PanelBody` applies row padding and bottom-border dividers to its **direct** children. With the ongoing scraps form migration, a direct child can now be a `<form>` (from `AutoSaveForm` / `useScrapsForm`) that wraps several field rows — so the whole form was styled as a single padded block instead of one row per field.

This makes a direct child `<form>` **transparent** for layout: the form element itself is left unstyled, and the row styles are applied to its first-level children instead (one level deep). Sibling-divider and last-row logic are preserved across the panel.

## Why keep the base `> *` selector unchanged

The obvious fix — `> *:not(form)` — bumps the selector's specificity from `(0,1,0)` to `(0,1,1)`, which then **overrides** the styles of components rendered directly inside a `FieldGroup` (e.g. `<Alert>`), breaking their padding. Keeping the base `> *` as-is preserves the specificity tie those components rely on, and forms are handled by separate, form-only rules that never touch a non-form child's cascade.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint:js`
- [x] Existing settings specs that render through `FieldGroup` pass (projectAlerts, projectGeneralSettings, projectSecurityAndPrivacy)
- Visual: single-field `AutoSaveForm` panels look unchanged; multi-field forms now show per-row dividers; a top-level `<Alert>` in a `FieldGroup` keeps its own padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)