### PR TITLE
feat(inbound-filters): Add custom inbound filter detail endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_custom_inbound_filters.py
+++ b/src/sentry/api/endpoints/project_custom_inbound_filters.py
@@ -232,3 +232,131 @@ class CustomInboundFiltersEndpoint(ProjectCustomInboundFilterEndpoint):
         )
 
         return Response(serializer.data, status=201)
+
+
+@cell_silo_endpoint
+@extend_schema(tags=["Projects"])
+class CustomInboundFilterDetailsEndpoint(ProjectCustomInboundFilterEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+        "PUT": ApiPublishStatus.EXPERIMENTAL,
+        "DELETE": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    def get_custom_inbound_filter(self, project: Project, filter_id: str) -> CustomInboundFilter:
+        try:
+            return CustomInboundFilter.objects.get(id=filter_id, project_id=project.id)
+        except (CustomInboundFilter.DoesNotExist, ValueError):
+            raise ResourceDoesNotExist
+
+    @extend_schema(
+        operation_id="Retrieve a Custom Inbound Filter",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+        ],
+        responses={
+            200: CustomInboundFilterSerializer,
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(self, request: Request, project: Project, filter_id: str) -> Response:
+        """
+        Retrieve a single custom inbound filter.
+        """
+        if not self.has_feature(request, project):
+            return Response({"detail": "You do not have that feature enabled"}, status=400)
+
+        custom_filter = self.get_custom_inbound_filter(project, filter_id)
+        return Response(CustomInboundFilterSerializer(custom_filter).data)
+
+    @extend_schema(
+        operation_id="Update a Custom Inbound Filter",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+        ],
+        request=CustomInboundFilterSerializer,
+        responses={
+            200: CustomInboundFilterSerializer,
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def put(self, request: Request, project: Project, filter_id: str) -> Response:
+        """
+        Update a custom inbound filter's name, active state, or conditions.
+        """
+        if not self.has_feature(request, project):
+            return Response({"detail": "You do not have that feature enabled"}, status=400)
+
+        custom_filter = self.get_custom_inbound_filter(project, filter_id)
+        serializer = CustomInboundFilterSerializer(
+            custom_filter,
+            data=request.data,
+            partial=True,
+            context={"project": project, "request": request},
+        )
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        changes: dict[str, Any] = {}
+        for field in ("name", "active", "conditions"):
+            if field not in serializer.validated_data:
+                continue
+
+            previous_value = getattr(custom_filter, field)
+            new_value = serializer.validated_data[field]
+            if previous_value != new_value:
+                changes[field] = {"old": previous_value, "new": new_value}
+                setattr(custom_filter, field, new_value)
+
+        if changes:
+            custom_filter.save(update_fields=[*changes.keys(), "date_updated"])
+            self.create_audit_entry(
+                request=request,
+                organization=project.organization,
+                target_object=custom_filter.id,
+                event=audit_log.get_event_id("CUSTOM_INBOUND_FILTER"),
+                data=self.get_audit_log_data(project, custom_filter, "edit", changes),
+            )
+
+        return Response(CustomInboundFilterSerializer(custom_filter).data)
+
+    @extend_schema(
+        operation_id="Delete a Custom Inbound Filter",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+        ],
+        responses={
+            204: None,
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def delete(self, request: Request, project: Project, filter_id: str) -> Response:
+        """
+        Delete a custom inbound filter.
+        """
+        if not self.has_feature(request, project):
+            return Response({"detail": "You do not have that feature enabled"}, status=400)
+
+        custom_filter = self.get_custom_inbound_filter(project, filter_id)
+        audit_log_data = self.get_audit_log_data(project, custom_filter, "remove")
+        target_object = custom_filter.id
+        custom_filter.delete()
+
+        self.create_audit_entry(
+            request=request,
+            organization=project.organization,
+            target_object=target_object,
+            event=audit_log.get_event_id("CUSTOM_INBOUND_FILTER"),
+            data=audit_log_data,
+        )
+
+        return Response(status=204)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -804,7 +804,10 @@ from .endpoints.project_artifact_bundle_file_details import ProjectArtifactBundl
 from .endpoints.project_artifact_bundle_files import ProjectArtifactBundleFilesEndpoint
 from .endpoints.project_commits import ProjectCommitsEndpoint
 from .endpoints.project_create_sample import ProjectCreateSampleEndpoint
-from .endpoints.project_custom_inbound_filters import CustomInboundFiltersEndpoint
+from .endpoints.project_custom_inbound_filters import (
+    CustomInboundFilterDetailsEndpoint,
+    CustomInboundFiltersEndpoint,
+)
 from .endpoints.project_filter_details import ProjectFilterDetailsEndpoint
 from .endpoints.project_filters import ProjectFiltersEndpoint
 from .endpoints.project_member_index import ProjectMemberIndexEndpoint
@@ -2836,6 +2839,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/custom-inbound-filters/$",
         CustomInboundFiltersEndpoint.as_view(),
         name="sentry-api-0-project-custom-inbound-filters",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/custom-inbound-filters/(?P<filter_id>[^/]+)/$",
+        CustomInboundFilterDetailsEndpoint.as_view(),
+        name="sentry-api-0-project-custom-inbound-filter-details",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/hooks/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -416,6 +416,7 @@ export type KnownSentryApiUrls =
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/commits/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/create-sample/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/custom-inbound-filters/'
+  | '/projects/$organizationIdOrSlug/$projectIdOrSlug/custom-inbound-filters/$filterId/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/$environment/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/events/'

--- a/tests/sentry/api/endpoints/test_project_custom_inbound_filters.py
+++ b/tests/sentry/api/endpoints/test_project_custom_inbound_filters.py
@@ -230,3 +230,195 @@ class CustomInboundFiltersTest(APITestCase):
                     conditions=[{"type": condition_type, "value": value}],
                 )
             assert expected in str(response.data["conditions"][0])
+
+
+class CustomInboundFilterDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-project-custom-inbound-filter-details"
+    method = "put"
+    features = ["organizations:inbound-filters-v2", "projects:custom-inbound-filters"]
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.organization)
+        self.project = self.create_project(organization=self.organization, teams=[self.team])
+        self.custom_filter = self.create_project_custom_inbound_filter(
+            project=self.project,
+            name="Original filter",
+            conditions=[{"type": "release", "value": ["1.*"]}],
+        )
+        self.login_as(user=self.user)
+
+    def test_get(self) -> None:
+        with self.feature(self.features):
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                method="get",
+            )
+
+        assert response.data["id"] == str(self.custom_filter.id)
+        assert response.data["name"] == "Original filter"
+        assert response.data["active"] is True
+        assert response.data["conditions"] == [{"type": "release", "value": ["1.*"]}]
+
+    def test_put(self) -> None:
+        new_conditions = [{"type": "error_message", "value": ["TypeError*"]}]
+
+        with self.feature(self.features), outbox_runner():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                name="Renamed filter",
+                active=False,
+                conditions=new_conditions,
+            )
+
+        self.custom_filter.refresh_from_db()
+        assert response.data["name"] == "Renamed filter"
+        assert response.data["active"] is False
+        assert response.data["conditions"] == new_conditions
+        assert self.custom_filter.name == "Renamed filter"
+        assert self.custom_filter.active is False
+        assert self.custom_filter.conditions == new_conditions
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            audit_entry = AuditLogEntry.objects.get(
+                organization_id=self.organization.id,
+                event=audit_log.get_event_id("CUSTOM_INBOUND_FILTER"),
+            )
+        assert audit_entry.target_object == self.custom_filter.id
+        assert audit_entry.data["operation"] == "edit"
+        assert audit_entry.data["filter_name"] == "Renamed filter"
+        assert audit_entry.data["changes"] == {
+            "name": {"old": "Original filter", "new": "Renamed filter"},
+            "active": {"old": True, "new": False},
+            "conditions": {
+                "old": [{"type": "release", "value": ["1.*"]}],
+                "new": new_conditions,
+            },
+        }
+
+    def test_put_partial_active_only(self) -> None:
+        with self.feature(self.features), outbox_runner():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                active=False,
+            )
+
+        self.custom_filter.refresh_from_db()
+        assert response.data["active"] is False
+        assert self.custom_filter.active is False
+        assert self.custom_filter.name == "Original filter"
+        assert self.custom_filter.conditions == [{"type": "release", "value": ["1.*"]}]
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            audit_entry = AuditLogEntry.objects.get(
+                organization_id=self.organization.id,
+                event=audit_log.get_event_id("CUSTOM_INBOUND_FILTER"),
+            )
+        assert audit_entry.data["operation"] == "edit"
+        assert audit_entry.data["changes"] == {"active": {"old": True, "new": False}}
+
+    def test_put_no_changes_skips_audit_log(self) -> None:
+        with self.feature(self.features), outbox_runner():
+            self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                name="Original filter",
+            )
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert not AuditLogEntry.objects.filter(
+                organization_id=self.organization.id,
+                event=audit_log.get_event_id("CUSTOM_INBOUND_FILTER"),
+            ).exists()
+
+    def test_put_rejects_incompatible_primary_conditions(self) -> None:
+        conditions = [
+            {"type": "error_message", "value": ["TypeError*"]},
+            {"type": "log_message", "value": ["Rate limit*"]},
+        ]
+
+        with self.feature([*self.features, "organizations:ourlogs-ingestion"]):
+            response = self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                conditions=conditions,
+            )
+
+        assert (
+            str(response.data["conditions"][0])
+            == "Only one of error_message, log_message, or metric_name can be used in a filter."
+        )
+
+    def test_delete(self) -> None:
+        with self.feature(self.features), outbox_runner():
+            self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                method="delete",
+                status_code=204,
+            )
+
+        assert not CustomInboundFilter.objects.filter(id=self.custom_filter.id).exists()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            audit_entry = AuditLogEntry.objects.get(
+                organization_id=self.organization.id,
+                event=audit_log.get_event_id("CUSTOM_INBOUND_FILTER"),
+            )
+        assert audit_entry.target_object == self.custom_filter.id
+        assert audit_entry.data["operation"] == "remove"
+        assert audit_entry.data["filter_name"] == "Original filter"
+
+    def test_returns_404_for_missing_filter(self) -> None:
+        with self.feature(self.features):
+            self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                "1234567890",
+                method="get",
+                status_code=404,
+            )
+
+    def test_scopes_lookup_to_project(self) -> None:
+        other_project = self.create_project(organization=self.organization, teams=[self.team])
+        other_filter = self.create_project_custom_inbound_filter(project=other_project)
+
+        with self.feature(self.features):
+            self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                other_filter.id,
+                method="get",
+                status_code=404,
+            )
+
+    def test_without_inbound_filters_v2_feature(self) -> None:
+        with self.feature(["projects:custom-inbound-filters"]):
+            self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                method="get",
+                status_code=404,
+            )
+
+    def test_without_custom_inbound_filters_plan_feature(self) -> None:
+        with self.feature(["organizations:inbound-filters-v2"]):
+            response = self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                method="get",
+                status_code=400,
+            )
+
+        assert response.data["detail"] == "You do not have that feature enabled"


### PR DESCRIPTION
- Add a detail endpoint for custom inbound filters at `/projects/{org}/{project}/custom-inbound-filters/{filter_id}/`, completing the CRUD surface alongside the merged list/create endpoint (#118142)- Gated behind the same `organizations:inbound-filters-v2` + `projects:custom-inbound-filters` checks as list/create; endpoints are `EXPERIMENTAL`

Closes TET-2585
