### PR TITLE
fix(pagefilters): clamp old absolute date changes

### DIFF
--- a/static/app/components/pageFilters/container.spec.tsx
+++ b/static/app/components/pageFilters/container.spec.tsx
@@ -560,6 +560,47 @@ describe('PageFiltersContainer', () => {
         })
       );
     });
+
+    it('applies maxPickableDays when mounted route changes to absolute params in the past', async () => {
+      const {router} = render(<PageFiltersContainer maxPickableDays={30} />, {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/test/',
+            query: {statsPeriod: '14d'},
+          },
+          route: '/organizations/:orgId/test/',
+        },
+      });
+
+      await waitFor(() =>
+        expect(PageFiltersStore.getState().selection.datetime).toEqual({
+          period: '14d',
+          utc: null,
+          start: null,
+          end: null,
+        })
+      );
+
+      const start = moment().subtract(45, 'days').format('YYYY-MM-DDTHH:mm:ss');
+      const end = moment().subtract(44, 'days').format('YYYY-MM-DDTHH:mm:ss');
+
+      act(() => {
+        router.navigate({
+          pathname: '/organizations/org-slug/test/',
+          search: `start=${start}&end=${end}`,
+        });
+      });
+
+      await waitFor(() =>
+        expect(PageFiltersStore.getState().selection.datetime).toEqual({
+          period: '30d',
+          utc: null,
+          start: null,
+          end: null,
+        })
+      );
+    });
   });
 
   describe('maxDateRange param', () => {

--- a/static/app/components/pageFilters/container.tsx
+++ b/static/app/components/pageFilters/container.tsx
@@ -22,7 +22,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useDefaultMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {usePrevious} from 'sentry/utils/usePrevious';
 import {useProjects} from 'sentry/utils/useProjects';
 import {SIDEBAR_NAVIGATION_SOURCE} from 'sentry/views/navigation/constants';
 
@@ -135,10 +134,8 @@ export function PageFiltersContainer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectsLoaded]);
 
-  // Handle dynamic maxPickableDays/maxDateRange changes (e.g., switching between pages with different limits).
-  // When the limit decreases and the current selection exceeds it, reset to the new max.
-  const previousMaxPickableDays = usePrevious(maxPickableDays);
-  const previousMaxDateRange = usePrevious(maxDateRange);
+  // Handle invalid date selections after initialization, including route changes
+  // while the container stays mounted.
   const shouldResetDateTime = useMemo(() => {
     // Don't act until page filters are initialized - selection.datetime contains
     // default values until isReady, not the actual URL state
@@ -147,16 +144,6 @@ export function PageFiltersContainer({
     }
 
     const effectiveMaxDays = maxDateRange ?? maxPickableDays;
-    const previousEffectiveMaxDays = previousMaxDateRange ?? previousMaxPickableDays;
-
-    // Only act when the effective limit decreases (increasing the limit never invalidates selection)
-    if (
-      previousEffectiveMaxDays === effectiveMaxDays ||
-      previousEffectiveMaxDays < effectiveMaxDays
-    ) {
-      return false;
-    }
-
     const {period, start, end} = selection.datetime;
 
     // For relative periods (e.g., "14d"), check if the period exceeds the new max
@@ -184,14 +171,7 @@ export function PageFiltersContainer({
     }
 
     return false;
-  }, [
-    isReady,
-    maxDateRange,
-    maxPickableDays,
-    previousMaxDateRange,
-    previousMaxPickableDays,
-    selection.datetime,
-  ]);
+  }, [isReady, maxDateRange, maxPickableDays, selection.datetime]);
 
   const resetPeriodDays = maxDateRange ?? maxPickableDays;
 


### PR DESCRIPTION
The goal of this PR is to handle users selecting an absolute date range in the past and while navigating from a shared link having that selection cleared.

### Summary of changes

- Clamp mounted page-filter datetime changes that become invalid for the current max date window
- Cover old absolute `start` / `end` route params being reset to the allowed relative period

Closes EXP-1076