### PR TITLE
fix(onboarding): Remove CocoaPods from Apple SDK onboarding

### DIFF
--- a/static/app/gettingStartedDocs/apple-ios/logs.tsx
+++ b/static/app/gettingStartedDocs/apple-ios/logs.tsx
@@ -35,13 +35,6 @@ export const logs: OnboardingConfig = {
               )}"),`,
             },
             {
-              label: 'CocoaPods (Deprecated)',
-              language: 'ruby',
-              code: `# CocoaPods is deprecated and will not receive updates after June 2026.
-# Migrate to SPM or use xcframeworks instead.
-pod update`,
-            },
-            {
               label: 'Carthage',
               language: 'swift',
               code: `github "getsentry/sentry-cocoa" "${getPackageVersion(

--- a/static/app/gettingStartedDocs/apple-ios/metrics.tsx
+++ b/static/app/gettingStartedDocs/apple-ios/metrics.tsx
@@ -35,13 +35,6 @@ export const metrics: OnboardingConfig = {
               )}"),`,
             },
             {
-              label: 'CocoaPods (Deprecated)',
-              language: 'ruby',
-              code: `# CocoaPods is deprecated and will not receive updates after June 2026.
-# Migrate to SPM or use xcframeworks instead.
-pod update`,
-            },
-            {
               label: 'Carthage',
               language: 'swift',
               code: `github "getsentry/sentry-cocoa" "${getPackageVersion(

--- a/static/app/gettingStartedDocs/apple-ios/sessionReplay.tsx
+++ b/static/app/gettingStartedDocs/apple-ios/sessionReplay.tsx
@@ -47,13 +47,6 @@ export const sessionReplay: OnboardingConfig = {
               )}"),`,
             },
             {
-              label: 'CocoaPods (Deprecated)',
-              language: 'ruby',
-              code: `# CocoaPods is deprecated and will not receive updates after June 2026.
-# Migrate to SPM or use xcframeworks instead.
-pod update`,
-            },
-            {
               label: 'Carthage',
               language: 'swift',
               code: `github "getsentry/sentry-cocoa" "${getPackageVersion(

--- a/static/app/gettingStartedDocs/apple-macos/logs.tsx
+++ b/static/app/gettingStartedDocs/apple-macos/logs.tsx
@@ -35,13 +35,6 @@ export const logs: OnboardingConfig = {
               )}"),`,
             },
             {
-              label: 'CocoaPods (Deprecated)',
-              language: 'ruby',
-              code: `# CocoaPods is deprecated and will not receive updates after June 2026.
-# Migrate to SPM or use xcframeworks instead.
-pod update`,
-            },
-            {
               label: 'Carthage',
               language: 'swift',
               code: `github "getsentry/sentry-cocoa" "${getPackageVersion(

--- a/static/app/gettingStartedDocs/apple-macos/metrics.tsx
+++ b/static/app/gettingStartedDocs/apple-macos/metrics.tsx
@@ -35,13 +35,6 @@ export const metrics: OnboardingConfig = {
               )}"),`,
             },
             {
-              label: 'CocoaPods (Deprecated)',
-              language: 'ruby',
-              code: `# CocoaPods is deprecated and will not receive updates after June 2026.
-# Migrate to SPM or use xcframeworks instead.
-pod update`,
-            },
-            {
               label: 'Carthage',
               language: 'swift',
               code: `github "getsentry/sentry-cocoa" "${getPackageVersion(


### PR DESCRIPTION
## Summary

Remove CocoaPods installation tabs from Apple SDK onboarding pages (iOS and macOS). CocoaPods trunk is going read-only on Dec 2, 2026, and we are discontinuing it as a supported distribution method after sentry-cocoa v9.19.1

- Remove CocoaPods tab from iOS logs, metrics, and session replay onboarding
- Remove CocoaPods tab from macOS logs and metrics onboarding
- SPM and Carthage remain as installation options

Closes https://github.com/getsentry/sentry-cocoa/issues/7381
Closes https://github.com/getsentry/sentry-cocoa/issues/7384

## Related PRs

- sentry-docs: https://github.com/getsentry/sentry-docs/pull/18600