### PR TITLE
fix(ai-conversations): Use uniform 16px padding on conversation detail page

### DIFF
--- a/static/app/views/explore/conversations/conversationDetailNew.tsx
+++ b/static/app/views/explore/conversations/conversationDetailNew.tsx
@@ -59,7 +59,7 @@ export function ConversationDetailPageNew() {
           isLoading={isLoading}
         />
       </Container>
-      <Stack flex={1} minHeight="0" overflow="hidden" padding="xl" gap="md">
+      <Stack flex={1} minHeight="0" overflow="hidden" padding="xl" gap="xl">
         <Flex flexShrink={0}>
           <Tabs value={queryState.tab} onChange={tab => setQueryState({tab})}>
             <TabList variant="floating">

--- a/static/app/views/explore/conversations/conversationDetailNew.tsx
+++ b/static/app/views/explore/conversations/conversationDetailNew.tsx
@@ -52,25 +52,14 @@ export function ConversationDetailPageNew() {
 
   return (
     <ViewportConstrainedPage background="secondary">
-      <Container
-        flexShrink={0}
-        background="primary"
-        borderBottom="primary"
-        padding={{'screen:sm': 'md lg', 'screen:md': 'md xl'}}
-      >
+      <Container flexShrink={0} background="primary" borderBottom="primary" padding="xl">
         <ConversationSummaryNew
           nodes={nodes}
           conversationId={conversationId}
           isLoading={isLoading}
         />
       </Container>
-      <Stack
-        flex={1}
-        minHeight="0"
-        overflow="hidden"
-        padding={{'screen:sm': 'md lg', 'screen:md': 'md xl'}}
-        gap="md"
-      >
+      <Stack flex={1} minHeight="0" overflow="hidden" padding="xl" gap="md">
         <Flex flexShrink={0}>
           <Tabs value={queryState.tab} onChange={tab => setQueryState({tab})}>
             <TabList variant="floating">


### PR DESCRIPTION
Aligns the redesigned conversation detail page with the design's uniform `16px` spacing:

- Header and body padding: `8px / 16px` (`md xl`) → `16px` (`xl`).
- Gap between the tabs and their content: `8px` (`md`) → `16px` (`xl`).