### PR TITLE
ref: always spread container props instead of destructing just className

### DIFF
--- a/static/app/components/core/splitPanel/splitPanel.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.tsx
@@ -129,9 +129,9 @@ function SplitDivider({
 
   return (
     <Container position="relative" flexShrink={0}>
-      {({className}) => (
+      {containerProps => (
         <DividerLine
-          className={className}
+          {...containerProps}
           $cursor={cursor}
           aria-orientation={orientation === 'horizontal' ? 'vertical' : 'horizontal'}
           aria-valuemax={Number.isFinite(max) ? max : undefined}

--- a/static/app/views/explore/conversations/components/conversationsTableEditModal.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableEditModal.tsx
@@ -124,9 +124,9 @@ function ColumnEditorRow({
 
   return (
     <Flex align="center" gap="md">
-      {({className}) => (
+      {flexProps => (
         <div
-          className={className}
+          {...flexProps}
           ref={setNodeRef}
           style={{transform: CSS.Transform.toString(transform), transition}}
           {...attributes}

--- a/static/app/views/navigation/topBar.tsx
+++ b/static/app/views/navigation/topBar.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
+import {mergeProps} from '@react-aria/utils';
 
 import {Flex} from '@sentry/scraps/layout';
 import {SizeProvider} from '@sentry/scraps/sizeContext';
@@ -79,8 +80,8 @@ function TopBarContent() {
         <Slot.Outlet name="title">
           {props => (
             <Flex align="center" gap="sm" minWidth="0">
-              {({className}) => (
-                <Heading as="h1" variant="inherit" className={className} {...props} />
+              {flexProps => (
+                <Heading as="h1" variant="inherit" {...mergeProps(flexProps, props)} />
               )}
             </Flex>
           )}

--- a/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
@@ -515,9 +515,9 @@ function IntegrationSettingsHeader({
           />
         </Container>
         <Container flex={1}>
-          {({className}) => (
+          {containerProps => (
             <SearchBar
-              className={className}
+              {...containerProps}
               query={search}
               onSearch={onChangeSearch}
               placeholder={t('Filter Integrations\u2026')}

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -381,9 +381,9 @@ function OrganizationMembersList() {
             onChange={handleQueryChange}
           />
           <Container flex={1}>
-            {({className}) => (
+            {containerProps => (
               <SearchBar
-                className={className}
+                {...containerProps}
                 placeholder={t('Search Members')}
                 query={searchQuery}
                 onSearch={handleQueryChange}

--- a/static/app/views/settings/organizationProjects/index.tsx
+++ b/static/app/views/settings/organizationProjects/index.tsx
@@ -90,9 +90,9 @@ function OrganizationProjects() {
       <SearchWrapper>
         <Flex align="center" gap="md">
           <Container flex={1}>
-            {({className}) => (
+            {containerProps => (
               <SearchBar
-                className={className}
+                {...containerProps}
                 placeholder={t('Search Projects')}
                 onChange={debouncedSearch}
                 query={query}

--- a/static/app/views/settings/organizationTeams/organizationTeams.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.tsx
@@ -90,9 +90,9 @@ export function OrganizationTeams({
       <SearchWrapper>
         <Flex align="center" gap="md">
           <Container flex={1}>
-            {({className}) => (
+            {containerProps => (
               <SearchBar
-                className={className}
+                {...containerProps}
                 placeholder={t('Search teams')}
                 onChange={handleSearch}
                 query={teamQuery}


### PR DESCRIPTION
this is a necessary preparation for containerQueries, where we will add another prop (ref) to the children render function