### PR TITLE
feat(ai-conversations): Add traces link to redesigned conversation header

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -17,7 +17,7 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Placeholder} from 'sentry/components/placeholder';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconCopy} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isUUID} from 'sentry/utils/string/isUUID';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
@@ -51,7 +51,7 @@ interface ConversationSummaryProps {
 const VISIBLE_TRACE_COUNT = 5;
 const VISIBLE_TOOL_COUNT = 4;
 
-function getTraceUrl(orgSlug: string, traceId: string, spanId: string) {
+export function getTraceUrl(orgSlug: string, traceId: string, spanId: string) {
   return normalizeUrl(
     `/organizations/${orgSlug}/explore/traces/trace/${traceId}/?node=span-${spanId}`
   );
@@ -313,7 +313,7 @@ export function ConversationSummary({
         {traces.length > 0 && (
           <Flex align="baseline" gap="xs">
             <Text size="sm" variant="muted">
-              {traces.length === 1 ? t('Trace') : t('Traces')}
+              {tn('Trace', 'Traces', traces.length)}
             </Text>
             {traces.slice(0, VISIBLE_TRACE_COUNT).map((trace, i) => (
               <Flex key={trace.traceId} align="baseline" gap="xs">

--- a/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
@@ -13,8 +13,8 @@ import {Count} from 'sentry/components/count';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Placeholder} from 'sentry/components/placeholder';
-import {IconUser} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {IconOpen, IconUser} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
 import {escapeDoubleQuotes} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isUUID} from 'sentry/utils/string/isUUID';
@@ -27,6 +27,7 @@ import {
 import {
   calculateAggregates,
   getConversationUser,
+  getTraceUrl,
 } from 'sentry/views/explore/conversations/components/conversationSummary';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
@@ -37,6 +38,7 @@ interface ConversationSummaryNewProps {
   conversationId: string;
   nodes: AITraceSpanNode[];
   isLoading?: boolean;
+  nodeTraceMap?: Map<string, string>;
 }
 
 const VISIBLE_TOOL_COUNT = 6;
@@ -45,6 +47,7 @@ export function ConversationSummaryNew({
   nodes,
   conversationId,
   isLoading,
+  nodeTraceMap,
 }: ConversationSummaryNewProps) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
@@ -69,6 +72,32 @@ export function ConversationSummaryNew({
     selection,
     query: `gen_ai.conversation.id:"${escapeDoubleQuotes(conversationId)}" span.status:[internal_error,error]`,
   });
+
+  // Distinct traces the conversation spans, keyed by trace ID with a
+  // representative span ID to deep-link into the trace view.
+  const traces = useMemo(() => {
+    if (!nodeTraceMap) {
+      return [];
+    }
+    const seen = new Map<string, string>();
+    for (const [spanId, traceId] of nodeTraceMap) {
+      if (!seen.has(traceId)) {
+        seen.set(traceId, spanId);
+      }
+    }
+    return Array.from(seen, ([traceId, spanId]) => ({traceId, spanId}));
+  }, [nodeTraceMap]);
+
+  // A single trace deep-links to the trace view; multiple traces open the
+  // traces explorer filtered to this conversation.
+  const singleTrace = traces.length === 1 ? traces[0] : undefined;
+  const tracesUrl = singleTrace
+    ? getTraceUrl(organization.slug, singleTrace.traceId, singleTrace.spanId)
+    : getExploreUrl({
+        organization,
+        selection,
+        query: `gen_ai.conversation.id:"${escapeDoubleQuotes(conversationId)}"`,
+      });
 
   return (
     <Flex
@@ -147,6 +176,23 @@ export function ConversationSummaryNew({
                   </InfoText>
                 )}
               </Flex>
+              {traces.length > 0 && (
+                <Link
+                  to={tracesUrl}
+                  onClick={() =>
+                    trackAnalytics('conversations.detail.click-trace-link', {
+                      organization,
+                    })
+                  }
+                >
+                  <Flex align="center" gap="xs">
+                    <IconOpen size="xs" />
+                    <Text size="xs" variant="inherit" wrap="nowrap">
+                      {tn('Trace', 'Traces', traces.length)}
+                    </Text>
+                  </Flex>
+                </Link>
+              )}
               {aggregates.toolNames.length > 0 && (
                 <Flex align="center" gap="sm" minWidth={0} wrap="wrap">
                   {aggregates.toolNames.slice(0, VISIBLE_TOOL_COUNT).map(name => (

--- a/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
@@ -97,6 +97,7 @@ export function ConversationSummaryNew({
         organization,
         selection,
         query: `gen_ai.conversation.id:"${escapeDoubleQuotes(conversationId)}"`,
+        table: 'trace',
       });
 
   return (

--- a/static/app/views/explore/conversations/conversationDetailNew.tsx
+++ b/static/app/views/explore/conversations/conversationDetailNew.tsx
@@ -35,7 +35,7 @@ export function ConversationDetailPageNew() {
 
   const conversation = useMemo(() => ({conversationId}), [conversationId]);
 
-  const {nodes, isLoading} = useConversation(conversation);
+  const {nodes, nodeTraceMap, isLoading} = useConversation(conversation);
 
   useEffect(() => {
     trackAnalytics('conversations.detail.page-view', {
@@ -60,6 +60,7 @@ export function ConversationDetailPageNew() {
       >
         <ConversationSummaryNew
           nodes={nodes}
+          nodeTraceMap={nodeTraceMap}
           conversationId={conversationId}
           isLoading={isLoading}
         />


### PR DESCRIPTION
Adds a **Traces** link to the redesigned conversation detail header (`ConversationSummaryNew`), matching the legacy header: a single-trace conversation deep-links to the trace view, while a multi-trace one opens the traces explorer filtered to `gen_ai.conversation.id`.


**Preview**

<img width="954" height="136" alt="image" src="https://github.com/user-attachments/assets/5ddf41af-5e3a-44d4-b242-c8a101f84932" />
