### PR TITLE
ref(pr-metrics): Drop comment_edited activity events

### DIFF
--- a/src/sentry/pr_metrics/activity_types.py
+++ b/src/sentry/pr_metrics/activity_types.py
@@ -110,14 +110,6 @@ class CommentCreatedPayload(BaseActivityPayload):
 
 
 @dataclass
-class CommentEditedPayload(BaseActivityPayload):
-    action: str = "comment_edited"
-    author_association: AuthorAssociation = "NONE"
-    is_review: bool = False
-    review_id: int | None = None
-
-
-@dataclass
 class ConvertedToDraftPayload(BaseActivityPayload):
     action: str = "converted_to_draft"
 

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -52,7 +52,6 @@ from sentry.pr_metrics.activity_types import (
     CheckSuiteCompletedPayload,
     ClosedPayload,
     CommentCreatedPayload,
-    CommentEditedPayload,
     ConvertedToDraftPayload,
     DequeuedPayload,
     EditedPayload,
@@ -439,7 +438,7 @@ def handle_comment(
 ) -> None:
     """Record PR comment activity from issue_comment webhook events."""
     action = event.get("action")
-    if action not in ("created", "edited"):
+    if action != "created":
         return
 
     if not is_activity_tracking_enabled(organization):
@@ -470,25 +469,18 @@ def handle_comment(
     sender = event.get("sender") or {}
     comment = event.get("comment") or {}
 
-    if action == "created":
-        event_type = PullRequestActivityType.COMMENT_CREATED
-        payload_obj: CommentCreatedPayload | CommentEditedPayload = CommentCreatedPayload(
-            sender_login=sender.get("login", ""),
-            sender_type=sender.get("type", ""),
-            author_association=comment.get("author_association", "NONE"),
-        )
-    else:
-        event_type = PullRequestActivityType.COMMENT_EDITED
-        payload_obj = CommentEditedPayload(
-            sender_login=sender.get("login", ""),
-            sender_type=sender.get("type", ""),
-            author_association=comment.get("author_association", "NONE"),
-        )
+    payload_obj = CommentCreatedPayload(
+        sender_login=sender.get("login", ""),
+        sender_type=sender.get("type", ""),
+        author_association=comment.get("author_association", "NONE"),
+    )
 
     if not webhook_id:
         return
 
-    _write_activity_row(pr, webhook_id, event_type, asdict(payload_obj))
+    _write_activity_row(
+        pr, webhook_id, PullRequestActivityType.COMMENT_CREATED, asdict(payload_obj)
+    )
 
 
 def handle_review(
@@ -563,7 +555,7 @@ def handle_review_comment(
 ) -> None:
     """Record inline PR review comments (pull_request_review_comment events)."""
     action = event.get("action")
-    if action not in ("created", "edited"):
+    if action != "created":
         return
 
     if not is_activity_tracking_enabled(organization):
@@ -582,29 +574,20 @@ def handle_review_comment(
     comment = event.get("comment") or {}
     sender = event.get("sender") or {}
 
-    if action == "created":
-        event_type = PullRequestActivityType.COMMENT_CREATED
-        payload_obj: CommentCreatedPayload | CommentEditedPayload = CommentCreatedPayload(
-            sender_login=sender.get("login", ""),
-            sender_type=sender.get("type", ""),
-            author_association=comment.get("author_association", "NONE"),
-            is_review=True,
-            review_id=comment.get("pull_request_review_id"),
-        )
-    else:
-        event_type = PullRequestActivityType.COMMENT_EDITED
-        payload_obj = CommentEditedPayload(
-            sender_login=sender.get("login", ""),
-            sender_type=sender.get("type", ""),
-            author_association=comment.get("author_association", "NONE"),
-            is_review=True,
-            review_id=comment.get("pull_request_review_id"),
-        )
+    payload_obj = CommentCreatedPayload(
+        sender_login=sender.get("login", ""),
+        sender_type=sender.get("type", ""),
+        author_association=comment.get("author_association", "NONE"),
+        is_review=True,
+        review_id=comment.get("pull_request_review_id"),
+    )
 
     webhook_id: str | None = kwargs.get("github_delivery_id")
     if not webhook_id:
         return
-    _write_activity_row(pr, webhook_id, event_type, asdict(payload_obj))
+    _write_activity_row(
+        pr, webhook_id, PullRequestActivityType.COMMENT_CREATED, asdict(payload_obj)
+    )
 
 
 def handle_review_thread(

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -984,11 +984,10 @@ class HandleCommentForPrMetricsTest(TestCase):
         assert activity.event_type == PullRequestActivityType.COMMENT_CREATED
         assert activity.webhook_id == "delivery-1"
 
-    def test_comment_edited_writes_activity(self) -> None:
-        self._call(action="edited")
+    def test_comment_edited_skipped(self) -> None:
+        self._call(action="edited", webhook_id="delivery-edit")
 
-        activity = PullRequestActivity.objects.get(pull_request=self.pr)
-        assert activity.event_type == PullRequestActivityType.COMMENT_EDITED
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
     def test_bot_sender_type_stored(self) -> None:
         self._call(sender_type="Bot")
@@ -1300,12 +1299,10 @@ class HandleReviewCommentForPrMetricsTest(TestCase):
         assert activity.payload["review_id"] == 42
         assert activity.payload["sender_login"] == "reviewer"
 
-    def test_edited_writes_comment_edited_activity(self) -> None:
-        self._call(action="edited")
+    def test_edited_skipped(self) -> None:
+        self._call(action="edited", webhook_id="delivery-edit")
 
-        activity = PullRequestActivity.objects.get(pull_request=self.pr)
-        assert activity.event_type == PullRequestActivityType.COMMENT_EDITED
-        assert activity.payload["is_review"] is True
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
     def test_deleted_action_skipped(self) -> None:
         self._call(action="deleted")


### PR DESCRIPTION
Stop writing `PullRequestActivity` rows for `edited` actions on both `issue_comment` and `pull_request_review_comment` webhooks.

These rows accumulate in the activity table without being read by any downstream pipeline (judge, emit, or Seer). Dropping them reduces write volume and table size without affecting any observable behavior. The `COMMENT_EDITED` enum value and `CommentEditedPayload` dataclass are kept for schema compatibility.

Dropping this activity should reduce total size of PullRequestActivity by 13% (based on current query)

Refs CORE-258