### PR TITLE
feat(conversations): Add saved query support for AI conversations

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -11,8 +11,6 @@ explore: 0010_remove_last_received_from_attribute_context
 
 feedback: 0007_cleanup_failed_safe_deletes
 
-feedback: 0007_cleanup_failed_safe_deletes
-
 flags: 0001_squashed_0004_add_flag_audit_log_provider_column
 
 hybridcloud: 0001_squashed_0030_remove_orgslugreservationreplica_delete

--- a/static/app/views/explore/conversations/components/saveConversationQueryButton.tsx
+++ b/static/app/views/explore/conversations/components/saveConversationQueryButton.tsx
@@ -1,0 +1,150 @@
+import {Fragment, useState} from 'react';
+import * as Sentry from '@sentry/react';
+import {parseAsString, useQueryState} from 'nuqs';
+
+import {Button} from '@sentry/scraps/button';
+import {Input} from '@sentry/scraps/input';
+import {Container, Flex} from '@sentry/scraps/layout';
+import {Switch} from '@sentry/scraps/switch';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import {type ModalRenderProps, openModal} from 'sentry/actionCreators/modal';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useApi} from 'sentry/utils/useApi';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {useInvalidateSavedQueries} from 'sentry/views/explore/hooks/useGetSavedQueries';
+
+type SaveModalProps = ModalRenderProps & {
+  onSave: (name: string, starred: boolean) => Promise<void>;
+};
+
+function SaveConversationQueryModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  onSave,
+}: SaveModalProps) {
+  const [name, setName] = useState('');
+  const [starred, setStarred] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function handleSave() {
+    try {
+      setIsSaving(true);
+      addLoadingMessage(t('Saving query...'));
+      await onSave(name, starred);
+      addSuccessMessage(t('Query saved successfully'));
+      closeModal();
+    } catch (error) {
+      addErrorMessage(t('Failed to save query'));
+      Sentry.captureException(error);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <h4>{t('New Query')}</h4>
+      </Header>
+      <Body>
+        <Container marginBottom="xl">
+          <h6>{t('Name')}</h6>
+          <Input
+            autoFocus
+            placeholder={t('Enter a name for your new query')}
+            onChange={e => setName(e.target.value)}
+            value={name}
+            title={t('Enter a name for your new query')}
+          />
+        </Container>
+        <Flex gap="md" align="center">
+          <Switch
+            checked={starred}
+            onChange={() => setStarred(!starred)}
+            title={t('Starred')}
+          />
+          <h6>{t('Starred')}</h6>
+        </Flex>
+      </Body>
+      <Footer>
+        <Flex gap="lg" align="center" justify="end">
+          <Button onClick={closeModal} disabled={isSaving}>
+            {t('Cancel')}
+          </Button>
+          <Button onClick={handleSave} disabled={!name || isSaving} variant="primary">
+            {t('Create a New Query')}
+          </Button>
+        </Flex>
+      </Footer>
+    </Fragment>
+  );
+}
+
+export function SaveConversationQueryButton() {
+  const api = useApi();
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const invalidateSavedQueries = useInvalidateSavedQueries();
+  const [searchQuery] = useQueryState(
+    'query',
+    parseAsString.withOptions({history: 'replace'})
+  );
+
+  function handleClick() {
+    trackAnalytics('conversations.save_query_modal', {
+      action: 'open',
+      organization,
+    });
+
+    openModal(modalProps => (
+      <SaveConversationQueryModal
+        {...modalProps}
+        onSave={async (name, starred) => {
+          const {datetime, projects, environments} = selection;
+          await api.requestPromise(`/organizations/${organization.slug}/explore/saved/`, {
+            method: 'POST',
+            data: {
+              name,
+              dataset: 'ai_conversations',
+              projects,
+              environment: environments,
+              range: datetime.period ?? undefined,
+              start: datetime.start ?? undefined,
+              end: datetime.end ?? undefined,
+              starred,
+              query: [
+                {
+                  fields: [],
+                  mode: Mode.SAMPLES,
+                  query: searchQuery ?? '',
+                },
+              ],
+            },
+          });
+          invalidateSavedQueries();
+
+          trackAnalytics('conversations.save_query_modal', {
+            action: 'submit',
+            organization,
+          });
+        }}
+      />
+    ));
+  }
+
+  return (
+    <Button variant="primary" onClick={handleClick} aria-label={t('Save as')}>
+      {t('Save as')}
+    </Button>
+  );
+}

--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -24,6 +24,7 @@ import {
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {ConversationsTable} from 'sentry/views/explore/conversations/components/conversationsTable';
 import {ConversationsTableNew} from 'sentry/views/explore/conversations/components/conversationsTableNew';
+import {SaveConversationQueryButton} from 'sentry/views/explore/conversations/components/saveConversationQueryButton';
 import {useShowConversationOnboarding} from 'sentry/views/explore/conversations/hooks/useShowConversationOnboarding';
 import {ConversationOnboarding} from 'sentry/views/explore/conversations/onboarding';
 import {MAX_PICKABLE_DAYS} from 'sentry/views/explore/conversations/settings';
@@ -119,6 +120,7 @@ function ConversationsOverviewPage() {
                   <TraceItemSearchQueryBuilder {...spanSearchQueryBuilderProps} />
                 </Flex>
               )}
+              {!showOnboarding && !isOnboardingLoading && <SaveConversationQueryButton />}
             </Flex>
           </Stack>
         </Layout.Main>

--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -105,7 +105,13 @@ export type SortOption =
 // Comes from ExploreSavedQueryModelSerializer
 export type ReadableSavedQuery = {
   // ExploreSavedQueryDataset
-  dataset: 'logs' | 'spans' | 'segment_spans' | 'metrics' | 'replays';
+  dataset:
+    | 'logs'
+    | 'spans'
+    | 'segment_spans'
+    | 'metrics'
+    | 'replays'
+    | 'ai_conversations';
   dateAdded: string;
   dateUpdated: string;
   id: number;
@@ -301,6 +307,7 @@ const DATASET_LABEL_MAP: Record<ReadableSavedQuery['dataset'], string> = {
   segment_spans: 'Traces',
   metrics: 'Application Metrics',
   replays: 'Replays',
+  ai_conversations: 'Conversations',
 };
 
 const DATASET_TO_TRACE_ITEM_DATASET_MAP: Record<
@@ -312,6 +319,7 @@ const DATASET_TO_TRACE_ITEM_DATASET_MAP: Record<
   segment_spans: TraceItemDataset.SPANS,
   metrics: TraceItemDataset.TRACEMETRICS,
   replays: TraceItemDataset.REPLAYS,
+  ai_conversations: TraceItemDataset.SPANS,
 };
 
 export function getSavedQueryDatasetLabel(dataset: ReadableSavedQuery['dataset']) {

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -32,7 +32,13 @@ export type ExploreQueryChangedReason = {
 };
 
 type ExploreSavedQueryRequest = {
-  dataset: 'logs' | 'spans' | 'segment_spans' | 'metrics' | 'replays';
+  dataset:
+    | 'logs'
+    | 'spans'
+    | 'segment_spans'
+    | 'metrics'
+    | 'replays'
+    | 'ai_conversations';
   name: string;
   projects: number[];
   changedReason?: ExploreQueryChangedReason;

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -25,6 +25,7 @@ import {
 } from 'sentry/utils/discover/fields';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {determineTimeSeriesConfidence} from 'sentry/views/alerts/rules/metric/utils/determineSeriesConfidence';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
@@ -33,6 +34,7 @@ import type {GroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggr
 import {isGroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import type {BaseVisualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/explore/conversations/settings';
 import type {
   RawGroupBy,
   RawVisualize,
@@ -666,6 +668,9 @@ export function getSavedQueryTraceItemUrl({
   organization: Organization;
   savedQuery: SavedQuery;
 }) {
+  if (savedQuery.dataset === 'ai_conversations') {
+    return getConversationsUrlFromSavedQueryUrl({savedQuery, organization});
+  }
   const traceItemDataset = getSavedQueryTraceItemDataset(savedQuery.dataset);
   const urlFunction = TRACE_ITEM_TO_URL_FUNCTION[traceItemDataset];
   if (urlFunction) {
@@ -676,6 +681,32 @@ export function getSavedQueryTraceItemUrl({
     `Saved query ${savedQuery.id} has an invalid dataset: ${savedQuery.dataset}`
   );
   return getExploreUrlFromSavedQueryUrl({savedQuery, organization});
+}
+
+function getConversationsUrlFromSavedQueryUrl({
+  savedQuery,
+  organization,
+}: {
+  organization: Organization;
+  savedQuery: SavedQuery;
+}) {
+  const firstQuery = savedQuery.query[0];
+  const queryParams = {
+    query: firstQuery?.query,
+    project: savedQuery.projects,
+    environment: savedQuery.environment,
+    start: normalizeDateTimeString(savedQuery.start),
+    end: normalizeDateTimeString(savedQuery.end),
+    statsPeriod: savedQuery.range,
+    id: savedQuery.id,
+    title: savedQuery.name,
+  };
+
+  const queryString = qs.stringify(queryParams, {skipNull: true});
+  const basePath = normalizeUrl(
+    `/organizations/${organization.slug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/`
+  );
+  return `${basePath}?${queryString}`;
 }
 
 function getReplayUrlFromSavedQueryUrl({


### PR DESCRIPTION
Wire up the frontend to save, load, and display `ai_conversations` saved queries using the existing ExploreSavedQuery API. Stacked on #118725.

**Save flow:** A "Save as" button next to the search bar (matching the logs explorer pattern) opens the standard `SaveQueryModal` with name input and starred toggle. On save, it POSTs to `/explore/saved/` with `dataset: 'ai_conversations'`, capturing the current search query and page filters.

**Load flow:** Starred `ai_conversations` queries appear in the sidebar automatically through the existing starred queries system. Clicking one routes to `/explore/conversations/` with the saved filters restored via `getConversationsUrlFromSavedQueryUrl`.

---

<img width="1077" height="55" alt="Screenshot 2026-07-01 at 14 52 19" src="https://github.com/user-attachments/assets/897c160a-2d29-4974-8824-02624bf86bc0" />

---

<img width="641" height="327" alt="Screenshot 2026-07-01 at 14 52 35" src="https://github.com/user-attachments/assets/f45c84ed-69b6-4e12-8608-dee5e163daff" />

---

<img width="302" height="350" alt="Screenshot 2026-07-01 at 14 52 49" src="https://github.com/user-attachments/assets/56abaa87-4e1e-4ba2-a35f-9a0c09e22d19" />

---

<img width="1232" height="140" alt="Screenshot 2026-07-01 at 14 53 05" src="https://github.com/user-attachments/assets/ec31862c-e3c5-43ad-9392-58e7f27ce263" />



Closes TET-2552