### PR TITLE
chore(explore): Remove attribute validation mocks

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -92,12 +92,6 @@ describe('SpansSearchBar', () => {
       url: '/organizations/org-slug/trace-items/attributes/',
       body: [],
     });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/trace-items/attributes/validate/',
-      method: 'POST',
-      body: {attributes: {}},
-    });
   });
 
   it('renders the initial query conditions', async () => {

--- a/static/app/views/detectors/components/forms/metric/metric.spec.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.spec.tsx
@@ -41,11 +41,6 @@ describe('NewMetricDetectorForm', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/trace-items/attributes/validate/',
-      method: 'POST',
-      body: {attributes: {}},
-    });
-    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/recent-searches/',
       body: [],
     });

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -94,11 +94,6 @@ describe('DetectorEdit', () => {
       url: `/organizations/${organization.slug}/trace-items/attributes/`,
       body: [],
     });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/trace-items/attributes/validate/`,
-      method: 'POST',
-      body: {attributes: {}},
-    });
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/workflows/`,

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -75,11 +75,6 @@ describe('DetectorEdit', () => {
       url: `/organizations/${organization.slug}/trace-items/attributes/`,
       body: [],
     });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/trace-items/attributes/validate/`,
-      method: 'POST',
-      body: {attributes: {}},
-    });
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/workflows/`,

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -171,11 +171,6 @@ describe('LogsTabContent', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/trace-items/attributes/validate/`,
-      method: 'POST',
-      body: {attributes: {}},
-    });
-    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/validate/`,
       method: 'GET',
       body: {

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -148,11 +148,6 @@ describe('MetricsTabContent', () => {
       method: 'GET',
       body: [],
     });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/trace-items/attributes/validate/`,
-      method: 'POST',
-      body: {attributes: {}},
-    });
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/stats_v2/`,

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -90,11 +90,6 @@ describe('MultiQueryModeContent', () => {
       method: 'GET',
       body: [],
     });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/trace-items/attributes/validate/`,
-      method: 'POST',
-      body: {attributes: {}},
-    });
   });
 
   it('disables changing fields for count', async () => {

--- a/static/app/views/explore/releases/list/index.spec.tsx
+++ b/static/app/views/explore/releases/list/index.spec.tsx
@@ -97,11 +97,6 @@ describe('ReleasesList', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/trace-items/attributes/validate/`,
-      method: 'POST',
-      body: {attributes: {}},
-    });
-    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/builds/`,
       body: [],
     });

--- a/static/app/views/explore/replays/detail/ourlogs/ourlogFilters.spec.tsx
+++ b/static/app/views/explore/replays/detail/ourlogs/ourlogFilters.spec.tsx
@@ -62,11 +62,6 @@ describe('OurLogFilters', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/trace-items/attributes/validate/',
-      method: 'POST',
-      body: {attributes: {}},
-    });
-    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/recent-searches/',
       body: [],
     });


### PR DESCRIPTION
This removes the test mocks for an old endpoint that has been removed.