### PR TITLE
feat(agent-monitoring): drop redundant stream_gen_ai_spans from Python onboarding

### DIFF
--- a/static/app/gettingStartedDocs/python/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/python/agentMonitoring.tsx
@@ -12,7 +12,7 @@ import {AgentIntegration} from 'sentry/views/insights/pages/agents/utils/agentIn
 
 import {getPythonInstallCodeBlock} from './utils';
 
-const MIN_REQUIRED_VERSION = '2.60.0';
+const MIN_REQUIRED_VERSION = '2.64.0';
 
 export const agentMonitoring: OnboardingConfig = {
   introduction: params => (
@@ -58,7 +58,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like inputs and responses to/from LLMs and tools;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
 )`,
         },
@@ -86,7 +85,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like inputs and responses to/from LLMs and tools;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
 )`,
         },
@@ -114,7 +112,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like inputs and responses to/from LLMs and tools;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
 )`,
         },
@@ -142,7 +139,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like inputs and responses to/from LLMs and tools;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
 )`,
         },
@@ -170,7 +166,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like inputs and responses to/from LLMs and tools;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
 )`,
         },
@@ -198,7 +193,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like inputs and responses to/from LLMs and tools;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
 )`,
         },
@@ -232,7 +226,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like inputs and responses to/from LLMs and tools;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         LiteLLMIntegration(),
@@ -257,7 +250,6 @@ sentry_sdk.init(
 sentry_sdk.init(
     dsn="${params.dsn.public}",
     traces_sample_rate=1.0,
-    stream_gen_ai_spans=True,
     send_default_pii=True,
 )`,
         },
@@ -296,7 +288,6 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     # Add data like inputs and responses to/from LLMs and tools;
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    stream_gen_ai_spans=True,
     send_default_pii=True,
 )`,
         },


### PR DESCRIPTION
The agent monitoring onboarding for Python drops the explicit `stream_gen_ai_spans=True` and raises the minimum SDK shown to users to 2.64.0. The option has defaulted to `True` since 2.64.0, so the opt-in only added noise — but the displayed minimum has to move up with it, otherwise users on 2.60.x–2.63.x following the examples would silently stop streaming Gen AI spans.

Mirrors the earlier JS change. Companion PRs:

- sentry-for-ai skills: getsentry/sentry-for-ai#231
- Python docs: getsentry/sentry-docs#18591

Refs TET-2553